### PR TITLE
fix: repair picklescan release wheel jobs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -507,7 +507,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           command: build
-          args: --release --wheel --out /tmp/modelaudit-picklescan-dist --compatibility manylinux_2_28
+          args: --release --out /tmp/modelaudit-picklescan-dist --compatibility manylinux_2_28
           manylinux: "2_28"
           working-directory: packages/modelaudit-picklescan
 
@@ -582,6 +582,11 @@ jobs:
         run: |
           set -euo pipefail
           uv venv /tmp/modelaudit-picklescan-wheel-smoke
+          if [[ -x /tmp/modelaudit-picklescan-wheel-smoke/bin/python ]]; then
+            SMOKE_PYTHON=/tmp/modelaudit-picklescan-wheel-smoke/bin/python
+          else
+            SMOKE_PYTHON=/tmp/modelaudit-picklescan-wheel-smoke/Scripts/python.exe
+          fi
 
           shopt -s nullglob
           picklescan_wheels=(/tmp/modelaudit-picklescan-dist/modelaudit_picklescan-*.whl)
@@ -591,12 +596,12 @@ jobs:
             exit 1
           fi
 
-          uv pip install --python /tmp/modelaudit-picklescan-wheel-smoke/bin/python "${picklescan_wheels[0]}"
+          uv pip install --python "$SMOKE_PYTHON" "${picklescan_wheels[0]}"
 
           smoke_dir="$(mktemp -d)"
           (
             cd "$smoke_dir"
-            PYTHONPATH='' /tmp/modelaudit-picklescan-wheel-smoke/bin/python -I - <<'PY'
+            PYTHONPATH='' "$SMOKE_PYTHON" -I - <<'PY'
           import importlib.util
 
           import modelaudit_picklescan


### PR DESCRIPTION
## Summary
- remove the stale maturin --wheel flag from the Linux manylinux build step
- make standalone wheel smoke tests choose bin/python or Scripts/python.exe so Windows runners work

## Validation
- npx prettier --check .github/workflows/release-please.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -color .github/workflows/release-please.yml
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1