### PR TITLE
fix: treat raw pickle pt files as unsupported

### DIFF
--- a/tests/test_pytorch_zip_scanner.py
+++ b/tests/test_pytorch_zip_scanner.py
@@ -138,3 +138,21 @@ def test_pytorch_zip_scanner_with_blacklist(tmp_path):
         if "suspicious_function" in issue.message.lower()
     ]
     assert len(blacklist_issues) > 0
+
+
+def test_pytorch_pickle_file_unsupported(tmp_path):
+    """Raw pickle files with .pt extension should be unsupported."""
+    from tests.evil_pickle import EvilClass
+
+    file_path = tmp_path / "raw_pickle.pt"
+    with file_path.open("wb") as f:
+        pickle.dump(EvilClass(), f)
+
+    scanner = PyTorchZipScanner()
+    result = scanner.scan(str(file_path))
+
+    assert result.success is False
+    assert any(
+        "zip" in issue.message.lower() or "pytorch" in issue.message.lower()
+        for issue in result.issues
+    )

--- a/tests/test_zip_scanner.py
+++ b/tests/test_zip_scanner.py
@@ -1,9 +1,9 @@
-import pytest
-import zipfile
-import tempfile
 import os
-from modelaudit.scanners.zip_scanner import ZipScanner
+import tempfile
+import zipfile
+
 from modelaudit.scanners.base import IssueSeverity
+from modelaudit.scanners.zip_scanner import ZipScanner
 
 
 class TestZipScanner:
@@ -206,8 +206,8 @@ class TestZipScanner:
         with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
             with zipfile.ZipFile(tmp.name, "w") as z:
                 # Create a pickle with suspicious content
-                import pickle
                 import os as os_module
+                import pickle
 
                 class DangerousClass:
                     def __reduce__(self):


### PR DESCRIPTION
## Summary
- handle raw `.pt` files as unsupported instead of delegating to `PickleScanner`
- add unit test for unsupported pickle `.pt` files
- fix ruff issues in `tests/test_zip_scanner.py`

## Testing
- `poetry run ruff check modelaudit/ tests/`
- `poetry run mypy modelaudit/`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ee2a67e748332ae8f4d2ff7c27247