### PR TITLE
fix(cli): surface operational scan error status in text output

### DIFF
--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -2029,9 +2029,19 @@ def format_text_output(results: dict[str, Any], verbose: bool = False) -> str:
     output_lines.append("")
     output_lines.append("═" * 80)
 
-    # Check if no files were scanned
+    # Check if scan had operational errors first (highest priority in exit code)
+    has_operational_errors = bool(results.get("has_errors"))
     files_scanned = results.get("files_scanned", 0)
-    if files_scanned == 0:
+    if has_operational_errors:
+        status_icon = "❌"
+        status_msg = "SCAN COMPLETED WITH OPERATIONAL ERRORS"
+        status_color = "red"
+        output_lines.append(f"  {style_text(f'{status_icon} {status_msg}', fg=status_color, bold=True)}")
+        output_lines.append(
+            f"  {style_text('Review warnings above and use --verbose for troubleshooting details.', fg='yellow')}"
+        )
+    # Check if no files were scanned
+    elif files_scanned == 0:
         status_icon = "❌"
         status_msg = "NO FILES SCANNED"
         status_color = "red"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -424,6 +424,22 @@ def test_format_text_output_only_debug_issues():
     assert "NO ISSUES FOUND" in clean_output
 
 
+def test_format_text_output_operational_errors_status():
+    """Ensure operational errors are surfaced in final text status."""
+    results = {
+        "files_scanned": 1,
+        "bytes_scanned": 10,
+        "duration": 0.1,
+        "issues": [],
+        "has_errors": True,
+    }
+
+    output = format_text_output(results, verbose=False)
+    clean_output = strip_ansi(output)
+    assert "SCAN COMPLETED WITH OPERATIONAL ERRORS" in clean_output
+    assert "NO ISSUES FOUND" not in clean_output
+
+
 def test_format_text_output_only_info_issues():
     """Ensure info-only issues result in a success status."""
     results = {


### PR DESCRIPTION
Users could see a clean-looking final status in text output even when scan execution had operational failures and returned exit code 2, which makes CI and local triage harder.

Root cause: the footer status logic prioritized security finding visibility and file-count checks, but did not prioritize `has_errors`.

This change updates the footer to explicitly report `SCAN COMPLETED WITH OPERATIONAL ERRORS` whenever `has_errors` is true, and adds a regression test to prevent fallback to `NO ISSUES FOUND` in that state.

Validation:
- `uv run ruff format --check modelaudit/cli.py tests/test_cli.py`
- `uv run ruff check modelaudit/cli.py tests/test_cli.py`
- `uv run pytest tests/test_cli.py -k "format_text_output_operational_errors_status or format_text_output_only_debug_issues" --maxfail=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Operational errors during scanning are now more prominently displayed with clearer status messaging and troubleshooting guidance when the scan completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->