### PR TITLE
fix: prevent JFrog folder download path traversal

### DIFF
--- a/modelaudit/utils/sources/jfrog.py
+++ b/modelaudit/utils/sources/jfrog.py
@@ -5,7 +5,7 @@ import logging
 import os
 import shutil
 import tempfile
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Literal, TypedDict
 from urllib.parse import urlparse
 
@@ -18,6 +18,22 @@ logger = logging.getLogger(__name__)
 
 # Constants
 MAX_RECURSION_DEPTH = 10  # Prevent infinite recursion in folder traversal
+
+
+def _safe_download_path(download_dir: Path, relative_path: str) -> Path:
+    """Build a safe local path for downloaded JFrog artifacts."""
+    normalized = PurePosixPath(relative_path)
+
+    if normalized.is_absolute() or any(part in {"", ".", ".."} for part in normalized.parts):
+        raise ValueError(f"Unsafe JFrog artifact path: {relative_path}")
+
+    local_file = (download_dir / Path(*normalized.parts)).resolve()
+    download_root = download_dir.resolve()
+
+    if local_file != download_root and download_root not in local_file.parents:
+        raise ValueError(f"Unsafe JFrog artifact path: {relative_path}")
+
+    return local_file
 
 
 # TypedDict definitions for JFrog API responses
@@ -513,7 +529,7 @@ def download_jfrog_folder(
             except (ValueError, IndexError):
                 relative_path = Path(file_info["name"]).name
 
-            local_file = download_dir / relative_path
+            local_file = _safe_download_path(download_dir, relative_path)
             local_file.parent.mkdir(parents=True, exist_ok=True)
 
             # Download the individual file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,8 @@ def pytest_runtest_setup(item):
             "test_telemetry_decoupling.py",  # telemetry failure-isolation tests
             "test_debug_command.py",  # debug output telemetry flags
             "test_oci_layer_scanner.py",  # OCI layer path safety regression tests
+            "test_jfrog.py",  # JFrog utility tests
+            "test_jfrog_integration.py",  # JFrog integration tests
         ]
 
         # Check if this is an allowed test file

--- a/tests/integrations/test_jfrog.py
+++ b/tests/integrations/test_jfrog.py
@@ -442,3 +442,27 @@ class TestJFrogFolderDownload:
 
         with pytest.raises(ValueError, match="No scannable model files found"):
             download_jfrog_folder("https://company.jfrog.io/artifactory/repo/empty-folder/")
+
+    @patch("modelaudit.utils.sources.jfrog.download_artifact")
+    @patch("modelaudit.utils.sources.jfrog.list_jfrog_folder_contents")
+    def test_download_jfrog_folder_rejects_traversal_paths(self, mock_list, mock_download, tmp_path):
+        """Test that traversal paths from JFrog metadata are rejected."""
+        mock_list.return_value = [
+            {
+                "name": "../../escape.pkl",
+                "path": "https://company.jfrog.io/artifactory/repo/models/../../escape.pkl",
+                "size": 1024,
+                "human_size": "1.0 KB",
+            }
+        ]
+
+        with pytest.raises(Exception, match="All downloads failed"):
+            download_jfrog_folder(
+                "https://company.jfrog.io/artifactory/repo/models/",
+                cache_dir=tmp_path,
+                api_token="test-token",
+                show_progress=False,
+            )
+
+        assert not any(tmp_path.iterdir())
+        mock_download.assert_not_called()


### PR DESCRIPTION
### Motivation

- Aardvark reported that JFrog folder download logic constructed local paths from untrusted Storage API URIs and could write files outside the intended download directory via `..`/absolute segments. 
- The change aims to close this path traversal vector while preserving folder download behavior and filtering.

### Description

- Add a safe path helper ` _safe_download_path(download_dir, relative_path)` in `modelaudit/utils/sources/jfrog.py` that normalizes using `PurePosixPath`, rejects absolute paths and any `""`, `"."`, or `".."` segments, and enforces the resolved path stays under the download root. 
- Replace the previous `download_dir / relative_path` usage with ` _safe_download_path(...)` before creating directories or moving files in `download_jfrog_folder`. 
- Add a regression integration test `test_download_jfrog_folder_rejects_traversal_paths` in `tests/integrations/test_jfrog.py` that simulates traversal-style metadata and verifies downloads are rejected and no files are written. 
- Include JFrog integration tests in the Python 3.12 allowlist in `tests/conftest.py` so the new regression executes in this environment.

### Testing

- Ran formatting and linting with `uv run ruff format modelaudit/ tests/` and `uv run ruff check --fix modelaudit/ tests/`, both succeeded. 
- Ran type checks with `uv run mypy modelaudit/`, which succeeded with no issues. 
- Ran the targeted integration test with `uv run pytest tests/integrations/test_jfrog.py -k traversal_paths`, which passed and confirmed traversal metadata is rejected. 
- Ran the broader non-integration test suite `uv run pytest -n auto -m "not slow and not integration" --maxfail=1`, which failed due to an existing unrelated flaky timing assertion in `tests/scanners/test_pytorch_zip_scanner.py::test_pytorch_zip_skips_numeric_data_files` and is not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1ef5a1ed883328a2d25b1d2314888)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
  * Enhanced security for JFrog artifact downloads by validating download paths to prevent path traversal attacks. Files now download only to the designated directory, protecting against unsafe path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->