### PR TITLE
fix(dvc): restrict target paths

### DIFF
--- a/modelaudit/utils/sources/dvc.py
+++ b/modelaudit/utils/sources/dvc.py
@@ -56,29 +56,17 @@ def resolve_dvc_file(file_path: str) -> list[str]:
         try:
             target = (dvc_dir / out_path).resolve()
 
-            # Check if target is within the DVC directory (or a reasonable parent)
-            # Allow up to 2 levels up to handle common DVC patterns
-            max_parent_levels = 2
-            current_check = dvc_dir
-            is_safe = False
-
-            for _ in range(max_parent_levels + 1):
+            try:
+                is_safe = target.is_relative_to(dvc_dir)
+            except (AttributeError, ValueError):
+                # Python < 3.9 or different drives on Windows
                 try:
-                    if target.is_relative_to(current_check):
-                        is_safe = True
-                        break
-                except (AttributeError, ValueError):
-                    # Python < 3.9 or different drives on Windows
-                    try:
-                        import os
+                    import os
 
-                        common = os.path.commonpath([target, current_check])
-                        if Path(common) == current_check:
-                            is_safe = True
-                            break
-                    except (ValueError, OSError):
-                        pass
-                current_check = current_check.parent
+                    common = os.path.commonpath([target, dvc_dir])
+                    is_safe = Path(common) == dvc_dir
+                except (ValueError, OSError):
+                    is_safe = False
 
             if not is_safe:
                 logger.warning(f"DVC target path outside safe boundaries: {file_path} -> {target}")

--- a/tests/utils/sources/test_dvc_integration.py
+++ b/tests/utils/sources/test_dvc_integration.py
@@ -1,4 +1,5 @@
 import pickle
+from pathlib import Path
 
 from modelaudit.core import scan_model_directory_or_file
 from modelaudit.utils.sources.dvc import resolve_dvc_file
@@ -127,7 +128,7 @@ class TestDvcSecurity:
         # Should be empty due to path traversal protection
         assert resolved == []
 
-    def test_parent_directory_target_prevention(self, tmp_path):
+    def test_parent_directory_target_prevention(self, tmp_path: Path) -> None:
         """Test that sibling-directory DVC targets are blocked."""
         outside_file = tmp_path / "secret.pkl"
         with outside_file.open("wb") as f:

--- a/tests/utils/sources/test_dvc_integration.py
+++ b/tests/utils/sources/test_dvc_integration.py
@@ -127,6 +127,20 @@ class TestDvcSecurity:
         # Should be empty due to path traversal protection
         assert resolved == []
 
+    def test_parent_directory_target_prevention(self, tmp_path):
+        """Test that sibling-directory DVC targets are blocked."""
+        outside_file = tmp_path / "secret.pkl"
+        with outside_file.open("wb") as f:
+            pickle.dump({"secret": "data"}, f)
+
+        dvc_dir = tmp_path / "dvc_project"
+        dvc_dir.mkdir()
+        dvc_file = dvc_dir / "sibling.dvc"
+        dvc_file.write_text("outs:\n- path: ../secret.pkl\n")
+
+        resolved = resolve_dvc_file(str(dvc_file))
+        assert resolved == []
+
     def test_absolute_path_prevention(self, tmp_path):
         """Test that absolute paths are handled safely."""
         # Create a target file


### PR DESCRIPTION
Keeps DVC pointer targets within the pointer file directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened DVC file path validation so targets are only accepted when strictly inside the resolved DVC directory, preventing parent/sibling references and reducing risk of accessing unintended files.

* **Tests**
  * Added a security test to confirm DVC files that reference targets outside the intended directory are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->