### PR TITLE
fix: clarify missing data.pkl warning

### DIFF
--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -128,8 +128,8 @@ class PyTorchZipScanner(BaseScanner):
                     os.path.basename(f) for f in pickle_files
                 ]:
                     result.add_issue(
-                        "PyTorch model missing data.pkl file - unusual for "
-                        "standard PyTorch models",
+                        "PyTorch model is missing 'data.pkl', which is "
+                        "unusual for standard PyTorch models.",
                         severity=IssueSeverity.WARNING,
                         location=self.current_file_path,
                         details={"missing_file": "data.pkl"},


### PR DESCRIPTION
## Summary
- clarify PyTorch zip scanner warning message for missing data.pkl

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run mypy modelaudit/`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68506cc88cf883328308fe8da6c960f9