### PR TITLE
fix: skip protocol-only streaming pickle warning

### DIFF
--- a/modelaudit/utils/file/streaming.py
+++ b/modelaudit/utils/file/streaming.py
@@ -199,7 +199,8 @@ def stream_analyze_file(
 
             if content.startswith(b"\x80"):  # Pickle protocol marker
                 protocol_version = content[1] if len(content) > 1 else 0
-                if protocol_version >= 3:
+                protocol_marker_only = len(content) == 2 and protocol_version in {2, 3, 4, 5}
+                if protocol_version >= 3 and not protocol_marker_only:
                     issues.append(
                         Issue(
                             message=f"Pickle protocol {protocol_version} detected",

--- a/modelaudit/utils/file/streaming.py
+++ b/modelaudit/utils/file/streaming.py
@@ -199,7 +199,7 @@ def stream_analyze_file(
 
             if content.startswith(b"\x80"):  # Pickle protocol marker
                 protocol_version = content[1] if len(content) > 1 else 0
-                protocol_marker_only = len(content) == 2 and protocol_version in {2, 3, 4, 5}
+                protocol_marker_only = was_complete and len(content) == 2 and protocol_version in {2, 3, 4, 5}
                 if protocol_version >= 3 and not protocol_marker_only:
                     issues.append(
                         Issue(

--- a/tests/utils/file/test_streaming_analysis.py
+++ b/tests/utils/file/test_streaming_analysis.py
@@ -197,6 +197,25 @@ def test_stream_analyze_file_protocol_with_payload_still_emits_warning(
     assert result.has_warnings is True
 
 
+def test_stream_analyze_file_partial_protocol_marker_still_emits_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    file_path = tmp_path / "partial_protocol.pkl"
+    file_path.write_bytes(b"\x80\x03N.")
+    url = f"file://{file_path}"
+
+    monkeypatch.setattr(streaming, "get_fs_protocol", lambda u: "file")
+    monkeypatch.setattr(fsspec, "filesystem", lambda protocol, token=None: LocalFileSystem())
+
+    result, was_complete = streaming.stream_analyze_file(url, HeaderOnlyScanner(), max_bytes=2)
+
+    assert was_complete is False
+    assert result is not None
+    assert any(issue.type == "streaming_pickle_protocol_check" for issue in result.issues)
+    assert result.has_warnings is True
+
+
 def test_stream_analyze_file_does_not_retry_sourceful_scan_stream_typeerror(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/utils/file/test_streaming_analysis.py
+++ b/tests/utils/file/test_streaming_analysis.py
@@ -159,6 +159,44 @@ def test_stream_analyze_file_returns_clean_partial_header_result(
     assert "failed closed" in result.metadata["scan_outcome_message"]
 
 
+def test_stream_analyze_file_protocol_marker_only_does_not_emit_protocol_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    file_path = tmp_path / "protocol_only.pkl"
+    file_path.write_bytes(b"\x80\x03")
+    url = f"file://{file_path}"
+
+    monkeypatch.setattr(streaming, "get_fs_protocol", lambda u: "file")
+    monkeypatch.setattr(fsspec, "filesystem", lambda protocol, token=None: LocalFileSystem())
+
+    result, was_complete = streaming.stream_analyze_file(url, HeaderOnlyScanner())
+
+    assert was_complete is True
+    assert result is not None
+    assert not any(issue.type == "streaming_pickle_protocol_check" for issue in result.issues)
+    assert result.has_warnings is False
+
+
+def test_stream_analyze_file_protocol_with_payload_still_emits_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    file_path = tmp_path / "protocol_payload.pkl"
+    file_path.write_bytes(b"\x80\x03N.")
+    url = f"file://{file_path}"
+
+    monkeypatch.setattr(streaming, "get_fs_protocol", lambda u: "file")
+    monkeypatch.setattr(fsspec, "filesystem", lambda protocol, token=None: LocalFileSystem())
+
+    result, was_complete = streaming.stream_analyze_file(url, HeaderOnlyScanner())
+
+    assert was_complete is True
+    assert result is not None
+    assert any(issue.type == "streaming_pickle_protocol_check" for issue in result.issues)
+    assert result.has_warnings is True
+
+
 def test_stream_analyze_file_does_not_retry_sourceful_scan_stream_typeerror(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Suppress streaming fallback protocol warnings for two-byte pickle protocol markers with no payload
- Preserve warnings when protocol bytes are followed by actual pickle payload content
- Add paired streaming regressions for marker-only and marker-plus-payload inputs

## Validation
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run env PROMPTFOO_DISABLE_TELEMETRY=1 pytest -n auto -m "not slow and not integration" --maxfail=1