### PR TITLE
fix: mark flaky timing test as performance to skip in CI

### DIFF
--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -4,6 +4,8 @@ import time
 import zipfile
 from pathlib import Path
 
+import pytest
+
 from modelaudit.scanners.base import CheckStatus, IssueSeverity
 from modelaudit.scanners.pytorch_zip_scanner import PyTorchZipScanner
 from tests.helpers import create_mock_pytorch_zip
@@ -141,6 +143,7 @@ def test_pytorch_zip_scanner_closes_bytesio(tmp_path, monkeypatch):
     assert closed.get("closed") is True
 
 
+@pytest.mark.performance
 def test_pytorch_zip_skips_numeric_data_files(tmp_path):
     """Test that numeric tensor data files in archive/data/ are skipped during JIT scanning."""
     zip_path = tmp_path / "model.pt"


### PR DESCRIPTION
## Summary
- Marks `test_pytorch_zip_skips_numeric_data_files` with `@pytest.mark.performance` so it is excluded from CI runs
- This test creates 30MB of zip data and asserts scan completion within 20s, which is unreliable on slow Windows CI runners (failed in [#3020](https://github.com/promptfoo/modelaudit/actions/runs/3020))
- The numeric-file-skip behavior remains covered by `test_pytorch_zip_scans_non_numeric_files_in_archive_data` and `test_pytorch_zip_numeric_detection_edge_cases`, which verify correctness without timing

## Test plan
- [x] `uv run ruff check` passes
- [x] `uv run pytest tests/scanners/test_pytorch_zip_scanner.py -m "not performance"` — 33 passed, 1 deselected
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with improved performance monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->