### PR TITLE
feat: support GGML format variants

### DIFF
--- a/modelaudit/scanners/gguf_scanner.py
+++ b/modelaudit/scanners/gguf_scanner.py
@@ -44,6 +44,15 @@ _TYPE_SIZES = {
     12: 8,  # FLOAT64
 }
 
+# Accepted GGML variant magic bytes
+GGML_VARIANT_MAGICS = {
+    b"GGML",
+    b"GGMF",
+    b"GGJT",
+    b"GGLA",
+    b"GGSA",
+}
+
 
 class GgufScanner(BaseScanner):
     """Scanner for GGUF/GGML model files with comprehensive parsing and security checks."""
@@ -52,7 +61,15 @@ class GgufScanner(BaseScanner):
     description = (
         "Validates GGUF/GGML model file headers, metadata, and tensor integrity"
     )
-    supported_extensions = [".gguf", ".ggml"]
+    # Include common GGML variant extensions as well
+    supported_extensions = [
+        ".gguf",
+        ".ggml",
+        ".ggmf",
+        ".ggjt",
+        ".ggla",
+        ".ggsa",
+    ]
 
     def __init__(self, config: Optional[Dict[str, Any]] = None):
         super().__init__(config)
@@ -72,7 +89,7 @@ class GgufScanner(BaseScanner):
         try:
             with open(path, "rb") as f:
                 magic = f.read(4)
-            return magic in (b"GGUF", b"GGML")
+            return magic == b"GGUF" or magic in GGML_VARIANT_MAGICS
         except Exception:
             return False
 
@@ -94,7 +111,7 @@ class GgufScanner(BaseScanner):
                 magic = f.read(4)
                 if magic == b"GGUF":
                     self._scan_gguf(f, file_size, result)
-                elif magic == b"GGML":
+                elif magic in GGML_VARIANT_MAGICS:
                     self._scan_ggml(f, file_size, magic, result)
                 else:
                     result.add_issue(

--- a/modelaudit/utils/filetype.py
+++ b/modelaudit/utils/filetype.py
@@ -1,6 +1,15 @@
 import re
 from pathlib import Path
 
+# Known GGML header variants (older formats like GGMF and GGJT)
+GGML_MAGIC_VARIANTS = {
+    b"GGML",
+    b"GGMF",
+    b"GGJT",
+    b"GGLA",
+    b"GGSA",
+}
+
 
 def is_zipfile(path: str) -> bool:
     """Check if file is a ZIP by reading the signature."""
@@ -50,7 +59,7 @@ def detect_file_format_from_magic(path: str) -> str:
 
     if magic4 == b"GGUF":
         return "gguf"
-    if magic4 == b"GGML":
+    if magic4 in GGML_MAGIC_VARIANTS:
         return "ggml"
 
     if magic4.startswith(b"PK"):
@@ -126,7 +135,7 @@ def detect_file_format(path: str) -> str:
     # Check for GGUF/GGML magic bytes
     if magic4 == b"GGUF":
         return "gguf"
-    if magic4 == b"GGML":
+    if magic4 in GGML_MAGIC_VARIANTS:
         return "ggml"
 
     ext = file_path.suffix.lower()
@@ -183,11 +192,12 @@ def detect_file_format(path: str) -> str:
         return "flax_msgpack"
     if ext == ".onnx":
         return "onnx"
-    if ext in (".gguf", ".ggml"):
+    ggml_exts = {".ggml", ".ggmf", ".ggjt", ".ggla", ".ggsa"}
+    if ext in (".gguf", *ggml_exts):
         # Check magic bytes first for accuracy
         if magic4 == b"GGUF":
             return "gguf"
-        elif magic4 == b"GGML":
+        elif magic4 in GGML_MAGIC_VARIANTS:
             return "ggml"
         # Fall back to extension-based detection
         return "gguf" if ext == ".gguf" else "ggml"
@@ -236,6 +246,10 @@ EXTENSION_FORMAT_MAP = {
     ".zip": "zip",
     ".gguf": "gguf",
     ".ggml": "ggml",
+    ".ggmf": "ggml",
+    ".ggjt": "ggml",
+    ".ggla": "ggml",
+    ".ggsa": "ggml",
     ".npy": "numpy",
     ".npz": "zip",
     ".joblib": "pickle",  # joblib can be either zip or pickle format

--- a/tests/test_filetype.py
+++ b/tests/test_filetype.py
@@ -159,6 +159,16 @@ def test_detect_gguf_ggml_formats(tmp_path):
     assert detect_format_from_extension(str(fake_gguf_path)) == "gguf"
 
 
+def test_detect_ggml_variant_formats(tmp_path):
+    """Ensure GGML variants are recognized."""
+    variants = [b"GGMF", b"GGJT"]
+    for magic in variants:
+        path = tmp_path / f"model_{magic.decode().lower()}.ggml"
+        path.write_bytes(magic + b"\x00" * 20)
+        assert detect_file_format(str(path)) == "ggml"
+        assert detect_format_from_extension(str(path)) == "ggml"
+
+
 def test_validate_file_type(tmp_path):
     """Validate files using magic numbers."""
     # Valid ZIP-based PyTorch file

--- a/tests/test_gguf_scanner.py
+++ b/tests/test_gguf_scanner.py
@@ -66,6 +66,14 @@ def _write_ggml_file(path):
         f.write(b"\0" * 24)  # padding to minimum size
 
 
+def _write_ggml_variant_file(path, magic):
+    """Create a GGML variant file with custom magic."""
+    with open(path, "wb") as f:
+        f.write(magic)
+        f.write(struct.pack("<I", 1))
+        f.write(b"\0" * 24)
+
+
 def test_gguf_scanner_can_handle_gguf(tmp_path):
     """Test that scanner can handle GGUF files."""
     path = tmp_path / "model.gguf"
@@ -78,6 +86,14 @@ def test_gguf_scanner_can_handle_ggml(tmp_path):
     path = tmp_path / "model.ggml"
     _write_ggml_file(path)
     assert GgufScanner.can_handle(str(path))
+
+
+def test_gguf_scanner_can_handle_ggml_variants(tmp_path):
+    """Scanner handles GGML variant magic codes."""
+    for magic in [b"GGMF", b"GGJT"]:
+        path = tmp_path / f"model_{magic.decode().lower()}.ggml"
+        _write_ggml_variant_file(path, magic)
+        assert GgufScanner.can_handle(str(path))
 
 
 def test_gguf_scanner_rejects_invalid_files(tmp_path):
@@ -190,6 +206,16 @@ def test_ggml_scanner_basic(tmp_path):
     assert result.success
     assert result.metadata["format"] == "ggml"
     assert result.metadata["version"] == 1
+
+
+def test_ggml_variant_scanner_basic(tmp_path):
+    """Ensure GGML variants are scanned correctly."""
+    path = tmp_path / "model.ggmf"
+    _write_ggml_variant_file(path, b"GGMF")
+    result = GgufScanner().scan(str(path))
+    assert result.success
+    assert result.metadata["format"] == "ggml"
+    assert result.metadata.get("magic") == "GGMF"
 
 
 def test_ggml_scanner_suspicious_version(tmp_path):


### PR DESCRIPTION
## Summary
- add GGML magic variants and extensions
- handle variants in `GgufScanner`
- recognize variant extensions in file type detection
- test GGML variant detection and scanning

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check --fix modelaudit/ tests/`
- `mypy modelaudit/`
- `pytest -m "not slow and not integration and not performance" -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3f15e1c88332815e9b3b7ac7991b