### PR TITLE
fix: correct Docker build order to handle editable install

### DIFF
--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -2,12 +2,12 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# Copy requirements lock file and install all dependencies
-COPY requirements.lock ./
-RUN pip install --no-cache-dir -r requirements.lock
-
-# Copy source code
+# Copy source code first
 COPY . .
+
+# Install all dependencies from requirements.lock
+# The lock file includes the current project as editable, so we need the source first
+RUN pip install --no-cache-dir -r requirements.lock
 
 # Install the application with all extras using pip
 RUN pip install --no-cache-dir .[all]

--- a/Dockerfile.tensorflow
+++ b/Dockerfile.tensorflow
@@ -2,12 +2,12 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# Copy requirements lock file and install dependencies
-COPY requirements.lock ./
-RUN pip install --no-cache-dir -r requirements.lock
-
-# Copy source code
+# Copy source code first
 COPY . .
+
+# Install dependencies from requirements.lock
+# The lock file includes the current project as editable, so we need the source first
+RUN pip install --no-cache-dir -r requirements.lock
 
 # Install the application with TensorFlow extras using pip
 RUN pip install --no-cache-dir .[tensorflow]


### PR DESCRIPTION
## Summary
Fixes Docker build failures in CI by correcting the build order in `Dockerfile.full` and `Dockerfile.tensorflow`.

## Problem
The `requirements.lock` file contains `-e file:.` (editable install of the current project), which requires the source code to be present when pip installs dependencies. The Dockerfiles were copying only `requirements.lock` first, causing pip to fail with:
```
ERROR: file:///. (from -r requirements.lock (line 12)) does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.
```

## Solution
Changed the build order to copy source code before running `pip install -r requirements.lock`, matching the pattern already used in the base `Dockerfile`.

## Test Instructions
```bash
docker build -f Dockerfile.full -t modelaudit:full .
docker build -f Dockerfile.tensorflow -t modelaudit:tensorflow .
```

🤖 Generated with [Claude Code](https://claude.ai/code)