### PR TITLE
fix: handle streaming URL query parameters

### DIFF
--- a/modelaudit/utils/streaming.py
+++ b/modelaudit/utils/streaming.py
@@ -3,6 +3,7 @@
 import io
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 import click
 
@@ -14,8 +15,10 @@ def can_stream_analyze(url: str, scanner: BaseScanner) -> bool:
     """Check if a file can be analyzed via streaming."""
     # Currently support streaming for pickle files
     # Can be extended to other formats that support partial reads
-    path = Path(url)
-    return path.suffix.lower() in {".pkl", ".pickle", ".joblib"}
+    parsed = urlparse(url)
+    path = Path(parsed.path)
+    suffix = path.suffix.lower()
+    return suffix in {".pkl", ".pickle", ".joblib"}
 
 
 def stream_analyze_file(

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,12 @@
+from modelaudit.scanners.pickle_scanner import PickleScanner
+from modelaudit.utils.streaming import can_stream_analyze
+
+
+def test_can_stream_analyze_with_query_params():
+    url = "https://example.com/model.pkl?token=abc"
+    assert can_stream_analyze(url, PickleScanner())
+
+
+def test_can_stream_analyze_rejects_non_pickle_with_query():
+    url = "https://example.com/model.zip?token=abc"
+    assert not can_stream_analyze(url, PickleScanner())


### PR DESCRIPTION
## Summary
- parse URLs with `urllib.parse` in streaming analyzer
- add tests for URLs containing query parameters

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check --fix modelaudit/ tests/`
- `ruff check --fix --select I modelaudit/ tests/`
- `mypy modelaudit/ tests/` *(fails: Library stubs not installed)*
- `pytest -n auto -m "not slow and not integration and not performance" --cov=modelaudit --tb=short` *(terminated: worker crashed)*
- `pytest tests/test_streaming.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a271ffa6d48332b1107d8c4a8b289b