### PR TITLE
perf: optimize model scan hot paths

### DIFF
--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -144,20 +144,6 @@ def _calculate_file_hash(file_path: str) -> str:
     return hash_sha256.hexdigest()
 
 
-def _extract_sha256_hash_from_scan_result(file_result: ScanResult) -> str | None:
-    """Return a scanner-computed SHA-256 hash when the scan result includes one."""
-    metadata = getattr(file_result, "metadata", None)
-    if not isinstance(metadata, dict):
-        return None
-
-    file_hashes = metadata.get("file_hashes")
-    if isinstance(file_hashes, dict):
-        sha256_hash = file_hashes.get("sha256")
-        return sha256_hash if isinstance(sha256_hash, str) and sha256_hash else None
-    sha256_hash = getattr(file_hashes, "sha256", None)
-    return sha256_hash if isinstance(sha256_hash, str) and sha256_hash else None
-
-
 def _group_files_by_content(file_paths: list[str]) -> dict[str, list[str]]:
     """Group files by their content hash to avoid scanning duplicates.
 
@@ -651,17 +637,16 @@ def scan_model_directory_or_file(
 
                 results.files_scanned += 1
 
-                file_result = scan_file(target, config)
-                file_hash = _extract_sha256_hash_from_scan_result(file_result)
-                if file_hash is None:
-                    # Fall back for scanner paths that do not emit file integrity metadata.
-                    try:
-                        file_hash = _calculate_file_hash(target)
-                    except Exception as e:
-                        logger.debug(f"Failed to hash file {target}: {e}")
-                        file_hash = None
-                if file_hash is not None:
+                # Hash the top-level target before scanning. Archive scanners merge
+                # nested member results into their metadata, so scanner-emitted
+                # hashes are not always the bytes of this target.
+                try:
+                    file_hash = _calculate_file_hash(target)
                     file_hashes.append(file_hash)
+                except Exception as e:
+                    logger.debug(f"Failed to hash file {target}: {e}")
+
+                file_result = scan_file(target, config)
 
                 # Use helper function to add scan result to Pydantic model
                 _add_scan_result_to_model(results, scan_metadata, file_result, target)

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -19,7 +19,7 @@ from modelaudit.models import ModelAuditResultModel, ScanConfigModel, create_ini
 from modelaudit.scanner_results import Issue, IssueSeverity, ScanResult
 from modelaudit.scanners import _registry
 from modelaudit.scanners.archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY
-from modelaudit.scanners.base import BaseScanner
+from modelaudit.scanners.base import FORMAT_VALIDATION_CONFIG_KEY, BaseScanner
 from modelaudit.telemetry import record_file_type_detected, record_issue_found, record_scanner_used
 from modelaudit.utils import is_within_directory, resolve_dvc_file, should_skip_file
 from modelaudit.utils.file.detection import (
@@ -31,7 +31,7 @@ from modelaudit.utils.file.detection import (
     is_pytorch_zip_archive,
     is_skops_archive,
     is_torchserve_mar_archive,
-    validate_file_type,
+    validate_file_type_with_formats,
 )
 from modelaudit.utils.file.handlers import (
     scan_advanced_large_file,
@@ -142,6 +142,20 @@ def _calculate_file_hash(file_path: str) -> str:
         for chunk in iter(lambda: f.read(8192), b""):
             hash_sha256.update(chunk)
     return hash_sha256.hexdigest()
+
+
+def _extract_sha256_hash_from_scan_result(file_result: ScanResult) -> str | None:
+    """Return a scanner-computed SHA-256 hash when the scan result includes one."""
+    metadata = getattr(file_result, "metadata", None)
+    if not isinstance(metadata, dict):
+        return None
+
+    file_hashes = metadata.get("file_hashes")
+    if isinstance(file_hashes, dict):
+        sha256_hash = file_hashes.get("sha256")
+        return sha256_hash if isinstance(sha256_hash, str) and sha256_hash else None
+    sha256_hash = getattr(file_hashes, "sha256", None)
+    return sha256_hash if isinstance(sha256_hash, str) and sha256_hash else None
 
 
 def _group_files_by_content(file_paths: list[str]) -> dict[str, list[str]]:
@@ -637,15 +651,17 @@ def scan_model_directory_or_file(
 
                 results.files_scanned += 1
 
-                # Compute hash for single file to enable aggregate hash
-                try:
-                    file_hash = _calculate_file_hash(target)
-                    file_hashes.append(file_hash)
-                except Exception as e:
-                    logger.debug(f"Failed to hash file {target}: {e}")
-                    # Continue without hash - not a critical error
-
                 file_result = scan_file(target, config)
+                file_hash = _extract_sha256_hash_from_scan_result(file_result)
+                if file_hash is None:
+                    # Fall back for scanner paths that do not emit file integrity metadata.
+                    try:
+                        file_hash = _calculate_file_hash(target)
+                    except Exception as e:
+                        logger.debug(f"Failed to hash file {target}: {e}")
+                        file_hash = None
+                if file_hash is not None:
+                    file_hashes.append(file_hash)
 
                 # Use helper function to add scan result to Pydantic model
                 _add_scan_result_to_model(results, scan_metadata, file_result, target)
@@ -930,14 +946,12 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
     record_file_type_detected(path, detected_format)
 
     # Validate file type consistency as a security check
-    file_type_valid = validate_file_type(path)
+    magic_format = detect_file_format_from_magic(path)
+    file_type_valid = validate_file_type_with_formats(path, magic_format, ext_format)
     discrepancy_msg = None
-    magic_format = None
 
     if not file_type_valid:
         # File type validation failed - this is a security concern
-        # Get the actual magic bytes format for accurate error message
-        magic_format = detect_file_format_from_magic(path)
         discrepancy_msg = (
             f"File type validation failed: extension indicates {ext_format} but magic bytes "
             f"indicate {magic_format}. This could indicate file spoofing or corruption."
@@ -967,6 +981,12 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
     use_large_handler = should_use_large_file_handler(path) and not use_extreme_handler
     progress_callback = config.get("progress_callback")
     timeout = config.get("timeout", 3600)
+    config[FORMAT_VALIDATION_CONFIG_KEY] = {
+        "path": os.path.abspath(path),
+        "header_format": magic_format,
+        "extension_format": ext_format,
+        "file_type_valid": file_type_valid,
+    }
 
     if (
         preferred_scanner

--- a/modelaudit/integrations/license_checker.py
+++ b/modelaudit/integrations/license_checker.py
@@ -2,6 +2,7 @@ import itertools
 import json
 import os
 import re
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -126,6 +127,28 @@ _COMPILED_LICENSE_PATTERNS = tuple(
 _COMPILED_COPYRIGHT_PATTERNS = tuple(
     re.compile(pattern, re.IGNORECASE | re.MULTILINE) for pattern in COPYRIGHT_PATTERNS
 )
+_LICENSE_PREFILTER_TERMS = (
+    "license",
+    "spdx",
+    "mit",
+    "apache",
+    "bsd",
+    "gnu",
+    "gpl",
+    "agpl",
+    "lgpl",
+    "creative commons",
+    "cc by",
+    "cc-by",
+    "open data commons",
+    "odbl",
+    "pddl",
+    "bigscience",
+    "responsible ai",
+    "rail",
+    "openrail",
+)
+_COPYRIGHT_PREFILTER_TERMS = ("copyright", "(c)", "©")
 
 
 def _looks_like_binary_header_sample(sample: bytes) -> bool:
@@ -165,6 +188,11 @@ def _read_header_text(file_path: str, max_lines: int) -> str | None:
             return "".join(itertools.islice(f, max_lines))
     except OSError:
         return None
+
+
+def _content_has_prefilter_term(content: str, terms: tuple[str, ...]) -> bool:
+    lowered = content.lower()
+    return any(term in lowered for term in terms)
 
 
 def load_spdx_license_data(download: bool = False) -> dict[str, Any]:
@@ -227,21 +255,9 @@ DATASET_EXTENSIONS = {
 MODEL_EXTENSIONS = COMMON_MODEL_EXTENSIONS
 
 
-def scan_for_license_headers(file_path: str, max_lines: int = 50) -> list[LicenseInfo]:
-    """
-    Scan a file's header for license information.
-
-    Args:
-        file_path: Path to the file to scan
-        max_lines: Maximum number of lines to scan from the beginning
-
-    Returns:
-        List of detected license information
-    """
+def _scan_license_headers_from_content(content: str) -> list[LicenseInfo]:
     licenses: list[LicenseInfo] = []
-
-    content = _read_header_text(file_path, max_lines)
-    if content is None:
+    if not _content_has_prefilter_term(content, _LICENSE_PREFILTER_TERMS):
         return licenses
 
     # Search for license patterns
@@ -261,24 +277,27 @@ def scan_for_license_headers(file_path: str, max_lines: int = 50) -> list[Licens
     return licenses
 
 
-def extract_copyright_notices(
-    file_path: str,
-    max_lines: int = 50,
-) -> list[CopyrightInfo]:
+def scan_for_license_headers(file_path: str, max_lines: int = 50) -> list[LicenseInfo]:
     """
-    Extract copyright notices from a file.
+    Scan a file's header for license information.
 
     Args:
         file_path: Path to the file to scan
-        max_lines: Maximum number of lines to scan
+        max_lines: Maximum number of lines to scan from the beginning
 
     Returns:
-        List of copyright information found
+        List of detected license information
     """
-    copyrights: list[CopyrightInfo] = []
-
     content = _read_header_text(file_path, max_lines)
     if content is None:
+        return []
+
+    return _scan_license_headers_from_content(content)
+
+
+def _extract_copyright_notices_from_content(content: str) -> list[CopyrightInfo]:
+    copyrights: list[CopyrightInfo] = []
+    if not _content_has_prefilter_term(content, _COPYRIGHT_PREFILTER_TERMS):
         return copyrights
 
     # Search for copyright patterns
@@ -297,6 +316,27 @@ def extract_copyright_notices(
                 copyrights.append(copyright_info)
 
     return copyrights
+
+
+def extract_copyright_notices(
+    file_path: str,
+    max_lines: int = 50,
+) -> list[CopyrightInfo]:
+    """
+    Extract copyright notices from a file.
+
+    Args:
+        file_path: Path to the file to scan
+        max_lines: Maximum number of lines to scan
+
+    Returns:
+        List of copyright information found
+    """
+    content = _read_header_text(file_path, max_lines)
+    if content is None:
+        return []
+
+    return _extract_copyright_notices_from_content(content)
 
 
 def find_license_files(directory: str) -> list[str]:
@@ -326,7 +366,11 @@ def find_license_files(directory: str) -> list[str]:
     return license_files
 
 
-def detect_unlicensed_datasets(file_paths: list[str]) -> list[str]:
+def detect_unlicensed_datasets(
+    file_paths: list[str],
+    *,
+    license_info_by_path: Mapping[str, object] | None = None,
+) -> list[str]:
     """
     Detect dataset files that may lack proper licensing.
 
@@ -363,12 +407,29 @@ def detect_unlicensed_datasets(file_paths: list[str]) -> list[str]:
                 has_license = False
 
             if not has_license:
-                # Check if the file itself contains license info
+                # Reuse metadata gathered during the scan when available.
+                if license_info_by_path is not None and file_path in license_info_by_path:
+                    if not license_info_by_path[file_path]:
+                        unlicensed.append(file_path)
+                    continue
+
                 licenses = scan_for_license_headers(file_path, max_lines=10)
                 if not licenses:
                     unlicensed.append(file_path)
 
     return unlicensed
+
+
+def _get_license_info_from_metadata(metadata: Any) -> object | None:
+    if isinstance(metadata, dict):
+        return metadata.get("license_info")
+    if hasattr(metadata, "license_info"):
+        license_info: object | None = metadata.license_info
+        return license_info
+    if hasattr(metadata, "get"):
+        license_info = metadata.get("license_info")
+        return license_info
+    return None
 
 
 def _is_ml_config_file(filename: str) -> bool:
@@ -572,8 +633,14 @@ def check_commercial_use_warnings(scan_results: dict[str, Any] | Any, *, strict:
 
     # Check for datasets with unspecified licenses
     # Only warn if we have multiple files or files that are clearly datasets
-    all_files = list(scan_results.get("file_metadata", {}).keys())
-    unlicensed_datasets = detect_unlicensed_datasets(all_files)
+    file_metadata = scan_results.get("file_metadata", {})
+    all_files = list(file_metadata.keys())
+    license_info_by_path = {}
+    for file_path, metadata in file_metadata.items():
+        license_info = _get_license_info_from_metadata(metadata)
+        if license_info is not None:
+            license_info_by_path[file_path] = license_info
+    unlicensed_datasets = detect_unlicensed_datasets(all_files, license_info_by_path=license_info_by_path)
 
     # Filter out single files that might be tests or simple examples
     significant_unlicensed_datasets = []
@@ -607,7 +674,6 @@ def check_commercial_use_warnings(scan_results: dict[str, Any] | Any, *, strict:
 
     # Check for non-commercial licenses
     nc_files = []
-    file_metadata = scan_results.get("file_metadata", {})
     for file_path, metadata in file_metadata.items():
         licenses = metadata.get("license_info", [])
         for license_info in licenses:
@@ -695,8 +761,10 @@ def collect_license_metadata(file_path: str) -> dict[str, Any]:
     metadata["is_dataset"] = ext in DATASET_EXTENSIONS
     metadata["is_model"] = ext in MODEL_EXTENSIONS
 
+    content = _read_header_text(file_path, max_lines=50)
+
     # Scan for license headers
-    licenses = scan_for_license_headers(file_path)
+    licenses = _scan_license_headers_from_content(content) if content is not None else []
     metadata["license_info"] = [
         {
             "spdx_id": lic.spdx_id,
@@ -709,7 +777,7 @@ def collect_license_metadata(file_path: str) -> dict[str, Any]:
     ]
 
     # Extract copyright notices
-    copyrights = extract_copyright_notices(file_path)
+    copyrights = _extract_copyright_notices_from_content(content) if content is not None else []
     metadata["copyright_notices"] = [
         {
             "holder": cr.holder,

--- a/modelaudit/scanners/base.py
+++ b/modelaudit/scanners/base.py
@@ -50,6 +50,7 @@ __all__ = [
 ]
 
 TRUSTED_HUGGINGFACE_SOURCES = frozenset({"huggingface"})
+FORMAT_VALIDATION_CONFIG_KEY: Final[str] = "_modelaudit_format_validation"
 _TRUSTED_SOURCE_PROVENANCE_TOKEN: Final[object] = object()
 _WHITELIST_STALE_WARNING_THRESHOLD_DAYS: Final[int] = 90
 _has_logged_stale_whitelist_warning = False
@@ -962,9 +963,20 @@ class BaseScanner(ABC):
                     validate_file_type,
                 )
 
-                if not validate_file_type(path):
-                    header_format = detect_file_format_from_magic(path)
-                    ext_format = detect_format_from_extension(path)
+                format_validation = self.config.get(FORMAT_VALIDATION_CONFIG_KEY)
+                if isinstance(format_validation, dict) and format_validation.get("path") == os.path.abspath(path):
+                    file_type_valid = bool(format_validation.get("file_type_valid", True))
+                    header_format = str(format_validation.get("header_format", "unknown"))
+                    ext_format = str(format_validation.get("extension_format", "unknown"))
+                else:
+                    file_type_valid = validate_file_type(path)
+                    header_format = "unknown"
+                    ext_format = "unknown"
+
+                if not file_type_valid:
+                    if header_format == "unknown" and ext_format == "unknown":
+                        header_format = detect_file_format_from_magic(path)
+                        ext_format = detect_format_from_extension(path)
                     result.add_check(
                         name="File Type Validation",
                         passed=False,

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -599,21 +599,39 @@ def _contains_any_seed(data: bytes, seeds: tuple[bytes, ...]) -> bool:
     return _contains_any_seed_lowered(data.lower(), seeds)
 
 
-def _contains_any_seed_lowered(lower_data: bytes, seeds: tuple[bytes, ...]) -> bool:
-    return any(seed in lower_data for seed in seeds)
+def _seed_possible_from_present_bytes(seed: bytes, present_bytes: frozenset[int] | None) -> bool:
+    return present_bytes is None or all(byte in present_bytes for byte in seed)
 
 
-def _has_raw_text_indicator_shape(data: bytes, lower_data: bytes, *, rust_clean: bool) -> bool:
-    if _contains_any_seed_lowered(lower_data, _RAW_TEXT_SCAN_SEEDS):
+def _contains_any_seed_lowered(
+    lower_data: bytes,
+    seeds: tuple[bytes, ...],
+    present_bytes: frozenset[int] | None = None,
+) -> bool:
+    return any(_seed_possible_from_present_bytes(seed, present_bytes) and seed in lower_data for seed in seeds)
+
+
+def _has_raw_text_indicator_shape(
+    data: bytes,
+    lower_data: bytes,
+    *,
+    rust_clean: bool,
+    present_bytes: frozenset[int] | None = None,
+) -> bool:
+    if _contains_any_seed_lowered(lower_data, _RAW_TEXT_SCAN_SEEDS, present_bytes):
         return True
     if rust_clean:
         return False
     return b"R" in data and any(opcode in data for opcode in _COPYREG_EXTENSION_OPCODES)
 
 
-def _has_alnum_secret_shape(data: bytes) -> bool:
-    lower = data.lower()
-    if not _contains_any_seed_lowered(lower, _SECRET_SHAPE_KEYWORDS):
+def _has_alnum_secret_shape(
+    data: bytes,
+    lower_data: bytes | None = None,
+    present_bytes: frozenset[int] | None = None,
+) -> bool:
+    lower = data.lower() if lower_data is None else lower_data
+    if not _contains_any_seed_lowered(lower, _SECRET_SHAPE_KEYWORDS, present_bytes):
         return False
     return _SECRET_ASSIGNMENT_SHAPE_RE.search(data) is not None
 
@@ -1600,9 +1618,12 @@ class PickleScanner(BaseScanner):
         if not data:
             return
 
-        self._scan_raw_text_indicators(data, result, source)
+        lower_data = data.lower()
+        present_bytes = frozenset(lower_data)
+
+        self._scan_raw_text_indicators(data, result, source, lower_data=lower_data, present_bytes=present_bytes)
         self._scan_encoded_text_indicators(data, result, source)
-        self._analyze_cve_patterns(data, result, source)
+        self._analyze_cve_patterns(data, result, source, lower_data=lower_data, present_bytes=present_bytes)
         if scan_binary_tail:
             self._scan_binary_tail_if_needed(data, result, source)
         if skip_expensive_detectors:
@@ -1618,22 +1639,33 @@ class PickleScanner(BaseScanner):
             result.metadata["pickle_expensive_raw_detector_skip_reason"] = "disabled"
             return
         expensive_data = data[:expensive_limit]
-        expensive_lower = expensive_data.lower()
+        if len(expensive_data) == len(data):
+            expensive_lower = lower_data
+            expensive_present_bytes = present_bytes
+        else:
+            expensive_lower = expensive_data.lower()
+            expensive_present_bytes = frozenset(expensive_lower)
         if len(expensive_data) < len(data):
             result.metadata["pickle_expensive_raw_detector_bytes_scanned"] = len(expensive_data)
             result.metadata["pickle_expensive_raw_detector_bytes_available"] = len(data)
 
-        if _contains_any_seed_lowered(expensive_lower, _SECRET_SCAN_SEEDS) or _has_alnum_secret_shape(expensive_data):
+        if _contains_any_seed_lowered(
+            expensive_lower,
+            _SECRET_SCAN_SEEDS,
+            expensive_present_bytes,
+        ) or _has_alnum_secret_shape(expensive_data, expensive_lower, expensive_present_bytes):
             self.check_for_embedded_secrets(expensive_data, result, source)
         else:
             result.metadata["pickle_secrets_raw_detector_skipped"] = True
 
-        if _contains_any_seed_lowered(expensive_lower, _JIT_SCAN_SEEDS):
+        if _contains_any_seed_lowered(expensive_lower, _JIT_SCAN_SEEDS, expensive_present_bytes):
             self.check_for_jit_script_code(expensive_data, result, model_type="pickle", context=source)
         else:
             result.metadata["pickle_jit_raw_detector_skipped"] = True
 
-        if _contains_any_seed_lowered(expensive_lower, _NETWORK_SCAN_SEEDS) or _has_domain_or_ip_shape(expensive_data):
+        if _contains_any_seed_lowered(expensive_lower, _NETWORK_SCAN_SEEDS, expensive_present_bytes) or (
+            _has_domain_or_ip_shape(expensive_data)
+        ):
             self.check_for_network_communication(expensive_data, result, context=source)
         else:
             result.metadata["pickle_network_raw_detector_skipped"] = True
@@ -1815,9 +1847,24 @@ class PickleScanner(BaseScanner):
                     rule_code="S207",
                 )
 
-    def _scan_raw_text_indicators(self, data: bytes, result: ScanResult, source: str) -> None:
-        lower = data.lower()
-        if not _has_raw_text_indicator_shape(data, lower, rust_clean=self._rust_scan_completed_cleanly(result)):
+    def _scan_raw_text_indicators(
+        self,
+        data: bytes,
+        result: ScanResult,
+        source: str,
+        *,
+        lower_data: bytes | None = None,
+        present_bytes: frozenset[int] | None = None,
+    ) -> None:
+        lower = data.lower() if lower_data is None else lower_data
+        if present_bytes is None:
+            present_bytes = frozenset(lower)
+        if not _has_raw_text_indicator_shape(
+            data,
+            lower,
+            rust_clean=self._rust_scan_completed_cleanly(result),
+            present_bytes=present_bytes,
+        ):
             result.metadata["pickle_raw_text_detector_skipped"] = True
             return
         documentation_spans = _documentation_literal_spans(data)
@@ -2039,7 +2086,15 @@ class PickleScanner(BaseScanner):
                 )
                 return
 
-    def _analyze_cve_patterns(self, data: bytes, result: ScanResult, source: str | None = None) -> None:
+    def _analyze_cve_patterns(
+        self,
+        data: bytes,
+        result: ScanResult,
+        source: str | None = None,
+        *,
+        lower_data: bytes | None = None,
+        present_bytes: frozenset[int] | None = None,
+    ) -> None:
         """Add CVE attribution checks from a bounded raw pickle scan window."""
         opcode_counts = _result_opcode_counts(result)
         has_setitem_opcode = opcode_counts.get("SETITEM", 0) > 0 or opcode_counts.get("SETITEMS", 0) > 0
@@ -2048,8 +2103,10 @@ class PickleScanner(BaseScanner):
             reference.get("import_reference") in {"os.system", "posix.system", "nt.system"}
             for reference in import_references
         )
-        lower = data.lower()
-        if not _contains_any_seed_lowered(lower, _CVE_RAW_SCAN_SEEDS) and not (
+        lower = data.lower() if lower_data is None else lower_data
+        if present_bytes is None:
+            present_bytes = frozenset(lower)
+        if not _contains_any_seed_lowered(lower, _CVE_RAW_SCAN_SEEDS, present_bytes) and not (
             has_setitem_opcode and has_dangerous_system_global
         ):
             result.metadata["pickle_cve_raw_detector_skipped"] = True

--- a/modelaudit/scanners/tar_scanner.py
+++ b/modelaudit/scanners/tar_scanner.py
@@ -33,6 +33,7 @@ CRITICAL_SYSTEM_PATHS = [
 DEFAULT_MAX_TAR_ENTRY_SIZE = 1024 * 1024 * 1024
 DEFAULT_MAX_DECOMPRESSED_BYTES = 512 * 1024 * 1024
 DEFAULT_MAX_DECOMPRESSION_RATIO = 250.0
+ARCHIVE_MEMBER_COPY_CHUNK_BYTES = 64 * 1024
 
 _GZIP_MAGIC = b"\x1f\x8b"
 _BZIP2_MAGIC = b"BZh"
@@ -235,7 +236,7 @@ class TarScanner(BaseScanner):
             with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
                 tmp_path = tmp.name
                 while True:
-                    chunk = fileobj.read(4096)
+                    chunk = fileobj.read(ARCHIVE_MEMBER_COPY_CHUNK_BYTES)
                     if not chunk:
                         break
                     total_size += len(chunk)

--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -27,6 +27,7 @@ CRITICAL_SYSTEM_PATHS = [
     "/sbin",
     "C:\\Windows",
 ]
+ARCHIVE_MEMBER_COPY_CHUNK_BYTES = 64 * 1024
 
 
 class ZipScanner(BaseScanner):
@@ -430,7 +431,7 @@ class ZipScanner(BaseScanner):
                             total_size = 0
                             with z.open(info) as entry:
                                 while True:
-                                    chunk = entry.read(4096)
+                                    chunk = entry.read(ARCHIVE_MEMBER_COPY_CHUNK_BYTES)
                                     if not chunk:
                                         break
                                     total_size += len(chunk)

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -1043,6 +1043,12 @@ def detect_file_format_for_skip_filter(path: str) -> str:
         if format_result != "unknown":
             return format_result
 
+        lightgbm_probe_size = min(size, _LIGHTGBM_SIGNATURE_READ_BYTES)
+        if len(prefix) < lightgbm_probe_size:
+            prefix += f.read(lightgbm_probe_size - len(prefix))
+        if _is_lightgbm_signature(prefix):
+            return "lightgbm"
+
         if _could_start_proto0_or_1_pickle(prefix):
             max_probe_size = min(size, PROTO0_1_MAX_PROBE_BYTES)
             if len(prefix) < max_probe_size:

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -58,9 +58,19 @@ _BZIP2_MAGIC = b"BZh"
 _XZ_MAGIC = b"\xfd7zXZ\x00"
 _SEVENZIP_MAGIC = b"7z\xbc\xaf\x27\x1c"
 _LZ4_FRAME_MAGIC = b"\x04\x22\x4d\x18"
+_TAR_BLOCK_SIZE = 512
 _TAR_USTAR_OFFSET = 257
 _TAR_USTAR_MAGIC_SIZE = 5
 _TAR_USTAR_MIN_BYTES = _TAR_USTAR_OFFSET + _TAR_USTAR_MAGIC_SIZE
+_TAR_CHECKSUM_OFFSET = 148
+_TAR_CHECKSUM_SIZE = 8
+_TAR_NUMERIC_FIELD_SLICES = (
+    (100, 108),  # mode
+    (108, 116),  # uid
+    (116, 124),  # gid
+    (124, 136),  # size
+    (136, 148),  # mtime
+)
 _TFLITE_MAGIC_OFFSET = 4
 _TFLITE_MAGIC_SIZE = 4
 _TFLITE_MIN_HEADER_SIZE = _TFLITE_MAGIC_OFFSET + _TFLITE_MAGIC_SIZE
@@ -626,18 +636,53 @@ def _is_tar_archive(path: str) -> bool:
         return False
 
 
-def _has_tar_ustar_signature(file_path: Path, size: int | None = None) -> bool:
-    """Return whether an uncompressed TAR ustar signature is present."""
+def _tar_octal_value(field: bytes) -> int | None:
+    stripped = field.split(b"\0", 1)[0].strip()
+    if not stripped or any(byte < ord("0") or byte > ord("7") for byte in stripped):
+        return None
     try:
-        if size is None:
-            size = file_path.stat().st_size
-        if size < _TAR_USTAR_MIN_BYTES:
-            return False
-        with file_path.open("rb") as f:
-            f.seek(_TAR_USTAR_OFFSET)
-            return f.read(_TAR_USTAR_MAGIC_SIZE).startswith(b"ustar")
-    except OSError:
+        return int(stripped, 8)
+    except ValueError:
+        return None
+
+
+def _tar_name_looks_plausible(name_field: bytes) -> bool:
+    name = name_field.split(b"\0", 1)[0]
+    return bool(name) and all(byte >= 0x20 and byte != 0x7F for byte in name)
+
+
+def _has_tar_ustar_signature(header: bytes) -> bool:
+    return len(header) >= _TAR_USTAR_MIN_BYTES and header[
+        _TAR_USTAR_OFFSET : _TAR_USTAR_OFFSET + _TAR_USTAR_MAGIC_SIZE
+    ].startswith(b"ustar")
+
+
+def _has_valid_tar_checksum_header(header: bytes) -> bool:
+    """Return whether a 512-byte TAR header block has a valid v7/POSIX checksum."""
+    if len(header) < _TAR_BLOCK_SIZE:
         return False
+
+    block = header[:_TAR_BLOCK_SIZE]
+    if block == b"\0" * _TAR_BLOCK_SIZE or not _tar_name_looks_plausible(block[:100]):
+        return False
+
+    if any(_tar_octal_value(block[start:end]) is None for start, end in _TAR_NUMERIC_FIELD_SLICES):
+        return False
+
+    expected_checksum = _tar_octal_value(block[_TAR_CHECKSUM_OFFSET : _TAR_CHECKSUM_OFFSET + _TAR_CHECKSUM_SIZE])
+    if expected_checksum is None:
+        return False
+
+    checksum = (
+        sum(block[:_TAR_CHECKSUM_OFFSET])
+        + (_TAR_CHECKSUM_SIZE * ord(" "))
+        + sum(block[_TAR_CHECKSUM_OFFSET + _TAR_CHECKSUM_SIZE :])
+    )
+    return checksum == expected_checksum
+
+
+def _looks_like_uncompressed_tar_header(header: bytes) -> bool:
+    return _has_tar_ustar_signature(header) or _has_valid_tar_checksum_header(header)
 
 
 def is_zipfile(path: str) -> bool:
@@ -867,15 +912,10 @@ def detect_file_format_from_magic(path: str) -> str:
             return "tf_metagraph" if _is_tensorflow_metagraph_file(path) else "unknown"
 
         with file_path.open("rb") as f:
-            header = f.read(16)
+            header = f.read(min(size, _TAR_BLOCK_SIZE))
 
-            # Check for TAR format by looking for the "ustar" signature
-            if size >= _TAR_USTAR_MIN_BYTES:
-                f.seek(_TAR_USTAR_OFFSET)
-                if f.read(_TAR_USTAR_MAGIC_SIZE).startswith(b"ustar"):
-                    return "tar"
-            # Reset to read from header for further checks
-            f.seek(0)
+            if _looks_like_uncompressed_tar_header(header):
+                return "tar"
 
             magic4 = header[:4]
             magic8 = header[:8]
@@ -976,7 +1016,7 @@ def detect_file_format_for_skip_filter(path: str) -> str:
     if size < 4:
         return "unknown"
 
-    initial_read_size = min(size, max(64, _TAR_USTAR_MIN_BYTES))
+    initial_read_size = min(size, max(64, _TAR_BLOCK_SIZE))
     with file_path.open("rb") as f:
         prefix = f.read(initial_read_size)
 
@@ -985,11 +1025,8 @@ def detect_file_format_for_skip_filter(path: str) -> str:
         magic8 = header[:8]
         magic16 = header[:16]
 
-        if size >= _TAR_USTAR_MIN_BYTES and len(prefix) >= _TAR_USTAR_MIN_BYTES:
-            tar_magic_start = _TAR_USTAR_OFFSET
-            tar_magic_end = tar_magic_start + _TAR_USTAR_MAGIC_SIZE
-            if prefix[tar_magic_start:tar_magic_end].startswith(b"ustar"):
-                return "tar"
+        if _looks_like_uncompressed_tar_header(prefix):
+            return "tar"
 
         if _looks_like_tflite_header(magic8):
             return "tflite"
@@ -1052,7 +1089,7 @@ def detect_file_format(path: str) -> str:
 
     # Read first bytes for format detection using a single file handle
     with file_path.open("rb") as f:
-        header = f.read(16)
+        header = f.read(min(size, _TAR_BLOCK_SIZE))
 
     magic4 = header[:4]
     magic8 = header[:8]
@@ -1093,7 +1130,7 @@ def detect_file_format(path: str) -> str:
         return "unknown"
     if magic8.startswith(_SEVENZIP_MAGIC):
         return "sevenzip"
-    if _has_tar_ustar_signature(file_path, size):
+    if _looks_like_uncompressed_tar_header(header):
         return "tar"
     if compression_format:
         if _is_tar_archive(path):

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -58,6 +58,9 @@ _BZIP2_MAGIC = b"BZh"
 _XZ_MAGIC = b"\xfd7zXZ\x00"
 _SEVENZIP_MAGIC = b"7z\xbc\xaf\x27\x1c"
 _LZ4_FRAME_MAGIC = b"\x04\x22\x4d\x18"
+_TAR_USTAR_OFFSET = 257
+_TAR_USTAR_MAGIC_SIZE = 5
+_TAR_USTAR_MIN_BYTES = _TAR_USTAR_OFFSET + _TAR_USTAR_MAGIC_SIZE
 _TFLITE_MAGIC_OFFSET = 4
 _TFLITE_MAGIC_SIZE = 4
 _TFLITE_MIN_HEADER_SIZE = _TFLITE_MAGIC_OFFSET + _TFLITE_MAGIC_SIZE
@@ -623,6 +626,20 @@ def _is_tar_archive(path: str) -> bool:
         return False
 
 
+def _has_tar_ustar_signature(file_path: Path, size: int | None = None) -> bool:
+    """Return whether an uncompressed TAR ustar signature is present."""
+    try:
+        if size is None:
+            size = file_path.stat().st_size
+        if size < _TAR_USTAR_MIN_BYTES:
+            return False
+        with file_path.open("rb") as f:
+            f.seek(_TAR_USTAR_OFFSET)
+            return f.read(_TAR_USTAR_MAGIC_SIZE).startswith(b"ustar")
+    except OSError:
+        return False
+
+
 def is_zipfile(path: str) -> bool:
     """Check if file is a ZIP by reading the signature."""
     file_path = Path(path)
@@ -853,9 +870,9 @@ def detect_file_format_from_magic(path: str) -> str:
             header = f.read(16)
 
             # Check for TAR format by looking for the "ustar" signature
-            if size >= 262:
-                f.seek(257)
-                if f.read(5).startswith(b"ustar"):
+            if size >= _TAR_USTAR_MIN_BYTES:
+                f.seek(_TAR_USTAR_OFFSET)
+                if f.read(_TAR_USTAR_MAGIC_SIZE).startswith(b"ustar"):
                     return "tar"
             # Reset to read from header for further checks
             f.seek(0)
@@ -932,6 +949,83 @@ def detect_file_format_from_magic(path: str) -> str:
     return "unknown"
 
 
+def _could_start_proto0_or_1_pickle(sample: bytes) -> bool:
+    if not sample:
+        return False
+    if sample[0] in PROTO0_1_START_BYTES:
+        return True
+    return len(sample) >= 2 and sample[0] == ord("#") and sample[1] in PROTO0_1_START_BYTES
+
+
+def detect_file_format_for_skip_filter(path: str) -> str:
+    """Cheap content detection for skipped-extension preservation.
+
+    This intentionally recognizes only content-derived format signals. It avoids
+    extension-based routing and uses one bounded prefix read for common skipped
+    files, while still preserving disguised model/archive payloads for full scans.
+    """
+    file_path = Path(path)
+    if file_path.is_dir():
+        if (file_path / "saved_model.pb").exists():
+            return "tensorflow_directory"
+        return "directory"
+    if not file_path.is_file():
+        return "unknown"
+
+    size = file_path.stat().st_size
+    if size < 4:
+        return "unknown"
+
+    initial_read_size = min(size, max(64, _TAR_USTAR_MIN_BYTES))
+    with file_path.open("rb") as f:
+        prefix = f.read(initial_read_size)
+
+        header = prefix[:16]
+        magic4 = header[:4]
+        magic8 = header[:8]
+        magic16 = header[:16]
+
+        if size >= _TAR_USTAR_MIN_BYTES and len(prefix) >= _TAR_USTAR_MIN_BYTES:
+            tar_magic_start = _TAR_USTAR_OFFSET
+            tar_magic_end = tar_magic_start + _TAR_USTAR_MAGIC_SIZE
+            if prefix[tar_magic_start:tar_magic_end].startswith(b"ustar"):
+                return "tar"
+
+        if _looks_like_tflite_header(magic8):
+            return "tflite"
+        if _is_executorch_binary_signature(magic8) and _is_valid_executorch_binary(file_path):
+            return "executorch"
+
+        format_result = detect_format_from_magic_bytes(magic4, magic8, magic16, size, file_path)
+        if format_result == "zip":
+            return "zip"
+        if format_result in {"gzip", "bzip2", "xz", "lz4", "zlib"}:
+            if _is_tar_archive(path):
+                return "tar"
+            return format_result
+        if format_result != "unknown":
+            return format_result
+
+        if _could_start_proto0_or_1_pickle(prefix):
+            max_probe_size = min(size, PROTO0_1_MAX_PROBE_BYTES)
+            if len(prefix) < max_probe_size:
+                prefix += f.read(max_probe_size - len(prefix))
+            if _looks_like_proto0_or_1_pickle(
+                prefix[:PROTO0_1_MAX_PROBE_BYTES],
+                sample_is_prefix=size > min(size, PROTO0_1_MAX_PROBE_BYTES),
+            ):
+                return "pickle"
+
+        if magic16.startswith(b"<?xml"):
+            xml_header = prefix[:64]
+            if b"<net" in xml_header:
+                return "openvino"
+            if b"<PMML" in xml_header:
+                return "pmml"
+
+    return "unknown"
+
+
 def detect_file_format(path: str) -> str:
     """
     Attempt to identify the format:
@@ -999,9 +1093,11 @@ def detect_file_format(path: str) -> str:
         return "unknown"
     if magic8.startswith(_SEVENZIP_MAGIC):
         return "sevenzip"
-    if _is_tar_archive(path):
+    if _has_tar_ustar_signature(file_path, size):
         return "tar"
     if compression_format:
+        if _is_tar_archive(path):
+            return "tar"
         return compression_format
     # Check ZIP magic first (for .pt/.pth files that are actually zips)
     if magic4.startswith(b"PK"):
@@ -1194,12 +1290,9 @@ def detect_format_from_extension(path: FilePath) -> FileFormat:
     return detect_format_from_extension_pattern_matching(file_path.suffix)
 
 
-def validate_file_type(path: str) -> bool:
-    """Validate that a file's magic bytes match its extension-based format."""
+def validate_file_type_with_formats(path: str, header_format: str, ext_format: str) -> bool:
+    """Validate file type using precomputed magic/header and extension formats."""
     try:
-        header_format = detect_file_format_from_magic(path)
-        ext_format = detect_format_from_extension(path)
-
         # If extension format is unknown, we can't validate - assume valid
         if ext_format == "unknown":
             return True
@@ -1395,3 +1488,10 @@ def validate_file_type(path: str) -> bool:
     except Exception:
         # If validation fails due to error, assume valid to avoid breaking scans
         return True
+
+
+def validate_file_type(path: str) -> bool:
+    """Validate that a file's magic bytes match its extension-based format."""
+    header_format = detect_file_format_from_magic(path)
+    ext_format = detect_format_from_extension(path)
+    return validate_file_type_with_formats(path, header_format, ext_format)

--- a/modelaudit/utils/file/filtering.py
+++ b/modelaudit/utils/file/filtering.py
@@ -184,9 +184,9 @@ def _has_scannable_content(path: str) -> bool:
         return False
 
     try:
-        from .detection import detect_file_format
+        from .detection import detect_file_format_for_skip_filter
 
-        detected_format = detect_file_format(path)
+        detected_format = detect_file_format_for_skip_filter(path)
         if detected_format == "unknown":
             return False
 

--- a/scripts/profile_scan.py
+++ b/scripts/profile_scan.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import argparse
+import cProfile
+import json
+import pstats
+import resource
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from modelaudit.core import scan_model_directory_or_file
+
+
+@dataclass(frozen=True)
+class ScanProfileRecord:
+    path: str
+    repeat_index: int
+    wall_seconds: float
+    cpu_seconds: float
+    bytes_scanned: int
+    files_scanned: int
+    checks: int
+    issues: int
+    success: bool
+
+
+def _max_rss_bytes() -> int:
+    max_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if sys.platform == "darwin":
+        return int(max_rss)
+    return int(max_rss) * 1024
+
+
+def _scan_once(path: Path, *, repeat_index: int, cache_enabled: bool) -> ScanProfileRecord:
+    wall_start = time.perf_counter()
+    cpu_start = time.process_time()
+    result = scan_model_directory_or_file(str(path), cache_enabled=cache_enabled)
+    return ScanProfileRecord(
+        path=str(path),
+        repeat_index=repeat_index,
+        wall_seconds=time.perf_counter() - wall_start,
+        cpu_seconds=time.process_time() - cpu_start,
+        bytes_scanned=result.bytes_scanned,
+        files_scanned=result.files_scanned,
+        checks=len(result.checks),
+        issues=len(result.issues),
+        success=result.success,
+    )
+
+
+def _format_seconds(seconds: float) -> str:
+    if seconds >= 1:
+        return f"{seconds:.3f}s"
+    return f"{seconds * 1000:.2f}ms"
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Profile ModelAudit scans with wall-clock, CPU, RSS, and cProfile.")
+    parser.add_argument("paths", nargs="+", type=Path, help="Files or directories to scan.")
+    parser.add_argument("--repeat", type=int, default=1, help="Number of scan repetitions per path.")
+    parser.add_argument("--cache-enabled", action="store_true", help="Enable ModelAudit's scan cache during profiling.")
+    parser.add_argument("--profile-out", type=Path, help="Write cProfile stats to this path.")
+    parser.add_argument("--json-out", type=Path, help="Write machine-readable profile summary JSON to this path.")
+    parser.add_argument("--sort", default="cumtime", help="pstats sort key for printed profile output.")
+    parser.add_argument("--limit", type=int, default=25, help="Number of cProfile rows to print.")
+    parser.add_argument("--no-profile-print", action="store_true", help="Suppress pstats output on stdout.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.repeat < 1:
+        raise SystemExit("--repeat must be at least 1")
+
+    missing_paths = [str(path) for path in args.paths if not path.exists()]
+    if missing_paths:
+        raise SystemExit(f"Path does not exist: {', '.join(missing_paths)}")
+
+    profiler = cProfile.Profile()
+    records: list[ScanProfileRecord] = []
+    profiler.enable()
+    try:
+        for repeat_index in range(args.repeat):
+            for path in args.paths:
+                records.append(
+                    _scan_once(
+                        path,
+                        repeat_index=repeat_index,
+                        cache_enabled=args.cache_enabled,
+                    )
+                )
+    finally:
+        profiler.disable()
+
+    if args.profile_out:
+        args.profile_out.parent.mkdir(parents=True, exist_ok=True)
+        profiler.dump_stats(args.profile_out)
+
+    total_wall = sum(record.wall_seconds for record in records)
+    total_cpu = sum(record.cpu_seconds for record in records)
+    payload = {
+        "cache_enabled": args.cache_enabled,
+        "repeat": args.repeat,
+        "max_rss_bytes": _max_rss_bytes(),
+        "total_wall_seconds": total_wall,
+        "total_cpu_seconds": total_cpu,
+        "records": [asdict(record) for record in records],
+    }
+
+    if args.json_out:
+        _write_json(args.json_out, payload)
+
+    print(
+        f"Profiled {len(records)} scan(s): wall={_format_seconds(total_wall)}, "
+        f"cpu={_format_seconds(total_cpu)}, max_rss={payload['max_rss_bytes']} bytes"
+    )
+    for record in records:
+        print(
+            f"- {record.path} repeat={record.repeat_index}: wall={_format_seconds(record.wall_seconds)}, "
+            f"cpu={_format_seconds(record.cpu_seconds)}, files={record.files_scanned}, "
+            f"bytes={record.bytes_scanned}, checks={record.checks}, issues={record.issues}, "
+            f"success={record.success}"
+        )
+
+    if not args.no_profile_print:
+        pstats.Stats(profiler).sort_stats(args.sort).print_stats(args.limit)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/profile_scan.py
+++ b/scripts/profile_scan.py
@@ -4,7 +4,6 @@ import argparse
 import cProfile
 import json
 import pstats
-import resource
 import sys
 import time
 from dataclasses import asdict, dataclass
@@ -12,6 +11,11 @@ from pathlib import Path
 from typing import Any
 
 from modelaudit.core import scan_model_directory_or_file
+
+try:
+    import resource as resource_module
+except ImportError:
+    resource_module = None
 
 
 @dataclass(frozen=True)
@@ -28,7 +32,10 @@ class ScanProfileRecord:
 
 
 def _max_rss_bytes() -> int:
-    max_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if resource_module is None:
+        return 0
+
+    max_rss = resource_module.getrusage(resource_module.RUSAGE_SELF).ru_maxrss
     if sys.platform == "darwin":
         return int(max_rss)
     return int(max_rss) * 1024

--- a/tests/benchmarks/test_scan_benchmarks.py
+++ b/tests/benchmarks/test_scan_benchmarks.py
@@ -10,6 +10,7 @@ import pytest
 
 from modelaudit.core import scan_model_directory_or_file
 from modelaudit.utils.file.detection import detect_file_format, validate_file_type
+from modelaudit.utils.file.filtering import should_skip_file
 from tests.helpers.file_creators import create_mock_manifest, create_safe_pickle
 
 pytest.importorskip("pytest_benchmark")
@@ -18,6 +19,7 @@ pytestmark = pytest.mark.performance
 
 DETECTION_ROUNDS = 25
 SCAN_ROUNDS = 5
+SKIP_FILTER_ROUNDS = 10
 WARMUP_ROUNDS = 1
 
 
@@ -121,6 +123,16 @@ def _benchmark_context(path: Path) -> dict[str, int | str]:
     }
 
 
+def _create_skip_filter_corpus(root: Path) -> list[Path]:
+    root.mkdir()
+    files = []
+    for index in range(256):
+        path = root / f"note_{index}.txt"
+        path.write_text(f"benchmark note {index}\n", encoding="utf-8")
+        files.append(path)
+    return files
+
+
 @pytest.fixture(scope="session")
 def benchmark_inputs(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path]:
     root = tmp_path_factory.mktemp("scan-benchmarks")
@@ -138,10 +150,16 @@ def benchmark_inputs(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path
     }
 
 
-def _benchmark_scan(benchmark: Any, path: Path, *, rounds: int = SCAN_ROUNDS) -> Any:
+@pytest.fixture(scope="session")
+def skip_filter_inputs(tmp_path_factory: pytest.TempPathFactory) -> list[Path]:
+    return _create_skip_filter_corpus(tmp_path_factory.mktemp("skip-filter-benchmark") / "plain-text")
+
+
+def _benchmark_scan(benchmark: Any, path: Path, *, rounds: int = SCAN_ROUNDS, cache_enabled: bool = False) -> Any:
     benchmark.extra_info.update(_benchmark_context(path))
+    benchmark.extra_info["cache_enabled"] = cache_enabled
     return benchmark.pedantic(
-        lambda: scan_model_directory_or_file(str(path)),
+        lambda: scan_model_directory_or_file(str(path), cache_enabled=cache_enabled),
         iterations=1,
         rounds=rounds,
         warmup_rounds=WARMUP_ROUNDS,
@@ -174,6 +192,24 @@ def test_validate_file_type_pytorch_zip(benchmark: Any, benchmark_inputs: dict[s
     )
 
     assert is_valid is True
+
+
+def test_skip_filter_plain_text_files(benchmark: Any, skip_filter_inputs: list[Path]) -> None:
+    benchmark.extra_info.update(
+        {
+            "files": len(skip_filter_inputs),
+            "bytes": sum(path.stat().st_size for path in skip_filter_inputs),
+        }
+    )
+
+    skipped_count = benchmark.pedantic(
+        lambda: sum(1 for path in skip_filter_inputs if should_skip_file(str(path))),
+        iterations=1,
+        rounds=SKIP_FILTER_ROUNDS,
+        warmup_rounds=WARMUP_ROUNDS,
+    )
+
+    assert skipped_count == len(skip_filter_inputs)
 
 
 def test_scan_safe_pickle(benchmark: Any, benchmark_inputs: dict[str, Path]) -> None:

--- a/tests/helpers/file_creators.py
+++ b/tests/helpers/file_creators.py
@@ -13,6 +13,33 @@ from pathlib import Path
 from typing import Any
 
 
+def _tar_octal_field(value: int, length: int) -> bytes:
+    return f"{value:0{length - 1}o}\0".encode("ascii")[-length:]
+
+
+def create_v7_tar_archive(path: Path, *, member_name: str = "payload.txt", payload: bytes = b"payload") -> Path:
+    """Create a legacy TAR archive without a ustar magic marker."""
+    header = bytearray(512)
+    encoded_name = member_name.encode("utf-8")
+    if not encoded_name or len(encoded_name) > 100:
+        raise ValueError("member_name must encode to 1-100 bytes")
+
+    header[: len(encoded_name)] = encoded_name
+    header[100:108] = _tar_octal_field(0o644, 8)
+    header[108:116] = _tar_octal_field(0, 8)
+    header[116:124] = _tar_octal_field(0, 8)
+    header[124:136] = _tar_octal_field(len(payload), 12)
+    header[136:148] = _tar_octal_field(0, 12)
+    header[148:156] = b"        "
+    header[156:157] = b"0"
+    checksum = sum(header)
+    header[148:156] = f"{checksum:06o}\0 ".encode("ascii")
+
+    padding = b"\0" * ((512 - (len(payload) % 512)) % 512)
+    path.write_bytes(bytes(header) + payload + padding + (b"\0" * 1024))
+    return path
+
+
 def create_safe_pickle(path: Path, data: dict[str, Any] | None = None) -> Path:
     """Create a safe pickle file for testing.
 

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -11,6 +11,7 @@ from modelaudit import core
 from modelaudit.scanners.archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY
 from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity, ScanResult
 from modelaudit.scanners.tar_scanner import (
+    ARCHIVE_MEMBER_COPY_CHUNK_BYTES,
     DEFAULT_MAX_DECOMPRESSED_BYTES,
     DEFAULT_MAX_DECOMPRESSION_RATIO,
     DEFAULT_MAX_TAR_ENTRY_SIZE,
@@ -423,7 +424,7 @@ class TestTarScanner:
             assert total_size == len(content)
             assert Path(extracted_path).read_bytes() == content
             assert len(read_sizes) > 1
-            assert set(read_sizes) == {4096}
+            assert set(read_sizes) == {ARCHIVE_MEMBER_COPY_CHUNK_BYTES}
         finally:
             os.unlink(extracted_path)
 

--- a/tests/test_nested_pickle_integration.py
+++ b/tests/test_nested_pickle_integration.py
@@ -360,17 +360,23 @@ class TestNestedPickleIntegration:
 
                 assert result.success, f"Scan should succeed for {description}"
 
-                nested_issues = [
+                nested_issue_messages = [
                     issue
                     for issue in result.issues
                     if "nested" in issue.message.lower() or "encoded" in issue.message.lower()
                 ]
+                nested_check_messages = [
+                    check
+                    for check in result.checks
+                    if "nested" in check.message.lower() or "encoded" in check.message.lower()
+                ]
+                nested_detection_count = len(nested_issue_messages) + len(nested_check_messages)
 
                 if should_detect:
-                    assert len(nested_issues) > 0, f"Should detect {description}"
+                    assert nested_detection_count > 0, f"Should detect {description}"
                     print("  ✅ Correctly detected nested pickle")
                 else:
-                    assert len(nested_issues) == 0, f"Should not detect {description} as nested pickle"
+                    assert nested_detection_count == 0, f"Should not detect {description} as nested pickle"
                     print("  ✅ Correctly ignored non-threat")
 
     def test_regression_existing_functionality(self, pickles_dir):

--- a/tests/test_regular_scan_hash.py
+++ b/tests/test_regular_scan_hash.py
@@ -1,6 +1,9 @@
 """Tests for content hash generation in regular scan mode."""
 
+import hashlib
 import pickle
+import zipfile
+from pathlib import Path
 
 import pytest
 
@@ -27,6 +30,20 @@ class TestRegularScanContentHash:
         assert result.content_hash is not None
         assert isinstance(result.content_hash, str)
         assert len(result.content_hash) == 64  # SHA-256 hex digest length
+
+    def test_single_archive_hash_uses_outer_file_bytes(self, tmp_path: Path) -> None:
+        """Archive scans must hash the scanned archive, not merged nested metadata."""
+        archive_path = tmp_path / "model.zip"
+        nested_payload = pickle.dumps({"nested": "payload"})
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("model.pkl", nested_payload)
+
+        result = scan_model_directory_or_file(str(archive_path))
+
+        outer_hash = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+        nested_hash = hashlib.sha256(nested_payload).hexdigest()
+        assert result.content_hash == compute_aggregate_hash([outer_hash])
+        assert result.content_hash != compute_aggregate_hash([nested_hash])
 
     def test_directory_generates_hash(self, tmp_path):
         """Test that scanning a directory generates an aggregate content hash."""

--- a/tests/utils/file/test_advanced_size_limits.py
+++ b/tests/utils/file/test_advanced_size_limits.py
@@ -41,19 +41,21 @@ class TestAdvancedSizeLimits:
                     mock_format.return_value = "unknown"
                     with patch("modelaudit.core.detect_format_from_extension") as mock_ext:
                         mock_ext.return_value = "unknown"
-                        with patch("modelaudit.core.validate_file_type") as mock_validate:
-                            mock_validate.return_value = True
+                        with patch("modelaudit.core.detect_file_format_from_magic") as mock_magic:
+                            mock_magic.return_value = "unknown"
+                            with patch("modelaudit.core.validate_file_type_with_formats") as mock_validate:
+                                mock_validate.return_value = True
 
-                            # Also need to mock the registry
-                            with patch("modelaudit.core._registry.get_scanner_for_path") as mock_registry:
-                                mock_registry.return_value = None  # No specific scanner
+                                # Also need to mock the registry
+                                with patch("modelaudit.core._registry.get_scanner_for_path") as mock_registry:
+                                    mock_registry.return_value = None  # No specific scanner
 
-                                # This should NOT be blocked by max_file_size
-                                result = scan_file(f.name, config)
+                                    # This should NOT be blocked by max_file_size
+                                    result = scan_file(f.name, config)
 
-                                # With new behavior, large files are still scanned
-                                # but using the normal large file handler
-                                assert result is not None
+                                    # With new behavior, large files are still scanned
+                                    # but using the normal large file handler
+                                    assert result is not None
 
     @patch("modelaudit.utils.file.handlers.os.path.getsize")
     def test_normal_files_respect_size_limit(self, mock_size):
@@ -122,17 +124,19 @@ class TestAdvancedSizeLimits:
                         mock_format.return_value = "unknown"
                         with patch("modelaudit.core.detect_format_from_extension") as mock_ext:
                             mock_ext.return_value = "unknown"
-                            with patch("modelaudit.core.validate_file_type") as mock_validate:
-                                mock_validate.return_value = True
+                            with patch("modelaudit.core.detect_file_format_from_magic") as mock_magic:
+                                mock_magic.return_value = "unknown"
+                                with patch("modelaudit.core.validate_file_type_with_formats") as mock_validate:
+                                    mock_validate.return_value = True
 
-                                # Also need to mock the registry
-                                with patch("modelaudit.core._registry.get_scanner_for_path") as mock_registry:
-                                    mock_registry.return_value = None  # No specific scanner
+                                    # Also need to mock the registry
+                                    with patch("modelaudit.core._registry.get_scanner_for_path") as mock_registry:
+                                        mock_registry.return_value = None  # No specific scanner
 
-                                    # Should not be blocked
-                                    result = scan_file(f.name, config)
-                                    # With new behavior, we scan all files
-                                    assert result is not None
+                                        # Should not be blocked
+                                        result = scan_file(f.name, config)
+                                        # With new behavior, we scan all files
+                                        assert result is not None
 
     def test_size_thresholds_are_sensible(self):
         """Verify that size thresholds make sense."""

--- a/tests/utils/file/test_file_filter.py
+++ b/tests/utils/file/test_file_filter.py
@@ -6,11 +6,29 @@ from pathlib import Path
 
 import pytest
 
+from modelaudit.utils.file.detection import detect_file_format_for_skip_filter
 from modelaudit.utils.file.filtering import (
     _ZIP_MEMBER_SNIFF_LIMIT,
     should_skip_file,
 )
 from tests.helpers.file_creators import create_v7_tar_archive
+
+
+def _build_lightgbm_text() -> str:
+    return "\n".join(
+        [
+            "tree=0",
+            "version=v4",
+            "num_class=1",
+            "num_tree_per_iteration=1",
+            "max_feature_idx=2",
+            "feature_names=f0 f1 f2",
+            "tree_sizes=12",
+            "num_leaves=2",
+            "split_feature=0",
+            "leaf_value=0.1 0.2",
+        ]
+    )
 
 
 class TestFileFilter:
@@ -163,6 +181,14 @@ class TestFileFilter:
         assert not should_skip_file(str(disguised_zip))
         assert not should_skip_file(str(disguised_legacy_tar))
         assert should_skip_file(str(real_image))
+
+    def test_disguised_lightgbm_text_model_bypasses_default_skip(self, tmp_path: Path) -> None:
+        """Default skip filtering must preserve supported text models under skipped suffixes."""
+        disguised_lightgbm = tmp_path / "model.txt"
+        disguised_lightgbm.write_text(("# preface\n" * 64) + _build_lightgbm_text(), encoding="utf-8")
+
+        assert detect_file_format_for_skip_filter(str(disguised_lightgbm)) == "lightgbm"
+        assert not should_skip_file(str(disguised_lightgbm))
 
     def test_executorch_payloads_bypass_extension_skip(self, tmp_path: Path) -> None:
         """Disguised ZIPs carrying supported ExecuTorch payloads should survive prefiltering."""

--- a/tests/utils/file/test_file_filter.py
+++ b/tests/utils/file/test_file_filter.py
@@ -145,6 +145,9 @@ class TestFileFilter:
         disguised_pickle = tmp_path / "payload.jpg"
         disguised_pickle.write_bytes(pickle.dumps({"safe": True}))
 
+        disguised_protocol0_pickle = tmp_path / "payload-protocol0.jpg"
+        disguised_protocol0_pickle.write_bytes(pickle.dumps({"safe": True}, protocol=0))
+
         disguised_zip = tmp_path / "archive.jpg"
         with zipfile.ZipFile(disguised_zip, "w") as archive:
             archive.writestr("payload.pkl", pickle.dumps({"safe": True}))
@@ -153,6 +156,7 @@ class TestFileFilter:
         real_image.write_bytes(b"\xff\xd8\xff\xe0" + b"jpeg")
 
         assert not should_skip_file(str(disguised_pickle))
+        assert not should_skip_file(str(disguised_protocol0_pickle))
         assert not should_skip_file(str(disguised_zip))
         assert should_skip_file(str(real_image))
 
@@ -219,6 +223,6 @@ class TestFileFilter:
         def raise_os_error(_path: str) -> str:
             raise OSError("synthetic sniff failure")
 
-        monkeypatch.setattr("modelaudit.utils.file.detection.detect_file_format", raise_os_error)
+        monkeypatch.setattr("modelaudit.utils.file.detection.detect_file_format_for_skip_filter", raise_os_error)
 
         assert not should_skip_file(str(disguised_payload))

--- a/tests/utils/file/test_file_filter.py
+++ b/tests/utils/file/test_file_filter.py
@@ -10,6 +10,7 @@ from modelaudit.utils.file.filtering import (
     _ZIP_MEMBER_SNIFF_LIMIT,
     should_skip_file,
 )
+from tests.helpers.file_creators import create_v7_tar_archive
 
 
 class TestFileFilter:
@@ -152,12 +153,15 @@ class TestFileFilter:
         with zipfile.ZipFile(disguised_zip, "w") as archive:
             archive.writestr("payload.pkl", pickle.dumps({"safe": True}))
 
+        disguised_legacy_tar = create_v7_tar_archive(tmp_path / "legacy-tar.jpg")
+
         real_image = tmp_path / "cover.jpg"
         real_image.write_bytes(b"\xff\xd8\xff\xe0" + b"jpeg")
 
         assert not should_skip_file(str(disguised_pickle))
         assert not should_skip_file(str(disguised_protocol0_pickle))
         assert not should_skip_file(str(disguised_zip))
+        assert not should_skip_file(str(disguised_legacy_tar))
         assert should_skip_file(str(real_image))
 
     def test_executorch_payloads_bypass_extension_skip(self, tmp_path: Path) -> None:

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -24,6 +24,7 @@ from modelaudit.utils.file.detection import (
     validate_file_type,
 )
 from modelaudit.utils.tensorflow_compat import has_tensorflow_protobuf_stubs as _has_tf_protos
+from tests.helpers.file_creators import create_v7_tar_archive
 
 
 def _create_mar_archive(
@@ -543,6 +544,16 @@ def test_detect_file_format_tar(tmp_path):
         info = tarfile.TarInfo(name="test.txt")
         tar.addfile(info, io.BytesIO(b"content"))
 
+    assert detect_file_format_from_magic(str(tar_path)) == "tar"
+    assert detect_file_format(str(tar_path)) == "tar"
+
+
+def test_detect_file_format_extensionless_legacy_tar_without_ustar(tmp_path: Path) -> None:
+    """Legacy TAR headers without ustar magic should still route by checksum."""
+    tar_path = create_v7_tar_archive(tmp_path / "legacy-archive")
+
+    assert tar_path.read_bytes()[257:262] == b"\0" * 5
+    assert tarfile.is_tarfile(tar_path) is True
     assert detect_file_format_from_magic(str(tar_path)) == "tar"
     assert detect_file_format(str(tar_path)) == "tar"
 


### PR DESCRIPTION
## Summary

- Add a repeatable profiling harness (`scripts/profile_scan.py`) and cold-cache scan benchmarks, including a skipped-file prefilter microbenchmark.
- Optimize skipped-extension content sniffing with a bounded header/pickle prefilter that preserves disguised pickle/archive/model payloads without full format detection for ordinary text/media files.
- Reduce license metadata rescans by sharing header reads, prefiltering license regexes, and reusing collected license metadata in warning checks.
- Reuse scanner-computed SHA-256 hashes for single-file aggregate hashes, and reuse core format validation inside scanner path checks.
- Tighten pickle raw detector seed checks and use larger ZIP/TAR extraction copy chunks.

## Benchmarks

Compared against the pre-change benchmark JSON captured during the audit:

- Shared benchmark aggregate median: `397.99ms -> 108.35ms` (`-72.8%`).
- Duplicate directory: `250.02ms -> 33.36ms` (`-86.7%`).
- Mixed directory: `98.24ms -> 44.11ms` (`-55.1%`).
- Safe pickle scan: `19.23ms -> 7.44ms` (`-61.3%`).
- PyTorch ZIP scan: `23.34ms -> 16.41ms` (`-29.7%`).
- New skipped plain-text prefilter benchmark: median `9.17ms` for 256 files.

Command:

```bash
uv run --locked --with pytest-benchmark pytest tests/benchmarks/test_scan_benchmarks.py tests/benchmarks/test_picklescan_benchmarks.py --benchmark-json=/tmp/modelaudit-bench-pr-final.json -q
```

## Validation

- `uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/ scripts/profile_scan.py`
- `uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/ scripts/profile_scan.py`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
  - Result: `3984 passed, 78 skipped, 21 warnings`
- Focused routing/archive/nested pickle tests passed.
