### PR TITLE
fix: double-counted bytes in ZipScanner

### DIFF
--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -162,7 +162,6 @@ class ZipScanner(BaseScanner):
                             if not chunk:
                                 break
                             data += chunk
-                            result.bytes_scanned += len(chunk)
                             if len(data) > max_entry_size:
                                 raise ValueError(
                                     f"ZIP entry {name} exceeds maximum size of "


### PR DESCRIPTION
## Summary
- avoid incrementing `bytes_scanned` while reading chunks in `ZipScanner`
- test that bytes scanned reflects the sum of embedded files once
- update nested zip test for new behaviour

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check modelaudit/ tests/`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee47eedc88332bd5dcac76490ed34