### PR TITLE
fix: harden lz4 wrapper decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - route helper-level ZIP-backed `.ckpt`/`.pkl` checkpoints through archive scanners
 - route gzip/bzip2/xz/lz4/zlib wrappers by magic bytes even when they use misleading extensions
 - reject raw trailers after bzip2 and xz compressed-wrapper payloads
+- reject raw trailers after lz4 compressed-wrapper frames and bound lz4 decompression output probes
 
 ## [0.2.31](https://github.com/promptfoo/modelaudit/compare/v0.2.30...v0.2.31) (2026-04-04)
 

--- a/modelaudit/scanners/compressed_scanner.py
+++ b/modelaudit/scanners/compressed_scanner.py
@@ -369,6 +369,41 @@ class CompressedScanner(BaseScanner):
         except Exception as exc:
             raise _MissingOptionalDependencyError("Optional dependency 'lz4' is not installed") from exc
 
+    @staticmethod
+    def _lz4_error_types(lz4_frame: Any) -> tuple[type[BaseException], ...]:
+        error_types: list[type[BaseException]] = [OSError, EOFError, RuntimeError]
+        frame_error = getattr(lz4_frame, "LZ4FrameError", None)
+        if isinstance(frame_error, type) and issubclass(frame_error, BaseException):
+            error_types.append(frame_error)
+        return tuple(error_types)
+
+    @staticmethod
+    def _read_lz4_stream_with_limits(
+        source: Any,
+        destination: Any,
+        lz4_frame: Any,
+        max_decompressed_bytes: int,
+        max_ratio: float,
+        compressed_size: int,
+        chunk_size: int,
+    ) -> int:
+        try:
+            decompressor_factory = lz4_frame.LZ4FrameDecompressor
+        except AttributeError as exc:
+            raise _CorruptStreamError("Invalid lz4 stream: lz4.frame lacks LZ4FrameDecompressor") from exc
+
+        return CompressedScanner._read_concatenated_stream_with_limits(
+            source=source,
+            destination=destination,
+            decompressor_factory=decompressor_factory,
+            error_types=CompressedScanner._lz4_error_types(lz4_frame),
+            codec="lz4",
+            max_decompressed_bytes=max_decompressed_bytes,
+            max_ratio=max_ratio,
+            compressed_size=compressed_size,
+            chunk_size=chunk_size,
+        )
+
     def _decompress_to_tempfile(self, path: str, codec: str) -> tuple[str, int]:
         compressed_size = self.get_file_size(path)
         suffix = self._derive_inner_suffix(path)
@@ -410,18 +445,15 @@ class CompressedScanner(BaseScanner):
                     )
                 elif codec == "lz4":
                     lz4_frame = self._get_lz4_frame_module()
-                    try:
-                        with lz4_frame.open(source, "rb") as reader:
-                            total_out = self._copy_stream_with_limits(
-                                source=reader,
-                                destination=temp_file,
-                                max_decompressed_bytes=self.max_decompressed_bytes,
-                                max_ratio=self.max_decompression_ratio,
-                                compressed_size=compressed_size,
-                                chunk_size=self.chunk_size,
-                            )
-                    except (OSError, EOFError, RuntimeError) as exc:
-                        raise _CorruptStreamError(f"Invalid lz4 stream: {exc}") from exc
+                    total_out = self._read_lz4_stream_with_limits(
+                        source=source,
+                        destination=temp_file,
+                        lz4_frame=lz4_frame,
+                        max_decompressed_bytes=self.max_decompressed_bytes,
+                        max_ratio=self.max_decompression_ratio,
+                        compressed_size=compressed_size,
+                        chunk_size=self.chunk_size,
+                    )
                 elif codec == "zlib":
                     total_out = self._read_zlib_stream_with_limits(
                         source=source,

--- a/modelaudit/scanners/compressed_scanner.py
+++ b/modelaudit/scanners/compressed_scanner.py
@@ -389,8 +389,16 @@ class CompressedScanner(BaseScanner):
     ) -> int:
         try:
             decompressor_factory = lz4_frame.LZ4FrameDecompressor
-        except AttributeError as exc:
-            raise _CorruptStreamError("Invalid lz4 stream: lz4.frame lacks LZ4FrameDecompressor") from exc
+        except AttributeError:
+            return CompressedScanner._read_lz4_chunk_stream_with_limits(
+                source=source,
+                destination=destination,
+                lz4_frame=lz4_frame,
+                max_decompressed_bytes=max_decompressed_bytes,
+                max_ratio=max_ratio,
+                compressed_size=compressed_size,
+                chunk_size=chunk_size,
+            )
 
         return CompressedScanner._read_concatenated_stream_with_limits(
             source=source,
@@ -403,6 +411,84 @@ class CompressedScanner(BaseScanner):
             compressed_size=compressed_size,
             chunk_size=chunk_size,
         )
+
+    @staticmethod
+    def _read_lz4_chunk_stream_with_limits(
+        source: Any,
+        destination: Any,
+        lz4_frame: Any,
+        max_decompressed_bytes: int,
+        max_ratio: float,
+        compressed_size: int,
+        chunk_size: int,
+    ) -> int:
+        create_context = getattr(lz4_frame, "create_decompression_context", None)
+        decompress_chunk = getattr(lz4_frame, "decompress_chunk", None)
+        if not callable(create_context) or not callable(decompress_chunk):
+            raise _CorruptStreamError("Invalid lz4 stream: lz4.frame lacks supported incremental decompression APIs")
+
+        context = create_context()
+        error_types = CompressedScanner._lz4_error_types(lz4_frame)
+        total_out = 0
+        frame_eof = False
+        pending = b""
+        probe_buffered_output = False
+
+        while True:
+            if not pending and not probe_buffered_output:
+                pending = source.read(chunk_size)
+                if not pending:
+                    break
+
+                if frame_eof:
+                    context = create_context()
+                    frame_eof = False
+
+            max_length = CompressedScanner._probe_limit(total_out, max_decompressed_bytes, chunk_size)
+            try:
+                output, bytes_read, frame_eof = decompress_chunk(
+                    context,
+                    pending,
+                    max_length=max_length,
+                )
+            except error_types as exc:
+                raise _CorruptStreamError(f"Invalid lz4 stream: {exc}") from exc
+
+            if not isinstance(bytes_read, int) or bytes_read < 0 or bytes_read > len(pending):
+                raise _CorruptStreamError("Invalid lz4 stream: decompressor reported invalid consumed byte count")
+
+            total_out = CompressedScanner._write_decompressed_output_with_limits(
+                output=output,
+                destination=destination,
+                total_out=total_out,
+                max_decompressed_bytes=max_decompressed_bytes,
+                max_ratio=max_ratio,
+                compressed_size=compressed_size,
+            )
+
+            pending = pending[bytes_read:]
+            if frame_eof:
+                if pending:
+                    context = create_context()
+                    frame_eof = False
+                probe_buffered_output = False
+                continue
+
+            if pending and bytes_read == 0 and not output:
+                next_chunk = source.read(chunk_size)
+                if not next_chunk:
+                    break
+                pending += next_chunk
+                continue
+
+            probe_buffered_output = not pending and bool(output) and len(output) >= max_length
+            if pending or probe_buffered_output:
+                continue
+
+        if not frame_eof:
+            raise _CorruptStreamError("Invalid lz4 stream: missing end-of-stream marker")
+
+        return total_out
 
     def _decompress_to_tempfile(self, path: str, codec: str) -> tuple[str, int]:
         compressed_size = self.get_file_size(path)

--- a/tests/scanners/test_compressed_scanner.py
+++ b/tests/scanners/test_compressed_scanner.py
@@ -70,6 +70,51 @@ class _FakeLz4FrameModule:
         return decompressor
 
 
+class _FakeLz4ChunkContext:
+    def __init__(self, frames: dict[bytes, bytes], error_type: type[RuntimeError]) -> None:
+        self.frames = frames
+        self.error_type = error_type
+        self.max_lengths: list[int] = []
+
+    def decompress_chunk(self, data: bytes, max_length: int = -1) -> tuple[bytes, int, bool]:
+        self.max_lengths.append(max_length)
+        if not data.startswith(_LZ4_FRAME_MAGIC):
+            raise self.error_type("Invalid lz4 frame")
+
+        marker_start = len(_LZ4_FRAME_MAGIC)
+        marker = data[marker_start : marker_start + 1]
+        if marker not in self.frames:
+            raise self.error_type("Invalid lz4 frame")
+
+        output = self.frames[marker]
+        if max_length >= 0 and len(output) > max_length:
+            raise AssertionError("Fake lz4 frame output exceeded max_length")
+
+        return output, marker_start + 1, True
+
+
+class _FakeLz4ChunkModule:
+    class LZ4FrameError(RuntimeError):
+        pass
+
+    def __init__(self, frames: dict[bytes, bytes]) -> None:
+        self.frames = frames
+        self.contexts: list[_FakeLz4ChunkContext] = []
+
+    def create_decompression_context(self) -> _FakeLz4ChunkContext:
+        context = _FakeLz4ChunkContext(self.frames, self.LZ4FrameError)
+        self.contexts.append(context)
+        return context
+
+    def decompress_chunk(
+        self,
+        context: _FakeLz4ChunkContext,
+        data: bytes,
+        max_length: int = -1,
+    ) -> tuple[bytes, int, bool]:
+        return context.decompress_chunk(data, max_length=max_length)
+
+
 def test_compressed_scanner_can_handle_requires_matching_signature(tmp_path: Path) -> None:
     valid_gzip_path = tmp_path / "model.pkl.gz"
     valid_gzip_path.write_bytes(gzip.compress(pickle.dumps({"weights": [1, 2, 3]})))
@@ -403,6 +448,25 @@ def test_read_lz4_stream_uses_chunk_bounded_decompression() -> None:
     assert [length for fake in fake_lz4_frame.decompressors for length in fake.max_lengths] == [8]
 
 
+def test_read_lz4_stream_falls_back_to_chunk_api_when_decompressor_class_missing() -> None:
+    fake_lz4_frame = _FakeLz4ChunkModule({b"S": b"12345678"})
+    destination = io.BytesIO()
+
+    total_out = CompressedScanner._read_lz4_stream_with_limits(
+        source=io.BytesIO(_LZ4_FRAME_MAGIC + b"S"),
+        destination=destination,
+        lz4_frame=fake_lz4_frame,
+        max_decompressed_bytes=512 * 1024 * 1024,
+        max_ratio=1000.0,
+        compressed_size=1,
+        chunk_size=8,
+    )
+
+    assert total_out == 8
+    assert destination.getvalue() == b"12345678"
+    assert [length for context in fake_lz4_frame.contexts for length in context.max_lengths] == [8]
+
+
 def test_read_zlib_stream_allows_exact_limit_real_stream() -> None:
     payload = b"A" * 1024
     compressed = zlib.compress(payload)
@@ -536,6 +600,29 @@ def test_compressed_scanner_rejects_raw_trailer_after_lz4_frame(
     assert not any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
 
 
+def test_compressed_scanner_rejects_raw_trailer_after_lz4_chunk_api_frame(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The legacy chunk API fallback must also fail closed on raw trailer bytes."""
+    safe_pickle = pickle.dumps({"safe": [1, 2, 3]})
+    malicious_pickle_trailer = b'cos\nsystem\n(S"echo owned"\ntR.'
+    fake_lz4_frame = _FakeLz4ChunkModule({b"S": safe_pickle})
+
+    monkeypatch.setattr(CompressedScanner, "_get_lz4_frame_module", staticmethod(lambda: fake_lz4_frame))
+
+    path = tmp_path / "payload.pkl.lz4"
+    path.write_bytes(_LZ4_FRAME_MAGIC + b"S" + malicious_pickle_trailer)
+
+    result = CompressedScanner().scan(str(path))
+
+    decode_checks = [check for check in result.checks if check.name == "Compressed Wrapper Stream Decode"]
+    assert decode_checks and decode_checks[0].status == CheckStatus.FAILED
+    assert "invalid lz4 stream" in decode_checks[0].message.lower()
+    assert result.success is False
+    assert not any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+
+
 def test_compressed_scanner_allows_concatenated_lz4_frames(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -544,6 +631,30 @@ def test_compressed_scanner_allows_concatenated_lz4_frames(
     payload_a = pickle.dumps({"weights": [1, 2, 3]}, protocol=4)
     payload_b = pickle.dumps({"bias": [4, 5, 6]}, protocol=4)
     fake_lz4_frame = _FakeLz4FrameModule({b"A": payload_a, b"B": payload_b})
+
+    monkeypatch.setattr(CompressedScanner, "_get_lz4_frame_module", staticmethod(lambda: fake_lz4_frame))
+
+    path = tmp_path / "safe_multi_frame.pkl.lz4"
+    path.write_bytes(_LZ4_FRAME_MAGIC + b"A" + _LZ4_FRAME_MAGIC + b"B")
+
+    result = CompressedScanner().scan(str(path))
+
+    assert result.success is True
+    assert not any(
+        check.name == "Compressed Wrapper Stream Decode" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+    assert not any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+
+
+def test_compressed_scanner_allows_concatenated_lz4_chunk_api_frames(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The legacy chunk API fallback should preserve valid concatenated lz4 frames."""
+    payload_a = pickle.dumps({"weights": [1, 2, 3]}, protocol=4)
+    payload_b = pickle.dumps({"bias": [4, 5, 6]}, protocol=4)
+    fake_lz4_frame = _FakeLz4ChunkModule({b"A": payload_a, b"B": payload_b})
 
     monkeypatch.setattr(CompressedScanner, "_get_lz4_frame_module", staticmethod(lambda: fake_lz4_frame))
 

--- a/tests/scanners/test_compressed_scanner.py
+++ b/tests/scanners/test_compressed_scanner.py
@@ -23,6 +23,53 @@ class _MaliciousPayload:
         return (eval, ("print('owned')",))
 
 
+_LZ4_FRAME_MAGIC = b"\x04\x22\x4d\x18"
+
+
+class _FakeLz4FrameDecompressor:
+    def __init__(self, frames: dict[bytes, bytes], error_type: type[RuntimeError]) -> None:
+        self.frames = frames
+        self.error_type = error_type
+        self.max_lengths: list[int] = []
+        self.eof = False
+        self.needs_input = True
+        self.unused_data = b""
+
+    def decompress(self, data: bytes, max_length: int = -1) -> bytes:
+        self.max_lengths.append(max_length)
+        if not data.startswith(_LZ4_FRAME_MAGIC):
+            raise self.error_type("Invalid lz4 frame")
+
+        marker_start = len(_LZ4_FRAME_MAGIC)
+        marker = data[marker_start : marker_start + 1]
+        if marker not in self.frames:
+            raise self.error_type("Invalid lz4 frame")
+
+        output = self.frames[marker]
+        if max_length >= 0 and len(output) > max_length:
+            raise AssertionError("Fake lz4 frame output exceeded max_length")
+
+        self.eof = True
+        self.needs_input = True
+        self.unused_data = data[marker_start + 1 :]
+        return output
+
+
+class _FakeLz4FrameModule:
+    class LZ4FrameError(RuntimeError):
+        pass
+
+    def __init__(self, frames: dict[bytes, bytes]) -> None:
+        self.frames = frames
+        self.decompressors: list[_FakeLz4FrameDecompressor] = []
+        self.LZ4FrameDecompressor: Callable[[], _FakeLz4FrameDecompressor] = self._create_decompressor
+
+    def _create_decompressor(self) -> _FakeLz4FrameDecompressor:
+        decompressor = _FakeLz4FrameDecompressor(self.frames, self.LZ4FrameError)
+        self.decompressors.append(decompressor)
+        return decompressor
+
+
 def test_compressed_scanner_can_handle_requires_matching_signature(tmp_path: Path) -> None:
     valid_gzip_path = tmp_path / "model.pkl.gz"
     valid_gzip_path.write_bytes(gzip.compress(pickle.dumps({"weights": [1, 2, 3]})))
@@ -337,6 +384,25 @@ def test_read_concatenated_stream_uses_chunk_bounded_decompression() -> None:
     assert [length for fake in fake_decompressors for length in fake.max_lengths] == [8]
 
 
+def test_read_lz4_stream_uses_chunk_bounded_decompression() -> None:
+    fake_lz4_frame = _FakeLz4FrameModule({b"S": b"12345678"})
+    destination = io.BytesIO()
+
+    total_out = CompressedScanner._read_lz4_stream_with_limits(
+        source=io.BytesIO(_LZ4_FRAME_MAGIC + b"S"),
+        destination=destination,
+        lz4_frame=fake_lz4_frame,
+        max_decompressed_bytes=512 * 1024 * 1024,
+        max_ratio=1000.0,
+        compressed_size=1,
+        chunk_size=8,
+    )
+
+    assert total_out == 8
+    assert destination.getvalue() == b"12345678"
+    assert [length for fake in fake_lz4_frame.decompressors for length in fake.max_lengths] == [8]
+
+
 def test_read_zlib_stream_allows_exact_limit_real_stream() -> None:
     payload = b"A" * 1024
     compressed = zlib.compress(payload)
@@ -436,6 +502,53 @@ def test_compressed_scanner_allows_concatenated_bzip2_and_xz_members(
 
     path = tmp_path / filename
     path.write_bytes(compressor(payload_a) + compressor(payload_b))
+
+    result = CompressedScanner().scan(str(path))
+
+    assert result.success is True
+    assert not any(
+        check.name == "Compressed Wrapper Stream Decode" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+    assert not any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+
+
+def test_compressed_scanner_rejects_raw_trailer_after_lz4_frame(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raw trailer after a valid lz4 frame must not hide an unscanned pickle payload."""
+    safe_pickle = pickle.dumps({"safe": [1, 2, 3]})
+    malicious_pickle_trailer = b'cos\nsystem\n(S"echo owned"\ntR.'
+    fake_lz4_frame = _FakeLz4FrameModule({b"S": safe_pickle})
+
+    monkeypatch.setattr(CompressedScanner, "_get_lz4_frame_module", staticmethod(lambda: fake_lz4_frame))
+
+    path = tmp_path / "payload.pkl.lz4"
+    path.write_bytes(_LZ4_FRAME_MAGIC + b"S" + malicious_pickle_trailer)
+
+    result = CompressedScanner().scan(str(path))
+
+    decode_checks = [check for check in result.checks if check.name == "Compressed Wrapper Stream Decode"]
+    assert decode_checks and decode_checks[0].status == CheckStatus.FAILED
+    assert "invalid lz4 stream" in decode_checks[0].message.lower()
+    assert result.success is False
+    assert not any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+
+
+def test_compressed_scanner_allows_concatenated_lz4_frames(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concatenated valid lz4 frames should remain supported when lz4 is installed."""
+    payload_a = pickle.dumps({"weights": [1, 2, 3]}, protocol=4)
+    payload_b = pickle.dumps({"bias": [4, 5, 6]}, protocol=4)
+    fake_lz4_frame = _FakeLz4FrameModule({b"A": payload_a, b"B": payload_b})
+
+    monkeypatch.setattr(CompressedScanner, "_get_lz4_frame_module", staticmethod(lambda: fake_lz4_frame))
+
+    path = tmp_path / "safe_multi_frame.pkl.lz4"
+    path.write_bytes(_LZ4_FRAME_MAGIC + b"A" + _LZ4_FRAME_MAGIC + b"B")
 
     result = CompressedScanner().scan(str(path))
 


### PR DESCRIPTION
## Summary
- route optional lz4 wrapper decoding through the bounded concatenated-stream decompressor loop
- fail closed on raw trailer bytes after an lz4 frame instead of silently ignoring unscanned data
- add fake lz4-frame regressions so the optional dependency path is covered without adding lz4 to the local test environment

## Validation
- uv run pytest tests/scanners/test_compressed_scanner.py -q --tb=short
- uv run pytest tests/scanners/test_compressed_scanner.py tests/test_core.py tests/scanners/test_scanner_registry.py tests/utils/file/test_filetype.py tests/utils/file/test_file_type_validation_integration.py -q --tb=short
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run pytest -n auto -m "not slow and not integration" --maxfail=1

Local full suite result: 3379 passed, 75 skipped, 16 warnings.