### PR TITLE
fix(metadata): reject symlink escapes

### DIFF
--- a/modelaudit/metadata_extractor.py
+++ b/modelaudit/metadata_extractor.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from .scanners import SCANNER_REGISTRY
+from .utils import is_within_directory
 
 logger = logging.getLogger("modelaudit.metadata_extractor")
 
@@ -71,11 +72,22 @@ class ModelMetadataExtractor:
     ) -> dict[str, Any]:
         """Extract metadata from all model files in a directory."""
         results: dict[str, Any] = {"directory": directory, "files": [], "summary": {"total_files": 0, "formats": {}}}
+        base_dir = str(Path(directory).resolve())
 
         for root, _, files in os.walk(directory):
             for file in files:
                 file_path = os.path.join(root, file)
                 try:
+                    if not is_within_directory(base_dir, file_path):
+                        results["files"].append(
+                            {
+                                "file": file,
+                                "path": file_path,
+                                "error": "Path traversal outside metadata directory",
+                            }
+                        )
+                        continue
+
                     file_metadata = self._extract_file_metadata(file_path, security_only, allow_deserialization)
                     if file_metadata.get("format") != "unknown":
                         results["files"].append(file_metadata)

--- a/tests/test_metadata_extractor.py
+++ b/tests/test_metadata_extractor.py
@@ -102,6 +102,35 @@ class TestModelMetadataExtractor:
             assert "safetensors" in metadata["summary"]["formats"]
             assert "pickle" in metadata["summary"]["formats"]
 
+    def test_extract_directory_metadata_rejects_symlink_escape(
+        self,
+        tmp_path: Path,
+        requires_symlinks: None,
+    ) -> None:
+        """Directory metadata extraction should not read symlinks outside the scan root."""
+        extractor = ModelMetadataExtractor()
+        scan_dir = tmp_path / "scan"
+        scan_dir.mkdir()
+        outside_dir = tmp_path / "outside"
+        outside_dir.mkdir()
+        outside_model = outside_dir / "secret.pkl"
+        with outside_model.open("wb") as f:
+            pickle.dump({"secret": "outside"}, f)
+
+        escaped_link = scan_dir / "model.pkl"
+        escaped_link.symlink_to(outside_model)
+
+        metadata = extractor.extract(str(scan_dir))
+
+        assert metadata["summary"]["total_files"] == 0
+        assert metadata["files"] == [
+            {
+                "file": "model.pkl",
+                "path": str(escaped_link),
+                "error": "Path traversal outside metadata directory",
+            }
+        ]
+
     def test_security_only_filter(self, tmp_path: Path) -> None:
         """Test security-only metadata filtering."""
         extractor = ModelMetadataExtractor()


### PR DESCRIPTION
Reject directory metadata symlinks that resolve outside the scan root.