### PR TITLE
feat: add scanner selection controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **cli:** add scanner selection with `--scanners`, `--exclude-scanner`, and `--list-scanners` wired into core routing, nested dispatch, remote prefilters, and scan metadata
 - **pickle:** replace the standalone pickle scanner's package-engine selector with the Rust-only runtime and explicit native-extension errors
 - **pickle:** scan PyTorch ZIP checkpoint pickle members directly in the standalone pickle scanner
 - **pickle:** bundle the standalone `modelaudit_picklescan` API in the root `modelaudit` wheel and add source-tree coverage for the package boundary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **cli:** add scanner selection with `--scanners`, `--exclude-scanner`, and `--list-scanners` wired into core routing, nested dispatch, remote prefilters, and scan metadata
+- **cli:** add scanner selection with `--scanners`, `--exclude-scanner`, and `--list-scanners` wired into core routing, nested dispatch, remote prefilters, and scan metadata; selection-suppressed preferred scanners emit a stderr warning and populate `scanner_selection.suppressed_preferred_scanner_ids`, and unknown scanner names suggest the closest match
 - **pickle:** replace the standalone pickle scanner's package-engine selector with the Rust-only runtime and explicit native-extension errors
 - **pickle:** scan PyTorch ZIP checkpoint pickle members directly in the standalone pickle scanner
 - **pickle:** bundle the standalone `modelaudit_picklescan` API in the root `modelaudit` wheel and add source-tree coverage for the package boundary

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Primary commands:
 ```bash
 modelaudit [PATHS...]                           # Default scan command
 modelaudit scan [OPTIONS] PATHS...              # Explicit scan command
+modelaudit scan --list-scanners                 # List scanner IDs for targeted scans
 modelaudit metadata [OPTIONS] PATH              # Extract model metadata safely (no deserialization by default)
 modelaudit doctor [--show-failed]               # Diagnose scanner/dependency availability
 modelaudit debug [--json] [--verbose]           # Environment and configuration diagnostics
@@ -176,7 +177,32 @@ Common scan options:
 --no-cache                   Disable result caching
 --cache-dir DIR              Set cache directory for downloads and scan results
 --progress                   Force progress display
+--scanners LIST              Only run selected scanners (IDs/classes; comma-separated or repeated)
+--exclude-scanner NAME       Exclude a scanner from the active set (comma-separated or repeated)
+--list-scanners              List scanner IDs, class names, extensions, and dependencies
 ```
+
+Targeted scanner selection:
+
+```bash
+# Discover scanner IDs and class names
+modelaudit scan --list-scanners
+modelaudit scan --list-scanners --format json
+
+# Run only selected scanners
+modelaudit scan ./models --scanners pickle,tf_savedmodel
+modelaudit scan ./model.pkl --scanners PickleScanner
+
+# Run the default scanner set except a noisy or slow scanner
+modelaudit scan ./models --exclude-scanner weight_distribution
+
+# For container formats, include both the container scanner and nested scanner
+modelaudit scan ./archive.zip --scanners zip,pickle
+```
+
+`--scanners` starts from an explicit allowlist. `--exclude-scanner` subtracts scanners from either that allowlist or the default scanner set. Scanner selection is reflected in JSON output under `scanner_selection`.
+
+For remote folders, ModelAudit narrows downloads by selected scanner extensions when safe, and keeps filtering conservative for container or header-routed scanners to avoid dropping extension-spoofed artifacts before scanning.
 
 ## Metadata Extraction
 
@@ -250,6 +276,7 @@ modelaudit model.pkl --format sarif --output results.sarif
 - **[Support policy](https://github.com/promptfoo/modelaudit/blob/main/SUPPORT.md)** — supported Python/OS versions and maintenance policy
 - **[Security model and limitations](https://github.com/promptfoo/modelaudit/blob/main/docs/user/security-model.md)** — what ModelAudit does and does not guarantee
 - **[Compatibility matrix](https://github.com/promptfoo/modelaudit/blob/main/docs/user/compatibility-matrix.md)** — file formats vs optional dependencies
+- **[Scanner selection](https://github.com/promptfoo/modelaudit/blob/main/docs/user/scanner-selection.md)** — targeted scanner allowlists and exclusions
 - **[Metadata extraction guide](https://github.com/promptfoo/modelaudit/blob/main/docs/user/metadata-extraction.md)** — safe metadata workflows and `--trust-loaders` guidance
 - **[Offline/air-gapped guide](https://github.com/promptfoo/modelaudit/blob/main/docs/user/offline-air-gapped.md)** — secure operation without internet access
 - **Troubleshooting** — run `modelaudit doctor --show-failed` to check scanner availability

--- a/docs/user/compatibility-matrix.md
+++ b/docs/user/compatibility-matrix.md
@@ -45,6 +45,7 @@ This page shows which model formats work in base install and which require optio
 ## Notes
 
 - Scanner selection is extension- and content-aware; overlapping extensions may be dispatched to different scanners based on file content.
+- Runtime scanner selection is available with `modelaudit scan --scanners ...` and `--exclude-scanner ...`; use `modelaudit scan --list-scanners` to discover scanner IDs.
 - Compressed wrappers enforce limits via `compressed_max_decompressed_bytes`, `compressed_max_decompression_ratio`, and `compressed_max_depth`.
 - R serialized (`.rds/.rda/.rdata`) support is static-only: ModelAudit does not execute R code or evaluate objects in an R runtime.
 - CNTK scanner scope in v1 is `.dnn`/`.cmf`; `.model` remains owned by XGBoost overlap handling.

--- a/docs/user/scanner-selection.md
+++ b/docs/user/scanner-selection.md
@@ -1,0 +1,38 @@
+# Scanner Selection
+
+Use scanner selection when you need a focused scan for CI, incident response, or targeted remediation.
+
+```bash
+# List available scanner IDs and class names
+modelaudit scan --list-scanners
+modelaudit scan --list-scanners --format json
+
+# Run only selected scanners
+modelaudit scan ./models --scanners pickle,tf_savedmodel
+modelaudit scan ./model.pkl --scanners PickleScanner
+
+# Run the default scanner set except selected scanners
+modelaudit scan ./models --exclude-scanner weight_distribution
+```
+
+`--scanners` accepts canonical scanner IDs and scanner class names. Values can be comma-separated or passed with repeated flags.
+
+```bash
+modelaudit scan ./models --scanners pickle --scanners tf_savedmodel
+```
+
+`--exclude-scanner` subtracts scanners from the active set. When used without `--scanners`, it subtracts from the default full scanner set. When combined with `--scanners`, it subtracts from that explicit allowlist.
+
+```bash
+modelaudit scan ./models --scanners zip,pickle --exclude-scanner pickle
+```
+
+Container scanners and nested scanners are selected independently. If you want to scan pickle files inside a ZIP archive, include both scanners:
+
+```bash
+modelaudit scan ./archive.zip --scanners zip,pickle
+```
+
+If a scanner is skipped because it is not enabled, ModelAudit records an informational `Scanner Selection` check. JSON output includes the effective policy under `scanner_selection`, so CI pipelines can verify which scanners were enabled.
+
+For remote sources, selective downloads use the enabled scanners' known extensions when it is safe to do so. ModelAudit keeps remote filtering conservative for container and header-routed scanners so extension-spoofed artifacts are not filtered out before download.

--- a/docs/user/scanner-selection.md
+++ b/docs/user/scanner-selection.md
@@ -37,4 +37,15 @@ If a scanner is skipped because it is not enabled, ModelAudit records a `Scanner
 
 Unknown scanner names in `--scanners`/`--exclude-scanner` exit with code 2 and include a `did you mean: …` suggestion built from all known IDs and class-name aliases.
 
+Programmatic callers of `scan_file` or `scan_model_directory_or_file` can reuse `modelaudit.scanner_selection.collect_suppressed_preferred_scanners(result.checks)` to enumerate preferred-scanner skips without parsing check details by hand:
+
+```python
+from modelaudit.core import scan_file
+from modelaudit.scanner_selection import collect_suppressed_preferred_scanners
+
+result = scan_file("./model.pkl", config={"exclude_scanners": ["pickle"]})
+for entry in collect_suppressed_preferred_scanners(result.checks):
+    print(entry["scanner_id"], entry["location"])
+```
+
 For remote sources, selective downloads use the enabled scanners' known extensions when it is safe to do so. ModelAudit keeps remote filtering conservative for container and header-routed scanners so extension-spoofed artifacts are not filtered out before download.

--- a/docs/user/scanner-selection.md
+++ b/docs/user/scanner-selection.md
@@ -33,6 +33,8 @@ Container scanners and nested scanners are selected independently. If you want t
 modelaudit scan ./archive.zip --scanners zip,pickle
 ```
 
-If a scanner is skipped because it is not enabled, ModelAudit records an informational `Scanner Selection` check. JSON output includes the effective policy under `scanner_selection`, so CI pipelines can verify which scanners were enabled.
+If a scanner is skipped because it is not enabled, ModelAudit records a `Scanner Selection` check. When the scanner that routing would have picked for a file is suppressed, the check is raised to WARNING severity, ModelAudit prints a stderr warning, and `scanner_selection.suppressed_preferred_scanner_ids` lists the affected scanner IDs. Embedded helper skips (for example, inner pickle analysis inside a PyTorch ZIP) remain informational because the primary scanner still runs. JSON output includes the effective policy under `scanner_selection`, so CI pipelines can verify both which scanners were enabled and which were suppressed.
+
+Unknown scanner names in `--scanners`/`--exclude-scanner` exit with code 2 and include a `did you mean: …` suggestion built from all known IDs and class-name aliases.
 
 For remote sources, selective downloads use the enabled scanners' known extensions when it is safe to do so. ModelAudit keeps remote filtering conservative for container and header-routed scanners so extension-spoofed artifacts are not filtered out before download.

--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -37,9 +37,8 @@ from .models import ModelAuditResultModel
 from .rules import Rule, RuleRegistry, Severity
 from .scanner_results import IssueSeverity
 from .scanner_selection import (
-    SCANNER_SELECTION_CHECK_NAME,
     SCANNER_SELECTION_CONFIG_KEY,
-    SCANNER_SELECTION_PREFERRED_KIND,
+    collect_suppressed_preferred_scanners,
     policy_from_config,
     scanner_catalog,
     scanner_selection_config_from_inputs,
@@ -827,36 +826,8 @@ def _emit_scanner_catalog(*, output_format: str, output: str | None) -> None:
     click.echo(output_text)
 
 
-def _collect_suppressed_preferred_scanners(audit_result: ModelAuditResultModel) -> list[dict[str, Any]]:
-    """Return aggregated scanner-selection suppressions of preferred scanners.
-
-    Walks the audit result's aggregated checks and returns one entry per
-    (scanner_id, location) that was flagged as a preferred-scanner skip. Used
-    to surface coverage gaps caused by user selection.
-    """
-    aggregated: dict[tuple[str, str], dict[str, Any]] = {}
-    for check in audit_result.checks or []:
-        if check.name != SCANNER_SELECTION_CHECK_NAME:
-            continue
-        details = check.details if isinstance(check.details, dict) else None
-        if not details or details.get("kind") != SCANNER_SELECTION_PREFERRED_KIND:
-            continue
-        scanner_id = str(details.get("skipped_scanner_id") or "unknown")
-        location = check.location or "<unknown>"
-        aggregated.setdefault(
-            (scanner_id, location),
-            {"scanner_id": scanner_id, "location": location, "context": details.get("context")},
-        )
-
-    return sorted(aggregated.values(), key=lambda entry: (entry["scanner_id"], entry["location"]))
-
-
-def _warn_about_suppressed_preferred_scanners(audit_result: ModelAuditResultModel) -> None:
+def _announce_suppressed_preferred_scanners(suppressions: list[dict[str, Any]]) -> None:
     """Print a stderr warning summarizing preferred scanners suppressed by selection."""
-    suppressions = _collect_suppressed_preferred_scanners(audit_result)
-    if not suppressions:
-        return
-
     suppressed_ids = sorted({entry["scanner_id"] for entry in suppressions})
     click.echo(
         "Warning: scanner selection suppressed the preferred scanner(s) for "
@@ -870,9 +841,19 @@ def _warn_about_suppressed_preferred_scanners(audit_result: ModelAuditResultMode
     if len(suppressions) > 5:
         click.echo(f"  … and {len(suppressions) - 5} more", err=True)
 
+
+def _record_suppressed_preferred_scanners(audit_result: ModelAuditResultModel) -> list[dict[str, Any]]:
+    """Populate audit metadata with preferred-scanner suppressions and return them."""
+    suppressions = collect_suppressed_preferred_scanners(audit_result.checks or [])
+    if not suppressions:
+        return suppressions
+
     if audit_result.scanner_selection is None:
         audit_result.scanner_selection = {}
-    audit_result.scanner_selection["suppressed_preferred_scanner_ids"] = suppressed_ids
+    audit_result.scanner_selection["suppressed_preferred_scanner_ids"] = sorted(
+        {entry["scanner_id"] for entry in suppressions}
+    )
+    return suppressions
 
 
 def _record_scan_end_and_exit(audit_result: ModelAuditResultModel, scan_start_time: float) -> NoReturn:
@@ -2434,7 +2415,9 @@ def scan_command(
     )
     _cleanup_temp_artifacts(path_state.temp_cleanup_entries, verbose=verbose)
 
-    _warn_about_suppressed_preferred_scanners(audit_result)
+    suppressions = _record_suppressed_preferred_scanners(audit_result)
+    if suppressions:
+        _announce_suppressed_preferred_scanners(suppressions)
     output_text = _format_scan_output(
         audit_result,
         expanded_paths,

--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -36,6 +36,13 @@ from .integrations.sarif_formatter import format_sarif_output
 from .models import ModelAuditResultModel
 from .rules import Rule, RuleRegistry, Severity
 from .scanner_results import IssueSeverity
+from .scanner_selection import (
+    SCANNER_SELECTION_CONFIG_KEY,
+    policy_from_config,
+    scanner_catalog,
+    scanner_selection_config_from_inputs,
+    selected_scanner_extensions,
+)
 from .scanners.base import make_trusted_source_provenance
 from .telemetry import (
     flush_telemetry,
@@ -113,6 +120,8 @@ class _ScanRuntimeConfig:
     jfrog_api_token: str | None
     jfrog_access_token: str | None
     mlflow_registry_uri: str | None
+    scanner_selection: dict[str, Any] | None
+    scannable_extensions: frozenset[str] | None
 
 
 @dataclass
@@ -390,6 +399,8 @@ def _build_user_scan_overrides(
     strict: bool,
     verbose: bool,
     quiet: bool,
+    scanners: tuple[str, ...],
+    exclude_scanners: tuple[str, ...],
     scan_start_time: float,
 ) -> dict[str, Any]:
     """Normalize scan command flags into config overrides."""
@@ -431,6 +442,18 @@ def _build_user_scan_overrides(
     if quiet:
         user_overrides["verbose"] = False
 
+    if scanners or exclude_scanners:
+        try:
+            user_overrides[SCANNER_SELECTION_CONFIG_KEY] = scanner_selection_config_from_inputs(
+                scanners=scanners,
+                exclude_scanners=exclude_scanners,
+            )
+        except ValueError as exc:
+            click.echo(f"Error parsing scanner selection: {exc}", err=True)
+            record_scan_failed(time.time() - scan_start_time, f"Invalid scanner selection: {exc}")
+            flush_telemetry()
+            sys.exit(2)
+
     return user_overrides
 
 
@@ -449,6 +472,8 @@ def _resolve_scan_runtime_config(
     strict: bool,
     verbose: bool,
     quiet: bool,
+    scanners: tuple[str, ...],
+    exclude_scanners: tuple[str, ...],
     suppress: tuple[str, ...],
     severity: tuple[str, ...],
     scan_start_time: float,
@@ -467,6 +492,8 @@ def _resolve_scan_runtime_config(
         strict=strict,
         verbose=verbose,
         quiet=quiet,
+        scanners=scanners,
+        exclude_scanners=exclude_scanners,
         scan_start_time=scan_start_time,
     )
     config_values = apply_auto_overrides(user_overrides, auto_defaults)
@@ -502,6 +529,12 @@ def _resolve_scan_runtime_config(
         with contextlib.suppress(ValueError):
             max_download_bytes = parse_size_string(max_size)
 
+    scanner_selection = config_values.get(SCANNER_SELECTION_CONFIG_KEY)
+    scanner_policy = policy_from_config(config_values)
+    scannable_extensions = (
+        selected_scanner_extensions(scanner_policy, conservative=True) if scanner_policy.active else None
+    )
+
     return _ScanRuntimeConfig(
         config=config_values,
         timeout=config_values.get("timeout", 3600),
@@ -522,7 +555,16 @@ def _resolve_scan_runtime_config(
         jfrog_api_token=os.getenv("JFROG_API_TOKEN"),
         jfrog_access_token=os.getenv("JFROG_ACCESS_TOKEN"),
         mlflow_registry_uri=os.getenv("MLFLOW_TRACKING_URI"),
+        scanner_selection=scanner_selection if isinstance(scanner_selection, dict) else None,
+        scannable_extensions=scannable_extensions,
     )
+
+
+def _scanner_selection_overrides(runtime: _ScanRuntimeConfig) -> dict[str, Any]:
+    """Return config kwargs needed to preserve scanner selection across scan paths."""
+    if runtime.scanner_selection is None:
+        return {}
+    return {SCANNER_SELECTION_CONFIG_KEY: runtime.scanner_selection}
 
 
 def _show_scan_runtime_defaults(
@@ -745,6 +787,42 @@ def _emit_scan_output(
     click.echo(output_text)
 
 
+def _format_scanner_catalog(output_format: str) -> str:
+    """Render registered scanners for CLI discovery."""
+    scanners = scanner_catalog()
+    if output_format == "json":
+        return json.dumps({"scanners": scanners}, indent=2)
+
+    lines = ["Registered scanners:"]
+    for scanner in scanners:
+        extensions = ", ".join(scanner["extensions"]) if scanner["extensions"] else "-"
+        dependencies = ", ".join(scanner["dependencies"]) if scanner["dependencies"] else "-"
+        lines.extend(
+            [
+                f"{scanner['id']} ({scanner['class']})",
+                f"  extensions: {extensions}",
+                f"  dependencies: {dependencies}",
+                f"  {scanner['description']}",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _emit_scanner_catalog(*, output_format: str, output: str | None) -> None:
+    """Write scanner discovery output to a file or stdout."""
+    if output_format == "sarif":
+        click.echo("Error: --list-scanners supports text or json output, not sarif", err=True)
+        sys.exit(2)
+
+    output_text = _format_scanner_catalog(output_format)
+    if output:
+        with open(output, "w", encoding="utf-8") as output_file:
+            output_file.write(output_text)
+            output_file.write("\n")
+        return
+    click.echo(output_text)
+
+
 def _record_scan_end_and_exit(audit_result: ModelAuditResultModel, scan_start_time: float) -> NoReturn:
     """Record final telemetry and exit with the scan result's status code."""
     scan_duration = time.time() - scan_start_time
@@ -902,6 +980,7 @@ def _scan_local_or_downloaded_path(
                 use_hf_whitelist=runtime.use_hf_whitelist,
                 cache_enabled=runtime.cache_enabled,
                 cache_dir=runtime.cache_dir,
+                **_scanner_selection_overrides(runtime),
             )
             audit_result.aggregate_scan_result(streaming_result.model_dump())
             path_state.track_streaming_paths_for_sbom(streaming_result, actual_path)
@@ -917,6 +996,7 @@ def _scan_local_or_downloaded_path(
             "progress_update_interval": 2.0,
             "cache_enabled": runtime.cache_enabled,
             "cache_dir": runtime.cache_dir,
+            **_scanner_selection_overrides(runtime),
         }
         if source_result.source_model_id and source_result.source_model_source == "huggingface":
             config_overrides["_trusted_source_provenance"] = make_trusted_source_provenance(
@@ -1132,6 +1212,7 @@ def _resolve_scan_source_for_path(
                 streaming_kwargs: dict[str, Any] = {}
                 if trusted_source_provenance is not None:
                     streaming_kwargs["_trusted_source_provenance"] = trusted_source_provenance
+                streaming_kwargs.update(_scanner_selection_overrides(runtime))
 
                 streaming_result = scan_model_streaming(
                     file_generator=file_generator,
@@ -1249,6 +1330,7 @@ def _resolve_scan_source_for_path(
                     use_hf_whitelist=runtime.use_hf_whitelist,
                     cache_enabled=runtime.cache_enabled,
                     cache_dir=runtime.cache_dir,
+                    **_scanner_selection_overrides(runtime),
                 )
                 path_state.track_streaming_paths_for_sbom(streaming_result, path)
                 audit_result.aggregate_scan_result(streaming_result.model_dump())
@@ -1331,7 +1413,10 @@ def _resolve_scan_source_for_path(
                     if runtime.selective_download:
                         from .utils.sources.cloud_storage import filter_scannable_files
 
-                        scannable = filter_scannable_files(metadata.get("files", []))
+                        scannable = filter_scannable_files(
+                            metadata.get("files", []),
+                            scannable_extensions=runtime.scannable_extensions,
+                        )
                         click.echo(f"   Scannable files: {len(scannable)} of {metadata.get('file_count', 0)}")
 
                 return _SourceDispatchResult(actual_path=path, local_scan_required=False)
@@ -1353,12 +1438,16 @@ def _resolve_scan_source_for_path(
                 if runtime.show_styled_output:
                     click.echo(style_text("🔄 Starting streaming scan from cloud storage...", fg="cyan"))
 
+                cloud_stream_kwargs: dict[str, Any] = {}
+                if runtime.scannable_extensions is not None:
+                    cloud_stream_kwargs["scannable_extensions"] = runtime.scannable_extensions
                 file_generator = download_from_cloud_streaming(
                     path,
                     cache_dir=Path(runtime.cache_dir) if runtime.cache_dir else None,
                     max_size=runtime.max_download_bytes,
                     show_progress=runtime.show_progress,
                     selective=runtime.selective_download,
+                    **cloud_stream_kwargs,
                 )
                 streaming_result = scan_model_streaming(
                     file_generator=file_generator,
@@ -1372,6 +1461,7 @@ def _resolve_scan_source_for_path(
                     use_hf_whitelist=runtime.use_hf_whitelist,
                     cache_enabled=runtime.cache_enabled,
                     cache_dir=runtime.cache_dir,
+                    **_scanner_selection_overrides(runtime),
                 )
                 path_state.track_streaming_paths_for_sbom(streaming_result, path)
                 audit_result.aggregate_scan_result(streaming_result.model_dump())
@@ -1389,6 +1479,9 @@ def _resolve_scan_source_for_path(
             elif runtime.show_styled_output:
                 click.echo(f"Downloading from {redact_url_for_display(path)}...")
 
+            cloud_download_kwargs: dict[str, Any] = {}
+            if runtime.scannable_extensions is not None:
+                cloud_download_kwargs["scannable_extensions"] = runtime.scannable_extensions
             download_path = download_from_cloud(  # type: ignore[assignment]
                 path,
                 cache_dir=Path(runtime.cache_dir) if runtime.cache_dir else None,
@@ -1397,6 +1490,7 @@ def _resolve_scan_source_for_path(
                 show_progress=verbose,
                 selective=runtime.selective_download,
                 stream_analyze=runtime.stream_analysis,
+                **cloud_download_kwargs,
             )
             download_duration = time.time() - download_start
             try:
@@ -1465,6 +1559,7 @@ def _resolve_scan_source_for_path(
                 cache_enabled=runtime.cache_enabled,
                 cache_dir=runtime.cache_dir,
                 use_hf_whitelist=runtime.use_hf_whitelist,
+                **_scanner_selection_overrides(runtime),
             )
 
             if download_spinner:
@@ -1503,6 +1598,9 @@ def _resolve_scan_source_for_path(
             record_feature_used("jfrog_download")
             download_start = time.time()
 
+            jfrog_scan_kwargs: dict[str, Any] = {}
+            if runtime.scannable_extensions is not None:
+                jfrog_scan_kwargs["scannable_extensions"] = runtime.scannable_extensions
             jfrog_results: ModelAuditResultModel = scan_jfrog_artifact(
                 path,
                 api_token=runtime.jfrog_api_token,
@@ -1517,6 +1615,8 @@ def _resolve_scan_source_for_path(
                 cache_dir=runtime.cache_dir,
                 selective_download=runtime.selective_download,
                 use_hf_whitelist=runtime.use_hf_whitelist,
+                **jfrog_scan_kwargs,
+                **_scanner_selection_overrides(runtime),
             )
 
             if download_spinner:
@@ -1955,7 +2055,7 @@ def delegate_info() -> None:
 
 
 @cli.command("scan")
-@click.argument("paths", nargs=-1, type=str, required=True)
+@click.argument("paths", nargs=-1, type=str, required=False)
 # Core output control (4 flags)
 @click.option(
     "--format",
@@ -1999,6 +2099,22 @@ def delegate_info() -> None:
     "-S",
     multiple=True,
     help="Override rule severities, format CODE=LEVEL (e.g., S101=CRITICAL). Can be specified multiple times.",
+)
+@click.option(
+    "--scanners",
+    multiple=True,
+    help="Only run the selected scanners (comma-separated or repeat the flag). Accepts scanner IDs or class names.",
+)
+@click.option(
+    "--exclude-scanner",
+    "exclude_scanners",
+    multiple=True,
+    help="Exclude scanners from the active scanner set (comma-separated or repeat the flag).",
+)
+@click.option(
+    "--list-scanners",
+    is_flag=True,
+    help="List registered scanner IDs, class names, extensions, and dependencies, then exit.",
 )
 # Progress & reporting (2 flags)
 @click.option(
@@ -2055,6 +2171,9 @@ def scan_command(
     no_whitelist: bool,
     suppress: tuple[str, ...],
     severity: tuple[str, ...],
+    scanners: tuple[str, ...],
+    exclude_scanners: tuple[str, ...],
+    list_scanners: bool,
     progress: bool,
     sbom: str | None,
     timeout: int | None,
@@ -2101,6 +2220,19 @@ def scan_command(
         2 - Errors occurred during scanning
     """
     scan_start_time = time.time()
+    if list_scanners:
+        output_format = format or "text"
+        _emit_scanner_catalog(output_format=output_format, output=output)
+        record_command_used("scan", duration=time.time() - scan_start_time, list_scanners=True, format=output_format)
+        flush_telemetry()
+        return
+
+    if not paths:
+        click.echo("Error: Missing argument 'PATHS...'.", err=True)
+        record_scan_failed(time.time() - scan_start_time, "No paths provided")
+        flush_telemetry()
+        sys.exit(2)
+
     # Telemetry options - only include non-sensitive data
     # DO NOT include actual blacklist patterns or file paths - only counts
     telemetry_options = {
@@ -2117,6 +2249,7 @@ def scan_command(
         "strict": strict,
         "no_whitelist": no_whitelist,
         "dry_run": dry_run,
+        "has_scanner_selection": bool(scanners or exclude_scanners),
         "num_paths": len(paths),
     }
 
@@ -2138,6 +2271,8 @@ def scan_command(
         strict=strict,
         verbose=verbose,
         quiet=quiet,
+        scanners=scanners,
+        exclude_scanners=exclude_scanners,
         suppress=suppress,
         severity=severity,
         scan_start_time=scan_start_time,
@@ -2161,6 +2296,8 @@ def scan_command(
     from .models import create_initial_audit_result
 
     audit_result = create_initial_audit_result()
+    if runtime.scanner_selection is not None:
+        audit_result.scanner_selection = policy_from_config(runtime.config).to_metadata()
     path_state = _ScanPathState()
 
     # Scan each path with interrupt handling

--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -37,7 +37,9 @@ from .models import ModelAuditResultModel
 from .rules import Rule, RuleRegistry, Severity
 from .scanner_results import IssueSeverity
 from .scanner_selection import (
+    SCANNER_SELECTION_CHECK_NAME,
     SCANNER_SELECTION_CONFIG_KEY,
+    SCANNER_SELECTION_PREFERRED_KIND,
     policy_from_config,
     scanner_catalog,
     scanner_selection_config_from_inputs,
@@ -121,6 +123,7 @@ class _ScanRuntimeConfig:
     jfrog_access_token: str | None
     mlflow_registry_uri: str | None
     scanner_selection: dict[str, Any] | None
+    scanner_selection_metadata: dict[str, Any] | None
     scannable_extensions: frozenset[str] | None
 
 
@@ -556,6 +559,7 @@ def _resolve_scan_runtime_config(
         jfrog_access_token=os.getenv("JFROG_ACCESS_TOKEN"),
         mlflow_registry_uri=os.getenv("MLFLOW_TRACKING_URI"),
         scanner_selection=scanner_selection if isinstance(scanner_selection, dict) else None,
+        scanner_selection_metadata=scanner_policy.to_metadata() if scanner_policy.active else None,
         scannable_extensions=scannable_extensions,
     )
 
@@ -821,6 +825,54 @@ def _emit_scanner_catalog(*, output_format: str, output: str | None) -> None:
             output_file.write("\n")
         return
     click.echo(output_text)
+
+
+def _collect_suppressed_preferred_scanners(audit_result: ModelAuditResultModel) -> list[dict[str, Any]]:
+    """Return aggregated scanner-selection suppressions of preferred scanners.
+
+    Walks the audit result's aggregated checks and returns one entry per
+    (scanner_id, location) that was flagged as a preferred-scanner skip. Used
+    to surface coverage gaps caused by user selection.
+    """
+    aggregated: dict[tuple[str, str], dict[str, Any]] = {}
+    for check in audit_result.checks or []:
+        if check.name != SCANNER_SELECTION_CHECK_NAME:
+            continue
+        details = check.details if isinstance(check.details, dict) else None
+        if not details or details.get("kind") != SCANNER_SELECTION_PREFERRED_KIND:
+            continue
+        scanner_id = str(details.get("skipped_scanner_id") or "unknown")
+        location = check.location or "<unknown>"
+        aggregated.setdefault(
+            (scanner_id, location),
+            {"scanner_id": scanner_id, "location": location, "context": details.get("context")},
+        )
+
+    return sorted(aggregated.values(), key=lambda entry: (entry["scanner_id"], entry["location"]))
+
+
+def _warn_about_suppressed_preferred_scanners(audit_result: ModelAuditResultModel) -> None:
+    """Print a stderr warning summarizing preferred scanners suppressed by selection."""
+    suppressions = _collect_suppressed_preferred_scanners(audit_result)
+    if not suppressions:
+        return
+
+    suppressed_ids = sorted({entry["scanner_id"] for entry in suppressions})
+    click.echo(
+        "Warning: scanner selection suppressed the preferred scanner(s) for "
+        f"{len(suppressions)} file(s): {', '.join(suppressed_ids)}. "
+        "These files were not analyzed by the scanner that routing would normally pick; "
+        "rerun without --scanners/--exclude-scanner or widen the selection to close the gap.",
+        err=True,
+    )
+    for entry in suppressions[:5]:
+        click.echo(f"  - {entry['location']} (would have used: {entry['scanner_id']})", err=True)
+    if len(suppressions) > 5:
+        click.echo(f"  … and {len(suppressions) - 5} more", err=True)
+
+    if audit_result.scanner_selection is None:
+        audit_result.scanner_selection = {}
+    audit_result.scanner_selection["suppressed_preferred_scanner_ids"] = suppressed_ids
 
 
 def _record_scan_end_and_exit(audit_result: ModelAuditResultModel, scan_start_time: float) -> NoReturn:
@@ -2296,8 +2348,8 @@ def scan_command(
     from .models import create_initial_audit_result
 
     audit_result = create_initial_audit_result()
-    if runtime.scanner_selection is not None:
-        audit_result.scanner_selection = policy_from_config(runtime.config).to_metadata()
+    if runtime.scanner_selection_metadata is not None:
+        audit_result.scanner_selection = dict(runtime.scanner_selection_metadata)
     path_state = _ScanPathState()
 
     # Scan each path with interrupt handling
@@ -2382,6 +2434,7 @@ def scan_command(
     )
     _cleanup_temp_artifacts(path_state.temp_cleanup_entries, verbose=verbose)
 
+    _warn_about_suppressed_preferred_scanners(audit_result)
     output_text = _format_scan_output(
         audit_result,
         expanded_paths,

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -18,6 +18,7 @@ from modelaudit.integrations.license_checker import (
 from modelaudit.models import ModelAuditResultModel, ScanConfigModel, create_initial_audit_result
 from modelaudit.scanner_results import Issue, IssueSeverity, ScanResult
 from modelaudit.scanner_selection import (
+    SCANNER_SELECTION_PREFERRED_KIND,
     add_scanner_selection_skip_check,
     make_scanner_selection_skip_result,
     normalize_scanner_selection_config,
@@ -1129,6 +1130,7 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
                     skipped_preferred_scanner_id,
                     scanner_selection,
                     context="preferred scanner",
+                    kind=SCANNER_SELECTION_PREFERRED_KIND,
                 )
         else:
             if scanner_selection.active:
@@ -1137,7 +1139,7 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
                     candidate_scanner_class = _registry.get_scanner_for_path(path)
                     if candidate_scanner_class:
                         candidate_scanner_id = (
-                            _registry._get_scanner_id_for_class(candidate_scanner_class.__name__)
+                            _registry.get_scanner_id_for_class(candidate_scanner_class.__name__)
                             or candidate_scanner_class.name
                         )
                 if candidate_scanner_id and not scanner_selection.allows(candidate_scanner_id):

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -17,6 +17,13 @@ from modelaudit.integrations.license_checker import (
 )
 from modelaudit.models import ModelAuditResultModel, ScanConfigModel, create_initial_audit_result
 from modelaudit.scanner_results import Issue, IssueSeverity, ScanResult
+from modelaudit.scanner_selection import (
+    add_scanner_selection_skip_check,
+    make_scanner_selection_skip_result,
+    normalize_scanner_selection_config,
+    policy_from_config,
+    selected_scanner_extensions,
+)
 from modelaudit.scanners import _registry
 from modelaudit.scanners.archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY
 from modelaudit.scanners.base import FORMAT_VALIDATION_CONFIG_KEY, BaseScanner
@@ -318,11 +325,16 @@ def scan_model_directory_or_file(
         "strict_license": strict_license,
         **kwargs,
     }
+    config = normalize_scanner_selection_config(config)
+    scanner_selection = policy_from_config(config)
+    scanner_selection_extensions = selected_scanner_extensions(scanner_selection) if scanner_selection.active else None
+    if scanner_selection.active:
+        results.scanner_selection = scanner_selection.to_metadata()
 
     validate_scan_config(config)
 
     # Check if metadata scanner is available once (optimization - avoids loading scanner)
-    metadata_scanner_available = _registry.has_scanner_class("MetadataScanner")
+    metadata_scanner_available = scanner_selection.allows("metadata") and _registry.has_scanner_class("MetadataScanner")
 
     try:
         # Handle streaming paths
@@ -432,7 +444,9 @@ def scan_model_directory_or_file(
                     # Skip non-model files early if filtering is enabled
                     # Note: skip_file_types parameter already contains the correct value
                     if skip_file_types and should_skip_file(
-                        file_path, metadata_scanner_available=metadata_scanner_available
+                        file_path,
+                        metadata_scanner_available=metadata_scanner_available,
+                        scanner_selection_extensions=scanner_selection_extensions,
                     ):
                         filename_lower = Path(file_path).name.lower()
                         if filename_lower in LICENSE_FILES:
@@ -852,7 +866,7 @@ def scan_file(path: str, config: dict[str, Any] | None = None) -> ScanResult:
     Returns:
         ScanResult object with the scan results
     """
-    config = {} if config is None else dict(config)
+    config = normalize_scanner_selection_config({} if config is None else dict(config))
     config.setdefault(NESTED_SCAN_CALLBACK_CONFIG_KEY, scan_file)
     validate_scan_config(config)
 
@@ -873,6 +887,8 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
     """
     if config is None:
         config = {}
+    config = normalize_scanner_selection_config(config)
+    scanner_selection = policy_from_config(config)
     validate_scan_config(config)
 
     # Skip HuggingFace cache files to reduce noise
@@ -1000,8 +1016,11 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
     # Prefer scanners based on trusted structure rather than the filename alone.
     preferred_scanner: type[BaseScanner] | None = None
     scanner_id = _select_preferred_scanner_id(path, header_format, ext)
-    if scanner_id:
+    skipped_preferred_scanner_id: str | None = None
+    if scanner_id and scanner_selection.allows(scanner_id):
         preferred_scanner = _registry.load_scanner_by_id(scanner_id)
+    elif scanner_id:
+        skipped_preferred_scanner_id = scanner_id
 
     result: ScanResult | None
 
@@ -1062,7 +1081,10 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
             result.finish(success=False)
     else:
         # Use registry's lazy loading method to avoid loading all scanners
-        scanner_class = _registry.get_scanner_for_path(path)
+        scanner_class = _registry.get_scanner_for_path(
+            path,
+            scanner_selection=scanner_selection if scanner_selection.active else None,
+        )
         if scanner_class:
             logger.debug(f"Using {scanner_class.name} scanner for {path}")
             scanner = scanner_class(config=config)
@@ -1100,7 +1122,30 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
                 )
                 _mark_operational_scan_error(result, "scan_timeout")
                 result.finish(success=False)
+            if skipped_preferred_scanner_id and result is not None:
+                add_scanner_selection_skip_check(
+                    result,
+                    path,
+                    skipped_preferred_scanner_id,
+                    scanner_selection,
+                    context="preferred scanner",
+                )
         else:
+            if scanner_selection.active:
+                candidate_scanner_id = skipped_preferred_scanner_id
+                if candidate_scanner_id is None:
+                    candidate_scanner_class = _registry.get_scanner_for_path(path)
+                    if candidate_scanner_class:
+                        candidate_scanner_id = (
+                            _registry._get_scanner_id_for_class(candidate_scanner_class.__name__)
+                            or candidate_scanner_class.name
+                        )
+                if candidate_scanner_id and not scanner_selection.allows(candidate_scanner_id):
+                    result = make_scanner_selection_skip_result(path, candidate_scanner_id, scanner_selection)
+                    if result.bytes_scanned == 0 and file_size > 0:
+                        result.bytes_scanned = file_size
+                    return result
+
             format_ = header_format
             sr = ScanResult(scanner_name="unknown")
             if format_ == "unknown":
@@ -1184,7 +1229,14 @@ def scan_model_streaming(
     file_hashes: list[str] = []
     files_processed = 0
     skip_file_types: bool = bool(kwargs.get("skip_file_types", False))
-    metadata_scanner_available: bool = _registry.has_scanner_class("MetadataScanner")
+    scan_kwargs = normalize_scanner_selection_config(kwargs)
+    scanner_selection = policy_from_config(scan_kwargs)
+    scanner_selection_extensions = selected_scanner_extensions(scanner_selection) if scanner_selection.active else None
+    if scanner_selection.active:
+        results.scanner_selection = scanner_selection.to_metadata()
+    metadata_scanner_available: bool = scanner_selection.allows("metadata") and _registry.has_scanner_class(
+        "MetadataScanner"
+    )
 
     base_dir = Path(scan_root).resolve() if scan_root is not None else None
     hf_cache_root = _find_hf_cache_root(base_dir) if base_dir is not None else None
@@ -1225,6 +1277,7 @@ def scan_model_streaming(
                 if skip_file_types and should_skip_file(
                     str(source_path),
                     metadata_scanner_available=metadata_scanner_available,
+                    scanner_selection_extensions=scanner_selection_extensions,
                 ):
                     filename_lower = source_path.name.lower()
                     if filename_lower in LICENSE_FILES:
@@ -1254,7 +1307,7 @@ def scan_model_streaming(
                 # Build config dict for scan_file
                 scan_config = {
                     "timeout": timeout - int(time.time() - start_time),
-                    **kwargs,
+                    **scan_kwargs,
                 }
 
                 scan_result = scan_file(

--- a/modelaudit/integrations/jfrog.py
+++ b/modelaudit/integrations/jfrog.py
@@ -7,6 +7,7 @@ import logging
 import shutil
 import tempfile
 import time
+from collections.abc import Collection
 from pathlib import Path
 from typing import Any
 
@@ -44,6 +45,7 @@ def scan_jfrog_artifact(
     max_file_size: int = 0,
     max_total_size: int = 0,
     selective_download: bool = True,
+    scannable_extensions: Collection[str] | None = None,
     **kwargs: Any,
 ) -> ModelAuditResultModel:
     """Download and scan an artifact or folder from JFrog Artifactory.
@@ -121,6 +123,9 @@ def scan_jfrog_artifact(
             )
         else:
             logger.debug(f"Downloading JFrog folder {display_url} to {download_dir}")
+            folder_download_kwargs: dict[str, Any] = {}
+            if scannable_extensions is not None:
+                folder_download_kwargs["scannable_extensions"] = scannable_extensions
             download_path = download_jfrog_folder(
                 url,
                 cache_dir=download_dir,
@@ -129,6 +134,7 @@ def scan_jfrog_artifact(
                 timeout=timeout,
                 selective=selective_download,
                 show_progress=True,
+                **folder_download_kwargs,
             )
 
         # Calculate remaining timeout for scanning phase

--- a/modelaudit/models.py
+++ b/modelaudit/models.py
@@ -425,6 +425,7 @@ class ModelAuditResultModel(BaseModel, DictCompatMixin):
     assets: list[AssetModel] = Field(default_factory=list, description="List of scanned assets")
     has_errors: bool = Field(..., description="Whether any critical issues were found")
     scanner_names: list[str] = Field(default_factory=list, description="Names of scanners used")
+    scanner_selection: dict[str, Any] | None = Field(default=None, description="Effective scanner selection policy")
     file_metadata: dict[str, FileMetadataModel] = Field(default_factory=dict, description="Metadata for each file")
     content_hash: str | None = Field(
         default=None, description="Aggregate SHA-256 hash of all scanned files (for deduplication)"
@@ -456,6 +457,9 @@ class ModelAuditResultModel(BaseModel, DictCompatMixin):
         self.files_scanned += results_dict.get("files_scanned", 0)
         if results_dict.get("has_errors", False):
             self.has_errors = True
+        incoming_scanner_selection = results_dict.get("scanner_selection")
+        if self.scanner_selection is None and isinstance(incoming_scanner_selection, dict):
+            self.scanner_selection = incoming_scanner_selection
 
         incoming_issues = results_dict.get("issues", [])
         incoming_has_security_findings = (
@@ -543,6 +547,10 @@ class ModelAuditResultModel(BaseModel, DictCompatMixin):
             self.success = False
 
         if metadata:
+            scanner_selection = metadata.get("scanner_selection")
+            if self.scanner_selection is None and isinstance(scanner_selection, dict):
+                self.scanner_selection = scanner_selection
+
             metadata_dict = metadata.copy()
             if "ml_context" in metadata_dict and isinstance(metadata_dict["ml_context"], dict):
                 metadata_dict["ml_context"] = MLContextModel(**metadata_dict["ml_context"])
@@ -682,6 +690,7 @@ def create_audit_result_model(aggregated_results: dict[str, Any]) -> ModelAuditR
         assets=assets,
         has_errors=aggregated_results.get("has_errors", False),
         scanner_names=aggregated_results.get("scanner_names", []),
+        scanner_selection=aggregated_results.get("scanner_selection"),
         file_metadata=file_metadata,
         start_time=aggregated_results.get("start_time", 0.0),
         duration=aggregated_results.get("duration", 0.0),

--- a/modelaudit/scanner_selection.py
+++ b/modelaudit/scanner_selection.py
@@ -8,6 +8,7 @@ and remote prefilters share the same semantics without loading scanner classes.
 
 from __future__ import annotations
 
+import difflib
 import os
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
@@ -106,9 +107,16 @@ def resolve_scanner_ids(tokens: Iterable[str] | str | None) -> tuple[str, ...]:
             resolved.append(scanner_id)
 
     if unknown:
+        candidate_ids = sorted(set(metadata.keys()) | set(aliases.values()))
+        suggestions: list[str] = []
+        for bad in unknown:
+            close = difflib.get_close_matches(bad.lower(), candidate_ids, n=2, cutoff=0.6)
+            if close:
+                suggestions.append(f"{bad} (did you mean: {', '.join(close)}?)")
+            else:
+                suggestions.append(bad)
         available = ", ".join(sorted(metadata.keys()))
-        unknown_text = ", ".join(unknown)
-        raise ValueError(f"Unknown scanner name(s): {unknown_text}. Available scanners: {available}")
+        raise ValueError(f"Unknown scanner name(s): {'; '.join(suggestions)}. Available scanners: {available}")
 
     return tuple(resolved)
 
@@ -242,6 +250,11 @@ def selected_scanner_extensions(
     return frozenset(extensions)
 
 
+SCANNER_SELECTION_CHECK_NAME = "Scanner Selection"
+SCANNER_SELECTION_PREFERRED_KIND = "preferred"
+SCANNER_SELECTION_EMBEDDED_KIND = "embedded"
+
+
 def add_scanner_selection_skip_check(
     result: ScanResult,
     location: str,
@@ -249,8 +262,16 @@ def add_scanner_selection_skip_check(
     policy: ScannerSelectionPolicy,
     *,
     context: str | None = None,
+    kind: str = SCANNER_SELECTION_EMBEDDED_KIND,
 ) -> None:
-    """Add an informational check for a scanner skipped by selection policy."""
+    """Add a check documenting a scanner that was skipped by selection policy.
+
+    ``kind`` controls severity: ``"preferred"`` uses WARNING because the
+    selection suppressed the scanner that routing would have picked for the
+    file (a potential coverage gap); ``"embedded"`` uses INFO because the file
+    is still being analyzed by its primary scanner and only an auxiliary
+    embedded pass was skipped.
+    """
     result.metadata.setdefault("scanner_selection", policy.to_metadata())
     skipped_scanner_ids = result.metadata.setdefault("skipped_scanner_ids", [])
     if isinstance(skipped_scanner_ids, list) and scanner_id and scanner_id not in skipped_scanner_ids:
@@ -261,16 +282,18 @@ def add_scanner_selection_skip_check(
     if context:
         message = f"{message} ({context})"
 
+    severity = IssueSeverity.WARNING if kind == SCANNER_SELECTION_PREFERRED_KIND else IssueSeverity.INFO
+
     result.add_check(
-        name="Scanner Selection",
+        name=SCANNER_SELECTION_CHECK_NAME,
         passed=True,
         message=message,
-        severity=IssueSeverity.INFO,
+        severity=severity,
         location=location,
         details={
             "skipped_scanner_id": scanner_id,
-            "enabled_scanner_ids": sorted(policy.enabled_scanner_ids),
             "context": context,
+            "kind": kind,
         },
     )
 
@@ -279,6 +302,8 @@ def make_scanner_selection_skip_result(
     path: str,
     scanner_id: str | None,
     policy: ScannerSelectionPolicy,
+    *,
+    kind: str = SCANNER_SELECTION_PREFERRED_KIND,
 ) -> ScanResult:
     """Build a successful result that makes intentional policy skips explicit."""
     result = ScanResult(scanner_name="scanner_selection")
@@ -297,6 +322,22 @@ def make_scanner_selection_skip_result(
     if result.bytes_scanned:
         result.metadata["file_size"] = result.bytes_scanned
 
-    add_scanner_selection_skip_check(result, path, scanner_id, policy)
+    add_scanner_selection_skip_check(result, path, scanner_id, policy, kind=kind)
     result.finish(success=True)
     return result
+
+
+def embedded_pickle_scanner(
+    config: Mapping[str, Any] | None,
+    pickle_scanner_factory: Any,
+) -> tuple[Any, ScannerSelectionPolicy]:
+    """Instantiate an embedded pickle helper scanner only if selection allows it.
+
+    Returns ``(scanner, policy)``. The scanner is ``None`` when pickle analysis
+    is disabled by the active selection policy; callers should record a
+    scanner-selection skip check for each embedded pickle they would have
+    scanned and continue processing.
+    """
+    policy = policy_from_config(config)
+    scanner = pickle_scanner_factory(config) if policy.allows("pickle") else None
+    return scanner, policy

--- a/modelaudit/scanner_selection.py
+++ b/modelaudit/scanner_selection.py
@@ -1,0 +1,302 @@
+"""Scanner selection policy helpers.
+
+Scanner selection is intentionally small: users may allowlist scanners with
+``--scanners`` and subtract scanners with ``--exclude-scanner``. Keeping the
+policy registry-metadata based lets CLI, core routing, nested archive dispatch,
+and remote prefilters share the same semantics without loading scanner classes.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from .scanner_registry_metadata import get_scanner_registry_metadata
+from .scanner_results import IssueSeverity, ScanResult
+
+SCANNER_SELECTION_CONFIG_KEY = "scanner_selection"
+_GENERIC_CONTAINER_SCANNER_IDS = frozenset({"compressed", "rar", "sevenzip", "tar", "zip"})
+
+
+def scanner_catalog() -> list[dict[str, Any]]:
+    """Return scanner metadata suitable for CLI discovery output."""
+    catalog: list[dict[str, Any]] = []
+    for scanner_id, scanner_info in sorted(get_scanner_registry_metadata().items()):
+        extensions = sorted(
+            {
+                str(extension)
+                for key in ("extensions", "content_routed_extensions", "scanner_only_extensions")
+                for extension in scanner_info.get(key, [])
+                if str(extension)
+            }
+        )
+        catalog.append(
+            {
+                "id": scanner_id,
+                "class": scanner_info.get("class", ""),
+                "description": scanner_info.get("description", ""),
+                "extensions": extensions,
+                "dependencies": sorted(str(dep) for dep in scanner_info.get("dependencies", [])),
+            }
+        )
+    return catalog
+
+
+def split_scanner_tokens(values: Iterable[str] | str | None) -> list[str]:
+    """Normalize repeatable/comma-separated scanner option values."""
+    if values is None:
+        return []
+    if isinstance(values, str):
+        values = [values]
+
+    tokens: list[str] = []
+    for value in values:
+        for token in str(value).split(","):
+            token = token.strip()
+            if token:
+                tokens.append(token)
+    return tokens
+
+
+def _alias_key(value: str) -> str:
+    return value.strip().lower().replace("_", "").replace("-", "")
+
+
+def _scanner_aliases(metadata: Mapping[str, Mapping[str, Any]]) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+
+    def add(alias: str, scanner_id: str) -> None:
+        key = _alias_key(alias)
+        if key:
+            aliases.setdefault(key, scanner_id)
+
+    for scanner_id, scanner_info in metadata.items():
+        add(scanner_id, scanner_id)
+        add(scanner_id.replace("_", "-"), scanner_id)
+
+        class_name = str(scanner_info.get("class", ""))
+        add(class_name, scanner_id)
+        if class_name.endswith("Scanner"):
+            add(class_name[: -len("Scanner")], scanner_id)
+
+    # Common user-facing aliases from docs and issue examples.
+    aliases.setdefault(_alias_key("H5Scanner"), "keras_h5")
+    aliases.setdefault(_alias_key("TensorflowSavedModelScanner"), "tf_savedmodel")
+    aliases.setdefault(_alias_key("TensorFlowSavedModelScanner"), "tf_savedmodel")
+    aliases.setdefault(_alias_key("TensorflowMetaGraphScanner"), "tf_metagraph")
+    aliases.setdefault(_alias_key("TensorFlowMetaGraphScanner"), "tf_metagraph")
+    return aliases
+
+
+def resolve_scanner_ids(tokens: Iterable[str] | str | None) -> tuple[str, ...]:
+    """Resolve scanner IDs, class names, and friendly aliases to canonical IDs."""
+    metadata = get_scanner_registry_metadata()
+    aliases = _scanner_aliases(metadata)
+    resolved: list[str] = []
+    unknown: list[str] = []
+
+    for token in split_scanner_tokens(tokens):
+        scanner_id = aliases.get(_alias_key(token))
+        if scanner_id is None:
+            unknown.append(token)
+            continue
+        if scanner_id not in resolved:
+            resolved.append(scanner_id)
+
+    if unknown:
+        available = ", ".join(sorted(metadata.keys()))
+        unknown_text = ", ".join(unknown)
+        raise ValueError(f"Unknown scanner name(s): {unknown_text}. Available scanners: {available}")
+
+    return tuple(resolved)
+
+
+@dataclass(frozen=True)
+class ScannerSelectionPolicy:
+    """Resolved scanner selection policy."""
+
+    enabled_scanner_ids: frozenset[str]
+    all_scanner_ids: frozenset[str]
+    exact_scanner_ids: frozenset[str] = frozenset()
+    exclude_scanner_ids: frozenset[str] = frozenset()
+    active: bool = False
+
+    def allows(self, scanner_id: str | None) -> bool:
+        """Return whether a canonical scanner ID may run."""
+        if scanner_id is None:
+            return False
+        if not self.active:
+            return True
+        return scanner_id in self.enabled_scanner_ids
+
+    def to_config(self) -> dict[str, Any]:
+        """Return a stable, JSON-friendly config payload."""
+        return {
+            "active": self.active,
+            "scanners": sorted(self.exact_scanner_ids) if self.exact_scanner_ids else None,
+            "exclude_scanners": sorted(self.exclude_scanner_ids),
+            "enabled_scanner_ids": sorted(self.enabled_scanner_ids),
+        }
+
+    def to_metadata(self) -> dict[str, Any]:
+        """Return user-facing scan metadata."""
+        return {
+            "requested_scanner_ids": sorted(self.exact_scanner_ids) if self.exact_scanner_ids else None,
+            "enabled_scanner_ids": sorted(self.enabled_scanner_ids),
+            "excluded_scanner_ids": sorted(self.exclude_scanner_ids),
+        }
+
+
+def resolve_scanner_selection_policy(
+    *,
+    scanners: Iterable[str] | str | None = None,
+    exclude_scanners: Iterable[str] | str | None = None,
+) -> ScannerSelectionPolicy:
+    """Resolve raw scanner selection inputs into a policy."""
+    metadata = get_scanner_registry_metadata()
+    all_scanner_ids = frozenset(metadata.keys())
+
+    exact_ids = frozenset(resolve_scanner_ids(scanners))
+    exclude_ids = frozenset(resolve_scanner_ids(exclude_scanners))
+    base_ids = set(exact_ids or all_scanner_ids)
+    enabled = frozenset(base_ids - set(exclude_ids))
+    active = bool(exact_ids or exclude_ids)
+
+    if active and not enabled:
+        raise ValueError("Scanner selection does not enable any scanners")
+
+    return ScannerSelectionPolicy(
+        enabled_scanner_ids=enabled,
+        all_scanner_ids=all_scanner_ids,
+        exact_scanner_ids=exact_ids,
+        exclude_scanner_ids=exclude_ids,
+        active=active,
+    )
+
+
+def scanner_selection_config_from_inputs(
+    *,
+    scanners: Iterable[str] | str | None = None,
+    exclude_scanners: Iterable[str] | str | None = None,
+) -> dict[str, Any]:
+    """Build a stable config dict for scanner selection inputs."""
+    return resolve_scanner_selection_policy(
+        scanners=scanners,
+        exclude_scanners=exclude_scanners,
+    ).to_config()
+
+
+def policy_from_config(config: Mapping[str, Any] | None) -> ScannerSelectionPolicy:
+    """Return the resolved selection policy from scanner config."""
+    raw_config = config if isinstance(config, Mapping) else {}
+    raw_selection = raw_config.get(SCANNER_SELECTION_CONFIG_KEY)
+
+    if isinstance(raw_selection, Mapping):
+        return resolve_scanner_selection_policy(
+            scanners=raw_selection.get("scanners"),
+            exclude_scanners=raw_selection.get("exclude_scanners"),
+        )
+
+    return resolve_scanner_selection_policy(
+        scanners=raw_config.get("scanners"),
+        exclude_scanners=raw_config.get("exclude_scanners"),
+    )
+
+
+def normalize_scanner_selection_config(config: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return a mutable config with a normalized scanner selection payload."""
+    normalized = dict(config or {})
+    has_raw_selection = any(key in normalized for key in (SCANNER_SELECTION_CONFIG_KEY, "scanners", "exclude_scanners"))
+    policy = policy_from_config(normalized)
+    if policy.active or has_raw_selection:
+        normalized[SCANNER_SELECTION_CONFIG_KEY] = policy.to_config()
+    normalized.pop("scanners", None)
+    normalized.pop("exclude_scanners", None)
+    return normalized
+
+
+def selected_scanner_extensions(
+    policy: ScannerSelectionPolicy,
+    *,
+    conservative: bool = False,
+) -> frozenset[str] | None:
+    """Return suffixes owned by the policy's enabled scanners.
+
+    When ``conservative`` is true, return ``None`` if suffix-only filtering
+    would narrow away files that selected scanners can route by trusted
+    headers. Remote sources only have filenames before download, so they need
+    this fail-open behavior to avoid selection-created coverage gaps.
+    """
+    metadata = get_scanner_registry_metadata()
+    extensions: set[str] = set()
+    for scanner_id in policy.enabled_scanner_ids:
+        scanner_info = metadata.get(scanner_id, {})
+        if conservative and (scanner_id in _GENERIC_CONTAINER_SCANNER_IDS or scanner_info.get("header_formats")):
+            return None
+        for key in ("extensions", "content_routed_extensions", "scanner_only_extensions"):
+            for extension in scanner_info.get(key, []):
+                extension_text = str(extension).lower()
+                extensions.add(extension_text)
+    return frozenset(extensions)
+
+
+def add_scanner_selection_skip_check(
+    result: ScanResult,
+    location: str,
+    scanner_id: str | None,
+    policy: ScannerSelectionPolicy,
+    *,
+    context: str | None = None,
+) -> None:
+    """Add an informational check for a scanner skipped by selection policy."""
+    result.metadata.setdefault("scanner_selection", policy.to_metadata())
+    skipped_scanner_ids = result.metadata.setdefault("skipped_scanner_ids", [])
+    if isinstance(skipped_scanner_ids, list) and scanner_id and scanner_id not in skipped_scanner_ids:
+        skipped_scanner_ids.append(scanner_id)
+
+    scanner_label = scanner_id or "candidate scanner"
+    message = f"Skipped {scanner_label} because it is not enabled by scanner selection policy"
+    if context:
+        message = f"{message} ({context})"
+
+    result.add_check(
+        name="Scanner Selection",
+        passed=True,
+        message=message,
+        severity=IssueSeverity.INFO,
+        location=location,
+        details={
+            "skipped_scanner_id": scanner_id,
+            "enabled_scanner_ids": sorted(policy.enabled_scanner_ids),
+            "context": context,
+        },
+    )
+
+
+def make_scanner_selection_skip_result(
+    path: str,
+    scanner_id: str | None,
+    policy: ScannerSelectionPolicy,
+) -> ScanResult:
+    """Build a successful result that makes intentional policy skips explicit."""
+    result = ScanResult(scanner_name="scanner_selection")
+    try:
+        result.bytes_scanned = os.path.getsize(path)
+    except OSError:
+        result.bytes_scanned = 0
+
+    result.metadata.update(
+        {
+            "scanner_selection": policy.to_metadata(),
+            "skipped_scanner_id": scanner_id,
+            "skip_reason": "scanner_not_enabled",
+        }
+    )
+    if result.bytes_scanned:
+        result.metadata["file_size"] = result.bytes_scanned
+
+    add_scanner_selection_skip_check(result, path, scanner_id, policy)
+    result.finish(success=True)
+    return result

--- a/modelaudit/scanner_selection.py
+++ b/modelaudit/scanner_selection.py
@@ -12,10 +12,12 @@ import difflib
 import os
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 from .scanner_registry_metadata import get_scanner_registry_metadata
 from .scanner_results import IssueSeverity, ScanResult
+
+ScannerSelectionSkipKind = Literal["preferred", "embedded"]
 
 SCANNER_SELECTION_CONFIG_KEY = "scanner_selection"
 _GENERIC_CONTAINER_SCANNER_IDS = frozenset({"compressed", "rar", "sevenzip", "tar", "zip"})
@@ -251,8 +253,8 @@ def selected_scanner_extensions(
 
 
 SCANNER_SELECTION_CHECK_NAME = "Scanner Selection"
-SCANNER_SELECTION_PREFERRED_KIND = "preferred"
-SCANNER_SELECTION_EMBEDDED_KIND = "embedded"
+SCANNER_SELECTION_PREFERRED_KIND: ScannerSelectionSkipKind = "preferred"
+SCANNER_SELECTION_EMBEDDED_KIND: ScannerSelectionSkipKind = "embedded"
 
 
 def add_scanner_selection_skip_check(
@@ -262,7 +264,7 @@ def add_scanner_selection_skip_check(
     policy: ScannerSelectionPolicy,
     *,
     context: str | None = None,
-    kind: str = SCANNER_SELECTION_EMBEDDED_KIND,
+    kind: ScannerSelectionSkipKind = SCANNER_SELECTION_EMBEDDED_KIND,
 ) -> None:
     """Add a check documenting a scanner that was skipped by selection policy.
 
@@ -303,7 +305,7 @@ def make_scanner_selection_skip_result(
     scanner_id: str | None,
     policy: ScannerSelectionPolicy,
     *,
-    kind: str = SCANNER_SELECTION_PREFERRED_KIND,
+    kind: ScannerSelectionSkipKind = SCANNER_SELECTION_PREFERRED_KIND,
 ) -> ScanResult:
     """Build a successful result that makes intentional policy skips explicit."""
     result = ScanResult(scanner_name="scanner_selection")
@@ -341,3 +343,26 @@ def embedded_pickle_scanner(
     policy = policy_from_config(config)
     scanner = pickle_scanner_factory(config) if policy.allows("pickle") else None
     return scanner, policy
+
+
+def collect_suppressed_preferred_scanners(checks: Iterable[Any]) -> list[dict[str, Any]]:
+    """Return one entry per (scanner_id, location) flagged as preferred skip.
+
+    Walks scan result checks and filters to preferred-kind Scanner Selection
+    skips — the coverage-gap signal that CLI, SDK, and CI consumers need when
+    a selection policy suppressed the scanner that routing would have picked.
+    """
+    aggregated: dict[tuple[str, str], dict[str, Any]] = {}
+    for check in checks:
+        if getattr(check, "name", None) != SCANNER_SELECTION_CHECK_NAME:
+            continue
+        details = getattr(check, "details", None)
+        if not isinstance(details, Mapping) or details.get("kind") != SCANNER_SELECTION_PREFERRED_KIND:
+            continue
+        scanner_id = str(details.get("skipped_scanner_id") or "unknown")
+        location = getattr(check, "location", None) or "<unknown>"
+        aggregated.setdefault(
+            (scanner_id, location),
+            {"scanner_id": scanner_id, "location": location, "context": details.get("context")},
+        )
+    return sorted(aggregated.values(), key=lambda entry: (entry["scanner_id"], entry["location"]))

--- a/modelaudit/scanners/__init__.py
+++ b/modelaudit/scanners/__init__.py
@@ -171,9 +171,9 @@ class ScannerRegistry:
         Returns:
             True if the scanner is registered and can potentially be loaded
         """
-        return self._get_scanner_id_for_class(class_name) is not None
+        return self.get_scanner_id_for_class(class_name) is not None
 
-    def _get_scanner_id_for_class(self, class_name: str) -> str | None:
+    def get_scanner_id_for_class(self, class_name: str) -> str | None:
         """Resolve a scanner class name from the registry's descriptor catalog."""
         for scanner_id, scanner_info in self._scanners.items():
             if scanner_info.get("class") == class_name:
@@ -448,7 +448,7 @@ SCANNER_REGISTRY = _LazyList(_registry)
 # Export scanner classes with lazy loading
 def __getattr__(name: str) -> Any:
     """Lazy-load scanner classes from the registry's descriptor catalog."""
-    scanner_id = _registry._get_scanner_id_for_class(name)
+    scanner_id = _registry.get_scanner_id_for_class(name)
     if scanner_id is not None:
         scanner_class = _registry.load_scanner_by_id(scanner_id)
         if scanner_class:

--- a/modelaudit/scanners/__init__.py
+++ b/modelaudit/scanners/__init__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from ..scanner_registry_metadata import get_scanner_registry_metadata
+from ..scanner_selection import ScannerSelectionPolicy, policy_from_config
 from .base import BaseScanner, Check, CheckStatus, Issue, IssueSeverity, ScanResult
 
 logger = logging.getLogger(__name__)
@@ -198,20 +199,29 @@ class ScannerRegistry:
                 header_format_to_scanner_id[header_format] = scanner_id
         return header_format_to_scanner_id
 
-    def get_scanner_classes(self) -> list[type[BaseScanner]]:
+    def get_scanner_classes(
+        self,
+        scanner_selection: ScannerSelectionPolicy | None = None,
+    ) -> list[type[BaseScanner]]:
         """Get all available scanner classes in priority order"""
         scanner_classes = []
         # Sort by priority
         sorted_scanners = sorted(self._scanners.items(), key=lambda x: x[1]["priority"])
 
         for scanner_id, _ in sorted_scanners:
+            if scanner_selection is not None and not scanner_selection.allows(scanner_id):
+                continue
             scanner_class = self._load_scanner(scanner_id)
             if scanner_class:
                 scanner_classes.append(scanner_class)
 
         return scanner_classes
 
-    def get_scanner_for_path(self, path: str) -> type[BaseScanner] | None:
+    def get_scanner_for_path(
+        self,
+        path: str,
+        scanner_selection: ScannerSelectionPolicy | None = None,
+    ) -> type[BaseScanner] | None:
         """Get the best scanner for a given path (lazy loaded)"""
         import os
 
@@ -221,6 +231,8 @@ class ScannerRegistry:
         filename = os.path.basename(path).lower()
         if os.path.isdir(path):
             for scanner_id, scanner_info in sorted_scanners:
+                if scanner_selection is not None and not scanner_selection.allows(scanner_id):
+                    continue
                 if "" not in scanner_info.get("extensions", []):
                     continue
                 scanner_class = self._load_scanner(scanner_id)
@@ -248,6 +260,8 @@ class ScannerRegistry:
 
         for candidate_extension in candidate_extensions:
             for scanner_id, scanner_info in sorted_scanners:
+                if scanner_selection is not None and not scanner_selection.allows(scanner_id):
+                    continue
                 extensions = scanner_info.get("extensions", [])
                 content_routed_extensions = scanner_info.get("content_routed_extensions", [])
                 if candidate_extension not in extensions and candidate_extension not in content_routed_extensions:
@@ -260,7 +274,7 @@ class ScannerRegistry:
         # Some ZIP-backed artifacts intentionally use pickle/checkpoint suffixes.
         # If stricter extension-specific scanners all decline, fall back to the
         # generic ZIP scanner so helper-level routing does not drop coverage.
-        if is_zip_file:
+        if is_zip_file and (scanner_selection is None or scanner_selection.allows("zip")):
             scanner_class = self._load_scanner("zip")
             if scanner_class and scanner_class.can_handle(path):
                 return scanner_class
@@ -274,7 +288,12 @@ class ScannerRegistry:
 
         header_scanner_id = self.get_scanner_id_for_header_format(header_format)
         header_scanner_info = self._scanners.get(header_scanner_id or "")
-        if header_scanner_id and header_scanner_info and header_format == header_scanner_id:
+        if (
+            header_scanner_id
+            and header_scanner_info
+            and header_format == header_scanner_id
+            and (scanner_selection is None or scanner_selection.allows(header_scanner_id))
+        ):
             scanner_class = self._load_scanner(header_scanner_id)
             if scanner_class and (scanner_class.can_handle(path) or os.path.exists(path)):
                 return scanner_class
@@ -282,6 +301,8 @@ class ScannerRegistry:
         # Manifest-like config files sometimes intentionally use generic or
         # missing extensions, so keep the descriptor-owned filename fallback.
         for scanner_id, scanner_info in sorted_scanners:
+            if scanner_selection is not None and not scanner_selection.allows(scanner_id):
+                continue
             if not self._is_content_routed_filename(filename, scanner_info):
                 continue
 
@@ -442,7 +463,11 @@ def __getattr__(name: str) -> Any:
 # Helper function for getting scanner for a file
 def get_scanner_for_file(path: str, config: dict[str, Any] | None = None) -> BaseScanner | None:
     """Get an instantiated scanner for a given file path"""
-    scanner_class = _registry.get_scanner_for_path(path)
+    scanner_selection = policy_from_config(config)
+    scanner_class = _registry.get_scanner_for_path(
+        path,
+        scanner_selection=scanner_selection if scanner_selection.active else None,
+    )
     if scanner_class:
         return scanner_class(config=config)
     return None

--- a/modelaudit/scanners/archive_dispatch.py
+++ b/modelaudit/scanners/archive_dispatch.py
@@ -6,7 +6,12 @@ from typing import Any
 
 from ..scanner_registry_metadata import get_scanner_registry_metadata
 from ..scanner_results import ScanResult
-from ..scanner_selection import add_scanner_selection_skip_check, make_scanner_selection_skip_result, policy_from_config
+from ..scanner_selection import (
+    SCANNER_SELECTION_PREFERRED_KIND,
+    add_scanner_selection_skip_check,
+    make_scanner_selection_skip_result,
+    policy_from_config,
+)
 from ..utils.file.detection import (
     detect_file_format,
     is_executorch_archive,
@@ -119,7 +124,7 @@ def scan_nested_file(path: str, config: dict[str, Any] | None = None) -> ScanRes
                 candidate_scanner_class = _registry.get_scanner_for_path(path)
                 if candidate_scanner_class:
                     candidate_scanner_id = (
-                        _registry._get_scanner_id_for_class(candidate_scanner_class.__name__)
+                        _registry.get_scanner_id_for_class(candidate_scanner_class.__name__)
                         or candidate_scanner_class.name
                     )
             if candidate_scanner_id and not scanner_selection.allows(candidate_scanner_id):
@@ -138,5 +143,6 @@ def scan_nested_file(path: str, config: dict[str, Any] | None = None) -> ScanRes
             skipped_preferred_scanner_id,
             scanner_selection,
             context="preferred nested scanner",
+            kind=SCANNER_SELECTION_PREFERRED_KIND,
         )
     return result

--- a/modelaudit/scanners/archive_dispatch.py
+++ b/modelaudit/scanners/archive_dispatch.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from ..scanner_registry_metadata import get_scanner_registry_metadata
 from ..scanner_results import ScanResult
+from ..scanner_selection import add_scanner_selection_skip_check, make_scanner_selection_skip_result, policy_from_config
 from ..utils.file.detection import (
     detect_file_format,
     is_executorch_archive,
@@ -94,20 +95,48 @@ def scan_nested_file(path: str, config: dict[str, Any] | None = None) -> ScanRes
     """Scan an extracted archive member without importing `modelaudit.core`."""
     from . import _registry
 
+    scanner_selection = policy_from_config(config)
     scanner_class = None
     scanner_id = _select_nested_scanner_id(path)
-    if scanner_id:
+    skipped_preferred_scanner_id: str | None = None
+    if scanner_id and scanner_selection.allows(scanner_id):
         scanner_class = _registry.load_scanner_by_id(scanner_id)
         if scanner_class and not _nested_scanner_can_handle(scanner_class, scanner_id, path):
             scanner_class = None
+    elif scanner_id:
+        skipped_preferred_scanner_id = scanner_id
 
     if scanner_class is None:
-        scanner_class = _registry.get_scanner_for_path(path)
+        if scanner_selection.active:
+            scanner_class = _registry.get_scanner_for_path(path, scanner_selection=scanner_selection)
+        else:
+            scanner_class = _registry.get_scanner_for_path(path)
 
     if scanner_class is None:
+        if scanner_selection.active:
+            candidate_scanner_id = skipped_preferred_scanner_id
+            if candidate_scanner_id is None:
+                candidate_scanner_class = _registry.get_scanner_for_path(path)
+                if candidate_scanner_class:
+                    candidate_scanner_id = (
+                        _registry._get_scanner_id_for_class(candidate_scanner_class.__name__)
+                        or candidate_scanner_class.name
+                    )
+            if candidate_scanner_id and not scanner_selection.allows(candidate_scanner_id):
+                return make_scanner_selection_skip_result(path, candidate_scanner_id, scanner_selection)
+
         result = ScanResult(scanner_name="unknown")
         result.finish(success=True)
         return result
 
     scanner = scanner_class(config=config)
-    return scanner.scan_with_cache(path)
+    result = scanner.scan_with_cache(path)
+    if skipped_preferred_scanner_id:
+        add_scanner_selection_skip_check(
+            result,
+            path,
+            skipped_preferred_scanner_id,
+            scanner_selection,
+            context="preferred nested scanner",
+        )
+    return result

--- a/modelaudit/scanners/executorch_scanner.py
+++ b/modelaudit/scanners/executorch_scanner.py
@@ -5,6 +5,7 @@ import tempfile
 import zipfile
 from typing import Any, BinaryIO, ClassVar, cast
 
+from ..scanner_selection import add_scanner_selection_skip_check, policy_from_config
 from ..utils import sanitize_archive_path
 from ..utils.file.detection import (
     _is_executorch_binary_signature,
@@ -27,7 +28,8 @@ class ExecuTorchScanner(BaseScanner):
 
     def __init__(self, config: dict[str, Any] | None = None) -> None:
         super().__init__(config)
-        self.pickle_scanner = PickleScanner(config=self.config)
+        self.scanner_selection = policy_from_config(self.config)
+        self.pickle_scanner = PickleScanner(config=self.config) if self.scanner_selection.allows("pickle") else None
 
     @classmethod
     def can_handle(cls, path: str) -> bool:
@@ -122,6 +124,16 @@ class ExecuTorchScanner(BaseScanner):
                 for name in pickle_files:
                     member_info = z.getinfo(name)
                     bytes_scanned += member_info.file_size
+                    if self.pickle_scanner is None:
+                        add_scanner_selection_skip_check(
+                            result,
+                            f"{path}:{name}",
+                            "pickle",
+                            self.scanner_selection,
+                            context="embedded ExecuTorch pickle analysis",
+                        )
+                        continue
+
                     with z.open(name, "r") as file_like:
                         sub_result = self.pickle_scanner.scan_stream(
                             cast(BinaryIO, file_like),

--- a/modelaudit/scanners/executorch_scanner.py
+++ b/modelaudit/scanners/executorch_scanner.py
@@ -5,7 +5,7 @@ import tempfile
 import zipfile
 from typing import Any, BinaryIO, ClassVar, cast
 
-from ..scanner_selection import add_scanner_selection_skip_check, policy_from_config
+from ..scanner_selection import add_scanner_selection_skip_check, embedded_pickle_scanner
 from ..utils import sanitize_archive_path
 from ..utils.file.detection import (
     _is_executorch_binary_signature,
@@ -28,8 +28,7 @@ class ExecuTorchScanner(BaseScanner):
 
     def __init__(self, config: dict[str, Any] | None = None) -> None:
         super().__init__(config)
-        self.scanner_selection = policy_from_config(self.config)
-        self.pickle_scanner = PickleScanner(config=self.config) if self.scanner_selection.allows("pickle") else None
+        self.pickle_scanner, self.scanner_selection = embedded_pickle_scanner(self.config, PickleScanner)
 
     @classmethod
     def can_handle(cls, path: str) -> bool:

--- a/modelaudit/scanners/joblib_scanner.py
+++ b/modelaudit/scanners/joblib_scanner.py
@@ -13,7 +13,7 @@ from contextlib import suppress
 from typing import Any, ClassVar
 
 from ..detectors.cve_patterns import analyze_cve_patterns, enhance_scan_result_with_cve
-from ..scanner_selection import add_scanner_selection_skip_check, policy_from_config
+from ..scanner_selection import add_scanner_selection_skip_check, embedded_pickle_scanner
 from ..utils.file.detection import read_magic_bytes
 from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, IssueSeverity, ScanResult
 from .pickle_scanner import PickleScanner, _looks_like_pickle
@@ -128,8 +128,7 @@ class JoblibScanner(BaseScanner):
     def __init__(self, config: dict[str, Any] | None = None):
         """Initialize Joblib scanning limits and the embedded Pickle scanner."""
         super().__init__(config)
-        self.scanner_selection = policy_from_config(self.config)
-        self.pickle_scanner = PickleScanner(config=self.config) if self.scanner_selection.allows("pickle") else None
+        self.pickle_scanner, self.scanner_selection = embedded_pickle_scanner(self.config, PickleScanner)
         # Security limits
         self.max_decompression_ratio = self.config.get("max_decompression_ratio", 100.0)
         self.max_decompressed_size = self.config.get(

--- a/modelaudit/scanners/joblib_scanner.py
+++ b/modelaudit/scanners/joblib_scanner.py
@@ -13,6 +13,7 @@ from contextlib import suppress
 from typing import Any, ClassVar
 
 from ..detectors.cve_patterns import analyze_cve_patterns, enhance_scan_result_with_cve
+from ..scanner_selection import add_scanner_selection_skip_check, policy_from_config
 from ..utils.file.detection import read_magic_bytes
 from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, IssueSeverity, ScanResult
 from .pickle_scanner import PickleScanner, _looks_like_pickle
@@ -127,7 +128,8 @@ class JoblibScanner(BaseScanner):
     def __init__(self, config: dict[str, Any] | None = None):
         """Initialize Joblib scanning limits and the embedded Pickle scanner."""
         super().__init__(config)
-        self.pickle_scanner = PickleScanner(config=self.config)
+        self.scanner_selection = policy_from_config(self.config)
+        self.pickle_scanner = PickleScanner(config=self.config) if self.scanner_selection.allows("pickle") else None
         # Security limits
         self.max_decompression_ratio = self.config.get("max_decompression_ratio", 100.0)
         self.max_decompressed_size = self.config.get(
@@ -234,6 +236,17 @@ class JoblibScanner(BaseScanner):
         """Analyze a raw or decompressed pickle payload with CVE and opcode checks."""
         self._detect_cve_patterns(payload, result, context)
         self._scan_for_joblib_specific_threats(payload, result, context)
+
+        if self.pickle_scanner is None:
+            add_scanner_selection_skip_check(
+                result,
+                context,
+                "pickle",
+                self.scanner_selection,
+                context="embedded joblib pickle analysis",
+            )
+            result.bytes_scanned = len(payload)
+            return
 
         with io.BytesIO(payload) as file_like:
             sub_result = self.pickle_scanner.scan_stream(

--- a/modelaudit/scanners/numpy_scanner.py
+++ b/modelaudit/scanners/numpy_scanner.py
@@ -6,6 +6,7 @@ import sys
 import warnings
 from typing import TYPE_CHECKING, Any, BinaryIO, ClassVar
 
+from ..scanner_selection import add_scanner_selection_skip_check, policy_from_config
 from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, Check, Issue, IssueSeverity, ScanResult
 from .pickle_scanner import PickleScanner
 
@@ -63,6 +64,7 @@ class NumPyScanner(BaseScanner):
 
     def __init__(self, config: dict[str, Any] | None = None) -> None:
         super().__init__(config)
+        self.scanner_selection = policy_from_config(self.config)
         # Security limits
         self.max_array_bytes = self.config.get(
             "max_array_bytes",
@@ -108,6 +110,19 @@ class NumPyScanner(BaseScanner):
         context_path: str,
     ) -> ScanResult:
         """Reuse PickleScanner analysis for object-dtype NumPy payloads."""
+        if not self.scanner_selection.allows("pickle"):
+            result = ScanResult(scanner_name="scanner_selection")
+            result.bytes_scanned = payload_size
+            add_scanner_selection_skip_check(
+                result,
+                context_path,
+                "pickle",
+                self.scanner_selection,
+                context="embedded NumPy object pickle analysis",
+            )
+            result.finish(success=True)
+            return result
+
         pickle_scanner = PickleScanner(config=self.config)
         return pickle_scanner.scan_stream(
             file_obj,
@@ -401,16 +416,23 @@ class NumPyScanner(BaseScanner):
                             # Object-dtype .npy payloads are stored as a pickle stream rather than
                             # fixed-width element data, so the numeric dtype/size validation path
                             # is not applicable after we recurse into the embedded pickle payload.
+                            pickle_scan_skipped = embedded_result.scanner_name == "scanner_selection"
                             result.add_check(
                                 name="Data Type Safety Check",
                                 passed=True,
-                                message=f"Object dtype '{dtype}' handled via recursive pickle analysis",
+                                message=(
+                                    f"Object dtype '{dtype}' embedded pickle analysis skipped by scanner selection"
+                                    if pickle_scan_skipped
+                                    else f"Object dtype '{dtype}' handled via recursive pickle analysis"
+                                ),
                                 location=path,
                                 rule_code=None,
                                 details={
                                     "dtype": str(dtype),
                                     "dtype_kind": dtype.kind,
-                                    "handled_via": "embedded_pickle_scan",
+                                    "handled_via": (
+                                        "scanner_selection_skip" if pickle_scan_skipped else "embedded_pickle_scan"
+                                    ),
                                     "cve_id": self.CVE_2019_6446_ID,
                                 },
                             )

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from typing import Any, ClassVar
 
 from ..detectors.suspicious_symbols import CVE_COMBINED_PATTERNS
+from ..scanner_selection import add_scanner_selection_skip_check, policy_from_config
 from ..utils import sanitize_archive_path
 from ..utils.file.detection import PROTO0_1_MAX_PROBE_BYTES, PROTO0_1_START_BYTES, _looks_like_proto0_or_1_pickle
 from .archive_member_security import is_executable_archive_member_name
@@ -229,8 +230,10 @@ class PyTorchZipScanner(BaseScanner):
 
     def __init__(self, config: dict[str, Any] | None = None):
         super().__init__(config)
-        # Initialize a pickle scanner for embedded pickles
-        self.pickle_scanner: PickleScanner = PickleScanner(config)
+        self.scanner_selection = policy_from_config(self.config)
+        self.pickle_scanner: PickleScanner | None = (
+            PickleScanner(config) if self.scanner_selection.allows("pickle") else None
+        )
         self.current_file_path = ""  # Will be set when scanning files
         self._relaxed_crc_tracker = RelaxedZipCrcTracker()
         # Configurable limits (can override class defaults via config)
@@ -964,11 +967,22 @@ class PyTorchZipScanner(BaseScanner):
         for info in pickle_files:
             name = self._get_zip_member_name(info)
             pickle_data_size = info.file_size
+            pickle_source = f"{path}:{name}"
+
+            if self.pickle_scanner is None:
+                bytes_scanned += pickle_data_size
+                add_scanner_selection_skip_check(
+                    result,
+                    pickle_source,
+                    "pickle",
+                    self.scanner_selection,
+                    context="embedded PyTorch pickle analysis",
+                )
+                continue
 
             # Choose scanning approach based on file size with spooling for seekability
             cfg = self.config or {}
             max_in_mem = int(cfg.get("pickle_max_memory_read", 32 * 1024 * 1024))  # 32MB default
-            pickle_source = f"{path}:{name}"
             if pickle_data_size <= max_in_mem:
                 data = self._read_member_bytes(
                     zip_file,

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from typing import Any, ClassVar
 
 from ..detectors.suspicious_symbols import CVE_COMBINED_PATTERNS
-from ..scanner_selection import add_scanner_selection_skip_check, policy_from_config
+from ..scanner_selection import add_scanner_selection_skip_check, embedded_pickle_scanner
 from ..utils import sanitize_archive_path
 from ..utils.file.detection import PROTO0_1_MAX_PROBE_BYTES, PROTO0_1_START_BYTES, _looks_like_proto0_or_1_pickle
 from .archive_member_security import is_executable_archive_member_name
@@ -230,10 +230,8 @@ class PyTorchZipScanner(BaseScanner):
 
     def __init__(self, config: dict[str, Any] | None = None):
         super().__init__(config)
-        self.scanner_selection = policy_from_config(self.config)
-        self.pickle_scanner: PickleScanner | None = (
-            PickleScanner(config) if self.scanner_selection.allows("pickle") else None
-        )
+        pickle_scanner, self.scanner_selection = embedded_pickle_scanner(self.config, PickleScanner)
+        self.pickle_scanner: PickleScanner | None = pickle_scanner
         self.current_file_path = ""  # Will be set when scanning files
         self._relaxed_crc_tracker = RelaxedZipCrcTracker()
         # Configurable limits (can override class defaults via config)

--- a/modelaudit/utils/file/filtering.py
+++ b/modelaudit/utils/file/filtering.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import zipfile
+from collections.abc import Collection
 from pathlib import Path
 
 # Default extensions to skip when scanning directories
@@ -314,6 +315,7 @@ def should_skip_file(
     skip_filenames: set[str] | None = None,
     skip_hidden: bool = True,
     metadata_scanner_available: bool = True,
+    scanner_selection_extensions: Collection[str] | None = None,
 ) -> bool:
     """
     Check if a file should be skipped based on its extension or name.
@@ -324,6 +326,7 @@ def should_skip_file(
         skip_filenames: Set of filenames to skip (defaults to DEFAULT_SKIP_FILENAMES)
         skip_hidden: Whether to skip hidden files (starting with .)
         metadata_scanner_available: Whether metadata scanner is available to handle metadata files
+        scanner_selection_extensions: Selected scanner suffixes that should be preserved from default skips
 
     Returns:
         True if the file should be skipped
@@ -352,6 +355,11 @@ def should_skip_file(
         ext in metadata_extensions or filename.lower() in metadata_filenames or is_readme_txt
     ):
         return False
+
+    if use_default_skip_extensions and scanner_selection_extensions is not None:
+        selected_extensions = {candidate.lower() for candidate in scanner_selection_extensions}
+        if any(candidate in selected_extensions for candidate in candidate_extensions):
+            return False
 
     # Preserve scanner coverage for archive/metadata formats that are otherwise
     # part of the default skip list.

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -6,7 +6,7 @@ import os
 import re
 import shutil
 import tempfile
-from collections.abc import Callable, Coroutine, Iterator
+from collections.abc import Callable, Collection, Coroutine, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -550,15 +550,22 @@ class GCSCache:
             click.echo(f"Cleaned {len(keys_to_remove)} old cache entries")
 
 
-def filter_scannable_files(files: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def filter_scannable_files(
+    files: list[dict[str, Any]],
+    scannable_extensions: Collection[str] | None = None,
+) -> list[dict[str, Any]]:
     """Filter files to only include scannable model types."""
+    extensions = SCANNABLE_MODEL_EXTENSIONS if scannable_extensions is None else frozenset(scannable_extensions)
     scannable = []
     for file in files:
         file_path = str(file["path"])
         path = Path(_cloud_url_basename(file_path) if is_cloud_url(file_path) else file_path)
         suffixes = [s.lower() for s in path.suffixes]
+        if not suffixes and "" in extensions:
+            scannable.append(file)
+            continue
         for i in range(1, len(suffixes) + 1):
-            if "".join(suffixes[-i:]) in SCANNABLE_MODEL_EXTENSIONS:
+            if "".join(suffixes[-i:]) in extensions:
                 scannable.append(file)
                 break
 
@@ -601,6 +608,7 @@ def download_from_cloud(
     show_progress: bool = True,
     selective: bool = True,
     stream_analyze: bool = False,
+    scannable_extensions: Collection[str] | None = None,
 ) -> Path | str:
     """Download a file or directory from cloud storage to a local path.
 
@@ -718,7 +726,7 @@ def download_from_cloud(
 
             if selective:
                 # Filter to only scannable files
-                files = filter_scannable_files(files)
+                files = filter_scannable_files(files, scannable_extensions=scannable_extensions)
                 if show_progress:
                     total = metadata.get("file_count", 0)
                     if files:
@@ -790,6 +798,7 @@ def download_from_cloud_streaming(
     max_size: int | None = None,
     show_progress: bool = True,
     selective: bool = True,
+    scannable_extensions: Collection[str] | None = None,
 ) -> Iterator[tuple[Path, bool]]:
     """
     Download files from cloud storage one at a time (streaming mode).
@@ -842,7 +851,7 @@ def download_from_cloud_streaming(
             raise ValueError(f"Invalid metadata for 'files': expected list, got {type(raw_files).__name__}")
 
         if selective:
-            files = filter_scannable_files(files)
+            files = filter_scannable_files(files, scannable_extensions=scannable_extensions)
             if show_progress and files:
                 click.echo(f"Found {len(files)} scannable files to stream")
 

--- a/modelaudit/utils/sources/jfrog.py
+++ b/modelaudit/utils/sources/jfrog.py
@@ -6,6 +6,7 @@ import os
 import re
 import shutil
 import tempfile
+from collections.abc import Collection
 from pathlib import Path, PurePosixPath
 from typing import Any, Literal, TypedDict
 from urllib.parse import urlparse, urlunparse
@@ -337,8 +338,12 @@ def format_size(size_bytes: int) -> str:
     return f"{size:.1f} PB"
 
 
-def filter_scannable_files(files: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def filter_scannable_files(
+    files: list[dict[str, Any]],
+    scannable_extensions: Collection[str] | None = None,
+) -> list[dict[str, Any]]:
     """Filter files to only include scannable model types."""
+    extensions = SCANNABLE_MODEL_EXTENSIONS if scannable_extensions is None else frozenset(scannable_extensions)
     scannable = []
     for file in files:
         file_path = file["path"]
@@ -354,8 +359,11 @@ def filter_scannable_files(files: list[dict[str, Any]]) -> list[dict[str, Any]]:
             path = Path(file_path)
 
         suffixes = [s.lower() for s in path.suffixes]
+        if not suffixes and "" in extensions:
+            scannable.append(file)
+            continue
         for i in range(1, len(suffixes) + 1):
-            if "".join(suffixes[-i:]) in SCANNABLE_MODEL_EXTENSIONS:
+            if "".join(suffixes[-i:]) in extensions:
                 scannable.append(file)
                 break
     return scannable
@@ -450,6 +458,7 @@ def list_jfrog_folder_contents(
     recursive: bool = True,
     selective: bool = True,
     fetch_sizes: bool = False,
+    scannable_extensions: Collection[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Recursively list all files in a JFrog folder.
 
@@ -535,7 +544,7 @@ def list_jfrog_folder_contents(
     _collect_files(base_url)
 
     if selective:
-        files = filter_scannable_files(files)
+        files = filter_scannable_files(files, scannable_extensions=scannable_extensions)
 
     return files
 
@@ -549,6 +558,7 @@ def download_jfrog_folder(
     selective: bool = True,
     show_progress: bool = True,
     fetch_sizes: bool = False,
+    scannable_extensions: Collection[str] | None = None,
 ) -> Path:
     """Download all files from a JFrog folder.
 
@@ -574,8 +584,18 @@ def download_jfrog_folder(
         raise ValueError(f"Not a JFrog URL: {display_url}")
 
     # List all files in the folder
+    list_kwargs: dict[str, Any] = {}
+    if scannable_extensions is not None:
+        list_kwargs["scannable_extensions"] = scannable_extensions
     files = list_jfrog_folder_contents(
-        url, api_token, access_token, timeout, recursive=True, selective=selective, fetch_sizes=fetch_sizes
+        url,
+        api_token,
+        access_token,
+        timeout,
+        recursive=True,
+        selective=selective,
+        fetch_sizes=fetch_sizes,
+        **list_kwargs,
     )
 
     if not files:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,7 @@ def pytest_runtest_setup(item):
             "test_picklescan_adapter.py",
             "test_joblib_scanner.py",
             "test_scanner_registry.py",  # Scanner registry routing and metadata tests
+            "test_scanner_selection.py",  # Scanner selection policy and routing tests
             "test_lazy_loading.py",  # Lazy scanner descriptor/catalog tests
             "test_graceful_degradation.py",  # Scanner dependency degradation tests
             "test_joblib_scanner_codecs.py",  # Joblib raw/compressed pickle fallback regression tests

--- a/tests/test_lazy_loading.py
+++ b/tests/test_lazy_loading.py
@@ -279,7 +279,7 @@ class TestBackwardsCompatibility:
         for scanner_id, scanner_info in _registry._scanners.items():
             class_name = scanner_info["class"]
             assert _registry.has_scanner_class(class_name)
-            assert _registry._get_scanner_id_for_class(class_name) == scanner_id
+            assert _registry.get_scanner_id_for_class(class_name) == scanner_id
 
         for scanner_id, scanner_info in _registry._scanners.items():
             if scanner_info.get("dependencies"):

--- a/tests/test_scanner_selection.py
+++ b/tests/test_scanner_selection.py
@@ -53,6 +53,19 @@ def test_scanner_name_resolution_accepts_ids_classes_and_common_aliases() -> Non
     )
 
 
+def test_hardcoded_user_facing_aliases_resolve() -> None:
+    """Pin the issue-facing aliases so class renames can't silently break selection."""
+    cases = {
+        "H5Scanner": "keras_h5",
+        "TensorflowSavedModelScanner": "tf_savedmodel",
+        "TensorFlowSavedModelScanner": "tf_savedmodel",
+        "TensorflowMetaGraphScanner": "tf_metagraph",
+        "TensorFlowMetaGraphScanner": "tf_metagraph",
+    }
+    for alias, expected_id in cases.items():
+        assert resolve_scanner_ids([alias]) == (expected_id,), f"alias {alias!r} failed to resolve"
+
+
 def test_every_registered_scanner_resolves_by_id_and_class() -> None:
     metadata = get_scanner_registry_metadata()
 
@@ -94,6 +107,49 @@ def test_scan_file_excluded_scanner_is_explicit_skip(tmp_path: Path) -> None:
     assert not result.issues
     assert any(check.name == "Scanner Selection" for check in result.checks)
     assert result.metadata["skipped_scanner_id"] == "pickle"
+
+
+def test_preferred_scanner_skip_is_warning_and_tracks_suppressed_ids(tmp_path: Path) -> None:
+    path = tmp_path / "payload.pkl"
+    path.write_bytes(_build_malicious_pickle())
+
+    result = scan_file(str(path), config={"exclude_scanners": ["pickle"], "cache_enabled": False})
+
+    from modelaudit.scanner_results import IssueSeverity
+
+    selection_checks = [c for c in result.checks if c.name == "Scanner Selection"]
+    assert selection_checks, "expected preferred-scanner skip to emit a Scanner Selection check"
+    assert any(c.severity == IssueSeverity.WARNING for c in selection_checks)
+    assert any(
+        c.details.get("kind") == "preferred" and c.details.get("skipped_scanner_id") == "pickle"
+        for c in selection_checks
+    )
+
+
+def test_cli_warns_on_preferred_scanner_suppression(tmp_path: Path) -> None:
+    path = tmp_path / "payload.pkl"
+    path.write_bytes(_build_malicious_pickle())
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "scan",
+            str(path),
+            "--exclude-scanner",
+            "pickle",
+            "--format",
+            "json",
+            "--no-cache",
+            "--quiet",
+        ],
+        env={"PROMPTFOO_DISABLE_TELEMETRY": "1"},
+    )
+
+    assert result.exit_code == 0
+    assert "scanner selection suppressed the preferred scanner" in result.stderr.lower()
+    output = json.loads(result.stdout)
+    assert "pickle" in (output.get("scanner_selection") or {}).get("suppressed_preferred_scanner_ids", [])
 
 
 def test_nested_archive_dispatch_honors_selection_policy(tmp_path: Path) -> None:
@@ -267,6 +323,22 @@ def test_cli_rejects_unknown_scanner(tmp_path: Path) -> None:
 
     assert result.exit_code == 2
     assert "Unknown scanner name" in result.output
+
+
+def test_cli_unknown_scanner_suggests_closest_match(tmp_path: Path) -> None:
+    path = tmp_path / "payload.pkl"
+    path.write_bytes(_build_malicious_pickle())
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["scan", str(path), "--scanners", "picle"],
+        env={"PROMPTFOO_DISABLE_TELEMETRY": "1"},
+    )
+
+    assert result.exit_code == 2
+    assert "did you mean" in result.output.lower()
+    assert "pickle" in result.output
 
 
 def test_remote_prefilters_use_selected_scanner_extensions() -> None:

--- a/tests/test_scanner_selection.py
+++ b/tests/test_scanner_selection.py
@@ -16,6 +16,7 @@ from modelaudit.cli import cli
 from modelaudit.core import scan_file, scan_model_directory_or_file
 from modelaudit.scanner_registry_metadata import get_scanner_registry_metadata
 from modelaudit.scanner_selection import (
+    collect_suppressed_preferred_scanners,
     resolve_scanner_ids,
     resolve_scanner_selection_policy,
     scanner_catalog,
@@ -107,6 +108,18 @@ def test_scan_file_excluded_scanner_is_explicit_skip(tmp_path: Path) -> None:
     assert not result.issues
     assert any(check.name == "Scanner Selection" for check in result.checks)
     assert result.metadata["skipped_scanner_id"] == "pickle"
+
+
+def test_collect_suppressed_preferred_scanners_derives_from_checks(tmp_path: Path) -> None:
+    path = tmp_path / "payload.pkl"
+    path.write_bytes(_build_malicious_pickle())
+
+    result = scan_file(str(path), config={"exclude_scanners": ["pickle"], "cache_enabled": False})
+
+    suppressions = collect_suppressed_preferred_scanners(result.checks)
+    assert suppressions
+    assert {entry["scanner_id"] for entry in suppressions} == {"pickle"}
+    assert all(entry["location"] == str(path) for entry in suppressions)
 
 
 def test_preferred_scanner_skip_is_warning_and_tracks_suppressed_ids(tmp_path: Path) -> None:

--- a/tests/test_scanner_selection.py
+++ b/tests/test_scanner_selection.py
@@ -1,0 +1,317 @@
+"""Scanner selection policy and routing regressions."""
+
+from __future__ import annotations
+
+import json
+import os
+import pickle
+import zipfile
+from pathlib import Path
+from typing import Any
+
+from click.testing import CliRunner
+
+from modelaudit.cache import reset_cache_manager
+from modelaudit.cli import cli
+from modelaudit.core import scan_file, scan_model_directory_or_file
+from modelaudit.scanner_registry_metadata import get_scanner_registry_metadata
+from modelaudit.scanner_selection import (
+    resolve_scanner_ids,
+    resolve_scanner_selection_policy,
+    scanner_catalog,
+    selected_scanner_extensions,
+)
+from modelaudit.scanners.archive_dispatch import scan_nested_file
+from modelaudit.utils.sources.cloud_storage import filter_scannable_files as filter_cloud_scannable_files
+from modelaudit.utils.sources.jfrog import filter_scannable_files as filter_jfrog_scannable_files
+from tests.helpers import create_mock_pytorch_zip
+
+
+def _build_malicious_pickle() -> bytes:
+    """Build a deterministic pickle payload with an unsafe reducer target."""
+
+    class DangerousPayload:
+        def __reduce__(self) -> tuple[Any, tuple[str]]:
+            return (os.system, ("echo scanner-selection-test",))
+
+    return pickle.dumps(DangerousPayload())
+
+
+def _has_pickle_execution_finding(result: Any) -> bool:
+    for issue in result.issues:
+        issue_text = f"{issue.message} {issue.details}".lower()
+        if issue.rule_code == "S201" or "os.system" in issue_text or "eval" in issue_text:
+            return True
+    return False
+
+
+def test_scanner_name_resolution_accepts_ids_classes_and_common_aliases() -> None:
+    assert resolve_scanner_ids(["pickle", "PickleScanner", "TensorflowSavedModelScanner", "H5Scanner"]) == (
+        "pickle",
+        "tf_savedmodel",
+        "keras_h5",
+    )
+
+
+def test_every_registered_scanner_resolves_by_id_and_class() -> None:
+    metadata = get_scanner_registry_metadata()
+
+    for scanner_id, scanner_info in metadata.items():
+        assert resolve_scanner_ids([scanner_id]) == (scanner_id,)
+        assert resolve_scanner_ids([str(scanner_info["class"])]) == (scanner_id,)
+
+
+def test_selection_policy_uses_allowlist_minus_exclusions() -> None:
+    policy = resolve_scanner_selection_policy(
+        scanners=["PickleScanner", "zip"],
+        exclude_scanners=["ZipScanner"],
+    )
+
+    assert policy.active
+    assert policy.enabled_scanner_ids == frozenset({"pickle"})
+    assert policy.allows("pickle")
+    assert not policy.allows("zip")
+
+
+def test_scan_file_exact_scanner_allows_pickle_detection(tmp_path: Path) -> None:
+    path = tmp_path / "payload.pkl"
+    path.write_bytes(_build_malicious_pickle())
+
+    result = scan_file(str(path), config={"scanners": ["PickleScanner"], "cache_enabled": False})
+
+    assert result.scanner_name == "pickle"
+    assert _has_pickle_execution_finding(result)
+
+
+def test_scan_file_excluded_scanner_is_explicit_skip(tmp_path: Path) -> None:
+    path = tmp_path / "payload.pkl"
+    path.write_bytes(_build_malicious_pickle())
+
+    result = scan_file(str(path), config={"exclude_scanners": ["pickle"], "cache_enabled": False})
+
+    assert result.scanner_name == "scanner_selection"
+    assert result.success
+    assert not result.issues
+    assert any(check.name == "Scanner Selection" for check in result.checks)
+    assert result.metadata["skipped_scanner_id"] == "pickle"
+
+
+def test_nested_archive_dispatch_honors_selection_policy(tmp_path: Path) -> None:
+    archive_path = tmp_path / "payload.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("payload.pkl", _build_malicious_pickle())
+
+    zip_only = scan_file(str(archive_path), config={"scanners": ["zip"], "cache_enabled": False})
+    assert zip_only.scanner_name == "zip"
+    assert not _has_pickle_execution_finding(zip_only)
+    assert any(check.name == "Scanner Selection" for check in zip_only.checks)
+
+    zip_and_pickle = scan_file(
+        str(archive_path),
+        config={"scanners": ["zip", "pickle"], "cache_enabled": False},
+    )
+    assert zip_and_pickle.scanner_name == "zip"
+    assert _has_pickle_execution_finding(zip_and_pickle)
+
+
+def test_selected_zip_scanner_handles_zip_backed_extension_fallback(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "model.pt")
+
+    result = scan_file(str(model_path), config={"scanners": ["zip"], "cache_enabled": False})
+
+    assert result.scanner_name == "zip"
+    assert any(
+        check.name == "Scanner Selection" and check.details.get("skipped_scanner_id") == "pytorch_zip"
+        for check in result.checks
+    )
+
+
+def test_nested_selected_zip_scanner_handles_zip_backed_extension_fallback(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "model.pt")
+
+    result = scan_nested_file(str(model_path), config={"scanners": ["zip"], "cache_enabled": False})
+
+    assert result.scanner_name == "zip"
+    assert any(
+        check.name == "Scanner Selection" and check.details.get("skipped_scanner_id") == "pytorch_zip"
+        for check in result.checks
+    )
+
+
+def test_embedded_pickle_helpers_honor_selection_policy(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "model.pt", malicious=True)
+
+    pytorch_only = scan_file(str(model_path), config={"scanners": ["pytorch_zip"], "cache_enabled": False})
+    assert pytorch_only.scanner_name == "pytorch_zip"
+    assert not _has_pickle_execution_finding(pytorch_only)
+    assert any(
+        check.name == "Scanner Selection" and check.details.get("skipped_scanner_id") == "pickle"
+        for check in pytorch_only.checks
+    )
+
+    pytorch_and_pickle = scan_file(
+        str(model_path),
+        config={"scanners": ["pytorch_zip", "pickle"], "cache_enabled": False},
+    )
+    assert pytorch_and_pickle.scanner_name == "pytorch_zip"
+    assert _has_pickle_execution_finding(pytorch_and_pickle)
+
+
+def test_directory_scan_preserves_selected_text_scanner_skip_extensions(tmp_path: Path) -> None:
+    text_path = tmp_path / "vocab.txt"
+    text_path.write_text("token\n", encoding="utf-8")
+
+    result = scan_model_directory_or_file(
+        str(tmp_path),
+        scanners=["text"],
+        cache_enabled=False,
+        skip_file_types=True,
+    )
+
+    assert result.files_scanned == 1
+    assert result.scanner_names == ["text"]
+    assert result.scanner_selection
+    assert result.scanner_selection["enabled_scanner_ids"] == ["text"]
+
+
+def test_cache_key_includes_scanner_selection_policy(tmp_path: Path) -> None:
+    path = tmp_path / "benign.pkl"
+    path.write_bytes(pickle.dumps({"payload": "x" * 2048}))
+    cache_dir = tmp_path / "cache"
+
+    reset_cache_manager()
+    skip_result = scan_file(
+        str(path),
+        config={
+            "scanners": ["manifest"],
+            "cache_enabled": True,
+            "cache_dir": str(cache_dir),
+            "min_cache_file_size": 0,
+        },
+    )
+
+    pickle_result = scan_file(
+        str(path),
+        config={
+            "scanners": ["pickle"],
+            "cache_enabled": True,
+            "cache_dir": str(cache_dir),
+            "min_cache_file_size": 0,
+        },
+    )
+    reset_cache_manager()
+
+    assert skip_result.scanner_name == "scanner_selection"
+    assert pickle_result.scanner_name == "pickle"
+
+
+def test_cli_accepts_scanner_selection_options(tmp_path: Path) -> None:
+    path = tmp_path / "payload.pkl"
+    path.write_bytes(_build_malicious_pickle())
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "scan",
+            str(path),
+            "--scanners",
+            "PickleScanner",
+            "--format",
+            "json",
+            "--no-cache",
+            "--quiet",
+        ],
+        env={"PROMPTFOO_DISABLE_TELEMETRY": "1"},
+    )
+
+    assert result.exit_code == 1
+    output = json.loads(result.output)
+    assert output["scanner_names"] == ["pickle"]
+    assert output["scanner_selection"]["enabled_scanner_ids"] == ["pickle"]
+
+
+def test_cli_lists_scanners_without_scan_path() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["scan", "--list-scanners"], env={"PROMPTFOO_DISABLE_TELEMETRY": "1"})
+
+    assert result.exit_code == 0
+    assert "pickle (PickleScanner)" in result.output
+    assert "tf_savedmodel" in result.output
+
+
+def test_cli_lists_scanners_as_json() -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["scan", "--list-scanners", "--format", "json"],
+        env={"PROMPTFOO_DISABLE_TELEMETRY": "1"},
+    )
+
+    assert result.exit_code == 0
+    output = json.loads(result.output)
+    assert output["scanners"] == scanner_catalog()
+    assert any(scanner["id"] == "pickle" and scanner["class"] == "PickleScanner" for scanner in output["scanners"])
+
+
+def test_cli_rejects_unknown_scanner(tmp_path: Path) -> None:
+    path = tmp_path / "payload.pkl"
+    path.write_bytes(_build_malicious_pickle())
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["scan", str(path), "--scanners", "NopeScanner"],
+        env={"PROMPTFOO_DISABLE_TELEMETRY": "1"},
+    )
+
+    assert result.exit_code == 2
+    assert "Unknown scanner name" in result.output
+
+
+def test_remote_prefilters_use_selected_scanner_extensions() -> None:
+    policy = resolve_scanner_selection_policy(scanners=["safetensors"])
+    extensions = selected_scanner_extensions(policy)
+    files = [
+        {"path": "model.pkl"},
+        {"path": "weights.safetensors"},
+        {"path": "checkpoint.pt"},
+    ]
+
+    assert filter_cloud_scannable_files(files, scannable_extensions=extensions) == [{"path": "weights.safetensors"}]
+    assert filter_jfrog_scannable_files(files, scannable_extensions=extensions) == [{"path": "weights.safetensors"}]
+
+
+def test_remote_prefilters_fail_open_for_header_routed_scanners() -> None:
+    policy = resolve_scanner_selection_policy(scanners=["zip"])
+
+    assert selected_scanner_extensions(policy, conservative=True) is None
+
+    files = [
+        {"path": "s3://bucket/model.pt"},
+        {"path": "s3://bucket/readme.md"},
+    ]
+
+    assert {"path": "s3://bucket/model.pt"} in filter_cloud_scannable_files(files, scannable_extensions=None)
+    assert {"path": "s3://bucket/model.pt"} in filter_jfrog_scannable_files(files, scannable_extensions=None)
+
+
+def test_remote_prefilters_preserve_selected_extensionless_scanners() -> None:
+    policy = resolve_scanner_selection_policy(scanners=["llamafile"])
+    extensions = selected_scanner_extensions(policy, conservative=True)
+    files = [
+        {"path": "s3://bucket/model"},
+        {"path": "s3://bucket/model.exe"},
+        {"path": "s3://bucket/notes.txt"},
+    ]
+
+    assert extensions is not None
+    assert "" in extensions
+    assert filter_cloud_scannable_files(files, scannable_extensions=extensions) == [
+        {"path": "s3://bucket/model"},
+        {"path": "s3://bucket/model.exe"},
+    ]
+    assert filter_jfrog_scannable_files(files, scannable_extensions=extensions) == [
+        {"path": "s3://bucket/model"},
+        {"path": "s3://bucket/model.exe"},
+    ]


### PR DESCRIPTION
## Summary

Closes #7520.

This adds the minimum scanner-selection surface for ModelAudit: explicit scanner allowlists, scanner exclusions, and scanner discovery. Users can now run focused scans with `--scanners`, subtract scanners with `--exclude-scanner`, and discover supported IDs/classes with `--list-scanners`.

## Product and developer experience

The implementation intentionally keeps the MVP small: no profiles, no UI, and no new dependencies. The CLI accepts scanner IDs, scanner class names, comma-separated values, and repeated flags so teams can use the same interface locally and in CI. JSON results include the effective `scanner_selection` policy, and policy skips are represented as informational `Scanner Selection` checks so CI logs show what was intentionally skipped.

## Implementation notes

- Adds shared scanner-selection policy helpers and catalog output.
- Wires selection through CLI, core scanning, directory/streaming scans, nested archive dispatch, scanner registry lookup, cache keys, JSON aggregation, cloud/JFrog filtering, and embedded helper scanners.
- Preserves nested scanner semantics: container scanners and inner scanners are selected independently, so `--scanners zip,pickle` scans ZIP containers and pickle members.
- Keeps remote selective downloads conservative for container/header-routed scanners to avoid dropping extension-spoofed artifacts before scan.
- Updates README, the compatibility matrix, user docs, and the changelog.

## Red-team fixes included

During review I found and fixed three coverage holes:

- ZIP-backed `.pt` files selected with `--scanners zip` now fall back to `ZipScanner` instead of returning an early scanner-selection skip.
- Nested archive dispatch now tries selected fallback scanners before emitting a skip.
- Remote cloud/JFrog prefilters fail open for header/container-routed scanners and preserve extensionless selected scanner routes.

## Validation

- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_scanner_selection.py -q`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_scanner_selection.py tests/utils/sources/test_cloud_storage.py tests/integrations/test_jfrog.py tests/utils/file/test_file_filter.py -q`
- `uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
- `git diff --check`
