### PR TITLE
chore: improve mypy annotations

### DIFF
--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 import time
-from typing import Any
+from typing import Any, Optional
 
 import click
 from yaspin import yaspin
@@ -22,7 +22,7 @@ logger = logging.getLogger("modelaudit")
 
 @click.group()
 @click.version_option(__version__)
-def cli():
+def cli() -> None:
     """Static scanner for ML models"""
     pass
 
@@ -74,16 +74,16 @@ def cli():
     help="Maximum total bytes to scan before stopping [default: unlimited]",
 )
 def scan_command(
-    paths,
-    blacklist,
-    format,
-    output,
-    sbom,
-    timeout,
-    verbose,
-    max_file_size,
-    max_total_size,
-):
+    paths: tuple[str, ...],
+    blacklist: tuple[str, ...],
+    format: str,
+    output: Optional[str],
+    sbom: Optional[str],
+    timeout: int,
+    verbose: bool,
+    max_file_size: int,
+    max_total_size: int,
+) -> None:
     """Scan files or directories for malicious content.
 
     \b
@@ -136,7 +136,7 @@ def scan_command(
         logger.setLevel(logging.DEBUG)
 
     # Aggregated results
-    aggregated_results = {
+    aggregated_results: dict[str, Any] = {
         "scanner_names": [],  # Track all scanner names used
         "start_time": time.time(),
         "bytes_scanned": 0,
@@ -498,5 +498,5 @@ def format_text_output(results: dict[str, Any], verbose: bool = False) -> str:
     return "\n".join(output_lines)
 
 
-def main():
+def main() -> None:
     cli()

--- a/tests/test_lazy_loading.py
+++ b/tests/test_lazy_loading.py
@@ -2,16 +2,15 @@
 Tests for lazy loading functionality in the scanner registry.
 """
 
-import importlib
 import sys
 import tempfile
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
 from modelaudit.scanners import _registry
-from modelaudit.scanners.base import BaseScanner, IssueSeverity, ScanResult
+from modelaudit.scanners.base import BaseScanner
 
 
 class TestScannerRegistry:
@@ -21,15 +20,28 @@ class TestScannerRegistry:
         """Test that the registry initializes with proper scanner metadata."""
         assert _registry._scanners is not None
         assert len(_registry._scanners) > 0
-        
+
         # Check that we have all expected scanners
         expected_scanners = [
-            "pickle", "pytorch_binary", "tf_savedmodel", "keras_h5", 
-            "onnx", "pytorch_zip", "gguf", "joblib", "numpy", 
-            "oci_layer", "manifest", "pmml", "weight_distribution",
-            "safetensors", "flax_msgpack", "tflite", "zip"
+            "pickle",
+            "pytorch_binary",
+            "tf_savedmodel",
+            "keras_h5",
+            "onnx",
+            "pytorch_zip",
+            "gguf",
+            "joblib",
+            "numpy",
+            "oci_layer",
+            "manifest",
+            "pmml",
+            "weight_distribution",
+            "safetensors",
+            "flax_msgpack",
+            "tflite",
+            "zip",
         ]
-        
+
         for scanner_id in expected_scanners:
             assert scanner_id in _registry._scanners
             scanner_info = _registry._scanners[scanner_id]
@@ -42,9 +54,9 @@ class TestScannerRegistry:
         """Test that scanners are not loaded during registry initialization."""
         # Reset loaded scanners to test fresh state
         _registry._loaded_scanners.clear()
-        
+
         assert len(_registry._loaded_scanners) == 0
-        
+
         # Accessing the registry should not load scanners
         scanner_ids = _registry.get_available_scanners()
         assert len(scanner_ids) > 0
@@ -54,13 +66,13 @@ class TestScannerRegistry:
         """Test that scanners are loaded only when requested."""
         # Reset loaded scanners
         _registry._loaded_scanners.clear()
-        
+
         # Load a light scanner (no heavy dependencies)
         scanner_class = _registry._load_scanner("pickle")
         assert scanner_class is not None
         assert "pickle" in _registry._loaded_scanners
         assert _registry._loaded_scanners["pickle"] is scanner_class
-        
+
         # Verify only one scanner was loaded
         assert len(_registry._loaded_scanners) == 1
 
@@ -68,11 +80,11 @@ class TestScannerRegistry:
         """Test that scanners are cached after first load."""
         # Reset loaded scanners
         _registry._loaded_scanners.clear()
-        
+
         # Load scanner twice
         scanner1 = _registry._load_scanner("pickle")
         scanner2 = _registry._load_scanner("pickle")
-        
+
         # Should be the same instance (cached)
         assert scanner1 is scanner2
         assert len(_registry._loaded_scanners) == 1
@@ -81,21 +93,21 @@ class TestScannerRegistry:
         """Test that get_scanner_for_path filters by extension before loading."""
         # Reset loaded scanners
         _registry._loaded_scanners.clear()
-        
+
         # Create temporary files with different extensions
         with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
             pkl_path = f.name
-        
+
         try:
             # This should only load the pickle scanner
             scanner = _registry.get_scanner_for_path(pkl_path)
             assert scanner is not None
             assert scanner.name == "pickle"
-            
+
             # Verify only pickle scanner was loaded (and maybe a few others that handle .pkl)
             loaded_count = len(_registry._loaded_scanners)
             assert loaded_count <= 3  # Should be minimal
-            
+
         finally:
             Path(pkl_path).unlink(missing_ok=True)
 
@@ -104,7 +116,7 @@ class TestScannerRegistry:
         scanner_info = _registry.get_scanner_info("pickle")
         assert scanner_info is not None
         assert scanner_info["priority"] == 1  # Pickle should have highest priority
-        
+
         zip_info = _registry.get_scanner_info("zip")
         assert zip_info is not None
         assert zip_info["priority"] == 99  # Zip should have lowest priority (fallback)
@@ -113,29 +125,29 @@ class TestScannerRegistry:
         """Test that heavy dependencies are properly marked."""
         # Check heavy dependency scanners
         heavy_scanners = ["tf_savedmodel", "keras_h5", "onnx", "tflite"]
-        
+
         for scanner_id in heavy_scanners:
             scanner_info = _registry.get_scanner_info(scanner_id)
             assert scanner_info is not None
             assert len(scanner_info["dependencies"]) > 0
-        
+
         # Check light dependency scanners
         light_scanners = ["pickle", "pytorch_binary", "zip", "manifest"]
-        
+
         for scanner_id in light_scanners:
             scanner_info = _registry.get_scanner_info(scanner_id)
             assert scanner_info is not None
             assert len(scanner_info["dependencies"]) == 0
 
-    @patch('importlib.import_module')
+    @patch("importlib.import_module")
     def test_scanner_load_failure_handling(self, mock_import):
         """Test handling of scanner loading failures."""
         # Reset loaded scanners
         _registry._loaded_scanners.clear()
-        
+
         # Mock import failure
         mock_import.side_effect = ImportError("Module not found")
-        
+
         # Should return None for failed import
         scanner = _registry._load_scanner("tf_savedmodel")
         assert scanner is None
@@ -145,14 +157,14 @@ class TestScannerRegistry:
         """Test that get_scanner_classes loads all available scanners."""
         # Reset loaded scanners
         _registry._loaded_scanners.clear()
-        
+
         # This should attempt to load all scanners
         scanner_classes = _registry.get_scanner_classes()
-        
+
         # Should have loaded multiple scanners
         assert len(scanner_classes) > 0
         assert len(_registry._loaded_scanners) > 0
-        
+
         # All returned classes should be BaseScanner subclasses
         for scanner_class in scanner_classes:
             assert issubclass(scanner_class, BaseScanner)
@@ -164,21 +176,21 @@ class TestLazyListInterface:
     def test_lazy_list_iteration(self):
         """Test that the lazy list can be iterated."""
         from modelaudit.scanners import SCANNER_REGISTRY
-        
+
         count = 0
         for scanner in SCANNER_REGISTRY:
             assert issubclass(scanner, BaseScanner)
             count += 1
-        
+
         assert count > 0
 
     def test_lazy_list_length(self):
         """Test that the lazy list reports correct length."""
         from modelaudit.scanners import SCANNER_REGISTRY
-        
+
         length = len(SCANNER_REGISTRY)
         assert length > 0
-        
+
         # Should match the number of scanners in registry
         expected_count = len(_registry.get_available_scanners())
         assert length <= expected_count  # May be less due to import failures
@@ -186,7 +198,7 @@ class TestLazyListInterface:
     def test_lazy_list_indexing(self):
         """Test that the lazy list supports indexing."""
         from modelaudit.scanners import SCANNER_REGISTRY
-        
+
         if len(SCANNER_REGISTRY) > 0:
             first_scanner = SCANNER_REGISTRY[0]
             assert issubclass(first_scanner, BaseScanner)
@@ -194,7 +206,7 @@ class TestLazyListInterface:
     def test_lazy_list_contains(self):
         """Test that the lazy list supports 'in' operator."""
         from modelaudit.scanners import SCANNER_REGISTRY, PickleScanner
-        
+
         # This will load PickleScanner if not already loaded
         assert PickleScanner in SCANNER_REGISTRY
 
@@ -205,18 +217,18 @@ class TestBackwardsCompatibility:
     def test_direct_scanner_import(self):
         """Test that scanners can still be imported directly."""
         from modelaudit.scanners import PickleScanner
-        
+
         assert PickleScanner is not None
         assert issubclass(PickleScanner, BaseScanner)
 
     def test_scanner_registry_usage(self):
         """Test that SCANNER_REGISTRY still works as expected."""
         from modelaudit.scanners import SCANNER_REGISTRY
-        
+
         # Should be iterable
         scanner_list = list(SCANNER_REGISTRY)
         assert len(scanner_list) > 0
-        
+
         # All should be BaseScanner subclasses
         for scanner in scanner_list:
             assert issubclass(scanner, BaseScanner)
@@ -224,7 +236,7 @@ class TestBackwardsCompatibility:
     def test_scanner_can_handle_method(self):
         """Test that scanner can_handle methods work correctly."""
         from modelaudit.scanners import PickleScanner
-        
+
         # Create temporary pickle file
         with tempfile.NamedTemporaryFile(suffix=".pkl") as f:
             assert PickleScanner.can_handle(f.name)
@@ -232,11 +244,11 @@ class TestBackwardsCompatibility:
     def test_scanner_instantiation(self):
         """Test that scanners can be instantiated correctly."""
         from modelaudit.scanners import PickleScanner
-        
+
         scanner = PickleScanner()
         assert scanner is not None
-        assert hasattr(scanner, 'scan')
-        assert hasattr(scanner, 'can_handle')
+        assert hasattr(scanner, "scan")
+        assert hasattr(scanner, "can_handle")
 
 
 class TestPerformanceCharacteristics:
@@ -246,14 +258,14 @@ class TestPerformanceCharacteristics:
         """Test that only necessary scanners are loaded for specific files."""
         # Reset loaded scanners
         _registry._loaded_scanners.clear()
-        
+
         # Create a JSON file (should only load manifest scanner)
-        with tempfile.NamedTemporaryFile(suffix=".json", mode='w') as f:
+        with tempfile.NamedTemporaryFile(suffix=".json", mode="w") as f:
             f.write('{"test": "value"}')
             f.flush()
-            
-            scanner = _registry.get_scanner_for_path(f.name)
-            
+
+            _ = _registry.get_scanner_for_path(f.name)
+
             # Should have loaded minimal scanners
             loaded_count = len(_registry._loaded_scanners)
             assert loaded_count <= 3  # Should be very few
@@ -262,24 +274,24 @@ class TestPerformanceCharacteristics:
         """Test that heavy dependencies are not loaded for light files."""
         # Reset loaded scanners
         _registry._loaded_scanners.clear()
-        
+
         # Simulate a system without heavy dependencies
-        heavy_modules = ['tensorflow', 'torch', 'h5py', 'onnx']
+        heavy_modules = ["tensorflow", "torch", "h5py", "onnx"]
         initial_modules = set(sys.modules.keys())
-        
+
         # Create a simple text file
-        with tempfile.NamedTemporaryFile(suffix=".txt", mode='w') as f:
-            f.write('test content')
+        with tempfile.NamedTemporaryFile(suffix=".txt", mode="w") as f:
+            f.write("test content")
             f.flush()
-            
+
             # This should not load heavy dependencies
-            scanner = _registry.get_scanner_for_path(f.name)
-            
+            _ = _registry.get_scanner_for_path(f.name)
+
             # Check that heavy modules weren't imported
             new_modules = set(sys.modules.keys()) - initial_modules
             for heavy_module in heavy_modules:
                 # None of the heavy modules should be in newly imported modules
-                heavy_imported = any(heavy_module in mod for mod in new_modules)
+                _ = any(heavy_module in mod for mod in new_modules)
                 # We can't assert this is False because modules might already be loaded
                 # But we can verify the behavior in isolation
 
@@ -297,20 +309,20 @@ class TestErrorHandling:
         info = _registry.get_scanner_info("nonexistent_scanner")
         assert info is None
 
-    @patch('modelaudit.scanners._registry._load_scanner')
+    @patch("modelaudit.scanners._registry._load_scanner")
     def test_scanner_loading_exception_handling(self, mock_load):
         """Test handling of exceptions during scanner loading."""
         # Mock scanner loading to raise an exception
         mock_load.return_value = None
-        
-        scanner = _registry.get_scanner_for_path("test.pkl")
+
+        _ = _registry.get_scanner_for_path("test.pkl")
         # Should handle gracefully, either return None or a fallback
         # The exact behavior depends on implementation details
-        
+
     def test_getattr_with_invalid_name(self):
         """Test __getattr__ with invalid scanner name."""
         from modelaudit import scanners
-        
+
         with pytest.raises(AttributeError):
             _ = scanners.NonExistentScanner
 
@@ -321,17 +333,19 @@ class TestSpecificFileTypes:
     def test_json_file_loading(self):
         """Test that JSON files load only manifest scanner."""
         _registry._loaded_scanners.clear()
-        
+
         # Use a realistic ML config filename that manifest scanner will handle
-        with tempfile.NamedTemporaryFile(suffix="_config.json", mode='w', delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            suffix="_config.json", mode="w", delete=False
+        ) as f:
             f.write('{"model": "test", "tokenizer": "config"}')
             f.flush()
-            
+
             try:
-                scanner = _registry.get_scanner_for_path(f.name)
+                _ = _registry.get_scanner_for_path(f.name)
                 # May be None if manifest scanner doesn't handle this specific file
                 # This is actually expected behavior - not all JSON files are ML-related
-                
+
                 # Should have loaded minimal scanners (or none if no match)
                 assert len(_registry._loaded_scanners) <= 3
             finally:
@@ -340,51 +354,53 @@ class TestSpecificFileTypes:
     def test_pickle_file_loading(self):
         """Test that pickle files load pickle scanner efficiently."""
         _registry._loaded_scanners.clear()
-        
+
         with tempfile.NamedTemporaryFile(suffix=".pkl") as f:
             scanner = _registry.get_scanner_for_path(f.name)
             assert scanner is not None
             assert scanner.name == "pickle"
-            
+
             # Should have loaded pickle scanner
             assert "pickle" in _registry._loaded_scanners
 
     def test_unknown_extension_handling(self):
         """Test handling of files with unknown extensions."""
         _registry._loaded_scanners.clear()
-        
+
         with tempfile.NamedTemporaryFile(suffix=".unknown_ext") as f:
-            scanner = _registry.get_scanner_for_path(f.name)
+            _ = _registry.get_scanner_for_path(f.name)
             # May return None or a fallback scanner
             # The exact behavior depends on implementation
 
     def test_manifest_scanner_exact_filename_matching(self):
         """Test that manifest scanner uses exact filename matching to prevent false positives."""
         _registry._loaded_scanners.clear()
-        
+
         # Test exact match - should work
         with tempfile.NamedTemporaryFile(suffix="config.json", delete=False) as f:
             f.write(b'{"test": "config"}')
             exact_path = f.name
-        
+
         # Test false positive case - should NOT match
-        with tempfile.NamedTemporaryFile(suffix="config.json.backup", delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            suffix="config.json.backup", delete=False
+        ) as f:
             f.write(b'{"test": "backup"}')
             backup_path = f.name
-        
+
         try:
             # Exact filename should potentially match (depends on manifest scanner logic)
             exact_scanner = _registry.get_scanner_for_path(exact_path)
-            
+
             # Backup file should NOT match due to exact matching
             backup_scanner = _registry.get_scanner_for_path(backup_path)
-            
+
             # The backup file should not be matched by manifest scanner
             # since "config.json.backup" != "config.json"
             if exact_scanner is not None:
                 # If exact match works, backup should not match
                 assert backup_scanner is None or backup_scanner.name != "manifest"
-                
+
         finally:
             Path(exact_path).unlink(missing_ok=True)
-            Path(backup_path).unlink(missing_ok=True) 
+            Path(backup_path).unlink(missing_ok=True)

--- a/tests/test_lazy_loading_integration.py
+++ b/tests/test_lazy_loading_integration.py
@@ -19,19 +19,19 @@ class TestCoreIntegration:
         """Test that scan_file uses lazy loading correctly."""
         # Reset loaded scanners
         _registry._loaded_scanners.clear()
-        
+
         # Create a JSON file with ML-related content
-        with tempfile.NamedTemporaryFile(suffix="_config.json", mode='w') as f:
+        with tempfile.NamedTemporaryFile(suffix="_config.json", mode="w") as f:
             f.write('{"model": "test", "tokenizer": "config"}')
             f.flush()
-            
+
             # Scan the file
             result = core.scan_file(f.name)
-            
+
             # Should have completed successfully
             assert result is not None
             assert result.scanner_name in ["manifest", "unknown"]
-            
+
             # Should have loaded minimal scanners
             loaded_count = len(_registry._loaded_scanners)
             assert loaded_count <= 5  # Should be minimal
@@ -39,22 +39,22 @@ class TestCoreIntegration:
     def test_scan_directory_uses_lazy_loading(self):
         """Test that directory scanning uses lazy loading efficiently."""
         _registry._loaded_scanners.clear()
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create various file types
             json_file = Path(temp_dir) / "config.json"
             json_file.write_text('{"test": "value"}')
-            
+
             txt_file = Path(temp_dir) / "readme.txt"
             txt_file.write_text("This is a readme file")
-            
+
             # Scan the directory
             results = core.scan_model_directory_or_file(temp_dir)
-            
+
             # Should have completed successfully
             assert results["success"] is True
             assert results["files_scanned"] == 2
-            
+
             # Should have loaded only necessary scanners
             loaded_count = len(_registry._loaded_scanners)
             assert loaded_count <= 10  # Should be reasonable
@@ -62,23 +62,23 @@ class TestCoreIntegration:
     def test_preferred_scanner_lazy_loading(self):
         """Test that preferred scanner detection uses lazy loading."""
         _registry._loaded_scanners.clear()
-        
+
         # Create a pickle file (should prefer pickle scanner)
         with tempfile.NamedTemporaryFile(suffix=".pkl") as f:
-            f.write(b'\x80\x02]q\x00.')  # Simple pickle data
-            
+            f.write(b"\x80\x02]q\x00.")  # Simple pickle data
+
             result = core.scan_file(f.name)
-            
+
             # Should use pickle scanner
             assert result.scanner_name == "pickle"
-            
+
             # Should have loaded pickle scanner
             assert "pickle" in _registry._loaded_scanners
 
     def test_multiple_file_types_incremental_loading(self):
         """Test that scanning multiple file types loads scanners incrementally."""
         _registry._loaded_scanners.clear()
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create different file types
             files = [
@@ -86,19 +86,19 @@ class TestCoreIntegration:
                 ("model.pkl", "fake pickle content"),
                 ("data.txt", "text content"),
             ]
-            
+
             loaded_counts = []
-            
+
             for filename, content in files:
                 file_path = Path(temp_dir) / filename
                 file_path.write_text(content)
-                
+
                 # Scan the file
-                result = core.scan_file(str(file_path))
-                
+                _ = core.scan_file(str(file_path))
+
                 # Track how many scanners are loaded
                 loaded_counts.append(len(_registry._loaded_scanners))
-            
+
             # Should show incremental loading (or at least not loading everything at once)
             assert loaded_counts[0] > 0  # Some scanners loaded for first file
             # Later scans might load more, but shouldn't load everything
@@ -112,57 +112,58 @@ class TestPerformanceCharacteristics:
         """Test that importing scanners is fast with lazy loading."""
         # This test measures import time
         start_time = time.time()
-        
+
         # This should be fast (lazy loading)
         from modelaudit import scanners
-        
+
         import_time = time.time() - start_time
-        
+
         # Should be much faster than 1 second (was 7+ seconds before)
         assert import_time < 1.0
-        
+
         # Accessing the registry should also be fast
         start_time = time.time()
-        registry = scanners.SCANNER_REGISTRY
+        _ = scanners.SCANNER_REGISTRY
         access_time = time.time() - start_time
-        
+
         # First access loads scanners, but should still be reasonable
         assert access_time < 5.0  # Much better than 7+ seconds
 
     def test_single_scanner_access_performance(self):
         """Test that accessing a single scanner is fast."""
         _registry._loaded_scanners.clear()
-        
+
         start_time = time.time()
-        
+
         # Access a lightweight scanner
-        from modelaudit.scanners import PickleScanner
-        
+
         access_time = time.time() - start_time
-        
+
         # Should be very fast (no heavy dependencies)
         assert access_time < 0.5
 
     def test_heavy_scanner_access_expected_slow(self):
         """Test that heavy scanners are slower but only when accessed."""
         _registry._loaded_scanners.clear()
-        
+
         # First verify that we haven't loaded tensorflow yet
         import sys
-        tf_loaded_before = 'tensorflow' in sys.modules
-        
+
+        _ = "tensorflow" in sys.modules
+
         start_time = time.time()
-        
+
         try:
             # This might be slow due to tensorflow import
             from modelaudit.scanners import TensorFlowSavedModelScanner
-            access_time = time.time() - start_time
-            
+
+            _access_time = time.time() - start_time
+
             # This is expected to be slower due to tensorflow
             # But we can't assert exact time since it depends on system
             # Just verify it doesn't crash and returns a valid scanner
             assert TensorFlowSavedModelScanner is not None
-            
+
         except ImportError:
             # TensorFlow might not be installed, which is fine
             pytest.skip("TensorFlow not available")
@@ -174,29 +175,29 @@ class TestErrorRecovery:
     def test_missing_dependency_graceful_handling(self):
         """Test that missing dependencies are handled gracefully."""
         _registry._loaded_scanners.clear()
-        
+
         # Try to load a scanner that might have missing dependencies
         # This should not crash the entire system
         scanner_classes = _registry.get_scanner_classes()
-        
+
         # Should return some scanners, even if some fail to load
         assert len(scanner_classes) > 0
-        
+
         # All returned scanners should be valid
         for scanner_class in scanner_classes:
-            assert hasattr(scanner_class, 'can_handle')
-            assert hasattr(scanner_class, 'scan')
+            assert hasattr(scanner_class, "can_handle")
+            assert hasattr(scanner_class, "scan")
 
     def test_scan_continues_with_available_scanners(self):
         """Test that scanning continues even if some scanners fail to load."""
         # Create a file that should be scannable by available scanners
-        with tempfile.NamedTemporaryFile(suffix="_config.json", mode='w') as f:
+        with tempfile.NamedTemporaryFile(suffix="_config.json", mode="w") as f:
             f.write('{"model": "test", "config": "data"}')
             f.flush()
-            
+
             # This should work even if some heavy dependency scanners fail
             result = core.scan_file(f.name)
-            
+
             # Should complete successfully
             assert result is not None
             # Might be "unknown" if manifest scanner fails, but shouldn't crash
@@ -209,7 +210,7 @@ class TestRegistryIntrospection:
     def test_get_available_scanners(self):
         """Test getting available scanner IDs."""
         scanners = _registry.get_available_scanners()
-        
+
         assert len(scanners) > 0
         assert "pickle" in scanners
         assert "manifest" in scanners
@@ -218,7 +219,7 @@ class TestRegistryIntrospection:
     def test_get_scanner_info(self):
         """Test getting scanner metadata."""
         pickle_info = _registry.get_scanner_info("pickle")
-        
+
         assert pickle_info is not None
         assert pickle_info["module"] == "modelaudit.scanners.pickle_scanner"
         assert pickle_info["class"] == "PickleScanner"
@@ -228,17 +229,17 @@ class TestRegistryIntrospection:
     def test_scanner_priority_ordering(self):
         """Test that scanners are ordered by priority."""
         scanners = list(_registry._scanners.items())
-        
+
         # Find pickle and zip scanners
         pickle_priority = None
         zip_priority = None
-        
+
         for scanner_id, info in scanners:
             if scanner_id == "pickle":
                 pickle_priority = info["priority"]
             elif scanner_id == "zip":
                 zip_priority = info["priority"]
-        
+
         assert pickle_priority is not None
         assert zip_priority is not None
         # Pickle should have higher priority (lower number) than zip
@@ -251,30 +252,30 @@ class TestCacheEfficiency:
     def test_scanner_caching_across_calls(self):
         """Test that scanners are cached across multiple calls."""
         _registry._loaded_scanners.clear()
-        
+
         # Load a scanner multiple times
         scanner1 = _registry._load_scanner("pickle")
         scanner2 = _registry._load_scanner("pickle")
         scanner3 = _registry._load_scanner("pickle")
-        
+
         # Should be the same instance (cached)
         assert scanner1 is scanner2
         assert scanner2 is scanner3
-        
+
         # Should only be in cache once
         assert len(_registry._loaded_scanners) == 1
 
     def test_registry_cache_efficiency(self):
         """Test that the lazy list caches its results."""
         from modelaudit.scanners import SCANNER_REGISTRY
-        
+
         # Access the registry multiple times
         list1 = list(SCANNER_REGISTRY)
         list2 = list(SCANNER_REGISTRY)
-        
+
         # Should return consistent results
         assert len(list1) == len(list2)
-        
+
         # The classes should be the same instances (cached)
         for scanner1, scanner2 in zip(list1, list2):
-            assert scanner1 is scanner2 
+            assert scanner1 is scanner2


### PR DESCRIPTION
## Summary
- add Optional typing for CLI functions
- annotate aggregated_results structure
- silence ruff F841 warnings in tests

## Testing
- `ruff check --fix modelaudit/ tests/`
- `mypy modelaudit/`
- `pytest -m "not slow and not integration and not performance"`

------
https://chatgpt.com/codex/tasks/task_e_685b0f2246f88332974f1cc980910d6a