### PR TITLE
feat: rich output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A security scanner for AI models. Quickly check your AIML models for potential s
     - [Command Line Options](#command-line-options)
     - [Exit Codes](#exit-codes)
   - [📋 JSON Output Format](#-json-output-format)
+  - [🖥 Rich Output Format](#-rich-output-format)
   - [🔄 CI/CD Integration](#-cicd-integration)
     - [Basic Integration](#basic-integration)
     - [Platform Examples](#platform-examples)
@@ -195,7 +196,7 @@ Issues found: 2 critical, 1 warnings
 
 ### Reporting & Integration
 
-- **Multiple Output Formats**: Human-readable text and machine-readable JSON
+- **Multiple Output Formats**: Human-readable text, Rich tables, and machine-readable JSON
 - **SBOM Generation**: CycloneDX Software Bill of Materials with license metadata
 - **Detailed Reporting**: Scan duration, files processed, bytes scanned, issue severity
 - **Severity Levels**: CRITICAL, WARNING, INFO, DEBUG for flexible filtering
@@ -319,6 +320,12 @@ When using `--format json`, ModelAudit outputs structured results:
 
 Each issue includes a `message`, `severity` level (`critical`, `warning`, `info`, `debug`), `location`, and scanner-specific `details`.
 The `assets` array lists every file and component encountered during the scan, including nested archive members and tensor names.
+
+## 🖥 Rich Output Format
+
+When using `--format rich`, ModelAudit displays results in colorful tables powered by the [rich](https://github.com/Textualize/rich) library.
+
+![Rich output](docs/rich_output.svg)
 
 ## 🔄 CI/CD Integration
 

--- a/docs/rich_output.svg
+++ b/docs/rich_output.svg
@@ -1,0 +1,108 @@
+<svg class="rich-terminal" viewBox="0 0 994 367.2" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-2074649077-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-2074649077-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-2074649077-r1 { fill: #c5c8c6;font-style: italic; }
+.terminal-2074649077-r2 { fill: #c5c8c6 }
+.terminal-2074649077-r3 { fill: #c5c8c6;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-2074649077-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="316.2" />
+    </clipPath>
+    <clipPath id="terminal-2074649077-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2074649077-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2074649077-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2074649077-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2074649077-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2074649077-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2074649077-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2074649077-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2074649077-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2074649077-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2074649077-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2074649077-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="365.2" rx="8"/><text class="terminal-2074649077-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">Rich</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-2074649077-clip-terminal)">
+    
+    <g class="terminal-2074649077-matrix">
+    <text class="terminal-2074649077-r1" x="0" y="20" textLength="536.8" clip-path="url(#terminal-2074649077-line-0)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Scan&#160;Summary&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2074649077-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-2074649077-line-0)">
+</text><text class="terminal-2074649077-r2" x="0" y="44.4" textLength="536.8" clip-path="url(#terminal-2074649077-line-1)">┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━┓</text><text class="terminal-2074649077-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-2074649077-line-1)">
+</text><text class="terminal-2074649077-r2" x="0" y="68.8" textLength="12.2" clip-path="url(#terminal-2074649077-line-2)">┃</text><text class="terminal-2074649077-r3" x="24.4" y="68.8" textLength="158.6" clip-path="url(#terminal-2074649077-line-2)">Files&#160;Scanned</text><text class="terminal-2074649077-r2" x="195.2" y="68.8" textLength="12.2" clip-path="url(#terminal-2074649077-line-2)">┃</text><text class="terminal-2074649077-r3" x="219.6" y="68.8" textLength="158.6" clip-path="url(#terminal-2074649077-line-2)">Bytes&#160;Scanned</text><text class="terminal-2074649077-r2" x="390.4" y="68.8" textLength="12.2" clip-path="url(#terminal-2074649077-line-2)">┃</text><text class="terminal-2074649077-r3" x="414.8" y="68.8" textLength="97.6" clip-path="url(#terminal-2074649077-line-2)">Duration</text><text class="terminal-2074649077-r2" x="524.6" y="68.8" textLength="12.2" clip-path="url(#terminal-2074649077-line-2)">┃</text><text class="terminal-2074649077-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-2074649077-line-2)">
+</text><text class="terminal-2074649077-r2" x="0" y="93.2" textLength="536.8" clip-path="url(#terminal-2074649077-line-3)">┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━┩</text><text class="terminal-2074649077-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-2074649077-line-3)">
+</text><text class="terminal-2074649077-r2" x="0" y="117.6" textLength="12.2" clip-path="url(#terminal-2074649077-line-4)">│</text><text class="terminal-2074649077-r2" x="24.4" y="117.6" textLength="158.6" clip-path="url(#terminal-2074649077-line-4)">2&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2074649077-r2" x="195.2" y="117.6" textLength="12.2" clip-path="url(#terminal-2074649077-line-4)">│</text><text class="terminal-2074649077-r2" x="219.6" y="117.6" textLength="158.6" clip-path="url(#terminal-2074649077-line-4)">2048&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2074649077-r2" x="390.4" y="117.6" textLength="12.2" clip-path="url(#terminal-2074649077-line-4)">│</text><text class="terminal-2074649077-r2" x="414.8" y="117.6" textLength="97.6" clip-path="url(#terminal-2074649077-line-4)">0.50s&#160;&#160;&#160;</text><text class="terminal-2074649077-r2" x="524.6" y="117.6" textLength="12.2" clip-path="url(#terminal-2074649077-line-4)">│</text><text class="terminal-2074649077-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-2074649077-line-4)">
+</text><text class="terminal-2074649077-r2" x="0" y="142" textLength="536.8" clip-path="url(#terminal-2074649077-line-5)">└───────────────┴───────────────┴──────────┘</text><text class="terminal-2074649077-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-2074649077-line-5)">
+</text><text class="terminal-2074649077-r1" x="0" y="166.4" textLength="536.8" clip-path="url(#terminal-2074649077-line-6)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Issues&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2074649077-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-2074649077-line-6)">
+</text><text class="terminal-2074649077-r2" x="0" y="190.8" textLength="536.8" clip-path="url(#terminal-2074649077-line-7)">┏━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┓</text><text class="terminal-2074649077-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-2074649077-line-7)">
+</text><text class="terminal-2074649077-r2" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-2074649077-line-8)">┃</text><text class="terminal-2074649077-r3" x="24.4" y="215.2" textLength="97.6" clip-path="url(#terminal-2074649077-line-8)">Severity</text><text class="terminal-2074649077-r2" x="134.2" y="215.2" textLength="12.2" clip-path="url(#terminal-2074649077-line-8)">┃</text><text class="terminal-2074649077-r3" x="158.6" y="215.2" textLength="97.6" clip-path="url(#terminal-2074649077-line-8)">Location</text><text class="terminal-2074649077-r2" x="268.4" y="215.2" textLength="12.2" clip-path="url(#terminal-2074649077-line-8)">┃</text><text class="terminal-2074649077-r3" x="292.8" y="215.2" textLength="219.6" clip-path="url(#terminal-2074649077-line-8)">Message&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2074649077-r2" x="524.6" y="215.2" textLength="12.2" clip-path="url(#terminal-2074649077-line-8)">┃</text><text class="terminal-2074649077-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-2074649077-line-8)">
+</text><text class="terminal-2074649077-r2" x="0" y="239.6" textLength="536.8" clip-path="url(#terminal-2074649077-line-9)">┡━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━┩</text><text class="terminal-2074649077-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-2074649077-line-9)">
+</text><text class="terminal-2074649077-r2" x="0" y="264" textLength="12.2" clip-path="url(#terminal-2074649077-line-10)">│</text><text class="terminal-2074649077-r2" x="24.4" y="264" textLength="97.6" clip-path="url(#terminal-2074649077-line-10)">warning&#160;</text><text class="terminal-2074649077-r2" x="134.2" y="264" textLength="12.2" clip-path="url(#terminal-2074649077-line-10)">│</text><text class="terminal-2074649077-r2" x="158.6" y="264" textLength="97.6" clip-path="url(#terminal-2074649077-line-10)">file.pkl</text><text class="terminal-2074649077-r2" x="268.4" y="264" textLength="12.2" clip-path="url(#terminal-2074649077-line-10)">│</text><text class="terminal-2074649077-r2" x="292.8" y="264" textLength="219.6" clip-path="url(#terminal-2074649077-line-10)">Suspicious&#160;pattern</text><text class="terminal-2074649077-r2" x="524.6" y="264" textLength="12.2" clip-path="url(#terminal-2074649077-line-10)">│</text><text class="terminal-2074649077-r2" x="976" y="264" textLength="12.2" clip-path="url(#terminal-2074649077-line-10)">
+</text><text class="terminal-2074649077-r2" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-2074649077-line-11)">│</text><text class="terminal-2074649077-r2" x="24.4" y="288.4" textLength="97.6" clip-path="url(#terminal-2074649077-line-11)">critical</text><text class="terminal-2074649077-r2" x="134.2" y="288.4" textLength="12.2" clip-path="url(#terminal-2074649077-line-11)">│</text><text class="terminal-2074649077-r2" x="158.6" y="288.4" textLength="97.6" clip-path="url(#terminal-2074649077-line-11)">model.h5</text><text class="terminal-2074649077-r2" x="268.4" y="288.4" textLength="12.2" clip-path="url(#terminal-2074649077-line-11)">│</text><text class="terminal-2074649077-r2" x="292.8" y="288.4" textLength="219.6" clip-path="url(#terminal-2074649077-line-11)">Malicious&#160;code&#160;&#160;&#160;&#160;</text><text class="terminal-2074649077-r2" x="524.6" y="288.4" textLength="12.2" clip-path="url(#terminal-2074649077-line-11)">│</text><text class="terminal-2074649077-r2" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-2074649077-line-11)">
+</text><text class="terminal-2074649077-r2" x="0" y="312.8" textLength="536.8" clip-path="url(#terminal-2074649077-line-12)">└──────────┴──────────┴────────────────────┘</text><text class="terminal-2074649077-r2" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-2074649077-line-12)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "scipy>=1.5.0",
     "cyclonedx-python-lib>=10.2.0",
     "defusedxml>=0.7.1",
+    "rich>=13.7.1",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -135,6 +135,19 @@ def test_scan_json_output(tmp_path):
         pytest.fail("Output is not valid JSON")
 
 
+def test_scan_rich_output(tmp_path):
+    """Test scanning with Rich output format."""
+    test_file = tmp_path / "test_file.dat"
+    test_file.write_bytes(b"test content")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["scan", str(test_file), "--format", "rich"])
+
+    assert "Severity" in result.output
+    assert "Location" in result.output
+    assert "Message" in result.output
+
+
 def test_scan_output_file(tmp_path):
     """Test scanning with output to a file."""
     test_file = tmp_path / "test_file.dat"

--- a/tests/test_lazy_loading.py
+++ b/tests/test_lazy_loading.py
@@ -21,15 +21,28 @@ class TestScannerRegistry:
         """Test that the registry initializes with proper scanner metadata."""
         assert _registry._scanners is not None
         assert len(_registry._scanners) > 0
-        
+
         # Check that we have all expected scanners
         expected_scanners = [
-            "pickle", "pytorch_binary", "tf_savedmodel", "keras_h5", 
-            "onnx", "pytorch_zip", "gguf", "joblib", "numpy", 
-            "oci_layer", "manifest", "pmml", "weight_distribution",
-            "safetensors", "flax_msgpack", "tflite", "zip"
+            "pickle",
+            "pytorch_binary",
+            "tf_savedmodel",
+            "keras_h5",
+            "onnx",
+            "pytorch_zip",
+            "gguf",
+            "joblib",
+            "numpy",
+            "oci_layer",
+            "manifest",
+            "pmml",
+            "weight_distribution",
+            "safetensors",
+            "flax_msgpack",
+            "tflite",
+            "zip",
         ]
-        
+
         for scanner_id in expected_scanners:
             assert scanner_id in _registry._scanners
             scanner_info = _registry._scanners[scanner_id]
@@ -42,9 +55,9 @@ class TestScannerRegistry:
         """Test that scanners are not loaded during registry initialization."""
         # Reset loaded scanners to test fresh state
         _registry._loaded_scanners.clear()
-        
+
         assert len(_registry._loaded_scanners) == 0
-        
+
         # Accessing the registry should not load scanners
         scanner_ids = _registry.get_available_scanners()
         assert len(scanner_ids) > 0
@@ -54,13 +67,13 @@ class TestScannerRegistry:
         """Test that scanners are loaded only when requested."""
         # Reset loaded scanners
         _registry._loaded_scanners.clear()
-        
+
         # Load a light scanner (no heavy dependencies)
         scanner_class = _registry._load_scanner("pickle")
         assert scanner_class is not None
         assert "pickle" in _registry._loaded_scanners
         assert _registry._loaded_scanners["pickle"] is scanner_class
-        
+
         # Verify only one scanner was loaded
         assert len(_registry._loaded_scanners) == 1
 
@@ -68,11 +81,11 @@ class TestScannerRegistry:
         """Test that scanners are cached after first load."""
         # Reset loaded scanners
         _registry._loaded_scanners.clear()
-        
+
         # Load scanner twice
         scanner1 = _registry._load_scanner("pickle")
         scanner2 = _registry._load_scanner("pickle")
-        
+
         # Should be the same instance (cached)
         assert scanner1 is scanner2
         assert len(_registry._loaded_scanners) == 1
@@ -81,21 +94,21 @@ class TestScannerRegistry:
         """Test that get_scanner_for_path filters by extension before loading."""
         # Reset loaded scanners
         _registry._loaded_scanners.clear()
-        
+
         # Create temporary files with different extensions
         with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
             pkl_path = f.name
-        
+
         try:
             # This should only load the pickle scanner
             scanner = _registry.get_scanner_for_path(pkl_path)
             assert scanner is not None
             assert scanner.name == "pickle"
-            
+
             # Verify only pickle scanner was loaded (and maybe a few others that handle .pkl)
             loaded_count = len(_registry._loaded_scanners)
             assert loaded_count <= 3  # Should be minimal
-            
+
         finally:
             Path(pkl_path).unlink(missing_ok=True)
 
@@ -104,7 +117,7 @@ class TestScannerRegistry:
         scanner_info = _registry.get_scanner_info("pickle")
         assert scanner_info is not None
         assert scanner_info["priority"] == 1  # Pickle should have highest priority
-        
+
         zip_info = _registry.get_scanner_info("zip")
         assert zip_info is not None
         assert zip_info["priority"] == 99  # Zip should have lowest priority (fallback)
@@ -113,29 +126,29 @@ class TestScannerRegistry:
         """Test that heavy dependencies are properly marked."""
         # Check heavy dependency scanners
         heavy_scanners = ["tf_savedmodel", "keras_h5", "onnx", "tflite"]
-        
+
         for scanner_id in heavy_scanners:
             scanner_info = _registry.get_scanner_info(scanner_id)
             assert scanner_info is not None
             assert len(scanner_info["dependencies"]) > 0
-        
+
         # Check light dependency scanners
         light_scanners = ["pickle", "pytorch_binary", "zip", "manifest"]
-        
+
         for scanner_id in light_scanners:
             scanner_info = _registry.get_scanner_info(scanner_id)
             assert scanner_info is not None
             assert len(scanner_info["dependencies"]) == 0
 
-    @patch('importlib.import_module')
+    @patch("importlib.import_module")
     def test_scanner_load_failure_handling(self, mock_import):
         """Test handling of scanner loading failures."""
         # Reset loaded scanners
         _registry._loaded_scanners.clear()
-        
+
         # Mock import failure
         mock_import.side_effect = ImportError("Module not found")
-        
+
         # Should return None for failed import
         scanner = _registry._load_scanner("tf_savedmodel")
         assert scanner is None
@@ -145,14 +158,14 @@ class TestScannerRegistry:
         """Test that get_scanner_classes loads all available scanners."""
         # Reset loaded scanners
         _registry._loaded_scanners.clear()
-        
+
         # This should attempt to load all scanners
         scanner_classes = _registry.get_scanner_classes()
-        
+
         # Should have loaded multiple scanners
         assert len(scanner_classes) > 0
         assert len(_registry._loaded_scanners) > 0
-        
+
         # All returned classes should be BaseScanner subclasses
         for scanner_class in scanner_classes:
             assert issubclass(scanner_class, BaseScanner)
@@ -164,21 +177,21 @@ class TestLazyListInterface:
     def test_lazy_list_iteration(self):
         """Test that the lazy list can be iterated."""
         from modelaudit.scanners import SCANNER_REGISTRY
-        
+
         count = 0
         for scanner in SCANNER_REGISTRY:
             assert issubclass(scanner, BaseScanner)
             count += 1
-        
+
         assert count > 0
 
     def test_lazy_list_length(self):
         """Test that the lazy list reports correct length."""
         from modelaudit.scanners import SCANNER_REGISTRY
-        
+
         length = len(SCANNER_REGISTRY)
         assert length > 0
-        
+
         # Should match the number of scanners in registry
         expected_count = len(_registry.get_available_scanners())
         assert length <= expected_count  # May be less due to import failures
@@ -186,7 +199,7 @@ class TestLazyListInterface:
     def test_lazy_list_indexing(self):
         """Test that the lazy list supports indexing."""
         from modelaudit.scanners import SCANNER_REGISTRY
-        
+
         if len(SCANNER_REGISTRY) > 0:
             first_scanner = SCANNER_REGISTRY[0]
             assert issubclass(first_scanner, BaseScanner)
@@ -194,7 +207,7 @@ class TestLazyListInterface:
     def test_lazy_list_contains(self):
         """Test that the lazy list supports 'in' operator."""
         from modelaudit.scanners import SCANNER_REGISTRY, PickleScanner
-        
+
         # This will load PickleScanner if not already loaded
         assert PickleScanner in SCANNER_REGISTRY
 
@@ -205,18 +218,18 @@ class TestBackwardsCompatibility:
     def test_direct_scanner_import(self):
         """Test that scanners can still be imported directly."""
         from modelaudit.scanners import PickleScanner
-        
+
         assert PickleScanner is not None
         assert issubclass(PickleScanner, BaseScanner)
 
     def test_scanner_registry_usage(self):
         """Test that SCANNER_REGISTRY still works as expected."""
         from modelaudit.scanners import SCANNER_REGISTRY
-        
+
         # Should be iterable
         scanner_list = list(SCANNER_REGISTRY)
         assert len(scanner_list) > 0
-        
+
         # All should be BaseScanner subclasses
         for scanner in scanner_list:
             assert issubclass(scanner, BaseScanner)
@@ -224,7 +237,7 @@ class TestBackwardsCompatibility:
     def test_scanner_can_handle_method(self):
         """Test that scanner can_handle methods work correctly."""
         from modelaudit.scanners import PickleScanner
-        
+
         # Create temporary pickle file
         with tempfile.NamedTemporaryFile(suffix=".pkl") as f:
             assert PickleScanner.can_handle(f.name)
@@ -232,11 +245,11 @@ class TestBackwardsCompatibility:
     def test_scanner_instantiation(self):
         """Test that scanners can be instantiated correctly."""
         from modelaudit.scanners import PickleScanner
-        
+
         scanner = PickleScanner()
         assert scanner is not None
-        assert hasattr(scanner, 'scan')
-        assert hasattr(scanner, 'can_handle')
+        assert hasattr(scanner, "scan")
+        assert hasattr(scanner, "can_handle")
 
 
 class TestPerformanceCharacteristics:
@@ -246,14 +259,14 @@ class TestPerformanceCharacteristics:
         """Test that only necessary scanners are loaded for specific files."""
         # Reset loaded scanners
         _registry._loaded_scanners.clear()
-        
+
         # Create a JSON file (should only load manifest scanner)
-        with tempfile.NamedTemporaryFile(suffix=".json", mode='w') as f:
+        with tempfile.NamedTemporaryFile(suffix=".json", mode="w") as f:
             f.write('{"test": "value"}')
             f.flush()
-            
+
             scanner = _registry.get_scanner_for_path(f.name)
-            
+
             # Should have loaded minimal scanners
             loaded_count = len(_registry._loaded_scanners)
             assert loaded_count <= 3  # Should be very few
@@ -262,19 +275,19 @@ class TestPerformanceCharacteristics:
         """Test that heavy dependencies are not loaded for light files."""
         # Reset loaded scanners
         _registry._loaded_scanners.clear()
-        
+
         # Simulate a system without heavy dependencies
-        heavy_modules = ['tensorflow', 'torch', 'h5py', 'onnx']
+        heavy_modules = ["tensorflow", "torch", "h5py", "onnx"]
         initial_modules = set(sys.modules.keys())
-        
+
         # Create a simple text file
-        with tempfile.NamedTemporaryFile(suffix=".txt", mode='w') as f:
-            f.write('test content')
+        with tempfile.NamedTemporaryFile(suffix=".txt", mode="w") as f:
+            f.write("test content")
             f.flush()
-            
+
             # This should not load heavy dependencies
             scanner = _registry.get_scanner_for_path(f.name)
-            
+
             # Check that heavy modules weren't imported
             new_modules = set(sys.modules.keys()) - initial_modules
             for heavy_module in heavy_modules:
@@ -297,20 +310,20 @@ class TestErrorHandling:
         info = _registry.get_scanner_info("nonexistent_scanner")
         assert info is None
 
-    @patch('modelaudit.scanners._registry._load_scanner')
+    @patch("modelaudit.scanners._registry._load_scanner")
     def test_scanner_loading_exception_handling(self, mock_load):
         """Test handling of exceptions during scanner loading."""
         # Mock scanner loading to raise an exception
         mock_load.return_value = None
-        
+
         scanner = _registry.get_scanner_for_path("test.pkl")
         # Should handle gracefully, either return None or a fallback
         # The exact behavior depends on implementation details
-        
+
     def test_getattr_with_invalid_name(self):
         """Test __getattr__ with invalid scanner name."""
         from modelaudit import scanners
-        
+
         with pytest.raises(AttributeError):
             _ = scanners.NonExistentScanner
 
@@ -321,17 +334,19 @@ class TestSpecificFileTypes:
     def test_json_file_loading(self):
         """Test that JSON files load only manifest scanner."""
         _registry._loaded_scanners.clear()
-        
+
         # Use a realistic ML config filename that manifest scanner will handle
-        with tempfile.NamedTemporaryFile(suffix="_config.json", mode='w', delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            suffix="_config.json", mode="w", delete=False
+        ) as f:
             f.write('{"model": "test", "tokenizer": "config"}')
             f.flush()
-            
+
             try:
                 scanner = _registry.get_scanner_for_path(f.name)
                 # May be None if manifest scanner doesn't handle this specific file
                 # This is actually expected behavior - not all JSON files are ML-related
-                
+
                 # Should have loaded minimal scanners (or none if no match)
                 assert len(_registry._loaded_scanners) <= 3
             finally:
@@ -340,19 +355,19 @@ class TestSpecificFileTypes:
     def test_pickle_file_loading(self):
         """Test that pickle files load pickle scanner efficiently."""
         _registry._loaded_scanners.clear()
-        
+
         with tempfile.NamedTemporaryFile(suffix=".pkl") as f:
             scanner = _registry.get_scanner_for_path(f.name)
             assert scanner is not None
             assert scanner.name == "pickle"
-            
+
             # Should have loaded pickle scanner
             assert "pickle" in _registry._loaded_scanners
 
     def test_unknown_extension_handling(self):
         """Test handling of files with unknown extensions."""
         _registry._loaded_scanners.clear()
-        
+
         with tempfile.NamedTemporaryFile(suffix=".unknown_ext") as f:
             scanner = _registry.get_scanner_for_path(f.name)
             # May return None or a fallback scanner
@@ -361,30 +376,32 @@ class TestSpecificFileTypes:
     def test_manifest_scanner_exact_filename_matching(self):
         """Test that manifest scanner uses exact filename matching to prevent false positives."""
         _registry._loaded_scanners.clear()
-        
+
         # Test exact match - should work
         with tempfile.NamedTemporaryFile(suffix="config.json", delete=False) as f:
             f.write(b'{"test": "config"}')
             exact_path = f.name
-        
+
         # Test false positive case - should NOT match
-        with tempfile.NamedTemporaryFile(suffix="config.json.backup", delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            suffix="config.json.backup", delete=False
+        ) as f:
             f.write(b'{"test": "backup"}')
             backup_path = f.name
-        
+
         try:
             # Exact filename should potentially match (depends on manifest scanner logic)
             exact_scanner = _registry.get_scanner_for_path(exact_path)
-            
+
             # Backup file should NOT match due to exact matching
             backup_scanner = _registry.get_scanner_for_path(backup_path)
-            
+
             # The backup file should not be matched by manifest scanner
             # since "config.json.backup" != "config.json"
             if exact_scanner is not None:
                 # If exact match works, backup should not match
                 assert backup_scanner is None or backup_scanner.name != "manifest"
-                
+
         finally:
             Path(exact_path).unlink(missing_ok=True)
-            Path(backup_path).unlink(missing_ok=True) 
+            Path(backup_path).unlink(missing_ok=True)

--- a/tests/test_lazy_loading_integration.py
+++ b/tests/test_lazy_loading_integration.py
@@ -19,19 +19,19 @@ class TestCoreIntegration:
         """Test that scan_file uses lazy loading correctly."""
         # Reset loaded scanners
         _registry._loaded_scanners.clear()
-        
+
         # Create a JSON file with ML-related content
-        with tempfile.NamedTemporaryFile(suffix="_config.json", mode='w') as f:
+        with tempfile.NamedTemporaryFile(suffix="_config.json", mode="w") as f:
             f.write('{"model": "test", "tokenizer": "config"}')
             f.flush()
-            
+
             # Scan the file
             result = core.scan_file(f.name)
-            
+
             # Should have completed successfully
             assert result is not None
             assert result.scanner_name in ["manifest", "unknown"]
-            
+
             # Should have loaded minimal scanners
             loaded_count = len(_registry._loaded_scanners)
             assert loaded_count <= 5  # Should be minimal
@@ -39,22 +39,22 @@ class TestCoreIntegration:
     def test_scan_directory_uses_lazy_loading(self):
         """Test that directory scanning uses lazy loading efficiently."""
         _registry._loaded_scanners.clear()
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create various file types
             json_file = Path(temp_dir) / "config.json"
             json_file.write_text('{"test": "value"}')
-            
+
             txt_file = Path(temp_dir) / "readme.txt"
             txt_file.write_text("This is a readme file")
-            
+
             # Scan the directory
             results = core.scan_model_directory_or_file(temp_dir)
-            
+
             # Should have completed successfully
             assert results["success"] is True
             assert results["files_scanned"] == 2
-            
+
             # Should have loaded only necessary scanners
             loaded_count = len(_registry._loaded_scanners)
             assert loaded_count <= 10  # Should be reasonable
@@ -62,23 +62,23 @@ class TestCoreIntegration:
     def test_preferred_scanner_lazy_loading(self):
         """Test that preferred scanner detection uses lazy loading."""
         _registry._loaded_scanners.clear()
-        
+
         # Create a pickle file (should prefer pickle scanner)
         with tempfile.NamedTemporaryFile(suffix=".pkl") as f:
-            f.write(b'\x80\x02]q\x00.')  # Simple pickle data
-            
+            f.write(b"\x80\x02]q\x00.")  # Simple pickle data
+
             result = core.scan_file(f.name)
-            
+
             # Should use pickle scanner
             assert result.scanner_name == "pickle"
-            
+
             # Should have loaded pickle scanner
             assert "pickle" in _registry._loaded_scanners
 
     def test_multiple_file_types_incremental_loading(self):
         """Test that scanning multiple file types loads scanners incrementally."""
         _registry._loaded_scanners.clear()
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create different file types
             files = [
@@ -86,19 +86,19 @@ class TestCoreIntegration:
                 ("model.pkl", "fake pickle content"),
                 ("data.txt", "text content"),
             ]
-            
+
             loaded_counts = []
-            
+
             for filename, content in files:
                 file_path = Path(temp_dir) / filename
                 file_path.write_text(content)
-                
+
                 # Scan the file
                 result = core.scan_file(str(file_path))
-                
+
                 # Track how many scanners are loaded
                 loaded_counts.append(len(_registry._loaded_scanners))
-            
+
             # Should show incremental loading (or at least not loading everything at once)
             assert loaded_counts[0] > 0  # Some scanners loaded for first file
             # Later scans might load more, but shouldn't load everything
@@ -112,57 +112,59 @@ class TestPerformanceCharacteristics:
         """Test that importing scanners is fast with lazy loading."""
         # This test measures import time
         start_time = time.time()
-        
+
         # This should be fast (lazy loading)
         from modelaudit import scanners
-        
+
         import_time = time.time() - start_time
-        
+
         # Should be much faster than 1 second (was 7+ seconds before)
         assert import_time < 1.0
-        
+
         # Accessing the registry should also be fast
         start_time = time.time()
         registry = scanners.SCANNER_REGISTRY
         access_time = time.time() - start_time
-        
+
         # First access loads scanners, but should still be reasonable
         assert access_time < 5.0  # Much better than 7+ seconds
 
     def test_single_scanner_access_performance(self):
         """Test that accessing a single scanner is fast."""
         _registry._loaded_scanners.clear()
-        
+
         start_time = time.time()
-        
+
         # Access a lightweight scanner
         from modelaudit.scanners import PickleScanner
-        
+
         access_time = time.time() - start_time
-        
+
         # Should be very fast (no heavy dependencies)
         assert access_time < 0.5
 
     def test_heavy_scanner_access_expected_slow(self):
         """Test that heavy scanners are slower but only when accessed."""
         _registry._loaded_scanners.clear()
-        
+
         # First verify that we haven't loaded tensorflow yet
         import sys
-        tf_loaded_before = 'tensorflow' in sys.modules
-        
+
+        tf_loaded_before = "tensorflow" in sys.modules
+
         start_time = time.time()
-        
+
         try:
             # This might be slow due to tensorflow import
             from modelaudit.scanners import TensorFlowSavedModelScanner
+
             access_time = time.time() - start_time
-            
+
             # This is expected to be slower due to tensorflow
             # But we can't assert exact time since it depends on system
             # Just verify it doesn't crash and returns a valid scanner
             assert TensorFlowSavedModelScanner is not None
-            
+
         except ImportError:
             # TensorFlow might not be installed, which is fine
             pytest.skip("TensorFlow not available")
@@ -174,29 +176,29 @@ class TestErrorRecovery:
     def test_missing_dependency_graceful_handling(self):
         """Test that missing dependencies are handled gracefully."""
         _registry._loaded_scanners.clear()
-        
+
         # Try to load a scanner that might have missing dependencies
         # This should not crash the entire system
         scanner_classes = _registry.get_scanner_classes()
-        
+
         # Should return some scanners, even if some fail to load
         assert len(scanner_classes) > 0
-        
+
         # All returned scanners should be valid
         for scanner_class in scanner_classes:
-            assert hasattr(scanner_class, 'can_handle')
-            assert hasattr(scanner_class, 'scan')
+            assert hasattr(scanner_class, "can_handle")
+            assert hasattr(scanner_class, "scan")
 
     def test_scan_continues_with_available_scanners(self):
         """Test that scanning continues even if some scanners fail to load."""
         # Create a file that should be scannable by available scanners
-        with tempfile.NamedTemporaryFile(suffix="_config.json", mode='w') as f:
+        with tempfile.NamedTemporaryFile(suffix="_config.json", mode="w") as f:
             f.write('{"model": "test", "config": "data"}')
             f.flush()
-            
+
             # This should work even if some heavy dependency scanners fail
             result = core.scan_file(f.name)
-            
+
             # Should complete successfully
             assert result is not None
             # Might be "unknown" if manifest scanner fails, but shouldn't crash
@@ -209,7 +211,7 @@ class TestRegistryIntrospection:
     def test_get_available_scanners(self):
         """Test getting available scanner IDs."""
         scanners = _registry.get_available_scanners()
-        
+
         assert len(scanners) > 0
         assert "pickle" in scanners
         assert "manifest" in scanners
@@ -218,7 +220,7 @@ class TestRegistryIntrospection:
     def test_get_scanner_info(self):
         """Test getting scanner metadata."""
         pickle_info = _registry.get_scanner_info("pickle")
-        
+
         assert pickle_info is not None
         assert pickle_info["module"] == "modelaudit.scanners.pickle_scanner"
         assert pickle_info["class"] == "PickleScanner"
@@ -228,17 +230,17 @@ class TestRegistryIntrospection:
     def test_scanner_priority_ordering(self):
         """Test that scanners are ordered by priority."""
         scanners = list(_registry._scanners.items())
-        
+
         # Find pickle and zip scanners
         pickle_priority = None
         zip_priority = None
-        
+
         for scanner_id, info in scanners:
             if scanner_id == "pickle":
                 pickle_priority = info["priority"]
             elif scanner_id == "zip":
                 zip_priority = info["priority"]
-        
+
         assert pickle_priority is not None
         assert zip_priority is not None
         # Pickle should have higher priority (lower number) than zip
@@ -251,30 +253,30 @@ class TestCacheEfficiency:
     def test_scanner_caching_across_calls(self):
         """Test that scanners are cached across multiple calls."""
         _registry._loaded_scanners.clear()
-        
+
         # Load a scanner multiple times
         scanner1 = _registry._load_scanner("pickle")
         scanner2 = _registry._load_scanner("pickle")
         scanner3 = _registry._load_scanner("pickle")
-        
+
         # Should be the same instance (cached)
         assert scanner1 is scanner2
         assert scanner2 is scanner3
-        
+
         # Should only be in cache once
         assert len(_registry._loaded_scanners) == 1
 
     def test_registry_cache_efficiency(self):
         """Test that the lazy list caches its results."""
         from modelaudit.scanners import SCANNER_REGISTRY
-        
+
         # Access the registry multiple times
         list1 = list(SCANNER_REGISTRY)
         list2 = list(SCANNER_REGISTRY)
-        
+
         # Should return consistent results
         assert len(list1) == len(list2)
-        
+
         # The classes should be the same instances (cached)
         for scanner1, scanner2 in zip(list1, list2):
-            assert scanner1 is scanner2 
+            assert scanner1 is scanner2


### PR DESCRIPTION
## Summary
- support `rich` output formatting in CLI
- add `rich` dependency
- implement `format_rich_output` for colorful tables
- document rich format and add screenshot
- test CLI with `--format rich`

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check modelaudit/`
- `mypy modelaudit/`
- `pytest -n auto -m "not slow and not integration and not performance" --cov=modelaudit --tb=short` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_685b1e5619d48332ba4f916d1c451419