### PR TITLE
fix: narrow safetensors path metadata checks

### DIFF
--- a/modelaudit/scanners/safetensors_scanner.py
+++ b/modelaudit/scanners/safetensors_scanner.py
@@ -456,7 +456,7 @@ class SafeTensorsScanner(BaseScanner):
                             lower_val = value.lower()
 
                             # Check for simple code-like patterns
-                            if any(s in lower_val for s in ["import ", "#!/", "\\"]):
+                            if any(s in lower_val for s in ["import ", "#!/"]):
                                 result.add_check(
                                     name="Metadata Code Pattern Check",
                                     passed=False,
@@ -651,13 +651,7 @@ class SafeTensorsScanner(BaseScanner):
         path_traversal_patterns = [
             r"\.\./+",
             r"\.\.\\+",
-            r"/etc/",
-            r"/proc/",
-            r"/root/",
-            r"/home/",
-            r"C:\\",
-            r"%[0-9a-fA-F]{2}",  # URL encoded characters
-            r"\\[a-zA-Z]:",  # Windows drive letters
+            r"%2e%2e(?:%2f|/|%5c|\\)",
         ]
 
         for pattern in path_traversal_patterns:

--- a/tests/scanners/test_safetensors_scanner.py
+++ b/tests/scanners/test_safetensors_scanner.py
@@ -453,6 +453,69 @@ def test_single_comment_token_does_not_bypass_unicode_escape_detection(tmp_path:
     assert all(check.severity == IssueSeverity.CRITICAL for check in code_injection_checks)
 
 
+def test_safetensors_benign_path_like_metadata_not_flagged(tmp_path: Path) -> None:
+    """Benign path references in metadata should not be treated as traversal."""
+    file_path = tmp_path / "benign_metadata.safetensors"
+    data = {"t": np.arange(5, dtype=np.float32)}
+    metadata = {
+        "source_path": "/home/alice/model-cache/run-1",
+        "root_copy": "/root/.cache/model.bin",
+        "win_path": r"C:\Users\alice\models\weights.safetensors",
+        "encoded_path": "%2Fhome%2Falice%2Fworkspace%2Fmodel.bin",
+    }
+    save_file(data, str(file_path), metadata=metadata)
+
+    result = SafeTensorsScanner().scan(str(file_path))
+
+    assert not [
+        check
+        for check in result.checks
+        if check.name == "SafeTensors Path Traversal Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert not [
+        check
+        for check in result.checks
+        if check.name == "Metadata Code Pattern Check" and check.status == CheckStatus.FAILED
+    ]
+
+
+def test_safetensors_traversal_metadata_still_detected(tmp_path: Path) -> None:
+    """Relative and URL-encoded traversal metadata should still be reported."""
+    file_path = tmp_path / "traversal_metadata.safetensors"
+    data = {"t": np.arange(5, dtype=np.float32)}
+    metadata = {
+        "payload_path": "../tmp/../../payload.bin",
+        "encoded_payload": "%2E%2e/%2e%2e/etc/shadow",
+    }
+    save_file(data, str(file_path), metadata=metadata)
+
+    result = SafeTensorsScanner().scan(str(file_path))
+
+    traversal_checks = [
+        check
+        for check in result.checks
+        if check.name == "SafeTensors Path Traversal Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert traversal_checks
+    assert any((check.details or {}).get("attack_type") == "path_traversal" for check in traversal_checks)
+
+
+def test_metadata_windows_drive_path_no_code_pattern_false_positive(tmp_path: Path) -> None:
+    """Windows path separators alone should not trip the metadata code-pattern check."""
+    file_path = tmp_path / "windows_path_only.safetensors"
+    data = {"t": np.arange(5, dtype=np.float32)}
+    metadata = {"artifact": r"D:\models\artifact\run.bin"}
+    save_file(data, str(file_path), metadata=metadata)
+
+    result = SafeTensorsScanner().scan(str(file_path))
+
+    assert not [
+        check
+        for check in result.checks
+        if check.name == "Metadata Code Pattern Check" and check.status == CheckStatus.FAILED
+    ]
+
+
 def test_mixed_suspicious_patterns(tmp_path: Path) -> None:
     """Test that both simple patterns and regex patterns are detected from the same metadata value."""
     file_path = tmp_path / "model.safetensors"


### PR DESCRIPTION
## Summary
- stop treating benign absolute paths, Windows paths, and arbitrary URL-encoded path bytes as SafeTensors traversal
- keep direct relative traversal and encoded traversal detection
- add regressions for benign path metadata, Windows path metadata, and real traversal metadata

## Validation
- uv run --extra all-ci pytest tests/scanners/test_safetensors_scanner.py::test_safetensors_benign_path_like_metadata_not_flagged tests/scanners/test_safetensors_scanner.py::test_safetensors_traversal_metadata_still_detected tests/scanners/test_safetensors_scanner.py::test_metadata_windows_drive_path_no_code_pattern_false_positive tests/scanners/test_safetensors_scanner.py::test_suspicious_metadata tests/scanners/test_safetensors_scanner.py::test_mixed_suspicious_patterns tests/scanners/test_safetensors_scanner.py::test_multiple_distinct_patterns
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run env PROMPTFOO_DISABLE_TELEMETRY=1 pytest -n auto -m "not slow and not integration" --maxfail=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SafeTensors metadata scanning accuracy by refining code pattern and path traversal detection, reducing false positives from benign file paths and system patterns.

* **Tests**
  * Added comprehensive test coverage for SafeTensors scanner metadata detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->