### PR TITLE
fix: close archive payload scan gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **security:** close archive payload coverage gaps by sniffing hidden PyTorch ZIP pickles, detecting extensionless 7-Zip protocol-0/1 pickles, failing closed on incomplete archive scans, preserving active-payload severities for trusted provenance, and scanning generic ZIP/TAR Python members.
 - **pickle:** restore ModelAudit nested-pickle findings from Rust standalone notices and keep network raw-detector coverage after native pickle findings
 - **telemetry:** strip query strings, fragments, and URL userinfo from cloud model names and file-extension metadata
 - preserve `S999` unknown-opcode mapping in generic rule fallback

--- a/modelaudit/scanner_results.py
+++ b/modelaudit/scanner_results.py
@@ -217,7 +217,13 @@ class ScanResult:
         if not passed and self.scanner:
             # At this point severity cannot be None due to the check above
             assert severity is not None
-            severity, details = self.scanner._apply_whitelist_downgrade(severity, details)
+            severity, details = self.scanner._apply_whitelist_downgrade(
+                severity,
+                details,
+                message=message,
+                rule_code=rule_code,
+                check_name=name,
+            )
 
         check = Check(
             name=name,

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -2,6 +2,8 @@
 
 import re
 
+from modelaudit.utils.helpers.code_validation import is_code_potentially_dangerous
+
 _EXECUTABLE_ARCHIVE_MEMBER_SUFFIXES = (
     ".sh",
     ".bash",
@@ -16,6 +18,7 @@ _EXECUTABLE_ARCHIVE_MEMBER_SUFFIXES = (
     ".ps1",
 )
 _VERSIONED_SHARED_OBJECT_SUFFIX_RE = re.compile(r"\.so(?:\.[0-9]+)+$")
+_PYTHON_ARCHIVE_MEMBER_SUFFIXES = (".py", ".pyw")
 
 
 def is_executable_archive_member_name(member_name: str) -> bool:
@@ -24,3 +27,15 @@ def is_executable_archive_member_name(member_name: str) -> bool:
     return normalized_name.endswith(_EXECUTABLE_ARCHIVE_MEMBER_SUFFIXES) or bool(
         _VERSIONED_SHARED_OBJECT_SUFFIX_RE.search(normalized_name)
     )
+
+
+def is_python_archive_member_name(member_name: str) -> bool:
+    """Return True when an archive member name looks like Python source."""
+    return member_name.lower().endswith(_PYTHON_ARCHIVE_MEMBER_SUFFIXES)
+
+
+def dangerous_python_archive_member_reason(source_bytes: bytes) -> str | None:
+    """Return a concise reason when Python source contains high-risk constructs."""
+    source = source_bytes.decode("utf-8", "replace")
+    is_dangerous, reason = is_code_potentially_dangerous(source, threshold="medium")
+    return reason if is_dangerous else None

--- a/modelaudit/scanners/base.py
+++ b/modelaudit/scanners/base.py
@@ -163,7 +163,60 @@ class BaseScanner(ABC):
             return val.strip().lower() not in {"false", "0", "no", "off"}
         return bool(val)
 
-    def _should_apply_whitelist(self, severity: IssueSeverity) -> bool:
+    @staticmethod
+    def _whitelist_downgrade_exempt(
+        *,
+        details: dict[str, Any] | None,
+        message: str | None,
+        rule_code: str | None,
+        check_name: str | None,
+    ) -> bool:
+        """Return True for active payload or incomplete-coverage findings."""
+        details = details or {}
+        if details.get("analysis_incomplete") is True or details.get("operational_error") is True:
+            return True
+        if details.get("cve_id"):
+            return True
+
+        if rule_code and (
+            rule_code.startswith("S2")
+            or rule_code
+            in {
+                "S405",
+                "S406",
+                "S410",
+                "S501",
+                "S502",
+                "S503",
+                "S504",
+            }
+        ):
+            return True
+
+        text = " ".join(value for value in (message, check_name) if value).lower()
+        return any(
+            token in text
+            for token in (
+                "arbitrary code",
+                "dangerous",
+                "executable file",
+                "inconclusive",
+                "path traversal",
+                "rce",
+                "remote code execution",
+                "unsafe deserialization",
+            )
+        )
+
+    def _should_apply_whitelist(
+        self,
+        severity: IssueSeverity,
+        *,
+        details: dict[str, Any] | None = None,
+        message: str | None = None,
+        rule_code: str | None = None,
+        check_name: str | None = None,
+    ) -> bool:
         """
         Check if the whitelist should be applied to downgrade an issue's severity.
 
@@ -175,6 +228,14 @@ class BaseScanner(ABC):
         """
         # Only downgrade severities higher than INFO
         if severity in (IssueSeverity.INFO, IssueSeverity.DEBUG):
+            return False
+
+        if self._whitelist_downgrade_exempt(
+            details=details,
+            message=message,
+            rule_code=rule_code,
+            check_name=check_name,
+        ):
             return False
 
         # Check if whitelist is enabled (default: True)
@@ -201,6 +262,10 @@ class BaseScanner(ABC):
         self,
         severity: IssueSeverity,
         details: dict[str, Any] | None,
+        *,
+        message: str | None = None,
+        rule_code: str | None = None,
+        check_name: str | None = None,
     ) -> tuple[IssueSeverity, dict[str, Any]]:
         """
         Apply whitelist downgrading logic to severity and details.
@@ -213,7 +278,13 @@ class BaseScanner(ABC):
             Tuple of (potentially modified severity, details dict)
         """
         original_severity = severity
-        if self._should_apply_whitelist(severity):
+        if self._should_apply_whitelist(
+            severity,
+            details=details,
+            message=message,
+            rule_code=rule_code,
+            check_name=check_name,
+        ):
             severity = IssueSeverity.INFO
             # Add note about whitelisting to the details
             if details is None:

--- a/modelaudit/scanners/manifest_scanner.py
+++ b/modelaudit/scanners/manifest_scanner.py
@@ -677,11 +677,12 @@ class ManifestScanner(BaseScanner):
                 name="Manifest Scan Timeout",
                 passed=False,
                 message=f"Scan timed out: {e!s}",
-                severity=IssueSeverity.WARNING,
+                severity=IssueSeverity.INFO,
                 location=path,
-                details={"timeout_seconds": self.timeout},
+                details={"timeout_seconds": self.timeout, "analysis_incomplete": True},
             )
-            result.finish(success=True)
+            self._mark_inconclusive_scan_result(result, "manifest_scan_timeout")
+            result.finish(success=False)
             return result
         except Exception as e:
             result.add_check(

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -4,6 +4,7 @@ import ast
 import io
 import logging
 import os
+import pickletools
 import re
 import stat
 import tempfile
@@ -14,6 +15,7 @@ from dataclasses import dataclass
 from typing import Any, ClassVar
 
 from ..detectors.suspicious_symbols import CVE_COMBINED_PATTERNS
+from ..scanner_results import INCONCLUSIVE_SCAN_OUTCOME, mark_inconclusive_scan_result
 from ..utils import sanitize_archive_path
 from ..utils.file.detection import PROTO0_1_MAX_PROBE_BYTES, PROTO0_1_START_BYTES, _looks_like_proto0_or_1_pickle
 from .archive_member_security import is_executable_archive_member_name
@@ -104,6 +106,8 @@ _PICKLE_BINARY_PROTOCOL_PREFIXES: tuple[bytes, ...] = (
     b"\x80\x05",
 )
 _PICKLE_DISCOVERY_SHORT_PROBE_BYTES = 16
+_PICKLE_DISCOVERY_LONG_PROBE_BYTES = PROTO0_1_MAX_PROBE_BYTES
+_JIT_SCAN_MEMBER_MAX_BYTES = 32 * 1024 * 1024
 _PYTORCH_STORAGE_BLOB_MEMBER_PATTERN = re.compile(r"^(?:.+/)?data/[0-9]+$")
 
 
@@ -240,6 +244,10 @@ class PyTorchZipScanner(BaseScanner):
             self.MIN_COMPRESSION_BOMB_UNCOMPRESSED_SIZE,
         )
         self.max_archive_entries = self.config.get("max_archive_entries", self.MAX_ARCHIVE_ENTRIES)
+        self.max_jit_scan_member_bytes = self._normalize_positive_int_config(
+            self.config.get("max_jit_scan_member_bytes"),
+            _JIT_SCAN_MEMBER_MAX_BYTES,
+        )
 
     @classmethod
     def can_handle(cls, path: str) -> bool:
@@ -309,7 +317,7 @@ class PyTorchZipScanner(BaseScanner):
                 self._validate_tensor_metadata_consistency(zip_file, safe_entries, pickle_files, result, path)
 
                 # Check for JIT/Script code execution risks
-                bytes_scanned += self._scan_for_jit_patterns(zip_file, safe_entries, result, path)
+                bytes_scanned += self._scan_for_jit_patterns(zip_file, safe_entries, pickle_files, result, path)
 
                 # Detect suspicious non-pickle files
                 self._detect_suspicious_files(zip_file, safe_entries, result, path)
@@ -324,22 +332,23 @@ class PyTorchZipScanner(BaseScanner):
 
         except TimeoutError as e:
             # Handle timeout gracefully
+            mark_inconclusive_scan_result(result, "pytorch_zip_scan_timeout")
             result.add_check(
                 name="Scan Timeout",
                 passed=False,
                 message=f"Scan timed out: {e!s}",
-                severity=IssueSeverity.WARNING,
+                severity=IssueSeverity.INFO,
                 location=path,
-                details={"timeout_seconds": self.timeout},
+                details={"timeout_seconds": self.timeout, "analysis_incomplete": True},
             )
-            result.finish(success=True)  # Partial results are still valid
+            result.finish(success=False)
             return result
         except zipfile.BadZipFile:
             return self._handle_bad_zip_error(path)
         except Exception as e:
             return self._handle_scan_error(path, e)
 
-        result.finish(success=True)
+        result.finish(success=result.metadata.get("scan_outcome") != INCONCLUSIVE_SCAN_OUTCOME)
         return result
 
     @staticmethod
@@ -881,48 +890,116 @@ class PyTorchZipScanner(BaseScanner):
         """Discover pickle files in the ZIP archive"""
         pickle_files: list[zipfile.ZipInfo] = []
 
+        seen_entries: set[int] = set()
+
+        def add_pickle_entry(entry: zipfile.ZipInfo) -> None:
+            entry_key = id(entry)
+            if entry_key in seen_entries:
+                return
+            pickle_files.append(entry)
+            seen_entries.add(entry_key)
+
         # First pass: Look for common pickle file patterns
         for entry in safe_entries:
             name = self._get_zip_member_name(entry)
             if name.endswith(".pkl") or name == "data.pkl" or name.endswith("/data.pkl"):
-                pickle_files.append(entry)
+                add_pickle_entry(entry)
 
-        # Second pass: If no obvious pickle files found, check for pickle magic bytes
-        if not pickle_files:
-            for entry in safe_entries:
-                try:
-                    data_start = self._read_member_prefix(
-                        zip_file,
-                        entry,
-                        _PICKLE_DISCOVERY_SHORT_PROBE_BYTES,
-                        phase="pickle_discovery",
-                        result=result,
-                    )
-                    if any(data_start.startswith(magic) for magic in _PICKLE_BINARY_PROTOCOL_PREFIXES):
-                        pickle_files.append(entry)
-                        continue
-
-                    if not data_start or data_start[0] not in PROTO0_1_START_BYTES:
-                        continue
-
-                    if entry.file_size > len(data_start):
-                        data_start = self._read_member_prefix(
-                            zip_file,
-                            entry,
-                            PROTO0_1_MAX_PROBE_BYTES,
-                            phase="pickle_discovery",
-                            result=result,
-                        )
-                    if _looks_like_proto0_or_1_pickle(
-                        data_start,
-                        sample_is_prefix=entry.file_size > len(data_start),
-                    ):
-                        pickle_files.append(entry)
-                except Exception as exc:
-                    logger.debug("Unable to inspect ZIP member %s as a pickle: %s", entry.filename, exc)
+        # Second pass: always sniff unselected members. A benign data.pkl must not
+        # hide an extensionless pickle payload or one placed under data/<n>.
+        for entry in safe_entries:
+            if id(entry) in seen_entries or entry.is_dir():
+                continue
+            try:
+                if self._entry_looks_like_pickle(zip_file, entry, result):
+                    add_pickle_entry(entry)
+            except Exception as exc:
+                logger.debug("Unable to inspect ZIP member %s as a pickle: %s", entry.filename, exc)
+                mark_inconclusive_scan_result(result, "pytorch_zip_pickle_discovery_incomplete")
+                result.add_check(
+                    name="Pickle Discovery",
+                    passed=False,
+                    message=f"Could not inspect PyTorch ZIP member {entry.filename} for hidden pickle payloads: {exc}",
+                    severity=IssueSeverity.INFO,
+                    location=f"{self.current_file_path}:{entry.filename}",
+                    details={
+                        "zip_entry": entry.filename,
+                        "exception": str(exc),
+                        "exception_type": type(exc).__name__,
+                        "analysis_incomplete": True,
+                    },
+                )
 
         result.metadata["pickle_files"] = self._get_zip_member_names(pickle_files)
         return pickle_files
+
+    def _entry_looks_like_pickle(
+        self,
+        zip_file: zipfile.ZipFile,
+        entry: zipfile.ZipInfo,
+        result: ScanResult,
+    ) -> bool:
+        """Return True when a bounded ZIP member prefix structurally resembles pickle."""
+        data_start = self._read_member_prefix(
+            zip_file,
+            entry,
+            _PICKLE_DISCOVERY_SHORT_PROBE_BYTES,
+            phase="pickle_discovery",
+            result=result,
+        )
+        if not data_start:
+            return False
+
+        if any(data_start.startswith(magic) for magic in _PICKLE_BINARY_PROTOCOL_PREFIXES):
+            sample = self._read_member_prefix(
+                zip_file,
+                entry,
+                _PICKLE_DISCOVERY_LONG_PROBE_BYTES,
+                phase="pickle_discovery",
+                result=result,
+            )
+            return self._looks_like_binary_pickle_prefix(sample, sample_is_prefix=entry.file_size > len(sample))
+
+        if data_start[0] not in PROTO0_1_START_BYTES:
+            return False
+
+        sample = data_start
+        if entry.file_size > len(data_start):
+            sample = self._read_member_prefix(
+                zip_file,
+                entry,
+                PROTO0_1_MAX_PROBE_BYTES,
+                phase="pickle_discovery",
+                result=result,
+            )
+        return _looks_like_proto0_or_1_pickle(
+            sample,
+            sample_is_prefix=entry.file_size > len(sample),
+        )
+
+    @staticmethod
+    def _looks_like_binary_pickle_prefix(sample: bytes, *, sample_is_prefix: bool) -> bool:
+        """Validate binary pickle-looking bytes enough to avoid random tensor false positives."""
+        if not any(sample.startswith(magic) for magic in _PICKLE_BINARY_PROTOCOL_PREFIXES):
+            return False
+
+        op_count = 0
+        try:
+            for opcode, _arg, _pos in pickletools.genops(sample):
+                op_count += 1
+                if opcode.name == "STOP":
+                    return True
+                if op_count >= 4:
+                    return True
+        except ValueError as exc:
+            message = str(exc).lower()
+            return (
+                sample_is_prefix
+                and op_count >= 2
+                and ("exhausted before seeing stop" in message or "not enough data" in message or "expected" in message)
+            )
+
+        return sample_is_prefix and op_count >= 2
 
     def _check_pytorch_vulnerabilities(
         self,
@@ -1074,6 +1151,7 @@ class PyTorchZipScanner(BaseScanner):
         self,
         zip_file: zipfile.ZipFile,
         safe_entries: list[zipfile.ZipInfo],
+        pickle_files: list[zipfile.ZipInfo],
         result: ScanResult,
         path: str,
     ) -> int:
@@ -1081,13 +1159,38 @@ class PyTorchZipScanner(BaseScanner):
         bytes_scanned = 0
         all_jit_findings = []
         all_network_findings = []
+        pickle_member_names = {
+            self._get_zip_member_name(entry).replace("\\", "/").lstrip("/") for entry in pickle_files
+        }
 
         for entry in safe_entries:
             name = self._get_zip_member_name(entry)
+            normalized_name = name.replace("\\", "/").lstrip("/")
             try:
                 # Skip numeric tensor data files to support different versions of PyTorch ZIP files
                 # These are binary weight files that cause performance issues when scanned
-                if _PYTORCH_STORAGE_BLOB_MEMBER_PATTERN.match(name):
+                if _PYTORCH_STORAGE_BLOB_MEMBER_PATTERN.match(normalized_name):
+                    continue
+                if normalized_name in pickle_member_names:
+                    continue
+                if entry.file_size > self.max_jit_scan_member_bytes:
+                    mark_inconclusive_scan_result(result, "pytorch_zip_jit_member_size_limit")
+                    result.add_check(
+                        name="JIT/Network Scan Size Limit",
+                        passed=False,
+                        message=(
+                            f"PyTorch ZIP member {name} skipped by JIT/network scanning because it exceeds "
+                            f"the bounded read limit ({entry.file_size} > {self.max_jit_scan_member_bytes})"
+                        ),
+                        severity=IssueSeverity.INFO,
+                        location=f"{path}:{name}",
+                        details={
+                            "zip_entry": name,
+                            "file_size": entry.file_size,
+                            "max_scan_bytes": self.max_jit_scan_member_bytes,
+                            "analysis_incomplete": True,
+                        },
+                    )
                     continue
 
                 file_data = self._read_member_bytes(
@@ -1095,6 +1198,7 @@ class PyTorchZipScanner(BaseScanner):
                     entry,
                     phase="jit_script_scan",
                     result=result,
+                    max_bytes=self.max_jit_scan_member_bytes,
                 )
                 bytes_scanned += len(file_data)
 

--- a/modelaudit/scanners/sevenzip_scanner.py
+++ b/modelaudit/scanners/sevenzip_scanner.py
@@ -14,7 +14,7 @@ else:
     _py7zr = None
 
 from ..utils import sanitize_archive_path
-from ..utils.file.detection import detect_format_from_magic_bytes
+from ..utils.file.detection import _looks_like_proto0_or_1_pickle, detect_format_from_magic_bytes
 from ._archive_config import get_archive_depth
 from ._archive_locations import rewrite_extracted_member_location
 from ._archive_outcomes import mark_archive_scan_incomplete, member_scan_incomplete
@@ -623,6 +623,9 @@ class SevenZipScanner(BaseScanner):
         prefix = probe.read(self._NESTED_MEMBER_PROBE_BYTES)
         if len(prefix) < 4:
             return None
+
+        if _looks_like_proto0_or_1_pickle(prefix, sample_is_prefix=len(prefix) == self._NESTED_MEMBER_PROBE_BYTES):
+            return "pickle"
 
         detected_format = detect_format_from_magic_bytes(
             prefix[:4],

--- a/modelaudit/scanners/tar_scanner.py
+++ b/modelaudit/scanners/tar_scanner.py
@@ -14,6 +14,11 @@ from ..utils.helpers.assets import asset_from_scan_result
 from ._archive_locations import rewrite_extracted_member_location
 from ._archive_outcomes import mark_archive_scan_incomplete, member_scan_incomplete
 from .archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY, scan_nested_file
+from .archive_member_security import (
+    dangerous_python_archive_member_reason,
+    is_executable_archive_member_name,
+    is_python_archive_member_name,
+)
 from .base import BaseScanner, IssueSeverity, ScanResult
 
 CRITICAL_SYSTEM_PATHS = [
@@ -34,6 +39,7 @@ DEFAULT_MAX_TAR_ENTRY_SIZE = 1024 * 1024 * 1024
 DEFAULT_MAX_DECOMPRESSED_BYTES = 512 * 1024 * 1024
 DEFAULT_MAX_DECOMPRESSION_RATIO = 250.0
 ARCHIVE_MEMBER_COPY_CHUNK_BYTES = 64 * 1024
+MAX_TAR_PYTHON_ANALYSIS_BYTES = 10 * 1024 * 1024
 
 _GZIP_MAGIC = b"\x1f\x8b"
 _BZIP2_MAGIC = b"BZh"
@@ -586,6 +592,8 @@ class TarScanner(BaseScanner):
                             result.merge(nested_result)
                             asset_entry = asset_from_scan_result(f"{path}:{name}", nested_result)
                         else:
+                            self._scan_generic_member_security(path, name, tmp_path, total_size, result)
+
                             nested_config = dict(self.config)
                             nested_config["_archive_depth"] = depth + 1
                             file_result = self._scan_nested_archive_entry(tmp_path, nested_config)
@@ -623,5 +631,60 @@ class TarScanner(BaseScanner):
         result.metadata["file_size"] = os.path.getsize(path)
         if not scan_complete:
             mark_archive_scan_incomplete(result, "tar_analysis_incomplete")
-        result.finish(success=scan_complete and not result.has_errors)
+        result.finish(success=scan_complete and not member_scan_incomplete(result) and not result.has_errors)
         return result
+
+    def _scan_generic_member_security(
+        self,
+        archive_path: str,
+        member_name: str,
+        tmp_path: str,
+        total_size: int,
+        result: ScanResult,
+    ) -> None:
+        """Inspect TAR members that nested dispatch would otherwise treat as unknown."""
+        normalized_name = member_name.replace("\\", "/").lstrip("/")
+        normalized_lower = normalized_name.lower()
+        location = f"{archive_path}:{member_name}"
+
+        if is_python_archive_member_name(normalized_lower):
+            if total_size > MAX_TAR_PYTHON_ANALYSIS_BYTES:
+                mark_archive_scan_incomplete(result, "tar_python_member_analysis_incomplete")
+                result.add_check(
+                    name="Python Archive Member Security",
+                    passed=False,
+                    message=f"Python archive member too large for bounded security analysis: {member_name}",
+                    severity=IssueSeverity.INFO,
+                    location=location,
+                    details={
+                        "entry": member_name,
+                        "file_size": total_size,
+                        "max_scan_bytes": MAX_TAR_PYTHON_ANALYSIS_BYTES,
+                        "analysis_incomplete": True,
+                    },
+                )
+                return
+
+            with open(tmp_path, "rb") as member_file:
+                reason = dangerous_python_archive_member_reason(member_file.read())
+            if reason is not None:
+                result.add_check(
+                    name="Python Archive Member Security",
+                    passed=False,
+                    message=f"High-risk Python code found in TAR member {member_name}: {reason}",
+                    severity=IssueSeverity.WARNING,
+                    location=location,
+                    details={"entry": member_name, "reason": reason},
+                    rule_code="S104",
+                )
+            return
+
+        if is_executable_archive_member_name(normalized_lower):
+            result.add_check(
+                name="Executable Archive Member Detection",
+                passed=False,
+                message=f"Executable file found in TAR archive: {member_name}",
+                severity=IssueSeverity.WARNING,
+                location=location,
+                details={"entry": member_name},
+            )

--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -12,6 +12,11 @@ from ._archive_config import get_archive_depth
 from ._archive_locations import rewrite_extracted_member_location
 from ._archive_outcomes import mark_archive_scan_incomplete, member_scan_incomplete
 from .archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY, scan_nested_file
+from .archive_member_security import (
+    dangerous_python_archive_member_reason,
+    is_executable_archive_member_name,
+    is_python_archive_member_name,
+)
 from .base import BaseScanner, IssueSeverity, ScanResult
 
 CRITICAL_SYSTEM_PATHS = [
@@ -571,6 +576,8 @@ class ZipScanner(BaseScanner):
                                 result.merge(mar_python_result)
                                 if not mar_python_result.success:
                                     scan_complete = False
+                        elif archive_ext != ".npz":
+                            self._scan_generic_member_security(path, name, tmp_path, total_size, result)
 
                         nested_config = dict(self.config)
                         nested_config["_archive_depth"] = depth + 1
@@ -619,8 +626,63 @@ class ZipScanner(BaseScanner):
         result.metadata["file_size"] = os.path.getsize(path)
         if not scan_complete:
             mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
-        result.finish(success=scan_complete and not result.has_errors)
+        result.finish(success=scan_complete and not member_scan_incomplete(result) and not result.has_errors)
         return result
+
+    def _scan_generic_member_security(
+        self,
+        archive_path: str,
+        member_name: str,
+        tmp_path: str,
+        total_size: int,
+        result: ScanResult,
+    ) -> None:
+        """Inspect generic archive members that nested dispatch would otherwise treat as unknown."""
+        normalized_name = member_name.replace("\\", "/").lstrip("/")
+        normalized_lower = normalized_name.lower()
+        location = f"{archive_path}:{member_name}"
+
+        if is_python_archive_member_name(normalized_lower):
+            if total_size > self.MAX_MAR_PYTHON_ANALYSIS_BYTES:
+                mark_archive_scan_incomplete(result, "zip_python_member_analysis_incomplete")
+                result.add_check(
+                    name="Python Archive Member Security",
+                    passed=False,
+                    message=f"Python archive member too large for bounded security analysis: {member_name}",
+                    severity=IssueSeverity.INFO,
+                    location=location,
+                    details={
+                        "entry": member_name,
+                        "file_size": total_size,
+                        "max_scan_bytes": self.MAX_MAR_PYTHON_ANALYSIS_BYTES,
+                        "analysis_incomplete": True,
+                    },
+                )
+                return
+
+            with open(tmp_path, "rb") as member_file:
+                reason = dangerous_python_archive_member_reason(member_file.read())
+            if reason is not None:
+                result.add_check(
+                    name="Python Archive Member Security",
+                    passed=False,
+                    message=f"High-risk Python code found in ZIP member {member_name}: {reason}",
+                    severity=IssueSeverity.WARNING,
+                    location=location,
+                    details={"entry": member_name, "reason": reason},
+                    rule_code="S104",
+                )
+            return
+
+        if is_executable_archive_member_name(normalized_lower):
+            result.add_check(
+                name="Executable Archive Member Detection",
+                passed=False,
+                message=f"Executable file found in ZIP archive: {member_name}",
+                severity=IssueSeverity.WARNING,
+                location=location,
+                details={"entry": member_name},
+            )
 
     def _scan_mar_python_entry(
         self,

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pickletools
 import tempfile
 import zipfile
 from collections.abc import Mapping
@@ -15,6 +16,17 @@ from .report import CoverageSummary, Finding, Notice, PickleReport, SafetyVerdic
 _RUST_STREAM_READ_CHUNK_SIZE = 1024 * 1024
 _PYTORCH_ZIP_METADATA_BASENAMES = frozenset({"version", "byteorder"})
 _PICKLE_MEMBER_SUFFIXES = (".pkl", ".pickle")
+_PICKLE_BINARY_PROTOCOL_PREFIXES = (b"\x80\x01", b"\x80\x02", b"\x80\x03", b"\x80\x04", b"\x80\x05")
+_PICKLE_DISCOVERY_SHORT_PROBE_BYTES = 16
+_PICKLE_DISCOVERY_LONG_PROBE_BYTES = 64 * 1024
+_PROTO0_1_START_BYTES = b"()]}cilp0FGIJKLMNSTUVX"
+_PROTO0_1_MAX_PROBE_OPCODES = _PICKLE_DISCOVERY_LONG_PROBE_BYTES
+_PROTO0_1_IGNORABLE_TRAILING_BYTES = b" \t\r\n\x00"
+_PROTO0_1_PREFIX_TRUNCATION_ERROR_PREFIXES = (
+    "pickle exhausted before seeing STOP",
+    "no newline found when trying to read ",
+)
+_PROTO0_1_TRIVIAL_LEADING_OPCODES = frozenset({"MARK", "POP", "DUP", "EMPTY_LIST", "EMPTY_DICT"})
 _MAX_PYTORCH_ZIP_ENTRIES = 10_000
 _MAX_PYTORCH_ZIP_PICKLE_MEMBER_BYTES = 512 * 1024 * 1024
 _RUST_EXTENSION_MODULE = "modelaudit_picklescan._rust"
@@ -176,7 +188,7 @@ class PickleScanner:
             if not _is_pytorch_zip_archive(entries):
                 return None
 
-            pickle_entries = _discover_pytorch_zip_pickle_entries(entries)
+            pickle_entries = _discover_pytorch_zip_pickle_entries(archive, entries)
             if not pickle_entries:
                 return _pytorch_zip_notice_report(
                     source=source,
@@ -345,16 +357,129 @@ def _is_pytorch_zip_archive(entries: list[zipfile.ZipInfo]) -> bool:
     return has_pickle_members
 
 
-def _discover_pytorch_zip_pickle_entries(entries: list[zipfile.ZipInfo]) -> list[zipfile.ZipInfo]:
+def _discover_pytorch_zip_pickle_entries(
+    archive: zipfile.ZipFile,
+    entries: list[zipfile.ZipInfo],
+) -> list[zipfile.ZipInfo]:
     pickle_entries: list[zipfile.ZipInfo] = []
+    seen_entries: set[int] = set()
+
+    def add_entry(entry: zipfile.ZipInfo) -> None:
+        entry_id = id(entry)
+        if entry_id in seen_entries:
+            return
+        pickle_entries.append(entry)
+        seen_entries.add(entry_id)
+
     for entry in entries:
         if entry.is_dir():
             continue
         name = entry.filename
         lowered = name.lower()
         if _is_data_pickle_member(lowered) or lowered.endswith(_PICKLE_MEMBER_SUFFIXES):
-            pickle_entries.append(entry)
+            add_entry(entry)
+
+    for entry in entries:
+        if entry.is_dir() or id(entry) in seen_entries:
+            continue
+        if _zip_entry_looks_like_pickle(archive, entry):
+            add_entry(entry)
+
     return pickle_entries
+
+
+def _zip_entry_looks_like_pickle(archive: zipfile.ZipFile, entry: zipfile.ZipInfo) -> bool:
+    with archive.open(entry, "r") as member:
+        prefix = member.read(_PICKLE_DISCOVERY_SHORT_PROBE_BYTES)
+    if not prefix:
+        return False
+
+    if prefix.startswith(_PICKLE_BINARY_PROTOCOL_PREFIXES):
+        with archive.open(entry, "r") as member:
+            sample = member.read(_PICKLE_DISCOVERY_LONG_PROBE_BYTES)
+        return _looks_like_binary_pickle_prefix(sample, sample_is_prefix=entry.file_size > len(sample))
+
+    if prefix[0] not in _PROTO0_1_START_BYTES:
+        return False
+
+    sample = prefix
+    if entry.file_size > len(prefix):
+        with archive.open(entry, "r") as member:
+            sample = member.read(_PICKLE_DISCOVERY_LONG_PROBE_BYTES)
+    return _looks_like_proto0_or_1_pickle(sample, sample_is_prefix=entry.file_size > len(sample))
+
+
+def _looks_like_binary_pickle_prefix(sample: bytes, *, sample_is_prefix: bool) -> bool:
+    if not sample.startswith(_PICKLE_BINARY_PROTOCOL_PREFIXES):
+        return False
+
+    op_count = 0
+    try:
+        for opcode, _arg, _pos in pickletools.genops(sample):
+            op_count += 1
+            if opcode.name == "STOP":
+                return True
+            if op_count >= 4:
+                return True
+    except ValueError as exc:
+        message = str(exc).lower()
+        return (
+            sample_is_prefix
+            and op_count >= 2
+            and ("exhausted before seeing stop" in message or "not enough data" in message or "expected" in message)
+        )
+
+    return sample_is_prefix and op_count >= 2
+
+
+def _looks_like_proto0_or_1_pickle(sample: bytes, *, sample_is_prefix: bool) -> bool:
+    if len(sample) < 2:
+        return False
+
+    def matches_proto_stream(candidate: bytes) -> bool:
+        if len(candidate) < 2 or candidate[0] not in _PROTO0_1_START_BYTES:
+            return False
+
+        opcode_count = 0
+        has_non_trivial_opcode = False
+        try:
+            for opcode, _arg, pos in pickletools.genops(candidate):
+                opcode_count += 1
+                if opcode.name == "STOP":
+                    stop_pos = 0 if pos is None else pos
+                    trailing = candidate[stop_pos + 1 :]
+                    if not trailing or not trailing.strip(_PROTO0_1_IGNORABLE_TRAILING_BYTES):
+                        return opcode_count >= 2
+                    if has_non_trivial_opcode:
+                        return opcode_count >= 2
+                    stripped_trailing = trailing.lstrip(_PROTO0_1_IGNORABLE_TRAILING_BYTES)
+                    return bool(stripped_trailing) and _looks_like_proto0_or_1_pickle(
+                        stripped_trailing,
+                        sample_is_prefix=sample_is_prefix,
+                    )
+                if opcode.name not in _PROTO0_1_TRIVIAL_LEADING_OPCODES:
+                    has_non_trivial_opcode = True
+                if opcode_count >= _PROTO0_1_MAX_PROBE_OPCODES:
+                    return False
+        except ValueError as exc:
+            exc_message = str(exc)
+            return (
+                sample_is_prefix
+                and opcode_count >= 2
+                and has_non_trivial_opcode
+                and any(
+                    exc_message.startswith(error_prefix) for error_prefix in _PROTO0_1_PREFIX_TRUNCATION_ERROR_PREFIXES
+                )
+            )
+        except Exception:
+            return False
+
+        return sample_is_prefix and opcode_count >= 2 and has_non_trivial_opcode
+
+    if matches_proto_stream(sample):
+        return True
+
+    return sample.startswith(b"#") and matches_proto_stream(sample[1:])
 
 
 def _is_data_pickle_member(name: str) -> bool:

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -825,6 +825,44 @@ def test_scan_file_scans_pytorch_zip_data_pickle(tmp_path: Path) -> None:
     assert report.coverage.bytes_scanned > 0
 
 
+def test_scan_file_detects_hidden_pytorch_zip_pickle_member_with_data_pickle(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model.pt"
+    hidden_payload = b"cposix\nsystem\n(S'echo hidden'\ntR."
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}, protocol=4))
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/payload", hidden_payload)
+
+    report = scan_file(archive_path)
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert list(report.metadata["pickle_files"]) == ["archive/data.pkl", "archive/payload"]
+    assert any(
+        finding.rule_code == "DANGEROUS_CALL"
+        and finding.location is not None
+        and f"{archive_path}:archive/payload" in finding.location
+        for finding in report.findings
+    )
+
+
+def test_scan_file_does_not_route_benign_storage_blob_as_hidden_pickle(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model.pt"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}, protocol=4))
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/data/0", b"\x00" * 1024)
+        archive.writestr("archive/notes", b"cat is a category label, not a GLOBAL opcode stream")
+
+    report = scan_file(archive_path)
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert list(report.metadata["pickle_files"]) == ["archive/data.pkl"]
+
+
 def test_scan_file_detects_malicious_pytorch_zip_data_pickle(tmp_path: Path) -> None:
     archive_path = tmp_path / "model.pt"
     with zipfile.ZipFile(archive_path, "w") as archive:

--- a/tests/scanners/test_base_scanner.py
+++ b/tests/scanners/test_base_scanner.py
@@ -925,7 +925,7 @@ def test_whitelist_downgrade_check_critical():
     result.add_check(
         name="Test Security Check",
         passed=False,
-        message="Dangerous pattern detected",
+        message="High confidence model anomaly detected",
         severity=IssueSeverity.CRITICAL,
     )
 
@@ -942,6 +942,61 @@ def test_whitelist_downgrade_check_critical():
     assert result.checks[0].severity == IssueSeverity.INFO
     assert result.checks[0].details.get("whitelist_downgrade") is True
     assert result.checks[0].details.get("original_severity") == "CRITICAL"
+
+
+@pytest.mark.parametrize(
+    ("name", "message", "rule_code", "details", "severity"),
+    [
+        ("Active Reducer", "Dangerous reducer invokes posix.system", "S201", {}, IssueSeverity.CRITICAL),
+        (
+            "RCE CVE",
+            "Known vulnerable deserialization construct",
+            None,
+            {"cve_id": "CVE-2026-1234"},
+            IssueSeverity.CRITICAL,
+        ),
+        ("Traversal", "Path traversal attempt detected", None, {}, IssueSeverity.CRITICAL),
+        ("Incomplete", "Archive scan inconclusive", None, {"analysis_incomplete": True}, IssueSeverity.WARNING),
+        ("Executable", "Executable file detected in archive", "S104", {}, IssueSeverity.WARNING),
+    ],
+)
+def test_whitelist_does_not_downgrade_active_or_incomplete_findings(
+    name: str,
+    message: str,
+    rule_code: str | None,
+    details: dict[str, object],
+    severity: IssueSeverity,
+) -> None:
+    """Trusted provenance must not hide active payloads or incomplete coverage."""
+    from modelaudit.whitelists import POPULAR_MODELS
+
+    whitelisted_model = next(iter(POPULAR_MODELS))
+
+    scanner = MockScanner()
+    scanner.context = UnifiedMLContext(
+        file_path=Path("/tmp/test.pkl"),
+        file_size=100,
+        file_type=".pkl",
+        model_id=whitelisted_model,
+        model_source="huggingface",
+    )
+
+    result = scanner._create_result()
+    result.add_check(
+        name=name,
+        passed=False,
+        message=message,
+        severity=severity,
+        details=dict(details),
+        rule_code=rule_code,
+    )
+
+    assert len(result.issues) == 1
+    assert result.issues[0].severity == severity
+    assert result.issues[0].details.get("whitelist_downgrade") is None
+    assert len(result.checks) == 1
+    assert result.checks[0].severity == severity
+    assert result.checks[0].details.get("whitelist_downgrade") is None
 
 
 def test_whitelist_downgrade_check_warning():

--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -14,6 +14,18 @@ def _https_url(host: str, path: str = "/model.bin") -> str:
     return f"https://{host}{path}"
 
 
+def _assert_manifest_timeout_result(result: ScanResult) -> None:
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert result.metadata["analysis_incomplete"] is True
+    assert "manifest_scan_timeout" in result.metadata["scan_outcome_reasons"]
+    timeout_checks = [check for check in result.checks if check.name == "Manifest Scan Timeout"]
+    assert len(timeout_checks) == 1
+    assert timeout_checks[0].status == CheckStatus.FAILED
+    assert timeout_checks[0].severity == IssueSeverity.INFO
+    assert timeout_checks[0].details["analysis_incomplete"] is True
+
+
 def test_manifest_scanner_blacklist(tmp_path):
     """Test the manifest scanner with blacklisted terms."""
     test_file = tmp_path / "model_card.json"
@@ -811,11 +823,7 @@ def test_manifest_scanner_enforces_timeout(
 
     result = scanner.scan(str(test_file))
 
-    assert result.success is True
-    timeout_checks = [check for check in result.checks if check.name == "Manifest Scan Timeout"]
-    assert len(timeout_checks) == 1
-    assert timeout_checks[0].status == CheckStatus.FAILED
-    assert timeout_checks[0].severity == IssueSeverity.WARNING
+    _assert_manifest_timeout_result(result)
 
 
 def test_manifest_scanner_blacklist_timeout_reports_only_timeout(
@@ -840,7 +848,7 @@ def test_manifest_scanner_blacklist_timeout_reports_only_timeout(
 
     result = scanner.scan(str(test_file))
 
-    assert result.success is True
+    _assert_manifest_timeout_result(result)
     assert [check.name for check in result.checks if check.status == CheckStatus.FAILED] == ["Manifest Scan Timeout"]
 
 
@@ -863,7 +871,7 @@ def test_manifest_scanner_parse_timeout_reports_only_timeout(
 
     result = scanner.scan(str(test_file))
 
-    assert result.success is True
+    _assert_manifest_timeout_result(result)
     assert [check.name for check in result.checks if check.status == CheckStatus.FAILED] == ["Manifest Scan Timeout"]
     assert not any(check.name == "File Parse Error" for check in result.checks)
     assert not any(check.name == "Manifest Parse Attempt" for check in result.checks)
@@ -892,7 +900,7 @@ def test_manifest_scanner_cloud_url_timeout_reports_only_timeout(
 
     result = scanner.scan(str(test_file))
 
-    assert result.success is True
+    _assert_manifest_timeout_result(result)
     assert [check.name for check in result.checks if check.status == CheckStatus.FAILED] == ["Manifest Scan Timeout"]
     assert not any(check.name == "Manifest File Scan" for check in result.checks)
 
@@ -918,7 +926,7 @@ def test_manifest_scanner_weak_hash_timeout_reports_only_timeout(
 
     result = scanner.scan(str(test_file))
 
-    assert result.success is True
+    _assert_manifest_timeout_result(result)
     assert [check.name for check in result.checks if check.status == CheckStatus.FAILED] == ["Manifest Scan Timeout"]
     assert not any(check.name == "Manifest File Scan" for check in result.checks)
 

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -10,7 +10,7 @@ from typing import IO
 import pytest
 
 from modelaudit.detectors.suspicious_symbols import CVE_COMBINED_PATTERNS
-from modelaudit.scanner_results import Check, ScanResult
+from modelaudit.scanner_results import INCONCLUSIVE_SCAN_OUTCOME, Check, ScanResult
 from modelaudit.scanners.base import CheckStatus, IssueSeverity
 from modelaudit.scanners.pytorch_zip_scanner import PyTorchZipScanner
 from tests.helpers import create_mock_pytorch_zip
@@ -50,6 +50,10 @@ def _malicious_eval_pickle_payload() -> bytes:
             return (eval, ("print('pwned')",))
 
     return pickle.dumps({"payload": MaliciousClass()})
+
+
+def _malicious_proto0_system_payload() -> bytes:
+    return b"cposix\nsystem\n(S'echo hidden'\ntR."
 
 
 def _pytorch_storage_persistent_id_payload(key: str | bytes) -> bytes:
@@ -194,6 +198,63 @@ def test_pytorch_zip_discovery_scans_only_real_extensionless_pickle_near_text(tm
 
     assert result.metadata["pickle_files"] == ["archive/data"]
     assert any(issue.severity == IssueSeverity.CRITICAL and "eval" in issue.message.lower() for issue in result.issues)
+
+
+def test_pytorch_zip_discovery_finds_hidden_extensionless_pickle_with_data_pkl(tmp_path: Path) -> None:
+    """A normal data.pkl must not short-circuit hidden member pickle discovery."""
+    model_path = tmp_path / "hidden_extensionless_pickle.pt"
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}, protocol=4))
+        zip_file.writestr("archive/payload", _malicious_proto0_system_payload())
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.metadata["pickle_files"] == ["archive/data.pkl", "archive/payload"]
+    assert any(
+        issue.severity == IssueSeverity.CRITICAL and issue.details.get("pickle_filename") == "archive/payload"
+        for issue in result.issues
+    )
+
+
+def test_pytorch_zip_discovery_finds_hidden_storage_pickle_with_data_pkl(tmp_path: Path) -> None:
+    """Bounded storage-prefix sniffing should catch pickles hidden under data/<n>."""
+    model_path = tmp_path / "hidden_storage_pickle.pt"
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}, protocol=4))
+        zip_file.writestr("archive/data/0", _malicious_proto0_system_payload())
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.metadata["pickle_files"] == ["archive/data.pkl", "archive/data/0"]
+    assert any(
+        issue.severity == IssueSeverity.CRITICAL and issue.details.get("pickle_filename") == "archive/data/0"
+        for issue in result.issues
+    )
+
+
+def test_pytorch_zip_discovery_ignores_benign_pickleish_text_with_data_pkl(tmp_path: Path) -> None:
+    """Text that starts with protocol-0-looking bytes should not become a hidden pickle false positive."""
+    model_path = tmp_path / "benign_pickleish_text.pt"
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}, protocol=4))
+        zip_file.writestr("archive/notes", b"cat is a category label, not a GLOBAL opcode stream")
+        zip_file.writestr("archive/data/0", b"\x00" * 1024)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert result.metadata["pickle_files"] == ["archive/data.pkl"]
+    assert not any(
+        issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL}
+        and issue.details.get("pickle_filename") in {"archive/notes", "archive/data/0"}
+        for issue in result.issues
+    )
 
 
 def test_pytorch_zip_scanner_detects_case_insensitive_native_library_members(tmp_path: Path) -> None:
@@ -452,11 +513,8 @@ def test_pytorch_zip_initialize_scan_does_not_read_archive_members(
     assert "pickle_files" not in result.metadata
 
 
-def test_pytorch_zip_scan_does_not_open_numeric_tensor_data_files(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Numeric tensor payloads should not be opened anywhere in the ZIP scan."""
+def test_pytorch_zip_scan_does_not_route_numeric_tensor_data_files_as_pickles(tmp_path: Path) -> None:
+    """Numeric tensor payloads should be prefix-probed but not routed as pickles."""
     zip_path = tmp_path / "model.pt"
 
     with zipfile.ZipFile(zip_path, "w") as zipf:
@@ -465,29 +523,14 @@ def test_pytorch_zip_scan_does_not_open_numeric_tensor_data_files(
         zipf.writestr("archive/data/0", b"\x00" * 1024)
         zipf.writestr("archive/data/1", b"\x00" * 1024)
 
-    opened_members: list[str] = []
-    original_open = zipfile.ZipFile.open
-
-    def track_open(
-        self: zipfile.ZipFile,
-        name: str | zipfile.ZipInfo,
-        mode: str = "r",
-        pwd: bytes | None = None,
-        *,
-        force_zip64: bool = False,
-    ) -> IO[bytes]:
-        opened_members.append(name.filename if isinstance(name, zipfile.ZipInfo) else str(name))
-        return original_open(self, name, mode, pwd, force_zip64=force_zip64)
-
-    monkeypatch.setattr(zipfile.ZipFile, "open", track_open)
-
     scanner = PyTorchZipScanner()
     result = scanner.scan(str(zip_path))
 
     assert result.success is True
-    assert "archive/data.pkl" in opened_members
-    assert "archive/data/0" not in opened_members
-    assert "archive/data/1" not in opened_members
+    assert result.metadata["pickle_files"] == ["archive/data.pkl"]
+    assert not any(
+        issue.details.get("pickle_filename") in {"archive/data/0", "archive/data/1"} for issue in result.issues
+    )
 
 
 def test_pytorch_zip_scanner_handles_zip_metadata_oserror(
@@ -507,6 +550,39 @@ def test_pytorch_zip_scanner_handles_zip_metadata_oserror(
 
     assert result.success is False
     assert any("zip metadata unavailable" in check.message for check in result.checks)
+
+
+def test_pytorch_zip_timeout_marks_inconclusive(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "timeout.pt")
+
+    result = PyTorchZipScanner(config={"timeout": -1}).scan(str(model_path))
+
+    assert result.success is False
+    assert result.metadata["analysis_incomplete"] is True
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "pytorch_zip_scan_timeout" in result.metadata["scan_outcome_reasons"]
+    timeout_checks = [check for check in result.checks if check.name == "Scan Timeout"]
+    assert len(timeout_checks) == 1
+    assert timeout_checks[0].severity == IssueSeverity.INFO
+
+
+def test_pytorch_zip_jit_scan_size_limit_marks_inconclusive(tmp_path: Path) -> None:
+    model_path = tmp_path / "large_jit_member.pt"
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}, protocol=4))
+        zip_file.writestr("archive/code/debug/source.py", b"print('hello')\n")
+
+    result = PyTorchZipScanner(config={"max_jit_scan_member_bytes": 4}).scan(str(model_path))
+
+    assert result.success is False
+    assert result.metadata["analysis_incomplete"] is True
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "pytorch_zip_jit_member_size_limit" in result.metadata["scan_outcome_reasons"]
+    size_checks = [check for check in result.checks if check.name == "JIT/Network Scan Size Limit"]
+    assert len(size_checks) >= 1
+    assert all(check.severity == IssueSeverity.INFO for check in size_checks)
 
 
 @pytest.mark.performance

--- a/tests/scanners/test_sevenzip_scanner.py
+++ b/tests/scanners/test_sevenzip_scanner.py
@@ -1658,6 +1658,20 @@ class TestSevenZipScannerHardening:
 
         assert scanner._probe_detected_format(probe) == "tar"
 
+    def test_probe_detected_format_recognizes_extensionless_proto0_pickle(self) -> None:
+        """Extensionless protocol-0 pickle payloads should not require a suffix."""
+        scanner = SevenZipScanner()
+        probe = io.BytesIO(b"cposix\nsystem\n(S'echo hidden'\ntR.")
+
+        assert scanner._probe_detected_format(probe) == "pickle"
+
+    def test_probe_detected_format_ignores_benign_proto0_near_match_text(self) -> None:
+        """Plain text that starts with pickle-ish bytes should not be routed as pickle."""
+        scanner = SevenZipScanner()
+        probe = io.BytesIO(b"cat is a category label, not a GLOBAL opcode stream")
+
+        assert scanner._probe_detected_format(probe) is None
+
     def test_extensionless_probe_without_header_is_not_scanned(
         self,
         scanner: SevenZipScanner,

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -102,6 +102,41 @@ class TestTarScanner:
         finally:
             os.unlink(tmp_path)
 
+    def test_scan_tar_flags_dangerous_python_member(self, tmp_path: Path) -> None:
+        """Generic TAR files should scan Python source members for active payloads."""
+        archive_path = tmp_path / "model_bundle.tar"
+        payload = b"import os\nos.system('echo hidden')\n"
+
+        with tarfile.open(archive_path, "w") as archive:
+            info = tarfile.TarInfo("handler.py")
+            info.size = len(payload)
+            archive.addfile(info, tarfile.io.BytesIO(payload))  # type: ignore[attr-defined]
+
+        result = self.scanner.scan(str(archive_path))
+
+        python_checks = [check for check in result.checks if check.name == "Python Archive Member Security"]
+        assert len(python_checks) == 1
+        assert python_checks[0].status == CheckStatus.FAILED
+        assert python_checks[0].severity == IssueSeverity.WARNING
+        assert python_checks[0].details["entry"] == "handler.py"
+        assert result.success is True
+
+    def test_scan_tar_ignores_benign_python_member(self, tmp_path: Path) -> None:
+        """Benign Python source in generic TAR archives should not produce security findings."""
+        archive_path = tmp_path / "model_bundle.tar"
+        source = b"def preprocess(value: str) -> str:\n    return value.strip().lower()\n"
+
+        with tarfile.open(archive_path, "w") as archive:
+            info = tarfile.TarInfo("preprocess.py")
+            info.size = len(source)
+            archive.addfile(info, tarfile.io.BytesIO(source))  # type: ignore[attr-defined]
+
+        result = self.scanner.scan(str(archive_path))
+
+        assert result.success is True
+        assert not any(check.name == "Python Archive Member Security" for check in result.checks)
+        assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
+
     def test_path_traversal_detection(self):
         """Test detection of path traversal attempts"""
         with tempfile.NamedTemporaryFile(suffix=".tar", delete=False) as tmp:

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -89,6 +89,35 @@ def test_nested_dispatch_routes_compressed_header_aliases_to_compressed_scanner(
     assert _select_nested_scanner_id(str(member_path)) == "compressed"
 
 
+def test_scan_zip_flags_dangerous_python_member(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", "import os\nos.system('echo hidden')\n")
+
+    result = ZipScanner().scan(str(archive_path))
+
+    python_checks = [
+        check
+        for check in result.checks
+        if check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED
+    ]
+    assert len(python_checks) == 1
+    assert python_checks[0].severity == IssueSeverity.WARNING
+    assert python_checks[0].details["entry"] == "handler.py"
+
+
+def test_scan_zip_ignores_benign_python_member(tmp_path: Path) -> None:
+    archive_path = tmp_path / "source_bundle.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("preprocess.py", "def normalize(value: float) -> float:\n    return value / 255.0\n")
+
+    result = ZipScanner().scan(str(archive_path))
+
+    assert result.success is True
+    assert not any(check.name == "Python Archive Member Security" for check in result.checks)
+    assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
+
+
 class _HeaderRoutedTempScanner(BaseScanner):
     name: ClassVar[str] = "header_routed_temp"
 


### PR DESCRIPTION
## Summary
- sniff hidden PyTorch ZIP pickle members even when data.pkl exists, including storage-looking paths, and fail closed on discovery/JIT coverage limits
- detect extensionless protocol 0/1 pickles in 7z probes and mark PyTorch/manifest timeouts inconclusive
- keep active payload/CVE/path traversal/incomplete findings from being downgraded by HuggingFace whitelist provenance
- scan generic ZIP/TAR Python members for dangerous handlers while preserving benign source and storage near-match negatives

## Validation
- uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_pytorch_zip_scanner.py tests/scanners/test_sevenzip_scanner.py tests/scanners/test_zip_scanner.py tests/scanners/test_tar_scanner.py tests/scanners/test_manifest_scanner.py tests/scanners/test_base_scanner.py packages/modelaudit-picklescan/tests/test_api.py --maxfail=1
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1