### PR TITLE
feat: streamline file format detection I/O

### DIFF
--- a/tests/test_filetype.py
+++ b/tests/test_filetype.py
@@ -1,3 +1,5 @@
+import io
+import tarfile
 import zipfile
 from pathlib import Path
 
@@ -105,6 +107,17 @@ def test_is_zipfile(tmp_path):
     assert is_zipfile(str(zip_path)) is True
     assert is_zipfile(str(non_zip_path)) is False
     assert is_zipfile("nonexistent_file.zip") is False
+
+
+def test_detect_file_format_tar(tmp_path):
+    """Detect tar archives by signature without extra I/O."""
+    tar_path = tmp_path / "archive.tar"
+    with tarfile.open(tar_path, "w") as tar:
+        info = tarfile.TarInfo(name="test.txt")
+        tar.addfile(info, io.BytesIO(b"content"))
+
+    assert detect_file_format_from_magic(str(tar_path)) == "tar"
+    assert detect_file_format(str(tar_path)) == "tar"
 
 
 def test_zip_magic_variants(tmp_path):


### PR DESCRIPTION
## Summary
- reuse magic-byte helper in `is_zipfile`
- detect tar archives and SafeTensors using a single file read
- cover tar detection with new unit test

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check --fix modelaudit/ tests/`
- `ruff check --fix --select I modelaudit/ tests/`
- `mypy modelaudit/ tests/`
- `pytest tests/test_filetype.py::test_detect_file_format_tar -q`
- `pytest -n auto -m "not slow and not integration and not performance" --cov=modelaudit --tb=short` *(fails: worker crashed / segmentation fault)*


------
https://chatgpt.com/codex/tasks/task_e_68a2d2c72fc88332ab6e5adf25797ba8