### PR TITLE
feat: improve typing coverage

### DIFF
--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -3,6 +3,7 @@ import logging
 import os
 import sys
 import time
+from typing import Any
 
 import click
 from yaspin import yaspin
@@ -253,7 +254,7 @@ def scan_command(paths, blacklist, format, output, timeout, verbose, max_file_si
     sys.exit(exit_code)
 
 
-def format_text_output(results, verbose=False):
+def format_text_output(results: dict[str, Any], verbose: bool = False) -> str:
     """Format scan results as human-readable text with colors"""
     output_lines = []
 

--- a/modelaudit/scanners/gguf_scanner.py
+++ b/modelaudit/scanners/gguf_scanner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import struct
-from typing import Any, Dict, Optional
+from typing import Any, BinaryIO, Dict, Optional
 
 from .base import BaseScanner, IssueSeverity, ScanResult
 
@@ -115,7 +115,7 @@ class GgufScanner(BaseScanner):
         )
         return result
 
-    def _read_string(self, f, max_length: int = 1024 * 1024) -> str:
+    def _read_string(self, f: BinaryIO, max_length: int = 1024 * 1024) -> str:
         """Read a string with length checking for security."""
         (length,) = struct.unpack("<Q", f.read(8))
         if length > max_length:
@@ -125,7 +125,7 @@ class GgufScanner(BaseScanner):
             raise ValueError("Unexpected end of file while reading string")
         return data.decode("utf-8", "ignore")
 
-    def _scan_gguf(self, f, file_size: int, result: ScanResult) -> None:
+    def _scan_gguf(self, f: BinaryIO, file_size: int, result: ScanResult) -> None:
         """Comprehensive GGUF file scanning with security checks."""
         # Read header
         version = struct.unpack("<I", f.read(4))[0]
@@ -326,7 +326,9 @@ class GgufScanner(BaseScanner):
 
         result.bytes_scanned = f.tell()
 
-    def _scan_ggml(self, f, file_size: int, magic: bytes, result: ScanResult) -> None:
+    def _scan_ggml(
+        self, f: BinaryIO, file_size: int, magic: bytes, result: ScanResult
+    ) -> None:
         """Basic GGML file validation with security checks."""
         result.metadata["format"] = "ggml"
         result.metadata["magic"] = magic.decode("ascii", "ignore")
@@ -364,7 +366,7 @@ class GgufScanner(BaseScanner):
 
         result.bytes_scanned = file_size
 
-    def _read_value(self, f, vtype: int):
+    def _read_value(self, f: BinaryIO, vtype: int) -> Any:
         """Read a value of the specified type with security checks."""
         if vtype == 0:  # UINT8
             return struct.unpack("<B", f.read(1))[0]

--- a/modelaudit/scanners/manifest_scanner.py
+++ b/modelaudit/scanners/manifest_scanner.py
@@ -431,7 +431,7 @@ class ManifestScanner(BaseScanner):
 
         return any(pattern in value_lower for pattern in dangerous_patterns)
 
-    def _detect_ml_context(self, content: dict) -> dict:
+    def _detect_ml_context(self, content: dict[str, Any]) -> dict[str, Any]:
         """Detect ML model context to adjust sensitivity"""
         indicators = {
             "framework": None,

--- a/modelaudit/utils/filetype.py
+++ b/modelaudit/utils/filetype.py
@@ -116,7 +116,7 @@ def detect_file_format(path: str) -> str:
     return "unknown"
 
 
-def find_sharded_files(directory: str) -> list:
+def find_sharded_files(directory: str) -> list[str]:
     """
     Look for sharded model files like:
     pytorch_model-00001-of-00002.bin


### PR DESCRIPTION
## Summary
- extend type hints in gguf scanner
- add Any typing and typed return for CLI output formatting
- refine manifest scanner context detection signature
- specify list return for `find_sharded_files`

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run mypy modelaudit/`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68520eb5a24c8332a29f664800fe2e2b