### PR TITLE
docs: clarify README exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,11 @@ docker run --rm -v "$(pwd)":/app ghcr.io/promptfoo/modelaudit:latest model.pkl
 --progress                   Force progress display
 ```
 
-Exit codes: `0` clean, `1` issues found, `2` errors.
+## Exit Codes
+
+- `0`: No security issues detected
+- `1`: Security issues detected
+- `2`: Scan errors
 
 ## Telemetry and Privacy
 


### PR DESCRIPTION
## Summary
Clarifies CLI return semantics by replacing the inline exit-code sentence with a dedicated  section in the README.

## User impact
Makes CI and automation integration expectations easier to find and less error-prone when wiring exit status handling.

## Validation
- uv run ruff format --check modelaudit/ tests/
- uv run ruff check modelaudit/ tests/
- uv run mypy modelaudit/
- uv run pytest -n auto -m "not slow and not integration" --maxfail=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added dedicated "Exit Codes" section with clear descriptions for each exit code (0: no issues, 1: issues detected, 2: scan errors).
  * Expanded Telemetry and Privacy section with detailed information on data collection, privacy considerations, and configuration options via environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->