### PR TITLE
fix: enforce ZIP aggregate size budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - preserve `S999` unknown-opcode mapping in generic rule fallback
 - **docker:** run the full parser image as a non-root `appuser`
 - **onnx:** mark weight-distribution analysis inconclusive when dependencies are missing or eligible tensors are external, oversized, or fail extraction
+- **zip:** enforce an aggregate uncompressed-size budget before extracting ZIP entries so split archive bombs cannot bypass per-entry limits
 - **security:** route renamed TFLite FlatBuffers by magic bytes, enforce scanner file-size limits before model reads, and fail closed instead of propagating malformed structure traversal exceptions
 - **onnx:** fail closed on CRITICAL findings, detect `PyFunc` operators and Windows absolute external-data paths, validate external tensor slices with the current ONNX dtype API, and avoid Python-op substring false positives
 - **tensorrt:** route `.trt` engines, detect case-variant and UTF-16 suspicious strings, and avoid substring false positives in benign engine metadata

--- a/modelaudit/scanners/keras_zip_scanner.py
+++ b/modelaudit/scanners/keras_zip_scanner.py
@@ -327,8 +327,11 @@ class KerasZipScanner(BaseScanner):
                 member_size_limits.append(configured_limit)
 
         recursive_member_size_limit = min(member_size_limits)
-        recursive_config["max_file_size"] = recursive_member_size_limit
         recursive_config["max_entry_size"] = recursive_member_size_limit
+        if self.config.get("max_file_size") not in (None, 0):
+            recursive_config["max_file_size"] = recursive_member_size_limit
+        else:
+            recursive_config.pop("max_file_size", None)
         return recursive_config
 
     def _merge_recursive_archive_scan(self, path: str, result: ScanResult) -> None:

--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -74,20 +74,40 @@ class ZipScanner(BaseScanner):
     def _get_max_entry_size(self) -> int:
         """Return the configured per-entry extraction limit with a safe unlimited fallback."""
         default_limit = self.DEFAULT_MAX_ENTRY_SIZE
-        max_entry_size = self.config.get("max_file_size", self.config.get("max_entry_size", default_limit))
-        if max_entry_size == 0:
-            return self.UNLIMITED_ARCHIVE_SIZE
-        return self._normalize_positive_int_config(max_entry_size, default_limit)
+        configured_file_limit = self.config.get("max_file_size")
+        configured_entry_limit = self.config.get("max_entry_size")
+
+        if configured_file_limit is not None and configured_file_limit != 0:
+            return self._normalize_positive_int_config(configured_file_limit, default_limit)
+
+        if configured_entry_limit is not None:
+            if configured_entry_limit == 0:
+                return self.UNLIMITED_ARCHIVE_SIZE
+            return self._normalize_positive_int_config(configured_entry_limit, default_limit)
+
+        return default_limit
 
     def _get_max_total_uncompressed_size(self) -> int:
         """Return the configured aggregate uncompressed ZIP budget."""
+        positive_limits: list[int] = []
         configured_limit = self.config.get("max_zip_total_uncompressed_size")
         if configured_limit is not None:
-            if configured_limit == 0:
-                return self.UNLIMITED_ARCHIVE_SIZE
-            return self._normalize_positive_int_config(configured_limit, self.DEFAULT_MAX_TOTAL_UNCOMPRESSED_SIZE)
+            if configured_limit != 0:
+                positive_limits.append(
+                    self._normalize_positive_int_config(configured_limit, self.DEFAULT_MAX_TOTAL_UNCOMPRESSED_SIZE)
+                )
+        else:
+            positive_limits.append(self.DEFAULT_MAX_TOTAL_UNCOMPRESSED_SIZE)
 
-        return self.DEFAULT_MAX_TOTAL_UNCOMPRESSED_SIZE
+        for config_key in ("max_total_size", "max_file_size"):
+            configured_public_limit = self.config.get(config_key)
+            if configured_public_limit is None or configured_public_limit == 0:
+                continue
+            positive_limits.append(
+                self._normalize_positive_int_config(configured_public_limit, self.DEFAULT_MAX_TOTAL_UNCOMPRESSED_SIZE)
+            )
+
+        return min(positive_limits) if positive_limits else self.UNLIMITED_ARCHIVE_SIZE
 
     def _read_symlink_target(self, archive: zipfile.ZipFile, info: zipfile.ZipInfo) -> str:
         """Read a symlink target with a hard cap to avoid materializing large archive members."""
@@ -222,6 +242,98 @@ class ZipScanner(BaseScanner):
             return nested_scan_callback(path, nested_config)
         return scan_nested_file(path, nested_config)
 
+    def _validate_entry_metadata(
+        self,
+        archive: zipfile.ZipFile,
+        info: zipfile.ZipInfo,
+        archive_path: str,
+        temp_base: str,
+        result: ScanResult,
+    ) -> tuple[bool, bool]:
+        """Validate ZIP entry metadata that does not require full extraction."""
+        name = info.filename
+        if not name:
+            return False, True
+
+        resolved_name, is_safe = sanitize_archive_path(name, temp_base)
+        if not is_safe:
+            result.add_check(
+                name="Path Traversal Protection",
+                passed=False,
+                message=f"Archive entry {name} attempted path traversal outside the archive",
+                severity=IssueSeverity.CRITICAL,
+                rule_code="S405",  # Path traversal
+                location=f"{archive_path}:{name}",
+                details={"entry": name},
+            )
+            return False, True
+
+        is_symlink = (info.external_attr >> 16) & 0o170000 == stat.S_IFLNK
+        if is_symlink:
+            try:
+                target = self._read_symlink_target(archive, info)
+            except Exception as exc:
+                result.add_check(
+                    name="Symlink Safety Validation",
+                    passed=False,
+                    message=f"Unable to read symlink target for {name}: {exc!s}",
+                    severity=IssueSeverity.WARNING,
+                    rule_code="S902",
+                    location=f"{archive_path}:{name}",
+                    details={
+                        "entry": name,
+                        "exception": str(exc),
+                        "exception_type": type(exc).__name__,
+                    },
+                )
+                return False, False
+
+            target_base = os.path.dirname(resolved_name)
+            _target_resolved, target_safe = sanitize_archive_path(
+                target,
+                target_base,
+            )
+            if not target_safe:
+                # Check if it's specifically a critical system path
+                if is_absolute_archive_path(target) and is_critical_system_path(target, CRITICAL_SYSTEM_PATHS):
+                    message = f"Symlink {name} points to critical system path: {target}"
+                else:
+                    message = f"Symlink {name} resolves outside extraction directory"
+                result.add_check(
+                    name="Symlink Safety Validation",
+                    passed=False,
+                    message=message,
+                    severity=IssueSeverity.CRITICAL,
+                    rule_code="S406",  # Symlink external
+                    location=f"{archive_path}:{name}",
+                    details={"target": target, "entry": name},
+                )
+            elif is_absolute_archive_path(target) and is_critical_system_path(target, CRITICAL_SYSTEM_PATHS):
+                result.add_check(
+                    name="Symlink Safety Validation",
+                    passed=False,
+                    message=f"Symlink {name} points to critical system path: {target}",
+                    severity=IssueSeverity.CRITICAL,
+                    rule_code="S408",  # System file access
+                    location=f"{archive_path}:{name}",
+                    details={"target": target, "entry": name},
+                )
+            else:
+                result.add_check(
+                    name="Symlink Safety Validation",
+                    passed=True,
+                    message=f"Symlink {name} is safe",
+                    location=f"{archive_path}:{name}",
+                    rule_code=None,  # Passing check
+                    details={"target": target, "entry": name},
+                )
+            return False, True
+
+        if info.is_dir():
+            return False, True
+
+        return True, True
+
     def _scan_zip_file(self, path: str, depth: int = 0) -> ScanResult:
         """Recursively scan a ZIP file and its contents"""
         result = ScanResult(scanner_name=self.name)
@@ -255,9 +367,10 @@ class ZipScanner(BaseScanner):
 
         with zipfile.ZipFile(path, "r") as z:
             max_total_uncompressed_size = self._get_max_total_uncompressed_size()
+            entries = z.infolist()
 
             # Check number of entries
-            entry_count = len(z.infolist())
+            entry_count = len(entries)
             if entry_count > self.max_entries:
                 result.add_check(
                     name="Entry Count Limit Check",
@@ -287,7 +400,20 @@ class ZipScanner(BaseScanner):
                     rule_code=None,  # Passing check
                 )
 
-            archive_uncompressed_size = sum(info.file_size for info in z.infolist() if not info.is_dir())
+            temp_base = os.path.join(tempfile.gettempdir(), "extract")
+            extractable_entries: list[zipfile.ZipInfo] = []
+            for info in entries:
+                should_extract, entry_metadata_complete = self._validate_entry_metadata(
+                    z, info, path, temp_base, result
+                )
+                if not entry_metadata_complete:
+                    scan_complete = False
+                if should_extract:
+                    extractable_entries.append(info)
+
+            archive_declared_uncompressed_size = sum(info.file_size for info in entries if not info.is_dir())
+            archive_uncompressed_size = sum(info.file_size for info in extractable_entries)
+            result.metadata["archive_declared_uncompressed_size"] = archive_declared_uncompressed_size
             result.metadata["archive_uncompressed_size"] = archive_uncompressed_size
             result.metadata["max_zip_total_uncompressed_size"] = max_total_uncompressed_size
             if archive_uncompressed_size > max_total_uncompressed_size:
@@ -303,6 +429,7 @@ class ZipScanner(BaseScanner):
                     location=path,
                     details={
                         "archive_uncompressed_size": archive_uncompressed_size,
+                        "archive_declared_uncompressed_size": archive_declared_uncompressed_size,
                         "max_zip_total_uncompressed_size": max_total_uncompressed_size,
                     },
                 )
@@ -320,6 +447,7 @@ class ZipScanner(BaseScanner):
                 location=path,
                 details={
                     "archive_uncompressed_size": archive_uncompressed_size,
+                    "archive_declared_uncompressed_size": archive_declared_uncompressed_size,
                     "max_zip_total_uncompressed_size": max_total_uncompressed_size,
                 },
                 rule_code=None,
@@ -327,91 +455,8 @@ class ZipScanner(BaseScanner):
 
             # Scan each file in the archive
             extracted_uncompressed_size = 0
-            for info in z.infolist():
+            for info in extractable_entries:
                 name = info.filename
-                if not name:
-                    continue
-
-                temp_base = os.path.join(tempfile.gettempdir(), "extract")
-                resolved_name, is_safe = sanitize_archive_path(name, temp_base)
-                if not is_safe:
-                    result.add_check(
-                        name="Path Traversal Protection",
-                        passed=False,
-                        message=f"Archive entry {name} attempted path traversal outside the archive",
-                        severity=IssueSeverity.CRITICAL,
-                        rule_code="S405",  # Path traversal
-                        location=f"{path}:{name}",
-                        details={"entry": name},
-                    )
-                    continue
-
-                is_symlink = (info.external_attr >> 16) & 0o170000 == stat.S_IFLNK
-                if is_symlink:
-                    try:
-                        target = self._read_symlink_target(z, info)
-                    except Exception as exc:
-                        scan_complete = False
-                        result.add_check(
-                            name="Symlink Safety Validation",
-                            passed=False,
-                            message=f"Unable to read symlink target for {name}: {exc!s}",
-                            severity=IssueSeverity.WARNING,
-                            rule_code="S902",
-                            location=f"{path}:{name}",
-                            details={
-                                "entry": name,
-                                "exception": str(exc),
-                                "exception_type": type(exc).__name__,
-                            },
-                        )
-                        continue
-
-                    target_base = os.path.dirname(resolved_name)
-                    _target_resolved, target_safe = sanitize_archive_path(
-                        target,
-                        target_base,
-                    )
-                    if not target_safe:
-                        # Check if it's specifically a critical system path
-                        if is_absolute_archive_path(target) and is_critical_system_path(target, CRITICAL_SYSTEM_PATHS):
-                            message = f"Symlink {name} points to critical system path: {target}"
-                        else:
-                            message = f"Symlink {name} resolves outside extraction directory"
-                        result.add_check(
-                            name="Symlink Safety Validation",
-                            passed=False,
-                            message=message,
-                            severity=IssueSeverity.CRITICAL,
-                            rule_code="S406",  # Symlink external
-                            location=f"{path}:{name}",
-                            details={"target": target, "entry": name},
-                        )
-                    elif is_absolute_archive_path(target) and is_critical_system_path(target, CRITICAL_SYSTEM_PATHS):
-                        result.add_check(
-                            name="Symlink Safety Validation",
-                            passed=False,
-                            message=f"Symlink {name} points to critical system path: {target}",
-                            severity=IssueSeverity.CRITICAL,
-                            rule_code="S408",  # System file access
-                            location=f"{path}:{name}",
-                            details={"target": target, "entry": name},
-                        )
-                    else:
-                        result.add_check(
-                            name="Symlink Safety Validation",
-                            passed=True,
-                            message=f"Symlink {name} is safe",
-                            location=f"{path}:{name}",
-                            rule_code=None,  # Passing check
-                            details={"target": target, "entry": name},
-                        )
-                    # Do not scan symlink contents
-                    continue
-
-                # Skip directories
-                if info.is_dir():
-                    continue
 
                 # Check compression ratio for zip bomb detection
                 if info.compress_size > 0:

--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -41,6 +41,9 @@ class ZipScanner(BaseScanner):
     MAX_SYMLINK_TARGET_BYTES: ClassVar[int] = 64 * 1024
     MAX_COMPRESSION_RATIO: ClassVar[int] = 100
     MIN_COMPRESSION_BOMB_UNCOMPRESSED_SIZE: ClassVar[int] = 1024 * 1024
+    DEFAULT_MAX_ENTRY_SIZE: ClassVar[int] = 10 * 1024 * 1024 * 1024
+    DEFAULT_MAX_TOTAL_UNCOMPRESSED_SIZE: ClassVar[int] = 10 * 1024 * 1024 * 1024
+    UNLIMITED_ARCHIVE_SIZE: ClassVar[int] = 1024 * 1024 * 1024 * 1024
 
     def __init__(self, config: dict[str, Any] | None = None):
         super().__init__(config)
@@ -70,11 +73,21 @@ class ZipScanner(BaseScanner):
 
     def _get_max_entry_size(self) -> int:
         """Return the configured per-entry extraction limit with a safe unlimited fallback."""
-        default_limit = 10 * 1024 * 1024 * 1024
+        default_limit = self.DEFAULT_MAX_ENTRY_SIZE
         max_entry_size = self.config.get("max_file_size", self.config.get("max_entry_size", default_limit))
         if max_entry_size == 0:
-            return 1024 * 1024 * 1024 * 1024
+            return self.UNLIMITED_ARCHIVE_SIZE
         return self._normalize_positive_int_config(max_entry_size, default_limit)
+
+    def _get_max_total_uncompressed_size(self) -> int:
+        """Return the configured aggregate uncompressed ZIP budget."""
+        configured_limit = self.config.get("max_zip_total_uncompressed_size")
+        if configured_limit is not None:
+            if configured_limit == 0:
+                return self.UNLIMITED_ARCHIVE_SIZE
+            return self._normalize_positive_int_config(configured_limit, self.DEFAULT_MAX_TOTAL_UNCOMPRESSED_SIZE)
+
+        return self.DEFAULT_MAX_TOTAL_UNCOMPRESSED_SIZE
 
     def _read_symlink_target(self, archive: zipfile.ZipFile, info: zipfile.ZipInfo) -> str:
         """Read a symlink target with a hard cap to avoid materializing large archive members."""
@@ -241,6 +254,8 @@ class ZipScanner(BaseScanner):
             )
 
         with zipfile.ZipFile(path, "r") as z:
+            max_total_uncompressed_size = self._get_max_total_uncompressed_size()
+
             # Check number of entries
             entry_count = len(z.infolist())
             if entry_count > self.max_entries:
@@ -271,7 +286,47 @@ class ZipScanner(BaseScanner):
                     },
                     rule_code=None,  # Passing check
                 )
+
+            archive_uncompressed_size = sum(info.file_size for info in z.infolist() if not info.is_dir())
+            result.metadata["archive_uncompressed_size"] = archive_uncompressed_size
+            result.metadata["max_zip_total_uncompressed_size"] = max_total_uncompressed_size
+            if archive_uncompressed_size > max_total_uncompressed_size:
+                result.add_check(
+                    name="ZIP Aggregate Size Limit Check",
+                    passed=False,
+                    message=(
+                        f"ZIP total uncompressed size exceeds limit "
+                        f"({archive_uncompressed_size} > {max_total_uncompressed_size} bytes); skipping extraction"
+                    ),
+                    severity=IssueSeverity.WARNING,
+                    rule_code="S410",  # Archive bomb
+                    location=path,
+                    details={
+                        "archive_uncompressed_size": archive_uncompressed_size,
+                        "max_zip_total_uncompressed_size": max_total_uncompressed_size,
+                    },
+                )
+                mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
+                result.finish(success=False)
+                return result
+
+            result.add_check(
+                name="ZIP Aggregate Size Limit Check",
+                passed=True,
+                message=(
+                    f"ZIP total uncompressed size ({archive_uncompressed_size}) is within "
+                    f"limit ({max_total_uncompressed_size})"
+                ),
+                location=path,
+                details={
+                    "archive_uncompressed_size": archive_uncompressed_size,
+                    "max_zip_total_uncompressed_size": max_total_uncompressed_size,
+                },
+                rule_code=None,
+            )
+
             # Scan each file in the archive
+            extracted_uncompressed_size = 0
             for info in z.infolist():
                 name = info.filename
                 if not name:
@@ -439,7 +494,13 @@ class ZipScanner(BaseScanner):
                                         raise ValueError(
                                             f"ZIP entry {name} exceeds maximum size of {max_entry_size} bytes",
                                         )
+                                    if extracted_uncompressed_size + total_size > max_total_uncompressed_size:
+                                        raise ValueError(
+                                            "ZIP archive exceeds maximum total uncompressed size of "
+                                            f"{max_total_uncompressed_size} bytes",
+                                        )
                                     tmp.write(chunk)
+                            extracted_uncompressed_size += total_size
 
                         if archive_ext == ".mar" and name.lower().endswith(".py"):
                             mar_python_result = self._scan_mar_python_entry(path, name, tmp_path, total_size)

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -862,6 +862,72 @@ class TestZipScanner:
         assert result.metadata["analysis_incomplete"] is True
         assert "zip_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
 
+    def test_aggregate_uncompressed_size_limit_fails_before_extraction(self, tmp_path: Path) -> None:
+        """Small entries split across a ZIP should still be bounded by an aggregate budget."""
+        archive_path = tmp_path / "split_budget.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("one.bin", b"A" * 8)
+            archive.writestr("two.bin", b"B" * 8)
+
+        def nested_scan(_path: str, _config: dict[str, Any]) -> ScanResult:
+            raise AssertionError("aggregate size preflight should stop before extracting members")
+
+        result = ZipScanner(
+            config={
+                NESTED_SCAN_CALLBACK_CONFIG_KEY: nested_scan,
+                "max_entry_size": 8,
+                "max_zip_total_uncompressed_size": 12,
+            },
+        ).scan(str(archive_path))
+
+        assert result.success is False
+        assert result.metadata["archive_uncompressed_size"] == 16
+        assert result.metadata["max_zip_total_uncompressed_size"] == 12
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "zip_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+        assert any(
+            check.name == "ZIP Aggregate Size Limit Check"
+            and check.status == CheckStatus.FAILED
+            and check.details["archive_uncompressed_size"] == 16
+            and check.details["max_zip_total_uncompressed_size"] == 12
+            for check in result.checks
+        )
+
+    def test_aggregate_uncompressed_size_limit_allows_near_match(self, tmp_path: Path) -> None:
+        """Archives at the aggregate budget should continue through normal member scanning."""
+        archive_path = tmp_path / "within_budget.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("one.bin", b"A" * 6)
+            archive.writestr("two.bin", b"B" * 6)
+
+        scanned_entries = 0
+
+        def nested_scan(path: str, _config: dict[str, Any]) -> ScanResult:
+            nonlocal scanned_entries
+            scanned_entries += 1
+            nested_result = ScanResult(scanner_name="test_nested")
+            nested_result.bytes_scanned = Path(path).stat().st_size
+            nested_result.finish(success=True)
+            return nested_result
+
+        result = ZipScanner(
+            config={
+                NESTED_SCAN_CALLBACK_CONFIG_KEY: nested_scan,
+                "max_entry_size": 8,
+                "max_zip_total_uncompressed_size": 12,
+            },
+        ).scan(str(archive_path))
+
+        assert result.success is True
+        assert scanned_entries == 2
+        assert result.metadata["archive_uncompressed_size"] == 12
+        assert any(
+            check.name == "ZIP Aggregate Size Limit Check"
+            and check.status == CheckStatus.PASSED
+            and check.details["archive_uncompressed_size"] == 12
+            for check in result.checks
+        )
+
     def test_core_zip_partial_nested_scan_without_findings_returns_exit_code_2(self, tmp_path: Path) -> None:
         """A failed nested ZIP member scan with no finding should stay inconclusive in aggregate output."""
         archive_path = tmp_path / "nested_failure.zip"

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -3,6 +3,7 @@ import gzip
 import io
 import lzma
 import os
+import stat
 import tarfile
 import tempfile
 import zipfile
@@ -862,6 +863,36 @@ class TestZipScanner:
         assert result.metadata["analysis_incomplete"] is True
         assert "zip_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
 
+    def test_aggregate_size_limit_uses_public_scan_limits(self) -> None:
+        """Public size limits should constrain ZIP aggregate extraction by default."""
+        assert ZipScanner(config={"max_total_size": 12})._get_max_total_uncompressed_size() == 12
+        assert ZipScanner(config={"max_file_size": 12})._get_max_total_uncompressed_size() == 12
+        assert (
+            ZipScanner(
+                config={
+                    "max_zip_total_uncompressed_size": 20,
+                    "max_total_size": 12,
+                }
+            )._get_max_total_uncompressed_size()
+            == 12
+        )
+        assert ZipScanner(config={"max_zip_total_uncompressed_size": 0})._get_max_total_uncompressed_size() == (
+            ZipScanner.UNLIMITED_ARCHIVE_SIZE
+        )
+        assert (
+            ZipScanner(
+                config={
+                    "max_zip_total_uncompressed_size": 0,
+                    "max_total_size": 12,
+                }
+            )._get_max_total_uncompressed_size()
+            == 12
+        )
+
+    def test_get_max_entry_size_uses_entry_limit_when_file_size_is_unlimited(self) -> None:
+        """An unlimited top-level file-size config should not hide explicit ZIP entry limits."""
+        assert ZipScanner(config={"max_file_size": 0, "max_entry_size": 128})._get_max_entry_size() == 128
+
     def test_aggregate_uncompressed_size_limit_fails_before_extraction(self, tmp_path: Path) -> None:
         """Small entries split across a ZIP should still be bounded by an aggregate budget."""
         archive_path = tmp_path / "split_budget.zip"
@@ -890,6 +921,88 @@ class TestZipScanner:
             and check.status == CheckStatus.FAILED
             and check.details["archive_uncompressed_size"] == 16
             and check.details["max_zip_total_uncompressed_size"] == 12
+            for check in result.checks
+        )
+
+    def test_aggregate_uncompressed_size_limit_preserves_traversal_findings(self, tmp_path: Path) -> None:
+        """Oversized ZIPs should still report deterministic path metadata findings."""
+        archive_path = tmp_path / "oversized_traversal.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("../evil.txt", b"x")
+            archive.writestr("filler.bin", b"A" * 16)
+
+        def nested_scan(_path: str, _config: dict[str, Any]) -> ScanResult:
+            raise AssertionError("aggregate size preflight should stop before extracting members")
+
+        result = ZipScanner(
+            config={
+                NESTED_SCAN_CALLBACK_CONFIG_KEY: nested_scan,
+                "max_zip_total_uncompressed_size": 10,
+            },
+        ).scan(str(archive_path))
+
+        assert result.success is False
+        assert result.has_errors is True
+        assert result.metadata["archive_declared_uncompressed_size"] == 17
+        assert result.metadata["archive_uncompressed_size"] == 16
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert any(issue.rule_code == "S405" and issue.details.get("entry") == "../evil.txt" for issue in result.issues)
+        assert any(issue.rule_code == "S410" for issue in result.issues)
+
+    def test_aggregate_uncompressed_size_limit_preserves_symlink_findings(self, tmp_path: Path) -> None:
+        """Oversized ZIPs should still report deterministic unsafe symlink metadata."""
+        archive_path = tmp_path / "oversized_symlink.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            info = zipfile.ZipInfo("link.txt")
+            info.create_system = 3
+            info.external_attr = (stat.S_IFLNK | 0o777) << 16
+            archive.writestr(info, "../outside.txt")
+            archive.writestr("filler.bin", b"A" * 16)
+
+        def nested_scan(_path: str, _config: dict[str, Any]) -> ScanResult:
+            raise AssertionError("aggregate size preflight should stop before extracting members")
+
+        result = ZipScanner(
+            config={
+                NESTED_SCAN_CALLBACK_CONFIG_KEY: nested_scan,
+                "max_zip_total_uncompressed_size": 10,
+            },
+        ).scan(str(archive_path))
+
+        assert result.success is False
+        assert result.has_errors is True
+        assert result.metadata["archive_declared_uncompressed_size"] == 30
+        assert result.metadata["archive_uncompressed_size"] == 16
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert any(issue.rule_code == "S406" and issue.details.get("entry") == "link.txt" for issue in result.issues)
+        assert any(issue.rule_code == "S410" for issue in result.issues)
+
+    def test_aggregate_uncompressed_size_limit_excludes_symlink_target_bytes(self, tmp_path: Path) -> None:
+        """Symlink target strings should not count toward bytes the scanner extracts."""
+        archive_path = tmp_path / "symlink_only.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            info = zipfile.ZipInfo("link.txt")
+            info.create_system = 3
+            info.external_attr = (stat.S_IFLNK | 0o777) << 16
+            archive.writestr(info, "safe-target.txt")
+
+        def nested_scan(_path: str, _config: dict[str, Any]) -> ScanResult:
+            raise AssertionError("symlink entries should not be extracted")
+
+        result = ZipScanner(
+            config={
+                NESTED_SCAN_CALLBACK_CONFIG_KEY: nested_scan,
+                "max_zip_total_uncompressed_size": 1,
+            },
+        ).scan(str(archive_path))
+
+        assert result.success is True
+        assert result.metadata["archive_declared_uncompressed_size"] == len("safe-target.txt")
+        assert result.metadata["archive_uncompressed_size"] == 0
+        assert any(
+            check.name == "ZIP Aggregate Size Limit Check"
+            and check.status == CheckStatus.PASSED
+            and check.details["archive_uncompressed_size"] == 0
             for check in result.checks
         )
 
@@ -927,6 +1040,33 @@ class TestZipScanner:
             and check.details["archive_uncompressed_size"] == 12
             for check in result.checks
         )
+
+    def test_core_zip_aggregate_limit_fails_closed_with_exit_code_and_cache(self, tmp_path: Path) -> None:
+        """Aggregate ZIP truncation should expose success, exit-code, and cache semantics."""
+        archive_path = tmp_path / "cached_split_budget.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("one.bin", b"A" * 8)
+            archive.writestr("two.bin", b"B" * 8)
+
+        config: dict[str, Any] = {
+            "cache_enabled": True,
+            "cache_dir": str(tmp_path / "scan-cache"),
+            "max_zip_total_uncompressed_size": 12,
+        }
+
+        first_result = core.scan_model_directory_or_file(str(archive_path), **config)
+        second_result = core.scan_model_directory_or_file(str(archive_path), **config)
+
+        for audit_result in (first_result, second_result):
+            metadata = audit_result.file_metadata[str(archive_path)]
+            assert audit_result.success is True
+            assert audit_result.has_errors is False
+            assert core.determine_exit_code(audit_result) == 1
+            assert metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+            assert metadata["analysis_incomplete"] is True
+            assert "zip_analysis_incomplete" in metadata["scan_outcome_reasons"]
+            assert metadata["archive_uncompressed_size"] == 16
+            assert any("ZIP total uncompressed size exceeds limit" in issue.message for issue in audit_result.issues)
 
     def test_core_zip_partial_nested_scan_without_findings_returns_exit_code_2(self, tmp_path: Path) -> None:
         """A failed nested ZIP member scan with no finding should stay inconclusive in aggregate output."""
@@ -1035,7 +1175,7 @@ class TestZipScanner:
         with zipfile.ZipFile(archive_path, "w") as archive:
             archive.writestr("big.bin", b"A" * 32)
 
-        result = ZipScanner(config={"max_file_size": 8}).scan(str(archive_path))
+        result = ZipScanner(config={"max_entry_size": 8}).scan(str(archive_path))
 
         assert result.success is False
         assert any(


### PR DESCRIPTION
## Summary
- Add a ZIP aggregate uncompressed-size budget before member extraction so many individually allowed entries cannot bypass per-entry limits.
- Record archive-wide uncompressed size metadata and fail closed with `zip_analysis_incomplete` when the budget is exceeded.
- Keep an actual-byte guard during extraction to catch malformed ZIP metadata that understates member sizes.
- Add positive and near-match regression tests for split-entry archive budget handling.

## Validation
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_zip_scanner.py -q`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
- `uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`