### PR TITLE
fix: redact telemetry issue fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **onnx:** mark weight-distribution analysis inconclusive when dependencies are missing or eligible tensors are external, oversized, or fail extraction
 - **zip:** enforce an aggregate uncompressed-size budget before extracting ZIP entries so split archive bombs cannot bypass per-entry limits
 - **security:** flag NeMo Hydra `_target_` values that invoke ML deserialization loaders such as `torch.load`, `joblib.load`, Keras load-model APIs, and related pickle-backed helpers.
+- **telemetry:** replace free-form issue messages in telemetry issue fields with stable rule/CVE/type identifiers
 - **security:** route renamed TFLite FlatBuffers by magic bytes, enforce scanner file-size limits before model reads, and fail closed instead of propagating malformed structure traversal exceptions
 - **onnx:** fail closed on CRITICAL findings, detect `PyFunc` operators and Windows absolute external-data paths, validate external tensor slices with the current ONNX dtype API, and avoid Python-op substring false positives
 - **tensorrt:** route `.trt` engines, detect case-variant and UTF-16 suspicious strings, and avoid substring false positives in benign engine metadata

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -542,11 +542,23 @@ def scan_model_directory_or_file(
                         for issue in file_result.issues:
                             issue_dict = issue.to_dict() if hasattr(issue, "to_dict") else issue
                             if isinstance(issue_dict, dict):
+                                issue_details = issue_dict.get("details")
+                                issue_details = issue_details if isinstance(issue_details, dict) else {}
                                 record_issue_found(
-                                    issue_type=str(issue_dict.get("message", "unknown_issue")),
+                                    issue_type=str(issue_dict.get("type") or "unknown_issue"),
                                     severity=_to_telemetry_severity(issue_dict.get("severity", "unknown")),
                                     scanner=file_result.scanner_name,
                                     file_path=representative_file,
+                                    rule_code=(
+                                        issue_dict.get("rule_code")
+                                        if isinstance(issue_dict.get("rule_code"), str)
+                                        else None
+                                    ),
+                                    cve_id=(
+                                        issue_details.get("cve_id")
+                                        if isinstance(issue_details.get("cve_id"), str)
+                                        else None
+                                    ),
                                 )
                                 if not issue_dict.get("location"):
                                     issue_dict["location"] = representative_file

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -559,6 +559,11 @@ def scan_model_directory_or_file(
                                         if isinstance(issue_details.get("cve_id"), str)
                                         else None
                                     ),
+                                    issue_message=(
+                                        issue_dict.get("message")
+                                        if isinstance(issue_dict.get("message"), str)
+                                        else None
+                                    ),
                                 )
                                 if not issue_dict.get("location"):
                                     issue_dict["location"] = representative_file

--- a/modelaudit/core_results.py
+++ b/modelaudit/core_results.py
@@ -167,6 +167,7 @@ def add_scan_result_to_model(
                 file_path=file_path,
                 rule_code=issue_dict.get("rule_code") if isinstance(issue_dict.get("rule_code"), str) else None,
                 cve_id=issue_details.get("cve_id") if isinstance(issue_details.get("cve_id"), str) else None,
+                issue_message=issue_dict.get("message") if isinstance(issue_dict.get("message"), str) else None,
             )
             results.issues.append(Issue(**issue_dict))
 
@@ -501,6 +502,7 @@ def merge_scan_result(
                 file_path=file_path,
                 rule_code=issue.rule_code,
                 cve_id=issue_details.get("cve_id") if isinstance(issue_details.get("cve_id"), str) else None,
+                issue_message=issue.message,
             )
         results.aggregate_scan_result_direct(scan_result)
     else:
@@ -515,5 +517,6 @@ def merge_scan_result(
                 file_path=file_path,
                 rule_code=issue.get("rule_code") if isinstance(issue.get("rule_code"), str) else None,
                 cve_id=issue_details.get("cve_id") if isinstance(issue_details.get("cve_id"), str) else None,
+                issue_message=issue.get("message") if isinstance(issue.get("message"), str) else None,
             )
         results.aggregate_scan_result(scan_result)

--- a/modelaudit/core_results.py
+++ b/modelaudit/core_results.py
@@ -158,11 +158,15 @@ def add_scan_result_to_model(
     for issue in file_result.issues:
         issue_dict = issue.to_dict() if hasattr(issue, "to_dict") else issue
         if isinstance(issue_dict, dict):
+            issue_details = issue_dict.get("details")
+            issue_details = issue_details if isinstance(issue_details, dict) else {}
             record_issue_found(
-                issue_type=str(issue_dict.get("message", "unknown_issue")),
+                issue_type=str(issue_dict.get("type") or "unknown_issue"),
                 severity=to_telemetry_severity(issue_dict.get("severity", "unknown")),
                 scanner=file_result.scanner_name,
                 file_path=file_path,
+                rule_code=issue_dict.get("rule_code") if isinstance(issue_dict.get("rule_code"), str) else None,
+                cve_id=issue_details.get("cve_id") if isinstance(issue_details.get("cve_id"), str) else None,
             )
             results.issues.append(Issue(**issue_dict))
 
@@ -489,20 +493,27 @@ def merge_scan_result(
     if isinstance(scan_result, ScanResult):
         file_path = scan_result.file_path if hasattr(scan_result, "file_path") else None
         for issue in scan_result.issues:
+            issue_details = issue.details if isinstance(issue.details, dict) else {}
             record_issue_found(
-                issue.message,
+                issue.type or "unknown_issue",
                 issue.severity.name if hasattr(issue.severity, "name") else str(issue.severity),
                 scan_result.scanner_name,
                 file_path=file_path,
+                rule_code=issue.rule_code,
+                cve_id=issue_details.get("cve_id") if isinstance(issue_details.get("cve_id"), str) else None,
             )
         results.aggregate_scan_result_direct(scan_result)
     else:
         file_path = scan_result.get("file_path")
         for issue in scan_result.get("issues", []):
+            raw_issue_details = issue.get("details") if isinstance(issue, dict) else None
+            issue_details = raw_issue_details if isinstance(raw_issue_details, dict) else {}
             record_issue_found(
-                issue.get("message", "unknown_issue"),
+                issue.get("type") or "unknown_issue",
                 issue.get("severity", "unknown"),
                 scan_result.get("scanner_name", "unknown"),
                 file_path=file_path,
+                rule_code=issue.get("rule_code") if isinstance(issue.get("rule_code"), str) else None,
+                cve_id=issue_details.get("cve_id") if isinstance(issue_details.get("cve_id"), str) else None,
             )
         results.aggregate_scan_result(scan_result)

--- a/modelaudit/telemetry.py
+++ b/modelaudit/telemetry.py
@@ -120,7 +120,15 @@ POSTHOG_PROJECT_KEY = os.getenv("PROMPTFOO_POSTHOG_KEY", os.getenv("MODELAUDIT_P
 POSTHOG_HOST = os.getenv("PROMPTFOO_POSTHOG_HOST", "https://a.promptfoo.app")
 _TELEMETRY_RULE_CODE_RE = re.compile(r"\bS\d{3,4}\b", re.IGNORECASE)
 _TELEMETRY_CVE_RE = re.compile(r"\bCVE-\d{4}-\d{4,7}\b", re.IGNORECASE)
-_TELEMETRY_STABLE_ISSUE_ID_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.-]{0,79}$")
+_TELEMETRY_STABLE_ISSUE_ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:_[a-z0-9]+){1,15}$")
+_TELEMETRY_SECRETLIKE_ISSUE_ID_RE = re.compile(
+    r"^(?:sk|pk|rk|ghp|github_pat|xox[baprs]?|glpat|hf|akia|asia)[_-]",
+    re.IGNORECASE,
+)
+_TELEMETRY_FILELIKE_ISSUE_ID_RE = re.compile(
+    r"\.(?:bin|ckpt|gguf|gz|h5|hdf5|json|keras|nemo|onnx|pb|pickle|pkl|pt|pth|safetensors|tar|yaml|yml|zip)$",
+    re.IGNORECASE,
+)
 
 
 def _is_development_install() -> bool:
@@ -413,8 +421,8 @@ class TelemetryClient:
         return counts
 
     @staticmethod
-    def _sanitize_issue_identifier(value: Any) -> str | None:
-        """Return a stable telemetry issue identifier without preserving free-form text."""
+    def _issue_text_rule_or_cve(value: Any) -> str | None:
+        """Extract a stable rule/CVE token from untrusted issue text."""
         if not isinstance(value, str):
             return None
 
@@ -430,6 +438,25 @@ class TelemetryClient:
         if cve_match:
             return f"cve:{cve_match.group(0).upper()}"
 
+        return None
+
+    @classmethod
+    def _sanitize_issue_identifier(cls, value: Any) -> str | None:
+        """Return a stable telemetry issue identifier without preserving free-form text."""
+        token_identifier = cls._issue_text_rule_or_cve(value)
+        if token_identifier:
+            return token_identifier
+
+        if not isinstance(value, str):
+            return None
+
+        stripped = value.strip()
+        if not stripped:
+            return None
+
+        if _TELEMETRY_SECRETLIKE_ISSUE_ID_RE.search(stripped) or _TELEMETRY_FILELIKE_ISSUE_ID_RE.search(stripped):
+            return None
+
         if _TELEMETRY_STABLE_ISSUE_ID_RE.fullmatch(stripped):
             return stripped
 
@@ -441,12 +468,19 @@ class TelemetryClient:
         issue_type: Any = None,
         rule_code: Any = None,
         cve_id: Any = None,
+        issue_message: Any = None,
     ) -> str:
         """Build the stable issue identifier used in telemetry payloads."""
-        for candidate in (rule_code, cve_id, issue_type):
+        for candidate in (rule_code, cve_id):
             sanitized = self._sanitize_issue_identifier(candidate)
             if sanitized:
                 return sanitized
+        message_identifier = self._issue_text_rule_or_cve(issue_message)
+        if message_identifier:
+            return message_identifier
+        sanitized_type = self._sanitize_issue_identifier(issue_type)
+        if sanitized_type:
+            return sanitized_type
         return "unknown_issue"
 
     def _issue_type_from_record(self, issue: dict[str, Any]) -> str:
@@ -454,9 +488,10 @@ class TelemetryClient:
         raw_details = issue.get("details")
         details = raw_details if isinstance(raw_details, dict) else {}
         return self._stable_issue_type(
-            issue_type=issue.get("type") or issue.get("message"),
+            issue_type=issue.get("type"),
             rule_code=issue.get("rule_code") or details.get("rule_code"),
             cve_id=issue.get("cve_id") or details.get("cve_id"),
+            issue_message=issue.get("message"),
         )
 
     def _send_event_internal(self, event: TelemetryEvent, properties: dict[str, Any]) -> None:
@@ -685,9 +720,15 @@ class TelemetryClient:
         *,
         rule_code: str | None = None,
         cve_id: str | None = None,
+        issue_message: str | None = None,
     ) -> None:
         """Record that a security issue was found."""
-        stable_issue_type = self._stable_issue_type(issue_type=issue_type, rule_code=rule_code, cve_id=cve_id)
+        stable_issue_type = self._stable_issue_type(
+            issue_type=issue_type,
+            rule_code=rule_code,
+            cve_id=cve_id,
+            issue_message=issue_message,
+        )
         properties: dict[str, Any] = {
             "severity": severity,
             "scanner": scanner,
@@ -923,11 +964,20 @@ def record_issue_found(
     *,
     rule_code: str | None = None,
     cve_id: str | None = None,
+    issue_message: str | None = None,
 ) -> None:
     """Record that a security issue was found."""
     client = get_telemetry_client()
     if client is not None:
-        client.record_issue_found(issue_type, severity, scanner, file_path, rule_code=rule_code, cve_id=cve_id)
+        client.record_issue_found(
+            issue_type,
+            severity,
+            scanner,
+            file_path,
+            rule_code=rule_code,
+            cve_id=cve_id,
+            issue_message=issue_message,
+        )
 
 
 @safe_telemetry

--- a/modelaudit/telemetry.py
+++ b/modelaudit/telemetry.py
@@ -118,6 +118,9 @@ class TelemetryEvent(str, Enum):
 _DEFAULT_POSTHOG_KEY = "phc_E5n5uHnDo2eREJL1uqX1cIlbkoRby4yFWt3V94HqRRg"
 POSTHOG_PROJECT_KEY = os.getenv("PROMPTFOO_POSTHOG_KEY", os.getenv("MODELAUDIT_POSTHOG_KEY", _DEFAULT_POSTHOG_KEY))
 POSTHOG_HOST = os.getenv("PROMPTFOO_POSTHOG_HOST", "https://a.promptfoo.app")
+_TELEMETRY_RULE_CODE_RE = re.compile(r"\bS\d{3,4}\b", re.IGNORECASE)
+_TELEMETRY_CVE_RE = re.compile(r"\bCVE-\d{4}-\d{4,7}\b", re.IGNORECASE)
+_TELEMETRY_STABLE_ISSUE_ID_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.-]{0,79}$")
 
 
 def _is_development_install() -> bool:
@@ -409,6 +412,53 @@ class TelemetryClient:
             counts[value] = counts.get(value, 0) + 1
         return counts
 
+    @staticmethod
+    def _sanitize_issue_identifier(value: Any) -> str | None:
+        """Return a stable telemetry issue identifier without preserving free-form text."""
+        if not isinstance(value, str):
+            return None
+
+        stripped = value.strip()
+        if not stripped:
+            return None
+
+        rule_match = _TELEMETRY_RULE_CODE_RE.search(stripped)
+        if rule_match:
+            return f"rule:{rule_match.group(0).upper()}"
+
+        cve_match = _TELEMETRY_CVE_RE.search(stripped)
+        if cve_match:
+            return f"cve:{cve_match.group(0).upper()}"
+
+        if _TELEMETRY_STABLE_ISSUE_ID_RE.fullmatch(stripped):
+            return stripped
+
+        return None
+
+    def _stable_issue_type(
+        self,
+        *,
+        issue_type: Any = None,
+        rule_code: Any = None,
+        cve_id: Any = None,
+    ) -> str:
+        """Build the stable issue identifier used in telemetry payloads."""
+        for candidate in (rule_code, cve_id, issue_type):
+            sanitized = self._sanitize_issue_identifier(candidate)
+            if sanitized:
+                return sanitized
+        return "unknown_issue"
+
+    def _issue_type_from_record(self, issue: dict[str, Any]) -> str:
+        """Extract a stable issue identifier from a serialized issue record."""
+        raw_details = issue.get("details")
+        details = raw_details if isinstance(raw_details, dict) else {}
+        return self._stable_issue_type(
+            issue_type=issue.get("type") or issue.get("message"),
+            rule_code=issue.get("rule_code") or details.get("rule_code"),
+            cve_id=issue.get("cve_id") or details.get("cve_id"),
+        )
+
     def _send_event_internal(self, event: TelemetryEvent, properties: dict[str, Any]) -> None:
         """Internal method to send events without checking disabled state."""
         event_properties = {
@@ -551,8 +601,7 @@ class TelemetryClient:
         issue_details: list[dict[str, Any]] = []
 
         for issue in issues:
-            # Prefer structured issue type when available, fall back to message for legacy payloads.
-            issue_type = str(issue.get("type") or issue.get("message") or "unknown")
+            issue_type = self._issue_type_from_record(issue)
             severity = str(issue.get("severity", "unknown"))
             issue_types[issue_type] = issue_types.get(issue_type, 0) + 1
             # Capture first 50 issues in detail without including raw paths or identifiers.
@@ -633,13 +682,16 @@ class TelemetryClient:
         severity: str,
         scanner: str,
         file_path: str | None = None,
+        *,
+        rule_code: str | None = None,
+        cve_id: str | None = None,
     ) -> None:
         """Record that a security issue was found."""
+        stable_issue_type = self._stable_issue_type(issue_type=issue_type, rule_code=rule_code, cve_id=cve_id)
         properties: dict[str, Any] = {
             "severity": severity,
             "scanner": scanner,
-            "issue_type": issue_type,
-            "issue_message": issue_type,  # Full message for analytics
+            "issue_type": stable_issue_type,
         }
 
         if file_path:
@@ -863,11 +915,19 @@ def record_file_type_detected(file_path: str, detected_type: str, confidence: fl
 
 
 @safe_telemetry
-def record_issue_found(issue_type: str, severity: str, scanner: str, file_path: str | None = None) -> None:
+def record_issue_found(
+    issue_type: str,
+    severity: str,
+    scanner: str,
+    file_path: str | None = None,
+    *,
+    rule_code: str | None = None,
+    cve_id: str | None = None,
+) -> None:
     """Record that a security issue was found."""
     client = get_telemetry_client()
     if client is not None:
-        client.record_issue_found(issue_type, severity, scanner, file_path)
+        client.record_issue_found(issue_type, severity, scanner, file_path, rule_code=rule_code, cve_id=cve_id)
 
 
 @safe_telemetry

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -322,10 +322,11 @@ class TestTelemetryClient:
 
             assert properties["total_files"] == 2
             assert properties["total_issues"] == 4
-            assert properties["issue_types"]["Issue A"] == 1
-            assert properties["issue_types"]["Issue B"] == 1
+            assert properties["issue_types"]["unknown_issue"] == 3
             assert properties["issue_types"]["pickle_dangerous_global"] == 1
-            assert properties["issue_types"]["Issue with no location"] == 1
+            assert "Issue A" not in properties["issue_types"]
+            assert "Issue B" not in properties["issue_types"]
+            assert "Issue with no location" not in properties["issue_types"]
             assert "Legacy message should not be used when type exists" not in properties["issue_types"]
             assert properties["issue_severities"]["critical"] == 1
             assert properties["issue_severities"]["warning"] == 2
@@ -342,7 +343,9 @@ class TestTelemetryClient:
             assert canonical_issue["model_name"] == "a.pkl"
             assert canonical_issue["model_reference"] == "a.pkl"
             missing_location_issue = next(
-                detail for detail in properties["issue_details"] if detail["type"] == "Issue with no location"
+                detail
+                for detail in properties["issue_details"]
+                if detail["type"] == "unknown_issue" and detail["location_type"] == "unknown"
             )
             assert missing_location_issue["location_type"] == "unknown"
             assert missing_location_issue["model_name"] is None

--- a/tests/test_telemetry_decoupling.py
+++ b/tests/test_telemetry_decoupling.py
@@ -3,6 +3,7 @@ Tests to ensure telemetry is properly decoupled from core functionality.
 """
 # ruff: noqa: SIM117
 
+import json
 import os
 import tempfile
 from pathlib import Path
@@ -11,6 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from modelaudit.telemetry import (
+    TelemetryClient,
     TelemetryEvent,
     disable_telemetry,
     enable_telemetry,
@@ -250,6 +252,75 @@ class TestTelemetryFunctionalityWhenWorking:
             result = "executed successfully"
 
         assert result == "executed successfully"
+
+    def test_record_issue_found_uses_stable_redacted_issue_type(self, tmp_path: Path) -> None:
+        """Issue telemetry should not copy free-form scanner messages into analytics fields."""
+        client = TelemetryClient()
+        captured: dict[str, object] = {}
+
+        def capture_event(event: TelemetryEvent, properties: dict[str, object] | None = None) -> None:
+            captured["event"] = event
+            captured["properties"] = properties or {}
+
+        client.record_event = capture_event  # type: ignore[method-assign]
+        sensitive_path = tmp_path / "private-model.pkl"
+        client.record_issue_found(
+            f"Unsafe pickle found in {sensitive_path} from https://example.com/model?token=secret",
+            "critical",
+            "pickle",
+            file_path=str(sensitive_path),
+        )
+
+        assert captured["event"] == TelemetryEvent.ISSUE_FOUND
+        properties = captured["properties"]
+        assert isinstance(properties, dict)
+        assert properties["issue_type"] == "unknown_issue"
+        assert "issue_message" not in properties
+        serialized = json.dumps(properties)
+        assert str(sensitive_path) not in serialized
+        assert "token=secret" not in serialized
+
+    def test_scan_completed_uses_rule_identifiers_not_issue_messages(self, tmp_path: Path) -> None:
+        """Completed-scan telemetry should count stable rule IDs and omit raw issue text."""
+        client = TelemetryClient()
+        captured: dict[str, object] = {}
+
+        def capture_event(event: TelemetryEvent, properties: dict[str, object] | None = None) -> None:
+            captured["event"] = event
+            captured["properties"] = properties or {}
+
+        client.record_event = capture_event  # type: ignore[method-assign]
+        sensitive_path = tmp_path / "secret-model.nemo"
+        raw_message = f"CVE-2025-23304: dangerous target in {sensitive_path} https://example.com/?token=secret"
+
+        client.record_scan_completed(
+            0.1,
+            {
+                "files_scanned": 1,
+                "scanner_names": ["nemo"],
+                "issues": [
+                    {
+                        "message": raw_message,
+                        "severity": "critical",
+                        "location": str(sensitive_path),
+                        "type": "nemo_check",
+                        "rule_code": "S1101",
+                        "details": {"cve_id": "CVE-2025-23304"},
+                    }
+                ],
+                "assets": [],
+            },
+        )
+
+        assert captured["event"] == TelemetryEvent.SCAN_COMPLETED
+        properties = captured["properties"]
+        assert isinstance(properties, dict)
+        assert properties["issue_types"] == {"rule:S1101": 1}
+        assert properties["issue_details"][0]["type"] == "rule:S1101"
+        serialized = json.dumps(properties)
+        assert raw_message not in serialized
+        assert str(sensitive_path) not in serialized
+        assert "token=secret" not in serialized
 
 
 if __name__ == "__main__":

--- a/tests/test_telemetry_decoupling.py
+++ b/tests/test_telemetry_decoupling.py
@@ -255,21 +255,23 @@ class TestTelemetryFunctionalityWhenWorking:
 
     def test_record_issue_found_uses_stable_redacted_issue_type(self, tmp_path: Path) -> None:
         """Issue telemetry should not copy free-form scanner messages into analytics fields."""
-        client = TelemetryClient()
         captured: dict[str, object] = {}
 
         def capture_event(event: TelemetryEvent, properties: dict[str, object] | None = None) -> None:
             captured["event"] = event
             captured["properties"] = properties or {}
 
-        client.record_event = capture_event  # type: ignore[method-assign]
         sensitive_path = tmp_path / "private-model.pkl"
-        client.record_issue_found(
-            f"Unsafe pickle found in {sensitive_path} from https://example.com/model?token=secret",
-            "critical",
-            "pickle",
-            file_path=str(sensitive_path),
-        )
+        with patch("modelaudit.telemetry.Path.home") as mock_home:
+            mock_home.return_value = tmp_path
+            client = TelemetryClient()
+            client.record_event = capture_event  # type: ignore[method-assign]
+            client.record_issue_found(
+                f"Unsafe pickle found in {sensitive_path} from https://example.com/model?token=secret",
+                "critical",
+                "pickle",
+                file_path=str(sensitive_path),
+            )
 
         assert captured["event"] == TelemetryEvent.ISSUE_FOUND
         properties = captured["properties"]
@@ -280,37 +282,100 @@ class TestTelemetryFunctionalityWhenWorking:
         assert str(sensitive_path) not in serialized
         assert "token=secret" not in serialized
 
-    def test_scan_completed_uses_rule_identifiers_not_issue_messages(self, tmp_path: Path) -> None:
-        """Completed-scan telemetry should count stable rule IDs and omit raw issue text."""
-        client = TelemetryClient()
+    def test_record_issue_found_rejects_token_shaped_issue_text(self, tmp_path: Path) -> None:
+        """Slug-like filenames and tokens must not be treated as stable issue IDs."""
         captured: dict[str, object] = {}
 
         def capture_event(event: TelemetryEvent, properties: dict[str, object] | None = None) -> None:
             captured["event"] = event
             captured["properties"] = properties or {}
 
-        client.record_event = capture_event  # type: ignore[method-assign]
+        with patch("modelaudit.telemetry.Path.home") as mock_home:
+            mock_home.return_value = tmp_path
+            client = TelemetryClient()
+            client.record_event = capture_event  # type: ignore[method-assign]
+            client.record_issue_found("private-model.pkl", "critical", "pickle")
+            filename_properties = captured["properties"]
+            client.record_issue_found("secret-token-abc123", "critical", "pickle")
+            slug_token_properties = captured["properties"]
+            client.record_issue_found("sk_live_1234567890abcdef", "critical", "pickle")
+            token_properties = captured["properties"]
+            client.record_issue_found(
+                "legacy message mentions CVE-2025-23304",
+                "critical",
+                "nemo",
+                issue_message="legacy message mentions CVE-2025-23304",
+            )
+            cve_properties = captured["properties"]
+            client.record_issue_found(
+                "legacy message mentions S1101",
+                "critical",
+                "nemo",
+                issue_message="legacy message mentions S1101",
+            )
+            rule_properties = captured["properties"]
+            client.record_issue_found("pickle_dangerous_global", "critical", "pickle")
+            structured_properties = captured["properties"]
+
+        assert isinstance(filename_properties, dict)
+        assert filename_properties["issue_type"] == "unknown_issue"
+        assert isinstance(slug_token_properties, dict)
+        assert slug_token_properties["issue_type"] == "unknown_issue"
+        assert isinstance(token_properties, dict)
+        assert token_properties["issue_type"] == "unknown_issue"
+        assert isinstance(cve_properties, dict)
+        assert cve_properties["issue_type"] == "cve:CVE-2025-23304"
+        assert "legacy message" not in json.dumps(cve_properties)
+        assert isinstance(rule_properties, dict)
+        assert rule_properties["issue_type"] == "rule:S1101"
+        assert "legacy message" not in json.dumps(rule_properties)
+        assert isinstance(structured_properties, dict)
+        assert structured_properties["issue_type"] == "pickle_dangerous_global"
+        serialized = json.dumps(
+            {
+                "filename": filename_properties,
+                "slug_token": slug_token_properties,
+                "token": token_properties,
+                "structured": structured_properties,
+            }
+        )
+        assert "private-model.pkl" not in serialized
+        assert "secret-token-abc123" not in serialized
+        assert "sk_live_1234567890abcdef" not in serialized
+
+    def test_scan_completed_uses_rule_identifiers_not_issue_messages(self, tmp_path: Path) -> None:
+        """Completed-scan telemetry should count stable rule IDs and omit raw issue text."""
+        captured: dict[str, object] = {}
+
+        def capture_event(event: TelemetryEvent, properties: dict[str, object] | None = None) -> None:
+            captured["event"] = event
+            captured["properties"] = properties or {}
+
         sensitive_path = tmp_path / "secret-model.nemo"
         raw_message = f"CVE-2025-23304: dangerous target in {sensitive_path} https://example.com/?token=secret"
 
-        client.record_scan_completed(
-            0.1,
-            {
-                "files_scanned": 1,
-                "scanner_names": ["nemo"],
-                "issues": [
-                    {
-                        "message": raw_message,
-                        "severity": "critical",
-                        "location": str(sensitive_path),
-                        "type": "nemo_check",
-                        "rule_code": "S1101",
-                        "details": {"cve_id": "CVE-2025-23304"},
-                    }
-                ],
-                "assets": [],
-            },
-        )
+        with patch("modelaudit.telemetry.Path.home") as mock_home:
+            mock_home.return_value = tmp_path
+            client = TelemetryClient()
+            client.record_event = capture_event  # type: ignore[method-assign]
+            client.record_scan_completed(
+                0.1,
+                {
+                    "files_scanned": 1,
+                    "scanner_names": ["nemo"],
+                    "issues": [
+                        {
+                            "message": raw_message,
+                            "severity": "critical",
+                            "location": str(sensitive_path),
+                            "type": "nemo_check",
+                            "rule_code": "S1101",
+                            "details": {"cve_id": "CVE-2025-23304"},
+                        }
+                    ],
+                    "assets": [],
+                },
+            )
 
         assert captured["event"] == TelemetryEvent.SCAN_COMPLETED
         properties = captured["properties"]
@@ -321,6 +386,47 @@ class TestTelemetryFunctionalityWhenWorking:
         assert raw_message not in serialized
         assert str(sensitive_path) not in serialized
         assert "token=secret" not in serialized
+
+    def test_scan_completed_rejects_token_shaped_legacy_messages(self, tmp_path: Path) -> None:
+        """Message-only telemetry can expose rule/CVE tokens, not arbitrary slug-like text."""
+        captured: dict[str, object] = {}
+
+        def capture_event(event: TelemetryEvent, properties: dict[str, object] | None = None) -> None:
+            captured["event"] = event
+            captured["properties"] = properties or {}
+
+        with patch("modelaudit.telemetry.Path.home") as mock_home:
+            mock_home.return_value = tmp_path
+            client = TelemetryClient()
+            client.record_event = capture_event  # type: ignore[method-assign]
+            client.record_scan_completed(
+                0.1,
+                {
+                    "files_scanned": 1,
+                    "scanner_names": ["pickle"],
+                    "issues": [
+                        {"message": "private-model.pkl", "severity": "critical"},
+                        {"message": "secret-token-abc123", "severity": "critical"},
+                        {"message": "sk_live_1234567890abcdef", "severity": "critical"},
+                        {"message": "CVE-2025-23304 in sanitized legacy text", "severity": "critical"},
+                        {"message": "S1101 in sanitized legacy text", "severity": "critical"},
+                    ],
+                    "assets": [],
+                },
+            )
+
+        assert captured["event"] == TelemetryEvent.SCAN_COMPLETED
+        properties = captured["properties"]
+        assert isinstance(properties, dict)
+        assert properties["issue_types"] == {
+            "unknown_issue": 3,
+            "cve:CVE-2025-23304": 1,
+            "rule:S1101": 1,
+        }
+        serialized = json.dumps(properties)
+        assert "private-model.pkl" not in serialized
+        assert "secret-token-abc123" not in serialized
+        assert "sk_live_1234567890abcdef" not in serialized
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Replace free-form telemetry issue identifiers with stable rule/CVE/type identifiers.
- Stop emitting `issue_message` from per-issue telemetry events.
- Update aggregate telemetry callers so they pass structured issue type, rule code, and CVE metadata instead of scanner messages.
- Add regressions proving local paths and tokenized URLs embedded in issue messages are not copied into telemetry issue fields.

## Validation
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_telemetry.py tests/test_telemetry_decoupling.py -q`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
- `uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`