### PR TITLE
feat: safely parse PyTorch ZIP weights

### DIFF
--- a/modelaudit/analysis/anomaly_detector.py
+++ b/modelaudit/analysis/anomaly_detector.py
@@ -312,7 +312,7 @@ class AnomalyDetector:
         # Look for ASCII-like patterns in float data
         if data.dtype == np.float32:
             # Check if values cluster around ASCII ranges when interpreted as bytes
-            byte_interpretation = (data * 255).astype(np.int32)
+            byte_interpretation: np.ndarray = (data * 255).astype(np.int32)
             ascii_printable = np.logical_and(byte_interpretation >= 32, byte_interpretation <= 126)
             ascii_ratio = np.mean(ascii_printable)
 

--- a/modelaudit/scanners/weight_distribution_scanner.py
+++ b/modelaudit/scanners/weight_distribution_scanner.py
@@ -62,6 +62,8 @@ class WeightDistributionScanner(BaseScanner):
         self.enable_llm_checks = self.config.get("enable_llm_checks", False)
         # Use max_array_size for in-memory array size limits (default 100MB)
         self.max_array_size = self.config.get("max_array_size", 100 * 1024 * 1024)
+        # Flag set when weight extraction would be unsafe
+        self.extraction_unsafe = False
 
     @classmethod
     def can_handle(cls, path: str) -> bool:
@@ -96,6 +98,8 @@ class WeightDistributionScanner(BaseScanner):
         result = self._create_result()
         file_size = self.get_file_size(path)
         result.metadata["file_size"] = file_size
+        # Reset flag before extraction
+        self.extraction_unsafe = False
 
         try:
             # Extract weights based on file format
@@ -127,11 +131,16 @@ class WeightDistributionScanner(BaseScanner):
                     return result
 
             if not weights_info:
+                message = "Failed to extract weights from model"
+                severity = IssueSeverity.DEBUG
+                if self.extraction_unsafe:
+                    message = "Unsafe to extract weights from data.pkl in PyTorch archive"
+                    severity = IssueSeverity.WARNING
                 result.add_check(
                     name="Weight Extraction",
                     passed=False,
-                    message="Failed to extract weights from model",
-                    severity=IssueSeverity.DEBUG,
+                    message=message,
+                    severity=severity,
                     location=path,
                 )
                 result.finish(success=True)
@@ -178,6 +187,9 @@ class WeightDistributionScanner(BaseScanner):
         if not HAS_TORCH:
             return {}
 
+        # Reset safety flag for each extraction
+        self.extraction_unsafe = False
+
         weights_info: dict[str, np.ndarray] = {}
 
         try:
@@ -223,12 +235,60 @@ class WeightDistributionScanner(BaseScanner):
             # Try loading as a zip file (newer PyTorch format)
             try:
                 with zipfile.ZipFile(path, "r") as z:
-                    # Look for data.pkl which contains the weights
-                    if "data.pkl" in z.namelist():
-                        # Cannot extract weights from pickle without execution
-                        pass
-            except Exception as e:
-                logger.debug(f"Failed to extract weights from {path}: {e}")
+                    data_pkl_path = next(
+                        (n for n in z.namelist() if n.endswith("/data.pkl") or n == "data.pkl"),
+                        None,
+                    )
+                    if data_pkl_path:
+                        import io
+                        import pickle
+                        import pickletools
+
+                        data = z.read(data_pkl_path)
+
+                        # Look for disallowed opcodes that could trigger code execution
+                        disallowed = {
+                            "GLOBAL",
+                            "STACK_GLOBAL",
+                            "REDUCE",
+                            "BUILD",
+                            "INST",
+                            "OBJ",
+                            "NEWOBJ",
+                            "NEWOBJ_EX",
+                        }
+                        unsafe = False
+                        for opcode, _arg, _pos in pickletools.genops(data):
+                            if opcode.name in disallowed:
+                                unsafe = True
+                                break
+
+                        if unsafe:
+                            self.extraction_unsafe = True
+                        else:
+                            try:
+
+                                class RestrictedUnpickler(pickle.Unpickler):
+                                    def find_class(self, module: str, name: str) -> Any:
+                                        raise pickle.UnpicklingError("global lookup not allowed")
+
+                                obj = RestrictedUnpickler(io.BytesIO(data)).load()
+                                if isinstance(obj, dict):
+                                    for key, value in obj.items():
+                                        array = np.array(value)
+                                        if len(array.shape) >= 2 and (
+                                            "weight" in key.lower() or "kernel" in key.lower()
+                                        ):
+                                            weights_info[key] = array
+                                else:
+                                    self.extraction_unsafe = True
+                            except Exception as e2:  # pragma: no cover - defensive
+                                logger.debug(
+                                    f"Failed restricted unpickle for {path}: {e2}",
+                                )
+                                self.extraction_unsafe = True
+            except Exception as e2:  # pragma: no cover - defensive
+                logger.debug(f"Failed to extract weights from {path}: {e2}")
 
         return weights_info
 


### PR DESCRIPTION
## Summary
- safely inspect `data.pkl` inside PyTorch zip archives without executing code
- track unsafe extraction and report when weights can't be loaded safely
- add tests for safe and unsafe `data.pkl` scenarios

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check --fix modelaudit/ tests/`
- `ruff check --fix --select I modelaudit/ tests/`
- `mypy modelaudit/ tests/`
- `pytest tests/test_weight_distribution_scanner.py::TestWeightDistributionScanner::test_pytorch_zip_data_pkl_safe_extraction tests/test_weight_distribution_scanner.py::TestWeightDistributionScanner::test_pytorch_zip_data_pkl_unsafe_extraction -q`
- `pytest tests/test_flax_msgpack_scanner.py::test_flax_msgpack_ml_context_confidence -q`

------
https://chatgpt.com/codex/tasks/task_e_68a2722ddf9c8332908ff120c89add13