### PR TITLE
fix: add content-based CVE detection to SkopsScanner

### DIFF
--- a/tests/scanners/test_skops_content_analysis.py
+++ b/tests/scanners/test_skops_content_analysis.py
@@ -1,0 +1,124 @@
+"""Tests for SkopsScanner content analysis fix."""
+
+import zipfile
+from pathlib import Path
+
+from modelaudit.scanners.base import CheckStatus, IssueSeverity
+from modelaudit.scanners.skops_scanner import SkopsScanner
+
+
+class TestSkopsScannerContentAnalysis:
+    """Test content-based CVE detection (not just filename patterns)."""
+
+    def test_detects_operatorfuncnode_in_content(self, tmp_path: Path) -> None:
+        """Test detection of OperatorFuncNode pattern in file content (not filename)."""
+        skops_file = tmp_path / "model.skops"
+        with zipfile.ZipFile(skops_file, "w") as zf:
+            # Pattern is in content, not filename
+            zf.writestr("data.json", '{"node_type": "OperatorFuncNode", "func": "eval"}')
+            zf.writestr("schema.json", '{"version": "1.0"}')
+
+        scanner = SkopsScanner()
+        result = scanner.scan(str(skops_file))
+
+        cve_checks = [c for c in result.checks if "CVE-2025-54412" in c.name]
+        assert len(cve_checks) > 0
+        assert cve_checks[0].status == CheckStatus.FAILED
+        assert cve_checks[0].severity == IssueSeverity.CRITICAL
+
+        # Verify it detected the content pattern, not filename
+        details = cve_checks[0].details
+        patterns_matched = details.get("patterns_matched", [])
+        assert any("content:" in p for p in patterns_matched)
+
+    def test_detects_methodnode_in_content(self, tmp_path: Path) -> None:
+        """Test detection of MethodNode pattern in file content (not filename)."""
+        skops_file = tmp_path / "model.skops"
+        with zipfile.ZipFile(skops_file, "w") as zf:
+            # Pattern is in content, not filename
+            zf.writestr("tree.json", '{"type": "MethodNode", "method": "__getattr__"}')
+            zf.writestr("schema.json", '{"version": "1.0"}')
+
+        scanner = SkopsScanner()
+        result = scanner.scan(str(skops_file))
+
+        cve_checks = [c for c in result.checks if "CVE-2025-54413" in c.name]
+        assert len(cve_checks) > 0
+        assert cve_checks[0].status == CheckStatus.FAILED
+        assert cve_checks[0].severity == IssueSeverity.CRITICAL
+
+        # Verify it detected the content pattern, not filename
+        details = cve_checks[0].details
+        patterns_matched = details.get("patterns_matched", [])
+        assert any("content:" in p for p in patterns_matched)
+
+    def test_detects_reduce_in_content(self, tmp_path: Path) -> None:
+        """Test detection of __reduce__ pattern in file content."""
+        skops_file = tmp_path / "model.skops"
+        with zipfile.ZipFile(skops_file, "w") as zf:
+            # Pattern is in content, not filename
+            zf.writestr("object.bin", b'{"method": "__reduce__", "args": ["os.system", "id"]}')
+            zf.writestr("schema.json", '{"version": "1.0"}')
+
+        scanner = SkopsScanner()
+        result = scanner.scan(str(skops_file))
+
+        cve_checks = [c for c in result.checks if "CVE-2025-54412" in c.name]
+        assert len(cve_checks) > 0
+        assert cve_checks[0].status == CheckStatus.FAILED
+
+    def test_detects_getattr_in_content(self, tmp_path: Path) -> None:
+        """Test detection of __getattr__ pattern in file content."""
+        skops_file = tmp_path / "model.skops"
+        with zipfile.ZipFile(skops_file, "w") as zf:
+            # Pattern is in content, not filename
+            zf.writestr("hooks.json", '{"hook": "__getattr__", "target": "os"}')
+            zf.writestr("schema.json", '{"version": "1.0"}')
+
+        scanner = SkopsScanner()
+        result = scanner.scan(str(skops_file))
+
+        cve_checks = [c for c in result.checks if "CVE-2025-54413" in c.name]
+        assert len(cve_checks) > 0
+        assert cve_checks[0].status == CheckStatus.FAILED
+
+    def test_clean_file_no_content_detection(self, tmp_path: Path) -> None:
+        """Test that clean files without malicious content don't trigger."""
+        skops_file = tmp_path / "clean.skops"
+        with zipfile.ZipFile(skops_file, "w") as zf:
+            zf.writestr("schema.json", '{"version": "1.0", "protocol": "3"}')
+            zf.writestr("model.bin", b"\x00\x01\x02\x03 model weights here")
+            zf.writestr("metadata.json", '{"name": "clean_model", "type": "sklearn"}')
+
+        scanner = SkopsScanner()
+        result = scanner.scan(str(skops_file))
+
+        # Should not have any CVE-2025-54412 or CVE-2025-54413 failed checks
+        cve_54412 = [c for c in result.checks if "CVE-2025-54412" in c.name and c.status == CheckStatus.FAILED]
+        cve_54413 = [c for c in result.checks if "CVE-2025-54413" in c.name and c.status == CheckStatus.FAILED]
+        assert len(cve_54412) == 0
+        assert len(cve_54413) == 0
+
+    def test_detects_both_filename_and_content(self, tmp_path: Path) -> None:
+        """Test that scanner detects patterns in both filename and content."""
+        skops_file = tmp_path / "malicious.skops"
+        with zipfile.ZipFile(skops_file, "w") as zf:
+            # Pattern in filename
+            zf.writestr("OperatorFuncNode.json", '{"type": "node"}')
+            # Different pattern in content
+            zf.writestr("data.json", '{"method": "__reduce__"}')
+            zf.writestr("schema.json", '{"version": "1.0"}')
+
+        scanner = SkopsScanner()
+        result = scanner.scan(str(skops_file))
+
+        cve_checks = [c for c in result.checks if "CVE-2025-54412" in c.name]
+        assert len(cve_checks) > 0
+
+        # Should detect both filename and content patterns
+        details = cve_checks[0].details
+        patterns_matched = details.get("patterns_matched", [])
+        has_filename = any("filename:" in p for p in patterns_matched)
+        has_content = any("content:" in p for p in patterns_matched)
+        assert has_filename, f"Expected filename pattern, got: {patterns_matched}"
+        assert has_content, f"Expected content pattern, got: {patterns_matched}"


### PR DESCRIPTION
## Summary
- Add content scanning to CVE-2025-54412 and CVE-2025-54413 detection
- Previously only scanned file names, now also scans file content for malicious patterns
- Improves detection of obfuscated exploits that hide patterns in file content

## Problem
The previous implementation only checked if suspicious patterns (e.g., "OperatorFuncNode", "MethodNode") appeared in ZIP file names. Attackers could bypass this by:
1. Using innocuous filenames like `data.json` or `model.bin`
2. Embedding malicious patterns in the file content instead

## Solution
Now the scanner:
1. Still checks file names (for quick detection)
2. Also reads and scans file content for the same patterns
3. Reports whether patterns were found in filename vs content for better diagnostics

## Test plan
- [x] All 6 new content analysis tests pass
- [x] Tests verify detection in content (not filename)
- [x] Tests verify clean files don't trigger false positives
- [x] Tests verify both filename and content detection work together
- [x] mypy passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)