### PR TITLE
fix: reduce pickle scanner false positives for BERT and standalone REDUCE opcodes

### DIFF
--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -1404,6 +1404,8 @@ def check_opcode_sequence(
 
             # Special handling for REDUCE - check if it's using safe globals
             elif opcode.name == "REDUCE":
+                # Default to dangerous if no associated GLOBAL/STACK_GLOBAL found
+                is_dangerous_opcode = True
                 # Look back to find the associated GLOBAL or STACK_GLOBAL
                 for j in range(i - 1, max(0, i - 10), -1):
                     prev_opcode, prev_arg, _prev_pos = opcodes[j]
@@ -1418,9 +1420,9 @@ def check_opcode_sequence(
                         )
                         if len(parts) == 2:
                             mod, func = parts
-                            # Only count as dangerous if NOT in safe globals
-                            if not _is_safe_ml_global(mod, func):
-                                is_dangerous_opcode = True
+                            # Only skip if in safe globals
+                            if _is_safe_ml_global(mod, func):
+                                is_dangerous_opcode = False
                             break
 
                     elif prev_opcode.name == "STACK_GLOBAL":
@@ -1442,9 +1444,9 @@ def check_opcode_sequence(
 
                         if len(recent_strings) >= 2:
                             mod, func = recent_strings[0], recent_strings[1]
-                            # Only count as dangerous if NOT in safe globals
-                            if not _is_safe_ml_global(mod, func):
-                                is_dangerous_opcode = True
+                            # Only skip if in safe globals
+                            if _is_safe_ml_global(mod, func):
+                                is_dangerous_opcode = False
                             break
 
             # GLOBAL/STACK_GLOBAL: only count when referencing non-safe modules


### PR DESCRIPTION
## Summary

- Exclude structural opcodes (PROTO, STOP, FRAME, MEMOIZE, EMPTY_DICT, MARK, SETITEMS, BINPUT, LONG_BINPUT, SHORT_BINUNICODE, BINUNICODE) from dangerous opcode count to prevent false positives on legitimate models like BERT
- Default REDUCE opcodes to dangerous when no associated GLOBAL is found, ensuring standalone REDUCE opcodes are not silently ignored

## Test plan

- [x] `uv run ruff format --check modelaudit/ tests/` passes
- [x] `uv run ruff check modelaudit/ tests/` passes
- [x] `uv run mypy modelaudit/` passes
- [x] `uv run pytest -n auto -m "not slow and not integration" --maxfail=1` — 315 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of security scanning by reducing false positives when analyzing potentially dangerous operations
  * Enhanced detection to better recognize and whitelist safe machine learning operations, decreasing unnecessary security warnings
  * Refined handling of memory and structural operations for more accurate threat assessment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->