### PR TITLE
chore: add scratch/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 venv
+scratch/
 
 ### Vim ###
 [._]*.s[a-w][a-z]


### PR DESCRIPTION
Add scratch/ directory to .gitignore to prevent tracking of temporary/scratch files.