### PR TITLE
test(archive): cover compressed nested routing

### DIFF
--- a/tests/scanners/test_scanner_registry.py
+++ b/tests/scanners/test_scanner_registry.py
@@ -343,6 +343,14 @@ def test_select_nested_scanner_id_routes_compressed_r_serialized_members(tmp_pat
     assert _select_nested_scanner_id(str(member_path)) == "r_serialized"
 
 
+def test_select_nested_scanner_id_does_not_route_compressed_non_target_suffix_to_r_serialized(
+    tmp_path: Path,
+) -> None:
+    member_path = _write_gzip_r_serialized(tmp_path / "workspace.txt", "workspace\nmodel")
+
+    assert _select_nested_scanner_id(str(member_path)) != "r_serialized"
+
+
 @pytest.mark.parametrize(
     ("header_format", "scanner_id"),
     [

--- a/tests/scanners/test_scanner_registry.py
+++ b/tests/scanners/test_scanner_registry.py
@@ -20,7 +20,7 @@ from modelaudit.scanner_registry_metadata import (
     get_registered_scanner_extensions,
 )
 from modelaudit.scanners import SCANNER_REGISTRY, ScannerRegistry, _registry
-from modelaudit.scanners.archive_dispatch import _HEADER_FORMAT_TO_SCANNER_ID
+from modelaudit.scanners.archive_dispatch import _HEADER_FORMAT_TO_SCANNER_ID, _select_nested_scanner_id
 from modelaudit.scanners.base import BaseScanner, IssueSeverity
 from tests.helpers import create_mock_pytorch_zip
 
@@ -58,6 +58,17 @@ def _write_tar_archive(path: Path, mode: TarWriteMode) -> Path:
 
 def _write_safe_pickle(path: Path) -> Path:
     path.write_bytes(pickle.dumps({"weights": [1, 2, 3]}, protocol=4))
+    return path
+
+
+def _write_gzip_joblib_pickle(path: Path) -> Path:
+    path.write_bytes(gzip.compress(pickle.dumps({"weights": [1, 2, 3]}, protocol=4)))
+    return path
+
+
+def _write_gzip_r_serialized(path: Path, body: str) -> Path:
+    with gzip.open(path, "wb") as stream:
+        stream.write(f"RDX2\nX\n{body}".encode())
     return path
 
 
@@ -317,6 +328,19 @@ def test_archive_dispatch_header_map_is_backed_by_scanner_descriptors() -> None:
             if mapped_scanner_id == scanner_id
         }
         assert actual_keys == expected_keys
+
+
+def test_select_nested_scanner_id_routes_compressed_joblib_members(tmp_path: Path) -> None:
+    member_path = _write_gzip_joblib_pickle(tmp_path / "nested.joblib")
+
+    assert _select_nested_scanner_id(str(member_path)) == "joblib"
+
+
+@pytest.mark.parametrize("suffix", [".rds", ".rda", ".rdata"])
+def test_select_nested_scanner_id_routes_compressed_r_serialized_members(tmp_path: Path, suffix: str) -> None:
+    member_path = _write_gzip_r_serialized(tmp_path / f"workspace{suffix}", "workspace\nmodel")
+
+    assert _select_nested_scanner_id(str(member_path)) == "r_serialized"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add nested dispatcher coverage for gzip-compressed `.joblib` members
- add nested dispatcher coverage for gzip-compressed `.rds`, `.rda`, and `.rdata` members

## Validation
- `uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for scanner routing logic to verify proper handling of compressed archives in different formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->