### PR TITLE
chore: release 0.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.16] - 2025-11-04
+
+### Added
+
+- **feat**: content hash generation for regular scan mode - all scans (not just streaming) now generate `content_hash` field for model deduplication and verification
+
 ### Changed
 
 - **refactor**: rename `--scan-and-delete` flag to `--stream` for clarity - streaming mode is now invoked with the more intuitive `--stream` flag

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "modelaudit"
-version = "0.2.15"
+version = "0.2.16"
 description = "Static scanning library for detecting malicious code, backdoors, and other security risks in ML model files"
 authors = [
     { name = "Ian Webster", email = "ian@promptfoo.dev" },


### PR DESCRIPTION
Release 0.2.16 includes:

- **feat**: Content hash generation for all scan modes (not just streaming) - enables model deduplication and verification
- **refactor**: Rename `--scan-and-delete` flag to `--stream` for better clarity and usability

## Changes

- Updated version to 0.2.16 in pyproject.toml
- Updated CHANGELOG.md with release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release 0.2.16

* **New Features**
  * Content hash generation now available in regular scan mode, enabling improved model deduplication and verification capabilities.

* **Changed**
  * Renamed CLI flag `--scan-and-delete` to `--stream` for improved clarity on streaming mode functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->