### PR TITLE
fix: mark partial archive scans inconclusive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ignore remote OCI `layers[].urls` entries during local layer discovery
 - fail closed on unterminated OpenVINO DOCTYPE declarations
 - avoid PMML `<Extension>` false positives for benign `subprocess` prose while preserving `subprocess.getoutput()`, `subprocess.getstatusoutput()`, and `importlib.import_module("subprocess")` detections
+- mark incomplete ZIP, TAR, and 7z archive traversals as inconclusive in scan metadata
 - route helper-level ZIP-backed `.ckpt`/`.pkl` checkpoints through archive scanners
 
 ## [0.2.31](https://github.com/promptfoo/modelaudit/compare/v0.2.30...v0.2.31) (2026-04-04)

--- a/modelaudit/scanners/_archive_outcomes.py
+++ b/modelaudit/scanners/_archive_outcomes.py
@@ -1,0 +1,17 @@
+"""Shared metadata helpers for archive scans that intentionally stop early."""
+
+from __future__ import annotations
+
+from .base import INCONCLUSIVE_SCAN_OUTCOME, ScanResult
+
+
+def mark_archive_scan_incomplete(result: ScanResult, reason: str) -> None:
+    """Mark an archive result as explicitly inconclusive without changing findings."""
+    result.metadata["analysis_incomplete"] = True
+    result.metadata["scan_outcome"] = INCONCLUSIVE_SCAN_OUTCOME
+
+    existing_reasons = result.metadata.get("scan_outcome_reasons")
+    reasons = existing_reasons if isinstance(existing_reasons, list) else []
+    if reason not in reasons:
+        reasons.append(reason)
+    result.metadata["scan_outcome_reasons"] = reasons

--- a/modelaudit/scanners/_archive_outcomes.py
+++ b/modelaudit/scanners/_archive_outcomes.py
@@ -15,3 +15,12 @@ def mark_archive_scan_incomplete(result: ScanResult, reason: str) -> None:
     if reason not in reasons:
         reasons.append(reason)
     result.metadata["scan_outcome_reasons"] = reasons
+
+
+def member_scan_incomplete(result: ScanResult) -> bool:
+    """Return whether a nested archive member scan stopped before complete analysis."""
+    return (
+        result.metadata.get("analysis_incomplete") is True
+        or result.metadata.get("scan_outcome") == INCONCLUSIVE_SCAN_OUTCOME
+        or (not result.success and not result.has_errors)
+    )

--- a/modelaudit/scanners/sevenzip_scanner.py
+++ b/modelaudit/scanners/sevenzip_scanner.py
@@ -16,7 +16,7 @@ else:
 from ..utils import sanitize_archive_path
 from ._archive_config import get_archive_depth
 from ._archive_locations import rewrite_extracted_member_location
-from ._archive_outcomes import mark_archive_scan_incomplete
+from ._archive_outcomes import mark_archive_scan_incomplete, member_scan_incomplete
 from .archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY
 from .base import BaseScanner, IssueSeverity, ScanResult
 
@@ -895,7 +895,7 @@ class SevenZipScanner(BaseScanner):
 
             self._rewrite_nested_result_context(file_result, extracted_path, archive_path, original_name)
             result.merge(file_result)
-            return file_result.success and not file_result.has_errors
+            return not member_scan_incomplete(file_result)
 
         except Exception as e:
             result.add_check(

--- a/modelaudit/scanners/sevenzip_scanner.py
+++ b/modelaudit/scanners/sevenzip_scanner.py
@@ -16,6 +16,8 @@ else:
 from ..utils import sanitize_archive_path
 from ._archive_config import get_archive_depth
 from ._archive_locations import rewrite_extracted_member_location
+from ._archive_outcomes import mark_archive_scan_incomplete
+from .archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY
 from .base import BaseScanner, IssueSeverity, ScanResult
 
 # Try to import py7zr with graceful fallback
@@ -278,6 +280,7 @@ class SevenZipScanner(BaseScanner):
                     "install_command": "pip install py7zr",
                 },
             )
+            mark_archive_scan_incomplete(result, "sevenzip_analysis_incomplete")
             result.finish(success=False)
             return result
 
@@ -311,6 +314,7 @@ class SevenZipScanner(BaseScanner):
                 location=path,
                 details={"error": str(e), "error_type": "invalid_format"},
             )
+            mark_archive_scan_incomplete(result, "sevenzip_analysis_incomplete")
             result.finish(success=False)
             return result
 
@@ -323,6 +327,7 @@ class SevenZipScanner(BaseScanner):
                 location=path,
                 details={"error": str(e), "error_type": "scan_failure"},
             )
+            mark_archive_scan_incomplete(result, "sevenzip_analysis_incomplete")
             result.finish(success=False)
             return result
 
@@ -345,6 +350,7 @@ class SevenZipScanner(BaseScanner):
         scan_complete = True
 
         if budget.should_stop():
+            mark_archive_scan_incomplete(result, "sevenzip_analysis_incomplete")
             result.finish(success=False)
             return result
 
@@ -357,6 +363,7 @@ class SevenZipScanner(BaseScanner):
                 location=path,
                 details={"depth": depth, "max_depth": self.max_depth},
             )
+            mark_archive_scan_incomplete(result, "sevenzip_analysis_incomplete")
             result.finish(success=False)
             return result
 
@@ -391,6 +398,7 @@ class SevenZipScanner(BaseScanner):
                 result.metadata["scannable_files"] = 0
                 result.metadata["unsafe_entries"] = 0
                 result.metadata["file_size"] = os.path.getsize(path)
+                mark_archive_scan_incomplete(result, "sevenzip_analysis_incomplete")
                 result.finish(success=False)
                 return result
 
@@ -417,6 +425,7 @@ class SevenZipScanner(BaseScanner):
                 result.metadata["scannable_files"] = 0
                 result.metadata["unsafe_entries"] = 0
                 result.metadata["file_size"] = os.path.getsize(path)
+                mark_archive_scan_incomplete(result, "sevenzip_analysis_incomplete")
                 result.finish(success=False)
                 return result
 
@@ -463,6 +472,8 @@ class SevenZipScanner(BaseScanner):
             result.metadata["unsafe_entries"] = len(file_names) - len(safe_file_names)
             result.metadata["file_size"] = os.path.getsize(path)
 
+        if not scan_complete or budget.should_stop():
+            mark_archive_scan_incomplete(result, "sevenzip_analysis_incomplete")
         result.finish(success=scan_complete and not budget.should_stop() and not result.has_errors)
         return result
 
@@ -851,6 +862,15 @@ class SevenZipScanner(BaseScanner):
                 preserve_non_delimited_suffix=True,
             )
 
+    def _scan_nested_archive_entry(self, path: str, nested_config: dict[str, Any]) -> ScanResult:
+        """Dispatch a nested archive member through an injected callback or registry fallback."""
+        nested_scan_callback = self.config.get(NESTED_SCAN_CALLBACK_CONFIG_KEY)
+        if callable(nested_scan_callback):
+            return nested_scan_callback(path, nested_config)
+        from .. import core
+
+        return core.scan_file(path, nested_config)
+
     def _scan_extracted_file(
         self,
         extracted_path: str,
@@ -869,11 +889,9 @@ class SevenZipScanner(BaseScanner):
                     budget=budget,
                 )
             else:
-                from .. import core
-
                 nested_config = dict(self.config)
                 nested_config["_archive_depth"] = depth + 1
-                file_result = core.scan_file(extracted_path, nested_config)
+                file_result = self._scan_nested_archive_entry(extracted_path, nested_config)
 
             self._rewrite_nested_result_context(file_result, extracted_path, archive_path, original_name)
             result.merge(file_result)

--- a/modelaudit/scanners/tar_scanner.py
+++ b/modelaudit/scanners/tar_scanner.py
@@ -12,7 +12,7 @@ from typing import Any, ClassVar
 from ..utils import is_absolute_archive_path, is_critical_system_path, sanitize_archive_path
 from ..utils.helpers.assets import asset_from_scan_result
 from ._archive_locations import rewrite_extracted_member_location
-from ._archive_outcomes import mark_archive_scan_incomplete
+from ._archive_outcomes import mark_archive_scan_incomplete, member_scan_incomplete
 from .archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY, scan_nested_file
 from .base import BaseScanner, IssueSeverity, ScanResult
 
@@ -578,7 +578,7 @@ class TarScanner(BaseScanner):
                     try:
                         if is_tar_extension and tarfile.is_tarfile(tmp_path):
                             nested_result = self._scan_tar_file(tmp_path, depth + 1)
-                            if not nested_result.success:
+                            if member_scan_incomplete(nested_result):
                                 scan_complete = False
 
                             self._rewrite_nested_result_context(nested_result, tmp_path, path, name)
@@ -588,7 +588,7 @@ class TarScanner(BaseScanner):
                             nested_config = dict(self.config)
                             nested_config["_archive_depth"] = depth + 1
                             file_result = self._scan_nested_archive_entry(tmp_path, nested_config)
-                            if not file_result.success:
+                            if member_scan_incomplete(file_result):
                                 scan_complete = False
 
                             self._rewrite_nested_result_context(file_result, tmp_path, path, name)

--- a/modelaudit/scanners/tar_scanner.py
+++ b/modelaudit/scanners/tar_scanner.py
@@ -9,10 +9,11 @@ import tarfile
 import tempfile
 from typing import Any, ClassVar
 
-from .. import core
 from ..utils import is_absolute_archive_path, is_critical_system_path, sanitize_archive_path
 from ..utils.helpers.assets import asset_from_scan_result
 from ._archive_locations import rewrite_extracted_member_location
+from ._archive_outcomes import mark_archive_scan_incomplete
+from .archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY, scan_nested_file
 from .base import BaseScanner, IssueSeverity, ScanResult
 
 CRITICAL_SYSTEM_PATHS = [
@@ -121,6 +122,7 @@ class TarScanner(BaseScanner):
                 details={"path": path},
                 rule_code="S902",
             )
+            mark_archive_scan_incomplete(result, "tar_analysis_incomplete")
             result.finish(success=False)
             return result
         except Exception as e:
@@ -132,6 +134,7 @@ class TarScanner(BaseScanner):
                 location=path,
                 details={"exception": str(e), "exception_type": type(e).__name__},
             )
+            mark_archive_scan_incomplete(result, "tar_analysis_incomplete")
             result.finish(success=False)
             return result
 
@@ -194,6 +197,13 @@ class TarScanner(BaseScanner):
                 if isinstance(existing_check_entry, str) and existing_check_entry
                 else entry_name
             )
+
+    def _scan_nested_archive_entry(self, path: str, nested_config: dict[str, Any]) -> ScanResult:
+        """Dispatch a nested archive member through an injected callback or registry fallback."""
+        nested_scan_callback = self.config.get(NESTED_SCAN_CALLBACK_CONFIG_KEY)
+        if callable(nested_scan_callback):
+            return nested_scan_callback(path, nested_config)
+        return scan_nested_file(path, nested_config)
 
     @staticmethod
     def _rewrite_archive_location(location: str | None, tmp_path: str, archive_location: str) -> str:
@@ -455,6 +465,7 @@ class TarScanner(BaseScanner):
                 location=path,
                 details={"depth": depth, "max_depth": self.max_depth},
             )
+            mark_archive_scan_incomplete(result, "tar_analysis_incomplete")
             result.finish(success=False)
             return result
         else:
@@ -470,6 +481,7 @@ class TarScanner(BaseScanner):
         if not self._preflight_tar_archive(path, result):
             result.metadata["contents"] = contents
             result.metadata["file_size"] = os.path.getsize(path)
+            mark_archive_scan_incomplete(result, "tar_analysis_incomplete")
             result.finish(success=False)
             return result
 
@@ -575,7 +587,7 @@ class TarScanner(BaseScanner):
                         else:
                             nested_config = dict(self.config)
                             nested_config["_archive_depth"] = depth + 1
-                            file_result = core.scan_file(tmp_path, nested_config)
+                            file_result = self._scan_nested_archive_entry(tmp_path, nested_config)
                             if not file_result.success:
                                 scan_complete = False
 
@@ -608,5 +620,7 @@ class TarScanner(BaseScanner):
 
         result.metadata["contents"] = contents
         result.metadata["file_size"] = os.path.getsize(path)
+        if not scan_complete:
+            mark_archive_scan_incomplete(result, "tar_analysis_incomplete")
         result.finish(success=scan_complete and not result.has_errors)
         return result

--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -9,7 +9,7 @@ from ..utils import is_absolute_archive_path, is_critical_system_path, sanitize_
 from ..utils.helpers.assets import asset_from_scan_result
 from ._archive_config import get_archive_depth
 from ._archive_locations import rewrite_extracted_member_location
-from ._archive_outcomes import mark_archive_scan_incomplete
+from ._archive_outcomes import mark_archive_scan_incomplete, member_scan_incomplete
 from .archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY, scan_nested_file
 from .base import BaseScanner, IssueSeverity, ScanResult
 
@@ -434,7 +434,7 @@ class ZipScanner(BaseScanner):
                         # so production scans preserve core routing while direct
                         # ZipScanner usage still falls back to registry routing.
                         file_result = self._scan_nested_archive_entry(tmp_path, nested_config)
-                        if not file_result.success:
+                        if member_scan_incomplete(file_result):
                             scan_complete = False
 
                         self._rewrite_nested_result_context(file_result, tmp_path, path, name)

--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -9,6 +9,7 @@ from ..utils import is_absolute_archive_path, is_critical_system_path, sanitize_
 from ..utils.helpers.assets import asset_from_scan_result
 from ._archive_config import get_archive_depth
 from ._archive_locations import rewrite_extracted_member_location
+from ._archive_outcomes import mark_archive_scan_incomplete
 from .archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY, scan_nested_file
 from .base import BaseScanner, IssueSeverity, ScanResult
 
@@ -124,6 +125,7 @@ class ZipScanner(BaseScanner):
                 location=path,
                 details={"path": path},
             )
+            mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
             result.finish(success=False)
             return result
         except Exception as e:
@@ -136,6 +138,7 @@ class ZipScanner(BaseScanner):
                 location=path,
                 details={"exception": str(e), "exception_type": type(e).__name__},
             )
+            mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
             result.finish(success=False)
             return result
 
@@ -215,6 +218,7 @@ class ZipScanner(BaseScanner):
                 location=path,
                 details={"depth": depth, "max_depth": self.max_depth},
             )
+            mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
             result.finish(success=False)
             return result
         else:
@@ -243,6 +247,7 @@ class ZipScanner(BaseScanner):
                         "max_entries": self.max_entries,
                     },
                 )
+                mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
                 result.finish(success=False)
                 return result
             else:
@@ -463,6 +468,8 @@ class ZipScanner(BaseScanner):
 
         result.metadata["contents"] = contents
         result.metadata["file_size"] = os.path.getsize(path)
+        if not scan_complete:
+            mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
         result.finish(success=scan_complete and not result.has_errors)
         return result
 

--- a/tests/scanners/test_sevenzip_scanner.py
+++ b/tests/scanners/test_sevenzip_scanner.py
@@ -19,8 +19,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from modelaudit.scanners.archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY
 from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity, ScanResult
-from modelaudit.scanners.sevenzip_scanner import HAS_PY7ZR, SevenZipScanner
+from modelaudit.scanners.sevenzip_scanner import HAS_PY7ZR, SevenZipScanner, _RecursiveScanBudget
 
 # Skip all tests if py7zr is not available for asset generation
 pytest_plugins: list[str] = []
@@ -112,6 +113,8 @@ class TestSevenZipScanner:
         assert issue.severity == IssueSeverity.WARNING
         assert "py7zr library not installed" in issue.message
         assert "pip install py7zr" in issue.message
+        assert result.has_warnings is True
+        assert result.has_errors is False
         assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
         assert result.metadata["analysis_incomplete"] is True
         assert "sevenzip_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
@@ -128,6 +131,8 @@ class TestSevenZipScanner:
         # Missing optional dependency is a WARNING, not CRITICAL
         assert issue.severity == IssueSeverity.WARNING
         assert "py7zr library not installed" in issue.message
+        assert result.has_warnings is True
+        assert result.has_errors is False
         assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
         assert result.metadata["analysis_incomplete"] is True
         assert "sevenzip_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
@@ -761,6 +766,41 @@ class TestSevenZipScanner:
             ]
             assert ["safe.pkl"] in extract_targets
             assert all("../../../escape.pkl" not in targets for targets in extract_targets)
+
+    def test_nested_critical_scan_does_not_mark_7z_extraction_incomplete(self, tmp_path: Path) -> None:
+        """A nested CRITICAL finding is complete analysis, not partial archive traversal."""
+        extracted_path = tmp_path / "model.pkl"
+        extracted_path.write_bytes(b"payload")
+        archive_path = tmp_path / "model.7z"
+        archive_result = ScanResult(scanner_name="sevenzip")
+
+        def nested_scan(path: str, _config: dict[str, Any]) -> ScanResult:
+            nested_result = ScanResult(scanner_name="test_nested")
+            nested_result.add_check(
+                name="Nested Critical Finding",
+                passed=False,
+                message="Nested member is malicious",
+                severity=IssueSeverity.CRITICAL,
+                location=path,
+            )
+            nested_result.finish(success=False)
+            return nested_result
+
+        scanner = SevenZipScanner(config={NESTED_SCAN_CALLBACK_CONFIG_KEY: nested_scan})
+        scan_complete = scanner._scan_extracted_file(
+            str(extracted_path),
+            "model.pkl",
+            str(archive_path),
+            archive_result,
+            depth=0,
+            budget=_RecursiveScanBudget(),
+        )
+
+        assert scan_complete is True
+        assert archive_result.has_errors is True
+        assert "scan_outcome" not in archive_result.metadata
+        assert archive_result.metadata.get("analysis_incomplete") is not True
+        assert any(check.name == "Nested Critical Finding" for check in archive_result.checks)
 
     def test_oversized_entries_are_skipped_before_extraction(
         self,

--- a/tests/scanners/test_sevenzip_scanner.py
+++ b/tests/scanners/test_sevenzip_scanner.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from modelaudit.scanners.base import CheckStatus, IssueSeverity, ScanResult
+from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity, ScanResult
 from modelaudit.scanners.sevenzip_scanner import HAS_PY7ZR, SevenZipScanner
 
 # Skip all tests if py7zr is not available for asset generation
@@ -112,6 +112,9 @@ class TestSevenZipScanner:
         assert issue.severity == IssueSeverity.WARNING
         assert "py7zr library not installed" in issue.message
         assert "pip install py7zr" in issue.message
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert result.metadata["analysis_incomplete"] is True
+        assert "sevenzip_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
 
     @patch("modelaudit.scanners.sevenzip_scanner.HAS_PY7ZR", False)
     def test_scan_mocked_unavailable(self, scanner, temp_7z_file):
@@ -125,6 +128,9 @@ class TestSevenZipScanner:
         # Missing optional dependency is a WARNING, not CRITICAL
         assert issue.severity == IssueSeverity.WARNING
         assert "py7zr library not installed" in issue.message
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert result.metadata["analysis_incomplete"] is True
+        assert "sevenzip_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
 
     @pytest.mark.skipif(not HAS_PY7ZR, reason="py7zr not available")
     def test_can_handle_valid_7z_magic_bytes(self, temp_7z_file):

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -734,7 +734,7 @@ class TestTarScanner:
             info.size = len(payload)
             archive.addfile(info, tarfile.io.BytesIO(payload))  # type: ignore[attr-defined]
 
-        def nested_scan(_path: str, _config: dict[str, Any] | None) -> ScanResult:
+        def nested_scan(_path: str, _config: dict[str, Any]) -> ScanResult:
             nested_result = ScanResult(scanner_name="test_nested")
             nested_result.finish(success=False)
             return nested_result
@@ -751,6 +751,35 @@ class TestTarScanner:
         assert metadata["analysis_incomplete"] is True
         assert audit_result.success is False
         assert core.determine_exit_code(audit_result) == 2
+
+    def test_tar_nested_critical_finding_does_not_mark_archive_incomplete(self, tmp_path: Path) -> None:
+        """Real nested findings should fail the archive without claiming partial traversal."""
+        archive_path = tmp_path / "nested_critical.tar"
+        with tarfile.open(archive_path, "w") as archive:
+            payload = b"payload"
+            info = tarfile.TarInfo("model.pkl")
+            info.size = len(payload)
+            archive.addfile(info, tarfile.io.BytesIO(payload))  # type: ignore[attr-defined]
+
+        def nested_scan(path: str, _config: dict[str, Any]) -> ScanResult:
+            nested_result = ScanResult(scanner_name="test_nested")
+            nested_result.add_check(
+                name="Nested Critical Finding",
+                passed=False,
+                message="Nested member is malicious",
+                severity=IssueSeverity.CRITICAL,
+                location=path,
+            )
+            nested_result.finish(success=False)
+            return nested_result
+
+        result = TarScanner(config={NESTED_SCAN_CALLBACK_CONFIG_KEY: nested_scan}).scan(str(archive_path))
+
+        assert result.success is False
+        assert result.has_errors is True
+        assert "scan_outcome" not in result.metadata
+        assert result.metadata.get("analysis_incomplete") is not True
+        assert any(check.name == "Nested Critical Finding" for check in result.checks)
 
     def test_scan_compressed_tar_detects_wrapper_by_content_not_suffix(self, tmp_path: Path) -> None:
         """Compressed TARs with plain .tar suffix should still enforce wrapper limits by magic bytes."""

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -2,12 +2,13 @@ import os
 import tarfile
 import tempfile
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 import pytest
 
 from modelaudit import core
-from modelaudit.scanners.base import CheckStatus, IssueSeverity
+from modelaudit.scanners.archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY
+from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity, ScanResult
 from modelaudit.scanners.tar_scanner import (
     DEFAULT_MAX_DECOMPRESSED_BYTES,
     DEFAULT_MAX_DECOMPRESSION_RATIO,
@@ -703,6 +704,53 @@ class TestTarScanner:
         entry_checks = [check for check in result.checks if check.name == "Entry Count Limit Check"]
         assert len(entry_checks) == 1
         assert entry_checks[0].status == CheckStatus.PASSED
+
+    def test_max_entries_limit_marks_inconclusive_metadata(self, tmp_path: Path) -> None:
+        """Entry-count truncation should make TAR coverage explicit in metadata."""
+        archive_path = tmp_path / "too_many_entries.tar"
+        with tarfile.open(archive_path, "w") as archive:
+            for index in range(2):
+                payload = f"payload-{index}".encode()
+                info = tarfile.TarInfo(f"payload-{index}.bin")
+                info.size = len(payload)
+                archive.addfile(info, tarfile.io.BytesIO(payload))  # type: ignore[attr-defined]
+
+        result = TarScanner(config={"max_tar_entries": 1}).scan(str(archive_path))
+
+        assert result.success is False
+        entry_checks = [check for check in result.checks if check.name == "Entry Count Limit Check"]
+        assert len(entry_checks) == 1
+        assert entry_checks[0].status == CheckStatus.FAILED
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert result.metadata["analysis_incomplete"] is True
+        assert "tar_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+
+    def test_core_tar_partial_nested_scan_without_findings_returns_exit_code_2(self, tmp_path: Path) -> None:
+        """A failed nested TAR member scan with no finding should stay inconclusive in aggregate output."""
+        archive_path = tmp_path / "nested_failure.tar"
+        with tarfile.open(archive_path, "w") as archive:
+            payload = b"payload"
+            info = tarfile.TarInfo("member.bin")
+            info.size = len(payload)
+            archive.addfile(info, tarfile.io.BytesIO(payload))  # type: ignore[attr-defined]
+
+        def nested_scan(_path: str, _config: dict[str, Any] | None) -> ScanResult:
+            nested_result = ScanResult(scanner_name="test_nested")
+            nested_result.finish(success=False)
+            return nested_result
+
+        scan_kwargs: dict[str, Any] = {NESTED_SCAN_CALLBACK_CONFIG_KEY: nested_scan}
+        audit_result = core.scan_model_directory_or_file(
+            str(archive_path),
+            cache_enabled=False,
+            **scan_kwargs,
+        )
+
+        metadata = audit_result.file_metadata[str(archive_path)]
+        assert metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert metadata["analysis_incomplete"] is True
+        assert audit_result.success is False
+        assert core.determine_exit_code(audit_result) == 2
 
     def test_scan_compressed_tar_detects_wrapper_by_content_not_suffix(self, tmp_path: Path) -> None:
         """Compressed TARs with plain .tar suffix should still enforce wrapper limits by magic bytes."""

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -7,9 +7,10 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from modelaudit import core
 from modelaudit.scanners._archive_locations import rewrite_extracted_member_location
 from modelaudit.scanners.archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY
-from modelaudit.scanners.base import CheckStatus, IssueSeverity, ScanResult
+from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity, ScanResult
 from modelaudit.scanners.zip_scanner import ZipScanner
 
 
@@ -577,6 +578,54 @@ class TestZipScanner:
             and "too many entries" in check.message.lower()
             for check in result.checks
         )
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert result.metadata["analysis_incomplete"] is True
+        assert "zip_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+
+    def test_core_zip_partial_nested_scan_without_findings_returns_exit_code_2(self, tmp_path: Path) -> None:
+        """A failed nested ZIP member scan with no finding should stay inconclusive in aggregate output."""
+        archive_path = tmp_path / "nested_failure.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("member.bin", b"payload")
+
+        def nested_scan(_path: str, _config: dict[str, Any] | None) -> ScanResult:
+            nested_result = ScanResult(scanner_name="test_nested")
+            nested_result.finish(success=False)
+            return nested_result
+
+        scan_kwargs: dict[str, Any] = {NESTED_SCAN_CALLBACK_CONFIG_KEY: nested_scan}
+        audit_result = core.scan_model_directory_or_file(
+            str(archive_path),
+            cache_enabled=False,
+            **scan_kwargs,
+        )
+
+        metadata = audit_result.file_metadata[str(archive_path)]
+        assert metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert metadata["analysis_incomplete"] is True
+        assert audit_result.success is False
+        assert core.determine_exit_code(audit_result) == 2
+
+    def test_zip_incomplete_metadata_survives_cache_roundtrip(self, tmp_path: Path) -> None:
+        """Cache conversion should preserve explicit partial-archive outcome metadata."""
+        archive_path = tmp_path / "cached_many_entries.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("one.txt", "one")
+            archive.writestr("two.txt", "two")
+
+        config = {
+            "cache_enabled": True,
+            "cache_dir": str(tmp_path / "scan-cache"),
+            "max_zip_entries": 1,
+        }
+
+        first_result = core.scan_file(str(archive_path), config=config)
+        second_result = core.scan_file(str(archive_path), config=config)
+
+        assert first_result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "zip_analysis_incomplete" in first_result.metadata["scan_outcome_reasons"]
+        assert second_result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "zip_analysis_incomplete" in second_result.metadata["scan_outcome_reasons"]
 
     def test_oversized_symlink_target_fails_closed(self, tmp_path: Path) -> None:
         """Symlink targets should be read with a bounded cap instead of being silently trusted."""

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -588,7 +588,7 @@ class TestZipScanner:
         with zipfile.ZipFile(archive_path, "w") as archive:
             archive.writestr("member.bin", b"payload")
 
-        def nested_scan(_path: str, _config: dict[str, Any] | None) -> ScanResult:
+        def nested_scan(_path: str, _config: dict[str, Any]) -> ScanResult:
             nested_result = ScanResult(scanner_name="test_nested")
             nested_result.finish(success=False)
             return nested_result
@@ -605,6 +605,32 @@ class TestZipScanner:
         assert metadata["analysis_incomplete"] is True
         assert audit_result.success is False
         assert core.determine_exit_code(audit_result) == 2
+
+    def test_zip_nested_critical_finding_does_not_mark_archive_incomplete(self, tmp_path: Path) -> None:
+        """Real nested findings should fail the archive without claiming partial traversal."""
+        archive_path = tmp_path / "nested_critical.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("model.pkl", b"payload")
+
+        def nested_scan(path: str, _config: dict[str, Any]) -> ScanResult:
+            nested_result = ScanResult(scanner_name="test_nested")
+            nested_result.add_check(
+                name="Nested Critical Finding",
+                passed=False,
+                message="Nested member is malicious",
+                severity=IssueSeverity.CRITICAL,
+                location=path,
+            )
+            nested_result.finish(success=False)
+            return nested_result
+
+        result = ZipScanner(config={NESTED_SCAN_CALLBACK_CONFIG_KEY: nested_scan}).scan(str(archive_path))
+
+        assert result.success is False
+        assert result.has_errors is True
+        assert "scan_outcome" not in result.metadata
+        assert result.metadata.get("analysis_incomplete") is not True
+        assert any(check.name == "Nested Critical Finding" for check in result.checks)
 
     def test_zip_incomplete_metadata_survives_cache_roundtrip(self, tmp_path: Path) -> None:
         """Cache conversion should preserve explicit partial-archive outcome metadata."""


### PR DESCRIPTION
## Summary
- mark fail-closed ZIP, TAR, and 7z archive traversal paths with explicit inconclusive scan metadata
- route TAR nested member scans through the archive callback boundary used by core scans
- add regressions for direct scanner metadata, aggregate exit-code behavior, and ZIP cache metadata round-trips

## Validation
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run pytest tests/scanners/test_zip_scanner.py tests/scanners/test_tar_scanner.py tests/scanners/test_sevenzip_scanner.py
- uv run pytest -n auto -m "not slow and not integration" --maxfail=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Archive scans (ZIP, TAR, 7z) that cannot be fully traversed are now properly recorded as "inconclusive" in scan metadata instead of being treated as complete outcomes.
  * Scan metadata now includes reasons why archive analysis was incomplete.

* **Tests**
  * Added test coverage for incomplete archive scan scenarios and metadata validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->