### PR TITLE
fix: skip prose-only network references

### DIFF
--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -8,18 +8,34 @@ import ipaddress
 import re
 from typing import Any, ClassVar
 
-_DOC_CONTEXT_MARKERS: tuple[str, ...] = (
+_DOC_CONTEXT_EXTENSIONS: tuple[str, ...] = (
     ".md",
     ".rst",
     ".txt",
     ".json",
     ".yaml",
     ".yml",
+)
+_DOC_CONTEXT_NAMES: frozenset[str] = frozenset(
+    {
+        "readme",
+        "metadata",
+        "description",
+        "model_card",
+        "manifest",
+    }
+)
+_DOC_CONTEXT_SEGMENTS: frozenset[str] = frozenset(
+    {
+        "metadata",
+        "description",
+        "model_card",
+        "manifest",
+    }
+)
+_DOC_CONTEXT_NAME_PREFIXES: tuple[str, ...] = (
     "readme",
-    "metadata",
-    "description",
     "model_card",
-    "manifest",
 )
 _PROSE_MARKERS: tuple[str, ...] = (
     " example",
@@ -50,7 +66,15 @@ _CODE_LINE_MARKERS: tuple[bytes, ...] = (
 def _is_metadata_context(context: str) -> bool:
     """Return whether the scan context appears to be documentation or metadata."""
     context_lower = context.lower()
-    return any(marker in context_lower for marker in _DOC_CONTEXT_MARKERS)
+    context_segments = [segment for segment in context_lower.replace("\\", "/").split("/") if segment]
+    filename = context_segments[-1] if context_segments else context_lower
+    stem = filename.rsplit(".", 1)[0]
+
+    if filename.endswith(_DOC_CONTEXT_EXTENSIONS):
+        return True
+    if stem in _DOC_CONTEXT_NAMES or stem.startswith(_DOC_CONTEXT_NAME_PREFIXES):
+        return True
+    return any(segment in _DOC_CONTEXT_SEGMENTS for segment in context_segments[:-1])
 
 
 def _extract_line(data: bytes, match_index: int) -> bytes:
@@ -88,7 +112,7 @@ def _is_doc_only_network_reference(
     word_count = len(_WORD_PATTERN.findall(line))
     metadata_context = _is_metadata_context(context)
 
-    if any(stripped.startswith(prefix) for prefix in _CODE_LINE_PREFIXES) and word_count <= 4:
+    if any(stripped.startswith(prefix) for prefix in _CODE_LINE_PREFIXES):
         return False
     if any(marker in line_lower for marker in _CODE_LINE_MARKERS):
         return False

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -49,6 +49,7 @@ _PROSE_MARKERS: tuple[str, ...] = (
     " mentions",
     " includes",
 )
+_MAX_PROSE_LINE_CONTEXT_BYTES = 512
 _WORD_PATTERN = re.compile(rb"[A-Za-z]{2,}")
 _CODE_LINE_PREFIXES: tuple[bytes, ...] = (
     b"import ",
@@ -62,6 +63,10 @@ _CODE_LINE_MARKERS: tuple[bytes, ...] = (
     b";",
     b"lambda ",
 )
+_INLINE_COMPOUND_STATEMENT_PATTERN = re.compile(
+    rb"^\s*(?:if|elif|else|for|while|with|try|except|finally|match|case)\b[^#\n]*:\s*\S"
+)
+_STRUCTURED_METADATA_PREFIXES: tuple[bytes, ...] = (b"{", b"[", b'"', b"'")
 
 
 def _is_metadata_context(context: str) -> bool:
@@ -80,10 +85,11 @@ def _is_metadata_context(context: str) -> bool:
 
 def _extract_line(data: bytes, match_index: int) -> bytes:
     """Extract the line containing a matched network token."""
-    line_start = data.rfind(b"\n", 0, match_index) + 1
+    line_start = max(data.rfind(b"\n", 0, match_index) + 1, match_index - _MAX_PROSE_LINE_CONTEXT_BYTES)
     line_end = data.find(b"\n", match_index)
     if line_end == -1:
         line_end = len(data)
+    line_end = min(line_end, match_index + _MAX_PROSE_LINE_CONTEXT_BYTES)
     return data[line_start:line_end]
 
 
@@ -126,7 +132,11 @@ def _is_doc_only_network_reference(
 
     if any(stripped.startswith(prefix) for prefix in _CODE_LINE_PREFIXES):
         return False
+    if _INLINE_COMPOUND_STATEMENT_PATTERN.match(line_lower):
+        return False
     if any(marker in line_lower for marker in _CODE_LINE_MARKERS):
+        return False
+    if metadata_context and stripped.startswith(_STRUCTURED_METADATA_PREFIXES):
         return False
 
     text = line.decode("utf-8", errors="ignore").lower()

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -48,7 +48,6 @@ _PROSE_MARKERS: tuple[str, ...] = (
     " says",
     " mentions",
     " includes",
-    " for ",
 )
 _WORD_PATTERN = re.compile(rb"[A-Za-z]{2,}")
 _CODE_LINE_PREFIXES: tuple[bytes, ...] = (
@@ -56,6 +55,7 @@ _CODE_LINE_PREFIXES: tuple[bytes, ...] = (
     b"from ",
     b"def ",
     b"class ",
+    b"if ",
 )
 _CODE_LINE_MARKERS: tuple[bytes, ...] = (
     b"=",
@@ -131,7 +131,9 @@ def _is_doc_only_network_reference(
 
     text = line.decode("utf-8", errors="ignore").lower()
     has_prose_marker = any(marker in text for marker in _PROSE_MARKERS)
-    return (metadata_context and word_count >= 4) or (word_count >= 6 and has_prose_marker)
+    if not has_prose_marker:
+        return False
+    return (metadata_context and word_count >= 4) or word_count >= 6
 
 
 class NetworkCommDetector:

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -6,6 +6,7 @@ that could be used for data exfiltration or command & control operations.
 
 import ipaddress
 import re
+from collections.abc import Iterator
 from typing import Any, ClassVar
 
 _DOC_CONTEXT_EXTENSIONS: tuple[str, ...] = (
@@ -84,6 +85,17 @@ def _extract_line(data: bytes, match_index: int) -> bytes:
     if line_end == -1:
         line_end = len(data)
     return data[line_start:line_end]
+
+
+def _iter_pattern_matches(data: bytes, pattern: bytes) -> Iterator[int]:
+    """Yield non-overlapping match positions for a byte pattern."""
+    start = 0
+    while True:
+        match_index = data.find(pattern, start)
+        if match_index < 0:
+            break
+        yield match_index
+        start = match_index + max(1, len(pattern))
 
 
 def _has_call_syntax(data: bytes, match_index: int, token_len: int) -> bool:
@@ -681,8 +693,7 @@ class NetworkCommDetector:
             patterns = [b"import " + lib, b"from " + lib, lib + b".connect", lib + b".request", lib + b".__init__"]
 
             for pattern in patterns:
-                match_index = data.find(pattern)
-                if match_index >= 0:
+                for match_index in _iter_pattern_matches(data, pattern):
                     if _is_doc_only_network_reference(
                         data,
                         match_index=match_index,
@@ -712,12 +723,14 @@ class NetworkCommDetector:
                         }
                     )
                     break  # One finding per library
+                else:
+                    continue
+                break
 
     def _scan_network_functions(self, data: bytes, context: str) -> None:
         """Scan for network function calls."""
         for func in self.NETWORK_FUNCTIONS:
-            idx = data.find(func)
-            if idx >= 0:
+            for idx in _iter_pattern_matches(data, func):
                 if _is_doc_only_network_reference(
                     data,
                     match_index=idx,
@@ -751,6 +764,7 @@ class NetworkCommDetector:
                         "context": context,
                     }
                 )
+                break
 
     def _scan_cc_patterns(self, data: bytes, context: str) -> None:
         """Scan for command & control patterns."""

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -8,6 +8,95 @@ import ipaddress
 import re
 from typing import Any, ClassVar
 
+_DOC_CONTEXT_MARKERS: tuple[str, ...] = (
+    ".md",
+    ".rst",
+    ".txt",
+    ".json",
+    ".yaml",
+    ".yml",
+    "readme",
+    "metadata",
+    "description",
+    "model_card",
+    "manifest",
+)
+_PROSE_MARKERS: tuple[str, ...] = (
+    " example",
+    " examples",
+    " documentation",
+    " readme",
+    " description",
+    " metadata",
+    " says",
+    " mentions",
+    " includes",
+    " for ",
+)
+_WORD_PATTERN = re.compile(rb"[A-Za-z]{2,}")
+_CODE_LINE_PREFIXES: tuple[bytes, ...] = (
+    b"import ",
+    b"from ",
+    b"def ",
+    b"class ",
+)
+_CODE_LINE_MARKERS: tuple[bytes, ...] = (
+    b"=",
+    b";",
+    b"lambda ",
+)
+
+
+def _is_metadata_context(context: str) -> bool:
+    """Return whether the scan context appears to be documentation or metadata."""
+    context_lower = context.lower()
+    return any(marker in context_lower for marker in _DOC_CONTEXT_MARKERS)
+
+
+def _extract_line(data: bytes, match_index: int) -> bytes:
+    """Extract the line containing a matched network token."""
+    line_start = data.rfind(b"\n", 0, match_index) + 1
+    line_end = data.find(b"\n", match_index)
+    if line_end == -1:
+        line_end = len(data)
+    return data[line_start:line_end]
+
+
+def _has_call_syntax(data: bytes, match_index: int, token_len: int) -> bool:
+    """Return whether a token is followed by call syntax after optional whitespace."""
+    cursor = match_index + token_len
+    while cursor < len(data) and data[cursor : cursor + 1] in {b" ", b"\t", b"\r", b"\n"}:
+        cursor += 1
+    return cursor < len(data) and data[cursor : cursor + 1] == b"("
+
+
+def _is_doc_only_network_reference(
+    data: bytes,
+    *,
+    match_index: int,
+    token_len: int,
+    context: str,
+    requires_call: bool,
+) -> bool:
+    """Return whether a raw network token appears in prose instead of executable code."""
+    if requires_call and _has_call_syntax(data, match_index, token_len):
+        return False
+
+    line = _extract_line(data, match_index)
+    line_lower = line.lower()
+    stripped = line_lower.lstrip()
+    word_count = len(_WORD_PATTERN.findall(line))
+    metadata_context = _is_metadata_context(context)
+
+    if any(stripped.startswith(prefix) for prefix in _CODE_LINE_PREFIXES) and word_count <= 4:
+        return False
+    if any(marker in line_lower for marker in _CODE_LINE_MARKERS):
+        return False
+
+    text = line.decode("utf-8", errors="ignore").lower()
+    has_prose_marker = any(marker in text for marker in _PROSE_MARKERS)
+    return (metadata_context and word_count >= 4) or (word_count >= 6 and has_prose_marker)
+
 
 class NetworkCommDetector:
     """Detector for network communication patterns in model files."""
@@ -568,7 +657,17 @@ class NetworkCommDetector:
             patterns = [b"import " + lib, b"from " + lib, lib + b".connect", lib + b".request", lib + b".__init__"]
 
             for pattern in patterns:
-                if pattern in data:
+                match_index = data.find(pattern)
+                if match_index >= 0:
+                    if _is_doc_only_network_reference(
+                        data,
+                        match_index=match_index,
+                        token_len=len(pattern),
+                        context=context,
+                        requires_call=False,
+                    ):
+                        continue
+
                     confidence = 0.7
                     severity = "HIGH"
 
@@ -593,9 +692,18 @@ class NetworkCommDetector:
     def _scan_network_functions(self, data: bytes, context: str) -> None:
         """Scan for network function calls."""
         for func in self.NETWORK_FUNCTIONS:
-            if func in data:
+            idx = data.find(func)
+            if idx >= 0:
+                if _is_doc_only_network_reference(
+                    data,
+                    match_index=idx,
+                    token_len=len(func),
+                    context=context,
+                    requires_call=True,
+                ):
+                    continue
+
                 # Try to get some context around the function call
-                idx = data.find(func)
                 start = max(0, idx - 50)
                 end = min(len(data), idx + 100)
                 snippet = data[start:end].decode("utf-8", errors="ignore")
@@ -716,6 +824,15 @@ class NetworkCommDetector:
             matches = regex.finditer(data)
 
             for match in matches:
+                if pattern_type == "network_import" and _is_doc_only_network_reference(
+                    data,
+                    match_index=match.start(),
+                    token_len=len(match.group()),
+                    context=context,
+                    requires_call=False,
+                ):
+                    continue
+
                 # Get context around the match to validate it's not in binary weights
                 start_pos = max(0, match.start() - 100)
                 end_pos = min(len(data), match.end() + 100)

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -153,6 +153,16 @@ class TestNetworkCommDetector:
         func_findings = [finding for finding in findings if finding["type"] == "network_function"]
         assert any(finding["function"] == "socket.connect" for finding in func_findings)
 
+    def test_network_function_after_doc_token_still_flagged(self) -> None:
+        """A prose token mention should not hide a later executable-looking function call."""
+        detector = NetworkCommDetector()
+        data = b'This README says requests.get is shown for examples.\nrequests.get("https://evil.example")'
+
+        findings = detector.scan(data, "metadata.json")
+
+        func_findings = [finding for finding in findings if finding["type"] == "network_function"]
+        assert any(finding["function"] == "requests.get" for finding in func_findings)
+
     def test_network_library_with_realistic_prose_context_not_flagged(self) -> None:
         """Import-like words in prose should not be treated as network imports."""
         detector = NetworkCommDetector()
@@ -170,6 +180,16 @@ class TestNetworkCommDetector:
         findings = detector.scan(data, "src/metadata_utils.py")
 
         assert any(finding["type"] == "network_library" for finding in findings)
+
+    def test_network_library_after_doc_import_still_flagged(self) -> None:
+        """A prose import mention should not hide a later executable import."""
+        detector = NetworkCommDetector()
+        data = b"Model documentation includes import socket for demos and troubleshooting examples.\nimport socket"
+
+        findings = detector.scan(data, "README.txt")
+
+        lib_findings = [finding for finding in findings if finding["type"] == "network_library"]
+        assert any(finding["library"] == "socket" for finding in lib_findings)
 
     def test_detect_cc_patterns(self):
         """Test detection of command & control patterns."""

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -181,6 +181,24 @@ class TestNetworkCommDetector:
 
         assert any(finding["type"] == "network_library" for finding in findings)
 
+    def test_metadata_context_without_prose_marker_still_flags_network_import(self) -> None:
+        """Metadata filenames alone should not suppress executable-looking imports."""
+        detector = NetworkCommDetector()
+        data = b'{"hook": "import socket then send payload"}'
+
+        findings = detector.scan(data, "metadata.json")
+
+        assert any(finding["type"] == "network_library" and finding["library"] == "socket" for finding in findings)
+
+    def test_inline_comment_prose_marker_after_code_still_flags_network_import(self) -> None:
+        """Inline prose markers should not hide executable import statements."""
+        detector = NetworkCommDetector()
+        data = b"if True: import socket  # for outbound callback"
+
+        findings = detector.scan(data, "model.pkl")
+
+        assert any(finding["type"] == "network_library" and finding["library"] == "socket" for finding in findings)
+
     def test_network_library_after_doc_import_still_flagged(self) -> None:
         """A prose import mention should not hide a later executable import."""
         detector = NetworkCommDetector()

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -134,6 +134,34 @@ class TestNetworkCommDetector:
         assert "requests.post" in funcs
         assert "urlopen" in funcs
 
+    def test_network_functions_not_flagged_in_documentation_metadata_context(self) -> None:
+        """Documentation prose should not report raw network library/function token mentions."""
+        detector = NetworkCommDetector()
+        data = b"This README says: import socket, requests.get, and urlopen are shown for examples."
+
+        findings = detector.scan(data, "model_card.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    def test_network_function_with_parentheses_still_flagged_in_metadata_context(self) -> None:
+        """Executable-looking calls should stay detectable even when embedded in metadata files."""
+        detector = NetworkCommDetector()
+        data = b'socket.connect(("api.example", 4444))'
+
+        findings = detector.scan(data, "metadata.json")
+
+        func_findings = [finding for finding in findings if finding["type"] == "network_function"]
+        assert any(finding["function"] == "socket.connect" for finding in func_findings)
+
+    def test_network_library_with_realistic_prose_context_not_flagged(self) -> None:
+        """Import-like words in prose should not be treated as network imports."""
+        detector = NetworkCommDetector()
+        data = b"Model documentation includes import socket for demos and troubleshooting examples."
+
+        findings = detector.scan(data, "README.txt")
+
+        assert not [finding for finding in findings if finding["type"] == "network_library"]
+
     def test_detect_cc_patterns(self):
         """Test detection of command & control patterns."""
         detector = NetworkCommDetector()

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -162,6 +162,15 @@ class TestNetworkCommDetector:
 
         assert not [finding for finding in findings if finding["type"] == "network_library"]
 
+    def test_executable_metadata_named_path_still_flags_network_import(self) -> None:
+        """Executable paths containing metadata-like words should not be treated as prose."""
+        detector = NetworkCommDetector()
+        data = b"import socket  # used by this metadata helper to open outbound connections"
+
+        findings = detector.scan(data, "src/metadata_utils.py")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+
     def test_detect_cc_patterns(self):
         """Test detection of command & control patterns."""
         detector = NetworkCommDetector()

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -190,10 +190,37 @@ class TestNetworkCommDetector:
 
         assert any(finding["type"] == "network_library" and finding["library"] == "socket" for finding in findings)
 
+    def test_metadata_context_with_marker_in_structured_hook_still_flags_network_import(self) -> None:
+        """Marker words in structured metadata should not hide executable import text."""
+        detector = NetworkCommDetector()
+        data = b'{"hook": "import socket includes callback"}'
+
+        findings = detector.scan(data, "metadata.json")
+
+        assert any(finding["type"] == "network_library" and finding["library"] == "socket" for finding in findings)
+
     def test_inline_comment_prose_marker_after_code_still_flags_network_import(self) -> None:
         """Inline prose markers should not hide executable import statements."""
         detector = NetworkCommDetector()
         data = b"if True: import socket  # for outbound callback"
+
+        findings = detector.scan(data, "model.pkl")
+
+        assert any(finding["type"] == "network_library" and finding["library"] == "socket" for finding in findings)
+
+    def test_inline_compound_statement_with_prose_marker_still_flags_network_import(self) -> None:
+        """Compound statements should stay executable even when comments look prose-like."""
+        detector = NetworkCommDetector()
+        data = b"for _ in [0]: import socket  # examples"
+
+        findings = detector.scan(data, "metadata.json")
+
+        assert any(finding["type"] == "network_library" and finding["library"] == "socket" for finding in findings)
+
+    def test_newline_free_binary_prose_marker_does_not_hide_later_import(self) -> None:
+        """A prose marker far away in a binary blob should not suppress a later import token."""
+        detector = NetworkCommDetector()
+        data = b"Model documentation includes examples " + (b"x" * 600) + b"import socket"
 
         findings = detector.scan(data, "model.pkl")
 

--- a/tests/test_network_comm_integration.py
+++ b/tests/test_network_comm_integration.py
@@ -2,6 +2,7 @@
 
 import pickle
 import zipfile
+from pathlib import Path
 
 from modelaudit.scanners.base import CheckStatus
 from modelaudit.scanners.pickle_scanner import PickleScanner
@@ -60,6 +61,25 @@ def exfiltrate(data):
         assert any("socket" in msg for msg in messages)
         assert any("requests" in msg or "http" in msg for msg in messages)
 
+    def test_pickle_scanner_metadata_field_description_text_no_fp(self, tmp_path: Path) -> None:
+        """Description prose mentioning network APIs should not fail network checks."""
+        test_file = tmp_path / "model_with_network_docs.pkl"
+        data = {
+            "model_weights": [1.0, 2.0, 3.0],
+            "description": "Model documentation includes import socket and requests.get examples.",
+        }
+
+        with open(test_file, "wb") as f:
+            pickle.dump(data, f)
+
+        result = PickleScanner().scan(str(test_file))
+
+        assert not [
+            check
+            for check in result.checks
+            if check.name == "Network Communication Detection" and check.status == CheckStatus.FAILED
+        ]
+
     def test_pytorch_zip_scanner_integration(self, tmp_path):
         """Test network communication detection in PyTorch ZIP scanner."""
         # Create a PyTorch ZIP file with network patterns
@@ -109,6 +129,27 @@ class NetworkExfiltrator:
         all_messages = " ".join(c.message for c in network_checks)
         # Check for backdoor detection (the scanner detects port 1337 as a common backdoor)
         assert "backdoor" in all_messages.lower() or "1337" in all_messages
+
+    def test_pytorch_zip_scanner_metadata_readme_member_no_network_fp(self, tmp_path: Path) -> None:
+        """README-style archive members should not fail network checks for prose mentions."""
+        test_file = tmp_path / "model_with_network_readme.pt"
+
+        with zipfile.ZipFile(test_file, "w") as zf:
+            zf.writestr("version", "3\n")
+            zf.writestr("byteorder", "little")
+            zf.writestr("data.pkl", pickle.dumps({"state_dict": {"layer1.weight": [1.0, 2.0]}}))
+            zf.writestr(
+                "metadata/README.md",
+                b"This README says import socket and requests.get can be used in client examples.",
+            )
+
+        result = PyTorchZipScanner().scan(str(test_file))
+
+        assert not [
+            check
+            for check in result.checks
+            if check.name == "Network Communication Detection" and check.status == CheckStatus.FAILED
+        ]
 
     def test_network_detection_can_be_disabled(self, tmp_path):
         """Test that network detection can be disabled via config."""

--- a/tests/test_network_comm_integration.py
+++ b/tests/test_network_comm_integration.py
@@ -74,11 +74,10 @@ def exfiltrate(data):
 
         result = PickleScanner().scan(str(test_file))
 
-        assert not [
-            check
-            for check in result.checks
-            if check.name == "Network Communication Detection" and check.status == CheckStatus.FAILED
-        ]
+        network_checks = [check for check in result.checks if check.name == "Network Communication Detection"]
+        assert network_checks, "Expected Network Communication Detection check to be emitted"
+        assert all(check.status != CheckStatus.FAILED for check in network_checks)
+        assert any(check.status == CheckStatus.PASSED for check in network_checks)
 
     def test_pytorch_zip_scanner_integration(self, tmp_path):
         """Test network communication detection in PyTorch ZIP scanner."""
@@ -145,11 +144,10 @@ class NetworkExfiltrator:
 
         result = PyTorchZipScanner().scan(str(test_file))
 
-        assert not [
-            check
-            for check in result.checks
-            if check.name == "Network Communication Detection" and check.status == CheckStatus.FAILED
-        ]
+        network_checks = [check for check in result.checks if check.name == "Network Communication Detection"]
+        assert network_checks, "Expected Network Communication Detection check to be emitted"
+        assert all(check.status != CheckStatus.FAILED for check in network_checks)
+        assert any(check.status == CheckStatus.PASSED for check in network_checks)
 
     def test_network_detection_can_be_disabled(self, tmp_path):
         """Test that network detection can be disabled via config."""


### PR DESCRIPTION
## Summary
- skip raw network library/function token findings when the matched line is documentation prose rather than executable code
- keep URL/IP/domain/C&C and call-like network detections intact
- add detector and scanner integration regressions for README/description metadata mentions

## Validation
- uv run --extra all-ci pytest tests/detectors/test_network_comm_detector.py::TestNetworkCommDetector::test_detect_network_libraries tests/detectors/test_network_comm_detector.py::TestNetworkCommDetector::test_detect_network_functions tests/detectors/test_network_comm_detector.py::TestNetworkCommDetector::test_network_functions_not_flagged_in_documentation_metadata_context tests/detectors/test_network_comm_detector.py::TestNetworkCommDetector::test_network_function_with_parentheses_still_flagged_in_metadata_context tests/detectors/test_network_comm_detector.py::TestNetworkCommDetector::test_network_library_with_realistic_prose_context_not_flagged tests/test_network_comm_integration.py::TestNetworkCommIntegration::test_pickle_scanner_integration tests/test_network_comm_integration.py::TestNetworkCommIntegration::test_pickle_scanner_metadata_field_description_text_no_fp tests/test_network_comm_integration.py::TestNetworkCommIntegration::test_pytorch_zip_scanner_integration tests/test_network_comm_integration.py::TestNetworkCommIntegration::test_pytorch_zip_scanner_metadata_readme_member_no_network_fp
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run env PROMPTFOO_DISABLE_TELEMETRY=1 pytest -n auto -m "not slow and not integration" --maxfail=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Network communication detection is now context-aware, distinguishing executable code from documentation and metadata. References to network libraries in markdown files, configurations, and prose are properly ignored, while actual executable network calls remain reliably detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->