### PR TITLE
fix: handle file size errors

### DIFF
--- a/modelaudit/scanners/base.py
+++ b/modelaudit/scanners/base.py
@@ -246,5 +246,10 @@ class BaseScanner(ABC):
         return None  # Path is valid
 
     def get_file_size(self, path: str) -> int:
-        """Get the size of a file in bytes"""
-        return os.path.getsize(path) if os.path.isfile(path) else 0
+        """Get the size of a file in bytes."""
+        try:
+            return os.path.getsize(path) if os.path.isfile(path) else 0
+        except OSError:
+            # If the file becomes inaccessible during scanning, treat the size
+            # as zero rather than raising an exception.
+            return 0

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -151,6 +151,23 @@ def test_base_scanner_get_file_size(tmp_path):
     assert size == len(content)
 
 
+def test_base_scanner_get_file_size_oserror(tmp_path, monkeypatch):
+    """get_file_size should handle OS errors gracefully."""
+
+    test_file = tmp_path / "test.test"
+    test_file.write_bytes(b"data")
+
+    def mock_getsize(_path):  # pragma: no cover - error simulation
+        raise OSError("bad file")
+
+    monkeypatch.setattr(os.path, "getsize", mock_getsize)
+
+    scanner = MockScanner()
+    size = scanner.get_file_size(str(test_file))
+
+    assert size == 0
+
+
 def test_scanner_implementation(tmp_path):
     """Test a complete scan with the test scanner implementation."""
     # Create a test file


### PR DESCRIPTION
## Summary
- handle `OSError` in `BaseScanner.get_file_size`
- test error handling when `get_file_size` fails

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run mypy modelaudit/`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6853789dec988332acae10c3cf1d41fe