### PR TITLE
feat: raise large model thresholds to 10GB

### DIFF
--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -212,7 +212,7 @@ def cli() -> None:
 @click.option(
     "--large-model-support/--no-large-model-support",
     default=True,
-    help="Enable optimized scanning for large models (>10MB) [default: enabled]",
+    help="Enable optimized scanning for large models (≈10GB+) [default: enabled]",
 )
 def scan_command(
     paths: tuple[str, ...],

--- a/modelaudit/scanners/base.py
+++ b/modelaudit/scanners/base.py
@@ -302,8 +302,8 @@ class BaseScanner(ABC):
         self.current_file_path = ""  # Track the current file being scanned
         self.chunk_size = self.config.get(
             "chunk_size",
-            10 * 1024 * 1024,
-        )  # Default: 10MB chunks
+            10 * 1024 * 1024 * 1024,
+        )  # Default: 10GB chunks
         self.max_file_read_size = self.config.get(
             "max_file_read_size",
             0,

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -157,8 +157,8 @@ class PyTorchZipScanner(BaseScanner):
                     # Set the current file path on the pickle scanner for proper error reporting
                     self.pickle_scanner.current_file_path = f"{path}:{name}"
 
-                    # For small pickle files (< 10MB), read normally
-                    if file_size < 10 * 1024 * 1024:
+                    # For small pickle files (< 10GB), read normally
+                    if file_size < 10 * 1024 * 1024 * 1024:
                         data = z.read(name)
                         bytes_scanned += len(data)
 
@@ -206,8 +206,8 @@ class PyTorchZipScanner(BaseScanner):
 
                     try:
                         info = z.getinfo(name)
-                        # Only check first 10MB of each file for JIT patterns
-                        check_size = min(info.file_size, 10 * 1024 * 1024)
+                        # Only check first 10GB of each file for JIT patterns
+                        check_size = min(info.file_size, 10 * 1024 * 1024 * 1024)
 
                         with z.open(name, "r") as zf:
                             chunk = zf.read(check_size)

--- a/modelaudit/scanners/tar_scanner.py
+++ b/modelaudit/scanners/tar_scanner.py
@@ -206,7 +206,7 @@ class TarScanner(BaseScanner):
                 if member.isdir():
                     continue
 
-                max_entry_size = self.config.get("max_entry_size", 10485760)
+                max_entry_size = self.config.get("max_entry_size", 10 * 1024 * 1024 * 1024)  # 10GB default
                 data = b""
                 fileobj = tar.extractfile(member)
                 if fileobj is None:

--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -270,8 +270,8 @@ class ZipScanner(BaseScanner):
                 try:
                     max_entry_size = self.config.get(
                         "max_entry_size",
-                        10485760,
-                    )  # 10 MB default
+                        10 * 1024 * 1024 * 1024,
+                    )  # 10 GB default
 
                     if name.lower().endswith(".zip"):
                         suffix = ".zip"

--- a/modelaudit/secrets_detector.py
+++ b/modelaudit/secrets_detector.py
@@ -448,7 +448,7 @@ class SecretsDetector:
         findings = []
 
         # Limit text size to prevent DoS
-        max_text_size = 10 * 1024 * 1024  # 10MB
+        max_text_size = 10 * 1024 * 1024 * 1024  # 10GB
         if len(text) > max_text_size:
             text = text[:max_text_size]
 

--- a/modelaudit/utils/advanced_file_handler.py
+++ b/modelaudit/utils/advanced_file_handler.py
@@ -424,9 +424,9 @@ class AdvancedFileHandler:
             # Also run the scanner's normal checks on sampled sections
             # to ensure we don't miss scanner-specific validations
             try:
-                # Let the scanner analyze the header (first 10MB)
+                # Let the scanner analyze the header (first 10GB)
                 with open(self.file_path, "rb") as f:
-                    header_data = f.read(min(10 * 1024 * 1024, self.total_size))
+                    header_data = f.read(min(10 * 1024 * 1024 * 1024, self.total_size))
 
                     # If scanner has special header analysis, use it
                     if hasattr(self.scanner, "_analyze_header"):

--- a/modelaudit/utils/cloud_storage.py
+++ b/modelaudit/utils/cloud_storage.py
@@ -495,7 +495,7 @@ def download_from_cloud(
         def download_single_file():
             fs.get(url, str(local_file))
 
-        if show_progress and size > 10_000_000:  # Show progress for files > 10MB
+        if show_progress and size > 10 * 1024 * 1024 * 1024:  # Show progress for files > 10GB
             with yaspin(text=f"Downloading {file_name}") as spinner:
                 download_single_file()
                 spinner.ok("✓")

--- a/modelaudit/utils/large_file_handler.py
+++ b/modelaudit/utils/large_file_handler.py
@@ -16,14 +16,14 @@ from ..scanners.base import IssueSeverity, ScanResult
 logger = logging.getLogger(__name__)
 
 # Size thresholds for different scanning strategies
-SMALL_FILE_THRESHOLD = 10 * 1024 * 1024  # 10MB - scan normally
-MEDIUM_FILE_THRESHOLD = 100 * 1024 * 1024  # 100MB - use chunking
-LARGE_FILE_THRESHOLD = 1024 * 1024 * 1024  # 1GB - use streaming
-VERY_LARGE_FILE_THRESHOLD = 8 * 1024 * 1024 * 1024  # 8GB - special handling
+SMALL_FILE_THRESHOLD = 10 * 1024 * 1024 * 1024  # 10GB - scan normally
+MEDIUM_FILE_THRESHOLD = 100 * 1024 * 1024 * 1024  # 100GB - use chunking
+LARGE_FILE_THRESHOLD = 1024 * 1024 * 1024 * 1024  # 1TB - use streaming
+VERY_LARGE_FILE_THRESHOLD = 8 * 1024 * 1024 * 1024 * 1024  # 8TB - special handling
 
 # Default chunk sizes for different file sizes
-DEFAULT_CHUNK_SIZE = 10 * 1024 * 1024  # 10MB chunks
-LARGE_CHUNK_SIZE = 50 * 1024 * 1024  # 50MB chunks for large files
+DEFAULT_CHUNK_SIZE = 10 * 1024 * 1024 * 1024  # 10GB chunks
+LARGE_CHUNK_SIZE = 50 * 1024 * 1024 * 1024  # 50GB chunks for large files
 STREAM_BUFFER_SIZE = 1024 * 1024  # 1MB buffer for streaming
 
 
@@ -198,7 +198,8 @@ def should_use_large_file_handler(file_path: str) -> bool:
         file_path: Path to the file
 
     Returns:
-        True if the file should use large file handler
+        True if the file exceeds approximately 10GB
+        and should use the large file handler
     """
     try:
         file_size = os.path.getsize(file_path)

--- a/modelaudit/utils/streaming.py
+++ b/modelaudit/utils/streaming.py
@@ -24,7 +24,7 @@ def can_stream_analyze(url: str, scanner: BaseScanner) -> bool:
 def stream_analyze_file(
     url: str,
     scanner: BaseScanner,
-    max_bytes: int = 10 * 1024 * 1024,  # 10MB default
+    max_bytes: int = 10 * 1024 * 1024 * 1024,  # 10GB default
 ) -> tuple[Optional[ScanResult], bool]:
     """
     Stream analyze a file from cloud storage.


### PR DESCRIPTION
## Summary
- bump large-model support threshold to ~10GB and scale chunk sizes
- update related handlers and scanners to new 10GB defaults
- adjust CLI help text for large model support

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check --fix modelaudit/ tests/`
- `ruff check --fix --select I modelaudit/ tests/`
- `mypy modelaudit/ tests/` *(fails: Library stubs not installed for "requests", "yaml" and others)*
- `pytest -m "not slow and not integration and not performance" --tb=short` *(fails: tests/test_tensorrt_scanner.py::test_tensorrt_scanner_safe_file)*

------
https://chatgpt.com/codex/tasks/task_e_68a28f058b88833280caf52baee7c75b