### PR TITLE
fix: downgrade file/array size limit errors to INFO severity

### DIFF
--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -907,10 +907,10 @@ def detect_jit_script_risks(file_path: str, max_size: int = 500 * 1024 * 1024) -
         return [
             create_jit_finding(
                 message=f"File too large: {file_size} bytes (max: {max_size})",
-                severity="WARNING",
+                severity="INFO",
                 context=file_path,
                 pattern=None,
-                recommendation="Use a smaller file for analysis",
+                recommendation="Consider increasing the max_size parameter for large model files",
                 confidence=1.0,
                 framework=None,
                 code_snippet=None,

--- a/modelaudit/detectors/secrets.py
+++ b/modelaudit/detectors/secrets.py
@@ -613,7 +613,7 @@ def detect_secrets_in_file(file_path: str, max_size: int = 500 * 1024 * 1024) ->
 
     file_size = os.path.getsize(file_path)
     if file_size > max_size:
-        return [{"type": "error", "message": f"File too large: {file_size} bytes (max: {max_size})"}]
+        return [{"type": "info", "severity": "INFO", "message": f"File too large: {file_size} bytes (max: {max_size})"}]
 
     detector = SecretsDetector()
 

--- a/modelaudit/scanners/base.py
+++ b/modelaudit/scanners/base.py
@@ -1199,7 +1199,7 @@ class BaseScanner(ABC):
                 name="File Size Limit",
                 passed=False,
                 message=f"File too large: {file_size} bytes (max: {self.max_file_read_size})",
-                severity=IssueSeverity.WARNING,
+                severity=IssueSeverity.INFO,
                 location=path,
                 details={
                     "file_size": file_size,

--- a/modelaudit/scanners/joblib_scanner.py
+++ b/modelaudit/scanners/joblib_scanner.py
@@ -26,8 +26,8 @@ class JoblibScanner(BaseScanner):
         self.max_decompression_ratio = self.config.get("max_decompression_ratio", 100.0)
         self.max_decompressed_size = self.config.get(
             "max_decompressed_size",
-            100 * 1024 * 1024,
-        )  # 100MB
+            10 * 1024 * 1024 * 1024,
+        )  # 10GB for large ML models
         self.chunk_size = self.config.get("chunk_size", 8192)  # 8KB chunks
 
     @classmethod
@@ -234,11 +234,13 @@ class JoblibScanner(BaseScanner):
                             },
                         )
                 except ValueError as e:
+                    # Size/ratio limit errors are informational - may indicate large legitimate models
+                    # Compression bombs are DoS concerns, not RCE vectors
                     result.add_check(
                         name="Compression Bomb Detection",
                         passed=False,
                         message=str(e),
-                        severity=IssueSeverity.CRITICAL,
+                        severity=IssueSeverity.INFO,
                         location=path,
                         details={"security_check": "compression_bomb_detection"},
                     )

--- a/modelaudit/scanners/numpy_scanner.py
+++ b/modelaudit/scanners/numpy_scanner.py
@@ -265,18 +265,20 @@ class NumPyScanner(BaseScanner):
                         expected_size = data_offset + expected_data_size
                     except ValueError as e:
                         # Determine which validation failed based on error message
-                        if "dimensions" in str(e).lower():
+                        error_msg = str(e).lower()
+                        if "dimensions" in error_msg:
                             check_name = "Array Dimension Validation"
-                        elif "dtype" in str(e).lower():
+                        elif "dtype" in error_msg:
                             check_name = "Data Type Safety Check"
                         else:
                             check_name = "Array Size Validation"
 
+                        # Size/dimension limit errors are informational - may indicate large legitimate arrays
                         result.add_check(
                             name=check_name,
                             passed=False,
                             message=f"Array validation failed: {e}",
-                            severity=IssueSeverity.CRITICAL,
+                            severity=IssueSeverity.INFO,
                             location=path,
                             details={
                                 "security_check": "array_validation",

--- a/tests/test_security_enhancements.py
+++ b/tests/test_security_enhancements.py
@@ -37,7 +37,8 @@ class TestJoblibScannerSecurity:
         assert result.success is False
         bomb_issues = [issue for issue in result.issues if "compression ratio" in issue.message.lower()]
         assert len(bomb_issues) > 0
-        assert any(issue.severity == IssueSeverity.CRITICAL for issue in bomb_issues)
+        # Compression bombs are INFO (DoS concern, not RCE vector)
+        assert any(issue.severity == IssueSeverity.INFO for issue in bomb_issues)
 
     def test_large_file_protection(self, tmp_path):
         """Test protection against reading very large files."""


### PR DESCRIPTION
## Summary

Size limit errors are not security vulnerabilities - they indicate large legitimate model files that may exceed arbitrary limits. Per CLAUDE.md security guidelines, size limits without CVE documentation should be INFO severity, not WARNING/CRITICAL. Size exhaustion is a DoS concern, not an RCE vector.

### Changes

- **Joblib scanner**: Bump decompressed size limit from 100MB to 10GB for large ML models, downgrade compression bomb/size errors to INFO
- **NumPy scanner**: Downgrade array size validation errors to INFO  
- **Base scanner**: Downgrade file size limit errors from WARNING to INFO
- **JIT script detector**: Downgrade file too large errors from WARNING to INFO
- **Secrets detector**: Change file too large from error type to info type

### Rationale

Following the security check guidelines from CLAUDE.md:

> **❌ UNACCEPTABLE - Remove these checks:**
> - **Arbitrary thresholds**: "More than N items could be a DoS" without CVE backing
> - **Theoretical DoS**: "This could potentially be slow" without documented attacks

> **ℹ️ UNCERTAIN - Downgrade to INFO severity:**
> - Large counts/sizes that might indicate issues but have no CVE

These size limits are arbitrary and have no CVE backing - they're informational observations, not security findings.

## Test Instructions

```bash
rye run pytest tests/test_security_enhancements.py -v -k "compression"
rye run ruff check modelaudit/scanners/joblib_scanner.py modelaudit/scanners/numpy_scanner.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Adjusted severity levels for file size and compression-related checks from critical/warning to informational, better reflecting the actual risk level.
  * Improved error messaging and recommendations for oversized files.

* **Chores**
  * Updated maximum decompressed size default limit from 100 MB to 10 GB to support larger legitimate model files.
  * Updated tests to align with revised severity classifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->