### PR TITLE
fix: exclude tflite dependency to fix CI builds

### DIFF
--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -3,7 +3,7 @@
 #
 # last locked with the following flags:
 #   pre: false
-#   features: ["all"]
+#   features: ["tensorflow,h5,pytorch,yaml,safetensors,onnx,dill,joblib,flax,mlflow,huggingface,cloud"]
 #   all-features: false
 #   with-sources: false
 #   generate-hashes: false
@@ -86,7 +86,6 @@ flask==3.1.1
     # via mlflow
 flatbuffers==25.2.10
     # via tensorflow
-    # via tflite
 fonttools==4.58.4
     # via matplotlib
 frozenlist==1.7.0
@@ -232,7 +231,6 @@ numpy==2.1.3
     # via scipy
     # via tensorboard
     # via tensorflow
-    # via tflite
     # via types-tensorflow
 oauthlib==3.3.1
     # via requests-oauthlib
@@ -385,8 +383,6 @@ tensorflow-io-gcs-filesystem==0.37.1
 termcolor==2.3.0
     # via tensorflow
     # via yaspin
-tflite==2.18.0
-    # via modelaudit
 threadpoolctl==3.6.0
     # via scikit-learn
 torch==2.7.1

--- a/requirements.lock
+++ b/requirements.lock
@@ -3,7 +3,7 @@
 #
 # last locked with the following flags:
 #   pre: false
-#   features: ["all"]
+#   features: ["tensorflow,h5,pytorch,yaml,safetensors,onnx,dill,joblib,flax,mlflow,huggingface,cloud"]
 #   all-features: false
 #   with-sources: false
 #   generate-hashes: false
@@ -82,7 +82,6 @@ flask==3.1.1
     # via mlflow
 flatbuffers==25.2.10
     # via tensorflow
-    # via tflite
 fonttools==4.58.4
     # via matplotlib
 frozenlist==1.7.0
@@ -223,7 +222,6 @@ numpy==2.1.3
     # via scipy
     # via tensorboard
     # via tensorflow
-    # via tflite
 oauthlib==3.3.1
     # via requests-oauthlib
 onnx==1.18.0
@@ -362,8 +360,6 @@ tensorflow-io-gcs-filesystem==0.37.1
 termcolor==2.3.0
     # via tensorflow
     # via yaspin
-tflite==2.18.0
-    # via modelaudit
 threadpoolctl==3.6.0
     # via scikit-learn
 torch==2.7.1


### PR DESCRIPTION
## Summary
- Updated lock files to exclude tflite dependency which was causing build failures on macOS due to tensorrt compatibility issues
- All CI checks now pass successfully

## Test plan
- [x] Ran all linting checks (`rye run ruff format --check` and `rye run ruff check`)
- [x] Ran type checking (`rye run mypy`)
- [x] Ran all unit tests (`rye run pytest`)
- [x] Verified integration tests pass
- [x] Confirmed numpy compatibility tests work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)