### PR TITLE
test: replace skipped YAML test with proper behavior assertions

### DIFF
--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -1,8 +1,6 @@
 import json
 import logging
 
-import pytest
-
 from modelaudit.scanners.base import CheckStatus, IssueSeverity, ScanResult
 from modelaudit.scanners.manifest_scanner import ManifestScanner
 
@@ -174,10 +172,22 @@ def test_parse_file_logs_warning(caplog, capsys):
     assert any(issue.severity == IssueSeverity.DEBUG for issue in result.issues)
 
 
-def test_manifest_scanner_yaml():
-    """Test the manifest scanner with a YAML file."""
-    # Skip this test - YAML files are no longer supported after whitelist changes
-    pytest.skip("YAML files are no longer supported by manifest scanner whitelist")
+def test_manifest_scanner_yaml_not_handled(tmp_path):
+    """Test that YAML files are not handled by the manifest scanner."""
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text("model_type: bert\nhidden_size: 768\n")
+
+    scanner = ManifestScanner()
+    assert scanner.can_handle(str(yaml_file)) is False
+
+
+def test_manifest_scanner_yml_not_handled(tmp_path):
+    """Test that .yml files are not handled by the manifest scanner."""
+    yml_file = tmp_path / "config.yml"
+    yml_file.write_text("model_type: gpt2\nhidden_size: 768\n")
+
+    scanner = ManifestScanner()
+    assert scanner.can_handle(str(yml_file)) is False
 
 
 def test_manifest_scanner_can_handle(tmp_path):


### PR DESCRIPTION
## Summary

- Replaces a `pytest.skip()` placeholder in `test_manifest_scanner.py` with two proper test functions
- `test_manifest_scanner_yaml_not_handled` — verifies `.yaml` files are rejected by `can_handle()`
- `test_manifest_scanner_yml_not_handled` — verifies `.yml` files are rejected by `can_handle()`
- Removes unused `pytest` import (caught by ruff)

Supersedes the stale `test/fix-skipped-yaml-test` branch (which targeted the pre-reorganization file path).

## Test plan

- [x] All 16 manifest scanner tests pass
- [x] Lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Manifest scanner no longer processes YAML files with .yaml and .yml extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->