### PR TITLE
test: harden rule registry coverage

### DIFF
--- a/modelaudit/rules.py
+++ b/modelaudit/rules.py
@@ -62,6 +62,13 @@ class RuleRegistry:
         cls._initialized = True
 
     @classmethod
+    def reset_for_testing(cls) -> None:
+        """Reset registry state for tests that need deterministic initialization."""
+        cls._rules.clear()
+        cls._message_match_cache.clear()
+        cls._initialized = False
+
+    @classmethod
     def _add_rule(cls, code: str, name: str, severity: Severity, description: str, patterns: list[str]) -> None:
         """Add a rule to the registry."""
         compiled_patterns = [re.compile(p, re.IGNORECASE) for p in patterns]
@@ -75,8 +82,11 @@ class RuleRegistry:
         return cls._rules.get(code)
 
     @classmethod
-    def find_matching_rule(cls, message: str) -> tuple[str, Rule] | None:
+    def find_matching_rule(cls, message: str | None) -> tuple[str, Rule] | None:
         """Find the first rule that matches a message."""
+        if not message or not message.strip():
+            return None
+
         cls.initialize()
         if message in cls._message_match_cache:
             return cls._message_match_cache[message]

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -92,7 +92,9 @@ class TestRuleRegistry:
     def test_initialize_loads_catalog_order_after_reset(self) -> None:
         """Catalog order should be preserved after a full registry reset."""
         RuleRegistry.find_matching_rule("import os")
+        assert "import os" in RuleRegistry._message_match_cache
         RuleRegistry.reset_for_testing()
+        assert RuleRegistry._message_match_cache == {}
 
         RuleRegistry.initialize()
         loaded_rules = RuleRegistry.get_all_rules()

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -34,7 +34,7 @@ class TestRuleRegistry:
         rule = RuleRegistry.get_rule("S9999")
         assert rule is None
 
-    def test_find_matching_rule(self):
+    def test_find_matching_rule(self) -> None:
         """Test finding rules by message patterns."""
         # Test exact pattern match
         match = RuleRegistry.find_matching_rule("import os")
@@ -51,6 +51,21 @@ class TestRuleRegistry:
         # Test no match
         match = RuleRegistry.find_matching_rule("this should not match anything")
         assert match is None
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "",
+            "   ",
+            None,
+            "import osx",
+            "from osx import path",
+            "import osx; import sysx",
+        ],
+    )
+    def test_find_matching_rule_edge_case_non_matches(self, message: str | None) -> None:
+        """Empty, missing, and partial messages should not match rule patterns."""
+        assert RuleRegistry.find_matching_rule(message) is None
 
     def test_get_all_rules(self):
         """Test getting all rules."""
@@ -74,18 +89,16 @@ class TestRuleRegistry:
         assert "S201" in rules
         assert "S101" not in rules
 
-    def test_initialize_loads_catalog_order_and_clears_cache(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Catalog order and cache reset behavior should be preserved."""
-        monkeypatch.setattr(RuleRegistry, "_rules", {})
-        monkeypatch.setattr(RuleRegistry, "_message_match_cache", {"import os": None})
-        monkeypatch.setattr(RuleRegistry, "_initialized", False)
+    def test_initialize_loads_catalog_order_after_reset(self) -> None:
+        """Catalog order should be preserved after a full registry reset."""
+        RuleRegistry.find_matching_rule("import os")
+        RuleRegistry.reset_for_testing()
 
         RuleRegistry.initialize()
         loaded_rules = RuleRegistry.get_all_rules()
 
         assert list(loaded_rules) == [entry.code for entry in RULE_CATALOG]
         assert len(loaded_rules) == len(RULE_CATALOG)
-        assert RuleRegistry._message_match_cache == {}
 
         RuleRegistry.initialize()
 
@@ -242,7 +255,10 @@ S301 = "HIGH"
             }
         )
 
+        # S700-S702 expands the whole numeric span, then filters out unknown S700.
+        assert "S700" not in RuleRegistry.get_all_rules()
         assert config.suppress == {"S701", "S702", "S710"}
+        assert "S700" not in config.suppress
         assert config.severity == {"S301": Severity.HIGH}
         assert set(config.ignore["tests/**"]) == {"S201", "S202", "ALL"}
 


### PR DESCRIPTION
## Summary

- Add a documented `RuleRegistry.reset_for_testing()` hook so tests no longer monkeypatch registry internals.
- Cover empty, whitespace, missing, and partial non-match messages for `find_matching_rule`.
- Clarify that config range expansion filters unknown codes such as `S700` while preserving known codes.

## Validation

- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_rules.py`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
