### PR TITLE
fix: restrict trusted jfrog hosts for auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **tests:** enable existing PaddlePaddle scanner tests in CI by adding `test_paddle_scanner.py` to the allowed test files list (Python 3.10/3.12/3.13)
 - **security:** detect CVE-2026-24747 PyTorch weights_only=True bypass via SETITEM/SETITEMS abuse and tensor metadata mismatch detection
 - **security:** detect CVE-2022-45907 PyTorch torch.jit.annotations.parse_type_line unsafe eval() injection (CVSS 9.8)
+
+### Fixed
+
+- **security:** require official or explicitly allowlisted JFrog hosts before treating `/artifactory/` URLs as authenticated JFrog endpoints
 - **security:** detect CVE-2024-5480 PyTorch torch.distributed.rpc arbitrary function execution via PythonUDF (CVSS 10.0)
 - **security:** detect CVE-2024-48063 PyTorch torch.distributed.rpc.RemoteModule deserialization RCE via pickle (CVSS 9.8)
 - **security:** detect CVE-2019-6446 in NumPy scanner when object-dtype arrays are found, with warning-level attribution (CVSS 9.8) due potential pickle deserialization via `allow_pickle=True`

--- a/modelaudit/utils/sources/jfrog.py
+++ b/modelaudit/utils/sources/jfrog.py
@@ -1,5 +1,6 @@
 """Utilities for handling JFrog Artifactory downloads and folder operations."""
 
+import ipaddress
 import logging
 import os
 import shutil
@@ -47,7 +48,43 @@ def is_jfrog_url(url: str) -> bool:
     parsed = urlparse(url)
     if parsed.scheme not in {"http", "https"}:
         return False
-    return parsed.netloc.endswith(".jfrog.io") or "/artifactory/" in parsed.path
+    hostname = (parsed.hostname or "").lower()
+    if "/artifactory/" not in parsed.path:
+        return False
+    return _is_trusted_jfrog_host(hostname)
+
+
+def _get_trusted_jfrog_hosts() -> set[str]:
+    """Return explicitly allowlisted JFrog hosts.
+
+    MODELAUDIT_JFROG_ALLOWED_HOSTS accepts a comma-separated list of hostnames.
+    This keeps automatic credential forwarding opt-in for self-hosted JFrog
+    instances while rejecting arbitrary lookalike URLs.
+    """
+    raw_hosts = os.getenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "")
+    return {host.strip().lower() for host in raw_hosts.split(",") if host.strip()}
+
+
+def _is_trusted_jfrog_host(hostname: str) -> bool:
+    """Return True when a hostname is trusted for JFrog authentication."""
+    if not hostname:
+        return False
+
+    if hostname == "jfrog.io" or hostname.endswith(".jfrog.io"):
+        return True
+
+    if hostname == "localhost":
+        return True
+
+    try:
+        parsed_ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        parsed_ip = None
+
+    if parsed_ip is not None and parsed_ip.is_loopback:
+        return True
+
+    return hostname in _get_trusted_jfrog_hosts()
 
 
 def download_artifact(

--- a/tests/integrations/test_jfrog.py
+++ b/tests/integrations/test_jfrog.py
@@ -21,7 +21,8 @@ class TestJFrogURLDetection:
     def test_valid_jfrog_urls(self):
         valid_urls = [
             "https://company.jfrog.io/artifactory/repo/model.bin",
-            "http://my-jfrog.com/artifactory/libs-release/model.pt",
+            "http://localhost/artifactory/libs-release/model.pt",
+            "http://127.0.0.1/artifactory/libs-release/model.pt",
         ]
         for url in valid_urls:
             assert is_jfrog_url(url)
@@ -29,11 +30,19 @@ class TestJFrogURLDetection:
     def test_invalid_jfrog_urls(self):
         invalid_urls = [
             "https://example.com/model",
+            "https://evil.example/artifactory/repo/model.bin",
+            "https://my-jfrog.com/artifactory/libs-release/model.pt",
             "hf://model",
             "",
         ]
         for url in invalid_urls:
             assert not is_jfrog_url(url)
+
+    def test_allowlisted_self_hosted_jfrog_urls(self, monkeypatch):
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "my-jfrog.com,artifacts.internal")
+
+        assert is_jfrog_url("https://my-jfrog.com/artifactory/libs-release/model.pt")
+        assert is_jfrog_url("https://artifacts.internal/artifactory/ml/model.pkl")
 
 
 class TestJFrogDownload:


### PR DESCRIPTION
## Summary
- require official or explicitly allowlisted JFrog hosts before treating /artifactory/ URLs as authenticated JFrog endpoints
- preserve localhost and loopback support for local development
- add regression coverage for attacker-controlled lookalike URLs and allowlisted self-hosted hosts

## Validation
- uv run ruff format modelaudit/ tests/
- uv run ruff check --fix modelaudit/ tests/
- uv run mypy modelaudit/
- uv run pytest tests/integrations/test_jfrog.py -q
- uv run pytest -n auto -m "not slow and not integration" --maxfail=1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced JFrog URL validation to require official or explicitly allowlisted hosts, improving security when handling JFrog endpoints. Users can configure trusted custom JFrog instances via the `MODELAUDIT_JFROG_ALLOWED_HOSTS` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->