### PR TITLE
fix: avoid safetensors unicode metadata false positive

### DIFF
--- a/modelaudit/scanners/safetensors_scanner.py
+++ b/modelaudit/scanners/safetensors_scanner.py
@@ -581,7 +581,7 @@ class SafeTensorsScanner(BaseScanner):
         # Convert metadata to string for pattern analysis
         import json
 
-        metadata_str = json.dumps(metadata, indent=2)
+        metadata_str = json.dumps(metadata, indent=2, ensure_ascii=False)
 
         # XSS/HTML injection patterns
         html_patterns = [

--- a/tests/scanners/test_safetensors_scanner.py
+++ b/tests/scanners/test_safetensors_scanner.py
@@ -411,6 +411,34 @@ def test_suspicious_metadata(tmp_path: Path) -> None:
     assert any("suspicious metadata" in issue.message.lower() for issue in result.issues)
 
 
+def test_unicode_metadata_is_not_code_injection(tmp_path: Path) -> None:
+    file_path = tmp_path / "unicode_metadata.safetensors"
+    data = {"t": np.arange(5, dtype=np.float32)}
+    metadata = {"description": "café model trained on multilingual text 日本語"}
+    save_file(data, str(file_path), metadata=metadata)
+
+    scanner = SafeTensorsScanner()
+    result = scanner.scan(str(file_path))
+
+    code_injection_checks = [check for check in result.checks if check.name == "SafeTensors Code Injection Detection"]
+    assert code_injection_checks == []
+    assert [issue for issue in result.issues if issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL}] == []
+
+
+def test_literal_unicode_escape_metadata_still_flags_code_injection(tmp_path: Path) -> None:
+    file_path = tmp_path / "escaped_payload_metadata.safetensors"
+    data = {"t": np.arange(5, dtype=np.float32)}
+    metadata = {"payload": r"\u0065\u0076\u0061\u006c\u0028"}
+    save_file(data, str(file_path), metadata=metadata)
+
+    scanner = SafeTensorsScanner()
+    result = scanner.scan(str(file_path))
+
+    code_injection_checks = [check for check in result.checks if check.name == "SafeTensors Code Injection Detection"]
+    assert code_injection_checks
+    assert all(check.severity == IssueSeverity.CRITICAL for check in code_injection_checks)
+
+
 def test_mixed_suspicious_patterns(tmp_path: Path) -> None:
     """Test that both simple patterns and regex patterns are detected from the same metadata value."""
     file_path = tmp_path / "model.safetensors"

--- a/tests/scanners/test_safetensors_scanner.py
+++ b/tests/scanners/test_safetensors_scanner.py
@@ -439,6 +439,20 @@ def test_literal_unicode_escape_metadata_still_flags_code_injection(tmp_path: Pa
     assert all(check.severity == IssueSeverity.CRITICAL for check in code_injection_checks)
 
 
+def test_single_comment_token_does_not_bypass_unicode_escape_detection(tmp_path: Path) -> None:
+    file_path = tmp_path / "commented_escape_payload_metadata.safetensors"
+    data = {"t": np.arange(5, dtype=np.float32)}
+    metadata = {"payload": r"\u0065#\u0076\u0061\u006c\u0028"}
+    save_file(data, str(file_path), metadata=metadata)
+
+    scanner = SafeTensorsScanner()
+    result = scanner.scan(str(file_path))
+
+    code_injection_checks = [check for check in result.checks if check.name == "SafeTensors Code Injection Detection"]
+    assert code_injection_checks
+    assert all(check.severity == IssueSeverity.CRITICAL for check in code_injection_checks)
+
+
 def test_mixed_suspicious_patterns(tmp_path: Path) -> None:
     """Test that both simple patterns and regex patterns are detected from the same metadata value."""
     file_path = tmp_path / "model.safetensors"


### PR DESCRIPTION
## Summary

This PR fixes a SafeTensors false positive where ordinary non-ASCII metadata text was treated as code injection.

SafeTensors metadata was converted with `json.dumps()` using the default `ensure_ascii=True`, which turns normal Unicode text such as `café` into JSON escape sequences like `\u00e9`. The scanner then matched those generated escapes with its obfuscation pattern and emitted a CRITICAL "SafeTensors Code Injection Detection" finding for clean metadata.

The fix keeps metadata text in its natural Unicode form during pattern analysis by using `ensure_ascii=False`. Literal backslash-u escape payloads in metadata are still detected, so the code-injection heuristic remains active for obfuscated strings supplied by the artifact.

## Tests

- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run --extra all-ci pytest tests/scanners/test_safetensors_scanner.py::test_unicode_metadata_is_not_code_injection tests/scanners/test_safetensors_scanner.py::test_literal_unicode_escape_metadata_still_flags_code_injection`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SafeTensors metadata scanning to properly handle Unicode characters, ensuring code injection detection patterns are correctly identified regardless of character encoding in metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->