### PR TITLE
feat: refine import pattern detection

### DIFF
--- a/modelaudit/suspicious_symbols.py
+++ b/modelaudit/suspicious_symbols.py
@@ -130,7 +130,8 @@ SUSPICIOUS_STRING_PATTERNS = [
     r"os\.system",  # Direct system command execution
     r"subprocess\.(?:Popen|call|check_output)",  # Process spawning
     # Dynamic imports - HIGH RISK
-    r"import ",  # Import statements in strings
+    # Match explicit module imports to reduce noise from unrelated "import" substrings
+    r"\bimport\s+[\w\.]+",  # Import statements referencing modules
     r"importlib",  # Dynamic import library
     r"__import__",  # Built-in import function
     # Code construction - MEDIUM RISK

--- a/tests/test_suspicious_symbols.py
+++ b/tests/test_suspicious_symbols.py
@@ -102,6 +102,7 @@ class TestSuspiciousStringPatterns:
             ),
             (r"__[\w]+__", "__reduce__"),
             (r"base64\.b64decode", "base64.b64decode(encoded_payload)"),
+            (r"\bimport\s+[\w\.]+", "import os"),
             (r"\\x[0-9a-fA-F]{2}", "\\x41\\x42\\x43"),
         ]
 
@@ -117,6 +118,7 @@ class TestSuspiciousStringPatterns:
             "model.eval()",  # This might match eval( pattern - that's expected
             "data.shape",
             "model.parameters()",
+            "important_variable",  # Contains 'import' substring but isn't a module import
         ]
 
         # Count false positives for documentation


### PR DESCRIPTION
## Summary
- tighten regex for detecting import statements
- test the refined import pattern for dangerous code
- ensure safe strings containing `import` aren't flagged

## Testing
- `poetry run ruff format modelaudit/suspicious_symbols.py tests/test_suspicious_symbols.py`
- `poetry run ruff check modelaudit/suspicious_symbols.py tests/test_suspicious_symbols.py`
- `poetry run mypy modelaudit/suspicious_symbols.py`
- `poetry run pytest tests/test_suspicious_symbols.py`
- `poetry run pytest` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6859c52dae908332b19f2f166bf273da