### PR TITLE
fix: align SARIF scan metadata with CLI results

### DIFF
--- a/modelaudit/integrations/sarif_formatter.py
+++ b/modelaudit/integrations/sarif_formatter.py
@@ -11,6 +11,7 @@ from typing import Any
 from urllib.parse import quote
 
 from modelaudit import __version__
+from modelaudit.core_results import determine_exit_code
 from modelaudit.models import ModelAuditResultModel
 from modelaudit.scanner_results import IssueSeverity
 
@@ -53,12 +54,14 @@ def _create_run(
 
     # Create rules from unique issue types
     rules = _create_rules(issues)
+    rule_indices = {rule["id"]: idx for idx, rule in enumerate(rules)}
 
     # Create results from issues
-    results = _create_results(issues)
+    results = _create_results(issues, rule_indices)
 
     # Create artifacts from scanned files
     artifacts = _create_artifacts(audit_result)
+    exit_code = determine_exit_code(audit_result)
 
     run = {
         "tool": {
@@ -77,12 +80,12 @@ def _create_run(
         },
         "invocations": [
             {
-                "executionSuccessful": audit_result.success,
+                "executionSuccessful": exit_code != 2,
                 "commandLine": f"modelaudit {' '.join(scan_paths)}",
                 "arguments": scan_paths,
                 "workingDirectory": {"uri": Path.cwd().as_uri()},
-                "exitCode": 0 if not audit_result.issues else 1,
-                "exitCodeDescription": "No issues found" if not audit_result.issues else "Security issues detected",
+                "exitCode": exit_code,
+                "exitCodeDescription": _exit_code_description(exit_code),
                 "exitSignalName": None,
                 "exitSignalNumber": None,
                 "processStartFailureMessage": None,
@@ -125,6 +128,15 @@ def _create_run(
     return run
 
 
+def _exit_code_description(exit_code: int) -> str:
+    """Return a user-facing description for ModelAudit CLI exit semantics."""
+    if exit_code == 0:
+        return "No security issues found"
+    if exit_code == 1:
+        return "Security issues detected"
+    return "Errors occurred during scanning"
+
+
 def _create_rules(issues: list) -> list[dict[str, Any]]:
     """Create SARIF rules from unique issue types."""
     rules = []
@@ -137,7 +149,7 @@ def _create_rules(issues: list) -> list[dict[str, Any]]:
         if rule_id not in seen_rules:
             seen_rules.add(rule_id)
 
-            rule = {
+            rule: dict[str, Any] = {
                 "id": rule_id,
                 "name": _get_rule_name(issue),
                 "shortDescription": {"text": _get_rule_short_description(issue)},
@@ -154,6 +166,10 @@ def _create_rules(issues: list) -> list[dict[str, Any]]:
                 },
             }
 
+            rule_code = _get_issue_rule_code(issue)
+            if rule_code:
+                rule["properties"]["rule_code"] = rule_code
+
             # Add help information if available
             if hasattr(issue, "why") and issue.why:
                 rule["help"] = {"text": issue.why, "markdown": issue.why}
@@ -163,14 +179,17 @@ def _create_rules(issues: list) -> list[dict[str, Any]]:
     return rules
 
 
-def _create_results(issues: list) -> list[dict[str, Any]]:
+def _create_results(issues: list, rule_indices: dict[str, int] | None = None) -> list[dict[str, Any]]:
     """Create SARIF results from issues."""
     results = []
+    if rule_indices is None:
+        rule_indices = {rule["id"]: idx for idx, rule in enumerate(_create_rules(issues))}
 
-    for idx, issue in enumerate(issues):
+    for issue in issues:
+        rule_id = _get_rule_id(issue)
         result = {
-            "ruleId": _get_rule_id(issue),
-            "ruleIndex": idx,
+            "ruleId": rule_id,
+            "ruleIndex": rule_indices[rule_id],
             "level": _severity_to_sarif_level(issue.severity),
             "message": {"text": issue.message},
             "locations": [],
@@ -206,8 +225,14 @@ def _create_results(issues: list) -> list[dict[str, Any]]:
         result["partialFingerprints"]["primaryLocationLineHash"] = fingerprint  # type: ignore[index]
 
         # Add properties with additional details
-        if issue.details:
-            result["properties"] = issue.details
+        properties = dict(issue.details or {})
+        rule_code = _get_issue_rule_code(issue)
+        if rule_code:
+            properties.setdefault("rule_code", rule_code)
+        if hasattr(issue, "type") and issue.type:
+            properties.setdefault("issue_type", issue.type)
+        if properties:
+            result["properties"] = properties
 
         # Add fix suggestions if available
         if hasattr(issue, "recommendation") and issue.recommendation:
@@ -255,6 +280,10 @@ def _create_artifacts(audit_result: ModelAuditResultModel) -> list[dict[str, Any
 
 def _get_rule_id(issue: Any) -> str:
     """Generate a rule ID from an issue."""
+    rule_code = _get_issue_rule_code(issue)
+    if rule_code:
+        return rule_code
+
     if hasattr(issue, "type") and issue.type:
         return f"MA{str(issue.type).replace(' ', '-').upper()}"
 
@@ -263,6 +292,14 @@ def _get_rule_id(issue: Any) -> str:
     # Remove special characters
     base = "".join(c if c.isalnum() or c == "-" else "" for c in base)
     return f"MA-{base}"
+
+
+def _get_issue_rule_code(issue: Any) -> str | None:
+    """Return the stable ModelAudit rule code for an issue when available."""
+    rule_code = getattr(issue, "rule_code", None)
+    if isinstance(rule_code, str) and rule_code:
+        return rule_code
+    return None
 
 
 def _get_rule_name(issue: Any) -> str:

--- a/modelaudit/integrations/sarif_formatter.py
+++ b/modelaudit/integrations/sarif_formatter.py
@@ -236,6 +236,8 @@ def _create_results(issues: list, rule_indices: dict[str, int] | None = None) ->
 
         # Add properties with additional details
         properties = dict(issue.details or {})
+        properties.pop("rule_code", None)
+        properties.pop("issue_type", None)
         rule_code = _get_issue_rule_code(issue)
         if rule_code:
             properties["rule_code"] = rule_code

--- a/modelaudit/integrations/sarif_formatter.py
+++ b/modelaudit/integrations/sarif_formatter.py
@@ -11,7 +11,11 @@ from typing import Any
 from urllib.parse import quote
 
 from modelaudit import __version__
-from modelaudit.core_results import determine_exit_code
+from modelaudit.core_results import (
+    determine_exit_code,
+    results_have_inconclusive_outcome,
+    results_have_operational_error,
+)
 from modelaudit.models import ModelAuditResultModel
 from modelaudit.scanner_results import IssueSeverity
 
@@ -85,7 +89,7 @@ def _create_run(
                 "arguments": scan_paths,
                 "workingDirectory": {"uri": Path.cwd().as_uri()},
                 "exitCode": exit_code,
-                "exitCodeDescription": _exit_code_description(exit_code),
+                "exitCodeDescription": _exit_code_description(audit_result, exit_code),
                 "exitSignalName": None,
                 "exitSignalNumber": None,
                 "processStartFailureMessage": None,
@@ -128,12 +132,18 @@ def _create_run(
     return run
 
 
-def _exit_code_description(exit_code: int) -> str:
+def _exit_code_description(audit_result: ModelAuditResultModel, exit_code: int) -> str:
     """Return a user-facing description for ModelAudit CLI exit semantics."""
     if exit_code == 0:
         return "No security issues found"
     if exit_code == 1:
         return "Security issues detected"
+    if results_have_operational_error(audit_result):
+        return "Errors occurred during scanning"
+    if results_have_inconclusive_outcome(audit_result):
+        return "Scan outcome was inconclusive"
+    if audit_result.files_scanned == 0:
+        return "No files were scanned"
     return "Errors occurred during scanning"
 
 
@@ -228,9 +238,9 @@ def _create_results(issues: list, rule_indices: dict[str, int] | None = None) ->
         properties = dict(issue.details or {})
         rule_code = _get_issue_rule_code(issue)
         if rule_code:
-            properties.setdefault("rule_code", rule_code)
+            properties["rule_code"] = rule_code
         if hasattr(issue, "type") and issue.type:
-            properties.setdefault("issue_type", issue.type)
+            properties["issue_type"] = issue.type
         if properties:
             result["properties"] = properties
 

--- a/tests/integrations/test_sarif_formatter.py
+++ b/tests/integrations/test_sarif_formatter.py
@@ -222,6 +222,22 @@ class TestCreateResults:
         assert region["startLine"] == 42
         assert region["startColumn"] == 10
 
+    def test_result_properties_prefer_issue_identity_fields(self) -> None:
+        """Canonical issue identity fields should override stale details."""
+        issue = Issue(
+            message="Test",
+            severity=IssueSeverity.WARNING,
+            details={"rule_code": "STALE", "issue_type": "stale"},
+            timestamp=time.time(),
+            type="pickle_check",
+            rule_code="S201",
+        )
+
+        results = _create_results([issue])
+
+        assert results[0]["properties"]["rule_code"] == "S201"
+        assert results[0]["properties"]["issue_type"] == "pickle_check"
+
     def test_result_fingerprints(self):
         """Test result has fingerprints for deduplication."""
         issue = Issue(

--- a/tests/integrations/test_sarif_formatter.py
+++ b/tests/integrations/test_sarif_formatter.py
@@ -238,6 +238,21 @@ class TestCreateResults:
         assert results[0]["properties"]["rule_code"] == "S201"
         assert results[0]["properties"]["issue_type"] == "pickle_check"
 
+    def test_result_properties_strip_legacy_identity_details(self) -> None:
+        """Legacy identity details should not imply canonical SARIF rule codes."""
+        issue = Issue(
+            message="Test",
+            severity=IssueSeverity.WARNING,
+            details={"rule_code": "S201", "issue_type": "pickle_check", "context": "kept"},
+            timestamp=time.time(),
+        )
+
+        results = _create_results([issue])
+
+        assert "rule_code" not in results[0]["properties"]
+        assert "issue_type" not in results[0]["properties"]
+        assert results[0]["properties"]["context"] == "kept"
+
     def test_result_fingerprints(self):
         """Test result has fingerprints for deduplication."""
         issue = Issue(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -256,6 +256,62 @@ def test_scan_json_subprocess_mixed_directory_keeps_stdout_parseable(tmp_path: P
     assert any(asset.get("path") == str(model_file) for asset in output_payload.get("assets", []))
 
 
+def test_scan_sarif_subprocess_single_skipped_file_reports_cli_exit_code(tmp_path: Path) -> None:
+    """SARIF invocation metadata should reflect the CLI exit code for skipped scans."""
+    skipped_file = tmp_path / "skip.py"
+    skipped_file.write_text("print('hello')\n")
+
+    completed = subprocess.run(
+        [sys.executable, "-m", "modelaudit", "scan", str(skipped_file), "--format", "sarif", "--no-cache"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 2
+    sarif_payload = json.loads(completed.stdout)
+    invocation = sarif_payload["runs"][0]["invocations"][0]
+    assert invocation["exitCode"] == 2
+    assert invocation["executionSuccessful"] is False
+    assert invocation["exitCodeDescription"] == "Errors occurred during scanning"
+    assert invocation["properties"]["filesScanned"] == 0
+
+
+def test_scan_sarif_subprocess_preserves_modelaudit_rule_codes() -> None:
+    """SARIF rule identifiers should match ModelAudit rule codes from JSON output."""
+    model_file = Path("tests/assets/samples/pickles/malicious_system_call.pkl").resolve()
+
+    json_completed = subprocess.run(
+        [sys.executable, "-m", "modelaudit", "scan", str(model_file), "--format", "json", "--no-cache"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    sarif_completed = subprocess.run(
+        [sys.executable, "-m", "modelaudit", "scan", str(model_file), "--format", "sarif", "--no-cache"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json_completed.returncode == 1
+    assert sarif_completed.returncode == 1
+
+    json_payload = json.loads(json_completed.stdout)
+    expected_rule_codes = {issue["rule_code"] for issue in json_payload["issues"] if issue.get("rule_code")}
+    assert "S201" in expected_rule_codes
+
+    sarif_payload = json.loads(sarif_completed.stdout)
+    run = sarif_payload["runs"][0]
+    result_rule_ids = {result["ruleId"] for result in run["results"]}
+    driver_rule_ids = {rule["id"] for rule in run["tool"]["driver"]["rules"]}
+
+    assert expected_rule_codes <= result_rule_ids
+    assert expected_rule_codes <= driver_rule_ids
+    assert run["invocations"][0]["exitCode"] == 1
+    assert run["invocations"][0]["executionSuccessful"] is True
+
+
 def test_scan_can_apply_local_config_once_when_confirmed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Interactive scans can apply a local config for the current run only."""
     import tarfile

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -273,7 +273,7 @@ def test_scan_sarif_subprocess_single_skipped_file_reports_cli_exit_code(tmp_pat
     invocation = sarif_payload["runs"][0]["invocations"][0]
     assert invocation["exitCode"] == 2
     assert invocation["executionSuccessful"] is False
-    assert invocation["exitCodeDescription"] == "Errors occurred during scanning"
+    assert invocation["exitCodeDescription"] == "No files were scanned"
     assert invocation["properties"]["filesScanned"] == 0
 
 
@@ -304,10 +304,18 @@ def test_scan_sarif_subprocess_preserves_modelaudit_rule_codes() -> None:
     sarif_payload = json.loads(sarif_completed.stdout)
     run = sarif_payload["runs"][0]
     result_rule_ids = {result["ruleId"] for result in run["results"]}
+    result_property_rule_codes = {
+        result["properties"]["rule_code"] for result in run["results"] if result.get("properties")
+    }
     driver_rule_ids = {rule["id"] for rule in run["tool"]["driver"]["rules"]}
+    driver_property_rule_codes = {
+        rule["properties"]["rule_code"] for rule in run["tool"]["driver"]["rules"] if rule.get("properties")
+    }
 
     assert expected_rule_codes <= result_rule_ids
+    assert expected_rule_codes <= result_property_rule_codes
     assert expected_rule_codes <= driver_rule_ids
+    assert expected_rule_codes <= driver_property_rule_codes
     assert run["invocations"][0]["exitCode"] == 1
     assert run["invocations"][0]["executionSuccessful"] is True
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -260,12 +260,14 @@ def test_scan_sarif_subprocess_single_skipped_file_reports_cli_exit_code(tmp_pat
     """SARIF invocation metadata should reflect the CLI exit code for skipped scans."""
     skipped_file = tmp_path / "skip.py"
     skipped_file.write_text("print('hello')\n")
+    env = {**os.environ, "PROMPTFOO_DISABLE_TELEMETRY": "1"}
 
     completed = subprocess.run(
         [sys.executable, "-m", "modelaudit", "scan", str(skipped_file), "--format", "sarif", "--no-cache"],
         check=False,
         capture_output=True,
         text=True,
+        env=env,
     )
 
     assert completed.returncode == 2
@@ -280,18 +282,21 @@ def test_scan_sarif_subprocess_single_skipped_file_reports_cli_exit_code(tmp_pat
 def test_scan_sarif_subprocess_preserves_modelaudit_rule_codes() -> None:
     """SARIF rule identifiers should match ModelAudit rule codes from JSON output."""
     model_file = Path("tests/assets/samples/pickles/malicious_system_call.pkl").resolve()
+    env = {**os.environ, "PROMPTFOO_DISABLE_TELEMETRY": "1"}
 
     json_completed = subprocess.run(
         [sys.executable, "-m", "modelaudit", "scan", str(model_file), "--format", "json", "--no-cache"],
         check=False,
         capture_output=True,
         text=True,
+        env=env,
     )
     sarif_completed = subprocess.run(
         [sys.executable, "-m", "modelaudit", "scan", str(model_file), "--format", "sarif", "--no-cache"],
         check=False,
         capture_output=True,
         text=True,
+        env=env,
     )
 
     assert json_completed.returncode == 1


### PR DESCRIPTION
## Summary
- align SARIF invocation exitCode/executionSuccessful metadata with the CLI exit-code aggregator
- preserve stable ModelAudit rule codes such as S201 in SARIF rule/result IDs and properties
- add subprocess CLI regressions for skipped scans and real malicious pickle findings

## Validation
- .venv/bin/ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- .venv/bin/ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- .venv/bin/ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- .venv/bin/ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- .venv/bin/mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- .venv/bin/pytest tests/test_cli.py tests/integrations/test_sarif_formatter.py -q
- .venv/bin/pytest -n auto -m "not slow and not integration" --maxfail=1
- smoke scanned safe, malicious, and skipped sample inputs in SARIF mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved SARIF output: more accurate exit codes and execution status, stable rule identifiers, and richer result properties (rule codes and issue types preserved where available).

* **Tests**
  * Added CLI and integration tests validating SARIF exit semantics, files-scanned reporting, and correct rule-code propagation in SARIF output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->