### PR TITLE
fix: log weight extraction failures

### DIFF
--- a/modelaudit/scanners/weight_distribution_scanner.py
+++ b/modelaudit/scanners/weight_distribution_scanner.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 from scipy import stats
 
-from .base import BaseScanner, IssueSeverity, ScanResult
+from .base import BaseScanner, IssueSeverity, ScanResult, logger
 
 # Try to import format-specific libraries
 try:
@@ -202,7 +202,8 @@ class WeightDistributionScanner(BaseScanner):
                         # PyTorch uses (out_features, in_features) but we expect (in_features, out_features)
                         weights_info[key] = value.detach().cpu().numpy().T
 
-        except Exception:
+        except Exception as e:
+            logger.debug(f"Failed to extract weights from {path}: {e}")
             # Try loading as a zip file (newer PyTorch format)
             try:
                 with zipfile.ZipFile(path, "r") as z:
@@ -211,8 +212,8 @@ class WeightDistributionScanner(BaseScanner):
                         # We can't easily extract weights from pickle without executing it
                         # This is a limitation we should document
                         pass
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Failed to extract weights from {path}: {e}")
 
         return weights_info
 
@@ -234,8 +235,8 @@ class WeightDistributionScanner(BaseScanner):
 
                 f.visititems(extract_weights)
 
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Failed to extract weights from {path}: {e}")
 
         return weights_info
 
@@ -276,8 +277,8 @@ class WeightDistributionScanner(BaseScanner):
                         initializer
                     )
 
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Failed to extract weights from {path}: {e}")
 
         return weights_info
 
@@ -301,8 +302,8 @@ class WeightDistributionScanner(BaseScanner):
                     if "weight" in key.lower():
                         weights_info[key] = f.get_tensor(key)
 
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Failed to extract weights from {path}: {e}")
 
         return weights_info
 


### PR DESCRIPTION
## Summary
- capture any exceptions when pulling weights so debugging is easier

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run mypy modelaudit/`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68506db6bfa483329e2b33063beb074f