### PR TITLE
feat: add scan config validation

### DIFF
--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -11,6 +11,24 @@ from modelaudit.utils.filetype import detect_file_format
 logger = logging.getLogger("modelaudit.core")
 
 
+def validate_scan_config(config: dict[str, Any]) -> None:
+    """Validate configuration parameters for scanning."""
+    timeout = config.get("timeout")
+    if timeout is not None:
+        if not isinstance(timeout, int) or timeout <= 0:
+            raise ValueError("timeout must be a positive integer")
+
+    max_file_size = config.get("max_file_size")
+    if max_file_size is not None:
+        if not isinstance(max_file_size, int) or max_file_size < 0:
+            raise ValueError("max_file_size must be a non-negative integer")
+
+    chunk_size = config.get("chunk_size")
+    if chunk_size is not None:
+        if not isinstance(chunk_size, int) or chunk_size <= 0:
+            raise ValueError("chunk_size must be a positive integer")
+
+
 def scan_model_directory_or_file(
     path: str,
     blacklist_patterns: Optional[list[str]] = None,
@@ -55,6 +73,8 @@ def scan_model_directory_or_file(
         "timeout": timeout,
         **kwargs,
     }
+
+    validate_scan_config(config)
 
     try:
         # Check if path exists
@@ -311,6 +331,7 @@ def scan_file(path: str, config: dict[str, Any] = None) -> ScanResult:
     """
     if config is None:
         config = {}
+    validate_scan_config(config)
 
     # Check file size first
     max_file_size = config.get("max_file_size", 0)  # Default unlimited

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,8 @@
 import re
 from importlib.metadata import PackageNotFoundError, version
 
+import pytest
+
 import modelaudit
 from modelaudit.core import scan_model_directory_or_file
 from modelaudit.scanners.base import IssueSeverity, ScanResult
@@ -234,6 +236,21 @@ def test_blacklist_patterns(tmp_path):
 
     # Just verify the scan completes successfully
     assert results["success"] is True
+
+
+def test_invalid_config_values(tmp_path):
+    """Test validation of configuration parameters."""
+    test_file = tmp_path / "test_invalid.dat"
+    test_file.write_bytes(b"data")
+
+    with pytest.raises(ValueError):
+        scan_model_directory_or_file(str(test_file), timeout=0)
+
+    with pytest.raises(ValueError):
+        scan_model_directory_or_file(str(test_file), max_file_size=-1)
+
+    with pytest.raises(ValueError):
+        scan_model_directory_or_file(str(test_file), chunk_size=0)
 
 
 def test_version_consistency():


### PR DESCRIPTION
## Summary
- validate configuration parameters in core
- ensure invalid parameters raise exceptions
- test configuration validation logic

## Testing
- `poetry run ruff format --check .`
- `poetry run ruff check .`
- `poetry run mypy modelaudit/`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68537896086c8332b015a1e08bf68fec