### PR TITLE
fix: mark incomplete sharded scans inconclusive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - avoid CoreML nested parse failures on bounded-read truncation
+- mark incomplete sharded-model scans as inconclusive, ignore shard-name prefix matches, and skip caching explicit incomplete outcomes
 - flag TensorFlow `LoadLibrary` and `LoadLibraryV2` graph ops as dangerous native-library loading
 - detect split CNTK native-user-function and native-library references
 - detect Linux/macOS native-library members in Keras archives and uppercase native-library members in PyTorch ZIPs

--- a/modelaudit/cache/cache_policy.py
+++ b/modelaudit/cache/cache_policy.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from modelaudit.scanner_results import INCONCLUSIVE_SCAN_OUTCOME
+
 _OPERATIONAL_ERROR_INDICATORS = (
     "error during scan",
     "error checking file size",
@@ -33,6 +35,14 @@ _OPERATIONAL_ERROR_INDICATORS = (
 
 def should_cache_scan_result(scan_result: dict[str, Any]) -> bool:
     """Return True when a scan result is stable enough to cache safely."""
+    metadata = scan_result.get("metadata")
+    if isinstance(metadata, dict) and (
+        bool(metadata.get("operational_error"))
+        or bool(metadata.get("analysis_incomplete"))
+        or metadata.get("scan_outcome") == INCONCLUSIVE_SCAN_OUTCOME
+    ):
+        return False
+
     for collection_name in ("issues", "checks"):
         collection = scan_result.get(collection_name)
         if not isinstance(collection, list):

--- a/modelaudit/utils/file/handlers.py
+++ b/modelaudit/utils/file/handlers.py
@@ -33,6 +33,7 @@ MMAP_MAX_WINDOW = 500 * 1024 * 1024  # 500MB max window size
 # Parallel scanning parameters
 MAX_PARALLEL_WORKERS = 4
 SHARD_SCAN_TIMEOUT = 600  # 10 minutes per shard
+MAX_RECORDED_MISSING_SHARD_INDICES = 1000
 
 
 def _mark_inconclusive_scan_outcome(result: "ScanResult", reason: str) -> None:
@@ -46,6 +47,33 @@ def _mark_inconclusive_scan_outcome(result: "ScanResult", reason: str) -> None:
     if reason not in reasons:
         reasons.append(reason)
     result.metadata["scan_outcome_reasons"] = reasons
+
+
+def _summarize_missing_shard_indices(
+    present_indices: set[int],
+    expected_total: int,
+) -> tuple[list[int], int, bool]:
+    """Return a bounded sample, total count, and truncation flag for missing shards."""
+    bounded_present_indices = {index for index in present_indices if 1 <= index <= expected_total}
+    missing_count = max(expected_total - len(bounded_present_indices), 0)
+    if missing_count == 0:
+        return [], 0, False
+
+    missing_indices: list[int] = []
+    next_candidate = 1
+    for present_index in sorted(bounded_present_indices):
+        while next_candidate < present_index and len(missing_indices) < MAX_RECORDED_MISSING_SHARD_INDICES:
+            missing_indices.append(next_candidate)
+            next_candidate += 1
+        if len(missing_indices) >= MAX_RECORDED_MISSING_SHARD_INDICES:
+            break
+        next_candidate = present_index + 1
+
+    while next_candidate <= expected_total and len(missing_indices) < MAX_RECORDED_MISSING_SHARD_INDICES:
+        missing_indices.append(next_candidate)
+        next_candidate += 1
+
+    return missing_indices, missing_count, missing_count > len(missing_indices)
 
 
 class ShardedModelDetector:
@@ -103,11 +131,14 @@ class ShardedModelDetector:
                     if len(expected_totals) > 1:
                         shard_info["inconsistent_expected_total_shards"] = sorted(expected_totals)
                     if present_indices:
-                        missing_indices = [
-                            index for index in range(1, expected_total + 1) if index not in present_indices
-                        ]
-                        if missing_indices:
+                        missing_indices, missing_count, missing_indices_truncated = _summarize_missing_shard_indices(
+                            present_indices,
+                            expected_total,
+                        )
+                        if missing_count:
+                            shard_info["missing_shard_count"] = missing_count
                             shard_info["missing_shard_indices"] = missing_indices
+                            shard_info["missing_shard_indices_truncated"] = missing_indices_truncated
 
                 # Calculate total size
                 total_size = sum(os.path.getsize(s) for s in shard_info["shards"])
@@ -497,18 +528,22 @@ class AdvancedFileHandler:
             parallel_scanner = ParallelShardHandler(self.shard_info, self.scanner.__class__)
             shard_results = parallel_scanner.scan_shards(self.progress_callback)
             result.merge(shard_results)
-            missing_indices = self.shard_info.get("missing_shard_indices")
-            if isinstance(missing_indices, list) and missing_indices:
+            missing_count = self.shard_info.get("missing_shard_count")
+            if isinstance(missing_count, int) and missing_count > 0:
                 _mark_inconclusive_scan_outcome(result, "missing_model_shards")
                 result.add_check(
                     name="Sharded Model Coverage Check",
                     passed=False,
-                    message=(f"Missing {len(missing_indices)} expected model shard(s); scan coverage is incomplete."),
+                    message=(f"Missing {missing_count} expected model shard(s); scan coverage is incomplete."),
                     severity=IssueSeverity.INFO,
                     details={
                         "expected_total_shards": self.shard_info.get("expected_total_shards"),
                         "present_total_shards": self.shard_info.get("total_shards"),
-                        "missing_shard_indices": missing_indices,
+                        "missing_shard_count": missing_count,
+                        "missing_shard_indices": self.shard_info.get("missing_shard_indices", []),
+                        "missing_shard_indices_truncated": self.shard_info.get(
+                            "missing_shard_indices_truncated", False
+                        ),
                         "analysis_incomplete": True,
                         "scan_outcome": "inconclusive",
                         "scan_outcome_reason": "missing_model_shards",

--- a/modelaudit/utils/file/handlers.py
+++ b/modelaudit/utils/file/handlers.py
@@ -524,9 +524,11 @@ class AdvancedFileHandler:
                 logger.warning(f"Failed to read config file: {e}")
 
         # Scan shards in parallel
+        shard_scan_success = True
         if self.shard_info:
             parallel_scanner = ParallelShardHandler(self.shard_info, self.scanner.__class__)
             shard_results = parallel_scanner.scan_shards(self.progress_callback)
+            shard_scan_success = bool(shard_results.success)
             result.merge(shard_results)
             missing_count = self.shard_info.get("missing_shard_count")
             if isinstance(missing_count, int) and missing_count > 0:
@@ -550,7 +552,7 @@ class AdvancedFileHandler:
                     },
                 )
 
-        result.finish(success=not result.has_errors and "scan_outcome" not in result.metadata)
+        result.finish(success=shard_scan_success and not result.has_errors and "scan_outcome" not in result.metadata)
         return result
 
     def _scan_with_mmap(self) -> "ScanResult":

--- a/modelaudit/utils/file/handlers.py
+++ b/modelaudit/utils/file/handlers.py
@@ -12,6 +12,7 @@ import re
 import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -32,6 +33,19 @@ MMAP_MAX_WINDOW = 500 * 1024 * 1024  # 500MB max window size
 # Parallel scanning parameters
 MAX_PARALLEL_WORKERS = 4
 SHARD_SCAN_TIMEOUT = 600  # 10 minutes per shard
+
+
+def _mark_inconclusive_scan_outcome(result: "ScanResult", reason: str) -> None:
+    """Mark a scan result as incomplete while preserving existing reasons."""
+    from ...scanner_results import INCONCLUSIVE_SCAN_OUTCOME
+
+    result.metadata["analysis_incomplete"] = True
+    result.metadata["scan_outcome"] = INCONCLUSIVE_SCAN_OUTCOME
+    existing_reasons = result.metadata.get("scan_outcome_reasons")
+    reasons = existing_reasons if isinstance(existing_reasons, list) else []
+    if reason not in reasons:
+        reasons.append(reason)
+    result.metadata["scan_outcome_reasons"] = reasons
 
 
 class ShardedModelDetector:
@@ -62,18 +76,38 @@ class ShardedModelDetector:
         dir_path = Path(file_path).parent
 
         for pattern in cls.SHARD_PATTERNS:
-            match = re.match(pattern, file_name)
+            match = re.fullmatch(pattern, file_name)
             if match:
                 # Found a sharded model
                 shard_info: dict[str, Any] = {"pattern": pattern, "current_file": file_path, "shards": []}
+                expected_totals: set[int] = set()
+                present_indices: set[int] = set()
 
                 # Find all related shards
                 for file in dir_path.glob("*"):
-                    if re.match(pattern, file.name):
+                    file_match = re.fullmatch(pattern, file.name)
+                    if file_match:
                         shard_info["shards"].append(str(file))
+                        if file_match.lastindex:
+                            with suppress(IndexError, ValueError):
+                                present_indices.add(int(file_match.group(1)))
+                        if (file_match.lastindex or 0) >= 2:
+                            with suppress(IndexError, ValueError):
+                                expected_totals.add(int(file_match.group(2)))
 
                 shard_info["shards"].sort()
                 shard_info["total_shards"] = len(shard_info["shards"])
+                if expected_totals:
+                    expected_total = max(expected_totals)
+                    shard_info["expected_total_shards"] = expected_total
+                    if len(expected_totals) > 1:
+                        shard_info["inconsistent_expected_total_shards"] = sorted(expected_totals)
+                    if present_indices:
+                        missing_indices = [
+                            index for index in range(1, expected_total + 1) if index not in present_indices
+                        ]
+                        if missing_indices:
+                            shard_info["missing_shard_indices"] = missing_indices
 
                 # Calculate total size
                 total_size = sum(os.path.getsize(s) for s in shard_info["shards"])
@@ -269,6 +303,7 @@ class ParallelShardHandler:
         shards = self.shard_info["shards"]
         total_shards = len(shards)
         completed_shards = 0
+        success = True
 
         # Add info about sharded model
         result.add_check(
@@ -295,6 +330,7 @@ class ParallelShardHandler:
                 try:
                     shard_result = future.result(timeout=SHARD_SCAN_TIMEOUT)
                     result.merge(shard_result)
+                    success = success and bool(shard_result.success)
 
                     if progress_callback:
                         percentage = (completed_shards / total_shards) * 100
@@ -302,15 +338,23 @@ class ParallelShardHandler:
 
                 except Exception as e:
                     logger.error(f"Error scanning shard {shard}: {e}")
+                    success = False
+                    _mark_inconclusive_scan_outcome(result, "shard_scan_error")
                     result.add_check(
                         name="Shard Scan",
                         passed=False,
                         message=f"Error scanning shard: {Path(shard).name}",
-                        severity=IssueSeverity.WARNING,
+                        severity=IssueSeverity.INFO,
                         location=shard,
-                        details={"error": str(e)},
+                        details={
+                            "error": str(e),
+                            "analysis_incomplete": True,
+                            "scan_outcome": "inconclusive",
+                            "scan_outcome_reason": "shard_scan_error",
+                        },
                     )
 
+        result.finish(success=success and not result.has_errors and "scan_outcome" not in result.metadata)
         return result
 
     def _scan_single_shard(self, shard_path: str) -> "ScanResult":
@@ -453,7 +497,25 @@ class AdvancedFileHandler:
             parallel_scanner = ParallelShardHandler(self.shard_info, self.scanner.__class__)
             shard_results = parallel_scanner.scan_shards(self.progress_callback)
             result.merge(shard_results)
+            missing_indices = self.shard_info.get("missing_shard_indices")
+            if isinstance(missing_indices, list) and missing_indices:
+                _mark_inconclusive_scan_outcome(result, "missing_model_shards")
+                result.add_check(
+                    name="Sharded Model Coverage Check",
+                    passed=False,
+                    message=(f"Missing {len(missing_indices)} expected model shard(s); scan coverage is incomplete."),
+                    severity=IssueSeverity.INFO,
+                    details={
+                        "expected_total_shards": self.shard_info.get("expected_total_shards"),
+                        "present_total_shards": self.shard_info.get("total_shards"),
+                        "missing_shard_indices": missing_indices,
+                        "analysis_incomplete": True,
+                        "scan_outcome": "inconclusive",
+                        "scan_outcome_reason": "missing_model_shards",
+                    },
+                )
 
+        result.finish(success=not result.has_errors and "scan_outcome" not in result.metadata)
         return result
 
     def _scan_with_mmap(self) -> "ScanResult":

--- a/tests/cache/test_cache_correctness.py
+++ b/tests/cache/test_cache_correctness.py
@@ -19,6 +19,7 @@ from modelaudit.cache.optimized_config import (
 )
 from modelaudit.cache.scan_results_cache import ScanResultsCache
 from modelaudit.config.rule_config import ModelAuditConfig, get_config, reset_config, set_config
+from modelaudit.scanner_results import INCONCLUSIVE_SCAN_OUTCOME
 from modelaudit.utils.helpers.cache_decorator import cached_scan
 
 
@@ -175,6 +176,42 @@ def test_cached_scan_skips_persisting_operational_failures_from_checks(tmp_path:
 
     cache_manager = get_cache_manager(str(cache_dir), enabled=True)
     assert cache_manager.get_stats()["total_entries"] == 0
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"scan_outcome": INCONCLUSIVE_SCAN_OUTCOME},
+        {"analysis_incomplete": True},
+        {"operational_error": True},
+    ],
+)
+def test_cached_scan_skips_persisting_incomplete_metadata(
+    tmp_path: Path,
+    metadata: dict[str, Any],
+) -> None:
+    file_path = _make_cacheable_file(tmp_path)
+    cache_dir = tmp_path / "cache"
+    config = {"cache_enabled": True, "cache_dir": str(cache_dir)}
+    calls = {"count": 0}
+
+    @cached_scan()
+    def scan(path: str, config: dict[str, Any] | None = None) -> dict[str, Any]:
+        calls["count"] += 1
+        return {
+            "checks": [],
+            "issues": [],
+            "metadata": metadata,
+            "scan_count": calls["count"],
+        }
+
+    first = scan(str(file_path), config)
+    second = scan(str(file_path), config)
+
+    assert first["scan_count"] == 1
+    assert second["scan_count"] == 2
+    assert calls["count"] == 2
+    assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
 
 
 def test_cached_scan_skips_persisting_scan_timed_out_messages(tmp_path: Path) -> None:

--- a/tests/utils/file/test_advanced_file_handler.py
+++ b/tests/utils/file/test_advanced_file_handler.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 from modelaudit.scanner_results import INCONCLUSIVE_SCAN_OUTCOME, IssueSeverity, ScanResult
 from modelaudit.utils.file.handlers import (
+    MAX_RECORDED_MISSING_SHARD_INDICES,
     AdvancedFileHandler,
     MemoryMappedHandler,
     ParallelShardHandler,
@@ -92,7 +93,21 @@ class TestShardedModelDetector:
         assert shard_info is not None
         assert shard_info["total_shards"] == 2
         assert shard_info["expected_total_shards"] == 3
+        assert shard_info["missing_shard_count"] == 1
         assert shard_info["missing_shard_indices"] == [2]
+
+    def test_detect_shards_bounds_missing_expected_indices(self, tmp_path: Path) -> None:
+        """Huge declared shard totals should not expand into huge missing-index lists."""
+        shard_one = tmp_path / "model-00001-of-999999999999.safetensors"
+        shard_one.write_bytes(b"test")
+
+        shard_info = ShardedModelDetector.detect_shards(str(shard_one))
+
+        assert shard_info is not None
+        assert shard_info["expected_total_shards"] == 999999999999
+        assert shard_info["missing_shard_count"] == 999999999998
+        assert len(shard_info["missing_shard_indices"]) == MAX_RECORDED_MISSING_SHARD_INDICES
+        assert shard_info["missing_shard_indices_truncated"] is True
 
     def test_detect_shards_ignores_suffix_near_matches(self, tmp_path: Path) -> None:
         """Shard routing should not count files that only prefix-match a shard name."""
@@ -275,7 +290,9 @@ class TestAdvancedFileHandler:
         coverage_checks = [check for check in result.checks if check.name == "Sharded Model Coverage Check"]
         assert len(coverage_checks) == 1
         assert coverage_checks[0].severity == IssueSeverity.INFO
+        assert coverage_checks[0].details["missing_shard_count"] == 1
         assert coverage_checks[0].details["missing_shard_indices"] == [2]
+        assert coverage_checks[0].details["missing_shard_indices_truncated"] is False
 
     def test_parallel_shard_errors_mark_scan_inconclusive(self, tmp_path: Path) -> None:
         """Shard scan exceptions are incomplete coverage, not security findings."""

--- a/tests/utils/file/test_advanced_file_handler.py
+++ b/tests/utils/file/test_advanced_file_handler.py
@@ -38,6 +38,24 @@ class FailingShardScanner:
         raise RuntimeError(f"cannot scan {Path(shard_path).name}")
 
 
+class IncompleteShardScanner:
+    """Scanner that returns an unsuccessful non-critical shard result."""
+
+    name = "incomplete_shard_scanner"
+
+    def scan(self, shard_path: str) -> ScanResult:
+        result = ScanResult(scanner_name=self.name)
+        result.add_check(
+            name="Shard Parse Coverage",
+            passed=False,
+            message=f"Shard could not be fully parsed: {Path(shard_path).name}",
+            severity=IssueSeverity.INFO,
+            location=shard_path,
+        )
+        result.finish(success=False)
+        return result
+
+
 class TestShardedModelDetector:
     """Test sharded model detection."""
 
@@ -317,3 +335,17 @@ class TestAdvancedFileHandler:
         shard_checks = [check for check in result.checks if check.name == "Shard Scan"]
         assert len(shard_checks) == 1
         assert shard_checks[0].severity == IssueSeverity.INFO
+
+    def test_sharded_model_preserves_unsuccessful_shard_result(self, tmp_path: Path) -> None:
+        """Non-critical shard failures must not be overwritten after aggregate merge."""
+        shard_path = tmp_path / "model-00001-of-00001.safetensors"
+        shard_path.write_bytes(b"partial")
+
+        handler = AdvancedFileHandler(str(shard_path), IncompleteShardScanner())
+        result = handler.scan()
+
+        assert result.end_time is not None
+        assert result.success is False
+        assert result.has_errors is False
+        assert "scan_outcome" not in result.metadata
+        assert any(check.name == "Shard Parse Coverage" for check in result.checks)

--- a/tests/utils/file/test_advanced_file_handler.py
+++ b/tests/utils/file/test_advanced_file_handler.py
@@ -6,12 +6,35 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+from modelaudit.scanner_results import INCONCLUSIVE_SCAN_OUTCOME, IssueSeverity, ScanResult
 from modelaudit.utils.file.handlers import (
     AdvancedFileHandler,
     MemoryMappedHandler,
+    ParallelShardHandler,
     ShardedModelDetector,
     should_use_advanced_handler,
 )
+
+
+class CompletingShardScanner:
+    """Minimal scanner for shard-handler coverage tests."""
+
+    name = "completing_shard_scanner"
+
+    def scan(self, shard_path: str) -> ScanResult:
+        result = ScanResult(scanner_name=self.name)
+        result.bytes_scanned = Path(shard_path).stat().st_size
+        result.finish(success=True)
+        return result
+
+
+class FailingShardScanner:
+    """Scanner that simulates an operational shard scan failure."""
+
+    name = "failing_shard_scanner"
+
+    def scan(self, shard_path: str) -> ScanResult:
+        raise RuntimeError(f"cannot scan {Path(shard_path).name}")
 
 
 class TestShardedModelDetector:
@@ -56,6 +79,33 @@ class TestShardedModelDetector:
 
             assert shard_info is not None
             assert shard_info["total_shards"] == 2
+
+    def test_detect_shards_records_missing_expected_indices(self, tmp_path: Path) -> None:
+        """Missing numbered shards should be explicit in detector metadata."""
+        shard_one = tmp_path / "model-00001-of-00003.safetensors"
+        shard_three = tmp_path / "model-00003-of-00003.safetensors"
+        shard_one.write_bytes(b"test")
+        shard_three.write_bytes(b"test")
+
+        shard_info = ShardedModelDetector.detect_shards(str(shard_one))
+
+        assert shard_info is not None
+        assert shard_info["total_shards"] == 2
+        assert shard_info["expected_total_shards"] == 3
+        assert shard_info["missing_shard_indices"] == [2]
+
+    def test_detect_shards_ignores_suffix_near_matches(self, tmp_path: Path) -> None:
+        """Shard routing should not count files that only prefix-match a shard name."""
+        shard_one = tmp_path / "model-00001-of-00001.safetensors"
+        near_match = tmp_path / "model-00001-of-00001.safetensors.bak"
+        shard_one.write_bytes(b"test")
+        near_match.write_bytes(b"backup")
+
+        shard_info = ShardedModelDetector.detect_shards(str(shard_one))
+
+        assert shard_info is not None
+        assert shard_info["shards"] == [str(shard_one)]
+        assert shard_info["total_shards"] == 1
 
     def test_no_shards_detected(self) -> None:
         """Test when file is not sharded."""
@@ -206,3 +256,47 @@ class TestAdvancedFileHandler:
             check.name == "Large File Coverage Check" and "Error scanning file:" in check.message
             for check in result.checks
         )
+
+    def test_sharded_model_missing_shards_marks_scan_inconclusive(self, tmp_path: Path) -> None:
+        """A partial shard set must not report complete coverage."""
+        shard_one = tmp_path / "model-00001-of-00003.safetensors"
+        shard_three = tmp_path / "model-00003-of-00003.safetensors"
+        shard_one.write_bytes(b"safe")
+        shard_three.write_bytes(b"safe")
+
+        handler = AdvancedFileHandler(str(shard_one), CompletingShardScanner())
+        result = handler.scan()
+
+        assert result.end_time is not None
+        assert result.success is False
+        assert result.metadata["analysis_incomplete"] is True
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "missing_model_shards" in result.metadata["scan_outcome_reasons"]
+        coverage_checks = [check for check in result.checks if check.name == "Sharded Model Coverage Check"]
+        assert len(coverage_checks) == 1
+        assert coverage_checks[0].severity == IssueSeverity.INFO
+        assert coverage_checks[0].details["missing_shard_indices"] == [2]
+
+    def test_parallel_shard_errors_mark_scan_inconclusive(self, tmp_path: Path) -> None:
+        """Shard scan exceptions are incomplete coverage, not security findings."""
+        shard_path = tmp_path / "model-00001-of-00001.safetensors"
+        shard_path.write_bytes(b"safe")
+        handler = ParallelShardHandler(
+            {
+                "shards": [str(shard_path)],
+                "total_shards": 1,
+                "total_size": shard_path.stat().st_size,
+            },
+            FailingShardScanner,
+        )
+
+        result = handler.scan_shards()
+
+        assert result.end_time is not None
+        assert result.success is False
+        assert result.metadata["analysis_incomplete"] is True
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "shard_scan_error" in result.metadata["scan_outcome_reasons"]
+        shard_checks = [check for check in result.checks if check.name == "Shard Scan"]
+        assert len(shard_checks) == 1
+        assert shard_checks[0].severity == IssueSeverity.INFO


### PR DESCRIPTION
## Summary
- require exact shard filename matches and record expected-vs-present shard coverage
- mark missing or failed shard scans as inconclusive metadata instead of security warnings
- skip caching explicit incomplete, inconclusive, or operational scan metadata

## Validation
- uv run pytest tests/utils/file/test_advanced_file_handler.py::TestShardedModelDetector::test_detect_shards_records_missing_expected_indices tests/utils/file/test_advanced_file_handler.py::TestShardedModelDetector::test_detect_shards_ignores_suffix_near_matches tests/utils/file/test_advanced_file_handler.py::TestAdvancedFileHandler::test_sharded_model_missing_shards_marks_scan_inconclusive tests/utils/file/test_advanced_file_handler.py::TestAdvancedFileHandler::test_parallel_shard_errors_mark_scan_inconclusive tests/cache/test_cache_correctness.py::test_cached_scan_skips_persisting_incomplete_metadata
- uv run pytest tests/utils/file/test_advanced_file_handler.py tests/utils/file/test_large_file_handler.py tests/cache/test_cache_correctness.py
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run pytest -n auto -m "not slow and not integration" --maxfail=1
- uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- git diff --check