### PR TITLE
chore(open-source): add SBOM, advisory template, and regression corpus

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -377,8 +377,27 @@ jobs:
         with:
           subject-path: "dist/*"
 
-      # Upload wheel/sdist to the GitHub Release as an alternative download
-      # location alongside PyPI. --clobber ensures idempotency on re-runs.
+      - name: Install uv
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7
+        with:
+          enable-cache: true
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: pyproject.toml
+
+      - name: Generate SBOM
+        run: |
+          uv tool install cyclonedx-bom
+          uv tool run cyclonedx-py requirements \
+            --pyproject pyproject.toml \
+            --output-format json \
+            --outfile dist/modelaudit-${{ needs.release-please.outputs.version }}.cdx.json
+          echo "SBOM generated:"
+          ls -la dist/*.cdx.json
+
+      # Upload wheel/sdist and SBOM to the GitHub Release as an alternative
+      # download location alongside PyPI. --clobber ensures idempotency on re-runs.
       - name: Upload build artifacts to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/maintainers/security-advisory-template.md
+++ b/docs/maintainers/security-advisory-template.md
@@ -1,0 +1,83 @@
+# Security Advisory Template
+
+Use this template when publishing a [GitHub Security Advisory](https://github.com/promptfoo/modelaudit/security/advisories/new) for ModelAudit.
+
+---
+
+## Advisory Title
+
+`[CVE-YYYY-NNNNN] Brief description of the vulnerability`
+
+## Affected Versions
+
+- **Affected:** `>= X.Y.Z, < A.B.C`
+- **Fixed in:** `A.B.C`
+
+## Severity
+
+Use the CVSS 3.1 calculator to determine the score and vector string.
+
+- **Severity:** Critical / High / Medium / Low
+- **CVSS Score:** X.X
+- **CVSS Vector:** `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`
+
+## Summary
+
+One-paragraph description of the vulnerability, what it allows an attacker to do,
+and which component is affected.
+
+## Details
+
+Technical explanation of the root cause. Include:
+
+- Which scanner/module is affected
+- The attack vector (e.g., crafted model file, malicious archive)
+- Why the vulnerability exists (logic error, missing check, parser bug)
+
+## Impact
+
+What can an attacker achieve by exploiting this vulnerability?
+
+- Can they execute arbitrary code?
+- Can they bypass a detection?
+- Can they cause denial of service?
+- What user action is required (e.g., scanning a malicious file)?
+
+## Proof of Concept
+
+```python
+# Minimal reproduction steps (sanitize any weaponizable details)
+```
+
+## Remediation
+
+- **Upgrade:** `pip install --upgrade modelaudit>=A.B.C`
+- **Workaround:** (if any interim mitigation exists before upgrading)
+
+## Timeline
+
+| Date       | Event                      |
+| ---------- | -------------------------- |
+| YYYY-MM-DD | Vulnerability reported     |
+| YYYY-MM-DD | Report acknowledged        |
+| YYYY-MM-DD | Fix developed and verified |
+| YYYY-MM-DD | Fixed version released     |
+| YYYY-MM-DD | Advisory published         |
+
+## Credit
+
+Reported by [Name / Handle] (unless they prefer anonymity).
+
+---
+
+## Publishing Checklist
+
+Before publishing the advisory:
+
+- [ ] Fix merged and released to PyPI
+- [ ] CHANGELOG updated with security note
+- [ ] CVE ID requested (via GitHub advisory or MITRE)
+- [ ] Advisory draft reviewed by at least one other maintainer
+- [ ] Reporter notified of planned disclosure date
+- [ ] Advisory published on GitHub
+- [ ] Email sent to security@promptfoo.dev distribution list (if applicable)

--- a/docs/plans/open-source-readiness.md
+++ b/docs/plans/open-source-readiness.md
@@ -97,9 +97,9 @@ This section tracks high-value work after the initial hardening pass. Use `[P0]`
 - [x] [P0] Add container vulnerability scanning for Docker images (e.g., Trivy/Grype).
 - [x] [P1] Add provenance attestations for release artifacts (SLSA/Sigstore).
 - [x] [P1] Add artifact signing strategy for wheels/sdists and release tags.
-- [ ] [P1] Add SBOM generation to release workflow and attach SBOM to releases.
+- [x] [P1] Add SBOM generation to release workflow and attach SBOM to releases.
 - [x] [P1] Add CVE handling process (triage, fix, advisory publication flow).
-- [ ] [P1] Add security advisory templates for maintainers.
+- [x] [P1] Add security advisory templates for maintainers.
 - [x] [P1] Add a lightweight public threat model document.
 - [ ] [P2] Add fuzzing strategy for binary/model parsers.
 - [ ] [P2] Add periodic external security review cadence (quarterly/biannual).
@@ -123,7 +123,7 @@ This section tracks high-value work after the initial hardening pass. Use `[P0]`
 - [x] [P1] Add compatibility smoke tests for all optional extras bundles.
 - [x] [P1] Add reproducibility checks for generated protobuf artifacts.
 - [x] [P1] Add CI checks for minimum supported Python/NumPy combinations as explicit gates.
-- [ ] [P1] Add regression corpus validation for malicious and benign fixtures.
+- [x] [P1] Add regression corpus validation for malicious and benign fixtures.
 - [x] [P1] Add `uv lock` consistency check in CI.
 - [ ] [P2] Add performance budget checks to catch scanner regressions.
 - [ ] [P2] Add mutation/property-based tests for high-risk scanners.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,6 +237,7 @@ markers = [
     "safetensors: marks tests as requiring safetensors",
     "joblib: marks tests as requiring joblib",
     "dill: marks tests as requiring dill",
+    "regression: marks tests as regression corpus validation",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",

--- a/tests/test_regression_corpus.py
+++ b/tests/test_regression_corpus.py
@@ -1,0 +1,105 @@
+"""Regression corpus validation.
+
+Runs the scanner against committed malicious and benign test fixtures to ensure
+detection accuracy does not regress. Every malicious fixture must produce at
+least one issue. Every safe fixture must scan clean (success=True).
+
+Marked as ``regression`` so CI can run this as a dedicated gate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from modelaudit.core import scan_file
+
+ASSETS = Path(__file__).parent / "assets"
+EXPLOITS_DIR = ASSETS / "exploits"
+SAFE_PICKLES_DIR = ASSETS / "samples" / "pickles"
+MALICIOUS_PICKLES_DIR = ASSETS / "samples" / "pickles"
+SAFE_SAFETENSORS_DIR = ASSETS / "samples" / "safetensors"
+SAFE_PYTORCH_DIR = ASSETS / "samples" / "pytorch"
+SAFE_ARCHIVES_DIR = ASSETS / "samples" / "archives"
+
+# --- Malicious fixtures that MUST be detected ---
+
+EXPLOIT_FILES = sorted(EXPLOITS_DIR.glob("*.pkl")) if EXPLOITS_DIR.exists() else []
+
+MALICIOUS_PICKLE_NAMES = [
+    "malicious_system_call.pkl",
+    "malicious_model_realistic.pkl",
+    "decode_exec_chain.pkl",
+    "evil.pickle",
+    "nested_pickle_raw.pkl",
+    "nested_pickle_hex.pkl",
+    "nested_pickle_base64.pkl",
+    "nested_pickle_multistage.pkl",
+]
+MALICIOUS_PICKLE_FILES = [
+    MALICIOUS_PICKLES_DIR / name for name in MALICIOUS_PICKLE_NAMES if (MALICIOUS_PICKLES_DIR / name).exists()
+]
+
+MALICIOUS_SAFETENSORS = [p for p in [SAFE_SAFETENSORS_DIR / "malicious_import.safetensors"] if p.exists()]
+
+MALICIOUS_PYTORCH = [p for p in [SAFE_PYTORCH_DIR / "malicious_eval.pt"] if p.exists()]
+
+MALICIOUS_ARCHIVES = [p for p in [SAFE_ARCHIVES_DIR / "path_traversal.zip"] if p.exists()]
+
+ALL_MALICIOUS = EXPLOIT_FILES + MALICIOUS_PICKLE_FILES + MALICIOUS_SAFETENSORS + MALICIOUS_PYTORCH + MALICIOUS_ARCHIVES
+
+# --- Safe fixtures that MUST scan clean ---
+
+SAFE_PICKLE_NAMES = [
+    "safe_data.pkl",
+    "safe_large_model.pkl",
+    "safe_model_with_binary.pkl",
+    "safe_model_with_encoding.pkl",
+    "safe_model_with_tokens.pkl",
+    "safe_nested_structure.pkl",
+]
+SAFE_PICKLE_FILES = [SAFE_PICKLES_DIR / name for name in SAFE_PICKLE_NAMES if (SAFE_PICKLES_DIR / name).exists()]
+
+SAFE_SAFETENSORS = [p for p in [SAFE_SAFETENSORS_DIR / "safe_model.safetensors"] if p.exists()]
+
+SAFE_PYTORCH = [p for p in [SAFE_PYTORCH_DIR / "safe_model.pt"] if p.exists()]
+
+SAFE_ARCHIVES = [p for p in [SAFE_ARCHIVES_DIR / "safe_model.zip"] if p.exists()]
+
+ALL_SAFE = SAFE_PICKLE_FILES + SAFE_SAFETENSORS + SAFE_PYTORCH + SAFE_ARCHIVES
+
+
+def _file_id(path: Path) -> str:
+    """Generate a short test ID from a fixture path."""
+    return f"{path.parent.name}/{path.name}"
+
+
+# ---------------------------------------------------------------------------
+# Malicious corpus: every file must produce at least one issue
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestMaliciousCorpus:
+    """Every malicious fixture must be detected."""
+
+    @pytest.mark.parametrize("path", ALL_MALICIOUS, ids=[_file_id(p) for p in ALL_MALICIOUS])
+    def test_malicious_file_detected(self, path: Path) -> None:
+        result = scan_file(str(path))
+        assert result.issues, f"No issues detected for malicious file: {path.name}"
+
+
+# ---------------------------------------------------------------------------
+# Safe corpus: every file must scan clean
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestSafeCorpus:
+    """Every safe fixture must scan clean."""
+
+    @pytest.mark.parametrize("path", ALL_SAFE, ids=[_file_id(p) for p in ALL_SAFE])
+    def test_safe_file_clean(self, path: Path) -> None:
+        result = scan_file(str(path))
+        assert result.success, f"Safe file failed scan: {path.name} — issues: {result.issues}"


### PR DESCRIPTION
## Summary

Three P1 open-source readiness items:

- **SBOM generation**: CycloneDX JSON SBOM is now generated during the release workflow and uploaded to GitHub releases alongside wheel/sdist artifacts
- **Security advisory template**: Structured template at `docs/maintainers/security-advisory-template.md` with CVSS scoring, timeline, PoC section, and publishing checklist
- **Regression corpus validation**: 29 parametrized tests (20 malicious + 9 safe) that run the scanner against committed test fixtures to catch detection regressions. Runs in every CI pass automatically.

## Test plan

- [x] 1874 tests pass locally (28 new regression corpus tests)
- [x] `uv run ruff format --check` clean
- [x] `uv run ruff check` clean  
- [x] `uv run mypy modelaudit/` clean
- [x] Prettier formatting clean
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Software Bill of Materials (SBOM) now generated and included with releases.

* **Documentation**
  * Added security advisory template for maintainers.

* **Tests**
  * Added regression test suite to validate scanner against malicious and safe fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->