### PR TITLE
fix: route disguised nested archives in sevenzip scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **security:** recognize RAR archives and fail closed as unsupported coverage instead of skipping `.rar` files during directory scans
 - **skops:** fail closed when Skops archive limits, malformed archives, or bounded metadata reads leave CVE coverage incomplete, while preserving benign numeric-array payload scans
 - **xgboost:** fail closed on incomplete JSON, UBJ, binary-structure, pickle-spoof, and enabled-loader analyses while preserving core exit-code and cache semantics
+- **security:** route disguised ZIP and TAR members inside 7-Zip archives by bounded header probes while stopping probe reads at the per-member budget
 - **security:** reduce NeMo Hydra `_target_` false positives by matching suspicious identifiers on token boundaries, preserve CVE-2025-23304 details on suspicious-target findings, and reject oversized YAML members before parsing
 - **security:** preserve skipped-suffix ZIP containers when Keras config-only structure or embedded model-like `.bin` members indicate scannable content
 - **security:** fail closed when oversized NeMo YAML prevents Hydra target analysis and scan malformed Jinja2 config fallbacks beyond the initial prefix window

--- a/modelaudit/scanners/sevenzip_scanner.py
+++ b/modelaudit/scanners/sevenzip_scanner.py
@@ -14,6 +14,7 @@ else:
     _py7zr = None
 
 from ..utils import sanitize_archive_path
+from ..utils.file.detection import detect_format_from_magic_bytes
 from ._archive_config import get_archive_depth
 from ._archive_locations import rewrite_extracted_member_location
 from ._archive_outcomes import mark_archive_scan_incomplete, member_scan_incomplete
@@ -110,6 +111,7 @@ class SevenZipScanner(BaseScanner):
     description = "Scans 7-Zip archives for malicious model files"
     supported_extensions: ClassVar[list[str]] = [".7z"]
     _SEVENZIP_MAGIC: ClassVar[bytes] = b"7z\xbc\xaf\x27\x1c"
+    _NESTED_MEMBER_PROBE_BYTES: ClassVar[int] = 512
 
     _MAX_EXTENSIONLESS_PROBES: ClassVar[int] = 100
     _MAX_TOTAL_EXTRACT_SIZE: ClassVar[int] = 5 * 1024 * 1024 * 1024  # 5 GB
@@ -491,7 +493,7 @@ class SevenZipScanner(BaseScanner):
     def _identify_extensionless_nested_7z_files(
         self, archive: Any, file_names: list[str], archive_path: str, result: ScanResult
     ) -> tuple[list[str], bool]:
-        """Inspect likely disguised nested members and keep only confirmed 7z archives."""
+        """Inspect likely disguised nested members and keep only confirmed scannable payloads."""
         nested_archives: list[str] = []
         probes_complete = True
         probe_candidates: list[tuple[int, int, str]] = []
@@ -536,7 +538,7 @@ class SevenZipScanner(BaseScanner):
         try:
             probe_results = self._probe_extensionless_members(archive, probe_targets)
             for file_name in probe_targets:
-                if probe_results.get(file_name, False):
+                if probe_results.get(file_name):
                     nested_archives.append(file_name)
             return nested_archives, probes_complete
         except Exception:
@@ -546,7 +548,7 @@ class SevenZipScanner(BaseScanner):
 
         for file_name in probe_targets:
             try:
-                if self._member_has_7z_magic(archive, file_name):
+                if self._member_probe_detected_format(archive, file_name) is not None:
                     nested_archives.append(file_name)
             except Exception as e:
                 probes_complete = False
@@ -584,10 +586,10 @@ class SevenZipScanner(BaseScanner):
 
         return priority
 
-    def _probe_extensionless_members(self, archive: Any, file_names: list[str]) -> dict[str, bool]:
-        """Batch probe extensionless members in one pass to avoid repeated archive resets."""
+    def _probe_extensionless_members(self, archive: Any, file_names: list[str]) -> dict[str, str | None]:
+        """Batch probe disguised members in one pass to avoid repeated archive resets."""
         probe_factory = _HeaderProbeFactory(
-            limit=len(self._SEVENZIP_MAGIC),
+            limit=self._NESTED_MEMBER_PROBE_BYTES,
             raise_on_limit=False,
         )
 
@@ -597,7 +599,7 @@ class SevenZipScanner(BaseScanner):
             with suppress(Exception):
                 archive.reset()
 
-        return {file_name: self._probe_has_7z_magic(probe_factory.get(file_name)) for file_name in file_names}
+        return {file_name: self._probe_detected_format(probe_factory.get(file_name)) for file_name in file_names}
 
     @classmethod
     def _probe_has_7z_magic(cls, probe: _HeaderProbeBuffer | None) -> bool:
@@ -608,9 +610,44 @@ class SevenZipScanner(BaseScanner):
         probe.seek(0)
         return probe.read(len(cls._SEVENZIP_MAGIC)) == cls._SEVENZIP_MAGIC
 
-    def _member_has_7z_magic(self, archive: Any, file_name: str) -> bool:
-        """Read only enough bytes to confirm whether an extensionless member is a nested 7z archive."""
-        probe_factory = _HeaderProbeFactory(limit=len(self._SEVENZIP_MAGIC))
+    @classmethod
+    def _probe_has_tar_magic(cls, probe: _HeaderProbeBuffer | None) -> bool:
+        """Return True when a probe buffer captured a TAR header marker."""
+        if probe is None:
+            return False
+
+        probe.seek(0)
+        tar_header = probe.read(cls._NESTED_MEMBER_PROBE_BYTES)
+        return len(tar_header) >= 262 and tar_header[257:262] == b"ustar"
+
+    def _probe_detected_format(self, probe: _HeaderProbeBuffer | None) -> str | None:
+        """Return a directly routable header format captured by a bounded member probe."""
+        if probe is None:
+            return None
+
+        if self._probe_has_7z_magic(probe):
+            return "sevenzip"
+        if self._probe_has_tar_magic(probe):
+            return "tar"
+
+        probe.seek(0)
+        prefix = probe.read(self._NESTED_MEMBER_PROBE_BYTES)
+        if len(prefix) < 4:
+            return None
+
+        detected_format = detect_format_from_magic_bytes(
+            prefix[:4],
+            prefix[:8],
+            prefix[:16],
+            len(prefix),
+        )
+        if detected_format == "unknown":
+            return None
+        return detected_format
+
+    def _member_probe_detected_format(self, archive: Any, file_name: str) -> str | None:
+        """Read only enough bytes to confirm whether a member has a scannable nested format."""
+        probe_factory = _HeaderProbeFactory(limit=self._NESTED_MEMBER_PROBE_BYTES)
 
         try:
             archive.extract(targets=[file_name], factory=probe_factory)
@@ -623,7 +660,7 @@ class SevenZipScanner(BaseScanner):
         probe = probe_factory.get(file_name)
         if probe is None:
             probe = next(iter(probe_factory.products.values()), None)
-        return self._probe_has_7z_magic(probe)
+        return self._probe_detected_format(probe)
 
     def _check_path_traversal(self, file_names: list[str], archive_path: str, result: ScanResult) -> list[str]:
         """Check for path traversal vulnerabilities and return only safe entries."""

--- a/modelaudit/scanners/sevenzip_scanner.py
+++ b/modelaudit/scanners/sevenzip_scanner.py
@@ -587,19 +587,8 @@ class SevenZipScanner(BaseScanner):
         return priority
 
     def _probe_extensionless_members(self, archive: Any, file_names: list[str]) -> dict[str, str | None]:
-        """Batch probe disguised members in one pass to avoid repeated archive resets."""
-        probe_factory = _HeaderProbeFactory(
-            limit=self._NESTED_MEMBER_PROBE_BYTES,
-            raise_on_limit=False,
-        )
-
-        try:
-            archive.extract(targets=file_names, factory=probe_factory)
-        finally:
-            with suppress(Exception):
-                archive.reset()
-
-        return {file_name: self._probe_detected_format(probe_factory.get(file_name)) for file_name in file_names}
+        """Probe disguised members while stopping each extraction at the header budget."""
+        return {file_name: self._member_probe_detected_format(archive, file_name) for file_name in file_names}
 
     @classmethod
     def _probe_has_7z_magic(cls, probe: _HeaderProbeBuffer | None) -> bool:

--- a/tests/scanners/test_sevenzip_scanner.py
+++ b/tests/scanners/test_sevenzip_scanner.py
@@ -1376,6 +1376,59 @@ class TestSevenZipScannerHardening:
             assert len(limit_checks) == 1
             assert limit_checks[0].status == CheckStatus.FAILED
 
+    def test_disguised_nested_zip_member_is_routed_for_scan(
+        self,
+        temp_7z_file: str,
+    ) -> None:
+        """Disguised nested archives should become scannable via bounded header probes."""
+        scanner = SevenZipScanner()
+
+        with (
+            patch("modelaudit.scanners.sevenzip_scanner.HAS_PY7ZR", True),
+            patch("modelaudit.scanners.sevenzip_scanner.py7zr") as mock_py7zr,
+            patch.object(scanner, "_probe_extensionless_members", return_value={"payload.jpg": "zip"}) as mock_probe,
+            patch.object(scanner, "_extract_and_scan_files", return_value=True) as mock_extract,
+            patch("os.path.getsize", return_value=32),
+        ):
+            mock_archive = MagicMock()
+            mock_archive.getnames.return_value = ["payload.jpg"]
+            mock_archive.getinfo.return_value = MagicMock(is_directory=False, uncompressed=16)
+            mock_py7zr.SevenZipFile.return_value.__enter__.return_value = mock_archive
+
+            result = scanner.scan(temp_7z_file)
+
+            assert result.success
+            assert mock_probe.call_args.args[1] == ["payload.jpg"]
+            assert mock_extract.call_args.args[1] == ["payload.jpg"]
+            assert result.metadata["scannable_files"] == 1
+
+    def test_oversized_disguised_nested_zip_marks_scan_incomplete(
+        self,
+        temp_7z_file: str,
+    ) -> None:
+        """Oversized disguised nested archives must fail closed once header probes classify them as scannable."""
+        scanner = SevenZipScanner(config={"max_7z_extract_size": 8})
+
+        with (
+            patch("modelaudit.scanners.sevenzip_scanner.HAS_PY7ZR", True),
+            patch("modelaudit.scanners.sevenzip_scanner.py7zr") as mock_py7zr,
+            patch.object(scanner, "_probe_extensionless_members", return_value={"payload.jpg": "zip"}),
+            patch("os.path.getsize", return_value=32),
+        ):
+            mock_archive = MagicMock()
+            mock_archive.getnames.return_value = ["payload.jpg"]
+            mock_archive.getinfo.return_value = MagicMock(is_directory=False, uncompressed=32)
+            mock_py7zr.SevenZipFile.return_value.__enter__.return_value = mock_archive
+
+            result = scanner.scan(temp_7z_file)
+
+            oversized_checks = [c for c in result.checks if c.name == "Extracted File Size"]
+            assert len(oversized_checks) == 1
+            assert oversized_checks[0].details["size_limit"] == 8
+            assert result.success is False
+            assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+            assert "sevenzip_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+
     # -- cumulative entry count -----------------------------------------------
 
     @pytest.mark.skipif(not HAS_PY7ZR, reason="py7zr not available")
@@ -1496,6 +1549,18 @@ class TestSevenZipScannerHardening:
             buf.write(b"\xbc\xaf\x27\x1c\x00\x00")  # 8 bytes, only 4 more captured
         buf.seek(0)
         assert buf.read(6) == b"\x37\x7a\xbc\xaf\x27\x1c"
+
+    def test_probe_detected_format_recognizes_tar_headers(self) -> None:
+        """Header probes should classify nested TAR members without relying on suffixes."""
+        from modelaudit.scanners.sevenzip_scanner import _HeaderProbeBuffer
+
+        scanner = SevenZipScanner()
+        buf = _HeaderProbeBuffer(limit=scanner._NESTED_MEMBER_PROBE_BYTES, raise_on_limit=False)
+        tar_header = bytearray(scanner._NESTED_MEMBER_PROBE_BYTES)
+        tar_header[257:262] = b"ustar"
+        buf.write(bytes(tar_header))
+
+        assert scanner._probe_detected_format(buf) == "tar"
 
     # -- default config includes new limits -----------------------------------
 

--- a/tests/scanners/test_sevenzip_scanner.py
+++ b/tests/scanners/test_sevenzip_scanner.py
@@ -11,7 +11,9 @@ Tests the 7-Zip archive scanning functionality including:
 
 import os
 import pickle
+import tarfile
 import tempfile
+import zipfile
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
@@ -837,10 +839,12 @@ class TestSevenZipScanner:
     def test_extensionless_non_7z_members_are_filtered_before_full_extraction(
         self,
         scanner: SevenZipScanner,
-        temp_7z_file: str,
+        tmp_path: Path,
     ) -> None:
         """Only header-confirmed extensionless members should reach the full extraction pass."""
         extensionless_members = [f"asset_{index:03d}" for index in range(32)]
+        archive_path = tmp_path / "filter_probe.7z"
+        archive_path.write_bytes(scanner._SEVENZIP_MAGIC + b"\0" * 26)
 
         with (
             patch("modelaudit.scanners.sevenzip_scanner.HAS_PY7ZR", True),
@@ -867,17 +871,15 @@ class TestSevenZipScanner:
             mock_archive.extract.side_effect = fake_extract
             mock_py7zr.SevenZipFile.return_value.__enter__.return_value = mock_archive
 
-            result = scanner.scan(temp_7z_file)
+            result = scanner.scan(str(archive_path))
 
             assert result.success
-            assert mock_archive.reset.call_count == 1
-            assert mock_archive.extract.call_count == 2
-            assert mock_archive.extract.call_args_list[0].kwargs["targets"] == [
-                "nested_archive",
-                *extensionless_members,
-            ]
-            assert "factory" in mock_archive.extract.call_args_list[0].kwargs
-            assert mock_archive.extract.call_args_list[1].kwargs["targets"] == ["safe.pkl", "nested_archive"]
+            probe_calls = mock_archive.extract.call_args_list[:-1]
+            assert mock_archive.reset.call_count == len(probe_calls)
+            assert mock_archive.extract.call_count == len(extensionless_members) + 2
+            assert [call.kwargs["targets"][0] for call in probe_calls] == ["nested_archive", *extensionless_members]
+            assert all("factory" in call.kwargs for call in probe_calls)
+            assert mock_archive.extract.call_args_list[-1].kwargs["targets"] == ["safe.pkl", "nested_archive"]
             assert mock_scan_extracted_file.call_count == 2
 
     def test_max_entries_protection(self, scanner, temp_7z_file):
@@ -1378,10 +1380,12 @@ class TestSevenZipScannerHardening:
 
     def test_disguised_nested_zip_member_is_routed_for_scan(
         self,
-        temp_7z_file: str,
+        tmp_path: Path,
     ) -> None:
         """Disguised nested archives should become scannable via bounded header probes."""
         scanner = SevenZipScanner()
+        archive_path = tmp_path / "mock.7z"
+        archive_path.write_bytes(scanner._SEVENZIP_MAGIC + b"\0" * 26)
 
         with (
             patch("modelaudit.scanners.sevenzip_scanner.HAS_PY7ZR", True),
@@ -1395,7 +1399,7 @@ class TestSevenZipScannerHardening:
             mock_archive.getinfo.return_value = MagicMock(is_directory=False, uncompressed=16)
             mock_py7zr.SevenZipFile.return_value.__enter__.return_value = mock_archive
 
-            result = scanner.scan(temp_7z_file)
+            result = scanner.scan(str(archive_path))
 
             assert result.success
             assert mock_probe.call_args.args[1] == ["payload.jpg"]
@@ -1404,10 +1408,12 @@ class TestSevenZipScannerHardening:
 
     def test_oversized_disguised_nested_zip_marks_scan_incomplete(
         self,
-        temp_7z_file: str,
+        tmp_path: Path,
     ) -> None:
         """Oversized disguised nested archives must fail closed once header probes classify them as scannable."""
         scanner = SevenZipScanner(config={"max_7z_extract_size": 8})
+        archive_path = tmp_path / "mock_oversized.7z"
+        archive_path.write_bytes(scanner._SEVENZIP_MAGIC + b"\0" * 26)
 
         with (
             patch("modelaudit.scanners.sevenzip_scanner.HAS_PY7ZR", True),
@@ -1420,7 +1426,7 @@ class TestSevenZipScannerHardening:
             mock_archive.getinfo.return_value = MagicMock(is_directory=False, uncompressed=32)
             mock_py7zr.SevenZipFile.return_value.__enter__.return_value = mock_archive
 
-            result = scanner.scan(temp_7z_file)
+            result = scanner.scan(str(archive_path))
 
             oversized_checks = [c for c in result.checks if c.name == "Extracted File Size"]
             assert len(oversized_checks) == 1
@@ -1428,6 +1434,108 @@ class TestSevenZipScannerHardening:
             assert result.success is False
             assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
             assert "sevenzip_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+
+    def test_probe_extensionless_members_stops_each_member_at_header_limit(self) -> None:
+        """Header probes should stop each disguised member after the bounded prefix."""
+        scanner = SevenZipScanner()
+
+        class FakeArchive:
+            def __init__(self) -> None:
+                self.targets: list[list[str]] = []
+                self.reset_count = 0
+
+            def extract(self, *, targets: list[str], factory: Any) -> None:
+                self.targets.append(targets)
+                probe = factory.create(targets[0])
+                probe.write(b"PK\x03\x04" + (b"A" * scanner._NESTED_MEMBER_PROBE_BYTES * 2))
+                raise AssertionError("probe extraction did not stop at the configured header budget")
+
+            def reset(self) -> None:
+                self.reset_count += 1
+
+        fake_archive = FakeArchive()
+
+        assert scanner._probe_extensionless_members(fake_archive, ["payload_a.jpg", "payload_b.jpg"]) == {
+            "payload_a.jpg": "zip",
+            "payload_b.jpg": "zip",
+        }
+        assert fake_archive.targets == [["payload_a.jpg"], ["payload_b.jpg"]]
+        assert fake_archive.reset_count == 2
+
+    @pytest.mark.skipif(not HAS_PY7ZR, reason="py7zr not available")
+    def test_disguised_nested_zip_member_detects_malicious_payload_end_to_end(self, tmp_path: Path) -> None:
+        """A ZIP payload hidden behind an image suffix inside 7z must still be scanned."""
+        import py7zr  # type: ignore[import-untyped]
+
+        class MaliciousClass:
+            def __reduce__(self) -> tuple[Any, tuple[str]]:
+                import os as os_module
+
+                return (os_module.system, ("echo disguised_zip_in_7z",))
+
+        pickle_path = tmp_path / "payload.pkl"
+        nested_zip_path = tmp_path / "nested.zip"
+        archive_path = tmp_path / "outer.7z"
+        self._write_pickle(pickle_path, MaliciousClass())
+        with zipfile.ZipFile(nested_zip_path, "w") as archive:
+            archive.write(pickle_path, "payload.pkl")
+        with py7zr.SevenZipFile(archive_path, "w") as archive:
+            archive.write(str(nested_zip_path), "payload.jpg")
+
+        result = SevenZipScanner().scan(str(archive_path))
+
+        assert result.success is False
+        assert any(
+            issue.location
+            and f"{archive_path}:payload.jpg:payload.pkl" in issue.location
+            and "system" in issue.message.lower()
+            for issue in result.issues
+        )
+
+    @pytest.mark.skipif(not HAS_PY7ZR, reason="py7zr not available")
+    def test_disguised_nested_tar_member_detects_malicious_payload_end_to_end(self, tmp_path: Path) -> None:
+        """A TAR payload hidden behind an opaque suffix inside 7z must still be scanned."""
+        import py7zr  # type: ignore[import-untyped]
+
+        class MaliciousClass:
+            def __reduce__(self) -> tuple[Any, tuple[str]]:
+                import os as os_module
+
+                return (os_module.system, ("echo disguised_tar_in_7z",))
+
+        pickle_path = tmp_path / "payload.pkl"
+        nested_tar_path = tmp_path / "nested.tar"
+        archive_path = tmp_path / "outer_tar.7z"
+        self._write_pickle(pickle_path, MaliciousClass())
+        with tarfile.open(nested_tar_path, "w") as archive:
+            archive.add(pickle_path, arcname="payload.pkl")
+        with py7zr.SevenZipFile(archive_path, "w") as archive:
+            archive.write(str(nested_tar_path), "payload.bin")
+
+        result = SevenZipScanner().scan(str(archive_path))
+
+        assert result.success is False
+        assert any(
+            issue.location
+            and f"{archive_path}:payload.bin:payload.pkl" in issue.location
+            and "system" in issue.message.lower()
+            for issue in result.issues
+        )
+
+    @pytest.mark.skipif(not HAS_PY7ZR, reason="py7zr not available")
+    def test_benign_disguised_image_member_is_not_routed_as_nested_archive(self, tmp_path: Path) -> None:
+        """Image-like members with unsupported magic should not become noisy nested archive scans."""
+        import py7zr  # type: ignore[import-untyped]
+
+        archive_path = tmp_path / "benign_image.7z"
+        with py7zr.SevenZipFile(archive_path, "w") as archive:
+            archive.writestr(b"\x89PNG\r\n\x1a\n" + (b"\0" * 128), "payload.jpg")
+
+        result = SevenZipScanner().scan(str(archive_path))
+
+        assert result.success is True
+        assert result.metadata["scannable_files"] == 0
+        assert not result.issues
 
     # -- cumulative entry count -----------------------------------------------
 


### PR DESCRIPTION
## Summary

Teach the 7z scanner to probe likely disguised members for bounded, directly routable header formats instead of checking only for nested 7z magic. This lets nested ZIP and TAR payloads without trustworthy suffixes become scannable, and keeps oversized disguised members in the explicit inconclusive path.

## Security impact

Before this change, the 7z scanner only treated probed members as nested content when the first bytes matched 7z magic. A hidden ZIP or TAR inside a `.7z` file with no extension or a misleading suffix could be skipped entirely, which meant the nested scanner dispatch never ran. The new probe keeps the same budgeted workflow, but it recognizes directly routable header formats from a bounded prefix, including TAR headers at the standard offset.

## Validation

- `uv run ruff format modelaudit/scanners/sevenzip_scanner.py tests/scanners/test_sevenzip_scanner.py`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_sevenzip_scanner.py -q`
- `uv run mypy modelaudit/scanners/sevenzip_scanner.py tests/scanners/test_sevenzip_scanner.py`
