### PR TITLE
fix: require nested pickle execution evidence

### DIFF
--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -3404,6 +3404,8 @@ def _classify_nested_pickle_payload(
     payload: bytes | bytearray,
     nested_match: Any,
     ml_context: dict[str, Any],
+    *,
+    deadline: float | None = None,
 ) -> tuple[IssueSeverity, str, dict[str, Any]]:
     """Classify nested pickle evidence without treating structure alone as critical."""
     nested_bytes = bytes(payload)[nested_match.offset :]
@@ -3413,6 +3415,7 @@ def _classify_nested_pickle_payload(
             io.BytesIO(nested_bytes),
             multi_stream=True,
             max_items=_POST_BUDGET_OPCODE_SCAN_LIMIT_OPCODES,
+            deadline=deadline,
         ):
             opcodes.append(opcode_info)
     except _GenopsBudgetExceeded as exc:
@@ -3448,16 +3451,29 @@ def _classify_nested_pickle_payload(
     except Exception as exc:
         if opcodes:
             severity, evidence, evidence_details = _classify_nested_pickle_opcodes(opcodes, ml_context)
-            if severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL}:
+            if severity == IssueSeverity.CRITICAL:
                 evidence_details["analysis_incomplete"] = True
                 evidence_details["analysis_error"] = str(exc)
                 evidence_details["analysis_error_type"] = type(exc).__name__
                 return severity, evidence, evidence_details
+            return (
+                _get_context_aware_severity(IssueSeverity.CRITICAL, ml_context),
+                "analysis_incomplete",
+                {
+                    "evidence": "analysis_incomplete",
+                    "partial_evidence": evidence,
+                    "partial_evidence_details": evidence_details,
+                    "analysis_incomplete": True,
+                    "analysis_error": str(exc),
+                    "analysis_error_type": type(exc).__name__,
+                },
+            )
         return (
-            _get_context_aware_severity(IssueSeverity.WARNING, ml_context),
+            _get_context_aware_severity(IssueSeverity.CRITICAL, ml_context),
             "analysis_incomplete",
             {
                 "evidence": "analysis_incomplete",
+                "analysis_incomplete": True,
                 "analysis_error": str(exc),
                 "analysis_error_type": type(exc).__name__,
             },
@@ -3588,6 +3604,8 @@ def _collect_nested_pickle_opcode_findings(
     arg: Any,
     pos: int | None,
     ml_context: dict[str, Any],
+    *,
+    deadline: float | None = None,
 ) -> list[dict[str, Any]]:
     """Return nested/encoded pickle findings for a single opcode payload."""
     findings: list[dict[str, Any]] = []
@@ -3595,7 +3613,12 @@ def _collect_nested_pickle_opcode_findings(
     if opcode_name in {"BINBYTES", "SHORT_BINBYTES", "BINBYTES8", "BYTEARRAY8"} and isinstance(arg, bytes | bytearray):
         nested_match = _find_nested_pickle_match(arg)
         if nested_match is not None:
-            severity, evidence, evidence_details = _classify_nested_pickle_payload(arg, nested_match, ml_context)
+            severity, evidence, evidence_details = _classify_nested_pickle_payload(
+                arg,
+                nested_match,
+                ml_context,
+                deadline=deadline,
+            )
             findings.append(
                 _build_opcode_check_finding(
                     check_name="Nested Pickle Detection",
@@ -3621,7 +3644,10 @@ def _collect_nested_pickle_opcode_findings(
             nested_match = _find_nested_pickle_match(payload)
             if nested_match is not None:
                 severity, evidence, evidence_details = _classify_nested_pickle_payload(
-                    payload, nested_match, ml_context
+                    payload,
+                    nested_match,
+                    ml_context,
+                    deadline=deadline,
                 )
                 findings.append(
                     _build_opcode_check_finding(
@@ -3652,7 +3678,10 @@ def _collect_nested_pickle_opcode_findings(
             nested_match = _find_nested_pickle_match(decoded)
             if nested_match is not None:
                 severity, evidence, evidence_details = _classify_nested_pickle_payload(
-                    decoded, nested_match, ml_context
+                    decoded,
+                    nested_match,
+                    ml_context,
+                    deadline=deadline,
                 )
                 findings.append(
                     _build_opcode_check_finding(
@@ -6153,7 +6182,15 @@ class PickleScanner(BaseScanner):
             if absolute_pos is None or absolute_pos < minimum_offset:
                 continue
 
-            findings.extend(_collect_nested_pickle_opcode_findings(opcode.name, arg, absolute_pos, ml_context))
+            findings.extend(
+                _collect_nested_pickle_opcode_findings(
+                    opcode.name,
+                    arg,
+                    absolute_pos,
+                    ml_context,
+                    deadline=deadline,
+                )
+            )
             findings.extend(_collect_encoded_python_opcode_findings(opcode.name, arg, absolute_pos, ml_context))
 
             if opcode.name == "STACK_GLOBAL":
@@ -7591,7 +7628,13 @@ class PickleScanner(BaseScanner):
                             ),
                         )
 
-                for nested_finding in _collect_nested_pickle_opcode_findings(opcode.name, arg, pos, ml_context):
+                for nested_finding in _collect_nested_pickle_opcode_findings(
+                    opcode.name,
+                    arg,
+                    pos,
+                    ml_context,
+                    deadline=deadline,
+                ):
                     result.add_check(
                         name=nested_finding["check_name"],
                         passed=False,

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -3411,6 +3411,7 @@ def _classify_nested_pickle_payload(
     try:
         for opcode_info in _genops_with_fallback(
             io.BytesIO(nested_bytes),
+            multi_stream=True,
             max_items=_POST_BUDGET_OPCODE_SCAN_LIMIT_OPCODES,
         ):
             opcodes.append(opcode_info)

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -3396,8 +3396,8 @@ def _build_opcode_check_finding(
 
 
 def _parse_global_reference_arg(arg: str) -> tuple[str, str]:
-    parts = arg.split(" ", 1) if " " in arg else arg.rsplit(".", 1) if "." in arg else [arg, ""]
-    return parts[0], parts[1] if len(parts) > 1 else ""
+    parsed = _parse_module_function(arg)
+    return parsed if parsed is not None else (arg, "")
 
 
 def _classify_nested_pickle_payload(
@@ -3422,9 +3422,13 @@ def _classify_nested_pickle_payload(
         )
     except Exception as exc:
         return (
-            IssueSeverity.INFO,
-            "structure_only",
-            {"evidence": "structure_only", "analysis_error": str(exc), "analysis_error_type": type(exc).__name__},
+            _get_context_aware_severity(IssueSeverity.WARNING, ml_context),
+            "analysis_incomplete",
+            {
+                "evidence": "analysis_incomplete",
+                "analysis_error": str(exc),
+                "analysis_error_type": type(exc).__name__,
+            },
         )
 
     (

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -3418,10 +3418,23 @@ def _classify_nested_pickle_payload(
     except _GenopsBudgetExceeded as exc:
         if opcodes:
             severity, evidence, evidence_details = _classify_nested_pickle_opcodes(opcodes, ml_context)
-            if severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL}:
+            if severity == IssueSeverity.CRITICAL:
                 evidence_details["analysis_incomplete"] = True
                 evidence_details["analysis_error"] = exc.reason
+                evidence_details["opcode_budget_exceeded"] = True
                 return severity, evidence, evidence_details
+            return (
+                _get_context_aware_severity(IssueSeverity.CRITICAL, ml_context),
+                "analysis_incomplete",
+                {
+                    "evidence": "analysis_incomplete",
+                    "partial_evidence": evidence,
+                    "partial_evidence_details": evidence_details,
+                    "analysis_incomplete": True,
+                    "analysis_error": exc.reason,
+                    "opcode_budget_exceeded": True,
+                },
+            )
         return (
             _get_context_aware_severity(IssueSeverity.CRITICAL, ml_context),
             "analysis_incomplete",

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -3407,20 +3407,33 @@ def _classify_nested_pickle_payload(
 ) -> tuple[IssueSeverity, str, dict[str, Any]]:
     """Classify nested pickle evidence without treating structure alone as critical."""
     nested_bytes = bytes(payload)[nested_match.offset :]
+    opcodes: list[tuple[Any, Any, int | None]] = []
     try:
-        opcodes = list(
-            _genops_with_fallback(
-                io.BytesIO(nested_bytes),
-                max_items=_POST_BUDGET_OPCODE_SCAN_LIMIT_OPCODES,
-            )
-        )
+        for opcode_info in _genops_with_fallback(
+            io.BytesIO(nested_bytes),
+            max_items=_POST_BUDGET_OPCODE_SCAN_LIMIT_OPCODES,
+        ):
+            opcodes.append(opcode_info)
     except _GenopsBudgetExceeded as exc:
+        if opcodes:
+            severity, evidence, evidence_details = _classify_nested_pickle_opcodes(opcodes, ml_context)
+            if severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL}:
+                evidence_details["analysis_incomplete"] = True
+                evidence_details["analysis_error"] = exc.reason
+                return severity, evidence, evidence_details
         return (
             _get_context_aware_severity(IssueSeverity.WARNING, ml_context),
             "analysis_incomplete",
             {"evidence": "analysis_incomplete", "analysis_error": exc.reason},
         )
     except Exception as exc:
+        if opcodes:
+            severity, evidence, evidence_details = _classify_nested_pickle_opcodes(opcodes, ml_context)
+            if severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL}:
+                evidence_details["analysis_incomplete"] = True
+                evidence_details["analysis_error"] = str(exc)
+                evidence_details["analysis_error_type"] = type(exc).__name__
+                return severity, evidence, evidence_details
         return (
             _get_context_aware_severity(IssueSeverity.WARNING, ml_context),
             "analysis_incomplete",
@@ -3431,6 +3444,14 @@ def _classify_nested_pickle_payload(
             },
         )
 
+    return _classify_nested_pickle_opcodes(opcodes, ml_context)
+
+
+def _classify_nested_pickle_opcodes(
+    opcodes: list[tuple[Any, Any, int | None]],
+    ml_context: dict[str, Any],
+) -> tuple[IssueSeverity, str, dict[str, Any]]:
+    """Classify already-collected nested pickle opcodes."""
     (
         stack_global_refs,
         callable_refs,

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -3422,9 +3422,14 @@ def _classify_nested_pickle_payload(
                 evidence_details["analysis_error"] = exc.reason
                 return severity, evidence, evidence_details
         return (
-            _get_context_aware_severity(IssueSeverity.WARNING, ml_context),
+            _get_context_aware_severity(IssueSeverity.CRITICAL, ml_context),
             "analysis_incomplete",
-            {"evidence": "analysis_incomplete", "analysis_error": exc.reason},
+            {
+                "evidence": "analysis_incomplete",
+                "analysis_incomplete": True,
+                "analysis_error": exc.reason,
+                "opcode_budget_exceeded": True,
+            },
         )
     except Exception as exc:
         if opcodes:

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -3395,6 +3395,133 @@ def _build_opcode_check_finding(
     }
 
 
+def _parse_global_reference_arg(arg: str) -> tuple[str, str]:
+    parts = arg.split(" ", 1) if " " in arg else arg.rsplit(".", 1) if "." in arg else [arg, ""]
+    return parts[0], parts[1] if len(parts) > 1 else ""
+
+
+def _classify_nested_pickle_payload(
+    payload: bytes | bytearray,
+    nested_match: Any,
+    ml_context: dict[str, Any],
+) -> tuple[IssueSeverity, str, dict[str, Any]]:
+    """Classify nested pickle evidence without treating structure alone as critical."""
+    nested_bytes = bytes(payload)[nested_match.offset :]
+    try:
+        opcodes = list(
+            _genops_with_fallback(
+                io.BytesIO(nested_bytes),
+                max_items=_POST_BUDGET_OPCODE_SCAN_LIMIT_OPCODES,
+            )
+        )
+    except _GenopsBudgetExceeded as exc:
+        return (
+            _get_context_aware_severity(IssueSeverity.WARNING, ml_context),
+            "analysis_incomplete",
+            {"evidence": "analysis_incomplete", "analysis_error": exc.reason},
+        )
+    except Exception as exc:
+        return (
+            IssueSeverity.INFO,
+            "structure_only",
+            {"evidence": "structure_only", "analysis_error": str(exc), "analysis_error_type": type(exc).__name__},
+        )
+
+    (
+        stack_global_refs,
+        callable_refs,
+        _callable_origin_refs,
+        callable_origin_is_ext,
+        _malformed_stack_globals,
+        mutation_target_refs,
+    ) = _simulate_symbolic_reference_maps(opcodes)
+
+    dangerous_pattern = is_dangerous_reduce_pattern(
+        opcodes,
+        stack_global_refs=stack_global_refs,
+        callable_refs=callable_refs,
+        callable_origin_is_ext=callable_origin_is_ext,
+        mutation_target_refs=mutation_target_refs,
+    )
+    if dangerous_pattern is not None:
+        return (
+            _get_context_aware_severity(IssueSeverity.CRITICAL, ml_context),
+            "dangerous_execution",
+            {"evidence": "dangerous_execution", "dangerous_pattern": dangerous_pattern},
+        )
+
+    strongest_severity = IssueSeverity.INFO
+    evidence = "structure_only"
+    evidence_details: dict[str, Any] = {"evidence": evidence}
+
+    for index, (opcode, arg, _pos) in enumerate(opcodes):
+        if opcode.name == "GLOBAL" and isinstance(arg, str):
+            module, function = _parse_global_reference_arg(arg)
+            is_failure, severity, classification = _classify_import_reference(
+                module,
+                function,
+                ml_context,
+                is_import_only=True,
+            )
+            if is_failure and severity == IssueSeverity.CRITICAL:
+                return (
+                    _get_context_aware_severity(IssueSeverity.CRITICAL, ml_context),
+                    "dangerous_import",
+                    {
+                        "evidence": "dangerous_import",
+                        "import_reference": f"{module}.{function}" if function else module,
+                        "classification": classification,
+                    },
+                )
+            if is_failure and severity == IssueSeverity.WARNING and strongest_severity == IssueSeverity.INFO:
+                strongest_severity = IssueSeverity.WARNING
+                evidence = "unknown_import"
+                evidence_details = {
+                    "evidence": evidence,
+                    "import_reference": f"{module}.{function}" if function else module,
+                    "classification": classification,
+                }
+        elif opcode.name == "STACK_GLOBAL" and index in stack_global_refs:
+            module, function = stack_global_refs[index]
+            is_failure, severity, classification = _classify_import_reference(
+                module,
+                function,
+                ml_context,
+                is_import_only=True,
+            )
+            if is_failure and severity == IssueSeverity.CRITICAL:
+                return (
+                    _get_context_aware_severity(IssueSeverity.CRITICAL, ml_context),
+                    "dangerous_import",
+                    {
+                        "evidence": "dangerous_import",
+                        "import_reference": f"{module}.{function}" if function else module,
+                        "classification": classification,
+                    },
+                )
+            if is_failure and severity == IssueSeverity.WARNING and strongest_severity == IssueSeverity.INFO:
+                strongest_severity = IssueSeverity.WARNING
+                evidence = "unknown_import"
+                evidence_details = {
+                    "evidence": evidence,
+                    "import_reference": f"{module}.{function}" if function else module,
+                    "classification": classification,
+                }
+    if strongest_severity == IssueSeverity.INFO:
+        return strongest_severity, evidence, evidence_details
+    return _get_context_aware_severity(strongest_severity, ml_context), evidence, evidence_details
+
+
+def _nested_pickle_detection_message(base_message: str, evidence: str) -> str:
+    if evidence in {"dangerous_execution", "dangerous_import"}:
+        return f"{base_message} with dangerous execution evidence"
+    if evidence == "analysis_incomplete":
+        return f"{base_message} with incomplete nested-pickle analysis"
+    if evidence == "unknown_import":
+        return f"{base_message} with executable reconstruction evidence"
+    return f"{base_message} without dangerous execution evidence"
+
+
 def _serialize_opcode_check_finding(finding: dict[str, Any]) -> dict[str, Any]:
     """Convert opcode finding payloads into check-detail-friendly data."""
     severity = finding.get("severity")
@@ -3424,11 +3551,11 @@ def _collect_nested_pickle_opcode_findings(
     if opcode_name in {"BINBYTES", "SHORT_BINBYTES", "BINBYTES8", "BYTEARRAY8"} and isinstance(arg, bytes | bytearray):
         nested_match = _find_nested_pickle_match(arg)
         if nested_match is not None:
-            severity = _get_context_aware_severity(IssueSeverity.CRITICAL, ml_context)
+            severity, evidence, evidence_details = _classify_nested_pickle_payload(arg, nested_match, ml_context)
             findings.append(
                 _build_opcode_check_finding(
                     check_name="Nested Pickle Detection",
-                    message="Nested pickle payload detected",
+                    message=_nested_pickle_detection_message("Nested pickle payload detected", evidence),
                     severity=severity,
                     position=pos,
                     rule_code="S213",
@@ -3438,6 +3565,7 @@ def _collect_nested_pickle_opcode_findings(
                         "nested_offset": nested_match.offset,
                         "sample_size": nested_match.sample_size,
                         "searched_bytes": nested_match.searched_bytes,
+                        **evidence_details,
                     },
                     why=get_pattern_explanation("nested_pickle"),
                 )
@@ -3445,13 +3573,19 @@ def _collect_nested_pickle_opcode_findings(
 
     if opcode_name in {"BINSTRING", "SHORT_BINSTRING"} and isinstance(arg, str):
         try:
-            nested_match = _find_nested_pickle_match(arg.encode("latin-1"))
+            payload = arg.encode("latin-1")
+            nested_match = _find_nested_pickle_match(payload)
             if nested_match is not None:
-                severity = _get_context_aware_severity(IssueSeverity.CRITICAL, ml_context)
+                severity, evidence, evidence_details = _classify_nested_pickle_payload(
+                    payload, nested_match, ml_context
+                )
                 findings.append(
                     _build_opcode_check_finding(
                         check_name="Nested Pickle Detection",
-                        message="Nested pickle payload detected in legacy string opcode",
+                        message=_nested_pickle_detection_message(
+                            "Nested pickle payload detected in legacy string opcode",
+                            evidence,
+                        ),
                         severity=severity,
                         position=pos,
                         rule_code="S213",
@@ -3461,6 +3595,7 @@ def _collect_nested_pickle_opcode_findings(
                             "nested_offset": nested_match.offset,
                             "sample_size": nested_match.sample_size,
                             "searched_bytes": nested_match.searched_bytes,
+                            **evidence_details,
                         },
                         why=get_pattern_explanation("nested_pickle"),
                     )
@@ -3472,11 +3607,13 @@ def _collect_nested_pickle_opcode_findings(
         for enc, decoded in _decode_string_to_bytes(arg):
             nested_match = _find_nested_pickle_match(decoded)
             if nested_match is not None:
-                severity = _get_context_aware_severity(IssueSeverity.CRITICAL, ml_context)
+                severity, evidence, evidence_details = _classify_nested_pickle_payload(
+                    decoded, nested_match, ml_context
+                )
                 findings.append(
                     _build_opcode_check_finding(
                         check_name="Encoded Pickle Detection",
-                        message="Encoded pickle payload detected",
+                        message=_nested_pickle_detection_message("Encoded pickle payload detected", evidence),
                         severity=severity,
                         position=pos,
                         rule_code=get_encoding_rule_code(enc),
@@ -3488,6 +3625,7 @@ def _collect_nested_pickle_opcode_findings(
                             "nested_offset": nested_match.offset,
                             "sample_size": nested_match.sample_size,
                             "searched_bytes": nested_match.searched_bytes,
+                            **evidence_details,
                         },
                         why=get_pattern_explanation("nested_pickle"),
                     )

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -3535,6 +3535,67 @@ class TestDillLoadersRegression:
         assert details["analysis_incomplete"] is True
         assert "analysis_error_type" in details
 
+    def test_nested_pickle_parse_error_without_dangerous_prefix_fails_closed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Parse aborts after benign prefix evidence should still be critical."""
+        from modelaudit.scanners import pickle_scanner as pickle_scanner_module
+
+        benign_opcodes = list(pickletools.genops(pickle.dumps({"padding": "benign"})))
+
+        def _benign_prefix_then_parse_error(
+            file_obj: BinaryIO,
+            *,
+            multi_stream: bool = False,
+            max_items: int | None = None,
+            deadline: float | None = None,
+        ) -> Iterator[tuple[Any, Any, int | None]]:
+            del file_obj, multi_stream, max_items, deadline
+            yield from benign_opcodes
+            raise ValueError("trailing nested parse error")
+
+        monkeypatch.setattr(pickle_scanner_module, "_genops_with_fallback", _benign_prefix_then_parse_error)
+
+        severity, evidence, details = _classify_nested_pickle_payload(
+            b"\x80\x04.",
+            SimpleNamespace(offset=0),
+            {},
+        )
+
+        assert severity == IssueSeverity.CRITICAL
+        assert evidence == "analysis_incomplete"
+        assert details["analysis_incomplete"] is True
+        assert details["analysis_error_type"] == "ValueError"
+        assert details["partial_evidence"] == "structure_only"
+
+    def test_nested_pickle_classification_passes_deadline_to_parser(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Nested re-parsing should preserve the active scan deadline."""
+        from modelaudit.scanners import pickle_scanner as pickle_scanner_module
+
+        observed_deadlines: list[float | None] = []
+
+        def _capture_deadline(
+            file_obj: BinaryIO,
+            *,
+            multi_stream: bool = False,
+            max_items: int | None = None,
+            deadline: float | None = None,
+        ) -> Iterator[tuple[Any, Any, int | None]]:
+            del file_obj, multi_stream, max_items
+            observed_deadlines.append(deadline)
+            yield from pickletools.genops(pickle.dumps({"safe": True}))
+
+        monkeypatch.setattr(pickle_scanner_module, "_genops_with_fallback", _capture_deadline)
+
+        _classify_nested_pickle_payload(
+            b"\x80\x04.",
+            SimpleNamespace(offset=0),
+            {},
+            deadline=123.0,
+        )
+
+        assert observed_deadlines == [123.0]
+
     def test_nested_pickle_budget_error_preserves_collected_dangerous_opcodes(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -2411,7 +2411,7 @@ def test_post_budget_global_scan_runs_after_deadline_truncation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Deadline-triggered truncation should not continue scanning past the timeout boundary."""
-    import modelaudit.scanners.pickle_scanner as pickle_scanner_module
+    from modelaudit.scanners import pickle_scanner as pickle_scanner_module
 
     pickle_path = tmp_path / "post-budget-deadline.pkl"
     pickle_path.write_bytes(b"\x80\x04cmysterypkg\nloader\n.")
@@ -3524,7 +3524,7 @@ class TestDillLoadersRegression:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Budget exhaustion should not discard dangerous nested opcodes already yielded."""
-        import modelaudit.scanners.pickle_scanner as pickle_scanner_module
+        from modelaudit.scanners import pickle_scanner as pickle_scanner_module
 
         dangerous_opcodes = list(pickletools.genops(_make_os_system_pickle()))
 
@@ -3554,6 +3554,36 @@ class TestDillLoadersRegression:
         assert evidence == "dangerous_execution"
         assert details["evidence"] == "dangerous_execution"
         assert details["analysis_incomplete"] is True
+
+    def test_nested_pickle_budget_error_without_dangerous_prefix_fails_closed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Budget exhaustion before a dangerous opcode should still fail closed."""
+        from modelaudit.scanners import pickle_scanner as pickle_scanner_module
+
+        def _benign_prefix_then_budget(
+            file_obj: BinaryIO,
+            *,
+            multi_stream: bool = False,
+            max_items: int | None = None,
+            deadline: float | None = None,
+        ) -> Iterator[tuple[Any, Any, int | None]]:
+            del file_obj, multi_stream, max_items, deadline
+            yield from pickletools.genops(pickle.dumps({"padding": "benign"}))
+            raise _GenopsBudgetExceeded("max_items")
+
+        monkeypatch.setattr(pickle_scanner_module, "_genops_with_fallback", _benign_prefix_then_budget)
+
+        severity, evidence, details = _classify_nested_pickle_payload(
+            b"\x80\x04.",
+            SimpleNamespace(offset=0),
+            {},
+        )
+
+        assert severity == IssueSeverity.CRITICAL
+        assert evidence == "analysis_incomplete"
+        assert details["analysis_incomplete"] is True
+        assert details["opcode_budget_exceeded"] is True
         assert details["analysis_error"] == "max_items"
 
     def test_nested_pickle_detection_scans_beyond_validation_sample(self, tmp_path: Path) -> None:

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -13,6 +13,7 @@ from collections import Counter
 from collections.abc import Callable, Iterator
 from io import BytesIO
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, BinaryIO, ClassVar, cast
 
 import pytest
@@ -34,6 +35,7 @@ from modelaudit.scanners.pickle_scanner import (
     _RAW_PATTERN_SCAN_LIMIT_BYTES,
     _RESYNC_FAST_FORWARD_PROBE_BYTES,
     PickleScanner,
+    _classify_nested_pickle_payload,
     _find_nested_pickle_match,
     _find_next_resync_stream_candidate_offset,
     _genops_with_fallback,
@@ -3503,6 +3505,56 @@ class TestDillLoadersRegression:
         ]
         assert nested_issues
         assert any(i.severity == IssueSeverity.CRITICAL for i in nested_issues)
+
+    def test_nested_pickle_parse_error_preserves_collected_dangerous_opcodes(self) -> None:
+        """Trailing parse errors should not hide dangerous nested opcodes already seen."""
+        severity, evidence, details = _classify_nested_pickle_payload(
+            _make_os_system_pickle()[:-1],
+            SimpleNamespace(offset=0),
+            {},
+        )
+
+        assert severity == IssueSeverity.CRITICAL
+        assert evidence == "dangerous_execution"
+        assert details["evidence"] == "dangerous_execution"
+        assert details["analysis_incomplete"] is True
+        assert "analysis_error_type" in details
+
+    def test_nested_pickle_budget_error_preserves_collected_dangerous_opcodes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Budget exhaustion should not discard dangerous nested opcodes already yielded."""
+        import modelaudit.scanners.pickle_scanner as pickle_scanner_module
+
+        dangerous_opcodes = list(pickletools.genops(_make_os_system_pickle()))
+
+        def _dangerous_then_budget(
+            file_obj: BinaryIO,
+            *,
+            multi_stream: bool = False,
+            max_items: int | None = None,
+            deadline: float | None = None,
+        ) -> Iterator[tuple[Any, Any, int | None]]:
+            del file_obj, multi_stream, max_items, deadline
+            for opcode_info in dangerous_opcodes:
+                if opcode_info[0].name == "STOP":
+                    break
+                yield opcode_info
+            raise _GenopsBudgetExceeded("max_items")
+
+        monkeypatch.setattr(pickle_scanner_module, "_genops_with_fallback", _dangerous_then_budget)
+
+        severity, evidence, details = _classify_nested_pickle_payload(
+            b"\x80\x04.",
+            SimpleNamespace(offset=0),
+            {},
+        )
+
+        assert severity == IssueSeverity.CRITICAL
+        assert evidence == "dangerous_execution"
+        assert details["evidence"] == "dangerous_execution"
+        assert details["analysis_incomplete"] is True
+        assert details["analysis_error"] == "max_items"
 
     def test_nested_pickle_detection_scans_beyond_validation_sample(self, tmp_path: Path) -> None:
         """Dangerous nested evidence beyond the header-validation window should stay critical."""

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -3506,6 +3506,21 @@ class TestDillLoadersRegression:
         assert nested_issues
         assert any(i.severity == IssueSeverity.CRITICAL for i in nested_issues)
 
+    def test_nested_pickle_detection_scans_later_streams_after_benign_prefix(self) -> None:
+        """A benign first pickle stream should not mask a malicious follow-on stream."""
+        benign_stream = pickle.dumps({"safe": True})
+        malicious_stream = _make_os_system_pickle()
+
+        severity, evidence, details = _classify_nested_pickle_payload(
+            benign_stream + malicious_stream,
+            SimpleNamespace(offset=0),
+            {},
+        )
+
+        assert severity == IssueSeverity.CRITICAL
+        assert evidence == "dangerous_execution"
+        assert details["evidence"] == "dangerous_execution"
+
     def test_nested_pickle_parse_error_preserves_collected_dangerous_opcodes(self) -> None:
         """Trailing parse errors should not hide dangerous nested opcodes already seen."""
         severity, evidence, details = _classify_nested_pickle_payload(

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -3470,9 +3470,15 @@ class TestDillLoadersRegression:
             for i in result.issues
             if "nested pickle payload" in i.message.lower() or "encoded pickle payload" in i.message.lower()
         ]
-        assert nested_issues
-        assert all(i.severity == IssueSeverity.INFO for i in nested_issues)
-        assert not any(i.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for i in nested_issues)
+        raw_issue = next((i for i in nested_issues if "nested pickle payload" in i.message.lower()), None)
+        encoded_issue = next((i for i in nested_issues if "encoded pickle payload" in i.message.lower()), None)
+        assert raw_issue is not None
+        assert encoded_issue is not None
+        assert raw_issue.severity == IssueSeverity.INFO
+        assert encoded_issue.severity == IssueSeverity.INFO
+        assert not any(
+            i.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for i in (raw_issue, encoded_issue)
+        )
 
     def test_malicious_nested_pickle_detection_stays_critical(self, tmp_path: Path) -> None:
         """Nested pickle payloads with dangerous reducers should remain critical."""

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -3601,6 +3601,20 @@ class TestDillLoadersRegression:
         assert details["opcode_budget_exceeded"] is True
         assert details["analysis_error"] == "max_items"
 
+    def test_nested_pickle_classification_scans_follow_on_streams(self) -> None:
+        """A benign first nested stream should not hide a malicious follow-on stream."""
+        payload = pickle.dumps({"safe": True}, protocol=4) + _make_os_system_pickle()
+
+        severity, evidence, details = _classify_nested_pickle_payload(
+            payload,
+            SimpleNamespace(offset=0),
+            {},
+        )
+
+        assert severity == IssueSeverity.CRITICAL
+        assert evidence == "dangerous_execution"
+        assert details["evidence"] == "dangerous_execution"
+
     def test_nested_pickle_detection_scans_beyond_validation_sample(self, tmp_path: Path) -> None:
         """Dangerous nested evidence beyond the header-validation window should stay critical."""
         scanner = PickleScanner()

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -3601,6 +3601,38 @@ class TestDillLoadersRegression:
         assert details["opcode_budget_exceeded"] is True
         assert details["analysis_error"] == "max_items"
 
+    def test_nested_pickle_budget_error_with_warning_prefix_fails_closed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Budget exhaustion after warning evidence should not leave the scan non-critical."""
+        from modelaudit.scanners import pickle_scanner as pickle_scanner_module
+
+        warning_opcodes = list(pickletools.genops(b"cthirdparty\nLoader\n."))
+
+        def _warning_prefix_then_budget(
+            file_obj: BinaryIO,
+            *,
+            multi_stream: bool = False,
+            max_items: int | None = None,
+            deadline: float | None = None,
+        ) -> Iterator[tuple[Any, Any, int | None]]:
+            del file_obj, multi_stream, max_items, deadline
+            yield from warning_opcodes
+            raise _GenopsBudgetExceeded("max_items")
+
+        monkeypatch.setattr(pickle_scanner_module, "_genops_with_fallback", _warning_prefix_then_budget)
+
+        severity, evidence, details = _classify_nested_pickle_payload(
+            b"\x80\x04.",
+            SimpleNamespace(offset=0),
+            {},
+        )
+
+        assert severity == IssueSeverity.CRITICAL
+        assert evidence == "analysis_incomplete"
+        assert details["analysis_incomplete"] is True
+        assert details["opcode_budget_exceeded"] is True
+        assert details["partial_evidence"] == "unknown_import"
+        assert details["partial_evidence_details"]["import_reference"] == "thirdparty.Loader"
+
     def test_nested_pickle_classification_scans_follow_on_streams(self) -> None:
         """A benign first nested stream should not hide a malicious follow-on stream."""
         payload = pickle.dumps({"safe": True}, protocol=4) + _make_os_system_pickle()

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -48,6 +48,7 @@ from modelaudit.scanners.pickle_scanner import (
     _simulate_symbolic_reference_maps,
     check_opcode_sequence,
 )
+from modelaudit.scanners.pickle_support import _NESTED_PICKLE_VALIDATION_WINDOW_BYTES
 from modelaudit.scanners.rule_mapper import get_pickle_opcode_rule_code
 from tests.assets.generators.generate_advanced_pickle_tests import (
     generate_memo_based_attack,
@@ -130,6 +131,19 @@ def _make_dup_heavy_pickle(iterations: int) -> bytes:
         payload += b"h\x002a0"
     payload += b"."
     return bytes(payload)
+
+
+def _make_os_system_pickle() -> bytes:
+    class Evil:
+        def __reduce__(self) -> tuple[object, tuple[str]]:
+            return (os.system, ("echo nested-pickle",))
+
+    return pickle.dumps(Evil(), protocol=4)
+
+
+def _make_delayed_os_system_pickle() -> bytes:
+    padding = b"K\x010" * ((_NESTED_PICKLE_VALIDATION_WINDOW_BYTES // 3) + 16)
+    return b"\x80\x04" + padding + b"cos\nsystem\n\x8c\x12echo nested-pickle\x85R."
 
 
 class _SliceCountingSearchWindow:
@@ -1939,7 +1953,7 @@ def test_post_budget_global_scan_uses_consumed_opcode_boundary(tmp_path: Path) -
 def test_post_budget_opcode_scan_uses_consumed_opcode_boundary(tmp_path: Path) -> None:
     """Opcode tail scans should start at the consumed boundary, not inside the prior payload."""
     pickle_path = tmp_path / "post-budget-opcode-consumed-boundary.pkl"
-    inner_pickle = pickle.dumps({"ab": 1}, protocol=4)
+    inner_pickle = _make_os_system_pickle()
     poison_payload = b"\x8c\xff" + (b"A" * 4998)
     payload = (
         b"\x80\x04"
@@ -2176,7 +2190,7 @@ def test_scan_pickle_detects_post_budget_stack_global_with_binget(tmp_path: Path
 
 def test_post_budget_opcode_scan_detects_nested_pickle_payload(tmp_path: Path) -> None:
     """Nested inner pickle payloads beyond the opcode budget should still be surfaced."""
-    inner_pickle = pickle.dumps({"ab": 1}, protocol=4)
+    inner_pickle = _make_os_system_pickle()
     pickle_path = tmp_path / "post-budget-nested-pickle.pkl"
     benign_padding = _make_opcode_padding_stream(opcode_pairs=512)
     malicious_stream = b"\x80\x04B" + struct.pack("<I", len(inner_pickle)) + inner_pickle + b"."
@@ -2193,10 +2207,6 @@ def test_post_budget_opcode_scan_detects_nested_pickle_payload(tmp_path: Path) -
         finding["check_name"] == "Nested Pickle Detection" and finding["details"].get("opcode") == "BINBYTES"
         for finding in checks[0].details["findings"]
     ), checks[0].details
-    assert not any(
-        check.name == "Post-Budget Global Reference Scan" and check.status == CheckStatus.FAILED
-        for check in result.checks
-    ), f"Expected opcode-based detection, got: {result.checks}"
     assert result.success is False
 
 
@@ -2204,7 +2214,7 @@ def test_post_budget_opcode_scan_detects_encoded_pickle_payload(tmp_path: Path) 
     """Encoded inner pickle payloads beyond the opcode budget should still be surfaced."""
     import base64
 
-    inner_pickle = pickle.dumps({"ab": 1}, protocol=4)
+    inner_pickle = _make_os_system_pickle()
     encoded_pickle = base64.b64encode(inner_pickle)
     pickle_path = tmp_path / "post-budget-encoded-pickle.pkl"
     benign_padding = _make_opcode_padding_stream(opcode_pairs=512)
@@ -3436,40 +3446,85 @@ class TestDillLoadersRegression:
         ]
         assert len(ignored_pe_issues) == 0, "Validated PE signatures should not be suppressed"
 
-    def test_nested_pickle_detection(self):
-        """Scanner should detect nested pickle bytes and encoded payloads"""
+    def test_benign_nested_pickle_detection_is_info_only(self, tmp_path: Path) -> None:
+        """Benign nested pickle bytes and encoded payloads should not be critical."""
         scanner = PickleScanner()
 
         import base64
-        import os
-        import tempfile
 
-        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
-            try:
-                inner = {"a": 1}
-                inner_bytes = pickle.dumps(inner)
-                outer = {
-                    "raw": inner_bytes,
-                    "enc": base64.b64encode(inner_bytes).decode("ascii"),
-                }
-                pickle.dump(outer, f)
-                f.flush()
-                f.close()  # Close file before scanning (required on Windows to allow deletion)
+        inner = {"a": 1}
+        inner_bytes = pickle.dumps(inner)
+        outer = {
+            "raw": inner_bytes,
+            "enc": base64.b64encode(inner_bytes).decode("ascii"),
+        }
+        pickle_path = tmp_path / "benign-nested.pkl"
+        pickle_path.write_bytes(pickle.dumps(outer))
 
-                result = scanner.scan(f.name)
+        result = scanner.scan(str(pickle_path))
 
-                assert result.success
+        assert result.success
 
-                nested_issues = [
-                    i
-                    for i in result.issues
-                    if "nested pickle payload" in i.message.lower() or "encoded pickle payload" in i.message.lower()
-                ]
-                assert nested_issues
-                assert any(i.severity == IssueSeverity.CRITICAL for i in nested_issues)
+        nested_issues = [
+            i
+            for i in result.issues
+            if "nested pickle payload" in i.message.lower() or "encoded pickle payload" in i.message.lower()
+        ]
+        assert nested_issues
+        assert all(i.severity == IssueSeverity.INFO for i in nested_issues)
+        assert not any(i.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for i in nested_issues)
 
-            finally:
-                os.unlink(f.name)
+    def test_malicious_nested_pickle_detection_stays_critical(self, tmp_path: Path) -> None:
+        """Nested pickle payloads with dangerous reducers should remain critical."""
+        scanner = PickleScanner()
+
+        import base64
+
+        inner_bytes = _make_os_system_pickle()
+        outer = {
+            "raw": inner_bytes,
+            "enc": base64.b64encode(inner_bytes).decode("ascii"),
+        }
+        pickle_path = tmp_path / "malicious-nested.pkl"
+        pickle_path.write_bytes(pickle.dumps(outer))
+
+        result = scanner.scan(str(pickle_path))
+
+        nested_issues = [
+            i
+            for i in result.issues
+            if "nested pickle payload" in i.message.lower() or "encoded pickle payload" in i.message.lower()
+        ]
+        assert nested_issues
+        assert any(i.severity == IssueSeverity.CRITICAL for i in nested_issues)
+
+    def test_nested_pickle_detection_scans_beyond_validation_sample(self, tmp_path: Path) -> None:
+        """Dangerous nested evidence beyond the header-validation window should stay critical."""
+        scanner = PickleScanner()
+        pickle_path = tmp_path / "delayed-malicious-nested.pkl"
+        pickle_path.write_bytes(pickle.dumps({"raw": _make_delayed_os_system_pickle()}))
+
+        result = scanner.scan(str(pickle_path))
+
+        nested_issues = [i for i in result.issues if "nested pickle payload" in i.message.lower()]
+        assert nested_issues
+        assert any(
+            i.severity == IssueSeverity.CRITICAL and i.details.get("evidence") == "dangerous_execution"
+            for i in nested_issues
+        )
+
+    def test_safe_nested_reduce_detection_is_info_only(self, tmp_path: Path) -> None:
+        """Benign nested reconstruction opcodes should not warn without dangerous evidence."""
+        scanner = PickleScanner()
+        pickle_path = tmp_path / "safe-nested-reduce.pkl"
+        pickle_path.write_bytes(pickle.dumps({"raw": pickle.dumps(slice(1, 5, 2), protocol=4)}))
+
+        result = scanner.scan(str(pickle_path))
+
+        assert result.success
+        nested_issues = [i for i in result.issues if "nested pickle payload" in i.message.lower()]
+        assert nested_issues
+        assert all(i.severity == IssueSeverity.INFO for i in nested_issues)
 
 
 class TestPickleScannerBlocklistHardening(unittest.TestCase):


### PR DESCRIPTION
## Summary
- downgrade structure-only nested pickle bytes/base64 detections to INFO
- keep dangerous nested reducers/imports critical and unknown imports warning
- parse the full embedded nested stream after bounded header detection so delayed dangerous evidence is preserved

## Validation
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run env PROMPTFOO_DISABLE_TELEMETRY=1 pytest -n auto -m "not slow and not integration" --maxfail=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced pickle scanner's nested/encoded pickle detection to perform opcode-level analysis and classify findings contextually as INFO, WARNING, or CRITICAL based on actual threat level, rather than always flagging as CRITICAL.
  * Improved severity messaging to reflect the specific evidence type and analysis completeness.

* **Tests**
  * Expanded test coverage for nested pickle detection with separate validation for benign payloads, malicious reducers, and timing-delayed threats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->