### PR TITLE
fix: finalize early scan file exits

### DIFF
--- a/modelaudit/analysis/anomaly_detector.py
+++ b/modelaudit/analysis/anomaly_detector.py
@@ -312,7 +312,7 @@ class AnomalyDetector:
         # Look for ASCII-like patterns in float data
         if data.dtype == np.float32:
             # Check if values cluster around ASCII ranges when interpreted as bytes
-            byte_interpretation = (data * 255).astype(np.int32)
+            byte_interpretation: np.ndarray = (data * 255).astype(np.int32)
             ascii_printable = np.logical_and(byte_interpretation >= 32, byte_interpretation <= 126)
             ascii_ratio = np.mean(ascii_printable)
 

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -711,6 +711,7 @@ def scan_file(path: str, config: Optional[dict[str, Any]] = None) -> ScanResult:
             severity=IssueSeverity.WARNING,
             details={"error": str(e), "path": path},
         )
+        sr.finish(success=False)
         return sr
 
     # Check if we should use extreme handler BEFORE applying size limits
@@ -731,6 +732,7 @@ def scan_file(path: str, config: Optional[dict[str, Any]] = None) -> ScanResult:
                 "hint": "Consider using extreme large model support for files over 50GB",
             },
         )
+        sr.finish(success=False)
         return sr
 
     logger.info(f"Scanning file: {path}")

--- a/tests/test_advanced_size_limits.py
+++ b/tests/test_advanced_size_limits.py
@@ -74,6 +74,17 @@ class TestAdvancedSizeLimits:
                 # Should have a size warning
                 assert any("too large" in issue.message.lower() for issue in result.issues)
                 assert any("hint" in issue.details for issue in result.issues if issue.details)
+                assert not result.success
+                assert result.end_time is not None
+
+    @patch("modelaudit.core.os.path.getsize", side_effect=OSError("stat failed"))
+    def test_stat_error_sets_failure_and_end_time(self, mock_size):
+        """Ensure stat errors mark result as failed and set end time."""
+        with tempfile.NamedTemporaryFile(suffix=".bin") as f:
+            result = scan_file(f.name, {})
+            assert any("Error checking file size" in issue.message for issue in result.issues)
+            assert not result.success
+            assert result.end_time is not None
 
     @patch("modelaudit.utils.advanced_file_handler.os.path.getsize")
     def test_colossal_files_handled(self, mock_size):


### PR DESCRIPTION
## Summary
- finalize ScanResult on file-size and stat-related early exits in scan_file
- test early exit behavior for success and end_time
- annotate anomaly detector variable for type checking

## Testing
- `python -m ruff format modelaudit/ tests/`
- `python -m ruff check --fix modelaudit/ tests/`
- `python -m ruff check --fix --select I modelaudit/ tests/`
- `python -m mypy modelaudit/ tests/`
- `pytest tests/test_advanced_size_limits.py::TestAdvancedSizeLimits::test_normal_files_respect_size_limit tests/test_advanced_size_limits.py::TestAdvancedSizeLimits::test_stat_error_sets_failure_and_end_time -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2724f8ab4833282abc755f8abe717