### PR TITLE
feat: Add ExecuTorch model scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,9 @@ ModelAudit provides specialized security scanners for different model formats:
 | ------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | **Pickle**          | `.pkl`, `.pickle`, `.dill`, `.bin`, `.pt`, `.pth`, `.ckpt`                                               | Malicious code execution, dangerous opcodes, suspicious imports, nested pickle detection, decode-exec chains       |
 | **PyTorch Zip**     | `.pt`, `.pth`                                                                                            | Embedded pickle analysis, suspicious files, custom patterns                                                        |
+| **ExecuTorch**      | `.ptl`, `.pte`
+                                                 | Mobile archives, embedded pickles, suspicious files
+      |
 | **PyTorch Binary**  | `.bin`                                                                                                   | Binary tensor data analysis, embedded content                                                                      |
 | **TensorFlow Lite** | `.tflite`                                                                                                | Extreme tensor shapes, custom ops, FlatBuffer integrity                                                            |
 | **TensorFlow**      | SavedModel dirs, `.pb`                                                                                   | Suspicious operations, file I/O, Python execution                                                                  |

--- a/modelaudit/scanners/__init__.py
+++ b/modelaudit/scanners/__init__.py
@@ -136,6 +136,15 @@ class ScannerRegistry:
                 "dependencies": [],  # No heavy dependencies
                 "numpy_sensitive": False,
             },
+            "executorch": {
+                "module": "modelaudit.scanners.executorch_scanner",
+                "class": "ExecuTorchScanner",
+                "description": "Scans ExecuTorch mobile archives",
+                "extensions": [".ptl", ".pte"],
+                "priority": 6,  # Similar priority to PyTorch Zip
+                "dependencies": [],
+                "numpy_sensitive": False,
+            },
             "gguf": {
                 "module": "modelaudit.scanners.gguf_scanner",
                 "class": "GgufScanner",
@@ -465,6 +474,7 @@ def __getattr__(name: str):
         "KerasH5Scanner": "keras_h5",
         "OnnxScanner": "onnx",
         "PyTorchZipScanner": "pytorch_zip",
+        "ExecuTorchScanner": "executorch",
         "GgufScanner": "gguf",
         "JoblibScanner": "joblib",
         "NumPyScanner": "numpy",

--- a/modelaudit/scanners/executorch_scanner.py
+++ b/modelaudit/scanners/executorch_scanner.py
@@ -1,0 +1,136 @@
+import io
+import os
+import tempfile
+import zipfile
+from typing import Any, ClassVar, Optional
+
+from ..utils import sanitize_archive_path
+from .base import BaseScanner, IssueSeverity, ScanResult
+from .pickle_scanner import PickleScanner
+
+
+class ExecuTorchScanner(BaseScanner):
+    """Scanner for PyTorch Mobile/ExecuTorch archives (.ptl, .pte)."""
+
+    name = "executorch"
+    description = "Scans ExecuTorch mobile model files for suspicious content"
+    supported_extensions: ClassVar[list[str]] = [".ptl", ".pte"]
+
+    def __init__(self, config: Optional[dict[str, Any]] = None) -> None:
+        super().__init__(config)
+        self.pickle_scanner = PickleScanner(config)
+
+    @classmethod
+    def can_handle(cls, path: str) -> bool:
+        if not os.path.isfile(path):
+            return False
+        ext = os.path.splitext(path)[1].lower()
+        return ext in cls.supported_extensions
+
+    @staticmethod
+    def _read_header(path: str, length: int = 4) -> bytes:
+        try:
+            with open(path, "rb") as f:
+                return f.read(length)
+        except Exception:
+            return b""
+
+    def scan(self, path: str) -> ScanResult:
+        path_check_result = self._check_path(path)
+        if path_check_result:
+            return path_check_result
+
+        size_check = self._check_size_limit(path)
+        if size_check:
+            return size_check
+
+        result = self._create_result()
+        file_size = self.get_file_size(path)
+        result.metadata["file_size"] = file_size
+
+        header = self._read_header(path)
+        if not header.startswith(b"PK"):
+            result.add_issue(
+                f"Not a valid ExecuTorch archive: {path}",
+                severity=IssueSeverity.CRITICAL,
+                location=path,
+                details={"path": path},
+            )
+            result.finish(success=False)
+            return result
+
+        try:
+            self.current_file_path = path
+            with zipfile.ZipFile(path, "r") as z:
+                safe_entries: list[str] = []
+                for name in z.namelist():
+                    temp_base = os.path.join(tempfile.gettempdir(), "extract")
+                    _, is_safe = sanitize_archive_path(name, temp_base)
+                    if not is_safe:
+                        result.add_issue(
+                            f"Archive entry {name} attempted path traversal outside the archive",
+                            severity=IssueSeverity.CRITICAL,
+                            location=f"{path}:{name}",
+                            details={"entry": name},
+                        )
+                        continue
+                    safe_entries.append(name)
+
+                pickle_files = [n for n in safe_entries if n.endswith(".pkl")]
+                result.metadata["pickle_files"] = pickle_files
+                bytes_scanned = 0
+
+                for name in pickle_files:
+                    data = z.read(name)
+                    bytes_scanned += len(data)
+                    with io.BytesIO(data) as file_like:
+                        sub_result = self.pickle_scanner._scan_pickle_bytes(file_like, len(data))
+                    for issue in sub_result.issues:
+                        if issue.details:
+                            issue.details["pickle_filename"] = name
+                        else:
+                            issue.details = {"pickle_filename": name}
+                        if not issue.location:
+                            issue.location = f"{path}:{name}"
+                        elif "pos" in issue.location:
+                            issue.location = f"{path}:{name} {issue.location}"
+                    result.merge(sub_result)
+
+                for name in safe_entries:
+                    if name.endswith(".py"):
+                        result.add_issue(
+                            f"Python code file found in ExecuTorch model: {name}",
+                            severity=IssueSeverity.INFO,
+                            location=f"{path}:{name}",
+                            details={"file": name},
+                        )
+                    elif name.endswith((".sh", ".bash", ".cmd", ".exe")):
+                        result.add_issue(
+                            f"Executable file found in ExecuTorch model: {name}",
+                            severity=IssueSeverity.CRITICAL,
+                            location=f"{path}:{name}",
+                            details={"file": name},
+                        )
+
+                result.bytes_scanned = bytes_scanned
+        except zipfile.BadZipFile:
+            result.add_issue(
+                f"Not a valid zip file: {path}",
+                severity=IssueSeverity.CRITICAL,
+                location=path,
+                details={"path": path},
+            )
+            result.finish(success=False)
+            return result
+        except Exception as e:  # pragma: no cover - unexpected errors
+            result.add_issue(
+                f"Error scanning ExecuTorch file: {e!s}",
+                severity=IssueSeverity.CRITICAL,
+                location=path,
+                details={"exception": str(e), "exception_type": type(e).__name__},
+            )
+            result.finish(success=False)
+            return result
+
+        result.finish(success=True)
+        return result

--- a/modelaudit/utils/filetype.py
+++ b/modelaudit/utils/filetype.py
@@ -178,6 +178,10 @@ def detect_file_format(path: str) -> str:
             return "zip"
         # If not ZIP, assume pickle format
         return "pickle"
+    if ext in (".ptl", ".pte"):
+        if magic4.startswith(b"PK"):
+            return "executorch"
+        return "executorch"
     if ext in (".pkl", ".pickle", ".dill"):
         return "pickle"
     if ext == ".h5":
@@ -249,6 +253,8 @@ EXTENSION_FORMAT_MAP = {
     ".ggjt": "ggml",
     ".ggla": "ggml",
     ".ggsa": "ggml",
+    ".ptl": "executorch",
+    ".pte": "executorch",
     ".npy": "numpy",
     ".npz": "zip",
     ".joblib": "pickle",  # joblib can be either zip or pickle format
@@ -300,9 +306,13 @@ def validate_file_type(path: str) -> bool:
         if ext_format == "protobuf" and header_format in {"protobuf", "unknown"}:
             return True
 
-        # ZIP files can have various extensions (.zip, .pt, .pth, .ckpt when they're torch.save() files)
-        if header_format == "zip" and ext_format in {"zip", "pickle", "pytorch_binary"}:
+        # ZIP files can have various extensions (.zip, .pt, .pth, .ckpt, .ptl, .pte)
+        if header_format == "zip" and ext_format in {"zip", "pickle", "pytorch_binary", "executorch"}:
             return True
+
+        # ExecuTorch files should be zip archives
+        if ext_format == "executorch":
+            return header_format == "zip"
 
         # HDF5 files should always match
         if ext_format == "hdf5":

--- a/tests/test_executorch_scanner.py
+++ b/tests/test_executorch_scanner.py
@@ -1,0 +1,56 @@
+import pickle
+import zipfile
+
+from modelaudit.scanners.base import IssueSeverity
+from modelaudit.scanners.executorch_scanner import ExecuTorchScanner
+
+
+def create_executorch_archive(tmp_path, *, malicious: bool = False):
+    zip_path = tmp_path / "model.ptl"
+    with zipfile.ZipFile(zip_path, "w") as z:
+        z.writestr("version", "1")
+        data: dict[str, object] = {"weights": [1, 2, 3]}
+        if malicious:
+
+            class Evil:
+                def __reduce__(self):
+                    return (eval, ("print('evil')",))
+
+            data["malicious"] = Evil()
+        z.writestr("bytecode.pkl", pickle.dumps(data))
+    return zip_path
+
+
+def test_executorch_scanner_can_handle(tmp_path):
+    path = create_executorch_archive(tmp_path)
+    assert ExecuTorchScanner.can_handle(str(path))
+    other = tmp_path / "model.h5"
+    other.write_bytes(b"data")
+    assert not ExecuTorchScanner.can_handle(str(other))
+
+
+def test_executorch_scanner_safe_model(tmp_path):
+    path = create_executorch_archive(tmp_path)
+    scanner = ExecuTorchScanner()
+    result = scanner.scan(str(path))
+    assert result.success is True
+    assert result.bytes_scanned > 0
+    critical = [i for i in result.issues if i.severity == IssueSeverity.CRITICAL]
+    assert not critical
+
+
+def test_executorch_scanner_malicious(tmp_path):
+    path = create_executorch_archive(tmp_path, malicious=True)
+    scanner = ExecuTorchScanner()
+    result = scanner.scan(str(path))
+    assert any(i.severity == IssueSeverity.CRITICAL for i in result.issues)
+    assert any("eval" in i.message.lower() for i in result.issues)
+
+
+def test_executorch_scanner_invalid_zip(tmp_path):
+    file_path = tmp_path / "bad.ptl"
+    file_path.write_bytes(b"not zip")
+    scanner = ExecuTorchScanner()
+    result = scanner.scan(str(file_path))
+    assert not result.success
+    assert any("executorch" in i.message.lower() for i in result.issues)


### PR DESCRIPTION
## Summary
- add ExecuTorch scanner for `.ptl` and `.pte` archives
- register scanner in registry and file type detection
- document ExecuTorch support in README
- provide unit tests for the new scanner

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check --fix modelaudit/ tests/`
- `ruff check --fix --select I modelaudit/ tests/`
- `mypy modelaudit/ tests/`
- `pytest -m "not slow and not integration and not performance" --tb=short`


------
https://chatgpt.com/codex/tasks/task_e_685f52808dc08332949caa64ade9f7dc