### PR TITLE
test(metadata): cover helper-routed extractor selection

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,7 @@ def pytest_runtest_setup(item):
             "test_core_asset_extraction.py",  # Check consolidation and location parsing regressions
             "test_manifest_scanner.py",  # Manifest scanner tests
             "test_metadata_scanner.py",  # Metadata scanner tests
+            "test_metadata_extractor.py",  # Metadata extractor helper routing and CLI tests
             "test_weak_hash_detection.py",  # Weak hash detection tests
             "test_cloud_url_detection.py",  # Cloud storage URL detection tests
             "tests/utils/sources/test_cloud_storage.py",  # Cloud storage source tests

--- a/tests/test_metadata_extractor.py
+++ b/tests/test_metadata_extractor.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import pytest
 
+import modelaudit.metadata_extractor as metadata_extractor_module
 from modelaudit.metadata_extractor import ModelMetadataExtractor
 from modelaudit.utils import tensorflow_compat
 from modelaudit.utils.tensorflow_compat import has_tensorflow_protobuf_stubs as _has_tf_protos
@@ -33,6 +34,39 @@ def test_has_tensorflow_protobuf_stubs_fails_closed_on_probe_error(monkeypatch: 
 
 class TestModelMetadataExtractor:
     """Test the ModelMetadataExtractor class."""
+
+    def test_extract_metadata_uses_scanner_helper_with_deserialization_config(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Metadata extraction should route through the helper-based scanner lookup."""
+        extractor = ModelMetadataExtractor()
+        target = tmp_path / "helper-routed.model"
+        target.write_bytes(b"placeholder")
+        helper_calls: list[tuple[str, dict[str, Any] | None]] = []
+
+        class HelperSelectedScanner:
+            def __init__(self) -> None:
+                self.name = "helper_selected"
+
+            def extract_metadata(self, file_path: str) -> dict[str, Any]:
+                assert file_path == str(target)
+                return {"file_size": 123}
+
+        def fake_get_scanner_for_file(path: str, config: dict[str, Any] | None = None) -> HelperSelectedScanner:
+            helper_calls.append((path, config))
+            return HelperSelectedScanner()
+
+        monkeypatch.setattr(metadata_extractor_module, "get_scanner_for_file", fake_get_scanner_for_file)
+
+        metadata = extractor.extract(str(target), allow_deserialization=True)
+
+        assert helper_calls == [(str(target), {"allow_metadata_deserialization": True})]
+        assert metadata["format"] == "helper_selected"
+        assert metadata["file"] == target.name
+        assert metadata["path"] == str(target)
+        assert metadata["file_size"] == 123
 
     def test_extract_metadata_unknown_format(self) -> None:
         """Test metadata extraction with unknown file format."""
@@ -449,6 +483,37 @@ class TestModelMetadataExtractor:
         assert "Simulated extraction failure" in metadata["extraction_error"]
         assert metadata["file"] == "broken.safetensors"
         assert metadata["format"] == "safetensors"
+
+    def test_extract_metadata_uses_instance_name_when_helper_scanner_extraction_fails(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Helper-selected scanners should still populate format from the instance on failure."""
+        extractor = ModelMetadataExtractor()
+        target = tmp_path / "instance-name-only.model"
+        target.write_bytes(b"placeholder")
+
+        class InstanceNamedScanner:
+            def __init__(self) -> None:
+                self.name = "instance_only_format"
+
+            def extract_metadata(self, file_path: str) -> dict[str, Any]:
+                raise RuntimeError(f"failed to read {Path(file_path).name}")
+
+        def fake_get_scanner_for_file(path: str, config: dict[str, Any] | None = None) -> InstanceNamedScanner | None:
+            assert path == str(target)
+            assert config == {"allow_metadata_deserialization": False}
+            return InstanceNamedScanner()
+
+        monkeypatch.setattr(metadata_extractor_module, "get_scanner_for_file", fake_get_scanner_for_file)
+
+        metadata = extractor.extract(str(target))
+
+        assert metadata["format"] == "instance_only_format"
+        assert metadata["file"] == target.name
+        assert metadata["path"] == str(target)
+        assert metadata["extraction_error"] == f"failed to read {target.name}"
 
 
 class TestPickleDangerousOpcodes:


### PR DESCRIPTION
## Summary
- add metadata extractor regression coverage for helper-based scanner lookup
- assert allow_metadata_deserialization is forwarded into get_scanner_for_file
- pin instance-name format fallback when helper-selected scanners fail during metadata extraction

## Root Cause
The metadata extractor was recently refactored to use get_scanner_for_file, but tests did not verify the new helper call path or the scanner-instance format fallback.

## Validation
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest tests/test_metadata_extractor.py -k "scanner_helper or instance_name_when_helper_scanner_extraction_fails" --maxfail=1
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest -n auto -m "not slow and not integration" --maxfail=1