### PR TITLE
fix: validate cloud metadata before download

### DIFF
--- a/modelaudit/utils/cloud_storage.py
+++ b/modelaudit/utils/cloud_storage.py
@@ -363,7 +363,13 @@ def download_from_cloud(
     selective: bool = True,
     stream_analyze: bool = False,
 ) -> Path:
-    """Download a file or directory from cloud storage to a local path."""
+    """Download a file or directory from cloud storage to a local path.
+
+    Raises:
+        ImportError: If the :mod:`fsspec` package is not installed.
+        ValueError: If the cloud target cannot be analyzed or its type is unknown.
+        ValueError: If the object exceeds ``max_size``.
+    """
     try:
         import fsspec
     except ImportError as e:
@@ -384,6 +390,11 @@ def download_from_cloud(
 
     # Analyze target
     metadata = asyncio.run(analyze_cloud_target(url))
+
+    # Ensure target was analyzed successfully
+    if "error" in metadata or metadata.get("type") == "unknown":
+        error_msg = metadata.get("error", "Unknown cloud target type")
+        raise ValueError(f"Failed to analyze cloud target {url}: {error_msg}")
 
     # Check if we can use streaming analysis
     if stream_analyze and metadata.get("type") == "file":


### PR DESCRIPTION
## Summary
- check cloud metadata for errors or unknown type before downloading
- document new error behavior in download_from_cloud
- add test for failure on invalid cloud metadata

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check --fix modelaudit/ tests/`
- `ruff check --fix --select I modelaudit/ tests/`
- `mypy modelaudit/ tests/` *(fails: Library stubs not installed for "requests" and "yaml")*
- `pytest -n auto -m "not slow and not integration and not performance" --cov=modelaudit --tb=short` *(fails: unrecognized arguments: -n --cov=modelaudit)*
- `pytest tests/test_cloud_storage.py::test_download_from_cloud_analysis_failure -q`


------
https://chatgpt.com/codex/tasks/task_e_68a271efa1188332af8fbac5258d80df