### PR TITLE
fix: update PyTorch minimum version to address CVE-2025-32434

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 # pip install "numpy<2.0" tensorflow h5py torch onnx
 tensorflow = ["tensorflow>=2.13.0,<3.0"]
 h5 = ["h5py>=3.1,<4.0"]
-pytorch = ["torch>=1.6,<3.0"]
+pytorch = ["torch>=2.6.0,<3.0"]
 yaml = ["pyyaml>=6.0,<7.0"]
 safetensors = ["safetensors>=0.4.0"]
 onnx = ["onnx>=1.12.0,<2.0"]
@@ -61,7 +61,7 @@ numpy1 = [
     "numpy>=1.19.0,<2.0",
     "tensorflow>=2.13.0,<3.0",
     "h5py>=3.1,<4.0",
-    "torch>=1.6,<3.0",
+    "torch>=2.6.0,<3.0",
     "pyyaml>=6.0,<7.0",
     "safetensors>=0.4.0",
     "onnx>=1.12.0,<2.0",
@@ -81,7 +81,7 @@ numpy1 = [
 all-ci = [
     "tensorflow>=2.13.0,<3.0",
     "h5py>=3.1,<4.0",
-    "torch>=1.6,<3.0",
+    "torch>=2.6.0,<3.0",
     "pyyaml>=6.0,<7.0",
     "safetensors>=0.4.0",
     "onnx>=1.12.0,<2.0",
@@ -100,7 +100,7 @@ all-ci = [
 all = [
     "tensorflow>=2.13.0,<3.0",
     "h5py>=3.1,<4.0",
-    "torch>=1.6,<3.0",
+    "torch>=2.6.0,<3.0",
     "pyyaml>=6.0,<7.0",
     "safetensors>=0.4.0",
     "onnx>=1.12.0,<2.0",


### PR DESCRIPTION
## Summary
- Updates PyTorch minimum version from 1.6 to 2.6.0 to address critical security vulnerability
- Fixes CVE-2025-32434: Critical RCE vulnerability affecting PyTorch versions ≤2.5.1
- Updates all occurrences in pyproject.toml (pytorch, numpy1, all-ci, all features)

## Context
During a security audit for deprecated dependencies, I discovered that the current PyTorch version constraint (`>=1.6,<3.0`) includes versions vulnerable to CVE-2025-32434, a critical remote code execution vulnerability.

## Test Instructions
```bash
rye sync --features pytorch
rye run pytest tests/test_pytorch_scanner.py
```

🤖 Generated with [Claude Code](https://claude.ai/code)