### PR TITLE
fix: avoid archive bin pickle routing

### DIFF
--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -89,11 +89,6 @@ def _select_preferred_scanner_id(path: str, header_format: str, ext: str) -> str
             return "skops"
         if ext == ".joblib":
             return "joblib"
-
-        if ext == ".bin":
-            # ZIP-backed torch.save() .bin files are routed through the pickle scanner,
-            # which already understands the ZIP serialization used by PyTorch.
-            return "pickle"
         return "zip"
 
     if ext == ".joblib" and header_format in _COMPRESSED_HEADER_FORMATS | {"pickle"}:

--- a/modelaudit/scanners/archive_dispatch.py
+++ b/modelaudit/scanners/archive_dispatch.py
@@ -55,8 +55,6 @@ def _select_nested_scanner_id(path: str) -> str | None:
             return "skops"
         if ext == ".joblib":
             return "joblib"
-        if ext == ".bin":
-            return "pickle"
         return "zip"
 
     if ext == ".joblib" and header_format in _COMPRESSED_HEADER_FORMATS | {"pickle"}:

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -12,7 +12,7 @@ import pytest
 
 from modelaudit import core
 from modelaudit.scanners._archive_locations import rewrite_extracted_member_location
-from modelaudit.scanners.archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY
+from modelaudit.scanners.archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY, _select_nested_scanner_id
 from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity, ScanResult
 from modelaudit.scanners.zip_scanner import ZipScanner
 
@@ -633,6 +633,14 @@ class TestZipScanner:
         compression_issues = [i for i in result.issues if i.rule_code == "S410"]
         assert len(compression_issues) == 1
         assert compression_issues[0].details["entry"] == "suspicious.txt"
+
+    def test_nested_zip_dispatch_does_not_route_generic_bin_zip_to_pickle(self, tmp_path: Path) -> None:
+        """A generic ZIP archive named .bin should not be forced through pickle routing."""
+        archive_path = tmp_path / "weights.bin"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("metadata.txt", "not a pickle")
+
+        assert _select_nested_scanner_id(str(archive_path)) == "zip"
 
     def test_max_depth_limit(self):
         """Test that maximum nesting depth is enforced"""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import pytest
 
+from modelaudit import core as core_module
 from modelaudit.core import scan_file
 from modelaudit.scanners.base import IssueSeverity, ScanResult
 from tests.helpers import create_mock_gguf, create_mock_pytorch_zip
@@ -568,6 +569,13 @@ def test_scan_file_routes_raw_bin_without_zip_structure_to_pytorch_binary(tmp_pa
 
     assert result.scanner_name == "pytorch_binary"
     assert result.success is True
+
+
+def test_preferred_scanner_does_not_route_generic_zip_bin_to_pickle(tmp_path: Path) -> None:
+    model_path = tmp_path / "weights.bin"
+    _create_misnamed_zip(model_path, {"metadata.txt": b"not a pickle"})
+
+    assert core_module._select_preferred_scanner_id(str(model_path), "zip", ".bin") == "zip"
 
 
 def test_scan_file_routes_misnamed_executorch_archive_by_content(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Remove unconditional .bin -> pickle routing from top-level and nested ZIP dispatch
- Preserve trusted structure routing for PyTorch ZIP .bin files before generic ZIP fallback
- Add regressions for generic ZIP content named .bin in both core and nested dispatch

## Validation
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run env PROMPTFOO_DISABLE_TELEMETRY=1 pytest -n auto -m "not slow and not integration" --maxfail=1