### PR TITLE
chore: update biome configuration to v2.0.0 schema

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,21 +1,24 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "files": {
-    "include": ["**/*.json", "**/*.jsonc", "**/*.yaml", "**/*.yml"],
-    "ignore": [
-      ".mypy_cache/**",
-      "__pycache__/**",
-      ".ruff_cache/**",
-      ".pytest_cache/**",
-      ".venv/**",
-      "venv/**",
-      "dist/**",
-      "build/**",
-      ".git/**",
-      ".cursor/**",
-      "node_modules/**",
-      "poetry.lock",
-      ".coverage"
+    "includes": [
+      "**/*.json",
+      "**/*.jsonc",
+      "**/*.yaml",
+      "**/*.yml",
+      "!**/.mypy_cache/**",
+      "!**/__pycache__/**",
+      "!**/.ruff_cache/**",
+      "!**/.pytest_cache/**",
+      "!**/.venv/**",
+      "!**/venv/**",
+      "!**/dist/**",
+      "!**/build/**",
+      "!**/.git/**",
+      "!**/.cursor/**",
+      "!**/node_modules/**",
+      "!**/poetry.lock",
+      "!**/.coverage"
     ]
   },
   "formatter": {
@@ -27,12 +30,22 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "style": {
+        "noParameterAssign": "error",
+        "useAsConstAssertion": "error",
+        "useDefaultParameterLast": "error",
+        "useEnumInitializers": "error",
+        "useSelfClosingElements": "error",
+        "useSingleVarDeclarator": "error",
+        "noUnusedTemplateLiteral": "error",
+        "useNumberNamespace": "error",
+        "noInferrableTypes": "error",
+        "noUselessElse": "error"
+      }
     }
   },
-  "organizeImports": {
-    "enabled": false
-  },
+  "assist": { "actions": { "source": { "organizeImports": "off" } } },
   "javascript": {
     "formatter": {
       "enabled": false


### PR DESCRIPTION
Updates Biome configuration to the latest v2.0.0 schema. This migration includes: - Schema version bump from 1.9.4 to 2.0.0 - File inclusion patterns reorganized from include/ignore to includes with negation patterns - Additional linting rules added - Import organization settings updated to new format. All formatting and CI checks continue to pass.