### PR TITLE
fix: bound standalone pickle stream reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - mark incomplete ZIP, TAR, and 7z archive traversals as inconclusive in scan metadata
 - route helper-level ZIP-backed `.ckpt`/`.pkl` checkpoints through archive scanners
 - harden standalone pickle scanner dangerous global coverage, nested payload bounds, incomplete-scan reporting, and standalone-primary migration behavior
+- cap standalone pickle stream line reads when callers do not provide a stream size
 
 ## [0.2.31](https://github.com/promptfoo/modelaudit/compare/v0.2.30...v0.2.31) (2026-04-04)
 

--- a/modelaudit/scanners/picklescan_adapter.py
+++ b/modelaudit/scanners/picklescan_adapter.py
@@ -105,6 +105,14 @@ def scan_options_from_config(config: Mapping[str, Any]) -> ScanOptions:
             _DEFAULT_SCAN_OPTIONS.post_budget_scan_bytes,
             minimum=0,
         ),
+        max_unbounded_stream_read_bytes=_parse_min_int(
+            config.get(
+                "max_unbounded_stream_read_bytes",
+                _DEFAULT_SCAN_OPTIONS.max_unbounded_stream_read_bytes,
+            ),
+            _DEFAULT_SCAN_OPTIONS.max_unbounded_stream_read_bytes,
+            minimum=1,
+        ),
         max_string_literal_scan_chars=_parse_min_int(
             config.get(
                 "max_string_literal_scan_chars",

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/engine/scanner.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/engine/scanner.py
@@ -91,7 +91,11 @@ def scan_pickle_stream(
     started_at = time.monotonic()
     scan = _ScanState(
         source=source,
-        stream=_BoundedPickleStream(stream, bytes_total),
+        stream=_BoundedPickleStream(
+            stream,
+            bytes_total,
+            unbounded_read_limit=options.max_unbounded_stream_read_bytes,
+        ),
         options=options,
         bytes_total=bytes_total,
         position_offset=position_offset,

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/engine/stream.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/engine/stream.py
@@ -100,7 +100,7 @@ class _BoundedPickleStream:
         if self._byte_limit is None:
             if requested_size is None:
                 return self._unbounded_read_limit
-            return min(requested_size, self._unbounded_read_limit)
+            return requested_size
 
         remaining = max(self._byte_limit - self._position, 0)
         if requested_size is None:

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/engine/stream.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/engine/stream.py
@@ -16,9 +16,16 @@ class _StreamReadError(Exception):
 class _BoundedPickleStream:
     """Incrementally read pickle bytes while enforcing an optional byte limit."""
 
-    def __init__(self, stream: BinaryIO, byte_limit: int | None) -> None:
+    def __init__(
+        self,
+        stream: BinaryIO,
+        byte_limit: int | None,
+        *,
+        unbounded_read_limit: int,
+    ) -> None:
         self._stream = stream
         self._byte_limit = byte_limit
+        self._unbounded_read_limit = max(unbounded_read_limit, 1)
         self._prefetched = bytearray()
         self._position = 0
         self.short_read = False
@@ -91,7 +98,9 @@ class _BoundedPickleStream:
         if requested_size is not None and requested_size < 0:
             requested_size = None
         if self._byte_limit is None:
-            return requested_size
+            if requested_size is None:
+                return self._unbounded_read_limit
+            return min(requested_size, self._unbounded_read_limit)
 
         remaining = max(self._byte_limit - self._position, 0)
         if requested_size is None:

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/options.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/options.py
@@ -9,6 +9,7 @@ from numbers import Real
 DEFAULT_TIMEOUT_S = 3600.0
 DEFAULT_MAX_OPCODES = 1_000_000
 DEFAULT_POST_BUDGET_SCAN_BYTES = 100 * 1024 * 1024
+DEFAULT_MAX_UNBOUNDED_STREAM_READ_BYTES = 8 * 1024 * 1024
 DEFAULT_MAX_STRING_LITERAL_SCAN_CHARS = 8 * 1024 * 1024
 DEFAULT_MAX_NESTED_PICKLE_BYTES = 2 * 1024 * 1024
 DEFAULT_MAX_NESTED_DEPTH = 1
@@ -21,6 +22,7 @@ class ScanOptions:
     timeout_s: float = DEFAULT_TIMEOUT_S
     max_opcodes: int = DEFAULT_MAX_OPCODES
     post_budget_scan_bytes: int = DEFAULT_POST_BUDGET_SCAN_BYTES
+    max_unbounded_stream_read_bytes: int = DEFAULT_MAX_UNBOUNDED_STREAM_READ_BYTES
     max_string_literal_scan_chars: int = DEFAULT_MAX_STRING_LITERAL_SCAN_CHARS
     max_nested_pickle_bytes: int = DEFAULT_MAX_NESTED_PICKLE_BYTES
     max_nested_depth: int = DEFAULT_MAX_NESTED_DEPTH
@@ -43,6 +45,17 @@ class ScanOptions:
             raise ValueError(
                 "post_budget_scan_bytes must be greater than or equal to 0 and an integer, "
                 f"got {post_budget_scan_bytes!r}",
+            )
+
+        max_unbounded_stream_read_bytes: object = self.max_unbounded_stream_read_bytes
+        if (
+            isinstance(max_unbounded_stream_read_bytes, bool)
+            or not isinstance(max_unbounded_stream_read_bytes, int)
+            or max_unbounded_stream_read_bytes <= 0
+        ):
+            raise ValueError(
+                "max_unbounded_stream_read_bytes must be greater than 0 and an integer, "
+                f"got {max_unbounded_stream_read_bytes!r}",
             )
 
         max_string_literal_scan_chars: object = self.max_string_literal_scan_chars

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -267,6 +267,20 @@ def test_scan_stream_incrementally_reads_bounded_streams_without_preloading_enti
     assert stream.max_seen_read_size <= 32
 
 
+def test_scan_stream_honors_explicit_reads_without_declared_size() -> None:
+    payload = pickle.dumps(b"a" * 64, protocol=4)
+
+    report = PickleScanner(ScanOptions(max_unbounded_stream_read_bytes=8)).scan_stream(
+        io.BytesIO(payload),
+        source="unknown-size-binbytes.pkl",
+    )
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert report.errors == ()
+    assert report.coverage.bytes_scanned == len(payload)
+
+
 def test_scan_stream_bounds_protocol_zero_readline_without_declared_size() -> None:
     stream = NoUnboundedReadlineStream(b"S'" + (b"a" * 64))
 
@@ -281,12 +295,12 @@ def test_scan_stream_bounds_protocol_zero_readline_without_declared_size() -> No
     assert stream.max_seen_readline_size <= 8
 
 
-def test_bounded_pickle_stream_caps_negative_reads_without_a_byte_limit() -> None:
+def test_bounded_pickle_stream_caps_unbounded_reads_without_a_byte_limit() -> None:
     stream = engine_scanner._BoundedPickleStream(io.BytesIO(b"abc"), None, unbounded_read_limit=16)
 
     assert stream._bounded_size(-1) == 16
     assert stream._bounded_size(None) == 16
-    assert stream._bounded_size(128) == 16
+    assert stream._bounded_size(128) == 128
     assert stream._bounded_size(8) == 8
 
 

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -55,6 +55,20 @@ class NoBulkReadStream(io.BytesIO):
         return super().read(size)
 
 
+class NoUnboundedReadlineStream(io.BytesIO):
+    def __init__(self, payload: bytes) -> None:
+        super().__init__(payload)
+        self.max_seen_readline_size = 0
+        self.unbounded_readline_attempted = False
+
+    def readline(self, size: int | None = -1) -> bytes:
+        if size is None or size < 0:
+            self.unbounded_readline_attempted = True
+            raise AssertionError("scan_stream() attempted an unbounded line read")
+        self.max_seen_readline_size = max(self.max_seen_readline_size, size)
+        return super().readline(size)
+
+
 def test_scan_bytes_returns_clean_report_for_safe_pickle() -> None:
     report = scan_bytes(pickle.dumps({"weights": [1, 2, 3]}), source="safe.pkl")
 
@@ -253,10 +267,32 @@ def test_scan_stream_incrementally_reads_bounded_streams_without_preloading_enti
     assert stream.max_seen_read_size <= 32
 
 
-def test_bounded_pickle_stream_normalizes_negative_reads_without_a_byte_limit() -> None:
-    stream = engine_scanner._BoundedPickleStream(io.BytesIO(b"abc"), None)
+def test_scan_stream_bounds_protocol_zero_readline_without_declared_size() -> None:
+    stream = NoUnboundedReadlineStream(b"S'" + (b"a" * 64))
 
-    assert stream._bounded_size(-1) is None
+    report = PickleScanner(ScanOptions(max_unbounded_stream_read_bytes=8)).scan_stream(
+        stream,
+        source="unterminated-protocol-zero.pkl",
+    )
+
+    assert report.status == ScanStatus.ERROR
+    assert report.errors[0].exception_type == "ValueError"
+    assert stream.unbounded_readline_attempted is False
+    assert stream.max_seen_readline_size <= 8
+
+
+def test_bounded_pickle_stream_caps_negative_reads_without_a_byte_limit() -> None:
+    stream = engine_scanner._BoundedPickleStream(io.BytesIO(b"abc"), None, unbounded_read_limit=16)
+
+    assert stream._bounded_size(-1) == 16
+    assert stream._bounded_size(None) == 16
+    assert stream._bounded_size(128) == 16
+    assert stream._bounded_size(8) == 8
+
+
+def test_scan_options_rejects_invalid_unbounded_stream_read_limit() -> None:
+    with pytest.raises(ValueError, match="max_unbounded_stream_read_bytes"):
+        ScanOptions(max_unbounded_stream_read_bytes=0)
 
 
 def test_scan_bytes_flags_malformed_stack_global_operands() -> None:


### PR DESCRIPTION
## Summary
- cap unbounded read/readline requests in the standalone pickle stream wrapper
- expose the cap through ScanOptions and ModelAudit config mapping
- add regression coverage for protocol-0 streams without declared size

## Validation
- env PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest packages/modelaudit-picklescan/tests/test_api.py
- uv run ruff format modelaudit/scanners/picklescan_adapter.py packages/modelaudit-picklescan/src/modelaudit_picklescan/options.py packages/modelaudit-picklescan/src/modelaudit_picklescan/engine/scanner.py packages/modelaudit-picklescan/src/modelaudit_picklescan/engine/stream.py packages/modelaudit-picklescan/tests/test_api.py
- uv run ruff check modelaudit/scanners/picklescan_adapter.py packages/modelaudit-picklescan/src/modelaudit_picklescan/options.py packages/modelaudit-picklescan/src/modelaudit_picklescan/engine/scanner.py packages/modelaudit-picklescan/src/modelaudit_picklescan/engine/stream.py packages/modelaudit-picklescan/tests/test_api.py
- uv run mypy modelaudit/scanners/picklescan_adapter.py packages/modelaudit-picklescan/src/modelaudit_picklescan/options.py packages/modelaudit-picklescan/src/modelaudit_picklescan/engine/scanner.py packages/modelaudit-picklescan/src/modelaudit_picklescan/engine/stream.py packages/modelaudit-picklescan/tests/test_api.py