### PR TITLE
fix: handle Windows drive letters in asset extraction

### DIFF
--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -120,7 +120,10 @@ def _extract_primary_asset_from_location(location: str) -> str:
 
     primary_location = locations[0]
     # Extract main file path (before any ':' separator for archive contents)
-    primary_asset = primary_location.split(":", 1)[0] if ":" in primary_location else primary_location
+    drive, tail = os.path.splitdrive(primary_location)
+    if ":" in tail:
+        tail = tail.split(":", 1)[0]
+    primary_asset = f"{drive}{tail}"
 
     # Normalize empty paths
     return primary_asset.strip() if primary_asset.strip() else "unknown"

--- a/tests/test_core_asset_extraction.py
+++ b/tests/test_core_asset_extraction.py
@@ -1,0 +1,16 @@
+import ntpath
+from unittest.mock import patch
+
+from modelaudit.core import _extract_primary_asset_from_location
+
+
+def test_extract_primary_asset_windows_path_with_archive():
+    location = r"C:\\Users\\test\\archive.zip:inner\\file"
+    with patch("modelaudit.core.os.path.splitdrive", ntpath.splitdrive):
+        assert _extract_primary_asset_from_location(location) == r"C:\\Users\\test\\archive.zip"
+
+
+def test_extract_primary_asset_windows_path_without_archive():
+    location = r"C:\\Users\\test\\file.txt"
+    with patch("modelaudit.core.os.path.splitdrive", ntpath.splitdrive):
+        assert _extract_primary_asset_from_location(location) == r"C:\\Users\\test\\file.txt"


### PR DESCRIPTION
## Summary
- handle Windows drive letters when deriving primary asset paths
- add tests for Windows-style asset locations

## Testing
- `ruff format modelaudit/ tests/`
- `ruff check --fix modelaudit/ tests/`
- `ruff check --fix --select I modelaudit/ tests/`
- `mypy --python-version 3.10 modelaudit/ tests/`
- `pytest -n auto -m "not slow and not integration and not performance" --cov=modelaudit --tb=short` *(fails: test_tensorrt_scanner_safe_file, test_flax_msgpack_ml_context_confidence, TestWeightDistributionScanner::test_llm_vocabulary_layer_handling)*

------
https://chatgpt.com/codex/tasks/task_e_68a73639e2e88332af5b2dc4e59a2a46