### PR TITLE
chore: release 0.2.40

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  ".": "0.2.39",
+  ".": "0.2.40",
   "packages/modelaudit-picklescan": "0.1.2"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.40](https://github.com/promptfoo/modelaudit/compare/v0.2.39...v0.2.40) (2026-04-17)
+
+### Bug Fixes
+
+- add manual release recovery path ([aeea2da](https://github.com/promptfoo/modelaudit/commit/aeea2da68099f42a2fae68a50fff9e64e5e2f86f))
+- avoid duplicate manylinux compatibility tag ([412677f](https://github.com/promptfoo/modelaudit/commit/412677f00e6a24b3471d9f14a36ef2b9405e5067))
+- persist manylinux picklescan artifacts ([346bb3f](https://github.com/promptfoo/modelaudit/commit/346bb3f048b646c69573812a08ffd23342843658))
+
 ## [0.2.39](https://github.com/promptfoo/modelaudit/compare/v0.2.38...v0.2.39) (2026-04-17)
 
 ### Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "modelaudit"
-version = "0.2.39"
+version = "0.2.40"
 description = "Static scanning library for detecting malicious code, potential backdoor indicators, and other security risks in ML model files"
 authors = [
     { name = "Ian Webster", email = "ian@promptfoo.dev" },

--- a/uv.lock
+++ b/uv.lock
@@ -2395,7 +2395,7 @@ wheels = [
 
 [[package]]
 name = "modelaudit"
-version = "0.2.39"
+version = "0.2.40"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Bump modelaudit to 0.2.40 with resolvable picklescan dependency
- Bundle three post-0.2.39 fixes (manual recovery path, manylinux tag dedup, artifact persistence)
- Re-establishes a working top-level release after 0.2.38/0.2.39 shipped with an unresolvable `modelaudit-picklescan>=0.1.0,<0.2.0` dependency

## Context

`modelaudit-picklescan` 0.1.2 failed its first PyPI publish (HTTP 400 — missing pending trusted publisher). `modelaudit` 0.2.38 and 0.2.39 were already on PyPI with a hard dep on it, making them uninstallable. Pending publisher has now been registered and `modelaudit-picklescan==0.1.2` is live on PyPI (workflow run 24589624956). This PR cuts the first working `modelaudit` release that points at it.

**Please yank 0.2.38 and 0.2.39 on PyPI once this merges** — they remain broken forever.

## Test plan

- [x] `pyproject.toml`, `.release-please-manifest.json`, and `CHANGELOG.md` bumped in lockstep
- [ ] CI passes on this PR
- [ ] After merge, release-please dispatches `publish-pypi` and 0.2.40 lands on PyPI
- [ ] Smoke: `pip install modelaudit==0.2.40 && modelaudit --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)