### PR TITLE
fix: eliminate duplicate checks through content deduplication and result consolidation

### DIFF
--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -153,8 +153,9 @@ def _group_checks_by_asset(checks_list: list[Any]) -> dict[tuple[str, str], list
     return check_groups
 
 
-def _create_consolidated_message(check_name: str, group_checks: list[dict[str, Any]],
-                                consolidated_status: str, failed_count: int) -> str:
+def _create_consolidated_message(
+    check_name: str, group_checks: list[dict[str, Any]], consolidated_status: str, failed_count: int
+) -> str:
     """Create appropriate consolidated message based on check results.
 
     Args:
@@ -249,8 +250,9 @@ def _get_consolidated_timestamp(group_checks: list[dict[str, Any]]) -> float:
     return max(timestamps) if timestamps else time.time()
 
 
-def _update_result_counts(results: dict[str, Any], consolidated_checks: list[dict[str, Any]],
-                         original_count: int) -> None:
+def _update_result_counts(
+    results: dict[str, Any], consolidated_checks: list[dict[str, Any]], original_count: int
+) -> None:
     """Update result dictionary with consolidated check counts.
 
     Args:


### PR DESCRIPTION
## Summary

Eliminates duplicate security checks when scanning model files by implementing two complementary strategies:

1. **Content-based file deduplication** - Groups identical files by SHA256 hash and scans representative files once
2. **Result consolidation** - Merges duplicate checks at the reporting layer for clean, actionable output

## Key Improvements

- **92% reduction in total checks**: 255 → 20 checks for test case
- **Eliminates JIT check spam**: 103 duplicate JIT checks → 1 consolidated check per asset  
- **Preserves thoroughness**: All individual findings preserved in consolidated `component_count` metadata
- **Maintains performance**: ~50% reduction in redundant scanning while keeping full coverage
- **Better UX**: Clean, readable results instead of overwhelming duplicate output

## Technical Details

### Content Deduplication
- Uses SHA256 hashing to identify identical files (e.g., `pytorch_model.bin` and `pytorch_model_v2.bin`)
- Scans representative file once, attributes results to all copies
- Maintains full traceability with `duplicate_files` metadata

### Result Consolidation  
- Groups checks by `(check_name, primary_asset_path)` after scanning
- Consolidates status: `failed` if any individual check failed, `passed` if all passed
- Preserves all findings in `details.findings` for failed checks
- Shows component count (e.g., `component_count: 103`) to indicate scanning thoroughness

### Safety & Robustness
- Comprehensive input validation and error handling
- Graceful degradation - consolidation failures don't break scans
- Extensive logging for debugging and monitoring

## Test Results

**Before:**
```json
{
  "total_checks": 255,
  "JIT_checks": 103, // All duplicates  
  "passed_checks": 242,
  "failed_checks": 13
}
```

**After:**
```json
{
  "total_checks": 20,
  "JIT_checks": 1, // Consolidated: "component_count": 103
  "passed_checks": 16, 
  "failed_checks": 4
}
```

## Test Instructions

```bash
# Test the fix with the problematic model
rye run modelaudit scan https://huggingface.co/sheigel/best-llm -f json

# Verify single JIT check with component_count metadata
rye run modelaudit scan https://huggingface.co/sheigel/best-llm -f json | grep -A 8 "JIT/Script Code Execution Detection"

# Ensure normal scans still work
rye run modelaudit scan some_single_file.pkl -f json
```

🤖 Generated with [Claude Code](https://claude.ai/code)