### PR TITLE
fix(picklescan): avoid call-graph false positives for PyTorch storage IDs

### DIFF
--- a/packages/modelaudit-picklescan/rust/src/stack.rs
+++ b/packages/modelaudit-picklescan/rust/src/stack.rs
@@ -293,6 +293,26 @@ pub(crate) fn pytorch_storage_key(value: &StackValue, payload: &[u8]) -> Option<
     stack_value_string(&items[2], payload)
 }
 
+pub(crate) fn pytorch_storage_descriptor_ref<'a>(
+    value: &'a StackValue,
+    payload: &[u8],
+) -> Option<&'a GlobalRef> {
+    let StackValue::Tuple(items) = value else {
+        return None;
+    };
+    if items.len() < 4 || stack_value_text(&items[0], payload).as_deref() != Some("storage") {
+        return None;
+    }
+    let StackValue::Global(reference) = &items[1] else {
+        return None;
+    };
+    if is_pytorch_storage_descriptor(&items[1], payload) {
+        Some(reference)
+    } else {
+        None
+    }
+}
+
 pub(crate) fn stack_value_from_integer_arg(arg: &ArgValue, payload: &[u8]) -> StackValue {
     match arg {
         ArgValue::Int(value) => StackValue::Primitive {

--- a/packages/modelaudit-picklescan/rust/src/state.rs
+++ b/packages/modelaudit-picklescan/rust/src/state.rs
@@ -29,9 +29,10 @@ use crate::report::{
     Finding, FindingDedupeKey, Notice, NoticeDedupeKey, ScanError,
 };
 use crate::stack::{
-    collapse_tuple_values, operand_preview, pytorch_storage_key, resolve_global_operand,
-    stack_value_from_integer_arg, stack_value_from_text_arg, stack_value_preview,
-    stack_value_string, FutureCallbacks, GlobalRef, RegexScannerRule, StackValue,
+    collapse_tuple_values, operand_preview, pytorch_storage_descriptor_ref, pytorch_storage_key,
+    resolve_global_operand, stack_value_from_integer_arg, stack_value_from_text_arg,
+    stack_value_preview, stack_value_string, FutureCallbacks, GlobalRef, RegexScannerRule,
+    StackValue,
 };
 use crate::strings::{is_repeated_single_byte, suspicious_string_matches};
 
@@ -3798,6 +3799,8 @@ impl<'a> ScanState<'a> {
                 DetailValue::String(stack_value_preview(value, 0)),
             ));
             if let Some(storage_key) = pytorch_storage_key(value, self.payload) {
+                let storage_descriptor =
+                    pytorch_storage_descriptor_ref(value, self.payload).cloned();
                 details.push((
                     "pytorch_storage_persistent_id".to_string(),
                     DetailValue::Bool(true),
@@ -3806,6 +3809,9 @@ impl<'a> ScanState<'a> {
                     "pytorch_storage_key".to_string(),
                     DetailValue::String(storage_key),
                 ));
+                if let Some(descriptor) = storage_descriptor.as_ref() {
+                    self.mark_pytorch_storage_persistent_id_import_reference(descriptor);
+                }
             }
         }
 
@@ -3819,6 +3825,29 @@ impl<'a> ScanState<'a> {
                 "Persistent pickle IDs delegate object resolution to loader-defined callbacks, which can hide external object construction or storage lookups.",
             ),
         });
+    }
+
+    fn mark_pytorch_storage_persistent_id_import_reference(&mut self, descriptor: &GlobalRef) {
+        for details in &mut self.import_references {
+            if detail_usize(details, "position") != Some(descriptor.position) {
+                continue;
+            }
+            if detail_string(details, "module").as_deref() != Some(descriptor.module.as_str())
+                || detail_string(details, "name").as_deref() != Some(descriptor.name.as_str())
+            {
+                continue;
+            }
+            if !details
+                .iter()
+                .any(|(key, _)| key == "pytorch_storage_persistent_id")
+            {
+                details.push((
+                    "pytorch_storage_persistent_id".to_string(),
+                    DetailValue::Bool(true),
+                ));
+            }
+            break;
+        }
     }
 
     fn emit_persistent_id_notice(&mut self) {

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -428,7 +428,7 @@ def _iter_call_graph_references(
     for item in callable_references:
         module = str(item.get("module", ""))
         name = str(item.get("name", ""))
-        if not module or not name or _is_torch_extension_global_reference(module, name):
+        if not module or not name or _is_skippable_torch_extension_global_reference(module, name):
             continue
         opcode = str(item.get("opcode", ""))
         positional_arg_count = item.get("positional_arg_count")
@@ -451,7 +451,7 @@ def _iter_call_graph_references(
             or not name
             or (module, name) in seen
             or (module, name) in invoked_references
-            or _is_torch_extension_global_reference(module, name)
+            or _is_skippable_torch_extension_global_reference(module, name)
         ):
             continue
         seen.add((module, name))
@@ -601,6 +601,28 @@ def _is_torch_extension_global_reference(module: str, name: str) -> bool:
     return module == "torch" and name in _TORCH_EXTENSION_GLOBALS
 
 
+def _is_skippable_torch_extension_global_reference(module: str, name: str) -> bool:
+    if not _is_torch_extension_global_reference(module, name):
+        return False
+    source_path = _resolve_module_source(module)
+    if source_path is not None and not _is_library_source_path(str(source_path)):
+        return False
+    return not _has_static_torch_extension_global_target(module, name)
+
+
+@lru_cache(maxsize=256)
+def _has_static_torch_extension_global_target(module: str, name: str) -> bool:
+    analysis = _analyze_module(module)
+    if analysis is None:
+        return False
+    full_name = f"{module}.{name}"
+    if full_name in analysis.calls_by_function or full_name in analysis.class_entrypoints:
+        return True
+    if analysis.aliases.get(name) is not None:
+        return True
+    return _resolve_wildcard_reexport_alias(module, name) is not None
+
+
 def has_unanalyzed_call_graph_import_references(import_references: object) -> bool:
     if not isinstance(import_references, list | tuple):
         return False
@@ -612,7 +634,9 @@ def has_unanalyzed_call_graph_import_references(import_references: object) -> bo
         name = str(item.get("name", ""))
         if not module or not name:
             continue
-        if _is_pytorch_storage_persistent_id_reference(item) or _is_torch_extension_global_reference(module, name):
+        if _is_pytorch_storage_persistent_id_reference(item) or _is_skippable_torch_extension_global_reference(
+            module, name
+        ):
             continue
         seen.add((module, name))
         if len(seen) > _MAX_IMPORT_REFERENCES:

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -880,7 +880,7 @@ def _resolve_dotted_module_getattr_target(
     first_component, _separator, _remaining = qualified_name.partition(".")
     if not first_component or first_component in analysis.direct_names:
         return None
-    if first_component.startswith("__") and first_component.endswith("__"):
+    if first_component == "__dict__":
         return None
     if analysis.aliases.get(first_component) is not None:
         return None

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -116,6 +116,79 @@ _SHORT_SINK_SECONDARY_PRIORITY_TOKENS = ("exec", "system", "run")
 _CALLABLE_SINGLETON_ALIASES = {
     ("builtins", "help"): (("_sitebuiltins", "_Helper.__call__"),),
 }
+_TORCH_EXTENSION_GLOBALS = frozenset(
+    {
+        "Size",
+        "Tensor",
+        "bfloat16",
+        "bits16",
+        "bits1x8",
+        "bits2x4",
+        "bits4x2",
+        "bits8",
+        "bool",
+        "cdouble",
+        "cfloat",
+        "chalf",
+        "channels_last",
+        "channels_last_3d",
+        "complex128",
+        "complex32",
+        "complex64",
+        "contiguous_format",
+        "device",
+        "double",
+        "float",
+        "float16",
+        "float32",
+        "float64",
+        "float8_e4m3fn",
+        "float8_e4m3fnuz",
+        "float8_e5m2",
+        "float8_e5m2fnuz",
+        "half",
+        "int",
+        "int16",
+        "int32",
+        "int64",
+        "int8",
+        "layout",
+        "long",
+        "memory_format",
+        "per_channel_affine",
+        "per_channel_affine_float_qparams",
+        "per_channel_symmetric",
+        "per_tensor_affine",
+        "per_tensor_symmetric",
+        "preserve_format",
+        "qint32",
+        "qint8",
+        "quint2x4",
+        "quint4x2",
+        "quint8",
+        "short",
+        "sparse_bsc",
+        "sparse_bsr",
+        "sparse_coo",
+        "sparse_csc",
+        "sparse_csr",
+        "strided",
+        "uint1",
+        "uint16",
+        "uint2",
+        "uint3",
+        "uint32",
+        "uint4",
+        "uint5",
+        "uint6",
+        "uint64",
+        "uint7",
+        "uint8",
+    }
+)
+_NEWOBJ_OPCODES = frozenset({"NEWOBJ", "NEWOBJ_EX"})
+_CONSTRUCTOR_OPCODES = frozenset({"INST", "OBJ", "REDUCE"})
+_BUILD_OPCODES = frozenset({"BUILD"})
 
 
 @dataclass(frozen=True)
@@ -188,16 +261,20 @@ def find_dangerous_call_graphs(
     callable_invocations: object | None = None,
 ) -> tuple[CallGraphFinding, ...]:
     findings: list[CallGraphFinding] = []
-    seen: set[tuple[str, str]] = set()
+    seen_findings: set[tuple[str, str, tuple[str, ...]]] = set()
     positional_arg_counts = _callable_invocation_positional_arg_counts(callable_invocations)
-    for reference in _iter_call_graph_references(import_references, callable_invocations):
+    callable_references = _iter_callable_invocation_references(callable_invocations)
+    invoked_references = {
+        (str(reference.get("module", "")), str(reference.get("name", ""))) for reference in callable_references
+    }
+
+    for reference in _iter_call_graph_references(import_references, callable_references, invoked_references):
         module = str(reference.get("module", ""))
         name = str(reference.get("name", ""))
-        if not module or not name or (module, name) in seen:
+        if not module or not name:
             continue
-        seen.add((module, name))
 
-        entrypoints = _safe_call_graph_entrypoints(f"{module}.{name}")
+        entrypoints = _call_graph_entrypoints_for_reference(module, name, reference)
         if not entrypoints:
             continue
         allow_invoked_non_lifecycle_entrypoint = _is_explicit_method_import_reference(name)
@@ -215,6 +292,11 @@ def find_dangerous_call_graphs(
                     break
         if sink_path is None:
             continue
+
+        finding_key = (module, name, sink_path)
+        if finding_key in seen_findings:
+            continue
+        seen_findings.add(finding_key)
 
         sink = sink_path[-1]
         findings.append(
@@ -337,21 +419,43 @@ def _invoked_import_execution_path_callback(
 
 def _iter_call_graph_references(
     import_references: object,
-    callable_invocations: object | None,
+    callable_references: tuple[dict[str, object], ...],
+    invoked_references: set[tuple[str, str]],
 ) -> tuple[dict[str, object], ...]:
     normalized: list[dict[str, object]] = []
     seen: set[tuple[str, str]] = set()
-    for references in (
-        _iter_import_references(import_references),
-        _iter_callable_invocation_references(callable_invocations),
-    ):
-        for item in references:
-            module = str(item.get("module", ""))
-            name = str(item.get("name", ""))
-            if not module or not name or (module, name) in seen:
-                continue
-            seen.add((module, name))
-            normalized.append(dict(item))
+    seen_invocations: set[tuple[str, str, str, int | None]] = set()
+    for item in callable_references:
+        module = str(item.get("module", ""))
+        name = str(item.get("name", ""))
+        if not module or not name or _is_torch_extension_global_reference(module, name):
+            continue
+        opcode = str(item.get("opcode", ""))
+        positional_arg_count = item.get("positional_arg_count")
+        invocation_key = (
+            module,
+            name,
+            opcode,
+            positional_arg_count if isinstance(positional_arg_count, int) else None,
+        )
+        if invocation_key in seen_invocations:
+            continue
+        seen_invocations.add(invocation_key)
+        normalized.append(dict(item))
+
+    for item in _iter_import_references(import_references):
+        module = str(item.get("module", ""))
+        name = str(item.get("name", ""))
+        if (
+            not module
+            or not name
+            or (module, name) in seen
+            or (module, name) in invoked_references
+            or _is_torch_extension_global_reference(module, name)
+        ):
+            continue
+        seen.add((module, name))
+        normalized.append(dict(item))
     return tuple(normalized)
 
 
@@ -381,7 +485,7 @@ def _iter_callable_invocation_references(callable_invocations: object | None) ->
         return ()
 
     normalized: list[dict[str, object]] = []
-    seen: set[tuple[str, str]] = set()
+    seen: set[tuple[str, str, str, int | None]] = set()
     for item in callable_invocations:
         if not isinstance(item, Mapping):
             continue
@@ -389,13 +493,21 @@ def _iter_callable_invocation_references(callable_invocations: object | None) ->
         name = str(item.get("name", ""))
         if not module or not name:
             continue
+        opcode = str(item.get("opcode", ""))
+        positional_arg_count = item.get("positional_arg_count")
         for reference_module, reference_name in (
             (module, name),
             *_callable_singleton_aliases(module, name),
         ):
-            if (reference_module, reference_name) in seen:
+            reference_key = (
+                reference_module,
+                reference_name,
+                opcode,
+                positional_arg_count if isinstance(positional_arg_count, int) else None,
+            )
+            if reference_key in seen:
                 continue
-            seen.add((reference_module, reference_name))
+            seen.add(reference_key)
             reference = dict(item)
             reference["module"] = reference_module
             reference["name"] = reference_name
@@ -408,6 +520,41 @@ def _iter_callable_invocation_references(callable_invocations: object | None) ->
 
 def _is_explicit_method_import_reference(name: str) -> bool:
     return "." in name
+
+
+def _call_graph_entrypoints_for_reference(
+    module: str,
+    name: str,
+    reference: Mapping[str, object],
+) -> tuple[str, ...]:
+    entrypoints = _safe_call_graph_entrypoints(f"{module}.{name}")
+    if not entrypoints:
+        return ()
+    if _is_explicit_method_import_reference(name):
+        return entrypoints
+    if _resolve_class_target(f"{module}.{name}") is None:
+        return entrypoints
+    opcode = str(reference.get("opcode", ""))
+    if opcode in _NEWOBJ_OPCODES:
+        return _filter_class_entrypoints(entrypoints, ("__new__",))
+    if opcode in _BUILD_OPCODES:
+        return _filter_class_entrypoints(entrypoints, _PICKLE_LIFECYCLE_ENTRYPOINT_METHODS)
+    if opcode in _CONSTRUCTOR_OPCODES:
+        return _filter_class_entrypoints(entrypoints, _PICKLE_CONSTRUCTOR_ENTRYPOINT_METHODS)
+    return entrypoints
+
+
+def _filter_class_entrypoints(entrypoints: tuple[str, ...], methods: tuple[str, ...]) -> tuple[str, ...]:
+    class_entrypoints = tuple(
+        entrypoint
+        for entrypoint in entrypoints
+        if any(entrypoint.endswith(f".{method}") for method in _CLASS_ENTRYPOINT_METHODS)
+    )
+    if not class_entrypoints:
+        return entrypoints
+    return tuple(
+        entrypoint for entrypoint in class_entrypoints if any(entrypoint.endswith(f".{method}") for method in methods)
+    )
 
 
 def _callable_invocation_positional_arg_counts(
@@ -450,6 +597,10 @@ def _is_pytorch_storage_persistent_id_reference(item: Mapping[str, object]) -> b
     )
 
 
+def _is_torch_extension_global_reference(module: str, name: str) -> bool:
+    return module == "torch" and name in _TORCH_EXTENSION_GLOBALS
+
+
 def has_unanalyzed_call_graph_import_references(import_references: object) -> bool:
     if not isinstance(import_references, list | tuple):
         return False
@@ -461,7 +612,7 @@ def has_unanalyzed_call_graph_import_references(import_references: object) -> bo
         name = str(item.get("name", ""))
         if not module or not name:
             continue
-        if _is_pytorch_storage_persistent_id_reference(item):
+        if _is_pytorch_storage_persistent_id_reference(item) or _is_torch_extension_global_reference(module, name):
             continue
         seen.add((module, name))
         if len(seen) > _MAX_IMPORT_REFERENCES:
@@ -695,6 +846,8 @@ def _resolve_dotted_module_getattr_target(
 ) -> str | None:
     first_component, _separator, _remaining = qualified_name.partition(".")
     if not first_component or first_component in analysis.direct_names:
+        return None
+    if first_component.startswith("__") and first_component.endswith("__"):
         return None
     if analysis.aliases.get(first_component) is not None:
         return None

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -471,7 +471,7 @@ def _iter_import_references(import_references: object) -> tuple[dict[str, object
         name = str(item.get("name", ""))
         if not module or not name or (module, name) in seen:
             continue
-        if _is_pytorch_storage_persistent_id_reference(item):
+        if _is_skippable_pytorch_storage_persistent_id_reference(item):
             continue
         seen.add((module, name))
         normalized.append(dict(item))
@@ -536,6 +536,8 @@ def _call_graph_entrypoints_for_reference(
         return entrypoints
     opcode = str(reference.get("opcode", ""))
     if opcode in _NEWOBJ_OPCODES:
+        if not isinstance(reference.get("positional_arg_count"), int):
+            return _filter_class_entrypoints(entrypoints, (*_PICKLE_LIFECYCLE_ENTRYPOINT_METHODS, "__new__"))
         return _filter_class_entrypoints(entrypoints, ("__new__",))
     if opcode in _BUILD_OPCODES:
         return _filter_class_entrypoints(entrypoints, _PICKLE_LIFECYCLE_ENTRYPOINT_METHODS)
@@ -597,6 +599,13 @@ def _is_pytorch_storage_persistent_id_reference(item: Mapping[str, object]) -> b
     )
 
 
+def _is_skippable_pytorch_storage_persistent_id_reference(item: Mapping[str, object]) -> bool:
+    if not _is_pytorch_storage_persistent_id_reference(item):
+        return False
+    source_path = _resolve_module_source("torch")
+    return source_path is None or _is_library_source_path(str(source_path))
+
+
 def _is_torch_extension_global_reference(module: str, name: str) -> bool:
     return module == "torch" and name in _TORCH_EXTENSION_GLOBALS
 
@@ -634,9 +643,9 @@ def has_unanalyzed_call_graph_import_references(import_references: object) -> bo
         name = str(item.get("name", ""))
         if not module or not name:
             continue
-        if _is_pytorch_storage_persistent_id_reference(item) or _is_skippable_torch_extension_global_reference(
-            module, name
-        ):
+        if _is_skippable_pytorch_storage_persistent_id_reference(
+            item
+        ) or _is_skippable_torch_extension_global_reference(module, name):
             continue
         seen.add((module, name))
         if len(seen) > _MAX_IMPORT_REFERENCES:

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -367,6 +367,8 @@ def _iter_import_references(import_references: object) -> tuple[dict[str, object
         name = str(item.get("name", ""))
         if not module or not name or (module, name) in seen:
             continue
+        if _is_pytorch_storage_persistent_id_reference(item):
+            continue
         seen.add((module, name))
         normalized.append(dict(item))
         if len(normalized) >= _MAX_IMPORT_REFERENCES:
@@ -440,6 +442,14 @@ def _callable_singleton_aliases(module: str, name: str) -> tuple[tuple[str, str]
     return _CALLABLE_SINGLETON_ALIASES.get((module, name), ())
 
 
+def _is_pytorch_storage_persistent_id_reference(item: Mapping[str, object]) -> bool:
+    return (
+        item.get("pytorch_storage_persistent_id") is True
+        and item.get("module") == "torch"
+        and str(item.get("name", "")).endswith("Storage")
+    )
+
+
 def has_unanalyzed_call_graph_import_references(import_references: object) -> bool:
     if not isinstance(import_references, list | tuple):
         return False
@@ -450,6 +460,8 @@ def has_unanalyzed_call_graph_import_references(import_references: object) -> bo
         module = str(item.get("module", ""))
         name = str(item.get("name", ""))
         if not module or not name:
+            continue
+        if _is_pytorch_storage_persistent_id_reference(item):
             continue
         seen.add((module, name))
         if len(seen) > _MAX_IMPORT_REFERENCES:

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -930,6 +930,13 @@ def test_scan_bytes_flags_canonical_pytorch_storage_persistent_ids() -> None:
         finding.rule_code == "PERSISTENT_ID" and finding.details.get("pytorch_storage_key") == "k"
         for finding in report.findings
     )
+    import_references = cast(tuple[dict[str, object], ...], report.metadata.get("import_references", ()))
+    assert any(
+        reference.get("import_reference") == "torch.FloatStorage"
+        and reference.get("pytorch_storage_persistent_id") is True
+        for reference in import_references
+    )
+    assert not any(finding.rule_code == "DANGEROUS_CALL_GRAPH" for finding in report.findings)
     assert report.notices == ()
 
 

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import pytest
 
+import modelaudit_picklescan.call_graph as call_graph_module
 from modelaudit_picklescan import PickleReport, SafetyVerdict, ScanOptions, Severity, scan_bytes
 from modelaudit_picklescan.api import _RUST_EXTENSION_MODULE
 from modelaudit_picklescan.call_graph import (
@@ -56,6 +57,23 @@ def _args_tuple(*arg_operands: bytes) -> bytes:
 
 def _global_call_payload(module: str, name: str, *arg_operands: bytes) -> bytes:
     return b"".join([b"\x80\x04", _global_operand(module, name), _args_tuple(*arg_operands), b"R."])
+
+
+def _clear_call_graph_caches() -> None:
+    for function_name in (
+        "_analyze_module",
+        "_call_graph_entrypoints",
+        "_find_sink_path",
+        "_has_static_torch_extension_global_target",
+        "_resolve_class_target",
+        "_resolve_function_target",
+        "_resolve_module_source",
+        "_safe_call_graph_entrypoints",
+        "_wildcard_export_summary",
+    ):
+        cache_clear = getattr(getattr(call_graph_module, function_name), "cache_clear", None)
+        if cache_clear is not None:
+            cache_clear()
 
 
 def _sitebuiltins_helper_instance_call_payload() -> bytes:
@@ -1356,6 +1374,32 @@ def test_scan_bytes_ignores_benign_torch_extension_metadata_globals() -> None:
 
     assert report.verdict == SafetyVerdict.CLEAN
     assert not any(finding.rule_code == "DANGEROUS_CALL_GRAPH" for finding in report.findings)
+
+
+def test_scan_bytes_analyzes_shadowed_torch_extension_callable_invocation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    (module_dir / "torch.py").write_text(
+        "import os\n\ndef device(command):\n    os.system(command)\n    return command\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(module_dir))
+    importlib.invalidate_caches()
+    _clear_call_graph_caches()
+
+    try:
+        report = scan_bytes(
+            _global_call_payload("torch", "device", _unicode_operand("echo shadowed-torch-device")),
+            source="shadowed-torch-device-rce.pkl",
+        )
+    finally:
+        _clear_call_graph_caches()
+
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert _has_critical_call_graph_finding(report, "torch", "device", "os.system")
 
 
 def test_scan_bytes_ignores_torch_layout_module_dict_lookup() -> None:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -14,7 +14,6 @@ from pathlib import Path
 
 import pytest
 
-import modelaudit_picklescan.call_graph as call_graph_module
 from modelaudit_picklescan import PickleReport, SafetyVerdict, ScanOptions, Severity, scan_bytes
 from modelaudit_picklescan.api import _RUST_EXTENSION_MODULE
 from modelaudit_picklescan.call_graph import (
@@ -60,6 +59,7 @@ def _global_call_payload(module: str, name: str, *arg_operands: bytes) -> bytes:
 
 
 def _clear_call_graph_caches() -> None:
+    call_graph_module = sys.modules["modelaudit_picklescan.call_graph"]
     for function_name in (
         "_analyze_module",
         "_call_graph_entrypoints",
@@ -1400,6 +1400,82 @@ def test_scan_bytes_analyzes_shadowed_torch_extension_callable_invocation(
 
     assert report.verdict == SafetyVerdict.MALICIOUS
     assert _has_critical_call_graph_finding(report, "torch", "device", "os.system")
+
+
+def test_call_graph_analyzes_shadowed_torch_storage_persistent_id_reference(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    (module_dir / "torch.py").write_text(
+        "import os\n\ndef __getattr__(name):\n    os.system(name)\n    raise AttributeError(name)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(module_dir))
+    importlib.invalidate_caches()
+    _clear_call_graph_caches()
+
+    try:
+        findings = find_dangerous_call_graphs(
+            [
+                {
+                    "module": "torch",
+                    "name": "FloatStorage",
+                    "import_reference": "torch.FloatStorage",
+                    "pytorch_storage_persistent_id": True,
+                }
+            ]
+        )
+    finally:
+        _clear_call_graph_caches()
+
+    assert any(
+        finding.module == "torch" and finding.name == "FloatStorage" and finding.sink == "os.system"
+        for finding in findings
+    )
+
+
+def test_call_graph_keeps_setstate_entrypoint_for_unknown_newobj_invocation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    module_name = "modelaudit_tp_probe_unknown_newobj_setstate"
+    (module_dir / f"{module_name}.py").write_text(
+        "import os\n\n"
+        "class Stateful:\n"
+        "    def __new__(cls):\n"
+        "        return super().__new__(cls)\n\n"
+        "    def __setstate__(self, state):\n"
+        "        os.system(state)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(module_dir))
+    importlib.invalidate_caches()
+    _clear_call_graph_caches()
+
+    try:
+        findings = find_dangerous_call_graphs(
+            [],
+            [
+                {
+                    "module": module_name,
+                    "name": "Stateful",
+                    "import_reference": f"{module_name}.Stateful",
+                    "opcode": "NEWOBJ",
+                    "positional_arg_count": None,
+                }
+            ],
+        )
+    finally:
+        _clear_call_graph_caches()
+
+    assert any(
+        finding.module == module_name and finding.name == "Stateful" and finding.sink == "os.system"
+        for finding in findings
+    )
 
 
 def test_scan_bytes_ignores_torch_layout_module_dict_lookup() -> None:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import importlib
+import io
 import os
+import pickle
 import subprocess
 import sys
+import zipfile
 from importlib.util import find_spec
 from pathlib import Path
 
@@ -1088,6 +1092,63 @@ if marker.exists():
     assert result.returncode == 0, result.stderr
 
 
+def test_scan_bytes_does_not_treat_newobj_as_init_invocation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    marker = tmp_path / "newobj_init_marker"
+    command = f"{sys.executable} -c \"from pathlib import Path; Path({str(marker)!r}).write_text('owned')\""
+    module_name = "modelaudit_fp_probe_newobj_init"
+    (module_dir / f"{module_name}.py").write_text(
+        "import os\n\n"
+        "class InitImports:\n"
+        "    def __init__(self):\n"
+        f"        os.system({command!r})\n"
+        "    def __setstate__(self, state):\n"
+        "        self.__dict__.update(state)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(module_dir))
+    module = importlib.import_module(module_name)
+    target_type = module.InitImports
+    instance = target_type.__new__(target_type)
+    instance.value = "safe"
+    payload = pickle.dumps(instance, protocol=4)
+
+    report = scan_bytes(payload, source="newobj-init-import-clean.pkl")
+
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert not _has_critical_call_graph_finding(report, module_name, "InitImports", "os.system")
+    child_code = """
+import pickle
+import sys
+from pathlib import Path
+
+module_dir = Path(sys.argv[1])
+marker = Path(sys.argv[2])
+payload = bytes.fromhex(sys.argv[3])
+
+sys.path.insert(0, str(module_dir))
+result = pickle.loads(payload)
+if getattr(result, "value", None) != "safe":
+    raise SystemExit(f"unexpected state: {result.__dict__!r}")
+if marker.exists():
+    raise SystemExit("NEWOBJ unexpectedly executed __init__")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", child_code, str(module_dir), str(marker), payload.hex()],
+        cwd=str(tmp_path.parent),
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+
+
 @pytest.mark.parametrize("function_name", ["nested_default_executes", "lambda_default_executes"])
 def test_scan_bytes_preserves_nested_signature_execution_calls(
     tmp_path: Path,
@@ -1278,6 +1339,50 @@ def test_call_graph_models_builtins_help_singleton_invocations() -> None:
     assert findings[0].name == "_Helper.__call__"
     assert findings[0].sink == "builtins.__import__"
     assert findings[0].call_path == ("_sitebuiltins._Helper.__call__", "builtins.__import__")
+
+
+def test_scan_bytes_ignores_benign_torch_extension_metadata_globals() -> None:
+    torch = pytest.importorskip("torch")
+    payload = pickle.dumps(
+        {
+            "device": torch.device("cpu"),
+            "dtype": torch.float32,
+            "shape": torch.Size([2, 3]),
+        },
+        protocol=4,
+    )
+
+    report = scan_bytes(payload, source="torch-extension-metadata-clean.pkl")
+
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert not any(finding.rule_code == "DANGEROUS_CALL_GRAPH" for finding in report.findings)
+
+
+def test_scan_bytes_ignores_torch_layout_module_dict_lookup() -> None:
+    torch = pytest.importorskip("torch")
+    payload = pickle.dumps(torch.strided, protocol=4)
+
+    report = scan_bytes(payload, source="torch-layout-clean.pkl")
+
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert not any(finding.rule_code == "DANGEROUS_CALL_GRAPH" for finding in report.findings)
+
+
+def test_scan_bytes_uses_torch_module_lifecycle_entrypoints_for_newobj() -> None:
+    torch = pytest.importorskip("torch")
+    buffer = io.BytesIO()
+    torch.save(torch.nn.Linear(2, 2), buffer)
+    with zipfile.ZipFile(io.BytesIO(buffer.getvalue())) as archive:
+        data_pickle = archive.read("archive/data.pkl")
+
+    report = scan_bytes(data_pickle, source="torch-linear-data-clean.pkl")
+
+    assert not any(
+        finding.rule_code == "DANGEROUS_CALL_GRAPH"
+        and finding.details.get("module") == "torch.nn.modules.linear"
+        and finding.details.get("name") == "Linear"
+        for finding in report.findings
+    )
 
 
 def test_call_graph_models_builtin_format_protocol_dispatch_invocations() -> None:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -1213,6 +1213,65 @@ def test_call_graph_models_direct_shadowable_function_body_imports() -> None:
     assert _find_sink_path("base64.main") == ("base64.main", "builtins.__import__")
 
 
+def test_call_graph_keeps_module_dict_dotted_lookup_clean(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    module_name = "modelaudit_tp_probe_dict_dunder_getattr"
+    (module_dir / f"{module_name}.py").write_text(
+        "import os\n\ndef __getattr__(name):\n    os.system(name)\n    raise AttributeError(name)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(module_dir))
+    importlib.invalidate_caches()
+    _clear_call_graph_caches()
+
+    try:
+        findings = find_dangerous_call_graphs(
+            [{"module": module_name, "name": "__dict__.values", "import_reference": f"{module_name}.__dict__.values"}]
+        )
+    finally:
+        _clear_call_graph_caches()
+
+    assert findings == ()
+
+
+def test_call_graph_models_missing_dotted_dunder_module_getattr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    module_name = "modelaudit_tp_probe_missing_dunder_getattr"
+    (module_dir / f"{module_name}.py").write_text(
+        "import os\n\ndef __getattr__(name):\n    os.system(name)\n    raise AttributeError(name)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(module_dir))
+    importlib.invalidate_caches()
+    _clear_call_graph_caches()
+
+    try:
+        findings = find_dangerous_call_graphs(
+            [
+                {
+                    "module": module_name,
+                    "name": "__missing__.x",
+                    "import_reference": f"{module_name}.__missing__.x",
+                }
+            ]
+        )
+    finally:
+        _clear_call_graph_caches()
+
+    assert any(
+        finding.module == module_name and finding.name == "__missing__.x" and finding.sink == "os.system"
+        for finding in findings
+    )
+
+
 def test_call_graph_propagates_wrapper_import_execution_fallbacks() -> None:
     calls = _calls_for_function("platform.mac_ver") or ()
 

--- a/tests/test_pytorch_zip_detection.py
+++ b/tests/test_pytorch_zip_detection.py
@@ -90,6 +90,8 @@ class TestPyTorchZipDetection:
             "weights": torch.randn(10, 10),
             "bias": torch.randn(10),
             "config": {"layers": 3, "hidden_size": 10},
+            "device": torch.device("cpu"),
+            "dtype": torch.float32,
         }
 
         # Save as .bin file


### PR DESCRIPTION
## Summary
- tag PyTorch storage descriptors consumed by BINPERSID in picklescan metadata
- skip benign PyTorch extension metadata globals without dropping shadowed/local callable analysis
- preserve persistent-ID suspicious signals, unknown NEWOBJ state handling, and dotted module `__getattr__` call-graph checks

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py -k "dunder_module_getattr or module_dict_dotted or shadowed_torch or unknown_newobj or torch_extension" -q` (`5 passed, 1 skipped`; local env lacks optional ML deps such as torch)
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` (`4025 passed, 1025 skipped, 21 warnings`; local env lacks optional ML deps such as torch)

CI: fresh head `6e80803a` is green across Python CI, Docker CI, CodeQL, and benchmarks.