### PR TITLE
fix: enforce consistent scanner patterns across all scanners

### DIFF
--- a/modelaudit/scanners/keras_zip_scanner.py
+++ b/modelaudit/scanners/keras_zip_scanner.py
@@ -295,7 +295,9 @@ class KerasZipScanner(BaseScanner):
                             found_patterns.append(pattern)
 
                     if found_patterns:
-                        result._add_issue(
+                        result.add_check(
+                            name="Dangerous Lambda Layer",
+                            passed=False,
                             message=f"Lambda layer '{layer_name}' contains dangerous code: {', '.join(found_patterns)}",
                             severity=IssueSeverity.CRITICAL,
                             location=f"{self.current_file_path} (layer: {layer_name})",

--- a/modelaudit/scanners/sevenzip_scanner.py
+++ b/modelaudit/scanners/sevenzip_scanner.py
@@ -64,7 +64,9 @@ class SevenZipScanner(BaseScanner):
         # Check if py7zr is available
         if not HAS_PY7ZR:
             result = self._create_result()
-            result._add_issue(
+            result.add_check(
+                name="Missing Dependency",
+                passed=False,
                 message=(
                     "py7zr library not installed. "
                     "Install with 'pip install py7zr' or 'pip install modelaudit[sevenzip]'"
@@ -105,7 +107,9 @@ class SevenZipScanner(BaseScanner):
 
                 # Check for zip bomb protection
                 if len(file_names) > self.max_entries:
-                    result._add_issue(
+                    result.add_check(
+                        name="Archive Entry Limit",
+                        passed=False,
                         message=f"7z archive contains {len(file_names)} files, exceeding limit of {self.max_entries}",
                         severity=IssueSeverity.CRITICAL,
                         location=path,
@@ -234,7 +238,9 @@ class SevenZipScanner(BaseScanner):
                             # Check extracted file size
                             extracted_size = os.path.getsize(extracted_path)
                             if extracted_size > self.max_extract_size:
-                                result._add_issue(
+                                result.add_check(
+                                    name="Extracted File Size",
+                                    passed=False,
                                     message=f"Extracted file {file_name} is too large ({extracted_size} bytes)",
                                     severity=IssueSeverity.WARNING,
                                     location=f"{archive_path}:{file_name}",

--- a/modelaudit/scanners/text_scanner.py
+++ b/modelaudit/scanners/text_scanner.py
@@ -43,9 +43,13 @@ class TextScanner(BaseScanner):
 
         return filename in ml_text_files or any(filename.startswith(prefix) for prefix in ["vocab", "token", "label"])
 
-    def scan(self, path: str, timeout: int | None = None) -> ScanResult:
+    def scan(self, path: str) -> ScanResult:
         """Scan a text file for security issues."""
-        result = ScanResult(scanner_name=self.name)
+        path_check_result = self._check_path(path)
+        if path_check_result:
+            return path_check_result
+
+        result = self._create_result()
 
         try:
             # Get file size

--- a/tests/scanners/test_metadata_scanner.py
+++ b/tests/scanners/test_metadata_scanner.py
@@ -109,10 +109,10 @@ class TestMetadataScanner:
 
         result = scanner.scan("/nonexistent/README.md")
 
-        assert len(result.issues) == 1
-        # File access errors are WARNING severity (may indicate tampering)
-        assert result.issues[0].severity == IssueSeverity.WARNING
-        assert "Error reading" in result.issues[0].message
+        assert len(result.issues) >= 1
+        # Base class _check_path returns CRITICAL for nonexistent paths
+        assert result.issues[0].severity == IssueSeverity.CRITICAL
+        assert "does not exist" in result.issues[0].message
 
     def test_bytes_scanned_reported(self):
         """Test that bytes scanned is properly reported."""


### PR DESCRIPTION
## Summary
- Fix **TextScanner** to use base class patterns: standard `scan(self, path)` signature, `_check_path()` validation, `_create_result()` factory
- Fix **MetadataScanner** to follow conventions: `@classmethod` for `can_handle`, standard `path` param name, `name`/`description` class vars, base class validation and result creation, convert direct `Issue` construction to `add_check()`
- Migrate **sevenzip_scanner** from deprecated `_add_issue()` to `add_check()` (3 call sites)
- Migrate **keras_zip_scanner** from deprecated `_add_issue()` to `add_check()` (1 call site)

These changes ensure all scanners follow the same contract established by `BaseScanner`, improving Liskov substitution compliance and enabling consistent path validation, file type checks, and whitelist logic across the scanner fleet.

## Test plan
- [x] `ruff format` and `ruff check` clean
- [x] `mypy` passes with no issues
- [x] All 1973 tests pass, 38 skipped
- [x] Updated metadata scanner test for new base class behavior
- [x] Targeted scanner tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced metadata scanning with improved detection of model documentation files.

* **Bug Fixes**
  * Improved error handling for missing or invalid paths with more descriptive error messages.
  * Better detection and reporting of dangerous Lambda layers in Keras models.

* **Refactor**
  * Simplified scanner API by removing timeout parameter.
  * Standardized issue reporting across scanners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->