### PR TITLE
chore: decrease frequency of Dependabot workflow updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,12 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Summary
- set GitHub Actions updates to run monthly
- group all action updates together

## Testing
- `poetry install` *(fails: PEP517 build of a dependency failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ef2ce66c48332895b346b0938bb77