### PR TITLE
feat: auto-rebuild scanner Docker image on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -142,6 +142,15 @@ jobs:
     needs: [publish-pypi, release-please]
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PROMPTFOO_APP_ID }}
+          private-key: ${{ secrets.PROMPTFOO_APP_PRIVATE_KEY }}
+          owner: promptfoo
+          repositories: promptfoo-cloud
+
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
         with:
@@ -151,13 +160,15 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Trigger scanner image rebuild
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           VERSION="${{ needs.release-please.outputs.version }}"
           echo "Rebuilding scanner image with modelaudit ${VERSION}..."
 
-          # Clone promptfoo-cloud repo
-          git clone --depth 1 https://github.com/promptfoo/promptfoo-cloud.git /tmp/promptfoo-cloud
+          # Clone promptfoo-cloud repo (private - using GitHub App token)
+          git clone --depth 1 https://x-access-token:${GH_TOKEN}@github.com/promptfoo/promptfoo-cloud.git /tmp/promptfoo-cloud
 
           # Verify the scanner directory exists
           if [ ! -d "/tmp/promptfoo-cloud/workers/gcp/modelaudit-automation/scanner" ]; then


### PR DESCRIPTION
## Summary
- Automatically rebuild the modelaudit-scanner Docker image when a new version is published to PyPI
- Ensures Cloud Run scanner job always has the latest modelaudit version

## How it works
1. After `publish-pypi` job completes successfully
2. New `trigger-scanner-rebuild` job runs:
   - Clones promptfoo-cloud repo
   - Builds scanner image with version tags (e.g., `1.2.3` and `latest`)
   - Pushes to Artifact Registry
   - Updates Cloud Run job to use the versioned image

## Changes
- Added `trigger-scanner-rebuild` job to release-please workflow
- Uses least-privilege GCP service account `github-scanner-rebuild`
- Includes CodeRabbit suggestions: `set -euo pipefail`, directory verification, 20m timeout, version tags

## Prerequisites
- `GCP_SA_KEY` secret added to this repo ✅

## Testing

### Build 1: Initial Dockerfile fix validation
- **Build ID:** `4010c12e-b1bd-4102-a508-8fbf04afe65a`
- **Status:** ✅ SUCCESS
- **Console:** https://console.cloud.google.com/cloud-build/builds/4010c12e-b1bd-4102-a508-8fbf04afe65a?project=58786025894
- **Purpose:** Verified the Dockerfile fix works

### Build 2: Full workflow simulation with version tags
- **Build ID:** `52fb0e82-3452-4d33-93af-2335672ff0af`
- **Status:** ✅ SUCCESS
- **Console:** https://console.cloud.google.com/cloud-build/builds/52fb0e82-3452-4d33-93af-2335672ff0af?project=58786025894
- **Purpose:** Simulated full release workflow with version tags (demo-1.0.0)
- **Command tested:**
```bash
gcloud builds submit \
  --tag=us-central1-docker.pkg.dev/promptfoo/modelaudit-scanner/modelaudit-scanner:demo-1.0.0 \
  --tag=us-central1-docker.pkg.dev/promptfoo/modelaudit-scanner/modelaudit-scanner:latest \
  --timeout=20m \
  --project=promptfoo \
  /tmp/promptfoo-cloud/workers/gcp/modelaudit-automation/scanner
```

## Test plan
- [x] Test manual Cloud Build with version tags
- [ ] Merge Dockerfile fix in promptfoo-cloud first (PR #2775)
- [ ] Test by manually triggering the release workflow
- [ ] Verify scanner image is rebuilt and Cloud Run job is updated

## Related
- Companion PR in promptfoo-cloud: https://github.com/promptfoo/promptfoo-cloud/pull/2775

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated scanner component deployment to the release workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->