### PR TITLE
chore: bump version to 0.2.6 with updated CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6] - 2025-09-10
+
+### Added
+
+- **feat**: add comprehensive JFrog folder scanning support (#380)
+- **feat**: add comprehensive XGBoost model scanner with security analysis (#378)
+- **feat**: consolidate duplicate caching logic into unified decorator (#347)
+- **test**: improve test architecture with dependency mocking (#374)
+
+### Fixed
+
+- **fix**: exclude Python 3.13 from NumPy 1.x compatibility tests (#375)
+
 ## [0.2.5] - 2025-09-05
 
 ### Added
@@ -358,7 +371,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **style**: improve code formatting and documentation standards (#12, #23)
 - **fix**: improve core scanner functionality and comprehensive test coverage (#11)
 
-[unreleased]: https://github.com/promptfoo/modelaudit/compare/v0.2.5...HEAD
+[unreleased]: https://github.com/promptfoo/modelaudit/compare/v0.2.6...HEAD
+[0.2.6]: https://github.com/promptfoo/modelaudit/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/promptfoo/modelaudit/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/promptfoo/modelaudit/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/promptfoo/modelaudit/compare/v0.2.2...v0.2.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "modelaudit"
-version = "0.2.5"
+version = "0.2.6"
 description = "Static scanning library for detecting malicious code, backdoors, and other security risks in ML model files"
 authors = [
     { name = "Ian Webster", email = "ian@promptfoo.dev" },


### PR DESCRIPTION
## Summary

- Bump version from 0.2.5 to 0.2.6 in pyproject.toml
- Update CHANGELOG.md with recent features and fixes that were missing from documentation

## Changes Documented

### Added
- **feat**: add comprehensive JFrog folder scanning support (#380)
- **feat**: add comprehensive XGBoost model scanner with security analysis (#378)
- **feat**: consolidate duplicate caching logic into unified decorator (#347)
- **test**: improve test architecture with dependency mocking (#374)

### Fixed
- **fix**: exclude Python 3.13 from NumPy 1.x compatibility tests (#375)

## Test plan

- [x] Version updated in pyproject.toml
- [x] CHANGELOG.md properly formatted
- [x] All git links updated correctly
- [x] Follows conventional commit format
- [x] Ready for merge to main

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added JFrog folder scanning support.
  - Introduced XGBoost model scanner with security analysis.
- Bug Fixes
  - Adjusted compatibility tests to exclude Python 3.13 with NumPy 1.x.
- Refactor
  - Consolidated duplicate caching logic.
- Tests
  - Improved test architecture with dependency mocking.
- Documentation
  - Updated changelog with v0.2.6 (Unreleased) entries and comparison links.
- Chores
  - Bumped package version to 0.2.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->