### PR TITLE
fix(cli): enforce UTF-8 file output

### DIFF
--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -594,7 +594,7 @@ def scan_command(
         from .sbom import generate_sbom
 
         sbom_text = generate_sbom(expanded_paths, aggregated_results)
-        with open(sbom, "w") as f:
+        with open(sbom, "w", encoding="utf-8") as f:
             f.write(sbom_text)
 
     # Format the output
@@ -607,7 +607,7 @@ def scan_command(
 
     # Send output to the specified destination
     if output:
-        with open(output, "w") as f:
+        with open(output, "w", encoding="utf-8") as f:
             f.write(output_text)
         click.echo(f"Results written to {output}")
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -173,6 +173,44 @@ def test_scan_sbom_output(tmp_path):
         pytest.fail("SBOM output is not valid JSON")
 
 
+def test_scan_output_utf8_locale(tmp_path):
+    """Ensure output file is valid UTF-8 even with ASCII locale."""
+    test_file = tmp_path / "utf8_test.dat"
+    test_file.write_bytes(b"test content")
+
+    output_file = tmp_path / "output.txt"
+
+    runner = CliRunner()
+    env = os.environ.copy()
+    env.update({"LC_ALL": "C", "LANG": "C"})
+    runner.invoke(cli, ["scan", str(test_file), "--output", str(output_file)], env=env)
+
+    assert output_file.exists()
+    try:
+        output_file.read_bytes().decode("utf-8")
+    except UnicodeDecodeError:
+        pytest.fail("Output file is not valid UTF-8")
+
+
+def test_scan_sbom_utf8_locale(tmp_path):
+    """Ensure SBOM file is valid UTF-8 even with ASCII locale."""
+    test_file = tmp_path / "utf8_test.dat"
+    test_file.write_bytes(b"test content")
+
+    sbom_file = tmp_path / "sbom.json"
+
+    runner = CliRunner()
+    env = os.environ.copy()
+    env.update({"LC_ALL": "C", "LANG": "C"})
+    runner.invoke(cli, ["scan", str(test_file), "--sbom", str(sbom_file)], env=env)
+
+    assert sbom_file.exists()
+    try:
+        sbom_file.read_bytes().decode("utf-8")
+    except UnicodeDecodeError:
+        pytest.fail("SBOM file is not valid UTF-8")
+
+
 def test_scan_verbose_mode(tmp_path):
     """Test scanning in verbose mode."""
     test_file = tmp_path / "test_file.dat"


### PR DESCRIPTION
## Summary
- ensure CLI writes SBOM and result files with UTF-8 encoding
- test CLI output and SBOM files are UTF-8 even when locale is ASCII

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check --fix modelaudit/ tests/`
- `ruff check --fix --select I modelaudit/ tests/`
- `mypy modelaudit/ tests/`
- `pytest -n 2 -m 'not slow and not integration and not performance' --cov=modelaudit --tb=short`

------
https://chatgpt.com/codex/tasks/task_e_687d12817f948332b13ffe9a60e5a3c4