### PR TITLE
feat: remove --dry-run flag to simplify CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,6 @@ modelaudit model.pkl --strict --format json --output report.json
 
 # Override size limits for huge models
 modelaudit huge-model.pt --max-size 50GB --timeout 7200
-
-# Preview mode without downloading
-modelaudit s3://bucket/model.pt --dry-run
 ```
 
 [View advanced usage examples →](https://www.promptfoo.dev/docs/model-audit/usage/)
@@ -193,12 +190,11 @@ ModelAudit uses **smart detection** to automatically configure optimal settings 
 - **Terminal type** (TTY/CI) → appropriate UI (progress vs quiet mode)
 - **Cloud operations** → automatic caching, size limits, timeouts
 
-**🎛️ Override Controls (13 focused flags):**
+**🎛️ Override Controls (12 focused flags):**
 
 - `--strict` – scan all file types, strict license validation, fail on warnings
 - `--max-size SIZE` – unified size limit (e.g., `10GB`, `500MB`)
 - `--timeout SECONDS` – override auto-detected timeout
-- `--dry-run` – preview what would be scanned/downloaded
 - `--progress` – force enable progress reporting
 - `--no-cache` – disable caching (overrides smart detection)
 - `--format json` / `--output file.json` – structured output for CI/CD

--- a/task.md
+++ b/task.md
@@ -40,9 +40,8 @@ Reduce ModelAudit CLI complexity from 25 flags to 12 flags (-52%) through smart 
 - `--timeout/-t SECONDS` - Override auto-detected timeout
 - `--max-size SIZE` - Override auto-detected size limits
 
-### Preview/debugging (2)
+### Cache control (1)
 
-- `--dry-run` - Preview what would happen
 - `--no-cache` - Force disable caching
 
 ## Flags to Remove (13 eliminated)
@@ -64,7 +63,7 @@ Reduce ModelAudit CLI complexity from 25 flags to 12 flags (-52%) through smart 
 ### Removed (rarely used/consolidated):
 
 - `--progress-log/--progress-format/--progress-interval` → Smart defaults only
-- `--preview` → Replaced by `--dry-run`
+- `--preview` → Removed (no longer needed)
 - `--strict-license` → Part of `--strict` mode
 
 ## Implementation Steps
@@ -78,7 +77,7 @@ Reduce ModelAudit CLI complexity from 25 flags to 12 flags (-52%) through smart 
 
 ### Phase 2: Update CLI Interface
 
-1. Add new consolidated flags (`--quiet`, `--strict`, `--dry-run`, `--no-cache`)
+1. Add new consolidated flags (`--quiet`, `--strict`, `--no-cache`)
 2. Update existing flags to use smart detection as defaults
 3. Remove deprecated flags from CLI definition
 4. Update help text and documentation

--- a/tests/test_cache_cli.py
+++ b/tests/test_cache_cli.py
@@ -27,14 +27,6 @@ class TestCacheCLI:
             assert "Total entries: 0" in result.output
             assert "Hit rate: 0.0%" in result.output
 
-    def test_cache_clear_dry_run(self):
-        """Test cache clear dry run."""
-        runner = CliRunner()
-        result = runner.invoke(cli, ["cache", "clear", "--dry-run"])
-
-        assert result.exit_code == 0
-        assert "Would clear" in result.output
-
     def test_cache_clear_with_data(self):
         """Test cache clear with actual data."""
         # Reset global cache manager to ensure isolation
@@ -61,14 +53,6 @@ class TestCacheCLI:
             # Verify cleared
             result = runner.invoke(cli, ["cache", "stats", "--cache-dir", temp_dir])
             assert "Total entries: 0" in result.output
-
-    def test_cache_cleanup_dry_run(self):
-        """Test cache cleanup dry run."""
-        runner = CliRunner()
-        result = runner.invoke(cli, ["cache", "cleanup", "--dry-run", "--max-age", "7"])
-
-        assert result.exit_code == 0
-        assert "Would cleanup cache entries older than 7 days" in result.output
 
     def test_cache_cleanup_with_max_age(self):
         """Test cache cleanup with custom max age."""
@@ -130,7 +114,7 @@ class TestCacheCLI:
         result = runner.invoke(cli, ["cache", "clear", "--help"])
         assert result.exit_code == 0
         assert "Clear the entire scan results cache" in result.output
-        assert "--dry-run" in result.output
+        assert "--cache-dir" in result.output
 
         # Test stats help
         result = runner.invoke(cli, ["cache", "stats", "--help"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,7 +92,7 @@ def test_scan_command_help():
     assert "--verbose" in result.output
     assert "--max-size" in result.output  # Updated from --max-file-size
     assert "--strict" in result.output  # New consolidated flag
-    assert "--dry-run" in result.output  # New flag
+    assert "--no-cache" in result.output  # Cache control flag
     assert "Smart Detection:" in result.output  # New feature documentation
 
 


### PR DESCRIPTION
## Summary

Removes the `--dry-run` flag from all commands to reduce CLI complexity and focus on actual scanning functionality.

## Changes

- Remove `--dry-run` option from scan command and associated preview logic
- Remove `--dry-run` option from cache clear/cleanup commands  
- Update documentation and help text to remove dry-run references
- Update tests to remove dry-run test cases
- Reduce CLI flag count from 13 to 12 focused options

## Test Instructions

```bash
# Verify CLI works without --dry-run flag
rye run modelaudit scan --help
rye run modelaudit cache clear --help
rye run modelaudit cache cleanup --help

# Test actual scanning still works
rye run modelaudit hf://microsoft/DialoGPT-small
```

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed dry-run/preview mode across the CLI. Cache clear and cache cleanup now always execute; scan no longer supports --dry-run and uses --no-cache for cache control.
* **Documentation**
  * Updated README and task docs to remove dry-run examples and references, adjust flag counts, and reflect the new cache control approach.
* **Tests**
  * Updated CLI tests to remove dry-run expectations and align help output and behavior with the new flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->