### PR TITLE
fix: fail closed on incomplete ONNX weight analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **pickle:** restore ModelAudit nested-pickle findings from Rust standalone notices and keep network raw-detector coverage after native pickle findings
 - preserve `S999` unknown-opcode mapping in generic rule fallback
 - **docker:** run the full parser image as a non-root `appuser`
+- **onnx:** mark weight-distribution analysis inconclusive when dependencies are missing or eligible tensors are external, oversized, or fail extraction
 - **security:** route renamed TFLite FlatBuffers by magic bytes, enforce scanner file-size limits before model reads, and fail closed instead of propagating malformed structure traversal exceptions
 - **onnx:** fail closed on CRITICAL findings, detect `PyFunc` operators and Windows absolute external-data paths, validate external tensor slices with the current ONNX dtype API, and avoid Python-op substring false positives
 - **tensorrt:** route `.trt` engines, detect case-variant and UTF-16 suspicious strings, and avoid substring false positives in benign engine metadata

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -58,6 +58,7 @@ STANDARD_ONNX_DOMAINS: frozenset[str] = frozenset(
     }
 )
 ONNX_STRUCTURE_INCONCLUSIVE_REASON = "onnx_structure_validation_failed"
+ONNX_WEIGHT_DISTRIBUTION_INCONCLUSIVE_REASON = "onnx_weight_distribution_analysis_incomplete"
 _PYTHON_OPERATOR_TYPES: frozenset[str] = frozenset(
     {
         "pyfunc",
@@ -770,32 +771,43 @@ class OnnxScanner(BaseScanner):
         analysis; 1-D tensors (biases, batch-norm params) are excluded.
         """
         try:
+            import numpy as np
             import onnx
+            from scipy import stats as _stats  # noqa: F401
 
             # Lazy-import the weight distribution scanner to avoid circular deps
             # and heavy library loads when the scanner is not needed.
             from modelaudit.scanners.weight_distribution_scanner import WeightDistributionScanner
-        except ImportError:
-            # numpy / scipy / onnx not available — silently skip
+        except ImportError as e:
+            self._mark_weight_distribution_incomplete(
+                result,
+                path,
+                reason="missing_dependency",
+                message=f"Weight distribution analysis dependency unavailable: {e!s}",
+                details={"exception": str(e), "exception_type": type(e).__name__},
+            )
             return
 
         # Max in-memory array size (default 100 MB)
         max_array_size = self.config.get("max_array_size", 100 * 1024 * 1024)
 
-        import numpy as np
-
+        eligible_initializers = 0
+        external_initializers_skipped = 0
+        oversized_initializers_skipped = 0
         extraction_failures = 0
         weights_info: dict[str, Any] = {}
         for initializer in model.graph.initializer:
             try:
                 self.check_interrupted()
 
-                # Skip external-data tensors — their bytes were not loaded.
-                if initializer.data_location == onnx.TensorProto.EXTERNAL:
-                    continue
-
                 # Only 2-D+ tensors are interesting for distribution analysis.
                 if len(initializer.dims) < 2:
+                    continue
+                eligible_initializers += 1
+
+                # Skip external-data tensors — their bytes were not loaded.
+                if initializer.data_location == onnx.TensorProto.EXTERNAL:
+                    external_initializers_skipped += 1
                     continue
 
                 # Pre-check estimated size before materializing the array.
@@ -805,6 +817,7 @@ class OnnxScanner(BaseScanner):
                 itemsize = int(np.dtype(onnx.helper.tensor_dtype_to_np_dtype(initializer.data_type)).itemsize)
                 estimated_bytes = numel * itemsize
                 if max_array_size and max_array_size > 0 and estimated_bytes > max_array_size:
+                    oversized_initializers_skipped += 1
                     continue
 
                 array = onnx.numpy_helper.to_array(initializer)
@@ -818,6 +831,22 @@ class OnnxScanner(BaseScanner):
                     e,
                 )
                 continue
+
+        if external_initializers_skipped or oversized_initializers_skipped or extraction_failures:
+            self._mark_weight_distribution_incomplete(
+                result,
+                path,
+                reason="partial_initializer_coverage",
+                message="Weight distribution analysis skipped one or more eligible ONNX initializers",
+                details={
+                    "eligible_initializers": eligible_initializers,
+                    "analyzed_initializers": len(weights_info),
+                    "external_initializers_skipped": external_initializers_skipped,
+                    "oversized_initializers_skipped": oversized_initializers_skipped,
+                    "extraction_failures": extraction_failures,
+                    "max_array_size": max_array_size,
+                },
+            )
 
         if not weights_info:
             # Nothing to analyse (external-only model, or all tensors too small / too large).
@@ -853,6 +882,37 @@ class OnnxScanner(BaseScanner):
                 location=path,
                 details={"exception": str(e), "exception_type": type(e).__name__},
             )
+            self._mark_weight_distribution_incomplete(
+                result,
+                path,
+                reason="analysis_failed",
+                message=f"Weight distribution analysis failed: {e!s}",
+                details={"exception": str(e), "exception_type": type(e).__name__},
+            )
+
+    def _mark_weight_distribution_incomplete(
+        self,
+        result: ScanResult,
+        path: str,
+        *,
+        reason: str,
+        message: str,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        _mark_inconclusive_scan_result(result, ONNX_WEIGHT_DISTRIBUTION_INCONCLUSIVE_REASON)
+        result.add_check(
+            name="Weight Distribution Analysis Coverage",
+            passed=False,
+            message=message,
+            severity=IssueSeverity.INFO,
+            location=path,
+            rule_code="S902",
+            details={
+                "scan_outcome_reason": ONNX_WEIGHT_DISTRIBUTION_INCONCLUSIVE_REASON,
+                "coverage_gap": reason,
+                **(details or {}),
+            },
+        )
 
     def extract_metadata(self, file_path: str) -> dict[str, Any]:
         """Extract ONNX model metadata."""

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -771,14 +771,8 @@ class OnnxScanner(BaseScanner):
         analysis; 1-D tensors (biases, batch-norm params) are excluded.
         """
         try:
-            import numpy as np
             import onnx
-            from scipy import stats as _stats  # noqa: F401
-
-            # Lazy-import the weight distribution scanner to avoid circular deps
-            # and heavy library loads when the scanner is not needed.
-            from modelaudit.scanners.weight_distribution_scanner import WeightDistributionScanner
-        except ImportError as e:
+        except Exception as e:
             self._mark_weight_distribution_incomplete(
                 result,
                 path,
@@ -814,7 +808,7 @@ class OnnxScanner(BaseScanner):
                 # Use math.prod for arbitrary-precision arithmetic (np.prod
                 # can silently overflow for very large dimension products).
                 numel = math.prod(int(dim) for dim in initializer.dims)
-                itemsize = int(np.dtype(onnx.helper.tensor_dtype_to_np_dtype(initializer.data_type)).itemsize)
+                itemsize = int(_tensor_data_type_to_np_dtype(initializer.data_type).itemsize)
                 estimated_bytes = numel * itemsize
                 if max_array_size and max_array_size > 0 and estimated_bytes > max_array_size:
                     oversized_initializers_skipped += 1
@@ -850,6 +844,22 @@ class OnnxScanner(BaseScanner):
 
         if not weights_info:
             # Nothing to analyse (external-only model, or all tensors too small / too large).
+            return
+
+        try:
+            from scipy import stats as _stats  # noqa: F401
+
+            # Lazy-import the weight distribution scanner to avoid circular deps
+            # and heavy library loads when the scanner is not needed.
+            from modelaudit.scanners.weight_distribution_scanner import WeightDistributionScanner
+        except Exception as e:
+            self._mark_weight_distribution_incomplete(
+                result,
+                path,
+                reason="missing_dependency",
+                message=f"Weight distribution analysis dependency unavailable: {e!s}",
+                details={"exception": str(e), "exception_type": type(e).__name__},
+            )
             return
 
         # Delegate the actual statistical analysis to WeightDistributionScanner.

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -12,6 +12,7 @@ import onnx
 from onnx import TensorProto, helper
 from onnx.onnx_ml_pb2 import StringStringEntryProto
 
+from modelaudit.cache import get_cache_manager, reset_cache_manager
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity
 from modelaudit.scanners.onnx_scanner import OnnxScanner
@@ -29,6 +30,7 @@ def create_onnx_model(
     external_file_bytes: bytes | None = None,
     missing_external: bool = False,
     tensor_shape: tuple[int, ...] = (1,),
+    include_initializer: bool = True,
 ) -> Path:
     X = helper.make_tensor_value_info("input", TensorProto.FLOAT, list(tensor_shape) or [1])
     Y = helper.make_tensor_value_info("output", TensorProto.FLOAT, list(tensor_shape) or [1])
@@ -44,8 +46,8 @@ def create_onnx_model(
         else helper.make_node("Relu", ["input"], ["output"], name="relu")
     )
 
-    initializers = []
-    if external:
+    initializers: list[Any] = []
+    if include_initializer and external:
         value_count = 1
         for dim in tensor_shape:
             value_count *= dim
@@ -66,7 +68,7 @@ def create_onnx_model(
             external_file.parent.mkdir(parents=True, exist_ok=True)
             with open(external_file, "wb") as f:
                 f.write(external_file_bytes or struct.pack("f", 1.0))
-    else:
+    elif include_initializer:
         value_count = 1
         for dim in tensor_shape:
             value_count *= dim
@@ -797,9 +799,71 @@ class TestExternalDataSizeValidation:
 class TestWeightDistributionCoverage:
     """Tests for ONNX weight-distribution analysis coverage gaps."""
 
+    _INCONCLUSIVE_REASON = "onnx_weight_distribution_analysis_incomplete"
+
     @staticmethod
     def _coverage_checks(result: Any) -> list[Any]:
         return [c for c in result.checks if c.name == "Weight Distribution Analysis Coverage"]
+
+    def _assert_uncached_inconclusive_exit2(self, model_path: Path, cache_dir: Path, **scan_kwargs: Any) -> None:
+        reset_cache_manager()
+        try:
+            first_result = scan_model_directory_or_file(
+                str(model_path),
+                recursive=False,
+                cache_enabled=True,
+                cache_dir=str(cache_dir),
+                min_cache_file_size=0,
+                **scan_kwargs,
+            )
+            second_result = scan_model_directory_or_file(
+                str(model_path),
+                recursive=False,
+                cache_enabled=True,
+                cache_dir=str(cache_dir),
+                min_cache_file_size=0,
+                **scan_kwargs,
+            )
+            metadata = second_result.file_metadata[str(model_path)]
+
+            assert first_result.success is False
+            assert second_result.success is False
+            assert metadata.get("scan_outcome") == INCONCLUSIVE_SCAN_OUTCOME
+            assert self._INCONCLUSIVE_REASON in metadata.get("scan_outcome_reasons", [])
+            assert determine_exit_code(first_result) == 2
+            assert determine_exit_code(second_result) == 2
+            assert not any(issue.severity == IssueSeverity.CRITICAL for issue in second_result.issues)
+            assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+        finally:
+            reset_cache_manager()
+
+    def test_missing_weight_distribution_dependency_ignores_model_without_initializers(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        monkeypatch.setitem(sys.modules, "scipy", None)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is True
+        assert "scan_outcome" not in result.metadata
+        assert self._coverage_checks(result) == []
+
+    def test_missing_weight_distribution_dependency_ignores_1d_only_initializers(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        model_path = create_onnx_model(tmp_path, tensor_shape=(4,))
+        monkeypatch.setitem(sys.modules, "scipy", None)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is True
+        assert "scan_outcome" not in result.metadata
+        assert self._coverage_checks(result) == []
 
     def test_missing_weight_distribution_dependency_is_inconclusive(
         self,
@@ -815,11 +879,13 @@ class TestWeightDistributionCoverage:
         assert result.success is False
         assert result.has_errors is False
         assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
-        assert "onnx_weight_distribution_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+        assert self._INCONCLUSIVE_REASON in result.metadata["scan_outcome_reasons"]
         assert len(coverage_checks) == 1
         assert coverage_checks[0].status == CheckStatus.FAILED
         assert coverage_checks[0].severity == IssueSeverity.INFO
+        assert "Weight distribution analysis dependency unavailable:" in coverage_checks[0].message
         assert coverage_checks[0].details["coverage_gap"] == "missing_dependency"
+        self._assert_uncached_inconclusive_exit2(model_path, tmp_path / "cache")
 
     def test_external_weight_distribution_tensors_are_inconclusive(self, tmp_path: Path) -> None:
         model_path = create_onnx_model(
@@ -836,12 +902,16 @@ class TestWeightDistributionCoverage:
         assert result.success is False
         assert result.has_errors is False
         assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
-        assert "onnx_weight_distribution_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+        assert self._INCONCLUSIVE_REASON in result.metadata["scan_outcome_reasons"]
         assert len(coverage_checks) == 1
+        assert (
+            coverage_checks[0].message == "Weight distribution analysis skipped one or more eligible ONNX initializers"
+        )
         assert coverage_checks[0].details["coverage_gap"] == "partial_initializer_coverage"
         assert coverage_checks[0].details["eligible_initializers"] == 1
         assert coverage_checks[0].details["external_initializers_skipped"] == 1
         assert coverage_checks[0].details["analyzed_initializers"] == 0
+        self._assert_uncached_inconclusive_exit2(model_path, tmp_path / "cache")
 
     def test_oversized_weight_distribution_tensors_are_inconclusive(self, tmp_path: Path) -> None:
         model_path = create_onnx_model(tmp_path, tensor_shape=(2, 2))
@@ -852,9 +922,13 @@ class TestWeightDistributionCoverage:
         assert result.success is False
         assert result.has_errors is False
         assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
-        assert "onnx_weight_distribution_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+        assert self._INCONCLUSIVE_REASON in result.metadata["scan_outcome_reasons"]
         assert len(coverage_checks) == 1
+        assert (
+            coverage_checks[0].message == "Weight distribution analysis skipped one or more eligible ONNX initializers"
+        )
         assert coverage_checks[0].details["coverage_gap"] == "partial_initializer_coverage"
         assert coverage_checks[0].details["eligible_initializers"] == 1
         assert coverage_checks[0].details["oversized_initializers_skipped"] == 1
         assert coverage_checks[0].details["analyzed_initializers"] == 0
+        self._assert_uncached_inconclusive_exit2(model_path, tmp_path / "cache", max_array_size=1)

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -1,4 +1,5 @@
 import struct
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -791,3 +792,69 @@ class TestExternalDataSizeValidation:
         assert len(size_checks) > 0
         assert size_checks[0].severity == IssueSeverity.CRITICAL
         assert "non-negative" in size_checks[0].message.lower()
+
+
+class TestWeightDistributionCoverage:
+    """Tests for ONNX weight-distribution analysis coverage gaps."""
+
+    @staticmethod
+    def _coverage_checks(result: Any) -> list[Any]:
+        return [c for c in result.checks if c.name == "Weight Distribution Analysis Coverage"]
+
+    def test_missing_weight_distribution_dependency_is_inconclusive(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        model_path = create_onnx_model(tmp_path, tensor_shape=(2, 2))
+        monkeypatch.setitem(sys.modules, "scipy", None)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        coverage_checks = self._coverage_checks(result)
+        assert result.success is False
+        assert result.has_errors is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "onnx_weight_distribution_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+        assert len(coverage_checks) == 1
+        assert coverage_checks[0].status == CheckStatus.FAILED
+        assert coverage_checks[0].severity == IssueSeverity.INFO
+        assert coverage_checks[0].details["coverage_gap"] == "missing_dependency"
+
+    def test_external_weight_distribution_tensors_are_inconclusive(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model(
+            tmp_path,
+            external=True,
+            external_path="weights.bin",
+            external_file_bytes=struct.pack("ffff", 1.0, 2.0, 3.0, 4.0),
+            tensor_shape=(2, 2),
+        )
+
+        result = OnnxScanner().scan(str(model_path))
+
+        coverage_checks = self._coverage_checks(result)
+        assert result.success is False
+        assert result.has_errors is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "onnx_weight_distribution_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+        assert len(coverage_checks) == 1
+        assert coverage_checks[0].details["coverage_gap"] == "partial_initializer_coverage"
+        assert coverage_checks[0].details["eligible_initializers"] == 1
+        assert coverage_checks[0].details["external_initializers_skipped"] == 1
+        assert coverage_checks[0].details["analyzed_initializers"] == 0
+
+    def test_oversized_weight_distribution_tensors_are_inconclusive(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model(tmp_path, tensor_shape=(2, 2))
+
+        result = OnnxScanner({"max_array_size": 1}).scan(str(model_path))
+
+        coverage_checks = self._coverage_checks(result)
+        assert result.success is False
+        assert result.has_errors is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "onnx_weight_distribution_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+        assert len(coverage_checks) == 1
+        assert coverage_checks[0].details["coverage_gap"] == "partial_initializer_coverage"
+        assert coverage_checks[0].details["eligible_initializers"] == 1
+        assert coverage_checks[0].details["oversized_initializers_skipped"] == 1
+        assert coverage_checks[0].details["analyzed_initializers"] == 0


### PR DESCRIPTION
## Summary
- Mark ONNX weight-distribution analysis inconclusive when SciPy/analysis dependencies are unavailable.
- Track eligible 2-D+ initializers and fail closed when any are external-data-only, oversized, or fail extraction.
- Add coverage checks with explicit skip counts so partial anomaly analysis is visible in metadata and scan checks.
- Add ONNX regressions for missing dependency, external tensor, and oversized tensor coverage gaps.

## Validation
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_onnx_scanner.py tests/scanners/test_onnx_dependency_handling.py -q` (local `test_onnx_scanner.py` skipped because `onnx` is not installed)
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
- `uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`