### PR TITLE
fix: route nested compressed archive members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - honor trusted header/content routing for misnamed ONNX, GGUF, and NumPy artifacts.
+- route extensionless compressed archive members through registry-backed nested dispatch.
 
 ## [0.2.36](https://github.com/promptfoo/modelaudit/compare/v0.2.35...v0.2.36) (2026-04-11)
 

--- a/modelaudit/scanners/archive_dispatch.py
+++ b/modelaudit/scanners/archive_dispatch.py
@@ -4,6 +4,7 @@ import os
 from collections.abc import Callable
 from typing import Any
 
+from ..scanner_registry_metadata import get_scanner_registry_metadata
 from ..scanner_results import ScanResult
 from ..utils.file.detection import (
     detect_file_format,
@@ -17,46 +18,21 @@ from ..utils.file.detection import (
 NESTED_SCAN_CALLBACK_CONFIG_KEY = "_archive_nested_scan_callback"
 NestedScanCallback = Callable[[str, dict[str, Any] | None], ScanResult]
 
-_HEADER_FORMAT_TO_SCANNER_ID = {
-    "pickle": "pickle",
-    "pytorch_binary": "pytorch_binary",
-    "hdf5": "keras_h5",
-    "keras": "keras_h5",
-    "safetensors": "safetensors",
-    "tensorflow_directory": "tf_savedmodel",
-    "protobuf": "tf_savedmodel",
-    "tf_metagraph": "tf_metagraph",
-    "tar": "tar",
-    "zip": "zip",
-    "onnx": "onnx",
-    "gguf": "gguf",
-    "ggml": "gguf",
-    "numpy": "numpy",
-    "openvino": "openvino",
-    "pmml": "pmml",
-    "cntk": "cntk",
-    "lightgbm": "lightgbm",
-    "torch7": "torch7",
-    "catboost": "catboost",
-    "rknn": "rknn",
-    "mxnet": "mxnet",
-    "nemo": "nemo",
-    "llamafile": "llamafile",
-    "tflite": "tflite",
-    "coreml": "coreml",
-    "paddle": "paddle",
-    "tensorrt": "tensorrt",
-    "flax_msgpack": "flax_msgpack",
-    "r_serialized": "r_serialized",
-    "executorch": "executorch",
-    "compressed": "compressed",
-    "sevenzip": "sevenzip",
-    "skops": "skops",
-    "torchserve_mar": "torchserve_mar",
-    "joblib": "joblib",
-    "xgboost": "xgboost",
-    "jax_checkpoint": "jax_checkpoint",
-}
+
+def _build_header_format_to_scanner_id() -> dict[str, str]:
+    metadata = get_scanner_registry_metadata()
+    header_format_to_scanner_id = {scanner_id: scanner_id for scanner_id in metadata}
+    for scanner_id, scanner_info in metadata.items():
+        for header_format in scanner_info.get("header_formats", ()):
+            header_format_to_scanner_id[str(header_format)] = scanner_id
+    return header_format_to_scanner_id
+
+
+_HEADER_FORMAT_TO_SCANNER_ID: dict[str, str] = _build_header_format_to_scanner_id()
+_COMPRESSED_HEADER_FORMATS: frozenset[str] = frozenset(
+    header_format for header_format, scanner_id in _HEADER_FORMAT_TO_SCANNER_ID.items() if scanner_id == "compressed"
+)
+_R_SERIALIZED_EXTENSIONS: frozenset[str] = frozenset({".rds", ".rda", ".rdata"})
 
 
 def _select_nested_scanner_id(path: str) -> str | None:
@@ -83,8 +59,11 @@ def _select_nested_scanner_id(path: str) -> str | None:
             return "pickle"
         return "zip"
 
-    if ext == ".joblib" and header_format in {"compressed", "pickle"}:
+    if ext == ".joblib" and header_format in _COMPRESSED_HEADER_FORMATS | {"pickle"}:
         return "joblib"
+
+    if ext in _R_SERIALIZED_EXTENSIONS and header_format in _COMPRESSED_HEADER_FORMATS | {"r_serialized"}:
+        return "r_serialized"
 
     if header_format == "tar" and ext == ".nemo":
         return "nemo"

--- a/tests/scanners/test_scanner_registry.py
+++ b/tests/scanners/test_scanner_registry.py
@@ -20,6 +20,7 @@ from modelaudit.scanner_registry_metadata import (
     get_registered_scanner_extensions,
 )
 from modelaudit.scanners import SCANNER_REGISTRY, ScannerRegistry, _registry
+from modelaudit.scanners.archive_dispatch import _HEADER_FORMAT_TO_SCANNER_ID
 from modelaudit.scanners.base import BaseScanner, IssueSeverity
 from tests.helpers import create_mock_pytorch_zip
 
@@ -304,6 +305,18 @@ def test_extension_format_map_excludes_ambiguous_routable_extensions() -> None:
 def test_scannable_model_extensions_are_registry_backed() -> None:
     """Source-download filters should not carry an independent scanner list."""
     assert frozenset(get_registered_scanner_extensions()) == SCANNABLE_MODEL_EXTENSIONS
+
+
+def test_archive_dispatch_header_map_is_backed_by_scanner_descriptors() -> None:
+    """Nested archive dispatch should consume scanner-owned header aliases."""
+    for scanner_id, scanner_info in SCANNER_REGISTRY_METADATA.items():
+        expected_keys = {scanner_id, *(str(header_format) for header_format in scanner_info.get("header_formats", ()))}
+        actual_keys = {
+            header_format
+            for header_format, mapped_scanner_id in _HEADER_FORMAT_TO_SCANNER_ID.items()
+            if mapped_scanner_id == scanner_id
+        }
+        assert actual_keys == expected_keys
 
 
 @pytest.mark.parametrize(

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -1,3 +1,4 @@
+import gzip
 import os
 import tarfile
 import tempfile
@@ -255,6 +256,36 @@ class TestTarScanner:
             "os.system" in issue.message.lower() or "posix.system" in issue.message.lower() for issue in critical_issues
         )
         assert any(issue.location == f"{archive_path}:payload.txt" for issue in critical_issues)
+
+    def test_scan_extensionless_nested_gzip_recurses_by_header(self, tmp_path: Path) -> None:
+        """Extensionless gzip members should route through CompressedScanner by header."""
+        archive_path = tmp_path / "outer.tar"
+        payload = b'cos\nsystem\n(S"echo tar gzip payload"\ntR.'
+        compressed_payload = gzip.compress(payload)
+
+        with tarfile.open(archive_path, "w") as archive:
+            info = tarfile.TarInfo("compressed_payload")
+            info.size = len(compressed_payload)
+            archive.addfile(info, tarfile.io.BytesIO(compressed_payload))  # type: ignore[attr-defined]
+
+        result = self.scanner.scan(str(archive_path))
+
+        assert result.success is False
+        assert result.has_errors is True
+        routing_checks = [check for check in result.checks if check.name == "Compressed Wrapper Inner Scanner Routing"]
+        assert any(
+            check.details.get("inner_scanner") == "pickle" and check.details.get("tar_entry") == "compressed_payload"
+            for check in routing_checks
+        ), f"Expected compressed nested routing check, got: {[(c.location, c.details) for c in routing_checks]}"
+        assert any(
+            issue.severity == IssueSeverity.CRITICAL
+            and issue.details.get("tar_entry") == "compressed_payload"
+            and ("os.system" in issue.message.lower() or "posix.system" in issue.message.lower())
+            for issue in result.issues
+        ), (
+            "Expected critical nested compressed pickle finding, got: "
+            f"{[(i.location, i.message, i.details) for i in result.issues]}"
+        )
 
     def test_invalid_tar_file(self):
         """Test handling of invalid TAR files"""

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -1,3 +1,4 @@
+import gzip
 import io
 import os
 import tarfile
@@ -390,6 +391,56 @@ class TestZipScanner:
             "Expected critical nested pickle finding, got: "
             f"{[(i.location, i.message, i.details) for i in result.issues]}"
         )
+
+    def test_scan_extensionless_nested_gzip_recurses_by_header(self, tmp_path: Path) -> None:
+        """Extensionless gzip members should route through CompressedScanner by header."""
+        archive_path = tmp_path / "outer.zip"
+        payload = b'cos\nsystem\n(S"echo zipped gzip payload"\ntR.'
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("compressed_payload", gzip.compress(payload))
+
+        result = self.scanner.scan(str(archive_path))
+
+        assert result.success is False
+        assert result.has_errors is True
+        routing_checks = [check for check in result.checks if check.name == "Compressed Wrapper Inner Scanner Routing"]
+        assert any(
+            check.details.get("inner_scanner") == "pickle" and check.details.get("zip_entry") == "compressed_payload"
+            for check in routing_checks
+        ), f"Expected compressed nested routing check, got: {[(c.location, c.details) for c in routing_checks]}"
+        assert any(
+            issue.severity == IssueSeverity.CRITICAL
+            and issue.details.get("zip_entry") == "compressed_payload"
+            and ("os.system" in issue.message.lower() or "posix.system" in issue.message.lower())
+            for issue in result.issues
+        ), (
+            "Expected critical nested compressed pickle finding, got: "
+            f"{[(i.location, i.message, i.details) for i in result.issues]}"
+        )
+
+    def test_scan_extensionless_nested_gzip_benign_text_does_not_route_to_pickle(self, tmp_path: Path) -> None:
+        """Extensionless gzip text should not be treated as a nested pickle just because it is compressed."""
+        archive_path = tmp_path / "outer-benign.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("compressed_payload", gzip.compress(b"just some harmless text\n"))
+
+        result = self.scanner.scan(str(archive_path))
+
+        routing_checks = [
+            check
+            for check in result.checks
+            if check.name == "Compressed Wrapper Inner Scanner Routing"
+            and check.details.get("zip_entry") == "compressed_payload"
+        ]
+        assert not any(check.details.get("inner_scanner") == "pickle" for check in routing_checks), (
+            "Expected benign gzip text to avoid pickle routing, got: "
+            f"{[(check.location, check.details) for check in routing_checks]}"
+        )
+        assert not [
+            issue
+            for issue in result.issues
+            if issue.severity == IssueSeverity.CRITICAL and issue.details.get("zip_entry") == "compressed_payload"
+        ]
 
     def test_nested_keras_member_routes_through_nested_scan_callback(self, tmp_path: Path) -> None:
         """Nested ZIP-based members should preserve ZIP depth and use the injected callback."""


### PR DESCRIPTION
## Summary

- Build nested archive header dispatch from scanner registry metadata instead of a stale hand-written map.
- Route extensionless gzip/bzip2/xz/lz4/zlib archive members through `CompressedScanner` when direct `ZipScanner` or `TarScanner` usage lacks the core callback.
- Add direct Zip/Tar regressions for extensionless gzip members containing malicious pickles, plus a registry parity guard for nested dispatch aliases.

## Root Cause

`archive_dispatch.py` kept an independent `_HEADER_FORMAT_TO_SCANNER_ID` map for direct nested scans. That map included `compressed` but omitted the concrete compressed header aliases registered for `CompressedScanner`, such as `gzip`, `bzip2`, `xz`, `lz4`, and `zlib`. As a result, direct archive scanner use could content-detect an extensionless compressed member and still fall through to `unknown` instead of decompressing and scanning the payload.

## Validation

- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_zip_scanner.py::TestZipScanner::test_scan_extensionless_nested_gzip_recurses_by_header tests/scanners/test_tar_scanner.py::TestTarScanner::test_scan_extensionless_nested_gzip_recurses_by_header tests/scanners/test_scanner_registry.py::test_archive_dispatch_header_map_is_backed_by_scanner_descriptors`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_zip_scanner.py tests/scanners/test_tar_scanner.py tests/scanners/test_scanner_registry.py`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`

Full pytest result: `3558 passed, 77 skipped`; skips were optional dependency/environment skips.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed routing for extensionless compressed members inside archives so compressed content is detected and routed to the appropriate inner scanner, improving detection of nested threats.
* **Tests**
  * Added tests covering extensionless gzip members in tar/zip scenarios to verify correct routing and propagation of nested scan findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->