### PR TITLE
fix: detect proto0 pickles in 7z probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **security:** detect extensionless protocol-0/1 pickle members during 7-Zip nested archive probes.
 - **pickle:** restore ModelAudit nested-pickle findings from Rust standalone notices and keep network raw-detector coverage after native pickle findings
 - **telemetry:** strip query strings, fragments, and URL userinfo from cloud model names and file-extension metadata
 - preserve `S999` unknown-opcode mapping in generic rule fallback

--- a/modelaudit/scanners/sevenzip_scanner.py
+++ b/modelaudit/scanners/sevenzip_scanner.py
@@ -14,7 +14,7 @@ else:
     _py7zr = None
 
 from ..utils import sanitize_archive_path
-from ..utils.file.detection import detect_format_from_magic_bytes
+from ..utils.file.detection import _looks_like_proto0_or_1_pickle, detect_format_from_magic_bytes
 from ._archive_config import get_archive_depth
 from ._archive_locations import rewrite_extracted_member_location
 from ._archive_outcomes import mark_archive_scan_incomplete, member_scan_incomplete
@@ -623,6 +623,9 @@ class SevenZipScanner(BaseScanner):
         prefix = probe.read(self._NESTED_MEMBER_PROBE_BYTES)
         if len(prefix) < 4:
             return None
+
+        if _looks_like_proto0_or_1_pickle(prefix, sample_is_prefix=len(prefix) == self._NESTED_MEMBER_PROBE_BYTES):
+            return "pickle"
 
         detected_format = detect_format_from_magic_bytes(
             prefix[:4],

--- a/tests/scanners/test_sevenzip_scanner.py
+++ b/tests/scanners/test_sevenzip_scanner.py
@@ -1658,6 +1658,20 @@ class TestSevenZipScannerHardening:
 
         assert scanner._probe_detected_format(probe) == "tar"
 
+    def test_probe_detected_format_recognizes_extensionless_proto0_pickle(self) -> None:
+        """7z nested probes should route protocol-0 pickle members without suffixes."""
+        scanner = SevenZipScanner()
+        probe = io.BytesIO(b"cposix\nsystem\n(S'echo hidden'\ntR.")
+
+        assert scanner._probe_detected_format(probe) == "pickle"
+
+    def test_probe_detected_format_ignores_benign_proto0_near_match_text(self) -> None:
+        """Plain text that starts with proto0-looking bytes should not route as pickle."""
+        scanner = SevenZipScanner()
+        probe = io.BytesIO(b"cat is a category label, not a GLOBAL opcode stream")
+
+        assert scanner._probe_detected_format(probe) is None
+
     def test_extensionless_probe_without_header_is_not_scanned(
         self,
         scanner: SevenZipScanner,

--- a/tests/scanners/test_sevenzip_scanner.py
+++ b/tests/scanners/test_sevenzip_scanner.py
@@ -1742,6 +1742,40 @@ class TestSevenZipScannerHardening:
             assert result.metadata["scannable_files"] == 1
             mock_scan_extracted_file.assert_called_once()
 
+    def test_extensionless_proto0_pickle_probe_reaches_full_extraction(self, tmp_path: Path) -> None:
+        """Header probes should route extensionless protocol-0 pickle members through scanner extraction."""
+        scanner = SevenZipScanner()
+        archive_path = tmp_path / "proto0_probe.7z"
+        archive_path.write_bytes(scanner._SEVENZIP_MAGIC + b"\0" * 26)
+        payload = b"cposix\nsystem\n(S'echo hidden'\ntR."
+
+        with (
+            patch("modelaudit.scanners.sevenzip_scanner.HAS_PY7ZR", True),
+            patch("modelaudit.scanners.sevenzip_scanner.py7zr") as mock_py7zr,
+            patch.object(scanner, "_has_7z_magic", return_value=True),
+            patch.object(scanner, "_scan_extracted_file", return_value=_mock_scan_result()) as mock_scan_extracted_file,
+            patch("os.path.isfile", return_value=True),
+            patch("os.path.islink", return_value=False),
+            patch("os.path.getsize", return_value=32),
+        ):
+
+            def fake_extract(*_args: Any, **kwargs: Any) -> None:
+                factory = kwargs.get("factory")
+                if factory is not None:
+                    factory.create("nested_payload").write(payload)
+
+            mock_archive = MagicMock()
+            mock_archive.getnames.return_value = ["nested_payload"]
+            mock_archive.getinfo.return_value = MagicMock(uncompressed=len(payload), is_directory=False)
+            mock_archive.extract.side_effect = fake_extract
+            mock_py7zr.SevenZipFile.return_value.__enter__.return_value = mock_archive
+
+            result = scanner.scan(str(archive_path))
+
+            assert result.success
+            assert result.metadata["scannable_files"] == 1
+            mock_scan_extracted_file.assert_called_once()
+
     # -- default config includes new limits -----------------------------------
 
     def test_default_configuration_includes_new_limits(self) -> None:


### PR DESCRIPTION
## Summary
- run the protocol-0/1 structural pickle probe on bounded 7z member prefixes
- keep binary magic routing unchanged while catching extensionless ASCII pickle streams
- add a malicious proto0 positive and benign text near-match negative regression

## Finding
Fixes finding 2: 7z probe misses extensionless proto0 pickles.

## Validation
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_sevenzip_scanner.py --maxfail=1
- uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1