### PR TITLE
fix: improve xgboost scanner severity levels

### DIFF
--- a/modelaudit/scanners/metadata_scanner.py
+++ b/modelaudit/scanners/metadata_scanner.py
@@ -200,7 +200,7 @@ class MetadataScanner(BaseScanner):
                     issues.append(
                         Issue(
                             message=f"Potential exposed secret in text metadata: {description}",
-                            severity=IssueSeverity.WARNING,
+                            severity=IssueSeverity.INFO,
                             location=file_path,
                             details={
                                 "pattern_description": description,


### PR DESCRIPTION
  This PR reduces false positives in XGBoost scanning while maintaining strong security detection.

  Key Changes

  🐛 Bug Fix
  - Fixed TypeError when scanning real-world XGBoost models that encode numeric values as strings (e.g.,
  "size_leaf_vector": "1000")
  - Added type conversion with error handling for tree parameter validation

  🎯 Scanner Selection
  - XGBoost scanner now validates JSON structure in can_handle() before claiming files
  - Prevents false positives from scanning non-XGBoost JSON files (e.g., HuggingFace configs)

  📏 File Size Thresholds
  - Implemented tiered approach: INFO (100MB JSON/100MB binary/50MB UBJ) → WARNING (500MB/350MB/200MB)
  - Large models now trigger INFO instead of failing scans

  ⚖️ Severity Adjustments
  - Upgraded to CRITICAL: Pickle masquerading as .bst (security evasion)
  - Changed to INFO: Tree count/depth, parameter ranges, UBJSON library missing
  
   Metadata Scanner: Downgrade generic secret patterns to INFO severity
     - Patterns like "[A-Za-z0-9]{20,}" match BibTeX citations, not just secrets
     - Example: "correa2024tucanoadvancingneuraltext" (citation key)
     - Example: "tokenizer = AutoTokenizer" (code example)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined exposed secrets detection severity reporting
  * Enhanced XGBoost model file format recognition and validation
  * Introduced tiered file size thresholds with granular severity levels (INFO, WARNING, CRITICAL)
  * Improved model loading verification with clearer diagnostic messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->