### PR TITLE
fix(cli): honor streaming file skips

### DIFF
--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -779,11 +779,22 @@ def _is_huggingface_cache_file(path: str) -> bool:
     # We no longer skip all HuggingFace cache files since we handle symlinks properly now
 
     # Check for Git-related files that are commonly cached
-    if filename in [".gitignore", ".gitattributes", "main", "HEAD"]:
+    if filename in [".gitignore", ".gitattributes"]:
         return True
 
-    # Check if file is in refs directory (Git references, not actual model files)
-    return bool("/refs/" in path and filename in ["main", "HEAD"])
+    if filename in ["main", "HEAD"]:
+        hf_cache_root = _find_hf_cache_root(path_obj)
+        if hf_cache_root is None:
+            return False
+
+        try:
+            relative_parts = _resolve_hf_cache_path(path_obj).relative_to(hf_cache_root).parts
+        except ValueError:
+            return False
+
+        return bool(relative_parts and relative_parts[0] == "refs")
+
+    return False
 
 
 @cached_scan()

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -1116,6 +1116,8 @@ def scan_model_streaming(
     results = create_initial_audit_result()
     file_hashes: list[str] = []
     files_processed = 0
+    skip_file_types = bool(kwargs.get("skip_file_types", False))
+    metadata_scanner_available = _registry.has_scanner_class("MetadataScanner")
 
     base_dir = Path(scan_root).resolve() if scan_root is not None else None
     hf_cache_root = _find_hf_cache_root(base_dir) if base_dir is not None else None
@@ -1137,6 +1139,10 @@ def scan_model_streaming(
                 break
 
             try:
+                if _is_huggingface_cache_file(str(source_path)):
+                    logger.debug(f"Skipping HuggingFace cache file: {source_path}")
+                    continue
+
                 if base_dir is not None:
                     resolved_path, _is_hf_cache_symlink = _resolve_directory_scan_target(
                         source_path,
@@ -1148,6 +1154,24 @@ def scan_model_streaming(
                     if resolved_path is None:
                         continue
                     scan_path = resolved_path
+
+                if skip_file_types and should_skip_file(
+                    str(source_path),
+                    metadata_scanner_available=metadata_scanner_available,
+                ):
+                    filename_lower = source_path.name.lower()
+                    if filename_lower in LICENSE_FILES:
+                        try:
+                            license_metadata = collect_license_metadata(str(scan_path))
+                            from .models import FileMetadataModel
+
+                            results.file_metadata[report_path] = FileMetadataModel(**license_metadata)
+                            logger.debug(f"Collected license metadata from skipped file: {source_path}")
+                        except Exception as e:
+                            logger.warning(f"Error collecting license metadata for {source_path}: {e}")
+                    else:
+                        logger.debug(f"Skipping non-model file: {source_path}")
+                    continue
 
                 # Compute file hash
                 if progress_callback:

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -1127,8 +1127,8 @@ def scan_model_streaming(
     results = create_initial_audit_result()
     file_hashes: list[str] = []
     files_processed = 0
-    skip_file_types = bool(kwargs.get("skip_file_types", False))
-    metadata_scanner_available = _registry.has_scanner_class("MetadataScanner")
+    skip_file_types: bool = bool(kwargs.get("skip_file_types", False))
+    metadata_scanner_available: bool = _registry.has_scanner_class("MetadataScanner")
 
     base_dir = Path(scan_root).resolve() if scan_root is not None else None
     hf_cache_root = _find_hf_cache_root(base_dir) if base_dir is not None else None
@@ -1150,7 +1150,7 @@ def scan_model_streaming(
                 break
 
             try:
-                if _is_huggingface_cache_file(str(source_path)):
+                if is_hf_cache and _is_huggingface_cache_file(str(source_path)):
                     logger.debug(f"Skipping HuggingFace cache file: {source_path}")
                     continue
 

--- a/tests/test_directory_file_filtering.py
+++ b/tests/test_directory_file_filtering.py
@@ -309,6 +309,27 @@ class TestDirectoryFileFiltering:
         # be treated as HuggingFace bookkeeping even though a sibling snapshots/ exists.
         assert _is_huggingface_cache_file(str(malicious_metadata)) is False
 
+    def test_huggingface_ref_names_only_skip_inside_hf_refs(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Files named main/HEAD are model payloads unless they are HF cache refs."""
+        hf_home = tmp_path / ".cache" / "huggingface"
+        monkeypatch.setenv("HF_HOME", str(hf_home))
+
+        local_main = tmp_path / "main"
+        local_head = tmp_path / "HEAD"
+        hf_ref_main = hf_home / "hub" / "models--org--repo" / "refs" / "main"
+        hf_ref_head = hf_home / "hub" / "models--org--repo" / "refs" / "HEAD"
+        hf_snapshot_main = hf_home / "hub" / "models--org--repo" / "snapshots" / "abc123" / "main"
+
+        assert _is_huggingface_cache_file(str(local_main)) is False
+        assert _is_huggingface_cache_file(str(local_head)) is False
+        assert _is_huggingface_cache_file(str(hf_ref_main)) is True
+        assert _is_huggingface_cache_file(str(hf_ref_head)) is True
+        assert _is_huggingface_cache_file(str(hf_snapshot_main)) is False
+
     def test_performance_with_many_files(self):
         """Test that file filtering improves performance with many non-model files."""
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -256,6 +256,23 @@ def test_scan_model_streaming_skips_huggingface_cache_metadata(
     assert result.files_scanned == 1
 
 
+def test_scan_model_streaming_scans_local_file_named_main(tmp_path: Path) -> None:
+    """A local payload named like an HF ref must still be scanned in streaming mode."""
+    payload = tmp_path / "main"
+    payload.write_bytes(b"\x80\x02cos\nsystem\n.")
+
+    result = scan_model_streaming(
+        file_generator=iter([(payload, True)]),
+        timeout=30,
+        delete_after_scan=False,
+        cache_enabled=False,
+    )
+
+    assert result.files_scanned == 1
+    assert any(issue.severity == IssueSeverity.CRITICAL and "system" in issue.message for issue in result.issues)
+    assert determine_exit_code(result) == 1
+
+
 def test_scan_model_streaming_symlink_outside_directory_matches_normal_scan(
     tmp_path: Path,
     requires_symlinks: None,

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -178,6 +178,84 @@ def test_scan_model_streaming_basic(temp_test_files: list[Path]) -> None:
         assert len(result.content_hash) == 64  # SHA256 hex string
 
 
+def test_scan_model_streaming_skips_non_model_files(tmp_path: Path) -> None:
+    """Streaming directory scans should honor the normal skip_file_types policy."""
+    ignored_file = tmp_path / "notes.log"
+    ignored_file.write_text("debug output")
+    model_file = tmp_path / "model.pkl"
+    with model_file.open("wb") as f:
+        pickle.dump({"data": "safe"}, f)
+
+    with patch("modelaudit.core.scan_file") as mock_scan:
+        mock_scan.return_value = create_mock_scan_result(bytes_scanned=100)
+
+        result = scan_model_streaming(
+            file_generator=iter([(ignored_file, False), (model_file, True)]),
+            timeout=30,
+            delete_after_scan=False,
+            skip_file_types=True,
+        )
+
+    mock_scan.assert_called_once()
+    assert mock_scan.call_args.args[0] == str(model_file)
+    assert mock_scan.call_args.kwargs["config"]["skip_file_types"] is True
+    assert result.files_scanned == 1
+
+
+def test_scan_model_streaming_keeps_non_model_files_when_skip_disabled(tmp_path: Path) -> None:
+    """The skip_file_types flag should remain opt-out for streaming scans."""
+    ignored_file = tmp_path / "notes.log"
+    ignored_file.write_text("debug output")
+    model_file = tmp_path / "model.pkl"
+    with model_file.open("wb") as f:
+        pickle.dump({"data": "safe"}, f)
+
+    with patch("modelaudit.core.scan_file") as mock_scan:
+        mock_scan.return_value = create_mock_scan_result(bytes_scanned=100)
+
+        result = scan_model_streaming(
+            file_generator=iter([(ignored_file, False), (model_file, True)]),
+            timeout=30,
+            delete_after_scan=False,
+            skip_file_types=False,
+        )
+
+    assert [call.args[0] for call in mock_scan.call_args_list] == [str(ignored_file), str(model_file)]
+    assert result.files_scanned == 2
+
+
+def test_scan_model_streaming_skips_huggingface_cache_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Streaming scans should skip HF bookkeeping metadata like regular scans."""
+    hf_home = tmp_path / ".cache" / "huggingface"
+    monkeypatch.setenv("HF_HOME", str(hf_home))
+    snapshots_dir = hf_home / "hub" / "models--test-model" / "snapshots" / "abc123"
+    snapshots_dir.mkdir(parents=True)
+
+    metadata_file = snapshots_dir / "config.json.metadata"
+    metadata_file.write_text("{}")
+    model_file = snapshots_dir / "model.pkl"
+    with model_file.open("wb") as f:
+        pickle.dump({"data": "safe"}, f)
+
+    with patch("modelaudit.core.scan_file") as mock_scan:
+        mock_scan.return_value = create_mock_scan_result(bytes_scanned=100)
+
+        result = scan_model_streaming(
+            file_generator=iter([(metadata_file, False), (model_file, True)]),
+            timeout=30,
+            delete_after_scan=False,
+            scan_root=str(snapshots_dir),
+            cache_enabled=False,
+        )
+
+    mock_scan.assert_called_once()
+    assert mock_scan.call_args.args[0] == str(model_file)
+    assert result.files_scanned == 1
+
+
 def test_scan_model_streaming_symlink_outside_directory_matches_normal_scan(
     tmp_path: Path,
     requires_symlinks: None,

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -202,6 +202,52 @@ def test_scan_model_streaming_skips_non_model_files(tmp_path: Path) -> None:
     assert result.files_scanned == 1
 
 
+def test_scan_model_streaming_preserves_license_metadata_when_skipped(tmp_path: Path) -> None:
+    """Skipped license files should still populate file metadata in streaming mode."""
+    license_file = tmp_path / "license.txt"
+    license_file.write_text("MIT License\nCopyright 2026 Example")
+
+    with patch("modelaudit.core.scan_file") as mock_scan:
+        result = scan_model_streaming(
+            file_generator=iter([(license_file, True)]),
+            timeout=30,
+            delete_after_scan=False,
+            skip_file_types=True,
+        )
+
+    mock_scan.assert_not_called()
+    assert result.files_scanned == 0
+    assert str(license_file) in result.file_metadata
+    metadata = result.file_metadata[str(license_file)].model_dump()
+    assert "license_info" in metadata
+    assert "copyright_notices" in metadata
+
+
+def test_scan_model_streaming_skip_file_types_preserves_malicious_findings(tmp_path: Path) -> None:
+    """Prefiltering should skip non-model files without dropping model security findings."""
+    ignored_file = tmp_path / "notes.log"
+    ignored_file.write_text("debug output")
+    model_file = tmp_path / "model.pkl"
+    with model_file.open("wb") as f:
+        pickle.dump({"data": "safe"}, f)
+
+    with patch("modelaudit.core.scan_file") as mock_scan:
+        mock_scan.return_value = create_mock_scan_result(bytes_scanned=100, with_critical_issue=True)
+
+        result = scan_model_streaming(
+            file_generator=iter([(ignored_file, False), (model_file, True)]),
+            timeout=30,
+            delete_after_scan=False,
+            skip_file_types=True,
+        )
+
+    mock_scan.assert_called_once()
+    assert mock_scan.call_args.args[0] == str(model_file)
+    assert result.files_scanned == 1
+    assert any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+    assert determine_exit_code(result) == 1
+
+
 def test_scan_model_streaming_keeps_non_model_files_when_skip_disabled(tmp_path: Path) -> None:
     """The skip_file_types flag should remain opt-out for streaming scans."""
     ignored_file = tmp_path / "notes.log"


### PR DESCRIPTION
Apply directory skip rules to streaming scans when skip_file_types is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for conditional skipping of file types during model scanning.
  * Improved handling of HuggingFace cache files by automatically excluding bookkeeping metadata.
  * Enhanced license file extraction for skipped files.

* **Tests**
  * Added comprehensive tests validating file-skipping behavior and cache metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->