### PR TITLE
fix(rule-mapper): preserve unknown opcode fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- preserve `S999` unknown-opcode mapping in generic rule fallback
+
 ## [0.2.37](https://github.com/promptfoo/modelaudit/compare/v0.2.36...v0.2.37) (2026-04-12)
 
 ### Bug Fixes

--- a/modelaudit/scanners/rule_mapper.py
+++ b/modelaudit/scanners/rule_mapper.py
@@ -323,12 +323,6 @@ def get_generic_rule_code(message: str) -> str | None:
     """
     msg_lower = message.lower()
 
-    # Try each specialized mapper
-    for mapper in _GENERIC_RULE_MAPPERS:
-        code = mapper(msg_lower)
-        if code:
-            return code
-
     # Check for specific patterns
     if "protocol" in msg_lower and "version" in msg_lower:
         # Informational protocol/version context; intentionally not a security rule.
@@ -337,10 +331,16 @@ def get_generic_rule_code(message: str) -> str | None:
         ("stack" in msg_lower and "depth" in msg_lower)
         or "timeout" in msg_lower
         or "timed out" in msg_lower
-        or ("opcode" in msg_lower and "count" in msg_lower)
+        or "opcode count" in msg_lower
     ):
         return None  # Internal check, no rule
     elif "unknown" in msg_lower and ("opcode" in msg_lower or "operation" in msg_lower):
         return _rule("S999")  # Unknown opcode/operation
+
+    # Try each specialized mapper
+    for mapper in _GENERIC_RULE_MAPPERS:
+        code = mapper(msg_lower)
+        if code:
+            return code
 
     return None

--- a/tests/scanners/test_rule_mapper.py
+++ b/tests/scanners/test_rule_mapper.py
@@ -1,5 +1,7 @@
 """Tests for scanner rule mapping helpers."""
 
+import pytest
+
 from modelaudit.rules import RuleRegistry
 from modelaudit.scanners.rule_mapper import (
     get_embedded_code_rule_code,
@@ -28,6 +30,21 @@ def test_generic_rule_prefers_network_codes_for_urls() -> None:
     assert get_generic_rule_code("Network communication pattern: https://evil.example") == "S309"
 
 
+@pytest.mark.parametrize(
+    ("message", "expected_rule_code"),
+    [
+        ("Type mismatch between payload and extension", "S901"),
+        ("ObFuScAtEd payload blob", "S604"),
+        ("OpenAI API Key exposed in artifact", "S701"),
+        ("TorchScript JIT payload embedded in model", "S510"),
+        ("Unsafe PyTorch torch.load usage detected", "S1101"),
+    ],
+)
+def test_generic_rule_covers_non_network_dispatch_categories(message: str, expected_rule_code: str) -> None:
+    """Generic dispatch should reach every non-network mapper in rule order."""
+    assert get_generic_rule_code(message) == expected_rule_code
+
+
 def test_network_rule_mapping_prioritizes_exfiltration_patterns() -> None:
     """Explicit exfil/C2 indicators should map to S310."""
     assert get_network_rule_code("blacklisted_domain c2.example beacon") == "S310"
@@ -36,3 +53,20 @@ def test_network_rule_mapping_prioritizes_exfiltration_patterns() -> None:
 def test_generic_rule_does_not_map_protocol_version_to_persistent_id() -> None:
     """Generic protocol-version text should not be classified as persistent ID use."""
     assert get_generic_rule_code("Valid pickle protocol version 4") is None
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Stack depth exceeded while scanning pickle stream",
+        "Scan timed out after opcode count threshold",
+    ],
+)
+def test_generic_rule_ignores_internal_operational_messages(message: str) -> None:
+    """Operational timeout/depth notices should not surface as rule violations."""
+    assert get_generic_rule_code(message) is None
+
+
+def test_generic_rule_maps_unknown_opcodes_to_internal_fallback_rule() -> None:
+    """Unknown opcode diagnostics should map to the generic internal fallback rule."""
+    assert get_generic_rule_code("Unknown opcode FOO encountered while parsing") == "S999"


### PR DESCRIPTION
## Summary
- preserve the generic `S999` fallback for unknown opcode and unknown operation diagnostics
- tighten the internal opcode-count no-op heuristic so `encountered` no longer suppresses unknown-opcode findings
- add focused regression coverage for generic rule dispatch, operational no-op messages, and unknown-opcode mapping

## Validation
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
