### PR TITLE
fix: fail closed on incomplete XGBoost analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **security:** detect direct `getattr(module, "dangerous")` handler calls in TorchServe MAR archives, parse conflicting duplicate manifests without silently downgrading hidden handlers, and suppress collision warnings for byte-identical duplicate manifests
 - **security:** recognize RAR archives and fail closed as unsupported coverage instead of skipping `.rar` files during directory scans
 - **skops:** fail closed when Skops archive limits, malformed archives, or bounded metadata reads leave CVE coverage incomplete, while preserving benign numeric-array payload scans
+- **xgboost:** fail closed on incomplete JSON, UBJ, binary-structure, pickle-spoof, and enabled-loader analyses while preserving core exit-code and cache semantics
 - **security:** reduce NeMo Hydra `_target_` false positives by matching suspicious identifiers on token boundaries, preserve CVE-2025-23304 details on suspicious-target findings, and reject oversized YAML members before parsing
 - **security:** preserve skipped-suffix ZIP containers when Keras config-only structure or embedded model-like `.bin` members indicate scannable content
 - **security:** fail closed when oversized NeMo YAML prevents Hydra target analysis and scan malformed Jinja2 config fallbacks beyond the initial prefix window

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -71,6 +71,8 @@ merge_scan_result = core_results.merge_scan_result
 HEADER_FORMAT_TO_SCANNER_ID = _registry.get_header_format_to_scanner_ids()
 _COMPRESSED_HEADER_FORMATS = frozenset({"compressed", "gzip", "bzip2", "xz", "lz4", "zlib"})
 _R_SERIALIZED_EXTENSIONS = frozenset({".rds", ".rda", ".rdata"})
+_XGBOOST_BINARY_EXTENSIONS = frozenset({".bst"})
+_XGBOOST_PICKLE_SPOOF_REASON = "xgboost_binary_pickle_spoof"
 
 
 def _select_preferred_scanner_id(path: str, header_format: str, ext: str) -> str | None:
@@ -129,6 +131,30 @@ def _preferred_scanner_can_handle(
         return True
 
     return False
+
+
+def _mark_xgboost_pickle_extension_spoof(result: ScanResult, path: str, ext: str) -> None:
+    """Preserve pickle analysis while flagging XGBoost extension spoofing."""
+    existing_reasons = result.metadata.get("scan_outcome_reasons")
+    if isinstance(existing_reasons, list) and _XGBOOST_PICKLE_SPOOF_REASON in existing_reasons:
+        result.success = False
+        return
+
+    claimed_format = ext.lower().lstrip(".") or "binary"
+    result.add_check(
+        name="File Format Validation",
+        passed=False,
+        message=f"File appears to be a pickle file with .{claimed_format} extension",
+        severity=IssueSeverity.WARNING,
+        location=path,
+        details={"detected_format": "pickle", "claimed_format": claimed_format},
+        why=(
+            "File extension spoofing is a security evasion technique used to bypass security scanners. "
+            "This may indicate malicious intent."
+        ),
+    )
+    _mark_inconclusive_scan_outcome(result, _XGBOOST_PICKLE_SPOOF_REASON)
+    result.success = False
 
 
 def _calculate_file_hash(file_path: str) -> str:
@@ -927,6 +953,7 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
     header_format = detect_file_format(path)
     ext_format = detect_format_from_extension(path)
     ext = os.path.splitext(path)[1].lower()
+    is_xgboost_pickle_spoof = ext in _XGBOOST_BINARY_EXTENSIONS and header_format == "pickle"
 
     # Record telemetry for file type detection
     detected_format = header_format if header_format != "unknown" else ext_format
@@ -998,6 +1025,8 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
             elif use_large_handler:
                 logger.debug(f"File size optimization: {path} ({file_size:,} bytes)")
                 result = scan_large_file(path, scanner, progress_callback, timeout)
+            elif is_xgboost_pickle_spoof:
+                result = scanner.scan(path)
             else:
                 result = scanner.scan_with_cache(path)
 
@@ -1036,6 +1065,8 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
                 elif use_large_handler:
                     logger.debug(f"File size optimization: {path} ({file_size:,} bytes)")
                     result = scan_large_file(path, scanner, progress_callback, timeout)
+                elif is_xgboost_pickle_spoof:
+                    result = scanner.scan(path)
                 else:
                     result = scanner.scan_with_cache(path)
 
@@ -1071,6 +1102,9 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
                     details={"format": format_, "path": path},
                 )
             result = sr
+
+    if is_xgboost_pickle_spoof:
+        _mark_xgboost_pickle_extension_spoof(result, path, ext)
 
     if discrepancy_msg:
         # Determine severity based on whether it's a validation failure or just a discrepancy

--- a/modelaudit/scanners/xgboost_scanner.py
+++ b/modelaudit/scanners/xgboost_scanner.py
@@ -27,7 +27,7 @@ import sys
 import tempfile
 from typing import Any, ClassVar
 
-from .base import BaseScanner, IssueSeverity, ScanResult
+from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, IssueSeverity, ScanResult
 
 # Precompiled regex patterns for performance
 SUSPICIOUS_JSON_PATTERNS = [
@@ -211,12 +211,36 @@ class XGBoostScanner(BaseScanner):
     description: ClassVar[str] = "Scans XGBoost models for security vulnerabilities"
     supported_extensions: ClassVar[list[str]] = [".bst", ".model", ".json", ".ubj"]
     default_max_file_read_size: ClassVar[int] = XGBOOST_DEFAULT_MAX_FILE_READ_SIZE
+    _INCONCLUSIVE_REASONS: ClassVar[dict[str, str]] = {
+        "json_parse_failed": "xgboost_json_parse_failed",
+        "json_analysis_failed": "xgboost_json_analysis_failed",
+        "ubj_dependency_missing": "xgboost_ubj_dependency_missing",
+        "ubj_analysis_failed": "xgboost_ubj_analysis_failed",
+        "binary_pickle_spoof": "xgboost_binary_pickle_spoof",
+    }
 
     def __init__(self, config: dict[str, Any] | None = None):
         super().__init__(config)
         self.enable_xgb_loading = self._get_bool_config("enable_xgb_loading", False)
         self.max_num_trees = self.config.get("max_num_trees", 10000)
         self.max_tree_depth = self.config.get("max_tree_depth", 1000)
+
+    def _mark_inconclusive_scan_result(self, result: ScanResult, reason: str) -> None:
+        """Mark XGBoost analysis as incomplete so callers fail closed."""
+        existing_reasons = result.metadata.get("scan_outcome_reasons")
+        reasons = existing_reasons if isinstance(existing_reasons, list) else []
+        if reason not in reasons:
+            reasons.append(reason)
+
+        result.metadata["scan_outcome"] = INCONCLUSIVE_SCAN_OUTCOME
+        result.metadata["scan_outcome_reasons"] = reasons
+        result.metadata["analysis_incomplete"] = True
+
+    def _finish_scan_result(self, result: ScanResult) -> None:
+        """Fail closed on inconclusive scans while preserving clean valid models."""
+        result.finish(
+            success=not result.has_errors and result.metadata.get("scan_outcome") != INCONCLUSIVE_SCAN_OUTCOME
+        )
 
     @classmethod
     def can_handle(cls, path: str) -> bool:
@@ -317,8 +341,9 @@ class XGBoostScanner(BaseScanner):
                 details={"exception": str(e), "exception_type": type(e).__name__},
                 why="Scanning failures may indicate file corruption or malicious content",
             )
+            self._mark_inconclusive_scan_result(result, "xgboost_scan_execution_failed")
 
-        result.finish(success=True)
+        self._finish_scan_result(result)
         return result
 
     def _scan_json_model(self, path: str, result: ScanResult) -> None:
@@ -353,6 +378,7 @@ class XGBoostScanner(BaseScanner):
                 details={"json_error": str(e)},
                 why="Malformed JSON may indicate file corruption or crafted exploit",
             )
+            self._mark_inconclusive_scan_result(result, self._INCONCLUSIVE_REASONS["json_parse_failed"])
         except Exception as e:
             result.add_check(
                 name="JSON Analysis",
@@ -362,6 +388,7 @@ class XGBoostScanner(BaseScanner):
                 location=path,
                 details={"exception": str(e)},
             )
+            self._mark_inconclusive_scan_result(result, self._INCONCLUSIVE_REASONS["json_analysis_failed"])
 
     def _scan_ubj_model(self, path: str, result: ScanResult) -> None:
         """Scan XGBoost UBJ (Universal Binary JSON) model for security issues."""
@@ -378,6 +405,7 @@ class XGBoostScanner(BaseScanner):
                 details={"required_package": "ubjson", "install_command": "pip install ubjson"},
                 why="UBJ file scanning requires the ubjson package to decode Universal Binary JSON format",
             )
+            self._mark_inconclusive_scan_result(result, self._INCONCLUSIVE_REASONS["ubj_dependency_missing"])
             return
 
         try:
@@ -407,6 +435,7 @@ class XGBoostScanner(BaseScanner):
                 details={"exception": str(e)},
                 why="UBJ decoding failures may indicate file corruption or malicious content",
             )
+            self._mark_inconclusive_scan_result(result, self._INCONCLUSIVE_REASONS["ubj_analysis_failed"])
 
     def _scan_binary_model(self, path: str, result: ScanResult) -> None:
         """Scan XGBoost binary (.bst) model for security issues."""
@@ -427,19 +456,20 @@ class XGBoostScanner(BaseScanner):
         try:
             # Check if it's actually a pickle file masquerading as .bst
             if self._is_pickle_file(path):
+                claimed_format = os.path.splitext(path)[1].lower().lstrip(".") or "binary"
                 result.add_check(
                     name="File Format Validation",
                     passed=False,
-                    message="File appears to be a pickle file with .bst/.model extension",
-                    severity=IssueSeverity.INFO,
+                    message=f"File appears to be a pickle file with .{claimed_format} extension",
+                    severity=IssueSeverity.WARNING,
                     location=path,
-                    details={"detected_format": "pickle", "claimed_format": "bst"},
+                    details={"detected_format": "pickle", "claimed_format": claimed_format},
                     why=(
                         "File extension spoofing is a security evasion technique "
                         "used to bypass security scanners. This may indicate malicious intent."
                     ),
                 )
-                # Let pickle scanner handle this file
+                self._mark_inconclusive_scan_result(result, self._INCONCLUSIVE_REASONS["binary_pickle_spoof"])
                 return
 
             # Basic binary structure validation

--- a/modelaudit/scanners/xgboost_scanner.py
+++ b/modelaudit/scanners/xgboost_scanner.py
@@ -211,12 +211,32 @@ class XGBoostScanner(BaseScanner):
     description: ClassVar[str] = "Scans XGBoost models for security vulnerabilities"
     supported_extensions: ClassVar[list[str]] = [".bst", ".model", ".json", ".ubj"]
     default_max_file_read_size: ClassVar[int] = XGBOOST_DEFAULT_MAX_FILE_READ_SIZE
+    _JSON_PROBE_READ_BYTES: ClassVar[int] = 256 * 1024
+    _JSON_REQUIRED_MARKERS: ClassVar[tuple[bytes, ...]] = (b'"learner"', b'"version"')
+    _JSON_STRONG_MARKERS: ClassVar[tuple[bytes, ...]] = (
+        b'"gradient_booster"',
+        b'"learner_model_param"',
+        b'"gbtree_model_param"',
+        b'"tree_info"',
+        b'"gbtree"',
+        b'"gblinear"',
+        b'"dart"',
+    )
+    _BINARY_MIN_STRUCTURE_BYTES: ClassVar[int] = 32
     _INCONCLUSIVE_REASONS: ClassVar[dict[str, str]] = {
         "json_parse_failed": "xgboost_json_parse_failed",
         "json_analysis_failed": "xgboost_json_analysis_failed",
         "ubj_dependency_missing": "xgboost_ubj_dependency_missing",
         "ubj_analysis_failed": "xgboost_ubj_analysis_failed",
+        "binary_empty": "xgboost_binary_empty",
+        "binary_structure_too_small": "xgboost_binary_structure_too_small",
+        "binary_structure_unrecognized": "xgboost_binary_structure_unrecognized",
+        "binary_analysis_failed": "xgboost_binary_analysis_failed",
         "binary_pickle_spoof": "xgboost_binary_pickle_spoof",
+        "binary_load_dependency_missing": "xgboost_binary_load_dependency_missing",
+        "binary_load_failed": "xgboost_binary_load_failed",
+        "binary_load_timeout": "xgboost_binary_load_timeout",
+        "binary_load_exception": "xgboost_binary_load_exception",
     }
 
     def __init__(self, config: dict[str, Any] | None = None):
@@ -256,7 +276,7 @@ class XGBoostScanner(BaseScanner):
 
         # For .json files, validate it's actually an XGBoost model
         if file_ext == ".json":
-            return cls._is_xgboost_json(path)
+            return cls._is_xgboost_json(path) or cls._is_probable_xgboost_json_candidate(path)
 
         # For .model files, accept (generic extension)
         if file_ext == ".model":
@@ -274,6 +294,21 @@ class XGBoostScanner(BaseScanner):
                 pass
 
         return False
+
+    @classmethod
+    def _is_probable_xgboost_json_candidate(cls, path: str) -> bool:
+        """Sniff malformed-but-XGBoost-like JSON so parse failures fail closed."""
+        try:
+            with open(path, "rb") as f:
+                probe = f.read(cls._JSON_PROBE_READ_BYTES).lower()
+        except OSError:
+            return False
+
+        has_required_markers = all(marker in probe for marker in cls._JSON_REQUIRED_MARKERS)
+        if not has_required_markers:
+            return False
+
+        return any(marker in probe for marker in cls._JSON_STRONG_MARKERS)
 
     @classmethod
     def _is_xgboost_json(cls, path: str) -> bool:
@@ -451,6 +486,7 @@ class XGBoostScanner(BaseScanner):
                 details={"file_size": 0},
                 why="Empty model files are invalid and may indicate corruption or attack",
             )
+            self._mark_inconclusive_scan_result(result, self._INCONCLUSIVE_REASONS["binary_empty"])
             return
 
         try:
@@ -476,7 +512,7 @@ class XGBoostScanner(BaseScanner):
             self._validate_binary_structure(path, result)
 
             # Attempt safe XGBoost loading if enabled
-            if self.enable_xgb_loading and _check_xgboost_available():
+            if self.enable_xgb_loading:
                 self._safe_xgboost_load(path, result)
             else:
                 result.add_check(
@@ -496,6 +532,7 @@ class XGBoostScanner(BaseScanner):
                 location=path,
                 details={"exception": str(e)},
             )
+            self._mark_inconclusive_scan_result(result, self._INCONCLUSIVE_REASONS["binary_analysis_failed"])
 
     def _validate_xgboost_json_schema(self, data: dict[str, Any], result: ScanResult, path: str) -> None:
         """Validate XGBoost JSON model schema and structure."""
@@ -656,15 +693,11 @@ class XGBoostScanner(BaseScanner):
     def _is_pickle_file(self, path: str) -> bool:
         """Check if file is actually a Python pickle file."""
         try:
-            with open(path, "rb") as f:
-                header = f.read(8)
-                # Check for pickle protocol headers
-                if len(header) >= 2:
-                    # Pickle protocols 0-5
-                    return header.startswith(b"\x80") or header[0:1] in [b"c", b"(", b"]", b"}"]
-        except OSError:
-            pass
-        return False
+            from modelaudit.utils.file.detection import detect_file_format
+
+            return detect_file_format(path) == "pickle"
+        except Exception:
+            return False
 
     def _validate_binary_structure(self, path: str, result: ScanResult) -> None:
         """Validate XGBoost binary file structure."""
@@ -673,21 +706,24 @@ class XGBoostScanner(BaseScanner):
                 # Read first few bytes to check for basic structure
                 header = f.read(64)
 
-                if len(header) < 4:
+                if len(header) < self._BINARY_MIN_STRUCTURE_BYTES:
                     result.add_check(
                         name="Binary Structure Validation",
                         passed=False,
                         message="XGBoost binary file too small to contain valid model",
                         severity=IssueSeverity.INFO,
                         location=path,
-                        details={"header_length": len(header)},
+                        details={"header_length": len(header), "min_header_length": self._BINARY_MIN_STRUCTURE_BYTES},
                         why="Truncated files may indicate corruption or attack",
+                    )
+                    self._mark_inconclusive_scan_result(
+                        result, self._INCONCLUSIVE_REASONS["binary_structure_too_small"]
                     )
                     return
 
                 # Check for readable strings that typically appear in XGBoost models
                 header_str = header.decode("utf-8", errors="ignore")
-                expected_patterns = ["gbtree", "gblinear", "dart", "reg:", "binary:", "multi:"]
+                expected_patterns = ["binf", "gbtree", "gblinear", "dart", "reg:", "binary:", "multi:"]
 
                 has_expected_pattern = any(pattern in header_str.lower() for pattern in expected_patterns)
 
@@ -708,10 +744,17 @@ class XGBoostScanner(BaseScanner):
                         )
                     else:
                         result.add_check(
-                            name="XGBoost Binary Pattern Check",
-                            passed=True,
-                            message="File appears to contain valid binary model structure",
+                            name="Binary Structure Validation",
+                            passed=False,
+                            message="File does not contain expected XGBoost binary model markers",
+                            severity=IssueSeverity.INFO,
                             location=path,
+                            details={"expected_patterns": expected_patterns},
+                            why="Missing XGBoost markers may indicate a truncated, corrupted, or mislabeled model file",
+                        )
+                    if not self.enable_xgb_loading:
+                        self._mark_inconclusive_scan_result(
+                            result, self._INCONCLUSIVE_REASONS["binary_structure_unrecognized"]
                         )
                 else:
                     result.add_check(
@@ -731,6 +774,7 @@ class XGBoostScanner(BaseScanner):
                 location=path,
                 details={"exception": str(e)},
             )
+            self._mark_inconclusive_scan_result(result, self._INCONCLUSIVE_REASONS["binary_analysis_failed"])
 
     def _safe_xgboost_load(self, path: str, result: ScanResult) -> None:
         """Attempt to safely load XGBoost model with timeout and error handling."""
@@ -739,10 +783,11 @@ class XGBoostScanner(BaseScanner):
                 name="XGBoost Library Check",
                 passed=False,
                 message="XGBoost library not available for model validation",
-                severity=IssueSeverity.WARNING,
+                severity=IssueSeverity.INFO,
                 location=path,
                 details={"required_package": "xgboost"},
             )
+            self._mark_inconclusive_scan_result(result, self._INCONCLUSIVE_REASONS["binary_load_dependency_missing"])
             return
 
         try:
@@ -801,6 +846,7 @@ except Exception as e:
                         "This is a compatibility test run in an isolated subprocess for safety."
                     ),
                 )
+                self._mark_inconclusive_scan_result(result, self._INCONCLUSIVE_REASONS["binary_load_failed"])
 
         except subprocess.TimeoutExpired:
             result.add_check(
@@ -812,6 +858,7 @@ except Exception as e:
                 details={"timeout": timeout},
                 why="Loading timeout may indicate an extremely large model. The subprocess was safely terminated.",
             )
+            self._mark_inconclusive_scan_result(result, self._INCONCLUSIVE_REASONS["binary_load_timeout"])
         except Exception as e:
             result.add_check(
                 name="XGBoost Model Loading",
@@ -821,6 +868,7 @@ except Exception as e:
                 location=path,
                 details={"exception": str(e)},
             )
+            self._mark_inconclusive_scan_result(result, self._INCONCLUSIVE_REASONS["binary_load_exception"])
 
     def extract_metadata(self, file_path: str) -> dict[str, Any]:
         """Extract XGBoost model metadata."""

--- a/tests/scanners/test_xgboost_scanner.py
+++ b/tests/scanners/test_xgboost_scanner.py
@@ -192,6 +192,9 @@ class TestXGBoostJSONScanning:
 
         # Should detect JSON parsing error
         assert any("Invalid JSON format" in str(issue.message) for issue in result.issues)
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "xgboost_json_parse_failed" in result.metadata["scan_outcome_reasons"]
 
     def test_missing_required_keys_detected(self, temp_dir):
         """Test that scanner rejects JSON files missing required XGBoost keys in can_handle()."""
@@ -306,6 +309,9 @@ class TestXGBoostUBJScanning:
 
         # Message changed to "Cannot scan UBJ file"
         assert any("cannot scan ubj file" in str(issue.message).lower() for issue in result.issues)
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "xgboost_ubj_dependency_missing" in result.metadata["scan_outcome_reasons"]
 
     def test_invalid_ubj_detected(self, temp_dir, xgboost_scanner):
         """Test detection of invalid UBJ content."""
@@ -337,17 +343,21 @@ class TestXGBoostBinaryScanning:
 
         assert any("empty" in str(issue.message).lower() for issue in result.issues)
 
-    def test_pickle_masquerading_as_bst_detected(self, temp_dir, xgboost_scanner):
-        """Test detection of pickle files with .bst extension."""
+    @pytest.mark.parametrize("suffix", [".bst", ".model"])
+    def test_pickle_masquerading_as_binary_model_is_inconclusive(self, temp_dir, xgboost_scanner, suffix):
+        """Pickle files masquerading as XGBoost binaries should fail closed."""
         # Create a pickle file
         pickle_data = pickle.dumps({"fake": "model"})
 
-        fake_bst = temp_dir / "fake.bst"
+        fake_bst = temp_dir / f"fake{suffix}"
         fake_bst.write_bytes(pickle_data)
 
         result = xgboost_scanner.scan(str(fake_bst))
 
         assert any("pickle file" in str(issue.message) for issue in result.issues)
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "xgboost_binary_pickle_spoof" in result.metadata["scan_outcome_reasons"]
 
     def test_binary_structure_validation(self, temp_dir, xgboost_scanner):
         """Test binary structure validation."""
@@ -523,6 +533,7 @@ class TestXGBoostPickleIntegration:
 
         # Should detect file format spoofing
         assert any("pickle file" in str(issue.message) for issue in result.issues)
+        assert result.success is False
 
 
 # Integration tests (require actual dependencies)

--- a/tests/scanners/test_xgboost_scanner.py
+++ b/tests/scanners/test_xgboost_scanner.py
@@ -11,13 +11,18 @@ Tests cover various XGBoost model formats and security vulnerabilities:
 
 import json
 import pickle
+import subprocess as real_subprocess
 import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
 
+from modelaudit.cache import get_cache_manager, reset_cache_manager
+from modelaudit.core import determine_exit_code, scan_file, scan_model_directory_or_file
+from modelaudit.models import ModelAuditResultModel
 from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity
 from modelaudit.scanners.xgboost_scanner import XGBOOST_JSON_ROUTING_CHUNK_BYTES, XGBoostScanner
 
@@ -30,20 +35,20 @@ class FakeBooster:
 
 
 @pytest.fixture
-def temp_dir():
+def temp_dir() -> Iterator[Path]:
     """Create a temporary directory for test files."""
     with tempfile.TemporaryDirectory() as tmpdir:
         yield Path(tmpdir)
 
 
 @pytest.fixture
-def xgboost_scanner():
+def xgboost_scanner() -> XGBoostScanner:
     """Create an XGBoost scanner instance."""
     return XGBoostScanner()
 
 
 @pytest.fixture
-def valid_xgboost_json():
+def valid_xgboost_json() -> dict[str, Any]:
     """Valid XGBoost JSON model structure."""
     return {
         "version": [1, 7, 4],
@@ -125,6 +130,29 @@ def valid_xgboost_json():
     }
 
 
+def _scan_twice_with_cache(path: Path, cache_dir: Path) -> tuple[ModelAuditResultModel, ModelAuditResultModel]:
+    first = scan_model_directory_or_file(
+        str(path),
+        cache_enabled=True,
+        cache_dir=str(cache_dir),
+        min_cache_file_size=0,
+    )
+    second = scan_model_directory_or_file(
+        str(path),
+        cache_enabled=True,
+        cache_dir=str(cache_dir),
+        min_cache_file_size=0,
+    )
+    return first, second
+
+
+def _assert_inconclusive_metadata(result: ModelAuditResultModel, path: Path, reason: str) -> None:
+    metadata = result.file_metadata[str(path)]
+    assert metadata.get("scan_outcome") == INCONCLUSIVE_SCAN_OUTCOME
+    assert metadata.get("analysis_incomplete") is True
+    assert reason in metadata.get("scan_outcome_reasons", [])
+
+
 class TestXGBoostScannerBasic:
     """Test basic XGBoost scanner functionality."""
 
@@ -183,7 +211,7 @@ class TestXGBoostJSONScanning:
         critical_issues = [i for i in result.issues if i.severity == IssueSeverity.INFO]
         assert len(critical_issues) == 0
 
-    def test_invalid_json_fails(self, temp_dir, xgboost_scanner):
+    def test_invalid_json_fails(self, temp_dir: Path, xgboost_scanner: XGBoostScanner) -> None:
         """Test that invalid JSON content is detected."""
         json_file = temp_dir / "invalid.json"
         json_file.write_text('{"invalid": json content}')  # Invalid JSON
@@ -196,7 +224,28 @@ class TestXGBoostJSONScanning:
         assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
         assert "xgboost_json_parse_failed" in result.metadata["scan_outcome_reasons"]
 
-    def test_missing_required_keys_detected(self, temp_dir):
+    def test_malformed_xgboost_json_candidate_is_routed(self, temp_dir: Path) -> None:
+        """Malformed XGBoost-shaped JSON should reach the fail-closed parser path."""
+        json_file = temp_dir / "booster.json"
+        json_file.write_text('{"version":[1,7,4],"learner":{"gradient_booster":')
+
+        assert XGBoostScanner.can_handle(str(json_file))
+
+    @pytest.mark.parametrize(
+        ("filename", "payload"),
+        [
+            ("model.json", '{"version":"1","learner":'),
+            ("settings.json", '{"version":"1","learner":{"objective":'),
+        ],
+    )
+    def test_generic_malformed_json_candidate_is_not_routed(self, temp_dir: Path, filename: str, payload: str) -> None:
+        """Generic malformed JSON should not be misclassified from weak key names alone."""
+        json_file = temp_dir / filename
+        json_file.write_text(payload)
+
+        assert not XGBoostScanner.can_handle(str(json_file))
+
+    def test_missing_required_keys_detected(self, temp_dir: Path) -> None:
         """Test that scanner rejects JSON files missing required XGBoost keys in can_handle()."""
         incomplete_json = {"version": [1, 0, 0]}  # Missing learner
 
@@ -299,7 +348,7 @@ class TestXGBoostJSONScanning:
 class TestXGBoostUBJScanning:
     """Test XGBoost UBJ model scanning."""
 
-    def test_ubj_without_ubjson_library(self, temp_dir, xgboost_scanner):
+    def test_ubj_without_ubjson_library(self, temp_dir: Path, xgboost_scanner: XGBoostScanner) -> None:
         """Test UBJ scanning without ubjson library (INFO level)."""
         ubj_file = temp_dir / "model.ubj"
         ubj_file.write_bytes(b"\x7b\x55")  # UBJ object start
@@ -313,7 +362,7 @@ class TestXGBoostUBJScanning:
         assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
         assert "xgboost_ubj_dependency_missing" in result.metadata["scan_outcome_reasons"]
 
-    def test_invalid_ubj_detected(self, temp_dir, xgboost_scanner):
+    def test_invalid_ubj_detected(self, temp_dir: Path, xgboost_scanner: XGBoostScanner) -> None:
         """Test detection of invalid UBJ content."""
         pytest.importorskip("ubjson", reason="ubjson not installed")
         ubj_file = temp_dir / "invalid.ubj"
@@ -334,7 +383,7 @@ class TestXGBoostUBJScanning:
 class TestXGBoostBinaryScanning:
     """Test XGBoost binary model scanning."""
 
-    def test_empty_binary_file_detected(self, temp_dir, xgboost_scanner):
+    def test_empty_binary_file_detected(self, temp_dir: Path, xgboost_scanner: XGBoostScanner) -> None:
         """Test detection of empty binary files."""
         binary_file = temp_dir / "empty.bst"
         binary_file.write_bytes(b"")
@@ -342,9 +391,14 @@ class TestXGBoostBinaryScanning:
         result = xgboost_scanner.scan(str(binary_file))
 
         assert any("empty" in str(issue.message).lower() for issue in result.issues)
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "xgboost_binary_empty" in result.metadata["scan_outcome_reasons"]
 
     @pytest.mark.parametrize("suffix", [".bst", ".model"])
-    def test_pickle_masquerading_as_binary_model_is_inconclusive(self, temp_dir, xgboost_scanner, suffix):
+    def test_pickle_masquerading_as_binary_model_is_inconclusive(
+        self, temp_dir: Path, xgboost_scanner: XGBoostScanner, suffix: str
+    ) -> None:
         """Pickle files masquerading as XGBoost binaries should fail closed."""
         # Create a pickle file
         pickle_data = pickle.dumps({"fake": "model"})
@@ -359,10 +413,53 @@ class TestXGBoostBinaryScanning:
         assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
         assert "xgboost_binary_pickle_spoof" in result.metadata["scan_outcome_reasons"]
 
-    def test_binary_structure_validation(self, temp_dir, xgboost_scanner):
+    def test_non_pickle_binary_starting_with_proto0_like_byte_is_not_spoof(
+        self, temp_dir: Path, xgboost_scanner: XGBoostScanner
+    ) -> None:
+        """Custom XGBoost-like binaries starting with 'c' are not automatically pickle spoofs."""
+        binary_file = temp_dir / "custom.bst"
+        binary_file.write_bytes(b"custom xgboost binary gbtree reg:squarederror")
+
+        result = xgboost_scanner.scan(str(binary_file))
+
+        assert result.success is True
+        assert "scan_outcome" not in result.metadata
+        assert not any("pickle file" in str(issue.message) for issue in result.issues)
+
+    def test_binary_structure_exception_is_inconclusive(self, temp_dir: Path, xgboost_scanner: XGBoostScanner) -> None:
+        """Binary analyzer exceptions should fail closed instead of returning success."""
+        binary_file = temp_dir / "broken.bst"
+        binary_file.write_bytes(b"gbtree reg:squarederror with enough bytes")
+
+        with patch.object(xgboost_scanner, "_validate_binary_structure", side_effect=RuntimeError("boom")):
+            result = xgboost_scanner.scan(str(binary_file))
+
+        assert any("Error analyzing XGBoost binary model: boom" in str(issue.message) for issue in result.issues)
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "xgboost_binary_analysis_failed" in result.metadata["scan_outcome_reasons"]
+
+    def test_binary_structure_read_failure_is_inconclusive(
+        self, temp_dir: Path, xgboost_scanner: XGBoostScanner
+    ) -> None:
+        """Read failures caught inside structure validation should still fail closed."""
+        binary_file = temp_dir / "unreadable.bst"
+        binary_file.write_bytes(b"gbtree reg:squarederror with enough bytes")
+        result = xgboost_scanner._create_result()
+
+        with patch("builtins.open", side_effect=OSError("forced read failure")):
+            xgboost_scanner._validate_binary_structure(str(binary_file), result)
+        xgboost_scanner._finish_scan_result(result)
+
+        assert any("forced read failure" in str(issue.message) for issue in result.issues)
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "xgboost_binary_analysis_failed" in result.metadata["scan_outcome_reasons"]
+
+    def test_binary_structure_validation(self, temp_dir: Path, xgboost_scanner: XGBoostScanner) -> None:
         """Test binary structure validation."""
         # Create a file with some XGBoost-like content
-        binary_content = b"gbtree\x00\x00\x01\x02reg:squarederror\x00\x00"
+        binary_content = b"gbtree\x00\x00\x01\x02reg:squarederror\x00\x00extra xgboost bytes"
 
         binary_file = temp_dir / "valid.bst"
         binary_file.write_bytes(binary_content)
@@ -373,7 +470,24 @@ class TestXGBoostBinaryScanning:
         pattern_checks = [c for c in result.checks if "Pattern Check" in c.name and c.status.value == "passed"]
         assert len(pattern_checks) > 0
 
-    def test_suspicious_binary_patterns_detected(self, temp_dir, xgboost_scanner):
+    def test_binf_binary_signature_passes_structure_validation(
+        self, temp_dir: Path, xgboost_scanner: XGBoostScanner
+    ) -> None:
+        """The binary binf signature should not be treated as markerless."""
+        binary_file = temp_dir / "signature.bst"
+        binary_file.write_bytes(b"binf" + (b"\0" * 60) + b"gbtree appears outside first read window")
+
+        result = xgboost_scanner.scan(str(binary_file))
+
+        assert result.success is True
+        assert "scan_outcome" not in result.metadata
+        assert any(
+            "binf" in check.details.get("patterns_found", [])
+            for check in result.checks
+            if "Pattern Check" in check.name
+        )
+
+    def test_suspicious_binary_patterns_detected(self, temp_dir: Path, xgboost_scanner: XGBoostScanner) -> None:
         """Test detection of suspicious binary patterns."""
         # Create binary data with no recognizable XGBoost patterns
         suspicious_binary = bytes(range(256))  # All byte values 0-255
@@ -385,14 +499,33 @@ class TestXGBoostBinaryScanning:
 
         # Should detect unusual binary patterns
         assert any("unusual binary patterns" in str(issue.message) for issue in result.issues)
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "xgboost_binary_structure_unrecognized" in result.metadata["scan_outcome_reasons"]
+
+    def test_printable_binary_without_xgboost_markers_is_inconclusive(
+        self, temp_dir: Path, xgboost_scanner: XGBoostScanner
+    ) -> None:
+        """Printable .bst content without XGBoost markers should not pass cleanly."""
+        binary_file = temp_dir / "printable.bst"
+        binary_file.write_bytes(b"abcdefghijklmnopqrstuvwxyzabcdef")
+
+        result = xgboost_scanner.scan(str(binary_file))
+
+        assert any("expected XGBoost binary model markers" in str(issue.message) for issue in result.issues)
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "xgboost_binary_structure_unrecognized" in result.metadata["scan_outcome_reasons"]
 
     @patch("modelaudit.scanners.xgboost_scanner._check_xgboost_available")
-    def test_xgboost_loading_disabled_by_default(self, mock_check_xgb, temp_dir, xgboost_scanner):
+    def test_xgboost_loading_disabled_by_default(
+        self, mock_check_xgb: Mock, temp_dir: Path, xgboost_scanner: XGBoostScanner
+    ) -> None:
         """Test that XGBoost loading is disabled by default."""
         mock_check_xgb.return_value = True
 
         binary_file = temp_dir / "test.bst"
-        binary_file.write_bytes(b"some_binary_data")
+        binary_file.write_bytes(b"some_binary_data gbtree reg:squarederror")
 
         result = xgboost_scanner.scan(str(binary_file))
 
@@ -401,7 +534,7 @@ class TestXGBoostBinaryScanning:
 
     @patch("modelaudit.scanners.xgboost_scanner._check_xgboost_available")
     @patch("modelaudit.scanners.xgboost_scanner.subprocess")
-    def test_xgboost_loading_success(self, mock_subprocess, mock_check_xgb, temp_dir):
+    def test_xgboost_loading_success(self, mock_subprocess: Mock, mock_check_xgb: Mock, temp_dir: Path) -> None:
         """Test successful XGBoost model loading."""
         mock_check_xgb.return_value = True
         mock_proc = Mock()
@@ -414,7 +547,7 @@ class TestXGBoostBinaryScanning:
         loading_scanner = XGBoostScanner({"enable_xgb_loading": True})
 
         binary_file = temp_dir / "valid.bst"
-        binary_file.write_bytes(b"dummy_xgboost_data")
+        binary_file.write_bytes(b"dummy_xgboost_data gbtree reg:squarederror")
 
         result = loading_scanner.scan(str(binary_file))
 
@@ -422,7 +555,7 @@ class TestXGBoostBinaryScanning:
 
     @patch("modelaudit.scanners.xgboost_scanner._check_xgboost_available")
     @patch("modelaudit.scanners.xgboost_scanner.subprocess")
-    def test_xgboost_loading_failure(self, mock_subprocess, mock_check_xgb, temp_dir):
+    def test_xgboost_loading_failure(self, mock_subprocess: Mock, mock_check_xgb: Mock, temp_dir: Path) -> None:
         """Test XGBoost model loading failure detection."""
         mock_check_xgb.return_value = True
         mock_proc = Mock()
@@ -434,11 +567,14 @@ class TestXGBoostBinaryScanning:
         loading_scanner = XGBoostScanner({"enable_xgb_loading": True})
 
         binary_file = temp_dir / "invalid.bst"
-        binary_file.write_bytes(b"invalid_data")
+        binary_file.write_bytes(b"invalid_data gbtree reg:squarederror")
 
         result = loading_scanner.scan(str(binary_file))
 
         assert any("Failed to load XGBoost model" in str(issue.message) for issue in result.issues)
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "xgboost_binary_load_failed" in result.metadata["scan_outcome_reasons"]
 
     @patch("modelaudit.scanners.xgboost_scanner._check_xgboost_available")
     @patch("modelaudit.scanners.xgboost_scanner.subprocess")
@@ -470,19 +606,165 @@ class TestXGBoostBinaryScanning:
 
     @patch("modelaudit.scanners.xgboost_scanner._check_xgboost_available")
     @patch("modelaudit.scanners.xgboost_scanner.subprocess")
-    def test_xgboost_loading_timeout(self, mock_subprocess, mock_check_xgb, temp_dir):
+    def test_xgboost_loading_timeout(self, mock_subprocess: Mock, mock_check_xgb: Mock, temp_dir: Path) -> None:
         """Test XGBoost model loading timeout handling."""
         mock_check_xgb.return_value = True
-        mock_subprocess.run.side_effect = mock_subprocess.TimeoutExpired(["python"], 30)
+        mock_subprocess.TimeoutExpired = real_subprocess.TimeoutExpired
+        mock_subprocess.run.side_effect = real_subprocess.TimeoutExpired(["python"], 30)
 
         loading_scanner = XGBoostScanner({"enable_xgb_loading": True})
 
         binary_file = temp_dir / "timeout.bst"
-        binary_file.write_bytes(b"data_that_causes_timeout")
+        binary_file.write_bytes(b"data_that_causes_timeout gbtree reg:squarederror")
 
         result = loading_scanner.scan(str(binary_file))
 
         assert any("timeout" in str(issue.message).lower() for issue in result.issues)
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "xgboost_binary_load_timeout" in result.metadata["scan_outcome_reasons"]
+
+
+class TestXGBoostFailClosedEndToEnd:
+    """Test CLI/core-visible XGBoost fail-closed semantics."""
+
+    def test_malformed_xgboost_json_core_fails_closed_and_is_uncached(self, tmp_path: Path) -> None:
+        json_file = tmp_path / "booster.json"
+        json_file.write_text('{"version":[1,7,4],"learner":{"gradient_booster":')
+        cache_dir = tmp_path / "cache"
+
+        reset_cache_manager()
+        try:
+            first, second = _scan_twice_with_cache(json_file, cache_dir)
+
+            for result in (first, second):
+                assert result.success is False
+                assert determine_exit_code(result) == 2
+                assert "xgboost" in result.scanner_names
+                _assert_inconclusive_metadata(result, json_file, "xgboost_json_parse_failed")
+                assert any("Invalid JSON format" in str(issue.message) for issue in result.issues)
+
+            assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+        finally:
+            reset_cache_manager()
+
+    def test_missing_ubjson_core_fails_closed_and_is_uncached(self, tmp_path: Path) -> None:
+        ubj_file = tmp_path / "model.ubj"
+        ubj_file.write_bytes(b"\x7b\x55")
+        cache_dir = tmp_path / "cache"
+
+        reset_cache_manager()
+        try:
+            with patch("modelaudit.scanners.xgboost_scanner._check_ubjson_available", return_value=False):
+                first, second = _scan_twice_with_cache(ubj_file, cache_dir)
+
+            for result in (first, second):
+                assert result.success is False
+                assert determine_exit_code(result) == 2
+                _assert_inconclusive_metadata(result, ubj_file, "xgboost_ubj_dependency_missing")
+                assert any("Cannot scan UBJ file" in str(issue.message) for issue in result.issues)
+
+            assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+        finally:
+            reset_cache_manager()
+
+    def test_pickle_spoof_core_preserves_pickle_scan_and_is_uncached(self, tmp_path: Path) -> None:
+        spoof_file = tmp_path / "spoof.bst"
+        spoof_file.write_bytes(pickle.dumps({"safe": True}, protocol=4))
+        cache_dir = tmp_path / "cache"
+
+        direct = scan_file(str(spoof_file), config={"cache_enabled": False})
+        assert direct.success is False
+        assert direct.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "xgboost_binary_pickle_spoof" in direct.metadata["scan_outcome_reasons"]
+
+        reset_cache_manager()
+        try:
+            first, second = _scan_twice_with_cache(spoof_file, cache_dir)
+
+            for result in (first, second):
+                assert determine_exit_code(result) == 1
+                assert "pickle" in result.scanner_names
+                _assert_inconclusive_metadata(result, spoof_file, "xgboost_binary_pickle_spoof")
+                assert any(
+                    issue.severity == IssueSeverity.WARNING and "pickle file with .bst extension" in str(issue.message)
+                    for issue in result.issues
+                )
+
+            assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+        finally:
+            reset_cache_manager()
+
+    def test_generic_model_pickle_core_does_not_false_positive(self, tmp_path: Path) -> None:
+        model_file = tmp_path / "safe.model"
+        model_file.write_bytes(pickle.dumps({"safe": True}, protocol=4))
+
+        result = scan_model_directory_or_file(str(model_file), cache_enabled=False)
+
+        assert result.success is True
+        assert determine_exit_code(result) == 0
+        assert "pickle" in result.scanner_names
+        assert not result.issues
+
+    def test_tiny_binary_core_fails_closed_and_is_uncached(self, tmp_path: Path) -> None:
+        binary_file = tmp_path / "tiny.bst"
+        binary_file.write_bytes(b"abcdefghijklmnopqrstuvwxyzabcde")
+        cache_dir = tmp_path / "cache"
+
+        reset_cache_manager()
+        try:
+            first, second = _scan_twice_with_cache(binary_file, cache_dir)
+
+            for result in (first, second):
+                assert result.success is False
+                assert determine_exit_code(result) == 2
+                _assert_inconclusive_metadata(result, binary_file, "xgboost_binary_structure_too_small")
+                assert any("too small" in str(issue.message).lower() for issue in result.issues)
+
+            assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+        finally:
+            reset_cache_manager()
+
+    def test_non_pickle_xgboost_binary_core_does_not_false_positive(self, tmp_path: Path) -> None:
+        binary_file = tmp_path / "custom.bst"
+        binary_file.write_bytes(b"custom xgboost binary gbtree reg:squarederror")
+
+        result = scan_model_directory_or_file(str(binary_file), cache_enabled=False)
+
+        assert result.success is True
+        assert determine_exit_code(result) == 0
+        assert "xgboost" in result.scanner_names
+        assert not result.issues
+
+    def test_binf_signature_core_does_not_false_positive(self, tmp_path: Path) -> None:
+        binary_file = tmp_path / "signature.bst"
+        binary_file.write_bytes(b"binf" + (b"\0" * 60) + b"gbtree appears outside first read window")
+
+        result = scan_model_directory_or_file(str(binary_file), cache_enabled=False)
+
+        assert result.success is True
+        assert determine_exit_code(result) == 0
+        assert "xgboost" in result.scanner_names
+        assert not result.issues
+
+    def test_markerless_binary_core_fails_closed_and_is_uncached(self, tmp_path: Path) -> None:
+        binary_file = tmp_path / "markerless.bst"
+        binary_file.write_bytes(b"abcdefghijklmnopqrstuvwxyzabcdef")
+        cache_dir = tmp_path / "cache"
+
+        reset_cache_manager()
+        try:
+            first, second = _scan_twice_with_cache(binary_file, cache_dir)
+
+            for result in (first, second):
+                assert result.success is False
+                assert determine_exit_code(result) == 2
+                _assert_inconclusive_metadata(result, binary_file, "xgboost_binary_structure_unrecognized")
+                assert any("expected XGBoost binary model markers" in str(issue.message) for issue in result.issues)
+
+            assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+        finally:
+            reset_cache_manager()
 
 
 class TestXGBoostScannerConfiguration:


### PR DESCRIPTION
## Summary

Fail closed when XGBoost analysis cannot complete because the model is malformed, the UBJ decoder is unavailable, or a `.bst`/`.model` file is actually a pickle.

## Security impact

Previously, several XGBoost scanner paths emitted informational findings but still finished successfully: malformed JSON, missing UBJSON support, and pickle spoofing on binary model extensions. That let these evasions exit cleanly even though analysis was incomplete. This change adds explicit inconclusive metadata for those cases and finishes the scan as unsuccessful so the gate does not pass them as clean models.

## Validation

- `uv run ruff format modelaudit/scanners/xgboost_scanner.py tests/scanners/test_xgboost_scanner.py`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_xgboost_scanner.py -q`
- `uv run mypy modelaudit/scanners/xgboost_scanner.py tests/scanners/test_xgboost_scanner.py`
