### PR TITLE
fix: fail closed on oversized Skops entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **security:** route ONNX protobuf payloads saved with a `.pb` suffix by content before TensorFlow protobuf extension fallback
 - **security:** detect direct `getattr(module, "dangerous")` handler calls in TorchServe MAR archives, parse conflicting duplicate manifests without silently downgrading hidden handlers, and suppress collision warnings for byte-identical duplicate manifests
 - **security:** recognize RAR archives and fail closed as unsupported coverage instead of skipping `.rar` files during directory scans
+- **skops:** fail closed when Skops archive limits, malformed archives, or bounded metadata reads leave CVE coverage incomplete, while preserving benign numeric-array payload scans
 - **security:** reduce NeMo Hydra `_target_` false positives by matching suspicious identifiers on token boundaries, preserve CVE-2025-23304 details on suspicious-target findings, and reject oversized YAML members before parsing
 - **security:** preserve skipped-suffix ZIP containers when Keras config-only structure or embedded model-like `.bin` members indicate scannable content
 - **security:** fail closed when oversized NeMo YAML prevents Hydra target analysis and scan malformed Jinja2 config fallbacks beyond the initial prefix window

--- a/modelaudit/scanners/skops_scanner.py
+++ b/modelaudit/scanners/skops_scanner.py
@@ -24,6 +24,10 @@ class SkopsScanner(BaseScanner):
     supported_extensions: ClassVar[list[str]] = [".skops"]
     _OVERSIZED_ENTRY_REASON: ClassVar[str] = "skops_zip_entry_size_limited"
     _OVERSIZED_ENTRY_METADATA_KEY: ClassVar[str] = "oversized_zip_entries"
+    _NOT_ZIP_REASON: ClassVar[str] = "skops_not_zip_archive"
+    _BAD_ZIP_REASON: ClassVar[str] = "skops_bad_zip_file"
+    _FILE_COUNT_LIMIT_REASON: ClassVar[str] = "skops_archive_file_count_limited"
+    _UNCOMPRESSED_SIZE_LIMIT_REASON: ClassVar[str] = "skops_archive_uncompressed_size_limited"
 
     def __init__(self, config: dict[str, Any] | None = None):
         super().__init__(config)
@@ -31,6 +35,11 @@ class SkopsScanner(BaseScanner):
         self.max_file_size = self.config.get("max_skops_file_size", 500 * 1024 * 1024)  # 500MB
         self.max_files_in_archive = self.config.get("max_files_in_archive", 10000)
         self.max_zip_entry_read_size = self.config.get("max_zip_entry_read_size", 10 * 1024 * 1024)
+
+    @staticmethod
+    def _is_nested_array_payload(filename: str) -> bool:
+        """Return True for Skops numeric payloads covered by nested archive scans."""
+        return os.path.splitext(filename.lower())[1] in {".npy", ".npz"}
 
     def _record_oversized_zip_entry(
         self,
@@ -61,6 +70,10 @@ class SkopsScanner(BaseScanner):
                 "entry_size": file_info.file_size,
                 "max_zip_entry_read_size": self.max_zip_entry_read_size,
             },
+            why=(
+                "The scanner did not inspect this archive member because reading it would exceed the configured "
+                "per-entry limit, so Skops CVE coverage for the archive is incomplete."
+            ),
         )
         mark_archive_scan_incomplete(result, self._OVERSIZED_ENTRY_REASON)
 
@@ -74,7 +87,7 @@ class SkopsScanner(BaseScanner):
     ) -> bytes | None:
         """Read a ZIP entry with a bounded memory limit."""
         if file_info.file_size > self.max_zip_entry_read_size:
-            if result is not None and zip_path is not None:
+            if result is not None and zip_path is not None and not self._is_nested_array_payload(file_info.filename):
                 self._record_oversized_zip_entry(result, zip_path, file_info)
             return None
 
@@ -82,7 +95,7 @@ class SkopsScanner(BaseScanner):
             content = entry.read(self.max_zip_entry_read_size + 1)
 
         if len(content) > self.max_zip_entry_read_size:
-            if result is not None and zip_path is not None:
+            if result is not None and zip_path is not None and not self._is_nested_array_payload(file_info.filename):
                 self._record_oversized_zip_entry(result, zip_path, file_info)
             return None
 
@@ -450,6 +463,7 @@ class SkopsScanner(BaseScanner):
                     location=path,
                     details={"magic_bytes": magic.hex()},
                 )
+                mark_archive_scan_incomplete(result, self._NOT_ZIP_REASON)
                 result.finish(success=False)
                 return result
 
@@ -474,6 +488,7 @@ class SkopsScanner(BaseScanner):
                         },
                         why="Excessive number of files may indicate a decompression bomb attack",
                     )
+                    mark_archive_scan_incomplete(result, self._FILE_COUNT_LIMIT_REASON)
                     result.finish(success=False)
                     return result
 
@@ -502,6 +517,7 @@ class SkopsScanner(BaseScanner):
                             "exhaust memory during scanning."
                         ),
                     )
+                    mark_archive_scan_incomplete(result, self._UNCOMPRESSED_SIZE_LIMIT_REASON)
                     result.finish(success=False)
                     return result
 
@@ -532,6 +548,7 @@ class SkopsScanner(BaseScanner):
                 severity=IssueSeverity.INFO,
                 location=path,
             )
+            mark_archive_scan_incomplete(result, self._BAD_ZIP_REASON)
             result.finish(success=False)
             return result
         except Exception as e:

--- a/modelaudit/scanners/skops_scanner.py
+++ b/modelaudit/scanners/skops_scanner.py
@@ -12,7 +12,8 @@ import zipfile
 from typing import Any, ClassVar
 
 from ..utils.file.detection import is_skops_archive, read_magic_bytes
-from .base import BaseScanner, IssueSeverity, ScanResult
+from ._archive_outcomes import mark_archive_scan_incomplete
+from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, IssueSeverity, ScanResult
 
 
 class SkopsScanner(BaseScanner):
@@ -21,6 +22,8 @@ class SkopsScanner(BaseScanner):
     name = "skops"
     description = "Scans skops files for CVE-2025-54412, CVE-2025-54413, CVE-2025-54886 vulnerabilities"
     supported_extensions: ClassVar[list[str]] = [".skops"]
+    _OVERSIZED_ENTRY_REASON: ClassVar[str] = "skops_zip_entry_size_limited"
+    _OVERSIZED_ENTRY_METADATA_KEY: ClassVar[str] = "oversized_zip_entries"
 
     def __init__(self, config: dict[str, Any] | None = None):
         super().__init__(config)
@@ -29,15 +32,58 @@ class SkopsScanner(BaseScanner):
         self.max_files_in_archive = self.config.get("max_files_in_archive", 10000)
         self.max_zip_entry_read_size = self.config.get("max_zip_entry_read_size", 10 * 1024 * 1024)
 
-    def _read_zip_entry_safely(self, zip_file: zipfile.ZipFile, file_info: zipfile.ZipInfo) -> bytes | None:
+    def _record_oversized_zip_entry(
+        self,
+        result: ScanResult,
+        zip_path: str,
+        file_info: zipfile.ZipInfo,
+    ) -> None:
+        oversized_entries = result.metadata.setdefault(self._OVERSIZED_ENTRY_METADATA_KEY, [])
+        if not isinstance(oversized_entries, list):
+            oversized_entries = []
+            result.metadata[self._OVERSIZED_ENTRY_METADATA_KEY] = oversized_entries
+
+        if file_info.filename in oversized_entries:
+            return
+
+        oversized_entries.append(file_info.filename)
+        result.add_check(
+            name="Skops Oversized ZIP Entry",
+            passed=False,
+            message=(
+                f"Skipped oversized ZIP entry {file_info.filename} "
+                f"({file_info.file_size} bytes > {self.max_zip_entry_read_size} byte read limit)"
+            ),
+            severity=IssueSeverity.WARNING,
+            location=f"{zip_path}:{file_info.filename}",
+            details={
+                "entry": file_info.filename,
+                "entry_size": file_info.file_size,
+                "max_zip_entry_read_size": self.max_zip_entry_read_size,
+            },
+        )
+        mark_archive_scan_incomplete(result, self._OVERSIZED_ENTRY_REASON)
+
+    def _read_zip_entry_safely(
+        self,
+        zip_file: zipfile.ZipFile,
+        file_info: zipfile.ZipInfo,
+        *,
+        result: ScanResult | None = None,
+        zip_path: str | None = None,
+    ) -> bytes | None:
         """Read a ZIP entry with a bounded memory limit."""
         if file_info.file_size > self.max_zip_entry_read_size:
+            if result is not None and zip_path is not None:
+                self._record_oversized_zip_entry(result, zip_path, file_info)
             return None
 
         with zip_file.open(file_info, "r") as entry:
             content = entry.read(self.max_zip_entry_read_size + 1)
 
         if len(content) > self.max_zip_entry_read_size:
+            if result is not None and zip_path is not None:
+                self._record_oversized_zip_entry(result, zip_path, file_info)
             return None
 
         return content
@@ -90,7 +136,7 @@ class SkopsScanner(BaseScanner):
         # Scan file contents for suspicious patterns
         for file_info in zip_file.filelist:
             try:
-                content = self._read_zip_entry_safely(zip_file, file_info)
+                content = self._read_zip_entry_safely(zip_file, file_info, result=result, zip_path=zip_path)
                 if content is None:
                     continue
                 for binary_pattern in suspicious_binary_patterns:
@@ -157,7 +203,7 @@ class SkopsScanner(BaseScanner):
         # Scan file contents for suspicious patterns
         for file_info in zip_file.filelist:
             try:
-                content = self._read_zip_entry_safely(zip_file, file_info)
+                content = self._read_zip_entry_safely(zip_file, file_info, result=result, zip_path=zip_path)
                 if content is None:
                     continue
                 for binary_pattern in suspicious_binary_patterns:
@@ -204,7 +250,7 @@ class SkopsScanner(BaseScanner):
             # Check for Card/model card files
             if "card" in file_name or "model_card" in file_name or "readme" in file_name:
                 try:
-                    raw_content = self._read_zip_entry_safely(zip_file, file_info)
+                    raw_content = self._read_zip_entry_safely(zip_file, file_info, result=result, zip_path=zip_path)
                     if raw_content is None:
                         continue
 
@@ -247,7 +293,7 @@ class SkopsScanner(BaseScanner):
             for file_name in zip_file.namelist():
                 if "schema" in file_name.lower() or "version" in file_name.lower() or "protocol" in file_name.lower():
                     file_info = zip_file.getinfo(file_name)
-                    raw_content = self._read_zip_entry_safely(zip_file, file_info)
+                    raw_content = self._read_zip_entry_safely(zip_file, file_info, result=result, zip_path=zip_path)
                     if raw_content is None:
                         continue
 
@@ -330,7 +376,7 @@ class SkopsScanner(BaseScanner):
             is_metadata = self._is_skops_metadata(file_info.filename)
 
             try:
-                content = self._read_zip_entry_safely(zip_file, file_info)
+                content = self._read_zip_entry_safely(zip_file, file_info, result=result, zip_path=zip_path)
                 if content is None:
                     continue
                 for pattern in joblib_patterns:
@@ -500,5 +546,7 @@ class SkopsScanner(BaseScanner):
             result.finish(success=False)
             return result
 
-        result.finish(success=not result.has_errors)
+        result.finish(
+            success=not result.has_errors and result.metadata.get("scan_outcome") != INCONCLUSIVE_SCAN_OUTCOME
+        )
         return result

--- a/tests/scanners/test_skops_scanner.py
+++ b/tests/scanners/test_skops_scanner.py
@@ -3,13 +3,58 @@
 import os
 import zipfile
 from pathlib import Path
+from typing import Any
 
 import pytest
 
+from modelaudit.cache import get_cache_manager, reset_cache_manager
+from modelaudit.core import determine_exit_code, scan_model_directory_or_file
+from modelaudit.models import ModelAuditResultModel
 from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity
 from modelaudit.scanners.skops_scanner import SkopsScanner
 
 SAMPLES_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "assets", "samples")
+
+
+def _make_numeric_npy(element_count: int = 64) -> bytes:
+    header = f"{{'descr': '<f8', 'fortran_order': False, 'shape': ({element_count},), }}"
+    header_bytes = header.encode("latin1")
+    header_len = len(header_bytes) + 1
+    padding_len = (16 - ((10 + header_len) % 16)) % 16
+    padded_header = header_bytes + (b" " * padding_len) + b"\n"
+    return (
+        b"\x93NUMPY\x01\x00" + len(padded_header).to_bytes(2, "little") + padded_header + (b"\x00" * element_count * 8)
+    )
+
+
+def _scan_twice_with_cache(
+    path: Path,
+    cache_dir: Path,
+    *,
+    max_files_in_archive: int | None = None,
+    max_skops_file_size: int | None = None,
+    max_zip_entry_read_size: int | None = None,
+) -> tuple[ModelAuditResultModel, ModelAuditResultModel]:
+    scan_kwargs: dict[str, Any] = {
+        "cache_enabled": True,
+        "cache_dir": str(cache_dir),
+        "min_cache_file_size": 0,
+    }
+    if max_files_in_archive is not None:
+        scan_kwargs["max_files_in_archive"] = max_files_in_archive
+    if max_skops_file_size is not None:
+        scan_kwargs["max_skops_file_size"] = max_skops_file_size
+    if max_zip_entry_read_size is not None:
+        scan_kwargs["max_zip_entry_read_size"] = max_zip_entry_read_size
+
+    first = scan_model_directory_or_file(str(path), **scan_kwargs)
+    second = scan_model_directory_or_file(str(path), **scan_kwargs)
+    return first, second
+
+
+def _assert_inconclusive_reason(metadata: Any, reason: str) -> None:
+    assert metadata.get("scan_outcome") == INCONCLUSIVE_SCAN_OUTCOME
+    assert reason in metadata.get("scan_outcome_reasons", [])
 
 
 class TestSkopsScannerCanHandle:
@@ -314,8 +359,10 @@ class TestSkopsScannerEdgeCases:
         scanner = SkopsScanner()
         result = scanner.scan(str(skops_file))
 
-        # Should have at least one check about the file
-        assert len(result.checks) > 0
+        assert result.success is False
+        _assert_inconclusive_reason(result.metadata, "skops_not_zip_archive")
+        format_checks = [c for c in result.checks if c.name == "Skops File Format Check"]
+        assert len(format_checks) > 0
 
     def test_handles_deeply_nested_files(self, tmp_path: Path) -> None:
         """Test handling of deeply nested file paths."""
@@ -356,6 +403,7 @@ class TestSkopsScannerEdgeCases:
         result = scanner.scan(str(skops_file))
 
         assert result.success is False
+        _assert_inconclusive_reason(result.metadata, "skops_archive_file_count_limited")
         bomb_checks = [c for c in result.checks if "Archive Bomb" in c.name]
         assert len(bomb_checks) > 0
         assert bomb_checks[0].status == CheckStatus.FAILED
@@ -371,6 +419,7 @@ class TestSkopsScannerEdgeCases:
         result = scanner.scan(str(skops_file))
 
         assert result.success is False
+        _assert_inconclusive_reason(result.metadata, "skops_archive_uncompressed_size_limited")
         size_checks = [c for c in result.checks if "Archive Uncompressed Size Limit" in c.name]
         assert len(size_checks) > 0
         assert size_checks[0].status == CheckStatus.FAILED
@@ -386,13 +435,27 @@ class TestSkopsScannerEdgeCases:
         result = scanner.scan(str(skops_file))
 
         assert result.success is False
-        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
-        assert "skops_zip_entry_size_limited" in result.metadata["scan_outcome_reasons"]
+        _assert_inconclusive_reason(result.metadata, "skops_zip_entry_size_limited")
         oversized_checks = [c for c in result.checks if c.name == "Skops Oversized ZIP Entry"]
         assert len(oversized_checks) == 1
         assert oversized_checks[0].details["entry"] == "README.md"
         cve_checks = [c for c in result.checks if "CVE-2025-54886" in c.name and c.status == CheckStatus.FAILED]
         assert len(cve_checks) == 0
+
+    def test_oversized_numpy_payload_does_not_mark_skops_incomplete(self, tmp_path: Path) -> None:
+        """Large Skops numeric arrays are covered by nested scanners, not Skops CVE text matching."""
+        skops_file = tmp_path / "oversized_array.skops"
+        with zipfile.ZipFile(skops_file, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("schema.json", '{"version": "1.0"}')
+            zf.writestr("step/0/content/0.npy", _make_numeric_npy())
+
+        scanner = SkopsScanner(config={"max_zip_entry_read_size": 128, "max_skops_file_size": 10 * 1024 * 1024})
+        result = scanner.scan(str(skops_file))
+
+        assert result.success is True
+        assert "scan_outcome" not in result.metadata
+        oversized_checks = [c for c in result.checks if c.name == "Skops Oversized ZIP Entry"]
+        assert len(oversized_checks) == 0
 
     def test_oversized_entry_warning_is_emitted_once(self, tmp_path: Path) -> None:
         """Repeated detector passes over one oversized member should emit one incomplete warning."""
@@ -409,6 +472,193 @@ class TestSkopsScannerEdgeCases:
         assert oversized_checks[0].details["entry"] == "payload.bin"
         assert result.success is False
         assert result.metadata["oversized_zip_entries"] == ["payload.bin"]
+
+    def test_oversized_entry_core_exits_one_and_avoids_cache_reuse(self, tmp_path: Path) -> None:
+        """Aggregate scans should preserve fail-closed exit and avoid reusing incomplete outer results."""
+        skops_file = tmp_path / "oversized_readme.skops"
+        with zipfile.ZipFile(skops_file, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("README.md", "get_model via joblib.load" * 512)
+            zf.writestr("schema.json", '{"version": "1.0"}')
+
+        cache_dir = tmp_path / "cache"
+        reset_cache_manager()
+        try:
+            first, second = _scan_twice_with_cache(
+                skops_file,
+                cache_dir,
+                max_zip_entry_read_size=128,
+                max_skops_file_size=10 * 1024 * 1024,
+            )
+
+            for result in (first, second):
+                assert result.success is True
+                assert determine_exit_code(result) == 1
+                assert "skops" in result.scanner_names
+                metadata = result.file_metadata[str(skops_file)]
+                _assert_inconclusive_reason(metadata, "skops_zip_entry_size_limited")
+                assert any("Skipped oversized ZIP entry README.md" in str(issue.message) for issue in result.issues)
+
+            assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["cache_hits"] == 0
+        finally:
+            reset_cache_manager()
+
+    def test_archive_file_count_limit_core_exits_two_and_avoids_cache_reuse(self, tmp_path: Path) -> None:
+        """Core scans should fail closed and avoid caching when Skops file-count limits stop analysis."""
+        skops_file = tmp_path / "too_many_files.skops"
+        with zipfile.ZipFile(skops_file, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            for index in range(6):
+                zf.writestr(f"file_{index}.bin", b"data")
+
+        cache_dir = tmp_path / "cache"
+        reset_cache_manager()
+        try:
+            first, second = _scan_twice_with_cache(
+                skops_file,
+                cache_dir,
+                max_files_in_archive=5,
+                max_skops_file_size=10 * 1024 * 1024,
+            )
+
+            for result in (first, second):
+                assert result.success is False
+                assert determine_exit_code(result) == 2
+                metadata = result.file_metadata[str(skops_file)]
+                _assert_inconclusive_reason(metadata, "skops_archive_file_count_limited")
+                assert any("Archive contains 6 files" in str(issue.message) for issue in result.issues)
+
+            stats = get_cache_manager(str(cache_dir), enabled=True).get_stats()
+            assert stats["cache_hits"] == 0
+            assert stats["total_entries"] == 0
+        finally:
+            reset_cache_manager()
+
+    def test_archive_uncompressed_size_limit_core_exits_two_and_avoids_cache_reuse(self, tmp_path: Path) -> None:
+        """Core scans should fail closed and avoid caching when Skops aggregate size limits stop analysis."""
+        skops_file = tmp_path / "too_large.skops"
+        with zipfile.ZipFile(skops_file, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("README.md", "A" * 4096)
+            zf.writestr("schema.json", '{"version": "1.0"}')
+
+        cache_dir = tmp_path / "cache"
+        reset_cache_manager()
+        try:
+            first, second = _scan_twice_with_cache(
+                skops_file,
+                cache_dir,
+                max_skops_file_size=2048,
+            )
+
+            for result in (first, second):
+                assert result.success is False
+                assert determine_exit_code(result) == 2
+                metadata = result.file_metadata[str(skops_file)]
+                _assert_inconclusive_reason(metadata, "skops_archive_uncompressed_size_limited")
+                assert any("uncompressed content exceeds" in str(issue.message) for issue in result.issues)
+
+            stats = get_cache_manager(str(cache_dir), enabled=True).get_stats()
+            assert stats["cache_hits"] == 0
+            assert stats["total_entries"] == 0
+        finally:
+            reset_cache_manager()
+
+    def test_not_zip_core_exits_one_and_avoids_cache_reuse(self, tmp_path: Path) -> None:
+        """A non-ZIP .skops path is incomplete Skops coverage, not a cacheable clean result."""
+        skops_file = tmp_path / "not_zip.skops"
+        skops_file.write_bytes(b"not a zip archive")
+
+        cache_dir = tmp_path / "cache"
+        reset_cache_manager()
+        try:
+            first, second = _scan_twice_with_cache(skops_file, cache_dir)
+
+            for result in (first, second):
+                assert result.success is True
+                assert determine_exit_code(result) == 1
+                metadata = result.file_metadata[str(skops_file)]
+                _assert_inconclusive_reason(metadata, "skops_not_zip_archive")
+                assert any("not a ZIP archive" in str(issue.message) for issue in result.issues)
+
+            stats = get_cache_manager(str(cache_dir), enabled=True).get_stats()
+            assert stats["cache_hits"] == 0
+            assert stats["total_entries"] == 0
+        finally:
+            reset_cache_manager()
+
+    def test_bad_zip_core_exits_two_and_avoids_cache_reuse(self, tmp_path: Path) -> None:
+        """A corrupt ZIP-like .skops path should also fail closed and stay uncached."""
+        skops_file = tmp_path / "bad_zip.skops"
+        skops_file.write_bytes(b"PK\x03\x04not a complete zip")
+
+        cache_dir = tmp_path / "cache"
+        reset_cache_manager()
+        try:
+            first, second = _scan_twice_with_cache(skops_file, cache_dir)
+
+            for result in (first, second):
+                assert result.success is False
+                assert determine_exit_code(result) == 2
+                metadata = result.file_metadata[str(skops_file)]
+                _assert_inconclusive_reason(metadata, "skops_bad_zip_file")
+                assert any("Invalid ZIP file" in str(issue.message) for issue in result.issues)
+
+            stats = get_cache_manager(str(cache_dir), enabled=True).get_stats()
+            assert stats["cache_hits"] == 0
+            assert stats["total_entries"] == 0
+        finally:
+            reset_cache_manager()
+
+    def test_oversized_numpy_payload_core_exits_zero_and_still_caches(self, tmp_path: Path) -> None:
+        """Oversized numeric arrays should not become Skops CVE false positives in aggregate scans."""
+        skops_file = tmp_path / "large_array.skops"
+        with zipfile.ZipFile(skops_file, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("schema.json", '{"version": "1.0"}')
+            zf.writestr("step/0/content/0.npy", _make_numeric_npy())
+
+        cache_dir = tmp_path / "cache"
+        reset_cache_manager()
+        try:
+            first, second = _scan_twice_with_cache(
+                skops_file,
+                cache_dir,
+                max_zip_entry_read_size=128,
+                max_skops_file_size=10 * 1024 * 1024,
+            )
+
+            for result in (first, second):
+                assert result.success is True
+                assert determine_exit_code(result) == 0
+                metadata = result.file_metadata[str(skops_file)]
+                assert "scan_outcome" not in metadata
+                assert not any("Skipped oversized ZIP entry" in str(issue.message) for issue in result.issues)
+
+            assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["cache_hits"] >= 1
+        finally:
+            reset_cache_manager()
+
+    def test_small_benign_core_scan_still_caches(self, tmp_path: Path) -> None:
+        """Clean Skops scans should still be cacheable."""
+        skops_file = tmp_path / "small_benign.skops"
+        with zipfile.ZipFile(skops_file, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("README.md", "normal safe model card")
+            zf.writestr("schema.json", '{"version": "1.0"}')
+
+        cache_dir = tmp_path / "cache"
+        reset_cache_manager()
+        try:
+            first, second = _scan_twice_with_cache(
+                skops_file,
+                cache_dir,
+                max_zip_entry_read_size=128,
+                max_skops_file_size=10 * 1024 * 1024,
+            )
+
+            assert first.success is True
+            assert second.success is True
+            assert determine_exit_code(first) == 0
+            assert determine_exit_code(second) == 0
+            assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["cache_hits"] >= 1
+        finally:
+            reset_cache_manager()
 
     def test_counts_embedded_member_bytes(self, tmp_path: Path) -> None:
         """Embedded member scans should contribute to total bytes_scanned."""

--- a/tests/scanners/test_skops_scanner.py
+++ b/tests/scanners/test_skops_scanner.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from modelaudit.scanners.base import CheckStatus, IssueSeverity
+from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity
 from modelaudit.scanners.skops_scanner import SkopsScanner
 
 SAMPLES_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "assets", "samples")
@@ -375,8 +375,8 @@ class TestSkopsScannerEdgeCases:
         assert len(size_checks) > 0
         assert size_checks[0].status == CheckStatus.FAILED
 
-    def test_skips_oversized_readme_entry_without_crashing(self, tmp_path: Path) -> None:
-        """Oversized archive entries should be skipped by bounded reads."""
+    def test_oversized_readme_entry_marks_scan_incomplete(self, tmp_path: Path) -> None:
+        """Oversized archive entries should fail closed when bounded reads skip them."""
         skops_file = tmp_path / "oversized_readme.skops"
         with zipfile.ZipFile(skops_file, "w", compression=zipfile.ZIP_DEFLATED) as zf:
             zf.writestr("README.md", "get_model via joblib.load" * 512)
@@ -385,9 +385,30 @@ class TestSkopsScannerEdgeCases:
         scanner = SkopsScanner(config={"max_zip_entry_read_size": 128, "max_skops_file_size": 10 * 1024 * 1024})
         result = scanner.scan(str(skops_file))
 
-        assert result.success is True
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "skops_zip_entry_size_limited" in result.metadata["scan_outcome_reasons"]
+        oversized_checks = [c for c in result.checks if c.name == "Skops Oversized ZIP Entry"]
+        assert len(oversized_checks) == 1
+        assert oversized_checks[0].details["entry"] == "README.md"
         cve_checks = [c for c in result.checks if "CVE-2025-54886" in c.name and c.status == CheckStatus.FAILED]
         assert len(cve_checks) == 0
+
+    def test_oversized_entry_warning_is_emitted_once(self, tmp_path: Path) -> None:
+        """Repeated detector passes over one oversized member should emit one incomplete warning."""
+        skops_file = tmp_path / "oversized_methodnode.skops"
+        with zipfile.ZipFile(skops_file, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("payload.bin", "MethodNode __getattr__" * 512)
+            zf.writestr("schema.json", '{"version": "1.0"}')
+
+        scanner = SkopsScanner(config={"max_zip_entry_read_size": 128, "max_skops_file_size": 10 * 1024 * 1024})
+        result = scanner.scan(str(skops_file))
+
+        oversized_checks = [c for c in result.checks if c.name == "Skops Oversized ZIP Entry"]
+        assert len(oversized_checks) == 1
+        assert oversized_checks[0].details["entry"] == "payload.bin"
+        assert result.success is False
+        assert result.metadata["oversized_zip_entries"] == ["payload.bin"]
 
     def test_counts_embedded_member_bytes(self, tmp_path: Path) -> None:
         """Embedded member scans should contribute to total bytes_scanned."""


### PR DESCRIPTION
## Summary

Fail closed when Skops content analysis has to skip oversized ZIP members because they exceed the bounded read limit.

## Security impact

Previously, `_read_zip_entry_safely()` returned `None` for oversized members and each CVE detector quietly continued. That meant a large malicious README, card, or payload file could evade content-based checks while the overall scan still finished successfully. This change records a single explicit oversized-entry warning, marks the scan outcome inconclusive, and preserves the bounded-read limit.

## Validation

- `uv run ruff format modelaudit/scanners/skops_scanner.py tests/scanners/test_skops_scanner.py`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_skops_scanner.py -q`
- `uv run mypy modelaudit/scanners/skops_scanner.py tests/scanners/test_skops_scanner.py`
