### PR TITLE
fix: streamline magic byte detection

### DIFF
--- a/modelaudit/utils/filetype.py
+++ b/modelaudit/utils/filetype.py
@@ -40,13 +40,19 @@ def detect_file_format_from_magic(path: str) -> str:
     if not file_path.is_file():
         return "unknown"
 
-    size = file_path.stat().st_size
-    if size < 4:
+    try:
+        size = file_path.stat().st_size
+        if size < 4:
+            return "unknown"
+
+        with file_path.open("rb") as f:
+            header = f.read(16)
+    except OSError:
         return "unknown"
 
-    magic4 = read_magic_bytes(path, 4)
-    magic8 = read_magic_bytes(path, 8)
-    magic16 = read_magic_bytes(path, 16)
+    magic4 = header[:4]
+    magic8 = header[:8]
+    magic16 = header[:16]
 
     # Check for TAR format
     try:


### PR DESCRIPTION
## Summary
- consolidate magic-byte reads into a single file open
- return `unknown` when magic-byte read fails
- test magic-byte detection error handling

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check --fix modelaudit/ tests/`
- `ruff check --fix --select I modelaudit/ tests/`
- `mypy modelaudit/ tests/` *(fails: Need type annotation for `byte_interpretation`)*
- `mypy modelaudit/utils/filetype.py tests/test_filetype.py`
- `pytest tests/test_filetype.py::test_detect_file_format_from_magic_oserror -q`


------
https://chatgpt.com/codex/tasks/task_e_68a272183bb8833282bab36c8459292e