### PR TITLE
fix(ci): resolve 4 release pipeline failures

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -48,6 +48,26 @@ jobs:
           # Shallow clone for speed - we only need to format and push
           fetch-depth: 1
 
+      - name: Install uv
+        if: steps.check-pr.outputs.has_pr == 'true'
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7
+
+      - name: Sync uv.lock with pyproject.toml
+        if: steps.check-pr.outputs.has_pr == 'true'
+        run: |
+          uv lock
+          if git diff --quiet uv.lock; then
+            echo "✓ uv.lock already in sync"
+          else
+            echo "→ uv.lock updated to match pyproject.toml version bump"
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add uv.lock
+            git commit -m "chore: sync uv.lock with pyproject.toml version bump"
+            git push
+            echo "✓ uv.lock committed and pushed"
+          fi
+
       - name: Setup Node.js
         if: steps.check-pr.outputs.has_pr == 'true'
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
@@ -392,7 +412,7 @@ jobs:
           uv tool run cyclonedx-py requirements \
             --pyproject pyproject.toml \
             --output-format json \
-            --outfile dist/modelaudit-${{ needs.release-please.outputs.version }}.cdx.json
+            --output-file dist/modelaudit-${{ needs.release-please.outputs.version }}.cdx.json
           echo "SBOM generated:"
           ls -la dist/*.cdx.json
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Audit dependencies for vulnerabilities
         run: |
-          uvx pip-audit --strict --desc -r <(uv export --no-hashes)
+          uvx pip-audit --strict --desc -r <(uv export --no-hashes --no-emit-project)
 
   license-check:
     name: License Compliance

--- a/uv.lock
+++ b/uv.lock
@@ -2717,7 +2717,7 @@ wheels = [
 
 [[package]]
 name = "modelaudit"
-version = "0.2.25"
+version = "0.2.26"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Fixes the 4 CI failures from the v0.2.26 release:

- **SBOM generation (`provenance` job):** `cyclonedx-bom` v7.x removed the `--outfile` CLI flag — replaced with `--output-file`
- **Dependency audit:** `pip-audit` was trying to look up `modelaudit==0.2.26` on PyPI before it was published — now uses `--no-emit-project` to exclude the project itself from the audit
- **Lock file consistency:** `uv.lock` was out of sync because release-please bumped the version in `pyproject.toml` without regenerating the lock file — regenerated now
- **Future-proofing:** Added a `uv lock` step to the release-please workflow so `uv.lock` is automatically synced on the release PR before merge

## Test plan

- [ ] `Python CI / Lock File Consistency` passes (uv.lock now matches pyproject.toml)
- [ ] `Python CI / Dependency Audit` passes (modelaudit excluded from pip-audit)
- [ ] `Python CI / CI Success` passes (gate job aggregates the above)
- [ ] Verify `--output-file` flag works on next release (cyclonedx-bom v7.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to improve dependency management and security processes.
  * Enhanced release workflow to automatically synchronize dependencies when pull requests exist.
  * Refined dependency audit configuration for more accurate scanning results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->