### PR TITLE
fix: preserve str.format lookup keys in picklescan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- avoid `str.format` picklescan false positives when a `ChainMap` shadows a `defaultdict`
 - preserve path-sensitive scan results while hashing duplicate directory contents
 - correct analysis suspiciousness scoring and alias-aware semantic risk handling
 - harden detector heuristics against comment padding, byte-backed credentials, unmarked Python blobs, and spoofed network context

--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -9,6 +9,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- avoid `str.format` false positives when a `ChainMap` shadows a `defaultdict`
 - detect dangerous positional lookups inside `str.format` replacement fields
 - recognize PyTorch ZIP archives that contain only hidden pickle members
 

--- a/packages/modelaudit-picklescan/rust/src/pybridge.rs
+++ b/packages/modelaudit-picklescan/rust/src/pybridge.rs
@@ -20,6 +20,7 @@ pub(crate) fn scan_bytes(
     let options = ScanOptions::from_py(options)?;
     let source = source.to_string();
     let started_at = Instant::now();
+    ScanState::set_runtime_python_minor_version(py.version_info().minor);
     let mut scan = ScanState::new(
         source,
         payload.as_ref(),

--- a/packages/modelaudit-picklescan/rust/src/state.rs
+++ b/packages/modelaudit-picklescan/rust/src/state.rs
@@ -1,6 +1,7 @@
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Instant;
 
 use crate::expansion::{
@@ -39,15 +40,16 @@ use crate::strings::{is_repeated_single_byte, suspicious_string_matches};
 const MIN_SUSPICIOUS_LITERAL_SCAN_WINDOW_CHARS: usize = 8192;
 const SUSPICIOUS_LITERAL_SCAN_OVERLAP_CHARS: usize = 4096;
 const MAX_STR_FORMAT_FIELD_NESTING: usize = 4;
+static RUNTIME_PYTHON_MINOR_VERSION: AtomicU8 = AtomicU8::new(13);
 const STR_FORMAT_DECIMAL_ZERO_CODEPOINTS: &[u32] = &[
     0x0030, 0x0660, 0x06F0, 0x07C0, 0x0966, 0x09E6, 0x0A66, 0x0AE6, 0x0B66, 0x0BE6, 0x0C66, 0x0CE6,
     0x0D66, 0x0DE6, 0x0E50, 0x0ED0, 0x0F20, 0x1040, 0x1090, 0x17E0, 0x1810, 0x1946, 0x19D0, 0x1A80,
     0x1A90, 0x1B50, 0x1BB0, 0x1C40, 0x1C50, 0xA620, 0xA8D0, 0xA900, 0xA9D0, 0xA9F0, 0xAA50, 0xABF0,
     0xFF10, 0x104A0, 0x10D30, 0x11066, 0x110F0, 0x11136, 0x111D0, 0x112F0, 0x11450, 0x114D0,
-    0x11650, 0x116C0, 0x11730, 0x118E0, 0x11950, 0x11C50, 0x11D50, 0x11DA0, 0x11F50, 0x16A60,
-    0x16AC0, 0x16B50, 0x1D7CE, 0x1D7D8, 0x1D7E2, 0x1D7EC, 0x1D7F6, 0x1E140, 0x1E2F0, 0x1E4F0,
-    0x1E950, 0x1FBF0,
+    0x11650, 0x116C0, 0x11730, 0x118E0, 0x11950, 0x11C50, 0x11D50, 0x11DA0, 0x16A60, 0x16B50,
+    0x1D7CE, 0x1D7D8, 0x1D7E2, 0x1D7EC, 0x1D7F6, 0x1E140, 0x1E2F0, 0x1E950, 0x1FBF0,
 ];
+const PYTHON_3_12_PLUS_STR_FORMAT_DECIMAL_ZERO_CODEPOINTS: &[u32] = &[0x11F50, 0x16AC0, 0x1E4F0];
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum FormatFieldNumbering {
@@ -466,6 +468,10 @@ pub(crate) struct ScanState<'a> {
 }
 
 impl<'a> ScanState<'a> {
+    pub(crate) fn set_runtime_python_minor_version(minor: u8) {
+        RUNTIME_PYTHON_MINOR_VERSION.store(minor, Ordering::Relaxed);
+    }
+
     pub(crate) fn new(
         source: String,
         payload: &'a [u8],
@@ -2271,7 +2277,27 @@ impl<'a> ScanState<'a> {
 
     fn str_format_decimal_digit_value(ch: char) -> Option<u32> {
         let codepoint = ch as u32;
-        STR_FORMAT_DECIMAL_ZERO_CODEPOINTS.iter().find_map(|zero| {
+        Self::str_format_decimal_digit_value_in_ranges(
+            codepoint,
+            STR_FORMAT_DECIMAL_ZERO_CODEPOINTS,
+        )
+        .or_else(|| {
+            (RUNTIME_PYTHON_MINOR_VERSION.load(Ordering::Relaxed) >= 12)
+                .then(|| {
+                    Self::str_format_decimal_digit_value_in_ranges(
+                        codepoint,
+                        PYTHON_3_12_PLUS_STR_FORMAT_DECIMAL_ZERO_CODEPOINTS,
+                    )
+                })
+                .flatten()
+        })
+    }
+
+    fn str_format_decimal_digit_value_in_ranges(
+        codepoint: u32,
+        zero_codepoints: &[u32],
+    ) -> Option<u32> {
+        zero_codepoints.iter().find_map(|zero| {
             (codepoint >= *zero && codepoint < *zero + 10).then_some(codepoint - *zero)
         })
     }

--- a/packages/modelaudit-picklescan/rust/src/state.rs
+++ b/packages/modelaudit-picklescan/rust/src/state.rs
@@ -55,6 +55,11 @@ enum FormatFieldNumbering {
     Auto,
     Manual,
 }
+
+enum StrFormatRootItemLookup<'a> {
+    Invalid,
+    Key(Option<&'a str>),
+}
 const TIME_CHECK_INTERVAL_OPCODES: usize = 4096;
 const MAX_IMPORT_REFERENCES: usize = 10_000;
 
@@ -2203,10 +2208,11 @@ impl<'a> ScanState<'a> {
 
         if has_item_lookup {
             if let Some(index) = positional_index {
-                lookups.push((
-                    index,
-                    Self::str_format_root_item_key(field_name, root_end).map(str::to_string),
-                ));
+                if let StrFormatRootItemLookup::Key(key) =
+                    Self::str_format_root_item_key(field_name, root_end)
+                {
+                    lookups.push((index, key.map(str::to_string)));
+                }
             }
         }
 
@@ -2222,13 +2228,26 @@ impl<'a> ScanState<'a> {
         Some(())
     }
 
-    fn str_format_root_item_key(field_name: &str, root_end: usize) -> Option<&str> {
-        let suffix = field_name.get(root_end..)?;
-        let key = suffix.strip_prefix('[')?.split_once(']')?.0;
-        if key.is_empty() || Self::parse_str_format_decimal_index(key).is_some() {
-            None
+    fn str_format_root_item_key(field_name: &str, root_end: usize) -> StrFormatRootItemLookup<'_> {
+        let Some(suffix) = field_name.get(root_end..) else {
+            return StrFormatRootItemLookup::Invalid;
+        };
+        let Some((key, _)) = suffix
+            .strip_prefix('[')
+            .and_then(|value| value.split_once(']'))
+        else {
+            return StrFormatRootItemLookup::Invalid;
+        };
+        if key.is_empty() {
+            StrFormatRootItemLookup::Key(None)
+        } else if Self::is_str_format_decimal_syntax(key) {
+            if Self::parse_str_format_decimal_index(key).is_some() {
+                StrFormatRootItemLookup::Key(None)
+            } else {
+                StrFormatRootItemLookup::Invalid
+            }
         } else {
-            Some(key)
+            StrFormatRootItemLookup::Key(Some(key))
         }
     }
 
@@ -2240,7 +2259,14 @@ impl<'a> ScanState<'a> {
             let digit = usize::try_from(Self::str_format_decimal_digit_value(ch)?).ok()?;
             index = index.checked_mul(10)?.checked_add(digit)?;
         }
-        Some(index)
+        (index <= isize::MAX as usize).then_some(index)
+    }
+
+    fn is_str_format_decimal_syntax(value: &str) -> bool {
+        !value.is_empty()
+            && value
+                .chars()
+                .all(|ch| Self::str_format_decimal_digit_value(ch).is_some())
     }
 
     fn str_format_decimal_digit_value(ch: char) -> Option<u32> {

--- a/packages/modelaudit-picklescan/rust/src/state.rs
+++ b/packages/modelaudit-picklescan/rust/src/state.rs
@@ -2047,12 +2047,12 @@ impl<'a> ScanState<'a> {
         let Some(format_string) = resolve_global_operand(arguments.first(), self.payload) else {
             return invocations;
         };
-        let lookup_indices = Self::str_format_positional_lookup_indices(&format_string);
+        let lookups = Self::str_format_positional_lookups(&format_string);
 
-        for index in lookup_indices {
+        for (index, key) in lookups {
             invocations.extend(self.mapping_lookup_invocations(
                 arguments.get(index + 1),
-                None,
+                key.as_deref(),
                 op_name,
                 position,
             ));
@@ -2060,18 +2060,18 @@ impl<'a> ScanState<'a> {
         invocations
     }
 
-    fn str_format_positional_lookup_indices(format_string: &str) -> Vec<usize> {
+    fn str_format_positional_lookups(format_string: &str) -> Vec<(usize, Option<String>)> {
         let mut numbering = FormatFieldNumbering::Unset;
         let mut next_auto_index = 0;
-        let mut lookup_indices = Vec::new();
+        let mut lookups = Vec::new();
         let _ = Self::collect_str_format_lookup_indices(
             format_string,
             0,
             &mut numbering,
             &mut next_auto_index,
-            &mut lookup_indices,
+            &mut lookups,
         );
-        lookup_indices
+        lookups
     }
 
     fn collect_str_format_lookup_indices(
@@ -2079,7 +2079,7 @@ impl<'a> ScanState<'a> {
         depth: usize,
         numbering: &mut FormatFieldNumbering,
         next_auto_index: &mut usize,
-        lookup_indices: &mut Vec<usize>,
+        lookups: &mut Vec<(usize, Option<String>)>,
     ) -> Option<()> {
         if depth > MAX_STR_FORMAT_FIELD_NESTING {
             return Some(());
@@ -2100,7 +2100,7 @@ impl<'a> ScanState<'a> {
                         depth,
                         numbering,
                         next_auto_index,
-                        lookup_indices,
+                        lookups,
                     )?;
                     cursor = next_cursor;
                 }
@@ -2146,7 +2146,7 @@ impl<'a> ScanState<'a> {
         depth: usize,
         numbering: &mut FormatFieldNumbering,
         next_auto_index: &mut usize,
-        lookup_indices: &mut Vec<usize>,
+        lookups: &mut Vec<(usize, Option<String>)>,
     ) -> Option<()> {
         let bytes = field.as_bytes();
         let mut delimiter_index = bytes.len();
@@ -2194,7 +2194,10 @@ impl<'a> ScanState<'a> {
 
         if has_item_lookup {
             if let Some(index) = positional_index {
-                lookup_indices.push(index);
+                lookups.push((
+                    index,
+                    Self::str_format_root_item_key(field_name, root_end).map(str::to_string),
+                ));
             }
         }
 
@@ -2204,10 +2207,20 @@ impl<'a> ScanState<'a> {
                 depth + 1,
                 numbering,
                 next_auto_index,
-                lookup_indices,
+                lookups,
             )?;
         }
         Some(())
+    }
+
+    fn str_format_root_item_key(field_name: &str, root_end: usize) -> Option<&str> {
+        let suffix = field_name.get(root_end..)?;
+        let key = suffix.strip_prefix('[')?.split_once(']')?.0;
+        if key.is_empty() || key.bytes().all(|byte| byte.is_ascii_digit()) {
+            None
+        } else {
+            Some(key)
+        }
     }
 
     fn str_format_map_invocations(

--- a/packages/modelaudit-picklescan/rust/src/state.rs
+++ b/packages/modelaudit-picklescan/rust/src/state.rs
@@ -39,6 +39,15 @@ use crate::strings::{is_repeated_single_byte, suspicious_string_matches};
 const MIN_SUSPICIOUS_LITERAL_SCAN_WINDOW_CHARS: usize = 8192;
 const SUSPICIOUS_LITERAL_SCAN_OVERLAP_CHARS: usize = 4096;
 const MAX_STR_FORMAT_FIELD_NESTING: usize = 4;
+const STR_FORMAT_DECIMAL_ZERO_CODEPOINTS: &[u32] = &[
+    0x0030, 0x0660, 0x06F0, 0x07C0, 0x0966, 0x09E6, 0x0A66, 0x0AE6, 0x0B66, 0x0BE6, 0x0C66, 0x0CE6,
+    0x0D66, 0x0DE6, 0x0E50, 0x0ED0, 0x0F20, 0x1040, 0x1090, 0x17E0, 0x1810, 0x1946, 0x19D0, 0x1A80,
+    0x1A90, 0x1B50, 0x1BB0, 0x1C40, 0x1C50, 0xA620, 0xA8D0, 0xA900, 0xA9D0, 0xA9F0, 0xAA50, 0xABF0,
+    0xFF10, 0x104A0, 0x10D30, 0x11066, 0x110F0, 0x11136, 0x111D0, 0x112F0, 0x11450, 0x114D0,
+    0x11650, 0x116C0, 0x11730, 0x118E0, 0x11950, 0x11C50, 0x11D50, 0x11DA0, 0x11F50, 0x16A60,
+    0x16AC0, 0x16B50, 0x1D7CE, 0x1D7D8, 0x1D7E2, 0x1D7EC, 0x1D7F6, 0x1E140, 0x1E2F0, 0x1E4F0,
+    0x1E950, 0x1FBF0,
+];
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum FormatFieldNumbering {
@@ -2182,12 +2191,12 @@ impl<'a> ScanState<'a> {
             let index = *next_auto_index;
             *next_auto_index += 1;
             Some(index)
-        } else if root.bytes().all(|byte| byte.is_ascii_digit()) {
+        } else if let Some(index) = Self::parse_str_format_decimal_index(root) {
             if *numbering == FormatFieldNumbering::Auto {
                 return None;
             }
             *numbering = FormatFieldNumbering::Manual;
-            root.parse::<usize>().ok()
+            Some(index)
         } else {
             None
         };
@@ -2216,11 +2225,29 @@ impl<'a> ScanState<'a> {
     fn str_format_root_item_key(field_name: &str, root_end: usize) -> Option<&str> {
         let suffix = field_name.get(root_end..)?;
         let key = suffix.strip_prefix('[')?.split_once(']')?.0;
-        if key.is_empty() || key.bytes().all(|byte| byte.is_ascii_digit()) {
+        if key.is_empty() || Self::parse_str_format_decimal_index(key).is_some() {
             None
         } else {
             Some(key)
         }
+    }
+
+    fn parse_str_format_decimal_index(value: &str) -> Option<usize> {
+        let mut chars = value.chars();
+        let first = chars.next()?;
+        let mut index = usize::try_from(Self::str_format_decimal_digit_value(first)?).ok()?;
+        for ch in chars {
+            let digit = usize::try_from(Self::str_format_decimal_digit_value(ch)?).ok()?;
+            index = index.checked_mul(10)?.checked_add(digit)?;
+        }
+        Some(index)
+    }
+
+    fn str_format_decimal_digit_value(ch: char) -> Option<u32> {
+        let codepoint = ch as u32;
+        STR_FORMAT_DECIMAL_ZERO_CODEPOINTS.iter().find_map(|zero| {
+            (codepoint >= *zero && codepoint < *zero + 10).then_some(codepoint - *zero)
+        })
     }
 
     fn str_format_map_invocations(

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -6550,6 +6550,141 @@ if marker.read_text() != marker_content:
     assert marker.read_text() == marker_content
 
 
+def test_scan_bytes_keeps_str_format_oversized_decimal_chainmap_lookup_clean(tmp_path: Path) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    marker = tmp_path / "str_format_oversized_decimal_chainmap_marker"
+    oversized_decimal_key = str(2**64)
+    (module_dir / "pydoc.py").write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text('pydoc-owned')\n"
+        "def help(*args, **kwargs):\n"
+        "    return 'factory-value'\n",
+        encoding="utf-8",
+    )
+    payload = _chainmap_defaultdict_str_format_payload(
+        key=oversized_decimal_key,
+        format_string=f"{{0[{oversized_decimal_key}]}}",
+    )
+
+    report = scan_bytes(payload, source="str-format-oversized-decimal-chainmap-clean.pkl")
+
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert not any(
+        invocation.get("module") == "builtins"
+        and invocation.get("name") == "help"
+        and invocation.get("positional_arg_count") == 0
+        for invocation in report.metadata.get("callable_invocations", [])
+    )
+
+    assert not marker.exists()
+    child_code = """
+import pickle
+import sys
+from pathlib import Path
+
+module_dir = Path(sys.argv[1])
+marker = Path(sys.argv[2])
+payload = bytes.fromhex(sys.argv[3])
+
+sys.path.insert(0, str(module_dir))
+sys.modules.pop("pydoc", None)
+try:
+    pickle.loads(payload)
+except ValueError as exc:
+    if str(exc) != "Too many decimal digits in format string":
+        raise
+else:
+    raise SystemExit("expected oversized decimal field to raise ValueError")
+if marker.exists():
+    raise SystemExit("default factory unexpectedly imported pydoc")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", child_code, str(module_dir), str(marker), payload.hex()],
+        cwd=str(tmp_path.parent),
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert not marker.exists()
+
+
+def test_scan_bytes_blocks_str_format_newer_unicode_decimal_chainmap_lookup_rce(tmp_path: Path) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    marker = tmp_path / "str_format_newer_unicode_decimal_chainmap_marker"
+    marker_content = "pydoc-owned"
+    newer_decimal_key = "\U00011f50"
+    (module_dir / "pydoc.py").write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text({marker_content!r})\n"
+        "def help(*args, **kwargs):\n"
+        "    return 'factory-value'\n",
+        encoding="utf-8",
+    )
+    payload = _chainmap_defaultdict_str_format_payload(
+        key=newer_decimal_key,
+        format_string=f"{{0[{newer_decimal_key}]}}",
+    )
+
+    report = scan_bytes(payload, source="str-format-newer-unicode-decimal-chainmap-rce.pkl")
+
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert _has_critical_call_graph_finding(
+        report,
+        "_sitebuiltins",
+        "_Helper.__call__",
+        "builtins.__import__",
+    )
+    assert any(
+        invocation.get("module") == "builtins"
+        and invocation.get("name") == "help"
+        and invocation.get("positional_arg_count") == 0
+        for invocation in report.metadata.get("callable_invocations", [])
+    )
+
+    assert not marker.exists()
+    if sys.version_info < (3, 12):
+        return
+
+    child_code = """
+import pickle
+import sys
+from pathlib import Path
+
+module_dir = Path(sys.argv[1])
+marker = Path(sys.argv[2])
+payload = bytes.fromhex(sys.argv[3])
+marker_content = sys.argv[4]
+
+if marker.exists():
+    raise SystemExit("marker already exists before pickle execution")
+sys.path.insert(0, str(module_dir))
+sys.modules.pop("pydoc", None)
+result = pickle.loads(payload)
+if result != "factory-value":
+    raise SystemExit(f"expected factory value result, got {result!r}")
+if not marker.exists():
+    raise SystemExit("marker was not written")
+if marker.read_text() != marker_content:
+    raise SystemExit("marker content mismatch")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", child_code, str(module_dir), str(marker), payload.hex(), marker_content],
+        cwd=str(tmp_path.parent),
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert marker.read_text() == marker_content
+
+
 def test_scan_bytes_keeps_format_map_defaultdict_bytes_receiver_clean() -> None:
     payload = _builtins_help_defaultdict_format_map_payload(
         lookup=True,

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -892,6 +892,34 @@ def _chainmap_shadowed_defaultdict_getitem_payload() -> bytes:
     )
 
 
+def _chainmap_shadowed_defaultdict_str_format_payload() -> bytes:
+    return b"".join(
+        [
+            b"\x80\x04",
+            b"}",
+            b"\x94",
+            _unicode_operand("present"),
+            _unicode_operand("safe"),
+            b"s",
+            b"0",
+            _global_operand("collections", "defaultdict"),
+            _global_operand("builtins", "help"),
+            b"\x85R",
+            b"\x94",
+            b"0",
+            _global_operand("collections", "ChainMap"),
+            b"h\x00",
+            b"h\x01",
+            b"\x86R",
+            b"\x94",
+            b"0",
+            _global_operand("builtins", "str.format"),
+            _args_tuple(_unicode_operand("{0[present]}"), b"h\x02"),
+            b"R.",
+        ]
+    )
+
+
 def _deep_mapping_proxy_defaultdict_getitem_payload(depth: int) -> bytes:
     if not 1 <= depth <= 255:
         raise ValueError("depth must fit one-byte memo references")
@@ -6401,6 +6429,59 @@ def test_scan_bytes_keeps_non_lookup_str_format_defaultdict_cases_clean(
         and invocation.get("positional_arg_count") == 0
         for invocation in report.metadata.get("callable_invocations", [])
     )
+
+
+def test_scan_bytes_keeps_str_format_chainmap_shadowed_defaultdict_lookup_clean(tmp_path: Path) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    marker = tmp_path / "str_format_chainmap_shadowed_defaultdict_marker"
+    (module_dir / "pydoc.py").write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text('pydoc-owned')\n"
+        "def help(*args, **kwargs):\n"
+        "    return 'factory-value'\n",
+        encoding="utf-8",
+    )
+    payload = _chainmap_shadowed_defaultdict_str_format_payload()
+
+    report = scan_bytes(payload, source="str-format-chainmap-shadowed-defaultdict-lookup.pkl")
+
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert not any(
+        invocation.get("module") == "builtins"
+        and invocation.get("name") == "help"
+        and invocation.get("positional_arg_count") == 0
+        for invocation in report.metadata.get("callable_invocations", [])
+    )
+
+    child_code = """
+import pickle
+import sys
+from pathlib import Path
+
+module_dir = Path(sys.argv[1])
+marker = Path(sys.argv[2])
+payload = bytes.fromhex(sys.argv[3])
+
+sys.path.insert(0, str(module_dir))
+sys.modules.pop("pydoc", None)
+result = pickle.loads(payload)
+if result != "safe":
+    raise SystemExit(f"expected shadowed ChainMap value, got {result!r}")
+if marker.exists():
+    raise SystemExit("default factory unexpectedly imported pydoc")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", child_code, str(module_dir), str(marker), payload.hex()],
+        cwd=str(tmp_path.parent),
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert not marker.exists()
 
 
 def test_scan_bytes_keeps_format_map_defaultdict_bytes_receiver_clean() -> None:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -892,13 +892,13 @@ def _chainmap_shadowed_defaultdict_getitem_payload() -> bytes:
     )
 
 
-def _chainmap_shadowed_defaultdict_str_format_payload() -> bytes:
+def _chainmap_defaultdict_str_format_payload(*, key: str, format_string: str) -> bytes:
     return b"".join(
         [
             b"\x80\x04",
             b"}",
             b"\x94",
-            _unicode_operand("present"),
+            _unicode_operand(key),
             _unicode_operand("safe"),
             b"s",
             b"0",
@@ -914,7 +914,7 @@ def _chainmap_shadowed_defaultdict_str_format_payload() -> bytes:
             b"\x94",
             b"0",
             _global_operand("builtins", "str.format"),
-            _args_tuple(_unicode_operand("{0[present]}"), b"h\x02"),
+            _args_tuple(_unicode_operand(format_string), b"h\x02"),
             b"R.",
         ]
     )
@@ -6442,7 +6442,7 @@ def test_scan_bytes_keeps_str_format_chainmap_shadowed_defaultdict_lookup_clean(
         "    return 'factory-value'\n",
         encoding="utf-8",
     )
-    payload = _chainmap_shadowed_defaultdict_str_format_payload()
+    payload = _chainmap_defaultdict_str_format_payload(key="present", format_string="{0[present]}")
 
     report = scan_bytes(payload, source="str-format-chainmap-shadowed-defaultdict-lookup.pkl")
 
@@ -6482,6 +6482,72 @@ if marker.exists():
     )
     assert result.returncode == 0, result.stderr
     assert not marker.exists()
+
+
+def test_scan_bytes_blocks_str_format_unicode_decimal_chainmap_lookup_rce(tmp_path: Path) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    marker = tmp_path / "str_format_unicode_decimal_chainmap_marker"
+    marker_content = "pydoc-owned"
+    (module_dir / "pydoc.py").write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text({marker_content!r})\n"
+        "def help(*args, **kwargs):\n"
+        "    return 'factory-value'\n",
+        encoding="utf-8",
+    )
+    payload = _chainmap_defaultdict_str_format_payload(key="١٢", format_string="{0[١٢]}")
+
+    report = scan_bytes(payload, source="str-format-unicode-decimal-chainmap-rce.pkl")
+
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert _has_critical_call_graph_finding(
+        report,
+        "_sitebuiltins",
+        "_Helper.__call__",
+        "builtins.__import__",
+    )
+    assert any(
+        invocation.get("module") == "builtins"
+        and invocation.get("name") == "help"
+        and invocation.get("positional_arg_count") == 0
+        for invocation in report.metadata.get("callable_invocations", [])
+    )
+
+    assert not marker.exists()
+    child_code = """
+import pickle
+import sys
+from pathlib import Path
+
+module_dir = Path(sys.argv[1])
+marker = Path(sys.argv[2])
+payload = bytes.fromhex(sys.argv[3])
+marker_content = sys.argv[4]
+
+if marker.exists():
+    raise SystemExit("marker already exists before pickle execution")
+sys.path.insert(0, str(module_dir))
+sys.modules.pop("pydoc", None)
+result = pickle.loads(payload)
+if result != "factory-value":
+    raise SystemExit(f"expected factory value result, got {result!r}")
+if not marker.exists():
+    raise SystemExit("marker was not written")
+if marker.read_text() != marker_content:
+    raise SystemExit("marker content mismatch")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", child_code, str(module_dir), str(marker), payload.hex(), marker_content],
+        cwd=str(tmp_path.parent),
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert marker.read_text() == marker_content
 
 
 def test_scan_bytes_keeps_format_map_defaultdict_bytes_receiver_clean() -> None:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -6612,6 +6612,7 @@ if marker.exists():
     assert not marker.exists()
 
 
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="newer Unicode decimal digit is unsupported before Python 3.12")
 def test_scan_bytes_blocks_str_format_newer_unicode_decimal_chainmap_lookup_rce(tmp_path: Path) -> None:
     module_dir = tmp_path / "modules"
     module_dir.mkdir()
@@ -6646,6 +6647,64 @@ def test_scan_bytes_blocks_str_format_newer_unicode_decimal_chainmap_lookup_rce(
         for invocation in report.metadata.get("callable_invocations", [])
     )
 
+    assert not marker.exists()
+
+
+@pytest.mark.skipif(sys.version_info >= (3, 12), reason="newer Unicode decimal digit is supported from Python 3.12")
+def test_scan_bytes_keeps_str_format_newer_unicode_decimal_chainmap_lookup_clean(tmp_path: Path) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    marker = tmp_path / "str_format_newer_unicode_decimal_chainmap_clean_marker"
+    newer_decimal_key = "\U00011f50"
+    (module_dir / "pydoc.py").write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text('pydoc-owned')\n"
+        "def help(*args, **kwargs):\n"
+        "    return 'factory-value'\n",
+        encoding="utf-8",
+    )
+    payload = _chainmap_defaultdict_str_format_payload(
+        key=newer_decimal_key,
+        format_string=f"{{0[{newer_decimal_key}]}}",
+    )
+
+    report = scan_bytes(payload, source="str-format-newer-unicode-decimal-chainmap-clean.pkl")
+
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert not any(
+        invocation.get("module") == "builtins"
+        and invocation.get("name") == "help"
+        and invocation.get("positional_arg_count") == 0
+        for invocation in report.metadata.get("callable_invocations", [])
+    )
+
+    child_code = """
+import pickle
+import sys
+from pathlib import Path
+
+module_dir = Path(sys.argv[1])
+marker = Path(sys.argv[2])
+payload = bytes.fromhex(sys.argv[3])
+
+sys.path.insert(0, str(module_dir))
+sys.modules.pop("pydoc", None)
+result = pickle.loads(payload)
+if result != "safe":
+    raise SystemExit(f"expected shadowed ChainMap value, got {result!r}")
+if marker.exists():
+    raise SystemExit("default factory unexpectedly imported pydoc")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", child_code, str(module_dir), str(marker), payload.hex()],
+        cwd=str(tmp_path.parent),
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
     assert not marker.exists()
 
 

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -6647,9 +6647,26 @@ def test_scan_bytes_blocks_str_format_newer_unicode_decimal_chainmap_lookup_rce(
     )
 
     assert not marker.exists()
-    if sys.version_info < (3, 12):
-        return
 
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="newer Unicode decimal digit is unsupported before Python 3.12")
+def test_scan_bytes_runtime_blocks_str_format_newer_unicode_decimal_chainmap_lookup_rce(tmp_path: Path) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    marker = tmp_path / "str_format_newer_unicode_decimal_chainmap_runtime_marker"
+    marker_content = "pydoc-owned"
+    newer_decimal_key = "\U00011f50"
+    (module_dir / "pydoc.py").write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text({marker_content!r})\n"
+        "def help(*args, **kwargs):\n"
+        "    return 'factory-value'\n",
+        encoding="utf-8",
+    )
+    payload = _chainmap_defaultdict_str_format_payload(
+        key=newer_decimal_key,
+        format_string=f"{{0[{newer_decimal_key}]}}",
+    )
     child_code = """
 import pickle
 import sys


### PR DESCRIPTION
## Summary
- preserve explicit root item keys while modeling str.format positional lookups
- let ChainMap shadowing suppress unreachable defaultdict factories
- add a runtime-proof regression for the clean shadowed-mapping case

## Validation
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py -k "str_format_chainmap_shadowed_defaultdict_lookup_clean or blocks_str_format_defaultdict_factory_rce or non_lookup_str_format_defaultdict_cases_clean"
- cargo fmt --check --manifest-path packages/modelaudit-picklescan/Cargo.toml
- cargo clippy --manifest-path packages/modelaudit-picklescan/Cargo.toml --all-targets -- -D warnings
- cargo test --manifest-path packages/modelaudit-picklescan/Cargo.toml
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1