### PR TITLE
fix: preserve rule codes through scan aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **rules:** preserve `rule_code` metadata through direct result aggregation and ensure dangerous advanced pickle globals emit explicit rule codes (with regression coverage)
 - **rules:** ignore unknown rule IDs in config files with warning logs, normalize rule-code casing in config parsing, and prevent invalid severity entries from being applied
 - **tests:** add scanner literal `rule_code` registry-consistency coverage to catch unknown rule identifiers early
 - **security**: harden pickle scanner stack resolution to correctly track `STACK_GLOBAL` and memoized `REDUCE` call targets, preventing decoy-string and `BINGET` bypasses

--- a/modelaudit/models.py
+++ b/modelaudit/models.py
@@ -451,7 +451,7 @@ class ModelAuditResultModel(BaseModel, DictCompatMixin):
         This is more efficient than converting to dict first and provides better type safety.
         """
         # Import here to avoid circular import
-        from ..scanners.base import Check, Issue, ScanResult  # type: ignore[import-untyped]
+        from .scanners.base import ScanResult
 
         if not isinstance(scan_result, ScanResult):
             raise TypeError(f"Expected ScanResult, got {type(scan_result)}")
@@ -478,6 +478,7 @@ class ModelAuditResultModel(BaseModel, DictCompatMixin):
                     timestamp=issue.timestamp,
                     why=issue.why,
                     type=getattr(issue, "type", None),  # Include type if available
+                    rule_code=getattr(issue, "rule_code", None),
                 )
             )
 
@@ -493,6 +494,7 @@ class ModelAuditResultModel(BaseModel, DictCompatMixin):
                     timestamp=check.timestamp,
                     severity=check.severity if check.severity else None,
                     why=check.why,
+                    rule_code=getattr(check, "rule_code", None),
                 )
             )
 

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -4243,12 +4243,16 @@ class PickleScanner(BaseScanner):
                         ml_context,
                         issue_type="dangerous_global",
                     )
+                    rule_code = get_import_rule_code(mod, func)
+                    if not rule_code:
+                        rule_code = "S205"  # STACK_GLOBAL/GLOBAL fallback
                     result.add_check(
                         name="Advanced Global Reference Check",
                         passed=False,
                         message=f"Suspicious reference {mod}.{func}",
                         severity=severity,
                         location=self.current_file_path,
+                        rule_code=rule_code,
                         details={
                             "module": mod,
                             "function": func,

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -237,6 +237,17 @@ class TestPickleScannerAdvanced(unittest.TestCase):
         ]
         assert len(os_issues) > 0, f"Expected OS-related issues, but found: {[i.message for i in result.issues]}"
 
+    def test_advanced_global_reference_issue_has_rule_code(self) -> None:
+        """Dangerous advanced global references should carry a rule code."""
+        scanner = PickleScanner()
+        result = scanner.scan(str(Path(__file__).parent.parent / "assets" / "pickles" / "stack_global_attack.pkl"))
+
+        advanced_issues = [i for i in result.issues if i.message.startswith("Suspicious reference ")]
+        assert advanced_issues, f"Expected advanced global issues, got: {[i.message for i in result.issues]}"
+        assert all(i.rule_code for i in advanced_issues), (
+            f"Expected rule codes on advanced global issues, got: {[i.rule_code for i in advanced_issues]}"
+        )
+
     def test_memo_object_tracking(self) -> None:
         scanner = PickleScanner()
         result = scanner.scan(str(Path(__file__).parent.parent / "assets" / "pickles" / "memo_attack.pkl"))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ from modelaudit.models import (
     create_initial_audit_result,
     rebuild_models,
 )
-from modelaudit.scanners.base import Issue, IssueSeverity
+from modelaudit.scanners.base import Issue, IssueSeverity, ScanResult
 
 
 class TestDetectorFinding:
@@ -518,6 +518,25 @@ class TestModelAuditResultModel:
         result = create_initial_audit_result()
         assert result["bytes_scanned"] == 0
         assert result.get("nonexistent", "default") == "default"
+
+    def test_aggregate_scan_result_direct_preserves_rule_code(self):
+        """Direct scan-result aggregation should preserve issue/check rule codes."""
+        result = create_initial_audit_result()
+        scan_result = ScanResult(scanner_name="test_scanner")
+        scan_result.add_check(
+            name="Dangerous Import Check",
+            passed=False,
+            message="import os",
+            severity=IssueSeverity.CRITICAL,
+            rule_code="S101",
+        )
+
+        result.aggregate_scan_result_direct(scan_result)
+
+        assert len(result.issues) == 1
+        assert len(result.checks) == 1
+        assert result.issues[0].rule_code == "S101"
+        assert result.checks[0].rule_code == "S101"
 
 
 class TestScanConfigModel:


### PR DESCRIPTION
## Summary
- preserve `rule_code` when using `ModelAuditResultModel.aggregate_scan_result_direct(...)`
- fix relative import in direct aggregation path (`modelaudit.models`)
- ensure Pickle scanner advanced global checks emit explicit rule codes (fallback `S205`)
- add regression tests for direct aggregation rule-code preservation and advanced-global rule-code emission
- add changelog entry under `[Unreleased] -> Fixed`

## Validation
- uv run ruff format modelaudit/ tests/
- uv run ruff check --fix modelaudit/ tests/
- uv run mypy modelaudit/
- uv run pytest -n auto -m "not slow and not integration" --maxfail=1
- end-to-end CLI check on crafted malicious pickle with baseline / suppress / severity override behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rule_code metadata preservation when aggregating scan results through direct aggregation paths
  * Advanced pickle global reference checks now consistently emit explicit rule codes for improved tracking

* **Tests**
  * Added test coverage validating rule_code preservation in direct scan result aggregation workflows
  * Added tests ensuring rule_code presence in advanced pickle global reference findings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->