### PR TITLE
fix(nemo): scan referenced non-checkpoint suffixes

### DIFF
--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -34,6 +34,7 @@ def _redact_url_for_finding(url: str) -> str:
     netloc = f"{hostname}:{port}" if port is not None else hostname
     return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
 
+
 _DOC_CONTEXT_EXTENSIONS: tuple[str, ...] = (
     ".md",
     ".rst",

--- a/modelaudit/scanners/nemo_scanner.py
+++ b/modelaudit/scanners/nemo_scanner.py
@@ -699,8 +699,9 @@ class NemoScanner(BaseScanner):
         path_prefix: str = "",
     ) -> list[tuple[str, str]]:
         """Collect internal `nemo:` artifact references from a parsed config."""
+        collected: list[tuple[str, str]] = []
+
         if isinstance(config, list):
-            collected: list[tuple[str, str]] = []
             for index, item in enumerate(config):
                 collected.extend(
                     cls._collect_nemo_member_references(
@@ -711,7 +712,6 @@ class NemoScanner(BaseScanner):
             return collected
 
         if isinstance(config, dict):
-            collected = []
             for key, value in config.items():
                 current_path = f"{path_prefix}.{key}" if path_prefix else key
                 collected.extend(cls._collect_nemo_member_references(value, current_path))

--- a/modelaudit/scanners/nemo_scanner.py
+++ b/modelaudit/scanners/nemo_scanner.py
@@ -352,7 +352,7 @@ class NemoScanner(BaseScanner):
                                 for config_path, referenced_member_name in self._collect_nemo_member_references(config):
                                     if referenced_member_name in scanned_member_entries:
                                         continue
-                                    self._scan_config_referenced_member(
+                                    referenced_member_scanned = self._scan_config_referenced_member(
                                         tar,
                                         referenced_member_name,
                                         path,
@@ -360,7 +360,8 @@ class NemoScanner(BaseScanner):
                                         config_file=member.name,
                                         config_path=config_path,
                                     )
-                                    scanned_member_entries.add(referenced_member_name)
+                                    if referenced_member_scanned:
+                                        scanned_member_entries.add(referenced_member_name)
                             else:
                                 self._mark_inconclusive_scan_result(
                                     result,
@@ -389,6 +390,8 @@ class NemoScanner(BaseScanner):
                             )
 
                 if name_lower.endswith(tuple(NEMO_CHECKPOINT_MEMBER_EXTENSIONS)):
+                    if member.name in scanned_member_entries:
+                        continue
                     self._scan_checkpoint_member(tar, member, path, result)
                     scanned_member_entries.add(member.name)
 
@@ -583,35 +586,63 @@ class NemoScanner(BaseScanner):
         *,
         config_file: str,
         config_path: str,
-    ) -> None:
+    ) -> bool:
         """Scan `nemo:`-referenced archive members through content-based nested dispatch."""
         try:
             member = tar.getmember(referenced_member_name)
         except KeyError:
-            return
+            return False
 
         if member.issym() or member.islnk():
             resolved_name = self._resolve_archive_link_member_name(member)
             if resolved_name is None:
-                return
+                return False
             try:
                 member = tar.getmember(resolved_name)
             except KeyError:
-                return
+                return False
 
         if not member.isfile():
-            return
+            return False
 
         max_scan_bytes = self._normalize_positive_int_config(
             self.config.get("max_nemo_checkpoint_scan_bytes"),
             NEMO_MAX_CHECKPOINT_SCAN_BYTES,
         )
         if member.size > max_scan_bytes:
-            return
+            self._mark_inconclusive_scan_result(
+                result,
+                reason="nemo_checkpoint_scan_skipped_size_limit",
+                check_name="NeMo Checkpoint Nested Scan",
+                message=f"Referenced member exceeds nested scan limit: {referenced_member_name}",
+                location=f"{archive_path}:{referenced_member_name}",
+                details={
+                    "entry": referenced_member_name,
+                    "source_entry": member.name,
+                    "config_file": config_file,
+                    "config_path": config_path,
+                    "size_bytes": member.size,
+                    "max_scan_bytes": max_scan_bytes,
+                },
+            )
+            return True
 
         extracted_path = self._extract_member_to_tempfile(tar, member, suffix_source=referenced_member_name)
         if extracted_path is None:
-            return
+            self._mark_inconclusive_scan_result(
+                result,
+                reason="nemo_checkpoint_extract_failed",
+                check_name="NeMo Checkpoint Nested Scan",
+                message=f"Could not extract referenced member for nested scan: {referenced_member_name}",
+                location=f"{archive_path}:{referenced_member_name}",
+                details={
+                    "entry": referenced_member_name,
+                    "source_entry": member.name,
+                    "config_file": config_file,
+                    "config_path": config_path,
+                },
+            )
+            return True
 
         try:
             from .archive_dispatch import scan_nested_file
@@ -635,6 +666,7 @@ class NemoScanner(BaseScanner):
                         "source_entry": member.name,
                     },
                 )
+            return True
         finally:
             try:
                 os.unlink(extracted_path)

--- a/modelaudit/scanners/nemo_scanner.py
+++ b/modelaudit/scanners/nemo_scanner.py
@@ -231,6 +231,7 @@ class NemoScanner(BaseScanner):
         """Extract and scan YAML configs from a NeMo tar archive."""
         yaml_configs_found = 0
         yaml_config_files_found = 0
+        scanned_member_entries: set[str] = set()
 
         with tarfile.open(path, "r:*") as tar:
             for member in tar:
@@ -290,6 +291,7 @@ class NemoScanner(BaseScanner):
                                         result,
                                         entry_name=member.name,
                                     )
+                                    scanned_member_entries.add(member.name)
                                 else:
                                     self._mark_inconclusive_scan_result(
                                         result,
@@ -347,6 +349,18 @@ class NemoScanner(BaseScanner):
                             if isinstance(config, dict | list):
                                 yaml_configs_found += 1
                                 self._check_hydra_targets(config, member.name, path, result)
+                                for config_path, referenced_member_name in self._collect_nemo_member_references(config):
+                                    if referenced_member_name in scanned_member_entries:
+                                        continue
+                                    self._scan_config_referenced_member(
+                                        tar,
+                                        referenced_member_name,
+                                        path,
+                                        result,
+                                        config_file=member.name,
+                                        config_path=config_path,
+                                    )
+                                    scanned_member_entries.add(referenced_member_name)
                             else:
                                 self._mark_inconclusive_scan_result(
                                     result,
@@ -376,6 +390,7 @@ class NemoScanner(BaseScanner):
 
                 if name_lower.endswith(tuple(NEMO_CHECKPOINT_MEMBER_EXTENSIONS)):
                     self._scan_checkpoint_member(tar, member, path, result)
+                    scanned_member_entries.add(member.name)
 
         if yaml_configs_found == 0:
             message = (
@@ -559,6 +574,129 @@ class NemoScanner(BaseScanner):
             except OSError:
                 logger.debug("Failed to remove temporary NeMo checkpoint scan file: %s", extracted_path)
 
+    def _scan_config_referenced_member(
+        self,
+        tar: tarfile.TarFile,
+        referenced_member_name: str,
+        archive_path: str,
+        result: ScanResult,
+        *,
+        config_file: str,
+        config_path: str,
+    ) -> None:
+        """Scan `nemo:`-referenced archive members through content-based nested dispatch."""
+        try:
+            member = tar.getmember(referenced_member_name)
+        except KeyError:
+            return
+
+        if member.issym() or member.islnk():
+            resolved_name = self._resolve_archive_link_member_name(member)
+            if resolved_name is None:
+                return
+            try:
+                member = tar.getmember(resolved_name)
+            except KeyError:
+                return
+
+        if not member.isfile():
+            return
+
+        max_scan_bytes = self._normalize_positive_int_config(
+            self.config.get("max_nemo_checkpoint_scan_bytes"),
+            NEMO_MAX_CHECKPOINT_SCAN_BYTES,
+        )
+        if member.size > max_scan_bytes:
+            return
+
+        extracted_path = self._extract_member_to_tempfile(tar, member, suffix_source=referenced_member_name)
+        if extracted_path is None:
+            return
+
+        try:
+            from .archive_dispatch import scan_nested_file
+
+            nested_result = scan_nested_file(extracted_path, config=dict(self.config))
+            critical_issues = [
+                issue
+                for issue in nested_result.issues
+                if issue.severity == IssueSeverity.CRITICAL and self._is_nested_checkpoint_deserialization_issue(issue)
+            ]
+            if critical_issues:
+                self._add_checkpoint_deserialization_check(
+                    result,
+                    archive_path=archive_path,
+                    entry=referenced_member_name,
+                    nested_scanner=nested_result.scanner_name,
+                    critical_issues=critical_issues,
+                    extra_details={
+                        "config_file": config_file,
+                        "config_path": config_path,
+                        "source_entry": member.name,
+                    },
+                )
+        finally:
+            try:
+                os.unlink(extracted_path)
+            except OSError:
+                logger.debug("Failed to remove temporary NeMo referenced scan file: %s", extracted_path)
+
+    @classmethod
+    def _collect_nemo_member_references(
+        cls,
+        config: Any,
+        path_prefix: str = "",
+    ) -> list[tuple[str, str]]:
+        """Collect internal `nemo:` artifact references from a parsed config."""
+        if isinstance(config, list):
+            collected: list[tuple[str, str]] = []
+            for index, item in enumerate(config):
+                collected.extend(
+                    cls._collect_nemo_member_references(
+                        item,
+                        f"{path_prefix}[{index}]" if path_prefix else f"[{index}]",
+                    )
+                )
+            return collected
+
+        if isinstance(config, dict):
+            collected = []
+            for key, value in config.items():
+                current_path = f"{path_prefix}.{key}" if path_prefix else key
+                collected.extend(cls._collect_nemo_member_references(value, current_path))
+            return collected
+
+        if isinstance(config, str):
+            member_name = cls._extract_nemo_member_reference(config)
+            if member_name is not None:
+                return [(path_prefix or "$", member_name)]
+
+        return []
+
+    @staticmethod
+    def _extract_nemo_member_reference(value: str) -> str | None:
+        normalized = value.strip()
+        if not normalized or ":" not in normalized:
+            return None
+
+        scheme, member_name = normalized.split(":", 1)
+        if scheme.lower() != "nemo":
+            return None
+
+        member_name = member_name.strip().replace("\\", "/")
+        if not member_name:
+            return None
+
+        normalized_member = os.path.normpath(member_name).replace("\\", "/")
+        if (
+            normalized_member in {"", ".", ".."}
+            or normalized_member.startswith("../")
+            or is_absolute_archive_path(normalized_member)
+        ):
+            return None
+
+        return normalized_member.lstrip("./")
+
     @staticmethod
     def _is_nested_checkpoint_deserialization_issue(issue: Any) -> bool:
         details = issue.details if isinstance(issue.details, dict) else {}
@@ -619,6 +757,7 @@ class NemoScanner(BaseScanner):
         entry: str,
         nested_scanner: str,
         critical_issues: list[Any],
+        extra_details: dict[str, Any] | None = None,
     ) -> None:
         result.add_check(
             name="CVE-2025-23249: NeMo Checkpoint Unsafe Deserialization",
@@ -646,6 +785,7 @@ class NemoScanner(BaseScanner):
                     "Update NVIDIA NeMo Framework to release 25.02 or later, keep current with subsequent "
                     "checkpoint-loading fixes, and reject untrusted checkpoint payloads."
                 ),
+                **(extra_details or {}),
             },
             why=(
                 "A nested scanner found critical unsafe-deserialization behavior inside a checkpoint bundled "

--- a/modelaudit/scanners/nemo_scanner.py
+++ b/modelaudit/scanners/nemo_scanner.py
@@ -647,7 +647,26 @@ class NemoScanner(BaseScanner):
         try:
             from .archive_dispatch import scan_nested_file
 
-            nested_result = scan_nested_file(extracted_path, config=dict(self.config))
+            try:
+                nested_result = scan_nested_file(extracted_path, config=dict(self.config))
+            except Exception as exc:
+                self._mark_inconclusive_scan_result(
+                    result,
+                    reason="nemo_referenced_nested_scan_failed",
+                    check_name="NeMo Checkpoint Nested Scan",
+                    message=f"Nested scan failed for referenced member {referenced_member_name}: {exc!s}",
+                    location=f"{archive_path}:{referenced_member_name}",
+                    details={
+                        "entry": referenced_member_name,
+                        "source_entry": member.name,
+                        "config_file": config_file,
+                        "config_path": config_path,
+                        "exception_type": type(exc).__name__,
+                        "exception_message": str(exc),
+                    },
+                )
+                return True
+
             critical_issues = [
                 issue
                 for issue in nested_result.issues

--- a/tests/scanners/test_nemo_scanner.py
+++ b/tests/scanners/test_nemo_scanner.py
@@ -340,6 +340,89 @@ class TestNemoArchiveVulnerabilityCoverage:
         assert cve_checks[0].details["config_path"] == "tokenizer.model"
         assert cve_checks[0].details["source_entry"] == "artifacts/payload.jpg"
 
+    def test_config_referenced_checkpoint_suffix_is_not_scanned_twice(self, tmp_path: Path) -> None:
+        nemo_path = tmp_path / "referenced-checkpoint.nemo"
+        config = {
+            "model": {"_target_": "nemo.Model"},
+            "checkpoint": "nemo:model_weights.ckpt",
+        }
+        with tarfile.open(nemo_path, "w") as tar:
+            _add_tar_bytes(tar, "model_config.yaml", yaml.safe_dump(config).encode())
+            _add_tar_bytes(tar, "model_weights.ckpt", _build_malicious_pickle())
+
+        result = NemoScanner().scan(str(nemo_path))
+
+        cve_checks = [check for check in result.checks if check.details.get("cve_id") == "CVE-2025-23249"]
+        assert len(cve_checks) == 1
+        assert cve_checks[0].details["entry"] == "model_weights.ckpt"
+        assert cve_checks[0].details["config_file"] == "model_config.yaml"
+        assert cve_checks[0].details["config_path"] == "checkpoint"
+
+    def test_large_config_referenced_member_fails_closed(self, tmp_path: Path) -> None:
+        nemo_path = tmp_path / "referenced-large-artifact.nemo"
+        config = {
+            "model": {"_target_": "nemo.Model"},
+            "tokenizer": {"model": "nemo:artifacts/tokenizer.model"},
+        }
+        with tarfile.open(nemo_path, "w") as tar:
+            _add_tar_bytes(tar, "model_config.yaml", yaml.safe_dump(config).encode())
+            _add_tar_bytes(tar, "artifacts/tokenizer.model", b"not scanned")
+
+        result = NemoScanner({"max_nemo_checkpoint_scan_bytes": 1}).scan(str(nemo_path))
+
+        skipped_checks = [
+            check
+            for check in result.checks
+            if check.details.get("scan_outcome_reason") == "nemo_checkpoint_scan_skipped_size_limit"
+        ]
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert len(skipped_checks) == 1
+        assert skipped_checks[0].details["entry"] == "artifacts/tokenizer.model"
+        assert skipped_checks[0].details["source_entry"] == "artifacts/tokenizer.model"
+        assert skipped_checks[0].details["config_file"] == "model_config.yaml"
+        assert skipped_checks[0].details["config_path"] == "tokenizer.model"
+        assert skipped_checks[0].details["max_scan_bytes"] == 1
+
+    def test_unextractable_config_referenced_member_fails_closed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def fail_extract(
+            _tar: tarfile.TarFile,
+            _member: tarfile.TarInfo,
+            *,
+            suffix_source: str | None = None,
+        ) -> str | None:
+            return None
+
+        monkeypatch.setattr(NemoScanner, "_extract_member_to_tempfile", staticmethod(fail_extract))
+
+        nemo_path = tmp_path / "referenced-unextractable-artifact.nemo"
+        config = {
+            "model": {"_target_": "nemo.Model"},
+            "tokenizer": {"model": "nemo:artifacts/tokenizer.model"},
+        }
+        with tarfile.open(nemo_path, "w") as tar:
+            _add_tar_bytes(tar, "model_config.yaml", yaml.safe_dump(config).encode())
+            _add_tar_bytes(tar, "artifacts/tokenizer.model", b"payload")
+
+        result = NemoScanner().scan(str(nemo_path))
+
+        failed_checks = [
+            check
+            for check in result.checks
+            if check.details.get("scan_outcome_reason") == "nemo_checkpoint_extract_failed"
+        ]
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert len(failed_checks) == 1
+        assert failed_checks[0].details["entry"] == "artifacts/tokenizer.model"
+        assert failed_checks[0].details["source_entry"] == "artifacts/tokenizer.model"
+        assert failed_checks[0].details["config_file"] == "model_config.yaml"
+        assert failed_checks[0].details["config_path"] == "tokenizer.model"
+
     def test_metadata_referenced_benign_non_checkpoint_suffix_stays_clean(self, tmp_path: Path) -> None:
         nemo_path = tmp_path / "referenced-benign-artifact.nemo"
         config = {

--- a/tests/scanners/test_nemo_scanner.py
+++ b/tests/scanners/test_nemo_scanner.py
@@ -423,6 +423,45 @@ class TestNemoArchiveVulnerabilityCoverage:
         assert failed_checks[0].details["config_file"] == "model_config.yaml"
         assert failed_checks[0].details["config_path"] == "tokenizer.model"
 
+    def test_config_referenced_nested_scan_failure_fails_closed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from modelaudit.scanners import archive_dispatch
+
+        def raise_nested_scan(_path: str, config: dict[str, Any] | None = None) -> Any:
+            _ = config
+            raise RuntimeError("referenced nested boom")
+
+        monkeypatch.setattr(archive_dispatch, "scan_nested_file", raise_nested_scan)
+
+        nemo_path = tmp_path / "referenced-nested-fails.nemo"
+        config = {
+            "model": {"_target_": "nemo.Model"},
+            "tokenizer": {"model": "nemo:artifacts/tokenizer.model"},
+        }
+        with tarfile.open(nemo_path, "w") as tar:
+            _add_tar_bytes(tar, "model_config.yaml", yaml.safe_dump(config).encode())
+            _add_tar_bytes(tar, "artifacts/tokenizer.model", b"payload")
+
+        result = NemoScanner().scan(str(nemo_path))
+
+        failed_checks = [
+            check
+            for check in result.checks
+            if check.details.get("scan_outcome_reason") == "nemo_referenced_nested_scan_failed"
+        ]
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert len(failed_checks) == 1
+        assert failed_checks[0].details["entry"] == "artifacts/tokenizer.model"
+        assert failed_checks[0].details["source_entry"] == "artifacts/tokenizer.model"
+        assert failed_checks[0].details["config_file"] == "model_config.yaml"
+        assert failed_checks[0].details["config_path"] == "tokenizer.model"
+        assert failed_checks[0].details["exception_type"] == "RuntimeError"
+        assert failed_checks[0].details["exception_message"] == "referenced nested boom"
+
     def test_metadata_referenced_benign_non_checkpoint_suffix_stays_clean(self, tmp_path: Path) -> None:
         nemo_path = tmp_path / "referenced-benign-artifact.nemo"
         config = {

--- a/tests/scanners/test_nemo_scanner.py
+++ b/tests/scanners/test_nemo_scanner.py
@@ -317,6 +317,45 @@ class TestNemoArchiveVulnerabilityCoverage:
 
         assert not [check for check in result.checks if check.details.get("cve_id") == "CVE-2025-23249"]
 
+    def test_metadata_referenced_misnamed_payload_detects_ne_mo_deserialization_cve(self, tmp_path: Path) -> None:
+        nemo_path = tmp_path / "referenced-misnamed-payload.nemo"
+        config = {
+            "model": {"_target_": "nemo.Model"},
+            "tokenizer": {"model": "nemo:artifacts/payload.jpg"},
+        }
+        with tarfile.open(nemo_path, "w") as tar:
+            _add_tar_bytes(tar, "model_config.yaml", yaml.safe_dump(config).encode())
+            _add_tar_bytes(tar, "artifacts/payload.jpg", _build_malicious_pickle())
+
+        result = NemoScanner().scan(str(nemo_path))
+
+        cve_checks = [
+            check
+            for check in result.checks
+            if check.details.get("cve_id") == "CVE-2025-23249" and check.details.get("entry") == "artifacts/payload.jpg"
+        ]
+        assert len(cve_checks) == 1
+        assert cve_checks[0].severity == IssueSeverity.CRITICAL
+        assert cve_checks[0].details["config_file"] == "model_config.yaml"
+        assert cve_checks[0].details["config_path"] == "tokenizer.model"
+        assert cve_checks[0].details["source_entry"] == "artifacts/payload.jpg"
+
+    def test_metadata_referenced_benign_non_checkpoint_suffix_stays_clean(self, tmp_path: Path) -> None:
+        nemo_path = tmp_path / "referenced-benign-artifact.nemo"
+        config = {
+            "model": {"_target_": "nemo.Model"},
+            "tokenizer": {"model": "nemo:artifacts/tokenizer.model"},
+        }
+        with tarfile.open(nemo_path, "w") as tar:
+            _add_tar_bytes(tar, "model_config.yaml", yaml.safe_dump(config).encode())
+            _add_tar_bytes(tar, "artifacts/tokenizer.model", b"plain tokenizer bytes")
+
+        result = NemoScanner().scan(str(nemo_path))
+
+        assert result.success is True
+        assert not [check for check in result.checks if check.details.get("cve_id") == "CVE-2025-23249"]
+        assert "scan_outcome" not in result.metadata
+
     def test_nested_checkpoint_archive_traversal_not_labeled_deserialization_cve(self, tmp_path: Path) -> None:
         nested_checkpoint = io.BytesIO()
         with zipfile.ZipFile(nested_checkpoint, "w") as zipf:


### PR DESCRIPTION
Scans nemo-referenced members through nested content routing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NeMo archive scanning now discovers and follows internal artifact references in configs, scanning referenced members with size-limit enforcement, extracting to temp files, and filtering nested findings to critical checkpoint deserialization issues. Deduplication prevents duplicate unsafe-deserialization findings for the same referenced member.

* **Bug Fixes / Fail-Closed Behavior**
  * Scans now emit inconclusive outcomes when referenced-member extraction, size limits, or nested scan errors occur, with clear skip/failure reasons.

* **Tests**
  * Added tests for referenced-member scanning, deduplication, size-limit, extraction failure, nested-scan errors, and benign non-checkpoint cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->