### PR TITLE
fix: close temporary file objects

### DIFF
--- a/modelaudit/scanners/joblib_scanner.py
+++ b/modelaudit/scanners/joblib_scanner.py
@@ -120,10 +120,10 @@ class JoblibScanner(BaseScanner):
                 return result
 
             if magic.startswith(b"\x80"):
-                file_like = io.BytesIO(data)
-                sub_result = self.pickle_scanner._scan_pickle_bytes(
-                    file_like, len(data)
-                )
+                with io.BytesIO(data) as file_like:
+                    sub_result = self.pickle_scanner._scan_pickle_bytes(
+                        file_like, len(data)
+                    )
                 result.merge(sub_result)
                 result.bytes_scanned = len(data)
             else:
@@ -147,10 +147,10 @@ class JoblibScanner(BaseScanner):
                     )
                     result.finish(success=False)
                     return result
-                file_like = io.BytesIO(decompressed)
-                sub_result = self.pickle_scanner._scan_pickle_bytes(
-                    file_like, len(decompressed)
-                )
+                with io.BytesIO(decompressed) as file_like:
+                    sub_result = self.pickle_scanner._scan_pickle_bytes(
+                        file_like, len(decompressed)
+                    )
                 result.merge(sub_result)
                 result.bytes_scanned = len(decompressed)
         except Exception as e:  # pragma: no cover

--- a/modelaudit/scanners/oci_layer_scanner.py
+++ b/modelaudit/scanners/oci_layer_scanner.py
@@ -110,6 +110,7 @@ class OciLayerScanner(BaseScanner):
                         ) as tmp:
                             tmp.write(fileobj.read())
                             tmp_path = tmp.name
+                        fileobj.close()
                         try:
                             from .. import core
 

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -92,12 +92,11 @@ class PyTorchZipScanner(BaseScanner):
                     data = z.read(name)
                     bytes_scanned += len(data)
 
-                    file_like = io.BytesIO(data)
-                    # Use the pickle scanner directly
-                    sub_result = self.pickle_scanner._scan_pickle_bytes(
-                        file_like,
-                        len(data),
-                    )
+                    with io.BytesIO(data) as file_like:
+                        sub_result = self.pickle_scanner._scan_pickle_bytes(
+                            file_like,
+                            len(data),
+                        )
 
                     # Include the pickle filename in each issue
                     for issue in sub_result.issues:

--- a/tests/test_joblib_scanner.py
+++ b/tests/test_joblib_scanner.py
@@ -17,3 +17,25 @@ def test_joblib_scanner_basic(tmp_path):
 
     assert result.success is True
     assert result.bytes_scanned > 0
+
+
+def test_joblib_scanner_closes_bytesio(tmp_path, monkeypatch):
+    """Ensure BytesIO objects used for pickles are closed."""
+    import io
+
+    closed = {}
+
+    class TrackedBytesIO(io.BytesIO):
+        def close(self) -> None:  # type: ignore[override]
+            closed["closed"] = True
+            super().close()
+
+    monkeypatch.setattr(io, "BytesIO", TrackedBytesIO)
+
+    path = tmp_path / "model.joblib"
+    joblib.dump({"a": np.arange(5)}, path, compress=3)
+
+    scanner = JoblibScanner()
+    scanner.scan(str(path))
+
+    assert closed.get("closed") is True


### PR DESCRIPTION
## Summary
- close extractfile handle in OCI layer scanner
- ensure BytesIO objects are closed in pytorch zip and joblib scanners
- add tests verifying BytesIO closure

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run mypy modelaudit/`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_685378aba01c8332879e8f52beb2b016