### PR TITLE
fix: optimize directory detection

### DIFF
--- a/modelaudit/utils/filetype.py
+++ b/modelaudit/utils/filetype.py
@@ -127,8 +127,7 @@ def detect_file_format(path: str) -> str:
     if file_path.is_dir():
         # We'll let the caller handle directory logic.
         # But we do a quick guess if there's a 'saved_model.pb'.
-        contents = list(file_path.iterdir())
-        if any(f.name == "saved_model.pb" for f in contents):
+        if any(f.name == "saved_model.pb" for f in file_path.iterdir()):
             return "tensorflow_directory"
         return "directory"
 

--- a/tests/test_filetype.py
+++ b/tests/test_filetype.py
@@ -27,6 +27,18 @@ def test_detect_file_format_directory(tmp_path):
     assert detect_file_format(str(tf_dir)) == "tensorflow_directory"
 
 
+def test_detect_file_format_large_directory(tmp_path):
+    """Ensure detection short-circuits in directories with many files."""
+    tf_dir = tmp_path / "tf_large"
+    tf_dir.mkdir()
+    (tf_dir / "saved_model.pb").write_bytes(b"dummy content")
+
+    for i in range(1000):
+        (tf_dir / f"file_{i}.txt").write_text("x")
+
+    assert detect_file_format(str(tf_dir)) == "tensorflow_directory"
+
+
 def test_detect_file_format_zip(tmp_path):
     """Test detecting a ZIP file format."""
     # Create a ZIP file


### PR DESCRIPTION
## Summary
- streamline directory format detection with generator instead of intermediate list
- validate new behavior with test covering directories containing many files

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check --fix modelaudit/ tests/`
- `ruff check --fix --select I modelaudit/ tests/`
- `mypy modelaudit/ tests/` *(fails: missing library stubs for requests, yaml, numpy; returning Any from function declared to return bool)*
- `pytest -n auto -m "not slow and not integration and not performance" --cov=modelaudit --tb=short` *(fails: numerous ModuleNotFoundError for numpy, requests, huggingface_hub, h5py; several assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a7b344bc833299cde566d44a0855