### PR TITLE
fix: honor header-routed scanners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+
+- honor trusted header/content routing for misnamed ONNX, GGUF, and NumPy artifacts.
+
 ## [0.2.36](https://github.com/promptfoo/modelaudit/compare/v0.2.35...v0.2.36) (2026-04-11)
 
 ### Documentation

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -108,6 +108,33 @@ def _select_preferred_scanner_id(path: str, header_format: str, ext: str) -> str
     return _registry.get_scanner_id_for_header_format(header_format)
 
 
+def _is_direct_header_route(scanner_id: str, header_format: str) -> bool:
+    """Return whether the detected header directly maps to this scanner."""
+    return header_format != "unknown" and HEADER_FORMAT_TO_SCANNER_ID.get(header_format) == scanner_id
+
+
+def _preferred_scanner_can_handle(
+    scanner_class: type[BaseScanner],
+    scanner_id: str,
+    header_format: str,
+    path: str,
+) -> bool:
+    """Honor trusted header routing even when scanner can_handle is suffix-gated."""
+    if scanner_class.can_handle(path):
+        return True
+
+    if os.path.exists(path) and _is_direct_header_route(scanner_id, header_format):
+        logger.debug(
+            "Using %s scanner for %s based on detected %s header despite can_handle rejection",
+            scanner_class.name,
+            path,
+            header_format,
+        )
+        return True
+
+    return False
+
+
 def _calculate_file_hash(file_path: str) -> str:
     """Calculate SHA256 hash of a file for deduplication purposes.
 
@@ -935,7 +962,11 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
     progress_callback = config.get("progress_callback")
     timeout = config.get("timeout", 3600)
 
-    if preferred_scanner and preferred_scanner.can_handle(path):
+    if (
+        preferred_scanner
+        and scanner_id
+        and _preferred_scanner_can_handle(preferred_scanner, scanner_id, header_format, path)
+    ):
         logger.debug(
             f"Using {preferred_scanner.name} scanner for {path} based on header",
         )

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -955,6 +955,11 @@ def detect_file_format(path: str) -> str:
     magic8 = header[:8]
     magic16 = header[:16]
 
+    if magic8.startswith(b"\x93NUMPY"):
+        return "numpy"
+    if magic4 == b"\x08\x01\x12\x00":
+        return "onnx"
+
     # Check first 8 bytes for HDF5 magic
     hdf5_magic = b"\x89HDF\r\n\x1a\n"
     if magic8 == hdf5_magic:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,7 +14,7 @@ import pytest
 
 from modelaudit.core import scan_file
 from modelaudit.scanners.base import IssueSeverity, ScanResult
-from tests.helpers import create_mock_pytorch_zip
+from tests.helpers import create_mock_gguf, create_mock_pytorch_zip
 
 _SYSTEM_GLOBAL_NAMES = ("os.system", "posix.system", "nt.system")
 
@@ -670,6 +670,46 @@ def test_scan_file_routes_misnamed_keras_hdf5_by_header(tmp_path: Path) -> None:
 
     assert result.scanner_name == "keras_h5"
     assert any("CVE-2025-9905" in issue.message for issue in result.issues)
+
+
+def test_scan_file_routes_misnamed_gguf_by_header(tmp_path: Path) -> None:
+    disguised_gguf = create_mock_gguf(tmp_path / "model.payload")
+
+    result = scan_file(str(disguised_gguf))
+
+    assert result.scanner_name == "gguf"
+    assert result.metadata["format"] == "gguf"
+
+
+def test_scan_file_does_not_route_gguf_magic_near_match_to_gguf(tmp_path: Path) -> None:
+    near_match = tmp_path / "model.payload"
+    near_match.write_bytes(b"GGU?" + b"\x00" * 32)
+
+    result = scan_file(str(near_match))
+
+    assert result.scanner_name == "unknown"
+    assert result.issues == []
+
+
+def test_scan_file_routes_misnamed_onnx_by_header(tmp_path: Path) -> None:
+    disguised_onnx = tmp_path / "model.payload"
+    disguised_onnx.write_bytes(b"\x08\x01\x12\x00onnx.proto" + b"\x00" * 32)
+
+    result = scan_file(str(disguised_onnx))
+
+    assert result.scanner_name == "onnx"
+
+
+def test_scan_file_routes_misnamed_numpy_by_header(tmp_path: Path) -> None:
+    np = pytest.importorskip("numpy")
+
+    disguised_numpy = tmp_path / "weights.payload"
+    with disguised_numpy.open("wb") as handle:
+        np.save(handle, np.array([1, 2, 3], dtype=np.float32), allow_pickle=False)
+
+    result = scan_file(str(disguised_numpy))
+
+    assert result.scanner_name == "numpy"
 
 
 def test_scan_file_routes_misnamed_sevenzip_by_header(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Treat direct header/content scanner routes as authoritative even when a scanner's `can_handle()` rejects a misleading suffix.
- Recognize NumPy magic and the exact ONNX protobuf header in the main file-format detection path.
- Add regressions for misnamed GGUF, ONNX, and NumPy artifacts, plus a GGUF near-match negative.

## Root Cause

`scan_file()` selected a preferred scanner from trusted file structure, then still required `preferred_scanner.can_handle(path)`. For scanners whose `can_handle()` methods are suffix-gated, content-detected but misnamed artifacts could fall through to suffix routing or `unknown` instead of being scanned by the format-specific scanner.

## Validation

- `uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`

Full pytest result: `3559 passed, 77 skipped`; skips were optional dependency/environment skips.