### PR TITLE
chore: upgrade Docker base images to Python 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 

--- a/Dockerfile.tensorflow
+++ b/Dockerfile.tensorflow
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Upgrades all Docker base images to Python 3.13-slim, the latest Python version supported by TensorFlow.

## Changes

| Dockerfile | Before | After |
|------------|--------|-------|
| `Dockerfile` | 3.10-slim | 3.13-slim |
| `Dockerfile.full` | 3.11-slim | 3.13-slim |
| `Dockerfile.tensorflow` | 3.12-slim | 3.13-slim |

## Why Python 3.13?

- **TensorFlow 2.20.0** supports Python 3.13 ✅
- **Python 3.14** is not yet supported by TensorFlow ❌
  - Tracking issues: [#102890](https://github.com/tensorflow/tensorflow/issues/102890), [#105912](https://github.com/tensorflow/tensorflow/issues/105912)

This PR supersedes #464 which attempted to upgrade to Python 3.14.

## Test Plan

- [ ] CI passes all checks
- [ ] Docker images build successfully
- [ ] TensorFlow dependencies install correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application runtime to Python 3.13-slim across all deployment configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->