### PR TITLE
fix: properly handle HuggingFace cache symlinks to avoid path traversal warnings

### DIFF
--- a/tests/test_huggingface_symlinks.py
+++ b/tests/test_huggingface_symlinks.py
@@ -1,0 +1,127 @@
+"""Test HuggingFace cache symlink handling."""
+
+import os
+
+import pytest
+
+from modelaudit.core import scan_model_directory_or_file
+
+
+class TestHuggingFaceSymlinks:
+    """Test that HuggingFace cache symlinks are handled correctly."""
+
+    @pytest.fixture
+    def mock_hf_cache(self, tmp_path):
+        """Create a mock HuggingFace cache structure with symlinks."""
+        # Create HuggingFace cache structure
+        cache_dir = tmp_path / ".cache" / "huggingface" / "hub" / "models--test-model"
+        snapshots_dir = cache_dir / "snapshots" / "abc123"
+        blobs_dir = cache_dir / "blobs"
+
+        # Create directories
+        snapshots_dir.mkdir(parents=True)
+        blobs_dir.mkdir(parents=True)
+
+        # Create blob files
+        blob1_path = blobs_dir / "blob1234567890"
+        blob2_path = blobs_dir / "blob0987654321"
+
+        with open(blob1_path, "w") as f:
+            f.write("Model data")
+
+        with open(blob2_path, "w") as f:
+            f.write("Config data")
+
+        # Create symlinks in snapshots directory
+        model_link = snapshots_dir / "model.safetensors"
+        config_link = snapshots_dir / "config.json"
+
+        # Create relative symlinks (as HuggingFace does)
+        os.symlink("../../blobs/blob1234567890", model_link)
+        os.symlink("../../blobs/blob0987654321", config_link)
+
+        return snapshots_dir
+
+    def test_hf_cache_symlinks_no_path_traversal_warnings(self, mock_hf_cache):
+        """Test that HuggingFace cache symlinks don't trigger path traversal warnings."""
+        # Scan the snapshots directory
+        results = scan_model_directory_or_file(str(mock_hf_cache))
+
+        # Check that files were scanned
+        assert results["files_scanned"] == 2
+
+        # Check that there are no path traversal warnings
+        path_traversal_issues = [
+            issue for issue in results["issues"] if "path traversal" in issue.get("message", "").lower()
+        ]
+        assert len(path_traversal_issues) == 0
+
+    def test_malicious_symlink_outside_cache(self, tmp_path):
+        """Test that symlinks pointing outside the cache structure are still caught."""
+        # Create a directory structure
+        scan_dir = tmp_path / "scan_me"
+        scan_dir.mkdir()
+
+        # Create a file outside the scan directory
+        outside_file = tmp_path / "outside.txt"
+        with open(outside_file, "w") as f:
+            f.write("Malicious content")
+
+        # Create a symlink pointing outside
+        symlink = scan_dir / "bad_link.txt"
+        os.symlink(str(outside_file), symlink)
+
+        # Scan the directory
+        results = scan_model_directory_or_file(str(scan_dir))
+
+        # Should have path traversal warning
+        path_traversal_issues = [
+            issue for issue in results["issues"] if "path traversal" in issue.get("message", "").lower()
+        ]
+        assert len(path_traversal_issues) == 1
+
+    def test_nested_hf_cache_structure(self, tmp_path):
+        """Test more complex nested HuggingFace cache structures."""
+        # Create nested cache structure
+        cache_dir = tmp_path / ".cache" / "huggingface" / "hub" / "models--org--model-name"
+        snapshots_dir = cache_dir / "snapshots" / "commit123456"
+        blobs_dir = cache_dir / "blobs"
+        refs_dir = cache_dir / "refs"
+
+        # Create all directories
+        for d in [snapshots_dir, blobs_dir, refs_dir]:
+            d.mkdir(parents=True)
+
+        # Create various files
+        blob_files = []
+        for i, (name, content) in enumerate(
+            [
+                ("model.bin", "PyTorch model"),
+                ("config.json", '{"model_type": "bert"}'),
+                ("tokenizer.json", '{"vocab_size": 30522}'),
+            ]
+        ):
+            blob_path = blobs_dir / f"blob{i:010d}"
+            with open(blob_path, "w") as f:
+                f.write(content)
+            blob_files.append((name, blob_path))
+
+            # Create symlink
+            link_path = snapshots_dir / name
+            os.symlink(f"../../blobs/{blob_path.name}", link_path)
+
+        # Create refs (these should be skipped)
+        with open(refs_dir / "main", "w") as f:
+            f.write("commit123456")
+
+        # Scan
+        results = scan_model_directory_or_file(str(snapshots_dir))
+
+        # Should scan the actual model files, not refs
+        assert results["files_scanned"] == 3
+
+        # No path traversal warnings
+        path_traversal_issues = [
+            issue for issue in results["issues"] if "path traversal" in issue.get("message", "").lower()
+        ]
+        assert len(path_traversal_issues) == 0


### PR DESCRIPTION
## Summary

This PR fixes false positive path traversal warnings when scanning HuggingFace cached models. HuggingFace uses a specific directory structure where model files in `snapshots/` are symlinks pointing to content-addressed files in `blobs/`. This is a legitimate storage optimization, not a security issue.

### Changes:
- Modified path traversal detection logic to recognize legitimate HuggingFace cache symlinks
- Added special handling for symlinks within the same model cache structure (snapshots → blobs)
- Removed overly broad HuggingFace cache file skipping that prevented scanning
- Added comprehensive test coverage for symlink scenarios

## Problem

When scanning HuggingFace cached models, modelaudit would report 12 CRITICAL path traversal warnings:
```
🚨 [/path/to/snapshots/abc123/model.safetensors]
   Path traversal outside scanned directory
   resolved_path: /path/to/blobs/5e3f1108e3cb34ee...
```

## Solution

The scanner now:
1. Detects when we're scanning within a HuggingFace cache structure
2. Allows symlinks from `snapshots/` to `blobs/` within the same model cache
3. Still catches malicious symlinks that point outside the expected structure
4. Properly scans the actual target files through the symlinks

## Test Plan

### Manual Testing
```bash
# Test with a real HuggingFace cached model
rye run modelaudit scan ~/.cache/huggingface/hub/models--distilbert-base-uncased/snapshots/12040accade4e8a0f71eabdb258fecc2e7e948be

# Expected: No path traversal warnings, all files scanned successfully
```

### Automated Tests
```bash
# Run the new symlink handling tests
rye run pytest tests/test_huggingface_symlinks.py -v

# Run existing path traversal tests to ensure no regression
rye run pytest tests/test_path_traversal.py -v
```

### Test Coverage
- ✅ HuggingFace cache symlinks don't trigger warnings
- ✅ Malicious symlinks outside cache are still caught
- ✅ Nested cache structures work correctly
- ✅ Existing path traversal protection remains intact

## Breaking Changes

None. This change only affects the detection logic for legitimate symlinks within HuggingFace cache directories.

🤖 Generated with [Claude Code](https://claude.ai/code)