### PR TITLE
fix: require latest picklescan release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "posthog>=7.0.0",
     "protobuf>=5.29.0",
     "msgpack>=1.0.0,<2.0",
-    "modelaudit-picklescan>=0.1.0,<0.2.0",
+    "modelaudit-picklescan>=0.1.3,<0.2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- tighten the root modelaudit dependency to require modelaudit-picklescan >=0.1.3
- ensures modelaudit upgrades pick up the sibling picklescan release from the coordinated 0.2.41 / 0.1.3 publish

## Validation
- uv lock
- uv build --wheel --out-dir /tmp/modelaudit-pr1-dist
- unzip -p /tmp/modelaudit-pr1-dist/modelaudit-0.2.41-py3-none-any.whl modelaudit-0.2.41.dist-info/METADATA | rg 'Requires-Dist: modelaudit-picklescan'