### PR TITLE
fix: mark missing numpy format as operational

### DIFF
--- a/modelaudit/scanners/numpy_scanner.py
+++ b/modelaudit/scanners/numpy_scanner.py
@@ -179,16 +179,29 @@ class NumPyScanner(BaseScanner):
 
         if not NUMPY_FORMAT_AVAILABLE:
             result = self._create_result()
+            result.metadata["numpy_version"] = NUMPY_VERSION
+            result.metadata["numpy_major_version"] = NUMPY_MAJOR_VERSION
+            result.metadata["operational_error"] = True
+            result.metadata["operational_error_reason"] = "numpy_format_module_unavailable"
+            _mark_inconclusive_scan_result(result, "numpy_format_module_unavailable")
             result.add_check(
                 name="NumPy Format Module Check",
                 passed=False,
                 message=f"NumPy format module not available (NumPy {NUMPY_VERSION}). May be a compatibility issue.",
-                severity=IssueSeverity.CRITICAL,
+                severity=IssueSeverity.INFO,
                 location=path,
                 rule_code=None,  # Library availability, no rule
-                details={"numpy_version": NUMPY_VERSION, "numpy_major": NUMPY_MAJOR_VERSION},
+                details={
+                    "numpy_version": NUMPY_VERSION,
+                    "numpy_major": NUMPY_MAJOR_VERSION,
+                    "analysis_incomplete": True,
+                    "scan_outcome": result.metadata["scan_outcome"],
+                    "scan_outcome_reason": "numpy_format_module_unavailable",
+                    "operational_error": True,
+                    "operational_error_reason": "numpy_format_module_unavailable",
+                },
             )
-            result.finish(success=False)
+            _finish_with_inconclusive_contract(result, default_success=False)
             return result
 
         path_check_result = self._check_path(path)

--- a/tests/scanners/test_numpy_scanner.py
+++ b/tests/scanners/test_numpy_scanner.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+import pytest
 
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, Check, IssueSeverity, ScanResult
@@ -34,6 +35,36 @@ def test_numpy_scanner_truncated(tmp_path):
     result = scanner.scan(str(path))
 
     assert any(i.severity == IssueSeverity.INFO for i in result.issues)
+
+
+def test_numpy_format_module_unavailable_is_operational_not_critical(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    arr = np.arange(3)
+    path = tmp_path / "array.npy"
+    np.save(path, arr)
+
+    import modelaudit.scanners.numpy_scanner as numpy_scanner_module
+
+    monkeypatch.setattr(numpy_scanner_module, "NUMPY_FORMAT_AVAILABLE", False)
+
+    result = NumPyScanner().scan(str(path))
+
+    assert result.success is False
+    assert result.has_errors is False
+    assert result.has_warnings is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert result.metadata["analysis_incomplete"] is True
+    assert result.metadata["operational_error"] is True
+    assert result.metadata["operational_error_reason"] == "numpy_format_module_unavailable"
+    assert "numpy_format_module_unavailable" in result.metadata["scan_outcome_reasons"]
+
+    check = next(check for check in result.checks if check.name == "NumPy Format Module Check")
+    assert check.severity == IssueSeverity.INFO
+    assert check.details["analysis_incomplete"] is True
+    assert check.details["operational_error"] is True
+    assert all(issue.severity != IssueSeverity.CRITICAL for issue in result.issues)
 
 
 class TestCVE20196446ObjectDtype:


### PR DESCRIPTION
## Summary
- Treat missing numpy.lib.format as an operational/inconclusive scan limitation instead of a critical model finding
- Preserve fail-closed behavior with operational metadata
- Add regression coverage for the unavailable format-module path

## Validation
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run env PROMPTFOO_DISABLE_TELEMETRY=1 pytest -n auto -m "not slow and not integration" --maxfail=1