### PR TITLE
chore: preserve changelog additions during merges

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,7 @@
 
 # Vendored protobuf stubs are generated artifacts.
 modelaudit/protos/* linguist-generated=true
+
+# Changelogs are append-heavy; preserve concurrent additions during merges.
+CHANGELOG.md merge=union
+packages/modelaudit-picklescan/CHANGELOG.md merge=union


### PR DESCRIPTION
## Summary
- configure Git's union merge driver for the root changelog
- configure the same behavior for the standalone picklescan changelog

## Verification
- git check-attr merge -- CHANGELOG.md packages/modelaudit-picklescan/CHANGELOG.md