### PR TITLE
fix: scan embedded manifest chat templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,6 +293,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **security:** run Jinja template analysis for manifest-owned configs that carry
+  embedded chat-template fields.
 - **pickle:** detect stdlib filesystem probe and process-state callables such as `pathlib` metadata methods, `decimal.setcontext`, and `gc.disable` during pickle scans, while keeping local container mutations clean and covering public `operator.setitem` registry poisoning plus target-aware `operator.imul` warning-filter mutation.
 - **pickle:** detect public `operator.setitem` pickle calls, keep callable
   invocation aliases ahead of import-reference budget exhaustion, dedupe repeated

--- a/modelaudit/scanners/jinja2_template_scanner.py
+++ b/modelaudit/scanners/jinja2_template_scanner.py
@@ -233,59 +233,7 @@ class Jinja2TemplateScanner(BaseScanner):
                 return result
 
             # Analyze each extracted template
-            total_detections = 0
-            for template_location, template_content in templates.items():
-                detections = self._analyze_template(template_content, context, f"{path}:{template_location}")
-                total_detections += len(detections)
-
-                # Convert detections to issues
-                for detection in detections:
-                    severity = self._get_severity_for_detection(detection, context)
-                    why_explanation = self._get_why_explanation(detection, context)
-
-                    result.add_check(
-                        name="Jinja2 Template Injection Detection",
-                        passed=False,
-                        message=f"Potential SSTI vulnerability detected: {detection.pattern_type}",
-                        severity=severity,
-                        location=detection.location or f"{path}:{template_location}",
-                        details={
-                            "pattern_type": detection.pattern_type,
-                            "pattern": detection.pattern,
-                            "match_text": detection.match_text[:200],  # Limit output size
-                            "risk_level": detection.risk_level,
-                            "template_location": template_location,
-                            "ml_context": context.framework,
-                        },
-                        why=why_explanation,
-                    )
-
-            # Overall assessment
-            if total_detections == 0:
-                result.add_check(
-                    name="Jinja2 SSTI Analysis",
-                    passed=True,
-                    message="No template injection patterns detected",
-                    location=path,
-                    details={"templates_analyzed": len(templates)},
-                )
-            else:
-                result.add_check(
-                    name="Jinja2 SSTI Analysis Summary",
-                    passed=False,
-                    message=f"Found {total_detections} potential SSTI patterns across {len(templates)} templates",
-                    severity=IssueSeverity.WARNING,
-                    location=path,
-                    details={
-                        "total_detections": total_detections,
-                        "templates_analyzed": len(templates),
-                        "sensitivity_level": self.sensitivity_level,
-                    },
-                )
-
-            result.bytes_scanned = file_size
-            self._finish_scan_result(result)
-            return result
+            return self._scan_extracted_templates(path, templates, context, result=result, file_size=file_size)
 
         except Exception as e:
             import traceback
@@ -308,6 +256,81 @@ class Jinja2TemplateScanner(BaseScanner):
             )
             result.finish(success=False)
             return result
+
+    def scan_extracted_templates(self, path: str, templates: dict[str, str]) -> ScanResult:
+        """Analyze templates that were already extracted by another structured scanner."""
+        result = self._create_result()
+        file_size = self.get_file_size(path)
+        result.metadata["file_size"] = file_size
+        context = self._determine_context(path)
+        result.metadata["ml_context"] = {
+            "framework": context.framework,
+            "file_type": context.file_type,
+            "is_tokenizer": context.is_tokenizer,
+            "confidence": context.confidence,
+        }
+        return self._scan_extracted_templates(path, templates, context, result=result, file_size=file_size)
+
+    def _scan_extracted_templates(
+        self,
+        path: str,
+        templates: dict[str, str],
+        context: MLContext,
+        *,
+        result: ScanResult,
+        file_size: int,
+    ) -> ScanResult:
+        total_detections = 0
+        for template_location, template_content in templates.items():
+            detections = self._analyze_template(template_content, context, f"{path}:{template_location}")
+            total_detections += len(detections)
+
+            for detection in detections:
+                severity = self._get_severity_for_detection(detection, context)
+                why_explanation = self._get_why_explanation(detection, context)
+
+                result.add_check(
+                    name="Jinja2 Template Injection Detection",
+                    passed=False,
+                    message=f"Potential SSTI vulnerability detected: {detection.pattern_type}",
+                    severity=severity,
+                    location=detection.location or f"{path}:{template_location}",
+                    details={
+                        "pattern_type": detection.pattern_type,
+                        "pattern": detection.pattern,
+                        "match_text": detection.match_text[:200],
+                        "risk_level": detection.risk_level,
+                        "template_location": template_location,
+                        "ml_context": context.framework,
+                    },
+                    why=why_explanation,
+                )
+
+        if total_detections == 0:
+            result.add_check(
+                name="Jinja2 SSTI Analysis",
+                passed=True,
+                message="No template injection patterns detected",
+                location=path,
+                details={"templates_analyzed": len(templates)},
+            )
+        else:
+            result.add_check(
+                name="Jinja2 SSTI Analysis Summary",
+                passed=False,
+                message=f"Found {total_detections} potential SSTI patterns across {len(templates)} templates",
+                severity=IssueSeverity.WARNING,
+                location=path,
+                details={
+                    "total_detections": total_detections,
+                    "templates_analyzed": len(templates),
+                    "sensitivity_level": self.sensitivity_level,
+                },
+            )
+
+        result.bytes_scanned = file_size
+        self._finish_scan_result(result)
+        return result
 
     def _mark_inconclusive_scan_result(
         self,

--- a/modelaudit/scanners/manifest_scanner.py
+++ b/modelaudit/scanners/manifest_scanner.py
@@ -842,24 +842,31 @@ class ManifestScanner(BaseScanner):
         return _PARSE_FAILED
 
     def _scan_embedded_jinja_templates(self, path: str, content: Any, result: ScanResult) -> None:
-        if not self._contains_jinja_template_field(content):
+        templates = self._collect_jinja_template_fields(content)
+        if not templates:
             return
 
         from .jinja2_template_scanner import Jinja2TemplateScanner
 
-        result.merge(Jinja2TemplateScanner(config=self.config).scan(path))
+        result.merge(Jinja2TemplateScanner(config=self.config).scan_extracted_templates(path, templates))
 
     @classmethod
-    def _contains_jinja_template_field(cls, value: Any) -> bool:
+    def _collect_jinja_template_fields(cls, value: Any, path: str = "") -> dict[str, str]:
         if isinstance(value, dict):
-            return any(
-                (key in JINJA_TEMPLATE_FIELD_NAMES and isinstance(item, str) and item.strip())
-                or cls._contains_jinja_template_field(item)
-                for key, item in value.items()
-            )
+            templates: dict[str, str] = {}
+            for key, item in value.items():
+                child_path = f"{path}.{key}" if path else str(key)
+                if key in JINJA_TEMPLATE_FIELD_NAMES and isinstance(item, str) and item.strip():
+                    templates[child_path] = item
+                templates.update(cls._collect_jinja_template_fields(item, child_path))
+            return templates
         if isinstance(value, list):
-            return any(cls._contains_jinja_template_field(item) for item in value)
-        return False
+            templates = {}
+            for index, item in enumerate(value):
+                child_path = f"{path}[{index}]" if path else f"[{index}]"
+                templates.update(cls._collect_jinja_template_fields(item, child_path))
+            return templates
+        return {}
 
     def _parse_ini_file(self, content: str) -> dict[str, Any]:
         """Parse INI-style manifests into nested dictionaries."""

--- a/modelaudit/scanners/manifest_scanner.py
+++ b/modelaudit/scanners/manifest_scanner.py
@@ -157,6 +157,7 @@ HASH_INTEGRITY_KEYS = [
 
 # Regex pattern for hexadecimal strings (used to detect hash values)
 HEX_PATTERN = re.compile(r"^[a-fA-F0-9]+$")
+JINJA_TEMPLATE_FIELD_NAMES = frozenset({"chat_template", "template", "jinja_template", "custom_chat_template"})
 
 # Comprehensive allowlist of trusted domains for ML model configs
 # URLs from domains NOT in this list will be flagged as untrusted
@@ -653,6 +654,12 @@ class ManifestScanner(BaseScanner):
                 self._check_weak_hashes(content, result)
                 self._check_timeout()
 
+                # Manifest-owned configs can still carry executable chat
+                # templates, so preserve manifest checks while delegating those
+                # embedded fields to the dedicated Jinja analyzer.
+                self._scan_embedded_jinja_templates(path, content, result)
+                self._check_timeout()
+
             else:
                 result.add_check(
                     name="Manifest Structure",
@@ -833,6 +840,26 @@ class ManifestScanner(BaseScanner):
                 )
 
         return _PARSE_FAILED
+
+    def _scan_embedded_jinja_templates(self, path: str, content: Any, result: ScanResult) -> None:
+        if not self._contains_jinja_template_field(content):
+            return
+
+        from .jinja2_template_scanner import Jinja2TemplateScanner
+
+        result.merge(Jinja2TemplateScanner(config=self.config).scan(path))
+
+    @classmethod
+    def _contains_jinja_template_field(cls, value: Any) -> bool:
+        if isinstance(value, dict):
+            return any(
+                (key in JINJA_TEMPLATE_FIELD_NAMES and isinstance(item, str) and item.strip())
+                or cls._contains_jinja_template_field(item)
+                for key, item in value.items()
+            )
+        if isinstance(value, list):
+            return any(cls._contains_jinja_template_field(item) for item in value)
+        return False
 
     def _parse_ini_file(self, content: str) -> dict[str, Any]:
         """Parse INI-style manifests into nested dictionaries."""

--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -288,6 +288,28 @@ def test_manifest_scanner_keeps_benign_chat_templates_clean(tmp_path: Path) -> N
     )
 
 
+def test_manifest_scanner_delegates_templates_from_parsed_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"chat_template": "{{ harmless }}"}', encoding="utf-8")
+    captured: dict[str, dict[str, str]] = {}
+
+    def capture_templates(self: object, path: str, templates: dict[str, str]) -> ScanResult:
+        captured[path] = templates
+        return ScanResult("jinja2_template")
+
+    monkeypatch.setattr(
+        "modelaudit.scanners.jinja2_template_scanner.Jinja2TemplateScanner.scan_extracted_templates",
+        capture_templates,
+    )
+
+    ManifestScanner().scan(str(config_path))
+
+    assert captured[str(config_path)] == {"chat_template": "{{ harmless }}"}
+
+
 def test_manifest_scanner_redacts_untrusted_url_credentials(tmp_path: Path) -> None:
     """Untrusted URL findings should not store userinfo, query strings, or fragments."""
     test_file = tmp_path / "config.json"

--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -247,6 +247,47 @@ def test_manifest_scanner_url_shortener_flagged(tmp_path):
     assert "bit.ly" in failed_url_checks[0].details.get("url", "")
 
 
+def test_manifest_scanner_delegates_malicious_chat_templates_to_jinja_analysis(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "model_type": "llama",
+                "chat_template": "{{ ''.__class__.__mro__[1].__subclasses__() }}",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = ManifestScanner().scan(str(config_path))
+
+    assert any(
+        check.name == "Jinja2 Template Injection Detection" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+
+
+def test_manifest_scanner_keeps_benign_chat_templates_clean(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "model_type": "llama",
+                "chat_template": "{% for message in messages %}{{ message['content'] }}{% endfor %}",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = ManifestScanner().scan(str(config_path))
+
+    assert any(check.name == "Jinja2 SSTI Analysis" and check.status == CheckStatus.PASSED for check in result.checks)
+    assert not any(
+        check.name == "Jinja2 Template Injection Detection" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+
+
 def test_manifest_scanner_redacts_untrusted_url_credentials(tmp_path: Path) -> None:
     """Untrusted URL findings should not store userinfo, query strings, or fragments."""
     test_file = tmp_path / "config.json"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -15,7 +15,7 @@ import pytest
 from modelaudit import core as core_module
 from modelaudit.cache import get_cache_manager, reset_cache_manager
 from modelaudit.core import scan_file
-from modelaudit.scanners.base import IssueSeverity, ScanResult
+from modelaudit.scanners.base import CheckStatus, IssueSeverity, ScanResult
 from tests.helpers import create_mock_gguf, create_mock_onnx, create_mock_pytorch_zip
 
 _SYSTEM_GLOBAL_NAMES = ("os.system", "posix.system", "nt.system")
@@ -917,3 +917,23 @@ def test_scan_file_routes_model_config_json_to_manifest_scanner(tmp_path: Path) 
 
     assert result.scanner_name == "manifest"
     assert result.success is True
+
+
+def test_scan_file_routes_manifest_owned_chat_templates_through_jinja_analysis(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "config.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "model_type": "llama",
+                "chat_template": "{{ ''.__class__.__mro__[1].__subclasses__() }}",
+            }
+        )
+    )
+
+    result = scan_file(str(manifest_path), config={"cache_scan_results": False})
+
+    assert result.scanner_name == "manifest"
+    assert any(
+        check.name == "Jinja2 Template Injection Detection" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )


### PR DESCRIPTION
## Summary
- keep manifest-owned configs on the manifest path while delegating embedded chat-template fields to Jinja analysis
- add malicious and benign chat-template regressions at the manifest layer
- add an end-to-end core regression for generic config.json dispatch

## Validation
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest tests/scanners/test_manifest_scanner.py -q -k 'delegates_malicious_chat_templates_to_jinja_analysis or keeps_benign_chat_templates_clean'
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest tests/test_core.py -q -k 'routes_manifest_owned_chat_templates_through_jinja_analysis'
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest -n auto -m 'not slow and not integration' --maxfail=1