### PR TITLE
fix: mark pickle parse failures inconclusive

### DIFF
--- a/modelaudit/scanners/joblib_scanner.py
+++ b/modelaudit/scanners/joblib_scanner.py
@@ -13,7 +13,7 @@ from typing import Any, ClassVar
 
 from ..detectors.cve_patterns import analyze_cve_patterns, enhance_scan_result_with_cve
 from ..utils.file.detection import read_magic_bytes
-from .base import BaseScanner, IssueSeverity, ScanResult
+from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, IssueSeverity, ScanResult
 from .pickle_scanner import PickleScanner, _looks_like_pickle
 
 
@@ -370,7 +370,18 @@ class JoblibScanner(BaseScanner):
             result.finish(success=False)
             return result
 
-        result.finish(success=not result.has_errors)
+        has_security_findings = any(
+            issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues
+        )
+        has_trusted_incomplete_tail = result.metadata.get("trusted_incomplete_tail") is True
+        if (
+            result.metadata.get("scan_outcome") == INCONCLUSIVE_SCAN_OUTCOME
+            and not has_security_findings
+            and not has_trusted_incomplete_tail
+        ):
+            result.finish(success=False)
+        else:
+            result.finish(success=not result.has_errors)
         return result
 
     def extract_metadata(self, file_path: str) -> dict[str, Any]:

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -4691,7 +4691,11 @@ class PickleScanner(BaseScanner):
                         error=e,
                         early_detection_successful=early_pattern_scan_completed,
                     )
-                    _finish_with_inconclusive_contract(result, default_success=False)
+                    _finish_with_inconclusive_contract(
+                        result,
+                        default_success=False,
+                        allow_security_findings_override=True,
+                    )
                     return result
 
             if pickle_file_opened:
@@ -4854,7 +4858,11 @@ class PickleScanner(BaseScanner):
                         location=source,
                         error=error,
                     )
-                    _finish_with_inconclusive_contract(result, default_success=False)
+                    _finish_with_inconclusive_contract(
+                        result,
+                        default_success=False,
+                        allow_security_findings_override=True,
+                    )
                     return result
 
             self._record_pickle_runtime_error(result, error, location=source)
@@ -8007,7 +8015,11 @@ class PickleScanner(BaseScanner):
                         location=self.current_file_path,
                         error=e,
                     )
-                    _finish_with_inconclusive_contract(result, default_success=False)
+                    _finish_with_inconclusive_contract(
+                        result,
+                        default_success=False,
+                        allow_security_findings_override=True,
+                    )
                     return result
 
                 # Determine user-friendly error message and severity

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -233,6 +233,49 @@ def _finish_with_inconclusive_contract(
     result.finish(success=default_success or (allow_security_findings_override and has_security_findings))
 
 
+def _add_pickle_parse_failure_check(
+    result: ScanResult,
+    *,
+    location: str,
+    error: Exception,
+    early_detection_successful: bool | None = None,
+) -> None:
+    """Record incomplete pickle parsing as an operationally inconclusive scan."""
+    details: dict[str, Any] = {
+        "file_type": "pickle",
+        "category": "parse_error",
+        "parse_error": str(error),
+        "exception_type": type(error).__name__,
+        "parsing_failed": True,
+        "failure_reason": "unknown_opcode_or_format_error",
+        "analysis_incomplete": True,
+    }
+    if early_detection_successful is not None:
+        details["early_detection_successful"] = early_detection_successful
+
+    result.add_check(
+        name="Pickle Format Check",
+        passed=False,
+        message="Pickle parsing failed before full scan completion",
+        severity=IssueSeverity.INFO,
+        location=location,
+        details=details,
+        why=(
+            "The scanner could not fully parse this pickle file due to an opcode/format error. "
+            "The scan is marked inconclusive rather than a security finding unless separate dangerous evidence exists."
+        ),
+    )
+    result.metadata.update(
+        {
+            "file_type": "pickle",
+            "parsing_failed": True,
+            "failure_reason": "unknown_opcode_or_format_error",
+            "analysis_incomplete": True,
+        }
+    )
+    _mark_inconclusive_scan_result(result, "pickle_analysis_incomplete")
+
+
 def _freeze_pickle_scan_value(value: Any) -> Hashable:
     """Convert nested check details into a hashable representation for dedupe."""
     if isinstance(value, Mapping):
@@ -4640,37 +4683,15 @@ class PickleScanner(BaseScanner):
                     return result
 
                 elif file_ext in [".pkl", ".pickle", ".joblib", ".dill", ".pt", ".pth", ".ckpt"]:
-                    # Pickle-like files must fail closed when parsing aborts on unknown opcodes.
+                    # Pickle-like files fail closed operationally when parsing aborts on unknown opcodes.
                     logger.warning(f"Pickle parse failed for {path}: {e}")
-                    result.add_check(
-                        name="Pickle Format Check",
-                        passed=False,
-                        message="Pickle parsing failed before full scan completion",
-                        severity=IssueSeverity.CRITICAL,
+                    _add_pickle_parse_failure_check(
+                        result,
                         location=path,
-                        details={
-                            "file_type": "pickle",
-                            "parse_error": str(e),
-                            "early_detection_successful": early_pattern_scan_completed,
-                            "parsing_failed": True,
-                            "failure_reason": "unknown_opcode_or_format_error",
-                        },
-                        why=(
-                            "The scanner could not fully parse this pickle file due to an opcode/format error. "
-                            "Because full opcode analysis did not complete, the file is treated as unsafe."
-                        ),
+                        error=e,
+                        early_detection_successful=early_pattern_scan_completed,
                     )
-
-                    # Fail closed metadata for parse failures on pickle-like files.
-                    result.metadata.update(
-                        {
-                            "file_type": "pickle",
-                            "parsing_failed": True,
-                            "failure_reason": "unknown_opcode_or_format_error",
-                        }
-                    )
-
-                    result.finish(success=False)
+                    _finish_with_inconclusive_contract(result, default_success=False)
                     return result
 
             if pickle_file_opened:
@@ -4828,27 +4849,12 @@ class PickleScanner(BaseScanner):
                     result.finish(success=True)
                     return result
                 if file_ext in {".pkl", ".pickle", ".joblib", ".dill", ".pt", ".pth", ".ckpt"}:
-                    result.add_check(
-                        name="Pickle Format Check",
-                        passed=False,
-                        message="Pickle parsing failed before full scan completion",
-                        severity=IssueSeverity.CRITICAL,
+                    _add_pickle_parse_failure_check(
+                        result,
                         location=source,
-                        details={
-                            "file_type": "pickle",
-                            "parse_error": str(error),
-                            "parsing_failed": True,
-                            "failure_reason": "unknown_opcode_or_format_error",
-                        },
+                        error=error,
                     )
-                    result.metadata.update(
-                        {
-                            "file_type": "pickle",
-                            "parsing_failed": True,
-                            "failure_reason": "unknown_opcode_or_format_error",
-                        }
-                    )
-                    result.finish(success=False)
+                    _finish_with_inconclusive_contract(result, default_success=False)
                     return result
 
             self._record_pickle_runtime_error(result, error, location=source)
@@ -7996,31 +8002,12 @@ class PickleScanner(BaseScanner):
                     ".ckpt",
                 ]:
                     logger.warning(f"Pickle parse failed for {self.current_file_path}: {e}")
-                    result.add_check(
-                        name="Pickle Format Check",
-                        passed=False,
-                        message="Pickle parsing failed before full scan completion",
-                        severity=IssueSeverity.CRITICAL,
+                    _add_pickle_parse_failure_check(
+                        result,
                         location=self.current_file_path,
-                        details={
-                            "file_type": "pickle",
-                            "parse_error": str(e),
-                            "parsing_failed": True,
-                            "failure_reason": "unknown_opcode_or_format_error",
-                        },
-                        why=(
-                            "The scanner could not fully parse this pickle file due to an opcode/format error. "
-                            "Because full opcode analysis did not complete, the file is treated as unsafe."
-                        ),
+                        error=e,
                     )
-                    result.metadata.update(
-                        {
-                            "file_type": "pickle",
-                            "parsing_failed": True,
-                            "failure_reason": "unknown_opcode_or_format_error",
-                        }
-                    )
-                    result.finish(success=False)
+                    _finish_with_inconclusive_contract(result, default_success=False)
                     return result
 
                 # Determine user-friendly error message and severity

--- a/modelaudit/scanners/picklescan_adapter.py
+++ b/modelaudit/scanners/picklescan_adapter.py
@@ -160,6 +160,10 @@ def pickle_report_to_scan_result(
             if notice.code in _INCONCLUSIVE_NOTICE_CODES
         ] or ["pickle_analysis_incomplete"]
         result.metadata["analysis_incomplete"] = True
+    elif report.status == ScanStatus.ERROR and any(error.category == "parse_error" for error in report.errors):
+        result.metadata["scan_outcome"] = INCONCLUSIVE_SCAN_OUTCOME
+        result.metadata["scan_outcome_reasons"] = ["pickle_analysis_incomplete"]
+        result.metadata["analysis_incomplete"] = True
 
     for finding in report.findings:
         details = _add_legacy_detail_aliases(
@@ -202,11 +206,12 @@ def pickle_report_to_scan_result(
                 name="Standalone Pickle Parse Failure",
                 passed=False,
                 message="Pickle parsing failed before full scan completion",
-                severity=IssueSeverity.CRITICAL,
+                severity=IssueSeverity.INFO,
                 location=notice.location,
                 details={
                     "pickle_source": report.source,
                     "file_type": "pickle",
+                    "category": "parse_error",
                     "parse_error": notice.details.get("exception"),
                     "exception_type": notice.details.get("exception_type"),
                     "parsing_failed": True,
@@ -256,12 +261,13 @@ def pickle_report_to_scan_result(
             name="Standalone Pickle Error",
             passed=False,
             message=error.message,
-            severity=IssueSeverity.CRITICAL,
+            severity=IssueSeverity.INFO if error.category == "parse_error" else IssueSeverity.CRITICAL,
             location=error.location,
             details={
                 "pickle_source": report.source,
                 "category": error.category,
                 "exception_type": error.exception_type,
+                "analysis_incomplete": error.category == "parse_error",
                 **error.to_dict()["details"],
             },
         )

--- a/tests/scanners/test_joblib_scanner.py
+++ b/tests/scanners/test_joblib_scanner.py
@@ -46,7 +46,7 @@ def test_joblib_scanner_closes_bytesio(tmp_path: Path, monkeypatch: pytest.Monke
     assert closed.get("closed") is True
 
 
-def test_joblib_scanner_fails_closed_on_incomplete_pickle_without_dangerous_findings(tmp_path: Path) -> None:
+def test_joblib_scanner_marks_incomplete_pickle_inconclusive_without_dangerous_findings(tmp_path: Path) -> None:
     path = tmp_path / "truncated.joblib"
     path.write_bytes(b"\x80\x04}q\x00")
 
@@ -55,12 +55,13 @@ def test_joblib_scanner_fails_closed_on_incomplete_pickle_without_dangerous_find
     assert result.success is False
     assert result.metadata["scan_outcome"] == "inconclusive"
     assert result.metadata["analysis_incomplete"] is True
-    assert any(
-        issue.severity.value == "critical"
-        and issue.message == "Pickle parsing failed before full scan completion"
-        and issue.details.get("failure_reason") == "unknown_opcode_or_format_error"
-        for issue in result.issues
+    parse_issue = next(
+        issue for issue in result.issues if issue.message == "Pickle parsing failed before full scan completion"
     )
+    assert parse_issue.severity.value == "info"
+    assert parse_issue.details.get("category") == "parse_error"
+    assert parse_issue.details.get("failure_reason") == "unknown_opcode_or_format_error"
+    assert not any(issue.severity.value in {"warning", "critical"} for issue in result.issues)
 
 
 def test_joblib_scanner_preserves_legacy_pickle_rule_codes_on_embedded_pickle() -> None:

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -623,7 +623,7 @@ def test_scan_stream_preserves_package_findings_when_legacy_fallback_raises(
     )
 
 
-def test_scan_stream_parse_failure_fails_closed_for_pickle_stream(
+def test_scan_stream_parse_failure_is_inconclusive_for_pickle_stream(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     scanner = PickleScanner()
@@ -640,15 +640,15 @@ def test_scan_stream_parse_failure_fails_closed_for_pickle_stream(
     assert result.metadata["file_type"] == "pickle"
     assert result.metadata["parsing_failed"] is True
     assert result.metadata["failure_reason"] == "unknown_opcode_or_format_error"
-    assert any(
-        check.name == "Pickle Format Check"
-        and check.status == CheckStatus.FAILED
-        and check.severity == IssueSeverity.CRITICAL
-        for check in result.checks
-    )
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    parse_check = next(check for check in result.checks if check.name == "Pickle Format Check")
+    assert parse_check.status == CheckStatus.FAILED
+    assert parse_check.severity == IssueSeverity.INFO
+    assert parse_check.details["category"] == "parse_error"
+    assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
 
 
-def test_scan_stream_non_seekable_parse_failure_fails_closed(
+def test_scan_stream_non_seekable_parse_failure_is_inconclusive(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     scanner = PickleScanner()
@@ -669,7 +669,12 @@ def test_scan_stream_non_seekable_parse_failure_fails_closed(
     assert result.metadata["file_type"] == "pickle"
     assert result.metadata["parsing_failed"] is True
     assert result.metadata["failure_reason"] == "unknown_opcode_or_format_error"
-    assert any(check.name == "Pickle Format Check" and check.status == CheckStatus.FAILED for check in result.checks)
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    parse_check = next(check for check in result.checks if check.name == "Pickle Format Check")
+    assert parse_check.status == CheckStatus.FAILED
+    assert parse_check.severity == IssueSeverity.INFO
+    assert parse_check.details["category"] == "parse_error"
+    assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
 
 
 def test_pickle_scanner_can_handle_rejects_non_pickle_content(tmp_path: Path) -> None:
@@ -907,14 +912,14 @@ def test_padding_stripped_base64_candidate_still_flags_potential_base64() -> Non
 
 
 @pytest.mark.parametrize("file_ext", [".pkl", ".pt", ".pth", ".ckpt"])
-def test_unknown_opcode_pickle_parse_failure_fails_closed(
+def test_unknown_opcode_pickle_parse_failure_is_inconclusive(
     file_ext: str,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Unknown opcode parse failures in raw pickle-backed checkpoint files must fail closed."""
+    """Unknown opcode parse failures in raw pickle-backed checkpoint files should be inconclusive."""
     pickle_path = tmp_path / f"unknown_opcode{file_ext}"
-    pickle_path.write_bytes(b"\x80\x04K\x01." + (b"A" * 9000) + b"os.system")
+    pickle_path.write_bytes(b"\x80\x04K\x01." + (b"A" * 9000))
 
     def _raise_unknown_opcode(self: PickleScanner, _file_obj: object, _file_size: int) -> ScanResult:
         raise ValueError("at position 2, opcode b'\\xff' unknown")
@@ -927,16 +932,16 @@ def test_unknown_opcode_pickle_parse_failure_fails_closed(
     assert result.metadata["file_type"] == "pickle"
     assert result.metadata["parsing_failed"] is True
     assert result.metadata["failure_reason"] == "unknown_opcode_or_format_error"
-    assert any(
-        check.name == "Pickle Format Check"
-        and check.status == CheckStatus.FAILED
-        and check.severity == IssueSeverity.CRITICAL
-        for check in result.checks
-    ), f"Expected fail-closed format check, got: {[(c.name, c.status, c.severity) for c in result.checks]}"
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    parse_check = next(check for check in result.checks if check.name == "Pickle Format Check")
+    assert parse_check.status == CheckStatus.FAILED
+    assert parse_check.severity == IssueSeverity.INFO
+    assert parse_check.details["category"] == "parse_error"
+    assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
 
 
-def test_merge_missing_pickle_checks_preserves_ruleless_parse_failures_and_fails_closed() -> None:
-    """Rule-less parse-failure fallback issues must survive merge and preserve fail-closed success."""
+def test_merge_missing_pickle_checks_preserves_ruleless_parse_failures_as_inconclusive() -> None:
+    """Rule-less parse-failure fallback issues must survive merge as inconclusive, not security."""
     scanner = PickleScanner()
     target = ScanResult(scanner_name="pickle", scanner=scanner)
     target.add_check(
@@ -952,7 +957,7 @@ def test_merge_missing_pickle_checks_preserves_ruleless_parse_failures_and_fails
         name="Standalone Pickle Parse Failure",
         passed=False,
         message="Pickle parsing failed before full scan completion",
-        severity=IssueSeverity.CRITICAL,
+        severity=IssueSeverity.INFO,
         location="truncated.pkl (pos 4)",
         details={
             "parse_error": "pickle exhausted before seeing STOP",
@@ -975,10 +980,11 @@ def test_merge_missing_pickle_checks_preserves_ruleless_parse_failures_and_fails
     assert target.metadata["scan_outcome_reasons"] == ["pickle_analysis_incomplete"]
     assert any(
         issue.rule_code is None
-        and issue.severity == IssueSeverity.CRITICAL
+        and issue.severity == IssueSeverity.INFO
         and issue.message == "Pickle parsing failed before full scan completion"
         for issue in target.issues
     )
+    assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in target.issues)
 
 
 def test_merge_missing_pickle_checks_propagates_fallback_operational_errors_and_fails_closed() -> None:
@@ -1124,7 +1130,7 @@ def test_merge_missing_pickle_checks_fails_closed_for_fallback_parse_errors_with
         name="Standalone Pickle Error",
         passed=False,
         message="Could not parse pickle stream: at position 0, opcode b'\\xff' unknown",
-        severity=IssueSeverity.CRITICAL,
+        severity=IssueSeverity.INFO,
         location="parse-error.bin (pos 0)",
         details={
             "pickle_source": "parse-error.bin",
@@ -1141,14 +1147,15 @@ def test_merge_missing_pickle_checks_fails_closed_for_fallback_parse_errors_with
     assert target.success is False
     assert any(
         issue.details.get("category") == "parse_error"
-        and issue.severity == IssueSeverity.CRITICAL
+        and issue.severity == IssueSeverity.INFO
         and issue.message.startswith("Could not parse pickle stream:")
         for issue in target.issues
     )
+    assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in target.issues)
 
 
-def test_merge_missing_pickle_checks_preserves_bin_parse_failures_and_fails_closed() -> None:
-    """Truncated `.bin` pickle payloads should preserve fallback parse failures and fail closed."""
+def test_merge_missing_pickle_checks_preserves_bin_parse_failures_as_inconclusive() -> None:
+    """Truncated `.bin` pickle payloads should preserve fallback parse failures as inconclusive."""
     scanner = PickleScanner()
     target = ScanResult(scanner_name="pickle", scanner=scanner)
     target.add_check(
@@ -1164,7 +1171,7 @@ def test_merge_missing_pickle_checks_preserves_bin_parse_failures_and_fails_clos
         name="Standalone Pickle Parse Failure",
         passed=False,
         message="Pickle parsing failed before full scan completion",
-        severity=IssueSeverity.CRITICAL,
+        severity=IssueSeverity.INFO,
         location="truncated.bin (pos 0)",
         details={
             "pickle_source": "truncated.bin",
@@ -1188,8 +1195,10 @@ def test_merge_missing_pickle_checks_preserves_bin_parse_failures_and_fails_clos
     assert any(
         issue.message == "Pickle parsing failed before full scan completion"
         and issue.location == "truncated.bin (pos 0)"
+        and issue.severity == IssueSeverity.INFO
         for issue in target.issues
     )
+    assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in target.issues)
 
 
 def test_merge_missing_pickle_checks_fails_closed_for_inconclusive_notice_only_fallback() -> None:
@@ -1268,7 +1277,7 @@ def test_merge_missing_pickle_checks_trusts_legacy_boundary_for_benign_joblib_ta
         name="Standalone Pickle Parse Failure",
         passed=False,
         message="Pickle parsing failed before full scan completion",
-        severity=IssueSeverity.CRITICAL,
+        severity=IssueSeverity.INFO,
         location="numpy_arrays.joblib (decompressed) (pos 227)",
         details={
             "pickle_source": "numpy_arrays.joblib (decompressed)",
@@ -1331,7 +1340,7 @@ def test_merge_missing_pickle_checks_does_not_trust_boundary_for_dangerous_jobli
         name="Standalone Pickle Parse Failure",
         passed=False,
         message="Pickle parsing failed before full scan completion",
-        severity=IssueSeverity.CRITICAL,
+        severity=IssueSeverity.INFO,
         location="dangerous.joblib (decompressed) (pos 227)",
         details={
             "pickle_source": "dangerous.joblib (decompressed)",
@@ -1361,7 +1370,10 @@ def test_merge_missing_pickle_checks_does_not_trust_boundary_for_dangerous_jobli
 
     assert target.success is False
     assert "trusted_incomplete_tail" not in target.metadata
-    assert any(issue.message == "Pickle parsing failed before full scan completion" for issue in target.issues)
+    assert any(
+        issue.message == "Pickle parsing failed before full scan completion" and issue.severity == IssueSeverity.INFO
+        for issue in target.issues
+    )
 
 
 @pytest.mark.parametrize(
@@ -4769,18 +4781,20 @@ class TestPickleScannerBlocklistHardening(unittest.TestCase):
             f"Expected CRITICAL __import__ detection, got: {critical_messages}"
         )
 
-    def test_malformed_unicode_tail_with_benign_prefix_fails_closed(self) -> None:
-        """Malformed tails without a trusted pickle boundary should fail closed."""
+    def test_malformed_unicode_tail_with_benign_prefix_is_inconclusive(self) -> None:
+        """Malformed tails without dangerous evidence should be operationally inconclusive."""
         payload = b"\x80\x02cbuiltins\nlen\nq\x00c\xff\n"
 
         result = self._scan_bytes(payload)
 
         assert not result.success
-        assert any(
-            issue.severity == IssueSeverity.CRITICAL
-            and issue.message == "Pickle parsing failed before full scan completion"
-            for issue in result.issues
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        parse_issue = next(
+            issue for issue in result.issues if issue.message == "Pickle parsing failed before full scan completion"
         )
+        assert parse_issue.severity == IssueSeverity.INFO
+        assert parse_issue.details["category"] == "parse_error"
+        assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
 
     # ------------------------------------------------------------------
     # Fix 3: joblib.load loader trampoline bypass

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -75,6 +75,16 @@ class _NonSeekableBytesIO(BytesIO):
         raise OSError("seek disabled")
 
 
+def _assert_user_visible_parse_failure_issue(result: ScanResult) -> None:
+    parse_issue = next(
+        issue for issue in result.issues if issue.message == "Pickle parsing failed before full scan completion"
+    )
+    assert parse_issue.severity == IssueSeverity.INFO
+    assert parse_issue.details["category"] == "parse_error"
+    assert parse_issue.details["analysis_incomplete"] is True
+    assert "opcode" in parse_issue.details["parse_error"]
+
+
 def test_pickle_scanner_star_import_exports_scanner_class() -> None:
     """Wildcard imports should still expose the scanner class after helper extraction."""
     namespace: dict[str, object] = {}
@@ -645,6 +655,7 @@ def test_scan_stream_parse_failure_is_inconclusive_for_pickle_stream(
     assert parse_check.status == CheckStatus.FAILED
     assert parse_check.severity == IssueSeverity.INFO
     assert parse_check.details["category"] == "parse_error"
+    _assert_user_visible_parse_failure_issue(result)
     assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
 
 
@@ -674,6 +685,7 @@ def test_scan_stream_non_seekable_parse_failure_is_inconclusive(
     assert parse_check.status == CheckStatus.FAILED
     assert parse_check.severity == IssueSeverity.INFO
     assert parse_check.details["category"] == "parse_error"
+    _assert_user_visible_parse_failure_issue(result)
     assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
 
 
@@ -937,6 +949,7 @@ def test_unknown_opcode_pickle_parse_failure_is_inconclusive(
     assert parse_check.status == CheckStatus.FAILED
     assert parse_check.severity == IssueSeverity.INFO
     assert parse_check.details["category"] == "parse_error"
+    _assert_user_visible_parse_failure_issue(result)
     assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
 
 
@@ -960,6 +973,7 @@ def test_merge_missing_pickle_checks_preserves_ruleless_parse_failures_as_inconc
         severity=IssueSeverity.INFO,
         location="truncated.pkl (pos 4)",
         details={
+            "category": "parse_error",
             "parse_error": "pickle exhausted before seeing STOP",
             "failure_reason": "unknown_opcode_or_format_error",
             "analysis_incomplete": True,
@@ -1175,6 +1189,7 @@ def test_merge_missing_pickle_checks_preserves_bin_parse_failures_as_inconclusiv
         location="truncated.bin (pos 0)",
         details={
             "pickle_source": "truncated.bin",
+            "category": "parse_error",
             "parse_error": "pickle exhausted before seeing STOP",
             "failure_reason": "unknown_opcode_or_format_error",
             "analysis_incomplete": True,
@@ -1281,6 +1296,7 @@ def test_merge_missing_pickle_checks_trusts_legacy_boundary_for_benign_joblib_ta
         location="numpy_arrays.joblib (decompressed) (pos 227)",
         details={
             "pickle_source": "numpy_arrays.joblib (decompressed)",
+            "category": "parse_error",
             "parse_error": "at position 226, opcode b'\\r' unknown",
             "failure_reason": "unknown_opcode_or_format_error",
             "analysis_incomplete": True,
@@ -1344,6 +1360,7 @@ def test_merge_missing_pickle_checks_does_not_trust_boundary_for_dangerous_jobli
         location="dangerous.joblib (decompressed) (pos 227)",
         details={
             "pickle_source": "dangerous.joblib (decompressed)",
+            "category": "parse_error",
             "parse_error": "at position 226, opcode b'\\r' unknown",
             "failure_reason": "unknown_opcode_or_format_error",
             "analysis_incomplete": True,

--- a/tests/scanners/test_picklescan_adapter.py
+++ b/tests/scanners/test_picklescan_adapter.py
@@ -431,7 +431,7 @@ def test_pickle_report_to_scan_result_fails_closed_for_nested_incomplete_notice(
     assert notice_check.message == "Nested pickle analysis did not complete"
 
 
-def test_pickle_report_to_scan_result_escalates_parse_incomplete_notices_to_parse_failures() -> None:
+def test_pickle_report_to_scan_result_keeps_parse_incomplete_notices_inconclusive() -> None:
     report = PickleReport(
         source="truncated.pkl",
         status=ScanStatus.INCONCLUSIVE,
@@ -456,17 +456,19 @@ def test_pickle_report_to_scan_result_escalates_parse_incomplete_notices_to_pars
     assert result.success is False
     assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
     assert result.metadata["scan_outcome_reasons"] == ["pickle_analysis_incomplete"]
-    assert any(
-        issue.severity == IssueSeverity.CRITICAL
-        and issue.message == "Pickle parsing failed before full scan completion"
-        and issue.location == "truncated.pkl (pos 4)"
-        and issue.details["parse_error"] == "pickle exhausted before seeing STOP"
-        and issue.details["failure_reason"] == "unknown_opcode_or_format_error"
-        for issue in result.issues
+    parse_issue = next(
+        issue for issue in result.issues if issue.message == "Pickle parsing failed before full scan completion"
     )
+    assert parse_issue.severity == IssueSeverity.INFO
+    assert parse_issue.location == "truncated.pkl (pos 4)"
+    assert parse_issue.details["category"] == "parse_error"
+    assert parse_issue.details["parse_error"] == "pickle exhausted before seeing STOP"
+    assert parse_issue.details["failure_reason"] == "unknown_opcode_or_format_error"
+    assert parse_issue.details["analysis_incomplete"] is True
+    assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
 
 
-def test_pickle_report_to_scan_result_escalates_parse_failure_for_truncated_bin_sources() -> None:
+def test_pickle_report_to_scan_result_keeps_truncated_bin_parse_failure_inconclusive() -> None:
     report = PickleReport(
         source="truncated.bin",
         status=ScanStatus.INCONCLUSIVE,
@@ -490,14 +492,16 @@ def test_pickle_report_to_scan_result_escalates_parse_failure_for_truncated_bin_
 
     assert result.success is False
     assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
-    assert any(
-        issue.severity == IssueSeverity.CRITICAL
-        and issue.message == "Pickle parsing failed before full scan completion"
-        and issue.location == "truncated.bin (pos 57)"
-        and issue.details["parse_error"] == "pickle exhausted before seeing STOP"
-        and issue.details["failure_reason"] == "unknown_opcode_or_format_error"
-        for issue in result.issues
+    parse_issue = next(
+        issue for issue in result.issues if issue.message == "Pickle parsing failed before full scan completion"
     )
+    assert parse_issue.severity == IssueSeverity.INFO
+    assert parse_issue.location == "truncated.bin (pos 57)"
+    assert parse_issue.details["category"] == "parse_error"
+    assert parse_issue.details["parse_error"] == "pickle exhausted before seeing STOP"
+    assert parse_issue.details["failure_reason"] == "unknown_opcode_or_format_error"
+    assert parse_issue.details["analysis_incomplete"] is True
+    assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
 
 
 def test_pickle_report_to_scan_result_keeps_trusted_bin_padding_tails_as_inconclusive_notices() -> None:
@@ -746,14 +750,15 @@ def test_pickle_report_to_scan_result_requires_boundary_for_tail_suppression() -
     result = pickle_report_to_scan_result(report)
 
     assert "trusted_incomplete_tail" not in result.metadata
-    assert any(
-        issue.severity == IssueSeverity.CRITICAL
-        and issue.message == "Pickle parsing failed before full scan completion"
-        for issue in result.issues
+    parse_issue = next(
+        issue for issue in result.issues if issue.message == "Pickle parsing failed before full scan completion"
     )
+    assert parse_issue.severity == IssueSeverity.INFO
+    assert parse_issue.details["category"] == "parse_error"
+    assert parse_issue.details["analysis_incomplete"] is True
 
 
-def test_pickle_report_to_scan_result_keeps_parse_errors_non_operational() -> None:
+def test_pickle_report_to_scan_result_keeps_parse_errors_inconclusive() -> None:
     report = PickleReport(
         source="bad.bin",
         status=ScanStatus.ERROR,
@@ -771,10 +776,15 @@ def test_pickle_report_to_scan_result_keeps_parse_errors_non_operational() -> No
     result = pickle_report_to_scan_result(report)
 
     assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert result.metadata["scan_outcome_reasons"] == ["pickle_analysis_incomplete"]
+    assert result.metadata["analysis_incomplete"] is True
     assert "operational_error" not in result.metadata
     assert "operational_error_reason" not in result.metadata
     assert len(result.issues) == 1
-    assert result.issues[0].severity == IssueSeverity.CRITICAL
+    assert result.issues[0].severity == IssueSeverity.INFO
+    assert result.issues[0].details["category"] == "parse_error"
+    assert result.issues[0].details["analysis_incomplete"] is True
 
 
 def test_pickle_report_to_scan_result_maps_non_parse_errors_to_operational_errors() -> None:

--- a/tests/test_exit_codes.py
+++ b/tests/test_exit_codes.py
@@ -202,6 +202,30 @@ def test_exit_code_inconclusive_pickle_without_security_findings() -> None:
     assert determine_exit_code(results) == 2
 
 
+def test_exit_code_inconclusive_pickle_with_info_parse_failure_without_security_findings() -> None:
+    """Operational parse failures should return exit code 2, not security exit code 1."""
+    results = _create_result_model(
+        success=False,
+        file_metadata={"model.pkl": {"scan_outcome": "inconclusive", "analysis_incomplete": True}},
+        issues=[
+            Issue(
+                message="Pickle parsing failed before full scan completion",
+                severity=IssueSeverity.INFO,
+                location="model.pkl",
+                details={
+                    "category": "parse_error",
+                    "failure_reason": "unknown_opcode_or_format_error",
+                    "analysis_incomplete": True,
+                },
+                timestamp=0.0,
+                why=None,
+                type=None,
+            ),
+        ],
+    )
+    assert determine_exit_code(results) == 2
+
+
 def test_exit_code_inconclusive_pickle_with_security_findings() -> None:
     """Security findings should still return exit code 1 even if analysis was inconclusive."""
     results = _create_result_model(


### PR DESCRIPTION
## Summary
- report standalone and legacy pickle parse failures as INFO-level inconclusive analysis instead of CRITICAL security findings
- keep scan success false for inconclusive parse failures without dangerous evidence so CLI aggregation returns exit code 2
- preserve trusted benign joblib tails as successful while keeping truncated joblib payloads inconclusive

## Validation
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run env PROMPTFOO_DISABLE_TELEMETRY=1 pytest -n auto -m "not slow and not integration" --maxfail=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Pickle parsing failures are now reported as informational issues rather than critical findings.
  * Incomplete or truncated pickle scans are correctly identified as inconclusive outcomes instead of failures.
  * Scan success determination enhanced to properly handle inconclusive analysis results.
  * Exit codes now accurately reflect inconclusive scans containing only informational parse issues.

* **Tests**
  * Expanded test coverage for inconclusive scan scenarios and informational parse failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->