### PR TITLE
fix: implement ML-context-aware stack depth limits to eliminate false positives

### DIFF
--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -1421,7 +1421,8 @@ class PickleScanner(BaseScanner):
             if stack_depth_warnings:
                 # Filter warnings based on adjusted limit
                 significant_warnings = [
-                    w for w in stack_depth_warnings
+                    w
+                    for w in stack_depth_warnings
                     if isinstance(w["current_depth"], int) and w["current_depth"] > adjusted_stack_depth_limit
                 ]
 
@@ -1429,6 +1430,7 @@ class PickleScanner(BaseScanner):
                     # Report only the most severe warning to avoid spam
                     def get_depth(x):
                         return x["current_depth"] if isinstance(x["current_depth"], int) else 0
+
                     worst_warning = max(significant_warnings, key=get_depth)
                     severity = _get_context_aware_severity(IssueSeverity.WARNING, ml_context)
 
@@ -1455,16 +1457,12 @@ class PickleScanner(BaseScanner):
                 else:
                     # Warnings were filtered out as benign for ML content
                     max_filtered_depth = max(
-                        w["current_depth"] for w in stack_depth_warnings
-                        if isinstance(w["current_depth"], int)
+                        w["current_depth"] for w in stack_depth_warnings if isinstance(w["current_depth"], int)
                     )
                     result.add_check(
                         name="Stack Depth Safety Check",
                         passed=True,
-                        message=(
-                            f"Stack depth warnings filtered as benign for ML content "
-                            f"(max: {max_filtered_depth})"
-                        ),
+                        message=(f"Stack depth warnings filtered as benign for ML content (max: {max_filtered_depth})"),
                         location=self.current_file_path,
                         details={
                             "max_depth_reached": max_stack_depth,


### PR DESCRIPTION
## Summary

- Fixes false positive stack depth warnings on legitimate large ML models (OpenAI CLIP, Facebook DETR)
- Implements dynamic, ML-context-aware stack depth limits based on detected framework patterns
- Preserves security detection capabilities for malicious content

## Problem

Legitimate large ML models like OpenAI CLIP (`openai/clip-vit-base-patch32`) and Facebook DETR (`facebook/detr-resnet-50`) were triggering false positive stack depth warnings due to a fixed limit of 1000. Complex neural network architectures commonly exceed this threshold during normal serialization.

## Solution

Implemented ML-context-aware stack depth validation:

- **High-confidence ML content** (>0.5 confidence): 5000 limit
- **Medium-confidence ML content** (>0.2 confidence): 2500 limit  
- **Unknown/suspicious content**: 1000 limit (unchanged for security)

Stack depth warnings are now collected during scanning and intelligently filtered after ML context determination.

## Test Plan

- [x] OpenAI CLIP model now passes cleanly (was showing stack depth 1605 warning)
- [x] Facebook DETR model now passes cleanly (was showing stack depth 1001 warning)  
- [x] Google ViT model continues to pass (no regression)
- [x] Malicious models still correctly detected with critical security issues
- [x] All existing pickle scanner tests pass
- [x] Type checking and linting pass

## Testing Commands

```bash
# Test legitimate models (should be clean)
rye run modelaudit hf://openai/clip-vit-base-patch32 --format json
rye run modelaudit hf://facebook/detr-resnet-50 --format json

# Test malicious models (should still detect issues)
rye run modelaudit hf://hf-internal-testing/unsafe-model --format json

# Run test suite
rye run pytest -n auto -m "not slow and not integration" -k "test_pickle"
```

🤖 Generated with [Claude Code](https://claude.ai/code)