### PR TITLE
fix: mark unknown ONNX tensor dtypes inconclusive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - detect embedded Windows DLL/PE, Linux ELF shared-object, and TensorRT plugin entry-point markers in TensorRT engines
 - detect punctuation-delimited TensorRT `/tmp` plugin paths
 - preserve HuggingFace cache provenance for symlinked custom cache roots
+- mark ONNX tensor dtype validation failures inconclusive instead of allowing clean scans
 - ignore remote OCI `layers[].urls` entries during local layer discovery
 - fail closed on unterminated OpenVINO DOCTYPE declarations
 - avoid PMML `<Extension>` false positives for benign `subprocess` prose while preserving `subprocess.getoutput()`, `subprocess.getstatusoutput()`, and `importlib.import_module("subprocess")` detections

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -8,7 +8,7 @@ import re
 from pathlib import Path
 from typing import Any, ClassVar
 
-from .base import BaseScanner, IssueSeverity, ScanResult
+from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, IssueSeverity, ScanResult
 
 logger = logging.getLogger("modelaudit.scanners")
 
@@ -57,6 +57,7 @@ STANDARD_ONNX_DOMAINS: frozenset[str] = frozenset(
         "ai.onnx.preview.training",
     }
 )
+ONNX_STRUCTURE_INCONCLUSIVE_REASON = "onnx_structure_validation_failed"
 _PYTHON_OPERATOR_TYPES: frozenset[str] = frozenset(
     {
         "pyfunc",
@@ -151,6 +152,25 @@ def _parse_external_data_extent(info: dict[str, str], key: str) -> int | None:
     if parsed < 0:
         raise ValueError(f"{key} must be non-negative, got {parsed}")
     return parsed
+
+
+def _mark_inconclusive_scan_result(result: ScanResult, reason: str) -> None:
+    """Mark the ONNX scan inconclusive when structure validation cannot complete."""
+    result.metadata["scan_outcome"] = INCONCLUSIVE_SCAN_OUTCOME
+    reasons = result.metadata.get("scan_outcome_reasons")
+    if not isinstance(reasons, list):
+        reasons = []
+    if reason not in reasons:
+        reasons.append(reason)
+    result.metadata["scan_outcome_reasons"] = reasons
+
+
+def _finish_scan_result(result: ScanResult) -> None:
+    """Finalize success so incomplete ONNX validation fails closed."""
+    success = not result.has_errors
+    if result.metadata.get("scan_outcome") == INCONCLUSIVE_SCAN_OUTCOME:
+        success = False
+    result.finish(success=success)
 
 
 class OnnxScanner(BaseScanner):
@@ -287,7 +307,7 @@ class OnnxScanner(BaseScanner):
         self._check_tensor_sizes(model, path, result)
         self._check_weight_distribution(model, path, result)
 
-        result.finish(success=not result.has_errors)
+        _finish_scan_result(result)
         return result
 
     def _check_custom_ops(self, model: Any, path: str, result: ScanResult) -> None:
@@ -601,13 +621,20 @@ class OnnxScanner(BaseScanner):
                     },
                 )
         except Exception as e:
+            _mark_inconclusive_scan_result(result, ONNX_STRUCTURE_INCONCLUSIVE_REASON)
             result.add_check(
                 name="External Data Size Validation",
                 passed=False,
                 message=f"Failed to validate external data size: {e}",
-                severity=IssueSeverity.DEBUG,
+                severity=IssueSeverity.INFO,
                 location=str(external_path),
                 rule_code="S902",
+                details={
+                    "tensor": tensor.name,
+                    "data_type": int(tensor.data_type),
+                    "exception": str(e),
+                    "exception_type": type(e).__name__,
+                },
             )
 
     def _check_tensor_sizes(self, model: Any, path: str, result: ScanResult) -> None:
@@ -651,13 +678,20 @@ class OnnxScanner(BaseScanner):
                             rule_code=None,  # Passing check
                         )
                 except Exception as e:
+                    _mark_inconclusive_scan_result(result, ONNX_STRUCTURE_INCONCLUSIVE_REASON)
                     result.add_check(
                         name="Tensor Validation",
                         passed=False,
                         message=f"Failed to validate tensor '{tensor.name}': {e}",
-                        severity=IssueSeverity.DEBUG,
+                        severity=IssueSeverity.INFO,
                         location=path,
                         rule_code="S703",
+                        details={
+                            "tensor": tensor.name,
+                            "data_type": int(tensor.data_type),
+                            "exception": str(e),
+                            "exception_type": type(e).__name__,
+                        },
                     )
 
     def _check_weight_distribution(self, model: Any, path: str, result: ScanResult) -> None:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -11,7 +11,8 @@ import onnx
 from onnx import TensorProto, helper
 from onnx.onnx_ml_pb2 import StringStringEntryProto
 
-from modelaudit.scanners.base import CheckStatus, IssueSeverity
+from modelaudit.core import determine_exit_code, scan_model_directory_or_file
+from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity
 from modelaudit.scanners.onnx_scanner import OnnxScanner
 
 
@@ -556,6 +557,12 @@ class TestCVE202427318NestedPathTraversal:
 class TestExternalDataSizeValidation:
     """Tests for external_data offset/length and dtype validation."""
 
+    @staticmethod
+    def _set_initializer_data_type(model_path: Path, data_type: int) -> None:
+        model = onnx.load(str(model_path), load_external_data=False)
+        model.graph.initializer[0].data_type = data_type
+        onnx.save(model, str(model_path))
+
     def test_offset_past_remaining_data_fails_size_validation(self, tmp_path: Path) -> None:
         model_path = create_onnx_model(
             tmp_path,
@@ -605,6 +612,49 @@ class TestExternalDataSizeValidation:
         size_checks = [c for c in result.checks if c.name == "External Data Size Validation"]
         assert len(size_checks) > 0
         assert size_checks[0].status == CheckStatus.PASSED
+
+    def test_unknown_external_data_dtype_is_inconclusive(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model(tmp_path, external=True, external_path="weights.bin")
+        self._set_initializer_data_type(model_path, 9999)
+
+        direct = OnnxScanner().scan(str(model_path))
+        aggregate = scan_model_directory_or_file(str(model_path), recursive=False)
+        metadata = next(iter(aggregate.file_metadata.values()))
+
+        assert direct.success is False
+        assert direct.has_errors is False
+        assert direct.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "onnx_structure_validation_failed" in direct.metadata["scan_outcome_reasons"]
+        size_checks = [
+            c for c in direct.checks if c.name == "External Data Size Validation" and c.status == CheckStatus.FAILED
+        ]
+        assert len(size_checks) > 0
+        assert size_checks[0].severity == IssueSeverity.INFO
+        assert size_checks[0].details["data_type"] == 9999
+        assert aggregate.success is False
+        assert metadata.get("scan_outcome") == INCONCLUSIVE_SCAN_OUTCOME
+        assert determine_exit_code(aggregate) == 2
+        assert not any(issue.severity == IssueSeverity.CRITICAL for issue in aggregate.issues)
+
+    def test_unknown_external_data_dtype_preserves_security_exit1(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model(
+            tmp_path,
+            custom=True,
+            custom_domain="",
+            custom_op_type="PyFunc",
+            external=True,
+            external_path="weights.bin",
+        )
+        self._set_initializer_data_type(model_path, 9999)
+
+        direct = OnnxScanner().scan(str(model_path))
+        aggregate = scan_model_directory_or_file(str(model_path), recursive=False)
+
+        assert direct.success is False
+        assert direct.has_errors is True
+        assert direct.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert any(issue.severity == IssueSeverity.CRITICAL for issue in aggregate.issues)
+        assert determine_exit_code(aggregate) == 1
 
     def test_invalid_offset_metadata_fails_size_validation(self, tmp_path: Path) -> None:
         model_path = create_onnx_model(


### PR DESCRIPTION
## Summary
- mark ONNX tensor-size validation failures as explicit inconclusive scan outcomes
- fail closed when external-data tensor dtype mapping prevents size validation
- preserve exit 1 precedence when a real security finding is present alongside an inconclusive validation result

## Validation
- uv run --python 3.12 --extra all-ci pytest tests/scanners/test_onnx_scanner.py -k "unknown_external_data_dtype or external_data_size_validation_uses_current_onnx_dtype_api"
- uv run --python 3.12 --extra all-ci pytest tests/scanners/test_onnx_scanner.py
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run pytest -n auto -m "not slow and not integration" --maxfail=1
- uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ONNX tensor data type validation failures are now reported as inconclusive scan outcomes instead of allowing scans to be marked clean. Validation failures now provide enhanced diagnostic information including tensor data type and exception metadata for further investigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->