### PR TITLE
test: use parsed host for network URL assertion

### DIFF
--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -1,12 +1,14 @@
 """Tests for network communication detection."""
 
+from urllib.parse import urlparse
+
 from modelaudit.detectors.network_comm import NetworkCommDetector, detect_network_communication
 
 
 class TestNetworkCommDetector:
     """Test the NetworkCommDetector class."""
 
-    def test_detect_urls(self):
+    def test_detect_urls(self) -> None:
         """Test detection of URLs in binary data."""
         detector = NetworkCommDetector()
 
@@ -27,7 +29,7 @@ class TestNetworkCommDetector:
         # Check specific URLs are detected
         urls = [f["url"] for f in url_findings]
         assert any("example.com" in url for url in urls)
-        assert any("malware.net" in url for url in urls)
+        assert any(urlparse(url).hostname == "malware.net" for url in urls)
 
     def test_detect_urls_redacts_credentials_and_query(self) -> None:
         """URL findings should not preserve credentialed or signed URL secrets."""


### PR DESCRIPTION
## Summary
- replace the flagged substring assertion for malware.net with parsed hostname equality
- add the missing return annotation on the touched URL detector test

## Why
CodeQL flagged the substring assertion as incomplete URL substring sanitization. Parsing the detected URL before comparing the hostname preserves the test intent while avoiding ambiguous substring matching.

## Validation
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m 'not slow and not integration' --maxfail=1