### PR TITLE
fix: preserve hidden model payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+
+- preserve supported payloads hidden behind default directory-skip names
+
 ## [0.2.42](https://github.com/promptfoo/modelaudit/compare/v0.2.41...v0.2.42) (2026-04-27)
 
 ### Bug Fixes

--- a/modelaudit/utils/file/filtering.py
+++ b/modelaudit/utils/file/filtering.py
@@ -384,10 +384,13 @@ def should_skip_file(
         and ext != ".dvc"
         and not any(candidate in scannable_extensions for candidate in candidate_extensions)
     ):
-        return True
+        return not (use_default_skip_extensions and _has_scannable_content(path))
 
     # Skip specific filenames
-    return filename in skip_filenames
+    if filename in skip_filenames:
+        return not (use_default_skip_extensions and _has_scannable_content(path))
+
+    return False
 
 
 logger = logging.getLogger(__name__)

--- a/tests/test_directory_file_filtering.py
+++ b/tests/test_directory_file_filtering.py
@@ -217,6 +217,30 @@ class TestDirectoryFileFiltering:
         assert results["files_scanned"] == 1
         assert any("payload.jpg" in (issue.location or "") for issue in results.issues)
 
+    @pytest.mark.parametrize("filename", [".payload", "Makefile", "package.json", "CHANGELOG"])
+    def test_disguised_pickle_with_default_hidden_or_basename_skip_is_scanned(
+        self,
+        tmp_path: Path,
+        filename: str,
+    ) -> None:
+        """Default hidden/basename filters must not suppress supported payload content."""
+
+        class DangerousPayload:
+            def __reduce__(self) -> tuple[object, tuple[str]]:
+                import os as os_module
+
+                return (os_module.system, ("echo directory-hidden-filter-test",))
+
+        safe_payload = tmp_path / "safe.pkl"
+        disguised_payload = tmp_path / filename
+        safe_payload.write_bytes(pickle.dumps({"safe": True}))
+        disguised_payload.write_bytes(pickle.dumps(DangerousPayload()))
+
+        results = scan_model_directory_or_file(str(tmp_path))
+
+        assert results["files_scanned"] == 2
+        assert any(filename in (issue.location or "") for issue in results.issues)
+
     def test_real_images_remain_skipped(self, tmp_path: Path) -> None:
         """Content sniffing should not promote ordinary media files into the scan set."""
         image_path = tmp_path / "cover.jpg"

--- a/tests/utils/file/test_file_filter.py
+++ b/tests/utils/file/test_file_filter.py
@@ -212,6 +212,18 @@ class TestFileFilter:
         assert not should_skip_file(str(disguised_legacy_tar))
         assert should_skip_file(str(real_image))
 
+    @pytest.mark.parametrize("filename", [".payload", "Makefile", "package.json", "CHANGELOG"])
+    def test_content_recognized_payloads_bypass_default_hidden_and_basename_skips(
+        self,
+        tmp_path: Path,
+        filename: str,
+    ) -> None:
+        """Supported payloads should survive default hidden and basename filters."""
+        disguised_pickle = tmp_path / filename
+        disguised_pickle.write_bytes(pickle.dumps({"safe": True}))
+
+        assert not should_skip_file(str(disguised_pickle))
+
     def test_disguised_lightgbm_text_model_bypasses_default_skip(self, tmp_path: Path) -> None:
         """Default skip filtering must preserve supported text models under skipped suffixes."""
         disguised_lightgbm = tmp_path / "model.txt"


### PR DESCRIPTION
## Summary
- preserve scannable payloads hidden behind default hidden-file and basename filters
- keep explicit custom skip policies intact
- add unit and directory-scan regressions for hidden and bookkeeping-looking payload names

## Verification
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/utils/file/test_file_filter.py tests/test_directory_file_filtering.py -q
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1