### PR TITLE
fix: narrow suspicious dunder string detection

### DIFF
--- a/modelaudit/detectors/suspicious_symbols.py
+++ b/modelaudit/detectors/suspicious_symbols.py
@@ -293,11 +293,16 @@ DANGEROUS_BUILTINS = [
 
 # Suspicious string patterns used by PickleScanner
 # Regex patterns that match potentially malicious code in string literals
+DANGEROUS_DUNDER_METHOD_PATTERN = (
+    r"(?<!\w)__(?:reduce(?:_ex)?|setstate|getstate|getnewargs(?:_ex)?|getinitargs|new|class|subclasses|globals|"
+    r"builtins|mro)__(?!\w)"
+)
+
 SUSPICIOUS_STRING_PATTERNS = [
-    # Python magic methods - can hide malicious code
-    # Require at least one letter between the double underscores to avoid matching
-    # feature column names like "Occupation________" from one-hot encoding
-    r"(?<!\w)__(?=[a-zA-Z])[a-zA-Z0-9_]*[a-zA-Z]__(?!\w)",  # Magic methods like __reduce__, __setstate__
+    # Dangerous Python magic methods/attributes that can participate in pickle
+    # execution or introspection chains. Common metadata keys like __version__
+    # and __metadata__ are intentionally excluded.
+    DANGEROUS_DUNDER_METHOD_PATTERN,
     # Encoding/decoding operations - often used for obfuscation
     r"base64\.b64decode",  # Base64 decoding
     # Dynamic code execution - CRITICAL

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/engine/policy.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/engine/policy.py
@@ -179,8 +179,13 @@ _WARNING_GLOBALS: dict[str, frozenset[str] | None] = {
     "tempfile": frozenset({"mktemp"}),
 }
 
+_DANGEROUS_DUNDER_METHOD_RE = re.compile(
+    r"(?<!\w)__(?:reduce(?:_ex)?|setstate|getstate|getnewargs(?:_ex)?|getinitargs|new|class|subclasses|globals|"
+    r"builtins|mro)__(?!\w)"
+)
+
 _SUSPICIOUS_STRING_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
-    ("magic method", re.compile(r"(?<!\w)__(?=[a-zA-Z])[a-zA-Z0-9_]*[a-zA-Z]__(?!\w)")),
+    ("magic method", _DANGEROUS_DUNDER_METHOD_RE),
     ("base64.b64decode", re.compile(r"base64\.b64decode", re.IGNORECASE)),
     ("eval(", re.compile(r"eval\s*\(", re.IGNORECASE)),
     ("exec(", re.compile(r"exec\s*\(", re.IGNORECASE)),

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -326,6 +326,24 @@ def test_scan_bytes_flags_suspicious_exec_string_literals() -> None:
     assert any(finding.rule_code == "SUSPICIOUS_STRING" and "exec(" in finding.message for finding in report.findings)
 
 
+def test_scan_bytes_allows_common_dunder_metadata_literals() -> None:
+    report = scan_bytes(
+        pickle.dumps(
+            {
+                "__version__": "1.0.0",
+                "__metadata__": {"format": "safe"},
+                "__schema__": "model-card-v1",
+                "__name__": "example-model",
+            }
+        ),
+        source="dunder-metadata.pkl",
+    )
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert not any(finding.rule_code == "SUSPICIOUS_STRING" for finding in report.findings)
+
+
 @pytest.mark.parametrize(
     ("literal", "expected_pattern"),
     [

--- a/tests/detectors/test_suspicious_symbols.py
+++ b/tests/detectors/test_suspicious_symbols.py
@@ -143,7 +143,10 @@ class TestSuspiciousStringPatterns:
                 r"subprocess\.(?:Popen|call|check_output)",
                 "subprocess.call(['rm', 'file'])",
             ),
-            (r"(?<!\w)__(?=[a-zA-Z])[a-zA-Z0-9_]*[a-zA-Z]__(?!\w)", "__reduce__"),
+            (
+                r"(?<!\w)__(?:reduce(?:_ex)?|setstate|getstate|getnewargs(?:_ex)?|getinitargs|new|class|subclasses|globals|builtins|mro)__(?!\w)",
+                "__reduce__",
+            ),
             (r"base64\.b64decode", "base64.b64decode(encoded_payload)"),
             (r"\bimport\s+[\w\.]+", "import os"),
             (r"\\x[0-9a-fA-F]{2}", "\\x41\\x42\\x43"),
@@ -172,6 +175,18 @@ class TestSuspiciousStringPatterns:
         # Document known false positives but don't fail
         # (These are trade-offs between security and usability)
         print(f"Known false positives: {false_positives}")
+
+    def test_magic_method_pattern_only_matches_dangerous_dunders(self) -> None:
+        """Common dunder metadata keys should not match the magic-method pattern."""
+        magic_method_pattern = next(pattern for pattern in SUSPICIOUS_STRING_PATTERNS if "reduce" in pattern)
+
+        dangerous_examples = ["__reduce__", "__reduce_ex__", "__setstate__", "__globals__", "__subclasses__"]
+        for example in dangerous_examples:
+            assert re.search(magic_method_pattern, example), f"Pattern failed to match dangerous key {example}"
+
+        benign_examples = ["__version__", "__metadata__", "__schema__", "__name__", "__doc__"]
+        for example in benign_examples:
+            assert not re.search(magic_method_pattern, example), f"Pattern should not match benign key {example}"
 
     def test_detects_getattr_system_evasion(self) -> None:
         """Test that getattr-based system call evasion is detected."""

--- a/tests/test_pickle_context_filtering.py
+++ b/tests/test_pickle_context_filtering.py
@@ -331,6 +331,32 @@ class TestPickleContextFiltering(unittest.TestCase):
             if test_file.exists():
                 test_file.unlink()
 
+    def test_plain_dunder_metadata_keys_are_not_suspicious_strings(self):
+        """Common dunder metadata keys should not produce string-literal warnings."""
+        test_file = Path(__file__).parent / "temp_dunder_metadata.pkl"
+        with test_file.open("wb") as f:
+            pickle.dump(
+                {
+                    "__version__": "1.0.0",
+                    "__metadata__": {"format": "safe"},
+                    "__schema__": "model-card-v1",
+                    "__name__": "example-model",
+                },
+                f,
+            )
+
+        try:
+            result = self.scanner.scan(str(test_file))
+
+            self.assertTrue(result.success)
+            self.assertEqual(
+                [issue for issue in result.issues if issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL}],
+                [],
+            )
+        finally:
+            if test_file.exists():
+                test_file.unlink()
+
     def test_actual_malicious_pickle_still_detected(self):
         """Test that genuinely malicious pickles are still caught"""
 


### PR DESCRIPTION
## Summary

This PR fixes a pickle false positive where ordinary dunder metadata keys such as `__version__`, `__metadata__`, `__schema__`, and `__name__` were treated as suspicious string literals.

The previous suspicious-string regex matched any double-underscore name. That caught dangerous pickle hooks like `__reduce__`, but it also caught common metadata fields that appear in clean model artifacts. The resulting warning could turn a benign metadata-only pickle into a security finding.

The fix narrows the dunder pattern to high-risk pickle and introspection hooks, including `__reduce__`, `__reduce_ex__`, `__setstate__`, `__globals__`, and `__subclasses__`. The same narrowing is applied to the standalone `modelaudit-picklescan` policy so both scanner paths behave consistently.

## Tests

- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/detectors/test_suspicious_symbols.py::TestSuspiciousStringPatterns::test_magic_method_pattern_only_matches_dangerous_dunders tests/test_pickle_context_filtering.py::TestPickleContextFiltering::test_plain_dunder_metadata_keys_are_not_suspicious_strings packages/modelaudit-picklescan/tests/test_api.py::test_scan_bytes_allows_common_dunder_metadata_literals packages/modelaudit-picklescan/tests/test_api.py::test_scan_bytes_flags_suspicious_exec_string_literals`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
