### PR TITLE
fix: route misnamed compressed wrappers by header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - avoid PMML `<Extension>` false positives for benign `subprocess` prose while preserving `subprocess.getoutput()`, `subprocess.getstatusoutput()`, and `importlib.import_module("subprocess")` detections
 - route helper-level ZIP-backed `.ckpt`/`.pkl` checkpoints through archive scanners
 - route gzip/bzip2/xz/lz4/zlib wrappers by magic bytes even when they use misleading extensions
+- reject raw trailers after bzip2 and xz compressed-wrapper payloads
+- reject raw trailers after lz4 compressed-wrapper frames and bound lz4 decompression output probes
 
 ## [0.2.31](https://github.com/promptfoo/modelaudit/compare/v0.2.30...v0.2.31) (2026-04-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fail closed on unterminated OpenVINO DOCTYPE declarations
 - avoid PMML `<Extension>` false positives for benign `subprocess` prose while preserving `subprocess.getoutput()`, `subprocess.getstatusoutput()`, and `importlib.import_module("subprocess")` detections
 - route helper-level ZIP-backed `.ckpt`/`.pkl` checkpoints through archive scanners
+- route gzip/bzip2/xz/lz4/zlib wrappers by magic bytes even when they use misleading extensions
 
 ## [0.2.31](https://github.com/promptfoo/modelaudit/compare/v0.2.30...v0.2.31) (2026-04-04)
 

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -58,6 +58,8 @@ _OPERATIONAL_ERROR_REASON_METADATA_KEY = "operational_error_reason"
 _SCAN_OUTCOME_METADATA_KEY = "scan_outcome"
 
 HEADER_FORMAT_TO_SCANNER_ID = _registry.get_header_format_to_scanner_ids()
+_COMPRESSED_HEADER_FORMATS = frozenset({"compressed", "gzip", "bzip2", "xz", "lz4", "zlib"})
+_R_SERIALIZED_EXTENSIONS = frozenset({".rds", ".rda", ".rdata"})
 
 
 def _mark_operational_scan_error(scan_result: ScanResult, reason: str) -> None:
@@ -238,8 +240,11 @@ def _select_preferred_scanner_id(path: str, header_format: str, ext: str) -> str
             return "pickle"
         return "zip"
 
-    if ext == ".joblib" and header_format in {"compressed", "pickle"}:
+    if ext == ".joblib" and header_format in _COMPRESSED_HEADER_FORMATS | {"pickle"}:
         return "joblib"
+
+    if ext in _R_SERIALIZED_EXTENSIONS and header_format in _COMPRESSED_HEADER_FORMATS | {"r_serialized"}:
+        return "r_serialized"
 
     if header_format == "tar" and ext == ".nemo":
         return "nemo"

--- a/modelaudit/scanner_registry_metadata.py
+++ b/modelaudit/scanner_registry_metadata.py
@@ -422,6 +422,7 @@ SCANNER_REGISTRY_METADATA: dict[str, dict[str, Any]] = {
         "class": "CompressedScanner",
         "description": "Scans standalone compressed wrappers and routes inner payloads to existing scanners",
         "extensions": [".gz", ".bz2", ".xz", ".lz4", ".zlib"],
+        "header_formats": ["gzip", "bzip2", "xz", "lz4", "zlib"],
         "priority": 95,
         "dependencies": [],
         "numpy_sensitive": False,

--- a/modelaudit/scanners/compressed_scanner.py
+++ b/modelaudit/scanners/compressed_scanner.py
@@ -9,6 +9,7 @@ import lzma
 import os
 import tempfile
 import zlib
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -159,6 +160,142 @@ class CompressedScanner(BaseScanner):
         return total_out
 
     @staticmethod
+    def _write_decompressed_output_with_limits(
+        output: bytes,
+        destination: Any,
+        total_out: int,
+        max_decompressed_bytes: int,
+        max_ratio: float,
+        compressed_size: int,
+    ) -> int:
+        if not output:
+            return total_out
+
+        total_out += len(output)
+        if total_out > max_decompressed_bytes:
+            raise _DecompressionLimitExceeded(
+                f"Decompressed size exceeded limit ({total_out} > {max_decompressed_bytes})",
+            )
+        if compressed_size > 0 and (total_out / compressed_size) > max_ratio:
+            raise _DecompressionLimitExceeded(
+                f"Decompression ratio exceeded limit ({total_out / compressed_size:.1f}x > {max_ratio:.1f}x)",
+            )
+
+        destination.write(output)
+        return total_out
+
+    @staticmethod
+    def _remaining_decompressed_budget(total_out: int, max_decompressed_bytes: int) -> int:
+        return max(max_decompressed_bytes - total_out, 0)
+
+    @staticmethod
+    def _probe_limit(total_out: int, max_decompressed_bytes: int, chunk_size: int) -> int:
+        remaining_budget = CompressedScanner._remaining_decompressed_budget(total_out, max_decompressed_bytes)
+        budget_probe = remaining_budget + 1 if remaining_budget > 0 else 1
+        return min(budget_probe, max(chunk_size, 1))
+
+    @staticmethod
+    def _read_concatenated_stream_with_limits(
+        source: Any,
+        destination: Any,
+        decompressor_factory: Callable[[], Any],
+        error_types: tuple[type[BaseException], ...],
+        codec: str,
+        max_decompressed_bytes: int,
+        max_ratio: float,
+        compressed_size: int,
+        chunk_size: int,
+    ) -> int:
+        decompressor = decompressor_factory()
+        total_out = 0
+
+        def _consume_pending(pending: bytes) -> None:
+            nonlocal decompressor, total_out
+            while pending or not getattr(decompressor, "needs_input", True):
+                if getattr(decompressor, "eof", False):
+                    if not pending:
+                        break
+                    decompressor = decompressor_factory()
+
+                try:
+                    output = decompressor.decompress(
+                        pending,
+                        max_length=CompressedScanner._probe_limit(total_out, max_decompressed_bytes, chunk_size),
+                    )
+                except error_types as exc:
+                    raise _CorruptStreamError(f"Invalid {codec} stream: {exc}") from exc
+
+                pending = b""
+                total_out = CompressedScanner._write_decompressed_output_with_limits(
+                    output=output,
+                    destination=destination,
+                    total_out=total_out,
+                    max_decompressed_bytes=max_decompressed_bytes,
+                    max_ratio=max_ratio,
+                    compressed_size=compressed_size,
+                )
+
+                unused_data = getattr(decompressor, "unused_data", b"")
+                if unused_data:
+                    pending = unused_data
+                    decompressor = decompressor_factory()
+
+        while True:
+            pending = source.read(chunk_size)
+            if not pending:
+                break
+            _consume_pending(pending)
+
+        _consume_pending(b"")
+
+        if not getattr(decompressor, "eof", False):
+            raise _CorruptStreamError(f"Invalid {codec} stream: missing end-of-stream marker")
+
+        return total_out
+
+    @staticmethod
+    def _read_bzip2_stream_with_limits(
+        source: Any,
+        destination: Any,
+        max_decompressed_bytes: int,
+        max_ratio: float,
+        compressed_size: int,
+        chunk_size: int,
+    ) -> int:
+        return CompressedScanner._read_concatenated_stream_with_limits(
+            source=source,
+            destination=destination,
+            decompressor_factory=bz2.BZ2Decompressor,
+            error_types=(OSError, EOFError),
+            codec="bzip2",
+            max_decompressed_bytes=max_decompressed_bytes,
+            max_ratio=max_ratio,
+            compressed_size=compressed_size,
+            chunk_size=chunk_size,
+        )
+
+    @staticmethod
+    def _read_xz_stream_with_limits(
+        source: Any,
+        destination: Any,
+        max_decompressed_bytes: int,
+        max_ratio: float,
+        compressed_size: int,
+        chunk_size: int,
+    ) -> int:
+        return CompressedScanner._read_concatenated_stream_with_limits(
+            source=source,
+            destination=destination,
+            decompressor_factory=lambda: lzma.LZMADecompressor(format=lzma.FORMAT_AUTO),
+            error_types=(lzma.LZMAError, EOFError),
+            codec="xz",
+            max_decompressed_bytes=max_decompressed_bytes,
+            max_ratio=max_ratio,
+            compressed_size=compressed_size,
+            chunk_size=chunk_size,
+        )
+
+    @staticmethod
     def _read_zlib_stream_with_limits(
         source: Any,
         destination: Any,
@@ -172,26 +309,17 @@ class CompressedScanner(BaseScanner):
 
         def _write_decompressed_output(output: bytes) -> None:
             nonlocal total_out
-            if not output:
-                return
-
-            total_out += len(output)
-            if total_out > max_decompressed_bytes:
-                raise _DecompressionLimitExceeded(
-                    f"Decompressed size exceeded limit ({total_out} > {max_decompressed_bytes})",
-                )
-            if compressed_size > 0 and (total_out / compressed_size) > max_ratio:
-                raise _DecompressionLimitExceeded(
-                    f"Decompression ratio exceeded limit ({total_out / compressed_size:.1f}x > {max_ratio:.1f}x)",
-                )
-            destination.write(output)
-
-        def _remaining_decompressed_budget() -> int:
-            return max(max_decompressed_bytes - total_out, 0)
+            total_out = CompressedScanner._write_decompressed_output_with_limits(
+                output=output,
+                destination=destination,
+                total_out=total_out,
+                max_decompressed_bytes=max_decompressed_bytes,
+                max_ratio=max_ratio,
+                compressed_size=compressed_size,
+            )
 
         def _probe_limit() -> int:
-            remaining_budget = _remaining_decompressed_budget()
-            return remaining_budget + 1 if remaining_budget > 0 else 1
+            return CompressedScanner._probe_limit(total_out, max_decompressed_bytes, chunk_size)
 
         while True:
             pending = source.read(chunk_size)
@@ -241,6 +369,127 @@ class CompressedScanner(BaseScanner):
         except Exception as exc:
             raise _MissingOptionalDependencyError("Optional dependency 'lz4' is not installed") from exc
 
+    @staticmethod
+    def _lz4_error_types(lz4_frame: Any) -> tuple[type[BaseException], ...]:
+        error_types: list[type[BaseException]] = [OSError, EOFError, RuntimeError]
+        frame_error = getattr(lz4_frame, "LZ4FrameError", None)
+        if isinstance(frame_error, type) and issubclass(frame_error, BaseException):
+            error_types.append(frame_error)
+        return tuple(error_types)
+
+    @staticmethod
+    def _read_lz4_stream_with_limits(
+        source: Any,
+        destination: Any,
+        lz4_frame: Any,
+        max_decompressed_bytes: int,
+        max_ratio: float,
+        compressed_size: int,
+        chunk_size: int,
+    ) -> int:
+        try:
+            decompressor_factory = lz4_frame.LZ4FrameDecompressor
+        except AttributeError:
+            return CompressedScanner._read_lz4_chunk_stream_with_limits(
+                source=source,
+                destination=destination,
+                lz4_frame=lz4_frame,
+                max_decompressed_bytes=max_decompressed_bytes,
+                max_ratio=max_ratio,
+                compressed_size=compressed_size,
+                chunk_size=chunk_size,
+            )
+
+        return CompressedScanner._read_concatenated_stream_with_limits(
+            source=source,
+            destination=destination,
+            decompressor_factory=decompressor_factory,
+            error_types=CompressedScanner._lz4_error_types(lz4_frame),
+            codec="lz4",
+            max_decompressed_bytes=max_decompressed_bytes,
+            max_ratio=max_ratio,
+            compressed_size=compressed_size,
+            chunk_size=chunk_size,
+        )
+
+    @staticmethod
+    def _read_lz4_chunk_stream_with_limits(
+        source: Any,
+        destination: Any,
+        lz4_frame: Any,
+        max_decompressed_bytes: int,
+        max_ratio: float,
+        compressed_size: int,
+        chunk_size: int,
+    ) -> int:
+        create_context = getattr(lz4_frame, "create_decompression_context", None)
+        decompress_chunk = getattr(lz4_frame, "decompress_chunk", None)
+        if not callable(create_context) or not callable(decompress_chunk):
+            raise _CorruptStreamError("Invalid lz4 stream: lz4.frame lacks supported incremental decompression APIs")
+
+        context = create_context()
+        error_types = CompressedScanner._lz4_error_types(lz4_frame)
+        total_out = 0
+        frame_eof = False
+        pending = b""
+        probe_buffered_output = False
+
+        while True:
+            if not pending and not probe_buffered_output:
+                pending = source.read(chunk_size)
+                if not pending:
+                    break
+
+                if frame_eof:
+                    context = create_context()
+                    frame_eof = False
+
+            max_length = CompressedScanner._probe_limit(total_out, max_decompressed_bytes, chunk_size)
+            try:
+                output, bytes_read, frame_eof = decompress_chunk(
+                    context,
+                    pending,
+                    max_length=max_length,
+                )
+            except error_types as exc:
+                raise _CorruptStreamError(f"Invalid lz4 stream: {exc}") from exc
+
+            if not isinstance(bytes_read, int) or bytes_read < 0 or bytes_read > len(pending):
+                raise _CorruptStreamError("Invalid lz4 stream: decompressor reported invalid consumed byte count")
+
+            total_out = CompressedScanner._write_decompressed_output_with_limits(
+                output=output,
+                destination=destination,
+                total_out=total_out,
+                max_decompressed_bytes=max_decompressed_bytes,
+                max_ratio=max_ratio,
+                compressed_size=compressed_size,
+            )
+
+            pending = pending[bytes_read:]
+            if frame_eof:
+                if pending:
+                    context = create_context()
+                    frame_eof = False
+                probe_buffered_output = False
+                continue
+
+            if pending and bytes_read == 0 and not output:
+                next_chunk = source.read(chunk_size)
+                if not next_chunk:
+                    break
+                pending += next_chunk
+                continue
+
+            probe_buffered_output = not pending and bool(output) and len(output) >= max_length
+            if pending or probe_buffered_output:
+                continue
+
+        if not frame_eof:
+            raise _CorruptStreamError("Invalid lz4 stream: missing end-of-stream marker")
+
+        return total_out
+
     def _decompress_to_tempfile(self, path: str, codec: str) -> tuple[str, int]:
         compressed_size = self.get_file_size(path)
         suffix = self._derive_inner_suffix(path)
@@ -263,45 +512,34 @@ class CompressedScanner(BaseScanner):
                     except (OSError, EOFError, gzip.BadGzipFile) as exc:
                         raise _CorruptStreamError(f"Invalid gzip stream: {exc}") from exc
                 elif codec == "bzip2":
-                    try:
-                        with bz2.BZ2File(source, "rb") as reader:
-                            total_out = self._copy_stream_with_limits(
-                                source=reader,
-                                destination=temp_file,
-                                max_decompressed_bytes=self.max_decompressed_bytes,
-                                max_ratio=self.max_decompression_ratio,
-                                compressed_size=compressed_size,
-                                chunk_size=self.chunk_size,
-                            )
-                    except (OSError, EOFError) as exc:
-                        raise _CorruptStreamError(f"Invalid bzip2 stream: {exc}") from exc
+                    total_out = self._read_bzip2_stream_with_limits(
+                        source=source,
+                        destination=temp_file,
+                        max_decompressed_bytes=self.max_decompressed_bytes,
+                        max_ratio=self.max_decompression_ratio,
+                        compressed_size=compressed_size,
+                        chunk_size=self.chunk_size,
+                    )
                 elif codec == "xz":
-                    try:
-                        with lzma.LZMAFile(source, "rb") as reader:
-                            total_out = self._copy_stream_with_limits(
-                                source=reader,
-                                destination=temp_file,
-                                max_decompressed_bytes=self.max_decompressed_bytes,
-                                max_ratio=self.max_decompression_ratio,
-                                compressed_size=compressed_size,
-                                chunk_size=self.chunk_size,
-                            )
-                    except (OSError, EOFError, lzma.LZMAError) as exc:
-                        raise _CorruptStreamError(f"Invalid xz stream: {exc}") from exc
+                    total_out = self._read_xz_stream_with_limits(
+                        source=source,
+                        destination=temp_file,
+                        max_decompressed_bytes=self.max_decompressed_bytes,
+                        max_ratio=self.max_decompression_ratio,
+                        compressed_size=compressed_size,
+                        chunk_size=self.chunk_size,
+                    )
                 elif codec == "lz4":
                     lz4_frame = self._get_lz4_frame_module()
-                    try:
-                        with lz4_frame.open(source, "rb") as reader:
-                            total_out = self._copy_stream_with_limits(
-                                source=reader,
-                                destination=temp_file,
-                                max_decompressed_bytes=self.max_decompressed_bytes,
-                                max_ratio=self.max_decompression_ratio,
-                                compressed_size=compressed_size,
-                                chunk_size=self.chunk_size,
-                            )
-                    except (OSError, EOFError, RuntimeError) as exc:
-                        raise _CorruptStreamError(f"Invalid lz4 stream: {exc}") from exc
+                    total_out = self._read_lz4_stream_with_limits(
+                        source=source,
+                        destination=temp_file,
+                        lz4_frame=lz4_frame,
+                        max_decompressed_bytes=self.max_decompressed_bytes,
+                        max_ratio=self.max_decompression_ratio,
+                        compressed_size=compressed_size,
+                        chunk_size=self.chunk_size,
+                    )
                 elif codec == "zlib":
                     total_out = self._read_zlib_stream_with_limits(
                         source=source,

--- a/modelaudit/scanners/compressed_scanner.py
+++ b/modelaudit/scanners/compressed_scanner.py
@@ -75,6 +75,10 @@ class CompressedScanner(BaseScanner):
         return cls._EXTENSION_TO_CODEC.get(extension)
 
     @classmethod
+    def _has_declared_wrapper_extension(cls, path: str) -> bool:
+        return Path(path).suffix.lower() in cls._EXTENSION_TO_CODEC
+
+    @classmethod
     def _detect_codec_from_header(cls, header: bytes) -> str | None:
         if header.startswith(cls._CODEC_MAGIC_PREFIXES["gzip"]):
             return "gzip"
@@ -93,10 +97,6 @@ class CompressedScanner(BaseScanner):
         if not os.path.isfile(path):
             return False
 
-        expected_codec = cls._expected_codec_for_path(path)
-        if expected_codec is None:
-            return False
-
         try:
             with open(path, "rb") as handle:
                 header = handle.read(8)
@@ -104,11 +104,17 @@ class CompressedScanner(BaseScanner):
             return False
 
         detected_codec = cls._detect_codec_from_header(header)
+        expected_codec = cls._expected_codec_for_path(path)
+        if expected_codec is None:
+            return detected_codec is not None
         return detected_codec == expected_codec
 
     @staticmethod
     def _derive_inner_suffix(path: str) -> str:
         wrapper_path = Path(path)
+        if not CompressedScanner._has_declared_wrapper_extension(path):
+            return wrapper_path.suffix or ".bin"
+
         stem_without_wrapper = (
             wrapper_path.name[: -len(wrapper_path.suffix)] if wrapper_path.suffix else wrapper_path.name
         )
@@ -118,7 +124,7 @@ class CompressedScanner(BaseScanner):
     @staticmethod
     def _derive_inner_display_name(path: str) -> str:
         wrapper_path = Path(path)
-        if wrapper_path.suffix:
+        if wrapper_path.suffix and CompressedScanner._has_declared_wrapper_extension(path):
             return wrapper_path.name[: -len(wrapper_path.suffix)]
         return f"{wrapper_path.name}.inner"
 
@@ -372,18 +378,6 @@ class CompressedScanner(BaseScanner):
             details={"depth": depth, "max_depth": self.max_depth},
         )
 
-        expected_codec = self._expected_codec_for_path(path)
-        if expected_codec is None:
-            result.add_check(
-                name="Compressed Wrapper Signature Validation",
-                passed=False,
-                message="Unsupported compressed wrapper extension",
-                severity=IssueSeverity.INFO,
-                location=path,
-            )
-            result.finish(success=False)
-            return result
-
         try:
             with open(path, "rb") as handle:
                 header = handle.read(8)
@@ -399,8 +393,21 @@ class CompressedScanner(BaseScanner):
             result.finish(success=False)
             return result
 
+        expected_codec = self._expected_codec_for_path(path)
         detected_codec = self._detect_codec_from_header(header)
-        if detected_codec != expected_codec:
+        if expected_codec is None:
+            if detected_codec is None:
+                result.add_check(
+                    name="Compressed Wrapper Signature Validation",
+                    passed=False,
+                    message="Unsupported compressed wrapper extension and no compressed magic bytes detected",
+                    severity=IssueSeverity.INFO,
+                    location=path,
+                )
+                result.finish(success=False)
+                return result
+            expected_codec = detected_codec
+        elif detected_codec != expected_codec:
             result.add_check(
                 name="Compressed Wrapper Signature Validation",
                 passed=False,

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -986,6 +986,8 @@ def detect_file_format(path: str) -> str:
         return "sevenzip"
     if _is_tar_archive(path):
         return "tar"
+    if compression_format:
+        return compression_format
     # Check ZIP magic first (for .pt/.pth files that are actually zips)
     if magic4.startswith(b"PK"):
         if ext == ".mar" and is_torchserve_mar_archive(path):

--- a/tests/scanners/test_compressed_scanner.py
+++ b/tests/scanners/test_compressed_scanner.py
@@ -23,6 +23,98 @@ class _MaliciousPayload:
         return (eval, ("print('owned')",))
 
 
+_LZ4_FRAME_MAGIC = b"\x04\x22\x4d\x18"
+
+
+class _FakeLz4FrameDecompressor:
+    def __init__(self, frames: dict[bytes, bytes], error_type: type[RuntimeError]) -> None:
+        self.frames = frames
+        self.error_type = error_type
+        self.max_lengths: list[int] = []
+        self.eof = False
+        self.needs_input = True
+        self.unused_data = b""
+
+    def decompress(self, data: bytes, max_length: int = -1) -> bytes:
+        self.max_lengths.append(max_length)
+        if not data.startswith(_LZ4_FRAME_MAGIC):
+            raise self.error_type("Invalid lz4 frame")
+
+        marker_start = len(_LZ4_FRAME_MAGIC)
+        marker = data[marker_start : marker_start + 1]
+        if marker not in self.frames:
+            raise self.error_type("Invalid lz4 frame")
+
+        output = self.frames[marker]
+        if max_length >= 0 and len(output) > max_length:
+            raise AssertionError("Fake lz4 frame output exceeded max_length")
+
+        self.eof = True
+        self.needs_input = True
+        self.unused_data = data[marker_start + 1 :]
+        return output
+
+
+class _FakeLz4FrameModule:
+    class LZ4FrameError(RuntimeError):
+        pass
+
+    def __init__(self, frames: dict[bytes, bytes]) -> None:
+        self.frames = frames
+        self.decompressors: list[_FakeLz4FrameDecompressor] = []
+        self.LZ4FrameDecompressor: Callable[[], _FakeLz4FrameDecompressor] = self._create_decompressor
+
+    def _create_decompressor(self) -> _FakeLz4FrameDecompressor:
+        decompressor = _FakeLz4FrameDecompressor(self.frames, self.LZ4FrameError)
+        self.decompressors.append(decompressor)
+        return decompressor
+
+
+class _FakeLz4ChunkContext:
+    def __init__(self, frames: dict[bytes, bytes], error_type: type[RuntimeError]) -> None:
+        self.frames = frames
+        self.error_type = error_type
+        self.max_lengths: list[int] = []
+
+    def decompress_chunk(self, data: bytes, max_length: int = -1) -> tuple[bytes, int, bool]:
+        self.max_lengths.append(max_length)
+        if not data.startswith(_LZ4_FRAME_MAGIC):
+            raise self.error_type("Invalid lz4 frame")
+
+        marker_start = len(_LZ4_FRAME_MAGIC)
+        marker = data[marker_start : marker_start + 1]
+        if marker not in self.frames:
+            raise self.error_type("Invalid lz4 frame")
+
+        output = self.frames[marker]
+        if max_length >= 0 and len(output) > max_length:
+            raise AssertionError("Fake lz4 frame output exceeded max_length")
+
+        return output, marker_start + 1, True
+
+
+class _FakeLz4ChunkModule:
+    class LZ4FrameError(RuntimeError):
+        pass
+
+    def __init__(self, frames: dict[bytes, bytes]) -> None:
+        self.frames = frames
+        self.contexts: list[_FakeLz4ChunkContext] = []
+
+    def create_decompression_context(self) -> _FakeLz4ChunkContext:
+        context = _FakeLz4ChunkContext(self.frames, self.LZ4FrameError)
+        self.contexts.append(context)
+        return context
+
+    def decompress_chunk(
+        self,
+        context: _FakeLz4ChunkContext,
+        data: bytes,
+        max_length: int = -1,
+    ) -> tuple[bytes, int, bool]:
+        return context.decompress_chunk(data, max_length=max_length)
+
+
 def test_compressed_scanner_can_handle_requires_matching_signature(tmp_path: Path) -> None:
     valid_gzip_path = tmp_path / "model.pkl.gz"
     valid_gzip_path.write_bytes(gzip.compress(pickle.dumps({"weights": [1, 2, 3]})))
@@ -297,8 +389,82 @@ def test_read_zlib_stream_uses_bounded_decompression(monkeypatch: pytest.MonkeyP
     )
 
     assert fake_decompressor.max_lengths
-    assert fake_decompressor.max_lengths == [1025, 769, 513]
-    assert fake_decompressor.flush_lengths == [257]
+    assert fake_decompressor.max_lengths == [4, 4, 4]
+    assert fake_decompressor.flush_lengths == [4]
+
+
+def test_read_concatenated_stream_uses_chunk_bounded_decompression() -> None:
+    class _FakeDecompressor:
+        def __init__(self) -> None:
+            self.max_lengths: list[int] = []
+            self.eof = False
+            self.needs_input = True
+            self.unused_data = b""
+
+        def decompress(self, _chunk: bytes, max_length: int = 0) -> bytes:
+            self.max_lengths.append(max_length)
+            self.eof = True
+            return b"x" * max_length
+
+    fake_decompressors: list[_FakeDecompressor] = []
+
+    def _factory() -> _FakeDecompressor:
+        fake_decompressor = _FakeDecompressor()
+        fake_decompressors.append(fake_decompressor)
+        return fake_decompressor
+
+    total_out = CompressedScanner._read_concatenated_stream_with_limits(
+        source=io.BytesIO(b"x"),
+        destination=io.BytesIO(),
+        decompressor_factory=_factory,
+        error_types=(ValueError,),
+        codec="fake",
+        max_decompressed_bytes=512 * 1024 * 1024,
+        max_ratio=1000.0,
+        compressed_size=1,
+        chunk_size=8,
+    )
+
+    assert total_out == 8
+    assert [length for fake in fake_decompressors for length in fake.max_lengths] == [8]
+
+
+def test_read_lz4_stream_uses_chunk_bounded_decompression() -> None:
+    fake_lz4_frame = _FakeLz4FrameModule({b"S": b"12345678"})
+    destination = io.BytesIO()
+
+    total_out = CompressedScanner._read_lz4_stream_with_limits(
+        source=io.BytesIO(_LZ4_FRAME_MAGIC + b"S"),
+        destination=destination,
+        lz4_frame=fake_lz4_frame,
+        max_decompressed_bytes=512 * 1024 * 1024,
+        max_ratio=1000.0,
+        compressed_size=1,
+        chunk_size=8,
+    )
+
+    assert total_out == 8
+    assert destination.getvalue() == b"12345678"
+    assert [length for fake in fake_lz4_frame.decompressors for length in fake.max_lengths] == [8]
+
+
+def test_read_lz4_stream_falls_back_to_chunk_api_when_decompressor_class_missing() -> None:
+    fake_lz4_frame = _FakeLz4ChunkModule({b"S": b"12345678"})
+    destination = io.BytesIO()
+
+    total_out = CompressedScanner._read_lz4_stream_with_limits(
+        source=io.BytesIO(_LZ4_FRAME_MAGIC + b"S"),
+        destination=destination,
+        lz4_frame=fake_lz4_frame,
+        max_decompressed_bytes=512 * 1024 * 1024,
+        max_ratio=1000.0,
+        compressed_size=1,
+        chunk_size=8,
+    )
+
+    assert total_out == 8
+    assert destination.getvalue() == b"12345678"
+    assert [length for context in fake_lz4_frame.contexts for length in context.max_lengths] == [8]
 
 
 def test_read_zlib_stream_allows_exact_limit_real_stream() -> None:
@@ -336,6 +502,34 @@ def test_compressed_scanner_rejects_raw_trailer_after_zlib_member(tmp_path: Path
     assert not any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
 
 
+@pytest.mark.parametrize(
+    ("filename", "compressor"),
+    [
+        ("payload.pkl.bz2", bz2.compress),
+        ("payload.pkl.xz", lzma.compress),
+    ],
+)
+def test_compressed_scanner_rejects_raw_trailer_after_bzip2_or_xz_member(
+    tmp_path: Path,
+    filename: str,
+    compressor: Callable[[bytes], bytes],
+) -> None:
+    """A raw trailer after a valid stream must not hide an unscanned pickle payload."""
+    safe_pickle = pickle.dumps({"safe": [1, 2, 3]})
+    malicious_pickle_trailer = b'cos\nsystem\n(S"echo owned"\ntR.'
+
+    path = tmp_path / filename
+    path.write_bytes(compressor(safe_pickle) + malicious_pickle_trailer)
+
+    result = CompressedScanner().scan(str(path))
+
+    decode_checks = [check for check in result.checks if check.name == "Compressed Wrapper Stream Decode"]
+    assert decode_checks and decode_checks[0].status == CheckStatus.FAILED
+    assert "invalid" in decode_checks[0].message.lower()
+    assert result.success is False
+    assert not any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+
+
 def test_compressed_scanner_allows_concatenated_zlib_members(tmp_path: Path) -> None:
     """Concatenated zlib members should remain a supported benign encoding shape."""
     payload_a = pickle.dumps({"weights": [1, 2, 3]}, protocol=4)
@@ -343,6 +537,129 @@ def test_compressed_scanner_allows_concatenated_zlib_members(tmp_path: Path) -> 
 
     path = tmp_path / "safe_multi_stream.pkl.zlib"
     path.write_bytes(zlib.compress(payload_a) + zlib.compress(payload_b))
+
+    result = CompressedScanner().scan(str(path))
+
+    assert result.success is True
+    assert not any(
+        check.name == "Compressed Wrapper Stream Decode" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+    assert not any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+
+
+@pytest.mark.parametrize(
+    ("filename", "compressor"),
+    [
+        ("safe_multi_stream.pkl.bz2", bz2.compress),
+        ("safe_multi_stream.pkl.xz", lzma.compress),
+    ],
+)
+def test_compressed_scanner_allows_concatenated_bzip2_and_xz_members(
+    tmp_path: Path,
+    filename: str,
+    compressor: Callable[[bytes], bytes],
+) -> None:
+    """Concatenated valid members should remain supported for bzip2 and xz."""
+    payload_a = pickle.dumps({"weights": [1, 2, 3]}, protocol=4)
+    payload_b = pickle.dumps({"bias": [4, 5, 6]}, protocol=4)
+
+    path = tmp_path / filename
+    path.write_bytes(compressor(payload_a) + compressor(payload_b))
+
+    result = CompressedScanner().scan(str(path))
+
+    assert result.success is True
+    assert not any(
+        check.name == "Compressed Wrapper Stream Decode" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+    assert not any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+
+
+def test_compressed_scanner_rejects_raw_trailer_after_lz4_frame(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raw trailer after a valid lz4 frame must not hide an unscanned pickle payload."""
+    safe_pickle = pickle.dumps({"safe": [1, 2, 3]})
+    malicious_pickle_trailer = b'cos\nsystem\n(S"echo owned"\ntR.'
+    fake_lz4_frame = _FakeLz4FrameModule({b"S": safe_pickle})
+
+    monkeypatch.setattr(CompressedScanner, "_get_lz4_frame_module", staticmethod(lambda: fake_lz4_frame))
+
+    path = tmp_path / "payload.pkl.lz4"
+    path.write_bytes(_LZ4_FRAME_MAGIC + b"S" + malicious_pickle_trailer)
+
+    result = CompressedScanner().scan(str(path))
+
+    decode_checks = [check for check in result.checks if check.name == "Compressed Wrapper Stream Decode"]
+    assert decode_checks and decode_checks[0].status == CheckStatus.FAILED
+    assert "invalid lz4 stream" in decode_checks[0].message.lower()
+    assert result.success is False
+    assert not any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+
+
+def test_compressed_scanner_rejects_raw_trailer_after_lz4_chunk_api_frame(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The legacy chunk API fallback must also fail closed on raw trailer bytes."""
+    safe_pickle = pickle.dumps({"safe": [1, 2, 3]})
+    malicious_pickle_trailer = b'cos\nsystem\n(S"echo owned"\ntR.'
+    fake_lz4_frame = _FakeLz4ChunkModule({b"S": safe_pickle})
+
+    monkeypatch.setattr(CompressedScanner, "_get_lz4_frame_module", staticmethod(lambda: fake_lz4_frame))
+
+    path = tmp_path / "payload.pkl.lz4"
+    path.write_bytes(_LZ4_FRAME_MAGIC + b"S" + malicious_pickle_trailer)
+
+    result = CompressedScanner().scan(str(path))
+
+    decode_checks = [check for check in result.checks if check.name == "Compressed Wrapper Stream Decode"]
+    assert decode_checks and decode_checks[0].status == CheckStatus.FAILED
+    assert "invalid lz4 stream" in decode_checks[0].message.lower()
+    assert result.success is False
+    assert not any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+
+
+def test_compressed_scanner_allows_concatenated_lz4_frames(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concatenated valid lz4 frames should remain supported when lz4 is installed."""
+    payload_a = pickle.dumps({"weights": [1, 2, 3]}, protocol=4)
+    payload_b = pickle.dumps({"bias": [4, 5, 6]}, protocol=4)
+    fake_lz4_frame = _FakeLz4FrameModule({b"A": payload_a, b"B": payload_b})
+
+    monkeypatch.setattr(CompressedScanner, "_get_lz4_frame_module", staticmethod(lambda: fake_lz4_frame))
+
+    path = tmp_path / "safe_multi_frame.pkl.lz4"
+    path.write_bytes(_LZ4_FRAME_MAGIC + b"A" + _LZ4_FRAME_MAGIC + b"B")
+
+    result = CompressedScanner().scan(str(path))
+
+    assert result.success is True
+    assert not any(
+        check.name == "Compressed Wrapper Stream Decode" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+    assert not any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+
+
+def test_compressed_scanner_allows_concatenated_lz4_chunk_api_frames(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The legacy chunk API fallback should preserve valid concatenated lz4 frames."""
+    payload_a = pickle.dumps({"weights": [1, 2, 3]}, protocol=4)
+    payload_b = pickle.dumps({"bias": [4, 5, 6]}, protocol=4)
+    fake_lz4_frame = _FakeLz4ChunkModule({b"A": payload_a, b"B": payload_b})
+
+    monkeypatch.setattr(CompressedScanner, "_get_lz4_frame_module", staticmethod(lambda: fake_lz4_frame))
+
+    path = tmp_path / "safe_multi_frame.pkl.lz4"
+    path.write_bytes(_LZ4_FRAME_MAGIC + b"A" + _LZ4_FRAME_MAGIC + b"B")
 
     result = CompressedScanner().scan(str(path))
 

--- a/tests/scanners/test_compressed_scanner.py
+++ b/tests/scanners/test_compressed_scanner.py
@@ -34,6 +34,17 @@ def test_compressed_scanner_can_handle_requires_matching_signature(tmp_path: Pat
     assert CompressedScanner.can_handle(str(invalid_gzip_path)) is False
 
 
+def test_compressed_scanner_can_handle_header_routed_misnamed_wrapper(tmp_path: Path) -> None:
+    disguised_gzip_path = tmp_path / "model.jpg"
+    disguised_gzip_path.write_bytes(gzip.compress(pickle.dumps({"weights": [1, 2, 3]})))
+
+    near_match_path = tmp_path / "near-match.jpg"
+    near_match_path.write_bytes(b"\x1f\x00not-a-gzip-stream")
+
+    assert CompressedScanner.can_handle(str(disguised_gzip_path)) is True
+    assert CompressedScanner.can_handle(str(near_match_path)) is False
+
+
 def test_compressed_scanner_can_handle_rejects_invalid_zlib_header_near_match(tmp_path: Path) -> None:
     zlib_path = tmp_path / "payload.bin.zlib"
     zlib_path.write_bytes(b"\x78\x00" + b"not-a-valid-zlib-stream")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import gzip
 import json
 import pickle
 import zipfile
@@ -79,6 +80,35 @@ def test_scan_file_detects_malicious_zip_with_misleading_extension(tmp_path: Pat
 
     assert result.scanner_name == "zip"
     _assert_system_pickle_detected(result, "payload.pkl")
+
+
+def test_scan_file_detects_misnamed_gzip_wrapped_pickle_by_header(tmp_path: Path) -> None:
+    disguised_gzip = tmp_path / "payload.jpg"
+    disguised_gzip.write_bytes(gzip.compress(_build_malicious_pickle()))
+
+    result = scan_file(str(disguised_gzip))
+
+    assert result.scanner_name == "compressed"
+    routing_checks = [check for check in result.checks if check.name == "Compressed Wrapper Inner Scanner Routing"]
+    assert routing_checks
+    assert routing_checks[0].details.get("inner_scanner") == "pickle"
+    assert any(
+        issue.severity == IssueSeverity.CRITICAL
+        and issue.details.get("compressed_wrapper") == f"{disguised_gzip} -> payload.jpg.inner"
+        and any(global_name in issue.message.lower() for global_name in _SYSTEM_GLOBAL_NAMES)
+        for issue in result.issues
+    ), f"Expected compressed inner pickle finding, got: {[(i.location, i.message, i.details) for i in result.issues]}"
+
+
+def test_scan_file_does_not_route_compression_magic_near_match_to_compressed(tmp_path: Path) -> None:
+    near_match = tmp_path / "payload.jpg"
+    near_match.write_bytes(b"\x1f\x00not-a-gzip-stream")
+
+    result = scan_file(str(near_match))
+
+    assert result.scanner_name == "unknown"
+    assert not [check for check in result.checks if check.name.startswith("Compressed Wrapper")]
+    assert result.issues == []
 
 
 def test_scan_file_detects_shadowed_duplicate_pickle_in_misleading_zip(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

This PR continues the picklescan audit stack with a focused archive/container routing fix. The compressed-wrapper scanner is now selected from exact gzip, bzip2, xz, lz4, and zlib magic bytes even when the file uses a misleading extension such as .jpg.

Root cause: header detection already knew these compressed formats, but scanner selection only routed the compressed scanner when the filename used a known compressed extension. That meant a gzipped malicious pickle named like an image could fall through to the unknown scanner and miss inner pickle analysis.

Fix:
- Register compressed header formats in scanner metadata.
- Return compressed magic formats from file detection before ZIP fallback.
- Let CompressedScanner accept exact compressed magic for unknown extensions while still rejecting near-match headers.
- Preserve extension-owned precedence for .joblib and R serialized files so compressed content still routes to their dedicated scanners.
- Add positive and benign near-match regressions, plus direct can_handle coverage.
- Add an Unreleased changelog note.

## Validation

- uv run pytest tests/scanners/test_r_serialized_scanner.py::test_large_non_r_xz_payload_is_not_claimed_by_r_scanner tests/scanners/test_joblib_scanner_codecs.py::test_scan_file_routes_gzip_joblib_to_joblib_scanner tests/test_core.py::test_scan_file_detects_misnamed_gzip_wrapped_pickle_by_header tests/scanners/test_compressed_scanner.py::test_compressed_scanner_can_handle_header_routed_misnamed_wrapper -q --tb=short
- uv run pytest tests/scanners/test_scanner_registry.py tests/utils/file/test_filetype.py tests/utils/file/test_file_type_validation_integration.py tests/test_core.py tests/scanners/test_compressed_scanner.py tests/scanners/test_r_serialized_scanner.py tests/scanners/test_joblib_scanner_codecs.py -q --tb=short
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run pytest -n auto -m "not slow and not integration" --maxfail=1

Full local result: 3371 passed, 75 skipped, 16 warnings.