### PR TITLE
fix: report success when only debug issues

### DIFF
--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -294,16 +294,14 @@ def format_text_output(results, verbose=False):
 
     # Add issue details with color-coded severity
     issues = results.get("issues", [])
-    if issues:
-        # Filter out DEBUG severity issues when not in verbose mode
-        visible_issues = [
-            issue
-            for issue in issues
-            if verbose
-            or not isinstance(issue, dict)
-            or issue.get("severity") != "debug"
-        ]
+    # Filter out DEBUG severity issues when not in verbose mode
+    visible_issues = [
+        issue
+        for issue in issues
+        if verbose or not isinstance(issue, dict) or issue.get("severity") != "debug"
+    ]
 
+    if visible_issues:
         # Count issues by severity (excluding DEBUG when not in verbose mode)
         error_count = sum(
             1
@@ -376,7 +374,7 @@ def format_text_output(results, verbose=False):
                 output_lines.append(f"{issue_num} {severity_style} {message}")
 
             # Add a small separator between issues for readability
-            if i < len(issues):
+            if i < len(visible_issues):
                 output_lines.append("")
     else:
         output_lines.append(
@@ -385,10 +383,10 @@ def format_text_output(results, verbose=False):
 
     # Add a footer
     output_lines.append("─" * 80)
-    if issues:
+    if visible_issues:
         if any(
             isinstance(issue, dict) and issue.get("severity") == "error"
-            for issue in issues
+            for issue in visible_issues
         ):
             status = click.style("✗ Scan completed with errors", fg="red", bold=True)
         else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -218,6 +218,23 @@ def test_format_text_output():
     # Verbose might include details, but we can't guarantee it
 
 
+def test_format_text_output_only_debug_issues():
+    """Ensure debug-only issues result in a success status."""
+    results = {
+        "files_scanned": 1,
+        "bytes_scanned": 10,
+        "duration": 0.1,
+        "issues": [
+            {"message": "Debug info", "severity": "debug", "location": "file.pkl"},
+        ],
+        "has_errors": False,
+    }
+
+    output = format_text_output(results, verbose=False)
+    assert "No issues found" in output
+    assert "Scan completed successfully" in output
+
+
 def test_exit_code_clean_scan(tmp_path):
     """Test exit code 0 when scan is clean with no issues."""
     import pickle

--- a/tests/test_zip_scanner.py
+++ b/tests/test_zip_scanner.py
@@ -1,9 +1,9 @@
-import pytest
-import zipfile
-import tempfile
 import os
-from modelaudit.scanners.zip_scanner import ZipScanner
+import tempfile
+import zipfile
+
 from modelaudit.scanners.base import IssueSeverity
+from modelaudit.scanners.zip_scanner import ZipScanner
 
 
 class TestZipScanner:
@@ -206,8 +206,8 @@ class TestZipScanner:
         with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
             with zipfile.ZipFile(tmp.name, "w") as z:
                 # Create a pickle with suspicious content
-                import pickle
                 import os as os_module
+                import pickle
 
                 class DangerousClass:
                     def __reduce__(self):


### PR DESCRIPTION
## Summary
- filter debug issues when evaluating CLI output status and separators
- add regression test for debug-only output
- clean up zip scanner imports

## Testing
- `poetry run ruff check modelaudit tests`
- `poetry run ruff format modelaudit tests`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee1bca6c083329b4b63acd91fa7e9