### PR TITLE
fix: improve Windows compatibility

### DIFF
--- a/modelaudit/scanners/manifest_scanner.py
+++ b/modelaudit/scanners/manifest_scanner.py
@@ -1,5 +1,7 @@
 import json
 import os
+import re
+from pathlib import Path
 from typing import Any, Optional
 
 from modelaudit.suspicious_symbols import SUSPICIOUS_CONFIG_PATTERNS
@@ -563,8 +565,8 @@ class ManifestScanner(BaseScanner):
         if not isinstance(value, str):
             return False
 
-        # Absolute paths
-        if value.startswith(("/", "\\", "C:", "D:")):
+        # Absolute paths (Unix or Windows)
+        if Path(value).is_absolute() or re.match(r"^[a-zA-Z]:\\", value):
             return True
 
         # Relative paths with separators
@@ -596,9 +598,10 @@ class ManifestScanner(BaseScanner):
             return True
 
         # Common path indicators
-        if any(
-            indicator in value.lower()
-            for indicator in ["/tmp", "/var", "/data", "/home", "/etc", "c:\\", "d:\\"]
+        lower_value = value.lower()
+        indicators = ["/tmp", "/var", "/data", "/home", "/etc"]
+        if any(indicator in lower_value for indicator in indicators) or re.search(
+            r"[a-z]:\\", lower_value
         ):
             return True
 

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -1,5 +1,6 @@
 import io
 import os
+import tempfile
 import zipfile
 from typing import Any, Optional
 
@@ -71,7 +72,8 @@ class PyTorchZipScanner(BaseScanner):
             with zipfile.ZipFile(path, "r") as z:
                 safe_entries: list[str] = []
                 for name in z.namelist():
-                    _, is_safe = sanitize_archive_path(name, "/tmp/extract")
+                    temp_base = os.path.join(tempfile.gettempdir(), "extract")
+                    _, is_safe = sanitize_archive_path(name, temp_base)
                     if not is_safe:
                         result.add_issue(
                             f"Archive entry {name} attempted path traversal outside the archive",

--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import zipfile
 from typing import Any, Dict, Optional
 
@@ -115,7 +116,8 @@ class ZipScanner(BaseScanner):
             for name in z.namelist():
                 info = z.getinfo(name)
 
-                _, is_safe = sanitize_archive_path(name, "/tmp/extract")
+                temp_base = os.path.join(tempfile.gettempdir(), "extract")
+                _, is_safe = sanitize_archive_path(name, temp_base)
                 if not is_safe:
                     result.add_issue(
                         f"Archive entry {name} attempted path traversal outside the archive",
@@ -167,7 +169,6 @@ class ZipScanner(BaseScanner):
                     # Check if it's another zip file
                     if name.lower().endswith(".zip"):
                         # Write to temporary file and scan recursively
-                        import tempfile
 
                         with tempfile.NamedTemporaryFile(
                             suffix=".zip", delete=False
@@ -191,7 +192,6 @@ class ZipScanner(BaseScanner):
                     else:
                         # Try to scan the file with appropriate scanner
                         # Write to temporary file with proper extension
-                        import tempfile
 
                         _, ext = os.path.splitext(name)
                         with tempfile.NamedTemporaryFile(


### PR DESCRIPTION
## Summary
- add path utilities in manifest scanner
- use tempfile paths instead of hardcoded /tmp paths
- remove redundant imports

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run mypy modelaudit/`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_685387217a0083329cc359650bec3f27