### PR TITLE
fix(gguf): detect tensor bounds overflow

### DIFF
--- a/modelaudit/scanners/gguf_scanner.py
+++ b/modelaudit/scanners/gguf_scanner.py
@@ -26,6 +26,7 @@ _GGML_TYPE_INFO = {
     14: (256, 210),  # Q6_K
     15: (256, 292),  # Q8_K
 }
+_UINT64_MAX = 2**64 - 1
 
 # Accepted GGML variant magic bytes
 GGML_VARIANT_MAGICS = {
@@ -441,6 +442,37 @@ class GgufScanner(BaseScanner):
                     )
 
                 expected = ((nelements + blck - 1) // blck) * ts
+                tensor_abs_start = tensor_data_start + tensor["offset"]
+                tensor_abs_end = tensor_abs_start + expected
+                offset_overflows_uint64 = tensor["offset"] > _UINT64_MAX - tensor_data_start
+                end_overflows_uint64 = tensor_abs_start > _UINT64_MAX - expected
+
+                if (
+                    offset_overflows_uint64
+                    or end_overflows_uint64
+                    or tensor_abs_start > file_size
+                    or tensor_abs_end > file_size
+                ):
+                    result.add_check(
+                        name="Tensor Data Bounds Check",
+                        passed=False,
+                        message=f"Tensor {tensor['name']} data extends outside file bounds",
+                        severity=IssueSeverity.WARNING,
+                        location=self.current_file_path,
+                        details={
+                            "tensor_name": tensor["name"],
+                            "offset": tensor["offset"],
+                            "expected": expected,
+                            "tensor_data_start": tensor_data_start,
+                            "tensor_abs_start": tensor_abs_start,
+                            "tensor_abs_end": tensor_abs_end,
+                            "file_size": file_size,
+                            "offset_overflows_uint64": offset_overflows_uint64,
+                            "end_overflows_uint64": end_overflows_uint64,
+                        },
+                        rule_code="S902",
+                    )
+                    continue
 
                 # Calculate actual size: use next tensor's offset, or file size for last tensor
                 if idx + 1 < len(tensors):
@@ -458,7 +490,6 @@ class GgufScanner(BaseScanner):
                     actual = next_offset - tensor["offset"]
                 else:
                     # Last tensor: calculate from absolute position to end of file
-                    tensor_abs_start = tensor_data_start + tensor["offset"]
                     actual = file_size - tensor_abs_start
 
                 # Allow for alignment padding (tensors may be aligned to 32 bytes)

--- a/modelaudit/scanners/gguf_scanner.py
+++ b/modelaudit/scanners/gguf_scanner.py
@@ -26,7 +26,7 @@ _GGML_TYPE_INFO = {
     14: (256, 210),  # Q6_K
     15: (256, 292),  # Q8_K
 }
-_UINT64_MAX = 2**64 - 1
+_UINT64_MAX: int = 2**64 - 1
 
 # Accepted GGML variant magic bytes
 GGML_VARIANT_MAGICS = {

--- a/tests/scanners/test_gguf_scanner.py
+++ b/tests/scanners/test_gguf_scanner.py
@@ -681,6 +681,67 @@ def test_gguf_scanner_tensor_size_validation(tmp_path):
     assert len(size_warnings) == 0
 
 
+def test_gguf_scanner_tensor_bounds_detects_uint64_wrap(tmp_path):
+    """Tensor offsets must not wrap or point outside the file."""
+    path = tmp_path / "tensor_bounds_wrap.gguf"
+    with open(path, "wb") as f:
+        f.write(b"GGUF")
+        f.write(struct.pack("<I", 3))
+        f.write(struct.pack("<Q", 1))
+        f.write(struct.pack("<Q", 0))
+
+        name = b"wrap_tensor"
+        f.write(struct.pack("<Q", len(name)))
+        f.write(name)
+        f.write(struct.pack("<I", 1))
+        f.write(struct.pack("<Q", 8))
+        f.write(struct.pack("<I", 0))
+        f.write(struct.pack("<Q", 2**64 - 16))
+
+        pad_to_tensor_data = (32 - (f.tell() % 32)) % 32
+        if pad_to_tensor_data:
+            f.write(b"\x00" * pad_to_tensor_data)
+        f.write(b"\x00" * 32)
+
+    result = GgufScanner().scan(str(path))
+
+    bounds_checks = [check for check in result.checks if check.name == "Tensor Data Bounds Check"]
+    assert len(bounds_checks) == 1
+    assert bounds_checks[0].status.value == "failed"
+    assert bounds_checks[0].details["offset_overflows_uint64"] is True
+    assert any(issue.severity == IssueSeverity.WARNING for issue in result.issues)
+
+
+def test_gguf_scanner_tensor_bounds_allows_exact_file_end(tmp_path):
+    """A tensor may end exactly at EOF when its offset and expected size fit."""
+    path = tmp_path / "tensor_bounds_exact_end.gguf"
+    with open(path, "wb") as f:
+        f.write(b"GGUF")
+        f.write(struct.pack("<I", 3))
+        f.write(struct.pack("<Q", 1))
+        f.write(struct.pack("<Q", 0))
+
+        name = b"offset_tensor"
+        f.write(struct.pack("<Q", len(name)))
+        f.write(name)
+        f.write(struct.pack("<I", 1))
+        f.write(struct.pack("<Q", 8))
+        f.write(struct.pack("<I", 0))
+        f.write(struct.pack("<Q", 32))
+
+        pad_to_tensor_data = (32 - (f.tell() % 32)) % 32
+        if pad_to_tensor_data:
+            f.write(b"\x00" * pad_to_tensor_data)
+        f.write(b"\x00" * 32)
+        f.write(b"\x00" * 32)
+
+    result = GgufScanner().scan(str(path))
+
+    assert result.success
+    assert not any(check.name == "Tensor Data Bounds Check" for check in result.checks)
+    assert not any("size mismatch" in issue.message.lower() for issue in result.issues)
+
+
 def test_gguf_scanner_last_tensor_size(tmp_path):
     """Test that the last tensor's size is calculated correctly using file size."""
     path = tmp_path / "last_tensor.gguf"

--- a/tests/scanners/test_gguf_scanner.py
+++ b/tests/scanners/test_gguf_scanner.py
@@ -681,7 +681,7 @@ def test_gguf_scanner_tensor_size_validation(tmp_path):
     assert len(size_warnings) == 0
 
 
-def test_gguf_scanner_tensor_bounds_detects_uint64_wrap(tmp_path):
+def test_gguf_scanner_tensor_bounds_detects_uint64_wrap(tmp_path: Path) -> None:
     """Tensor offsets must not wrap or point outside the file."""
     path = tmp_path / "tensor_bounds_wrap.gguf"
     with open(path, "wb") as f:
@@ -712,7 +712,7 @@ def test_gguf_scanner_tensor_bounds_detects_uint64_wrap(tmp_path):
     assert any(issue.severity == IssueSeverity.WARNING for issue in result.issues)
 
 
-def test_gguf_scanner_tensor_bounds_allows_exact_file_end(tmp_path):
+def test_gguf_scanner_tensor_bounds_allows_exact_file_end(tmp_path: Path) -> None:
     """A tensor may end exactly at EOF when its offset and expected size fit."""
     path = tmp_path / "tensor_bounds_exact_end.gguf"
     with open(path, "wb") as f:


### PR DESCRIPTION
Detects GGUF tensor metadata that points outside the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved GGUF scanning: detects and reports tensor data boundary violations and 64-bit offset wraparound with detailed diagnostics; skips further size checks for flagged tensors.

* **Tests**
  * Added regression tests covering offset wraparound detection and acceptance of tensors that end exactly at EOF.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->