### PR TITLE
chore: Add Michael D'Angelo as an author

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ name = "modelaudit"
 version = "0.1.5"
 description = "Static scanning library for detecting malicious code, backdoors, and other security risks in ML model files"
 authors = [
-    { name = "Ian Webster", email = "ian@promptfoo.dev" }
+    { name = "Ian Webster", email = "ian@promptfoo.dev" },
+    { name = "Michael D'Angelo", email = "michael@promptfoo.dev" }
 ]
 license = { text = "MIT" }
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Added Michael D'Angelo (michael@promptfoo.dev) to the authors list in pyproject.toml

## Test plan
- [x] No code changes, only metadata update
- [x] Verified pyproject.toml syntax is valid

🤖 Generated with [Claude Code](https://claude.ai/code)