### PR TITLE
fix(manifest): redact url secrets

### DIFF
--- a/modelaudit/scanners/manifest_scanner.py
+++ b/modelaudit/scanners/manifest_scanner.py
@@ -7,7 +7,7 @@ import os
 import re
 from types import ModuleType
 from typing import Any, Final
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlsplit, urlunsplit
 
 from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, IssueSeverity, ScanResult, logger
 
@@ -416,6 +416,7 @@ _TRUSTED_S3_ENDPOINT_HOST_PATTERNS: tuple[re.Pattern[str], ...] = (
 )
 _PARSE_FAILED: Final = object()
 _INI_SECTION_HEADER_RE = re.compile(r"^\s*\[[A-Za-z0-9_. -]+\]\s*(?:[#;].*)?(?:\r?\n|$)")
+_AT_SIGN_CONTAINER_SCHEMES = {"abfs", "abfss", "wasb", "wasbs"}
 
 
 def _scan_result_has_security_findings(result: ScanResult) -> bool:
@@ -426,6 +427,31 @@ def _scan_result_has_security_findings(result: ScanResult) -> bool:
 def _is_trusted_s3_endpoint_host(host: str) -> bool:
     """Return True for supported S3 endpoint host layouts only."""
     return any(pattern.match(host) for pattern in _TRUSTED_S3_ENDPOINT_HOST_PATTERNS)
+
+
+def _redact_url_for_display(url: str) -> str:
+    """Strip credential-bearing URL components before storing scan output."""
+    try:
+        parts = urlsplit(url)
+    except Exception:
+        return "<url redacted>"
+
+    if not parts.scheme:
+        return url
+
+    scheme = parts.scheme.lower()
+    netloc = parts.netloc
+    if "@" in parts.netloc and scheme not in _AT_SIGN_CONTAINER_SCHEMES:
+        netloc = parts.hostname or ""
+        try:
+            port = parts.port
+        except ValueError:
+            port = None
+        if port is not None:
+            netloc = f"{netloc}:{port}"
+        netloc = f"<credentials-redacted>@{netloc}"
+
+    return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
 
 
 def _is_trusted_url_domain(url: str) -> bool:
@@ -958,14 +984,15 @@ class ManifestScanner(BaseScanner):
                     if any(indicator in url_lower for indicator in suspicious_indicators):
                         severity = IssueSeverity.WARNING
 
+                    display_url = _redact_url_for_display(url)
                     result.add_check(
                         name="Cloud Storage URL Detection",
                         passed=False,  # Finding a cloud URL is informational, not a pass/fail
-                        message=f"{description} detected: {url[:150]}",
+                        message=f"{description} detected: {display_url[:150]}",
                         severity=severity,
                         location=self.current_file_path,
                         details={
-                            "url": url,
+                            "url": display_url,
                             "provider": provider,
                             "description": description,
                         },
@@ -1008,14 +1035,15 @@ class ManifestScanner(BaseScanner):
                     seen_urls.add(url)
                     # Flag any URL not from a trusted domain
                     if not is_trusted_domain(url):
+                        display_url = _redact_url_for_display(url)
                         result.add_check(
                             name="Untrusted URL Check",
                             passed=False,
-                            message=f"URL from untrusted domain: {url}",
+                            message=f"URL from untrusted domain: {display_url}",
                             severity=IssueSeverity.INFO,
                             location=self.current_file_path,
                             details={
-                                "url": url,
+                                "url": display_url,
                                 "key_path": key_path,
                             },
                             why=(

--- a/modelaudit/scanners/manifest_scanner.py
+++ b/modelaudit/scanners/manifest_scanner.py
@@ -416,7 +416,6 @@ _TRUSTED_S3_ENDPOINT_HOST_PATTERNS: tuple[re.Pattern[str], ...] = (
 )
 _PARSE_FAILED: Final = object()
 _INI_SECTION_HEADER_RE = re.compile(r"^\s*\[[A-Za-z0-9_. -]+\]\s*(?:[#;].*)?(?:\r?\n|$)")
-_AT_SIGN_CONTAINER_SCHEMES: Final[frozenset[str]] = frozenset({"abfs", "abfss", "wasb", "wasbs"})
 
 
 def _scan_result_has_security_findings(result: ScanResult) -> bool:
@@ -439,9 +438,8 @@ def _redact_url_for_display(url: str) -> str:
     if not parts.scheme:
         return url
 
-    scheme = parts.scheme.lower()
     netloc = parts.netloc
-    if "@" in parts.netloc and scheme not in _AT_SIGN_CONTAINER_SCHEMES:
+    if "@" in parts.netloc:
         netloc = parts.hostname or ""
         try:
             port = parts.port

--- a/modelaudit/scanners/manifest_scanner.py
+++ b/modelaudit/scanners/manifest_scanner.py
@@ -416,7 +416,7 @@ _TRUSTED_S3_ENDPOINT_HOST_PATTERNS: tuple[re.Pattern[str], ...] = (
 )
 _PARSE_FAILED: Final = object()
 _INI_SECTION_HEADER_RE = re.compile(r"^\s*\[[A-Za-z0-9_. -]+\]\s*(?:[#;].*)?(?:\r?\n|$)")
-_AT_SIGN_CONTAINER_SCHEMES = {"abfs", "abfss", "wasb", "wasbs"}
+_AT_SIGN_CONTAINER_SCHEMES: Final[frozenset[str]] = frozenset({"abfs", "abfss", "wasb", "wasbs"})
 
 
 def _scan_result_has_security_findings(result: ScanResult) -> bool:

--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -248,6 +248,28 @@ def test_manifest_scanner_url_shortener_flagged(tmp_path):
     assert "bit.ly" in failed_url_checks[0].details.get("url", "")
 
 
+def test_manifest_scanner_redacts_untrusted_url_credentials(tmp_path: Path) -> None:
+    """Untrusted URL findings should not store userinfo, query strings, or fragments."""
+    test_file = tmp_path / "config.json"
+    raw_url = "https://user:leaky-pass@totally-legit-models.com/model.bin?token=leaky-token#fragment"
+    test_file.write_text(json.dumps({"model_type": "bert", "download_url": raw_url}))
+
+    scanner = ManifestScanner()
+    result = scanner.scan(str(test_file))
+
+    failed_url_checks = [c for c in result.checks if c.name == "Untrusted URL Check" and c.status == CheckStatus.FAILED]
+    assert len(failed_url_checks) == 1
+
+    check = failed_url_checks[0]
+    assert check.details["url"] == "https://<credentials-redacted>@totally-legit-models.com/model.bin"
+    assert "leaky-pass" not in check.message
+    assert "leaky-token" not in check.message
+    assert "fragment" not in check.message
+    assert "leaky-pass" not in check.details["url"]
+    assert "leaky-token" not in check.details["url"]
+    assert "fragment" not in check.details["url"]
+
+
 def test_manifest_scanner_tunnel_service_flagged(tmp_path):
     """Test that tunnel services (ngrok, localtunnel) are flagged (not in allowlist)."""
     test_file = tmp_path / "config.json"
@@ -325,6 +347,26 @@ def test_manifest_scanner_regional_s3_urls_not_flagged(tmp_path: Path) -> None:
         config_with_s3_urls["regional_virtual_hosted"],
         config_with_s3_urls["legacy_regional_virtual_hosted"],
     }
+
+
+def test_manifest_scanner_redacts_cloud_url_query_credentials(tmp_path: Path) -> None:
+    """Cloud URL findings should not store signed query strings."""
+    test_file = tmp_path / "config.json"
+    raw_url = "https://bucket.s3.amazonaws.com/model.bin?X-Amz-Credential=leaky-cred&X-Amz-Signature=leaky-sig"
+    test_file.write_text(json.dumps({"model_type": "bert", "weights": raw_url}))
+
+    scanner = ManifestScanner()
+    result = scanner.scan(str(test_file))
+
+    cloud_storage_checks = [c for c in result.checks if c.name == "Cloud Storage URL Detection"]
+    assert len(cloud_storage_checks) == 1
+
+    check = cloud_storage_checks[0]
+    assert check.details["url"] == "https://bucket.s3.amazonaws.com/model.bin"
+    assert "leaky-cred" not in check.message
+    assert "leaky-sig" not in check.message
+    assert "leaky-cred" not in check.details["url"]
+    assert "leaky-sig" not in check.details["url"]
 
 
 def test_manifest_scanner_non_s3_amazonaws_hosts_flagged(tmp_path: Path) -> None:
@@ -932,7 +974,7 @@ def test_manifest_scanner_userinfo_url_flagged(tmp_path: Path) -> None:
     failed_url_checks = [c for c in result.checks if c.name == "Untrusted URL Check" and c.status == CheckStatus.FAILED]
     assert len(failed_url_checks) >= 1
     detected_urls = {c.details.get("url", "") for c in failed_url_checks}
-    assert any("evil.com@huggingface.co" in u for u in detected_urls)
+    assert "https://<credentials-redacted>@huggingface.co/model.bin" in detected_urls
 
 
 def test_manifest_scanner_expanded_exact_domains_flagged(tmp_path: Path) -> None:

--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -270,6 +270,40 @@ def test_manifest_scanner_redacts_untrusted_url_credentials(tmp_path: Path) -> N
     assert "fragment" not in check.details["url"]
 
 
+def test_manifest_scanner_container_schemes_preserve_at_symbol(tmp_path: Path) -> None:
+    """Azure container URI findings should preserve the container/account separator."""
+    test_file = tmp_path / "config.json"
+    raw_urls = {
+        "abfs": "abfs://container:secret@workspace.dfs.core.windows.net/models/path.bin?token=leak#frag",
+        "abfss": "abfss://container:secret@workspace.dfs.core.windows.net/models/path.bin?token=leak#frag",
+        "wasb": "wasb://container:secret@workspace.blob.core.windows.net/models/path.bin?token=leak#frag",
+        "wasbs": "wasbs://container:secret@workspace.blob.core.windows.net/models/path.bin?token=leak#frag",
+    }
+    test_file.write_text(json.dumps({"model_type": "bert", "download_urls": raw_urls}))
+
+    scanner = ManifestScanner()
+    result = scanner.scan(str(test_file))
+
+    cloud_storage_checks = [
+        check
+        for check in result.checks
+        if check.name == "Cloud Storage URL Detection" and check.status == CheckStatus.FAILED
+    ]
+    urls_by_scheme = {check.details["url"].split(":", 1)[0]: check for check in cloud_storage_checks}
+
+    assert set(raw_urls).issubset(urls_by_scheme)
+    for scheme, raw_url in raw_urls.items():
+        check = urls_by_scheme[scheme]
+        redacted_url = check.details["url"]
+        assert redacted_url == raw_url.split("?", 1)[0]
+        assert "container:secret@" in redacted_url
+        assert "<credentials-redacted>" not in redacted_url
+        assert "token=leak" not in redacted_url
+        assert "frag" not in redacted_url
+        assert "token=leak" not in check.message
+        assert "frag" not in check.message
+
+
 def test_manifest_scanner_tunnel_service_flagged(tmp_path):
     """Test that tunnel services (ngrok, localtunnel) are flagged (not in allowlist)."""
     test_file = tmp_path / "config.json"

--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -270,8 +270,8 @@ def test_manifest_scanner_redacts_untrusted_url_credentials(tmp_path: Path) -> N
     assert "fragment" not in check.details["url"]
 
 
-def test_manifest_scanner_container_schemes_preserve_at_symbol(tmp_path: Path) -> None:
-    """Azure container URI findings should preserve the container/account separator."""
+def test_manifest_scanner_container_schemes_redact_userinfo(tmp_path: Path) -> None:
+    """Azure container URI findings should redact userinfo-looking values."""
     test_file = tmp_path / "config.json"
     raw_urls = {
         "abfs": "abfs://container:secret@workspace.dfs.core.windows.net/models/path.bin?token=leak#frag",
@@ -295,11 +295,13 @@ def test_manifest_scanner_container_schemes_preserve_at_symbol(tmp_path: Path) -
     for scheme, raw_url in raw_urls.items():
         check = urls_by_scheme[scheme]
         redacted_url = check.details["url"]
-        assert redacted_url == raw_url.split("?", 1)[0]
-        assert "container:secret@" in redacted_url
-        assert "<credentials-redacted>" not in redacted_url
+        expected_url = raw_url.replace("container:secret", "<credentials-redacted>").split("?", 1)[0]
+        assert redacted_url == expected_url
+        assert "container:secret@" not in redacted_url
+        assert "<credentials-redacted>" in redacted_url
         assert "token=leak" not in redacted_url
         assert "frag" not in redacted_url
+        assert "container:secret@" not in check.message
         assert "token=leak" not in check.message
         assert "frag" not in check.message
 


### PR DESCRIPTION
Redacts credentials and signed query strings from manifest URL findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * URLs containing credentials are now automatically redacted in manifest scanner output. Cloud storage and suspicious URL reports will mask userinfo patterns to prevent exposure of sensitive authentication data.

* **Tests**
  * Added tests verifying credential redaction behavior across cloud storage and suspicious URL detection checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->