### PR TITLE
test(picklescan): cover global storage persistent ids

### DIFF
--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -940,6 +940,30 @@ def test_scan_bytes_flags_canonical_pytorch_storage_persistent_ids() -> None:
     assert report.notices == ()
 
 
+def test_scan_bytes_marks_global_pytorch_storage_persistent_id_import_reference() -> None:
+    payload = (
+        b"\x80\x02("
+        + _binunicode(b"storage")
+        + _global(b"torch", b"FloatStorage")
+        + _binunicode(b"k")
+        + _binunicode(b"cpu")
+        + b"K\x01tQ."
+    )
+
+    report = scan_bytes(payload, source="global-pytorch-storage.pkl")
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.SUSPICIOUS
+    import_references = cast(tuple[dict[str, object], ...], report.metadata.get("import_references", ()))
+    assert any(
+        reference.get("import_reference") == "torch.FloatStorage"
+        and reference.get("pytorch_storage_persistent_id") is True
+        for reference in import_references
+    )
+    assert not any(finding.rule_code == "DANGEROUS_CALL_GRAPH" for finding in report.findings)
+    assert report.notices == ()
+
+
 def test_scan_bytes_flags_noncanonical_pytorch_storage_persistent_ids() -> None:
     payload = b"\x80\x04(\x8c\x07storage\x94\x8c\x12torch.FloatStorage\x94\x8c\x04evil\x94\x8c\x03cpu\x94K\x01tQ."
 


### PR DESCRIPTION
Summary:
- Add focused picklescan coverage for legacy GLOBAL torch storage persistent IDs.
- Assert the descriptor import reference is marked as PyTorch storage metadata and does not produce DANGEROUS_CALL_GRAPH.

Validation:
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest packages/modelaudit-picklescan/tests/test_api.py -k global_pytorch_storage_persistent_id_import_reference
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m 'not slow and not integration' --maxfail=1
- uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/