### PR TITLE
fix(ci): reorder provenance job steps to prevent SBOM failure

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -386,6 +386,15 @@ jobs:
       id-token: write
       attestations: write
     steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7
+        with:
+          enable-cache: true
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: pyproject.toml
+
       - name: Download build artifacts
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
         with:
@@ -396,15 +405,6 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-path: "dist/*"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7
-        with:
-          enable-cache: true
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          sparse-checkout: pyproject.toml
 
       - name: Generate SBOM
         run: |


### PR DESCRIPTION
## Summary
- The `provenance` job in `release-please.yml` had `actions/checkout` (with `clean: true` default) running **after** `download-artifact`, which wiped the `dist/` directory before `cyclonedx-py` could write the SBOM
- Reordered steps so checkout and uv setup happen **before** artifact download, preventing the directory wipe

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Next release-please run should successfully generate SBOM in `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build workflow by reorganizing setup steps to execute earlier in the provenance generation process, ensuring necessary dependencies are available before artifact processing and improving overall workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->