### PR TITLE
fix: tighten ONNX preview signature

### DIFF
--- a/modelaudit/utils/streaming.py
+++ b/modelaudit/utils/streaming.py
@@ -228,7 +228,7 @@ def get_streaming_preview(url: str, max_bytes: int = 1024) -> Optional[dict[str,
             preview["detected_format"] = "zip (possibly pytorch/tensorflow)"
         elif b"HDF" in header[:10]:
             preview["detected_format"] = "HDF5 (keras/tensorflow)"
-        elif header.startswith(b"\x08\x08"):
+        elif header.startswith(b"\x08\x01\x12\x00") or b"onnx" in header[:32].lower():
             preview["detected_format"] = "ONNX"
 
         return preview

--- a/tests/test_streaming_preview.py
+++ b/tests/test_streaming_preview.py
@@ -1,0 +1,28 @@
+import fsspec
+from fsspec.implementations.local import LocalFileSystem
+
+from modelaudit.utils import streaming
+
+
+def _setup_local(monkeypatch) -> None:
+    """Configure streaming helpers to use local file system."""
+    monkeypatch.setattr(streaming, "get_fs_protocol", lambda u: "file")
+    monkeypatch.setattr(fsspec, "filesystem", lambda protocol, token=None: LocalFileSystem())
+
+
+def test_get_streaming_preview_detects_onnx(tmp_path, monkeypatch):
+    _setup_local(monkeypatch)
+    file_path = tmp_path / "model.onnx"
+    file_path.write_bytes(b"\x08\x01\x12\x00onnxmodel")
+    preview = streaming.get_streaming_preview(f"file://{file_path}")
+    assert preview is not None
+    assert preview["detected_format"] == "ONNX"
+
+
+def test_get_streaming_preview_avoids_false_positive(tmp_path, monkeypatch):
+    _setup_local(monkeypatch)
+    file_path = tmp_path / "not_onnx.bin"
+    file_path.write_bytes(b"\x08\x08random")
+    preview = streaming.get_streaming_preview(f"file://{file_path}")
+    assert preview is not None
+    assert preview["detected_format"] is None


### PR DESCRIPTION
## Summary
- use stricter ONNX magic bytes in streaming preview
- test ONNX preview detection and false-positive avoidance

## Testing
- `ruff format modelaudit/utils/streaming.py tests/test_streaming_preview.py`
- `ruff check --fix modelaudit/utils/streaming.py tests/test_streaming_preview.py`
- `ruff check --fix --select I modelaudit/utils/streaming.py tests/test_streaming_preview.py`
- `mypy --python-version 3.10 modelaudit/ tests/`
- `pytest -n auto -m "not slow and not integration and not performance" --cov=modelaudit --tb=short` (failed: test_tensorrt_scanner_safe_file, test_flax_msgpack_ml_context_confidence)
- `pytest tests/test_streaming_preview.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a736707ab483329503c46778fb901c