### PR TITLE
fix(zip): fail closed on MAR handler parse errors

### DIFF
--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -527,7 +527,7 @@ class ZipScanner(BaseScanner):
                 message=f"Unable to parse Python entry for static analysis: {parse_error}",
                 severity=IssueSeverity.WARNING,
                 location=f"{archive_path}:{entry_name}",
-                details={"entry": entry_name},
+                details={"entry": entry_name, "analysis_kind": "syntax", "parse_error": parse_error},
             )
         else:
             result.add_check(

--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -419,6 +419,8 @@ class ZipScanner(BaseScanner):
                             mar_python_result = self._scan_mar_python_entry(path, name, tmp_path, total_size)
                             if mar_python_result is not None:
                                 result.merge(mar_python_result)
+                                if not mar_python_result.success:
+                                    scan_complete = False
 
                         nested_config = dict(self.config)
                         nested_config["_archive_depth"] = depth + 1

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -334,6 +334,25 @@ class TestZipScanner:
         assert handler_failures[0].details.get("size_limit") == 16
         assert handler_failures[0].location == f"{mar_path}:handler.py"
 
+    def test_scan_manifestless_mar_reports_malformed_python_handler(self, tmp_path: Path) -> None:
+        """Manifest-less .mar handlers with invalid syntax should emit parse-error analysis checks."""
+        mar_path = tmp_path / "malformed_handler.mar"
+        with zipfile.ZipFile(mar_path, "w") as archive:
+            archive.writestr("handler.py", "def handle(data, context)\n    return data\n")
+
+        result = self.scanner.scan(str(mar_path))
+
+        handler_failures = [
+            check
+            for check in result.checks
+            if check.name == "TorchServe Handler Static Analysis" and check.status == CheckStatus.FAILED
+        ]
+        assert len(handler_failures) == 1
+        assert handler_failures[0].severity == IssueSeverity.WARNING
+        assert "unable to parse python entry for static analysis" in handler_failures[0].message.lower()
+        assert handler_failures[0].details.get("entry") == "handler.py"
+        assert handler_failures[0].location == f"{mar_path}:handler.py"
+
     def test_scan_extensionless_nested_zip_recurses(self, tmp_path: Path) -> None:
         """Extensionless ZIP members should be recursively scanned by content."""
         inner_zip = io.BytesIO()

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -342,6 +342,8 @@ class TestZipScanner:
 
         result = self.scanner.scan(str(mar_path))
         assert result.success is False
+        assert result.has_warnings is True
+        assert result.has_errors is False
 
         handler_failures = [
             check
@@ -352,6 +354,8 @@ class TestZipScanner:
         assert handler_failures[0].severity == IssueSeverity.WARNING
         assert "unable to parse python entry for static analysis" in handler_failures[0].message.lower()
         assert handler_failures[0].details.get("entry") == "handler.py"
+        assert handler_failures[0].details.get("analysis_kind") == "syntax"
+        assert "expected ':'" in str(handler_failures[0].details.get("parse_error")).lower()
         assert handler_failures[0].location == f"{mar_path}:handler.py"
 
     def test_scan_extensionless_nested_zip_recurses(self, tmp_path: Path) -> None:

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -341,6 +341,7 @@ class TestZipScanner:
             archive.writestr("handler.py", "def handle(data, context)\n    return data\n")
 
         result = self.scanner.scan(str(mar_path))
+        assert result.success is False
 
         handler_failures = [
             check


### PR DESCRIPTION
## Summary
- add regression coverage for manifest-less `.mar` handler static analysis parse-error path
- ensure invalid Python handler syntax emits a failed `TorchServe Handler Static Analysis` warning check with entry context
- keep scope limited to ZIP scanner tests only

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/scanners/test_zip_scanner.py -k malformed_python_handler --maxfail=1`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto -m "not slow and not integration" --maxfail=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a unit test verifying malformed Python handlers in TorchServe archives produce a single warning with parse-error details and expected metadata.
* **Bug Fixes**
  * Ensured failed handler/static analysis within an archive correctly marks the overall scan as not complete and influences the final reported scan status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->