### PR TITLE
fix(ci): resolve Ruff failures on main

### DIFF
--- a/modelaudit/config/explanations.py
+++ b/modelaudit/config/explanations.py
@@ -696,8 +696,7 @@ def get_cve_2025_51480_explanation(vulnerability_type: str) -> str:
 
     return explanations.get(
         vulnerability_type,
-        "CVE-2025-51480: ONNX external_data path traversal can enable arbitrary "
-        "file overwrite during save operations.",
+        "CVE-2025-51480: ONNX external_data path traversal can enable arbitrary file overwrite during save operations.",
     )
 
 

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -335,11 +335,6 @@ ALWAYS_DANGEROUS_FUNCTIONS: set[str] = {
     "torch.distributed.rpc.RemoteModule",
     # NumPy dangerous functions (Fickling)
     "numpy.testing._private.utils.runstring",
-    # PyTorch distributed RPC functions (CVE-2024-5480, CVE-2024-48063)
-    "torch.distributed.rpc.rpc_sync",
-    "torch.distributed.rpc.rpc_async",
-    "torch.distributed.rpc.remote",
-    "torch.distributed.rpc.RemoteModule",
     # Shell utilities
     "shutil.rmtree",
     "shutil.move",


### PR DESCRIPTION
## Summary
- remove duplicated PyTorch RPC symbols from `ALWAYS_DANGEROUS_FUNCTIONS` in `modelaudit/scanners/pickle_scanner.py` (fixes Ruff B033 failures on `main`)
- apply a Ruff formatter-required line wrap in `modelaudit/config/explanations.py` so `ruff format --check` passes

## CI context
- failing `main` runs: `22613549465`, `22613305471`
- primary failure from logs: duplicate set entries in `modelaudit/scanners/pickle_scanner.py`

## Validation
- `uv run ruff check modelaudit/ tests/`
- `uv run ruff format --check modelaudit/ tests/`
- `uv run mypy modelaudit/`
- `uv run pytest -n auto -m "not slow and not integration" --maxfail=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Adjusted pickle scanner to no longer flag certain PyTorch distributed RPC functions as automatically dangerous.

* **Style**
  * Code formatting improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->