### PR TITLE
fix: exclude Python 3.13 from NumPy 1.x compatibility tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -254,6 +254,11 @@ jobs:
         # Reduced matrix for PRs
         python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.11"]') || fromJSON('["3.10", "3.11", "3.12", "3.13"]') }}
         numpy-mode: ["1.x", "2.x"]
+        exclude:
+          # TensorFlow doesn't support Python 3.13 yet, so skip NumPy 1.x mode
+          # which requires TensorFlow installation
+          - python-version: "3.13"
+            numpy-mode: "1.x"
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- Fixes CI failures on main branch by excluding Python 3.13 from NumPy 1.x compatibility tests
- TensorFlow doesn't have wheels for Python 3.13 yet, causing dependency resolution failures
- NumPy 2.x tests still run on Python 3.13 successfully

## Test plan
- [x] Validated YAML syntax is correct
- [x] Confirmed formatting follows repository standards  
- [ ] CI should pass with this exclusion in place
- [ ] Re-enable Python 3.13 + NumPy 1.x when TensorFlow supports Python 3.13

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI test matrix to exclude an unsupported Python and NumPy combination, improving build reliability.
* **Tests**
  * Adjusted compatibility testing to skip a failing environment, reducing noise in test results.

No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->