### PR TITLE
chore: add .prettierignore to exclude cache and build directories

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,38 @@
+# Prettier ignore patterns
+
+# Build and cache directories
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+build/
+dist/
+*.egg-info/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+
+# Coverage reports
+htmlcov/
+.coverage
+coverage.xml
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Test artifacts
+test-results/
+test-reports/


### PR DESCRIPTION
## Summary
- Add .prettierignore file to exclude mypy cache and other build/cache directories from prettier formatting

## Test Instructions
```bash
npx prettier@latest --write "**/*.{md,yaml,yml,json}"
```

The command should now skip .mypy_cache/ and other ignored directories.

🤖 Generated with [Claude Code](https://claude.ai/code)