### PR TITLE
test: replace placeholder blacklist assertion

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -245,10 +245,8 @@ def test_merge_scan_results():
 
 def test_blacklist_patterns(tmp_path):
     """Test blacklist patterns parameter."""
-    # This test is a placeholder since we don't have the actual implementation
-    # of how blacklist patterns are used in the scanners
-    test_file = tmp_path / "test_file.dat"
-    test_file.write_bytes(b"test content")
+    test_file = tmp_path / "config.json"
+    test_file.write_text('{"name": "malicious_pattern"}', encoding="utf-8")
 
     # Scan with blacklist patterns
     results = scan_model_directory_or_file(
@@ -256,8 +254,12 @@ def test_blacklist_patterns(tmp_path):
         blacklist_patterns=["malicious_pattern", "evil_function"],
     )
 
-    # Just verify the scan completes successfully
-    assert results.success is True
+    blacklist_issues = [
+        issue
+        for issue in results.issues
+        if issue.severity == IssueSeverity.CRITICAL and "blacklisted term" in issue.message.lower()
+    ]
+    assert any("malicious_pattern" in issue.message for issue in blacklist_issues)
 
 
 def test_invalid_config_values(tmp_path):


### PR DESCRIPTION
## Why
The blacklist-pattern check in `tests/test_basic.py` was a placeholder that only asserted scan completion, so it could pass even if blacklist detection regressed.

## Root cause
The test used a generic `.dat` file and did not assert on emitted security findings.

## What changed
The test now writes a minimal `config.json` containing a blacklisted term, runs the scan with `blacklist_patterns`, and asserts that a `CRITICAL` blacklist issue is emitted with the expected term.

## Validation
- `uv run pytest tests/test_basic.py -k blacklist_patterns --maxfail=1` (skipped on Python 3.12 due existing project gating)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for blacklist pattern detection. The test now validates that CRITICAL severity security issues are properly identified when blacklist patterns are enabled in configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->