### PR TITLE
fix(openvino): flag sidecar symlink escapes

### DIFF
--- a/modelaudit/scanners/openvino_scanner.py
+++ b/modelaudit/scanners/openvino_scanner.py
@@ -6,6 +6,7 @@ import os
 import re
 from collections.abc import Iterator
 from io import BytesIO
+from pathlib import Path
 from typing import Any, ClassVar
 
 from modelaudit.detectors.suspicious_symbols import SUSPICIOUS_STRING_PATTERNS
@@ -39,6 +40,15 @@ _OPENVINO_NATIVE_LIBRARY_SUFFIX = re.compile(r"(?:\.so(?:\.\d+)*|\.dll|\.dylib|\
 def _local_tag_name(tag: str) -> str:
     """Return an XML tag's namespace-stripped local name."""
     return tag.rsplit("}", 1)[-1].lower()
+
+
+def _is_contained_in(child: Path, parent: Path) -> bool:
+    """Return True when child resolves under parent directory."""
+    try:
+        child.relative_to(parent)
+        return True
+    except ValueError:
+        return False
 
 
 def _skip_doctype_declaration(xml_prefix: bytes, start_offset: int) -> int | None:
@@ -186,17 +196,41 @@ class OpenVinoScanner(BaseScanner):
 
         result.metadata["xml_size"] = self.get_file_size(path)
 
-        bin_path = os.path.splitext(path)[0] + ".bin"
-        if os.path.isfile(bin_path):
-            result.metadata["bin_size"] = self.get_file_size(bin_path)
+        model_dir = Path(path).resolve().parent
+        bin_path = Path(os.path.splitext(path)[0] + ".bin")
+        if bin_path.is_symlink():
+            resolved_bin_path = bin_path.resolve(strict=False)
+            if not _is_contained_in(resolved_bin_path, model_dir):
+                result.add_check(
+                    name="OpenVINO Weights Symlink Boundary Check",
+                    passed=False,
+                    message="Associated .bin weights file resolves outside the model directory",
+                    severity=IssueSeverity.CRITICAL,
+                    location=str(bin_path),
+                    details={
+                        "expected_file": str(bin_path),
+                        "resolved_path": str(resolved_bin_path),
+                        "model_directory": str(model_dir),
+                        "cwe": "CWE-22",
+                    },
+                    rule_code="S701",
+                    why=(
+                        "OpenVINO sidecar weights are loaded from the .bin file adjacent to the XML. "
+                        "A symlinked sidecar can make model loading read data outside the model directory."
+                    ),
+                )
+            elif bin_path.is_file():
+                result.metadata["bin_size"] = self.get_file_size(str(bin_path))
+        elif bin_path.is_file():
+            result.metadata["bin_size"] = self.get_file_size(str(bin_path))
         else:
             result.add_check(
                 name="OpenVINO Weights File Check",
                 passed=False,
                 message="Associated .bin weights file not found",
                 severity=IssueSeverity.INFO,
-                location=bin_path,
-                details={"expected_file": bin_path},
+                location=str(bin_path),
+                details={"expected_file": str(bin_path)},
                 rule_code="S701",
             )
 

--- a/tests/scanners/test_openvino_scanner.py
+++ b/tests/scanners/test_openvino_scanner.py
@@ -142,6 +142,45 @@ def test_openvino_scanner_missing_bin(tmp_path: Path) -> None:
     assert any(i.severity == IssueSeverity.INFO for i in result.issues)
 
 
+def test_openvino_scanner_flags_bin_symlink_escape(tmp_path: Path, requires_symlinks: None) -> None:
+    model_dir = tmp_path / "model"
+    outside_dir = tmp_path / "outside"
+    model_dir.mkdir()
+    outside_dir.mkdir()
+
+    xml_path = model_dir / "model.xml"
+    escaped_weights = outside_dir / "secret.bin"
+    xml_path.write_text("<net version='10'></net>", encoding="utf-8")
+    escaped_weights.write_bytes(b"secret-weights")
+    (model_dir / "model.bin").symlink_to(escaped_weights)
+
+    result = OpenVinoScanner().scan(str(xml_path))
+
+    symlink_checks = [check for check in result.checks if check.name == "OpenVINO Weights Symlink Boundary Check"]
+    assert result.success is False
+    assert symlink_checks
+    assert symlink_checks[0].severity == IssueSeverity.CRITICAL
+    assert symlink_checks[0].details["resolved_path"] == str(escaped_weights.resolve())
+    assert symlink_checks[0].details["model_directory"] == str(model_dir.resolve())
+    assert "bin_size" not in result.metadata
+
+
+def test_openvino_scanner_allows_bin_symlink_inside_model_dir(tmp_path: Path, requires_symlinks: None) -> None:
+    xml_path = tmp_path / "model.xml"
+    weights_dir = tmp_path / "weights"
+    weights_dir.mkdir()
+    target_weights = weights_dir / "model.bin"
+    xml_path.write_text("<net version='10'></net>", encoding="utf-8")
+    target_weights.write_bytes(b"\x00" * 12)
+    (tmp_path / "model.bin").symlink_to(target_weights)
+
+    result = OpenVinoScanner().scan(str(xml_path))
+
+    assert result.success is True
+    assert result.metadata["bin_size"] == target_weights.stat().st_size
+    assert not any(check.name == "OpenVINO Weights Symlink Boundary Check" for check in result.checks)
+
+
 def test_openvino_scanner_forbidden_doctype_fails_closed_with_exit_2(tmp_path: Path) -> None:
     """Forbidden DOCTYPE payloads should produce an explicit OpenVINO parse failure and exit 2."""
     xml_path = tmp_path / "model.xml"


### PR DESCRIPTION
Detect .bin sidecars that resolve outside the model directory.