### PR TITLE
feat(cli): add summary line to scan footer

### DIFF
--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -350,29 +350,29 @@ def format_text_output(results: dict[str, Any], verbose: bool = False) -> str:
         if verbose or not isinstance(issue, dict) or issue.get("severity") != "debug"
     ]
 
-    if visible_issues:
-        # Count issues by severity (excluding DEBUG when not in verbose mode)
-        error_count = sum(
-            1
-            for issue in visible_issues
-            if isinstance(issue, dict) and issue.get("severity") == "critical"
-        )
-        warning_count = sum(
-            1
-            for issue in visible_issues
-            if isinstance(issue, dict) and issue.get("severity") == "warning"
-        )
-        info_count = sum(
-            1
-            for issue in visible_issues
-            if isinstance(issue, dict) and issue.get("severity") == "info"
-        )
-        debug_count = sum(
-            1
-            for issue in issues
-            if isinstance(issue, dict) and issue.get("severity") == "debug"
-        )
+    # Count issues by severity (excluding DEBUG when not in verbose mode)
+    error_count = sum(
+        1
+        for issue in visible_issues
+        if isinstance(issue, dict) and issue.get("severity") == "critical"
+    )
+    warning_count = sum(
+        1
+        for issue in visible_issues
+        if isinstance(issue, dict) and issue.get("severity") == "warning"
+    )
+    info_count = sum(
+        1
+        for issue in visible_issues
+        if isinstance(issue, dict) and issue.get("severity") == "info"
+    )
+    debug_count = sum(
+        1
+        for issue in issues
+        if isinstance(issue, dict) and issue.get("severity") == "debug"
+    )
 
+    if visible_issues:
         # Only show debug count in verbose mode
         issue_summary = []
         if error_count:
@@ -493,7 +493,12 @@ def format_text_output(results: dict[str, Any], verbose: bool = False) -> str:
             status = click.style("✓ Scan completed successfully", fg="green", bold=True)
     else:
         status = click.style("✓ Scan completed successfully", fg="green", bold=True)
+
     output_lines.append(status)
+    summary_line = (
+        f"Summary: {error_count} critical, {warning_count} warnings, {info_count} info"
+    )
+    output_lines.append(summary_line)
 
     return "\n".join(output_lines)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -236,12 +236,14 @@ def test_format_text_output():
     assert "Files scanned: 5" in output
     assert "Test issue" in output
     assert "warning" in output.lower()
+    assert "Summary: 0 critical, 1 warnings, 0 info" in output
 
     # Test verbose output
     output = format_text_output(results, verbose=True)
     assert "Files scanned: 5" in output
     assert "Test issue" in output
     assert "warning" in output.lower()
+    assert "Summary: 0 critical, 1 warnings, 0 info" in output
     # Verbose might include details, but we can't guarantee it
 
 
@@ -260,6 +262,7 @@ def test_format_text_output_only_debug_issues():
     output = format_text_output(results, verbose=False)
     assert "No issues found" in output
     assert "Scan completed successfully" in output
+    assert "Summary: 0 critical, 0 warnings, 0 info" in output
 
 
 def test_format_text_output_only_info_issues():
@@ -278,6 +281,7 @@ def test_format_text_output_only_info_issues():
     assert "1 info" in output
     assert "Scan completed successfully" in output
     assert "Scan completed with warnings" not in output
+    assert "Summary: 0 critical, 0 warnings, 1 info" in output
 
 
 def test_format_text_output_debug_and_info_issues():
@@ -298,6 +302,7 @@ def test_format_text_output_debug_and_info_issues():
     assert "1 debug" in output
     assert "Scan completed successfully" in output
     assert "Scan completed with warnings" not in output
+    assert "Summary: 0 critical, 0 warnings, 1 info" in output
 
 
 def test_format_text_output_fast_scan_duration():


### PR DESCRIPTION
## Summary
- show issue counts at end of text output
- test summary line in `format_text_output`

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check modelaudit/cli.py tests/test_cli.py`
- `mypy modelaudit/`
- `CI=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b1e4604888332acac7e6003a0d777