### PR TITLE
fix: defer CLI logging configuration

### DIFF
--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -21,11 +21,6 @@ from .utils.huggingface import download_model, is_huggingface_url
 from .utils.jfrog import is_jfrog_url
 from .utils.pytorch_hub import download_pytorch_hub_model, is_pytorch_hub_url
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-)
 logger = logging.getLogger("modelaudit")
 
 
@@ -1358,4 +1353,12 @@ def doctor(show_failed: bool):
 
 
 def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
     cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli_logging_handlers.py
+++ b/tests/test_cli_logging_handlers.py
@@ -1,0 +1,20 @@
+import importlib
+import logging
+import sys
+
+
+def test_import_cli_does_not_configure_logging():
+    """Importing modelaudit.cli should not modify root logging handlers."""
+    root_logger = logging.getLogger()
+    original_handlers = list(root_logger.handlers)
+    for handler in list(root_logger.handlers):
+        root_logger.removeHandler(handler)
+
+    try:
+        assert len(root_logger.handlers) == 0
+        sys.modules.pop("modelaudit.cli", None)
+        importlib.import_module("modelaudit.cli")
+        assert len(root_logger.handlers) == 0
+    finally:
+        for handler in original_handlers:
+            root_logger.addHandler(handler)


### PR DESCRIPTION
## Summary
- avoid configuring logging at import time
- ensure CLI import leaves existing logging handlers intact

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check --fix modelaudit/ tests/`
- `ruff check --fix --select I modelaudit/ tests/`
- `mypy modelaudit/ tests/` *(fails: Need type annotation for "byte_interpretation" in modelaudit/analysis/anomaly_detector.py)*
- `pytest -n auto -m "not slow and not integration and not performance" --cov=modelaudit --tb=short` *(fails: worker crashed)*

------
https://chatgpt.com/codex/tasks/task_e_68a272247cdc8332a7ca4a0d305c6127