### PR TITLE
feat: add PyTorch Hub model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ NO_COLOR=1 modelaudit models/
 ### **Third-Party Model Validation**
 
 ```bash
-# Scan models from HuggingFace or cloud storage
+# Scan models from HuggingFace, PyTorch Hub, or cloud storage
 modelaudit https://huggingface.co/gpt2
+modelaudit https://pytorch.org/hub/pytorch_vision_resnet/
 modelaudit s3://my-bucket/downloaded-model.pt
 ```
 

--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -18,6 +18,7 @@ from .utils import resolve_dvc_file
 from .utils.cloud_storage import download_from_cloud, is_cloud_url
 from .utils.huggingface import download_model, is_huggingface_url
 from .utils.jfrog import download_artifact, is_jfrog_url
+from .utils.pytorch_hub import download_pytorch_hub_model, is_pytorch_hub_url
 
 # Configure logging
 logging.basicConfig(
@@ -87,6 +88,7 @@ class DefaultCommandGroup(click.Group):
             formatter.write_text("modelaudit model.pkl")
             formatter.write_text("modelaudit /path/to/models/")
             formatter.write_text("modelaudit https://huggingface.co/user/model")
+            formatter.write_text("modelaudit https://pytorch.org/hub/pytorch_vision_resnet/")
 
         formatter.write_paragraph()
         formatter.write_text("Other commands:")
@@ -228,6 +230,7 @@ def scan_command(
     Usage:
         modelaudit scan /path/to/model1 /path/to/model2 ...
         modelaudit scan https://huggingface.co/user/model
+        modelaudit scan https://pytorch.org/hub/pytorch_vision_resnet/
         modelaudit scan hf://user/model
         modelaudit scan s3://my-bucket/models/
         modelaudit scan gs://my-bucket/model.pt
@@ -357,6 +360,55 @@ def scan_command(
                                 style_text(
                                     "💡 Tip: Free up disk space or use --cache-dir to specify a "
                                     "directory with more space",
+                                    fg="cyan",
+                                ),
+                                err=True,
+                            )
+                        else:
+                            logger.error(f"Failed to download model from {path}: {error_msg}", exc_info=verbose)
+                            click.echo(f"Error downloading model from {path}: {error_msg}", err=True)
+
+                        aggregated_results["has_errors"] = True
+                        continue
+
+                # Check if this is a PyTorch Hub URL
+                elif is_pytorch_hub_url(path):
+                    download_spinner = None
+                    if format == "text" and not output and should_show_spinner():
+                        download_spinner = yaspin(Spinners.dots, text=f"Downloading from {style_text(path, fg='cyan')}")
+                        download_spinner.start()
+                    elif format == "text" and not output:
+                        click.echo(f"Downloading from {path}...")
+
+                    try:
+                        download_path = download_pytorch_hub_model(
+                            path,
+                            cache_dir=Path(cache_dir) if cache_dir else None,
+                        )
+                        actual_path = str(download_path)
+                        temp_dir = str(download_path)
+
+                        if download_spinner:
+                            download_spinner.ok(style_text("✅ Downloaded", fg="green", bold=True))
+                        elif format == "text" and not output:
+                            click.echo("Downloaded successfully")
+
+                    except Exception as e:
+                        if download_spinner:
+                            download_spinner.fail(style_text("❌ Download failed", fg="red", bold=True))
+                        elif format == "text" and not output:
+                            click.echo("Download failed")
+
+                        error_msg = str(e)
+                        if "insufficient disk space" in error_msg.lower():
+                            logger.error(f"Disk space error for {path}: {error_msg}")
+                            click.echo(style_text(f"\n⚠️  {error_msg}", fg="yellow"), err=True)
+                            click.echo(
+                                style_text(
+                                    (
+                                        "💡 Tip: Free up disk space or use --cache-dir "
+                                        "to specify a directory with more space"
+                                    ),
                                     fg="cyan",
                                 ),
                                 err=True,

--- a/modelaudit/utils/pytorch_hub.py
+++ b/modelaudit/utils/pytorch_hub.py
@@ -1,0 +1,78 @@
+import re
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+from .disk_space import check_disk_space
+
+_PYTORCH_HUB_PATTERN = r"^https?://pytorch\.org/hub/[\w\-_.]+/?$"
+
+
+def is_pytorch_hub_url(url: str) -> bool:
+    """Return True if the URL points to a PyTorch Hub model page."""
+    return bool(re.match(_PYTORCH_HUB_PATTERN, url))
+
+
+def _extract_weight_urls(html: str) -> list[str]:
+    """Extract weight file URLs from a PyTorch Hub page."""
+    pattern = r"https://download\.pytorch\.org/models/[\w\-_.]+\.(?:pth|pt|pth\.tar\.gz|pth\.zip)"
+    return re.findall(pattern, html)
+
+
+def _get_total_size(urls: list[str]) -> int:
+    total = 0
+    for u in urls:
+        try:
+            resp = requests.head(u, timeout=10)
+            if resp.ok and "content-length" in resp.headers:
+                total += int(resp.headers["content-length"])
+        except Exception:
+            continue
+    return total
+
+
+def download_pytorch_hub_model(url: str, cache_dir: Optional[Path] = None) -> Path:
+    """Download model weights referenced from a PyTorch Hub page."""
+    if not is_pytorch_hub_url(url):
+        raise ValueError(f"Not a PyTorch Hub URL: {url}")
+
+    try:
+        page = requests.get(url, timeout=10)
+        page.raise_for_status()
+    except Exception as e:  # pragma: no cover - network errors
+        raise Exception(f"Failed to fetch PyTorch Hub page {url}: {e!s}") from e
+
+    weight_urls = _extract_weight_urls(page.text)
+    if not weight_urls:
+        raise Exception(f"No model files found at {url}")
+
+    dest_dir = cache_dir or Path(tempfile.mkdtemp(prefix="modelaudit_pth_"))
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    total_size = _get_total_size(weight_urls)
+    if total_size > 0:
+        has_space, message = check_disk_space(dest_dir, total_size)
+        if not has_space:
+            if cache_dir is None:
+                shutil.rmtree(dest_dir, ignore_errors=True)
+            raise Exception(f"Cannot download model from {url}: {message}")
+
+    for weight_url in weight_urls:
+        filename = weight_url.split("/")[-1]
+        dest_file = dest_dir / filename
+        try:
+            with requests.get(weight_url, stream=True, timeout=30) as resp:
+                resp.raise_for_status()
+                with open(dest_file, "wb") as f:
+                    for chunk in resp.iter_content(chunk_size=8192):
+                        if chunk:
+                            f.write(chunk)
+        except Exception as e:
+            if cache_dir is None:
+                shutil.rmtree(dest_dir, ignore_errors=True)
+            raise Exception(f"Failed to download weights from {weight_url}: {e!s}") from e
+
+    return dest_dir

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -374,6 +374,7 @@ def test_scan_huggingface_url_help():
     result = runner.invoke(cli, ["scan", "--help"])
     assert result.exit_code == 0
     assert "https://huggingface.co/user/model" in result.output
+    assert "https://pytorch.org/hub/pytorch_vision_resnet/" in result.output
     assert "hf://user/model" in result.output
     assert "s3://my-bucket/models/" in result.output
     assert "models:/MyModel/1" in result.output
@@ -521,6 +522,48 @@ def test_scan_mixed_paths_and_urls(mock_scan):
 
         # Should report error for missing local file
         assert "Path does not exist: /local/path/model.pkl" in result.output
+
+
+@patch("modelaudit.cli.is_pytorch_hub_url")
+@patch("modelaudit.cli.download_pytorch_hub_model")
+@patch("modelaudit.cli.scan_model_directory_or_file")
+@patch("shutil.rmtree")
+def test_scan_pytorchhub_url_success(mock_rmtree, mock_scan, mock_download, mock_is_ph_url, tmp_path):
+    """Test scanning a PyTorch Hub URL successfully."""
+    mock_is_ph_url.return_value = True
+    test_dir = tmp_path / "hub"
+    test_dir.mkdir()
+    (test_dir / "model.pt").write_text("dummy")
+    mock_download.return_value = test_dir
+    mock_scan.return_value = {
+        "bytes_scanned": 1,
+        "issues": [],
+        "files_scanned": 1,
+        "assets": [],
+        "has_errors": False,
+        "scanners": ["test"],
+    }
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["scan", "https://pytorch.org/hub/pytorch_vision_resnet/"])
+
+    assert result.exit_code == 0
+    mock_download.assert_called_once()
+    mock_scan.assert_called_once()
+    mock_rmtree.assert_called()
+
+
+@patch("modelaudit.cli.is_pytorch_hub_url")
+@patch("modelaudit.cli.download_pytorch_hub_model")
+def test_scan_pytorchhub_url_download_failure(mock_download, mock_is_ph_url):
+    """Test download failure for PyTorch Hub URL."""
+    mock_is_ph_url.return_value = True
+    mock_download.side_effect = Exception("boom")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["scan", "https://pytorch.org/hub/pytorch_vision_resnet/"])
+
+    assert result.exit_code == 2
+    assert "Error downloading model" in result.output
 
 
 @patch("modelaudit.cli.is_cloud_url")

--- a/tests/test_pytorch_hub.py
+++ b/tests/test_pytorch_hub.py
@@ -1,0 +1,59 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modelaudit.utils.pytorch_hub import (
+    download_pytorch_hub_model,
+    is_pytorch_hub_url,
+)
+
+
+class TestPytorchHubURLDetection:
+    def test_valid_urls(self):
+        valid = [
+            "https://pytorch.org/hub/pytorch_vision_resnet/",
+            "https://pytorch.org/hub/ultralytics_yolov5/",
+        ]
+        for url in valid:
+            assert is_pytorch_hub_url(url)
+
+    def test_invalid_urls(self):
+        invalid = [
+            "https://example.com/model",
+            "pytorch.org/hub/model",  # missing scheme
+            "",
+        ]
+        for url in invalid:
+            assert not is_pytorch_hub_url(url)
+
+
+@patch("modelaudit.utils.pytorch_hub.check_disk_space")
+@patch("modelaudit.utils.pytorch_hub.requests.head")
+@patch("modelaudit.utils.pytorch_hub.requests.get")
+def test_download_pytorch_hub_model_success(mock_get, mock_head, mock_check, tmp_path):
+    html_resp = MagicMock()
+    html_resp.text = '<a href="https://download.pytorch.org/models/resnet50.pth">link</a>'
+    html_resp.raise_for_status = lambda: None
+    file_resp = MagicMock()
+    file_resp.__enter__.return_value = file_resp
+    file_resp.iter_content.return_value = [b"abc"]
+    file_resp.raise_for_status = lambda: None
+    mock_get.side_effect = [html_resp, file_resp]
+
+    head_resp = MagicMock()
+    head_resp.ok = True
+    head_resp.headers = {"content-length": "3"}
+    mock_head.return_value = head_resp
+    mock_check.return_value = (True, "ok")
+
+    result = download_pytorch_hub_model(
+        "https://pytorch.org/hub/pytorch_vision_resnet/",
+        cache_dir=tmp_path,
+    )
+    assert (tmp_path / "resnet50.pth").exists()
+    assert result == tmp_path
+
+
+def test_download_pytorch_hub_model_invalid_url():
+    with pytest.raises(ValueError):
+        download_pytorch_hub_model("https://example.com/model")


### PR DESCRIPTION
## Summary
- support scanning models from PyTorch Hub URLs
- show PyTorch Hub examples in CLI and README
- handle PyTorch Hub downloads in the CLI
- test PyTorch Hub utilities and CLI flow

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check --fix modelaudit/ tests/`
- `ruff check --fix --select I modelaudit/ tests/`
- `mypy modelaudit/ tests/`
- `pytest -n 1 -m "not slow and not integration and not performance" --cov=modelaudit --tb=short`

------
https://chatgpt.com/codex/tasks/task_e_687d3dc78430833285427f4f21ace516