### PR TITLE
fix: info and debug severity checks no longer count as failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **fix**: INFO and DEBUG severity checks no longer count as failures in success rate calculations
+
 ## [0.2.10] - 2025-10-22
 
 ### Fixed

--- a/modelaudit/scanners/base.py
+++ b/modelaudit/scanners/base.py
@@ -280,6 +280,14 @@ class ScanResult:
 
     def to_dict(self) -> dict[str, Any]:
         """Convert the scan result to a dictionary for serialization"""
+        # Only count WARNING and CRITICAL severity checks as failures
+        # INFO and DEBUG are informational - they should not count as failures
+        failed_checks_count = sum(
+            1
+            for c in self.checks
+            if c.status == CheckStatus.FAILED and c.severity in (IssueSeverity.WARNING, IssueSeverity.CRITICAL)
+        )
+
         return {
             "scanner": self.scanner_name,
             "success": self.success,
@@ -292,7 +300,7 @@ class ScanResult:
             "has_warnings": self.has_warnings,
             "total_checks": len(self.checks),
             "passed_checks": sum(1 for c in self.checks if c.status == CheckStatus.PASSED),
-            "failed_checks": sum(1 for c in self.checks if c.status == CheckStatus.FAILED),
+            "failed_checks": failed_checks_count,
         }
 
     def to_json(self, indent: int = 2) -> str:


### PR DESCRIPTION
## Summary

Fixes false positives where informational findings (INFO and DEBUG severity) were counted as failures in the success rate calculation.

## Changes

- Modified `ScanResult.to_dict()` in `base.py` to filter `failed_checks` by severity
- Modified `ModelAuditResultModel._finalize_checks()` in `models.py` to match the same filtering
- Only WARNING and CRITICAL severity checks now count toward the `failed_checks` metric
- INFO and DEBUG checks are informational and don't indicate actual failures
- Added comprehensive test to verify new behavior

## Root Cause

The issue was semantic: INFO and DEBUG severity checks with `status==FAILED` were being counted as failures, even though they represent informational findings rather than actual security problems.

There were two code paths calculating `failed_checks`:
1. `ScanResult.to_dict()` in `base.py` (per-scanner results)
2. `ModelAuditResultModel._finalize_checks()` in `models.py` (aggregated results)

Both now filter to only count WARNING and CRITICAL severity.

## Test Instructions

```bash
# Run unit tests
rye run pytest tests/test_checks_recording.py -v

# Test with sentence-transformers model (should show 0 failed checks)
rye run modelaudit hf://sentence-transformers/all-MiniLM-L6-v2
```

## Before/After

**Before:**
```
Security Checks:
  ✅ 116 passed / ❌ 3 failed (Total: 119)
  ✅ Success Rate: 97.5%
```

**After:**
```
Security Checks:
  ✅ 116 passed / ✅ 0 failed (Total: 119)
  ✅ Success Rate: 97.5%
```

## Generalizes

This fix applies to ALL scanners and ALL frameworks - no whitelist maintenance needed. Any scanner that creates INFO or DEBUG severity checks will benefit from this semantic correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * INFO and DEBUG severity checks no longer count as failures in success rate calculations; only WARNING and CRITICAL severity issues are now counted.

* **Tests**
  * Added test coverage verifying the updated failure counting behavior.

* **Documentation**
  * Updated changelog to document the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->