### PR TITLE
fix: optimize file reader

### DIFF
--- a/modelaudit/scanners/base.py
+++ b/modelaudit/scanners/base.py
@@ -330,7 +330,7 @@ class BaseScanner(ABC):
 
     def _read_file_safely(self, path: str) -> bytes:
         """Read a file with size validation and chunking."""
-        data = b""
+        data = bytearray()
         file_size = self.get_file_size(path)
 
         if self.max_file_read_size and self.max_file_read_size > 0 and file_size > self.max_file_read_size:
@@ -346,12 +346,12 @@ class BaseScanner(ABC):
                 chunk = f.read(self.chunk_size)
                 if not chunk:
                     break
-                data += chunk
+                data.extend(chunk)
                 if self.max_file_read_size and self.max_file_read_size > 0 and len(data) > self.max_file_read_size:
                     raise ValueError(
                         f"File read exceeds limit: {len(data)} bytes (max: {self.max_file_read_size})",
                     )
-        return data
+        return bytes(data)
 
     def check_interrupted(self) -> None:
         """Check if the scan has been interrupted.

--- a/tests/test_base_scanner.py
+++ b/tests/test_base_scanner.py
@@ -282,3 +282,17 @@ def test_base_scanner_small_file_handling(tmp_path):
 
     # Should return None (path is valid) - small files can't be validated
     assert result is None
+
+
+def test_base_scanner_read_file_safely(tmp_path):
+    """_read_file_safely should return bytes with chunking."""
+    scanner = MockScanner(config={"chunk_size": 4})
+
+    file_path = tmp_path / "data.test"
+    content = b"0123456789"
+    file_path.write_bytes(content)
+
+    data = scanner._read_file_safely(str(file_path))
+
+    assert isinstance(data, bytes)
+    assert data == content


### PR DESCRIPTION
## Summary
- use `bytearray` in `_read_file_safely`
- add unit test for reading in chunks

## Testing
- `mypy modelaudit/scanners/base.py tests/test_base_scanner.py`
- `pytest tests/test_base_scanner.py::test_base_scanner_read_file_safely -q`

------
https://chatgpt.com/codex/tasks/task_e_687d128d8ec083329e590694be84b626