### PR TITLE
docs: disable telemetry during agent validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ uv sync --extra all-ci
 uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
 uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
 uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
-uv run pytest -n auto -m "not slow and not integration" --maxfail=1
+PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1
 ```
 
 ## Standard Workflow
@@ -74,7 +74,7 @@ gh pr create --title "feat: descriptive title" --body "Brief description"
 uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/          # Lint (no errors)
 uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/ # Format (no changes)
 uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/                # Types (no errors)
-uv run pytest -n auto -m "not slow and not integration" --maxfail=1
+PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1
 ```
 
 | Issue               | Fix                                                                                                                             |
@@ -111,6 +111,7 @@ uv run pytest -n auto -m "not slow and not integration" --maxfail=1
 - Keep fixtures deterministic and self-contained under `tmp_path`; never rely on host paths or global temp filenames.
 - If a new regression test must run on reduced CI lanes, add the file to `allowed_test_files` in `tests/conftest.py`.
 - Match local validation to the CI lane that will exercise the change when possible; if optional dependencies or Python-version gates prevent that, call it out explicitly in the PR.
+- Disable telemetry for local validation unless the task explicitly tests telemetry behavior: prefix pytest runs with `PROMPTFOO_DISABLE_TELEMETRY=1` (or `NO_ANALYTICS=1`). Do not request approval to contact `a.promptfoo.app` for normal unit, scanner, or integration-excluded test runs; telemetry tests must mock the transport or make network intent explicit before running.
 - For file routing, prefiltering, or archive-triage changes, add at least one malicious positive regression and one benign near-match negative regression.
 - Reuse shared fixture helpers for container formats. For PyTorch ZIP tests, prefer
   `tests.helpers.create_mock_pytorch_zip`; if you hand-roll a ZIP-backed `.pt`/`.pkl`,


### PR DESCRIPTION
## Summary

- Update `AGENTS.md` so local pytest validation disables telemetry by default with `PROMPTFOO_DISABLE_TELEMETRY=1`.
- Clarify that agents should not request approval to contact `a.promptfoo.app` during normal unit, scanner, or integration-excluded test runs.
- Keep explicit telemetry behavior tests available, but require them to mock transport or state network intent before running.

## Rationale

Normal validation should be hermetic and should not need outbound analytics egress. This avoids approval guardrail blocks and prevents accidental telemetry from local agent test runs.

## Validation

- `git diff --check`

Docs-only change; no runtime tests run.