### PR TITLE
fix: fail closed on template truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **security:** recognize RAR archives and fail closed as unsupported coverage instead of skipping `.rar` files during directory scans
 - **security:** reduce NeMo Hydra `_target_` false positives by matching suspicious identifiers on token boundaries, preserve CVE-2025-23304 details on suspicious-target findings, and reject oversized YAML members before parsing
 - **security:** preserve skipped-suffix ZIP containers when Keras config-only structure or embedded model-like `.bin` members indicate scannable content
+- **security:** fail closed when oversized NeMo YAML prevents Hydra target analysis and scan malformed Jinja2 config fallbacks beyond the initial prefix window
 - **security:** detect protocol 0/1 pickle streams with trivial opcode prefixes even when `STOP` is followed by trailing junk, while preserving plain-text near-match rejection
 - **security:** detect protocol 0/1 pickle streams whose dangerous opcode appears after large trivial padding or after a non-trivial probe-boundary prelude, reject all-trivial no-`STOP` probe prefixes, and preserve rule codes across cached scan-result round trips
 - **pickle:** propagate standalone fallback parse and stream-read failures into merged scan success, preserve truncated `.bin` fail-closed behavior, reuse non-seekable stream spools for the legacy parity pass, clamp negative stream sizes, and reset post-budget scan state between reused scanner runs

--- a/modelaudit/scanners/jinja2_template_scanner.py
+++ b/modelaudit/scanners/jinja2_template_scanner.py
@@ -524,11 +524,11 @@ class Jinja2TemplateScanner(BaseScanner):
         if file_size <= 0:
             return []
 
-        marker_offsets = self._template_marker_offsets_from_file(path)
+        window_size = self._raw_template_fallback_window_size(file_size)
+        marker_offsets = self._template_marker_offsets_from_file(path, file_size, window_size)
         if not marker_offsets:
             return []
 
-        window_size = self._raw_template_fallback_window_size(file_size)
         windows: list[tuple[int, int]] = []
         for marker_offset in marker_offsets:
             if any(start <= marker_offset < end for start, end in windows):
@@ -580,10 +580,7 @@ class Jinja2TemplateScanner(BaseScanner):
         return [text[start:end] for start, end in windows]
 
     def _raw_template_fallback_window_size(self, content_size: int) -> int:
-        configured_window_size = self.max_template_size
-        if not isinstance(configured_window_size, int) or configured_window_size <= 0:
-            configured_window_size = _RAW_PARSE_FALLBACK_READ_BYTES
-        return min(configured_window_size, _RAW_PARSE_FALLBACK_READ_BYTES, content_size)
+        return self._raw_template_fallback_window_size_for_config(content_size, self.max_template_size)
 
     @staticmethod
     def _template_marker_offsets(text: str) -> list[int]:
@@ -597,8 +594,9 @@ class Jinja2TemplateScanner(BaseScanner):
         return sorted(offsets)
 
     @staticmethod
-    def _template_marker_offsets_from_file(path: str) -> list[int]:
+    def _template_marker_offsets_from_file(path: str, file_size: int, window_size: int) -> list[int]:
         offsets: set[int] = set()
+        windows: list[tuple[int, int]] = []
         max_indicator_size = max(len(indicator) for indicator in _JINJA_TEMPLATE_INDICATOR_BYTES)
         overlap_size = max_indicator_size - 1
         overlap = b""
@@ -606,7 +604,7 @@ class Jinja2TemplateScanner(BaseScanner):
 
         try:
             with open(path, "rb") as f:
-                while len(offsets) < _RAW_PARSE_FALLBACK_MAX_WINDOWS:
+                while len(windows) < _RAW_PARSE_FALLBACK_MAX_WINDOWS:
                     chunk = f.read(_RAW_PARSE_FALLBACK_READ_BYTES)
                     if not chunk:
                         break
@@ -623,9 +621,15 @@ class Jinja2TemplateScanner(BaseScanner):
                             marker_offset = data.find(indicator, marker_offset + len(indicator))
 
                     for absolute_offset in sorted(chunk_offsets):
-                        offsets.add(absolute_offset)
-                        if len(offsets) >= _RAW_PARSE_FALLBACK_MAX_WINDOWS:
-                            break
+                        if Jinja2TemplateScanner._add_fallback_window_for_marker(
+                            windows,
+                            absolute_offset,
+                            file_size,
+                            window_size,
+                        ):
+                            offsets.add(absolute_offset)
+                            if len(windows) >= _RAW_PARSE_FALLBACK_MAX_WINDOWS:
+                                break
 
                     overlap = data[-overlap_size:] if overlap_size else b""
                     chunk_start += len(chunk)
@@ -634,6 +638,31 @@ class Jinja2TemplateScanner(BaseScanner):
             return []
 
         return sorted(offsets)
+
+    @staticmethod
+    def _raw_template_fallback_window_size_for_config(content_size: int, configured_window_size: Any) -> int:
+        if not isinstance(configured_window_size, int) or configured_window_size <= 0:
+            configured_window_size = _RAW_PARSE_FALLBACK_READ_BYTES
+        return min(configured_window_size, _RAW_PARSE_FALLBACK_READ_BYTES, content_size)
+
+    @staticmethod
+    def _fallback_window_for_marker(marker_offset: int, content_size: int, window_size: int) -> tuple[int, int]:
+        start = max(0, marker_offset - _RAW_PARSE_FALLBACK_CONTEXT_BYTES)
+        end = min(content_size, start + window_size)
+        start = max(0, end - window_size)
+        return start, end
+
+    @staticmethod
+    def _add_fallback_window_for_marker(
+        windows: list[tuple[int, int]],
+        marker_offset: int,
+        content_size: int,
+        window_size: int,
+    ) -> bool:
+        if any(start <= marker_offset < end for start, end in windows):
+            return False
+        windows.append(Jinja2TemplateScanner._fallback_window_for_marker(marker_offset, content_size, window_size))
+        return True
 
     def _extract_template_file(self, path: str) -> dict[str, str]:
         """Extract content from standalone template files"""

--- a/modelaudit/scanners/jinja2_template_scanner.py
+++ b/modelaudit/scanners/jinja2_template_scanner.py
@@ -59,6 +59,7 @@ except ImportError:
 _INCONCLUSIVE_METADATA_KEY = "scan_outcome"
 _INCONCLUSIVE_REASONS_METADATA_KEY = "scan_outcome_reasons"
 _JINJA_TEMPLATE_INDICATORS = ("{{", "{%", "{#")
+_JINJA_TEMPLATE_INDICATOR_BYTES = tuple(indicator.encode("utf-8") for indicator in _JINJA_TEMPLATE_INDICATORS)
 _RAW_PARSE_FALLBACK_CONTEXT_BYTES = 1024
 _RAW_PARSE_FALLBACK_MAX_WINDOWS = 8
 _RAW_PARSE_FALLBACK_READ_BYTES = 256 * 1024
@@ -509,26 +510,56 @@ class Jinja2TemplateScanner(BaseScanner):
         }
 
     def _extract_raw_template_fallback(self, path: str, templates: dict[str, str], template_key: str) -> None:
-        try:
-            with open(path, "rb") as f:
-                raw = f.read(_RAW_PARSE_FALLBACK_READ_BYTES)
-        except OSError as exc:
-            logger.debug("Error reading raw template fallback from %s: %s", path, exc)
-            return
-
-        text = raw.decode("utf-8", errors="replace")
-        for index, fallback_text in enumerate(self._raw_template_fallback_windows(text)):
+        for index, fallback_text in enumerate(self._raw_template_fallback_windows_from_file(path)):
             fallback_key = template_key if index == 0 else f"{template_key}_{index + 1}"
             templates[fallback_key] = fallback_text
+
+    def _raw_template_fallback_windows_from_file(self, path: str) -> list[str]:
+        try:
+            file_size = os.path.getsize(path)
+        except OSError as exc:
+            logger.debug("Error sizing raw template fallback from %s: %s", path, exc)
+            return []
+
+        if file_size <= 0:
+            return []
+
+        marker_offsets = self._template_marker_offsets_from_file(path)
+        if not marker_offsets:
+            return []
+
+        window_size = self._raw_template_fallback_window_size(file_size)
+        windows: list[tuple[int, int]] = []
+        for marker_offset in marker_offsets:
+            if any(start <= marker_offset < end for start, end in windows):
+                continue
+
+            start = max(0, marker_offset - _RAW_PARSE_FALLBACK_CONTEXT_BYTES)
+            end = min(file_size, start + window_size)
+            start = max(0, end - window_size)
+            windows.append((start, end))
+
+            if len(windows) >= _RAW_PARSE_FALLBACK_MAX_WINDOWS:
+                break
+
+        fallback_windows: list[str] = []
+        try:
+            with open(path, "rb") as f:
+                for start, end in windows:
+                    f.seek(start)
+                    raw = f.read(end - start)
+                    fallback_windows.append(raw.decode("utf-8", errors="replace"))
+        except OSError as exc:
+            logger.debug("Error reading raw template fallback from %s: %s", path, exc)
+            return []
+
+        return fallback_windows
 
     def _raw_template_fallback_windows(self, text: str) -> list[str]:
         if not self._looks_like_template(text):
             return []
 
-        configured_window_size = self.max_template_size
-        if not isinstance(configured_window_size, int) or configured_window_size <= 0:
-            configured_window_size = _RAW_PARSE_FALLBACK_READ_BYTES
-        window_size = min(configured_window_size, _RAW_PARSE_FALLBACK_READ_BYTES, len(text))
+        window_size = self._raw_template_fallback_window_size(len(text))
 
         if len(text) <= window_size:
             return [text]
@@ -548,6 +579,12 @@ class Jinja2TemplateScanner(BaseScanner):
 
         return [text[start:end] for start, end in windows]
 
+    def _raw_template_fallback_window_size(self, content_size: int) -> int:
+        configured_window_size = self.max_template_size
+        if not isinstance(configured_window_size, int) or configured_window_size <= 0:
+            configured_window_size = _RAW_PARSE_FALLBACK_READ_BYTES
+        return min(configured_window_size, _RAW_PARSE_FALLBACK_READ_BYTES, content_size)
+
     @staticmethod
     def _template_marker_offsets(text: str) -> list[int]:
         offsets: set[int] = set()
@@ -556,6 +593,45 @@ class Jinja2TemplateScanner(BaseScanner):
             while marker_offset != -1:
                 offsets.add(marker_offset)
                 marker_offset = text.find(indicator, marker_offset + len(indicator))
+
+        return sorted(offsets)
+
+    @staticmethod
+    def _template_marker_offsets_from_file(path: str) -> list[int]:
+        offsets: set[int] = set()
+        max_indicator_size = max(len(indicator) for indicator in _JINJA_TEMPLATE_INDICATOR_BYTES)
+        overlap_size = max_indicator_size - 1
+        overlap = b""
+        chunk_start = 0
+
+        try:
+            with open(path, "rb") as f:
+                while len(offsets) < _RAW_PARSE_FALLBACK_MAX_WINDOWS:
+                    chunk = f.read(_RAW_PARSE_FALLBACK_READ_BYTES)
+                    if not chunk:
+                        break
+
+                    data_start = max(0, chunk_start - len(overlap))
+                    data = overlap + chunk
+                    chunk_offsets: set[int] = set()
+                    for indicator in _JINJA_TEMPLATE_INDICATOR_BYTES:
+                        marker_offset = data.find(indicator)
+                        while marker_offset != -1:
+                            absolute_offset = data_start + marker_offset
+                            if absolute_offset not in offsets:
+                                chunk_offsets.add(absolute_offset)
+                            marker_offset = data.find(indicator, marker_offset + len(indicator))
+
+                    for absolute_offset in sorted(chunk_offsets):
+                        offsets.add(absolute_offset)
+                        if len(offsets) >= _RAW_PARSE_FALLBACK_MAX_WINDOWS:
+                            break
+
+                    overlap = data[-overlap_size:] if overlap_size else b""
+                    chunk_start += len(chunk)
+        except OSError as exc:
+            logger.debug("Error searching raw template fallback markers in %s: %s", path, exc)
+            return []
 
         return sorted(offsets)
 

--- a/modelaudit/scanners/nemo_scanner.py
+++ b/modelaudit/scanners/nemo_scanner.py
@@ -231,6 +231,7 @@ class NemoScanner(BaseScanner):
         message: str,
         location: str,
         details: dict[str, Any] | None = None,
+        severity: IssueSeverity = IssueSeverity.INFO,
     ) -> None:
         reasons = result.metadata.get(_INCONCLUSIVE_REASONS_METADATA_KEY)
         if not isinstance(reasons, list):
@@ -244,7 +245,7 @@ class NemoScanner(BaseScanner):
             name=check_name,
             passed=False,
             message=message,
-            severity=IssueSeverity.INFO,
+            severity=severity,
             location=location,
             details={"scan_outcome_reason": reason, **(details or {})},
         )
@@ -353,12 +354,18 @@ class NemoScanner(BaseScanner):
                 if name_lower.endswith((".yaml", ".yml")):
                     yaml_config_files_found += 1
                     if member.size > self.MAX_CONFIG_SIZE:
-                        result.add_check(
-                            name="NeMo Config Size Check",
-                            passed=False,
+                        self._mark_inconclusive_scan_result(
+                            result,
+                            reason="nemo_config_size_limit",
+                            check_name="NeMo Config Size Check",
                             message=(f"Config file too large: {member.name} ({member.size} bytes)"),
-                            severity=IssueSeverity.WARNING,
                             location=f"{path}:{member.name}",
+                            severity=IssueSeverity.WARNING,
+                            details={
+                                "config_file": member.name,
+                                "size_bytes": member.size,
+                                "max_config_size": self.MAX_CONFIG_SIZE,
+                            },
                         )
                         continue
 
@@ -369,12 +376,18 @@ class NemoScanner(BaseScanner):
                         try:
                             raw = f.read(self.MAX_CONFIG_SIZE + 1)
                             if len(raw) > self.MAX_CONFIG_SIZE:
-                                result.add_check(
-                                    name="NeMo Config Size Check",
-                                    passed=False,
+                                self._mark_inconclusive_scan_result(
+                                    result,
+                                    reason="nemo_config_size_limit",
+                                    check_name="NeMo Config Size Check",
                                     message=(f"Config file too large: {member.name} ({len(raw)} bytes)"),
-                                    severity=IssueSeverity.WARNING,
                                     location=f"{path}:{member.name}",
+                                    severity=IssueSeverity.WARNING,
+                                    details={
+                                        "config_file": member.name,
+                                        "size_bytes": len(raw),
+                                        "max_config_size": self.MAX_CONFIG_SIZE,
+                                    },
                                 )
                                 continue
                             config = yaml.safe_load(raw)

--- a/tests/scanners/test_jinja2_template_scanner.py
+++ b/tests/scanners/test_jinja2_template_scanner.py
@@ -409,6 +409,33 @@ class TestJinja2TemplateScannerEdgeCases:
         )
         assert determine_exit_code(aggregate_result) == 1
 
+    def test_malformed_large_json_raw_template_fallback_ignores_clustered_benign_markers(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Clustered early markers should not consume the full fallback window budget."""
+        tokenizer_file = tmp_path / "tokenizer_config.json"
+        benign_prefix = "".join("{{ content }}" for _ in range(8))
+        payload = "{{ lipsum.__globals__.os.popen('id').read() }}"
+        tokenizer_file.write_text(
+            '{"chat_template":"' + benign_prefix + ("a" * 400000) + payload + ("b" * 1000),
+            encoding="utf-8",
+        )
+
+        result = Jinja2TemplateScanner().scan(str(tokenizer_file))
+
+        assert result.metadata["scan_outcome"] == "inconclusive"
+        assert "jinja2_json_parse_failed" in result.metadata["scan_outcome_reasons"]
+        failed_checks = [c for c in result.checks if c.name == "Jinja2 Template Injection Detection"]
+        assert failed_checks
+        assert any(str(c.details.get("template_location")).startswith("raw_json_parse_fallback") for c in failed_checks)
+
+        aggregate_result = scan_model_directory_or_file(
+            str(tokenizer_file),
+            config={"cache_scan_results": False},
+        )
+        assert determine_exit_code(aggregate_result) == 1
+
     def test_malformed_large_json_benign_raw_template_stays_inconclusive_only(self, tmp_path: Path) -> None:
         """Benign raw-template recovery should not create security findings."""
         tokenizer_file = tmp_path / "tokenizer_config.json"

--- a/tests/scanners/test_jinja2_template_scanner.py
+++ b/tests/scanners/test_jinja2_template_scanner.py
@@ -386,6 +386,29 @@ class TestJinja2TemplateScannerEdgeCases:
         )
         assert determine_exit_code(aggregate_result) == 1
 
+    def test_malformed_large_json_raw_template_fallback_detects_ssti_after_prefix(self, tmp_path: Path) -> None:
+        """Raw fallback should find template markers beyond the initial read window."""
+        tokenizer_file = tmp_path / "tokenizer_config.json"
+        payload = "{{ lipsum.__globals__.os.popen('id').read() }}"
+        tokenizer_file.write_text(
+            '{"chat_template":"' + ("a" * 300000) + payload + ("b" * 70000),
+            encoding="utf-8",
+        )
+
+        result = Jinja2TemplateScanner().scan(str(tokenizer_file))
+
+        assert result.metadata["scan_outcome"] == "inconclusive"
+        assert "jinja2_json_parse_failed" in result.metadata["scan_outcome_reasons"]
+        failed_checks = [c for c in result.checks if c.name == "Jinja2 Template Injection Detection"]
+        assert failed_checks
+        assert any(str(c.details.get("template_location")).startswith("raw_json_parse_fallback") for c in failed_checks)
+
+        aggregate_result = scan_model_directory_or_file(
+            str(tokenizer_file),
+            config={"cache_scan_results": False},
+        )
+        assert determine_exit_code(aggregate_result) == 1
+
     def test_malformed_large_json_benign_raw_template_stays_inconclusive_only(self, tmp_path: Path) -> None:
         """Benign raw-template recovery should not create security findings."""
         tokenizer_file = tmp_path / "tokenizer_config.json"

--- a/tests/scanners/test_nemo_scanner.py
+++ b/tests/scanners/test_nemo_scanner.py
@@ -846,6 +846,10 @@ class TestCVE202523304HydraTarget:
         assert len(size_checks) == 1
         assert size_checks[0].status == CheckStatus.FAILED
         assert size_checks[0].severity == IssueSeverity.WARNING
+        assert size_checks[0].details["scan_outcome_reason"] == "nemo_config_size_limit"
+        assert size_checks[0].details["max_config_size"] == NemoScanner.MAX_CONFIG_SIZE
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "nemo_config_size_limit" in result.metadata["scan_outcome_reasons"]
 
     def test_safe_nemo_target_passes(self, tmp_path):
         """Known-safe NeMo/PyTorch targets should pass."""

--- a/tests/scanners/test_nemo_scanner.py
+++ b/tests/scanners/test_nemo_scanner.py
@@ -16,6 +16,7 @@ try:
 except ImportError:
     HAS_YAML = False
 
+from modelaudit.cache import get_cache_manager, reset_cache_manager
 from modelaudit.core import determine_exit_code, scan_file, scan_model_directory_or_file
 from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity
 from modelaudit.scanners.nemo_scanner import NemoScanner, _get_nested_scanner_for_file
@@ -846,10 +847,31 @@ class TestCVE202523304HydraTarget:
         assert len(size_checks) == 1
         assert size_checks[0].status == CheckStatus.FAILED
         assert size_checks[0].severity == IssueSeverity.WARNING
+        assert size_checks[0].message == (f"Config file too large: model_config.yaml ({len(oversized_config)} bytes)")
         assert size_checks[0].details["scan_outcome_reason"] == "nemo_config_size_limit"
         assert size_checks[0].details["max_config_size"] == NemoScanner.MAX_CONFIG_SIZE
+        assert result.success is True
         assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
         assert "nemo_config_size_limit" in result.metadata["scan_outcome_reasons"]
+
+        cache_dir = tmp_path / "cache"
+        reset_cache_manager()
+        try:
+            aggregate = scan_model_directory_or_file(
+                str(path),
+                cache_enabled=True,
+                cache_dir=str(cache_dir),
+                min_cache_file_size=0,
+            )
+            metadata = aggregate.file_metadata[str(path)]
+
+            assert aggregate.success is True
+            assert metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+            assert metadata["scan_outcome_reasons"] == ["nemo_config_size_limit"]
+            assert determine_exit_code(aggregate) == 1
+            assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+        finally:
+            reset_cache_manager()
 
     def test_safe_nemo_target_passes(self, tmp_path):
         """Known-safe NeMo/PyTorch targets should pass."""


### PR DESCRIPTION
## Summary
- mark oversized NeMo YAML configs as inconclusive coverage while preserving the existing warning signal
- scan malformed Jinja2 JSON/YAML fallback windows across the full file instead of only the first 256 KiB
- add regressions for post-prefix SSTI payload recovery and NeMo size-limit metadata

## Validation
- uv run ruff format modelaudit/scanners/nemo_scanner.py modelaudit/scanners/jinja2_template_scanner.py tests/scanners/test_nemo_scanner.py tests/scanners/test_jinja2_template_scanner.py
- uv run ruff check modelaudit/scanners/nemo_scanner.py modelaudit/scanners/jinja2_template_scanner.py tests/scanners/test_nemo_scanner.py tests/scanners/test_jinja2_template_scanner.py
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_jinja2_template_scanner.py tests/scanners/test_nemo_scanner.py -q
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1