### PR TITLE
fix: hide false positive info messages from normal output

### DIFF
--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -1719,12 +1719,12 @@ class PickleScanner(BaseScanner):
                         ),
                     )
 
-                # Add informational note about ignored patterns if significant
+                # Add debug note about ignored patterns if significant (only shown in verbose mode)
                 if ignored_count > 0 and len(positions) > 10:
                     explanation = get_ml_context_explanation(first_chunk_ml_context, len(positions))
                     result.add_issue(
                         f"Ignored {ignored_count} likely false positive {description} patterns in ML weight data",
-                        severity=IssueSeverity.INFO,
+                        severity=IssueSeverity.DEBUG,
                         location=f"{self.current_file_path}",
                         details={
                             "signature": sig.hex(),
@@ -1804,12 +1804,12 @@ class PickleScanner(BaseScanner):
                         ),
                     )
 
-                # Note about ignored PE patterns
+                # Note about ignored PE patterns (only shown in verbose mode)
                 if ignored_pe_count > 0:
                     explanation = get_ml_context_explanation(first_chunk_ml_context, len(pe_positions))
                     result.add_issue(
                         f"Ignored {ignored_pe_count} likely false positive PE executable patterns in ML weight data",
-                        severity=IssueSeverity.INFO,
+                        severity=IssueSeverity.DEBUG,
                         location=f"{self.current_file_path}",
                         details={
                             "signature": pe_sig.hex(),

--- a/modelaudit/scanners/pytorch_binary_scanner.py
+++ b/modelaudit/scanners/pytorch_binary_scanner.py
@@ -241,14 +241,14 @@ class PyTorchBinaryScanner(BaseScanner):
                     },
                 )
 
-            # Add informational note about ignored patterns
+            # Add debug note about ignored patterns (only shown in verbose mode)
             if ignored_count > 0 and len(positions) > 5:
                 from modelaudit.utils.ml_context import get_ml_context_explanation
 
                 explanation = get_ml_context_explanation(ml_context, len(positions))
                 result.add_issue(
                     f"Ignored {ignored_count} likely false positive {description} patterns",
-                    severity=IssueSeverity.INFO,
+                    severity=IssueSeverity.DEBUG,
                     location=f"{self.current_file_path}",
                     details={
                         "signature": sig.hex(),


### PR DESCRIPTION
## Summary
- Changed false positive reporting from INFO to DEBUG severity level
- Users will no longer see confusing messages about ignored patterns in normal output
- Messages are still available when using --verbose flag

## Problem
When scanning models, users were seeing messages like:
```
[i] Information
────────────────────────────────────────
└─ [i] [/path/to/pytorch_model.bin]
   Ignored 151 likely false positive Shell script shebang patterns in ML weight data
   Why: These patterns were ignored because they appear in what looks like ML model weight data...
```

These messages were confusing because they report on patterns that were already filtered out as false positives.

## Solution
Changed the severity level from `IssueSeverity.INFO` to `IssueSeverity.DEBUG` in:
- `modelaudit/scanners/pickle_scanner.py` (2 occurrences)
- `modelaudit/scanners/pytorch_binary_scanner.py` (1 occurrence)

Now these messages only appear when running with `--verbose` flag.

## Test Instructions
```bash
# Normal mode - should not show false positive messages
rye run modelaudit hf://microsoft/DialoGPT-small

# Verbose mode - should show false positive messages as DEBUG
rye run modelaudit --verbose hf://microsoft/DialoGPT-small
```