### PR TITLE
fix(cli): redact cloud urls in output

### DIFF
--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -53,7 +53,7 @@ from .utils.helpers.auto_defaults import (
     parse_size_string,
 )
 from .utils.helpers.interrupt_handler import interruptible_scan
-from .utils.sources.cloud_storage import download_from_cloud, is_cloud_url
+from .utils.sources.cloud_storage import download_from_cloud, is_cloud_url, redact_url_for_display
 from .utils.sources.huggingface import (
     download_file_from_hf,
     download_model,
@@ -1284,7 +1284,7 @@ def _resolve_scan_source_for_path(
 
             try:
                 metadata = asyncio.run(analyze_cloud_target(path))
-                click.echo(f"\n📊 Preview for {style_text(path, fg='cyan')}:")
+                click.echo(f"\n📊 Preview for {style_text(redact_url_for_display(path), fg='cyan')}:")
                 click.echo(f"   Type: {metadata['type']}")
 
                 if metadata["type"] == "file":
@@ -1303,7 +1303,7 @@ def _resolve_scan_source_for_path(
 
                 return _SourceDispatchResult(actual_path=path, local_scan_required=False)
             except Exception as exc:
-                click.echo(f"Error analyzing {path}: {exc!s}", err=True)
+                click.echo(f"Error analyzing {redact_url_for_display(path)}: {exc!s}", err=True)
                 audit_result.has_errors = True
                 return None
 
@@ -1350,11 +1350,11 @@ def _resolve_scan_source_for_path(
                 return _SourceDispatchResult(actual_path=path, local_scan_required=False)
 
             if runtime.show_styled_output and should_show_spinner():
-                spinner_text = f"Downloading from {style_text(path, fg='cyan')}"
+                spinner_text = f"Downloading from {style_text(redact_url_for_display(path), fg='cyan')}"
                 download_spinner = yaspin(Spinners.dots, text=spinner_text)
                 download_spinner.start()
             elif runtime.show_styled_output:
-                click.echo(f"Downloading from {path}...")
+                click.echo(f"Downloading from {redact_url_for_display(path)}...")
 
             download_path = download_from_cloud(  # type: ignore[assignment]
                 path,
@@ -1391,7 +1391,7 @@ def _resolve_scan_source_for_path(
 
             error_msg = str(exc)
             if "insufficient disk space" in error_msg.lower():
-                logger.error(f"Disk space error for {path}: {error_msg}")
+                logger.error(f"Disk space error for {redact_url_for_display(path)}: {error_msg}")
                 click.echo(style_text(f"\n⚠️  {error_msg}", fg="yellow"), err=True)
                 click.echo(
                     style_text(
@@ -1401,8 +1401,8 @@ def _resolve_scan_source_for_path(
                     err=True,
                 )
             else:
-                logger.error(f"Failed to download from {path}: {error_msg}", exc_info=verbose)
-                click.echo(f"Error downloading from {path}: {error_msg}", err=True)
+                logger.error(f"Failed to download from {redact_url_for_display(path)}: {error_msg}", exc_info=verbose)
+                click.echo(f"Error downloading from {redact_url_for_display(path)}: {error_msg}", err=True)
 
             audit_result.has_errors = True
             return None

--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -53,7 +53,12 @@ from .utils.helpers.auto_defaults import (
     parse_size_string,
 )
 from .utils.helpers.interrupt_handler import interruptible_scan
-from .utils.sources.cloud_storage import download_from_cloud, is_cloud_url, redact_url_for_display
+from .utils.sources.cloud_storage import (
+    download_from_cloud,
+    is_cloud_url,
+    redact_cloud_error_for_display,
+    redact_url_for_display,
+)
 from .utils.sources.huggingface import (
     download_file_from_hf,
     download_model,
@@ -65,6 +70,16 @@ from .utils.sources.jfrog import is_jfrog_url
 from .utils.sources.pytorch_hub import download_pytorch_hub_model, is_pytorch_hub_url
 
 logger = logging.getLogger("modelaudit")
+
+
+def _display_path(path: str) -> str:
+    """Return a path safe for user-facing CLI output."""
+    return redact_url_for_display(path) if is_cloud_url(path) else path
+
+
+def _display_error(error: object, path: str) -> str:
+    """Return an error safe for user-facing CLI output."""
+    return redact_cloud_error_for_display(error, path) if is_cloud_url(path) else str(error)
 
 
 @dataclass
@@ -237,6 +252,10 @@ def expand_paths(paths: tuple[str, ...]) -> tuple[list[str], list[str]]:
     expanded: list[str] = []
     missing_globs: list[str] = []
     for path_str in paths:
+        if is_cloud_url(path_str):
+            expanded.append(path_str)
+            continue
+
         # Handle glob patterns and resolve paths
         path = Path(path_str)
         if "*" in path_str or "?" in path_str:
@@ -532,7 +551,8 @@ def _show_scan_runtime_defaults(
             "─" * 80,
         ]
         click.echo("\n".join(header))
-        click.echo(f"Paths to scan: {style_text(', '.join(expanded_paths), fg='green')}")
+        display_paths = [_display_path(path) for path in expanded_paths]
+        click.echo(f"Paths to scan: {style_text(', '.join(display_paths), fg='green')}")
         if blacklist:
             click.echo(
                 f"Additional blacklist patterns: {style_text(', '.join(blacklist), fg='yellow')}",
@@ -832,16 +852,17 @@ def _scan_local_or_downloaded_path(
 ) -> None:
     """Scan a local artifact or a downloaded path resolved by source dispatch."""
     actual_path = source_result.actual_path
+    display_path = _display_path(path)
     if _should_skip_non_model_file(actual_path, runtime, verbose=verbose):
         return
 
     spinner = None
     if runtime.show_styled_output and should_show_spinner():
-        spinner_text = f"Scanning {style_text(path, fg='cyan')}"
+        spinner_text = f"Scanning {style_text(display_path, fg='cyan')}"
         spinner = yaspin(Spinners.dots, text=spinner_text)
         spinner.start()
     elif runtime.show_styled_output:
-        click.echo(f"Scanning {path}...")
+        click.echo(f"Scanning {display_path}...")
 
     try:
         progress_callback = _create_path_progress_callback(
@@ -925,7 +946,7 @@ def _scan_local_or_downloaded_path(
         has_critical = any(issue.severity == IssueSeverity.CRITICAL for issue in visible_issues)
 
         if spinner:
-            spinner.text = f"Scanned {style_text(path, fg='cyan')}"
+            spinner.text = f"Scanned {style_text(display_path, fg='cyan')}"
             if issue_count == 0:
                 spinner.ok(style_text("✅ Clean", fg="green", bold=True))
             elif has_critical:
@@ -946,22 +967,23 @@ def _scan_local_or_downloaded_path(
                 )
         elif runtime.show_styled_output:
             if issue_count == 0:
-                click.echo(f"Scanned {path}: Clean")
+                click.echo(f"Scanned {display_path}: Clean")
             else:
                 issues_str = "issue" if issue_count == 1 else "issues"
                 if has_critical:
-                    click.echo(f"Scanned {path}: Found {issue_count} {issues_str} (CRITICAL)")
+                    click.echo(f"Scanned {display_path}: Found {issue_count} {issues_str} (CRITICAL)")
                 else:
-                    click.echo(f"Scanned {path}: Found {issue_count} {issues_str}")
+                    click.echo(f"Scanned {display_path}: Found {issue_count} {issues_str}")
     except Exception as exc:
+        display_error = _display_error(exc, path)
         if spinner:
-            spinner.text = f"Error scanning {style_text(path, fg='cyan')}"
+            spinner.text = f"Error scanning {style_text(display_path, fg='cyan')}"
             spinner.fail(style_text("❌ Error", fg="red", bold=True))
         elif runtime.show_styled_output:
-            click.echo(f"Error scanning {path}")
+            click.echo(f"Error scanning {display_path}")
 
-        logger.error(f"Error during scan of {path}: {exc!s}", exc_info=verbose)
-        click.echo(f"Error scanning {path}: {exc!s}", err=True)
+        logger.error(f"Error during scan of {display_path}: {display_error}", exc_info=verbose)
+        click.echo(f"Error scanning {display_path}: {display_error}", err=True)
         audit_result.has_errors = True
         path_state.scanned_paths.append(actual_path)
 
@@ -1389,7 +1411,7 @@ def _resolve_scan_source_for_path(
             elif runtime.show_styled_output:
                 click.echo("Download failed")
 
-            error_msg = str(exc)
+            error_msg = _display_error(exc, path)
             if "insufficient disk space" in error_msg.lower():
                 logger.error(f"Disk space error for {redact_url_for_display(path)}: {error_msg}")
                 click.echo(style_text(f"\n⚠️  {error_msg}", fg="yellow"), err=True)

--- a/modelaudit/utils/helpers/retry.py
+++ b/modelaudit/utils/helpers/retry.py
@@ -31,6 +31,7 @@ def exponential_backoff(
     jitter: bool = True,
     retry_on: tuple[type[Exception], ...] | None = None,
     verbose: bool = False,
+    sanitize_error: Callable[[Exception], object] | None = None,
 ) -> Callable[..., T]:
     """
     Decorator for exponential backoff retry logic.
@@ -75,8 +76,9 @@ def exponential_backoff(
                     delay *= 0.5 + random.random()
 
                 # Log retry attempt
+                display_error = sanitize_error(e) if sanitize_error else e
                 logger.debug(
-                    f"Attempt {attempt + 1} failed for {getattr(func, '__name__', 'unknown')}: {e}. "
+                    f"Attempt {attempt + 1} failed for {getattr(func, '__name__', 'unknown')}: {display_error}. "
                     f"Retrying in {delay:.1f} seconds..."
                 )
 
@@ -105,6 +107,7 @@ def retry_with_backoff(
     jitter: bool = True,
     retry_on: tuple[type[Exception], ...] | None = None,
     verbose: bool = False,
+    sanitize_error: Callable[[Exception], object] | None = None,
 ) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """
     Decorator factory for retry with exponential backoff.
@@ -126,6 +129,7 @@ def retry_with_backoff(
             jitter=jitter,
             retry_on=retry_on,
             verbose=verbose,
+            sanitize_error=sanitize_error,
         )
 
     return decorator
@@ -136,6 +140,7 @@ def retry_cloud_operation(
     *args: Any,
     max_retries: int = 3,
     verbose: bool = False,
+    sanitize_error: Callable[[Exception], object] | None = None,
     **kwargs: Any,
 ) -> T:
     """
@@ -192,6 +197,7 @@ def retry_cloud_operation(
         max_retries=max_retries,
         retry_on=retry_exceptions,
         verbose=verbose,
+        sanitize_error=sanitize_error,
     )(func)
 
     return wrapped_func(*args, **kwargs)

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -559,9 +559,7 @@ def download_from_cloud(
 
     # Ensure target was analyzed successfully
     if "error" in metadata or metadata.get("type") == "unknown":
-        error_msg = redact_cloud_error_for_display(
-            metadata.get("error", "Unknown cloud target type"), url
-        )
+        error_msg = redact_cloud_error_for_display(metadata.get("error", "Unknown cloud target type"), url)
         raise ValueError(f"Failed to analyze cloud target {redact_url_for_display(url)}: {error_msg}")
 
     # Check if we can use streaming analysis

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -103,6 +103,12 @@ def _cloud_url_basename(url: str) -> str:
     return Path(path).name
 
 
+def _cloud_url_without_query(url: str) -> str:
+    """Return a cloud URL without signed query or fragment material for path comparison."""
+    parsed = urlsplit(url)
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", ""))
+
+
 def get_fs_protocol(url: str) -> str:
     """Get the fsspec protocol for a given URL."""
     parsed = urlparse(url)
@@ -518,11 +524,12 @@ def filter_scannable_files(files: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 def _build_safe_local_path(base_url: str, file_url: str, download_path: Path) -> Path:
     """Build a local path for a cloud object and reject traversal attempts."""
-    normalized_base = base_url.rstrip("/")
+    normalized_base = _cloud_url_without_query(base_url)
+    normalized_file_url = _cloud_url_without_query(file_url)
 
-    if file_url.startswith(f"{normalized_base}/"):
-        relative_path = file_url[len(normalized_base) + 1 :]
-    elif file_url == normalized_base:
+    if normalized_file_url.startswith(f"{normalized_base}/"):
+        relative_path = normalized_file_url[len(normalized_base) + 1 :]
+    elif normalized_file_url == normalized_base:
         relative_path = _cloud_url_basename(file_url)
     else:
         # Fallback to basename for unexpected path shapes.

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -11,7 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, TypeVar
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlsplit, urlunsplit
 
 import click
 from yaspin import yaspin
@@ -52,6 +52,23 @@ def is_cloud_url(url: str) -> bool:
     return any(re.match(p, url) for p in patterns)
 
 
+def redact_url_for_display(url: str) -> str:
+    """Remove credentials, query strings, and fragments from a URL for display."""
+    try:
+        parts = urlsplit(url)
+    except Exception:
+        return "<cloud URL redacted>"
+
+    if not parts.scheme:
+        return url
+
+    netloc = parts.hostname or ""
+    if parts.port is not None:
+        netloc = f"{netloc}:{parts.port}"
+
+    return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+
+
 def get_fs_protocol(url: str) -> str:
     """Get the fsspec protocol for a given URL."""
     parsed = urlparse(url)
@@ -65,13 +82,13 @@ def get_fs_protocol(url: str) -> str:
         elif parsed.netloc.endswith(".r2.cloudflarestorage.com"):
             return "s3"
         else:
-            raise ValueError(f"Unsupported cloud storage URL: {url}")
+            raise ValueError(f"Unsupported cloud storage URL: {redact_url_for_display(url)}")
     elif scheme == "gcs" or scheme == "gs":
         return "gcs"
     elif scheme in {"s3", "r2"}:
         return "s3"
     else:
-        raise ValueError(f"Unsupported cloud storage URL: {url}")
+        raise ValueError(f"Unsupported cloud storage URL: {redact_url_for_display(url)}")
 
 
 def estimate_download_time(size_bytes: int, bandwidth_mbps: float = 10.0) -> str:
@@ -147,7 +164,7 @@ def get_cloud_object_size(fs: Any, url: str, strict: bool = False) -> int | None
         info = fs.info(url)
     except Exception as exc:
         if strict:
-            raise ValueError(f"Unable to read cloud object info for {url}: {exc}") from exc
+            raise ValueError(f"Unable to read cloud object info for {redact_url_for_display(url)}: {exc}") from exc
         return None
 
     top_level_size_error: Exception | None = None
@@ -212,7 +229,9 @@ def get_cloud_object_size(fs: Any, url: str, strict: bool = False) -> int | None
             error_parts.append(f"ls() failed: {ls_error}")
         if not error_parts:
             error_parts.append("cloud provider did not return file sizes")
-        raise ValueError(f"Unable to determine cloud object size for {url}: {'; '.join(error_parts)}")
+        raise ValueError(
+            f"Unable to determine cloud object size for {redact_url_for_display(url)}: {'; '.join(error_parts)}"
+        )
 
     return None
 
@@ -520,7 +539,7 @@ def download_from_cloud(
     # Ensure target was analyzed successfully
     if "error" in metadata or metadata.get("type") == "unknown":
         error_msg = metadata.get("error", "Unknown cloud target type")
-        raise ValueError(f"Failed to analyze cloud target {url}: {error_msg}")
+        raise ValueError(f"Failed to analyze cloud target {redact_url_for_display(url)}: {error_msg}")
 
     # Check if we can use streaming analysis
     if stream_analyze and metadata.get("type") == "file":
@@ -581,12 +600,15 @@ def download_from_cloud(
             else:
                 object_size = None
                 if show_progress:
-                    click.echo(f"⚠️  Unable to determine download size for {url}; continuing without disk check: {exc}")
+                    click.echo(
+                        "⚠️  Unable to determine download size for "
+                        f"{redact_url_for_display(url)}; continuing without disk check: {exc}"
+                    )
 
         if object_size is not None:
             has_space, message = check_disk_space(download_path, object_size)
             if not has_space:
-                raise Exception(f"Cannot download from {url}: {message}")
+                raise Exception(f"Cannot download from {redact_url_for_display(url)}: {message}")
 
         # Download based on type
         if metadata["type"] == "directory":
@@ -694,7 +716,7 @@ def download_from_cloud_streaming(
 
     if "error" in metadata or metadata.get("type") == "unknown":
         error_msg = metadata.get("error", "Unknown cloud target type")
-        raise ValueError(f"Failed to analyze cloud target {url}: {error_msg}")
+        raise ValueError(f"Failed to analyze cloud target {redact_url_for_display(url)}: {error_msg}")
 
     # Check size limits
     size = metadata.get("total_size", metadata.get("size", 0))

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -87,6 +87,13 @@ def redact_cloud_error_for_display(message: object, source_url: str | None = Non
     return _SENSITIVE_QUERY_PARAM_RE.sub(r"\1<redacted>", redacted)
 
 
+def _cloud_error_sanitizer(source_url: str) -> Callable[[Exception], str]:
+    def sanitize(exc: Exception) -> str:
+        return redact_cloud_error_for_display(exc, source_url)
+
+    return sanitize
+
+
 def _cloud_url_basename(url: str) -> str:
     """Return a local filename derived from a cloud URL without query secrets."""
     try:
@@ -287,7 +294,7 @@ async def analyze_cloud_target(url: str) -> dict[str, Any]:
         @retry_with_backoff(
             max_retries=3,
             verbose=True,
-            sanitize_error=lambda exc: redact_cloud_error_for_display(exc, url),
+            sanitize_error=_cloud_error_sanitizer(url),
         )
         def get_info():
             return fs.info(url)
@@ -684,7 +691,7 @@ def download_from_cloud(
                 @retry_with_backoff(
                     max_retries=3,
                     verbose=show_progress,
-                    sanitize_error=lambda exc, source_url=file_url: redact_cloud_error_for_display(exc, source_url),
+                    sanitize_error=_cloud_error_sanitizer(file_url),
                 )
                 def download_file(url=file_url, path=local_path):
                     fs.get(url, str(path))
@@ -698,7 +705,7 @@ def download_from_cloud(
             @retry_with_backoff(
                 max_retries=3,
                 verbose=show_progress,
-                sanitize_error=lambda exc: redact_cloud_error_for_display(exc, url),
+                sanitize_error=_cloud_error_sanitizer(url),
             )
             def download_single_file():
                 fs.get(url, str(local_file))
@@ -816,7 +823,7 @@ def download_from_cloud_streaming(
             @retry_with_backoff(
                 max_retries=3,
                 verbose=show_progress,
-                sanitize_error=lambda exc, source_url=file_url: redact_cloud_error_for_display(exc, source_url),
+                sanitize_error=_cloud_error_sanitizer(file_url),
             )
             def download_file(url=file_url, path=local_path):
                 fs.get(url, str(path))

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -24,6 +24,15 @@ from ..helpers.disk_space import check_disk_space
 logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
+_SENSITIVE_QUERY_PARAM_RE = re.compile(
+    (
+        r"([?&][^=\s&]*(?:signature|credential|security-token|access-key|access_key|token|"
+        r"secret|api-key|api_key|apikey|sig|sas)[^=\s&]*=)[^\s&#]+"
+    ),
+    re.IGNORECASE,
+)
+_URL_USERINFO_RE = re.compile(r"([a-z][a-z0-9+.-]*://)([^/@\s]+)@", re.IGNORECASE)
+
 
 def _run_coroutine_sync(coro_factory: Callable[[], Coroutine[Any, Any, _T]]) -> _T:
     """Run a coroutine from sync code without deadlocking an active event loop."""
@@ -67,6 +76,15 @@ def redact_url_for_display(url: str) -> str:
         netloc = f"{netloc}:{parts.port}"
 
     return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+
+
+def redact_cloud_error_for_display(message: object, source_url: str | None = None) -> str:
+    """Remove signed URL credentials from provider exception text."""
+    redacted = str(message)
+    if source_url:
+        redacted = redacted.replace(source_url, redact_url_for_display(source_url))
+    redacted = _URL_USERINFO_RE.sub(r"\1<credentials-redacted>@", redacted)
+    return _SENSITIVE_QUERY_PARAM_RE.sub(r"\1<redacted>", redacted)
 
 
 def get_fs_protocol(url: str) -> str:
@@ -164,7 +182,10 @@ def get_cloud_object_size(fs: Any, url: str, strict: bool = False) -> int | None
         info = fs.info(url)
     except Exception as exc:
         if strict:
-            raise ValueError(f"Unable to read cloud object info for {redact_url_for_display(url)}: {exc}") from exc
+            redacted_error = redact_cloud_error_for_display(exc, url)
+            raise ValueError(
+                f"Unable to read cloud object info for {redact_url_for_display(url)}: {redacted_error}"
+            ) from exc
         return None
 
     top_level_size_error: Exception | None = None
@@ -224,9 +245,9 @@ def get_cloud_object_size(fs: Any, url: str, strict: bool = False) -> int | None
         if top_level_size_error is not None:
             error_parts.append(f"invalid size from info(): {top_level_size_error}")
         if walk_error:
-            error_parts.append(f"walk() failed: {walk_error}")
+            error_parts.append(f"walk() failed: {redact_cloud_error_for_display(walk_error, url)}")
         if ls_error:
-            error_parts.append(f"ls() failed: {ls_error}")
+            error_parts.append(f"ls() failed: {redact_cloud_error_for_display(ls_error, url)}")
         if not error_parts:
             error_parts.append("cloud provider did not return file sizes")
         raise ValueError(
@@ -297,7 +318,7 @@ async def analyze_cloud_target(url: str) -> dict[str, Any]:
         }
     except Exception as e:
         # If we can't get info, assume it's a file
-        return {"type": "unknown", "error": str(e)}
+        return {"type": "unknown", "error": redact_cloud_error_for_display(e, url)}
 
 
 def prompt_for_large_download(metadata: dict[str, Any]) -> bool:
@@ -538,7 +559,9 @@ def download_from_cloud(
 
     # Ensure target was analyzed successfully
     if "error" in metadata or metadata.get("type") == "unknown":
-        error_msg = metadata.get("error", "Unknown cloud target type")
+        error_msg = redact_cloud_error_for_display(
+            metadata.get("error", "Unknown cloud target type"), url
+        )
         raise ValueError(f"Failed to analyze cloud target {redact_url_for_display(url)}: {error_msg}")
 
     # Check if we can use streaming analysis

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -87,6 +87,15 @@ def redact_cloud_error_for_display(message: object, source_url: str | None = Non
     return _SENSITIVE_QUERY_PARAM_RE.sub(r"\1<redacted>", redacted)
 
 
+def _cloud_url_basename(url: str) -> str:
+    """Return a local filename derived from a cloud URL without query secrets."""
+    try:
+        path = urlsplit(url).path
+    except Exception:
+        path = url
+    return Path(path).name
+
+
 def get_fs_protocol(url: str) -> str:
     """Get the fsspec protocol for a given URL."""
     parsed = urlparse(url)
@@ -275,7 +284,11 @@ async def analyze_cloud_target(url: str) -> dict[str, Any]:
         fs = fsspec.filesystem(fs_protocol, **fs_args)
 
         # Get info about the target with retry
-        @retry_with_backoff(max_retries=3, verbose=True)
+        @retry_with_backoff(
+            max_retries=3,
+            verbose=True,
+            sanitize_error=lambda exc: redact_cloud_error_for_display(exc, url),
+        )
         def get_info():
             return fs.info(url)
 
@@ -286,7 +299,7 @@ async def analyze_cloud_target(url: str) -> dict[str, Any]:
             return {
                 "type": "file",
                 "size": info.get("size", 0),
-                "name": Path(url).name,
+                "name": _cloud_url_basename(url),
                 "estimated_time": estimate_download_time(info.get("size", 0)),
                 "human_size": format_size(info.get("size", 0)),
             }
@@ -303,7 +316,9 @@ async def analyze_cloud_target(url: str) -> dict[str, Any]:
                 item_info = fs.info(item)
                 if item_info.get("type") == "file" or "size" in item_info:
                     size = item_info.get("size", 0)
-                    files.append({"path": item, "name": Path(item).name, "size": size, "human_size": format_size(size)})
+                    files.append(
+                        {"path": item, "name": _cloud_url_basename(item), "size": size, "human_size": format_size(size)}
+                    )
                     total_size += size
             except Exception:
                 continue
@@ -483,7 +498,8 @@ def filter_scannable_files(files: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Filter files to only include scannable model types."""
     scannable = []
     for file in files:
-        path = Path(file["path"])
+        file_path = str(file["path"])
+        path = Path(_cloud_url_basename(file_path) if is_cloud_url(file_path) else file_path)
         suffixes = [s.lower() for s in path.suffixes]
         for i in range(1, len(suffixes) + 1):
             if "".join(suffixes[-i:]) in SCANNABLE_MODEL_EXTENSIONS:
@@ -500,11 +516,12 @@ def _build_safe_local_path(base_url: str, file_url: str, download_path: Path) ->
     if file_url.startswith(f"{normalized_base}/"):
         relative_path = file_url[len(normalized_base) + 1 :]
     elif file_url == normalized_base:
-        relative_path = Path(file_url).name
+        relative_path = _cloud_url_basename(file_url)
     else:
         # Fallback to basename for unexpected path shapes.
-        relative_path = Path(file_url).name
+        relative_path = _cloud_url_basename(file_url)
 
+    relative_path = urlsplit(relative_path).path
     if not relative_path:
         raise ValueError(f"Invalid cloud object path: {file_url}")
 
@@ -664,17 +681,25 @@ def download_from_cloud(
                 if show_progress:
                     click.echo(f"Downloading {file_info['name']} ({file_info['human_size']})")
 
-                @retry_with_backoff(max_retries=3, verbose=show_progress)
+                @retry_with_backoff(
+                    max_retries=3,
+                    verbose=show_progress,
+                    sanitize_error=lambda exc, source_url=file_url: redact_cloud_error_for_display(exc, source_url),
+                )
                 def download_file(url=file_url, path=local_path):
                     fs.get(url, str(path))
 
                 download_file()
         else:
             # Single file download
-            file_name = Path(url).name
+            file_name = _cloud_url_basename(url)
             local_file = download_path / file_name
 
-            @retry_with_backoff(max_retries=3, verbose=show_progress)
+            @retry_with_backoff(
+                max_retries=3,
+                verbose=show_progress,
+                sanitize_error=lambda exc: redact_cloud_error_for_display(exc, url),
+            )
             def download_single_file():
                 fs.get(url, str(local_file))
 
@@ -768,7 +793,7 @@ def download_from_cloud_streaming(
             raise ValueError("No scannable model files found")
     else:
         # Single file
-        files = [{"path": url, "name": Path(url).name, "size": metadata.get("size", 0)}]
+        files = [{"path": url, "name": _cloud_url_basename(url), "size": metadata.get("size", 0)}]
 
     # Create temp directory for downloads
     temp_dir = Path(tempfile.mkdtemp(prefix="modelaudit_stream_"))
@@ -778,7 +803,7 @@ def download_from_cloud_streaming(
         total_files = len(files)
         for i, file_info in enumerate(files):
             file_url = file_info["path"]
-            file_name = file_info.get("name") or Path(file_url).name
+            file_name = file_info.get("name") or _cloud_url_basename(file_url)
             is_last = i == total_files - 1
 
             # Build a safe local path relative to the requested cloud base path.
@@ -788,7 +813,11 @@ def download_from_cloud_streaming(
             if show_progress:
                 click.echo(f"⬇️  Downloading {file_name} ({file_info.get('human_size', 'unknown size')})")
 
-            @retry_with_backoff(max_retries=3, verbose=show_progress)
+            @retry_with_backoff(
+                max_retries=3,
+                verbose=show_progress,
+                sanitize_error=lambda exc, source_url=file_url: redact_cloud_error_for_display(exc, source_url),
+            )
             def download_file(url=file_url, path=local_path):
                 fs.get(url, str(path))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1589,6 +1589,22 @@ def test_scan_cloud_url_download_failure(mock_download: MagicMock, mock_is_cloud
 
 @patch("modelaudit.cli.is_cloud_url")
 @patch("modelaudit.cli.download_from_cloud")
+def test_scan_cloud_url_download_failure_redacts_signed_url(mock_download: MagicMock, mock_is_cloud: MagicMock) -> None:
+    """Signed cloud URL secrets should not leak through shared CLI output."""
+    url = "s3://bucket/model.bin?X-Amz-Signature=secret"
+    mock_is_cloud.return_value = True
+    mock_download.side_effect = Exception(f"Forbidden while opening {url}")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["scan", url])
+
+    assert result.exit_code == 2
+    assert "s3://bucket/model.bin" in result.output
+    assert "X-Amz-Signature" not in result.output
+    assert "secret" not in result.output
+
+
+@patch("modelaudit.cli.is_cloud_url")
+@patch("modelaudit.cli.download_from_cloud")
 @patch("modelaudit.cli.scan_model_directory_or_file")
 @patch("shutil.rmtree")
 def test_scan_cloud_url_with_issues(
@@ -2352,6 +2368,13 @@ class TestExpandPaths:
         pattern = str(tmp_path / "?.pt")
         expanded, missing = expand_paths((pattern,))
         assert len(expanded) == 1
+        assert missing == []
+
+    def test_expand_paths_signed_cloud_url_is_not_a_glob(self):
+        """Signed cloud URLs may contain query wildcards but are not local globs."""
+        url = "s3://bucket/model.bin?X-Amz-Signature=secret"
+        expanded, missing = expand_paths((url,))
+        assert expanded == [url]
         assert missing == []
 
     def test_expand_paths_empty_input(self):

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from modelaudit.utils.helpers.retry import RetryError
 from modelaudit.utils.sources.cloud_storage import (
     GCSCache,
     _run_coroutine_sync,
@@ -92,6 +93,31 @@ class TestCloudURLRedaction:
         assert "abc123" not in redacted
 
 
+@patch("modelaudit.utils.helpers.retry.time.sleep")
+@patch("fsspec.filesystem")
+def test_analyze_cloud_target_redacts_signed_url_retry_logs(mock_fs, mock_sleep, caplog):
+    url = "s3://bucket/model.bin?X-Amz-Signature=secret"
+    fs = make_fs_mock()
+    fs.info.side_effect = OSError(f"Forbidden while opening {url}")
+    mock_fs.return_value = fs
+    caplog.set_level(logging.DEBUG, logger="modelaudit.utils.helpers.retry")
+
+    result = asyncio.run(analyze_cloud_target(url))
+
+    assert "X-Amz-Signature" not in result["error"]
+    assert "secret" not in result["error"]
+    assert "s3://bucket/model.bin" in caplog.text
+    assert "X-Amz-Signature" not in caplog.text
+    assert "secret" not in caplog.text
+    mock_sleep.assert_called()
+
+
+def test_filter_scannable_files_handles_signed_cloud_urls() -> None:
+    files = [{"path": "s3://bucket/model.pkl?X-Amz-Signature=secret"}]
+
+    assert filter_scannable_files(files) == files
+
+
 @patch("fsspec.filesystem")
 def test_download_from_cloud(mock_fs, tmp_path):
     fs_meta = make_fs_mock()
@@ -122,6 +148,34 @@ def test_download_from_cloud(mock_fs, tmp_path):
 @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
 @patch("modelaudit.utils.sources.cloud_storage.check_disk_space")
 @patch("fsspec.filesystem")
+def test_download_from_cloud_strips_signed_url_from_local_filename(mock_fs, mock_disk_space, mock_analyze, tmp_path):
+    url = "s3://bucket/model.bin?X-Amz-Signature=secret"
+    fs = make_fs_mock()
+    fs.info.return_value = {"type": "file", "size": 1024}
+    fs.get.side_effect = lambda _src, dst: Path(dst).write_bytes(b"data")
+    mock_fs.return_value = fs
+    mock_analyze.return_value = {
+        "type": "file",
+        "size": 1024,
+        "name": "model.bin",
+        "human_size": "1.0 KB",
+        "estimated_time": "1 second",
+    }
+    mock_disk_space.return_value = (True, "")
+
+    result = download_from_cloud(url, cache_dir=tmp_path, use_cache=False, show_progress=False)
+
+    assert isinstance(result, Path)
+    assert result.name == "model.bin"
+    assert "X-Amz-Signature" not in str(result)
+    assert "secret" not in str(result)
+    assert "X-Amz-Signature" not in fs.get.call_args.args[1]
+    assert "secret" not in fs.get.call_args.args[1]
+
+
+@patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+@patch("modelaudit.utils.sources.cloud_storage.check_disk_space")
+@patch("fsspec.filesystem")
 def test_download_from_cloud_redacts_sensitive_url_in_errors(mock_fs, mock_disk_space, mock_analyze, tmp_path):
     fs = make_fs_mock()
     fs.info.return_value = {"type": "file", "size": 1024}
@@ -142,6 +196,37 @@ def test_download_from_cloud_redacts_sensitive_url_in_errors(mock_fs, mock_disk_
 
     assert "s3://bucket/model.bin" in str(excinfo.value)
     assert "X-Amz-Signature" not in str(excinfo.value)
+
+
+@patch("modelaudit.utils.helpers.retry.time.sleep")
+@patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+@patch("modelaudit.utils.sources.cloud_storage.check_disk_space")
+@patch("fsspec.filesystem")
+def test_download_from_cloud_redacts_signed_url_retry_logs(
+    mock_fs, mock_disk_space, mock_analyze, mock_sleep, tmp_path, caplog
+):
+    url = "s3://bucket/model.bin?X-Amz-Signature=secret"
+    fs = make_fs_mock()
+    fs.info.return_value = {"type": "file", "size": 1024}
+    fs.get.side_effect = OSError(f"Forbidden while opening {url}")
+    mock_fs.return_value = fs
+    mock_analyze.return_value = {
+        "type": "file",
+        "size": 1024,
+        "name": "model.bin",
+        "human_size": "1.0 KB",
+        "estimated_time": "1 second",
+    }
+    mock_disk_space.return_value = (True, "")
+    caplog.set_level(logging.DEBUG, logger="modelaudit.utils.helpers.retry")
+
+    with pytest.raises(RetryError):
+        download_from_cloud(url, cache_dir=tmp_path, use_cache=False, show_progress=False)
+
+    assert "s3://bucket/model.bin" in caplog.text
+    assert "X-Amz-Signature" not in caplog.text
+    assert "secret" not in caplog.text
+    mock_sleep.assert_called()
 
 
 @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -81,8 +81,7 @@ class TestCloudURLRedaction:
 
     def test_redact_cloud_error_for_display_redacts_query_credentials_without_exact_url(self) -> None:
         message = (
-            "provider failed: https://storage.googleapis.com/bucket/model.bin"
-            "?X-Goog-Signature=secret&token=abc123"
+            "provider failed: https://storage.googleapis.com/bucket/model.bin?X-Goog-Signature=secret&token=abc123"
         )
 
         redacted = redact_cloud_error_for_display(message)

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -14,6 +14,7 @@ from modelaudit.utils.sources.cloud_storage import (
     filter_scannable_files,
     get_cloud_object_size,
     is_cloud_url,
+    redact_url_for_display,
 )
 
 
@@ -57,6 +58,16 @@ class TestCloudURLDetection:
             assert not is_cloud_url(url), f"Incorrectly detected {url}"
 
 
+class TestCloudURLRedaction:
+    def test_redact_url_for_display_strips_credentials_and_query(self) -> None:
+        url = "https://user:pass@example.com:8443/path/to/model.bin?X-Amz-Signature=secret#fragment"
+        assert redact_url_for_display(url) == "https://example.com:8443/path/to/model.bin"
+
+    def test_redact_url_for_display_strips_cloud_query_params(self) -> None:
+        url = "s3://bucket/model.bin?X-Amz-Credential=secret&X-Amz-Signature=secret"
+        assert redact_url_for_display(url) == "s3://bucket/model.bin"
+
+
 @patch("fsspec.filesystem")
 def test_download_from_cloud(mock_fs, tmp_path):
     fs_meta = make_fs_mock()
@@ -82,6 +93,31 @@ def test_download_from_cloud(mock_fs, tmp_path):
     assert result.exists() or True  # Mock doesn't create actual files
 
     # Note: fsspec filesystems don't need explicit cleanup according to implementation
+
+
+@patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+@patch("modelaudit.utils.sources.cloud_storage.check_disk_space")
+@patch("fsspec.filesystem")
+def test_download_from_cloud_redacts_sensitive_url_in_errors(mock_fs, mock_disk_space, mock_analyze, tmp_path):
+    fs = make_fs_mock()
+    fs.info.return_value = {"type": "file", "size": 1024}
+    mock_fs.return_value = fs
+    mock_analyze.return_value = {
+        "type": "file",
+        "size": 1024,
+        "name": "model.bin",
+        "human_size": "1.0 KB",
+        "estimated_time": "1 second",
+    }
+    mock_disk_space.return_value = (False, "not enough space")
+
+    url = "s3://bucket/model.bin?X-Amz-Signature=secret"
+
+    with pytest.raises(Exception) as excinfo:
+        download_from_cloud(url, cache_dir=tmp_path, use_cache=False, show_progress=False)
+
+    assert "s3://bucket/model.bin" in str(excinfo.value)
+    assert "X-Amz-Signature" not in str(excinfo.value)
 
 
 @pytest.mark.asyncio

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -8,6 +8,7 @@ import pytest
 from modelaudit.utils.helpers.retry import RetryError
 from modelaudit.utils.sources.cloud_storage import (
     GCSCache,
+    _build_safe_local_path,
     _run_coroutine_sync,
     analyze_cloud_target,
     download_from_cloud,
@@ -171,6 +172,21 @@ def test_download_from_cloud_strips_signed_url_from_local_filename(mock_fs, mock
     assert "secret" not in str(result)
     assert "X-Amz-Signature" not in fs.get.call_args.args[1]
     assert "secret" not in fs.get.call_args.args[1]
+
+
+def test_build_safe_local_path_preserves_signed_directory_relative_paths(tmp_path: Path) -> None:
+    """Signed directory URLs should keep object-relative paths without query secrets."""
+    base_url = "s3://bucket/models?X-Amz-Signature=base-secret"
+    first = "s3://bucket/models/a/model.pkl?X-Amz-Signature=first-secret"
+    second = "s3://bucket/models/b/model.pkl?X-Amz-Signature=second-secret"
+
+    first_path = _build_safe_local_path(base_url, first, tmp_path)
+    second_path = _build_safe_local_path(base_url, second, tmp_path)
+
+    assert first_path == tmp_path / "a" / "model.pkl"
+    assert second_path == tmp_path / "b" / "model.pkl"
+    assert "X-Amz-Signature" not in str(first_path)
+    assert "X-Amz-Signature" not in str(second_path)
 
 
 @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -14,6 +14,7 @@ from modelaudit.utils.sources.cloud_storage import (
     filter_scannable_files,
     get_cloud_object_size,
     is_cloud_url,
+    redact_cloud_error_for_display,
     redact_url_for_display,
 )
 
@@ -67,6 +68,30 @@ class TestCloudURLRedaction:
         url = "s3://bucket/model.bin?X-Amz-Credential=secret&X-Amz-Signature=secret"
         assert redact_url_for_display(url) == "s3://bucket/model.bin"
 
+    def test_redact_cloud_error_for_display_redacts_embedded_signed_urls(self) -> None:
+        url = "s3://bucket/model.bin?X-Amz-Credential=cred&X-Amz-Signature=secret"
+        message = f"Forbidden while opening {url}"
+
+        redacted = redact_cloud_error_for_display(message, url)
+
+        assert "s3://bucket/model.bin" in redacted
+        assert "X-Amz-Credential" not in redacted
+        assert "X-Amz-Signature" not in redacted
+        assert "secret" not in redacted
+
+    def test_redact_cloud_error_for_display_redacts_query_credentials_without_exact_url(self) -> None:
+        message = (
+            "provider failed: https://storage.googleapis.com/bucket/model.bin"
+            "?X-Goog-Signature=secret&token=abc123"
+        )
+
+        redacted = redact_cloud_error_for_display(message)
+
+        assert "X-Goog-Signature=<redacted>" in redacted
+        assert "token=<redacted>" in redacted
+        assert "secret" not in redacted
+        assert "abc123" not in redacted
+
 
 @patch("fsspec.filesystem")
 def test_download_from_cloud(mock_fs, tmp_path):
@@ -118,6 +143,23 @@ def test_download_from_cloud_redacts_sensitive_url_in_errors(mock_fs, mock_disk_
 
     assert "s3://bucket/model.bin" in str(excinfo.value)
     assert "X-Amz-Signature" not in str(excinfo.value)
+
+
+@patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+def test_download_from_cloud_redacts_raw_analyzer_error_url(mock_analyze):
+    url = "s3://bucket/model.bin?X-Amz-Signature=secret"
+    mock_analyze.return_value = {
+        "type": "unknown",
+        "error": f"Forbidden while opening {url}",
+    }
+
+    with pytest.raises(ValueError) as excinfo:
+        download_from_cloud(url, use_cache=False, show_progress=False)
+
+    message = str(excinfo.value)
+    assert "s3://bucket/model.bin" in message
+    assert "X-Amz-Signature" not in message
+    assert "secret" not in message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Redacts signed cloud URLs before printing or logging cloud download errors.