### PR TITLE
docs: clarify scanner registry usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,16 +129,25 @@ class MyScanner(BaseScanner):
 
 ### Scanner Registration
 
-Add new scanners to `SCANNER_REGISTRY` in `modelaudit/scanners/__init__.py`:
+Scanners are registered lazily via `ScannerRegistry` in
+`modelaudit/scanners/__init__.py`. `SCANNER_REGISTRY` exposes a lazy list of
+available scanner classes. To register a new scanner, add its metadata to the
+`_scanners` dictionary inside `ScannerRegistry._init_registry`:
 
 ```python
-SCANNER_REGISTRY = [
-    PickleScanner,
-    PyTorchZipScanner,
-    # ... existing scanners
-    MyScanner,  # Add here
-]
+self._scanners["my_scanner"] = {
+    "module": "modelaudit.scanners.my_scanner",
+    "class": "MyScanner",
+    "description": "Scans My format",
+    "extensions": [".my"],
+    "priority": 10,
+    "dependencies": [],
+    "numpy_sensitive": False,
+}
 ```
+
+After adding the entry, the scanner will appear in `SCANNER_REGISTRY` when it is
+first accessed.
 
 ### Issue Reporting
 


### PR DESCRIPTION
## Summary
- document the lazy-loading `ScannerRegistry`
- show how to add metadata to `_scanners`

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check --fix modelaudit/ tests/`
- `ruff check --fix --select I modelaudit/ tests/`
- `mypy modelaudit/ tests/`
- `pytest tests/test_scanner_registry.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d1291345483328012be5c51dca8bb