### PR TITLE
fix: add size floor for ZIP compression ratio warnings

### DIFF
--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -149,6 +149,7 @@ class PyTorchZipScanner(BaseScanner):
 
     # Security limits for archive manipulation protection
     MAX_COMPRESSION_RATIO: ClassVar[int] = 100  # 100:1 compression ratio threshold
+    MIN_COMPRESSION_BOMB_UNCOMPRESSED_SIZE: ClassVar[int] = 1024 * 1024
     MAX_ARCHIVE_ENTRIES: ClassVar[int] = 10000  # Maximum number of entries in archive
 
     def __init__(self, config: dict[str, Any] | None = None):
@@ -159,6 +160,10 @@ class PyTorchZipScanner(BaseScanner):
         self._relaxed_crc_tracker = RelaxedZipCrcTracker()
         # Configurable limits (can override class defaults via config)
         self.max_compression_ratio = self.config.get("max_compression_ratio", self.MAX_COMPRESSION_RATIO)
+        self.min_compression_bomb_uncompressed_size = self._normalize_positive_int_config(
+            self.config.get("min_compression_bomb_uncompressed_size"),
+            self.MIN_COMPRESSION_BOMB_UNCOMPRESSED_SIZE,
+        )
         self.max_archive_entries = self.config.get("max_archive_entries", self.MAX_ARCHIVE_ENTRIES)
 
     @classmethod
@@ -530,11 +535,17 @@ class PyTorchZipScanner(BaseScanner):
             # where the size field is zero) are skipped since ratio is undefined.
             if info.compress_size > 0:
                 compression_ratio = info.file_size / info.compress_size
-                if compression_ratio > self.max_compression_ratio:
+                if (
+                    compression_ratio > self.max_compression_ratio
+                    and info.file_size >= self.min_compression_bomb_uncompressed_size
+                ):
                     result.add_check(
                         name="Compression Ratio Check",
                         passed=False,
-                        message=f"Suspicious compression ratio ({compression_ratio:.1f}x) in entry: {name}",
+                        message=(
+                            f"Suspicious compression ratio ({compression_ratio:.1f}x) and "
+                            f"uncompressed size ({info.file_size} bytes) in entry: {name}"
+                        ),
                         severity=IssueSeverity.WARNING,
                         location=f"{path}:{name}",
                         details={
@@ -543,6 +554,7 @@ class PyTorchZipScanner(BaseScanner):
                             "uncompressed_size": info.file_size,
                             "ratio": compression_ratio,
                             "threshold": self.max_compression_ratio,
+                            "min_uncompressed_size": self.min_compression_bomb_uncompressed_size,
                             "risk": "High compression ratio may indicate a decompression bomb",
                         },
                         why="Decompression bombs use high compression ratios to exhaust system resources",
@@ -576,7 +588,10 @@ class PyTorchZipScanner(BaseScanner):
                 passed=True,
                 message="All entries have safe compression ratios",
                 location=path,
-                details={"threshold": self.max_compression_ratio},
+                details={
+                    "threshold": self.max_compression_ratio,
+                    "min_uncompressed_size": self.min_compression_bomb_uncompressed_size,
+                },
             )
 
         if not duplicate_entry_collisions_found and archive_entries:

--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -38,6 +38,8 @@ class ZipScanner(BaseScanner):
     supported_extensions: ClassVar[list[str]] = [".zip", ".npz", ".mar"]
     MAX_MAR_PYTHON_ANALYSIS_BYTES: ClassVar[int] = 10 * 1024 * 1024
     MAX_SYMLINK_TARGET_BYTES: ClassVar[int] = 64 * 1024
+    MAX_COMPRESSION_RATIO: ClassVar[int] = 100
+    MIN_COMPRESSION_BOMB_UNCOMPRESSED_SIZE: ClassVar[int] = 1024 * 1024
 
     def __init__(self, config: dict[str, Any] | None = None):
         super().__init__(config)
@@ -46,6 +48,11 @@ class ZipScanner(BaseScanner):
             "max_zip_entries",
             10000,
         )  # Limit number of entries
+        self.max_compression_ratio = self.MAX_COMPRESSION_RATIO
+        self.min_compression_bomb_uncompressed_size = self._normalize_positive_int_config(
+            self.config.get("zip_min_compression_bomb_uncompressed_size"),
+            self.MIN_COMPRESSION_BOMB_UNCOMPRESSED_SIZE,
+        )
 
     def _get_zip_depth(self) -> int:
         """Return the current nested ZIP depth from config."""
@@ -353,13 +360,16 @@ class ZipScanner(BaseScanner):
                 # Check compression ratio for zip bomb detection
                 if info.compress_size > 0:
                     compression_ratio = info.file_size / info.compress_size
-                    if compression_ratio > 100:
+                    if (
+                        compression_ratio > self.max_compression_ratio
+                        and info.file_size >= self.min_compression_bomb_uncompressed_size
+                    ):
                         result.add_check(
                             name="Compression Ratio Check",
                             passed=False,
                             message=(
-                                f"Suspicious compression ratio ({compression_ratio:.1f}x) in entry: {name}; "
-                                "skipping extraction"
+                                f"Suspicious compression ratio ({compression_ratio:.1f}x) and "
+                                f"uncompressed size ({info.file_size} bytes) in entry: {name}; skipping extraction"
                             ),
                             severity=IssueSeverity.WARNING,
                             rule_code="S410",  # Archive bomb
@@ -369,24 +379,32 @@ class ZipScanner(BaseScanner):
                                 "compressed_size": info.compress_size,
                                 "uncompressed_size": info.file_size,
                                 "ratio": compression_ratio,
-                                "threshold": 100,
+                                "threshold": self.max_compression_ratio,
+                                "min_uncompressed_size": self.min_compression_bomb_uncompressed_size,
                             },
                         )
                         scan_complete = False
                         continue
                     else:
                         # Record safe compression ratio
+                        if compression_ratio > self.max_compression_ratio:
+                            message = (
+                                f"Compression ratio ({compression_ratio:.1f}x) is below actionable size floor: {name}"
+                            )
+                        else:
+                            message = f"Compression ratio ({compression_ratio:.1f}x) is within safe limits: {name}"
                         result.add_check(
                             name="Compression Ratio Check",
                             passed=True,
-                            message=f"Compression ratio ({compression_ratio:.1f}x) is within safe limits: {name}",
+                            message=message,
                             location=f"{path}:{name}",
                             details={
                                 "entry": name,
                                 "compressed_size": info.compress_size,
                                 "uncompressed_size": info.file_size,
                                 "ratio": compression_ratio,
-                                "threshold": 100,
+                                "threshold": self.max_compression_ratio,
+                                "min_uncompressed_size": self.min_compression_bomb_uncompressed_size,
                             },
                             rule_code=None,  # Passing check
                         )

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -702,6 +702,36 @@ def test_pytorch_zip_scanner_compression_ratio_check(tmp_path):
     assert ratio_issues[0].severity == IssueSeverity.WARNING
 
 
+def test_pytorch_zip_scanner_small_high_ratio_metadata_stays_clean(tmp_path: Path) -> None:
+    """Small repetitive metadata should not fail the compression ratio check."""
+    zip_path = create_mock_pytorch_zip(tmp_path / "model.pt")
+    with zipfile.ZipFile(zip_path, "a", compression=zipfile.ZIP_DEFLATED) as zipf:
+        zipf.writestr("metadata/repetitive.txt", "A" * 16384)
+
+    scanner = PyTorchZipScanner()
+    result = scanner.scan(str(zip_path))
+
+    ratio_failures = [
+        check
+        for check in result.checks
+        if check.name == "Compression Ratio Check" and check.status == CheckStatus.FAILED
+    ]
+    assert ratio_failures == []
+    assert not [
+        issue
+        for issue in result.issues
+        if "compression ratio" in issue.message.lower()
+        and issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL}
+    ]
+    ratio_successes = [
+        check
+        for check in result.checks
+        if check.name == "Compression Ratio Check" and check.status == CheckStatus.PASSED
+    ]
+    assert len(ratio_successes) == 1
+    assert ratio_successes[0].details["min_uncompressed_size"] == 1024 * 1024
+
+
 def test_pytorch_zip_scanner_compression_ratio_passes(tmp_path):
     """Test that scanner passes when compression ratio is within limits."""
     zip_path = tmp_path / "model.pt"

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -511,8 +511,7 @@ class TestZipScanner:
         """High compression-ratio entries should be reported without extracting them."""
         archive_path = tmp_path / "suspicious.zip"
         with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as z:
-            # Keep highly compressible but smaller to speed CI.
-            z.writestr("suspicious.txt", "A" * 300000)
+            z.writestr("suspicious.txt", "A" * (2 * 1024 * 1024))
 
         nested_scan_paths: list[str] = []
 
@@ -532,11 +531,39 @@ class TestZipScanner:
         assert compression_issues[0].details["entry"] == "suspicious.txt"
         assert "skipping extraction" in compression_issues[0].message
 
+    def test_small_high_compression_ratio_entry_stays_clean(self, tmp_path: Path) -> None:
+        """Small repetitive metadata should not be treated as a ZIP bomb."""
+        archive_path = tmp_path / "metadata.zip"
+        with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as z:
+            z.writestr("metadata.txt", "A" * 16384)
+
+        nested_scan_paths: list[str] = []
+
+        def nested_scan(path: str, _config: dict[str, Any]) -> ScanResult:
+            nested_scan_paths.append(path)
+            return ScanResult(scanner_name="test")
+
+        scanner = ZipScanner(config={NESTED_SCAN_CALLBACK_CONFIG_KEY: nested_scan})
+        result = scanner.scan(str(archive_path))
+
+        assert result.success is True
+        assert any(path.endswith("_metadata.txt") for path in nested_scan_paths)
+        assert not [issue for issue in result.issues if issue.rule_code == "S410"]
+        compression_checks = [
+            check
+            for check in result.checks
+            if check.name == "Compression Ratio Check" and check.details.get("entry") == "metadata.txt"
+        ]
+        assert len(compression_checks) == 1
+        assert compression_checks[0].status == CheckStatus.PASSED
+        assert "size floor" in compression_checks[0].message
+        assert compression_checks[0].details["min_uncompressed_size"] == 1024 * 1024
+
     def test_zip_bomb_detection_skips_only_suspicious_entry(self, tmp_path: Path) -> None:
         """Suspicious entries should be skipped while safe entries still route to nested scanning."""
         archive_path = tmp_path / "mixed.zip"
         with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as z:
-            z.writestr("suspicious.txt", "A" * 300000)
+            z.writestr("suspicious.txt", "A" * (2 * 1024 * 1024))
             z.writestr("safe.bin", os.urandom(4096))
 
         nested_scan_paths: list[str] = []


### PR DESCRIPTION
## Summary
- require high compression ratio entries to also exceed a 1 MiB uncompressed-size floor before ZIP-bomb warnings fire
- include the size floor in compression-ratio check details for generic ZIP and PyTorch ZIP scanners
- keep large high-ratio archive entries blocked while allowing tiny repetitive metadata to scan normally

## Validation
- uv run --extra all-ci pytest tests/scanners/test_zip_scanner.py::TestZipScanner::test_zip_bomb_detection tests/scanners/test_zip_scanner.py::TestZipScanner::test_small_high_compression_ratio_entry_stays_clean tests/scanners/test_zip_scanner.py::TestZipScanner::test_zip_bomb_detection_skips_only_suspicious_entry tests/scanners/test_pytorch_zip_scanner.py::test_pytorch_zip_scanner_compression_ratio_check tests/scanners/test_pytorch_zip_scanner.py::test_pytorch_zip_scanner_small_high_ratio_metadata_stays_clean
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1