### PR TITLE
test: isolate lazy-loading failure test to prevent registry pollution

### DIFF
--- a/tests/test_lazy_loading.py
+++ b/tests/test_lazy_loading.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 import pytest
 
-from modelaudit.scanners import _registry
+from modelaudit.scanners import ScannerRegistry, _registry
 from modelaudit.scanners.base import BaseScanner
 
 
@@ -142,16 +142,17 @@ class TestScannerRegistry:
     @patch("importlib.import_module")
     def test_scanner_load_failure_handling(self, mock_import):
         """Test handling of scanner loading failures."""
-        # Reset loaded scanners
-        _registry._loaded_scanners.clear()
+        # Use an isolated registry so this test can't pollute global state.
+        fresh_registry = ScannerRegistry()
 
         # Mock import failure
         mock_import.side_effect = ImportError("Module not found")
 
         # Should return None for failed import
-        scanner = _registry._load_scanner("tf_savedmodel")
+        scanner = fresh_registry._load_scanner("tf_savedmodel")
         assert scanner is None
-        assert "tf_savedmodel" not in _registry._loaded_scanners
+        assert "tf_savedmodel" not in fresh_registry._loaded_scanners
+        assert "tf_savedmodel" in fresh_registry._failed_scanners
 
     def test_get_scanner_classes_loads_available_scanners(self):
         """Test that get_scanner_classes loads all available scanners."""


### PR DESCRIPTION
## Summary
- isolates `test_scanner_load_failure_handling` in `tests/test_lazy_loading.py` to use a fresh `ScannerRegistry`
- prevents mutation of global `_registry._failed_scanners`, which could leak into later tests

## Root cause
`test_scanner_load_failure_handling` mocked `importlib.import_module` and called `_registry._load_scanner("tf_savedmodel")`. That permanently marked `tf_savedmodel` as failed in the shared global registry for the process. Later metadata tests then fell back to `weight_distribution` for `.pb`, failing assertions.

## Validation
- `uv run --python 3.11 pytest tests/test_lazy_loading.py::TestScannerRegistry::test_scanner_load_failure_handling tests/test_metadata_extractor.py::TestModelMetadataExtractor::test_tf_savedmodel_metadata_no_deserialization tests/test_metadata_extractor.py::TestModelMetadataExtractor::test_tf_savedmodel_metadata_signature_extraction_without_runtime_load -q`
- `uv run --python 3.11 pytest -n auto tests/test_lazy_loading.py tests/test_metadata_extractor.py -q`
- `uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
- `uv run ruff check modelaudit/ tests/`
- `uv run ruff format --check modelaudit/ tests/`
- `uv run mypy modelaudit/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ScannerRegistry is now publicly available for direct use.

* **Tests**
  * Improved test reliability through better isolation using independent instances instead of shared global state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->