### PR TITLE
fix: avoid duplicate manylinux compatibility tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -572,7 +572,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           command: build
-          args: --release --out /tmp/modelaudit-picklescan-dist --compatibility manylinux_2_28
+          args: --release --out /tmp/modelaudit-picklescan-dist
           manylinux: "2_28"
           working-directory: packages/modelaudit-picklescan
 


### PR DESCRIPTION
## Summary
- remove the redundant maturin --compatibility flag from the manylinux wheel build
- keep the PyO3 action manylinux input as the single source of the platform tag

## Validation
- npx prettier --check .github/workflows/release-please.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -color .github/workflows/release-please.yml
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1