### PR TITLE
fix: default unknown severities to info

### DIFF
--- a/modelaudit/core_results.py
+++ b/modelaudit/core_results.py
@@ -185,18 +185,26 @@ def add_scan_result_to_model(
 def add_issue_to_model(
     results: ModelAuditResultModel,
     message: str,
-    severity: str = "warning",
+    severity: str | IssueSeverity | None = "info",
     location: str | None = None,
     details: dict | None = None,
     issue_type: str | None = None,
 ) -> None:
     """Add an issue directly to the aggregate results model."""
-    severity_enum = {
-        "debug": IssueSeverity.DEBUG,
-        "info": IssueSeverity.INFO,
-        "warning": IssueSeverity.WARNING,
-        "critical": IssueSeverity.CRITICAL,
-    }.get(severity.lower(), IssueSeverity.WARNING)
+    if isinstance(severity, IssueSeverity):
+        severity_enum = severity
+    else:
+        severity_str = str(severity).lower() if severity is not None else "info"
+        if severity_str == "warn":
+            severity_str = "warning"
+        if severity_str in {"error", "err"}:
+            severity_str = "critical"
+        severity_enum = {
+            "debug": IssueSeverity.DEBUG,
+            "info": IssueSeverity.INFO,
+            "warning": IssueSeverity.WARNING,
+            "critical": IssueSeverity.CRITICAL,
+        }.get(severity_str, IssueSeverity.INFO)
 
     issue = Issue(
         message=message,

--- a/modelaudit/utils/helpers/result_conversion.py
+++ b/modelaudit/utils/helpers/result_conversion.py
@@ -51,7 +51,7 @@ def scan_result_from_dict(result_dict: dict[str, Any]) -> "ScanResult":
     def _normalize_issue_severity(val: Any) -> IssueSeverity:
         if isinstance(val, IssueSeverity):
             return val
-        s = str(val).lower() if val is not None else "warning"
+        s = str(val).lower() if val is not None else "info"
         # Back-compat synonyms
         if s in ("warn",):
             s = "warning"
@@ -60,7 +60,7 @@ def scan_result_from_dict(result_dict: dict[str, Any]) -> "ScanResult":
         try:
             return IssueSeverity(s)
         except Exception:
-            return IssueSeverity.WARNING
+            return IssueSeverity.INFO
 
     def _coerce_details(val: Any) -> dict[str, Any]:
         if isinstance(val, dict):
@@ -99,7 +99,7 @@ def scan_result_from_dict(result_dict: dict[str, Any]) -> "ScanResult":
         try:
             issue = Issue(
                 message=issue_dict.get("message", ""),
-                severity=_normalize_issue_severity(issue_dict.get("severity", "warning")),
+                severity=_normalize_issue_severity(issue_dict.get("severity")),
                 location=issue_dict.get("location"),
                 details=_coerce_details(issue_dict.get("details", {})),
                 why=issue_dict.get("why"),

--- a/tests/test_exit_codes.py
+++ b/tests/test_exit_codes.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import patch
 
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
+from modelaudit.core_results import add_issue_to_model
 
 # Ensure models are rebuilt for forward references
 from modelaudit.models import ModelAuditResultModel, rebuild_models
@@ -191,6 +192,26 @@ def test_exit_code_info_level_issues():
         ]
     )
     assert determine_exit_code(results) == 0  # INFO level should not trigger exit code 1
+
+
+def test_add_issue_to_model_unknown_severity_defaults_to_info():
+    """Unknown aggregate issue severity should not become a warning."""
+    results = _create_result_model()
+
+    add_issue_to_model(results, "unknown severity diagnostic", severity="unknown")
+
+    assert results.issues[0].severity == IssueSeverity.INFO
+    assert determine_exit_code(results) == 0
+
+
+def test_add_issue_to_model_missing_severity_defaults_to_info():
+    """Omitted aggregate issue severity should not become a warning."""
+    results = _create_result_model()
+
+    add_issue_to_model(results, "missing severity diagnostic")
+
+    assert results.issues[0].severity == IssueSeverity.INFO
+    assert determine_exit_code(results) == 0
 
 
 def test_exit_code_inconclusive_pickle_without_security_findings() -> None:

--- a/tests/utils/test_result_conversion.py
+++ b/tests/utils/test_result_conversion.py
@@ -156,7 +156,7 @@ class TestScanResultFromDict:
         assert result.issues[0].severity == IssueSeverity.CRITICAL
 
     def test_severity_normalization_invalid(self) -> None:
-        """Test invalid severity defaults to WARNING."""
+        """Test invalid severity defaults to INFO."""
         result_dict = {
             "scanner": "test",
             "issues": [{"message": "Test", "severity": "invalid_value", "timestamp": FIXED_TIMESTAMP}],
@@ -165,7 +165,19 @@ class TestScanResultFromDict:
 
         result = scan_result_from_dict(result_dict)
 
-        assert result.issues[0].severity == IssueSeverity.WARNING
+        assert result.issues[0].severity == IssueSeverity.INFO
+
+    def test_missing_issue_severity_defaults_to_info(self) -> None:
+        """Missing cached issue severity should not become a warning."""
+        result_dict = {
+            "scanner": "test",
+            "issues": [{"message": "Test", "timestamp": FIXED_TIMESTAMP}],
+            "checks": [],
+        }
+
+        result = scan_result_from_dict(result_dict)
+
+        assert result.issues[0].severity == IssueSeverity.INFO
 
     def test_check_status_normalization_ok(self) -> None:
         """Test 'ok' is normalized to 'passed'."""


### PR DESCRIPTION
## Summary
- Default missing or unknown cached issue severities to INFO instead of WARNING
- Default aggregate issues with omitted or unknown severity to INFO while preserving warn/error legacy aliases
- Add regressions for cache/result conversion and exit-code behavior

## Validation
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run env PROMPTFOO_DISABLE_TELEMETRY=1 pytest -n auto -m "not slow and not integration" --maxfail=1