### PR TITLE
fix: stop importing dotenv in jfrog helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **security:** stop loading `.env` files implicitly during JFrog helper import so untrusted working directories cannot rewrite proxy or auth-related environment variables
 - **rules:** preserve `rule_code` metadata through direct result aggregation and ensure dangerous advanced pickle globals emit explicit rule codes (with regression coverage)
 - **rules:** ignore unknown rule IDs in config files with warning logs, normalize rule-code casing in config parsing, and prevent invalid severity entries from being applied
 - **telemetry:** refresh the cached telemetry client when runtime context changes and lazily initialize PostHog when telemetry is re-enabled in-process

--- a/modelaudit/utils/sources/jfrog.py
+++ b/modelaudit/utils/sources/jfrog.py
@@ -10,14 +10,10 @@ from urllib.parse import urlparse
 
 import click
 import requests
-from dotenv import load_dotenv
 
 from ...config.constants import SCANNABLE_MODEL_EXTENSIONS
 
 logger = logging.getLogger(__name__)
-
-# Load environment variables from .env file if it exists
-load_dotenv()
 
 # Constants
 MAX_RECURSION_DEPTH = 10  # Prevent infinite recursion in folder traversal

--- a/tests/integrations/test_jfrog.py
+++ b/tests/integrations/test_jfrog.py
@@ -1,4 +1,7 @@
 import logging
+import os
+import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -128,20 +131,37 @@ class TestJFrogDownload:
         assert not call_args[1]["headers"]  # Empty headers dict
 
     @patch("modelaudit.utils.sources.jfrog.requests.get")
-    def test_dotenv_file_support(self, mock_get, tmp_path, monkeypatch):
-        """Test that .env file variables are loaded via python-dotenv."""
-        # This test verifies that dotenv is loaded, but since we can't easily mock
-        # the dotenv loading in tests, we verify the environment variable fallback works
+    def test_import_does_not_load_dotenv_from_cwd(self, mock_get, tmp_path):
+        """Importing the JFrog helper must not mutate env from an untrusted cwd."""
         mock_response = mock_get.return_value
         mock_response.raise_for_status.return_value = None
         mock_response.iter_content.return_value = [b"data"]
 
-        # Simulate .env file loaded environment variable
-        monkeypatch.setenv("JFROG_API_TOKEN", "dotenv-token")
-        download_artifact("https://company.jfrog.io/artifactory/repo/model.bin", cache_dir=tmp_path)
+        repo_root = Path(__file__).resolve().parents[2]
+        dotenv_dir = tmp_path / "dotenv-cwd"
+        dotenv_dir.mkdir()
+        (dotenv_dir / ".env").write_text("HTTP_PROXY=http://attacker.invalid:8080\n", encoding="utf-8")
 
-        call_args = mock_get.call_args
-        assert call_args[1]["headers"]["X-JFrog-Art-Api"] == "dotenv-token"
+        env = os.environ.copy()
+        env.pop("HTTP_PROXY", None)
+        env.pop("HTTPS_PROXY", None)
+        pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = str(repo_root) if not pythonpath else f"{repo_root}{os.pathsep}{pythonpath}"
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                ("import os; import modelaudit.utils.sources.jfrog; print(os.environ.get('HTTP_PROXY'))"),
+            ],
+            cwd=dotenv_dir,
+            capture_output=True,
+            check=True,
+            env=env,
+            text=True,
+        )
+
+        assert completed.stdout.strip() == "None"
 
 
 class TestJFrogStorageAPI:


### PR DESCRIPTION
## Summary
- remove import-time python-dotenv loading from the JFrog helper
- keep JFrog authentication strictly environment-driven instead of mutating env from the current working directory
- add a subprocess regression test proving that importing the module no longer loads HTTP_PROXY from an untrusted .env file

## Validation
- uv run ruff format modelaudit/ tests/
- uv run ruff check --fix modelaudit/ tests/
- uv run mypy modelaudit/
- uv run pytest tests/integrations/test_jfrog.py -q
- uv run pytest -n auto -m "not slow and not integration" --maxfail=1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security vulnerability preventing untrusted working directories from overriding proxy and authentication environment variables during JFrog helper import.

* **Tests**
  * Updated integration tests to verify import isolation from untrusted environment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->