### PR TITLE
fix: tighten pytorch zip pickle discovery

### DIFF
--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -13,6 +13,7 @@ from typing import Any, ClassVar
 
 from ..detectors.suspicious_symbols import CVE_COMBINED_PATTERNS
 from ..utils import sanitize_archive_path
+from ..utils.file.detection import PROTO0_1_MAX_PROBE_BYTES, PROTO0_1_START_BYTES, _looks_like_proto0_or_1_pickle
 from .archive_member_security import is_executable_archive_member_name
 from .base import BaseScanner, IssueSeverity, ScanResult
 from .pickle_scanner import PickleScanner
@@ -30,6 +31,14 @@ from .pytorch_zip_support import (
 
 logger = logging.getLogger(__name__)
 _INSTALLED_PYTORCH_VERSION_UNSET = object()
+_PICKLE_BINARY_PROTOCOL_PREFIXES: tuple[bytes, ...] = (
+    b"\x80\x01",
+    b"\x80\x02",
+    b"\x80\x03",
+    b"\x80\x04",
+    b"\x80\x05",
+)
+_PICKLE_DISCOVERY_SHORT_PROBE_BYTES = 16
 
 
 @dataclass(frozen=True)
@@ -612,17 +621,28 @@ class PyTorchZipScanner(BaseScanner):
                     data_start = self._read_member_prefix(
                         zip_file,
                         entry,
-                        8,
+                        _PICKLE_DISCOVERY_SHORT_PROBE_BYTES,
                         phase="pickle_discovery",
                         result=result,
                     )
-                    # Include protocol 1 and check for protocol 0 ASCII pickles
-                    pickle_magics = [b"\x80\x01", b"\x80\x02", b"\x80\x03", b"\x80\x04", b"\x80\x05"]
-                    # Common Protocol 0 ASCII opcodes: MARK '(', PUT 'p', GLOBAL 'c',
-                    # LIST 'l', DICT 'd', INT 'I'/'i', STRING 'S', UNICODE 'V', etc.
-                    ascii_pickle_opcodes = [b"(", b"p", b"c", b"l", b"d", b"I", b"i", b"S", b"V", b"q", b"t", b"u"]
-                    if any(data_start.startswith(m) for m in pickle_magics) or any(
-                        data_start.startswith(op) for op in ascii_pickle_opcodes
+                    if any(data_start.startswith(magic) for magic in _PICKLE_BINARY_PROTOCOL_PREFIXES):
+                        pickle_files.append(entry)
+                        continue
+
+                    if not data_start or data_start[0] not in PROTO0_1_START_BYTES:
+                        continue
+
+                    if entry.file_size > len(data_start):
+                        data_start = self._read_member_prefix(
+                            zip_file,
+                            entry,
+                            PROTO0_1_MAX_PROBE_BYTES,
+                            phase="pickle_discovery",
+                            result=result,
+                        )
+                    if _looks_like_proto0_or_1_pickle(
+                        data_start,
+                        sample_is_prefix=entry.file_size > len(data_start),
                     ):
                         pickle_files.append(entry)
                 except Exception:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -128,6 +128,56 @@ def test_pytorch_zip_scanner_malicious_model(tmp_path):
     assert any("eval" in issue.message.lower() for issue in result.issues)
 
 
+def test_pytorch_zip_discovery_rejects_ascii_opcode_plain_text_members(tmp_path: Path) -> None:
+    """Plain text members that start with protocol-0 opcode bytes should not be routed as pickles."""
+    model_path = tmp_path / "ascii_text_members.pt"
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data", b"cat is a category label, not a GLOBAL opcode stream")
+        zip_file.writestr("archive/constants", b"I keep integer-looking notes in this checkpoint manifest")
+        zip_file.writestr("archive/notes", b"(plain prose inside parentheses)")
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert result.metadata["pickle_files"] == []
+    assert not any(
+        check.name == "Pickle Format Check" and check.status == CheckStatus.FAILED for check in result.checks
+    )
+    assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
+
+
+def test_pytorch_zip_discovery_accepts_extensionless_proto0_pickle(tmp_path: Path) -> None:
+    """Extensionless PyTorch pickle members should still be discovered through structural probing."""
+    model_path = tmp_path / "extensionless_proto0.pt"
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data", pickle.dumps({"weights": [1, 2, 3]}, protocol=0))
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert result.metadata["pickle_files"] == ["archive/data"]
+    assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
+
+
+def test_pytorch_zip_discovery_scans_only_real_extensionless_pickle_near_text(tmp_path: Path) -> None:
+    """A real extensionless pickle should still be scanned when sibling text starts with pickle-ish bytes."""
+    model_path = tmp_path / "mixed_extensionless_members.pt"
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data", b"cbuiltins\neval\n(S'print(1)'\ntR.")
+        zip_file.writestr("archive/constants", b"compiled constants are documented here")
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.metadata["pickle_files"] == ["archive/data"]
+    assert any(issue.severity == IssueSeverity.CRITICAL and "eval" in issue.message.lower() for issue in result.issues)
+
+
 def test_pytorch_zip_scanner_detects_case_insensitive_native_library_members(tmp_path: Path) -> None:
     model_path = create_mock_pytorch_zip(tmp_path / "native_libs.pt")
     with zipfile.ZipFile(model_path, "a") as zip_file:


### PR DESCRIPTION
## Summary
- replace broad ASCII opcode prefix matching with binary-protocol and structural protocol 0/1 pickle probing for extensionless PyTorch ZIP members
- add regressions for prose members that start with pickle-like bytes and for real extensionless pickles

## Validation
- uv run --extra all-ci pytest tests/scanners/test_pytorch_zip_scanner.py::test_pytorch_zip_discovery_rejects_ascii_opcode_plain_text_members tests/scanners/test_pytorch_zip_scanner.py::test_pytorch_zip_discovery_accepts_extensionless_proto0_pickle tests/scanners/test_pytorch_zip_scanner.py::test_pytorch_zip_discovery_scans_only_real_extensionless_pickle_near_text
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run env PROMPTFOO_DISABLE_TELEMETRY=1 pytest -n auto -m "not slow and not integration" --maxfail=1