### PR TITLE
fix: refine dangerous pattern detection check

### DIFF
--- a/modelaudit/analysis/anomaly_detector.py
+++ b/modelaudit/analysis/anomaly_detector.py
@@ -312,7 +312,7 @@ class AnomalyDetector:
         # Look for ASCII-like patterns in float data
         if data.dtype == np.float32:
             # Check if values cluster around ASCII ranges when interpreted as bytes
-            byte_interpretation = (data * 255).astype(np.int32)
+            byte_interpretation: np.ndarray = (data * 255).astype(np.int32)
             ascii_printable = np.logical_and(byte_interpretation >= 32, byte_interpretation <= 126)
             ascii_ratio = np.mean(ascii_printable)
 

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -24,7 +24,7 @@ from ..explanations import (
     get_pattern_explanation,
 )
 from ..suspicious_symbols import DANGEROUS_OPCODES
-from .base import BaseScanner, IssueSeverity, ScanResult, logger
+from .base import BaseScanner, CheckStatus, IssueSeverity, ScanResult, logger
 
 # ============================================================================
 # SMART DETECTION SYSTEM - ML Context Awareness
@@ -870,9 +870,8 @@ class PickleScanner(BaseScanner):
 
                 # If we scanned for dangerous patterns but found none, record a successful check
                 dangerous_found = any(
-                    issue.severity == IssueSeverity.CRITICAL
-                    for issue in result.issues
-                    if "Dangerous Pattern Detection" in issue.details.get("check_name", "")
+                    check.name == "Dangerous Pattern Detection" and check.status == CheckStatus.FAILED
+                    for check in result.checks
                 )
                 if not dangerous_found:
                     result.add_check(
@@ -882,7 +881,14 @@ class PickleScanner(BaseScanner):
                         location=path,
                         details={
                             "detection_method": "raw_content_scan",
-                            "patterns_checked": ["posix", "subprocess", "eval", "exec", "__import__", "builtins"],
+                            "patterns_checked": [
+                                "posix",
+                                "subprocess",
+                                "eval",
+                                "exec",
+                                "__import__",
+                                "builtins",
+                            ],
                         },
                     )
 


### PR DESCRIPTION
## Summary
- improve detection of previous dangerous pattern checks
- annotate byte_interpretation variable for mypy

## Testing
- `npm install`
- `npm test` *(fails: Missing script: "test")*
- `ruff format modelaudit/analysis/anomaly_detector.py modelaudit/scanners/pickle_scanner.py tests/`
- `ruff check --fix modelaudit/analysis/anomaly_detector.py modelaudit/scanners/pickle_scanner.py tests/`
- `ruff check --fix --select I modelaudit/analysis/anomaly_detector.py modelaudit/scanners/pickle_scanner.py tests/`
- `mypy modelaudit/ tests/`
- `pytest -n auto -m "not slow and not integration and not performance" --cov=modelaudit --tb=short` *(fails: plugin raised an exception during teardown)*


------
https://chatgpt.com/codex/tasks/task_e_68a27264e09c83329e109e97a8189d91