### PR TITLE
fix: persist manylinux picklescan artifacts

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -565,24 +565,24 @@ jobs:
       - name: Build standalone package sdist
         if: matrix.build-sdist == 'true'
         run: |
-          uv build --sdist --out-dir /tmp/modelaudit-picklescan-dist
+          uv build --sdist --out-dir dist
 
       - name: Build standalone package manylinux wheel
         if: runner.os == 'Linux'
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           command: build
-          args: --release --out /tmp/modelaudit-picklescan-dist
+          args: --release --out dist
           manylinux: "2_28"
           working-directory: packages/modelaudit-picklescan
 
       - name: Build standalone package wheel
         if: runner.os != 'Linux'
         run: |
-          uv build --wheel --out-dir /tmp/modelaudit-picklescan-dist
+          uv build --wheel --out-dir dist
 
       - name: Validate standalone package metadata
-        run: uvx twine check /tmp/modelaudit-picklescan-dist/*
+        run: uvx twine check dist/*
 
       - name: Verify standalone artifact version consistency
         run: |
@@ -590,10 +590,10 @@ jobs:
           EXPECTED_VERSION="${{ needs.release-please.outputs.picklescan_version }}"
 
           shopt -s nullglob
-          artifacts=(/tmp/modelaudit-picklescan-dist/modelaudit_picklescan-*.whl /tmp/modelaudit-picklescan-dist/modelaudit_picklescan-*.tar.gz)
+          artifacts=(dist/modelaudit_picklescan-*.whl dist/modelaudit_picklescan-*.tar.gz)
           if [[ ${#artifacts[@]} -eq 0 ]]; then
             echo "ERROR: Expected at least one modelaudit_picklescan artifact"
-            ls -la /tmp/modelaudit-picklescan-dist/
+            ls -la dist/
             exit 1
           fi
 
@@ -654,10 +654,10 @@ jobs:
           fi
 
           shopt -s nullglob
-          picklescan_wheels=(/tmp/modelaudit-picklescan-dist/modelaudit_picklescan-*.whl)
+          picklescan_wheels=(dist/modelaudit_picklescan-*.whl)
           if [[ ${#picklescan_wheels[@]} -ne 1 ]]; then
             echo "ERROR: Expected exactly 1 modelaudit_picklescan wheel artifact, found ${#picklescan_wheels[@]}"
-            ls -la /tmp/modelaudit-picklescan-dist/
+            ls -la dist/
             exit 1
           fi
 
@@ -685,7 +685,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: modelaudit-picklescan-dist-${{ matrix.artifact-suffix }}
-          path: /tmp/modelaudit-picklescan-dist/
+          path: packages/modelaudit-picklescan/dist/
 
   publish-pypi:
     if: needs.release-please.outputs.release_created == 'true'


### PR DESCRIPTION
## Summary
- move standalone picklescan release artifacts into packages/modelaudit-picklescan/dist
- make manylinux, metadata validation, smoke install, and upload steps use the shared workspace artifact path
- fixes the recovery failures where manylinux wheels were built inside the container but absent from later host steps

## Validation
- npx prettier --check .github/workflows/release-please.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -color .github/workflows/release-please.yml
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1