### PR TITLE
fix: flag additional dangerous builtins

### DIFF
--- a/modelaudit/suspicious_symbols.py
+++ b/modelaudit/suspicious_symbols.py
@@ -69,7 +69,14 @@ SUSPICIOUS_GLOBALS = {
     "subprocess": "*",  # Process spawning and control
     "runpy": "*",  # Dynamic module execution
     # Code execution functions - CRITICAL RISK
-    "builtins": ["eval", "exec", "__import__"],  # Dynamic code evaluation
+    "builtins": [
+        "eval",
+        "exec",
+        "compile",
+        "open",
+        "input",
+        "__import__",
+    ],  # Dynamic code evaluation and file access
     "operator": ["attrgetter"],  # Attribute access bypass
     "importlib": ["import_module"],  # Dynamic module loading
     # Serialization/deserialization - MEDIUM RISK

--- a/tests/test_suspicious_symbols.py
+++ b/tests/test_suspicious_symbols.py
@@ -47,7 +47,14 @@ class TestSuspiciousGlobals:
         assert "builtins" in SUSPICIOUS_GLOBALS
         builtins_funcs = SUSPICIOUS_GLOBALS["builtins"]
 
-        dangerous_builtins = ["eval", "exec", "__import__"]
+        dangerous_builtins = [
+            "eval",
+            "exec",
+            "compile",
+            "open",
+            "input",
+            "__import__",
+        ]
         for func in dangerous_builtins:
             assert func in builtins_funcs, f"Dangerous builtin {func} not flagged"
 


### PR DESCRIPTION
## Summary
- extend builtins list with more dangerous functions
- update tests for new builtin detection

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run mypy modelaudit/`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_685378568acc8332a568872f84a4df0e