### PR TITLE
test: fix Windows lazy-loading temp file lock

### DIFF
--- a/tests/test_lazy_loading_integration.py
+++ b/tests/test_lazy_loading_integration.py
@@ -63,22 +63,21 @@ class TestCoreIntegration:
             loaded_count = len(_registry._loaded_scanners)
             assert loaded_count <= 10  # Should be reasonable
 
-    def test_preferred_scanner_lazy_loading(self):
+    def test_preferred_scanner_lazy_loading(self, tmp_path: Path) -> None:
         """Test that preferred scanner detection uses lazy loading."""
         _registry._loaded_scanners.clear()
 
         # Create a pickle file (should prefer pickle scanner)
-        with tempfile.NamedTemporaryFile(suffix=".pkl") as f:
-            f.write(b"\x80\x02]q\x00.")  # Simple pickle data
-            f.flush()
+        file_path = tmp_path / "model.pkl"
+        file_path.write_bytes(b"\x80\x02]q\x00.")  # Simple pickle data
 
-            result = core.scan_file(f.name)
+        result = core.scan_file(str(file_path))
 
-            # Should use pickle scanner
-            assert result.scanner_name == "pickle"
+        # Should use pickle scanner
+        assert result.scanner_name == "pickle"
 
-            # Should have loaded pickle scanner
-            assert "pickle" in _registry._loaded_scanners
+        # Should have loaded pickle scanner
+        assert "pickle" in _registry._loaded_scanners
 
     def test_multiple_file_types_incremental_loading(self):
         """Test that scanning multiple file types loads scanners incrementally."""


### PR DESCRIPTION
## Summary

- Fix the Windows-only lazy-loading integration test failure by writing the pickle fixture through `tmp_path` instead of scanning an open `NamedTemporaryFile`.
- Add the required type annotation to the touched pytest method.

## Root Cause

The nightly Windows Python 3.11 job failed in `tests/test_lazy_loading_integration.py::TestCoreIntegration::test_preferred_scanner_lazy_loading` because Windows prevents reopening a `NamedTemporaryFile` while the original handle is still open. `core.scan_file()` reopens the path during format detection, which raised `PermissionError`.

## Validation

- `uv run pytest tests/test_lazy_loading_integration.py::TestCoreIntegration::test_preferred_scanner_lazy_loading -q`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run pytest -n auto -m "not slow and not integration" --maxfail=1`

Nightly failure inspected: https://github.com/promptfoo/modelaudit/actions/runs/24274807876

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored integration test to use more deterministic file handling, improving test reliability and reducing code complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->