### PR TITLE
chore: bump version to 0.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "modelaudit"
-version = "0.2.2"
+version = "0.2.3"
 description = "Static scanning library for detecting malicious code, backdoors, and other security risks in ML model files"
 authors = [
     { name = "Ian Webster", email = "ian@promptfoo.dev" },


### PR DESCRIPTION
## Summary
- Bump version from 0.2.2 to 0.2.3
- Includes the max_entry_size fixes for large language models in ZIP and TAR scanners

## Changes
- Update `pyproject.toml` version field

## Context
This version includes the merged PR #298 which increased default max_entry_size from 10GB to 100GB for ZIP and TAR scanners, resolving issues with scanning large language models.

🤖 Generated with [Claude Code](https://claude.ai/code)