### PR TITLE
feat: increase default scan timeout to 1 hour

### DIFF
--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -256,8 +256,8 @@ def delegate_info():
     "--timeout",
     "-t",
     type=int,
-    default=300,
-    help="Scan timeout in seconds [default: 300]",
+    default=3600,
+    help="Scan timeout in seconds [default: 3600]",
 )
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
 @click.option(

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -77,7 +77,7 @@ def validate_scan_config(config: dict[str, Any]) -> None:
 def scan_model_directory_or_file(
     path: str,
     blacklist_patterns: Optional[list[str]] = None,
-    timeout: int = 1800,  # Increased to 30 minutes for large models (up to 8GB+)
+    timeout: int = 3600,  # 1 hour for large models (up to 8GB+)
     max_file_size: int = 0,  # 0 means unlimited - support any size
     max_total_size: int = 0,  # 0 means unlimited
     strict_license: bool = False,
@@ -812,7 +812,7 @@ def scan_file(path: str, config: Optional[dict[str, Any]] = None) -> ScanResult:
     # Now check if we should use regular large handler
     use_large_handler = should_use_large_file_handler(path) and not use_extreme_handler
     progress_callback = config.get("progress_callback")
-    timeout = config.get("timeout", 1800)
+    timeout = config.get("timeout", 3600)
 
     if preferred_scanner and preferred_scanner.can_handle(path):
         logger.debug(
@@ -838,7 +838,7 @@ def scan_file(path: str, config: Optional[dict[str, Any]] = None) -> ScanResult:
                 f"Scan timeout: {e}",
                 severity=IssueSeverity.WARNING,
                 location=path,
-                details={"timeout": config.get("timeout", 300), "error": str(e)},
+                details={"timeout": config.get("timeout", 3600), "error": str(e)},
             )
             result.finish(success=False)
     else:
@@ -866,7 +866,7 @@ def scan_file(path: str, config: Optional[dict[str, Any]] = None) -> ScanResult:
                     f"Scan timeout: {e}",
                     severity=IssueSeverity.WARNING,
                     location=path,
-                    details={"timeout": config.get("timeout", 300), "error": str(e)},
+                    details={"timeout": config.get("timeout", 3600), "error": str(e)},
                 )
                 result.finish(success=False)
         else:

--- a/modelaudit/jfrog_integration.py
+++ b/modelaudit/jfrog_integration.py
@@ -19,7 +19,7 @@ def scan_jfrog_artifact(
     *,
     api_token: str | None = None,
     access_token: str | None = None,
-    timeout: int = 300,
+    timeout: int = 3600,
     blacklist_patterns: list[str] | None = None,
     max_file_size: int = 0,
     max_total_size: int = 0,

--- a/modelaudit/mlflow_integration.py
+++ b/modelaudit/mlflow_integration.py
@@ -13,7 +13,7 @@ def scan_mlflow_model(
     model_uri: str,
     *,
     registry_uri: Optional[str] = None,
-    timeout: int = 300,
+    timeout: int = 3600,
     blacklist_patterns: Optional[list[str]] = None,
     max_file_size: int = 0,
     max_total_size: int = 0,

--- a/modelaudit/scanners/base.py
+++ b/modelaudit/scanners/base.py
@@ -314,7 +314,7 @@ class BaseScanner(ABC):
     def __init__(self, config: Optional[dict[str, Any]] = None):
         """Initialize the scanner with configuration"""
         self.config = config or {}
-        self.timeout = self.config.get("timeout", 1800)  # Default 30 minutes for large models
+        self.timeout = self.config.get("timeout", 3600)  # Default 1 hour for large models
         self.current_file_path = ""  # Track the current file being scanned
         self.chunk_size = self.config.get(
             "chunk_size",

--- a/modelaudit/utils/large_file_handler.py
+++ b/modelaudit/utils/large_file_handler.py
@@ -35,7 +35,7 @@ class LargeFileHandler:
         file_path: str,
         scanner: Any,
         progress_callback: Optional[Callable[[str, float], None]] = None,
-        timeout: int = 1800,
+        timeout: int = 3600,
     ):
         """
         Initialize the large file handler.
@@ -212,7 +212,7 @@ def scan_large_file(
     file_path: str,
     scanner: Any,
     progress_callback: Optional[Callable[[str, float], None]] = None,
-    timeout: int = 1800,
+    timeout: int = 3600,
 ) -> ScanResult:
     """
     Scan a large file with appropriate strategy.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -656,7 +656,7 @@ def test_scan_jfrog_url_success(mock_scan_jfrog, mock_is_jfrog):
         "https://company.jfrog.io/artifactory/repo/model.bin",
         api_token=None,
         access_token=None,
-        timeout=300,
+        timeout=3600,
         blacklist_patterns=None,
         max_file_size=0,
         max_total_size=0,
@@ -748,7 +748,7 @@ def test_scan_mlflow_uri_success(mock_scan_mlflow):
     mock_scan_mlflow.assert_called_once_with(
         "models:/TestModel/1",
         registry_uri="http://localhost:5000",
-        timeout=300,
+        timeout=3600,
         blacklist_patterns=None,
         max_file_size=0,
         max_total_size=0,

--- a/tests/test_timeout_configuration.py
+++ b/tests/test_timeout_configuration.py
@@ -79,7 +79,7 @@ class TestTimeoutConfiguration:
     def test_default_timeout(self):
         """Test default timeout value"""
         scanner = SlowTestScanner()
-        assert scanner.timeout == 1800  # Default 30 minutes for large models
+        assert scanner.timeout == 3600  # Default 1 hour for large models
 
     def test_timeout_error_handling(self):
         """Test that TimeoutError is caught and handled gracefully"""


### PR DESCRIPTION
## Summary

This PR increases the default scan timeout from 5 minutes (300 seconds) to 1 hour (3600 seconds) to provide more time for scanning large models and complex files.

## Changes

- **CLI Interface**: Updated `--timeout` option default from 300 to 3600 seconds
- **Core Functions**: Updated default timeout in `scan_model_directory_or_file()`
- **BaseScanner**: Updated default timeout in scanner initialization
- **Integration Modules**: Updated defaults in MLflow and JFrog integrations
- **Large File Handler**: Updated timeout defaults for large file processing
- **Tests**: Updated test expectations to match new defaults

## Test Instructions

```bash
# Run the updated tests
rye run pytest tests/test_timeout_configuration.py -v
rye run pytest tests/test_cli.py -v

# Verify CLI shows new default
rye run modelaudit --help | grep timeout
```

## Backwards Compatibility

✅ Fully backwards compatible - users can still specify custom timeout values via the `--timeout` option.

🤖 Generated with [Claude Code](https://claude.ai/code)