### PR TITLE
chore: refine package build configuration

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+exclude tests*
+exclude Dockerfile*
+exclude docker-compose.yml
+exclude setup-poetry.sh
+exclude AGENTS.md
+exclude CLAUDE.md
+exclude llm_context.txt

--- a/README.md
+++ b/README.md
@@ -339,6 +339,10 @@ poetry run mypy modelaudit/
 # Build package
 poetry build
 
+# The generated distribution contains only the `modelaudit` code and metadata.
+# Unnecessary files like tests and Docker configurations are excluded via
+# `MANIFEST.in`.
+
 # Publish (maintainers only)
 poetry publish
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
+packages = [{ include = "modelaudit" }]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
## Summary
- include only the modelaudit package in Poetry config
- add MANIFEST.in to exclude dev artifacts from the wheel
- document how MANIFEST.in affects packaging

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run mypy modelaudit/`
- `poetry run pytest -q`
- `poetry build`


------
https://chatgpt.com/codex/tasks/task_e_6850844ddea08332830d3a2a1713bf21