### PR TITLE
fix: resolve release-please CHANGELOG formatting race condition

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,34 +21,49 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
+      pr_number: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).number || '' }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Format CHANGELOG.md after release-please creates/updates the PR
-      - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
-        with:
-          fetch-depth: 0
-
-      - name: Format CHANGELOG.md
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
+      # Format CHANGELOG.md immediately after release-please creates/updates a PR
+      # This runs for BOTH new PRs (prs_created) and existing PRs (pr output exists)
+      - name: Check if PR exists
+        id: check-pr
         run: |
-          PR_BRANCH=$(echo '${{ steps.release.outputs.pr }}' | jq -r '.headBranchName')
-          echo "Formatting CHANGELOG.md on branch: $PR_BRANCH"
-          git fetch origin "$PR_BRANCH"
-          git checkout "$PR_BRANCH"
-          npx --yes prettier@latest --write CHANGELOG.md
-          if git diff --quiet CHANGELOG.md; then
-            echo "No formatting changes needed"
+          PR_OUTPUT='${{ steps.release.outputs.pr }}'
+          if [ -n "$PR_OUTPUT" ] && [ "$PR_OUTPUT" != "null" ]; then
+            echo "has_pr=true" >> $GITHUB_OUTPUT
+            echo "pr_branch=$(echo '${{ steps.release.outputs.pr }}' | jq -r '.headBranchName')" >> $GITHUB_OUTPUT
           else
+            echo "has_pr=false" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.check-pr.outputs.has_pr == 'true'
+        with:
+          ref: ${{ steps.check-pr.outputs.pr_branch }}
+          # Shallow clone for speed - we only need to format and push
+          fetch-depth: 1
+
+      - name: Format CHANGELOG.md with Prettier
+        if: steps.check-pr.outputs.has_pr == 'true'
+        run: |
+          echo "Formatting CHANGELOG.md on branch: ${{ steps.check-pr.outputs.pr_branch }}"
+          npx --yes prettier@latest --write CHANGELOG.md
+
+          if git diff --quiet CHANGELOG.md; then
+            echo "✓ No formatting changes needed"
+          else
+            echo "→ Formatting changes detected, committing..."
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add CHANGELOG.md
             git commit -m "chore: format CHANGELOG.md with prettier"
-            git push origin "$PR_BRANCH"
+            git push
+            echo "✓ Formatting committed and pushed"
           fi
 
   build:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,13 +41,15 @@ uv run pytest -n auto -m "not slow and not integration" --maxfail=1
 
 ## Branch & Git Hygiene
 
+**NEVER commit or push directly to `main`.** All changes must go through pull requests.
+
 ```bash
 # Start clean
 git fetch origin main
 git checkout main
 git merge --no-edit origin/main
 
-# Work on a branch
+# Work on a branch (REQUIRED - never commit to main)
 git checkout -b feat/your-feature-name  # or fix/, chore/, test/
 
 # Commit (conventional)
@@ -57,11 +59,12 @@ Description here.
 
 Co-Authored-By: Claude <noreply@anthropic.com>"
 
-# PR (after validation)
+# PR (after validation) - ALL changes go through PRs
 git push -u origin feat/your-feature-name
 gh pr create --title "feat: descriptive title" --body "Brief description"
 ```
 
+- **NEVER push to main.** Always create a feature branch and open a PR.
 - Use non-interactive flags (`--no-edit`, `-m`). One command per invocation; avoid long `&&` chains.
 - If `.git/index.lock` exists and no git process is running, remove the lock file.
 - Add only intended paths; avoid committing artifacts. Prefer `gh run rerun <run-id>` over force-pushing to rerun CI.
@@ -118,6 +121,8 @@ Key docs: `docs/agents/commands.md`, `docs/agents/testing.md`, `docs/agents/secu
 
 - **Do:** Keep responses short; surface only relevant details; prefer targeted tests; propose clear next steps; cite file paths when reporting.
 - **Do:** Use iterative refinement—small changes, verify, then proceed.
+- **Do:** Always use feature branches and PRs for all changes.
+- **Don't:** Commit or push directly to `main`—always use a PR.
 - **Don't:** Introduce new dependencies, weaken security checks, or bypass validation.
 - **Don't:** Leave formatting/lint failures or unaddressed test regressions.
 


### PR DESCRIPTION
## Summary

Fixes the race condition where release-please PRs fail the docs formatting check because CHANGELOG.md isn't formatted before CI runs.

## Changes

### release-please.yml
- Format CHANGELOG for **both** new and updated PRs (was only `prs_created`)
- Use shallow clone (`fetch-depth: 1`) for faster checkout
- Checkout PR branch directly instead of `fetch + checkout`
- Add clearer logging for formatting steps

### AGENTS.md
- Add explicit prohibition: **"NEVER commit or push directly to main"**
- Emphasize that all changes must go through pull requests
- Update DO/DON'T cheatsheet with branch/PR requirements

## Root Cause

The race condition occurred because:
1. release-please created PR with unformatted CHANGELOG
2. test.yml docs check ran and failed on original commit
3. Formatting commit pushed after CI already failed
4. Squash merge used unformatted state from failed commit

## Testing

- YAML syntax validated locally
- Workflow logic verified for both new and existing PR scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD automation for improved release management and code formatting processes.

* **Documentation**
  * Updated development guidelines with strengthened Git workflow practices and changelog management requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->