### PR TITLE
test: align inconclusive cache rerun expectations

### DIFF
--- a/tests/scanners/test_gguf_scanner.py
+++ b/tests/scanners/test_gguf_scanner.py
@@ -4,8 +4,6 @@ import struct
 from pathlib import Path
 from typing import Any
 
-import pytest
-
 from modelaudit.cache import get_cache_manager, reset_cache_manager
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, IssueSeverity
@@ -119,10 +117,9 @@ def _assert_inconclusive_exit2(aggregate: Any, reason: str) -> None:
     assert not any(issue.severity == IssueSeverity.CRITICAL for issue in aggregate.issues)
 
 
-def _assert_cached_rerun_preserves_inconclusive_exit2(
+def _assert_uncached_rerun_preserves_inconclusive_exit2(
     path: Path,
     cache_dir: Path,
-    monkeypatch: pytest.MonkeyPatch,
     reason: str,
 ) -> None:
     reset_cache_manager()
@@ -133,11 +130,6 @@ def _assert_cached_rerun_preserves_inconclusive_exit2(
             cache_dir=str(cache_dir),
             min_cache_file_size=0,
         )
-
-        def fail_if_rescanned(self: GgufScanner, scan_path: str) -> Any:
-            raise AssertionError(f"cached rerun unexpectedly rescanned {scan_path}")
-
-        monkeypatch.setattr(GgufScanner, "scan", fail_if_rescanned)
         second = scan_model_directory_or_file(
             str(path),
             cache_enabled=True,
@@ -147,7 +139,7 @@ def _assert_cached_rerun_preserves_inconclusive_exit2(
 
         _assert_inconclusive_exit2(first, reason)
         _assert_inconclusive_exit2(second, reason)
-        assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] > 0
+        assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
     finally:
         reset_cache_manager()
 
@@ -305,9 +297,8 @@ def test_gguf_truncated_metadata_returns_exit2(tmp_path: Path) -> None:
     assert not any(issue.severity == IssueSeverity.CRITICAL for issue in aggregate.issues)
 
 
-def test_gguf_truncated_metadata_cached_rerun_preserves_exit2(
+def test_gguf_truncated_metadata_uncached_rerun_preserves_exit2(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     path = tmp_path / "truncated_metadata.gguf"
     with path.open("wb") as f:
@@ -316,10 +307,9 @@ def test_gguf_truncated_metadata_cached_rerun_preserves_exit2(
         f.write(struct.pack("<Q", 0))
         f.write(struct.pack("<Q", 5))
 
-    _assert_cached_rerun_preserves_inconclusive_exit2(
+    _assert_uncached_rerun_preserves_inconclusive_exit2(
         path,
         tmp_path / "cache",
-        monkeypatch,
         "gguf_parse_incomplete",
     )
 
@@ -339,17 +329,15 @@ def test_gguf_unknown_tensor_type_is_inconclusive(tmp_path: Path) -> None:
     assert determine_exit_code(aggregate) == 2
 
 
-def test_gguf_unknown_tensor_type_cached_rerun_preserves_exit2(
+def test_gguf_unknown_tensor_type_uncached_rerun_preserves_exit2(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     path = tmp_path / "unknown_tensor_type.gguf"
     _write_gguf_with_tensor_type(path, tensor_type=999)
 
-    _assert_cached_rerun_preserves_inconclusive_exit2(
+    _assert_uncached_rerun_preserves_inconclusive_exit2(
         path,
         tmp_path / "cache",
-        monkeypatch,
         "gguf_structure_validation_failed",
     )
 

--- a/tests/scanners/test_tflite_scanner.py
+++ b/tests/scanners/test_tflite_scanner.py
@@ -154,7 +154,7 @@ def test_tflite_invalid_magic_returns_inconclusive_exit2(tmp_path: Path) -> None
     _assert_tflite_inconclusive_exit2(aggregate, "tflite_magic_validation_failed")
 
 
-def test_tflite_invalid_magic_cached_rerun_preserves_exit2(tmp_path: Path) -> None:
+def test_tflite_invalid_magic_uncached_rerun_preserves_exit2(tmp_path: Path) -> None:
     path = tmp_path / "model.tflite"
     path.write_bytes(b"invalid tflite data")
     cache_dir = tmp_path / "cache"
@@ -169,18 +169,17 @@ def test_tflite_invalid_magic_cached_rerun_preserves_exit2(tmp_path: Path) -> No
                 cache_dir=str(cache_dir),
                 min_cache_file_size=0,
             )
-            with patch.object(TFLiteScanner, "scan", side_effect=AssertionError("cached rerun rescanned TFLite")):
-                second = core.scan_model_directory_or_file(
-                    str(path),
-                    recursive=False,
-                    cache_enabled=True,
-                    cache_dir=str(cache_dir),
-                    min_cache_file_size=0,
-                )
+            second = core.scan_model_directory_or_file(
+                str(path),
+                recursive=False,
+                cache_enabled=True,
+                cache_dir=str(cache_dir),
+                min_cache_file_size=0,
+            )
 
         _assert_tflite_inconclusive_exit2(first, "tflite_magic_validation_failed")
         _assert_tflite_inconclusive_exit2(second, "tflite_magic_validation_failed")
-        assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] > 0
+        assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
     finally:
         reset_cache_manager()
 


### PR DESCRIPTION
## Summary
- update GGUF and TFLite inconclusive rerun tests to match the current cache policy
- assert incomplete scan outcomes are rescanned and not persisted in cache

## Validation
- env UV_CACHE_DIR=/tmp/codex-uv-cache uv run --python python3.11 --extra all-ci pytest tests/scanners/test_gguf_scanner.py tests/scanners/test_tflite_scanner.py -q
- env UV_CACHE_DIR=/tmp/codex-uv-cache uv run --python python3.11 ruff check tests/scanners/test_gguf_scanner.py tests/scanners/test_tflite_scanner.py