### PR TITLE
test(picklescan): cover repeated storage persistent ids

### DIFF
--- a/packages/modelaudit-picklescan/rust/src/state.rs
+++ b/packages/modelaudit-picklescan/rust/src/state.rs
@@ -3785,6 +3785,12 @@ impl<'a> ScanState<'a> {
             Some(StackValue::Text(opcode.arg.coerce_text(self.payload)))
         };
         self.stack.push(StackValue::Other);
+        let storage_descriptor = persistent_id
+            .as_ref()
+            .and_then(|value| pytorch_storage_descriptor_ref(value, self.payload).cloned());
+        if let Some(descriptor) = storage_descriptor.as_ref() {
+            self.mark_pytorch_storage_persistent_id_import_reference(descriptor);
+        }
         if self.persistent_id_count > 1 {
             return;
         }
@@ -3799,8 +3805,6 @@ impl<'a> ScanState<'a> {
                 DetailValue::String(stack_value_preview(value, 0)),
             ));
             if let Some(storage_key) = pytorch_storage_key(value, self.payload) {
-                let storage_descriptor =
-                    pytorch_storage_descriptor_ref(value, self.payload).cloned();
                 details.push((
                     "pytorch_storage_persistent_id".to_string(),
                     DetailValue::Bool(true),
@@ -3809,9 +3813,6 @@ impl<'a> ScanState<'a> {
                     "pytorch_storage_key".to_string(),
                     DetailValue::String(storage_key),
                 ));
-                if let Some(descriptor) = storage_descriptor.as_ref() {
-                    self.mark_pytorch_storage_persistent_id_import_reference(descriptor);
-                }
             }
         }
 

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -940,6 +940,40 @@ def test_scan_bytes_flags_canonical_pytorch_storage_persistent_ids() -> None:
     assert report.notices == ()
 
 
+def test_scan_bytes_marks_each_pytorch_storage_persistent_id_import_reference() -> None:
+    def storage_persistent_id(name: str, key: str, terminator: bytes) -> bytes:
+        return (
+            b"("
+            + _short_binunicode(b"storage")
+            + _short_binunicode(b"torch")
+            + _short_binunicode(name.encode())
+            + b"\x93"
+            + _short_binunicode(key.encode())
+            + _short_binunicode(b"cpu")
+            + b"K\x01tQ"
+            + terminator
+        )
+
+    storage_names = [f"Synthetic{index}Storage" for index in range(33)]
+    payload = b"\x80\x04" + b"".join(
+        storage_persistent_id(name, str(index), b"." if index == len(storage_names) - 1 else b"0")
+        for index, name in enumerate(storage_names)
+    )
+
+    report = scan_bytes(payload, source="many-pytorch-storage-persistent-ids.pkl")
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.SUSPICIOUS
+    assert not any(finding.rule_code == "DANGEROUS_CALL_GRAPH_LIMIT" for finding in report.findings)
+    storage_references = [
+        reference
+        for reference in report.metadata["import_references"]
+        if reference.get("module") == "torch" and str(reference.get("name", "")).endswith("Storage")
+    ]
+    assert len(storage_references) == len(storage_names)
+    assert all(reference.get("pytorch_storage_persistent_id") is True for reference in storage_references)
+
+
 def test_scan_bytes_flags_noncanonical_pytorch_storage_persistent_ids() -> None:
     payload = b"\x80\x04(\x8c\x07storage\x94\x8c\x12torch.FloatStorage\x94\x8c\x04evil\x94\x8c\x03cpu\x94K\x01tQ."
 


### PR DESCRIPTION
## Summary
- tag every PyTorch storage persistent-ID import reference, even after persistent ID findings are summarized
- add a regression with more than the call-graph import-reference limit of storage descriptors

## Validation
- cargo fmt --manifest-path packages/modelaudit-picklescan/Cargo.toml -- --check
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest packages/modelaudit-picklescan/tests/test_api.py::test_scan_bytes_flags_canonical_pytorch_storage_persistent_ids packages/modelaudit-picklescan/tests/test_api.py::test_scan_bytes_marks_each_pytorch_storage_persistent_id_import_reference packages/modelaudit-picklescan/tests/test_api.py::test_scan_bytes_flags_noncanonical_pytorch_storage_persistent_ids -q
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- cargo check --manifest-path packages/modelaudit-picklescan/Cargo.toml
- cargo test --manifest-path packages/modelaudit-picklescan/Cargo.toml
- cargo clippy --manifest-path packages/modelaudit-picklescan/Cargo.toml --all-targets -- -D warnings