### PR TITLE
test: address AI quality findings

### DIFF
--- a/modelaudit/scanners/rule_mapper.py
+++ b/modelaudit/scanners/rule_mapper.py
@@ -81,7 +81,7 @@ def get_import_rule_code(module: str, function: str | None = None) -> str | None
         return _rule("S404")
 
     # Pickle/serialization
-    elif module_lower in ["pickle", "cpickle", "_pickle"] or module_lower in ["dill", "cloudpickle"]:
+    elif module_lower in ["pickle", "cpickle", "_pickle", "dill", "cloudpickle"]:
         return _rule("S213")
 
     return None
@@ -194,7 +194,9 @@ def get_secret_rule_code(secret_type: str) -> str | None:
         return _rule("S704")
     elif "azure" in secret_lower or "gcp" in secret_lower:
         return _rule("S705")
-    elif any(db in secret_lower for db in ["mongodb", "postgresql", "mysql", "sqlite"]):
+    elif (
+        "mongodb" in secret_lower or "postgresql" in secret_lower or "mysql" in secret_lower or "sqlite" in secret_lower
+    ):
         return _rule("S706")
     elif "jwt" in secret_lower or "bearer" in secret_lower:
         return _rule("S707")
@@ -329,6 +331,7 @@ def get_generic_rule_code(message: str) -> str | None:
 
     # Check for specific patterns
     if "protocol" in msg_lower and "version" in msg_lower:
+        # Informational protocol/version context; intentionally not a security rule.
         return None
     elif (
         ("stack" in msg_lower and "depth" in msg_lower)

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -1,5 +1,6 @@
 """Tests for network communication detection."""
 
+from pathlib import Path
 from urllib.parse import urlparse
 
 from modelaudit.detectors.network_comm import NetworkCommDetector, detect_network_communication
@@ -80,7 +81,7 @@ class TestNetworkCommDetector:
         assert "SECRET_SIGNATURE" not in serialized
         assert cloud_finding["provider"] == "s3"
 
-    def test_detect_ipv4_addresses(self):
+    def test_detect_ipv4_addresses(self) -> None:
         """Test detection of IPv4 addresses."""
         detector = NetworkCommDetector()
 
@@ -103,7 +104,7 @@ class TestNetworkCommDetector:
         assert len(private_ips) == 3  # 192.168, 10.0, 172.16
         assert len(public_ips) == 1  # 8.8.8.8
 
-    def test_detect_ipv6_addresses(self):
+    def test_detect_ipv6_addresses(self) -> None:
         """Test detection of IPv6 addresses."""
         detector = NetworkCommDetector()
 
@@ -117,7 +118,7 @@ class TestNetworkCommDetector:
 
         assert len(ipv6_findings) == 2
 
-    def test_detect_domain_names(self):
+    def test_detect_domain_names(self) -> None:
         """Test detection of domain names."""
         detector = NetworkCommDetector()
 
@@ -136,7 +137,7 @@ class TestNetworkCommDetector:
         suspicious = [f for f in domain_findings if f["confidence"] > 0.6]
         assert len(suspicious) >= 2  # .tk and .ml are suspicious
 
-    def test_detect_network_libraries(self):
+    def test_detect_network_libraries(self) -> None:
         """Test detection of network library imports."""
         detector = NetworkCommDetector()
 
@@ -163,7 +164,7 @@ class TestNetworkCommDetector:
         critical = [f for f in lib_findings if f["severity"] == "CRITICAL"]
         assert len(critical) >= 2  # socket and paramiko are critical
 
-    def test_detect_network_functions(self):
+    def test_detect_network_functions(self) -> None:
         """Test detection of network function calls."""
         detector = NetworkCommDetector()
 
@@ -287,7 +288,7 @@ class TestNetworkCommDetector:
         lib_findings = [finding for finding in findings if finding["type"] == "network_library"]
         assert any(finding["library"] == "socket" for finding in lib_findings)
 
-    def test_detect_cc_patterns(self):
+    def test_detect_cc_patterns(self) -> None:
         """Test detection of command & control patterns."""
         detector = NetworkCommDetector()
 
@@ -344,7 +345,7 @@ class TestNetworkCommDetector:
             }
         )
 
-    def test_detect_suspicious_ports(self):
+    def test_detect_suspicious_ports(self) -> None:
         """Test detection of suspicious port numbers."""
         detector = NetworkCommDetector()
 
@@ -367,7 +368,7 @@ class TestNetworkCommDetector:
         assert 4444 in ports  # Metasploit
         assert 6379 in ports  # Redis
 
-    def test_suspicious_port_scan_performance(self):
+    def test_suspicious_port_scan_performance(self) -> None:
         """Ensure port scanning remains performant with precompiled patterns."""
         detector = NetworkCommDetector()
         data = b"connect to server:1337" * 100
@@ -386,7 +387,7 @@ class TestNetworkCommDetector:
 
         assert duration < 1.0
 
-    def test_blacklist_detection(self):
+    def test_blacklist_detection(self) -> None:
         """Test detection of blacklisted domains when configured."""
         # Configure with specific blacklisted domains
         config = {"custom_blacklist": [b"malicious-site.com", b"known-c2.net", b"phishing-domain.org"]}
@@ -407,7 +408,7 @@ class TestNetworkCommDetector:
         assert all(f["confidence"] == 1.0 for f in blacklist_findings)
         assert all(f["severity"] == "CRITICAL" for f in blacklist_findings)
 
-    def test_custom_config(self):
+    def test_custom_config(self) -> None:
         """Test custom configuration options."""
         config = {
             "custom_cc_patterns": [b"custom_beacon", b"my_backdoor"],
@@ -436,7 +437,7 @@ class TestNetworkCommDetector:
         assert "custom-evil.com" in domains
         assert "my-c2.net" in domains
 
-    def test_custom_patterns_isolated_between_instances(self):
+    def test_custom_patterns_isolated_between_instances(self) -> None:
         """Ensure custom patterns and blacklists do not leak between instances."""
         config = {
             "custom_cc_patterns": ["LEAK_PATTERN"],
@@ -455,7 +456,7 @@ class TestNetworkCommDetector:
         assert all(f["type"] != "cc_pattern" for f in findings_default)
         assert all(f["type"] != "blacklisted_domain" for f in findings_default)
 
-    def test_confidence_scoring(self):
+    def test_confidence_scoring(self) -> None:
         """Test confidence scoring for different patterns."""
         detector = NetworkCommDetector()
 
@@ -489,7 +490,7 @@ class TestNetworkCommDetector:
         malware_findings = [f for f in cc_findings if "malware" in f["pattern"]]
         assert all(f["confidence"] >= 0.95 for f in malware_findings)
 
-    def test_no_false_positives_on_clean_data(self):
+    def test_no_false_positives_on_clean_data(self) -> None:
         """Test that clean model data doesn't trigger false positives."""
         detector = NetworkCommDetector()
 
@@ -511,7 +512,7 @@ class TestNetworkCommDetector:
         # Should not detect any network patterns
         assert len(findings) == 0
 
-    def test_context_extraction(self):
+    def test_context_extraction(self) -> None:
         """Test that context/snippets are properly extracted."""
         detector = NetworkCommDetector()
 
@@ -534,7 +535,7 @@ class TestNetworkCommDetector:
 class TestDetectNetworkCommunication:
     """Test the convenience function."""
 
-    def test_scan_file(self, tmp_path):
+    def test_scan_file(self, tmp_path: Path) -> None:
         """Test scanning a file for network patterns."""
         test_file = tmp_path / "model.pkl"
         test_file.write_bytes(b"http://malicious.com/payload")
@@ -543,14 +544,14 @@ class TestDetectNetworkCommunication:
         assert len(findings) > 0
         assert any("malicious.com" in f.get("url", "") for f in findings)
 
-    def test_file_not_found(self):
+    def test_file_not_found(self) -> None:
         """Test handling of non-existent files."""
         findings = detect_network_communication("/non/existent/file.pkl")
         assert len(findings) == 1
         assert findings[0]["type"] == "error"
         assert "not found" in findings[0]["message"]
 
-    def test_with_config(self, tmp_path):
+    def test_with_config(self, tmp_path: Path) -> None:
         """Test scanning with custom configuration."""
         test_file = tmp_path / "model.pkl"
         test_file.write_bytes(b"my_custom_pattern")

--- a/tests/scanners/test_picklescan_adapter.py
+++ b/tests/scanners/test_picklescan_adapter.py
@@ -26,20 +26,22 @@ from modelaudit.scanners.pytorch_zip_scanner import PyTorchZipScanner
 from tests.helpers import create_mock_pytorch_zip
 
 
-def test_scan_options_from_config_parses_string_values_and_falls_back_for_bad_values() -> None:
-    defaults = ScanOptions()
-
+def test_scan_options_from_config_parses_string_values() -> None:
     parsed = scan_options_from_config(
         {
             "timeout": "2.5",
             "max_opcodes": "4096",
-            "post_budget_global_scan_limit_bytes": "not-an-int",
+            "post_budget_global_scan_limit_bytes": "8192",
         }
     )
 
     assert parsed.timeout_s == 2.5
     assert parsed.max_opcodes == 4096
-    assert parsed.post_budget_scan_bytes == defaults.post_budget_scan_bytes
+    assert parsed.post_budget_scan_bytes == 8192
+
+
+def test_scan_options_from_config_falls_back_for_bad_values() -> None:
+    defaults = ScanOptions()
 
     fallback = scan_options_from_config(
         {

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -13,6 +13,18 @@ from modelaudit.rules import RuleRegistry, Severity
 from modelaudit.scanners.base import Issue, IssueSeverity, ScanResult
 
 
+@pytest.fixture
+def requires_symlinks(tmp_path: Path) -> None:
+    """Skip tests when creating symlinks is not supported in this environment."""
+    target = tmp_path / "target"
+    link = tmp_path / "link"
+    target.mkdir()
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlinks are not supported in this environment")
+
+
 class TestRuleRegistry:
     """Test the rule registry functionality."""
 
@@ -236,29 +248,30 @@ S301 = "HIGH"
         assert config.suppress == {"S710", "S801"}
         assert base_config.suppress == {"S710"}
 
-    def test_ignore_range_expansion(self):
+    def test_ignore_range_expansion(self) -> None:
         """Test that ignore ranges expand correctly."""
         config = ModelAuditConfig()
         config._parse_config({"ignore": {"tests/**": ["S200-S202", "S999"]}})
 
         assert "tests/**" in config.ignore
         assert set(config.ignore["tests/**"]) == {"S201", "S202", "S999"}
+        assert "S200" not in config.ignore["tests/**"]
         assert config.is_suppressed("S201", "tests/example.py")
         assert not config.is_suppressed("S203", "tests/example.py")
 
-    def test_parse_config_filters_unknown_codes(self):
+    def test_parse_config_filters_unknown_codes(self) -> None:
         """Unknown config rule codes should be ignored instead of persisted."""
         config = ModelAuditConfig()
         config._parse_config(
             {
                 "suppress": ["S710", "S700-S702", "s9999"],
                 "severity": {"s301": "HIGH", "S302": "INVALID", "S9999": "CRITICAL"},
+                # Lowercase "all" exercises keyword normalization to "ALL".
                 "ignore": {"tests/**": ["S200-S202", "S9999", "all"]},
             }
         )
 
-        # S700-S702 expands the whole numeric span, then filters out unknown S700.
-        assert "S700" not in RuleRegistry.get_all_rules()
+        # S700-S702 expands the whole numeric span, then filters out currently unknown S700.
         assert config.suppress == {"S701", "S702", "S710"}
         assert "S700" not in config.suppress
         assert config.severity == {"S301": Severity.HIGH}

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -24,7 +24,11 @@ from modelaudit.utils.sources.cloud_storage import (
 def make_fs_mock() -> MagicMock:
     fs = MagicMock()
     fs.__enter__.return_value = fs
-    fs.__exit__.side_effect = lambda exc_type, exc, tb: fs.close()
+
+    def close_context(_exc_type: object, _exc: object, _tb: object) -> None:
+        fs.close()
+
+    fs.__exit__.side_effect = close_context
     return fs
 
 
@@ -147,7 +151,7 @@ def test_filter_scannable_files_handles_signed_cloud_urls() -> None:
 
 
 @patch("fsspec.filesystem")
-def test_download_from_cloud(mock_fs, tmp_path):
+def test_download_from_cloud(mock_fs: MagicMock, tmp_path: Path) -> None:
     fs_meta = make_fs_mock()
     fs_meta.info.return_value = {"type": "file", "size": 1024}
 
@@ -168,7 +172,6 @@ def test_download_from_cloud(mock_fs, tmp_path):
     # Result should be a path containing the filename
     assert isinstance(result, Path)
     assert result.name == "model.pt"
-    assert result.exists() or True  # Mock doesn't create actual files
 
     # Note: fsspec filesystems don't need explicit cleanup according to implementation
 
@@ -731,7 +734,7 @@ class TestCloudCacheSafety:
         cached_path = cache.get_cached_path("s3://bucket/model.bin")
         assert cached_path is not None
         assert cached_path.resolve() != source_file.resolve()
-        cached_path.resolve().relative_to(cache.cache_dir.resolve())
+        assert cached_path.resolve().is_relative_to(cache.cache_dir.resolve())
         assert source_file.exists()
 
     def test_clean_old_cache_does_not_delete_outside_cache(


### PR DESCRIPTION
## Summary
- clean up rule-mapper conditionals and document the protocol/version no-rule case
- add missing return annotations in the network detector tests
- split picklescan config parsing and fallback coverage into separate tests
- tighten cloud storage mock/context assertions and add the missing symlink fixture coverage

## Notes
- I kept the lowercase `all` config input in `tests/test_rules.py` because the parser intentionally normalizes rule keywords to uppercase; the test now documents that intent.

## Validation
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m 'not slow and not integration' --maxfail=1