### PR TITLE
docs: complete next-phase open-source readiness docs items

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,27 @@
 # Default ownership for all repository files.
-# Replace with an org team if/when one is created.
 * @mdangelo
+
+# Scanner engine and detection logic
+/modelaudit/scanners/ @mdangelo
+/modelaudit/detectors/ @mdangelo
+/modelaudit/analysis/ @mdangelo
+
+# CLI, core orchestration, and package metadata
+/modelaudit/cli.py @mdangelo
+/modelaudit/core.py @mdangelo
+/pyproject.toml @mdangelo
+/uv.lock @mdangelo
+
+# CI/CD, release automation, and repo governance
+/.github/workflows/ @mdangelo
+/.github/CODEOWNERS @mdangelo
+/.github/PULL_REQUEST_TEMPLATE.md @mdangelo
+/.github/ISSUE_TEMPLATE/ @mdangelo
+
+# Documentation and contributor guidance
+/README.md @mdangelo
+/CONTRIBUTING.md @mdangelo
+/SECURITY.md @mdangelo
+/SUPPORT.md @mdangelo
+/MAINTAINERS.md @mdangelo
+/docs/ @mdangelo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,6 +183,26 @@ git push origin feature/your-feature-name
 - Add tests for new functionality
 - Update documentation as needed
 
+### Reporting False Positives / False Negatives
+
+Detection quality reports are high priority and should be reproducible.
+
+Include the following:
+
+- ModelAudit version and Python version
+- Exact command used (including flags)
+- Expected result vs actual result
+- Minimal reproducible sample (or a redacted/synthetic equivalent)
+- Why the behavior is a false positive or false negative
+
+If sharing a model artifact is not possible, include:
+
+- File format and extension
+- Relevant metadata/layout details
+- Representative snippets (redacted) that trigger or evade detection
+
+For sensitive security bypass details, use the private disclosure process in `SECURITY.md` instead of a public issue.
+
 ### Commit Message Format
 
 We use [Conventional Commits](https://www.conventionalcommits.org/) format:

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,33 @@
+# Maintainers
+
+This file documents project roles and default ownership expectations.
+
+## Roles
+
+### Maintainer
+
+- Owns security posture, release quality, and roadmap decisions.
+- Reviews and merges pull requests.
+- Handles security escalations and incident communication.
+
+### Reviewer
+
+- Reviews pull requests for correctness, safety, and tests.
+- Requests changes when behavior, security, or compatibility risks are found.
+
+### Triage
+
+- Labels and routes issues/PRs.
+- Requests missing reproduction details.
+- Closes duplicates and stale reports per policy.
+
+## Current Maintainers
+
+- `@mdangelo`
+
+## Coverage Expectations
+
+- At least one maintainer review for code changes.
+- Security-sensitive changes should receive explicit security-focused review.
+- Keep `CODEOWNERS` aligned with active maintainers and reviewer coverage.
+- Follow `docs/maintainers/triage-playbook.md` for issue and PR triage operations.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,28 @@ docker run --rm -v "$(pwd)":/app ghcr.io/promptfoo/modelaudit:latest model.pkl
 
 Exit codes: `0` clean, `1` issues found, `2` errors.
 
+## Telemetry and Privacy
+
+ModelAudit includes telemetry for product reliability and usage analytics.
+
+- Collected metadata can include command usage, scan timing, scanner/file-type usage, issue severity/type aggregates, and model path or URL identifiers.
+- Model files are scanned locally and ModelAudit does not upload model binary contents as telemetry events.
+- Telemetry is disabled automatically in CI/test environments and in editable development installs by default.
+
+Opt out explicitly with either environment variable:
+
+```bash
+export PROMPTFOO_DISABLE_TELEMETRY=1
+# or
+export NO_ANALYTICS=1
+```
+
+To opt in during editable/development installs:
+
+```bash
+export MODELAUDIT_TELEMETRY_DEV=1
+```
+
 ## Output Examples
 
 ```bash
@@ -171,6 +193,7 @@ modelaudit model.pkl --format sarif --output results.sarif
 - **[Full docs](https://www.promptfoo.dev/docs/model-audit/)** — setup, configuration, and advanced usage
 - **[Usage examples](https://www.promptfoo.dev/docs/model-audit/usage/)** — CI/CD integration, remote scanning, SBOM generation
 - **[Supported formats](https://www.promptfoo.dev/docs/model-audit/scanners/)** — detailed scanner documentation
+- **[Support policy](SUPPORT.md)** — supported Python/OS versions and maintenance policy
 - **Troubleshooting** — run `modelaudit doctor --show-failed` to check scanner availability
 
 ## License

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,32 @@
+# Support Policy
+
+This document defines what versions and environments are currently supported for ModelAudit.
+
+## Supported Versions
+
+| Component        | Supported              |
+| ---------------- | ---------------------- |
+| ModelAudit       | Latest release         |
+| Python           | 3.10, 3.11, 3.12, 3.13 |
+| Operating system | Linux, macOS, Windows  |
+
+Older ModelAudit releases may continue to function, but only the latest release receives routine fixes.
+
+## Dependency Model
+
+ModelAudit supports a core scanner set with optional extras for framework-specific scanners.
+
+- Core install (`pip install modelaudit`) is supported.
+- Optional extras are supported on a best-effort basis based on upstream ecosystem compatibility.
+- CI validates the project's supported Python versions and main dependency sets.
+
+## Maintenance Window
+
+- Security and reliability fixes are prioritized for the latest release line.
+- We may ask reporters to reproduce issues on the latest release before triage.
+
+## Getting Help
+
+- Usage and troubleshooting: open a GitHub issue.
+- Feature requests: open a GitHub issue with the feature template.
+- Security vulnerabilities: do not file public issues. Follow `SECURITY.md`.

--- a/docs/maintainers/triage-playbook.md
+++ b/docs/maintainers/triage-playbook.md
@@ -1,0 +1,50 @@
+# Issue Triage Playbook
+
+This playbook standardizes issue and pull request triage for maintainers.
+
+## Triage Flow
+
+1. Confirm scope (`bug`, `enhancement`, `question`, `security`).
+2. Confirm reproducibility details (version, Python version, command, expected/actual behavior).
+3. Route to the right owner area and add labels.
+4. Decide next action: `accept`, `needs-repro`, `needs-info`, `duplicate`, `won't-fix`.
+5. Link related issues/PRs and add milestone when applicable.
+
+## Label Taxonomy
+
+### Type labels
+
+- `bug` - Incorrect behavior.
+- `enhancement` - New or improved capability.
+- `documentation` - Docs-only changes.
+- `security` - Security-impacting issue (non-sensitive/public-safe only).
+
+### Status labels
+
+- `needs-repro` - Cannot reproduce yet.
+- `needs-info` - Reporter details missing.
+- `blocked` - Waiting on dependency or external decision.
+- `ready` - Ready for implementation/review.
+
+### Priority labels
+
+- `priority:P0` - Critical breakage or security risk.
+- `priority:P1` - Important near-term work.
+- `priority:P2` - Normal backlog.
+
+### Contributor experience labels
+
+- `good first issue` - Scoped and newcomer-friendly.
+- `help wanted` - Maintainers welcome community contributions.
+
+## Security-Specific Handling
+
+- If a report may disclose a vulnerability, move it to private handling per `SECURITY.md`.
+- Do not request exploit details in public threads.
+
+## Pull Request Triage
+
+1. Validate CI status and failing checks.
+2. Ensure scope is focused and tests are present.
+3. Check compatibility claims (Python 3.10-3.13).
+4. Request follow-up changes or route to reviewer.

--- a/docs/plans/open-source-readiness.md
+++ b/docs/plans/open-source-readiness.md
@@ -2,7 +2,7 @@
 
 **Status:** HEAD CHANGES COMPLETE; NEXT-PHASE CHECKLIST ACTIVE
 **Created:** 2026-02-18
-**Updated:** 2026-02-20
+**Updated:** 2026-02-21
 **Branch:** `chore/open-source-readiness`
 
 ## Overview
@@ -85,17 +85,17 @@ This section tracks high-value work after the initial hardening pass. Use `[P0]`
 - [ ] [P1] Prevent branch deletions and force-pushes on protected branches.
 - [ ] [P1] Restrict who can create/modify tags matching `v*`.
 - [ ] [P1] Add at least one backup maintainer to reduce single-maintainer risk.
-- [ ] [P1] Expand `.github/CODEOWNERS` with per-area ownership (scanners, docs, CI, release).
-- [ ] [P2] Add `MAINTAINERS.md` with roles (maintainer, reviewer, triage).
+- [x] [P1] Expand `.github/CODEOWNERS` with per-area ownership (scanners, docs, CI, release).
+- [x] [P2] Add `MAINTAINERS.md` with roles (maintainer, reviewer, triage).
 - [ ] [P2] Define maintainer response expectations (issues/PR triage SLO).
 
 ### 7b. Security Program & Supply Chain
 
 - [ ] [P0] Enable GitHub security features: dependency graph, Dependabot alerts, secret scanning, push protection.
 - [ ] [P0] Enable and monitor private vulnerability reporting (via `SECURITY.md` workflow).
-- [ ] [P0] Add CodeQL workflow for Python and GitHub Actions analysis.
-- [ ] [P0] Add dependency vulnerability scanning in CI (`pip-audit` or equivalent).
-- [ ] [P0] Add container vulnerability scanning for Docker images (e.g., Trivy/Grype).
+- [x] [P0] Add CodeQL workflow for Python and GitHub Actions analysis.
+- [x] [P0] Add dependency vulnerability scanning in CI (`pip-audit` or equivalent).
+- [x] [P0] Add container vulnerability scanning for Docker images (e.g., Trivy/Grype).
 - [ ] [P1] Add provenance attestations for release artifacts (SLSA/Sigstore).
 - [ ] [P1] Add artifact signing strategy for wheels/sdists and release tags.
 - [ ] [P1] Add SBOM generation to release workflow and attach SBOM to releases.
@@ -107,7 +107,7 @@ This section tracks high-value work after the initial hardening pass. Use `[P0]`
 
 ### 7c. Release Engineering & Distribution
 
-- [ ] [P0] Add `twine check dist/*` to release workflow.
+- [x] [P0] Add `twine check dist/*` to release workflow.
 - [ ] [P0] Add clean-room install smoke tests from built wheel/sdist.
 - [ ] [P0] Ensure release workflow validates exactly one version in `dist/` artifacts.
 - [ ] [P1] Publish Docker images in CI (if advertised in README), with semver tags and digests.
@@ -120,7 +120,7 @@ This section tracks high-value work after the initial hardening pass. Use `[P0]`
 
 ### 7d. CI/CD Quality Gates
 
-- [ ] [P0] Add scheduled nightly CI run for full matrix (including slow/integration/performance tests).
+- [x] [P0] Add scheduled nightly CI run for full matrix (including slow/integration/performance tests).
 - [ ] [P1] Add compatibility smoke tests for all optional extras bundles.
 - [ ] [P1] Add reproducibility checks for generated protobuf artifacts.
 - [ ] [P1] Add CI checks for minimum supported Python/NumPy combinations as explicit gates.
@@ -133,10 +133,10 @@ This section tracks high-value work after the initial hardening pass. Use `[P0]`
 
 ### 7e. Documentation & User Trust
 
-- [ ] [P0] Add README section explaining telemetry behavior and explicit opt-out controls.
-- [ ] [P0] Add clear support policy (supported versions and maintenance window).
+- [x] [P0] Add README section explaining telemetry behavior and explicit opt-out controls.
+- [x] [P0] Add clear support policy (supported versions and maintenance window).
 - [ ] [P1] Add "security model and limitations" page for users.
-- [ ] [P1] Add "false positives/false negatives" reporting guidelines.
+- [x] [P1] Add "false positives/false negatives" reporting guidelines.
 - [ ] [P1] Add contributor quickstart focused on adding a new scanner safely.
 - [ ] [P1] Add compatibility matrix page for file formats vs optional dependencies.
 - [ ] [P1] Add offline/air-gapped usage guidance.
@@ -157,9 +157,9 @@ This section tracks high-value work after the initial hardening pass. Use `[P0]`
 ### 7g. Community & Project Operations
 
 - [ ] [P1] Enable GitHub Discussions with categories (Q&A, Ideas, Show and Tell).
-- [ ] [P1] Define label taxonomy (`good first issue`, `help wanted`, `security`, `needs-repro`).
+- [x] [P1] Define label taxonomy (`good first issue`, `help wanted`, `security`, `needs-repro`).
 - [ ] [P1] Seed onboarding issues for first-time external contributors.
-- [ ] [P1] Add issue triage playbook for maintainers.
+- [x] [P1] Add issue triage playbook for maintainers.
 - [ ] [P2] Add stale-issue policy and automation.
 - [ ] [P2] Publish roadmap/milestones for upcoming releases.
 - [ ] [P2] Add community acknowledgements/contributors section.


### PR DESCRIPTION
## Summary

Implements a focused batch of next-phase open-source readiness items that can be completed directly in-repo (without admin-only GitHub settings).

### Completed in this PR

- Added `SUPPORT.md` with explicit support policy (versions, environments, maintenance expectations).
- Added `MAINTAINERS.md` with role definitions and coverage expectations.
- Added maintainer operations guide at `docs/maintainers/triage-playbook.md`, including label taxonomy.
- Expanded `.github/CODEOWNERS` to per-area ownership paths.
- Added telemetry + opt-out guidance to `README.md`.
- Added false-positive/false-negative reporting guidance to `CONTRIBUTING.md`.
- Updated `docs/plans/open-source-readiness.md` checklist statuses for:
  - newly completed docs/governance items in this PR
  - already-landed CI/security items on `main` (CodeQL, pip-audit, Trivy, nightly CI, twine check)

## Validation

- `npm ci --ignore-scripts`
- `npx prettier --write README.md CONTRIBUTING.md SUPPORT.md MAINTAINERS.md docs/maintainers/triage-playbook.md docs/plans/open-source-readiness.md`
- `uv run ruff format modelaudit/ tests/`
- `uv run ruff check --fix modelaudit/ tests/`
- `uv run mypy modelaudit/`
- `uv run pytest -n auto -m "not slow and not integration" --maxfail=1`

All checks passed locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Telemetry and Privacy section explaining data collection practices with opt-out options (environment variables).
  * New Support.md documenting supported versions and help channels.
  * Enhanced CONTRIBUTING.md with guidelines for reporting false positives/negatives, commit message examples, and project structure details.
  * Updated project governance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->