### PR TITLE
fix(cli): correct debug message color

### DIFF
--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -363,7 +363,7 @@ def format_text_output(results, verbose=False):
             elif severity == "info":
                 severity_style = click.style("[INFO]", fg="blue")
             elif severity == "debug":
-                severity_style = click.style("[DEBUG]", fg="gray")
+                severity_style = click.style("[DEBUG]", fg="bright_black")
 
             # Format the issue line
             issue_num = click.style(f"{i}.", fg="white", bold=True)


### PR DESCRIPTION
## Summary
- use `bright_black` instead of `gray` for debug messages in CLI

## Testing
- `pytest tests/test_cli.py::test_scan_verbose_mode tests/test_integration.py::test_cli_with_all_options -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee1b733288332abde65e99c0fbd81