### PR TITLE
chore: add __all__ with lazy public API exports

### DIFF
--- a/modelaudit/__init__.py
+++ b/modelaudit/__init__.py
@@ -6,6 +6,15 @@ pyproject.toml and accessed at runtime via importlib.metadata.
 """
 
 import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from modelaudit.core import scan_file as scan_file
+    from modelaudit.core import scan_model_directory_or_file as scan_model_directory_or_file
+    from modelaudit.scanners.base import BaseScanner as BaseScanner
+    from modelaudit.scanners.base import Issue as Issue
+    from modelaudit.scanners.base import IssueSeverity as IssueSeverity
+    from modelaudit.scanners.base import ScanResult as ScanResult
 
 if sys.version_info < (3, 10):  # noqa: UP036 — intentional safety net for bypassed requires-python
     import warnings


### PR DESCRIPTION
## Summary

- Adds `__all__` to `modelaudit/__init__.py` exposing the core public API: `scan_file`, `scan_model_directory_or_file`, `ScanResult`, `IssueSeverity`, `Issue`, `BaseScanner`, `__version__`
- Uses lazy `__getattr__` loading to avoid circular imports at package init time
- Enables `from modelaudit import scan_file, ScanResult` for external library users

Previously, external users had to know internal module paths like `from modelaudit.core import scan_file` or `from modelaudit.scanners.base import ScanResult`.

## Test plan

- [x] `ruff check` — passed
- [x] `mypy` — no issues
- [x] Manual verification: `from modelaudit import scan_file, ScanResult, IssueSeverity` works
- [x] `pytest -n auto -m "not slow and not integration"` — 1845 passed, 67 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Package initialization now defers loading of public API symbols to first use, reducing import-time overhead and memory usage.
  * Type hints were adjusted to avoid affecting runtime behavior.
  * Public APIs and runtime behavior remain unchanged; callers should observe no functional differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->