### PR TITLE
fix(test): relax benchmark timing assertions for Windows CI

### DIFF
--- a/tests/utils/helpers/test_secure_hasher.py
+++ b/tests/utils/helpers/test_secure_hasher.py
@@ -235,9 +235,10 @@ class TestBenchmarking:
         assert "hash_result" in results
 
         # Verify reasonable values
+        # Timing values may be 0.0 on fast CI runners (Windows timer resolution ~15.6ms)
         assert results["file_size_mb"] > 0
-        assert results["avg_time_seconds"] > 0
-        assert results["throughput_mbps"] > 0
+        assert results["avg_time_seconds"] >= 0
+        assert results["throughput_mbps"] > 0 or results["avg_time_seconds"] == 0
         assert results["hash_method"] in ["full_hash", "enhanced_fingerprint"]
         assert results["hash_result"].startswith(("secure:", "fingerprint:"))
 


### PR DESCRIPTION
## Summary
- Fix `test_benchmark_hashing_performance` failing on Windows CI runners where `time.time()` resolution (~15.6ms) causes hashing a ~17KB file to report `0.0` seconds elapsed
- Change `assert avg_time_seconds > 0` to `>= 0` and handle the zero-time throughput edge case

## Test plan
- [ ] Windows Tests (Python 3.11) CI job passes
- [ ] All other CI checks remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved benchmark test reliability to handle edge cases on high-performance systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->