### PR TITLE
fix: keep inert dotted global metadata clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- avoid picklescan false positives for inert metadata under dangerous dotted globals
 - preserve path-sensitive scan results while hashing duplicate directory contents
 - correct analysis suspiciousness scoring and alias-aware semantic risk handling
 - harden detector heuristics against comment padding, byte-backed credentials, unmarked Python blobs, and spoofed network context

--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -9,6 +9,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- avoid false positives for inert metadata under dangerous dotted globals
 - detect dangerous positional lookups inside `str.format` replacement fields
 - recognize PyTorch ZIP archives that contain only hidden pickle members
 

--- a/packages/modelaudit-picklescan/rust/src/policy.rs
+++ b/packages/modelaudit-picklescan/rust/src/policy.rs
@@ -46,6 +46,9 @@ fn strip_wrapper_global_suffix(name: &str) -> Option<&str> {
 fn dangerous_global_prefix_severity(module: &str, name: &str) -> Option<&'static str> {
     let parts = name.split('.').collect::<Vec<_>>();
     for split in 1..parts.len() {
+        if is_inert_global_metadata_tail(&parts[split..]) {
+            continue;
+        }
         let candidate = parts[..split].join(".");
         if let Some(severity) = direct_global_severity_without_wrapper_alias(module, &candidate)
             .or_else(|| wrapper_global_alias_severity(module, &candidate))
@@ -54,6 +57,13 @@ fn dangerous_global_prefix_severity(module: &str, name: &str) -> Option<&'static
         }
     }
     None
+}
+
+fn is_inert_global_metadata_tail(parts: &[&str]) -> bool {
+    matches!(
+        parts,
+        ["__doc__"] | ["__name__"] | ["__module__"] | ["__qualname__"]
+    )
 }
 
 fn direct_global_severity_without_wrapper_alias(module: &str, name: &str) -> Option<&'static str> {
@@ -665,6 +675,18 @@ mod tests {
         );
         assert_eq!(global_severity("statistics", "mean.__self__"), None);
         assert_eq!(global_severity("statistics", "mean.subclasses"), None);
+        for name in [
+            "eval.__doc__",
+            "eval.__name__",
+            "eval.__module__",
+            "eval.__qualname__",
+        ] {
+            assert_eq!(global_severity("builtins", name), None);
+        }
+        assert_eq!(
+            global_severity("builtins", "eval.__repr__.__self__"),
+            Some("critical")
+        );
         assert_eq!(global_severity("os.path", "__call__"), None);
         assert_eq!(global_severity("os.path", "__get__"), None);
         assert_eq!(global_severity("os.path", "__get__.__self__"), None);

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -2191,6 +2191,20 @@ def test_scan_bytes_can_decode_stack_global_from_memoized_operands() -> None:
     assert any("posix.system" in finding.message for finding in report.findings)
 
 
+@pytest.mark.parametrize(
+    "name",
+    ["eval.__doc__", "eval.__name__", "eval.__module__", "eval.__qualname__"],
+)
+def test_scan_bytes_keeps_stack_global_metadata_attributes_clean(name: str) -> None:
+    payload = b"\x80\x04" + _short_binunicode(b"builtins") + _short_binunicode(name.encode()) + b"\x93."
+
+    report = scan_bytes(payload, source=f"{name}.pkl")
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert report.findings == ()
+
+
 def test_scan_bytes_warns_on_functools_partial_without_marking_benign_partial_malicious() -> None:
     payload = pickle.dumps(functools.partial(int, base=10), protocol=4)
 


### PR DESCRIPTION
## Summary
- keep exact inert metadata tails such as eval.__doc__ from inheriting dangerous-prefix severity
- preserve the existing wrapper-alias behavior for callable recovery paths like eval.__repr__.__self__
- add scanner-level clean regressions for safe builtins metadata globals

## Validation
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest packages/modelaudit-picklescan/tests/test_api.py -k "stack_global_metadata_attributes_clean or can_decode_stack_global_from_memoized_operands"
- cargo fmt --check --manifest-path packages/modelaudit-picklescan/Cargo.toml
- cargo clippy --manifest-path packages/modelaudit-picklescan/Cargo.toml --all-targets -- -D warnings
- cargo test --manifest-path packages/modelaudit-picklescan/Cargo.toml
- uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1