### PR TITLE
fix: cast sbom output string

### DIFF
--- a/modelaudit/sbom.py
+++ b/modelaudit/sbom.py
@@ -1,7 +1,7 @@
 import hashlib
 import os
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, cast
 
 from cyclonedx.model import HashType, Property
 from cyclonedx.model.bom import Bom
@@ -137,4 +137,7 @@ def generate_sbom(paths: Iterable[str], results: dict[str, Any]) -> str:
             bom.components.add(component)
 
     outputter = make_outputter(bom, OutputFormat.JSON, SchemaVersion.V1_5)
-    return outputter.output_as_string(indent=2)
+    return cast(  # type: ignore[redundant-cast]
+        str,
+        outputter.output_as_string(indent=2),
+    )


### PR DESCRIPTION
## Summary
- use cast when generating sbom string output

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check --fix modelaudit/ tests/`
- `ruff check --fix --select I modelaudit/ tests/`
- `mypy modelaudit/ tests/`
- `pytest -n auto -m "not slow and not integration and not performance" --cov=modelaudit --tb=short` *(fails: TestWeightDistributionScanner::test_llm_vocabulary_layer_handling, TestWeightDistributionScanner::test_llm_checks_disabled_by_default)*

------
https://chatgpt.com/codex/tasks/task_e_687d1275be848332beb6f50b09f10e23