### PR TITLE
chore: pin release workflow actions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       pr_number: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).number || '' }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -41,7 +41,7 @@ jobs:
             echo "has_pr=false" >> $GITHUB_OUTPUT
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.check-pr.outputs.has_pr == 'true'
         with:
           ref: ${{ steps.check-pr.outputs.pr_branch }}
@@ -128,7 +128,7 @@ jobs:
     outputs:
       artifact-name: ${{ steps.upload.outputs.artifact-id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
@@ -438,7 +438,7 @@ jobs:
         shell: bash
         working-directory: packages/modelaudit-picklescan
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
@@ -455,7 +455,7 @@ jobs:
           rustup default stable
 
       - name: Cache Cargo dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/registry
@@ -501,7 +501,7 @@ jobs:
 
       - name: Build standalone package manylinux wheel
         if: runner.os == 'Linux'
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           command: build
           args: --release --wheel --out /tmp/modelaudit-picklescan-dist --compatibility manylinux_2_28
@@ -550,7 +550,7 @@ jobs:
           )
 
       - name: Upload standalone package artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: modelaudit-picklescan-dist-${{ matrix.artifact-suffix }}
           path: /tmp/modelaudit-picklescan-dist/
@@ -573,7 +573,7 @@ jobs:
           path: dist/
 
       - name: Download standalone pickle package artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: modelaudit-picklescan-dist-*
           path: dist/
@@ -594,7 +594,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             pyproject.toml
@@ -612,7 +612,7 @@ jobs:
           path: dist/
 
       - name: Download standalone pickle package artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: modelaudit-picklescan-dist-*
           path: dist/

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,10 +35,10 @@ jobs:
         run: |
           PR_OUTPUT='${{ steps.release.outputs.pr }}'
           if [ -n "$PR_OUTPUT" ] && [ "$PR_OUTPUT" != "null" ]; then
-            echo "has_pr=true" >> $GITHUB_OUTPUT
-            echo "pr_branch=$(echo '${{ steps.release.outputs.pr }}' | jq -r '.headBranchName')" >> $GITHUB_OUTPUT
+            echo "has_pr=true" >> "$GITHUB_OUTPUT"
+            echo "pr_branch=$(echo '${{ steps.release.outputs.pr }}' | jq -r '.headBranchName')" >> "$GITHUB_OUTPUT"
           else
-            echo "has_pr=false" >> $GITHUB_OUTPUT
+            echo "has_pr=false" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -534,7 +534,7 @@ jobs:
           smoke_dir="$(mktemp -d)"
           (
             cd "$smoke_dir"
-            PYTHONPATH= /tmp/modelaudit-picklescan-wheel-smoke/bin/python -I - <<'PY'
+            PYTHONPATH='' /tmp/modelaudit-picklescan-wheel-smoke/bin/python -I - <<'PY'
           import importlib.util
 
           import modelaudit_picklescan


### PR DESCRIPTION
## Summary

- Pin release workflow GitHub Actions to immutable commit SHAs
- Keep version comments next to each SHA for readability and future updates

## Why

Release-path actions were using mutable version tags. Pinning these actions reduces supply-chain risk while preserving the existing version breadcrumbs.

## Validation

- `uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/release-please.yml')); print('yaml ok')"`
- `rg -n "uses: .+@[A-Za-z0-9_.-]+$" .github/workflows/release-please.yml` returned no matches
