### PR TITLE
fix: narrow flax suspicious key criticals

### DIFF
--- a/modelaudit/scanners/flax_msgpack_scanner.py
+++ b/modelaudit/scanners/flax_msgpack_scanner.py
@@ -102,17 +102,33 @@ class FlaxMsgpackScanner(BaseScanner):
                 "__globals__",
                 "__builtins__",
                 "__import__",
-                # JAX/Flax specific suspicious keys
-                "__jax_array__",  # Potential fake JAX array
-                "__tree_flatten__",
-                "__tree_unflatten__",
+            },
+        )
+        self.function_metadata_keys = self.config.get(
+            "function_metadata_keys",
+            {
                 "jax_fn",
                 "compiled_fn",
                 "eval_fn",
                 "exec_fn",
-                # Orbax specific
                 "restore_fn",
                 "transform_fn",
+                "__tree_flatten__",
+                "__tree_unflatten__",
+            },
+        )
+        self.dangerous_callable_names = self.config.get(
+            "dangerous_callable_names",
+            {
+                "eval",
+                "exec",
+                "compile",
+                "__import__",
+                "os.system",
+                "os.popen",
+                "subprocess.run",
+                "subprocess.call",
+                "subprocess.popen",
             },
         )
 
@@ -426,6 +442,7 @@ class FlaxMsgpackScanner(BaseScanner):
     def _check_suspicious_keys(
         self,
         key: str,
+        value: Any,
         location: str,
         result: ScanResult,
     ) -> None:
@@ -443,6 +460,28 @@ class FlaxMsgpackScanner(BaseScanner):
                 details={"suspicious_key": key},
                 rule_code=rule_code,
             )
+            return
+
+        if key in self.function_metadata_keys and self._value_names_dangerous_callable(value):
+            result.add_check(
+                name="Object Attribute Security Check",
+                passed=False,
+                message=f"Suspicious object attribute value detected: {key}",
+                severity=IssueSeverity.CRITICAL,
+                location=location,
+                details={
+                    "suspicious_key": key,
+                    "value_sample": str(value)[:200],
+                },
+                rule_code="S999",
+            )
+
+    def _value_names_dangerous_callable(self, value: Any) -> bool:
+        """Return whether a metadata value directly names a dangerous callable."""
+        if not isinstance(value, str):
+            return False
+        normalized = value.strip().lower()
+        return normalized in self.dangerous_callable_names
 
     def _analyze_content(
         self,
@@ -522,7 +561,7 @@ class FlaxMsgpackScanner(BaseScanner):
 
             for k, v in value.items():
                 key_str = str(k)
-                self._check_suspicious_keys(key_str, f"{location}/{key_str}", result)
+                self._check_suspicious_keys(key_str, v, f"{location}/{key_str}", result)
 
                 # Check if key itself contains suspicious patterns
                 if isinstance(k, str):
@@ -866,11 +905,6 @@ class FlaxMsgpackScanner(BaseScanner):
             "__globals__",
             "__builtins__",
             "__import__",
-            "eval",
-            "exec",
-            "subprocess",
-            "os",
-            "system",
         }
 
         suspicious_top_level = found_keys & dangerous_keys

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -96,6 +96,69 @@ def test_flax_msgpack_malicious_content_marks_scan_unsuccessful(tmp_path: Path) 
     )
 
 
+def test_flax_msgpack_restore_fn_custom_value_no_critical(tmp_path: Path) -> None:
+    """Benign Orbax restore function names should not be key-name criticals."""
+    path = tmp_path / "benign_restore_fn.msgpack"
+    create_msgpack_file(path, {"params": {"w": [1, 2, 3]}, "restore_fn": "custom_deserialize"})
+
+    result = FlaxMsgpackScanner().scan(str(path))
+
+    assert result.success is True
+    assert not [
+        issue for issue in result.issues if issue.severity == IssueSeverity.CRITICAL and "restore_fn" in issue.message
+    ]
+
+
+def test_flax_msgpack_restore_fn_dangerous_value_still_critical(tmp_path: Path) -> None:
+    """Function metadata that directly names dangerous callables should stay critical."""
+    path = tmp_path / "dangerous_restore_fn.msgpack"
+    create_msgpack_file(path, {"params": {"w": [1, 2, 3]}, "restore_fn": "eval"})
+
+    result = FlaxMsgpackScanner().scan(str(path))
+
+    assert result.success is False
+    assert any(
+        issue.severity == IssueSeverity.CRITICAL
+        and issue.message == "Suspicious object attribute value detected: restore_fn"
+        for issue in result.issues
+    )
+
+
+def test_flax_msgpack_jax_internal_key_metadata_is_not_critical(tmp_path: Path) -> None:
+    """JAX internal metadata key names should not become critical without dangerous values."""
+    path = tmp_path / "benign_jax_internal_keys.msgpack"
+    create_msgpack_file(
+        path,
+        {
+            "params": {"w": [1, 2, 3]},
+            "__jax_array__": {"dtype": "float32", "shape": [3]},
+            "__tree_flatten__": "tree_def",
+            "__tree_unflatten__": "tree_def",
+        },
+    )
+
+    result = FlaxMsgpackScanner().scan(str(path))
+
+    critical_messages = [issue.message for issue in result.issues if issue.severity == IssueSeverity.CRITICAL]
+    assert not any("__jax_array__" in message for message in critical_messages)
+    assert not any("__tree_flatten__" in message for message in critical_messages)
+    assert not any("__tree_unflatten__" in message for message in critical_messages)
+
+
+def test_flax_msgpack_metadata_system_os_keys_not_critical(tmp_path: Path) -> None:
+    """Environment-like top-level metadata keys should not be unconditional criticals."""
+    path = tmp_path / "benign_system_metadata.msgpack"
+    create_msgpack_file(path, {"params": {"w": [1, 2, 3]}, "system": "linux", "os": "linux-x86_64"})
+
+    result = FlaxMsgpackScanner().scan(str(path))
+
+    assert not [
+        issue
+        for issue in result.issues
+        if issue.severity == IssueSeverity.CRITICAL and "top-level keys" in issue.message.lower()
+    ]
+
+
 def test_flax_msgpack_respects_file_size_limit(tmp_path: Path) -> None:
     """Scanner should fail closed before reading files larger than max_file_read_size."""
     path = tmp_path / "too_large.msgpack"
@@ -376,9 +439,11 @@ def test_flax_msgpack_jax_specific_threats(tmp_path):
     scanner = FlaxMsgpackScanner()
     result = scanner.scan(str(path))
 
-    # Should detect multiple threats (CRITICAL or INFO severity)
+    # Should detect multiple threats (CRITICAL, WARNING, or INFO severity)
     security_issues = [
-        issue for issue in result.issues if issue.severity in (IssueSeverity.CRITICAL, IssueSeverity.INFO)
+        issue
+        for issue in result.issues
+        if issue.severity in (IssueSeverity.CRITICAL, IssueSeverity.WARNING, IssueSeverity.INFO)
     ]
 
     # Check for JAX-specific threats

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -124,6 +124,41 @@ def test_flax_msgpack_restore_fn_dangerous_value_still_critical(tmp_path: Path) 
     )
 
 
+@pytest.mark.parametrize(
+    ("metadata_key", "dangerous_callable"),
+    [
+        ("restore_fn", "eval"),
+        ("jax_fn", "exec"),
+        ("compiled_fn", "compile"),
+        ("exec_fn", "os.system"),
+        ("transform_fn", "subprocess.run"),
+        ("__tree_flatten__", "__import__"),
+        ("__tree_unflatten__", "subprocess.Popen"),
+    ],
+)
+def test_flax_msgpack_function_metadata_key_value_combinations(
+    tmp_path: Path,
+    metadata_key: str,
+    dangerous_callable: str,
+) -> None:
+    """Function metadata keys should be value-aware across common callable names."""
+    for value, should_be_critical in ((dangerous_callable, True), ("custom_deserialize", False)):
+        path = tmp_path / f"{metadata_key.strip('_') or 'dunder'}_{value.replace('.', '_')}.msgpack"
+        create_msgpack_file(path, {"params": {"w": [1, 2, 3]}, metadata_key: value})
+
+        result = FlaxMsgpackScanner().scan(str(path))
+        key_critical_issues = [
+            issue
+            for issue in result.issues
+            if issue.severity == IssueSeverity.CRITICAL and metadata_key in issue.message
+        ]
+
+        if should_be_critical:
+            assert key_critical_issues, f"Expected CRITICAL for {metadata_key}={value!r}: {result.issues}"
+        else:
+            assert not key_critical_issues, f"Expected no CRITICAL for {metadata_key}={value!r}: {result.issues}"
+
+
 def test_flax_msgpack_jax_internal_key_metadata_is_not_critical(tmp_path: Path) -> None:
     """JAX internal metadata key names should not become critical without dangerous values."""
     path = tmp_path / "benign_jax_internal_keys.msgpack"


### PR DESCRIPTION
## Summary
- stop treating benign JAX/Orbax metadata key names as unconditional CRITICAL findings
- keep Python serialization keys critical and keep direct dangerous callable values under function metadata keys critical
- add regressions for benign restore_fn/internal JAX metadata and dangerous restore_fn values

## Validation
- uv run --extra all-ci pytest tests/scanners/test_flax_msgpack_scanner.py::test_flax_msgpack_malicious_content_marks_scan_unsuccessful tests/scanners/test_flax_msgpack_scanner.py::test_flax_msgpack_restore_fn_custom_value_no_critical tests/scanners/test_flax_msgpack_scanner.py::test_flax_msgpack_restore_fn_dangerous_value_still_critical tests/scanners/test_flax_msgpack_scanner.py::test_flax_msgpack_jax_internal_key_metadata_is_not_critical tests/scanners/test_flax_msgpack_scanner.py::test_flax_msgpack_metadata_system_os_keys_not_critical tests/scanners/test_flax_msgpack_scanner.py::test_flax_msgpack_jax_specific_threats tests/test_jax_flax_integration.py::TestJaxFlaxIntegration::test_clean_flax_model_no_false_positives tests/test_jax_flax_integration.py::TestJaxFlaxIntegration::test_malicious_jax_model_detection
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run env PROMPTFOO_DISABLE_TELEMETRY=1 pytest -n auto -m "not slow and not integration" --maxfail=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced security scanning with improved detection of dangerous callable names referenced in model metadata.
  * Implemented value-aware inspection to better distinguish safe from potentially malicious patterns.

* **Bug Fixes**
  * Significantly reduced false positive critical security alerts for legitimate and benign metadata configurations.
  * Improved detection precision for model structure security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->