### PR TITLE
fix: harden native code detection in model scanners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - avoid CoreML nested parse failures on bounded-read truncation
+- flag TensorFlow `LoadLibrary` and `LoadLibraryV2` graph ops as dangerous native-library loading
+- detect split CNTK native-user-function and native-library references
+- detect Linux/macOS native-library members in Keras archives and uppercase native-library members in PyTorch ZIPs
+- detect embedded Windows DLL/PE, Linux ELF shared-object, and TensorRT plugin entry-point markers in TensorRT engines
 - detect punctuation-delimited TensorRT `/tmp` plugin paths
 - preserve HuggingFace cache provenance for symlinked custom cache roots
 - ignore remote OCI `layers[].urls` entries during local layer discovery

--- a/modelaudit/config/explanations.py
+++ b/modelaudit/config/explanations.py
@@ -326,7 +326,8 @@ PATTERN_EXPLANATIONS = {
 # Explanations for suspicious TensorFlow operations
 #
 # Risk Categories:
-# - CRITICAL: Code execution (PyFunc, PyCall, ExecuteOp, ShellExecute) & System access (SystemConfig)
+# - CRITICAL: Code execution (PyFunc, PyCall, ExecuteOp, ShellExecute), native library loading
+#   (LoadLibrary/LoadLibraryV2), & System access (SystemConfig)
 # - HIGH: File system operations (ReadFile, WriteFile, Save, SaveV2, MergeV2Checkpoints)
 # - MEDIUM: Data processing with potential exploits (DecodeRaw, DecodeJpeg, DecodePng)
 #
@@ -359,6 +360,14 @@ TF_OP_EXPLANATIONS = {
     "ShellExecute": (
         "ShellExecute runs shell commands from the TensorFlow graph, posing severe security risks by enabling "
         "arbitrary command execution, potentially compromising the host system."
+    ),
+    "LoadLibrary": (
+        "LoadLibrary loads native TensorFlow op libraries from the graph, creating dangerous security risks "
+        "because an untrusted model can point runtime execution at attacker-controlled native code."
+    ),
+    "LoadLibraryV2": (
+        "LoadLibraryV2 loads native TensorFlow op libraries from the graph, creating dangerous security risks "
+        "because an untrusted model can point runtime execution at attacker-controlled native code."
     ),
     "SystemConfig": (
         "SystemConfig operations access or modify system configuration, creating dangerous security risks "

--- a/modelaudit/detectors/suspicious_symbols.py
+++ b/modelaudit/detectors/suspicious_symbols.py
@@ -605,6 +605,8 @@ SUSPICIOUS_OPS = {
     # System operations - CRITICAL RISK
     "ShellExecute",  # Execute shell commands
     "ExecuteOp",  # Execute arbitrary operations
+    "LoadLibrary",  # Load native TensorFlow op libraries
+    "LoadLibraryV2",  # Load native TensorFlow op libraries (V2 variant)
     "SystemConfig",  # System configuration access
     # Queue operations - data exfiltration risk
     "QueueEnqueue",  # Enqueue data (potential exfiltration)
@@ -648,6 +650,8 @@ TENSORFLOW_DANGEROUS_OPS: dict[str, str] = {
     # System operations - CRITICAL RISK
     "ShellExecute": "Can execute shell commands",
     "ExecuteOp": "Can execute arbitrary operations",
+    "LoadLibrary": "Can load native TensorFlow op libraries",
+    "LoadLibraryV2": "Can load native TensorFlow op libraries (V2 variant)",
     "SystemConfig": "Can access system configuration",
     # Queue operations - data exfiltration risk
     "QueueEnqueue": "Can enqueue data to queues, potential data exfiltration vector",

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -1,0 +1,26 @@
+"""Shared security helpers for archive member names."""
+
+import re
+
+_EXECUTABLE_ARCHIVE_MEMBER_SUFFIXES = (
+    ".sh",
+    ".bash",
+    ".cmd",
+    ".exe",
+    ".dll",
+    ".so",
+    ".dylib",
+    ".scr",
+    ".com",
+    ".bat",
+    ".ps1",
+)
+_VERSIONED_SHARED_OBJECT_SUFFIX_RE = re.compile(r"\.so(?:\.[0-9]+)+$")
+
+
+def is_executable_archive_member_name(member_name: str) -> bool:
+    """Return True when an archive member name has an executable/native-library suffix."""
+    normalized_name = member_name.lower()
+    return normalized_name.endswith(_EXECUTABLE_ARCHIVE_MEMBER_SUFFIXES) or bool(
+        _VERSIONED_SHARED_OBJECT_SUFFIX_RE.search(normalized_name)
+    )

--- a/modelaudit/scanners/cntk_scanner.py
+++ b/modelaudit/scanners/cntk_scanner.py
@@ -46,6 +46,15 @@ _LOAD_CONTEXT_RE = re.compile(
     r"(?:loadlibrary|dlopen|native_user_function|plugin|importlib|__import__|module|library)",
     re.IGNORECASE,
 )
+_STRONG_LOAD_CONTEXT_RE = re.compile(
+    r"(?:loadlibrary|dlopen|native_user_function|register_native_user_function|plugin|importlib|__import__)",
+    re.IGNORECASE,
+)
+_NATIVE_LIBRARY_REFERENCE_RE = re.compile(
+    r"(?:\b[a-z]:\\[^\s\"']+\.(?:dll|so|dylib)\b|\.{2}[/\\][^\s\"']+\.(?:dll|so|dylib)\b|"
+    r"(?:/[^\s\"']+)+\.(?:dll|so|dylib)\b|[^\s\"']+\.(?:dll|so|dylib)\b)",
+    re.IGNORECASE,
+)
 _COMMAND_CONTEXT_RE = re.compile(
     r"(?:os\.system|subprocess\.(?:run|popen|call)|powershell(?:\.exe)?|cmd\.exe|/bin/sh|bash\s+-c|curl\s+|wget\s+|netcat|nc\s+)",
     re.IGNORECASE,
@@ -173,6 +182,38 @@ def _has_external_load_reference(text: str) -> bool:
     return bool(_PATH_OR_LIBRARY_RE.search(text) and _LOAD_CONTEXT_RE.search(text))
 
 
+def _collect_split_external_load_references(strings: list[str]) -> list[str]:
+    load_context_examples: list[str] = []
+    library_reference_examples: list[str] = []
+
+    for text in strings:
+        if _is_known_safe_metadata_entry(text):
+            continue
+
+        if (
+            _STRONG_LOAD_CONTEXT_RE.search(text)
+            and not _NATIVE_LIBRARY_REFERENCE_RE.search(text)
+            and len(load_context_examples) < _MAX_EVIDENCE_PER_CATEGORY
+        ):
+            load_context_examples.append(_snippet(text))
+        if (
+            _NATIVE_LIBRARY_REFERENCE_RE.search(text)
+            and not _STRONG_LOAD_CONTEXT_RE.search(text)
+            and len(library_reference_examples) < _MAX_EVIDENCE_PER_CATEGORY
+        ):
+            library_reference_examples.append(_snippet(text))
+
+    if not load_context_examples or not library_reference_examples:
+        return []
+
+    evidence: list[str] = []
+    for context, library_reference in zip(load_context_examples, library_reference_examples, strict=False):
+        evidence.append(f"context={context}; library_reference={library_reference}")
+        if len(evidence) >= _MAX_EVIDENCE_PER_CATEGORY:
+            break
+    return evidence
+
+
 def _has_command_network_execution(text: str) -> bool:
     if not _COMMAND_CONTEXT_RE.search(text):
         return False
@@ -208,6 +249,9 @@ def _collect_security_evidence(strings: list[str]) -> dict[str, list[str]]:
             and len(evidence["obfuscated_payload_indicator"]) < _MAX_EVIDENCE_PER_CATEGORY
         ):
             evidence["obfuscated_payload_indicator"].append(_snippet(text))
+
+    if not evidence["external_load_reference"]:
+        evidence["external_load_reference"].extend(_collect_split_external_load_references(strings))
 
     return evidence
 

--- a/modelaudit/scanners/cntk_scanner.py
+++ b/modelaudit/scanners/cntk_scanner.py
@@ -39,7 +39,11 @@ _ASCII_STRING_RE = re.compile(rb"[ -~]{6,512}")
 _UTF16LE_STRING_RE = re.compile(rb"(?:[\x20-\x7e]\x00){6,256}")
 
 _PATH_OR_LIBRARY_RE = re.compile(
-    r"(?:\b[a-z]:\\[^\s\"']+|\.{2}[/\\][^\s\"']+|(?:/[^\s\"']+){2,}|[^\s\"']+\.(?:dll|so|dylib)\b|https?://[^\s\"']+)",
+    r"(?:\b[a-z]:\\(?:[^\s\"'\\]+\\)*[^\s\"'\\]+|"
+    r"\.{2}[/\\](?:[^\s\"'/\\]+[/\\])*[^\s\"'/\\]+|"
+    r"/(?:[^\s\"'/]+/)+[^\s\"'/]+|"
+    r"(?:[^\s\"'/\\]+[/\\])*[^\s\"'/\\]+\.(?:dll|so|dylib)\b|"
+    r"https?://[^\s\"']+)",
     re.IGNORECASE,
 )
 _LOAD_CONTEXT_RE = re.compile(
@@ -51,8 +55,10 @@ _STRONG_LOAD_CONTEXT_RE = re.compile(
     re.IGNORECASE,
 )
 _NATIVE_LIBRARY_REFERENCE_RE = re.compile(
-    r"(?:\b[a-z]:\\[^\s\"']+\.(?:dll|so|dylib)\b|\.{2}[/\\][^\s\"']+\.(?:dll|so|dylib)\b|"
-    r"(?:/[^\s\"']+)+\.(?:dll|so|dylib)\b|[^\s\"']+\.(?:dll|so|dylib)\b)",
+    r"(?:\b[a-z]:\\(?:[^\s\"'\\]+\\)*[^\s\"'\\]+\.(?:dll|so|dylib)\b|"
+    r"\.{2}[/\\](?:[^\s\"'/\\]+[/\\])*[^\s\"'/\\]+\.(?:dll|so|dylib)\b|"
+    r"/(?:[^\s\"'/]+/)*[^\s\"'/]+\.(?:dll|so|dylib)\b|"
+    r"(?:[^\s\"'/\\]+[/\\])*[^\s\"'/\\]+\.(?:dll|so|dylib)\b)",
     re.IGNORECASE,
 )
 _COMMAND_CONTEXT_RE = re.compile(

--- a/modelaudit/scanners/keras_zip_scanner.py
+++ b/modelaudit/scanners/keras_zip_scanner.py
@@ -85,6 +85,19 @@ _GET_FILE_PATTERN = re.compile(r"get_file", re.IGNORECASE)
 _URL_PATTERN = re.compile(r"https?://", re.IGNORECASE)
 _URL_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
 _WINDOWS_ABSOLUTE_PATH_PATTERN = re.compile(r"^(?:[a-zA-Z]:[\\/]|\\\\)")
+_EXECUTABLE_ARCHIVE_EXTENSIONS = (
+    ".sh",
+    ".bash",
+    ".cmd",
+    ".exe",
+    ".dll",
+    ".so",
+    ".dylib",
+    ".scr",
+    ".com",
+    ".bat",
+    ".ps1",
+)
 _KERAS_CONFIG_ENTRY = "config.json"
 _KERAS_CONFIG_MAX_BYTES = 10 * 1024 * 1024
 _KERAS_METADATA_ENTRY = "metadata.json"
@@ -434,7 +447,7 @@ class KerasZipScanner(BaseScanner):
                             location=f"{path}/{filename}",
                             details={"filename": filename},
                         )
-                    elif normalized_name.endswith((".sh", ".bat", ".exe", ".dll")):
+                    elif normalized_name.endswith(_EXECUTABLE_ARCHIVE_EXTENSIONS):
                         result.add_check(
                             name="Executable File Detection",
                             passed=False,

--- a/modelaudit/scanners/keras_zip_scanner.py
+++ b/modelaudit/scanners/keras_zip_scanner.py
@@ -29,6 +29,7 @@ from ..config.explanations import (
     get_pattern_explanation,
 )
 from ..utils.file.detection import _normalize_archive_member_name, _read_zip_member_bounded
+from .archive_member_security import is_executable_archive_member_name
 from .base import BaseScanner, IssueSeverity, ScanResult
 from .keras_utils import (
     check_custom_loss_config,
@@ -85,20 +86,6 @@ _GET_FILE_PATTERN = re.compile(r"get_file", re.IGNORECASE)
 _URL_PATTERN = re.compile(r"https?://", re.IGNORECASE)
 _URL_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
 _WINDOWS_ABSOLUTE_PATH_PATTERN = re.compile(r"^(?:[a-zA-Z]:[\\/]|\\\\)")
-_EXECUTABLE_ARCHIVE_EXTENSIONS = (
-    ".sh",
-    ".bash",
-    ".cmd",
-    ".exe",
-    ".dll",
-    ".so",
-    ".dylib",
-    ".scr",
-    ".com",
-    ".bat",
-    ".ps1",
-)
-_VERSIONED_SHARED_OBJECT_EXTENSION_RE = re.compile(r"\.so(?:\.[0-9]+)+$")
 _KERAS_CONFIG_ENTRY = "config.json"
 _KERAS_CONFIG_MAX_BYTES = 10 * 1024 * 1024
 _KERAS_METADATA_ENTRY = "metadata.json"
@@ -131,12 +118,6 @@ class _AmbiguousKerasArchiveMemberError(Exception):
         )
         self.member_name = member_name
         self.candidate_filenames = candidate_filenames
-
-
-def _is_executable_archive_member(normalized_name: str) -> bool:
-    return normalized_name.endswith(_EXECUTABLE_ARCHIVE_EXTENSIONS) or bool(
-        _VERSIONED_SHARED_OBJECT_EXTENSION_RE.search(normalized_name)
-    )
 
 
 class KerasZipScanner(BaseScanner):
@@ -454,7 +435,7 @@ class KerasZipScanner(BaseScanner):
                             location=f"{path}/{filename}",
                             details={"filename": filename},
                         )
-                    elif _is_executable_archive_member(normalized_name):
+                    elif is_executable_archive_member_name(normalized_name):
                         result.add_check(
                             name="Executable File Detection",
                             passed=False,

--- a/modelaudit/scanners/keras_zip_scanner.py
+++ b/modelaudit/scanners/keras_zip_scanner.py
@@ -98,6 +98,7 @@ _EXECUTABLE_ARCHIVE_EXTENSIONS = (
     ".bat",
     ".ps1",
 )
+_VERSIONED_SHARED_OBJECT_EXTENSION_RE = re.compile(r"\.so(?:\.[0-9]+)+$")
 _KERAS_CONFIG_ENTRY = "config.json"
 _KERAS_CONFIG_MAX_BYTES = 10 * 1024 * 1024
 _KERAS_METADATA_ENTRY = "metadata.json"
@@ -130,6 +131,12 @@ class _AmbiguousKerasArchiveMemberError(Exception):
         )
         self.member_name = member_name
         self.candidate_filenames = candidate_filenames
+
+
+def _is_executable_archive_member(normalized_name: str) -> bool:
+    return normalized_name.endswith(_EXECUTABLE_ARCHIVE_EXTENSIONS) or bool(
+        _VERSIONED_SHARED_OBJECT_EXTENSION_RE.search(normalized_name)
+    )
 
 
 class KerasZipScanner(BaseScanner):
@@ -447,7 +454,7 @@ class KerasZipScanner(BaseScanner):
                             location=f"{path}/{filename}",
                             details={"filename": filename},
                         )
-                    elif normalized_name.endswith(_EXECUTABLE_ARCHIVE_EXTENSIONS):
+                    elif _is_executable_archive_member(normalized_name):
                         result.add_check(
                             name="Executable File Detection",
                             passed=False,

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -798,8 +798,9 @@ class PyTorchZipScanner(BaseScanner):
 
         for entry in safe_entries:
             name = self._get_zip_member_name(entry)
+            normalized_name = name.lower()
             # Check for Python code files
-            if name.endswith(".py"):
+            if normalized_name.endswith(".py"):
                 result.add_check(
                     name="Python Code File Detection",
                     passed=False,
@@ -810,7 +811,7 @@ class PyTorchZipScanner(BaseScanner):
                 )
                 python_files_found = True
             # Check for shell scripts or other executable files
-            elif name.endswith(
+            elif normalized_name.endswith(
                 (".sh", ".bash", ".cmd", ".exe", ".dll", ".so", ".dylib", ".scr", ".com", ".bat", ".ps1")
             ):
                 result.add_check(

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -29,6 +29,26 @@ from .pytorch_zip_support import (
 
 logger = logging.getLogger(__name__)
 _INSTALLED_PYTORCH_VERSION_UNSET = object()
+_EXECUTABLE_ARCHIVE_EXTENSIONS = (
+    ".sh",
+    ".bash",
+    ".cmd",
+    ".exe",
+    ".dll",
+    ".so",
+    ".dylib",
+    ".scr",
+    ".com",
+    ".bat",
+    ".ps1",
+)
+_VERSIONED_SHARED_OBJECT_EXTENSION_RE = re.compile(r"\.so(?:\.[0-9]+)+$")
+
+
+def _is_executable_archive_member(normalized_name: str) -> bool:
+    return normalized_name.endswith(_EXECUTABLE_ARCHIVE_EXTENSIONS) or bool(
+        _VERSIONED_SHARED_OBJECT_EXTENSION_RE.search(normalized_name)
+    )
 
 
 @dataclass(frozen=True)
@@ -811,9 +831,7 @@ class PyTorchZipScanner(BaseScanner):
                 )
                 python_files_found = True
             # Check for shell scripts or other executable files
-            elif normalized_name.endswith(
-                (".sh", ".bash", ".cmd", ".exe", ".dll", ".so", ".dylib", ".scr", ".com", ".bat", ".ps1")
-            ):
+            elif _is_executable_archive_member(normalized_name):
                 result.add_check(
                     name="Executable File Detection",
                     passed=False,

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -13,6 +13,7 @@ from typing import Any, ClassVar
 
 from ..detectors.suspicious_symbols import CVE_COMBINED_PATTERNS
 from ..utils import sanitize_archive_path
+from .archive_member_security import is_executable_archive_member_name
 from .base import BaseScanner, IssueSeverity, ScanResult
 from .pickle_scanner import PickleScanner
 from .picklescan_adapter import apply_pickle_member_context
@@ -29,26 +30,6 @@ from .pytorch_zip_support import (
 
 logger = logging.getLogger(__name__)
 _INSTALLED_PYTORCH_VERSION_UNSET = object()
-_EXECUTABLE_ARCHIVE_EXTENSIONS = (
-    ".sh",
-    ".bash",
-    ".cmd",
-    ".exe",
-    ".dll",
-    ".so",
-    ".dylib",
-    ".scr",
-    ".com",
-    ".bat",
-    ".ps1",
-)
-_VERSIONED_SHARED_OBJECT_EXTENSION_RE = re.compile(r"\.so(?:\.[0-9]+)+$")
-
-
-def _is_executable_archive_member(normalized_name: str) -> bool:
-    return normalized_name.endswith(_EXECUTABLE_ARCHIVE_EXTENSIONS) or bool(
-        _VERSIONED_SHARED_OBJECT_EXTENSION_RE.search(normalized_name)
-    )
 
 
 @dataclass(frozen=True)
@@ -831,7 +812,7 @@ class PyTorchZipScanner(BaseScanner):
                 )
                 python_files_found = True
             # Check for shell scripts or other executable files
-            elif _is_executable_archive_member(normalized_name):
+            elif is_executable_archive_member_name(normalized_name):
                 result.add_check(
                     name="Executable File Detection",
                     passed=False,

--- a/modelaudit/scanners/tensorrt_scanner.py
+++ b/modelaudit/scanners/tensorrt_scanner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import re
 from collections.abc import Iterator
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 from .base import BaseScanner, IssueSeverity, ScanResult
 
@@ -18,6 +18,18 @@ SUSPICIOUS_PATTERN_RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
             r"(?<![A-Za-z0-9_.-])(?:[A-Za-z0-9_+.-]+)?\.so(?:\.[0-9]+(?:\.[0-9]+)*)?(?![A-Za-z0-9_.-])",
             re.IGNORECASE,
         ),
+    ),
+    (
+        ".dll",
+        re.compile(r"(?<![A-Za-z0-9_.-])(?:[A-Za-z0-9_+.-]+)?\.dll(?![A-Za-z0-9_.-])", re.IGNORECASE),
+    ),
+    (
+        "LoadLibrary",
+        re.compile(r"(?<![A-Za-z0-9_])LoadLibrary(?:Ex)?[AW]?(?![A-Za-z0-9_])", re.IGNORECASE),
+    ),
+    (
+        "TensorRT plugin entry point",
+        re.compile(r"(?<![A-Za-z0-9_])(?:setLoggerFinder|getCreators|getPluginCreators)(?![A-Za-z0-9_])"),
     ),
     ("python", re.compile(r"(?<![A-Za-z0-9_])python(?:[0-9.]+)?(?:\.exe)?(?![A-Za-z0-9_])", re.IGNORECASE)),
     ("import", re.compile(r"(?<![A-Za-z0-9_])import(?![A-Za-z0-9_])", re.IGNORECASE)),
@@ -33,6 +45,13 @@ SUSPICIOUS_PATTERN_RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
 _ASCII_STRING_PATTERN = re.compile(rb"[\t\n\r\x20-\x7e]{3,}")
 _UTF16LE_STRING_PATTERN = re.compile(rb"(?:(?:[\t\n\r\x20-\x7e]\x00){3,})")
 _UTF16BE_STRING_PATTERN = re.compile(rb"(?:(?:\x00[\t\n\r\x20-\x7e]){3,})")
+_PE_POINTER_OFFSET = 0x3C
+_PE_MIN_HEADER_OFFSET = 0x40
+_PE_MAX_HEADER_OFFSET = 1024 * 1024
+_PE_SIGNATURE = b"PE\x00\x00"
+_ELF_SIGNATURE = b"\x7fELF"
+_ELF_TYPE_SHARED_OBJECT = 3
+_ELF_SUPPORTED_MACHINES = {3, 40, 62, 183}
 
 
 def _iter_engine_strings(data: bytes) -> Iterator[str]:
@@ -45,6 +64,55 @@ def _iter_engine_strings(data: bytes) -> Iterator[str]:
 
     for match in _UTF16BE_STRING_PATTERN.finditer(data):
         yield match.group(0).decode("utf-16be", "ignore")
+
+
+def _find_embedded_pe_header(data: bytes) -> int | None:
+    """Return the offset of a validated embedded Windows PE header, if present."""
+    start = 0
+    while True:
+        mz_offset = data.find(b"MZ", start)
+        if mz_offset == -1:
+            return None
+
+        pe_pointer_offset = mz_offset + _PE_POINTER_OFFSET
+        if pe_pointer_offset + 4 <= len(data):
+            pe_offset = int.from_bytes(data[pe_pointer_offset : pe_pointer_offset + 4], "little")
+            pe_signature_offset = mz_offset + pe_offset
+            if (
+                _PE_MIN_HEADER_OFFSET <= pe_offset <= _PE_MAX_HEADER_OFFSET
+                and pe_signature_offset + len(_PE_SIGNATURE) <= len(data)
+                and data[pe_signature_offset : pe_signature_offset + len(_PE_SIGNATURE)] == _PE_SIGNATURE
+            ):
+                return mz_offset
+
+        start = mz_offset + 1
+
+
+def _find_embedded_elf_shared_object(data: bytes) -> int | None:
+    """Return the offset of a validated embedded ELF shared object, if present."""
+    start = 0
+    while True:
+        elf_offset = data.find(_ELF_SIGNATURE, start)
+        if elf_offset == -1:
+            return None
+
+        if elf_offset + 24 <= len(data):
+            elf_class = data[elf_offset + 4]
+            byte_order = data[elf_offset + 5]
+            elf_version = data[elf_offset + 6]
+            if elf_class in {1, 2} and byte_order in {1, 2} and elf_version == 1:
+                endian: Literal["little", "big"] = "little" if byte_order == 1 else "big"
+                object_type = int.from_bytes(data[elf_offset + 16 : elf_offset + 18], endian)
+                machine = int.from_bytes(data[elf_offset + 18 : elf_offset + 20], endian)
+                object_version = int.from_bytes(data[elf_offset + 20 : elf_offset + 24], endian)
+                if (
+                    object_type == _ELF_TYPE_SHARED_OBJECT
+                    and machine in _ELF_SUPPORTED_MACHINES
+                    and object_version == 1
+                ):
+                    return elf_offset
+
+        start = elf_offset + 1
 
 
 class TensorRTScanner(BaseScanner):
@@ -104,6 +172,30 @@ class TensorRTScanner(BaseScanner):
                     details={"pattern": pattern_name},
                     rule_code="S902",
                 )
+
+        pe_header_offset = _find_embedded_pe_header(data)
+        if pe_header_offset is not None:
+            result.add_check(
+                name="Embedded PE Detection",
+                passed=False,
+                message="Embedded Windows PE/DLL header found",
+                severity=IssueSeverity.CRITICAL,
+                location=path,
+                details={"pattern": "embedded PE", "offset": pe_header_offset},
+                rule_code="S902",
+            )
+
+        elf_header_offset = _find_embedded_elf_shared_object(data)
+        if elf_header_offset is not None:
+            result.add_check(
+                name="Embedded ELF Detection",
+                passed=False,
+                message="Embedded Linux ELF shared-object header found",
+                severity=IssueSeverity.CRITICAL,
+                location=path,
+                details={"pattern": "embedded ELF", "offset": elf_header_offset},
+                rule_code="S902",
+            )
 
         result.finish(success=not result.has_errors)
         return result

--- a/modelaudit/scanners/tensorrt_scanner.py
+++ b/modelaudit/scanners/tensorrt_scanner.py
@@ -50,7 +50,9 @@ _PE_MIN_HEADER_OFFSET = 0x40
 _PE_MAX_HEADER_OFFSET = 1024 * 1024
 _PE_SIGNATURE = b"PE\x00\x00"
 _ELF_SIGNATURE = b"\x7fELF"
+_ELF_TYPE_EXECUTABLE = 2
 _ELF_TYPE_SHARED_OBJECT = 3
+_ELF_EXECUTABLE_TYPES = {_ELF_TYPE_EXECUTABLE, _ELF_TYPE_SHARED_OBJECT}
 _ELF_SUPPORTED_MACHINES = {3, 40, 62, 183}
 
 
@@ -88,8 +90,8 @@ def _find_embedded_pe_header(data: bytes) -> int | None:
         start = mz_offset + 1
 
 
-def _find_embedded_elf_shared_object(data: bytes) -> int | None:
-    """Return the offset of a validated embedded ELF shared object, if present."""
+def _find_embedded_elf_executable(data: bytes) -> int | None:
+    """Return the offset of a validated embedded ELF executable, if present."""
     start = 0
     while True:
         elf_offset = data.find(_ELF_SIGNATURE, start)
@@ -105,11 +107,7 @@ def _find_embedded_elf_shared_object(data: bytes) -> int | None:
                 object_type = int.from_bytes(data[elf_offset + 16 : elf_offset + 18], endian)
                 machine = int.from_bytes(data[elf_offset + 18 : elf_offset + 20], endian)
                 object_version = int.from_bytes(data[elf_offset + 20 : elf_offset + 24], endian)
-                if (
-                    object_type == _ELF_TYPE_SHARED_OBJECT
-                    and machine in _ELF_SUPPORTED_MACHINES
-                    and object_version == 1
-                ):
+                if object_type in _ELF_EXECUTABLE_TYPES and machine in _ELF_SUPPORTED_MACHINES and object_version == 1:
                     return elf_offset
 
         start = elf_offset + 1
@@ -185,12 +183,12 @@ class TensorRTScanner(BaseScanner):
                 rule_code="S902",
             )
 
-        elf_header_offset = _find_embedded_elf_shared_object(data)
+        elf_header_offset = _find_embedded_elf_executable(data)
         if elf_header_offset is not None:
             result.add_check(
                 name="Embedded ELF Detection",
                 passed=False,
-                message="Embedded Linux ELF shared-object header found",
+                message="Embedded Linux ELF executable/shared-object header found",
                 severity=IssueSeverity.CRITICAL,
                 location=path,
                 details={"pattern": "embedded ELF", "offset": elf_header_offset},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,6 +141,7 @@ def pytest_runtest_setup(item):
             "test_tf_metagraph_scanner.py",  # TensorFlow MetaGraph scanner tests
             "test_tf_savedmodel_scanner.py",  # TensorFlow SavedModel scanner tests
             "test_tflite_scanner.py",  # TFLite scanner guardrail tests
+            "test_tensorrt_scanner.py",  # TensorRT scanner tests
             "test_torchserve_mar_scanner.py",  # TorchServe .mar scanner tests
             "test_executorch_scanner.py",  # ExecuTorch scanner tests
             "test_telemetry.py",  # telemetry payload and availability tests

--- a/tests/detectors/test_suspicious_symbols.py
+++ b/tests/detectors/test_suspicious_symbols.py
@@ -229,7 +229,7 @@ class TestSuspiciousOps:
 
     def test_critical_operations_present(self) -> None:
         """Test that critical dangerous operations are included."""
-        critical_ops = ["PyFunc", "ReadFile", "WriteFile", "ShellExecute"]
+        critical_ops = ["PyFunc", "ReadFile", "WriteFile", "ShellExecute", "LoadLibrary"]
 
         for op in critical_ops:
             assert op in SUSPICIOUS_OPS, f"Critical operation {op} not flagged"

--- a/tests/scanners/test_cntk_scanner.py
+++ b/tests/scanners/test_cntk_scanner.py
@@ -65,6 +65,34 @@ def test_cntk_scanner_detects_multi_signal_payload_as_critical(tmp_path: Path) -
     assert any("multiple independent suspicious signals" in issue.message.lower() for issue in result.issues)
 
 
+def test_cntk_scanner_detects_split_native_library_load_reference(tmp_path: Path) -> None:
+    path = tmp_path / "split_native_load.dnn"
+    payload = b" native_user_function\x00C:\\temp\\evil.dll "
+    _write_cntkv2(path, payload=payload)
+
+    result = CntkScanner().scan(str(path))
+
+    matching_issues = [
+        issue
+        for issue in result.issues
+        if issue.details.get("category") == "external_load_reference"
+        and "library_reference=C:\\temp\\evil.dll" in " ".join(issue.details.get("examples", []))
+    ]
+    assert matching_issues
+    assert all(issue.severity == IssueSeverity.WARNING for issue in matching_issues)
+
+
+def test_cntk_scanner_split_load_correlation_ignores_generic_metadata(tmp_path: Path) -> None:
+    path = tmp_path / "benign_split_words.cmf"
+    payload = b" module\x00/model/base\x00library_version\x00native_user_functional_features\x00evil.dllcache "
+    _write_cntkv2(path, payload=payload)
+
+    result = CntkScanner().scan(str(path))
+
+    assert result.success is True
+    assert result.issues == []
+
+
 def test_cntk_scanner_false_positive_control_no_critical(tmp_path: Path) -> None:
     path = tmp_path / "benign_risky_words.cmf"
     payload = b" exec_summary network_score library_version model_path=/models/base "

--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -845,33 +845,29 @@ __import__('pickle').loads(data)
         finally:
             os.unlink(temp_path)
 
-    def test_case_insensitive_suspicious_extension_detection(self) -> None:
+    def test_case_insensitive_suspicious_extension_detection(self, tmp_path: Path) -> None:
         """Uppercase/mixed-case executable extensions should be detected."""
         scanner = KerasZipScanner()
 
         config = {"class_name": "Sequential", "config": {"layers": []}}
+        archive_path = tmp_path / "suspicious_extensions.keras"
 
-        with tempfile.NamedTemporaryFile(suffix=".keras", delete=False) as f:
-            with zipfile.ZipFile(f, "w") as zf:
-                zf.writestr("config.json", json.dumps(config))
-                zf.writestr("MALWARE.PY", "print('evil')")
-                zf.writestr("run.SH", "#!/bin/bash\necho evil")
-                zf.writestr("plugin.SO", b"\x7fELF")
-                zf.writestr("plugin.Dylib", b"\xfe\xed\xfa\xcf")
-            temp_path = f.name
+        with zipfile.ZipFile(archive_path, "w") as zf:
+            zf.writestr("config.json", json.dumps(config))
+            zf.writestr("MALWARE.PY", "print('evil')")
+            zf.writestr("run.SH", "#!/bin/bash\necho evil")
+            zf.writestr("plugin.SO", b"\x7fELF")
+            zf.writestr("libpayload.SO.6", b"\x7fELF")
+            zf.writestr("plugin.Dylib", b"\xfe\xed\xfa\xcf")
 
-        try:
-            result = scanner.scan(temp_path)
-            suspicious_files = [
-                check.message
-                for check in result.checks
-                if "Python file found in Keras ZIP" in check.message
-                or "Executable file found in Keras ZIP" in check.message
-            ]
-            assert len(suspicious_files) >= 4, f"Should detect uppercase suspicious files, found: {suspicious_files}"
-
-        finally:
-            os.unlink(temp_path)
+        result = scanner.scan(str(archive_path))
+        suspicious_files = [
+            check.message
+            for check in result.checks
+            if "Python file found in Keras ZIP" in check.message
+            or "Executable file found in Keras ZIP" in check.message
+        ]
+        assert len(suspicious_files) >= 5, f"Should detect uppercase suspicious files, found: {suspicious_files}"
 
     def test_native_library_near_match_extension_stays_clean(self, tmp_path: Path) -> None:
         """Native-library extension near matches should not be treated as executable archive members."""
@@ -880,6 +876,8 @@ __import__('pickle').loads(data)
         with zipfile.ZipFile(archive_path, "w") as zf:
             zf.writestr("config.json", json.dumps(config))
             zf.writestr("plugin.sology", "not a shared object")
+            zf.writestr("plugin.so.version", "not a versioned shared object")
+            zf.writestr("plugin.so.6cache", "not a versioned shared object")
             zf.writestr("plugin.dllcache", "not a dll")
 
         result = KerasZipScanner().scan(str(archive_path))

--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -861,13 +861,13 @@ __import__('pickle').loads(data)
             zf.writestr("plugin.Dylib", b"\xfe\xed\xfa\xcf")
 
         result = scanner.scan(str(archive_path))
-        suspicious_files = [
-            check.message
+        suspicious_filenames = {
+            check.details.get("filename")
             for check in result.checks
             if "Python file found in Keras ZIP" in check.message
             or "Executable file found in Keras ZIP" in check.message
-        ]
-        assert len(suspicious_files) >= 5, f"Should detect uppercase suspicious files, found: {suspicious_files}"
+        }
+        assert {"MALWARE.PY", "run.SH", "plugin.SO", "libpayload.SO.6", "plugin.Dylib"}.issubset(suspicious_filenames)
 
     def test_native_library_near_match_extension_stays_clean(self, tmp_path: Path) -> None:
         """Native-library extension near matches should not be treated as executable archive members."""

--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -845,7 +845,7 @@ __import__('pickle').loads(data)
         finally:
             os.unlink(temp_path)
 
-    def test_case_insensitive_suspicious_extension_detection(self):
+    def test_case_insensitive_suspicious_extension_detection(self) -> None:
         """Uppercase/mixed-case executable extensions should be detected."""
         scanner = KerasZipScanner()
 
@@ -856,6 +856,8 @@ __import__('pickle').loads(data)
                 zf.writestr("config.json", json.dumps(config))
                 zf.writestr("MALWARE.PY", "print('evil')")
                 zf.writestr("run.SH", "#!/bin/bash\necho evil")
+                zf.writestr("plugin.SO", b"\x7fELF")
+                zf.writestr("plugin.Dylib", b"\xfe\xed\xfa\xcf")
             temp_path = f.name
 
         try:
@@ -866,10 +868,25 @@ __import__('pickle').loads(data)
                 if "Python file found in Keras ZIP" in check.message
                 or "Executable file found in Keras ZIP" in check.message
             ]
-            assert len(suspicious_files) >= 2, f"Should detect uppercase suspicious files, found: {suspicious_files}"
+            assert len(suspicious_files) >= 4, f"Should detect uppercase suspicious files, found: {suspicious_files}"
 
         finally:
             os.unlink(temp_path)
+
+    def test_native_library_near_match_extension_stays_clean(self, tmp_path: Path) -> None:
+        """Native-library extension near matches should not be treated as executable archive members."""
+        archive_path = tmp_path / "safe.keras"
+        config = {"class_name": "Sequential", "config": {"layers": []}}
+        with zipfile.ZipFile(archive_path, "w") as zf:
+            zf.writestr("config.json", json.dumps(config))
+            zf.writestr("plugin.sology", "not a shared object")
+            zf.writestr("plugin.dllcache", "not a dll")
+
+        result = KerasZipScanner().scan(str(archive_path))
+
+        assert not any(
+            check.name == "Executable File Detection" and check.status == CheckStatus.FAILED for check in result.checks
+        )
 
     def test_nested_models(self):
         """Test scanning of nested model structures."""

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -128,6 +128,34 @@ def test_pytorch_zip_scanner_malicious_model(tmp_path):
     assert any("eval" in issue.message.lower() for issue in result.issues)
 
 
+def test_pytorch_zip_scanner_detects_case_insensitive_native_library_members(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "native_libs.pt")
+    with zipfile.ZipFile(model_path, "a") as zip_file:
+        zip_file.writestr("archive/data/MALICIOUS.SO", b"\x7fELF")
+        zip_file.writestr("archive/data/plugin.Dylib", b"\xfe\xed\xfa\xcf")
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    executable_issues = [
+        issue for issue in result.issues if issue.message and "Executable file found in PyTorch model" in issue.message
+    ]
+    assert len(executable_issues) >= 2
+    assert all(issue.severity == IssueSeverity.CRITICAL for issue in executable_issues)
+
+
+def test_pytorch_zip_scanner_native_library_near_match_extension_stays_clean(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "near_match.pt")
+    with zipfile.ZipFile(model_path, "a") as zip_file:
+        zip_file.writestr("archive/data/plugin.sology", b"not a shared object")
+        zip_file.writestr("archive/data/plugin.dllcache", b"not a dll")
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert not any(
+        issue.message and "Executable file found in PyTorch model" in issue.message for issue in result.issues
+    )
+
+
 def test_pytorch_zip_scanner_relaxes_crc_for_pickle_scan(tmp_path: Path) -> None:
     """CRC-mismatched pickle entries should still be scanned with an explicit warning."""
     model_path = create_mock_pytorch_zip(tmp_path / "crc_mismatch.pt", malicious=True)

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -132,6 +132,7 @@ def test_pytorch_zip_scanner_detects_case_insensitive_native_library_members(tmp
     model_path = create_mock_pytorch_zip(tmp_path / "native_libs.pt")
     with zipfile.ZipFile(model_path, "a") as zip_file:
         zip_file.writestr("archive/data/MALICIOUS.SO", b"\x7fELF")
+        zip_file.writestr("archive/data/libpayload.SO.6", b"\x7fELF")
         zip_file.writestr("archive/data/plugin.Dylib", b"\xfe\xed\xfa\xcf")
 
     result = PyTorchZipScanner().scan(str(model_path))
@@ -139,7 +140,7 @@ def test_pytorch_zip_scanner_detects_case_insensitive_native_library_members(tmp
     executable_issues = [
         issue for issue in result.issues if issue.message and "Executable file found in PyTorch model" in issue.message
     ]
-    assert len(executable_issues) >= 2
+    assert len(executable_issues) >= 3
     assert all(issue.severity == IssueSeverity.CRITICAL for issue in executable_issues)
 
 
@@ -147,6 +148,8 @@ def test_pytorch_zip_scanner_native_library_near_match_extension_stays_clean(tmp
     model_path = create_mock_pytorch_zip(tmp_path / "near_match.pt")
     with zipfile.ZipFile(model_path, "a") as zip_file:
         zip_file.writestr("archive/data/plugin.sology", b"not a shared object")
+        zip_file.writestr("archive/data/plugin.so.version", b"not a versioned shared object")
+        zip_file.writestr("archive/data/plugin.so.6cache", b"not a versioned shared object")
         zip_file.writestr("archive/data/plugin.dllcache", b"not a dll")
 
     result = PyTorchZipScanner().scan(str(model_path))

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -140,7 +140,12 @@ def test_pytorch_zip_scanner_detects_case_insensitive_native_library_members(tmp
     executable_issues = [
         issue for issue in result.issues if issue.message and "Executable file found in PyTorch model" in issue.message
     ]
-    assert len(executable_issues) >= 3
+    executable_files = {issue.details.get("file") for issue in executable_issues}
+    assert {
+        "archive/data/MALICIOUS.SO",
+        "archive/data/libpayload.SO.6",
+        "archive/data/plugin.Dylib",
+    }.issubset(executable_files)
     assert all(issue.severity == IssueSeverity.CRITICAL for issue in executable_issues)
 
 

--- a/tests/scanners/test_tensorrt_scanner.py
+++ b/tests/scanners/test_tensorrt_scanner.py
@@ -14,12 +14,20 @@ def _minimal_pe_header() -> bytes:
 
 
 def _minimal_elf_shared_object() -> bytes:
+    return _minimal_elf_header(object_type=3)
+
+
+def _minimal_elf_executable() -> bytes:
+    return _minimal_elf_header(object_type=2)
+
+
+def _minimal_elf_header(*, object_type: int) -> bytes:
     data = bytearray(b"\x00" * 0x80)
     data[0:4] = b"\x7fELF"
     data[4] = 2  # ELFCLASS64
     data[5] = 1  # ELFDATA2LSB
     data[6] = 1  # EV_CURRENT
-    data[16:18] = (3).to_bytes(2, "little")  # ET_DYN
+    data[16:18] = object_type.to_bytes(2, "little")
     data[18:20] = (62).to_bytes(2, "little")  # x86_64
     data[20:24] = (1).to_bytes(4, "little")  # EV_CURRENT
     return bytes(data)
@@ -110,6 +118,20 @@ def test_tensorrt_scanner_detects_embedded_elf_shared_object(tmp_path: Path) -> 
     path = tmp_path / "embedded_elf.engine"
     prefix = b"tensorrt engine prefix\x00"
     path.write_bytes(prefix + _minimal_elf_shared_object())
+
+    result = TensorRTScanner().scan(str(path))
+
+    assert result.success is False
+    assert any(
+        issue.details.get("pattern") == "embedded ELF" and issue.details.get("offset") == len(prefix)
+        for issue in result.issues
+    )
+
+
+def test_tensorrt_scanner_detects_embedded_elf_executable(tmp_path: Path) -> None:
+    path = tmp_path / "embedded_elf_exec.engine"
+    prefix = b"tensorrt engine prefix\x00"
+    path.write_bytes(prefix + _minimal_elf_executable())
 
     result = TensorRTScanner().scan(str(path))
 

--- a/tests/scanners/test_tensorrt_scanner.py
+++ b/tests/scanners/test_tensorrt_scanner.py
@@ -5,6 +5,26 @@ from modelaudit.scanners.tensorrt_scanner import TensorRTScanner
 from modelaudit.utils.file.detection import detect_file_format, detect_format_from_extension
 
 
+def _minimal_pe_header() -> bytes:
+    data = bytearray(b"\x00" * 0x100)
+    data[0:2] = b"MZ"
+    data[0x3C:0x40] = (0x80).to_bytes(4, "little")
+    data[0x80:0x84] = b"PE\x00\x00"
+    return bytes(data)
+
+
+def _minimal_elf_shared_object() -> bytes:
+    data = bytearray(b"\x00" * 0x80)
+    data[0:4] = b"\x7fELF"
+    data[4] = 2  # ELFCLASS64
+    data[5] = 1  # ELFDATA2LSB
+    data[6] = 1  # EV_CURRENT
+    data[16:18] = (3).to_bytes(2, "little")  # ET_DYN
+    data[18:20] = (62).to_bytes(2, "little")  # x86_64
+    data[20:24] = (1).to_bytes(4, "little")  # EV_CURRENT
+    return bytes(data)
+
+
 def test_tensorrt_scanner_can_handle(tmp_path: Path) -> None:
     path = tmp_path / "model.engine"
     path.write_bytes(b"dummy")
@@ -61,6 +81,55 @@ def test_tensorrt_scanner_detects_uppercase_and_shared_library_paths(tmp_path: P
     assert {"/tmp/", ".so", "python", "import", "eval"}.issubset(matched_patterns)
 
 
+def test_tensorrt_scanner_detects_windows_dll_plugin_markers(tmp_path: Path) -> None:
+    path = tmp_path / "malicious.engine"
+    path.write_bytes(b"plugin=malicious_plugin.dll\x00LoadLibraryExW\x00")
+
+    result = TensorRTScanner().scan(str(path))
+
+    assert result.success is False
+    matched_patterns = {issue.details.get("pattern") for issue in result.issues}
+    assert {".dll", "LoadLibrary"}.issubset(matched_patterns)
+
+
+def test_tensorrt_scanner_detects_embedded_pe_header(tmp_path: Path) -> None:
+    path = tmp_path / "embedded_pe.engine"
+    prefix = b"tensorrt engine prefix\x00"
+    path.write_bytes(prefix + _minimal_pe_header())
+
+    result = TensorRTScanner().scan(str(path))
+
+    assert result.success is False
+    assert any(
+        issue.details.get("pattern") == "embedded PE" and issue.details.get("offset") == len(prefix)
+        for issue in result.issues
+    )
+
+
+def test_tensorrt_scanner_detects_embedded_elf_shared_object(tmp_path: Path) -> None:
+    path = tmp_path / "embedded_elf.engine"
+    prefix = b"tensorrt engine prefix\x00"
+    path.write_bytes(prefix + _minimal_elf_shared_object())
+
+    result = TensorRTScanner().scan(str(path))
+
+    assert result.success is False
+    assert any(
+        issue.details.get("pattern") == "embedded ELF" and issue.details.get("offset") == len(prefix)
+        for issue in result.issues
+    )
+
+
+def test_tensorrt_scanner_detects_plugin_shared_library_entry_points(tmp_path: Path) -> None:
+    path = tmp_path / "plugin_entry_points.engine"
+    path.write_bytes(b"setLoggerFinder\x00getPluginCreators\x00getCreators\x00")
+
+    result = TensorRTScanner().scan(str(path))
+
+    assert result.success is False
+    assert any(issue.details.get("pattern") == "TensorRT plugin entry point" for issue in result.issues)
+
+
 def test_tensorrt_scanner_detects_utf16_python_marker(tmp_path: Path) -> None:
     path = tmp_path / "utf16.engine"
     path.write_bytes("python".encode("utf-16le"))
@@ -88,6 +157,34 @@ def test_tensorrt_scanner_avoids_substring_near_match_false_positives(tmp_path: 
         b"attempt/tmpology LD_LIBRARY_PATH:/tmpology C:\\tmpology\\payload "
         b"load(/tmpbackup/safe.so.txt)"
     )
+
+    result = TensorRTScanner().scan(str(path))
+
+    assert result.success is True
+    assert result.issues == []
+
+
+def test_tensorrt_scanner_avoids_windows_native_near_match_false_positives(tmp_path: Path) -> None:
+    path = tmp_path / "safe.engine"
+    invalid_pe_near_match = bytearray(b"\x00" * 0x100)
+    invalid_pe_near_match[0:2] = b"MZ"
+    invalid_pe_near_match[0x3C:0x40] = (0x80).to_bytes(4, "little")
+    invalid_pe_near_match[0x80:0x84] = b"PX\x00\x00"
+    path.write_bytes(
+        b"plugin.dllcache KERNEL32.dllology LoadLibraryExWidget preLoadLibrary " + bytes(invalid_pe_near_match)
+    )
+
+    result = TensorRTScanner().scan(str(path))
+
+    assert result.success is True
+    assert result.issues == []
+
+
+def test_tensorrt_scanner_avoids_elf_and_plugin_entry_point_near_match_false_positives(tmp_path: Path) -> None:
+    path = tmp_path / "safe.engine"
+    invalid_elf_near_match = bytearray(_minimal_elf_shared_object())
+    invalid_elf_near_match[16:18] = (1).to_bytes(2, "little")
+    path.write_bytes(b"getCreatorsWidget setLoggerFinderish getPluginCreatorsExtra " + bytes(invalid_elf_near_match))
 
     result = TensorRTScanner().scan(str(path))
 

--- a/tests/scanners/test_tf_metagraph_scanner.py
+++ b/tests/scanners/test_tf_metagraph_scanner.py
@@ -179,6 +179,32 @@ def test_tf_metagraph_scanner_detects_unsafe_ops_and_executable_payload_signals(
     )
 
 
+@pytest.mark.parametrize("op_name", ["LoadLibrary", "LoadLibraryV2"])
+def test_tf_metagraph_scanner_flags_loadlibrary_ops_without_path_attributes(tmp_path: Path, op_name: str) -> None:
+    loadlibrary_meta = tmp_path / f"{op_name.lower()}.meta"
+    loadlibrary_meta.write_bytes(
+        _build_metagraph(
+            graph_nodes=[
+                {
+                    "name": "plugin_loader",
+                    "op": op_name,
+                }
+            ]
+        )
+    )
+
+    result = TensorFlowMetaGraphScanner().scan(str(loadlibrary_meta))
+
+    assert result.success is False
+    assert any(
+        issue.message
+        and f"Dangerous TensorFlow operation: {op_name}" in issue.message
+        and issue.severity == IssueSeverity.CRITICAL
+        and issue.details.get("op_type") == op_name
+        for issue in result.issues
+    )
+
+
 def test_tf_metagraph_scanner_comment_token_does_not_suppress_malicious_detection(tmp_path: Path) -> None:
     malicious_meta = tmp_path / "malicious-comment.meta"
     malicious_meta.write_bytes(

--- a/tests/scanners/test_tf_savedmodel_scanner.py
+++ b/tests/scanners/test_tf_savedmodel_scanner.py
@@ -240,6 +240,25 @@ def test_detect_pyfunc_operation(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(not has_tf_protos(), reason="TensorFlow protobuf stubs unavailable")
+@pytest.mark.parametrize("op_name", ["LoadLibrary", "LoadLibraryV2"])
+def test_detect_loadlibrary_operation(tmp_path: Path, op_name: str) -> None:
+    model_path = _create_test_savedmodel_with_op(tmp_path, op_name, f"{op_name.lower()}_test")
+
+    result = TensorFlowSavedModelScanner().scan(model_path)
+
+    load_library_issues = [
+        issue
+        for issue in result.issues
+        if issue.message and f"Dangerous TensorFlow operation: {op_name}" in issue.message
+    ]
+    assert result.success is False
+    assert load_library_issues
+    assert any(issue.severity == IssueSeverity.CRITICAL for issue in load_library_issues)
+    assert all(issue.details.get("op_type") == op_name for issue in load_library_issues)
+    assert all(issue.why for issue in load_library_issues)
+
+
+@pytest.mark.skipif(not has_tf_protos(), reason="TensorFlow protobuf stubs unavailable")
 def test_detect_writefile_operation(tmp_path: Path) -> None:
     # Synthesize a SavedModel containing a WriteFile node
     model_path = _create_test_savedmodel_with_op(tmp_path, "WriteFile", "writefile_test")
@@ -1083,7 +1102,7 @@ def test_tf_scanner_explanations_for_all_suspicious_ops(tmp_path: Path) -> None:
 def test_tf_scanner_explanation_categories(tmp_path: Path) -> None:
     """Test that TensorFlow scanner provides appropriate explanations by operation category."""
     # Test critical risk operations (code execution)
-    critical_ops = ["PyFunc", "PyCall", "ExecuteOp", "ShellExecute"]
+    critical_ops = ["PyFunc", "PyCall", "ExecuteOp", "ShellExecute", "LoadLibrary"]
     for op_name in critical_ops:
         model_path = _create_test_savedmodel_with_op(tmp_path, op_name, f"critical_test_{op_name.lower()}")
 


### PR DESCRIPTION
Summary
- Harden native-code indicator detection across TensorRT, TensorFlow graph operations, CNTK, and archive-backed model scanners.
- Share archive executable-member detection for ZIP-backed scanner paths.
- Add targeted regression coverage and explanation metadata.

Security handling
- This PR intentionally avoids exploit artifacts and public reproduction details.

Validation
- uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run pytest -n auto -m "not slow and not integration" --maxfail=1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced detection of TensorFlow ops that load native libraries, native-library members in Keras/PyTorch archives, and embedded executables in TensorRT engines
  * Improved split-reference detection for native library loading across multiple model artifacts

* **Bug Fixes**
  * Case-insensitive and more accurate executable/member name detection to reduce false negatives

* **Tests**
  * Added extensive tests covering new detections and regression cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->