### PR TITLE
fix: resolve UnicodeDecodeError when scanning PyTorch .pkl files with ZIP format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **fix**: resolve UnicodeDecodeError when scanning PyTorch .pkl files saved with default ZIP serialization - torch.save() uses ZIP format by default since PyTorch 1.6 (`_use_new_zipfile_serialization=True`), but ModelAudit was incorrectly routing these files to PickleScanner which failed to parse the ZIP header. Now correctly routes ZIP-format .pkl files to PyTorchZipScanner.
+
 ## [0.2.20] - 2025-12-01
 
 ### Added

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -1290,7 +1290,9 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
     preferred_scanner: type[BaseScanner] | None = None
 
     # Special handling for PyTorch files that are ZIP-based
-    if header_format == "zip" and ext in [".pt", ".pth"]:
+    # PyTorch's torch.save() uses ZIP format by default since v1.6 (_use_new_zipfile_serialization=True)
+    # This applies to .pt, .pth, and .pkl files saved with torch.save()
+    if header_format == "zip" and ext in [".pt", ".pth", ".pkl"]:
         preferred_scanner = _registry.load_scanner_by_id("pytorch_zip")
     elif header_format == "zip" and ext == ".bin":
         # PyTorch .bin files saved with torch.save() are ZIP format internally

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -14,11 +14,12 @@ logger = logging.getLogger(__name__)
 
 
 class PyTorchZipScanner(BaseScanner):
-    """Scanner for PyTorch Zip-based model files (.pt, .pth)"""
+    """Scanner for PyTorch Zip-based model files (.pt, .pth, .pkl, .bin)"""
 
     name = "pytorch_zip"
     description = "Scans PyTorch model files for suspicious code in embedded pickles"
-    supported_extensions: ClassVar[list[str]] = [".pt", ".pth", ".bin"]
+    # Include .pkl since torch.save() uses ZIP format by default since PyTorch 1.6
+    supported_extensions: ClassVar[list[str]] = [".pt", ".pth", ".pkl", ".bin"]
 
     # CVE-2025-32434 constants
     CVE_2025_32434_ID: ClassVar[str] = "CVE-2025-32434"
@@ -51,8 +52,9 @@ class PyTorchZipScanner(BaseScanner):
         if ext not in cls.supported_extensions:
             return False
 
-        # For .bin files, only handle if they're ZIP format (torch.save() output)
-        if ext == ".bin":
+        # For .bin and .pkl files, only handle if they're ZIP format (torch.save() output)
+        # torch.save() uses ZIP format by default since PyTorch 1.6 (_use_new_zipfile_serialization=True)
+        if ext in [".bin", ".pkl"]:
             try:
                 from modelaudit.utils.file.detection import detect_file_format
 

--- a/tests/test_pytorch_zip_detection.py
+++ b/tests/test_pytorch_zip_detection.py
@@ -177,3 +177,115 @@ class TestPyTorchBinaryDetection:
         # Verify correct scanner is used
         result = scan_file(str(bin_file))
         assert result.scanner_name == "pickle"
+
+
+class TestPyTorchZipPklExtension:
+    """Test that .pkl files with ZIP format are handled by PyTorchZipScanner.
+
+    PyTorch's torch.save() uses ZIP format by default since v1.6 (_use_new_zipfile_serialization=True).
+    This means .pkl files saved with torch.save() are actually ZIP files containing pickle data.
+    These tests verify the fix for the UnicodeDecodeError that occurred when ModelAudit tried
+    to parse ZIP-format .pkl files as raw pickle files.
+    """
+
+    def test_detect_zip_pkl_file(self, tmp_path):
+        """Test that .pkl files with ZIP format are detected correctly."""
+        # Create a .pkl file using torch.save (creates a ZIP by default)
+        model_data = {"weights": torch.tensor([1.0, 2.0, 3.0])}
+        pkl_file = tmp_path / "model.pkl"
+        torch.save(model_data, pkl_file)
+
+        # Verify file format detection
+        format_type = detect_file_format(str(pkl_file))
+        assert format_type == "zip", f"Expected 'zip' but got '{format_type}'"
+
+        # Verify the file can be scanned without UnicodeDecodeError
+        result = scan_file(str(pkl_file))
+        assert result is not None
+        assert result.scanner_name == "pytorch_zip"
+        assert result.bytes_scanned > 0
+
+    def test_detect_raw_pkl_file(self, tmp_path):
+        """Test that raw pickle .pkl files still work with PickleScanner."""
+        # Create a raw pickle .pkl file (using _use_new_zipfile_serialization=False)
+        model_data = {"weights": torch.tensor([1.0, 2.0, 3.0])}
+        pkl_file = tmp_path / "model.pkl"
+        torch.save(model_data, pkl_file, _use_new_zipfile_serialization=False)
+
+        # Verify file format detection
+        format_type = detect_file_format(str(pkl_file))
+        assert format_type == "pickle", f"Expected 'pickle' but got '{format_type}'"
+
+        # Verify the file can be scanned with pickle scanner
+        result = scan_file(str(pkl_file))
+        assert result is not None
+        assert result.scanner_name == "pickle"
+        assert result.bytes_scanned > 0
+
+    def test_scan_safe_zip_pkl(self, tmp_path):
+        """Test that safe ZIP-format .pkl files don't trigger false positives."""
+        # Create a safe PyTorch model with .pkl extension
+        model_data = {
+            "weights": torch.randn(10, 10),
+            "bias": torch.randn(10),
+        }
+        pkl_file = tmp_path / "safe_model.pkl"
+        torch.save(model_data, pkl_file)
+
+        # Scan the file
+        result = scan_file(str(pkl_file))
+
+        # Should not have critical issues
+        critical_issues = [i for i in result.issues if i.severity == IssueSeverity.CRITICAL]
+        assert len(critical_issues) == 0, f"Unexpected critical issues: {[i.message for i in critical_issues]}"
+
+    def test_scan_malicious_zip_pkl(self, tmp_path):
+        """Test detection of malicious code in ZIP-format .pkl files."""
+        # Create a ZIP file with malicious pickle content, saved as .pkl
+        pkl_file = tmp_path / "malicious_model.pkl"
+        with zipfile.ZipFile(pkl_file, "w") as zf:
+            # Create a malicious pickle payload
+            class MaliciousClass:
+                def __reduce__(self):
+                    import os
+
+                    return (os.system, ("echo pwned",))
+
+            pickle_data = io.BytesIO()
+            pickle.dump({"model": MaliciousClass()}, pickle_data)
+            zf.writestr("data.pkl", pickle_data.getvalue())
+
+        # Scan the file
+        result = scan_file(str(pkl_file))
+
+        # Should detect the malicious pattern
+        assert result.scanner_name == "pytorch_zip"
+        assert any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues), (
+            f"Expected CRITICAL issue but got: {[i.message for i in result.issues]}"
+        )
+
+    def test_zip_pkl_no_unicode_error(self, tmp_path):
+        """Regression test: ZIP-format .pkl files should not cause UnicodeDecodeError.
+
+        This is the specific bug that was reported. torch.save() creates ZIP files
+        by default, but ModelAudit was trying to parse them as raw pickle, causing
+        UnicodeDecodeError when encountering the binary ZIP header.
+        """
+        # Create a ZIP-format .pkl file
+        model_data = {"tensor": torch.tensor([1.0, 2.0, 3.0])}
+        pkl_file = tmp_path / "model.pkl"
+        torch.save(model_data, pkl_file)
+
+        # Verify it's a ZIP file
+        with open(pkl_file, "rb") as f:
+            header = f.read(4)
+        assert header == b"PK\x03\x04", f"Expected ZIP header but got {header.hex()}"
+
+        # This should NOT raise UnicodeDecodeError
+        result = scan_file(str(pkl_file))
+        assert result is not None
+        assert result.scanner_name == "pytorch_zip"
+
+        # Should not have any issues about UnicodeDecodeError
+        error_issues = [i for i in result.issues if "unicode" in i.message.lower()]
+        assert len(error_issues) == 0, f"Got UnicodeDecodeError issues: {[i.message for i in error_issues]}"


### PR DESCRIPTION
## Summary

- Fixes UnicodeDecodeError when scanning .pkl files saved with PyTorch's default `torch.save()` (ZIP serialization)
- Routes ZIP-format .pkl files to PyTorchZipScanner instead of PickleScanner
- Adds comprehensive tests for both ZIP and raw pickle .pkl files

## Problem

PyTorch's `torch.save()` uses ZIP format by default since v1.6 (`_use_new_zipfile_serialization=True`). ModelAudit was incorrectly routing these `.pkl` files to PickleScanner, which failed to parse the ZIP header:

```
[WARNING] Unable to parse pickle file: UnicodeDecodeError
'ascii' codec can't decode byte 0x80 in position 63: ordinal not in range(128)
```

## Solution

- Added `.pkl` to `PyTorchZipScanner.supported_extensions`
- Updated `can_handle()` to check ZIP format for `.pkl` files (same logic as `.bin`)
- Updated `core.py` routing to use `pytorch_zip` scanner for ZIP-header `.pkl` files

## Test plan

```bash
# Run the new tests
rye run python -c "
import pickle, zipfile, tempfile
from pathlib import Path
from modelaudit.scanners.pytorch_zip_scanner import PyTorchZipScanner

tmp = Path(tempfile.mkdtemp())
pkl = tmp / 'model.pkl'
with zipfile.ZipFile(pkl, 'w') as z:
    z.writestr('data.pkl', pickle.dumps({'x': 1}))
print('can_handle:', PyTorchZipScanner.can_handle(str(pkl)))
print('scan:', PyTorchZipScanner().scan(str(pkl)).success)
"

# Test with actual torch.save() output
rye run python -c "
import torch
torch.save({'x': torch.tensor([1.0])}, '/tmp/test.pkl')
" && rye run modelaudit /tmp/test.pkl
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UnicodeDecodeError when scanning PyTorch .pkl files saved with ZIP serialization format. PyTorch adopted ZIP compression as the default serialization method since version 1.6. The scanner now correctly routes and processes ZIP-format .pkl files without errors, improving compatibility with modern PyTorch saved models.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->