### PR TITLE
fix: clean up numpy and jax scanners

### DIFF
--- a/modelaudit/scanners/jax_checkpoint_scanner.py
+++ b/modelaudit/scanners/jax_checkpoint_scanner.py
@@ -7,15 +7,18 @@ import os
 from pathlib import Path
 from typing import Any, ClassVar
 
+from .base import BaseScanner, IssueSeverity, ScanResult
+
+np: Any
+
 try:
     import numpy as np
 
     HAS_NUMPY = True
 except ImportError:  # pragma: no cover
     HAS_NUMPY = False
-    np = None  # type: ignore[assignment]
+    np = None
 
-from .base import BaseScanner, IssueSeverity, ScanResult
 
 
 class JaxCheckpointScanner(BaseScanner):

--- a/modelaudit/scanners/numpy_scanner.py
+++ b/modelaudit/scanners/numpy_scanner.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import sys
 import warnings
-from typing import ClassVar
+from typing import Any, ClassVar
+
+from .base import BaseScanner, IssueSeverity, ScanResult
 
 # Import NumPy with compatibility handling
+np: Any
+fmt: Any
 try:
     import numpy as np
 
@@ -16,7 +20,7 @@ try:
     except (ImportError, AttributeError):
         # Fallback for potential import issues
         NUMPY_FORMAT_AVAILABLE = False
-        fmt = None  # type: ignore
+        fmt = None
 
     NUMPY_AVAILABLE = True
     NUMPY_VERSION = getattr(np, "__version__", "unknown")
@@ -26,10 +30,9 @@ except ImportError:
     NUMPY_FORMAT_AVAILABLE = False
     NUMPY_VERSION = "not available"
     NUMPY_MAJOR_VERSION = 0
-    np = None  # type: ignore
-    fmt = None  # type: ignore
+    np = None
+    fmt = None
 
-from .base import BaseScanner, IssueSeverity, ScanResult
 
 
 class NumPyScanner(BaseScanner):


### PR DESCRIPTION
## Summary
- remove obsolete `type: ignore` comments in numpy and jax scanners
- ensure mypy passes without ignores

## Testing
- `ruff check modelaudit/ tests/`
- `mypy modelaudit/scanners/numpy_scanner.py modelaudit/scanners/jax_checkpoint_scanner.py`
- `pytest tests/test_numpy_scanner.py -m "not slow and not integration and not performance" --tb=short`

------
https://chatgpt.com/codex/tasks/task_e_687d1279e890833299297597f53ce9c4