### PR TITLE
fix: use None instead of empty strings for failed hash calculations

### DIFF
--- a/modelaudit/scanners/base.py
+++ b/modelaudit/scanners/base.py
@@ -1155,12 +1155,13 @@ class BaseScanner(ABC):
             # as zero rather than raising an exception.
             return 0
 
-    def calculate_file_hashes(self, path: str) -> dict[str, str]:
+    def calculate_file_hashes(self, path: str) -> dict[str, str | None]:
         """Calculate MD5, SHA256, and SHA512 hashes of a file.
 
-        Returns a dictionary with hash values or error messages.
+        Returns a dictionary with hash values or None if calculation fails.
+        Uses None instead of empty strings to satisfy Pydantic validation.
         """
-        hashes = {"md5": "", "sha256": "", "sha512": ""}
+        hashes: dict[str, str | None] = {"md5": None, "sha256": None, "sha512": None}
 
         if not os.path.isfile(path):
             return hashes
@@ -1184,7 +1185,7 @@ class BaseScanner(ABC):
 
         except Exception as e:
             logger.warning(f"Failed to calculate hashes for {path}: {e}")
-            # Return empty hashes on error rather than failing
+            # Return None hashes on error - Pydantic will accept None but not empty strings
 
         return hashes
 


### PR DESCRIPTION
## Summary

Fixes a Pydantic ValidationError that occurs when hash calculation fails during model scanning.

### Problem

When `calculate_file_hashes()` fails (e.g., due to `RecursionError` or other exceptions), it was returning empty strings for md5, sha256, sha512:

```python
hashes = {"md5": "", "sha256": "", "sha512": ""}  # Bug: empty strings
```

This caused `pydantic_core.ValidationError` when creating `FileMetadataModel` because `FileHashesModel` expects either `None` or valid hash strings matching specific regex patterns:

```
pydantic_core.ValidationError: 3 validation errors for FileMetadataModel
file_hashes.md5
  String should match pattern '^[a-fA-F0-9]{32}$' [type=string_pattern_mismatch, input_value='', input_type=str]
file_hashes.sha256
  String should match pattern '^[a-fA-F0-9]{64}$' [type=string_pattern_mismatch, input_value='', input_type=str]
file_hashes.sha512
  String should match pattern '^[a-fA-F0-9]{128}$' [type=string_pattern_mismatch, input_value='', input_type=str]
```

### Root Cause

The error was triggered when scanning certain `.pth` files that caused maximum recursion depth exceeded errors during processing. When hash calculation subsequently failed, the empty string defaults violated Pydantic validation.

### Solution

Return `None` instead of empty strings when hash calculation fails:

```python
hashes: dict[str, str | None] = {"md5": None, "sha256": None, "sha512": None}  # Fix: use None
```

Pydantic accepts `None` values but rejects empty strings that don't match the hash regex patterns.

## Test Instructions

```bash
# Verify None values pass validation
rye run python -c "
from modelaudit.models import FileHashesModel, FileMetadataModel
hashes = {'md5': None, 'sha256': None, 'sha512': None}
model = FileHashesModel(**hashes)
print('SUCCESS:', model)
"

# Run related tests
rye run pytest tests/test_security_enhancements.py -v -k "hash"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated hash value handling to properly indicate unavailable or failed hash operations using null values instead of empty strings for improved error representation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->