### PR TITLE
fix: whitelist trusted ONNX operator domains to eliminate false positive failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **fix**: whitelist trusted ONNX operator domains to eliminate false positive failures
+  - Add `TRUSTED_ONNX_DOMAINS` whitelist for reputable operator sources (com.microsoft, ai.onnx.ml, com.nvidia, etc.)
+  - Trusted domains now pass with INFO severity instead of failing checks
+  - Reduces false positives for legitimate models like sentence-transformers
+  - Example: sentence-transformers/all-MiniLM-L6-v2 now shows 100% success rate (was 97.6%)
+
 ## [0.2.10] - 2025-10-22
 
 ### Fixed


### PR DESCRIPTION
## Summary

Eliminates false positive failures for trusted ONNX operator domains by implementing a whitelist of reputable sources (Microsoft, NVIDIA, PyTorch, etc.).

## Changes

- Add `TRUSTED_ONNX_DOMAINS` whitelist with 5 trusted operator sources
- Update ONNX scanner to distinguish trusted vs untrusted domains
- Trusted domains now pass with INFO severity (not failed checks)
- Untrusted domains remain flagged for manual review
- Add comprehensive tests for both trusted and untrusted domains

## Impact

**Before:**
- sentence-transformers/all-MiniLM-L6-v2: 97.6% success rate (3 failed checks)
- Microsoft ONNX Runtime operators flagged as failures

**After:**
- sentence-transformers/all-MiniLM-L6-v2: 100% success rate
- Clean scan results for legitimate models
- Unknown domains still flagged for security review

## Test Instructions

```bash
# Run ONNX scanner tests
rye run pytest tests/scanners/test_onnx_scanner.py -v

# Test with real model
rye run modelaudit hf://sentence-transformers/all-MiniLM-L6-v2
```

Expected: 100% success rate, no failed checks, clean scan report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a trusted ONNX operator domains whitelist to improve model validation accuracy.

* **Bug Fixes**
  * Reduced false positives in ONNX scanning, increasing success rates for legitimate models.

* **Tests**
  * Expanded test coverage for trusted and untrusted domain handling in ONNX scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->