### PR TITLE
fix: broaden ZIP signature detection

### DIFF
--- a/modelaudit/utils/filetype.py
+++ b/modelaudit/utils/filetype.py
@@ -10,7 +10,7 @@ def is_zipfile(path: str) -> bool:
     try:
         with file_path.open("rb") as f:
             signature = f.read(4)
-        return signature in [b"PK\x03\x04", b"PK\x05\x06"]
+        return signature.startswith(b"PK")
     except OSError:
         return False
 
@@ -57,8 +57,7 @@ def detect_file_format(path: str) -> str:
     ext = file_path.suffix.lower()
 
     # Check ZIP magic first (for .pt/.pth files that are actually zips)
-    # Common ZIP signatures: PK\x03\x04 (local file header) or PK\x05\x06 (end of central directory)
-    if magic4[:2] == b"PK" and magic4[2:4] in [b"\x03\x04", b"\x05\x06", b"\x01\x02"]:
+    if magic4.startswith(b"PK"):
         return "zip"
 
     # Check pickle magic patterns
@@ -91,7 +90,7 @@ def detect_file_format(path: str) -> str:
     # For .pt/.pth/.ckpt files, check if they're ZIP format first
     if ext in (".pt", ".pth", ".ckpt"):
         # These files can be either ZIP or pickle format
-        if magic4[:2] == b"PK":
+        if magic4.startswith(b"PK"):
             return "zip"
         # If not ZIP, assume pickle format
         return "pickle"
@@ -110,7 +109,7 @@ def detect_file_format(path: str) -> str:
     if ext == ".npz":
         return "zip"
     if ext == ".joblib":
-        if magic4[:2] == b"PK":
+        if magic4.startswith(b"PK"):
             return "zip"
         return "pickle"
 

--- a/tests/test_filetype.py
+++ b/tests/test_filetype.py
@@ -84,6 +84,15 @@ def test_is_zipfile(tmp_path):
     assert is_zipfile("nonexistent_file.zip") is False
 
 
+def test_zip_magic_variants(tmp_path):
+    """Ensure alternate PK signatures are detected as ZIP."""
+    for sig in (b"PK\x06\x06", b"PK\x06\x07"):
+        path = tmp_path / f"file_{sig.hex()}.zip"
+        path.write_bytes(sig + b"extra")
+        assert is_zipfile(str(path)) is True
+        assert detect_file_format(str(path)) == "zip"
+
+
 def test_find_sharded_files(tmp_path):
     """Test finding sharded model files."""
     # Create directory with sharded files


### PR DESCRIPTION
## Summary
- allow any `PK` prefix for ZIP detection
- add tests for ZIP64 signatures

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run mypy modelaudit/`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6851d63ce4788332948e3d18d51a4b99