### PR TITLE
fix: define analysis lazy exports

### DIFF
--- a/modelaudit/analysis/__init__.py
+++ b/modelaudit/analysis/__init__.py
@@ -12,9 +12,17 @@ This package contains modules for analyzing ML models and detecting framework-sp
 - unified_context.py - Unified ML context for cross-framework analysis
 """
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from modelaudit.analysis import framework_patterns, unified_context
+
+if TYPE_CHECKING:
+    from modelaudit.analysis.anomaly_detector import AnomalyDetector as AnomalyDetector
+    from modelaudit.analysis.entropy_analyzer import EntropyAnalyzer as EntropyAnalyzer
+    from modelaudit.analysis.integrated_analyzer import AnalysisConfidence as AnalysisConfidence
+    from modelaudit.analysis.integrated_analyzer import IntegratedAnalyzer as IntegratedAnalyzer
+    from modelaudit.analysis.semantic_analyzer import CodeRiskLevel as CodeRiskLevel
+    from modelaudit.analysis.semantic_analyzer import SemanticAnalyzer as SemanticAnalyzer
 
 # Lazy imports to avoid circular dependencies
 # Import specific classes only when accessed via __getattr__

--- a/tests/test_lazy_loading.py
+++ b/tests/test_lazy_loading.py
@@ -218,6 +218,18 @@ class TestLazyListInterface:
 class TestBackwardsCompatibility:
     """Test backwards compatibility of the lazy loading system."""
 
+    def test_analysis_all_exports_resolve(self) -> None:
+        """Analysis package __all__ entries should resolve through lazy imports."""
+        import modelaudit.analysis as analysis
+
+        namespace: dict[str, object] = {}
+
+        exec("from modelaudit.analysis import *", {}, namespace)
+
+        for name in analysis.__all__:
+            assert name in namespace
+            assert getattr(analysis, name) is namespace[name]
+
     def test_direct_scanner_import(self):
         """Test that scanners can still be imported directly."""
         from modelaudit.scanners import PickleScanner


### PR DESCRIPTION
## Summary
- Add static `TYPE_CHECKING` declarations for `modelaudit.analysis` lazy exports so explicit `__all__` entries are defined for static analysis.
- Keep runtime imports lazy to preserve the existing circular-import avoidance behavior.
- Add regression coverage that `from modelaudit.analysis import *` resolves every exported name.
- Swept literal `__all__` exports across `modelaudit`, standalone picklescan, and test helpers; no other missing static definitions were found.

## Validation
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` (`3766 passed, 77 skipped`)
- Static `__all__` export sweep (`All literal __all__ exports have matching static definitions`)