### PR TITLE
test: normalize NeMo scanner test names

### DIFF
--- a/tests/scanners/test_nemo_scanner.py
+++ b/tests/scanners/test_nemo_scanner.py
@@ -184,7 +184,7 @@ class TestNemoArchiveVulnerabilityCoverage:
         assert not [check for check in result.checks if check.details.get("cve_id") == "CVE-2025-23360"]
         assert not [check for check in result.checks if check.details.get("cve_id") == "CVE-2025-23250"]
 
-    def test_malicious_checkpoint_detects_ne_mo_deserialization_cve(self, tmp_path: Path) -> None:
+    def test_malicious_checkpoint_detects_nemo_deserialization_cve(self, tmp_path: Path) -> None:
         nemo_path = tmp_path / "checkpoint-rce.nemo"
         with tarfile.open(nemo_path, "w") as tar:
             _add_tar_bytes(tar, "model_config.yaml", b"model: safe\n")
@@ -201,7 +201,7 @@ class TestNemoArchiveVulnerabilityCoverage:
         assert "CVE-2026-24157" in details["related_cves"]
         assert details["nested_scanner"] == "pickle"
 
-    def test_symlink_checkpoint_alias_detects_ne_mo_deserialization_cve(self, tmp_path: Path) -> None:
+    def test_symlink_checkpoint_alias_detects_nemo_deserialization_cve(self, tmp_path: Path) -> None:
         nemo_path = tmp_path / "checkpoint-symlink-alias.nemo"
         with tarfile.open(nemo_path, "w") as tar:
             _add_tar_bytes(tar, "model_config.yaml", b"model: safe\n")
@@ -307,7 +307,7 @@ class TestNemoArchiveVulnerabilityCoverage:
         assert len(unsupported_checks) == 1
         assert unsupported_checks[0].details["entry"] == "model_weights.ckpt"
 
-    def test_benign_checkpoint_pickle_no_ne_mo_deserialization_cve(self, tmp_path: Path) -> None:
+    def test_benign_checkpoint_pickle_no_nemo_deserialization_cve(self, tmp_path: Path) -> None:
         nemo_path = tmp_path / "checkpoint-safe.nemo"
         with tarfile.open(nemo_path, "w") as tar:
             _add_tar_bytes(tar, "model_config.yaml", b"model: safe\n")
@@ -317,7 +317,7 @@ class TestNemoArchiveVulnerabilityCoverage:
 
         assert not [check for check in result.checks if check.details.get("cve_id") == "CVE-2025-23249"]
 
-    def test_metadata_referenced_misnamed_payload_detects_ne_mo_deserialization_cve(self, tmp_path: Path) -> None:
+    def test_metadata_referenced_misnamed_payload_detects_nemo_deserialization_cve(self, tmp_path: Path) -> None:
         nemo_path = tmp_path / "referenced-misnamed-payload.nemo"
         config = {
             "model": {"_target_": "nemo.Model"},


### PR DESCRIPTION
## Summary

- Renamed four NeMo scanner pytest methods from `ne_mo_deserialization` to `nemo_deserialization`.
- Kept the change limited to test names; scanner behavior and assertions are unchanged.

## Why

GitHub AI/SAST flagged the split spelling as a code-quality issue in `tests/scanners/test_nemo_scanner.py`. I agree with the finding because `nemo` is the project and file naming convention here, while `ne_mo` only adds noise.

## Validation

- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` — 3735 passed, 77 skipped
