### PR TITLE
feat: add optional pickle rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ modelaudit scan large_model.pkl --timeout 300
 
 # Verbose output for debugging
 modelaudit scan model.pkl --verbose
+
+# Attempt to rewrite unsafe pickle files
+modelaudit scan malicious.pkl --rewrite
 ```
 
 **Example output:**

--- a/modelaudit/utils/rewrite.py
+++ b/modelaudit/utils/rewrite.py
@@ -1,0 +1,57 @@
+"""Utilities for rewriting pickle files using Fickling."""
+
+from __future__ import annotations
+
+import difflib
+import pickle
+from pathlib import Path
+
+from fickling.fickle import Memoize, Pickled, ShortBinUnicode, StackGlobal
+
+
+def _contains_dangerous_chain(ops: list) -> bool:
+    for i in range(4, len(ops)):
+        op = ops[i]
+        if (
+            isinstance(op, StackGlobal)
+            and isinstance(ops[i - 1], Memoize)
+            and isinstance(ops[i - 2], ShortBinUnicode)
+            and isinstance(ops[i - 3], Memoize)
+            and isinstance(ops[i - 4], ShortBinUnicode)
+        ):
+            module = ops[i - 4].arg
+            func = ops[i - 2].arg
+            if (module in {"os", "posix"} and func == "system") or (
+                module == "subprocess" and func in {"Popen", "call", "check_output"}
+            ):
+                return True
+    return False
+
+
+def safe_rewrite_pickle(path: str, output_path: str | None = None) -> tuple[str, str]:
+    """Rewrite a pickle file removing obvious dangerous gadget chains."""
+
+    in_path = Path(path)
+    if output_path is None:
+        output_path = str(in_path.with_suffix(in_path.suffix + ".safe"))
+    out_path = Path(output_path)
+
+    original_data = in_path.read_bytes()
+    pickled = Pickled.load(original_data)
+
+    if _contains_dangerous_chain(list(pickled)):
+        sanitized_data = pickle.dumps("sanitized")
+        out_path.write_bytes(sanitized_data)
+        diff = "\n".join(
+            difflib.unified_diff(
+                original_data.decode("latin1").splitlines(),
+                sanitized_data.decode("latin1").splitlines(),
+                fromfile=str(in_path),
+                tofile=str(out_path),
+            )
+        )
+    else:
+        out_path.write_bytes(original_data)
+        diff = ""
+
+    return str(out_path), diff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 python = ">=3.9,<4.0"
 click = "^8.1.3"
 yaspin = "^2.3.0"
+fickling = { version = ">=0.0.8", optional = true }
 
 # Optional dependencies for specific scanners
 tensorflow = { version = ">=2.6", optional = true }
@@ -49,7 +50,8 @@ tensorflow = ["tensorflow"]
 h5 = ["h5py"]
 pytorch = ["torch"]
 yaml = ["pyyaml"]
-all = ["tensorflow", "h5py", "torch", "pyyaml"]
+rewrite = ["fickling"]
+all = ["tensorflow", "h5py", "torch", "pyyaml", "fickling"]
 
 [tool.poetry.scripts]
 modelaudit = "modelaudit.cli:main"

--- a/tests/test_pickle_rewrite.py
+++ b/tests/test_pickle_rewrite.py
@@ -1,0 +1,16 @@
+import pickle
+from pathlib import Path
+
+from modelaudit.utils.rewrite import safe_rewrite_pickle
+
+
+def test_safe_rewrite_pickle(tmp_path):
+    evil_pickle = Path(__file__).parent / "evil.pickle"
+    rewritten, diff = safe_rewrite_pickle(
+        str(evil_pickle), output_path=str(tmp_path / "rewritten.pkl")
+    )
+    assert Path(rewritten).exists()
+    with open(rewritten, "rb") as f:
+        obj = pickle.load(f)
+    assert obj == "sanitized"
+    assert "os.system" not in diff


### PR DESCRIPTION
## Summary
- add fickling optional dependency and extras
- add `--rewrite` flag to the CLI
- implement simple pickle rewriting utility
- document rewrite flag
- test rewrite helper

## Testing
- `poetry run ruff check modelaudit/utils/rewrite.py modelaudit/cli.py tests/test_pickle_rewrite.py`
- `poetry run black modelaudit/utils/rewrite.py modelaudit/cli.py tests/test_pickle_rewrite.py`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f8b261cf483328fa235d2cb91acf9