### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "modelaudit"
-version = "0.2.1"
+version = "0.2.2"
 description = "Static scanning library for detecting malicious code, backdoors, and other security risks in ML model files"
 authors = [
     { name = "Ian Webster", email = "ian@promptfoo.dev" },


### PR DESCRIPTION
## Summary

Bumps the patch version from 0.2.1 to 0.2.2 following semantic versioning conventions.

## Changes

- Updated `version = "0.2.2"` in `pyproject.toml`
- Version is dynamically accessed via `importlib.metadata` in `__init__.py`

## Purpose

This version bump is prepared for the next release following recent improvements to the CLI output system and other enhancements.

## Test Instructions

```bash
# Verify version is correctly updated
python -c "import modelaudit; print(modelaudit.__version__)"

# Or via CLI
rye run modelaudit --version
```

🤖 Generated with [Claude Code](https://claude.ai/code)