### PR TITLE
fix(picklescan): detect statistics quantiles iterator consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - avoid `str.format` picklescan false positives when a `ChainMap` shadows a `defaultdict`
+- block `statistics.quantiles` call-iterator consumption in picklescan call-graph analysis
 - block additional eager `statistics` consumers in picklescan call-graph analysis
 - avoid picklescan false positives for inert metadata under dangerous dotted globals
 - preserve path-sensitive scan results while hashing duplicate directory contents

--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -10,6 +10,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - avoid `str.format` false positives when a `ChainMap` shadows a `defaultdict`
+- block `statistics.quantiles` call-iterator consumption in call-graph analysis
 - block additional eager `statistics` consumers in call-graph analysis
 - avoid false positives for inert metadata under dangerous dotted globals
 - detect dangerous positional lookups inside `str.format` replacement fields

--- a/packages/modelaudit-picklescan/rust/src/state.rs
+++ b/packages/modelaudit-picklescan/rust/src/state.rs
@@ -132,6 +132,7 @@ const EXACT_ARITY_STDLIB_EAGER_ITERABLE_CONSUMERS: &[(&str, &str, usize, usize)]
     ("statistics", "median_low", 1, 0),
     ("statistics", "mode", 1, 0),
     ("statistics", "multimode", 1, 0),
+    ("statistics", "quantiles", 1, 0),
     ("statistics", "pstdev", 1, 0),
     ("statistics", "pstdev", 2, 0),
     ("statistics", "pvariance", 1, 0),

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -3427,6 +3427,12 @@ if marker.read_text() != marker_content:
             False,
         ),
         (
+            _builtins_help_call_iterator_stdlib_materializer_payload("statistics", "quantiles", b"h\x00"),
+            "[7, 8, 'stop']",
+            "[6.75, 7.5, 8.25]",
+            False,
+        ),
+        (
             _builtins_help_call_iterator_stdlib_materializer_payload("statistics", "pstdev", b"h\x00"),
             "[7, 7, 'stop']",
             "0.0",


### PR DESCRIPTION
## Summary
- add `statistics.quantiles` to the picklescan eager iterable consumer table
- add a focused regression proving an `iter(help, "stop")` payload is malicious when consumed by `statistics.quantiles`
- update root and picklescan changelogs

## Tests
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py::test_scan_bytes_blocks_stdlib_eager_call_iterator_consumption_rce --tb=short -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
- `cargo fmt --manifest-path packages/modelaudit-picklescan/Cargo.toml -- --check`
- `cargo check --manifest-path packages/modelaudit-picklescan/Cargo.toml`
- `cargo clippy --manifest-path packages/modelaudit-picklescan/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path packages/modelaudit-picklescan/Cargo.toml`