### PR TITLE
fix: include license files in metadata scan

### DIFF
--- a/modelaudit/analysis/anomaly_detector.py
+++ b/modelaudit/analysis/anomaly_detector.py
@@ -312,7 +312,7 @@ class AnomalyDetector:
         # Look for ASCII-like patterns in float data
         if data.dtype == np.float32:
             # Check if values cluster around ASCII ranges when interpreted as bytes
-            byte_interpretation = (data * 255).astype(np.int32)
+            byte_interpretation: np.ndarray = (data * 255).astype(np.int32)
             ascii_printable = np.logical_and(byte_interpretation >= 32, byte_interpretation <= 126)
             ascii_ratio = np.mean(ascii_printable)
 

--- a/modelaudit/utils/file_filter.py
+++ b/modelaudit/utils/file_filter.py
@@ -79,7 +79,6 @@ DEFAULT_SKIP_EXTENSIONS = {
 
 # Default filenames to skip
 DEFAULT_SKIP_FILENAMES = {
-    "LICENSE",
     "README",
     "CHANGELOG",
     "AUTHORS",

--- a/tests/test_directory_file_filtering.py
+++ b/tests/test_directory_file_filtering.py
@@ -98,6 +98,22 @@ class TestDirectoryFileFiltering:
             results_skip = scan_model_directory_or_file(tmp_dir, skip_file_types=True)
             assert results_skip["files_scanned"] == 1  # only model.bin
 
+    def test_license_files_metadata_collected(self):
+        """Ensure license files are processed for metadata even when skipped."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            license_plain = Path(tmp_dir) / "LICENSE"
+            license_txt = Path(tmp_dir) / "LICENSE.txt"
+            license_plain.write_text("MIT License")
+            license_txt.write_text("MIT License")
+
+            results = scan_model_directory_or_file(tmp_dir)
+
+            file_meta = results.get("file_metadata", {})
+            assert str(license_plain) in file_meta
+            assert file_meta[str(license_plain)]["license_info"]
+            assert str(license_txt) in file_meta
+            assert file_meta[str(license_txt)]["license_info"]
+
     def test_performance_with_many_files(self):
         """Test that file filtering improves performance with many non-model files."""
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_file_filter.py
+++ b/tests/test_file_filter.py
@@ -62,7 +62,7 @@ class TestFileFilter:
 
     def test_skip_specific_filenames(self):
         """Test that specific filenames are skipped."""
-        skip_names = ["LICENSE", "README", "Makefile", "requirements.txt", "package.json"]
+        skip_names = ["README", "Makefile", "requirements.txt", "package.json"]
 
         for name in skip_names:
             assert should_skip_file(name), f"Should skip {name}"
@@ -83,7 +83,7 @@ class TestFileFilter:
     def test_custom_skip_filenames(self):
         """Test custom skip filenames."""
         # Default behavior
-        assert should_skip_file("LICENSE")
+        assert not should_skip_file("LICENSE")
         assert not should_skip_file("CUSTOM_FILE")
 
         # With custom skip filenames


### PR DESCRIPTION
## Summary
- ensure license files aren't skipped and metadata is collected
- add tests verifying license metadata capture and adjust file filter expectations

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check --fix modelaudit/ tests/`
- `ruff check --fix --select I modelaudit/ tests/`
- `mypy modelaudit/ tests/`
- `pytest -m "not slow and not integration and not performance" --cov=modelaudit --tb=short`


------
https://chatgpt.com/codex/tasks/task_e_68a2721556048332bf43436a227e5956