### PR TITLE
docs: clarify pickle allowlist status for numpy and codecs functions

### DIFF
--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -706,6 +706,20 @@ ML_SAFE_GLOBALS: dict[str, list[str]] = {
     ],
 }
 
+# IMPORTANT: Why certain functions are/aren't in the allowlist:
+#
+# ✅ numpy.core.multiarray._reconstruct (line 559 - ALLOWED)
+#    Despite CVE-2019-6446, this is the standard NumPy array reconstruction function
+#    and appears in all legitimate NumPy pickles. The vulnerability comes from malicious
+#    objects INSIDE dtype=object arrays, not from _reconstruct itself. Our scanner checks
+#    array contents separately, so whitelisting _reconstruct reduces false positives.
+#
+# ⚠️ _codecs.encode (NOT in allowlist)
+#    While legitimate for pickle protocol 2 backward compatibility (encoding bytes),
+#    it can obfuscate malicious payloads. Attackers use it to encode commands that
+#    decode into executable code during unpickling, bypassing string pattern detection.
+#    Not critical for ML models (protocol 3+ preferred), so excluded to prevent abuse.
+
 # Dangerous actual code execution patterns in strings
 ACTUAL_DANGEROUS_STRING_PATTERNS = [
     r"os\.system\s*\(",


### PR DESCRIPTION
## Summary

Documents why `numpy.core.multiarray._reconstruct` IS whitelisted and `_codecs.encode` is NOT, with accurate CVE references and security rationale.

## Clarifications

### ✅ numpy.core.multiarray._reconstruct (Already whitelisted)

**Why it's allowed:**
- Standard NumPy array deserialization function
- Appears in ALL legitimate NumPy pickles
- CVE-2019-6446 exploits malicious objects INSIDE dtype=object arrays, not _reconstruct itself
- Our scanner checks array contents separately, so allowing _reconstruct reduces false positives

**Security note:** The function is the reconstruction mechanism, not the vulnerability source. Malicious payloads hide inside the arrays being reconstructed, which we scan independently.

### ⚠️ _codecs.encode (NOT whitelisted)

**Why it's excluded:**
- Used in pickle protocol 2 for backward compatibility (encoding bytes)
- Can obfuscate malicious payloads via base64, rot13, or other encodings
- Bypasses string pattern detection by encoding dangerous code
- Not critical for ML models (protocol 3+ is standard and doesn't need it)

**Security note:** While legitimate in protocol 2 pickles, it enables payload obfuscation attacks. Better to flag it than create a blind spot for encoded exploits.

## Status Check

All other requested functions are already in the allowlist:
- ✅ `numpy.dtype`
- ✅ `numpy.ndarray`
- ✅ `collections.OrderedDict`
- ✅ `torch.ByteStorage`
- ✅ `torch._utils._rebuild_tensor_v2`

This PR only adds documentation, no functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security scanning to detect additional dangerous patterns in pickle files, including subprocess operations, exec calls, and import statements, improving vulnerability detection capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->