### PR TITLE
feat: add total size limit for scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ ModelAudit can detect anomalous weight patterns that may indicate trojaned model
 # Set maximum file size to scan (1GB limit)
 modelaudit scan model.pkl --max-file-size 1073741824
 
+# Stop scanning after a total of 5GB has been processed
+modelaudit scan models/ --max-total-size 5368709120
+
 # Add custom blacklist patterns
 modelaudit scan model.pkl --blacklist "unsafe_model" --blacklist "malicious_net"
 
@@ -326,7 +329,7 @@ pip install tensorflow h5py torch pyyaml safetensors onnx joblib  # Add what you
 
 ```bash
 # Increase file size limit and timeout for large models
-modelaudit scan large_model.pt --max-file-size 5000000000 --timeout 600
+modelaudit scan large_model.pt --max-file-size 5000000000 --timeout 600 --max-total-size 10000000000
 ```
 
 **Debug Mode:**

--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -62,7 +62,15 @@ def cli():
     default=0,
     help="Maximum file size to scan in bytes [default: unlimited]",
 )
-def scan_command(paths, blacklist, format, output, timeout, verbose, max_file_size):
+@click.option(
+    "--max-total-size",
+    type=int,
+    default=0,
+    help="Maximum total bytes to scan before stopping [default: unlimited]",
+)
+def scan_command(
+    paths, blacklist, format, output, timeout, verbose, max_file_size, max_total_size
+):
     """Scan files or directories for malicious content.
 
     \b
@@ -80,6 +88,7 @@ def scan_command(paths, blacklist, format, output, timeout, verbose, max_file_si
         --timeout, -t      Set scan timeout in seconds
         --verbose, -v      Show detailed information during scanning
         --max-file-size    Maximum file size to scan in bytes
+        --max-total-size   Maximum total bytes to scan before stopping
 
     \b
     Exit codes:
@@ -168,6 +177,7 @@ def scan_command(paths, blacklist, format, output, timeout, verbose, max_file_si
                 blacklist_patterns=list(blacklist) if blacklist else None,
                 timeout=timeout,
                 max_file_size=max_file_size,
+                max_total_size=max_total_size,
                 progress_callback=progress_callback,
             )
 

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -16,6 +16,7 @@ def scan_model_directory_or_file(
     blacklist_patterns: Optional[list[str]] = None,
     timeout: int = 300,
     max_file_size: int = 0,
+    max_total_size: int = 0,
     progress_callback: Optional[Callable[[str, float], None]] = None,
     **kwargs,
 ) -> dict[str, Any]:
@@ -27,6 +28,7 @@ def scan_model_directory_or_file(
         blacklist_patterns: Additional blacklist patterns to check against model names
         timeout: Scan timeout in seconds
         max_file_size: Maximum file size to scan in bytes
+        max_total_size: Maximum total bytes to scan across all files
         progress_callback: Optional callback function to report progress
                           (message, percentage)
         **kwargs: Additional arguments to pass to scanners
@@ -52,6 +54,7 @@ def scan_model_directory_or_file(
     config = {
         "blacklist_patterns": blacklist_patterns,
         "max_file_size": max_file_size,
+        "max_total_size": max_total_size,
         "timeout": timeout,
         **kwargs,
     }
@@ -73,6 +76,7 @@ def scan_model_directory_or_file(
             # Scan all files in the directory
             total_files = sum(1 for _ in Path(path).rglob("*") if _.is_file())
             processed_files = 0
+            limit_reached = False
 
             for root, _, files in os.walk(path):
                 for file in files:
@@ -112,6 +116,21 @@ def scan_model_directory_or_file(
                         issues_list = cast(list[dict[str, Any]], results["issues"])
                         for issue in file_result.issues:
                             issues_list.append(issue.to_dict())
+
+                        if (
+                            max_total_size > 0
+                            and cast(int, results["bytes_scanned"]) > max_total_size
+                        ):
+                            issues_list.append(
+                                {
+                                    "message": f"Total scan size limit exceeded: {results['bytes_scanned']} bytes (max: {max_total_size})",
+                                    "severity": IssueSeverity.WARNING.value,
+                                    "location": file_path,
+                                    "details": {"max_total_size": max_total_size},
+                                }
+                            )
+                            limit_reached = True
+                            break
                     except Exception as e:
                         logger.warning(f"Error scanning file {file_path}: {str(e)}")
                         # Add as an issue
@@ -124,6 +143,11 @@ def scan_model_directory_or_file(
                                 "details": {"exception_type": type(e).__name__},
                             },
                         )
+                if limit_reached:
+                    break
+            # Stop scanning if size limit reached
+            if limit_reached:
+                pass
         else:
             # Scan a single file
             if progress_callback:
@@ -192,6 +216,19 @@ def scan_model_directory_or_file(
             issues_list = cast(list[dict[str, Any]], results["issues"])
             for issue in file_result.issues:
                 issues_list.append(issue.to_dict())
+
+            if (
+                max_total_size > 0
+                and cast(int, results["bytes_scanned"]) > max_total_size
+            ):
+                issues_list.append(
+                    {
+                        "message": f"Total scan size limit exceeded: {results['bytes_scanned']} bytes (max: {max_total_size})",
+                        "severity": IssueSeverity.WARNING.value,
+                        "location": path,
+                        "details": {"max_total_size": max_total_size},
+                    }
+                )
 
             if progress_callback:
                 progress_callback(f"Completed scanning: {path}", 100.0)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -109,6 +109,28 @@ def test_max_file_size(tmp_path):
     assert len(large_file_issues) == 0
 
 
+def test_max_total_size(tmp_path):
+    """Test max_total_size parameter."""
+    import pickle
+
+    file1 = tmp_path / "a.pkl"
+    with file1.open("wb") as f:
+        pickle.dump({"data": "x" * 100}, f)
+
+    file2 = tmp_path / "b.pkl"
+    with file2.open("wb") as f:
+        pickle.dump({"data": "y" * 100}, f)
+
+    results = scan_model_directory_or_file(str(tmp_path), max_total_size=150)
+
+    assert results["success"] is True
+
+    limit_issues = [
+        i for i in results["issues"] if "Total scan size limit exceeded" in i["message"]
+    ]
+    assert len(limit_issues) == 1
+
+
 def test_timeout(tmp_path, monkeypatch):
     """Test timeout parameter."""
     # Create a test file


### PR DESCRIPTION
## Summary
- limit cumulative bytes scanned via `max_total_size`
- expose new limit in CLI and docs
- document usage examples for new flag
- test new size limit functionality

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run mypy modelaudit/`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68537869823c8332ab6eb2cdb3d2adb8