### PR TITLE
fix: narrow network c2 metadata patterns

### DIFF
--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -143,18 +143,14 @@ class NetworkCommDetector:
         b"dns.resolver",
     ]
 
-    # Known C&C patterns
+    # Known C&C patterns. Keep this list to high-signal indicators; ordinary
+    # metadata keys like download_url or heartbeat are common in model cards.
     CC_PATTERNS: ClassVar[list[bytes]] = [
         b"beacon_url",
         b"callback_url",
         b"c2_server",
         b"command_server",
         b"exfil_endpoint",
-        b"report_url",
-        b"telemetry_endpoint",
-        b"update_server",
-        b"download_url",
-        b"upload_endpoint",
         b"malware",
         b"backdoor",
         b"trojan",
@@ -162,8 +158,6 @@ class NetworkCommDetector:
         b"zombie",
         b"phone_home",
         b"check_in",
-        b"heartbeat",
-        b"keepalive",
     ]
 
     # Suspicious ports

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -160,7 +160,7 @@ class TestNetworkCommDetector:
         assert "backdoor" in patterns
         assert "botnet" in patterns
 
-    def test_benign_metadata_reference_keys_are_not_cc_patterns(self):
+    def test_benign_metadata_reference_keys_are_not_cc_patterns(self) -> None:
         """Common model metadata URL keys are not C&C indicators by themselves."""
         detector = NetworkCommDetector()
 

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -160,6 +160,37 @@ class TestNetworkCommDetector:
         assert "backdoor" in patterns
         assert "botnet" in patterns
 
+    def test_benign_metadata_reference_keys_are_not_cc_patterns(self):
+        """Common model metadata URL keys are not C&C indicators by themselves."""
+        detector = NetworkCommDetector()
+
+        data = b"""
+        {
+            "download_url": "https://huggingface.co/example/model",
+            "report_url": "https://huggingface.co/example/model/blob/main/README.md",
+            "telemetry_endpoint": "disabled",
+            "heartbeat_interval": 30,
+            "keepalive": true,
+            "update_server": "none",
+            "upload_endpoint": "none"
+        }
+        """
+
+        findings = detector.scan(data)
+        cc_patterns = {f["pattern"] for f in findings if f["type"] == "cc_pattern"}
+
+        assert cc_patterns.isdisjoint(
+            {
+                "download_url",
+                "report_url",
+                "telemetry_endpoint",
+                "heartbeat",
+                "keepalive",
+                "update_server",
+                "upload_endpoint",
+            }
+        )
+
     def test_detect_suspicious_ports(self):
         """Test detection of suspicious port numbers."""
         detector = NetworkCommDetector()


### PR DESCRIPTION
## Summary

This PR reduces a network-detector false positive where common model metadata keys were classified as command-and-control indicators by name alone.

The default `CC_PATTERNS` list included ordinary metadata/reference fields such as `download_url`, `report_url`, `telemetry_endpoint`, `update_server`, `upload_endpoint`, `heartbeat`, and `keepalive`. Those names are common in model cards, manifests, and model provenance metadata, but the detector emitted every match as CRITICAL. A clean artifact could therefore look malicious simply because it records where a model or report can be downloaded.

The fix keeps the built-in C&C list focused on high-signal indicators such as beacon/callback/C2/exfil/malware/backdoor/botnet terms. Custom configured C&C patterns still work unchanged for users who want organization-specific policy matches.

## Tests

- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/detectors/test_network_comm_detector.py::TestNetworkCommDetector::test_detect_cc_patterns tests/detectors/test_network_comm_detector.py::TestNetworkCommDetector::test_benign_metadata_reference_keys_are_not_cc_patterns tests/detectors/test_network_comm_detector.py::TestNetworkCommDetector::test_custom_config tests/detectors/test_network_comm_detector.py::TestNetworkCommDetector::test_custom_patterns_isolated_between_instances`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined network communication detection to exclude common metadata reference indicators from being flagged as suspicious patterns, improving scanning accuracy for model artifacts.

* **Tests**
  * Added validation tests to ensure benign metadata keys are correctly excluded from detection results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->