### PR TITLE
feat: add caching and concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,9 @@ modelaudit scan model.pkl --sbom sbom.json
 
 # Verbose output for debugging
 modelaudit scan model.pkl --verbose
+
+# Enable caching and concurrent scanning
+modelaudit scan model.pkl --cache-dir .cache --jobs 4
 ```
 
 ### Exit Codes

--- a/modelaudit/scanners/base.py
+++ b/modelaudit/scanners/base.py
@@ -146,6 +146,28 @@ class ScanResult:
         """Convert the scan result to a JSON string"""
         return json.dumps(self.to_dict(), indent=indent)
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ScanResult":
+        """Create a ScanResult from a dictionary."""
+        sr = cls(scanner_name=data.get("scanner", "unknown"))
+        sr.success = data.get("success", True)
+        sr.bytes_scanned = data.get("bytes_scanned", 0)
+        sr.metadata = data.get("metadata", {})
+        for issue_data in data.get("issues", []):
+            severity_value = issue_data.get("severity", "warning")
+            try:
+                severity = IssueSeverity(severity_value)
+            except ValueError:
+                severity = IssueSeverity.WARNING
+            sr.add_issue(
+                issue_data.get("message", ""),
+                severity=severity,
+                location=issue_data.get("location"),
+                details=issue_data.get("details"),
+                why=issue_data.get("why"),
+            )
+        return sr
+
     def summary(self) -> str:
         """Return a human-readable summary of the scan result"""
         error_count = sum(

--- a/modelaudit/utils/__init__.py
+++ b/modelaudit/utils/__init__.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 from pathlib import Path
 
@@ -47,3 +48,12 @@ def sanitize_archive_path(entry_name: str, base_dir: str) -> tuple[str, bool]:
         except ValueError:  # Windows: different drives
             is_safe = False
     return str(resolved), is_safe
+
+
+def sha256_file(path: str) -> str:
+    """Return SHA-256 hash of the file."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -183,6 +183,22 @@ def test_progress_callback(tmp_path):
     assert 100.0 in progress_percentages  # Should reach 100%
 
 
+def test_scan_file_caching(tmp_path):
+    """Ensure cached scan results are reused."""
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("test")
+    cache_dir = tmp_path / "cache"
+
+    _ = scan_model_directory_or_file(str(test_file), cache_dir=str(cache_dir))
+    second = scan_model_directory_or_file(str(test_file), cache_dir=str(cache_dir))
+
+    cache_files = list(cache_dir.glob("*.json"))
+    assert cache_files, "Cache file should be created"
+    assert second["file_metadata"][str(test_file)].get("cached") is True, (
+        "Second scan should use cache"
+    )
+
+
 def test_scan_result_class():
     """Test the ScanResult class functionality."""
     # Create a scan result

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,6 +37,8 @@ def test_scan_command_help():
     assert "--timeout" in result.output
     assert "--verbose" in result.output
     assert "--max-file-size" in result.output
+    assert "--cache-dir" in result.output
+    assert "--jobs" in result.output
 
 
 def test_scan_nonexistent_file():
@@ -96,6 +98,23 @@ def test_scan_multiple_paths(tmp_path):
     assert (
         str(file1) in result.output or str(file2) in result.output
     )  # Should mention at least one file path
+
+
+def test_scan_multiple_paths_jobs(tmp_path):
+    """Test scanning multiple paths concurrently."""
+    file1 = tmp_path / "file1.dat"
+    file1.write_bytes(b"test1")
+    file2 = tmp_path / "file2.dat"
+    file2.write_bytes(b"test2")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["scan", str(file1), str(file2), "--jobs", "2"],
+        catch_exceptions=True,
+    )
+
+    assert result.output
 
 
 def test_scan_with_blacklist(tmp_path):


### PR DESCRIPTION
## Summary
- implement SHA-256 based cache for scanned files
- skip scanning when cached results exist
- add concurrent scanning of paths
- document new `--cache-dir` and `--jobs` CLI options
- test caching and concurrency

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check --fix modelaudit/ tests/`
- `mypy modelaudit/`
- `pytest -m "not performance" -q` *(fails: KeyboardInterrupt after tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_685a44948a4483329c7b09b505af711b