### PR TITLE
fix: allow generated TorchScript source files

### DIFF
--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -380,6 +380,8 @@ class PyTorchZipScanner(BaseScanner):
             if isinstance(node, ast.ClassDef):
                 if node.decorator_list:
                     return False
+                if not PyTorchZipScanner._is_torchscript_class_header_safe(node):
+                    return False
                 if not any(isinstance(item, ast.FunctionDef) for item in node.body):
                     return False
                 for item in node.body:
@@ -409,6 +411,13 @@ class PyTorchZipScanner(BaseScanner):
     @staticmethod
     def _is_torchscript_definition_time_expression_safe(expression: ast.expr) -> bool:
         return not any(isinstance(node, _TORCHSCRIPT_UNSAFE_DEFINITION_EXPR_NODES) for node in ast.walk(expression))
+
+    @staticmethod
+    def _is_torchscript_class_header_safe(node: ast.ClassDef) -> bool:
+        if node.keywords or len(node.bases) != 1:
+            return False
+        base = node.bases[0]
+        return isinstance(base, ast.Name) and base.id == "Module"
 
     @staticmethod
     def _is_torchscript_function_definition_safe(node: ast.FunctionDef) -> bool:

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -30,6 +30,14 @@ from .pytorch_zip_support import (
 
 logger = logging.getLogger(__name__)
 _INSTALLED_PYTORCH_VERSION_UNSET = object()
+_TORCHSCRIPT_DEBUG_PAYLOAD_MARKER = b"FORMAT_WITH_STRING_TABLE"
+_TORCHSCRIPT_DEBUG_PREFIX_BYTES = 256
+_TORCHSCRIPT_SOURCE_MAX_BYTES = 1024 * 1024
+_TORCHSCRIPT_GENERATED_CLASS_PATTERN = re.compile(r"(?m)^class\s+[A-Za-z_][A-Za-z0-9_]*\(Module\):\s*$")
+_TORCHSCRIPT_GENERATED_METHOD_PATTERN = re.compile(r"(?m)^\s+def\s+\w+\(self:\s+__torch__\.")
+_TORCHSCRIPT_FORBIDDEN_SOURCE_PATTERN = re.compile(
+    r"(?im)(?:^\s*(?:import|from)\s+|\b(?:__import__|eval|exec|compile|open)\s*\(|\b(?:os|subprocess|socket|requests)\s*\.)"
+)
 
 
 @dataclass(frozen=True)
@@ -225,7 +233,7 @@ class PyTorchZipScanner(BaseScanner):
                 bytes_scanned += self._scan_for_jit_patterns(zip_file, safe_entries, result, path)
 
                 # Detect suspicious non-pickle files
-                self._detect_suspicious_files(safe_entries, result, path)
+                self._detect_suspicious_files(zip_file, safe_entries, result, path)
 
                 # Validate PyTorch model structure
                 self._validate_pytorch_structure(pickle_files, result)
@@ -266,28 +274,80 @@ class PyTorchZipScanner(BaseScanner):
         return get_zip_member_names(entries)
 
     @staticmethod
-    def _is_torchscript_generated_python(name: str, member_names: set[str]) -> bool:
-        """Return true for TorchScript's generated Python source archive layout."""
+    def _torchscript_debug_member_name(name: str, member_names: set[str]) -> str | None:
+        """Return the sibling TorchScript debug member name for a generated-source path."""
         normalized = name.replace("\\", "/").lstrip("/").lower()
         parts = tuple(part for part in normalized.split("/") if part)
         if not parts or not parts[-1].endswith(".py"):
-            return False
+            return None
 
         try:
             code_index = parts.index("code")
         except ValueError:
-            return False
+            return None
 
         # TorchScript writes generated Python directly under the archive root
         # (optionally behind a single top-level archive prefix like "archive/").
         if code_index > 1:
-            return False
+            return None
 
         torchscript_parts = parts[code_index + 1 :]
         is_generated_path = torchscript_parts == ("__torch__.py",) or (
             len(torchscript_parts) > 1 and torchscript_parts[0] == "__torch__"
         )
-        return is_generated_path and f"{normalized}.debug_pkl" in member_names
+        debug_name = f"{normalized}.debug_pkl"
+        if not is_generated_path or debug_name not in member_names:
+            return None
+        return debug_name
+
+    @staticmethod
+    def _looks_like_torchscript_generated_source(source: bytes) -> bool:
+        """Return true when source text has TorchScript-generated structure and no Python escape hatches."""
+        try:
+            text = source.decode("utf-8")
+        except UnicodeDecodeError:
+            return False
+
+        if _TORCHSCRIPT_FORBIDDEN_SOURCE_PATTERN.search(text):
+            return False
+        return (
+            "__parameters__ = [" in text
+            and "__buffers__ = [" in text
+            and _TORCHSCRIPT_GENERATED_CLASS_PATTERN.search(text) is not None
+            and _TORCHSCRIPT_GENERATED_METHOD_PATTERN.search(text) is not None
+        )
+
+    def _is_torchscript_generated_python(
+        self,
+        zip_file: zipfile.ZipFile,
+        entry: zipfile.ZipInfo,
+        debug_entry: zipfile.ZipInfo,
+        result: ScanResult,
+    ) -> bool:
+        """Return true for validated TorchScript-generated Python source members."""
+        try:
+            debug_prefix = self._read_member_prefix(
+                zip_file,
+                debug_entry,
+                _TORCHSCRIPT_DEBUG_PREFIX_BYTES,
+                phase="torchscript generated source validation",
+                result=result,
+            )
+            if _TORCHSCRIPT_DEBUG_PAYLOAD_MARKER not in debug_prefix:
+                return False
+
+            source = self._read_member_bytes(
+                zip_file,
+                entry,
+                phase="torchscript generated source validation",
+                result=result,
+                max_bytes=_TORCHSCRIPT_SOURCE_MAX_BYTES,
+            )
+        except Exception as exc:
+            logger.debug("Unable to validate TorchScript generated source member %s: %s", entry.filename, exc)
+            return False
+
+        return self._looks_like_torchscript_generated_source(source)
 
     @staticmethod
     def _find_zip_entry(entries: list[zipfile.ZipInfo], member_name: str) -> zipfile.ZipInfo | None:
@@ -813,6 +873,7 @@ class PyTorchZipScanner(BaseScanner):
 
     def _detect_suspicious_files(
         self,
+        zip_file: zipfile.ZipFile,
         safe_entries: list[zipfile.ZipInfo],
         result: ScanResult,
         path: str,
@@ -823,13 +884,23 @@ class PyTorchZipScanner(BaseScanner):
         member_names = {
             self._get_zip_member_name(entry).replace("\\", "/").lstrip("/").lower() for entry in safe_entries
         }
+        entries_by_normalized_name = {
+            self._get_zip_member_name(entry).replace("\\", "/").lstrip("/").lower(): entry for entry in safe_entries
+        }
 
         for entry in safe_entries:
             name = self._get_zip_member_name(entry)
             normalized_name = name.lower()
             # Check for Python code files
             if normalized_name.endswith(".py"):
-                if self._is_torchscript_generated_python(name, member_names):
+                debug_member_name = self._torchscript_debug_member_name(name, member_names)
+                debug_entry = entries_by_normalized_name.get(debug_member_name or "")
+                if debug_entry is not None and self._is_torchscript_generated_python(
+                    zip_file,
+                    entry,
+                    debug_entry,
+                    result,
+                ):
                     continue
                 result.add_check(
                     name="Python Code File Detection",

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -276,13 +276,14 @@ class PyTorchZipScanner(BaseScanner):
     @staticmethod
     def _torchscript_debug_member_name(name: str, member_names: set[str]) -> str | None:
         """Return the sibling TorchScript debug member name for a generated-source path."""
-        normalized = name.replace("\\", "/").lstrip("/").lower()
+        normalized = name.replace("\\", "/").lstrip("/")
         parts = tuple(part for part in normalized.split("/") if part)
-        if not parts or not parts[-1].endswith(".py"):
+        lower_parts = tuple(part.lower() for part in parts)
+        if not parts or not lower_parts[-1].endswith(".py"):
             return None
 
         try:
-            code_index = parts.index("code")
+            code_index = lower_parts.index("code")
         except ValueError:
             return None
 
@@ -291,7 +292,7 @@ class PyTorchZipScanner(BaseScanner):
         if code_index > 1:
             return None
 
-        torchscript_parts = parts[code_index + 1 :]
+        torchscript_parts = lower_parts[code_index + 1 :]
         is_generated_path = torchscript_parts == ("__torch__.py",) or (
             len(torchscript_parts) > 1 and torchscript_parts[0] == "__torch__"
         )
@@ -881,18 +882,17 @@ class PyTorchZipScanner(BaseScanner):
         """Detect suspicious non-pickle files in the archive"""
         python_files_found = False
         executable_files_found = False
-        member_names = {
-            self._get_zip_member_name(entry).replace("\\", "/").lstrip("/").lower() for entry in safe_entries
-        }
+        member_names = {self._get_zip_member_name(entry).replace("\\", "/").lstrip("/") for entry in safe_entries}
         entries_by_normalized_name = {
-            self._get_zip_member_name(entry).replace("\\", "/").lstrip("/").lower(): entry for entry in safe_entries
+            self._get_zip_member_name(entry).replace("\\", "/").lstrip("/"): entry for entry in safe_entries
         }
 
         for entry in safe_entries:
             name = self._get_zip_member_name(entry)
-            normalized_name = name.lower()
+            normalized_name = name.replace("\\", "/").lstrip("/")
+            normalized_name_lower = normalized_name.lower()
             # Check for Python code files
-            if normalized_name.endswith(".py"):
+            if normalized_name_lower.endswith(".py"):
                 debug_member_name = self._torchscript_debug_member_name(name, member_names)
                 debug_entry = entries_by_normalized_name.get(debug_member_name or "")
                 if debug_entry is not None and self._is_torchscript_generated_python(
@@ -912,7 +912,7 @@ class PyTorchZipScanner(BaseScanner):
                 )
                 python_files_found = True
             # Check for shell scripts or other executable files
-            elif is_executable_archive_member_name(normalized_name):
+            elif is_executable_archive_member_name(normalized_name_lower):
                 result.add_check(
                     name="Executable File Detection",
                     passed=False,

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -302,12 +302,11 @@ class PyTorchZipScanner(BaseScanner):
         """Return the sibling TorchScript debug member name for a generated-source path."""
         normalized = name.replace("\\", "/").lstrip("/")
         parts = tuple(part for part in normalized.split("/") if part)
-        lower_parts = tuple(part.lower() for part in parts)
-        if not parts or not lower_parts[-1].endswith(".py"):
+        if not parts or not parts[-1].endswith(".py"):
             return None
 
         try:
-            code_index = lower_parts.index("code")
+            code_index = parts.index("code")
         except ValueError:
             return None
 
@@ -316,7 +315,7 @@ class PyTorchZipScanner(BaseScanner):
         if code_index > 1:
             return None
 
-        torchscript_parts = lower_parts[code_index + 1 :]
+        torchscript_parts = parts[code_index + 1 :]
         is_generated_path = torchscript_parts == ("__torch__.py",) or (
             len(torchscript_parts) > 1 and torchscript_parts[0] == "__torch__"
         )

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -1,5 +1,6 @@
 """Scanner for PyTorch zip-archived model files (.pt, .pth)."""
 
+import ast
 import io
 import logging
 import os
@@ -37,6 +38,29 @@ _TORCHSCRIPT_GENERATED_CLASS_PATTERN = re.compile(r"(?m)^class\s+[A-Za-z_][A-Za-
 _TORCHSCRIPT_GENERATED_METHOD_PATTERN = re.compile(r"(?m)^\s+def\s+\w+\(self:\s+__torch__\.")
 _TORCHSCRIPT_FORBIDDEN_SOURCE_PATTERN = re.compile(
     r"(?im)(?:^\s*(?:import|from)\s+|\b(?:__import__|eval|exec|compile|open)\s*\(|\b(?:os|subprocess|socket|requests)\s*\.)"
+)
+_TORCHSCRIPT_FORBIDDEN_AST_NAMES: frozenset[str] = frozenset(
+    {
+        "__builtins__",
+        "__class__",
+        "__dict__",
+        "__getattribute__",
+        "__globals__",
+        "__import__",
+        "__mro__",
+        "__subclasses__",
+        "compile",
+        "delattr",
+        "eval",
+        "exec",
+        "getattr",
+        "globals",
+        "input",
+        "locals",
+        "open",
+        "setattr",
+        "vars",
+    }
 )
 
 
@@ -316,7 +340,40 @@ class PyTorchZipScanner(BaseScanner):
             and "__buffers__ = [" in text
             and _TORCHSCRIPT_GENERATED_CLASS_PATTERN.search(text) is not None
             and _TORCHSCRIPT_GENERATED_METHOD_PATTERN.search(text) is not None
+            and PyTorchZipScanner._has_torchscript_generated_ast_shape(text)
         )
+
+    @staticmethod
+    def _has_torchscript_generated_ast_shape(text: str) -> bool:
+        try:
+            tree = ast.parse(text)
+        except SyntaxError:
+            return False
+
+        if not tree.body or any(not isinstance(node, ast.ClassDef) for node in tree.body):
+            return False
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Name) and node.id in _TORCHSCRIPT_FORBIDDEN_AST_NAMES:
+                return False
+            if isinstance(node, ast.Attribute) and node.attr in _TORCHSCRIPT_FORBIDDEN_AST_NAMES:
+                return False
+            if (
+                isinstance(node, ast.Constant)
+                and isinstance(node.value, str)
+                and node.value in _TORCHSCRIPT_FORBIDDEN_AST_NAMES
+            ):
+                return False
+
+            if isinstance(node, ast.ClassDef):
+                if not any(isinstance(item, ast.FunctionDef) for item in node.body):
+                    return False
+                if any(
+                    not isinstance(item, (ast.AnnAssign, ast.Assign, ast.FunctionDef, ast.Pass)) for item in node.body
+                ):
+                    return False
+
+        return True
 
     def _is_torchscript_generated_python(
         self,

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -266,6 +266,25 @@ class PyTorchZipScanner(BaseScanner):
         return get_zip_member_names(entries)
 
     @staticmethod
+    def _is_torchscript_generated_python(name: str) -> bool:
+        """Return true for TorchScript's generated Python source archive layout."""
+        normalized = name.replace("\\", "/").lstrip("/").lower()
+        parts = tuple(part for part in normalized.split("/") if part)
+        if not parts or not parts[-1].endswith(".py"):
+            return False
+
+        for index, part in enumerate(parts):
+            if part != "code":
+                continue
+            torchscript_parts = parts[index + 1 :]
+            if torchscript_parts == ("__torch__.py",) or (
+                len(torchscript_parts) > 1 and torchscript_parts[0] == "__torch__"
+            ):
+                return True
+
+        return False
+
+    @staticmethod
     def _find_zip_entry(entries: list[zipfile.ZipInfo], member_name: str) -> zipfile.ZipInfo | None:
         """Return the first matching ZipInfo entry for a member name, or None."""
         return find_zip_entry(entries, member_name)
@@ -802,6 +821,8 @@ class PyTorchZipScanner(BaseScanner):
             normalized_name = name.lower()
             # Check for Python code files
             if normalized_name.endswith(".py"):
+                if self._is_torchscript_generated_python(name):
+                    continue
                 result.add_check(
                     name="Python Code File Detection",
                     passed=False,
@@ -828,7 +849,7 @@ class PyTorchZipScanner(BaseScanner):
             result.add_check(
                 name="Python Code File Detection",
                 passed=True,
-                message="No Python code files found in model",
+                message="No unexpected Python code files found in model",
                 location=path,
             )
 

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -57,10 +57,23 @@ _TORCHSCRIPT_FORBIDDEN_AST_NAMES: frozenset[str] = frozenset(
         "globals",
         "input",
         "locals",
+        "load_library",
         "open",
         "setattr",
         "vars",
     }
+)
+_TORCHSCRIPT_UNSAFE_DEFINITION_EXPR_NODES: tuple[type[ast.AST], ...] = (
+    ast.Await,
+    ast.Call,
+    ast.DictComp,
+    ast.GeneratorExp,
+    ast.Lambda,
+    ast.ListComp,
+    ast.NamedExpr,
+    ast.SetComp,
+    ast.Yield,
+    ast.YieldFrom,
 )
 
 
@@ -365,14 +378,56 @@ class PyTorchZipScanner(BaseScanner):
                 return False
 
             if isinstance(node, ast.ClassDef):
+                if node.decorator_list:
+                    return False
                 if not any(isinstance(item, ast.FunctionDef) for item in node.body):
                     return False
-                if any(
-                    not isinstance(item, (ast.AnnAssign, ast.Assign, ast.FunctionDef, ast.Pass)) for item in node.body
-                ):
+                for item in node.body:
+                    if isinstance(item, ast.Pass):
+                        continue
+                    if isinstance(item, ast.Assign):
+                        if not PyTorchZipScanner._is_torchscript_definition_time_expression_safe(item.value):
+                            return False
+                        continue
+                    if isinstance(item, ast.AnnAssign):
+                        if not PyTorchZipScanner._is_torchscript_definition_time_expression_safe(item.annotation):
+                            return False
+                        if (
+                            item.value is not None
+                            and not PyTorchZipScanner._is_torchscript_definition_time_expression_safe(item.value)
+                        ):
+                            return False
+                        continue
+                    if isinstance(item, ast.FunctionDef):
+                        if not PyTorchZipScanner._is_torchscript_function_definition_safe(item):
+                            return False
+                        continue
                     return False
 
         return True
+
+    @staticmethod
+    def _is_torchscript_definition_time_expression_safe(expression: ast.expr) -> bool:
+        return not any(isinstance(node, _TORCHSCRIPT_UNSAFE_DEFINITION_EXPR_NODES) for node in ast.walk(expression))
+
+    @staticmethod
+    def _is_torchscript_function_definition_safe(node: ast.FunctionDef) -> bool:
+        if node.decorator_list:
+            return False
+        definition_expressions: list[ast.expr] = [
+            *node.args.defaults,
+            *(default for default in node.args.kw_defaults if default is not None),
+        ]
+        if node.returns is not None:
+            definition_expressions.append(node.returns)
+        for arg in [*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs]:
+            if arg.annotation is not None:
+                definition_expressions.append(arg.annotation)
+
+        return all(
+            PyTorchZipScanner._is_torchscript_definition_time_expression_safe(expression)
+            for expression in definition_expressions
+        )
 
     def _is_torchscript_generated_python(
         self,

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -60,6 +60,7 @@ _TORCHSCRIPT_FORBIDDEN_AST_NAMES: frozenset[str] = frozenset(
         "locals",
         "load_library",
         "open",
+        "print",
         "setattr",
         "vars",
     }
@@ -73,6 +74,23 @@ _TORCHSCRIPT_UNSAFE_DEFINITION_EXPR_NODES: tuple[type[ast.AST], ...] = (
     ast.ListComp,
     ast.NamedExpr,
     ast.SetComp,
+    ast.Yield,
+    ast.YieldFrom,
+)
+_TORCHSCRIPT_UNSAFE_BODY_NODES: tuple[type[ast.AST], ...] = (
+    ast.AsyncFor,
+    ast.AsyncFunctionDef,
+    ast.AsyncWith,
+    ast.Await,
+    ast.Delete,
+    ast.Global,
+    ast.Import,
+    ast.ImportFrom,
+    ast.Lambda,
+    ast.Nonlocal,
+    ast.Raise,
+    ast.Try,
+    ast.With,
     ast.Yield,
     ast.YieldFrom,
 )
@@ -358,22 +376,14 @@ class PyTorchZipScanner(BaseScanner):
     def _has_torchscript_generated_ast_shape(text: str) -> bool:
         try:
             tree = ast.parse(text)
-        except SyntaxError:
+        except (SyntaxError, ValueError):
             return False
 
         if not tree.body or any(not isinstance(node, ast.ClassDef) for node in tree.body):
             return False
 
         for node in ast.walk(tree):
-            if isinstance(node, ast.Name) and node.id in _TORCHSCRIPT_FORBIDDEN_AST_NAMES:
-                return False
-            if isinstance(node, ast.Attribute) and node.attr in _TORCHSCRIPT_FORBIDDEN_AST_NAMES:
-                return False
-            if (
-                isinstance(node, ast.Constant)
-                and isinstance(node.value, str)
-                and node.value in _TORCHSCRIPT_FORBIDDEN_AST_NAMES
-            ):
+            if PyTorchZipScanner._is_torchscript_forbidden_ast_symbol(node):
                 return False
 
             if isinstance(node, ast.ClassDef):
@@ -425,6 +435,18 @@ class PyTorchZipScanner(BaseScanner):
         return not any(isinstance(node, _TORCHSCRIPT_UNSAFE_DEFINITION_EXPR_NODES) for node in ast.walk(expression))
 
     @staticmethod
+    def _is_torchscript_forbidden_ast_symbol(node: ast.AST) -> bool:
+        if isinstance(node, ast.Name):
+            return node.id in _TORCHSCRIPT_FORBIDDEN_AST_NAMES
+        if isinstance(node, ast.Attribute):
+            return node.attr in _TORCHSCRIPT_FORBIDDEN_AST_NAMES
+        return (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and node.value in _TORCHSCRIPT_FORBIDDEN_AST_NAMES
+        )
+
+    @staticmethod
     def _is_torchscript_class_header_safe(node: ast.ClassDef) -> bool:
         if node.keywords or len(node.bases) != 1:
             return False
@@ -448,7 +470,17 @@ class PyTorchZipScanner(BaseScanner):
         return all(
             PyTorchZipScanner._is_torchscript_definition_time_expression_safe(expression)
             for expression in definition_expressions
-        )
+        ) and PyTorchZipScanner._is_torchscript_function_body_safe(node.body)
+
+    @staticmethod
+    def _is_torchscript_function_body_safe(statements: list[ast.stmt]) -> bool:
+        for statement in statements:
+            for node in ast.walk(statement):
+                if isinstance(node, _TORCHSCRIPT_UNSAFE_BODY_NODES):
+                    return False
+                if PyTorchZipScanner._is_torchscript_forbidden_ast_symbol(node):
+                    return False
+        return True
 
     def _is_torchscript_generated_python(
         self,

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -49,6 +49,7 @@ _TORCHSCRIPT_FORBIDDEN_AST_NAMES: frozenset[str] = frozenset(
         "__import__",
         "__mro__",
         "__subclasses__",
+        "breakpoint",
         "compile",
         "delattr",
         "eval",
@@ -348,9 +349,7 @@ class PyTorchZipScanner(BaseScanner):
         if _TORCHSCRIPT_FORBIDDEN_SOURCE_PATTERN.search(text):
             return False
         return (
-            "__parameters__ = [" in text
-            and "__buffers__ = [" in text
-            and _TORCHSCRIPT_GENERATED_CLASS_PATTERN.search(text) is not None
+            _TORCHSCRIPT_GENERATED_CLASS_PATTERN.search(text) is not None
             and _TORCHSCRIPT_GENERATED_METHOD_PATTERN.search(text) is not None
             and PyTorchZipScanner._has_torchscript_generated_ast_shape(text)
         )
@@ -384,14 +383,21 @@ class PyTorchZipScanner(BaseScanner):
                     return False
                 if not any(isinstance(item, ast.FunctionDef) for item in node.body):
                     return False
+                generated_marker_assignments: set[str] = set()
                 for item in node.body:
                     if isinstance(item, ast.Pass):
                         continue
                     if isinstance(item, ast.Assign):
+                        generated_marker_assignments.update(
+                            PyTorchZipScanner._torchscript_assignment_target_names(item.targets)
+                        )
                         if not PyTorchZipScanner._is_torchscript_definition_time_expression_safe(item.value):
                             return False
                         continue
                     if isinstance(item, ast.AnnAssign):
+                        generated_marker_assignments.update(
+                            PyTorchZipScanner._torchscript_assignment_target_names([item.target])
+                        )
                         if not PyTorchZipScanner._is_torchscript_definition_time_expression_safe(item.annotation):
                             return False
                         if (
@@ -405,8 +411,14 @@ class PyTorchZipScanner(BaseScanner):
                             return False
                         continue
                     return False
+                if not {"__parameters__", "__buffers__"}.issubset(generated_marker_assignments):
+                    return False
 
         return True
+
+    @staticmethod
+    def _torchscript_assignment_target_names(targets: list[ast.expr]) -> set[str]:
+        return {target.id for target in targets if isinstance(target, ast.Name)}
 
     @staticmethod
     def _is_torchscript_definition_time_expression_safe(expression: ast.expr) -> bool:

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -273,16 +273,20 @@ class PyTorchZipScanner(BaseScanner):
         if not parts or not parts[-1].endswith(".py"):
             return False
 
-        for index, part in enumerate(parts):
-            if part != "code":
-                continue
-            torchscript_parts = parts[index + 1 :]
-            if torchscript_parts == ("__torch__.py",) or (
-                len(torchscript_parts) > 1 and torchscript_parts[0] == "__torch__"
-            ):
-                return True
+        try:
+            code_index = parts.index("code")
+        except ValueError:
+            return False
 
-        return False
+        # TorchScript writes generated Python directly under the archive root
+        # (optionally behind a single top-level archive prefix like "archive/").
+        if code_index > 1:
+            return False
+
+        torchscript_parts = parts[code_index + 1 :]
+        return torchscript_parts == ("__torch__.py",) or (
+            len(torchscript_parts) > 1 and torchscript_parts[0] == "__torch__"
+        )
 
     @staticmethod
     def _find_zip_entry(entries: list[zipfile.ZipInfo], member_name: str) -> zipfile.ZipInfo | None:

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -266,7 +266,7 @@ class PyTorchZipScanner(BaseScanner):
         return get_zip_member_names(entries)
 
     @staticmethod
-    def _is_torchscript_generated_python(name: str) -> bool:
+    def _is_torchscript_generated_python(name: str, member_names: set[str]) -> bool:
         """Return true for TorchScript's generated Python source archive layout."""
         normalized = name.replace("\\", "/").lstrip("/").lower()
         parts = tuple(part for part in normalized.split("/") if part)
@@ -284,9 +284,10 @@ class PyTorchZipScanner(BaseScanner):
             return False
 
         torchscript_parts = parts[code_index + 1 :]
-        return torchscript_parts == ("__torch__.py",) or (
+        is_generated_path = torchscript_parts == ("__torch__.py",) or (
             len(torchscript_parts) > 1 and torchscript_parts[0] == "__torch__"
         )
+        return is_generated_path and f"{normalized}.debug_pkl" in member_names
 
     @staticmethod
     def _find_zip_entry(entries: list[zipfile.ZipInfo], member_name: str) -> zipfile.ZipInfo | None:
@@ -819,13 +820,16 @@ class PyTorchZipScanner(BaseScanner):
         """Detect suspicious non-pickle files in the archive"""
         python_files_found = False
         executable_files_found = False
+        member_names = {
+            self._get_zip_member_name(entry).replace("\\", "/").lstrip("/").lower() for entry in safe_entries
+        }
 
         for entry in safe_entries:
             name = self._get_zip_member_name(entry)
             normalized_name = name.lower()
             # Check for Python code files
             if normalized_name.endswith(".py"):
-                if self._is_torchscript_generated_python(name):
+                if self._is_torchscript_generated_python(name, member_names):
                     continue
                 result.add_check(
                     name="Python Code File Detection",

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -505,6 +505,54 @@ def test_pytorch_zip_scans_non_numeric_files_in_archive_data(tmp_path):
     # At minimum, the file should have been scanned (not skipped)
 
 
+def test_pytorch_zip_allows_torchscript_generated_python_files(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "scripted.pt", prefix="archive")
+    with zipfile.ZipFile(model_path, "a") as zip_file:
+        zip_file.writestr("archive/code/__torch__.py", "class Module:\n    pass\n")
+        zip_file.writestr("archive/code/__torch__/torch/nn/modules/container.py", "class Sequential:\n    pass\n")
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    python_failures = [
+        check
+        for check in result.checks
+        if check.name == "Python Code File Detection" and check.status == CheckStatus.FAILED
+    ]
+    python_successes = [
+        check
+        for check in result.checks
+        if check.name == "Python Code File Detection" and check.status == CheckStatus.PASSED
+    ]
+    assert python_failures == []
+    assert len(python_successes) == 1
+    assert python_successes[0].message == "No unexpected Python code files found in model"
+    assert not [
+        issue
+        for issue in result.issues
+        if issue.location
+        and "archive/code/__torch__" in issue.location
+        and issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL}
+    ]
+
+
+def test_pytorch_zip_still_warns_on_unexpected_python_files(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "model.pt", prefix="archive")
+    with zipfile.ZipFile(model_path, "a") as zip_file:
+        zip_file.writestr("archive/code/helper.py", "print('not generated TorchScript source')\n")
+        zip_file.writestr("archive/data/malicious.py", "import os\nos.system('id')\n")
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    python_failures = [
+        check
+        for check in result.checks
+        if check.name == "Python Code File Detection" and check.status == CheckStatus.FAILED
+    ]
+    failed_files = {check.details["file"] for check in python_failures}
+    assert {"archive/code/helper.py", "archive/data/malicious.py"}.issubset(failed_files)
+    assert all(check.severity == IssueSeverity.WARNING for check in python_failures)
+
+
 def test_pytorch_zip_numeric_detection_edge_cases(tmp_path):
     """Test edge cases for numeric file detection in archive/data/."""
     zip_path = tmp_path / "model.pt"

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -535,6 +535,28 @@ def test_pytorch_zip_allows_torchscript_generated_python_files(tmp_path: Path) -
     ]
 
 
+def test_pytorch_zip_does_not_allow_nested_torchscript_generated_python_files(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "nested_scripted.pt", prefix="archive")
+    nested_path = "archive/data/code/__torch__/payload.py"
+    with zipfile.ZipFile(model_path, "a") as zip_file:
+        zip_file.writestr(nested_path, "class Payload:\n    pass\n")
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    python_failures = [
+        check
+        for check in result.checks
+        if check.name == "Python Code File Detection" and check.status == CheckStatus.FAILED
+    ]
+    failed_files = {check.details["file"] for check in python_failures}
+
+    assert nested_path in failed_files
+    assert any(
+        issue.location == f"{model_path}:{nested_path}" and issue.severity == IssueSeverity.WARNING
+        for issue in result.issues
+    )
+
+
 def test_pytorch_zip_still_warns_on_unexpected_python_files(tmp_path: Path) -> None:
     model_path = create_mock_pytorch_zip(tmp_path / "model.pt", prefix="archive")
     with zipfile.ZipFile(model_path, "a") as zip_file:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -601,6 +601,41 @@ def test_pytorch_zip_requires_exact_case_torchscript_debug_pair(tmp_path: Path) 
     )
 
 
+def test_pytorch_zip_requires_exact_case_torchscript_tree(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "scripted_tree_case_mismatch.pt", prefix="archive")
+    source_path = "archive/code/__TORCH__/payload.py"
+    debug_pkl = b"\x80\x02X\x18\x00\x00\x00FORMAT_WITH_STRING_TABLEq\x00."
+    with zipfile.ZipFile(model_path, "a") as zip_file:
+        zip_file.writestr(
+            source_path,
+            "\n".join(
+                [
+                    "class Payload(Module):",
+                    "  __parameters__ = []",
+                    "  __buffers__ = []",
+                    "  def forward(self: __torch__.Payload,",
+                    "    x: Tensor) -> Tensor:",
+                    "    return x",
+                    "",
+                ]
+            ),
+        )
+        zip_file.writestr("archive/code/__TORCH__/payload.py.debug_pkl", debug_pkl)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    python_failures = [
+        check
+        for check in result.checks
+        if check.name == "Python Code File Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert any(check.details.get("file") == source_path for check in python_failures)
+    assert any(
+        issue.location == f"{model_path}:{source_path}" and issue.severity == IssueSeverity.WARNING
+        for issue in result.issues
+    )
+
+
 def test_pytorch_zip_does_not_allow_nested_torchscript_generated_python_files(tmp_path: Path) -> None:
     model_path = create_mock_pytorch_zip(tmp_path / "nested_scripted.pt", prefix="archive")
     nested_path = "archive/data/code/__torch__/payload.py"

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -509,7 +509,9 @@ def test_pytorch_zip_allows_torchscript_generated_python_files(tmp_path: Path) -
     model_path = create_mock_pytorch_zip(tmp_path / "scripted.pt", prefix="archive")
     with zipfile.ZipFile(model_path, "a") as zip_file:
         zip_file.writestr("archive/code/__torch__.py", "class Module:\n    pass\n")
+        zip_file.writestr("archive/code/__torch__.py.debug_pkl", b"\x80\x04N.")
         zip_file.writestr("archive/code/__torch__/torch/nn/modules/container.py", "class Sequential:\n    pass\n")
+        zip_file.writestr("archive/code/__torch__/torch/nn/modules/container.py.debug_pkl", b"\x80\x04N.")
 
     result = PyTorchZipScanner().scan(str(model_path))
 
@@ -572,6 +574,22 @@ def test_pytorch_zip_still_warns_on_unexpected_python_files(tmp_path: Path) -> N
     ]
     failed_files = {check.details["file"] for check in python_failures}
     assert {"archive/code/helper.py", "archive/data/malicious.py"}.issubset(failed_files)
+    assert all(check.severity == IssueSeverity.WARNING for check in python_failures)
+
+
+def test_pytorch_zip_warns_on_unpaired_python_under_torchscript_tree(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "model.pt", prefix="archive")
+    with zipfile.ZipFile(model_path, "a") as zip_file:
+        zip_file.writestr("archive/code/__torch__/payload.py", "import os\nos.system('id')\n")
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    python_failures = [
+        check
+        for check in result.checks
+        if check.name == "Python Code File Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert any(check.details.get("file") == "archive/code/__torch__/payload.py" for check in python_failures)
     assert all(check.severity == IssueSeverity.WARNING for check in python_failures)
 
 

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -759,6 +759,74 @@ def test_pytorch_zip_warns_on_torchscript_stub_with_builtins_indirection(tmp_pat
     assert all(check.severity == IssueSeverity.WARNING for check in python_failures)
 
 
+def test_pytorch_zip_warns_on_torchscript_stub_with_markers_only_in_comments(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "model.pt", prefix="archive")
+    source_path = "archive/code/__torch__/payload.py"
+    with zipfile.ZipFile(model_path, "a") as zip_file:
+        zip_file.writestr(
+            source_path,
+            "\n".join(
+                [
+                    "class Payload(Module):",
+                    "  # __parameters__ = []",
+                    "  # __buffers__ = []",
+                    "  def forward(self: __torch__.Payload,",
+                    "    x: Tensor) -> Tensor:",
+                    "    return x",
+                    "",
+                ]
+            ),
+        )
+        zip_file.writestr(
+            "archive/code/__torch__/payload.py.debug_pkl",
+            b"\x80\x02X\x18\x00\x00\x00FORMAT_WITH_STRING_TABLEq\x00.",
+        )
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    python_failures = [
+        check
+        for check in result.checks
+        if check.name == "Python Code File Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert any(check.details.get("file") == source_path for check in python_failures)
+    assert all(check.severity == IssueSeverity.WARNING for check in python_failures)
+
+
+def test_pytorch_zip_warns_on_torchscript_stub_with_breakpoint_body_call(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "model.pt", prefix="archive")
+    source_path = "archive/code/__torch__/payload.py"
+    with zipfile.ZipFile(model_path, "a") as zip_file:
+        zip_file.writestr(
+            source_path,
+            "\n".join(
+                [
+                    "class Payload(Module):",
+                    "  __parameters__ = []",
+                    "  __buffers__ = []",
+                    "  def forward(self: __torch__.Payload,",
+                    "    x: Tensor) -> Tensor:",
+                    "    return breakpoint()",
+                    "",
+                ]
+            ),
+        )
+        zip_file.writestr(
+            "archive/code/__torch__/payload.py.debug_pkl",
+            b"\x80\x02X\x18\x00\x00\x00FORMAT_WITH_STRING_TABLEq\x00.",
+        )
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    python_failures = [
+        check
+        for check in result.checks
+        if check.name == "Python Code File Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert any(check.details.get("file") == source_path for check in python_failures)
+    assert all(check.severity == IssueSeverity.WARNING for check in python_failures)
+
+
 def test_pytorch_zip_warns_on_torchscript_stub_with_class_decorator_call(tmp_path: Path) -> None:
     model_path = create_mock_pytorch_zip(tmp_path / "model.pt", prefix="archive")
     source_path = "archive/code/__torch__/payload.py"

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -827,6 +827,74 @@ def test_pytorch_zip_warns_on_torchscript_stub_with_breakpoint_body_call(tmp_pat
     assert all(check.severity == IssueSeverity.WARNING for check in python_failures)
 
 
+def test_pytorch_zip_warns_on_torchscript_stub_with_print_body_call(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "model.pt", prefix="archive")
+    source_path = "archive/code/__torch__/payload.py"
+    with zipfile.ZipFile(model_path, "a") as zip_file:
+        zip_file.writestr(
+            source_path,
+            "\n".join(
+                [
+                    "class Payload(Module):",
+                    "  __parameters__ = []",
+                    "  __buffers__ = []",
+                    "  def forward(self: __torch__.Payload,",
+                    "    x: Tensor) -> Tensor:",
+                    "    return print('pwn')",
+                    "",
+                ]
+            ),
+        )
+        zip_file.writestr(
+            "archive/code/__torch__/payload.py.debug_pkl",
+            b"\x80\x02X\x18\x00\x00\x00FORMAT_WITH_STRING_TABLEq\x00.",
+        )
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    python_failures = [
+        check
+        for check in result.checks
+        if check.name == "Python Code File Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert result.success is True
+    assert any(check.details.get("file") == source_path for check in python_failures)
+    assert all(check.severity == IssueSeverity.WARNING for check in python_failures)
+
+
+def test_pytorch_zip_warns_on_torchscript_stub_with_nul_byte(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "model.pt", prefix="archive")
+    source_path = "archive/code/__torch__/payload.py"
+    with zipfile.ZipFile(model_path, "a") as zip_file:
+        zip_file.writestr(
+            source_path,
+            (
+                b"class Payload(Module):\n"
+                b"  __parameters__ = []\n"
+                b"  __buffers__ = []\n"
+                b"  def forward(self: __torch__.Payload,\n"
+                b"    x: Tensor) -> Tensor:\n"
+                b"    return x\n"
+                b"\x00"
+            ),
+        )
+        zip_file.writestr(
+            "archive/code/__torch__/payload.py.debug_pkl",
+            b"\x80\x02X\x18\x00\x00\x00FORMAT_WITH_STRING_TABLEq\x00.",
+        )
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    python_failures = [
+        check
+        for check in result.checks
+        if check.name == "Python Code File Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert result.success is True
+    assert any(check.details.get("file") == source_path for check in python_failures)
+    assert all(check.severity == IssueSeverity.WARNING for check in python_failures)
+
+
 def test_pytorch_zip_warns_on_torchscript_stub_with_class_decorator_call(tmp_path: Path) -> None:
     model_path = create_mock_pytorch_zip(tmp_path / "model.pt", prefix="archive")
     source_path = "archive/code/__torch__/payload.py"

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -829,6 +829,46 @@ def test_pytorch_zip_warns_on_torchscript_stub_with_class_assignment_call(tmp_pa
     assert all(check.severity == IssueSeverity.WARNING for check in python_failures)
 
 
+def test_pytorch_zip_warns_on_torchscript_stub_with_class_keyword_call(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "model.pt", prefix="archive")
+    source_path = "archive/code/__torch__/payload.py"
+    with zipfile.ZipFile(model_path, "a") as zip_file:
+        zip_file.writestr(
+            source_path,
+            "\n".join(
+                [
+                    "class Payload(Module, metaclass=print('loaded')):",
+                    "  __parameters__ = []",
+                    "  __buffers__ = []",
+                    "  def forward(self: __torch__.Payload,",
+                    "    x: Tensor) -> Tensor:",
+                    "    return x",
+                    "class Benign(Module):",
+                    "  __parameters__ = []",
+                    "  __buffers__ = []",
+                    "  def forward(self: __torch__.Benign,",
+                    "    x: Tensor) -> Tensor:",
+                    "    return x",
+                    "",
+                ]
+            ),
+        )
+        zip_file.writestr(
+            "archive/code/__torch__/payload.py.debug_pkl",
+            b"\x80\x02X\x18\x00\x00\x00FORMAT_WITH_STRING_TABLEq\x00.",
+        )
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    python_failures = [
+        check
+        for check in result.checks
+        if check.name == "Python Code File Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert any(check.details.get("file") == source_path for check in python_failures)
+    assert all(check.severity == IssueSeverity.WARNING for check in python_failures)
+
+
 def test_pytorch_zip_numeric_detection_edge_cases(tmp_path):
     """Test edge cases for numeric file detection in archive/data/."""
     zip_path = tmp_path / "model.pt"

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -566,6 +566,41 @@ def test_pytorch_zip_allows_torchscript_generated_python_files(tmp_path: Path) -
     ]
 
 
+def test_pytorch_zip_requires_exact_case_torchscript_debug_pair(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "scripted_case_mismatch.pt", prefix="archive")
+    source_path = "archive/code/__torch__/PAYLOAD.py"
+    debug_pkl = b"\x80\x02X\x18\x00\x00\x00FORMAT_WITH_STRING_TABLEq\x00."
+    with zipfile.ZipFile(model_path, "a") as zip_file:
+        zip_file.writestr(
+            source_path,
+            "\n".join(
+                [
+                    "class Payload(Module):",
+                    "  __parameters__ = []",
+                    "  __buffers__ = []",
+                    "  def forward(self: __torch__.Payload,",
+                    "    x: Tensor) -> Tensor:",
+                    "    return x",
+                    "",
+                ]
+            ),
+        )
+        zip_file.writestr("archive/code/__torch__/payload.py.debug_pkl", debug_pkl)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    python_failures = [
+        check
+        for check in result.checks
+        if check.name == "Python Code File Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert any(check.details.get("file") == source_path for check in python_failures)
+    assert any(
+        issue.location == f"{model_path}:{source_path}" and issue.severity == IssueSeverity.WARNING
+        for issue in result.issues
+    )
+
+
 def test_pytorch_zip_does_not_allow_nested_torchscript_generated_python_files(tmp_path: Path) -> None:
     model_path = create_mock_pytorch_zip(tmp_path / "nested_scripted.pt", prefix="archive")
     nested_path = "archive/data/code/__torch__/payload.py"

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -759,6 +759,76 @@ def test_pytorch_zip_warns_on_torchscript_stub_with_builtins_indirection(tmp_pat
     assert all(check.severity == IssueSeverity.WARNING for check in python_failures)
 
 
+def test_pytorch_zip_warns_on_torchscript_stub_with_class_decorator_call(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "model.pt", prefix="archive")
+    source_path = "archive/code/__torch__/payload.py"
+    with zipfile.ZipFile(model_path, "a") as zip_file:
+        zip_file.writestr(
+            source_path,
+            "\n".join(
+                [
+                    "@torch.classes.load_library('libpayload.so')",
+                    "class Payload(Module):",
+                    "  __parameters__ = []",
+                    "  __buffers__ = []",
+                    "  def forward(self: __torch__.Payload,",
+                    "    x: Tensor) -> Tensor:",
+                    "    return x",
+                    "",
+                ]
+            ),
+        )
+        zip_file.writestr(
+            "archive/code/__torch__/payload.py.debug_pkl",
+            b"\x80\x02X\x18\x00\x00\x00FORMAT_WITH_STRING_TABLEq\x00.",
+        )
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    python_failures = [
+        check
+        for check in result.checks
+        if check.name == "Python Code File Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert any(check.details.get("file") == source_path for check in python_failures)
+    assert all(check.severity == IssueSeverity.WARNING for check in python_failures)
+
+
+def test_pytorch_zip_warns_on_torchscript_stub_with_class_assignment_call(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "model.pt", prefix="archive")
+    source_path = "archive/code/__torch__/payload.py"
+    with zipfile.ZipFile(model_path, "a") as zip_file:
+        zip_file.writestr(
+            source_path,
+            "\n".join(
+                [
+                    "class Payload(Module):",
+                    "  __parameters__ = []",
+                    "  __buffers__ = []",
+                    "  payload = torch.classes.load_library('libpayload.so')",
+                    "  def forward(self: __torch__.Payload,",
+                    "    x: Tensor) -> Tensor:",
+                    "    return x",
+                    "",
+                ]
+            ),
+        )
+        zip_file.writestr(
+            "archive/code/__torch__/payload.py.debug_pkl",
+            b"\x80\x02X\x18\x00\x00\x00FORMAT_WITH_STRING_TABLEq\x00.",
+        )
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    python_failures = [
+        check
+        for check in result.checks
+        if check.name == "Python Code File Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert any(check.details.get("file") == source_path for check in python_failures)
+    assert all(check.severity == IssueSeverity.WARNING for check in python_failures)
+
+
 def test_pytorch_zip_numeric_detection_edge_cases(tmp_path):
     """Test edge cases for numeric file detection in archive/data/."""
     zip_path = tmp_path / "model.pt"

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -690,6 +690,40 @@ def test_pytorch_zip_warns_on_forged_torchscript_debug_pair(tmp_path: Path) -> N
     assert all(check.severity == IssueSeverity.WARNING for check in python_failures)
 
 
+def test_pytorch_zip_warns_on_torchscript_stub_with_builtins_indirection(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "model.pt", prefix="archive")
+    source_path = "archive/code/__torch__/payload.py"
+    with zipfile.ZipFile(model_path, "a") as zip_file:
+        zip_file.writestr(
+            source_path,
+            "\n".join(
+                [
+                    "class Payload(Module):",
+                    "  __parameters__ = []",
+                    "  __buffers__ = []",
+                    "  def forward(self: __torch__.Payload,",
+                    "    x: Tensor) -> Tensor:",
+                    "    return __globals__['__builtins__']['__import__']('os').system('id')",
+                    "",
+                ]
+            ),
+        )
+        zip_file.writestr(
+            "archive/code/__torch__/payload.py.debug_pkl",
+            b"\x80\x02X\x18\x00\x00\x00FORMAT_WITH_STRING_TABLEq\x00.",
+        )
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    python_failures = [
+        check
+        for check in result.checks
+        if check.name == "Python Code File Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert any(check.details.get("file") == source_path for check in python_failures)
+    assert all(check.severity == IssueSeverity.WARNING for check in python_failures)
+
+
 def test_pytorch_zip_numeric_detection_edge_cases(tmp_path):
     """Test edge cases for numeric file detection in archive/data/."""
     zip_path = tmp_path / "model.pt"

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -507,11 +507,40 @@ def test_pytorch_zip_scans_non_numeric_files_in_archive_data(tmp_path):
 
 def test_pytorch_zip_allows_torchscript_generated_python_files(tmp_path: Path) -> None:
     model_path = create_mock_pytorch_zip(tmp_path / "scripted.pt", prefix="archive")
+    debug_pkl = b"\x80\x02X\x18\x00\x00\x00FORMAT_WITH_STRING_TABLEq\x00."
     with zipfile.ZipFile(model_path, "a") as zip_file:
-        zip_file.writestr("archive/code/__torch__.py", "class Module:\n    pass\n")
-        zip_file.writestr("archive/code/__torch__.py.debug_pkl", b"\x80\x04N.")
-        zip_file.writestr("archive/code/__torch__/torch/nn/modules/container.py", "class Sequential:\n    pass\n")
-        zip_file.writestr("archive/code/__torch__/torch/nn/modules/container.py.debug_pkl", b"\x80\x04N.")
+        zip_file.writestr(
+            "archive/code/__torch__.py",
+            "\n".join(
+                [
+                    "class Module(Module):",
+                    "  __parameters__ = []",
+                    "  __buffers__ = []",
+                    "  training : bool",
+                    "  def forward(self: __torch__.Module,",
+                    "    x: Tensor) -> Tensor:",
+                    "    return torch.relu(x)",
+                    "",
+                ]
+            ),
+        )
+        zip_file.writestr("archive/code/__torch__.py.debug_pkl", debug_pkl)
+        zip_file.writestr(
+            "archive/code/__torch__/torch/nn/modules/container.py",
+            "\n".join(
+                [
+                    "class Sequential(Module):",
+                    "  __parameters__ = []",
+                    "  __buffers__ = []",
+                    "  training : bool",
+                    "  def forward(self: __torch__.torch.nn.modules.container.Sequential,",
+                    "    x: Tensor) -> Tensor:",
+                    "    return x",
+                    "",
+                ]
+            ),
+        )
+        zip_file.writestr("archive/code/__torch__/torch/nn/modules/container.py.debug_pkl", debug_pkl)
 
     result = PyTorchZipScanner().scan(str(model_path))
 
@@ -581,6 +610,39 @@ def test_pytorch_zip_warns_on_unpaired_python_under_torchscript_tree(tmp_path: P
     model_path = create_mock_pytorch_zip(tmp_path / "model.pt", prefix="archive")
     with zipfile.ZipFile(model_path, "a") as zip_file:
         zip_file.writestr("archive/code/__torch__/payload.py", "import os\nos.system('id')\n")
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    python_failures = [
+        check
+        for check in result.checks
+        if check.name == "Python Code File Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert any(check.details.get("file") == "archive/code/__torch__/payload.py" for check in python_failures)
+    assert all(check.severity == IssueSeverity.WARNING for check in python_failures)
+
+
+def test_pytorch_zip_warns_on_forged_torchscript_debug_pair(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "model.pt", prefix="archive")
+    with zipfile.ZipFile(model_path, "a") as zip_file:
+        zip_file.writestr(
+            "archive/code/__torch__/payload.py",
+            "\n".join(
+                [
+                    "class Payload(Module):",
+                    "  __parameters__ = []",
+                    "  __buffers__ = []",
+                    "  def forward(self: __torch__.Payload,",
+                    "    x: Tensor) -> Tensor:",
+                    "    return __import__('os').system('id')",
+                    "",
+                ]
+            ),
+        )
+        zip_file.writestr(
+            "archive/code/__torch__/payload.py.debug_pkl",
+            b"\x80\x02X\x18\x00\x00\x00FORMAT_WITH_STRING_TABLEq\x00.",
+        )
 
     result = PyTorchZipScanner().scan(str(model_path))
 


### PR DESCRIPTION
## Summary
- allow TorchScript-generated archive source files under code/__torch__ to avoid generic Python-file warnings
- keep warnings for arbitrary Python files elsewhere in PyTorch ZIP archives
- add benign and malicious-adjacent regression coverage for the PyTorch ZIP scanner

## Validation
- uv run --extra all-ci pytest tests/scanners/test_pytorch_zip_scanner.py::test_pytorch_zip_allows_torchscript_generated_python_files tests/scanners/test_pytorch_zip_scanner.py::test_pytorch_zip_still_warns_on_unexpected_python_files
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced validation for TorchScript-generated Python code in PyTorch models, enabling more accurate detection of legitimate vs. suspicious code and reducing false positives.

* **Tests**
  * Added comprehensive test coverage for TorchScript Python file validation and edge case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->