### PR TITLE
fix(security): use URL hostname parsing instead of substring matching

### DIFF
--- a/modelaudit/telemetry.py
+++ b/modelaudit/telemetry.py
@@ -593,11 +593,12 @@ class TelemetryClient:
         path_lower = path.lower()
 
         if path_lower.startswith(("http://", "https://")):
-            if "huggingface.co" in path_lower:
+            hostname = (urlparse(path).hostname or "").lower()
+            if hostname == "huggingface.co" or hostname.endswith(".huggingface.co"):
                 return "huggingface"
-            elif "pytorch.org" in path_lower:
+            elif hostname == "pytorch.org" or hostname.endswith(".pytorch.org"):
                 return "pytorch_hub"
-            elif "jfrog" in path_lower:
+            elif hostname.endswith(".jfrog.io") or hostname == "jfrog.io":
                 return "jfrog"
             else:
                 return "http"


### PR DESCRIPTION
## Summary
- Replace substring-based URL checks with proper `urlparse().hostname` extraction in `smart_detection.py` and `telemetry.py`
- Substring checks like `".jfrog.io/" in path` can be spoofed (e.g., `evil.com/.jfrog.io/foo`); using `urlparse` and `endswith()` on the hostname ensures only the actual domain is matched
- Resolves CodeQL alerts #4, #5, #6 (`py/incomplete-url-substring-sanitization`)

## What changed
- `smart_detection.py`: Added `_get_hostname()` helper using `urlparse`, replaced `.blob.core.windows.net in path` with `hostname.endswith()`, replaced `"pytorch.org/hub/" in path` with hostname check (preserving bare-domain fallback for scheme-less inputs), replaced `".jfrog.io/" in path` with hostname check
- `telemetry.py`: Replaced `"huggingface.co" in path_lower` / `"pytorch.org" in path_lower` / `"jfrog" in path_lower` with `urlparse().hostname` equality/endswith checks

## Test plan
- [x] All `test_smart_detection.py` tests pass (8/8)
- [x] All telemetry tests pass (35/35)
- [ ] CI passes
- [ ] CodeQL re-scan shows alerts #4-6 resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced URL detection and classification logic for improved accuracy when identifying model sources from HuggingFace, PyTorch Hub, JFrog, and Azure services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->