### PR TITLE
fix: default bytes_scanned in streaming

### DIFF
--- a/modelaudit/utils/streaming.py
+++ b/modelaudit/utils/streaming.py
@@ -171,7 +171,8 @@ def stream_analyze_file(
         # Create scan result
         if issues or was_complete:
             result = ScanResult(scanner_name="streaming")
-            result.bytes_scanned = scan_result.bytes_scanned if scan_result is not None else bytes_to_read
+            scanned = getattr(scan_result, "bytes_scanned", 0) if scan_result is not None else 0
+            result.bytes_scanned = scanned or bytes_to_read
             result.issues = issues
             result.metadata = {
                 "streaming_analysis": True,

--- a/tests/test_streaming_analysis.py
+++ b/tests/test_streaming_analysis.py
@@ -35,3 +35,31 @@ def test_stream_analyze_file_uses_scanner(tmp_path, monkeypatch):
     assert called["called"] is True
     assert any(issue.message == "scanner issue" for issue in result.issues)
     assert result.metadata.get("scanner_used") is True
+
+
+def test_stream_analyze_file_falls_back_to_bytes_to_read(tmp_path, monkeypatch):
+    file_path = tmp_path / "sample.pkl"
+    file_path.write_bytes(b"\x80\x04K*\x85q\x00." * 2)
+    url = f"file://{file_path}"
+
+    monkeypatch.setattr(streaming, "get_fs_protocol", lambda u: "file")
+    monkeypatch.setattr(fsspec, "filesystem", lambda protocol, token=None: LocalFileSystem())
+
+    called: dict[str, bool] = {"called": False}
+
+    def fake_scan_pickle_bytes(self, file_obj, size):
+        called["called"] = True
+        result = ScanResult(scanner_name=self.name)
+        result.add_issue("scanner issue", IssueSeverity.WARNING, location="memory")
+        result.finish(success=True)
+        return result
+
+    monkeypatch.setattr(PickleScanner, "_scan_pickle_bytes", fake_scan_pickle_bytes)
+
+    scanner = PickleScanner()
+    result, was_complete = streaming.stream_analyze_file(url, scanner, max_bytes=4)
+
+    assert called["called"] is True
+    assert was_complete is False
+    assert result is not None
+    assert result.bytes_scanned == 4


### PR DESCRIPTION
## Summary
- ensure streaming analysis uses bytes read when sub-scanner omits `bytes_scanned`
- add regression test for partial streaming scan

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check --fix modelaudit/ tests/`
- `ruff check --fix --select I modelaudit/ tests/`
- `mypy modelaudit/ tests/` *(fails: Pattern matching is only supported in Python 3.10 and greater)*
- `pytest tests/test_streaming_analysis.py::test_stream_analyze_file_falls_back_to_bytes_to_read -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73676d61883329860d0f4f6f047da