### PR TITLE
chore: bump version to 0.2.10 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.10] - 2025-10-22
+
+### Fixed
+
+- **fix**: eliminate false positive REDUCE warnings for safe ML framework operations (#398)
+- **fix**: eliminate ONNX custom domain and PyTorch pickle false positives (#400)
+- **fix**: eliminate false positive JIT/Script warnings on ONNX files (#399)
+
 ## [0.2.9] - 2025-10-21
 
 ### Added
@@ -440,7 +448,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **style**: improve code formatting and documentation standards (#12, #23)
 - **fix**: improve core scanner functionality and comprehensive test coverage (#11)
 
-[unreleased]: https://github.com/promptfoo/modelaudit/compare/v0.2.9...HEAD
+[unreleased]: https://github.com/promptfoo/modelaudit/compare/v0.2.10...HEAD
+[0.2.10]: https://github.com/promptfoo/modelaudit/compare/v0.2.9...v0.2.10
 [0.2.9]: https://github.com/promptfoo/modelaudit/compare/v0.2.8...v0.2.9
 [0.2.8]: https://github.com/promptfoo/modelaudit/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/promptfoo/modelaudit/compare/v0.2.6...v0.2.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "modelaudit"
-version = "0.2.9"
+version = "0.2.10"
 description = "Static scanning library for detecting malicious code, backdoors, and other security risks in ML model files"
 authors = [
     { name = "Ian Webster", email = "ian@promptfoo.dev" },


### PR DESCRIPTION
## Summary
- Bump version from 0.2.9 to 0.2.10 (patch version)
- Update CHANGELOG.md with new 0.2.10 section
- Add version comparison links

## Changes in 0.2.10
- Fix: eliminate false positive REDUCE warnings for safe ML framework operations (#398)
- Fix: eliminate ONNX custom domain and PyTorch pickle false positives (#400)
- Fix: eliminate false positive JIT/Script warnings on ONNX files (#399)

## Test Instructions
```bash
rye run pytest -n auto -m "not slow and not integration"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes - Version 0.2.10

* **Bug Fixes**
  * Eliminated false positive warnings when analyzing machine learning framework operations
  * Improved accuracy for ONNX and PyTorch file analysis
  * Resolved erroneous warnings on ONNX files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->