### PR TITLE
fix: fail closed on unanalyzable call graphs

### DIFF
--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -136,6 +136,8 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Mark invoked call-graph targets as incomplete when Python source cannot be
+  analyzed, and refresh source-derived call-graph caches between scans.
 - Detect additional stdlib callable pickle targets that can access files,
   mutate registries, suppress diagnostics, or change process state, including
   Python 3.13 `pathlib._local` concrete path aliases, public `operator.setitem`

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -13,8 +13,10 @@ from typing import Any, BinaryIO, cast
 from .call_graph import (
     CallGraphFinding,
     StartupHookWriteFinding,
+    UnanalyzedCallGraphReference,
     find_dangerous_call_graphs,
     find_startup_hook_write_call_graphs,
+    find_unanalyzed_callable_call_graph_references,
     has_unanalyzed_call_graph_import_references,
 )
 from .options import ScanOptions
@@ -956,43 +958,88 @@ def _with_call_graph_findings(report: PickleReport) -> PickleReport:
         startup_hook_write_findings = find_startup_hook_write_call_graphs(import_references)
     except Exception:
         startup_hook_write_findings = ()
+    try:
+        unanalyzed_references = find_unanalyzed_callable_call_graph_references(callable_invocations)
+    except Exception:
+        unanalyzed_references = ()
+
+    updated_report = (
+        _with_unanalyzed_call_graph_notices(report, unanalyzed_references) if unanalyzed_references else report
+    )
     if not call_graph_findings and not startup_hook_write_findings and not call_graph_limit_exceeded:
-        return report
+        return updated_report
 
     existing_critical_globals = {
         (str(finding.details.get("module", "")), str(finding.details.get("name", "")))
-        for finding in report.findings
+        for finding in updated_report.findings
         if finding.severity == Severity.CRITICAL
     }
     rce_findings = tuple(
-        _call_graph_finding_to_report_finding(report, finding)
+        _call_graph_finding_to_report_finding(updated_report, finding)
         for finding in call_graph_findings
         if (finding.module, finding.name) not in existing_critical_globals
     )
     startup_findings = tuple(
-        _startup_hook_write_finding_to_report_finding(report, finding)
+        _startup_hook_write_finding_to_report_finding(updated_report, finding)
         for finding in startup_hook_write_findings
         if (finding.writer_module, finding.writer_name) not in existing_critical_globals
         and (finding.opener_module, finding.opener_name) not in existing_critical_globals
     )
     limit_findings = (
-        (_call_graph_import_reference_limit_finding_to_report_finding(report),)
+        (_call_graph_import_reference_limit_finding_to_report_finding(updated_report),)
         if call_graph_limit_exceeded and not rce_findings and not startup_findings
         else ()
     )
     additional_findings = (*rce_findings, *startup_findings, *limit_findings)
     if not additional_findings:
-        return report
+        return updated_report
 
     return PickleReport(
-        source=report.source,
-        status=report.status,
+        source=updated_report.source,
+        status=updated_report.status,
         verdict=SafetyVerdict.MALICIOUS,
-        findings=(*report.findings, *additional_findings),
-        notices=report.notices,
+        findings=(*updated_report.findings, *additional_findings),
+        notices=updated_report.notices,
+        errors=updated_report.errors,
+        coverage=updated_report.coverage,
+        metadata=updated_report.to_dict()["metadata"],
+        duration_s=updated_report.duration_s,
+    )
+
+
+def _with_unanalyzed_call_graph_notices(
+    report: PickleReport,
+    references: tuple[UnanalyzedCallGraphReference, ...],
+) -> PickleReport:
+    notices = (
+        *report.notices,
+        *(
+            Notice(
+                message="Python call-graph analysis could not inspect invoked callable source",
+                severity=Severity.INFO,
+                location=report.source,
+                code="call_graph_source_unavailable",
+                details={
+                    "module": reference.module,
+                    "name": reference.name,
+                    "import_reference": reference.import_reference,
+                    "reason": reference.reason,
+                    "analysis_incomplete": True,
+                },
+            )
+            for reference in references
+        ),
+    )
+    metadata = {**report.to_dict()["metadata"], "analysis_incomplete": True}
+    return PickleReport(
+        source=report.source,
+        status=ScanStatus.INCONCLUSIVE if report.status == ScanStatus.COMPLETE else report.status,
+        verdict=SafetyVerdict.UNKNOWN if report.verdict == SafetyVerdict.CLEAN else report.verdict,
+        findings=report.findings,
+        notices=notices,
         errors=report.errors,
         coverage=report.coverage,
-        metadata=report.to_dict()["metadata"],
+        metadata=metadata,
         duration_s=report.duration_s,
     )
 

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -1033,7 +1033,11 @@ def _with_unanalyzed_call_graph_notices(
     metadata = {**report.to_dict()["metadata"], "analysis_incomplete": True}
     return PickleReport(
         source=report.source,
-        status=ScanStatus.INCONCLUSIVE if report.status == ScanStatus.COMPLETE else report.status,
+        status=(
+            ScanStatus.INCONCLUSIVE
+            if report.status == ScanStatus.COMPLETE and report.verdict == SafetyVerdict.CLEAN
+            else report.status
+        ),
         verdict=SafetyVerdict.UNKNOWN if report.verdict == SafetyVerdict.CLEAN else report.verdict,
         findings=report.findings,
         notices=notices,

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -10,7 +10,7 @@ from collections import deque
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from functools import lru_cache
-from importlib.util import find_spec
+from importlib.machinery import ModuleSpec, PathFinder
 from pathlib import Path
 
 _MAX_IMPORT_REFERENCES = 32
@@ -739,14 +739,33 @@ def _call_graph_source_unavailable_reason(module_name: str) -> str | None:
         return None
 
     try:
-        spec = find_spec(module_name)
+        spec = _find_module_spec_without_imports(module_name)
     except Exception:
-        return None
-    if spec is None or spec.origin is None or spec.origin in {"built-in", "frozen"}:
-        return None
-    if spec.origin.lower().endswith((".py", ".pyw")):
         return "source_unavailable"
-    return None
+    if spec is None or spec.origin in {"built-in", "frozen"}:
+        return None
+    return "source_unavailable"
+
+
+def _find_module_spec_without_imports(module_name: str) -> ModuleSpec | None:
+    parts = module_name.split(".")
+    if not parts or any(not part or "/" in part or "\\" in part for part in parts):
+        return None
+
+    search_path: list[str] | None = None
+    spec: ModuleSpec | None = None
+    for index in range(len(parts)):
+        qualified_name = ".".join(parts[: index + 1])
+        spec = PathFinder.find_spec(qualified_name, search_path)
+        if spec is None:
+            return None
+        if index == len(parts) - 1:
+            return spec
+        locations = spec.submodule_search_locations
+        if locations is None:
+            return None
+        search_path = list(locations)
+    return spec
 
 
 @lru_cache(maxsize=4096)

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -10,7 +10,7 @@ from collections import deque
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from functools import lru_cache
-from importlib.machinery import EXTENSION_SUFFIXES, ModuleSpec, PathFinder
+from importlib.machinery import EXTENSION_SUFFIXES, BuiltinImporter, FrozenImporter, ModuleSpec, PathFinder
 from pathlib import Path
 
 _MAX_IMPORT_REFERENCES = 32
@@ -746,7 +746,12 @@ def _call_graph_source_unavailable_reason(module_name: str) -> str | None:
     except Exception:
         return "source_unavailable"
     if spec is None:
-        return "source_unavailable"
+        try:
+            spec = _find_meta_path_module_spec_without_imports(module_name)
+        except Exception:
+            return "source_unavailable"
+        if spec is None:
+            return None
     if spec.origin in {"built-in", "frozen"}:
         return None
     if spec.origin is not None and any(spec.origin.endswith(suffix) for suffix in EXTENSION_SUFFIXES):
@@ -773,6 +778,20 @@ def _find_module_spec_without_imports(module_name: str) -> ModuleSpec | None:
             return None
         search_path = list(locations)
     return spec
+
+
+def _find_meta_path_module_spec_without_imports(module_name: str) -> ModuleSpec | None:
+    """Consult non-standard meta path finders without importing parent packages."""
+    for finder in sys.meta_path:
+        if finder is BuiltinImporter or finder is FrozenImporter or finder is PathFinder:
+            continue
+        find_spec = getattr(finder, "find_spec", None)
+        if find_spec is None:
+            continue
+        spec = find_spec(module_name, None)
+        if isinstance(spec, ModuleSpec):
+            return spec
+    return None
 
 
 @lru_cache(maxsize=4096)

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -10,6 +10,7 @@ from collections import deque
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from functools import lru_cache
+from importlib.util import find_spec
 from pathlib import Path
 
 _MAX_IMPORT_REFERENCES = 32
@@ -215,6 +216,14 @@ class StartupHookWriteFinding:
 
 
 @dataclass(frozen=True)
+class UnanalyzedCallGraphReference:
+    module: str
+    name: str
+    import_reference: str
+    reason: str
+
+
+@dataclass(frozen=True)
 class _ModuleAnalysis:
     module: str
     source_path: str
@@ -260,6 +269,7 @@ def find_dangerous_call_graphs(
     import_references: object,
     callable_invocations: object | None = None,
 ) -> tuple[CallGraphFinding, ...]:
+    _clear_source_sensitive_caches()
     findings: list[CallGraphFinding] = []
     seen_findings: set[tuple[str, str, tuple[str, ...]]] = set()
     positional_arg_counts = _callable_invocation_positional_arg_counts(callable_invocations)
@@ -314,6 +324,7 @@ def find_dangerous_call_graphs(
 
 
 def find_startup_hook_write_call_graphs(import_references: object) -> tuple[StartupHookWriteFinding, ...]:
+    _clear_source_sensitive_caches()
     openers: list[_ImportCallPath] = []
     writers: list[_ImportCallPath] = []
     seen: set[tuple[str, str]] = set()
@@ -378,6 +389,39 @@ def find_startup_hook_write_call_graphs(import_references: object) -> tuple[Star
             if len(findings) >= _MAX_IMPORT_REFERENCES:
                 return tuple(findings)
     return tuple(findings)
+
+
+def find_unanalyzed_callable_call_graph_references(
+    callable_invocations: object | None,
+) -> tuple[UnanalyzedCallGraphReference, ...]:
+    _clear_source_sensitive_caches()
+    references: list[UnanalyzedCallGraphReference] = []
+    seen: set[tuple[str, str]] = set()
+
+    for reference in _iter_callable_invocation_references(callable_invocations):
+        module = str(reference.get("module", ""))
+        name = str(reference.get("name", ""))
+        if not module or not name or (module, name) in seen:
+            continue
+        seen.add((module, name))
+        if _is_skippable_torch_extension_global_reference(module, name):
+            continue
+        if _call_graph_entrypoints_for_reference(module, name, reference):
+            continue
+        reason = _call_graph_source_unavailable_reason(module)
+        if reason is None:
+            continue
+        references.append(
+            UnanalyzedCallGraphReference(
+                module=module,
+                name=name,
+                import_reference=f"{module}.{name}",
+                reason=reason,
+            )
+        )
+        if len(references) >= _MAX_IMPORT_REFERENCES:
+            break
+    return tuple(references)
 
 
 @lru_cache(maxsize=4096)
@@ -651,6 +695,58 @@ def has_unanalyzed_call_graph_import_references(import_references: object) -> bo
         if len(seen) > _MAX_IMPORT_REFERENCES:
             return True
     return False
+
+
+def _clear_source_sensitive_caches() -> None:
+    for function in (
+        _safe_call_graph_entrypoints,
+        _has_static_torch_extension_global_target,
+        _find_sink_path,
+        _find_invoked_import_execution_path,
+        _find_file_open_path,
+        _find_file_write_path,
+        _call_graph_entrypoints,
+        _resolve_function_target,
+        _resolve_wildcard_reexport_alias,
+        _wildcard_export_summary,
+        _resolve_class_target,
+        _analyze_module,
+        _source_function_context,
+        _source_class_context,
+        _constructor_parameter_self_attribute_targets,
+        _can_invoke_function_with_positional_args,
+        _can_follow_import_execution_fallback,
+        _resolve_module_source,
+    ):
+        function.cache_clear()
+
+
+def _call_graph_source_unavailable_reason(module_name: str) -> str | None:
+    source_path = _resolve_module_source(module_name)
+    if source_path is not None:
+        try:
+            if source_path.stat().st_size > _MAX_SOURCE_BYTES:
+                return "source_too_large"
+            source = source_path.read_text(encoding="utf-8")
+        except OSError:
+            return "source_unreadable"
+        except UnicodeError:
+            return "source_unreadable"
+        try:
+            ast.parse(source, filename=str(source_path))
+        except SyntaxError:
+            return "source_parse_error"
+        return None
+
+    try:
+        spec = find_spec(module_name)
+    except Exception:
+        return None
+    if spec is None or spec.origin is None or spec.origin in {"built-in", "frozen"}:
+        return None
+    if spec.origin.lower().endswith((".py", ".pyw")):
+        return "source_unavailable"
+    return None
 
 
 @lru_cache(maxsize=4096)

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -10,7 +10,7 @@ from collections import deque
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from functools import lru_cache
-from importlib.machinery import ModuleSpec, PathFinder
+from importlib.machinery import EXTENSION_SUFFIXES, ModuleSpec, PathFinder
 from pathlib import Path
 
 _MAX_IMPORT_REFERENCES = 32
@@ -738,11 +738,18 @@ def _call_graph_source_unavailable_reason(module_name: str) -> str | None:
             return "source_parse_error"
         return None
 
+    if module_name.split(".", maxsplit=1)[0] in sys.builtin_module_names:
+        return None
+
     try:
         spec = _find_module_spec_without_imports(module_name)
     except Exception:
         return "source_unavailable"
-    if spec is None or spec.origin in {"built-in", "frozen"}:
+    if spec is None:
+        return "source_unavailable"
+    if spec.origin in {"built-in", "frozen"}:
+        return None
+    if spec.origin is not None and any(spec.origin.endswith(suffix) for suffix in EXTENSION_SUFFIXES):
         return None
     return "source_unavailable"
 

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -6,6 +6,7 @@ import importlib
 import io
 import os
 import pickle
+import py_compile
 import subprocess
 import sys
 import zipfile
@@ -14,6 +15,7 @@ from pathlib import Path
 
 import pytest
 
+import modelaudit_picklescan.call_graph as call_graph
 from modelaudit_picklescan import PickleReport, SafetyVerdict, ScanOptions, ScanStatus, Severity, scan_bytes
 from modelaudit_picklescan.api import _RUST_EXTENSION_MODULE
 from modelaudit_picklescan.call_graph import (
@@ -1314,6 +1316,93 @@ def test_scan_bytes_marks_zipimported_invoked_call_graph_source_unavailable(
         report = scan_bytes(
             _global_call_payload(module_name, "invoke", _unicode_operand("echo hidden")),
             source="zipimport-call-graph-source.pkl",
+        )
+    finally:
+        _clear_call_graph_caches()
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.UNKNOWN
+    assert _has_call_graph_source_unavailable_notice(report, module_name, "invoke", "source_unavailable")
+
+
+def test_scan_bytes_marks_zipimported_dotted_source_unavailable_without_parent_import(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package_name = "modelaudit_tp_zip_parent_probe"
+    module_name = f"{package_name}.child"
+    marker = tmp_path / "parent_imported"
+    module_zip = tmp_path / "modules.zip"
+    with zipfile.ZipFile(module_zip, "w") as archive:
+        archive.writestr(
+            f"{package_name}/__init__.py",
+            f"from pathlib import Path\nPath({str(marker)!r}).write_text('imported')\n",
+        )
+        archive.writestr(
+            f"{package_name}/child.py",
+            "def invoke(command):\n    return command\n",
+        )
+    monkeypatch.syspath_prepend(str(module_zip))
+    importlib.invalidate_caches()
+    _clear_call_graph_caches()
+
+    try:
+        report = scan_bytes(
+            _global_call_payload(module_name, "invoke", _unicode_operand("echo hidden")),
+            source="zipimport-dotted-call-graph-source.pkl",
+        )
+    finally:
+        _clear_call_graph_caches()
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.UNKNOWN
+    assert _has_call_graph_source_unavailable_notice(report, module_name, "invoke", "source_unavailable")
+    assert not marker.exists()
+
+
+def test_scan_bytes_marks_lookup_failures_as_unanalyzable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "modelaudit_tp_lookup_failure_probe"
+
+    def raise_lookup_failure(_: str) -> None:
+        raise RuntimeError("lookup failed")
+
+    monkeypatch.setattr(call_graph, "_find_module_spec_without_imports", raise_lookup_failure)
+    _clear_call_graph_caches()
+
+    try:
+        report = scan_bytes(
+            _global_call_payload(module_name, "invoke", _unicode_operand("echo hidden")),
+            source="lookup-failure-call-graph-source.pkl",
+        )
+    finally:
+        _clear_call_graph_caches()
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.UNKNOWN
+    assert _has_call_graph_source_unavailable_notice(report, module_name, "invoke", "source_unavailable")
+
+
+def test_scan_bytes_marks_bytecode_only_invoked_call_graph_source_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    module_name = "modelaudit_tp_bytecode_only_call_graph_source"
+    source_path = module_dir / f"{module_name}.py"
+    source_path.write_text("def invoke(command):\n    return command\n", encoding="utf-8")
+    py_compile.compile(str(source_path), cfile=str(module_dir / f"{module_name}.pyc"), doraise=True)
+    source_path.unlink()
+    monkeypatch.syspath_prepend(str(module_dir))
+    importlib.invalidate_caches()
+    _clear_call_graph_caches()
+
+    try:
+        report = scan_bytes(
+            _global_call_payload(module_name, "invoke", _unicode_operand("echo hidden")),
+            source="bytecode-only-call-graph-source.pkl",
         )
     finally:
         _clear_call_graph_caches()

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -10,6 +10,7 @@ import py_compile
 import subprocess
 import sys
 import zipfile
+from importlib.machinery import ModuleSpec
 from importlib.util import find_spec
 from pathlib import Path
 
@@ -1378,18 +1379,26 @@ def test_scan_bytes_marks_lookup_failures_as_unanalyzable(
     assert _has_call_graph_source_unavailable_notice(report, module_name, "invoke", "source_unavailable")
 
 
-def test_scan_bytes_marks_unresolved_specs_as_unanalyzable(
+def test_scan_bytes_marks_custom_meta_path_specs_as_unanalyzable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    module_name = "modelaudit_tp_unresolved_spec_probe"
+    module_name = "modelaudit_tp_meta_path_spec_probe"
 
-    monkeypatch.setattr(call_graph, "_find_module_spec_without_imports", lambda _: None)
+    class CustomMetaPathFinder:
+        @staticmethod
+        def find_spec(fullname: str, path: object | None = None) -> ModuleSpec | None:
+            del path
+            if fullname == module_name:
+                return ModuleSpec(fullname, loader=None, origin="custom://module")
+            return None
+
+    monkeypatch.setattr(sys, "meta_path", [CustomMetaPathFinder(), *sys.meta_path])
     _clear_call_graph_caches()
 
     try:
         report = scan_bytes(
             _global_call_payload(module_name, "invoke", _unicode_operand("echo hidden")),
-            source="unresolved-spec-call-graph-source.pkl",
+            source="meta-path-spec-call-graph-source.pkl",
         )
     finally:
         _clear_call_graph_caches()

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from modelaudit_picklescan import PickleReport, SafetyVerdict, ScanOptions, Severity, scan_bytes
+from modelaudit_picklescan import PickleReport, SafetyVerdict, ScanOptions, ScanStatus, Severity, scan_bytes
 from modelaudit_picklescan.api import _RUST_EXTENSION_MODULE
 from modelaudit_picklescan.call_graph import (
     _call_graph_entrypoints,
@@ -961,6 +961,21 @@ def _has_critical_call_graph_finding(report: PickleReport, module: str, name: st
     )
 
 
+def _has_call_graph_source_unavailable_notice(
+    report: PickleReport,
+    module: str,
+    name: str,
+    reason: str,
+) -> bool:
+    return any(
+        notice.code == "call_graph_source_unavailable"
+        and notice.details.get("module") == module
+        and notice.details.get("name") == name
+        and notice.details.get("reason") == reason
+        for notice in report.notices
+    )
+
+
 def _has_critical_call_graph_finding_with_sink_prefix(
     report: PickleReport,
     module: str,
@@ -1278,6 +1293,65 @@ def test_call_graph_models_missing_dotted_dunder_module_getattr(
         finding.module == module_name and finding.name == "__missing__.x" and finding.sink == "os.system"
         for finding in findings
     )
+
+
+def test_scan_bytes_marks_zipimported_invoked_call_graph_source_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "modelaudit_tp_zip_call_graph_source"
+    module_zip = tmp_path / "modules.zip"
+    with zipfile.ZipFile(module_zip, "w") as archive:
+        archive.writestr(
+            f"{module_name}.py",
+            "import os\n\ndef invoke(command):\n    return os.system(command)\n",
+        )
+    monkeypatch.syspath_prepend(str(module_zip))
+    importlib.invalidate_caches()
+    _clear_call_graph_caches()
+
+    try:
+        report = scan_bytes(
+            _global_call_payload(module_name, "invoke", _unicode_operand("echo hidden")),
+            source="zipimport-call-graph-source.pkl",
+        )
+    finally:
+        _clear_call_graph_caches()
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.UNKNOWN
+    assert _has_call_graph_source_unavailable_notice(report, module_name, "invoke", "source_unavailable")
+
+
+def test_scan_bytes_refreshes_call_graph_after_source_rewrite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    module_name = "modelaudit_tp_rewritten_call_graph_source"
+    module_path = module_dir / f"{module_name}.py"
+    module_path.write_text("def invoke(command):\n    return command\n", encoding="utf-8")
+    monkeypatch.syspath_prepend(str(module_dir))
+    importlib.invalidate_caches()
+    _clear_call_graph_caches()
+    payload = _global_call_payload(module_name, "invoke", _unicode_operand("echo rewritten"))
+
+    try:
+        safe_report = scan_bytes(payload, source="rewritten-call-graph-safe.pkl")
+
+        module_path.write_text(
+            "import os\n\ndef invoke(command):\n    return os.system(command)\n",
+            encoding="utf-8",
+        )
+        importlib.invalidate_caches()
+        dangerous_report = scan_bytes(payload, source="rewritten-call-graph-dangerous.pkl")
+    finally:
+        _clear_call_graph_caches()
+
+    assert safe_report.verdict == SafetyVerdict.CLEAN
+    assert dangerous_report.verdict == SafetyVerdict.MALICIOUS
+    assert _has_critical_call_graph_finding(dangerous_report, module_name, "invoke", "os.system")
 
 
 def test_call_graph_propagates_wrapper_import_execution_fallbacks() -> None:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -18,12 +18,6 @@ import pytest
 import modelaudit_picklescan.call_graph as call_graph
 from modelaudit_picklescan import PickleReport, SafetyVerdict, ScanOptions, ScanStatus, Severity, scan_bytes
 from modelaudit_picklescan.api import _RUST_EXTENSION_MODULE
-from modelaudit_picklescan.call_graph import (
-    _call_graph_entrypoints,
-    _calls_for_function,
-    _find_sink_path,
-    find_dangerous_call_graphs,
-)
 
 pytestmark = pytest.mark.skipif(
     find_spec(_RUST_EXTENSION_MODULE) is None,
@@ -1227,15 +1221,15 @@ def test_scan_bytes_preserves_nested_signature_execution_calls(
 def test_call_graph_models_site_customization_import_statements(helper_name: str) -> None:
     function_name = f"site.{helper_name}"
 
-    assert "builtins.__import__" in (_calls_for_function(function_name) or ())
-    assert _find_sink_path(function_name) == (function_name, "builtins.__import__")
+    assert "builtins.__import__" in (call_graph._calls_for_function(function_name) or ())
+    assert call_graph._find_sink_path(function_name) == (function_name, "builtins.__import__")
 
 
 def test_call_graph_models_direct_shadowable_function_body_imports() -> None:
-    calls = _calls_for_function("base64.main") or ()
+    calls = call_graph._calls_for_function("base64.main") or ()
 
     assert "builtins.__import__" in calls
-    assert _find_sink_path("base64.main") == ("base64.main", "builtins.__import__")
+    assert call_graph._find_sink_path("base64.main") == ("base64.main", "builtins.__import__")
 
 
 def test_call_graph_keeps_module_dict_dotted_lookup_clean(
@@ -1254,7 +1248,7 @@ def test_call_graph_keeps_module_dict_dotted_lookup_clean(
     _clear_call_graph_caches()
 
     try:
-        findings = find_dangerous_call_graphs(
+        findings = call_graph.find_dangerous_call_graphs(
             [{"module": module_name, "name": "__dict__.values", "import_reference": f"{module_name}.__dict__.values"}]
         )
     finally:
@@ -1279,7 +1273,7 @@ def test_call_graph_models_missing_dotted_dunder_module_getattr(
     _clear_call_graph_caches()
 
     try:
-        findings = find_dangerous_call_graphs(
+        findings = call_graph.find_dangerous_call_graphs(
             [
                 {
                     "module": module_name,
@@ -1444,10 +1438,10 @@ def test_scan_bytes_refreshes_call_graph_after_source_rewrite(
 
 
 def test_call_graph_propagates_wrapper_import_execution_fallbacks() -> None:
-    calls = _calls_for_function("platform.mac_ver") or ()
+    calls = call_graph._calls_for_function("platform.mac_ver") or ()
 
     assert "platform._mac_ver_xml" in calls
-    assert _find_sink_path("platform.mac_ver") == (
+    assert call_graph._find_sink_path("platform.mac_ver") == (
         "platform.mac_ver",
         "platform._mac_ver_xml",
         "builtins.__import__",
@@ -1455,17 +1449,17 @@ def test_call_graph_propagates_wrapper_import_execution_fallbacks() -> None:
 
 
 def test_call_graph_ignores_imports_inside_nested_functions_until_called() -> None:
-    calls = _calls_for_function("site.enablerlcompleter") or ()
+    calls = call_graph._calls_for_function("site.enablerlcompleter") or ()
 
     assert "builtins.__import__" not in calls
-    assert _find_sink_path("site.enablerlcompleter") is None
+    assert call_graph._find_sink_path("site.enablerlcompleter") is None
 
 
 def test_call_graph_models_getattr_default_callable_fallbacks() -> None:
-    calls = _calls_for_function("platform._Processor.get") or ()
+    calls = call_graph._calls_for_function("platform._Processor.get") or ()
 
     assert "platform._Processor.from_subprocess" in calls
-    assert _find_sink_path("platform._Processor.get") == (
+    assert call_graph._find_sink_path("platform._Processor.get") == (
         "platform._Processor.get",
         "platform._Processor.from_subprocess",
         "subprocess.check_output",
@@ -1476,10 +1470,10 @@ def test_call_graph_models_version_gated_typing_extensions_definitions() -> None
     pytest.importorskip("typing_extensions")
 
     function_name = "typing_extensions.get_type_hints"
-    calls = _calls_for_function(function_name) or ()
-    path = _find_sink_path(function_name)
+    calls = call_graph._calls_for_function(function_name) or ()
+    path = call_graph._find_sink_path(function_name)
 
-    assert _call_graph_entrypoints(function_name) == (function_name,)
+    assert call_graph._call_graph_entrypoints(function_name) == (function_name,)
     assert "typing.get_type_hints" in calls
     assert path is not None
     assert path[0] == function_name
@@ -1495,10 +1489,10 @@ def test_call_graph_models_required_arg_imports_when_pickle_supplies_args() -> N
         }
     ]
 
-    assert _find_sink_path("_pyio._open_code_with_warning") is None
-    assert find_dangerous_call_graphs(import_references) == ()
+    assert call_graph._find_sink_path("_pyio._open_code_with_warning") is None
+    assert call_graph.find_dangerous_call_graphs(import_references) == ()
     assert (
-        find_dangerous_call_graphs(
+        call_graph.find_dangerous_call_graphs(
             import_references,
             [
                 {
@@ -1511,7 +1505,7 @@ def test_call_graph_models_required_arg_imports_when_pickle_supplies_args() -> N
         == ()
     )
 
-    findings = find_dangerous_call_graphs(
+    findings = call_graph.find_dangerous_call_graphs(
         import_references,
         [
             {
@@ -1551,9 +1545,9 @@ def test_call_graph_models_constructed_callable_instance_invocations() -> None:
         },
     ]
 
-    assert find_dangerous_call_graphs(import_references, constructor_only_invocations) == ()
+    assert call_graph.find_dangerous_call_graphs(import_references, constructor_only_invocations) == ()
 
-    findings = find_dangerous_call_graphs(import_references, callable_instance_invocations)
+    findings = call_graph.find_dangerous_call_graphs(import_references, callable_instance_invocations)
 
     assert len(findings) == 1
     assert findings[0].module == "_sitebuiltins"
@@ -1578,9 +1572,9 @@ def test_call_graph_models_builtins_help_singleton_invocations() -> None:
         }
     ]
 
-    assert find_dangerous_call_graphs(import_references) == ()
+    assert call_graph.find_dangerous_call_graphs(import_references) == ()
 
-    findings = find_dangerous_call_graphs(import_references, help_invocations)
+    findings = call_graph.find_dangerous_call_graphs(import_references, help_invocations)
 
     assert len(findings) == 1
     assert findings[0].module == "_sitebuiltins"
@@ -1647,7 +1641,7 @@ def test_call_graph_analyzes_shadowed_torch_storage_persistent_id_reference(
     _clear_call_graph_caches()
 
     try:
-        findings = find_dangerous_call_graphs(
+        findings = call_graph.find_dangerous_call_graphs(
             [
                 {
                     "module": "torch",
@@ -1687,7 +1681,7 @@ def test_call_graph_keeps_setstate_entrypoint_for_unknown_newobj_invocation(
     _clear_call_graph_caches()
 
     try:
-        findings = find_dangerous_call_graphs(
+        findings = call_graph.find_dangerous_call_graphs(
             [],
             [
                 {
@@ -1769,9 +1763,9 @@ def test_call_graph_models_builtin_format_protocol_dispatch_invocations() -> Non
         },
     ]
 
-    assert find_dangerous_call_graphs(import_references, direct_invocations) == ()
+    assert call_graph.find_dangerous_call_graphs(import_references, direct_invocations) == ()
 
-    findings = find_dangerous_call_graphs(import_references, protocol_invocations)
+    findings = call_graph.find_dangerous_call_graphs(import_references, protocol_invocations)
 
     assert len(findings) == 1
     assert findings[0].module == "ipaddress"
@@ -1814,9 +1808,9 @@ def test_call_graph_models_str_format_protocol_dispatch_invocations() -> None:
         },
     ]
 
-    assert find_dangerous_call_graphs(import_references, direct_invocations) == ()
+    assert call_graph.find_dangerous_call_graphs(import_references, direct_invocations) == ()
 
-    findings = find_dangerous_call_graphs(import_references, protocol_invocations)
+    findings = call_graph.find_dangerous_call_graphs(import_references, protocol_invocations)
 
     assert len(findings) == 1
     assert findings[0].module == "ipaddress"

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -1378,6 +1378,27 @@ def test_scan_bytes_marks_lookup_failures_as_unanalyzable(
     assert _has_call_graph_source_unavailable_notice(report, module_name, "invoke", "source_unavailable")
 
 
+def test_scan_bytes_marks_unresolved_specs_as_unanalyzable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "modelaudit_tp_unresolved_spec_probe"
+
+    monkeypatch.setattr(call_graph, "_find_module_spec_without_imports", lambda _: None)
+    _clear_call_graph_caches()
+
+    try:
+        report = scan_bytes(
+            _global_call_payload(module_name, "invoke", _unicode_operand("echo hidden")),
+            source="unresolved-spec-call-graph-source.pkl",
+        )
+    finally:
+        _clear_call_graph_caches()
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.UNKNOWN
+    assert _has_call_graph_source_unavailable_notice(report, module_name, "invoke", "source_unavailable")
+
+
 def test_scan_bytes_marks_bytecode_only_invoked_call_graph_source_unavailable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- mark invoked call-graph targets inconclusive when Python source cannot be analyzed
- refresh source-derived call-graph caches between scans so rewritten modules are re-evaluated
- add focused regressions for zipimported modules and same-process source rewrites

## Validation
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py -q -k 'zipimported_invoked_call_graph_source_unavailable or refreshes_call_graph_after_source_rewrite'
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py -q
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest -n auto -m 'not slow and not integration' --maxfail=1