### PR TITLE
fix: analyze jax-like pickle checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **security:** run JAX checkpoint analysis for JAX-like pickle payloads that
+  stay on the primary pickle scanner path
 - **security:** detect `mailcap.findmatch` pickle call targets that can execute
   attacker-controlled mailcap `test` commands on Python versions that still
   provide `mailcap`

--- a/modelaudit/scanners/jax_checkpoint_scanner.py
+++ b/modelaudit/scanners/jax_checkpoint_scanner.py
@@ -411,6 +411,21 @@ class JaxCheckpointScanner(BaseScanner):
             )
             finding_budget.recorded_findings += 1
 
+    def scan_pickle_pattern_text(self, path: str, text: str) -> ScanResult:
+        """Run the JAX-specific pickle text checks on already-read data."""
+        result = self._create_result()
+        self._add_suspicious_pattern_checks(
+            text,
+            context="pickle_checkpoint",
+            check_name="JAX Pattern Security Check",
+            message_prefix="Suspicious JAX pattern in pickle",
+            location=path,
+            result=result,
+            finding_budget=_PatternFindingBudget(self.max_metadata_pattern_findings),
+        )
+        result.finish(success=True)
+        return result
+
     @staticmethod
     def _parse_pickle_global_reference(arg: str) -> tuple[str, str] | None:
         """Parse pickle GLOBAL/INST opcode args into ``(module, name)``."""
@@ -910,17 +925,7 @@ class JaxCheckpointScanner(BaseScanner):
                 if not pickle_prefix_truncated:
                     raise
 
-            # Check for JAX-specific suspicious content
-            data_str = data.decode("utf-8", errors="ignore")
-            self._add_suspicious_pattern_checks(
-                data_str,
-                context="pickle_checkpoint",
-                check_name="JAX Pattern Security Check",
-                message_prefix="Suspicious JAX pattern in pickle",
-                location=path,
-                result=result,
-                finding_budget=_PatternFindingBudget(self.max_metadata_pattern_findings),
-            )
+            result.merge(self.scan_pickle_pattern_text(path, data.decode("utf-8", errors="ignore")))
 
         except Exception as e:
             result.add_check(

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -2455,6 +2455,11 @@ class PickleScanner(BaseScanner):
             for check in jax_result.checks
         )
         if len(data) > jax_scanner.max_pickle_scan_bytes:
+            result.metadata["analysis_incomplete"] = True
+            result.metadata["scan_outcome"] = INCONCLUSIVE_SCAN_OUTCOME
+            scan_outcome_reasons = result.metadata.setdefault("scan_outcome_reasons", [])
+            if isinstance(scan_outcome_reasons, list) and "jax_pickle_scan_limit_exceeded" not in scan_outcome_reasons:
+                scan_outcome_reasons.append("jax_pickle_scan_limit_exceeded")
             jax_result.add_check(
                 name="Pickle Checkpoint Prefix Scan Limit",
                 passed=False,

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -18,7 +18,7 @@ from modelaudit_picklescan import PickleScanner as StandalonePickleScanner
 from modelaudit.detectors.suspicious_symbols import SUSPICIOUS_GLOBALS
 from modelaudit.utils.helpers.code_validation import validate_python_syntax
 
-from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, IssueSeverity, ScanResult, logger
+from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, CheckStatus, IssueSeverity, ScanResult, logger
 from .picklescan_adapter import pickle_report_to_scan_result, scan_options_from_config
 
 _NESTED_PICKLE_HEADER_SEARCH_LIMIT_BYTES = 64 * 1024
@@ -2439,19 +2439,22 @@ class PickleScanner(BaseScanner):
     def _scan_jax_checkpoint_patterns_if_needed(self, path: str, file_size: int, result: ScanResult) -> None:
         from .jax_checkpoint_scanner import JaxCheckpointScanner
 
-        if Path(path).suffix.lower() not in _KNOWN_PICKLE_EXTENSIONS and not JaxCheckpointScanner.can_handle(path):
-            return
-
         jax_scanner = JaxCheckpointScanner(config=self.config)
         read_limit = min(file_size, jax_scanner.max_pickle_scan_bytes)
         with open(path, "rb") as handle:
             data = handle.read(read_limit + 1)
 
+        decoded_text = data[: jax_scanner.max_pickle_scan_bytes].decode("utf-8", errors="ignore")
         jax_result = jax_scanner.scan_pickle_pattern_text(
             path,
-            data[: jax_scanner.max_pickle_scan_bytes].decode("utf-8", errors="ignore"),
+            decoded_text,
         )
-        if len(data) > jax_scanner.max_pickle_scan_bytes:
+        has_jax_context = any(indicator in decoded_text.lower() for indicator in jax_scanner._JAX_INDICATORS)
+        has_jax_findings = any(
+            check.name == "JAX Pattern Security Check" and check.status == CheckStatus.FAILED
+            for check in jax_result.checks
+        )
+        if len(data) > jax_scanner.max_pickle_scan_bytes and (has_jax_context or has_jax_findings):
             jax_result.add_check(
                 name="Pickle Checkpoint Prefix Scan Limit",
                 passed=False,

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -2432,17 +2432,36 @@ class PickleScanner(BaseScanner):
             return result
 
         self._add_root_legacy_metadata_detectors(result, path)
-        self._scan_jax_checkpoint_patterns_if_needed(path, raw_data, result)
+        self._scan_jax_checkpoint_patterns_if_needed(path, file_size, result)
         self._finish_after_wrapper_analysis(result, base_success=scan_result.success)
         return result
 
-    def _scan_jax_checkpoint_patterns_if_needed(self, path: str, raw_data: bytes, result: ScanResult) -> None:
+    def _scan_jax_checkpoint_patterns_if_needed(self, path: str, file_size: int, result: ScanResult) -> None:
         from .jax_checkpoint_scanner import JaxCheckpointScanner
 
-        if JaxCheckpointScanner.can_handle(path):
-            result.merge(
-                JaxCheckpointScanner(config=self.config).scan_pickle_pattern_text(
-                    path,
-                    raw_data.decode("utf-8", errors="ignore"),
-                )
+        if Path(path).suffix.lower() not in _KNOWN_PICKLE_EXTENSIONS and not JaxCheckpointScanner.can_handle(path):
+            return
+
+        jax_scanner = JaxCheckpointScanner(config=self.config)
+        read_limit = min(file_size, jax_scanner.max_pickle_scan_bytes)
+        with open(path, "rb") as handle:
+            data = handle.read(read_limit + 1)
+
+        jax_result = jax_scanner.scan_pickle_pattern_text(
+            path,
+            data[: jax_scanner.max_pickle_scan_bytes].decode("utf-8", errors="ignore"),
+        )
+        if len(data) > jax_scanner.max_pickle_scan_bytes:
+            jax_result.add_check(
+                name="Pickle Checkpoint Prefix Scan Limit",
+                passed=False,
+                message=(
+                    f"Only the first {jax_scanner.max_pickle_scan_bytes} bytes of the pickle checkpoint were "
+                    "inspected for opcode patterns"
+                ),
+                severity=IssueSeverity.WARNING,
+                location=path,
+                details={"max_pickle_scan_bytes": jax_scanner.max_pickle_scan_bytes},
+                rule_code="S902",
             )
+        result.merge(jax_result)

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -2454,7 +2454,7 @@ class PickleScanner(BaseScanner):
             check.name == "JAX Pattern Security Check" and check.status == CheckStatus.FAILED
             for check in jax_result.checks
         )
-        if len(data) > jax_scanner.max_pickle_scan_bytes and (has_jax_context or has_jax_findings):
+        if len(data) > jax_scanner.max_pickle_scan_bytes:
             jax_result.add_check(
                 name="Pickle Checkpoint Prefix Scan Limit",
                 passed=False,
@@ -2462,7 +2462,7 @@ class PickleScanner(BaseScanner):
                     f"Only the first {jax_scanner.max_pickle_scan_bytes} bytes of the pickle checkpoint were "
                     "inspected for opcode patterns"
                 ),
-                severity=IssueSeverity.WARNING,
+                severity=IssueSeverity.WARNING if has_jax_context or has_jax_findings else IssueSeverity.INFO,
                 location=path,
                 details={"max_pickle_scan_bytes": jax_scanner.max_pickle_scan_bytes},
                 rule_code="S902",

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -2432,5 +2432,17 @@ class PickleScanner(BaseScanner):
             return result
 
         self._add_root_legacy_metadata_detectors(result, path)
+        self._scan_jax_checkpoint_patterns_if_needed(path, raw_data, result)
         self._finish_after_wrapper_analysis(result, base_success=scan_result.success)
         return result
+
+    def _scan_jax_checkpoint_patterns_if_needed(self, path: str, raw_data: bytes, result: ScanResult) -> None:
+        from .jax_checkpoint_scanner import JaxCheckpointScanner
+
+        if JaxCheckpointScanner.can_handle(path):
+            result.merge(
+                JaxCheckpointScanner(config=self.config).scan_pickle_pattern_text(
+                    path,
+                    raw_data.decode("utf-8", errors="ignore"),
+                )
+            )

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -1462,6 +1462,39 @@ def test_pickle_scanner_delegates_jax_specific_patterns_for_jax_pickles(tmp_path
     )
 
 
+def test_pickle_scanner_delegates_jax_patterns_for_pkl_suffixes(tmp_path: Path) -> None:
+    path = tmp_path / "jax_state.pkl"
+    path.write_bytes(pickle.dumps({"payload": "jax.experimental.io_callback"}))
+
+    result = PickleScanner().scan(str(path))
+
+    assert any(
+        check.name == "JAX Pattern Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.details["pattern"] == r"jax\.experimental\.io_callback"
+        for check in result.checks
+    )
+
+
+def test_pickle_scanner_uses_jax_window_beyond_root_raw_scan_limit(tmp_path: Path) -> None:
+    path = tmp_path / "late-jax.pkl"
+    path.write_bytes(pickle.dumps({"padding": "a" * 256, "payload": "jax.experimental.io_callback"}))
+
+    result = PickleScanner(
+        config={
+            "pickle_root_raw_scan_limit_bytes": 64,
+            "jax_pickle_max_scan_bytes": 1024,
+        }
+    ).scan(str(path))
+
+    assert any(
+        check.name == "JAX Pattern Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.details["pattern"] == r"jax\.experimental\.io_callback"
+        for check in result.checks
+    )
+
+
 def test_policy_compatibility_exports_cover_required_dangerous_symbols() -> None:
     assert {"os.system", "subprocess.Popen", "eval", "exec", "__import__"} <= ALWAYS_DANGEROUS_FUNCTIONS
     assert {"os", "subprocess", "posix", "nt"} <= ALWAYS_DANGEROUS_MODULES

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -1516,8 +1516,26 @@ def test_pickle_scanner_reports_info_only_jax_truncation_without_jax_context(tmp
     result = PickleScanner(config={"jax_pickle_max_scan_bytes": 1024}).scan(str(path))
 
     prefix_limit_checks = [check for check in result.checks if check.name == "Pickle Checkpoint Prefix Scan Limit"]
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert result.metadata["scan_outcome_reasons"] == ["jax_pickle_scan_limit_exceeded"]
     assert len(prefix_limit_checks) == 1
     assert prefix_limit_checks[0].severity == IssueSeverity.INFO
+
+
+def test_pickle_scanner_fails_closed_when_jax_payload_is_after_delegated_scan_window(tmp_path: Path) -> None:
+    path = tmp_path / "late-hidden-jax.pkl"
+    path.write_bytes(pickle.dumps({"padding": "a" * 4096, "payload": "jax.experimental.io_callback"}))
+
+    result = PickleScanner(config={"jax_pickle_max_scan_bytes": 1024}).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert result.metadata["scan_outcome_reasons"] == ["jax_pickle_scan_limit_exceeded"]
+    assert any(check.name == "Pickle Checkpoint Prefix Scan Limit" for check in result.checks)
+    assert not any(
+        check.name == "JAX Pattern Security Check" and check.status == CheckStatus.FAILED for check in result.checks
+    )
 
 
 def test_policy_compatibility_exports_cover_required_dangerous_symbols() -> None:

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -1495,6 +1495,29 @@ def test_pickle_scanner_uses_jax_window_beyond_root_raw_scan_limit(tmp_path: Pat
     )
 
 
+def test_pickle_scanner_delegates_late_jax_patterns_for_ckpt_suffixes(tmp_path: Path) -> None:
+    path = tmp_path / "late-jax.ckpt"
+    path.write_bytes(pickle.dumps({"padding": "a" * 9000, "payload": "jax.experimental.io_callback"}))
+
+    result = PickleScanner().scan(str(path))
+
+    assert any(
+        check.name == "JAX Pattern Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.details["pattern"] == r"jax\.experimental\.io_callback"
+        for check in result.checks
+    )
+
+
+def test_pickle_scanner_suppresses_jax_truncation_warning_without_jax_context(tmp_path: Path) -> None:
+    path = tmp_path / "large-benign.pkl"
+    path.write_bytes(pickle.dumps({"padding": "a" * 4096}))
+
+    result = PickleScanner(config={"jax_pickle_max_scan_bytes": 1024}).scan(str(path))
+
+    assert not any(check.name == "Pickle Checkpoint Prefix Scan Limit" for check in result.checks)
+
+
 def test_policy_compatibility_exports_cover_required_dangerous_symbols() -> None:
     assert {"os.system", "subprocess.Popen", "eval", "exec", "__import__"} <= ALWAYS_DANGEROUS_FUNCTIONS
     assert {"os", "subprocess", "posix", "nt"} <= ALWAYS_DANGEROUS_MODULES

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -11,7 +11,7 @@ import pytest
 
 from modelaudit.cache import get_cache_manager, reset_cache_manager
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
-from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, IssueSeverity, ScanResult
+from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity, ScanResult
 from modelaudit.scanners.pickle_scanner import (
     ALWAYS_DANGEROUS_FUNCTIONS,
     ALWAYS_DANGEROUS_MODULES,
@@ -1439,6 +1439,27 @@ def test_direct_scan_delegates_zip_backed_pytorch_container(tmp_path: Path) -> N
 
     assert result.scanner_name == "pytorch_zip"
     assert any(issue.details.get("pickle_filename") == "data.pkl" for issue in result.issues)
+
+
+def test_pickle_scanner_delegates_jax_specific_patterns_for_jax_pickles(tmp_path: Path) -> None:
+    path = tmp_path / "jax_state.pickle"
+    path.write_bytes(
+        pickle.dumps(
+            {
+                "framework": "jax",
+                "payload": "jax.experimental.io_callback",
+            }
+        )
+    )
+
+    result = PickleScanner().scan(str(path))
+
+    assert any(
+        check.name == "JAX Pattern Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.details["pattern"] == r"jax\.experimental\.io_callback"
+        for check in result.checks
+    )
 
 
 def test_policy_compatibility_exports_cover_required_dangerous_symbols() -> None:

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -1509,13 +1509,15 @@ def test_pickle_scanner_delegates_late_jax_patterns_for_ckpt_suffixes(tmp_path: 
     )
 
 
-def test_pickle_scanner_suppresses_jax_truncation_warning_without_jax_context(tmp_path: Path) -> None:
+def test_pickle_scanner_reports_info_only_jax_truncation_without_jax_context(tmp_path: Path) -> None:
     path = tmp_path / "large-benign.pkl"
     path.write_bytes(pickle.dumps({"padding": "a" * 4096}))
 
     result = PickleScanner(config={"jax_pickle_max_scan_bytes": 1024}).scan(str(path))
 
-    assert not any(check.name == "Pickle Checkpoint Prefix Scan Limit" for check in result.checks)
+    prefix_limit_checks = [check for check in result.checks if check.name == "Pickle Checkpoint Prefix Scan Limit"]
+    assert len(prefix_limit_checks) == 1
+    assert prefix_limit_checks[0].severity == IssueSeverity.INFO
 
 
 def test_policy_compatibility_exports_cover_required_dangerous_symbols() -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -15,7 +15,7 @@ import pytest
 from modelaudit import core as core_module
 from modelaudit.cache import get_cache_manager, reset_cache_manager
 from modelaudit.core import scan_file
-from modelaudit.scanners.base import IssueSeverity, ScanResult
+from modelaudit.scanners.base import CheckStatus, IssueSeverity, ScanResult
 from tests.helpers import create_mock_gguf, create_mock_onnx, create_mock_pytorch_zip
 
 _SYSTEM_GLOBAL_NAMES = ("os.system", "posix.system", "nt.system")
@@ -617,6 +617,28 @@ def test_scan_file_routes_raw_pickle_torch_suffix_collisions_to_pickle(
 
     assert result.scanner_name == "pickle"
     assert result.success is True
+
+
+def test_scan_file_routes_jax_pickles_through_jax_specific_analysis(tmp_path: Path) -> None:
+    model_path = tmp_path / "state.pickle"
+    model_path.write_bytes(
+        pickle.dumps(
+            {
+                "framework": "jax",
+                "payload": "jax.experimental.io_callback",
+            }
+        )
+    )
+
+    result = scan_file(str(model_path), config={"cache_scan_results": False})
+
+    assert result.scanner_name == "pickle"
+    assert any(
+        check.name == "JAX Pattern Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.details["pattern"] == r"jax\.experimental\.io_callback"
+        for check in result.checks
+    )
 
 
 def test_scan_file_routes_raw_bin_without_zip_structure_to_pytorch_binary(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- preserve `pickle` as the owning scanner for raw pickle headers while layering in JAX-specific pattern checks for JAX-like pickle payloads
- reuse the JAX scanner's existing pickle text analysis on bytes the pickle scanner already read
- add direct and routed regressions for a JAX-only payload that previously stayed clean under normal dispatch

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_pickle_scanner.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_jax_checkpoint_scanner.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_core.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`