### PR TITLE
test(scanners): cover native code detection gaps

### DIFF
--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -885,8 +885,8 @@ __import__('pickle').loads(data)
             "dropper.PS1",
         }.issubset(suspicious_filenames)
 
-    def test_native_library_near_match_extension_stays_clean(self, tmp_path: Path) -> None:
-        """Native-library extension near matches should not be treated as executable archive members."""
+    def test_executable_extension_near_matches_stay_clean(self, tmp_path: Path) -> None:
+        """Executable extension near matches should not be treated as executable archive members."""
         archive_path = tmp_path / "safe.keras"
         config = {"class_name": "Sequential", "config": {"layers": []}}
         with zipfile.ZipFile(archive_path, "w") as zf:
@@ -895,6 +895,13 @@ __import__('pickle').loads(data)
             zf.writestr("plugin.so.version", "not a versioned shared object")
             zf.writestr("plugin.so.6cache", "not a versioned shared object")
             zf.writestr("plugin.dllcache", "not a dll")
+            zf.writestr("launcher.bashrc", "not a standalone bash script")
+            zf.writestr("runner.cmdline", "not a cmd script")
+            zf.writestr("screensaver.scrub", "not a screensaver")
+            zf.writestr("payload.composer", "not a DOS executable")
+            zf.writestr("dropper.ps10", "not a PowerShell script")
+            zf.writestr("installer.executable", "not a PE executable")
+            zf.writestr("batch.baton", "not a batch script")
 
         result = KerasZipScanner().scan(str(archive_path))
 

--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -859,6 +859,11 @@ __import__('pickle').loads(data)
             zf.writestr("plugin.SO", b"\x7fELF")
             zf.writestr("libpayload.SO.6", b"\x7fELF")
             zf.writestr("plugin.Dylib", b"\xfe\xed\xfa\xcf")
+            zf.writestr("launcher.BASH", "#!/usr/bin/env bash\necho evil")
+            zf.writestr("runner.Cmd", "@echo off")
+            zf.writestr("screensaver.SCR", b"MZ")
+            zf.writestr("payload.COM", b"MZ")
+            zf.writestr("dropper.PS1", "Start-Process calc.exe")
 
         result = scanner.scan(str(archive_path))
         suspicious_filenames = {
@@ -867,7 +872,18 @@ __import__('pickle').loads(data)
             if "Python file found in Keras ZIP" in check.message
             or "Executable file found in Keras ZIP" in check.message
         }
-        assert {"MALWARE.PY", "run.SH", "plugin.SO", "libpayload.SO.6", "plugin.Dylib"}.issubset(suspicious_filenames)
+        assert {
+            "MALWARE.PY",
+            "run.SH",
+            "plugin.SO",
+            "libpayload.SO.6",
+            "plugin.Dylib",
+            "launcher.BASH",
+            "runner.Cmd",
+            "screensaver.SCR",
+            "payload.COM",
+            "dropper.PS1",
+        }.issubset(suspicious_filenames)
 
     def test_native_library_near_match_extension_stays_clean(self, tmp_path: Path) -> None:
         """Native-library extension near matches should not be treated as executable archive members."""

--- a/tests/scanners/test_tensorrt_scanner.py
+++ b/tests/scanners/test_tensorrt_scanner.py
@@ -114,6 +114,26 @@ def test_tensorrt_scanner_detects_embedded_pe_header(tmp_path: Path) -> None:
     )
 
 
+def test_tensorrt_scanner_detects_embedded_pe_header_after_invalid_decoy(tmp_path: Path) -> None:
+    path = tmp_path / "embedded_pe_after_decoy.engine"
+    prefix = b"tensorrt engine prefix\x00"
+    invalid_pe_near_match = bytearray(b"\x00" * 0x100)
+    invalid_pe_near_match[0:2] = b"MZ"
+    invalid_pe_near_match[0x3C:0x40] = (0x80).to_bytes(4, "little")
+    invalid_pe_near_match[0x80:0x84] = b"PX\x00\x00"
+    separator = b"\x00decoy boundary\x00"
+    path.write_bytes(prefix + bytes(invalid_pe_near_match) + separator + _minimal_pe_header())
+
+    result = TensorRTScanner().scan(str(path))
+
+    assert result.success is False
+    assert any(
+        issue.details.get("pattern") == "embedded PE"
+        and issue.details.get("offset") == len(prefix) + len(invalid_pe_near_match) + len(separator)
+        for issue in result.issues
+    )
+
+
 def test_tensorrt_scanner_detects_embedded_elf_shared_object(tmp_path: Path) -> None:
     path = tmp_path / "embedded_elf.engine"
     prefix = b"tensorrt engine prefix\x00"


### PR DESCRIPTION
## Summary
- Add Keras ZIP coverage for the executable archive suffixes newly routed through the shared archive-member helper.
- Add TensorRT coverage to ensure embedded PE scanning continues past an invalid MZ decoy to a later valid PE header.

## Validation
- `UV_CACHE_DIR=/tmp/codex-uv-cache uv run --python python3.13 ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/codex-uv-cache uv run --python python3.13 ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/codex-uv-cache uv run --python python3.13 mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/codex-uv-cache uv run --python python3.13 pytest -n auto -m "not slow and not integration" --maxfail=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded ZIP archive test coverage to detect mixed-case executable-like members and to ensure near-match non-executable extensions remain clean.
  * Added coverage for detecting embedded PE headers inside TensorRT engine-like files even when preceded by invalid decoy data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->