### PR TITLE
docs: clarify difference between static scanning and redteaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ modelaudit model_package.zip --sbom compliance_report.json --verbose
 
 [View advanced usage examples →](https://www.promptfoo.dev/docs/model-audit/usage/)
 
+### Static Scanning vs. Promptfoo Redteaming
+
+ModelAudit performs **static** analysis only. It examines model files for risky patterns
+without ever loading or executing them. Promptfoo's redteaming module is
+**dynamic**—it loads the model (locally or via API) and sends crafted prompts to
+probe runtime behavior. Use ModelAudit first to verify the model file itself,
+then run redteaming if you need to test how the model responds when invoked.
+
 ## ⚙️ Installation Options
 
 **Basic installation (recommended for most users):**


### PR DESCRIPTION
## Summary
- document how ModelAudit static scanning differs from promptfoo redteaming

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check --fix modelaudit/ tests/`
- `ruff check --fix --select I modelaudit/ tests/`
- `mypy modelaudit/ tests/`
- `pytest -m "not slow and not integration and not performance" --cov=modelaudit --tb=short`


------
https://chatgpt.com/codex/tasks/task_e_687d1e1c34d08332be6effe9faf9cccd