### PR TITLE
fix: reduce benign Keras Lambda bytecode noise

### DIFF
--- a/modelaudit/scanners/keras_utils.py
+++ b/modelaudit/scanners/keras_utils.py
@@ -332,7 +332,7 @@ def check_lambda_dict_function(
                 f"Lambda layer '{layer_name}' contains embedded bytecode (dict-format) with no dangerous "
                 "text patterns detected"
             ),
-            severity=IssueSeverity.INFO,
+            severity=IssueSeverity.WARNING,
             location=location,
             details={
                 "layer_name": layer_name,

--- a/modelaudit/scanners/keras_utils.py
+++ b/modelaudit/scanners/keras_utils.py
@@ -328,17 +328,21 @@ def check_lambda_dict_function(
         result.add_check(
             name="Lambda Layer Code Analysis",
             passed=False,
-            message=f"Lambda layer '{layer_name}' contains embedded bytecode (dict-format)",
-            severity=IssueSeverity.WARNING,
+            message=(
+                f"Lambda layer '{layer_name}' contains embedded bytecode (dict-format) with no dangerous "
+                "text patterns detected"
+            ),
+            severity=IssueSeverity.INFO,
             location=location,
             details={
                 "layer_name": layer_name,
                 "layer_class": "Lambda",
                 "function_format": "dict_bytecode",
+                "analysis_status": "opaque_bytecode",
             },
             why=(
                 "Keras 3.x Lambda layers embed compiled bytecode that will execute "
-                "arbitrary code during model loading or inference."
+                "during model loading or inference; no high-risk text patterns were detected."
             ),
         )
     return True

--- a/modelaudit/scanners/keras_zip_scanner.py
+++ b/modelaudit/scanners/keras_zip_scanner.py
@@ -1740,15 +1740,22 @@ class KerasZipScanner(BaseScanner):
                             result.add_check(
                                 name="Lambda Layer Detection",
                                 passed=False,
-                                message=f"Lambda layer '{layer_name}' contains encoded data (unable to validate)",
-                                severity=IssueSeverity.WARNING,
+                                message=(
+                                    f"Lambda layer '{layer_name}' contains opaque encoded bytecode with no dangerous "
+                                    "text patterns detected"
+                                ),
+                                severity=IssueSeverity.INFO,
                                 location=f"{self.current_file_path} (layer: {layer_name})",
                                 details={
                                     "layer_name": layer_name,
                                     "layer_class": "Lambda",
                                     "validation_error": error,
+                                    "analysis_status": "opaque_bytecode",
                                 },
-                                why="Lambda layers with encoded data may contain arbitrary code.",
+                                why=(
+                                    "Keras Lambda layers can embed bytecode that executes during model loading or "
+                                    "inference; no high-risk text patterns were detected."
+                                ),
                             )
 
                 except Exception as e:

--- a/modelaudit/scanners/keras_zip_scanner.py
+++ b/modelaudit/scanners/keras_zip_scanner.py
@@ -1744,7 +1744,7 @@ class KerasZipScanner(BaseScanner):
                                     f"Lambda layer '{layer_name}' contains opaque encoded bytecode with no dangerous "
                                     "text patterns detected"
                                 ),
-                                severity=IssueSeverity.INFO,
+                                severity=IssueSeverity.WARNING,
                                 location=f"{self.current_file_path} (layer: {layer_name})",
                                 details={
                                     "layer_name": layer_name,

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -804,7 +804,7 @@ def test_lambda_safe_prefix_with_comment_token_in_malicious_payload_is_flagged(t
     )
 
 
-def test_lambda_dict_bytecode_without_dangerous_patterns_is_info_only(tmp_path: Path) -> None:
+def test_lambda_dict_bytecode_without_dangerous_patterns_stays_warning(tmp_path: Path) -> None:
     encoded_code = base64.b64encode(marshal.dumps((lambda x: x + 1).__code__)).decode()
     model_path = create_custom_h5_file(
         tmp_path,
@@ -831,11 +831,11 @@ def test_lambda_dict_bytecode_without_dangerous_patterns_is_info_only(tmp_path: 
         issue for issue in result.issues if "embedded bytecode" in issue.message and "safe_dict_lambda" in issue.message
     ]
     assert len(bytecode_issues) == 1
-    assert bytecode_issues[0].severity == IssueSeverity.INFO
+    assert bytecode_issues[0].severity == IssueSeverity.WARNING
     assert not [
         issue
         for issue in result.issues
-        if "safe_dict_lambda" in issue.message and issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL}
+        if "safe_dict_lambda" in issue.message and issue.severity == IssueSeverity.CRITICAL
     ]
 
 

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -1,4 +1,6 @@
+import base64
 import json
+import marshal
 from pathlib import Path
 from typing import Any
 
@@ -800,6 +802,76 @@ def test_lambda_safe_prefix_with_comment_token_in_malicious_payload_is_flagged(t
         and check.details.get("pattern_type") == "safe_normalization"
         for check in result.checks
     )
+
+
+def test_lambda_dict_bytecode_without_dangerous_patterns_is_info_only(tmp_path: Path) -> None:
+    encoded_code = base64.b64encode(marshal.dumps((lambda x: x + 1).__code__)).decode()
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "name": "safe_dict_lambda_model",
+                "layers": [
+                    {
+                        "class_name": "Lambda",
+                        "config": {
+                            "name": "safe_dict_lambda",
+                            "function": {"class_name": "__lambda__", "config": {"code": encoded_code}},
+                        },
+                    }
+                ],
+            },
+        },
+    )
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    bytecode_issues = [
+        issue for issue in result.issues if "embedded bytecode" in issue.message and "safe_dict_lambda" in issue.message
+    ]
+    assert len(bytecode_issues) == 1
+    assert bytecode_issues[0].severity == IssueSeverity.INFO
+    assert not [
+        issue
+        for issue in result.issues
+        if "safe_dict_lambda" in issue.message and issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL}
+    ]
+
+
+def test_lambda_dict_bytecode_with_dangerous_pattern_still_critical(tmp_path: Path) -> None:
+    encoded_code = base64.b64encode(b"import os\nos.system('id')\neval('__import__(\"os\")')").decode()
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "name": "dangerous_dict_lambda_model",
+                "layers": [
+                    {
+                        "class_name": "Lambda",
+                        "config": {
+                            "name": "dangerous_dict_lambda",
+                            "function": {"class_name": "__lambda__", "config": {"code": encoded_code}},
+                        },
+                    }
+                ],
+            },
+        },
+    )
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    dangerous_checks = [
+        check
+        for check in result.checks
+        if check.name == "Lambda Layer Code Analysis"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details.get("layer_name") == "dangerous_dict_lambda"
+    ]
+    assert len(dangerous_checks) == 1
+    assert {"eval", "__import__", "os.system"}.issubset(set(dangerous_checks[0].details["dangerous_patterns"]))
 
 
 def test_keras_h5_scanner_empty_file(tmp_path):

--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -868,8 +868,8 @@ __import__('pickle').loads(data)
         finally:
             os.unlink(temp_path)
 
-    def test_opaque_lambda_bytecode_is_info_only(self, tmp_path: Path) -> None:
-        """Benign compiled Lambda bytecode should not produce warning-level noise."""
+    def test_opaque_lambda_bytecode_stays_warning(self, tmp_path: Path) -> None:
+        """Opaque compiled Lambda bytecode should remain a warning-level finding."""
         scanner = KerasZipScanner()
         encoded_code = base64.b64encode(marshal.dumps((lambda x: x + 1).__code__)).decode()
         config = {
@@ -893,11 +893,11 @@ __import__('pickle').loads(data)
             if "opaque encoded bytecode" in issue.message and "opaque_lambda" in issue.message
         ]
         assert len(opaque_issues) == 1
-        assert opaque_issues[0].severity == IssueSeverity.INFO
+        assert opaque_issues[0].severity == IssueSeverity.WARNING
         assert not [
             issue
             for issue in result.issues
-            if "opaque_lambda" in issue.message and issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL}
+            if "opaque_lambda" in issue.message and issue.severity == IssueSeverity.CRITICAL
         ]
 
     def test_stringlookup_external_vocabulary_path_triggers_cve_2025_12058(self, tmp_path: Path) -> None:

--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -9,6 +9,7 @@ The new .keras format is a ZIP archive containing:
 
 import base64
 import json
+import marshal
 import os
 import tempfile
 import warnings
@@ -866,6 +867,38 @@ __import__('pickle').loads(data)
 
         finally:
             os.unlink(temp_path)
+
+    def test_opaque_lambda_bytecode_is_info_only(self, tmp_path: Path) -> None:
+        """Benign compiled Lambda bytecode should not produce warning-level noise."""
+        scanner = KerasZipScanner()
+        encoded_code = base64.b64encode(marshal.dumps((lambda x: x + 1).__code__)).decode()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Lambda",
+                        "name": "opaque_lambda",
+                        "config": {"function": [encoded_code, None, None]},
+                    }
+                ]
+            },
+        }
+
+        result = scanner.scan(str(create_configured_keras_zip(tmp_path, config)))
+
+        opaque_issues = [
+            issue
+            for issue in result.issues
+            if "opaque encoded bytecode" in issue.message and "opaque_lambda" in issue.message
+        ]
+        assert len(opaque_issues) == 1
+        assert opaque_issues[0].severity == IssueSeverity.INFO
+        assert not [
+            issue
+            for issue in result.issues
+            if "opaque_lambda" in issue.message and issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL}
+        ]
 
     def test_stringlookup_external_vocabulary_path_triggers_cve_2025_12058(self, tmp_path: Path) -> None:
         """Absolute StringLookup vocabulary paths should be attributed to CVE-2025-12058 on vulnerable Keras."""


### PR DESCRIPTION
## Summary
- downgrade opaque/benign Keras Lambda bytecode findings to INFO when no dangerous text patterns are detected
- keep malformed Lambda metadata and dangerous Lambda payloads warning/critical
- add H5 and .keras regression coverage for benign bytecode plus a dangerous dict-format payload

## Validation
- uv run --extra all-ci pytest tests/scanners/test_keras_zip_scanner.py::TestKerasZipScanner::test_opaque_lambda_bytecode_is_info_only tests/scanners/test_keras_h5_scanner.py::test_lambda_dict_bytecode_without_dangerous_patterns_is_info_only tests/scanners/test_keras_h5_scanner.py::test_lambda_dict_bytecode_with_dangerous_pattern_still_critical tests/scanners/test_keras_h5_scanner.py::test_lambda_safe_prefix_with_comment_token_in_malicious_payload_is_flagged
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1