### PR TITLE
fix: preserve informational network findings

### DIFF
--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -220,6 +220,15 @@ class NetworkCommDetector:
     # via config parameter if they have specific domains to block
     BLACKLISTED_DOMAINS: ClassVar[list[bytes]] = []
 
+    INFORMATIONAL_DOMAIN_SUFFIXES: ClassVar[tuple[str, ...]] = (
+        "huggingface.co",
+        "amazonaws.com",
+        "storage.googleapis.com",
+        "storage.cloud.google.com",
+        "blob.core.windows.net",
+        "dfs.core.windows.net",
+    )
+
     def __init__(self, config: dict[str, Any] | None = None):
         """Initialize the detector with optional configuration."""
         self.config = config or {}
@@ -286,17 +295,22 @@ class NetworkCommDetector:
 
             # Calculate confidence based on URL characteristics
             confidence = 0.5
+            severity = "MEDIUM"
             if any(pattern in url.lower() for pattern in ["eval", "exec", "cmd", "shell"]):
                 confidence = 0.9
+                severity = "HIGH"
             elif any(port in url for port in [":1337", ":4444", ":31337"]):
                 confidence = 0.8
+                severity = "HIGH"
             elif "://" in url and not url.startswith(("http://", "https://")):
                 confidence = 0.7
+            elif self._is_cloud_storage_url(url):
+                severity = "INFO"
 
             self.findings.append(
                 {
                     "type": "url_detected",
-                    "severity": "HIGH" if confidence > 0.7 else "MEDIUM",
+                    "severity": severity,
                     "confidence": confidence,
                     "message": f"URL detected in model: {url[:100]}",
                     "url": url,
@@ -457,11 +471,13 @@ class NetworkCommDetector:
 
                     if domain not in seen_domains:
                         seen_domains.add(domain)
+                        severity = "INFO" if self._is_informational_domain(domain) else "MEDIUM"
+                        confidence = 0.3 if severity == "INFO" else 0.8
                         self.findings.append(
                             {
                                 "type": "domain",
-                                "severity": "MEDIUM",
-                                "confidence": 0.8,
+                                "severity": severity,
+                                "confidence": confidence,
                                 "message": f"Domain name detected: {domain}",
                                 "domain": domain,
                                 "position": match.start(),
@@ -548,10 +564,13 @@ class NetworkCommDetector:
                 confidence = 0.9
 
             if confidence > 0.2:  # Only report domains with reasonable confidence
+                severity = "INFO" if self._is_informational_domain(domain) else "MEDIUM"
+                if confidence >= 0.7:
+                    severity = "HIGH"
                 self.findings.append(
                     {
                         "type": "domain_name",
-                        "severity": "MEDIUM" if confidence < 0.7 else "HIGH",
+                        "severity": severity,
                         "confidence": confidence,
                         "message": f"Domain name detected: {domain}",
                         "domain": domain,
@@ -560,6 +579,17 @@ class NetworkCommDetector:
                         "context": context,
                     }
                 )
+
+    @classmethod
+    def _is_cloud_storage_url(cls, url: str) -> bool:
+        """Return whether a URL is already covered by specific informational cloud URL detection."""
+        url_bytes = url.encode()
+        return any(pattern.fullmatch(url_bytes) for pattern, _, _ in cls.CLOUD_STORAGE_PATTERNS)
+
+    @classmethod
+    def _is_informational_domain(cls, domain: str) -> bool:
+        """Return whether a generic domain hit is covered by informational model/cloud URL handling."""
+        return any(domain == suffix or domain.endswith(f".{suffix}") for suffix in cls.INFORMATIONAL_DOMAIN_SUFFIXES)
 
     def _scan_network_libraries(self, data: bytes, context: str) -> None:
         """Scan for network library imports."""

--- a/modelaudit/scanners/base.py
+++ b/modelaudit/scanners/base.py
@@ -860,10 +860,14 @@ class BaseScanner(ABC):
             severity_map = {
                 "CRITICAL": IssueSeverity.CRITICAL,
                 "HIGH": IssueSeverity.CRITICAL,
+                "WARNING": IssueSeverity.WARNING,
                 "MEDIUM": IssueSeverity.WARNING,
                 "LOW": IssueSeverity.INFO,
+                "INFO": IssueSeverity.INFO,
+                "DEBUG": IssueSeverity.DEBUG,
             }
-            severity = severity_map.get(finding.get("severity", "WARNING"), IssueSeverity.WARNING)
+            finding_severity = str(finding.get("severity", "WARNING")).upper()
+            severity = severity_map.get(finding_severity, IssueSeverity.WARNING)
             network_indicator = " ".join(
                 str(part)
                 for part in [

--- a/tests/test_network_comm_integration.py
+++ b/tests/test_network_comm_integration.py
@@ -2,8 +2,9 @@
 
 import pickle
 import zipfile
+from pathlib import Path
 
-from modelaudit.scanners.base import CheckStatus
+from modelaudit.scanners.base import CheckStatus, IssueSeverity
 from modelaudit.scanners.pickle_scanner import PickleScanner
 from modelaudit.scanners.pytorch_zip_scanner import PyTorchZipScanner
 
@@ -240,3 +241,25 @@ class NetworkExfiltrator:
 
         assert len(network_pass) == 1
         assert "No network communication patterns detected" in network_pass[0].message
+
+    def test_huggingface_homepage_url_stays_informational(self, tmp_path: Path) -> None:
+        """Benign Hugging Face metadata URLs should not become security warnings."""
+        test_file = tmp_path / "model_metadata.pkl"
+        data = {"homepage": "https://huggingface.co/meta-llama/Llama-2-7b"}
+
+        with test_file.open("wb") as f:
+            pickle.dump(data, f)
+
+        scanner = PickleScanner()
+        result = scanner.scan(str(test_file))
+
+        network_checks = [
+            c for c in result.checks if "Network Communication" in c.name and c.status == CheckStatus.FAILED
+        ]
+        assert network_checks
+        assert all(c.severity == IssueSeverity.INFO for c in network_checks)
+
+        warning_or_critical_issues = [
+            issue for issue in result.issues if issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL}
+        ]
+        assert warning_or_critical_issues == []


### PR DESCRIPTION
## Summary
- preserve INFO and DEBUG detector severities in BaseScanner network finding mapping
- keep benign cloud/model-hosting URL and domain echoes informational unless suspicious indicators are present
- add a regression for a Hugging Face homepage URL stored in pickle metadata

## Validation
- uv run pytest tests/test_network_comm_integration.py -q
- uv run ruff format modelaudit/scanners/base.py modelaudit/detectors/network_comm.py tests/test_network_comm_integration.py
- uv run ruff check --fix modelaudit/scanners/base.py modelaudit/detectors/network_comm.py tests/test_network_comm_integration.py
- uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m 'not slow and not integration' --maxfail=1