### PR TITLE
test(nemo): cover lazy nested scanner resolution

### DIFF
--- a/tests/scanners/test_nemo_scanner.py
+++ b/tests/scanners/test_nemo_scanner.py
@@ -18,7 +18,7 @@ except ImportError:
 
 from modelaudit.core import determine_exit_code, scan_file, scan_model_directory_or_file
 from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity
-from modelaudit.scanners.nemo_scanner import NemoScanner
+from modelaudit.scanners.nemo_scanner import NemoScanner, _get_nested_scanner_for_file
 
 
 def _create_nemo_file_from_bytes(
@@ -119,6 +119,26 @@ class TestNemoScannerBasic:
         assert len(checks) == 1
         assert checks[0].status != CheckStatus.PASSED
         assert checks[0].severity == IssueSeverity.WARNING
+
+    def test_get_nested_scanner_for_file_delegates_to_registry(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+        sentinel = object()
+
+        def fake_get_scanner_for_file(path: str, *, config: dict[str, Any]) -> object:
+            captured["path"] = path
+            captured["config"] = config
+            return sentinel
+
+        monkeypatch.setattr("modelaudit.scanners.get_scanner_for_file", fake_get_scanner_for_file)
+
+        config = {"max_nemo_checkpoint_scan_bytes": 1024}
+
+        assert _get_nested_scanner_for_file("/tmp/model_weights.ckpt", config=config) is sentinel
+        assert captured["path"] == "/tmp/model_weights.ckpt"
+        assert captured["config"] is config
 
 
 @pytest.mark.skipif(not HAS_YAML, reason="PyYAML not installed")


### PR DESCRIPTION
## Summary
A recent NeMo scanner refactor introduced `_get_nested_scanner_for_file` to resolve nested scanners lazily and avoid registry import cycles. The surrounding archive tests patch around that helper, so the new delegation path itself was present in the codebase without a direct regression test.

This change adds a focused unit test that exercises the helper directly and asserts that it forwards both the checkpoint path and config object to `modelaudit.scanners.get_scanner_for_file`. That keeps the scope on the recent refactor and gives us a stable signal if lazy nested scanner resolution stops delegating correctly.

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
