### PR TITLE
fix(detectors): redact network urls in findings

### DIFF
--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -19,7 +19,9 @@ def _redact_url_for_finding(url: str) -> str:
     if not parsed.scheme or not parsed.netloc:
         return "[invalid-url]"
 
-    hostname = parsed.hostname or ""
+    hostname = parsed.hostname
+    if not hostname:
+        return "[invalid-url]"
     if ":" in hostname and not hostname.startswith("["):
         hostname = f"[{hostname}]"
 
@@ -28,7 +30,7 @@ def _redact_url_for_finding(url: str) -> str:
     except ValueError:
         port = None
 
-    netloc = f"{hostname}:{port}" if port else hostname
+    netloc = f"{hostname}:{port}" if port is not None else hostname
     return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
 
 

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -7,6 +7,29 @@ that could be used for data exfiltration or command & control operations.
 import ipaddress
 import re
 from typing import Any, ClassVar
+from urllib.parse import urlsplit, urlunsplit
+
+
+def _redact_url_for_finding(url: str) -> str:
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return "[invalid-url]"
+
+    if not parsed.scheme or not parsed.netloc:
+        return "[invalid-url]"
+
+    hostname = parsed.hostname or ""
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+
+    netloc = f"{hostname}:{port}" if port else hostname
+    return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
 
 
 class NetworkCommDetector:
@@ -283,6 +306,7 @@ class NetworkCommDetector:
         """Scan for URL patterns."""
         for match in self.URL_PATTERN.finditer(data):
             url = match.group().decode("utf-8", errors="ignore")
+            safe_url = _redact_url_for_finding(url)
 
             # Calculate confidence based on URL characteristics
             confidence = 0.5
@@ -298,8 +322,8 @@ class NetworkCommDetector:
                     "type": "url_detected",
                     "severity": "HIGH" if confidence > 0.7 else "MEDIUM",
                     "confidence": confidence,
-                    "message": f"URL detected in model: {url[:100]}",
-                    "url": url,
+                    "message": f"URL detected in model: {safe_url[:100]}",
+                    "url": safe_url,
                     "position": match.start(),
                     "context": context,
                 }
@@ -318,6 +342,7 @@ class NetworkCommDetector:
         for pattern, description, provider in self.CLOUD_STORAGE_PATTERNS:
             for match in pattern.finditer(data):
                 url = match.group().decode("utf-8", errors="ignore")
+                safe_url = _redact_url_for_finding(url)
 
                 # Skip duplicates
                 if url in seen_urls:
@@ -342,8 +367,8 @@ class NetworkCommDetector:
                         "type": "cloud_storage_url",
                         "severity": severity,
                         "confidence": confidence,
-                        "message": f"{description} detected: {url[:150]}",
-                        "url": url,
+                        "message": f"{description} detected: {safe_url[:150]}",
+                        "url": safe_url,
                         "provider": provider,
                         "description": description,
                         "position": match.start(),

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -29,7 +29,7 @@ class TestNetworkCommDetector:
         assert any("example.com" in url for url in urls)
         assert any("malware.net" in url for url in urls)
 
-    def test_detect_urls_redacts_credentials_and_query(self):
+    def test_detect_urls_redacts_credentials_and_query(self) -> None:
         """URL findings should not preserve credentialed or signed URL secrets."""
         detector = NetworkCommDetector()
         data = (
@@ -48,7 +48,22 @@ class TestNetworkCommDetector:
         assert "SECRET_TOKEN" not in serialized
         assert "SECRET_FRAGMENT" not in serialized
 
-    def test_cloud_storage_urls_redact_signed_query(self):
+    def test_detect_urls_preserves_port_zero_and_rejects_hostless_netloc(self) -> None:
+        """URL redaction should preserve explicit port 0 and avoid hostless netloc output."""
+        detector = NetworkCommDetector()
+        data = b"https://example.com:0/model.bin?token=SECRET https://@/missing-host"
+
+        findings = detector.scan(data, "model.bin")
+        url_findings = [finding for finding in findings if finding["type"] == "url_detected"]
+        urls = [finding["url"] for finding in url_findings]
+
+        assert "https://example.com:0/model.bin" in urls
+        assert "[invalid-url]" in urls
+        serialized = " ".join(f"{finding['url']} {finding['message']}" for finding in url_findings)
+        assert "token=SECRET" not in serialized
+        assert "https:///missing-host" not in serialized
+
+    def test_cloud_storage_urls_redact_signed_query(self) -> None:
         """Cloud storage findings should redact signed URL query material."""
         detector = NetworkCommDetector()
         data = b"s3://model-bucket/path/model.bin?X-Amz-Credential=SECRET_CREDENTIAL&X-Amz-Signature=SECRET_SIGNATURE"

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -29,6 +29,40 @@ class TestNetworkCommDetector:
         assert any("example.com" in url for url in urls)
         assert any("malware.net" in url for url in urls)
 
+    def test_detect_urls_redacts_credentials_and_query(self):
+        """URL findings should not preserve credentialed or signed URL secrets."""
+        detector = NetworkCommDetector()
+        data = (
+            b"https://user:pass@example.com/model.bin?"
+            b"X-Amz-Signature=SECRET_SIGNATURE&token=SECRET_TOKEN#SECRET_FRAGMENT"
+        )
+
+        findings = detector.scan(data, "model.bin")
+        url_finding = next(f for f in findings if f["type"] == "url_detected")
+
+        assert url_finding["url"] == "https://example.com/model.bin"
+        assert "example.com/model.bin" in url_finding["message"]
+        serialized = f"{url_finding['url']} {url_finding['message']}"
+        assert "user:pass" not in serialized
+        assert "SECRET_SIGNATURE" not in serialized
+        assert "SECRET_TOKEN" not in serialized
+        assert "SECRET_FRAGMENT" not in serialized
+
+    def test_cloud_storage_urls_redact_signed_query(self):
+        """Cloud storage findings should redact signed URL query material."""
+        detector = NetworkCommDetector()
+        data = b"s3://model-bucket/path/model.bin?X-Amz-Credential=SECRET_CREDENTIAL&X-Amz-Signature=SECRET_SIGNATURE"
+
+        findings = detector.scan(data, "model.bin")
+        cloud_finding = next(f for f in findings if f["type"] == "cloud_storage_url")
+
+        assert cloud_finding["url"] == "s3://model-bucket/path/model.bin"
+        assert "model-bucket/path/model.bin" in cloud_finding["message"]
+        serialized = f"{cloud_finding['url']} {cloud_finding['message']}"
+        assert "SECRET_CREDENTIAL" not in serialized
+        assert "SECRET_SIGNATURE" not in serialized
+        assert cloud_finding["provider"] == "s3"
+
     def test_detect_ipv4_addresses(self):
         """Test detection of IPv4 addresses."""
         detector = NetworkCommDetector()


### PR DESCRIPTION
Redacts credentialed and signed URLs from network detector findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * URLs in findings are now automatically redacted to remove sensitive information including credentials, API signatures, and query parameters, ensuring confidential data is not exposed in reports.

* **Improvements**
  * Enhanced cloud storage URL detection with improved credential and signature masking in reported findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->