### PR TITLE
fix(torchserve): redact manifest urls

### DIFF
--- a/modelaudit/scanners/torchserve_mar_scanner.py
+++ b/modelaudit/scanners/torchserve_mar_scanner.py
@@ -15,7 +15,7 @@ import tempfile
 import zipfile
 from pathlib import PurePosixPath
 from typing import Any, ClassVar
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 from ..utils import is_absolute_archive_path, is_critical_system_path, sanitize_archive_path
 from ..utils.helpers.assets import asset_from_scan_result
@@ -69,6 +69,28 @@ HIGH_RISK_CALLS = {
 SAFE_IMPORT_TIME_CALLS = {
     "logging.getLogger",
 }
+
+
+def redact_manifest_url_reference(value: str) -> str:
+    """Return a display-safe URL reference for scan output."""
+    parsed = urlparse(value)
+    if not parsed.scheme:
+        return "[redacted-url]"
+
+    host = parsed.hostname
+    if not host:
+        return f"{parsed.scheme}://[redacted-url]"
+
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+
+    netloc = f"{host}:{port}" if port else host
+    return urlunparse((parsed.scheme, netloc, parsed.path, "", "", ""))
 
 
 class TorchServeMarScanner(BaseScanner):
@@ -643,7 +665,7 @@ class TorchServeMarScanner(BaseScanner):
                 continue
 
             if URL_SCHEME_PATTERN.match(value):
-                url_like_paths.append({"field": field, "value": value})
+                url_like_paths.append({"field": field, "value": redact_manifest_url_reference(value)})
                 continue
 
             if is_absolute_archive_path(value):

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -1208,6 +1208,35 @@ def test_scan_handles_corrupt_mar_gracefully(tmp_path: Path) -> None:
     assert result.success is False
 
 
+def test_scan_redacts_url_like_manifest_references(tmp_path: Path) -> None:
+    manifest = {
+        "model": {
+            "handler": "https://user:pass@example.com/handler.py?X-Amz-Signature=secret-signature#frag",
+            "serializedFile": "s3://access:secret@bucket.s3.amazonaws.com/model.pt?token=secret-token",
+        },
+    }
+    mar_path = _create_mar_archive(
+        tmp_path,
+        manifest=manifest,
+        entries={},
+        filename="url_references.mar",
+    )
+
+    result = TorchServeMarScanner().scan(str(mar_path))
+
+    url_failures = _failed_checks(result, "TorchServe Manifest URL Reference Check")
+    assert len(url_failures) == 1
+    references = url_failures[0].details["references"]
+    serialized_references = json.dumps(references)
+    assert "https://example.com/handler.py" in serialized_references
+    assert "s3://bucket.s3.amazonaws.com/model.pt" in serialized_references
+    assert "user:pass" not in serialized_references
+    assert "access:secret" not in serialized_references
+    assert "secret-signature" not in serialized_references
+    assert "secret-token" not in serialized_references
+    assert "X-Amz-Signature" not in serialized_references
+
+
 def test_scan_detects_nested_zip_payloads(tmp_path: Path) -> None:
     nested_zip = tmp_path / "nested.zip"
     with zipfile.ZipFile(nested_zip, "w") as nested:


### PR DESCRIPTION
Redacts credentialed and signed manifest URLs from MAR scan output.