### PR TITLE
refactor: remove redundant scanner test imports

### DIFF
--- a/modelaudit/rules.py
+++ b/modelaudit/rules.py
@@ -5,7 +5,6 @@ Rule system for ModelAudit - Simple, centralized rule definitions and management
 import re
 from dataclasses import dataclass
 from enum import Enum
-from re import Pattern
 from typing import ClassVar
 
 from .rule_catalog import RULE_CATALOG
@@ -29,7 +28,7 @@ class Rule:
     name: str
     default_severity: Severity
     description: str
-    message_patterns: list[Pattern[str]]
+    message_patterns: list[re.Pattern[str]]
 
     def matches_message(self, message: str) -> bool:
         """Check if this rule matches a given message."""

--- a/modelaudit/scanners/nemo_scanner.py
+++ b/modelaudit/scanners/nemo_scanner.py
@@ -130,6 +130,13 @@ def _scan_result_has_security_findings(result: ScanResult) -> bool:
     return any(issue.severity in (IssueSeverity.WARNING, IssueSeverity.CRITICAL) for issue in result.issues)
 
 
+def _get_nested_scanner_for_file(path: str, *, config: dict[str, Any]) -> BaseScanner | None:
+    """Resolve nested scanners lazily to avoid scanner registry import cycles."""
+    from modelaudit.scanners import get_scanner_for_file
+
+    return get_scanner_for_file(path, config=config)
+
+
 class NemoScanner(BaseScanner):
     """Scanner for NVIDIA NeMo model files.
 
@@ -526,9 +533,7 @@ class NemoScanner(BaseScanner):
             return
 
         try:
-            from modelaudit.scanners import get_scanner_for_file
-
-            scanner = get_scanner_for_file(extracted_path, config=dict(self.config))
+            scanner = _get_nested_scanner_for_file(extracted_path, config=dict(self.config))
             if scanner is None:
                 self._mark_inconclusive_scan_result(
                     result,

--- a/tests/scanners/test_base_scanner.py
+++ b/tests/scanners/test_base_scanner.py
@@ -6,8 +6,6 @@ from typing import ClassVar
 
 import pytest
 
-import modelaudit.scanners.base as base_module
-import modelaudit.whitelists as whitelist_module
 from modelaudit.analysis.unified_context import UnifiedMLContext
 from modelaudit.scanners.base import (
     BaseScanner,
@@ -519,8 +517,11 @@ def test_whitelist_staleness_recent_no_warning(
     """Recent whitelist snapshots should not emit a staleness warning."""
     from modelaudit.whitelists import POPULAR_MODELS
 
-    monkeypatch.setattr(base_module, "_has_logged_stale_whitelist_warning", False)
-    monkeypatch.setattr(whitelist_module, "WHITELIST_GENERATED_AT", datetime.now(timezone.utc).date().isoformat())
+    monkeypatch.setattr("modelaudit.scanners.base._has_logged_stale_whitelist_warning", False)
+    monkeypatch.setattr(
+        "modelaudit.whitelists.WHITELIST_GENERATED_AT",
+        datetime.now(timezone.utc).date().isoformat(),
+    )
 
     scanner = MockScanner()
     scanner.context = UnifiedMLContext(
@@ -546,8 +547,8 @@ def test_whitelist_staleness_warning_logged_for_stale_snapshot(
     from modelaudit.whitelists import POPULAR_MODELS
 
     stale_date = (datetime.now(timezone.utc).date() - timedelta(days=180)).isoformat()
-    monkeypatch.setattr(base_module, "_has_logged_stale_whitelist_warning", False)
-    monkeypatch.setattr(whitelist_module, "WHITELIST_GENERATED_AT", stale_date)
+    monkeypatch.setattr("modelaudit.scanners.base._has_logged_stale_whitelist_warning", False)
+    monkeypatch.setattr("modelaudit.whitelists.WHITELIST_GENERATED_AT", stale_date)
 
     scanner = MockScanner()
     scanner.context = UnifiedMLContext(
@@ -573,8 +574,8 @@ def test_whitelist_staleness_warning_only_logs_once(
     from modelaudit.whitelists import POPULAR_MODELS
 
     stale_date = (datetime.now(timezone.utc).date() - timedelta(days=180)).isoformat()
-    monkeypatch.setattr(base_module, "_has_logged_stale_whitelist_warning", False)
-    monkeypatch.setattr(whitelist_module, "WHITELIST_GENERATED_AT", stale_date)
+    monkeypatch.setattr("modelaudit.scanners.base._has_logged_stale_whitelist_warning", False)
+    monkeypatch.setattr("modelaudit.whitelists.WHITELIST_GENERATED_AT", stale_date)
 
     scanner_one = MockScanner()
     scanner_one.context = UnifiedMLContext(
@@ -611,8 +612,8 @@ def test_whitelist_staleness_unknown_model_no_warning(
 ) -> None:
     """Unknown models should not emit a stale whitelist warning."""
     stale_date = (datetime.now(timezone.utc).date() - timedelta(days=180)).isoformat()
-    monkeypatch.setattr(base_module, "_has_logged_stale_whitelist_warning", False)
-    monkeypatch.setattr(whitelist_module, "WHITELIST_GENERATED_AT", stale_date)
+    monkeypatch.setattr("modelaudit.scanners.base._has_logged_stale_whitelist_warning", False)
+    monkeypatch.setattr("modelaudit.whitelists.WHITELIST_GENERATED_AT", stale_date)
 
     scanner = MockScanner()
     scanner.context = UnifiedMLContext(

--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -4,10 +4,9 @@ from pathlib import Path
 
 import pytest
 
-import modelaudit.scanners.manifest_scanner as manifest_scanner_module
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity, ScanResult
-from modelaudit.scanners.manifest_scanner import ManifestScanner, _is_trusted_url_domain
+from modelaudit.scanners.manifest_scanner import _PARSE_FAILED, ManifestScanner, _is_trusted_url_domain
 
 
 def _https_url(host: str, path: str = "/model.bin") -> str:
@@ -176,7 +175,7 @@ def test_parse_file_logs_warning(caplog, capsys):
         result = ScanResult(scanner.name)
         content = scanner._parse_file("nonexistent.json", ".json", result)
 
-    assert content is manifest_scanner_module._PARSE_FAILED
+    assert content is _PARSE_FAILED
     assert any("Error parsing file nonexistent.json" in record.getMessage() for record in caplog.records)
     assert capsys.readouterr().out == ""
     assert any(issue.severity == IssueSeverity.DEBUG for issue in result.issues)
@@ -860,7 +859,7 @@ def test_manifest_scanner_parse_timeout_reports_only_timeout(
     def raise_timeout(_content: str) -> dict:
         raise TimeoutError("parse helper timed out")
 
-    monkeypatch.setattr(manifest_scanner_module.json, "loads", raise_timeout)
+    monkeypatch.setattr(json, "loads", raise_timeout)
 
     result = scanner.scan(str(test_file))
 

--- a/tests/scanners/test_mxnet_scanner.py
+++ b/tests/scanners/test_mxnet_scanner.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 
-import modelaudit.scanners.mxnet_scanner as mxnet_scanner
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.models import ModelAuditResultModel
 from modelaudit.scanners import get_scanner_for_file
@@ -328,7 +327,7 @@ def test_mxnet_truncated_symbol_scan_is_inconclusive(
 ) -> None:
     symbol_path = tmp_path / "truncated-symbol.json"
     _write_symbol_file(symbol_path)
-    monkeypatch.setattr(mxnet_scanner, "MAX_SYMBOL_READ_BYTES", 8)
+    monkeypatch.setattr("modelaudit.scanners.mxnet_scanner.MAX_SYMBOL_READ_BYTES", 8)
 
     result = MXNetScanner().scan(str(symbol_path))
 

--- a/tests/scanners/test_nemo_scanner.py
+++ b/tests/scanners/test_nemo_scanner.py
@@ -250,7 +250,7 @@ class TestNemoArchiveVulnerabilityCoverage:
                 raise RuntimeError("nested boom")
 
         monkeypatch.setattr(
-            "modelaudit.scanners.get_scanner_for_file",
+            "modelaudit.scanners.nemo_scanner._get_nested_scanner_for_file",
             lambda _path, config=None: RaisingScanner(),
         )
 
@@ -278,7 +278,7 @@ class TestNemoArchiveVulnerabilityCoverage:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setattr(
-            "modelaudit.scanners.get_scanner_for_file",
+            "modelaudit.scanners.nemo_scanner._get_nested_scanner_for_file",
             lambda _path, config=None: None,
         )
 

--- a/tests/scanners/test_nemo_scanner.py
+++ b/tests/scanners/test_nemo_scanner.py
@@ -110,10 +110,8 @@ class TestNemoScannerBasic:
 
     def test_missing_yaml_dependency_is_reported_as_warning(self, tmp_path, monkeypatch):
         """Missing PyYAML should be a non-passing warning, not a pass."""
-        import modelaudit.scanners.nemo_scanner as nemo_scanner_mod
-
         path = _create_nemo_file(tmp_path, {"model": "test"})
-        monkeypatch.setattr(nemo_scanner_mod, "HAS_YAML", False)
+        monkeypatch.setattr("modelaudit.scanners.nemo_scanner.HAS_YAML", False)
         scanner = NemoScanner()
         result = scanner.scan(str(path))
 
@@ -251,11 +249,8 @@ class TestNemoArchiveVulnerabilityCoverage:
             def scan(self, _path: str) -> None:
                 raise RuntimeError("nested boom")
 
-        import modelaudit.scanners as scanner_registry
-
         monkeypatch.setattr(
-            scanner_registry,
-            "get_scanner_for_file",
+            "modelaudit.scanners.get_scanner_for_file",
             lambda _path, config=None: RaisingScanner(),
         )
 
@@ -282,11 +277,8 @@ class TestNemoArchiveVulnerabilityCoverage:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        import modelaudit.scanners as scanner_registry
-
         monkeypatch.setattr(
-            scanner_registry,
-            "get_scanner_for_file",
+            "modelaudit.scanners.get_scanner_for_file",
             lambda _path, config=None: None,
         )
 

--- a/tests/scanners/test_numpy_scanner.py
+++ b/tests/scanners/test_numpy_scanner.py
@@ -45,9 +45,7 @@ def test_numpy_format_module_unavailable_is_operational_not_critical(
     path = tmp_path / "array.npy"
     np.save(path, arr)
 
-    import modelaudit.scanners.numpy_scanner as numpy_scanner_module
-
-    monkeypatch.setattr(numpy_scanner_module, "NUMPY_FORMAT_AVAILABLE", False)
+    monkeypatch.setattr("modelaudit.scanners.numpy_scanner.NUMPY_FORMAT_AVAILABLE", False)
 
     result = NumPyScanner().scan(str(path))
 

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -9,7 +9,7 @@ import tempfile
 import unittest
 import uuid
 import zipfile
-from collections import Counter
+from collections import Counter, OrderedDict
 from collections.abc import Callable, Iterator
 from io import BytesIO
 from pathlib import Path
@@ -3296,12 +3296,9 @@ class TestDillLoadersRegression:
 
         # Create a complex ML-like data structure that might trigger some ML detection
         # Focus on collections.OrderedDict which is a common PyTorch pattern
-        import collections
-        import os
-        import tempfile
 
         # Create nested OrderedDict structures that mimic PyTorch state_dict patterns
-        complex_ml_data = collections.OrderedDict(
+        complex_ml_data = OrderedDict(
             [
                 ("features.0.weight", "tensor_data_placeholder"),
                 ("features.0.bias", "tensor_data_placeholder"),
@@ -3309,9 +3306,9 @@ class TestDillLoadersRegression:
                 ("features.3.bias", "tensor_data_placeholder"),
                 ("classifier.weight", "tensor_data_placeholder"),
                 ("classifier.bias", "tensor_data_placeholder"),
-                ("_metadata", collections.OrderedDict([("version", 1)])),
-                ("_modules", collections.OrderedDict()),
-                ("_parameters", collections.OrderedDict()),
+                ("_metadata", OrderedDict([("version", 1)])),
+                ("_modules", OrderedDict()),
+                ("_parameters", OrderedDict()),
             ],
         )
 
@@ -7963,9 +7960,7 @@ def test_safe_ml_reconstruction_globals_remain_non_failing(tmp_path: Path, paylo
 
 def test_safe_pytorch_state_dict_pickle_remains_non_failing(tmp_path: Path) -> None:
     """State-dict-style payloads should not start failing under the risky-ML policy."""
-    import collections
-
-    safe_state_dict = collections.OrderedDict(
+    safe_state_dict = OrderedDict(
         [
             ("layer1.weight", [1.0, 2.0, 3.0]),
             ("layer1.bias", [0.1, 0.2, 0.3]),
@@ -7974,7 +7969,7 @@ def test_safe_pytorch_state_dict_pickle_remains_non_failing(tmp_path: Path) -> N
     )
     payload = {
         "state_dict": safe_state_dict,
-        "_metadata": collections.OrderedDict([("", {"version": 1})]),
+        "_metadata": OrderedDict([("", {"version": 1})]),
     }
     path = tmp_path / "safe_state_dict.pth"
     with path.open("wb") as handle:


### PR DESCRIPTION
## Summary
- Remove duplicate module import shapes flagged by SAST.
- Use dotted monkeypatch targets or direct symbols for test-only module access.
- Keep scanner behavior unchanged while preserving regression coverage.

## Validation
- `uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by standardizing how tests patch and monkeypatch internal attributes, reducing brittle imports and making tests more robust.

* **Refactor**
  * Minor type-annotation cleanup for internal consistency (no behavioral changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->