### PR TITLE
fix: detect nested brace-format mapping lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- detect nested brace-format lookups that reach tracked `defaultdict` factories
 - avoid `str.format` picklescan false positives when a `ChainMap` shadows a `defaultdict`
 - block additional eager `statistics` consumers in picklescan call-graph analysis
 - avoid picklescan false positives for inert metadata under dangerous dotted globals

--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -9,6 +9,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- detect nested brace-format lookups that reach tracked `defaultdict` factories
 - avoid `str.format` false positives when a `ChainMap` shadows a `defaultdict`
 - block additional eager `statistics` consumers in call-graph analysis
 - avoid false positives for inert metadata under dangerous dotted globals

--- a/packages/modelaudit-picklescan/rust/src/stack.rs
+++ b/packages/modelaudit-picklescan/rust/src/stack.rs
@@ -58,7 +58,7 @@ pub(crate) enum StackValue {
         default_factory: GlobalRef,
     },
     TrackedDict {
-        keys: Vec<String>,
+        entries: Vec<(String, StackValue)>,
         memo_index: Option<i64>,
     },
     MappingWrapper {
@@ -116,8 +116,10 @@ pub(crate) fn operand_preview(value: Option<&StackValue>) -> String {
         Some(StackValue::DefaultDict { default_factory }) => {
             format!("defaultdict(factory={})", default_factory.symbol())
         }
-        Some(StackValue::TrackedDict { keys, .. }) if keys.is_empty() => "dict:{}".to_string(),
-        Some(StackValue::TrackedDict { keys, .. }) => format!("dict(keys={})", keys.len()),
+        Some(StackValue::TrackedDict { entries, .. }) if entries.is_empty() => {
+            "dict:{}".to_string()
+        }
+        Some(StackValue::TrackedDict { entries, .. }) => format!("dict(keys={})", entries.len()),
         Some(StackValue::MappingWrapper {
             reference,
             mappings,
@@ -221,8 +223,8 @@ pub(crate) fn stack_value_preview(value: &StackValue, depth: usize) -> String {
         StackValue::DefaultDict { default_factory } => {
             format!("defaultdict(factory={})", default_factory.symbol())
         }
-        StackValue::TrackedDict { keys, .. } if keys.is_empty() => "dict:{}".to_string(),
-        StackValue::TrackedDict { keys, .. } => format!("dict(keys={})", keys.len()),
+        StackValue::TrackedDict { entries, .. } if entries.is_empty() => "dict:{}".to_string(),
+        StackValue::TrackedDict { entries, .. } => format!("dict(keys={})", entries.len()),
         StackValue::MappingWrapper {
             reference,
             mappings,

--- a/packages/modelaudit-picklescan/rust/src/state.rs
+++ b/packages/modelaudit-picklescan/rust/src/state.rs
@@ -58,9 +58,9 @@ enum FormatFieldNumbering {
     Manual,
 }
 
-enum StrFormatRootItemLookup<'a> {
+enum StrFormatRootItemLookup {
     Invalid,
-    Key(Option<&'a str>),
+    Path(Vec<Option<String>>),
 }
 const TIME_CHECK_INTERVAL_OPCODES: usize = 4096;
 const MAX_IMPORT_REFERENCES: usize = 10_000;
@@ -883,7 +883,7 @@ impl<'a> ScanState<'a> {
             }
             "EMPTY_DICT" => {
                 self.stack.push(StackValue::TrackedDict {
-                    keys: Vec::new(),
+                    entries: Vec::new(),
                     memo_index: None,
                 });
             }
@@ -1253,61 +1253,76 @@ impl<'a> ScanState<'a> {
     }
 
     fn apply_setitem(&mut self) {
-        let _value = self.pop_value_operand_preserving_mark();
+        let value = self.pop_value_operand_preserving_mark();
         let key = self.pop_value_operand_preserving_mark();
-        if let Some(key) = key
-            .as_ref()
-            .and_then(|value| stack_value_string(value, self.payload))
-        {
-            self.record_top_tracked_dict_key(key.as_ref());
+        if let (Some(key), Some(value)) = (
+            key.as_ref()
+                .and_then(|value| stack_value_string(value, self.payload)),
+            value,
+        ) {
+            self.record_top_tracked_dict_entry(key.as_ref(), value);
         }
     }
 
     fn apply_setitems(&mut self, values: &[StackValue]) {
         for pair in values.chunks_exact(2) {
-            if let Some(key) = pair
-                .first()
-                .and_then(|value| stack_value_string(value, self.payload))
-            {
-                self.record_top_tracked_dict_key(key.as_ref());
+            if let (Some(key), Some(value)) = (
+                pair.first()
+                    .and_then(|value| stack_value_string(value, self.payload)),
+                pair.get(1),
+            ) {
+                self.record_top_tracked_dict_entry(key.as_ref(), value.clone());
             }
         }
     }
 
     fn tracked_dict_from_values(&self, values: &[StackValue]) -> StackValue {
-        let mut keys = Vec::new();
+        let mut entries = Vec::new();
         for pair in values.chunks_exact(2) {
-            if let Some(key) = pair
-                .first()
-                .and_then(|value| stack_value_string(value, self.payload))
-            {
-                Self::insert_tracked_dict_key(&mut keys, key);
+            if let (Some(key), Some(value)) = (
+                pair.first()
+                    .and_then(|value| stack_value_string(value, self.payload)),
+                pair.get(1),
+            ) {
+                Self::insert_tracked_dict_entry(&mut entries, key, value.clone());
             }
         }
         StackValue::TrackedDict {
-            keys,
+            entries,
             memo_index: None,
         }
     }
 
-    fn record_top_tracked_dict_key(&mut self, key: &str) {
+    fn record_top_tracked_dict_entry(&mut self, key: &str, value: StackValue) {
         let memo_index = match self.stack.last_mut() {
-            Some(StackValue::TrackedDict { keys, memo_index }) => {
-                Self::insert_tracked_dict_key(keys, key.to_string());
+            Some(StackValue::TrackedDict {
+                entries,
+                memo_index,
+            }) => {
+                Self::insert_tracked_dict_entry(entries, key.to_string(), value.clone());
                 *memo_index
             }
             _ => None,
         };
         if let Some(memo_index) = memo_index {
-            if let Some(StackValue::TrackedDict { keys, .. }) = self.memo.get_mut(&memo_index) {
-                Self::insert_tracked_dict_key(keys, key.to_string());
+            if let Some(StackValue::TrackedDict { entries, .. }) = self.memo.get_mut(&memo_index) {
+                Self::insert_tracked_dict_entry(entries, key.to_string(), value);
             }
         }
     }
 
-    fn insert_tracked_dict_key(keys: &mut Vec<String>, key: String) {
-        if !keys.iter().any(|existing| existing == &key) {
-            keys.push(key);
+    fn insert_tracked_dict_entry(
+        entries: &mut Vec<(String, StackValue)>,
+        key: String,
+        value: StackValue,
+    ) {
+        if let Some((_, existing_value)) = entries
+            .iter_mut()
+            .find(|(existing_key, _)| existing_key == &key)
+        {
+            *existing_value = value;
+        } else {
+            entries.push((key, value));
         }
     }
 
@@ -2090,10 +2105,10 @@ impl<'a> ScanState<'a> {
         };
         let lookups = Self::str_format_positional_lookups(&format_string);
 
-        for (index, key) in lookups {
-            invocations.extend(self.mapping_lookup_invocations(
+        for (index, path) in lookups {
+            invocations.extend(self.mapping_lookup_path_invocations(
                 arguments.get(index + 1),
-                key.as_deref(),
+                &path,
                 op_name,
                 position,
             ));
@@ -2101,7 +2116,7 @@ impl<'a> ScanState<'a> {
         invocations
     }
 
-    fn str_format_positional_lookups(format_string: &str) -> Vec<(usize, Option<String>)> {
+    fn str_format_positional_lookups(format_string: &str) -> Vec<(usize, Vec<Option<String>>)> {
         let mut numbering = FormatFieldNumbering::Unset;
         let mut next_auto_index = 0;
         let mut lookups = Vec::new();
@@ -2120,7 +2135,7 @@ impl<'a> ScanState<'a> {
         depth: usize,
         numbering: &mut FormatFieldNumbering,
         next_auto_index: &mut usize,
-        lookups: &mut Vec<(usize, Option<String>)>,
+        lookups: &mut Vec<(usize, Vec<Option<String>>)>,
     ) -> Option<()> {
         if depth > MAX_STR_FORMAT_FIELD_NESTING {
             return Some(());
@@ -2187,30 +2202,9 @@ impl<'a> ScanState<'a> {
         depth: usize,
         numbering: &mut FormatFieldNumbering,
         next_auto_index: &mut usize,
-        lookups: &mut Vec<(usize, Option<String>)>,
+        lookups: &mut Vec<(usize, Vec<Option<String>>)>,
     ) -> Option<()> {
-        let bytes = field.as_bytes();
-        let mut delimiter_index = bytes.len();
-        let mut format_spec_index = None;
-        let mut item_depth = 0usize;
-        for (index, byte) in bytes.iter().enumerate() {
-            match byte {
-                b'[' => item_depth += 1,
-                b']' if item_depth > 0 => item_depth -= 1,
-                b'!' | b':' if item_depth == 0 => {
-                    if delimiter_index == bytes.len() {
-                        delimiter_index = index;
-                    }
-                    if *byte == b':' {
-                        format_spec_index = Some(index + 1);
-                        break;
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        let field_name = &field[..delimiter_index];
+        let (field_name, format_spec_index) = Self::str_format_field_name_and_spec(field);
         let root_end = field_name.find(['[', '.']).unwrap_or(field_name.len());
         let root = &field_name[..root_end];
         let has_item_lookup = field_name[root_end..].contains('[');
@@ -2235,10 +2229,10 @@ impl<'a> ScanState<'a> {
 
         if has_item_lookup {
             if let Some(index) = positional_index {
-                if let StrFormatRootItemLookup::Key(key) =
+                if let StrFormatRootItemLookup::Path(path) =
                     Self::str_format_root_item_key(field_name, root_end)
                 {
-                    lookups.push((index, key.map(str::to_string)));
+                    lookups.push((index, path));
                 }
             }
         }
@@ -2255,26 +2249,63 @@ impl<'a> ScanState<'a> {
         Some(())
     }
 
-    fn str_format_root_item_key(field_name: &str, root_end: usize) -> StrFormatRootItemLookup<'_> {
+    fn str_format_field_name_and_spec(field: &str) -> (&str, Option<usize>) {
+        let bytes = field.as_bytes();
+        let mut delimiter_index = bytes.len();
+        let mut format_spec_index = None;
+        let mut item_depth = 0usize;
+        for (index, byte) in bytes.iter().enumerate() {
+            match byte {
+                b'[' => item_depth += 1,
+                b']' if item_depth > 0 => item_depth -= 1,
+                b'!' | b':' if item_depth == 0 => {
+                    if delimiter_index == bytes.len() {
+                        delimiter_index = index;
+                    }
+                    if *byte == b':' {
+                        format_spec_index = Some(index + 1);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        (&field[..delimiter_index], format_spec_index)
+    }
+
+    fn str_format_root_item_key(field_name: &str, root_end: usize) -> StrFormatRootItemLookup {
         let Some(suffix) = field_name.get(root_end..) else {
             return StrFormatRootItemLookup::Invalid;
         };
-        let Some((key, _)) = suffix
-            .strip_prefix('[')
-            .and_then(|value| value.split_once(']'))
-        else {
-            return StrFormatRootItemLookup::Invalid;
-        };
-        if key.is_empty() {
-            StrFormatRootItemLookup::Key(None)
-        } else if Self::is_str_format_decimal_syntax(key) {
-            if Self::parse_str_format_decimal_index(key).is_some() {
-                StrFormatRootItemLookup::Key(None)
+        let mut remaining = suffix;
+        let mut path = Vec::new();
+
+        while !remaining.is_empty() {
+            let Some(after_open) = remaining.strip_prefix('[') else {
+                return StrFormatRootItemLookup::Invalid;
+            };
+            let Some((key, after_close)) = after_open.split_once(']') else {
+                return StrFormatRootItemLookup::Invalid;
+            };
+            if key.is_empty() {
+                path.push(None);
+            } else if Self::is_str_format_decimal_syntax(key) {
+                if Self::parse_str_format_decimal_index(key).is_some() {
+                    path.push(None);
+                } else {
+                    return StrFormatRootItemLookup::Invalid;
+                }
             } else {
-                StrFormatRootItemLookup::Invalid
+                path.push(Some(key.to_string()));
             }
+            remaining = after_close;
+        }
+
+        if path.is_empty() {
+            StrFormatRootItemLookup::Invalid
         } else {
-            StrFormatRootItemLookup::Key(Some(key))
+            StrFormatRootItemLookup::Path(path)
         }
     }
 
@@ -2332,7 +2363,79 @@ impl<'a> ScanState<'a> {
         if arguments.len() != 2 || !self.brace_format_string_may_use_field(arguments.first()) {
             return Vec::new();
         }
-        self.mapping_lookup_invocations(arguments.get(1), None, op_name, position)
+        let Some(format_string) = resolve_global_operand(arguments.first(), self.payload) else {
+            return self.mapping_lookup_invocations(arguments.get(1), None, op_name, position);
+        };
+        Self::str_format_named_lookups(&format_string)
+            .into_iter()
+            .flat_map(|path| {
+                self.mapping_lookup_path_invocations(arguments.get(1), &path, op_name, position)
+            })
+            .collect()
+    }
+
+    fn str_format_named_lookups(format_string: &str) -> Vec<Vec<Option<String>>> {
+        let mut lookups = Vec::new();
+        let _ = Self::collect_str_format_named_lookup_paths(format_string, 0, &mut lookups);
+        lookups
+    }
+
+    fn collect_str_format_named_lookup_paths(
+        format_string: &str,
+        depth: usize,
+        lookups: &mut Vec<Vec<Option<String>>>,
+    ) -> Option<()> {
+        if depth > MAX_STR_FORMAT_FIELD_NESTING {
+            return Some(());
+        }
+
+        let bytes = format_string.as_bytes();
+        let mut cursor = 0;
+        while cursor < bytes.len() {
+            match bytes[cursor] {
+                b'{' if bytes.get(cursor + 1) == Some(&b'{') => {
+                    cursor += 2;
+                }
+                b'{' => {
+                    let (field, next_cursor) =
+                        Self::extract_str_format_field(format_string, cursor + 1)?;
+                    Self::collect_str_format_field_named_lookup_paths(field, depth, lookups)?;
+                    cursor = next_cursor;
+                }
+                b'}' if bytes.get(cursor + 1) == Some(&b'}') => {
+                    cursor += 2;
+                }
+                b'}' => return None,
+                _ => cursor += 1,
+            }
+        }
+        Some(())
+    }
+
+    fn collect_str_format_field_named_lookup_paths(
+        field: &str,
+        depth: usize,
+        lookups: &mut Vec<Vec<Option<String>>>,
+    ) -> Option<()> {
+        let (field_name, format_spec_index) = Self::str_format_field_name_and_spec(field);
+        let root_end = field_name.find(['[', '.']).unwrap_or(field_name.len());
+        let root = &field_name[..root_end];
+        if !root.is_empty() && Self::parse_str_format_decimal_index(root).is_none() {
+            let mut path = vec![Some(root.to_string())];
+            if field_name[root_end..].contains('[') {
+                if let StrFormatRootItemLookup::Path(item_path) =
+                    Self::str_format_root_item_key(field_name, root_end)
+                {
+                    path.extend(item_path);
+                }
+            }
+            lookups.push(path);
+        }
+
+        if let Some(spec_start) = format_spec_index {
+            Self::collect_str_format_named_lookup_paths(&field[spec_start..], depth + 1, lookups)?;
+        }
+        Some(())
     }
 
     fn operator_mod_invocations(
@@ -2368,11 +2471,37 @@ impl<'a> ScanState<'a> {
         )]
     }
 
+    fn mapping_lookup_path_invocations(
+        &self,
+        mapping: Option<&StackValue>,
+        path: &[Option<String>],
+        op_name: &'static str,
+        position: usize,
+    ) -> Vec<CallableInvocation> {
+        let Some(MappingLookup::Found(default_factory)) =
+            Self::mapping_lookup_default_factory_path(mapping, path)
+        else {
+            return Vec::new();
+        };
+        vec![Self::zero_arg_invocation(
+            default_factory,
+            op_name,
+            position,
+        )]
+    }
+
     fn mapping_lookup_default_factory<'b>(
         mapping: Option<&'b StackValue>,
         key: Option<&str>,
     ) -> Option<MappingLookup<'b>> {
         Self::mapping_lookup_default_factory_inner(mapping?, key)
+    }
+
+    fn mapping_lookup_default_factory_path<'b>(
+        mapping: Option<&'b StackValue>,
+        path: &[Option<String>],
+    ) -> Option<MappingLookup<'b>> {
+        Self::mapping_lookup_default_factory_path_inner(mapping?, path)
     }
 
     fn mapping_lookup_default_factory_inner<'b>(
@@ -2383,8 +2512,8 @@ impl<'a> ScanState<'a> {
             StackValue::DefaultDict { default_factory } => {
                 Some(MappingLookup::Found(default_factory))
             }
-            StackValue::TrackedDict { keys, .. } => {
-                if key.is_some_and(|key| keys.iter().any(|candidate| candidate == key)) {
+            StackValue::TrackedDict { entries, .. } => {
+                if key.is_some_and(|key| entries.iter().any(|(candidate, _)| candidate == key)) {
                     Some(MappingLookup::Shadowed)
                 } else {
                     None
@@ -2411,6 +2540,49 @@ impl<'a> ScanState<'a> {
             } if reference.module == "types" && reference.name == "MappingProxyType" => mappings
                 .first()
                 .and_then(|mapping| Self::mapping_lookup_default_factory_inner(mapping, key)),
+            _ => None,
+        }
+    }
+
+    fn mapping_lookup_default_factory_path_inner<'b>(
+        mapping: &'b StackValue,
+        path: &[Option<String>],
+    ) -> Option<MappingLookup<'b>> {
+        match mapping {
+            StackValue::DefaultDict { default_factory } => {
+                Some(MappingLookup::Found(default_factory))
+            }
+            StackValue::TrackedDict { entries, .. } => {
+                let (key, remaining_path) = path.split_first()?;
+                let key = key.as_deref()?;
+                let (_, value) = entries.iter().find(|(candidate, _)| candidate == key)?;
+                if remaining_path.is_empty() {
+                    Some(MappingLookup::Shadowed)
+                } else {
+                    Self::mapping_lookup_default_factory_path_inner(value, remaining_path)
+                }
+            }
+            StackValue::MappingWrapper {
+                reference,
+                mappings,
+            } if reference.module == "collections" && reference.name == "ChainMap" => {
+                for mapping in mappings {
+                    match Self::mapping_lookup_default_factory_path_inner(mapping, path) {
+                        Some(MappingLookup::Found(default_factory)) => {
+                            return Some(MappingLookup::Found(default_factory));
+                        }
+                        Some(MappingLookup::Shadowed) => return Some(MappingLookup::Shadowed),
+                        None => {}
+                    }
+                }
+                None
+            }
+            StackValue::MappingWrapper {
+                reference,
+                mappings,
+            } if reference.module == "types" && reference.name == "MappingProxyType" => mappings
+                .first()
+                .and_then(|mapping| Self::mapping_lookup_default_factory_path_inner(mapping, path)),
             _ => None,
         }
     }
@@ -2445,7 +2617,15 @@ impl<'a> ScanState<'a> {
         {
             return Vec::new();
         }
-        self.mapping_lookup_invocations(arguments.get(3), None, op_name, position)
+        let Some(format_string) = resolve_global_operand(arguments.get(1), self.payload) else {
+            return self.mapping_lookup_invocations(arguments.get(3), None, op_name, position);
+        };
+        Self::str_format_named_lookups(&format_string)
+            .into_iter()
+            .flat_map(|path| {
+                self.mapping_lookup_path_invocations(arguments.get(3), &path, op_name, position)
+            })
+            .collect()
     }
 
     fn template_substitute_invocations(
@@ -3076,8 +3256,8 @@ impl<'a> ScanState<'a> {
                 callbacks.memo_index = Some(index);
                 StackValue::FutureCallbacks(callbacks)
             }
-            StackValue::TrackedDict { keys, .. } => StackValue::TrackedDict {
-                keys,
+            StackValue::TrackedDict { entries, .. } => StackValue::TrackedDict {
+                entries,
                 memo_index: Some(index),
             },
             value => value,
@@ -3553,7 +3733,7 @@ impl<'a> ScanState<'a> {
 
         if mappings
             .iter()
-            .all(|mapping| Self::mapping_lookup_default_factory(Some(mapping), None).is_none())
+            .all(|mapping| !Self::mapping_may_contain_default_factory(mapping))
         {
             return None;
         }
@@ -3562,6 +3742,19 @@ impl<'a> ScanState<'a> {
             reference: callable_reference.clone(),
             mappings,
         })
+    }
+
+    fn mapping_may_contain_default_factory(mapping: &StackValue) -> bool {
+        match mapping {
+            StackValue::DefaultDict { .. } => true,
+            StackValue::TrackedDict { entries, .. } => entries
+                .iter()
+                .any(|(_, value)| Self::mapping_may_contain_default_factory(value)),
+            StackValue::MappingWrapper { mappings, .. } => mappings
+                .iter()
+                .any(Self::mapping_may_contain_default_factory),
+            _ => false,
+        }
     }
 
     fn callable_reference_from_value(value: Option<&StackValue>) -> Option<GlobalRef> {

--- a/packages/modelaudit-picklescan/rust/src/state.rs
+++ b/packages/modelaudit-picklescan/rust/src/state.rs
@@ -2282,6 +2282,9 @@ impl<'a> ScanState<'a> {
         let mut path = Vec::new();
 
         while !remaining.is_empty() {
+            if remaining.starts_with('.') {
+                break;
+            }
             let Some(after_open) = remaining.strip_prefix('[') else {
                 return StrFormatRootItemLookup::Invalid;
             };
@@ -2460,7 +2463,7 @@ impl<'a> ScanState<'a> {
         position: usize,
     ) -> Vec<CallableInvocation> {
         let Some(MappingLookup::Found(default_factory)) =
-            Self::mapping_lookup_default_factory(mapping, key)
+            self.mapping_lookup_default_factory(mapping, key)
         else {
             return Vec::new();
         };
@@ -2479,7 +2482,7 @@ impl<'a> ScanState<'a> {
         position: usize,
     ) -> Vec<CallableInvocation> {
         let Some(MappingLookup::Found(default_factory)) =
-            Self::mapping_lookup_default_factory_path(mapping, path)
+            self.mapping_lookup_default_factory_path(mapping, path)
         else {
             return Vec::new();
         };
@@ -2491,20 +2494,23 @@ impl<'a> ScanState<'a> {
     }
 
     fn mapping_lookup_default_factory<'b>(
+        &'b self,
         mapping: Option<&'b StackValue>,
         key: Option<&str>,
     ) -> Option<MappingLookup<'b>> {
-        Self::mapping_lookup_default_factory_inner(mapping?, key)
+        self.mapping_lookup_default_factory_inner(mapping?, key)
     }
 
     fn mapping_lookup_default_factory_path<'b>(
+        &'b self,
         mapping: Option<&'b StackValue>,
         path: &[Option<String>],
     ) -> Option<MappingLookup<'b>> {
-        Self::mapping_lookup_default_factory_path_inner(mapping?, path)
+        self.mapping_lookup_default_factory_path_inner(mapping?, path)
     }
 
     fn mapping_lookup_default_factory_inner<'b>(
+        &'b self,
         mapping: &'b StackValue,
         key: Option<&str>,
     ) -> Option<MappingLookup<'b>> {
@@ -2512,7 +2518,11 @@ impl<'a> ScanState<'a> {
             StackValue::DefaultDict { default_factory } => {
                 Some(MappingLookup::Found(default_factory))
             }
-            StackValue::TrackedDict { entries, .. } => {
+            StackValue::TrackedDict {
+                entries,
+                memo_index,
+            } => {
+                let entries = self.current_tracked_dict_entries(entries, *memo_index);
                 if key.is_some_and(|key| entries.iter().any(|(candidate, _)| candidate == key)) {
                     Some(MappingLookup::Shadowed)
                 } else {
@@ -2524,7 +2534,7 @@ impl<'a> ScanState<'a> {
                 mappings,
             } if reference.module == "collections" && reference.name == "ChainMap" => {
                 for mapping in mappings {
-                    match Self::mapping_lookup_default_factory_inner(mapping, key) {
+                    match self.mapping_lookup_default_factory_inner(mapping, key) {
                         Some(MappingLookup::Found(default_factory)) => {
                             return Some(MappingLookup::Found(default_factory));
                         }
@@ -2539,12 +2549,13 @@ impl<'a> ScanState<'a> {
                 mappings,
             } if reference.module == "types" && reference.name == "MappingProxyType" => mappings
                 .first()
-                .and_then(|mapping| Self::mapping_lookup_default_factory_inner(mapping, key)),
+                .and_then(|mapping| self.mapping_lookup_default_factory_inner(mapping, key)),
             _ => None,
         }
     }
 
     fn mapping_lookup_default_factory_path_inner<'b>(
+        &'b self,
         mapping: &'b StackValue,
         path: &[Option<String>],
     ) -> Option<MappingLookup<'b>> {
@@ -2552,14 +2563,18 @@ impl<'a> ScanState<'a> {
             StackValue::DefaultDict { default_factory } => {
                 Some(MappingLookup::Found(default_factory))
             }
-            StackValue::TrackedDict { entries, .. } => {
+            StackValue::TrackedDict {
+                entries,
+                memo_index,
+            } => {
+                let entries = self.current_tracked_dict_entries(entries, *memo_index);
                 let (key, remaining_path) = path.split_first()?;
                 let key = key.as_deref()?;
                 let (_, value) = entries.iter().find(|(candidate, _)| candidate == key)?;
                 if remaining_path.is_empty() {
                     Some(MappingLookup::Shadowed)
                 } else {
-                    Self::mapping_lookup_default_factory_path_inner(value, remaining_path)
+                    self.mapping_lookup_default_factory_path_inner(value, remaining_path)
                 }
             }
             StackValue::MappingWrapper {
@@ -2567,7 +2582,7 @@ impl<'a> ScanState<'a> {
                 mappings,
             } if reference.module == "collections" && reference.name == "ChainMap" => {
                 for mapping in mappings {
-                    match Self::mapping_lookup_default_factory_path_inner(mapping, path) {
+                    match self.mapping_lookup_default_factory_path_inner(mapping, path) {
                         Some(MappingLookup::Found(default_factory)) => {
                             return Some(MappingLookup::Found(default_factory));
                         }
@@ -2582,9 +2597,23 @@ impl<'a> ScanState<'a> {
                 mappings,
             } if reference.module == "types" && reference.name == "MappingProxyType" => mappings
                 .first()
-                .and_then(|mapping| Self::mapping_lookup_default_factory_path_inner(mapping, path)),
+                .and_then(|mapping| self.mapping_lookup_default_factory_path_inner(mapping, path)),
             _ => None,
         }
+    }
+
+    fn current_tracked_dict_entries<'b>(
+        &'b self,
+        entries: &'b [(String, StackValue)],
+        memo_index: Option<i64>,
+    ) -> &'b [(String, StackValue)] {
+        memo_index
+            .and_then(|index| self.memo.get(&index))
+            .and_then(|value| match value {
+                StackValue::TrackedDict { entries, .. } => Some(entries.as_slice()),
+                _ => None,
+            })
+            .unwrap_or(entries)
     }
 
     fn formatter_vformat_invocations(
@@ -3171,7 +3200,7 @@ impl<'a> ScanState<'a> {
             .get(1)
             .and_then(|value| stack_value_string(value, self.payload));
         let Some(MappingLookup::Found(default_factory)) =
-            Self::mapping_lookup_default_factory(argument_values.first(), key.as_deref())
+            self.mapping_lookup_default_factory(argument_values.first(), key.as_deref())
         else {
             return Vec::new();
         };
@@ -3318,7 +3347,7 @@ impl<'a> ScanState<'a> {
             self.stack.push(defaultdict);
             return;
         }
-        if let Some(mapping_wrapper) = Self::mapping_wrapper_result(values) {
+        if let Some(mapping_wrapper) = self.mapping_wrapper_result(values) {
             self.stack.push(mapping_wrapper);
             return;
         }
@@ -3709,7 +3738,7 @@ impl<'a> ScanState<'a> {
         Some(StackValue::DefaultDict { default_factory })
     }
 
-    fn mapping_wrapper_result(values: &[StackValue]) -> Option<StackValue> {
+    fn mapping_wrapper_result(&self, values: &[StackValue]) -> Option<StackValue> {
         let Some(StackValue::Global(callable_reference)) = values.first() else {
             return None;
         };
@@ -3733,7 +3762,7 @@ impl<'a> ScanState<'a> {
 
         if mappings
             .iter()
-            .all(|mapping| !Self::mapping_may_contain_default_factory(mapping))
+            .all(|mapping| !self.mapping_may_contain_default_factory(mapping))
         {
             return None;
         }
@@ -3744,15 +3773,19 @@ impl<'a> ScanState<'a> {
         })
     }
 
-    fn mapping_may_contain_default_factory(mapping: &StackValue) -> bool {
+    fn mapping_may_contain_default_factory(&self, mapping: &StackValue) -> bool {
         match mapping {
             StackValue::DefaultDict { .. } => true,
-            StackValue::TrackedDict { entries, .. } => entries
+            StackValue::TrackedDict {
+                entries,
+                memo_index,
+            } => self
+                .current_tracked_dict_entries(entries, *memo_index)
                 .iter()
-                .any(|(_, value)| Self::mapping_may_contain_default_factory(value)),
+                .any(|(_, value)| self.mapping_may_contain_default_factory(value)),
             StackValue::MappingWrapper { mappings, .. } => mappings
                 .iter()
-                .any(Self::mapping_may_contain_default_factory),
+                .any(|mapping| self.mapping_may_contain_default_factory(mapping)),
             _ => false,
         }
     }

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -926,6 +926,104 @@ def _chainmap_defaultdict_str_format_payload(*, key: str, format_string: str) ->
     )
 
 
+def _nested_defaultdict_str_format_payload() -> bytes:
+    return b"".join(
+        [
+            b"\x80\x04",
+            _global_operand("collections", "defaultdict"),
+            _global_operand("builtins", "help"),
+            b"\x85R",
+            b"\x94",
+            b"0",
+            b"}",
+            b"\x94",
+            _unicode_operand("present"),
+            b"h\x00",
+            b"s",
+            b"0",
+            _global_operand("builtins", "str.format"),
+            _args_tuple(_unicode_operand("{0[present][missing]}"), b"h\x01"),
+            b"R.",
+        ]
+    )
+
+
+def _nested_defaultdict_format_map_payload() -> bytes:
+    return b"".join(
+        [
+            b"\x80\x04",
+            _global_operand("collections", "defaultdict"),
+            _global_operand("builtins", "help"),
+            b"\x85R",
+            b"\x94",
+            b"0",
+            b"}",
+            b"\x94",
+            _unicode_operand("present"),
+            b"h\x00",
+            b"s",
+            b"0",
+            _global_operand("builtins", "str.format_map"),
+            _args_tuple(_unicode_operand("{present[missing]}"), b"h\x01"),
+            b"R.",
+        ]
+    )
+
+
+def _nested_defaultdict_formatter_payload(method_name: str) -> bytes:
+    parts = [
+        b"\x80\x04",
+        _global_operand("string", "Formatter"),
+        b")R",
+        b"\x94",
+        b"0",
+        _global_operand("collections", "defaultdict"),
+        _global_operand("builtins", "help"),
+        b"\x85R",
+        b"\x94",
+        b"0",
+        b"}",
+        b"\x94",
+        _unicode_operand("present"),
+        b"h\x01",
+        b"s",
+        b"0",
+        _global_operand("string", f"Formatter.{method_name}"),
+    ]
+    arguments = [b"h\x00", _unicode_operand("{present[missing]}"), b"N", b"h\x02"]
+    if method_name == "_vformat":
+        arguments.extend([b"\x8f", b"K\x02"])
+    parts.extend([_args_tuple(*arguments), b"R."])
+    return b"".join(parts)
+
+
+def _nested_wrapped_defaultdict_str_format_payload(wrapper_module: str, wrapper_name: str) -> bytes:
+    return b"".join(
+        [
+            b"\x80\x04",
+            _global_operand("collections", "defaultdict"),
+            _global_operand("builtins", "help"),
+            b"\x85R",
+            b"\x94",
+            b"0",
+            b"}",
+            b"\x94",
+            _unicode_operand("present"),
+            b"h\x00",
+            b"s",
+            b"0",
+            _global_operand(wrapper_module, wrapper_name),
+            _args_tuple(b"h\x01"),
+            b"R",
+            b"\x94",
+            b"0",
+            _global_operand("builtins", "str.format"),
+            _args_tuple(_unicode_operand("{0[present][missing]}"), b"h\x02"),
+            b"R.",
+        ]
+    )
+
+
 def _deep_mapping_proxy_defaultdict_getitem_payload(depth: int) -> bytes:
     if not 1 <= depth <= 255:
         raise ValueError("depth must fit one-byte memo references")
@@ -6740,6 +6838,290 @@ if marker.exists():
     )
     assert result.returncode == 0, result.stderr
     assert not marker.exists()
+
+
+def test_scan_bytes_blocks_nested_str_format_defaultdict_lookup_rce(tmp_path: Path) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    marker = tmp_path / "nested_str_format_defaultdict_marker"
+    marker_content = "pydoc-owned"
+    (module_dir / "pydoc.py").write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text({marker_content!r})\n"
+        "def help(*args, **kwargs):\n"
+        "    return 'factory-value'\n",
+        encoding="utf-8",
+    )
+    payload = _nested_defaultdict_str_format_payload()
+
+    report = scan_bytes(payload, source="nested-str-format-defaultdict-rce.pkl")
+
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert _has_critical_call_graph_finding(
+        report,
+        "_sitebuiltins",
+        "_Helper.__call__",
+        "builtins.__import__",
+    )
+    assert any(
+        invocation.get("module") == "builtins"
+        and invocation.get("name") == "help"
+        and invocation.get("positional_arg_count") == 0
+        for invocation in report.metadata.get("callable_invocations", [])
+    )
+
+    assert not marker.exists()
+    child_code = """
+import pickle
+import sys
+from pathlib import Path
+
+module_dir = Path(sys.argv[1])
+marker = Path(sys.argv[2])
+payload = bytes.fromhex(sys.argv[3])
+marker_content = sys.argv[4]
+
+if marker.exists():
+    raise SystemExit("marker already exists before pickle execution")
+sys.path.insert(0, str(module_dir))
+sys.modules.pop("pydoc", None)
+result = pickle.loads(payload)
+if result != "factory-value":
+    raise SystemExit(f"expected factory value result, got {result!r}")
+if not marker.exists():
+    raise SystemExit("marker was not written")
+if marker.read_text() != marker_content:
+    raise SystemExit("marker content mismatch")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", child_code, str(module_dir), str(marker), payload.hex(), marker_content],
+        cwd=str(tmp_path.parent),
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert marker.read_text() == marker_content
+
+
+def test_scan_bytes_blocks_nested_format_map_defaultdict_lookup_rce(tmp_path: Path) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    marker = tmp_path / "nested_format_map_defaultdict_marker"
+    marker_content = "pydoc-owned"
+    (module_dir / "pydoc.py").write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text({marker_content!r})\n"
+        "def help(*args, **kwargs):\n"
+        "    return 'factory-value'\n",
+        encoding="utf-8",
+    )
+    payload = _nested_defaultdict_format_map_payload()
+
+    report = scan_bytes(payload, source="nested-format-map-defaultdict-rce.pkl")
+
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert _has_critical_call_graph_finding(
+        report,
+        "_sitebuiltins",
+        "_Helper.__call__",
+        "builtins.__import__",
+    )
+    assert any(
+        invocation.get("module") == "builtins"
+        and invocation.get("name") == "help"
+        and invocation.get("positional_arg_count") == 0
+        for invocation in report.metadata.get("callable_invocations", [])
+    )
+
+    assert not marker.exists()
+    child_code = """
+import pickle
+import sys
+from pathlib import Path
+
+module_dir = Path(sys.argv[1])
+marker = Path(sys.argv[2])
+payload = bytes.fromhex(sys.argv[3])
+marker_content = sys.argv[4]
+
+if marker.exists():
+    raise SystemExit("marker already exists before pickle execution")
+sys.path.insert(0, str(module_dir))
+sys.modules.pop("pydoc", None)
+result = pickle.loads(payload)
+if result != "factory-value":
+    raise SystemExit(f"expected factory value result, got {result!r}")
+if not marker.exists():
+    raise SystemExit("marker was not written")
+if marker.read_text() != marker_content:
+    raise SystemExit("marker content mismatch")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", child_code, str(module_dir), str(marker), payload.hex(), marker_content],
+        cwd=str(tmp_path.parent),
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert marker.read_text() == marker_content
+
+
+@pytest.mark.parametrize("method_name", ["vformat", "_vformat"])
+def test_scan_bytes_blocks_nested_formatter_defaultdict_lookup_rce(tmp_path: Path, method_name: str) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    marker = tmp_path / f"nested_formatter_{method_name}_defaultdict_marker"
+    marker_content = "pydoc-owned"
+    (module_dir / "pydoc.py").write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text({marker_content!r})\n"
+        "def help(*args, **kwargs):\n"
+        "    return 'factory-value'\n",
+        encoding="utf-8",
+    )
+    payload = _nested_defaultdict_formatter_payload(method_name)
+
+    report = scan_bytes(payload, source=f"nested-formatter-{method_name}-defaultdict-rce.pkl")
+
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert _has_critical_call_graph_finding(
+        report,
+        "_sitebuiltins",
+        "_Helper.__call__",
+        "builtins.__import__",
+    )
+    assert any(
+        invocation.get("module") == "builtins"
+        and invocation.get("name") == "help"
+        and invocation.get("positional_arg_count") == 0
+        for invocation in report.metadata.get("callable_invocations", [])
+    )
+
+    assert not marker.exists()
+    expected_result = "('factory-value', 0)" if method_name == "_vformat" else "'factory-value'"
+    child_code = """
+import pickle
+import sys
+from pathlib import Path
+
+module_dir = Path(sys.argv[1])
+marker = Path(sys.argv[2])
+payload = bytes.fromhex(sys.argv[3])
+marker_content = sys.argv[4]
+expected_result = sys.argv[5]
+
+if marker.exists():
+    raise SystemExit("marker already exists before pickle execution")
+sys.path.insert(0, str(module_dir))
+sys.modules.pop("pydoc", None)
+result = pickle.loads(payload)
+if repr(result) != expected_result:
+    raise SystemExit(f"expected factory value result, got {result!r}")
+if not marker.exists():
+    raise SystemExit("marker was not written")
+if marker.read_text() != marker_content:
+    raise SystemExit("marker content mismatch")
+"""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            child_code,
+            str(module_dir),
+            str(marker),
+            payload.hex(),
+            marker_content,
+            expected_result,
+        ],
+        cwd=str(tmp_path.parent),
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert marker.read_text() == marker_content
+
+
+@pytest.mark.parametrize(
+    ("wrapper_module", "wrapper_name"),
+    [("collections", "ChainMap"), ("types", "MappingProxyType")],
+)
+def test_scan_bytes_blocks_nested_wrapped_str_format_defaultdict_lookup_rce(
+    tmp_path: Path,
+    wrapper_module: str,
+    wrapper_name: str,
+) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    marker = tmp_path / f"nested_{wrapper_name.lower()}_str_format_defaultdict_marker"
+    marker_content = "pydoc-owned"
+    (module_dir / "pydoc.py").write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text({marker_content!r})\n"
+        "def help(*args, **kwargs):\n"
+        "    return 'factory-value'\n",
+        encoding="utf-8",
+    )
+    payload = _nested_wrapped_defaultdict_str_format_payload(wrapper_module, wrapper_name)
+
+    report = scan_bytes(payload, source=f"nested-{wrapper_name.lower()}-str-format-defaultdict-rce.pkl")
+
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert _has_critical_call_graph_finding(
+        report,
+        "_sitebuiltins",
+        "_Helper.__call__",
+        "builtins.__import__",
+    )
+    assert any(
+        invocation.get("module") == "builtins"
+        and invocation.get("name") == "help"
+        and invocation.get("positional_arg_count") == 0
+        for invocation in report.metadata.get("callable_invocations", [])
+    )
+
+    assert not marker.exists()
+    child_code = """
+import pickle
+import sys
+from pathlib import Path
+
+module_dir = Path(sys.argv[1])
+marker = Path(sys.argv[2])
+payload = bytes.fromhex(sys.argv[3])
+marker_content = sys.argv[4]
+
+if marker.exists():
+    raise SystemExit("marker already exists before pickle execution")
+sys.path.insert(0, str(module_dir))
+sys.modules.pop("pydoc", None)
+result = pickle.loads(payload)
+if result != "factory-value":
+    raise SystemExit(f"expected factory value result, got {result!r}")
+if not marker.exists():
+    raise SystemExit("marker was not written")
+if marker.read_text() != marker_content:
+    raise SystemExit("marker content mismatch")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", child_code, str(module_dir), str(marker), payload.hex(), marker_content],
+        cwd=str(tmp_path.parent),
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert marker.read_text() == marker_content
 
 
 def test_scan_bytes_blocks_str_format_unicode_decimal_chainmap_lookup_rce(tmp_path: Path) -> None:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -1024,6 +1024,33 @@ def _nested_wrapped_defaultdict_str_format_payload(wrapper_module: str, wrapper_
     )
 
 
+def _memoized_nested_defaultdict_str_format_payload() -> bytes:
+    return b"".join(
+        [
+            b"\x80\x04",
+            b"}",
+            b"\x94",
+            b"0",
+            b"}",
+            b"\x94",
+            _unicode_operand("present"),
+            b"h\x00",
+            b"s",
+            b"0",
+            b"h\x00",
+            _unicode_operand("nested"),
+            _global_operand("collections", "defaultdict"),
+            _global_operand("builtins", "help"),
+            b"\x85R",
+            b"s",
+            b"0",
+            _global_operand("builtins", "str.format"),
+            _args_tuple(_unicode_operand("{0[present][nested][missing]}"), b"h\x01"),
+            b"R.",
+        ]
+    )
+
+
 def _deep_mapping_proxy_defaultdict_getitem_payload(depth: int) -> bytes:
     if not 1 <= depth <= 255:
         raise ValueError("depth must fit one-byte memo references")
@@ -6733,6 +6760,7 @@ def test_scan_bytes_keeps_format_map_defaultdict_without_live_fields_clean(forma
     ("format_string", "format_arguments"),
     [
         ("{0[x]}", (b"h\x00",)),
+        ("{0[x].upper}", (b"h\x00",)),
         ("{[x]}", (b"h\x00",)),
         ("{0:{1[x]}}", (_unicode_operand("safe"), b"h\x00")),
         ("{0!r:{1[x]}}", (_unicode_operand("safe"), b"h\x00")),
@@ -7073,6 +7101,72 @@ def test_scan_bytes_blocks_nested_wrapped_str_format_defaultdict_lookup_rce(
     payload = _nested_wrapped_defaultdict_str_format_payload(wrapper_module, wrapper_name)
 
     report = scan_bytes(payload, source=f"nested-{wrapper_name.lower()}-str-format-defaultdict-rce.pkl")
+
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert _has_critical_call_graph_finding(
+        report,
+        "_sitebuiltins",
+        "_Helper.__call__",
+        "builtins.__import__",
+    )
+    assert any(
+        invocation.get("module") == "builtins"
+        and invocation.get("name") == "help"
+        and invocation.get("positional_arg_count") == 0
+        for invocation in report.metadata.get("callable_invocations", [])
+    )
+
+    assert not marker.exists()
+    child_code = """
+import pickle
+import sys
+from pathlib import Path
+
+module_dir = Path(sys.argv[1])
+marker = Path(sys.argv[2])
+payload = bytes.fromhex(sys.argv[3])
+marker_content = sys.argv[4]
+
+if marker.exists():
+    raise SystemExit("marker already exists before pickle execution")
+sys.path.insert(0, str(module_dir))
+sys.modules.pop("pydoc", None)
+result = pickle.loads(payload)
+if result != "factory-value":
+    raise SystemExit(f"expected factory value result, got {result!r}")
+if not marker.exists():
+    raise SystemExit("marker was not written")
+if marker.read_text() != marker_content:
+    raise SystemExit("marker content mismatch")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", child_code, str(module_dir), str(marker), payload.hex(), marker_content],
+        cwd=str(tmp_path.parent),
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert marker.read_text() == marker_content
+
+
+def test_scan_bytes_blocks_memoized_nested_str_format_defaultdict_lookup_rce(tmp_path: Path) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    marker = tmp_path / "memoized_nested_str_format_defaultdict_marker"
+    marker_content = "pydoc-owned"
+    (module_dir / "pydoc.py").write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text({marker_content!r})\n"
+        "def help(*args, **kwargs):\n"
+        "    return 'factory-value'\n",
+        encoding="utf-8",
+    )
+    payload = _memoized_nested_defaultdict_str_format_payload()
+
+    report = scan_bytes(payload, source="memoized-nested-str-format-defaultdict-rce.pkl")
 
     assert report.verdict == SafetyVerdict.MALICIOUS
     assert _has_critical_call_graph_finding(


### PR DESCRIPTION
## Summary
- track concrete values inside Rust `TrackedDict` state so nested mapping traversals can follow real object paths
- detect nested brace-format lookups across `str.format`, `str.format_map`, and both `Formatter` vformat entry points
- preserve nested `defaultdict` reachability through `ChainMap` and `MappingProxyType` wrappers

## Verification
- `cargo fmt --manifest-path packages/modelaudit-picklescan/Cargo.toml -- --check`
- `cargo check --manifest-path packages/modelaudit-picklescan/Cargo.toml`
- `cargo clippy --manifest-path packages/modelaudit-picklescan/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path packages/modelaudit-picklescan/Cargo.toml`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`