### PR TITLE
fix: narrow openvino external library checks

### DIFF
--- a/modelaudit/scanners/openvino_scanner.py
+++ b/modelaudit/scanners/openvino_scanner.py
@@ -33,6 +33,7 @@ _OPENVINO_SUSPICIOUS_PATTERN = (
     if _OPENVINO_SUSPICIOUS_STRING_PATTERNS
     else None
 )
+_OPENVINO_NATIVE_LIBRARY_SUFFIX = re.compile(r"(?:\.so(?:\.\d+)*|\.dll|\.dylib|\.lib)$", re.IGNORECASE)
 
 
 def _local_tag_name(tag: str) -> str:
@@ -138,6 +139,18 @@ def _iter_element_attributes(layer: Any) -> Iterator[tuple[str, str, str]]:
                 yield element_tag, attr_name.strip().lower(), normalized_value
 
 
+def _is_likely_external_library_reference(value: str) -> bool:
+    """Return True for native-library filenames or path-like OpenVINO plugin references."""
+    normalized_value = value.strip().strip("\"'")
+    if not normalized_value:
+        return False
+
+    if _OPENVINO_NATIVE_LIBRARY_SUFFIX.search(normalized_value):
+        return True
+
+    return "/" in normalized_value or "\\" in normalized_value
+
+
 class OpenVinoScanner(BaseScanner):
     """Scanner for OpenVINO IR (.xml/.bin) model files."""
 
@@ -227,7 +240,7 @@ class OpenVinoScanner(BaseScanner):
                 )
 
             for element_tag, attr_name, attr_val in _iter_element_attributes(layer):
-                if attr_name in {"library", "implementation"}:
+                if attr_name in {"library", "implementation"} and _is_likely_external_library_reference(attr_val):
                     result.add_check(
                         name="External Library Reference Check",
                         passed=False,

--- a/tests/scanners/test_openvino_scanner.py
+++ b/tests/scanners/test_openvino_scanner.py
@@ -219,6 +219,75 @@ def test_openvino_scanner_detects_nested_external_library_references(tmp_path: P
     assert any("external library 'evil.so'" in issue.message for issue in result.issues)
 
 
+def test_openvino_scanner_symbolic_implementation_metadata_is_not_external_library(tmp_path: Path) -> None:
+    """OpenVINO backend labels should not be treated as native library references."""
+    xml_path = tmp_path / "model.xml"
+    xml_path.write_text(
+        """
+        <net version='10'>
+          <layers>
+            <layer id='1' name='conv' type='Convolution'>
+              <data implementation='fp16' library='CPU'/>
+            </layer>
+          </layers>
+        </net>
+        """,
+        encoding="utf-8",
+    )
+    (tmp_path / "model.bin").write_bytes(b"\x00")
+
+    result = OpenVinoScanner().scan(str(xml_path))
+
+    assert result.success is True
+    assert not any(check.name == "External Library Reference Check" for check in result.checks)
+
+
+def test_openvino_scanner_detects_versioned_native_library_reference(tmp_path: Path) -> None:
+    """Native library filenames should still be treated as external references."""
+    xml_path = tmp_path / "model.xml"
+    xml_path.write_text(
+        """
+        <net version='10'>
+          <layers>
+            <layer id='1' name='conv' type='Convolution'>
+              <data implementation='libcustom_op.so.1'/>
+            </layer>
+          </layers>
+        </net>
+        """,
+        encoding="utf-8",
+    )
+    (tmp_path / "model.bin").write_bytes(b"\x00")
+
+    result = OpenVinoScanner().scan(str(xml_path))
+
+    assert result.success is False
+    assert any("external library 'libcustom_op.so.1'" in issue.message for issue in result.issues)
+
+
+def test_openvino_scanner_detects_path_external_library_reference(tmp_path: Path) -> None:
+    """Path-like plugin references should still be treated as external libraries."""
+    xml_path = tmp_path / "model.xml"
+    xml_path.write_text(
+        """
+        <net version='10'>
+          <layers>
+            <layer id='1' name='conv' type='Convolution'>
+              <data library='../plugins/custom_op'/>
+            </layer>
+          </layers>
+        </net>
+        """,
+        encoding="utf-8",
+    )
+    (tmp_path / "model.bin").write_bytes(b"\x00")
+
+    result = OpenVinoScanner().scan(str(xml_path))
+
+    assert result.success is False
+    assert any("external library '../plugins/custom_op'" in issue.message for issue in result.issues)
+
+
 def test_openvino_scanner_layer_attribute_importlib_false_positive_control(tmp_path: Path) -> None:
     """Benign names containing importlib as a substring should not be flagged."""
     xml_path = tmp_path / "model.xml"


### PR DESCRIPTION
## Summary
- Only flag OpenVINO library/implementation attributes when they look like native library files or path-like plugin references
- Keep CRITICAL coverage for .so/.dll/.dylib/.lib and path references
- Add regressions for benign symbolic backend metadata and dangerous references

## Validation
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run env PROMPTFOO_DISABLE_TELEMETRY=1 pytest -n auto -m "not slow and not integration" --maxfail=1