### PR TITLE
fix(jfrog): redact url secrets

### DIFF
--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -61,7 +61,7 @@ from .utils.sources.huggingface import (
     is_huggingface_file_url,
     is_huggingface_url,
 )
-from .utils.sources.jfrog import is_jfrog_url
+from .utils.sources.jfrog import is_jfrog_url, redact_jfrog_error_for_display, redact_jfrog_url_for_display
 from .utils.sources.pytorch_hub import download_pytorch_hub_model, is_pytorch_hub_url
 
 logger = logging.getLogger("modelaudit")
@@ -237,6 +237,10 @@ def expand_paths(paths: tuple[str, ...]) -> tuple[list[str], list[str]]:
     expanded: list[str] = []
     missing_globs: list[str] = []
     for path_str in paths:
+        if "://" in path_str:
+            expanded.append(path_str)
+            continue
+
         # Handle glob patterns and resolve paths
         path = Path(path_str)
         if "*" in path_str or "?" in path_str:
@@ -306,6 +310,13 @@ def create_progress_callback_wrapper(progress_callback: Any | None, spinner: Any
 def is_mlflow_uri(path: str) -> bool:
     """Check if a path is an MLflow model URI."""
     return path.startswith("models:/")
+
+
+def _redact_scan_path_for_display(path: str) -> str:
+    """Redact credentials from remote paths before printing them."""
+    if is_jfrog_url(path):
+        return redact_jfrog_url_for_display(path)
+    return path
 
 
 def _resolve_scan_paths(paths: tuple[str, ...], scan_start_time: float) -> list[str]:
@@ -532,7 +543,8 @@ def _show_scan_runtime_defaults(
             "─" * 80,
         ]
         click.echo("\n".join(header))
-        click.echo(f"Paths to scan: {style_text(', '.join(expanded_paths), fg='green')}")
+        display_paths = [_redact_scan_path_for_display(path) for path in expanded_paths]
+        click.echo(f"Paths to scan: {style_text(', '.join(display_paths), fg='green')}")
         if blacklist:
             click.echo(
                 f"Additional blacklist patterns: {style_text(', '.join(blacklist), fg='yellow')}",
@@ -1454,15 +1466,16 @@ def _resolve_scan_source_for_path(
             return None
 
     if is_jfrog_url(path):
+        display_path = redact_jfrog_url_for_display(path)
         download_spinner = None
         if runtime.show_styled_output and should_show_spinner():
             download_spinner = yaspin(
                 Spinners.dots,
-                text=f"Downloading and scanning from {style_text(path, fg='cyan')}",
+                text=f"Downloading and scanning from {style_text(display_path, fg='cyan')}",
             )
             download_spinner.start()
         elif runtime.show_styled_output:
-            click.echo(f"Downloading and scanning from {path}...")
+            click.echo(f"Downloading and scanning from {display_path}...")
 
         try:
             record_download_started("jfrog", path)
@@ -1499,8 +1512,9 @@ def _resolve_scan_source_for_path(
             elif runtime.show_styled_output:
                 click.echo("Download/scan failed")
 
-            logger.error(f"Failed to download/scan model from {path}: {exc!s}", exc_info=verbose)
-            click.echo(f"Error downloading/scanning model from {path}: {exc!s}", err=True)
+            error_msg = redact_jfrog_error_for_display(exc, path)
+            logger.error(f"Failed to download/scan model from {display_path}: {error_msg}", exc_info=verbose)
+            click.echo(f"Error downloading/scanning model from {display_path}: {error_msg}", err=True)
             audit_result.has_errors = True
             return None
 

--- a/modelaudit/integrations/jfrog.py
+++ b/modelaudit/integrations/jfrog.py
@@ -11,7 +11,12 @@ from pathlib import Path
 from typing import Any
 
 from ..models import ModelAuditResultModel
-from ..utils.sources.jfrog import detect_jfrog_target_type, download_artifact, download_jfrog_folder
+from ..utils.sources.jfrog import (
+    detect_jfrog_target_type,
+    download_artifact,
+    download_jfrog_folder,
+    redact_jfrog_url_for_display,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -93,10 +98,11 @@ def scan_jfrog_artifact(
     scan_cache_dir = str(Path(raw_cache_dir).expanduser()) if cache_enabled and raw_cache_dir else None
     download_dir, cleanup_download_dir = _prepare_download_dir(url, scan_cache_dir)
     start_time = time.time()
+    display_url = redact_jfrog_url_for_display(url)
 
     try:
         # Detect if URL points to a file or folder
-        logger.debug(f"Analyzing JFrog target {url}")
+        logger.debug(f"Analyzing JFrog target {display_url}")
         target_info = detect_jfrog_target_type(
             url,
             api_token=api_token,
@@ -105,7 +111,7 @@ def scan_jfrog_artifact(
         )
 
         if target_info["type"] == "file":
-            logger.debug(f"Downloading JFrog file {url} to {download_dir}")
+            logger.debug(f"Downloading JFrog file {display_url} to {download_dir}")
             download_path = download_artifact(
                 url,
                 cache_dir=download_dir,
@@ -114,7 +120,7 @@ def scan_jfrog_artifact(
                 timeout=timeout,
             )
         else:
-            logger.debug(f"Downloading JFrog folder {url} to {download_dir}")
+            logger.debug(f"Downloading JFrog folder {display_url} to {download_dir}")
             download_path = download_jfrog_folder(
                 url,
                 cache_dir=download_dir,
@@ -153,7 +159,7 @@ def scan_jfrog_artifact(
 
         # Add JFrog source information
         result.metadata["jfrog_source"] = {  # type: ignore[attr-defined]
-            "url": url,
+            "url": display_url,
             "type": target_info["type"],
             "repo": target_info.get("repo", ""),
         }

--- a/modelaudit/utils/sources/jfrog.py
+++ b/modelaudit/utils/sources/jfrog.py
@@ -3,11 +3,12 @@
 import ipaddress
 import logging
 import os
+import re
 import shutil
 import tempfile
 from pathlib import Path, PurePosixPath
 from typing import Any, Literal, TypedDict
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 import click
 import requests
@@ -18,6 +19,44 @@ logger = logging.getLogger(__name__)
 
 # Constants
 MAX_RECURSION_DEPTH = 64  # Prevent runaway recursion in folder traversal
+_SENSITIVE_QUERY_PARAM_RE = re.compile(
+    r"([?&][^=\s&]*(?:signature|credential|security-token|access-key|access_key|token|secret|api-key|api_key|apikey|sig)[^=\s&]*=)[^\s&#]+",
+    re.IGNORECASE,
+)
+_URL_USERINFO_RE = re.compile(r"([a-z][a-z0-9+.-]*://)([^/@\s]+)@", re.IGNORECASE)
+
+
+def redact_jfrog_url_for_display(url: str) -> str:
+    """Remove credentials, query strings, and fragments from a JFrog URL for display."""
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return "<jfrog URL redacted>"
+
+    if not parsed.scheme:
+        return url
+
+    netloc = parsed.netloc
+    if "@" in parsed.netloc:
+        netloc = parsed.hostname or ""
+        try:
+            port = parsed.port
+        except ValueError:
+            port = None
+        if port is not None:
+            netloc = f"{netloc}:{port}"
+        netloc = f"<credentials-redacted>@{netloc}"
+
+    return urlunparse((parsed.scheme, netloc, parsed.path, "", "", ""))
+
+
+def redact_jfrog_error_for_display(message: object, source_url: str | None = None) -> str:
+    """Remove JFrog URL credentials from exception text."""
+    redacted = str(message)
+    if source_url:
+        redacted = redacted.replace(source_url, redact_jfrog_url_for_display(source_url))
+    redacted = _URL_USERINFO_RE.sub(r"\1<credentials-redacted>@", redacted)
+    return _SENSITIVE_QUERY_PARAM_RE.sub(r"\1<redacted>", redacted)
 
 
 def _safe_download_path(download_dir: Path, relative_path: str) -> Path:
@@ -167,8 +206,9 @@ def download_artifact(
         requests.HTTPError: If authentication fails or download fails
         Exception: For other download errors
     """
+    display_url = redact_jfrog_url_for_display(url)
     if not is_jfrog_url(url):
-        raise ValueError(f"Not a JFrog URL: {url}")
+        raise ValueError(f"Not a JFrog URL: {display_url}")
 
     filename = os.path.basename(urlparse(url).path)
     temp_dir: Path | None = None
@@ -234,24 +274,27 @@ def download_artifact(
     except requests.exceptions.HTTPError as e:  # type: ignore[attr-defined]
         if temp_dir is not None and temp_dir.exists():
             shutil.rmtree(temp_dir)
+        error_msg = redact_jfrog_error_for_display(e, url)
         if e.response.status_code == 401:
             raise Exception(
-                f"Authentication failed for JFrog URL {url}. Please provide a valid API token or access token."
+                f"Authentication failed for JFrog URL {display_url}. Please provide a valid API token or access token."
             ) from e
         if e.response.status_code == 403:
-            raise Exception(f"Access denied for JFrog URL {url}. Please check your permissions.") from e
+            raise Exception(f"Access denied for JFrog URL {display_url}. Please check your permissions.") from e
         if e.response.status_code == 404:
-            raise Exception(f"Artifact not found at {url}") from e
+            raise Exception(f"Artifact not found at {display_url}") from e
 
-        raise Exception(f"HTTP error {e.response.status_code} downloading from {url}: {e}") from e
+        raise Exception(f"HTTP error {e.response.status_code} downloading from {display_url}: {error_msg}") from e
     except requests.exceptions.RequestException as e:  # type: ignore[attr-defined]
         if temp_dir is not None and temp_dir.exists():
             shutil.rmtree(temp_dir)
-        raise Exception(f"Network error downloading from {url}: {e}") from e
+        error_msg = redact_jfrog_error_for_display(e, url)
+        raise Exception(f"Network error downloading from {display_url}: {error_msg}") from e
     except Exception as e:
         if temp_dir is not None and temp_dir.exists():
             shutil.rmtree(temp_dir)
-        raise Exception(f"Failed to download artifact from {url}: {e!s}") from e
+        error_msg = redact_jfrog_error_for_display(e, url)
+        raise Exception(f"Failed to download artifact from {display_url}: {error_msg}") from e
 
 
 def get_jfrog_base_url(url: str) -> str:
@@ -266,7 +309,7 @@ def get_jfrog_base_url(url: str) -> str:
         base_path = "/".join(path_parts[: artifactory_index + 1])
         return f"{parsed.scheme}://{parsed.netloc}{base_path}"
     except ValueError as e:
-        raise ValueError(f"Invalid JFrog Artifactory URL format: {url}") from e
+        raise ValueError(f"Invalid JFrog Artifactory URL format: {redact_jfrog_url_for_display(url)}") from e
 
 
 def get_storage_api_url(url: str) -> str:
@@ -281,7 +324,7 @@ def get_storage_api_url(url: str) -> str:
         api_path = "/".join(api_parts)
         return f"{parsed.scheme}://{parsed.netloc}{api_path}"
     except (ValueError, IndexError) as e:
-        raise ValueError(f"Invalid JFrog Artifactory URL format: {url}") from e
+        raise ValueError(f"Invalid JFrog Artifactory URL format: {redact_jfrog_url_for_display(url)}") from e
 
 
 def format_size(size_bytes: int) -> str:
@@ -336,10 +379,12 @@ def detect_jfrog_target_type(
         ValueError: If URL is not a valid JFrog URL
         Exception: If API request fails
     """
+    display_url = redact_jfrog_url_for_display(url)
     if not is_jfrog_url(url):
-        raise ValueError(f"Not a JFrog URL: {url}")
+        raise ValueError(f"Not a JFrog URL: {display_url}")
 
     storage_api_url = get_storage_api_url(url)
+    display_storage_api_url = redact_jfrog_url_for_display(storage_api_url)
 
     # Prepare authentication headers
     headers = {}
@@ -381,14 +426,20 @@ def detect_jfrog_target_type(
             )
 
     except requests.exceptions.HTTPError as e:
+        error_msg = redact_jfrog_error_for_display(e, url)
         if e.response.status_code == 404:
-            raise Exception(f"JFrog artifact not found at {url}") from e
+            raise Exception(f"JFrog artifact not found at {display_url}") from e
         elif e.response.status_code in {401, 403}:
-            raise Exception(f"Authentication failed for JFrog URL {url}. Please provide valid credentials.") from e
+            raise Exception(
+                f"Authentication failed for JFrog URL {display_url}. Please provide valid credentials."
+            ) from e
         else:
-            raise Exception(f"HTTP error {e.response.status_code} accessing {storage_api_url}: {e}") from e
+            raise Exception(
+                f"HTTP error {e.response.status_code} accessing {display_storage_api_url}: {error_msg}"
+            ) from e
     except requests.exceptions.RequestException as e:
-        raise Exception(f"Network error accessing {storage_api_url}: {e}") from e
+        error_msg = redact_jfrog_error_for_display(e, url)
+        raise Exception(f"Network error accessing {display_storage_api_url}: {error_msg}") from e
 
 
 def list_jfrog_folder_contents(
@@ -421,7 +472,7 @@ def list_jfrog_folder_contents(
     target_info = detect_jfrog_target_type(url, api_token, access_token, timeout)
 
     if target_info["type"] != "folder":
-        raise ValueError(f"URL is not a JFrog folder: {url}")
+        raise ValueError(f"URL is not a JFrog folder: {redact_jfrog_url_for_display(url)}")
 
     files = []
     base_url = url.rstrip("/")
@@ -433,16 +484,18 @@ def list_jfrog_folder_contents(
         on a partial file listing.
         """
         if depth > MAX_RECURSION_DEPTH:
+            display_folder_url = redact_jfrog_url_for_display(folder_url)
             raise Exception(
-                f"Maximum recursion depth ({MAX_RECURSION_DEPTH}) exceeded listing {folder_url}. "
+                f"Maximum recursion depth ({MAX_RECURSION_DEPTH}) exceeded listing {display_folder_url}. "
                 "Aborting to avoid incomplete file listing."
             )
 
         folder_info = detect_jfrog_target_type(folder_url, api_token, access_token, timeout)
 
         if folder_info["type"] != "folder":
+            display_folder_url = redact_jfrog_url_for_display(folder_url)
             raise Exception(
-                f"Expected JFrog folder while listing {folder_url}, got {folder_info['type']}. "
+                f"Expected JFrog folder while listing {display_folder_url}, got {folder_info['type']}. "
                 "Aborting to avoid incomplete file listing."
             )
 
@@ -465,7 +518,10 @@ def list_jfrog_folder_contents(
                         if file_info["type"] == "file":
                             size = file_info.get("size", 0)
                     except Exception as e:
-                        logger.warning(f"Failed to fetch size for {child_url}: {e}")
+                        logger.warning(
+                            "Failed to fetch size for "
+                            f"{redact_jfrog_url_for_display(child_url)}: {redact_jfrog_error_for_display(e)}"
+                        )
 
                 files.append(
                     {
@@ -513,8 +569,9 @@ def download_jfrog_folder(
         ValueError: If URL is not a valid JFrog folder
         Exception: If downloads fail
     """
+    display_url = redact_jfrog_url_for_display(url)
     if not is_jfrog_url(url):
-        raise ValueError(f"Not a JFrog URL: {url}")
+        raise ValueError(f"Not a JFrog URL: {display_url}")
 
     # List all files in the folder
     files = list_jfrog_folder_contents(
@@ -599,7 +656,8 @@ def download_jfrog_folder(
             downloaded_files.append(downloaded_file)
 
         except Exception as e:
-            error_msg = f"Failed to download {file_info['name']}: {e}"
+            redacted_error = redact_jfrog_error_for_display(e)
+            error_msg = f"Failed to download {file_info['name']}: {redacted_error}"
             logger.warning(error_msg)
             if show_progress:
                 click.echo("❌ Aborting JFrog folder download to avoid scanning a partial dataset")
@@ -612,7 +670,7 @@ def download_jfrog_folder(
             )
             raise Exception(
                 "JFrog folder download failed after "
-                f"{completed_downloads} of {len(files)} file(s) completed. {file_info['name']}: {e}"
+                f"{completed_downloads} of {len(files)} file(s) completed. {file_info['name']}: {redacted_error}"
             ) from e
 
     return download_dir

--- a/tests/integrations/test_jfrog.py
+++ b/tests/integrations/test_jfrog.py
@@ -17,6 +17,7 @@ from modelaudit.utils.sources.jfrog import (
     get_storage_api_url,
     is_jfrog_url,
     list_jfrog_folder_contents,
+    redact_jfrog_url_for_display,
 )
 
 
@@ -49,6 +50,16 @@ class TestJFrogURLDetection:
 
 
 class TestJFrogDownload:
+    def test_redact_jfrog_url_for_display(self) -> None:
+        raw_url = "https://user:leaky-pass@company.jfrog.io/artifactory/repo/model.bin?token=leaky-token#fragment"
+
+        redacted = redact_jfrog_url_for_display(raw_url)
+
+        assert redacted == "https://<credentials-redacted>@company.jfrog.io/artifactory/repo/model.bin"
+        assert "leaky-pass" not in redacted
+        assert "leaky-token" not in redacted
+        assert "fragment" not in redacted
+
     @patch("modelaudit.utils.sources.jfrog.requests.get")
     def test_download_success(self, mock_get, tmp_path):
         # Mock successful response
@@ -138,6 +149,25 @@ class TestJFrogDownload:
         # Verify request was made without auth headers
         call_args = mock_get.call_args
         assert not call_args[1]["headers"]  # Empty headers dict
+
+    @patch("modelaudit.utils.sources.jfrog.requests.get")
+    def test_download_error_redacts_sensitive_url(self, mock_get, tmp_path):
+        """Download errors should not expose URL credentials or query tokens."""
+        mock_response = mock_get.return_value
+        mock_error_response = MagicMock(spec=requests.Response)
+        mock_error_response.status_code = 401
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(response=mock_error_response)
+        raw_url = "https://user:leaky-pass@company.jfrog.io/artifactory/repo/model.bin?token=leaky-token"
+
+        with pytest.raises(Exception) as excinfo:
+            download_artifact(raw_url, cache_dir=tmp_path)
+
+        message = str(excinfo.value)
+        assert "https://<credentials-redacted>@company.jfrog.io/artifactory/repo/model.bin" in message
+        assert "user:leaky-pass" not in message
+        assert "leaky-token" not in message
+        assert "?token=" not in message
+        assert mock_get.call_args[0][0] == raw_url
 
     @patch("modelaudit.utils.sources.jfrog.requests.get")
     def test_import_does_not_load_dotenv_from_cwd(self, mock_get, tmp_path):

--- a/tests/integrations/test_jfrog_integration.py
+++ b/tests/integrations/test_jfrog_integration.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -76,7 +77,54 @@ def test_scan_jfrog_artifact_success(mock_scan, mock_download, mock_detect, mock
     metadata = results.metadata
     assert "jfrog_source" in metadata
     assert metadata["jfrog_source"]["type"] == "file"
+    assert metadata["jfrog_source"]["url"] == "https://company.jfrog.io/artifactory/repo/model.pt"
     assert metadata["jfrog_source"]["repo"] == "test-repo"
+
+
+@patch("modelaudit.integrations.jfrog.shutil.rmtree")
+@patch("modelaudit.integrations.jfrog.tempfile.mkdtemp")
+@patch("modelaudit.integrations.jfrog.detect_jfrog_target_type")
+@patch("modelaudit.integrations.jfrog.download_artifact")
+@patch("modelaudit.core.scan_model_directory_or_file")
+def test_scan_jfrog_artifact_redacts_source_url(
+    mock_scan: MagicMock,
+    mock_download: MagicMock,
+    mock_detect: MagicMock,
+    mock_mkdtemp: MagicMock,
+    mock_rmtree: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """JFrog scan logs and metadata should not store URL credentials."""
+    temp_dir = "/tmp/modelaudit_jfrog_test"
+    mock_mkdtemp.return_value = temp_dir
+    mock_detect.return_value = {"type": "file", "repo": "test-repo"}
+    mock_download.return_value = Path(f"{temp_dir}/model.pt")
+
+    from modelaudit.models import create_initial_audit_result
+
+    mock_result = create_initial_audit_result()
+    mock_scan.return_value = mock_result
+    raw_url = "https://user:leaky-pass@company.jfrog.io/artifactory/repo/model.pt?token=leaky-token"
+
+    with caplog.at_level(logging.DEBUG, logger="modelaudit.integrations.jfrog"):
+        results = scan_jfrog_artifact(raw_url, api_token="token")
+
+    assert results.metadata["jfrog_source"]["url"] == (
+        "https://<credentials-redacted>@company.jfrog.io/artifactory/repo/model.pt"
+    )
+    assert "user:leaky-pass" not in caplog.text
+    assert "leaky-token" not in caplog.text
+    assert "user:leaky-pass" not in results.metadata["jfrog_source"]["url"]
+    assert "leaky-token" not in results.metadata["jfrog_source"]["url"]
+    mock_detect.assert_called_once_with(raw_url, api_token="token", access_token=None, timeout=30)
+    mock_download.assert_called_once_with(
+        raw_url,
+        cache_dir=Path(temp_dir),
+        api_token="token",
+        access_token=None,
+        timeout=3600,
+    )
+    mock_rmtree.assert_called_once_with(Path(temp_dir), ignore_errors=True)
 
 
 @patch("modelaudit.integrations.jfrog.shutil.rmtree")

--- a/tests/integrations/test_jfrog_integration.py
+++ b/tests/integrations/test_jfrog_integration.py
@@ -109,13 +109,13 @@ def test_scan_jfrog_artifact_redacts_source_url(
     with caplog.at_level(logging.DEBUG, logger="modelaudit.integrations.jfrog"):
         results = scan_jfrog_artifact(raw_url, api_token="token")
 
-    assert results.metadata["jfrog_source"]["url"] == (
-        "https://<credentials-redacted>@company.jfrog.io/artifactory/repo/model.pt"
-    )
+    assert results.model_extra is not None
+    jfrog_source = results.model_extra["metadata"]["jfrog_source"]
+    assert jfrog_source["url"] == "https://<credentials-redacted>@company.jfrog.io/artifactory/repo/model.pt"
     assert "user:leaky-pass" not in caplog.text
     assert "leaky-token" not in caplog.text
-    assert "user:leaky-pass" not in results.metadata["jfrog_source"]["url"]
-    assert "leaky-token" not in results.metadata["jfrog_source"]["url"]
+    assert "user:leaky-pass" not in jfrog_source["url"]
+    assert "leaky-token" not in jfrog_source["url"]
     mock_detect.assert_called_once_with(raw_url, api_token="token", access_token=None, timeout=30)
     mock_download.assert_called_once_with(
         raw_url,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1730,6 +1730,24 @@ def test_scan_jfrog_url_download_failure(mock_scan_jfrog, mock_is_jfrog):
 
 @patch("modelaudit.cli.is_jfrog_url")
 @patch("modelaudit.cli.scan_jfrog_artifact")
+def test_scan_jfrog_url_download_failure_redacts_sensitive_url(mock_scan_jfrog, mock_is_jfrog):
+    """JFrog CLI errors should not print URL credentials or query tokens."""
+    raw_url = "https://user:leaky-pass@company.jfrog.io/artifactory/repo/model.bin?token=leaky-token"
+    mock_is_jfrog.return_value = True
+    mock_scan_jfrog.side_effect = Exception(f"failed to fetch {raw_url}")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["scan", raw_url])
+
+    assert result.exit_code == 2
+    assert "https://<credentials-redacted>@company.jfrog.io/artifactory/repo/model.bin" in result.output
+    assert "user:leaky-pass" not in result.output
+    assert "leaky-token" not in result.output
+    assert "?token=" not in result.output
+
+
+@patch("modelaudit.cli.is_jfrog_url")
+@patch("modelaudit.cli.scan_jfrog_artifact")
 def test_scan_jfrog_url_with_auth(
     mock_scan_jfrog: MagicMock,
     mock_is_jfrog: MagicMock,
@@ -2352,6 +2370,13 @@ class TestExpandPaths:
         pattern = str(tmp_path / "?.pt")
         expanded, missing = expand_paths((pattern,))
         assert len(expanded) == 1
+        assert missing == []
+
+    def test_expand_paths_url_query_is_not_glob(self):
+        """Remote URLs with query strings should stay literal."""
+        url = "https://company.jfrog.io/artifactory/repo/model.bin?token=secret"
+        expanded, missing = expand_paths((url,))
+        assert expanded == [url]
         assert missing == []
 
     def test_expand_paths_empty_input(self):


### PR DESCRIPTION
Redacts JFrog URLs in logs, CLI output, and scan metadata.