### PR TITLE
fix(telemetry): stabilize modelaudit identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,7 +250,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **telemetry:** persist ModelAudit distinct IDs in Promptfoo's global config
-  format and include `isRunningInCi` on analytics payloads
+  format (creating `~/.promptfoo/promptfoo.yaml` if absent and migrating any
+  legacy `~/.modelaudit/user_config.json` ID) and include `isRunningInCi` on
+  analytics payloads, with presence-based detection for marker-style providers
+  (TeamCity, CodeBuild, Bitbucket, Jenkins)
 - **docs:** align public README and compatibility guidance with supported Python 3.10-3.13, TensorFlow extra requirements, supported formats, and telemetry sanitization behavior
 - **security:** credit @mosebit for privately reporting a TensorRT native-code detection gap that helped harden native-code scanner coverage
 - **security-policy:** clarify when low-impact scanner coverage gaps may be closed without publishing a public advisory while still crediting reporters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,6 +249,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **telemetry:** persist ModelAudit distinct IDs in Promptfoo's global config
+  format and include `isRunningInCi` on analytics payloads
 - **docs:** align public README and compatibility guidance with supported Python 3.10-3.13, TensorFlow extra requirements, supported formats, and telemetry sanitization behavior
 - **security:** credit @mosebit for privately reporting a TensorRT native-code detection gap that helped harden native-code scanner coverage
 - **security-policy:** clarify when low-impact scanner coverage gaps may be closed without publishing a public advisory while still crediting reporters

--- a/README.md
+++ b/README.md
@@ -244,7 +244,8 @@ ModelAudit includes telemetry for product reliability and usage analytics.
 - Collected metadata can include command usage, scan timing, scanner/file-type usage, issue severity/type aggregates, sanitized model names/references, and coarse metadata like file extension/domain.
 - URL telemetry strips userinfo, query strings, and fragments from model references. Avoid putting credentials in model names, file names, or artifact paths when telemetry is enabled.
 - Model files are scanned locally and ModelAudit does not upload model binary contents as telemetry events.
-- Telemetry is disabled automatically in CI/test environments and in editable development installs by default.
+- Telemetry is disabled automatically when `CI=true` is set or `IS_TESTING=true` is set, and in editable development installs by default. Events that are sent from other CI providers (TeamCity, CodeBuild, Bitbucket Pipelines, Jenkins) are tagged with `isRunningInCi=true` so they can be filtered downstream.
+- The anonymous user identifier is stored in `~/.promptfoo/promptfoo.yaml` for cross-tool correlation with [Promptfoo](https://www.promptfoo.dev/). Existing IDs from `~/.modelaudit/user_config.json` are migrated on first run after upgrade.
 
 Opt out explicitly with either environment variable:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -123,6 +123,7 @@ When in doubt, we err toward issuing a CVE.
 **In scope:**
 
 - The `modelaudit` Python package published on [PyPI](https://pypi.org/project/modelaudit/).
+- The `modelaudit-picklescan` Python package published on [PyPI](https://pypi.org/project/modelaudit-picklescan/), including its bundled Rust pickle engine.
 - The official Docker images.
 - The GitHub Actions CI/CD workflows in the [modelaudit repository](https://github.com/promptfoo/modelaudit).
 

--- a/modelaudit/telemetry.py
+++ b/modelaudit/telemetry.py
@@ -180,28 +180,20 @@ def _is_development_install() -> bool:
     This prevents polluting production analytics with development test data.
     Uses importlib.metadata to properly detect editable installs.
     See: https://stackoverflow.com/questions/43348746/how-to-detect-if-module-is-installed-in-editable-mode
-
-    Returns True if:
-    - Package is installed in editable mode (pip install -e)
-    - MODELAUDIT_DEV=1 is explicitly set
     """
-    # Explicit dev mode flag
-    if os.getenv("MODELAUDIT_DEV", "").lower() in ("1", "true", "yes"):
+    if _env_truthy("MODELAUDIT_DEV"):
         return True
 
-    # Check if installed in editable mode using importlib.metadata
     try:
         from importlib.metadata import Distribution
 
         dist = Distribution.from_name("modelaudit")
-        # Modern pip (21.3+) uses direct_url.json for editable installs
         direct_url_text = dist.read_text("direct_url.json")
         if direct_url_text:
             direct_url = json.loads(direct_url_text)
             if direct_url.get("dir_info", {}).get("editable", False):
                 return True
     except Exception as exc:
-        # Package not installed or metadata not available - not editable.
         logger.debug("Unable to inspect editable install metadata: %s", exc)
 
     return False
@@ -209,6 +201,18 @@ def _is_development_install() -> bool:
 
 # Cache the development check at module load time
 _IS_DEVELOPMENT = _is_development_install()
+
+# Env vars that gate the telemetry client's behavior. Changes here invalidate
+# the cached client; `_CI_PRESENCE_ENV_VARS` are excluded because they only
+# tag events with `isRunningInCi` and don't change disable state.
+_BEHAVIOR_GATING_ENV_VARS = (
+    "MODELAUDIT_TELEMETRY_DEV",
+    "PROMPTFOO_DISABLE_TELEMETRY",
+    "NO_ANALYTICS",
+    "CI",
+    "IS_TESTING",
+    "MODELAUDIT_TELEMETRY_FLUSH_IMMEDIATELY",
+)
 
 
 def _runtime_signature() -> tuple[Any, ...]:
@@ -219,12 +223,7 @@ def _runtime_signature() -> tuple[Any, ...]:
         POSTHOG_PROJECT_KEY,
         POSTHOG_HOST,
         _IS_DEVELOPMENT,
-        os.getenv("MODELAUDIT_TELEMETRY_DEV", "").lower(),
-        os.getenv("PROMPTFOO_DISABLE_TELEMETRY", "").lower(),
-        os.getenv("NO_ANALYTICS", "").lower(),
-        *(os.getenv(name, "").lower() for name in _CI_ENV_VARS),
-        os.getenv("IS_TESTING", "").lower(),
-        os.getenv("MODELAUDIT_TELEMETRY_FLUSH_IMMEDIATELY", "").lower(),
+        *(_env_truthy(name) for name in _BEHAVIOR_GATING_ENV_VARS),
     )
 
 
@@ -236,8 +235,8 @@ class UserConfig:
         self._config_file = self._config_dir / "user_config.json"
         self._promptfoo_config_file = Path.home() / ".promptfoo" / "promptfoo.yaml"
         self._config = self._load_config()
-        self._promptfoo_user_id: str | None = None
-        self._promptfoo_user_id_loaded = False
+        self._promptfoo_config_cache: dict[str, Any] | None = None
+        self._promptfoo_config_loaded = False
 
     def _load_config(self) -> dict[str, Any]:
         """Load user configuration from file."""
@@ -261,88 +260,75 @@ class UserConfig:
         except OSError as e:
             logger.debug(f"Failed to save user config: {e}")
 
-    def _read_promptfoo_config(self) -> dict[str, Any] | None:
-        """Read Promptfoo's global config without creating or mutating it."""
+    def _load_promptfoo_config(self) -> dict[str, Any] | None:
+        """Load Promptfoo's global config once, caching the result.
+
+        Returns the loaded mapping (possibly empty if the file is absent), or
+        None if the file is unreadable or contains non-mapping data.
+        """
+        if self._promptfoo_config_loaded:
+            return self._promptfoo_config_cache
+
+        self._promptfoo_config_loaded = True
+
         if not self._promptfoo_config_file.exists():
-            return {}
+            self._promptfoo_config_cache = {}
+            return self._promptfoo_config_cache
 
         try:
             with open(self._promptfoo_config_file) as f:
-                config = yaml.safe_load(f)
+                loaded = yaml.safe_load(f)
         except (OSError, yaml.YAMLError) as exc:
             logger.debug("Unable to read promptfoo telemetry config: %s", exc)
             return None
 
-        if config is None:
-            return {}
-        if isinstance(config, dict):
-            return cast(dict[str, Any], config)
-
-        logger.debug("Ignoring non-object promptfoo telemetry config")
-        return None
-
-    def _get_promptfoo_user_id(self) -> str | None:
-        """Read Promptfoo's user ID for cross-tool correlation."""
-        if self._promptfoo_user_id_loaded:
-            return self._promptfoo_user_id
-
-        self._promptfoo_user_id_loaded = True
-        config = self._read_promptfoo_config()
-        if config is None:
+        if loaded is None:
+            self._promptfoo_config_cache = {}
+        elif isinstance(loaded, dict):
+            self._promptfoo_config_cache = cast(dict[str, Any], loaded)
+        else:
+            logger.debug("Ignoring non-object promptfoo telemetry config")
             return None
 
-        user_id = config.get("id")
-        if isinstance(user_id, str) and user_id:
-            self._promptfoo_user_id = user_id
-        return self._promptfoo_user_id
+        return self._promptfoo_config_cache
 
-    def _write_promptfoo_user_id(self, user_id: str, config: dict[str, Any] | None = None) -> bool:
-        """Persist a user ID in Promptfoo's global config format.
+    def _persist_user_id_to_promptfoo(self, user_id: str, config: dict[str, Any]) -> bool:
+        """Write user_id into promptfoo.yaml using auth.config's hardened atomic writer.
 
-        Pass an already-loaded config to avoid a redundant disk read.
+        Skips the disk write when the file already holds the same id.
         """
-        if config is None:
-            config = self._read_promptfoo_config()
-            if config is None:
-                return False
+        if config.get("id") == user_id:
+            self._promptfoo_config_cache = config
+            return True
 
-        config["id"] = user_id
         try:
+            from .auth.config import _write_yaml_atomic
+
             self._promptfoo_config_file.parent.mkdir(parents=True, exist_ok=True)
-            temp_config_file = self._promptfoo_config_file.with_suffix(".yaml.tmp")
-            with open(temp_config_file, "w") as f:
-                yaml.safe_dump(config, f, sort_keys=False)
-            temp_config_file.replace(self._promptfoo_config_file)
-        except OSError as exc:
+            updated = {**config, "id": user_id}
+            _write_yaml_atomic(self._promptfoo_config_file, updated)
+        except (OSError, ImportError) as exc:
             logger.debug("Unable to write promptfoo telemetry config: %s", exc)
             return False
 
-        self._promptfoo_user_id = user_id
-        self._promptfoo_user_id_loaded = True
+        self._promptfoo_config_cache = updated
         return True
 
     @property
     def user_id(self) -> str:
-        """Get or generate user ID.
+        """Return a stable identifier, preferring Promptfoo's for cross-tool correlation."""
+        promptfoo_config = self._load_promptfoo_config()
+        if promptfoo_config is not None:
+            existing = promptfoo_config.get("id")
+            if isinstance(existing, str) and existing:
+                return existing
 
-        Prefers Promptfoo's user ID if available for cross-tool correlation,
-        otherwise migrates ModelAudit's legacy ID into Promptfoo's config.
-        """
-        # Try Promptfoo's user ID first for correlation
-        promptfoo_id = self._get_promptfoo_user_id()
-        if promptfoo_id:
-            return promptfoo_id
+        legacy = self._config.get("user_id")
+        user_id = legacy if isinstance(legacy, str) and legacy else str(uuid.uuid4())
 
-        user_id = self._config.get("user_id")
-        if not isinstance(user_id, str) or not user_id:
-            user_id = str(uuid.uuid4())
-
-        # Reuse the config we just read instead of re-opening the file.
-        promptfoo_config = self._read_promptfoo_config()
-        if promptfoo_config is not None and self._write_promptfoo_user_id(user_id, promptfoo_config):
+        if promptfoo_config is not None and self._persist_user_id_to_promptfoo(user_id, promptfoo_config):
             return user_id
 
-        # Fall back to ModelAudit's legacy config only when Promptfoo's config cannot be written.
         if self._config.get("user_id") != user_id:
             self._config["user_id"] = user_id
             self._save_config()
@@ -391,35 +377,21 @@ class TelemetryClient:
         self._session_id = str(uuid.uuid4())
         self._telemetry_disabled_recorded = False
         self._atexit_flush_registered = False
-        self._flush_immediately = os.getenv("MODELAUDIT_TELEMETRY_FLUSH_IMMEDIATELY", "").lower() in (
-            "1",
-            "true",
-            "yes",
-        )
+        self._flush_immediately = _env_truthy("MODELAUDIT_TELEMETRY_FLUSH_IMMEDIATELY")
 
         self._ensure_posthog_client()
 
     def _is_disabled(self) -> bool:
         """Check if telemetry is disabled via environment variables or user config."""
-        # Development installs don't send telemetry by default (prevents polluting analytics)
-        # Allow explicit opt-in during development with MODELAUDIT_TELEMETRY_DEV=1
-        if _IS_DEVELOPMENT and os.getenv("MODELAUDIT_TELEMETRY_DEV", "").lower() not in ("1", "true", "yes"):
+        # Editable installs are off by default; MODELAUDIT_TELEMETRY_DEV=1 opts back in.
+        if _IS_DEVELOPMENT and not _env_truthy("MODELAUDIT_TELEMETRY_DEV"):
             return True
 
-        # Check environment variables - use Promptfoo's standard env var
-        if os.getenv("PROMPTFOO_DISABLE_TELEMETRY", "").lower() in ("1", "true", "yes"):
-            return True
-        if os.getenv("NO_ANALYTICS", "").lower() in ("1", "true", "yes"):
-            return True
-        # Intentionally narrower than `_is_running_in_ci()`: only an explicit
-        # CI=true disables telemetry, while the `isRunningInCi` analytics
-        # property is also set for marker-style providers.
-        if os.getenv("CI", "").lower() in ("1", "true", "yes"):
-            return True
-        if os.getenv("IS_TESTING", "").lower() in ("1", "true", "yes"):
+        # `CI` here is the universal opt-out flag. The broader `_is_running_in_ci()`
+        # only tags events; events from marker-only providers still get sent.
+        if any(_env_truthy(name) for name in ("PROMPTFOO_DISABLE_TELEMETRY", "NO_ANALYTICS", "CI", "IS_TESTING")):
             return True
 
-        # Check user configuration - defaults to enabled (opt-out model)
         return not self._user_config.telemetry_enabled
 
     def _identify_user(self) -> None:

--- a/modelaudit/telemetry.py
+++ b/modelaudit/telemetry.py
@@ -130,30 +130,48 @@ _TELEMETRY_FILELIKE_ISSUE_ID_RE = re.compile(
     re.IGNORECASE,
 )
 _TRUE_ENV_VALUES = frozenset({"1", "true", "yes", "yup", "yeppers"})
-_CI_ENV_VARS = (
+# Vars whose CI providers set a truthy literal ("true"/"1").
+_CI_TRUTHY_ENV_VARS = (
     "CI",
     "GITHUB_ACTIONS",
     "TRAVIS",
     "CIRCLECI",
-    "JENKINS",
     "GITLAB_CI",
     "APPVEYOR",
-    "CODEBUILD_BUILD_ID",
     "TF_BUILD",
-    "BITBUCKET_COMMIT",
-    "BUDDY",
     "BUILDKITE",
+    "BUDDY",
+)
+# Vars whose CI providers set a marker value (build ID, version, commit SHA),
+# so any non-empty value indicates CI. Promptfoo's upstream `getEnvBool` misses
+# these; we diverge intentionally so analytics filters work in the wild.
+_CI_PRESENCE_ENV_VARS = (
+    "JENKINS",
+    "CODEBUILD_BUILD_ID",
+    "BITBUCKET_COMMIT",
     "TEAMCITY_VERSION",
 )
+_CI_ENV_VARS = _CI_TRUTHY_ENV_VARS + _CI_PRESENCE_ENV_VARS
 
 
 def _env_truthy(name: str) -> bool:
     return os.getenv(name, "").lower() in _TRUE_ENV_VALUES
 
 
+def _env_present(name: str) -> bool:
+    return bool(os.getenv(name, "").strip())
+
+
 def _is_running_in_ci() -> bool:
-    """Match Promptfoo's CI telemetry property semantics."""
-    return any(_env_truthy(name) for name in _CI_ENV_VARS)
+    """Detect CI for the `isRunningInCi` telemetry property.
+
+    Mirrors Promptfoo's variable list but uses presence-based detection for
+    marker-style vars (TEAMCITY_VERSION, CODEBUILD_BUILD_ID, BITBUCKET_COMMIT,
+    JENKINS) that providers set to non-truthy values like build IDs.
+    """
+    if any(_env_truthy(name) for name in _CI_TRUTHY_ENV_VARS):
+        return True
+    return any(_env_present(name) for name in _CI_PRESENCE_ENV_VARS)
 
 
 def _is_development_install() -> bool:
@@ -278,11 +296,15 @@ class UserConfig:
             self._promptfoo_user_id = user_id
         return self._promptfoo_user_id
 
-    def _write_promptfoo_user_id(self, user_id: str) -> bool:
-        """Persist a user ID in Promptfoo's global config format."""
-        config = self._read_promptfoo_config()
+    def _write_promptfoo_user_id(self, user_id: str, config: dict[str, Any] | None = None) -> bool:
+        """Persist a user ID in Promptfoo's global config format.
+
+        Pass an already-loaded config to avoid a redundant disk read.
+        """
         if config is None:
-            return False
+            config = self._read_promptfoo_config()
+            if config is None:
+                return False
 
         config["id"] = user_id
         try:
@@ -304,7 +326,7 @@ class UserConfig:
         """Get or generate user ID.
 
         Prefers Promptfoo's user ID if available for cross-tool correlation,
-        otherwise uses ModelAudit's own user ID.
+        otherwise migrates ModelAudit's legacy ID into Promptfoo's config.
         """
         # Try Promptfoo's user ID first for correlation
         promptfoo_id = self._get_promptfoo_user_id()
@@ -315,7 +337,9 @@ class UserConfig:
         if not isinstance(user_id, str) or not user_id:
             user_id = str(uuid.uuid4())
 
-        if self._write_promptfoo_user_id(user_id):
+        # Reuse the config we just read instead of re-opening the file.
+        promptfoo_config = self._read_promptfoo_config()
+        if promptfoo_config is not None and self._write_promptfoo_user_id(user_id, promptfoo_config):
             return user_id
 
         # Fall back to ModelAudit's legacy config only when Promptfoo's config cannot be written.
@@ -387,6 +411,9 @@ class TelemetryClient:
             return True
         if os.getenv("NO_ANALYTICS", "").lower() in ("1", "true", "yes"):
             return True
+        # Intentionally narrower than `_is_running_in_ci()`: only an explicit
+        # CI=true disables telemetry, while the `isRunningInCi` analytics
+        # property is also set for marker-style providers.
         if os.getenv("CI", "").lower() in ("1", "true", "yes"):
             return True
         if os.getenv("IS_TESTING", "").lower() in ("1", "true", "yes"):

--- a/modelaudit/telemetry.py
+++ b/modelaudit/telemetry.py
@@ -129,6 +129,31 @@ _TELEMETRY_FILELIKE_ISSUE_ID_RE = re.compile(
     r"\.(?:bin|ckpt|gguf|gz|h5|hdf5|json|keras|nemo|onnx|pb|pickle|pkl|pt|pth|safetensors|tar|yaml|yml|zip)$",
     re.IGNORECASE,
 )
+_TRUE_ENV_VALUES = frozenset({"1", "true", "yes", "yup", "yeppers"})
+_CI_ENV_VARS = (
+    "CI",
+    "GITHUB_ACTIONS",
+    "TRAVIS",
+    "CIRCLECI",
+    "JENKINS",
+    "GITLAB_CI",
+    "APPVEYOR",
+    "CODEBUILD_BUILD_ID",
+    "TF_BUILD",
+    "BITBUCKET_COMMIT",
+    "BUDDY",
+    "BUILDKITE",
+    "TEAMCITY_VERSION",
+)
+
+
+def _env_truthy(name: str) -> bool:
+    return os.getenv(name, "").lower() in _TRUE_ENV_VALUES
+
+
+def _is_running_in_ci() -> bool:
+    """Match Promptfoo's CI telemetry property semantics."""
+    return any(_env_truthy(name) for name in _CI_ENV_VARS)
 
 
 def _is_development_install() -> bool:
@@ -179,7 +204,7 @@ def _runtime_signature() -> tuple[Any, ...]:
         os.getenv("MODELAUDIT_TELEMETRY_DEV", "").lower(),
         os.getenv("PROMPTFOO_DISABLE_TELEMETRY", "").lower(),
         os.getenv("NO_ANALYTICS", "").lower(),
-        os.getenv("CI", "").lower(),
+        *(os.getenv(name, "").lower() for name in _CI_ENV_VARS),
         os.getenv("IS_TESTING", "").lower(),
         os.getenv("MODELAUDIT_TELEMETRY_FLUSH_IMMEDIATELY", "").lower(),
     )
@@ -191,8 +216,10 @@ class UserConfig:
     def __init__(self):
         self._config_dir = Path.home() / ".modelaudit"
         self._config_file = self._config_dir / "user_config.json"
+        self._promptfoo_config_file = Path.home() / ".promptfoo" / "promptfoo.yaml"
         self._config = self._load_config()
         self._promptfoo_user_id: str | None = None
+        self._promptfoo_user_id_loaded = False
 
     def _load_config(self) -> dict[str, Any]:
         """Load user configuration from file."""
@@ -216,25 +243,61 @@ class UserConfig:
         except OSError as e:
             logger.debug(f"Failed to save user config: {e}")
 
-    def _get_promptfoo_user_id(self) -> str | None:
-        """Try to read Promptfoo's user ID for cross-tool correlation.
+    def _read_promptfoo_config(self) -> dict[str, Any] | None:
+        """Read Promptfoo's global config without creating or mutating it."""
+        if not self._promptfoo_config_file.exists():
+            return {}
 
-        This allows correlating ModelAudit usage with Promptfoo usage for the same user.
-        """
-        if self._promptfoo_user_id is not None:
+        try:
+            with open(self._promptfoo_config_file) as f:
+                config = yaml.safe_load(f)
+        except (OSError, yaml.YAMLError) as exc:
+            logger.debug("Unable to read promptfoo telemetry config: %s", exc)
+            return None
+
+        if config is None:
+            return {}
+        if isinstance(config, dict):
+            return cast(dict[str, Any], config)
+
+        logger.debug("Ignoring non-object promptfoo telemetry config")
+        return None
+
+    def _get_promptfoo_user_id(self) -> str | None:
+        """Read Promptfoo's user ID for cross-tool correlation."""
+        if self._promptfoo_user_id_loaded:
             return self._promptfoo_user_id
 
-        promptfoo_config = Path.home() / ".promptfoo" / "promptfoo.yaml"
-        if promptfoo_config.exists():
-            try:
-                with open(promptfoo_config) as f:
-                    config = yaml.safe_load(f)
-                if isinstance(config, dict) and "id" in config:
-                    self._promptfoo_user_id = str(config["id"])
-                    return self._promptfoo_user_id
-            except (OSError, yaml.YAMLError) as exc:
-                logger.debug("Unable to read promptfoo telemetry config: %s", exc)
-        return None
+        self._promptfoo_user_id_loaded = True
+        config = self._read_promptfoo_config()
+        if config is None:
+            return None
+
+        user_id = config.get("id")
+        if isinstance(user_id, str) and user_id:
+            self._promptfoo_user_id = user_id
+        return self._promptfoo_user_id
+
+    def _write_promptfoo_user_id(self, user_id: str) -> bool:
+        """Persist a user ID in Promptfoo's global config format."""
+        config = self._read_promptfoo_config()
+        if config is None:
+            return False
+
+        config["id"] = user_id
+        try:
+            self._promptfoo_config_file.parent.mkdir(parents=True, exist_ok=True)
+            temp_config_file = self._promptfoo_config_file.with_suffix(".yaml.tmp")
+            with open(temp_config_file, "w") as f:
+                yaml.safe_dump(config, f, sort_keys=False)
+            temp_config_file.replace(self._promptfoo_config_file)
+        except OSError as exc:
+            logger.debug("Unable to write promptfoo telemetry config: %s", exc)
+            return False
+
+        self._promptfoo_user_id = user_id
+        self._promptfoo_user_id_loaded = True
+        return True
 
     @property
     def user_id(self) -> str:
@@ -248,11 +311,18 @@ class UserConfig:
         if promptfoo_id:
             return promptfoo_id
 
-        # Fall back to ModelAudit's own user ID
-        if "user_id" not in self._config:
-            self._config["user_id"] = str(uuid.uuid4())
+        user_id = self._config.get("user_id")
+        if not isinstance(user_id, str) or not user_id:
+            user_id = str(uuid.uuid4())
+
+        if self._write_promptfoo_user_id(user_id):
+            return user_id
+
+        # Fall back to ModelAudit's legacy config only when Promptfoo's config cannot be written.
+        if self._config.get("user_id") != user_id:
+            self._config["user_id"] = user_id
             self._save_config()
-        return str(self._config["user_id"])
+        return user_id
 
     @property
     def email(self) -> str | None:
@@ -340,6 +410,7 @@ class TelemetryClient:
                 "modelaudit_version": __version__,
                 "platform": os.name,
                 "python_version": f"{sys.version_info.major}.{sys.version_info.minor}",
+                "isRunningInCi": _is_running_in_ci(),
             }
 
             # PostHog v7 uses set() instead of identify()
@@ -519,6 +590,7 @@ class TelemetryClient:
             "user_id": self._user_config.user_id,
             "platform": sys.platform,
             "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+            "isRunningInCi": _is_running_in_ci(),
         }
 
         # Send to PostHog

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
 from modelaudit.telemetry import (
     TelemetryClient,
@@ -21,14 +22,33 @@ from modelaudit.telemetry import (
     record_scan_started,
 )
 
+_NO_CI_ENV = {
+    "CI": "",
+    "GITHUB_ACTIONS": "",
+    "TRAVIS": "",
+    "CIRCLECI": "",
+    "JENKINS": "",
+    "GITLAB_CI": "",
+    "APPVEYOR": "",
+    "CODEBUILD_BUILD_ID": "",
+    "TF_BUILD": "",
+    "BITBUCKET_COMMIT": "",
+    "BUDDY": "",
+    "BUILDKITE": "",
+    "TEAMCITY_VERSION": "",
+    "IS_TESTING": "",
+    "PROMPTFOO_DISABLE_TELEMETRY": "",
+    "NO_ANALYTICS": "",
+}
+
 
 class TestUserConfig:
     """Test user configuration management."""
 
     def test_user_config_creates_user_id(self) -> None:
-        """Test that user config generates a UUID."""
+        """Test that user config generates a UUID in Promptfoo's config format."""
         with tempfile.TemporaryDirectory() as temp_dir:
-            config_file = Path(temp_dir) / ".modelaudit" / "user_config.json"
+            promptfoo_config_file = Path(temp_dir) / ".promptfoo" / "promptfoo.yaml"
 
             with patch("modelaudit.telemetry.Path.home") as mock_home:
                 mock_home.return_value = Path(temp_dir)
@@ -36,8 +56,43 @@ class TestUserConfig:
 
                 assert config.user_id
                 assert len(config.user_id) == 36  # UUID length
-                assert config_file.parent.exists()
-                assert config_file.exists()
+                assert promptfoo_config_file.parent.exists()
+                assert promptfoo_config_file.exists()
+                assert yaml.safe_load(promptfoo_config_file.read_text())["id"] == config.user_id
+
+    def test_user_config_uses_existing_promptfoo_user_id(self) -> None:
+        """Existing Promptfoo IDs should be reused without rewriting ModelAudit config."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            home = Path(temp_dir)
+            promptfoo_config_file = home / ".promptfoo" / "promptfoo.yaml"
+            promptfoo_config_file.parent.mkdir()
+            promptfoo_config_file.write_text(yaml.safe_dump({"id": "promptfoo-id", "cloud": {"enabled": True}}))
+
+            with patch("modelaudit.telemetry.Path.home") as mock_home:
+                mock_home.return_value = home
+                config = UserConfig()
+
+                assert config.user_id == "promptfoo-id"
+                promptfoo_config = yaml.safe_load(promptfoo_config_file.read_text())
+                assert promptfoo_config["cloud"] == {"enabled": True}
+                assert not (home / ".modelaudit" / "user_config.json").exists()
+
+    def test_user_config_migrates_legacy_modelaudit_user_id_to_promptfoo_config(self) -> None:
+        """Legacy ModelAudit IDs should remain stable when adopting Promptfoo config."""
+        legacy_user_id = "11111111-2222-4333-8444-555555555555"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            home = Path(temp_dir)
+            modelaudit_config_file = home / ".modelaudit" / "user_config.json"
+            modelaudit_config_file.parent.mkdir()
+            modelaudit_config_file.write_text(json.dumps({"user_id": legacy_user_id}))
+            promptfoo_config_file = home / ".promptfoo" / "promptfoo.yaml"
+
+            with patch("modelaudit.telemetry.Path.home") as mock_home:
+                mock_home.return_value = home
+                config = UserConfig()
+
+                assert config.user_id == legacy_user_id
+                assert yaml.safe_load(promptfoo_config_file.read_text())["id"] == legacy_user_id
 
     def test_user_config_defaults_to_enabled(self):
         """Test that telemetry defaults to enabled (opt-out model)."""
@@ -204,7 +259,7 @@ class TestTelemetryClient:
             patch("modelaudit.telemetry.Posthog", return_value=mock_posthog),
             patch.dict(
                 os.environ,
-                {"CI": "", "IS_TESTING": "", "PROMPTFOO_DISABLE_TELEMETRY": "", "NO_ANALYTICS": ""},
+                _NO_CI_ENV,
                 clear=False,
             ),
         ):
@@ -217,7 +272,55 @@ class TestTelemetryClient:
 
             # Should call PostHog capture
             mock_posthog.capture.assert_called_once()
+            capture_kwargs = mock_posthog.capture.call_args.kwargs
+            assert capture_kwargs["distinct_id"] == client._user_config.user_id
+            assert capture_kwargs["properties"]["isRunningInCi"] is False
             mock_posthog.flush.assert_not_called()
+
+    def test_identify_user_uses_stable_promptfoo_id_and_ci_property(self) -> None:
+        """Identify should use the same stable ID and Promptfoo-style CI property."""
+        mock_posthog = MagicMock()
+
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch("modelaudit.telemetry.Path.home") as mock_home,
+            patch("modelaudit.telemetry._IS_DEVELOPMENT", False),
+            patch("modelaudit.telemetry.POSTHOG_AVAILABLE", True),
+            patch("modelaudit.telemetry.Posthog", return_value=mock_posthog),
+            patch.dict(os.environ, _NO_CI_ENV, clear=False),
+        ):
+            home = Path(temp_dir)
+            promptfoo_config_file = home / ".promptfoo" / "promptfoo.yaml"
+            promptfoo_config_file.parent.mkdir()
+            promptfoo_config_file.write_text(yaml.safe_dump({"id": "promptfoo-id"}))
+            mock_home.return_value = home
+
+            TelemetryClient()
+
+            mock_posthog.set.assert_called_once()
+            set_kwargs = mock_posthog.set.call_args.kwargs
+            assert set_kwargs["distinct_id"] == "promptfoo-id"
+            assert set_kwargs["properties"]["isRunningInCi"] is False
+
+    def test_event_properties_mark_ci_environment(self) -> None:
+        """Telemetry payloads should expose Promptfoo-compatible CI state."""
+        mock_posthog = MagicMock()
+
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch("modelaudit.telemetry.Path.home") as mock_home,
+            patch("modelaudit.telemetry._IS_DEVELOPMENT", False),
+            patch("modelaudit.telemetry.POSTHOG_AVAILABLE", False),
+            patch.dict(os.environ, {**_NO_CI_ENV, "GITHUB_ACTIONS": "true"}, clear=False),
+        ):
+            mock_home.return_value = Path(temp_dir)
+            client = TelemetryClient()
+            client._posthog_client = mock_posthog
+
+            client._send_event_internal(TelemetryEvent.COMMAND_USED, {"command": "test"})
+
+            properties = mock_posthog.capture.call_args.kwargs["properties"]
+            assert properties["isRunningInCi"] is True
 
     def test_event_recording_can_flush_immediately_when_configured(self):
         """Immediate flush can be enabled for low-latency delivery."""

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -45,94 +45,84 @@ _NO_CI_ENV = {
 class TestUserConfig:
     """Test user configuration management."""
 
-    def test_user_config_creates_user_id(self) -> None:
+    def test_user_config_creates_user_id(self, tmp_path: Path) -> None:
         """Test that user config generates a UUID in Promptfoo's config format."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            promptfoo_config_file = Path(temp_dir) / ".promptfoo" / "promptfoo.yaml"
+        promptfoo_config_file = tmp_path / ".promptfoo" / "promptfoo.yaml"
 
-            with patch("modelaudit.telemetry.Path.home") as mock_home:
-                mock_home.return_value = Path(temp_dir)
-                config = UserConfig()
+        with patch("modelaudit.telemetry.Path.home") as mock_home:
+            mock_home.return_value = tmp_path
+            config = UserConfig()
 
-                assert config.user_id
-                assert len(config.user_id) == 36  # UUID length
-                assert promptfoo_config_file.parent.exists()
-                assert promptfoo_config_file.exists()
-                assert yaml.safe_load(promptfoo_config_file.read_text())["id"] == config.user_id
+            assert config.user_id
+            assert len(config.user_id) == 36  # UUID length
+            assert promptfoo_config_file.parent.exists()
+            assert promptfoo_config_file.exists()
+            assert yaml.safe_load(promptfoo_config_file.read_text())["id"] == config.user_id
 
-    def test_user_config_uses_existing_promptfoo_user_id(self) -> None:
+    def test_user_config_uses_existing_promptfoo_user_id(self, tmp_path: Path) -> None:
         """Existing Promptfoo IDs should be reused without rewriting ModelAudit config."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            home = Path(temp_dir)
-            promptfoo_config_file = home / ".promptfoo" / "promptfoo.yaml"
-            promptfoo_config_file.parent.mkdir()
-            promptfoo_config_file.write_text(yaml.safe_dump({"id": "promptfoo-id", "cloud": {"enabled": True}}))
+        promptfoo_config_file = tmp_path / ".promptfoo" / "promptfoo.yaml"
+        promptfoo_config_file.parent.mkdir()
+        promptfoo_config_file.write_text(yaml.safe_dump({"id": "promptfoo-id", "cloud": {"enabled": True}}))
 
-            with patch("modelaudit.telemetry.Path.home") as mock_home:
-                mock_home.return_value = home
-                config = UserConfig()
+        with patch("modelaudit.telemetry.Path.home") as mock_home:
+            mock_home.return_value = tmp_path
+            config = UserConfig()
 
-                assert config.user_id == "promptfoo-id"
-                promptfoo_config = yaml.safe_load(promptfoo_config_file.read_text())
-                assert promptfoo_config["cloud"] == {"enabled": True}
-                assert not (home / ".modelaudit" / "user_config.json").exists()
+            assert config.user_id == "promptfoo-id"
+            promptfoo_config = yaml.safe_load(promptfoo_config_file.read_text())
+            assert promptfoo_config["cloud"] == {"enabled": True}
+            assert not (tmp_path / ".modelaudit" / "user_config.json").exists()
 
-    def test_user_config_migrates_legacy_modelaudit_user_id_to_promptfoo_config(self) -> None:
+    def test_user_config_migrates_legacy_modelaudit_user_id_to_promptfoo_config(self, tmp_path: Path) -> None:
         """Legacy ModelAudit IDs should remain stable when adopting Promptfoo config."""
         legacy_user_id = "11111111-2222-4333-8444-555555555555"
-        with tempfile.TemporaryDirectory() as temp_dir:
-            home = Path(temp_dir)
-            modelaudit_config_file = home / ".modelaudit" / "user_config.json"
-            modelaudit_config_file.parent.mkdir()
-            modelaudit_config_file.write_text(json.dumps({"user_id": legacy_user_id}))
-            promptfoo_config_file = home / ".promptfoo" / "promptfoo.yaml"
+        modelaudit_config_file = tmp_path / ".modelaudit" / "user_config.json"
+        modelaudit_config_file.parent.mkdir()
+        modelaudit_config_file.write_text(json.dumps({"user_id": legacy_user_id}))
+        promptfoo_config_file = tmp_path / ".promptfoo" / "promptfoo.yaml"
 
-            with patch("modelaudit.telemetry.Path.home") as mock_home:
-                mock_home.return_value = home
-                config = UserConfig()
+        with patch("modelaudit.telemetry.Path.home") as mock_home:
+            mock_home.return_value = tmp_path
+            config = UserConfig()
 
-                assert config.user_id == legacy_user_id
-                assert yaml.safe_load(promptfoo_config_file.read_text())["id"] == legacy_user_id
+            assert config.user_id == legacy_user_id
+            assert yaml.safe_load(promptfoo_config_file.read_text())["id"] == legacy_user_id
 
-    def test_user_config_falls_back_when_promptfoo_yaml_is_corrupt(self) -> None:
+    def test_user_config_falls_back_when_promptfoo_yaml_is_corrupt(self, tmp_path: Path) -> None:
         """A malformed promptfoo.yaml must not crash; the legacy file is used."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            home = Path(temp_dir)
-            promptfoo_config_file = home / ".promptfoo" / "promptfoo.yaml"
-            promptfoo_config_file.parent.mkdir()
-            # Invalid YAML — colons without values inside a flow mapping.
-            promptfoo_config_file.write_text("{not: valid: yaml: ::")
-            modelaudit_config_file = home / ".modelaudit" / "user_config.json"
+        promptfoo_config_file = tmp_path / ".promptfoo" / "promptfoo.yaml"
+        promptfoo_config_file.parent.mkdir()
+        promptfoo_config_file.write_text("{not: valid: yaml: ::")
+        modelaudit_config_file = tmp_path / ".modelaudit" / "user_config.json"
 
-            with patch("modelaudit.telemetry.Path.home") as mock_home:
-                mock_home.return_value = home
-                config = UserConfig()
-                user_id = config.user_id
+        with patch("modelaudit.telemetry.Path.home") as mock_home:
+            mock_home.return_value = tmp_path
+            config = UserConfig()
+            user_id = config.user_id
 
-            assert len(user_id) == 36
-            # The corrupt promptfoo file is left alone.
-            assert promptfoo_config_file.read_text() == "{not: valid: yaml: ::"
-            # Legacy fallback persists the freshly-minted ID.
-            assert modelaudit_config_file.exists()
-            assert json.loads(modelaudit_config_file.read_text())["user_id"] == user_id
+        assert len(user_id) == 36
+        # The corrupt promptfoo file is left alone.
+        assert promptfoo_config_file.read_text() == "{not: valid: yaml: ::"
+        # Legacy fallback persists the freshly-minted ID.
+        assert modelaudit_config_file.exists()
+        assert json.loads(modelaudit_config_file.read_text())["user_id"] == user_id
 
-    def test_user_config_falls_back_when_promptfoo_yaml_is_unwritable(self) -> None:
+    def test_user_config_falls_back_when_promptfoo_yaml_is_unwritable(self, tmp_path: Path) -> None:
         """If we cannot persist to promptfoo.yaml, the ID still lands in the legacy config."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            home = Path(temp_dir)
-            modelaudit_config_file = home / ".modelaudit" / "user_config.json"
+        modelaudit_config_file = tmp_path / ".modelaudit" / "user_config.json"
 
-            with (
-                patch("modelaudit.telemetry.Path.home") as mock_home,
-                patch("modelaudit.telemetry.yaml.safe_dump", side_effect=OSError("disk full")),
-            ):
-                mock_home.return_value = home
-                config = UserConfig()
-                user_id = config.user_id
+        with (
+            patch("modelaudit.telemetry.Path.home") as mock_home,
+            patch("modelaudit.auth.config._write_yaml_atomic", side_effect=OSError("disk full")),
+        ):
+            mock_home.return_value = tmp_path
+            config = UserConfig()
+            user_id = config.user_id
 
-            assert len(user_id) == 36
-            assert modelaudit_config_file.exists()
-            assert json.loads(modelaudit_config_file.read_text())["user_id"] == user_id
+        assert len(user_id) == 36
+        assert modelaudit_config_file.exists()
+        assert json.loads(modelaudit_config_file.read_text())["user_id"] == user_id
 
     def test_user_config_defaults_to_enabled(self):
         """Test that telemetry defaults to enabled (opt-out model)."""

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -94,6 +94,46 @@ class TestUserConfig:
                 assert config.user_id == legacy_user_id
                 assert yaml.safe_load(promptfoo_config_file.read_text())["id"] == legacy_user_id
 
+    def test_user_config_falls_back_when_promptfoo_yaml_is_corrupt(self) -> None:
+        """A malformed promptfoo.yaml must not crash; the legacy file is used."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            home = Path(temp_dir)
+            promptfoo_config_file = home / ".promptfoo" / "promptfoo.yaml"
+            promptfoo_config_file.parent.mkdir()
+            # Invalid YAML — colons without values inside a flow mapping.
+            promptfoo_config_file.write_text("{not: valid: yaml: ::")
+            modelaudit_config_file = home / ".modelaudit" / "user_config.json"
+
+            with patch("modelaudit.telemetry.Path.home") as mock_home:
+                mock_home.return_value = home
+                config = UserConfig()
+                user_id = config.user_id
+
+            assert len(user_id) == 36
+            # The corrupt promptfoo file is left alone.
+            assert promptfoo_config_file.read_text() == "{not: valid: yaml: ::"
+            # Legacy fallback persists the freshly-minted ID.
+            assert modelaudit_config_file.exists()
+            assert json.loads(modelaudit_config_file.read_text())["user_id"] == user_id
+
+    def test_user_config_falls_back_when_promptfoo_yaml_is_unwritable(self) -> None:
+        """If we cannot persist to promptfoo.yaml, the ID still lands in the legacy config."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            home = Path(temp_dir)
+            modelaudit_config_file = home / ".modelaudit" / "user_config.json"
+
+            with (
+                patch("modelaudit.telemetry.Path.home") as mock_home,
+                patch("modelaudit.telemetry.yaml.safe_dump", side_effect=OSError("disk full")),
+            ):
+                mock_home.return_value = home
+                config = UserConfig()
+                user_id = config.user_id
+
+            assert len(user_id) == 36
+            assert modelaudit_config_file.exists()
+            assert json.loads(modelaudit_config_file.read_text())["user_id"] == user_id
+
     def test_user_config_defaults_to_enabled(self):
         """Test that telemetry defaults to enabled (opt-out model)."""
         with tempfile.TemporaryDirectory() as temp_dir, patch("modelaudit.telemetry.Path.home") as mock_home:
@@ -312,6 +352,35 @@ class TestTelemetryClient:
             patch("modelaudit.telemetry._IS_DEVELOPMENT", False),
             patch("modelaudit.telemetry.POSTHOG_AVAILABLE", False),
             patch.dict(os.environ, {**_NO_CI_ENV, "GITHUB_ACTIONS": "true"}, clear=False),
+        ):
+            mock_home.return_value = Path(temp_dir)
+            client = TelemetryClient()
+            client._posthog_client = mock_posthog
+
+            client._send_event_internal(TelemetryEvent.COMMAND_USED, {"command": "test"})
+
+            properties = mock_posthog.capture.call_args.kwargs["properties"]
+            assert properties["isRunningInCi"] is True
+
+    @pytest.mark.parametrize(
+        ("env_var", "value"),
+        [
+            ("TEAMCITY_VERSION", "2024.07.1"),
+            ("CODEBUILD_BUILD_ID", "codebuild:abc-123"),
+            ("BITBUCKET_COMMIT", "deadbeefcafef00ddeadbeefcafef00ddeadbeef"),
+            ("JENKINS", "/var/jenkins_home"),
+        ],
+    )
+    def test_marker_style_ci_vars_are_detected_by_presence(self, env_var: str, value: str) -> None:
+        """Marker-style CI vars carry build IDs, version strings, or paths — not booleans."""
+        mock_posthog = MagicMock()
+
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch("modelaudit.telemetry.Path.home") as mock_home,
+            patch("modelaudit.telemetry._IS_DEVELOPMENT", False),
+            patch("modelaudit.telemetry.POSTHOG_AVAILABLE", False),
+            patch.dict(os.environ, {**_NO_CI_ENV, env_var: value}, clear=False),
         ):
             mock_home.return_value = Path(temp_dir)
             client = TelemetryClient()


### PR DESCRIPTION
ModelAudit telemetry was creating new PostHog identities when it could not reuse a Promptfoo ID, which inflated user counts.

This stores the ID in `~/.promptfoo/promptfoo.yaml`, migrates existing ModelAudit IDs, and sends `isRunningInCi` on identify and event payloads.

Checks: ruff format/check, telemetry tests, telemetry decoupling tests, mypy.
