### PR TITLE
test: address AI quality findings

### DIFF
--- a/tests/scanners/test_sevenzip_scanner.py
+++ b/tests/scanners/test_sevenzip_scanner.py
@@ -233,6 +233,7 @@ class TestSevenZipScanner:
 
                 assert result.success is False
                 assert len(result.issues) > 0  # But issues are found
+                assert any("eval" in getattr(issue, "message", "").lower() for issue in result.issues)
                 mock_scan_file.assert_called_once()
 
                 # Check that location was adjusted for archive context
@@ -842,7 +843,7 @@ class TestSevenZipScanner:
         tmp_path: Path,
     ) -> None:
         """Only header-confirmed extensionless members should reach the full extraction pass."""
-        extensionless_members = [f"asset_{index:03d}" for index in range(32)]
+        extensionless_members = [f"asset_{index:03d}" for index in range(3)]
         archive_path = tmp_path / "filter_probe.7z"
         archive_path.write_bytes(scanner._SEVENZIP_MAGIC + b"\0" * 26)
 
@@ -1632,43 +1633,77 @@ class TestSevenZipScannerHardening:
             assert len(depth_checks) >= 1
             assert result.metadata.get("file_size") is not None
 
-    # -- _HeaderProbeBuffer empty write guard ---------------------------------
+    # -- nested header probe behavior via scanner API -------------------------
 
-    def test_header_probe_buffer_empty_write_returns_zero(self) -> None:
-        """_HeaderProbeBuffer.write(b'') must return 0 without looping."""
-        from modelaudit.scanners.sevenzip_scanner import _HeaderProbeBuffer
+    def test_extensionless_probe_without_header_is_not_scanned(
+        self,
+        scanner: SevenZipScanner,
+        tmp_path: Path,
+    ) -> None:
+        """Extensionless members without captured archive headers should be ignored."""
+        archive_path = tmp_path / "empty_probe.7z"
+        archive_path.write_bytes(scanner._SEVENZIP_MAGIC + b"\0" * 26)
 
-        buf = _HeaderProbeBuffer(limit=6)
-        written = buf.write(b"")
-        assert written == 0
-        assert buf.size() == 0
+        with (
+            patch("modelaudit.scanners.sevenzip_scanner.HAS_PY7ZR", True),
+            patch("modelaudit.scanners.sevenzip_scanner.py7zr") as mock_py7zr,
+            patch.object(scanner, "_scan_extracted_file") as mock_scan_extracted_file,
+            patch("os.path.isfile", return_value=True),
+            patch("os.path.getsize", return_value=32),
+        ):
 
-    def test_header_probe_buffer_normal_flow(self) -> None:
-        """_HeaderProbeBuffer should capture up to limit bytes then raise."""
-        from modelaudit.scanners.sevenzip_scanner import (
-            _HeaderProbeBuffer,
-            _HeaderProbeComplete,
-        )
+            def fake_extract(*_args: Any, **kwargs: Any) -> None:
+                factory = kwargs.get("factory")
+                if factory is not None:
+                    factory.create("nested_payload").write(b"")
 
-        buf = _HeaderProbeBuffer(limit=6)
-        buf.write(b"\x37\x7a")  # 2 bytes
-        assert buf.size() == 2
-        with pytest.raises(_HeaderProbeComplete):
-            buf.write(b"\xbc\xaf\x27\x1c\x00\x00")  # 8 bytes, only 4 more captured
-        buf.seek(0)
-        assert buf.read(6) == b"\x37\x7a\xbc\xaf\x27\x1c"
+            mock_archive = MagicMock()
+            mock_archive.getnames.return_value = ["nested_payload"]
+            mock_archive.getinfo.return_value = MagicMock(uncompressed=16, is_directory=False)
+            mock_archive.extract.side_effect = fake_extract
+            mock_py7zr.SevenZipFile.return_value.__enter__.return_value = mock_archive
 
-    def test_probe_detected_format_recognizes_tar_headers(self) -> None:
-        """Header probes should classify nested TAR members without relying on suffixes."""
-        from modelaudit.scanners.sevenzip_scanner import _HeaderProbeBuffer
+            result = scanner.scan(str(archive_path))
 
+            assert result.success
+            assert result.metadata["scannable_files"] == 0
+            assert mock_scan_extracted_file.call_count == 0
+
+    def test_extensionless_tar_header_reaches_full_extraction(self, tmp_path: Path) -> None:
+        """Header probes should route extensionless TAR members through scanner extraction."""
         scanner = SevenZipScanner()
-        buf = _HeaderProbeBuffer(limit=scanner._NESTED_MEMBER_PROBE_BYTES, raise_on_limit=False)
+        archive_path = tmp_path / "tar_probe.7z"
+        archive_path.write_bytes(scanner._SEVENZIP_MAGIC + b"\0" * 26)
+
         tar_header = bytearray(scanner._NESTED_MEMBER_PROBE_BYTES)
         tar_header[257:262] = b"ustar"
-        buf.write(bytes(tar_header))
 
-        assert scanner._probe_detected_format(buf) == "tar"
+        with (
+            patch("modelaudit.scanners.sevenzip_scanner.HAS_PY7ZR", True),
+            patch("modelaudit.scanners.sevenzip_scanner.py7zr") as mock_py7zr,
+            patch.object(scanner, "_has_7z_magic", return_value=True),
+            patch.object(scanner, "_scan_extracted_file", return_value=_mock_scan_result()) as mock_scan_extracted_file,
+            patch("os.path.isfile", return_value=True),
+            patch("os.path.islink", return_value=False),
+            patch("os.path.getsize", return_value=32),
+        ):
+
+            def fake_extract(*_args: Any, **kwargs: Any) -> None:
+                factory = kwargs.get("factory")
+                if factory is not None:
+                    factory.create("nested_payload").write(bytes(tar_header))
+
+            mock_archive = MagicMock()
+            mock_archive.getnames.return_value = ["nested_payload"]
+            mock_archive.getinfo.return_value = MagicMock(uncompressed=16, is_directory=False)
+            mock_archive.extract.side_effect = fake_extract
+            mock_py7zr.SevenZipFile.return_value.__enter__.return_value = mock_archive
+
+            result = scanner.scan(str(archive_path))
+
+            assert result.success
+            assert result.metadata["scannable_files"] == 1
+            mock_scan_extracted_file.assert_called_once()
 
     # -- default config includes new limits -----------------------------------
 

--- a/tests/scanners/test_xgboost_scanner.py
+++ b/tests/scanners/test_xgboost_scanner.py
@@ -195,7 +195,12 @@ class TestXGBoostScannerBasic:
 class TestXGBoostJSONScanning:
     """Test XGBoost JSON model scanning."""
 
-    def test_valid_json_model_passes(self, temp_dir, xgboost_scanner, valid_xgboost_json):
+    def test_valid_json_model_passes(
+        self,
+        temp_dir: Path,
+        xgboost_scanner: XGBoostScanner,
+        valid_xgboost_json: dict[str, Any],
+    ) -> None:
         """Test that valid XGBoost JSON model passes all checks."""
         json_file = temp_dir / "valid_model.json"
         json_file.write_text(json.dumps(valid_xgboost_json, indent=2))
@@ -208,7 +213,7 @@ class TestXGBoostJSONScanning:
         assert len(passing_checks) > 0
 
         # Should not have critical issues
-        critical_issues = [i for i in result.issues if i.severity == IssueSeverity.INFO]
+        critical_issues = [i for i in result.issues if i.severity == IssueSeverity.CRITICAL]
         assert len(critical_issues) == 0
 
     def test_invalid_json_fails(self, temp_dir: Path, xgboost_scanner: XGBoostScanner) -> None:

--- a/tests/test_regression_corpus.py
+++ b/tests/test_regression_corpus.py
@@ -21,7 +21,10 @@ from tests.assets.generators.generate_safetensors_assets import generate_safeten
 ASSETS = Path(__file__).parent / "assets"
 EXPLOITS_DIR = ASSETS / "exploits"
 SAFE_PICKLES_DIR = ASSETS / "samples" / "pickles"
-MALICIOUS_PICKLES_DIR = ASSETS / "samples" / "pickles"
+_DEDICATED_MALICIOUS_PICKLES_DIR = ASSETS / "samples" / "malicious_pickles"
+MALICIOUS_PICKLES_DIR = (
+    _DEDICATED_MALICIOUS_PICKLES_DIR if _DEDICATED_MALICIOUS_PICKLES_DIR.exists() else SAFE_PICKLES_DIR
+)
 SAFE_SAFETENSORS_DIR = ASSETS / "samples" / "safetensors"
 SAFE_PYTORCH_DIR = ASSETS / "samples" / "pytorch"
 SAFE_ARCHIVES_DIR = ASSETS / "samples" / "archives"

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -25,7 +25,7 @@ from modelaudit.telemetry import (
 class TestUserConfig:
     """Test user configuration management."""
 
-    def test_user_config_creates_user_id(self):
+    def test_user_config_creates_user_id(self) -> None:
         """Test that user config generates a UUID."""
         with tempfile.TemporaryDirectory() as temp_dir:
             config_file = Path(temp_dir) / ".modelaudit" / "user_config.json"
@@ -36,6 +36,7 @@ class TestUserConfig:
 
                 assert config.user_id
                 assert len(config.user_id) == 36  # UUID length
+                assert config_file.parent.exists()
                 assert config_file.exists()
 
     def test_user_config_defaults_to_enabled(self):
@@ -708,13 +709,13 @@ class TestTelemetryIntegration:
             # Should still work without PostHog
             assert client._posthog_client is None
 
-    @patch("modelaudit.core_results.record_issue_found")
-    def test_core_scan_emits_issue_found_telemetry(self, mock_record_issue_found):
+    def test_core_scan_emits_issue_found_telemetry(self) -> None:
         """Core scans should emit issue telemetry for detected findings."""
         from modelaudit.core import scan_model_directory_or_file
 
         sample = Path(__file__).parent / "assets" / "samples" / "pickles" / "malicious_system_call.pkl"
-        result = scan_model_directory_or_file(str(sample))
+        with patch("modelaudit.core_results.record_issue_found") as mock_record_issue_found:
+            result = scan_model_directory_or_file(str(sample))
 
         assert len(result.issues) > 0
         assert mock_record_issue_found.call_count > 0

--- a/tests/test_telemetry_decoupling.py
+++ b/tests/test_telemetry_decoupling.py
@@ -253,7 +253,7 @@ class TestTelemetryFunctionalityWhenWorking:
 
         assert result == "executed successfully"
 
-    def test_record_issue_found_uses_stable_redacted_issue_type(self, tmp_path: Path) -> None:
+    def test_record_issue_found_redacts_sensitive_data(self, tmp_path: Path) -> None:
         """Issue telemetry should not copy free-form scanner messages into analytics fields."""
         captured: dict[str, object] = {}
 
@@ -282,7 +282,7 @@ class TestTelemetryFunctionalityWhenWorking:
         assert str(sensitive_path) not in serialized
         assert "token=secret" not in serialized
 
-    def test_record_issue_found_rejects_token_shaped_issue_text(self, tmp_path: Path) -> None:
+    def test_record_issue_found_filters_token_like_strings(self, tmp_path: Path) -> None:
         """Slug-like filenames and tokens must not be treated as stable issue IDs."""
         captured: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary
- strengthen 7z scanner tests to assert malicious eval reporting and exercise nested header probing through scanner-level behavior
- fix XGBoost critical-issue assertion and clarify regression corpus pickle fixture routing
- tighten telemetry tests with clearer names, parent directory assertion, and localized issue telemetry patching

## Validation
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1

## Notes
- I reviewed all 9 GitHub AI quality findings from the repository Security and quality page in Chrome and addressed each one.
- The telemetry finding suggested patching modelaudit.core.record_issue_found, but the single-file scan path emits through modelaudit.core_results.add_scan_result_to_model, so the test now uses a localized patch on modelaudit.core_results.record_issue_found.