### PR TITLE
fix(cli): fail fast when glob patterns match nothing

### DIFF
--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -602,7 +602,7 @@ def scan_command(
             ),
             err=True,
         )
-        record_scan_failed(0.0, "No matching paths")
+        record_scan_failed(time.time() - scan_start_time, "No matching paths")
         flush_telemetry()
         sys.exit(2)
 


### PR DESCRIPTION
## Summary
Users passing a glob that matches no local files currently get no explicit feedback until a later generic "no files scanned" result. This makes path typos and shell-glob mistakes harder to diagnose.

## User impact
A scan invocation can look valid but effectively do nothing, forcing users to debug from indirect output instead of getting immediate actionable guidance.

## Root cause
`expand_paths` dropped unmatched glob patterns silently and returned only matched values. When every glob missed, scanning continued without clear context about why no inputs were selected.

## Fix
`expand_paths` now returns both expanded paths and unmatched glob patterns.
The scan command now:
- warns when one or more glob patterns do not match local files,
- exits early with code `2` when no paths remain after expansion,
- records and flushes telemetry for this early failure path.

## Validation
- `uv run ruff format modelaudit/ tests/`
- `uv run ruff check --fix modelaudit/ tests/`
- `uv run mypy modelaudit/`
- `uv run pytest -n auto -m "not slow and not integration" --maxfail=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection and warnings for unmatched glob patterns during path expansion; warns when patterns yield no local matches.

* **Bug Fixes**
  * Improved error handling and messaging when no valid paths are found; ensures scan exits with an appropriate failure status.

* **Tests**
  * Expanded test coverage for path expansion and CLI scan behaviors, including glob handling, formats, exit codes, and streaming/telemetry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->