### PR TITLE
feat: enforce model name policies in manifests

### DIFF
--- a/tests/test_manifest_name_policy.py
+++ b/tests/test_manifest_name_policy.py
@@ -1,0 +1,19 @@
+import json
+from pathlib import Path
+
+from modelaudit.scanners.base import IssueSeverity
+from modelaudit.scanners.manifest_scanner import ManifestScanner
+
+
+def test_manifest_scanner_model_name_blacklist(tmp_path):
+    """Manifests with blacklisted model names should trigger an error."""
+    manifest_content = {"model_name": "malicious_model"}
+    test_file = tmp_path / "manifest.json"
+    with test_file.open("w") as f:
+        json.dump(manifest_content, f)
+
+    scanner = ManifestScanner()
+    result = scanner.scan(str(test_file))
+
+    assert any(issue.severity == IssueSeverity.ERROR for issue in result.issues)
+    assert any("model" in issue.message.lower() and "blocked" in issue.message.lower() for issue in result.issues)


### PR DESCRIPTION
## Summary
- check model name keys in ManifestScanner
- raise error when a blocked model name is found
- test blocking blacklisted model names in manifests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ee46cb0f483328dd5c183dfaa23a0