### PR TITLE
fix: ignore pmml documentation urls

### DIFF
--- a/modelaudit/scanners/pmml_scanner.py
+++ b/modelaudit/scanners/pmml_scanner.py
@@ -41,6 +41,7 @@ XML_CDATA_PATTERN = re.compile(r"<!\[CDATA\[.*?\]\]>", re.DOTALL)
 SUSPICIOUS_ELEMENT_NAMES = frozenset({"script", "javascript", "python", "exec", "eval"})
 DOCUMENTATION_ELEMENT_NAMES = frozenset({"annotation", "copyright", "description", "documentation"})
 DOCUMENTATION_ATTRIBUTE_NAMES = frozenset({"description", "documentation", "label"})
+PMML_NAMESPACE_PATTERN = re.compile(r"^https?://(?:www\.)?dmg\.org/PMML-\d+(?:_\d+)*$")
 EXTERNAL_RESOURCE_ATTRIBUTE_NAMES = frozenset(
     {
         "file",
@@ -470,6 +471,10 @@ class PmmlScanner(BaseScanner):
     @classmethod
     def _is_pmml_element(cls, tag: Any, root_namespace: str | None) -> bool:
         """Return whether a tag belongs to the PMML document namespace."""
+        if root_namespace is None:
+            return cls._xml_namespace(tag) is None
+        if PMML_NAMESPACE_PATTERN.fullmatch(root_namespace) is None:
+            return False
         return cls._xml_namespace(tag) == root_namespace
 
     def _get_all_text_content(self, element: Any) -> tuple[str, bool]:

--- a/modelaudit/scanners/pmml_scanner.py
+++ b/modelaudit/scanners/pmml_scanner.py
@@ -39,7 +39,8 @@ XML_COMMENT_PATTERN = re.compile(r"<!--.*?-->", re.DOTALL)
 XML_CDATA_PATTERN = re.compile(r"<!\[CDATA\[.*?\]\]>", re.DOTALL)
 SUSPICIOUS_ELEMENT_NAMES = frozenset({"script", "javascript", "python", "exec", "eval"})
 DOCUMENTATION_ELEMENT_NAMES = frozenset({"annotation", "copyright", "description", "documentation"})
-DOCUMENTATION_ATTRIBUTE_NAMES = frozenset({"description", "documentation", "label", "reference"})
+DOCUMENTATION_ATTRIBUTE_NAMES = frozenset({"description", "documentation", "label"})
+DOCUMENTATION_REFERENCE_TAG_NAMES = frozenset({"application", "header"})
 EXTERNAL_RESOURCE_ATTRIBUTE_NAMES = frozenset(
     {
         "file",
@@ -354,6 +355,8 @@ class PmmlScanner(BaseScanner):
         """Return True when a URL-bearing attribute is an external resource reference."""
         if attr_name in DOCUMENTATION_ATTRIBUTE_NAMES:
             return False
+        if attr_name == "reference":
+            return tag_name not in DOCUMENTATION_REFERENCE_TAG_NAMES
         if attr_name in EXTERNAL_RESOURCE_ATTRIBUTE_NAMES:
             return True
 

--- a/modelaudit/scanners/pmml_scanner.py
+++ b/modelaudit/scanners/pmml_scanner.py
@@ -38,6 +38,21 @@ DANGEROUS_ENTITIES = ["<!DOCTYPE", "<!ENTITY", "<!ELEMENT", "<!ATTLIST"]
 XML_COMMENT_PATTERN = re.compile(r"<!--.*?-->", re.DOTALL)
 XML_CDATA_PATTERN = re.compile(r"<!\[CDATA\[.*?\]\]>", re.DOTALL)
 SUSPICIOUS_ELEMENT_NAMES = frozenset({"script", "javascript", "python", "exec", "eval"})
+DOCUMENTATION_ELEMENT_NAMES = frozenset({"annotation", "copyright", "description", "documentation"})
+DOCUMENTATION_ATTRIBUTE_NAMES = frozenset({"description", "documentation", "label", "reference"})
+EXTERNAL_RESOURCE_ATTRIBUTE_NAMES = frozenset(
+    {
+        "file",
+        "filename",
+        "href",
+        "location",
+        "path",
+        "source",
+        "src",
+        "uri",
+        "url",
+    },
+)
 
 
 class PmmlScanner(BaseScanner):
@@ -275,22 +290,23 @@ class PmmlScanner(BaseScanner):
                 combined = f"{elem_text} {attr_text}".lower()
 
             # Check for external resource references
-            for url_pattern in URL_PATTERNS:
-                if url_pattern in combined:
-                    result.add_check(
-                        name="External Resource Reference Check",
-                        passed=False,
-                        message=f"PMML references external resource: {url_pattern}",
-                        severity=IssueSeverity.WARNING,
-                        location=path,
-                        details={"tag": elem.tag, "url_pattern": url_pattern},
-                        why=(
-                            "External references in PMML files may be used to exfiltrate data or perform "
-                            "network requests."
-                        ),
-                        rule_code="S902",
-                    )
-                    break
+            if tag_name == "extension":
+                self._add_external_resource_check_if_url(result, path, elem.tag, combined, context="extension")
+            else:
+                if tag_name not in DOCUMENTATION_ELEMENT_NAMES:
+                    self._add_external_resource_check_if_url(result, path, elem.tag, elem_text, context="text")
+
+                for attr_name, attr_value in elem.attrib.items():
+                    normalized_attr_name = attr_name.strip().lower()
+                    if self._is_external_resource_attribute(tag_name, normalized_attr_name, elem.attrib):
+                        self._add_external_resource_check_if_url(
+                            result,
+                            path,
+                            elem.tag,
+                            str(attr_value),
+                            context="attribute",
+                            attribute=attr_name,
+                        )
 
             # Check for suspicious element names (like <script>)
             if tag_name in SUSPICIOUS_ELEMENT_NAMES:
@@ -323,6 +339,55 @@ class PmmlScanner(BaseScanner):
                             rule_code="S902",
                         )
                         break
+
+    @staticmethod
+    def _find_url_pattern(text: str) -> str | None:
+        """Return the first URL scheme pattern found in text."""
+        normalized_text = text.lower()
+        for url_pattern in URL_PATTERNS:
+            if url_pattern in normalized_text:
+                return url_pattern
+        return None
+
+    @staticmethod
+    def _is_external_resource_attribute(tag_name: str, attr_name: str, attributes: dict[str, Any]) -> bool:
+        """Return True when a URL-bearing attribute is an external resource reference."""
+        if attr_name in DOCUMENTATION_ATTRIBUTE_NAMES:
+            return False
+        if attr_name in EXTERNAL_RESOURCE_ATTRIBUTE_NAMES:
+            return True
+
+        return tag_name == "value" and attr_name == "value" and attributes.get("property", "").lower() == "external"
+
+    def _add_external_resource_check_if_url(
+        self,
+        result: ScanResult,
+        path: str,
+        tag: Any,
+        text: str,
+        *,
+        context: str,
+        attribute: str | None = None,
+    ) -> None:
+        """Add an external resource warning when text contains a resource URL."""
+        url_pattern = self._find_url_pattern(text)
+        if url_pattern is None:
+            return
+
+        details = {"tag": tag, "url_pattern": url_pattern, "context": context}
+        if attribute is not None:
+            details["attribute"] = attribute
+
+        result.add_check(
+            name="External Resource Reference Check",
+            passed=False,
+            message=f"PMML references external resource: {url_pattern}",
+            severity=IssueSeverity.WARNING,
+            location=path,
+            details=details,
+            why=("External references in PMML files may be used to exfiltrate data or perform network requests."),
+            rule_code="S902",
+        )
 
     @staticmethod
     def _local_tag_name(tag: Any) -> str:

--- a/modelaudit/scanners/pmml_scanner.py
+++ b/modelaudit/scanners/pmml_scanner.py
@@ -407,20 +407,15 @@ class PmmlScanner(BaseScanner):
     ) -> str | None:
         """Return the URL pattern when an attribute is an external resource reference."""
         normalized_attr_name_lower = normalized_attr_name.lower()
+        is_unqualified_attr = PmmlScanner._xml_namespace(attr_name) is None and ":" not in attr_name
         if normalized_attr_name_lower in DOCUMENTATION_ATTRIBUTE_NAMES:
-            ignored_patterns = (
-                BENIGN_DOCUMENTATION_URL_PATTERNS
-                if in_pmml_element and attr_name == normalized_attr_name_lower
-                else None
-            )
+            ignored_patterns = BENIGN_DOCUMENTATION_URL_PATTERNS if in_pmml_element and is_unqualified_attr else None
             return PmmlScanner._find_url_pattern(
                 attr_value,
                 ignored_patterns=ignored_patterns,
             )
         if normalized_attr_name_lower == "reference":
-            ignored_patterns = (
-                BENIGN_DOCUMENTATION_URL_PATTERNS if attr_name == "reference" and in_header_metadata else None
-            )
+            ignored_patterns = BENIGN_DOCUMENTATION_URL_PATTERNS if is_unqualified_attr and in_header_metadata else None
             return PmmlScanner._find_url_pattern(attr_value, ignored_patterns=ignored_patterns)
         if normalized_attr_name_lower in EXTERNAL_RESOURCE_ATTRIBUTE_NAMES:
             return PmmlScanner._find_url_pattern(attr_value)

--- a/modelaudit/scanners/pmml_scanner.py
+++ b/modelaudit/scanners/pmml_scanner.py
@@ -34,6 +34,7 @@ SUSPICIOUS_PATTERNS = [
     r"system\s*\(",
 ]
 URL_PATTERNS = ["http://", "https://", "file://", "ftp://"]
+BENIGN_DOCUMENTATION_URL_PATTERNS = frozenset({"http://", "https://"})
 DANGEROUS_ENTITIES = ["<!DOCTYPE", "<!ENTITY", "<!ELEMENT", "<!ATTLIST"]
 XML_COMMENT_PATTERN = re.compile(r"<!--.*?-->", re.DOTALL)
 XML_CDATA_PATTERN = re.compile(r"<!\[CDATA\[.*?\]\]>", re.DOTALL)
@@ -296,10 +297,30 @@ class PmmlScanner(BaseScanner):
             else:
                 if tag_name not in DOCUMENTATION_ELEMENT_NAMES:
                     self._add_external_resource_check_if_url(result, path, elem.tag, elem_text, context="text")
+                else:
+                    url_pattern = self._find_url_pattern(
+                        elem_text,
+                        ignored_patterns=BENIGN_DOCUMENTATION_URL_PATTERNS,
+                    )
+                    if url_pattern is not None:
+                        self._add_external_resource_check_if_url(
+                            result,
+                            path,
+                            elem.tag,
+                            elem_text,
+                            context="text",
+                            url_pattern=url_pattern,
+                        )
 
                 for attr_name, attr_value in elem.attrib.items():
                     normalized_attr_name = self._local_xml_name(attr_name)
-                    if self._is_external_resource_attribute(tag_name, normalized_attr_name, elem.attrib):
+                    url_pattern = self._external_resource_attribute_url_pattern(
+                        tag_name,
+                        normalized_attr_name,
+                        str(attr_value),
+                        elem.attrib,
+                    )
+                    if url_pattern is not None:
                         self._add_external_resource_check_if_url(
                             result,
                             path,
@@ -307,6 +328,7 @@ class PmmlScanner(BaseScanner):
                             str(attr_value),
                             context="attribute",
                             attribute=attr_name,
+                            url_pattern=url_pattern,
                         )
 
             # Check for suspicious element names (like <script>)
@@ -342,25 +364,40 @@ class PmmlScanner(BaseScanner):
                         break
 
     @staticmethod
-    def _find_url_pattern(text: str) -> str | None:
+    def _find_url_pattern(text: str, *, ignored_patterns: frozenset[str] | None = None) -> str | None:
         """Return the first URL scheme pattern found in text."""
         normalized_text = text.lower()
         for url_pattern in URL_PATTERNS:
+            if ignored_patterns is not None and url_pattern in ignored_patterns:
+                continue
             if url_pattern in normalized_text:
                 return url_pattern
         return None
 
     @staticmethod
-    def _is_external_resource_attribute(tag_name: str, attr_name: str, attributes: dict[str, Any]) -> bool:
-        """Return True when a URL-bearing attribute is an external resource reference."""
+    def _external_resource_attribute_url_pattern(
+        tag_name: str,
+        attr_name: str,
+        attr_value: str,
+        attributes: dict[str, Any],
+    ) -> str | None:
+        """Return the URL pattern when an attribute is an external resource reference."""
         if attr_name in DOCUMENTATION_ATTRIBUTE_NAMES:
-            return False
+            return PmmlScanner._find_url_pattern(
+                attr_value,
+                ignored_patterns=BENIGN_DOCUMENTATION_URL_PATTERNS,
+            )
         if attr_name == "reference":
-            return tag_name not in DOCUMENTATION_REFERENCE_TAG_NAMES
+            ignored_patterns = (
+                BENIGN_DOCUMENTATION_URL_PATTERNS if tag_name in DOCUMENTATION_REFERENCE_TAG_NAMES else None
+            )
+            return PmmlScanner._find_url_pattern(attr_value, ignored_patterns=ignored_patterns)
         if attr_name in EXTERNAL_RESOURCE_ATTRIBUTE_NAMES:
-            return True
+            return PmmlScanner._find_url_pattern(attr_value)
 
-        return tag_name == "value" and attr_name == "value" and attributes.get("property", "").lower() == "external"
+        if tag_name == "value" and attr_name == "value" and attributes.get("property", "").lower() == "external":
+            return PmmlScanner._find_url_pattern(attr_value)
+        return None
 
     def _add_external_resource_check_if_url(
         self,
@@ -371,9 +408,10 @@ class PmmlScanner(BaseScanner):
         *,
         context: str,
         attribute: str | None = None,
+        url_pattern: str | None = None,
     ) -> None:
         """Add an external resource warning when text contains a resource URL."""
-        url_pattern = self._find_url_pattern(text)
+        url_pattern = url_pattern or self._find_url_pattern(text)
         if url_pattern is None:
             return
 

--- a/modelaudit/scanners/pmml_scanner.py
+++ b/modelaudit/scanners/pmml_scanner.py
@@ -319,6 +319,7 @@ class PmmlScanner(BaseScanner):
                     normalized_attr_name = self._local_xml_name(attr_name)
                     url_pattern = self._external_resource_attribute_url_pattern(
                         tag_name,
+                        attr_name,
                         normalized_attr_name,
                         str(attr_value),
                         elem.attrib,
@@ -382,24 +383,31 @@ class PmmlScanner(BaseScanner):
     def _external_resource_attribute_url_pattern(
         tag_name: str,
         attr_name: str,
+        normalized_attr_name: str,
         attr_value: str,
         attributes: dict[str, Any],
         *,
         in_header_metadata: bool,
     ) -> str | None:
         """Return the URL pattern when an attribute is an external resource reference."""
-        if attr_name in DOCUMENTATION_ATTRIBUTE_NAMES:
+        if normalized_attr_name in DOCUMENTATION_ATTRIBUTE_NAMES:
             return PmmlScanner._find_url_pattern(
                 attr_value,
                 ignored_patterns=BENIGN_DOCUMENTATION_URL_PATTERNS,
             )
-        if attr_name == "reference":
-            ignored_patterns = BENIGN_DOCUMENTATION_URL_PATTERNS if in_header_metadata else None
+        if normalized_attr_name == "reference":
+            ignored_patterns = (
+                BENIGN_DOCUMENTATION_URL_PATTERNS if attr_name == "reference" and in_header_metadata else None
+            )
             return PmmlScanner._find_url_pattern(attr_value, ignored_patterns=ignored_patterns)
-        if attr_name in EXTERNAL_RESOURCE_ATTRIBUTE_NAMES:
+        if normalized_attr_name in EXTERNAL_RESOURCE_ATTRIBUTE_NAMES:
             return PmmlScanner._find_url_pattern(attr_value)
 
-        if tag_name == "value" and attr_name == "value" and attributes.get("property", "").lower() == "external":
+        if (
+            tag_name == "value"
+            and normalized_attr_name == "value"
+            and attributes.get("property", "").lower() == "external"
+        ):
             return PmmlScanner._find_url_pattern(attr_value)
         return None
 

--- a/modelaudit/scanners/pmml_scanner.py
+++ b/modelaudit/scanners/pmml_scanner.py
@@ -332,6 +332,7 @@ class PmmlScanner(BaseScanner):
                         normalized_attr_name,
                         str(attr_value),
                         elem.attrib,
+                        in_pmml_element=is_pmml_element,
                         in_header_metadata=in_header_metadata,
                     )
                     if url_pattern is not None:
@@ -396,12 +397,17 @@ class PmmlScanner(BaseScanner):
         attr_value: str,
         attributes: dict[str, Any],
         *,
+        in_pmml_element: bool,
         in_header_metadata: bool,
     ) -> str | None:
         """Return the URL pattern when an attribute is an external resource reference."""
         normalized_attr_name_lower = normalized_attr_name.lower()
         if normalized_attr_name_lower in DOCUMENTATION_ATTRIBUTE_NAMES:
-            ignored_patterns = BENIGN_DOCUMENTATION_URL_PATTERNS if attr_name == normalized_attr_name_lower else None
+            ignored_patterns = (
+                BENIGN_DOCUMENTATION_URL_PATTERNS
+                if in_pmml_element and attr_name == normalized_attr_name_lower
+                else None
+            )
             return PmmlScanner._find_url_pattern(
                 attr_value,
                 ignored_patterns=ignored_patterns,

--- a/modelaudit/scanners/pmml_scanner.py
+++ b/modelaudit/scanners/pmml_scanner.py
@@ -263,12 +263,17 @@ class PmmlScanner(BaseScanner):
         """Check for suspicious patterns and external references in PMML content."""
         parent_by_child = {child: parent for parent in root.iter() for child in parent}
         root_namespace = self._xml_namespace(root.tag)
+        root_is_pmml = self._is_pmml_root(root.tag, root_namespace)
         for elem in root.iter():
             tag_name = self._local_xml_name(elem.tag)
-            is_pmml_element = self._is_pmml_element(elem.tag, root_namespace)
+            is_pmml_element = self._is_pmml_element(elem.tag, root_namespace, root_is_pmml=root_is_pmml)
             parent = parent_by_child.get(elem)
             parent_tag_name = self._local_xml_name(parent.tag) if parent is not None else ""
-            parent_is_pmml_element = parent is not None and self._is_pmml_element(parent.tag, root_namespace)
+            parent_is_pmml_element = parent is not None and self._is_pmml_element(
+                parent.tag,
+                root_namespace,
+                root_is_pmml=root_is_pmml,
+            )
             in_header_metadata = (is_pmml_element and tag_name == "header") or (
                 is_pmml_element and parent_is_pmml_element and tag_name == "application" and parent_tag_name == "header"
             )
@@ -475,12 +480,19 @@ class PmmlScanner(BaseScanner):
         return name[1:].split("}", 1)[0]
 
     @classmethod
-    def _is_pmml_element(cls, tag: Any, root_namespace: str | None) -> bool:
+    def _is_pmml_root(cls, tag: Any, root_namespace: str | None) -> bool:
+        """Return whether the document root is a recognized PMML root."""
+        if cls._local_xml_name(tag) != "pmml":
+            return False
+        return root_namespace is None or PMML_NAMESPACE_PATTERN.fullmatch(root_namespace) is not None
+
+    @classmethod
+    def _is_pmml_element(cls, tag: Any, root_namespace: str | None, *, root_is_pmml: bool) -> bool:
         """Return whether a tag belongs to the PMML document namespace."""
+        if not root_is_pmml:
+            return False
         if root_namespace is None:
             return cls._xml_namespace(tag) is None
-        if PMML_NAMESPACE_PATTERN.fullmatch(root_namespace) is None:
-            return False
         return cls._xml_namespace(tag) == root_namespace
 
     def _get_all_text_content(self, element: Any) -> tuple[str, bool]:

--- a/modelaudit/scanners/pmml_scanner.py
+++ b/modelaudit/scanners/pmml_scanner.py
@@ -47,7 +47,9 @@ EXTERNAL_RESOURCE_ATTRIBUTE_NAMES = frozenset(
         "filename",
         "href",
         "location",
+        "nonamespaceschemalocation",
         "path",
+        "schemalocation",
         "source",
         "src",
         "uri",
@@ -259,11 +261,16 @@ class PmmlScanner(BaseScanner):
     def _check_suspicious_content(self, root: Any, result: ScanResult, path: str) -> None:
         """Check for suspicious patterns and external references in PMML content."""
         parent_by_child = {child: parent for parent in root.iter() for child in parent}
+        root_namespace = self._xml_namespace(root.tag)
         for elem in root.iter():
             tag_name = self._local_xml_name(elem.tag)
+            is_pmml_element = self._is_pmml_element(elem.tag, root_namespace)
             parent = parent_by_child.get(elem)
             parent_tag_name = self._local_xml_name(parent.tag) if parent is not None else ""
-            in_header_metadata = tag_name == "header" or (tag_name == "application" and parent_tag_name == "header")
+            parent_is_pmml_element = parent is not None and self._is_pmml_element(parent.tag, root_namespace)
+            in_header_metadata = (is_pmml_element and tag_name == "header") or (
+                is_pmml_element and parent_is_pmml_element and tag_name == "application" and parent_tag_name == "header"
+            )
 
             # Combine element text content with attributes for comprehensive scanning
             elem_text = elem.text or ""
@@ -298,7 +305,8 @@ class PmmlScanner(BaseScanner):
             if tag_name == "extension":
                 self._add_external_resource_check_if_url(result, path, elem.tag, combined, context="extension")
             else:
-                if tag_name not in DOCUMENTATION_ELEMENT_NAMES:
+                is_pmml_documentation_element = is_pmml_element and tag_name in DOCUMENTATION_ELEMENT_NAMES
+                if not is_pmml_documentation_element:
                     self._add_external_resource_check_if_url(result, path, elem.tag, elem_text, context="text")
                 else:
                     url_pattern = self._find_url_pattern(
@@ -390,22 +398,24 @@ class PmmlScanner(BaseScanner):
         in_header_metadata: bool,
     ) -> str | None:
         """Return the URL pattern when an attribute is an external resource reference."""
-        if normalized_attr_name in DOCUMENTATION_ATTRIBUTE_NAMES:
+        normalized_attr_name_lower = normalized_attr_name.lower()
+        if normalized_attr_name_lower in DOCUMENTATION_ATTRIBUTE_NAMES:
+            ignored_patterns = BENIGN_DOCUMENTATION_URL_PATTERNS if attr_name == normalized_attr_name_lower else None
             return PmmlScanner._find_url_pattern(
                 attr_value,
-                ignored_patterns=BENIGN_DOCUMENTATION_URL_PATTERNS,
+                ignored_patterns=ignored_patterns,
             )
-        if normalized_attr_name == "reference":
+        if normalized_attr_name_lower == "reference":
             ignored_patterns = (
                 BENIGN_DOCUMENTATION_URL_PATTERNS if attr_name == "reference" and in_header_metadata else None
             )
             return PmmlScanner._find_url_pattern(attr_value, ignored_patterns=ignored_patterns)
-        if normalized_attr_name in EXTERNAL_RESOURCE_ATTRIBUTE_NAMES:
+        if normalized_attr_name_lower in EXTERNAL_RESOURCE_ATTRIBUTE_NAMES:
             return PmmlScanner._find_url_pattern(attr_value)
 
         if (
             tag_name == "value"
-            and normalized_attr_name == "value"
+            and normalized_attr_name_lower == "value"
             and attributes.get("property", "").lower() == "external"
         ):
             return PmmlScanner._find_url_pattern(attr_value)
@@ -449,6 +459,18 @@ class PmmlScanner(BaseScanner):
             return ""
         local_name = name.split("}")[-1] if "}" in name else name
         return local_name.rsplit(":", 1)[-1].strip().lower()
+
+    @staticmethod
+    def _xml_namespace(name: Any) -> str | None:
+        """Extract an ElementTree expanded namespace URI from a tag or attribute name."""
+        if not isinstance(name, str) or not name.startswith("{") or "}" not in name:
+            return None
+        return name[1:].split("}", 1)[0]
+
+    @classmethod
+    def _is_pmml_element(cls, tag: Any, root_namespace: str | None) -> bool:
+        """Return whether a tag belongs to the PMML document namespace."""
+        return cls._xml_namespace(tag) == root_namespace
 
     def _get_all_text_content(self, element: Any) -> tuple[str, bool]:
         """Collect Extension text and report whether traversal hit the node budget."""

--- a/modelaudit/scanners/pmml_scanner.py
+++ b/modelaudit/scanners/pmml_scanner.py
@@ -229,7 +229,7 @@ class PmmlScanner(BaseScanner):
         """Validate basic PMML structure and extract metadata."""
         # Extract local tag name (without namespace)
         # Tags can be "{http://namespace}PMML" or just "PMML"
-        tag_name = self._local_tag_name(root.tag)
+        tag_name = self._local_xml_name(root.tag)
 
         if tag_name != "pmml":
             result.add_check(
@@ -258,7 +258,7 @@ class PmmlScanner(BaseScanner):
     def _check_suspicious_content(self, root: Any, result: ScanResult, path: str) -> None:
         """Check for suspicious patterns and external references in PMML content."""
         for elem in root.iter():
-            tag_name = self._local_tag_name(elem.tag)
+            tag_name = self._local_xml_name(elem.tag)
 
             # Combine element text content with attributes for comprehensive scanning
             elem_text = elem.text or ""
@@ -297,7 +297,7 @@ class PmmlScanner(BaseScanner):
                     self._add_external_resource_check_if_url(result, path, elem.tag, elem_text, context="text")
 
                 for attr_name, attr_value in elem.attrib.items():
-                    normalized_attr_name = attr_name.strip().lower()
+                    normalized_attr_name = self._local_xml_name(attr_name)
                     if self._is_external_resource_attribute(tag_name, normalized_attr_name, elem.attrib):
                         self._add_external_resource_check_if_url(
                             result,
@@ -390,11 +390,12 @@ class PmmlScanner(BaseScanner):
         )
 
     @staticmethod
-    def _local_tag_name(tag: Any) -> str:
-        """Extract a lowercase local tag name from namespaced ElementTree tags."""
-        if not isinstance(tag, str):
+    def _local_xml_name(name: Any) -> str:
+        """Extract a lowercase local name from namespaced ElementTree names."""
+        if not isinstance(name, str):
             return ""
-        return tag.split("}")[-1].lower() if "}" in tag else tag.lower()
+        local_name = name.split("}")[-1] if "}" in name else name
+        return local_name.rsplit(":", 1)[-1].strip().lower()
 
     def _get_all_text_content(self, element: Any) -> tuple[str, bool]:
         """Collect Extension text and report whether traversal hit the node budget."""
@@ -411,7 +412,7 @@ class PmmlScanner(BaseScanner):
             current = stack.pop()
             nodes_seen += 1
 
-            tag_name = self._local_tag_name(current.tag)
+            tag_name = self._local_xml_name(current.tag)
             if tag_name:
                 text_parts.append(tag_name)
 

--- a/modelaudit/scanners/pmml_scanner.py
+++ b/modelaudit/scanners/pmml_scanner.py
@@ -41,7 +41,6 @@ XML_CDATA_PATTERN = re.compile(r"<!\[CDATA\[.*?\]\]>", re.DOTALL)
 SUSPICIOUS_ELEMENT_NAMES = frozenset({"script", "javascript", "python", "exec", "eval"})
 DOCUMENTATION_ELEMENT_NAMES = frozenset({"annotation", "copyright", "description", "documentation"})
 DOCUMENTATION_ATTRIBUTE_NAMES = frozenset({"description", "documentation", "label"})
-DOCUMENTATION_REFERENCE_TAG_NAMES = frozenset({"application", "header"})
 EXTERNAL_RESOURCE_ATTRIBUTE_NAMES = frozenset(
     {
         "file",
@@ -259,8 +258,12 @@ class PmmlScanner(BaseScanner):
 
     def _check_suspicious_content(self, root: Any, result: ScanResult, path: str) -> None:
         """Check for suspicious patterns and external references in PMML content."""
+        parent_by_child = {child: parent for parent in root.iter() for child in parent}
         for elem in root.iter():
             tag_name = self._local_xml_name(elem.tag)
+            parent = parent_by_child.get(elem)
+            parent_tag_name = self._local_xml_name(parent.tag) if parent is not None else ""
+            in_header_metadata = tag_name == "header" or (tag_name == "application" and parent_tag_name == "header")
 
             # Combine element text content with attributes for comprehensive scanning
             elem_text = elem.text or ""
@@ -319,6 +322,7 @@ class PmmlScanner(BaseScanner):
                         normalized_attr_name,
                         str(attr_value),
                         elem.attrib,
+                        in_header_metadata=in_header_metadata,
                     )
                     if url_pattern is not None:
                         self._add_external_resource_check_if_url(
@@ -380,6 +384,8 @@ class PmmlScanner(BaseScanner):
         attr_name: str,
         attr_value: str,
         attributes: dict[str, Any],
+        *,
+        in_header_metadata: bool,
     ) -> str | None:
         """Return the URL pattern when an attribute is an external resource reference."""
         if attr_name in DOCUMENTATION_ATTRIBUTE_NAMES:
@@ -388,9 +394,7 @@ class PmmlScanner(BaseScanner):
                 ignored_patterns=BENIGN_DOCUMENTATION_URL_PATTERNS,
             )
         if attr_name == "reference":
-            ignored_patterns = (
-                BENIGN_DOCUMENTATION_URL_PATTERNS if tag_name in DOCUMENTATION_REFERENCE_TAG_NAMES else None
-            )
+            ignored_patterns = BENIGN_DOCUMENTATION_URL_PATTERNS if in_header_metadata else None
             return PmmlScanner._find_url_pattern(attr_value, ignored_patterns=ignored_patterns)
         if attr_name in EXTERNAL_RESOURCE_ATTRIBUTE_NAMES:
             return PmmlScanner._find_url_pattern(attr_value)

--- a/tests/scanners/test_pmml_scanner.py
+++ b/tests/scanners/test_pmml_scanner.py
@@ -248,6 +248,26 @@ def test_pmml_scanner_resource_url_attributes_still_warn(tmp_path: Path) -> None
     assert any(issue.details.get("attribute") == "source" for issue in external_issues)
 
 
+def test_pmml_scanner_non_documentation_reference_attribute_still_warns(tmp_path: Path) -> None:
+    """Non-documentation reference attributes should remain external resource references."""
+    pmml = """<?xml version='1.0'?>
+<PMML version='4.4'>
+  <Header/>
+  <DataDictionary>
+    <DataField name="payload" optype="categorical" dataType="string" reference="https://evil.example/payload"/>
+  </DataDictionary>
+</PMML>"""
+    path = tmp_path / "reference_attr.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    result = PmmlScanner().scan(str(path))
+
+    external_issues = [issue for issue in result.issues if "external resource" in issue.message.lower()]
+    assert external_issues
+    assert all(issue.severity == IssueSeverity.WARNING for issue in external_issues)
+    assert any(issue.details.get("attribute") == "reference" for issue in external_issues)
+
+
 def test_pmml_scanner_namespaced_resource_url_attributes_warn(tmp_path: Path) -> None:
     """Namespaced resource attributes should still be treated as external references."""
     pmml = """<?xml version='1.0'?>

--- a/tests/scanners/test_pmml_scanner.py
+++ b/tests/scanners/test_pmml_scanner.py
@@ -248,6 +248,26 @@ def test_pmml_scanner_resource_url_attributes_still_warn(tmp_path: Path) -> None
     assert any(issue.details.get("attribute") == "source" for issue in external_issues)
 
 
+def test_pmml_scanner_namespaced_resource_url_attributes_warn(tmp_path: Path) -> None:
+    """Namespaced resource attributes should still be treated as external references."""
+    pmml = """<?xml version='1.0'?>
+<PMML xmlns:xlink="http://www.w3.org/1999/xlink" version='4.4'>
+  <Header/>
+  <DataDictionary>
+    <DataField name="payload" optype="categorical" dataType="string" xlink:href="https://evil.example/payload"/>
+  </DataDictionary>
+</PMML>"""
+    path = tmp_path / "namespaced_resource_attr.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    result = PmmlScanner().scan(str(path))
+
+    external_issues = [issue for issue in result.issues if "external resource" in issue.message.lower()]
+    assert external_issues
+    assert all(issue.severity == IssueSeverity.WARNING for issue in external_issues)
+    assert any(str(issue.details.get("attribute", "")).endswith("}href") for issue in external_issues)
+
+
 def test_pmml_scanner_malformed_xml(tmp_path: Path) -> None:
     """Test handling of malformed XML."""
     malformed_xml = """<?xml version='1.0'?>

--- a/tests/scanners/test_pmml_scanner.py
+++ b/tests/scanners/test_pmml_scanner.py
@@ -228,6 +228,47 @@ def test_pmml_scanner_documentation_urls_are_not_external_resources(tmp_path: Pa
     assert not any("external resource" in issue.message.lower() for issue in result.issues)
 
 
+def test_pmml_scanner_standard_namespaced_documentation_urls_are_not_external_resources(
+    tmp_path: Path,
+) -> None:
+    """Recognized PMML namespaces should preserve benign documentation URL handling."""
+    pmml = """<?xml version='1.0'?>
+<PMML xmlns="https://www.dmg.org/PMML-4_4" version='4.4'>
+  <Header description="https://example.com/model-card">
+    <Annotation>See https://example.com/docs for training notes.</Annotation>
+    <Application name="Trainer" reference="https://example.com/reference"/>
+  </Header>
+  <DataDictionary numberOfFields='0'/>
+</PMML>"""
+    path = tmp_path / "namespaced_documented.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    result = PmmlScanner().scan(str(path))
+
+    assert result.success is True
+    assert not any(check.name == "External Resource Reference Check" for check in result.checks)
+    assert not any("external resource" in issue.message.lower() for issue in result.issues)
+
+
+def test_pmml_scanner_unrecognized_root_namespace_documentation_urls_warn(tmp_path: Path) -> None:
+    """Documentation-looking elements in an unrecognized root namespace should not get PMML exemptions."""
+    pmml = """<?xml version='1.0'?>
+<PMML xmlns="https://attacker.example/not-pmml" version='4.4'>
+  <Header description="https://evil.example/model-card">
+    <Annotation>See https://evil.example/docs for payload notes.</Annotation>
+  </Header>
+  <DataDictionary numberOfFields='0'/>
+</PMML>"""
+    path = tmp_path / "unrecognized_namespace_documented.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    result = PmmlScanner().scan(str(path))
+
+    external_issues = [issue for issue in result.issues if "external resource" in issue.message.lower()]
+    assert external_issues
+    assert all(issue.severity == IssueSeverity.WARNING for issue in external_issues)
+
+
 def test_pmml_scanner_namespaced_application_reference_still_warns(tmp_path: Path) -> None:
     """Only unqualified Header/Application reference URLs are treated as documentation."""
     pmml = """<?xml version='1.0'?>

--- a/tests/scanners/test_pmml_scanner.py
+++ b/tests/scanners/test_pmml_scanner.py
@@ -269,6 +269,24 @@ def test_pmml_scanner_unrecognized_root_namespace_documentation_urls_warn(tmp_pa
     assert all(issue.severity == IssueSeverity.WARNING for issue in external_issues)
 
 
+def test_pmml_scanner_unrecognized_root_namespace_documentation_attributes_warn(tmp_path: Path) -> None:
+    """Documentation-looking attributes in an unrecognized root namespace should not get PMML exemptions."""
+    pmml = """<?xml version='1.0'?>
+<PMML xmlns="https://attacker.example/not-pmml" version='4.4'>
+  <Header description="https://evil.example/model-card"/>
+  <DataDictionary numberOfFields='0'/>
+</PMML>"""
+    path = tmp_path / "unrecognized_namespace_documentation_attribute.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    result = PmmlScanner().scan(str(path))
+
+    external_issues = [issue for issue in result.issues if "external resource" in issue.message.lower()]
+    assert external_issues
+    assert all(issue.severity == IssueSeverity.WARNING for issue in external_issues)
+    assert any(str(issue.details.get("attribute", "")).endswith("description") for issue in external_issues)
+
+
 def test_pmml_scanner_namespaced_application_reference_still_warns(tmp_path: Path) -> None:
     """Only unqualified Header/Application reference URLs are treated as documentation."""
     pmml = """<?xml version='1.0'?>

--- a/tests/scanners/test_pmml_scanner.py
+++ b/tests/scanners/test_pmml_scanner.py
@@ -250,6 +250,27 @@ def test_pmml_scanner_standard_namespaced_documentation_urls_are_not_external_re
     assert not any("external resource" in issue.message.lower() for issue in result.issues)
 
 
+def test_pmml_scanner_mixed_case_documentation_attrs_are_not_external_resources(tmp_path: Path) -> None:
+    """Unqualified PMML documentation attributes keep exemptions even when mixed case."""
+    pmml = """<?xml version='1.0'?>
+<PMML version='4.4'>
+  <Header Description="https://example.com/model-card"
+          Documentation="https://example.com/docs"
+          Label="https://example.com/label">
+    <Application name="Trainer" Reference="https://example.com/reference"/>
+  </Header>
+  <DataDictionary numberOfFields='0'/>
+</PMML>"""
+    path = tmp_path / "mixed_case_documentation_attrs.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    result = PmmlScanner().scan(str(path))
+
+    assert result.success is True
+    assert not any(check.name == "External Resource Reference Check" for check in result.checks)
+    assert not any("external resource" in issue.message.lower() for issue in result.issues)
+
+
 def test_pmml_scanner_unrecognized_root_namespace_documentation_urls_warn(tmp_path: Path) -> None:
     """Documentation-looking elements in an unrecognized root namespace should not get PMML exemptions."""
     pmml = """<?xml version='1.0'?>

--- a/tests/scanners/test_pmml_scanner.py
+++ b/tests/scanners/test_pmml_scanner.py
@@ -289,6 +289,28 @@ def test_pmml_scanner_non_documentation_reference_attribute_still_warns(tmp_path
     assert any(issue.details.get("attribute") == "reference" for issue in external_issues)
 
 
+def test_pmml_scanner_application_reference_outside_header_still_warns(tmp_path: Path) -> None:
+    """Application reference URLs are documentation only when nested under Header."""
+    pmml = """<?xml version='1.0'?>
+<PMML version='4.4'>
+  <Header/>
+  <DataDictionary>
+    <DataField name="payload" optype="categorical" dataType="string">
+      <Application name="NestedTrainer" reference="https://evil.example/payload"/>
+    </DataField>
+  </DataDictionary>
+</PMML>"""
+    path = tmp_path / "application_reference_outside_header.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    result = PmmlScanner().scan(str(path))
+
+    external_issues = [issue for issue in result.issues if "external resource" in issue.message.lower()]
+    assert external_issues
+    assert all(issue.severity == IssueSeverity.WARNING for issue in external_issues)
+    assert any(issue.details.get("attribute") == "reference" for issue in external_issues)
+
+
 def test_pmml_scanner_namespaced_resource_url_attributes_warn(tmp_path: Path) -> None:
     """Namespaced resource attributes should still be treated as external references."""
     pmml = """<?xml version='1.0'?>

--- a/tests/scanners/test_pmml_scanner.py
+++ b/tests/scanners/test_pmml_scanner.py
@@ -228,6 +228,27 @@ def test_pmml_scanner_documentation_urls_are_not_external_resources(tmp_path: Pa
     assert not any("external resource" in issue.message.lower() for issue in result.issues)
 
 
+def test_pmml_scanner_documentation_file_urls_still_warn(tmp_path: Path) -> None:
+    """Documentation contexts should still warn on local or transfer URL schemes."""
+    pmml = """<?xml version='1.0'?>
+<PMML version='4.4'>
+  <Header description="file:///var/tmp/model-card">
+    <Annotation>Read ftp://example.com/archive before loading.</Annotation>
+    <Application name="Trainer" reference="file:///tmp/reference"/>
+  </Header>
+  <DataDictionary numberOfFields='0'/>
+</PMML>"""
+    path = tmp_path / "documented_file_refs.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    result = PmmlScanner().scan(str(path))
+
+    external_issues = [issue for issue in result.issues if "external resource" in issue.message.lower()]
+    assert external_issues
+    assert {issue.details.get("url_pattern") for issue in external_issues} >= {"file://", "ftp://"}
+    assert all(issue.severity == IssueSeverity.WARNING for issue in external_issues)
+
+
 def test_pmml_scanner_resource_url_attributes_still_warn(tmp_path: Path) -> None:
     """Explicit resource attributes should remain warning-level external references."""
     pmml = """<?xml version='1.0'?>

--- a/tests/scanners/test_pmml_scanner.py
+++ b/tests/scanners/test_pmml_scanner.py
@@ -228,6 +228,26 @@ def test_pmml_scanner_documentation_urls_are_not_external_resources(tmp_path: Pa
     assert not any("external resource" in issue.message.lower() for issue in result.issues)
 
 
+def test_pmml_scanner_namespaced_application_reference_still_warns(tmp_path: Path) -> None:
+    """Only unqualified Header/Application reference URLs are treated as documentation."""
+    pmml = """<?xml version='1.0'?>
+<PMML xmlns:x="https://example.com/custom" version='4.4'>
+  <Header>
+    <Application name="Trainer" x:reference="https://evil.example/payload"/>
+  </Header>
+  <DataDictionary numberOfFields='0'/>
+</PMML>"""
+    path = tmp_path / "namespaced_application_reference.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    result = PmmlScanner().scan(str(path))
+
+    external_issues = [issue for issue in result.issues if "external resource" in issue.message.lower()]
+    assert external_issues
+    assert all(issue.severity == IssueSeverity.WARNING for issue in external_issues)
+    assert any(str(issue.details.get("attribute", "")).endswith("}reference") for issue in external_issues)
+
+
 def test_pmml_scanner_documentation_file_urls_still_warn(tmp_path: Path) -> None:
     """Documentation contexts should still warn on local or transfer URL schemes."""
     pmml = """<?xml version='1.0'?>

--- a/tests/scanners/test_pmml_scanner.py
+++ b/tests/scanners/test_pmml_scanner.py
@@ -351,6 +351,63 @@ def test_pmml_scanner_namespaced_resource_url_attributes_warn(tmp_path: Path) ->
     assert any(str(issue.details.get("attribute", "")).endswith("}href") for issue in external_issues)
 
 
+def test_pmml_scanner_schema_location_urls_warn(tmp_path: Path) -> None:
+    """XML schemaLocation attributes are external references."""
+    pmml = """<?xml version='1.0'?>
+<PMML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      version='4.4'
+      xsi:schemaLocation="https://evil.example/schema.xsd">
+  <Header/>
+  <DataDictionary numberOfFields='0'/>
+</PMML>"""
+    path = tmp_path / "schema_location.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    result = PmmlScanner().scan(str(path))
+
+    external_issues = [issue for issue in result.issues if "external resource" in issue.message.lower()]
+    assert external_issues
+    assert all(issue.severity == IssueSeverity.WARNING for issue in external_issues)
+    assert any(str(issue.details.get("attribute", "")).endswith("}schemaLocation") for issue in external_issues)
+
+
+def test_pmml_scanner_namespaced_documentation_element_urls_warn(tmp_path: Path) -> None:
+    """Custom namespaced documentation-looking elements should not receive PMML doc URL exemptions."""
+    pmml = """<?xml version='1.0'?>
+<PMML xmlns:x="https://example.com/custom" version='4.4'>
+  <Header/>
+  <x:annotation>https://evil.example/payload</x:annotation>
+  <DataDictionary numberOfFields='0'/>
+</PMML>"""
+    path = tmp_path / "namespaced_doc_element.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    result = PmmlScanner().scan(str(path))
+
+    external_issues = [issue for issue in result.issues if "external resource" in issue.message.lower()]
+    assert external_issues
+    assert all(issue.severity == IssueSeverity.WARNING for issue in external_issues)
+    assert any(str(issue.details.get("tag", "")).endswith("}annotation") for issue in external_issues)
+
+
+def test_pmml_scanner_namespaced_documentation_attribute_urls_warn(tmp_path: Path) -> None:
+    """Custom namespaced documentation-looking attributes should not receive PMML doc URL exemptions."""
+    pmml = """<?xml version='1.0'?>
+<PMML xmlns:x="https://example.com/custom" version='4.4'>
+  <Header x:label="https://evil.example/payload"/>
+  <DataDictionary numberOfFields='0'/>
+</PMML>"""
+    path = tmp_path / "namespaced_doc_attribute.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    result = PmmlScanner().scan(str(path))
+
+    external_issues = [issue for issue in result.issues if "external resource" in issue.message.lower()]
+    assert external_issues
+    assert all(issue.severity == IssueSeverity.WARNING for issue in external_issues)
+    assert any(str(issue.details.get("attribute", "")).endswith("}label") for issue in external_issues)
+
+
 def test_pmml_scanner_malformed_xml(tmp_path: Path) -> None:
     """Test handling of malformed XML."""
     malformed_xml = """<?xml version='1.0'?>

--- a/tests/scanners/test_pmml_scanner.py
+++ b/tests/scanners/test_pmml_scanner.py
@@ -287,6 +287,28 @@ def test_pmml_scanner_unrecognized_root_namespace_documentation_attributes_warn(
     assert any(str(issue.details.get("attribute", "")).endswith("description") for issue in external_issues)
 
 
+def test_pmml_scanner_non_pmml_root_documentation_urls_warn(tmp_path: Path) -> None:
+    """Documentation-looking fields require an actual PMML root to get PMML exemptions."""
+    pmml = """<?xml version='1.0'?>
+<ModelPackage>
+  <Header description="https://evil.example/model-card">
+    <Annotation>See https://evil.example/docs for payload notes.</Annotation>
+    <Application name="Trainer" reference="https://evil.example/reference"/>
+  </Header>
+</ModelPackage>"""
+    path = tmp_path / "non_pmml_root_documentation.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    result = PmmlScanner().scan(str(path))
+
+    external_issues = [issue for issue in result.issues if "external resource" in issue.message.lower()]
+    assert external_issues
+    assert all(issue.severity == IssueSeverity.WARNING for issue in external_issues)
+    assert any(issue.details.get("context") == "text" for issue in external_issues)
+    assert any(str(issue.details.get("attribute", "")).endswith("description") for issue in external_issues)
+    assert any(str(issue.details.get("attribute", "")).endswith("reference") for issue in external_issues)
+
+
 def test_pmml_scanner_namespaced_application_reference_still_warns(tmp_path: Path) -> None:
     """Only unqualified Header/Application reference URLs are treated as documentation."""
     pmml = """<?xml version='1.0'?>

--- a/tests/scanners/test_pmml_scanner.py
+++ b/tests/scanners/test_pmml_scanner.py
@@ -208,6 +208,46 @@ def test_pmml_scanner_external_references(tmp_path: Path) -> None:
     assert all(i.severity == IssueSeverity.WARNING for i in external_issues)
 
 
+def test_pmml_scanner_documentation_urls_are_not_external_resources(tmp_path: Path) -> None:
+    """Documentation and reference metadata URLs should not be warning-level resource references."""
+    pmml = """<?xml version='1.0'?>
+<PMML version='4.4'>
+  <Header description="https://example.com/model-card">
+    <Annotation>See https://example.com/docs for training notes.</Annotation>
+    <Application name="Trainer" reference="https://example.com/reference"/>
+  </Header>
+  <DataDictionary numberOfFields='0'/>
+</PMML>"""
+    path = tmp_path / "documented.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    result = PmmlScanner().scan(str(path))
+
+    assert result.success is True
+    assert not any(check.name == "External Resource Reference Check" for check in result.checks)
+    assert not any("external resource" in issue.message.lower() for issue in result.issues)
+
+
+def test_pmml_scanner_resource_url_attributes_still_warn(tmp_path: Path) -> None:
+    """Explicit resource attributes should remain warning-level external references."""
+    pmml = """<?xml version='1.0'?>
+<PMML version='4.4'>
+  <Header/>
+  <DataDictionary>
+    <DataField name="payload" optype="categorical" dataType="string" source="https://evil.example/payload"/>
+  </DataDictionary>
+</PMML>"""
+    path = tmp_path / "resource_attr.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    result = PmmlScanner().scan(str(path))
+
+    external_issues = [issue for issue in result.issues if "external resource" in issue.message.lower()]
+    assert external_issues
+    assert all(issue.severity == IssueSeverity.WARNING for issue in external_issues)
+    assert any(issue.details.get("attribute") == "source" for issue in external_issues)
+
+
 def test_pmml_scanner_malformed_xml(tmp_path: Path) -> None:
     """Test handling of malformed XML."""
     malformed_xml = """<?xml version='1.0'?>


### PR DESCRIPTION
## Summary
- Stop treating PMML documentation and metadata reference URLs as warning-level external resources
- Keep warnings for URLs in Extension content and explicit resource attributes
- Add regressions for benign documentation URLs and suspicious resource attributes

## Validation
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run env PROMPTFOO_DISABLE_TELEMETRY=1 pytest -n auto -m "not slow and not integration" --maxfail=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PMML-aware scanner improvements to distinguish benign documentation URLs from true external resource references, with targeted checks for extension content and attribute-level references.
  * Suppressed false positives for standard PMML documentation fields while still flagging explicit resource/reference attributes and non-exempt contexts.

* **Tests**
  * Expanded test coverage for URL detection across PMML elements, attributes, namespaces, and exemption cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->