### PR TITLE
ci: fail full docker image when ml deps are missing

### DIFF
--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Verify ML dependencies in full image
         run: |
           # Test that ML dependencies are available
-          docker run --rm modelaudit:full python -c "import tensorflow, torch, onnx; print('All ML dependencies available')" || echo "Warning: Some ML dependencies missing"
+          docker run --rm modelaudit:full python -c "import tensorflow, torch, onnx; print('All ML dependencies available')"
 
       - name: Test full container with ML model scan
         run: |


### PR DESCRIPTION
## Summary
- remove the warning-only fallback from the full Docker image ML dependency check
- make missing TensorFlow, Torch, or ONNX fail the full image job

## Validation
- python yaml.safe_load(.github/workflows/docker-image-test.yml)
- npx prettier --write .github/workflows/docker-image-test.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'SC2046' .github/workflows/docker-image-test.yml