### PR TITLE
perf: reuse normalized scanner selection policy

### DIFF
--- a/modelaudit/scanner_selection.py
+++ b/modelaudit/scanner_selection.py
@@ -253,6 +253,8 @@ def _policy_from_normalized_selection(selection: Mapping[str, Any]) -> ScannerSe
     expected_enabled = frozenset((exact_ids or all_scanner_ids) - exclude_ids)
     if enabled_ids != expected_enabled or active != bool(exact_ids or exclude_ids):
         return None
+    if active and not enabled_ids:
+        return None
 
     return ScannerSelectionPolicy(
         enabled_scanner_ids=enabled_ids,

--- a/modelaudit/scanner_selection.py
+++ b/modelaudit/scanner_selection.py
@@ -12,6 +12,7 @@ import difflib
 import os
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any, Literal
 
 from .scanner_registry_metadata import get_scanner_registry_metadata
@@ -67,7 +68,15 @@ def _alias_key(value: str) -> str:
     return value.strip().lower().replace("_", "").replace("-", "")
 
 
-def _scanner_aliases(metadata: Mapping[str, Mapping[str, Any]]) -> dict[str, str]:
+@lru_cache(maxsize=1)
+def _scanner_metadata() -> dict[str, dict[str, Any]]:
+    """Return the static registry metadata used by hot selection paths."""
+    return get_scanner_registry_metadata()
+
+
+@lru_cache(maxsize=1)
+def _scanner_aliases() -> dict[str, str]:
+    """Return canonical aliases derived from the static registry metadata."""
     aliases: dict[str, str] = {}
 
     def add(alias: str, scanner_id: str) -> None:
@@ -75,7 +84,7 @@ def _scanner_aliases(metadata: Mapping[str, Mapping[str, Any]]) -> dict[str, str
         if key:
             aliases.setdefault(key, scanner_id)
 
-    for scanner_id, scanner_info in metadata.items():
+    for scanner_id, scanner_info in _scanner_metadata().items():
         add(scanner_id, scanner_id)
         add(scanner_id.replace("_", "-"), scanner_id)
 
@@ -95,8 +104,8 @@ def _scanner_aliases(metadata: Mapping[str, Mapping[str, Any]]) -> dict[str, str
 
 def resolve_scanner_ids(tokens: Iterable[str] | str | None) -> tuple[str, ...]:
     """Resolve scanner IDs, class names, and friendly aliases to canonical IDs."""
-    metadata = get_scanner_registry_metadata()
-    aliases = _scanner_aliases(metadata)
+    metadata = _scanner_metadata()
+    aliases = _scanner_aliases()
     resolved: list[str] = []
     unknown: list[str] = []
 
@@ -165,7 +174,7 @@ def resolve_scanner_selection_policy(
     exclude_scanners: Iterable[str] | str | None = None,
 ) -> ScannerSelectionPolicy:
     """Resolve raw scanner selection inputs into a policy."""
-    metadata = get_scanner_registry_metadata()
+    metadata = _scanner_metadata()
     all_scanner_ids = frozenset(metadata.keys())
 
     exact_ids = frozenset(resolve_scanner_ids(scanners))
@@ -204,6 +213,9 @@ def policy_from_config(config: Mapping[str, Any] | None) -> ScannerSelectionPoli
     raw_selection = raw_config.get(SCANNER_SELECTION_CONFIG_KEY)
 
     if isinstance(raw_selection, Mapping):
+        normalized_policy = _policy_from_normalized_selection(raw_selection)
+        if normalized_policy is not None:
+            return normalized_policy
         return resolve_scanner_selection_policy(
             scanners=raw_selection.get("scanners"),
             exclude_scanners=raw_selection.get("exclude_scanners"),
@@ -212,6 +224,42 @@ def policy_from_config(config: Mapping[str, Any] | None) -> ScannerSelectionPoli
     return resolve_scanner_selection_policy(
         scanners=raw_config.get("scanners"),
         exclude_scanners=raw_config.get("exclude_scanners"),
+    )
+
+
+def _policy_from_normalized_selection(selection: Mapping[str, Any]) -> ScannerSelectionPolicy | None:
+    """Rehydrate a policy from ``to_config()`` output without re-resolving aliases."""
+    active = selection.get("active")
+    enabled_values = selection.get("enabled_scanner_ids")
+    if not isinstance(active, bool) or not isinstance(enabled_values, list):
+        return None
+
+    all_scanner_ids = frozenset(_scanner_metadata().keys())
+
+    def parse_ids(value: Any, *, allow_none: bool = False) -> frozenset[str] | None:
+        if value is None and allow_none:
+            return frozenset()
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            return None
+        ids = frozenset(value)
+        return ids if ids <= all_scanner_ids else None
+
+    enabled_ids = parse_ids(enabled_values)
+    exact_ids = parse_ids(selection.get("scanners"), allow_none=True)
+    exclude_ids = parse_ids(selection.get("exclude_scanners"))
+    if enabled_ids is None or exact_ids is None or exclude_ids is None:
+        return None
+
+    expected_enabled = frozenset((exact_ids or all_scanner_ids) - exclude_ids)
+    if enabled_ids != expected_enabled or active != bool(exact_ids or exclude_ids):
+        return None
+
+    return ScannerSelectionPolicy(
+        enabled_scanner_ids=enabled_ids,
+        all_scanner_ids=all_scanner_ids,
+        exact_scanner_ids=exact_ids,
+        exclude_scanner_ids=exclude_ids,
+        active=active,
     )
 
 
@@ -239,7 +287,7 @@ def selected_scanner_extensions(
     headers. Remote sources only have filenames before download, so they need
     this fail-open behavior to avoid selection-created coverage gaps.
     """
-    metadata = get_scanner_registry_metadata()
+    metadata = _scanner_metadata()
     extensions: set[str] = set()
     for scanner_id in policy.enabled_scanner_ids:
         scanner_info = metadata.get(scanner_id, {})

--- a/tests/test_scanner_selection.py
+++ b/tests/test_scanner_selection.py
@@ -106,6 +106,21 @@ def test_normalized_selection_rehydrates_without_alias_resolution(monkeypatch: p
     assert policy.exclude_scanner_ids == frozenset({"zip"})
 
 
+def test_normalized_selection_rejects_payloads_that_disable_every_scanner() -> None:
+    all_scanner_ids = sorted(get_scanner_registry_metadata())
+    config = {
+        "scanner_selection": {
+            "active": True,
+            "scanners": None,
+            "exclude_scanners": all_scanner_ids,
+            "enabled_scanner_ids": [],
+        }
+    }
+
+    with pytest.raises(ValueError, match="Scanner selection does not enable any scanners"):
+        policy_from_config(config)
+
+
 def test_scan_file_exact_scanner_allows_pickle_detection(tmp_path: Path) -> None:
     path = tmp_path / "payload.pkl"
     path.write_bytes(_build_malicious_pickle())

--- a/tests/test_scanner_selection.py
+++ b/tests/test_scanner_selection.py
@@ -9,6 +9,7 @@ import zipfile
 from pathlib import Path
 from typing import Any
 
+import pytest
 from click.testing import CliRunner
 
 from modelaudit.cache import reset_cache_manager
@@ -17,6 +18,8 @@ from modelaudit.core import scan_file, scan_model_directory_or_file
 from modelaudit.scanner_registry_metadata import get_scanner_registry_metadata
 from modelaudit.scanner_selection import (
     collect_suppressed_preferred_scanners,
+    normalize_scanner_selection_config,
+    policy_from_config,
     resolve_scanner_ids,
     resolve_scanner_selection_policy,
     scanner_catalog,
@@ -85,6 +88,22 @@ def test_selection_policy_uses_allowlist_minus_exclusions() -> None:
     assert policy.enabled_scanner_ids == frozenset({"pickle"})
     assert policy.allows("pickle")
     assert not policy.allows("zip")
+
+
+def test_normalized_selection_rehydrates_without_alias_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = normalize_scanner_selection_config({"scanners": ["PickleScanner"], "exclude_scanners": ["zip"]})
+
+    def fail_resolve(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("normalized selection should not re-resolve aliases")
+
+    monkeypatch.setattr("modelaudit.scanner_selection.resolve_scanner_selection_policy", fail_resolve)
+
+    policy = policy_from_config(config)
+
+    assert policy.active
+    assert policy.enabled_scanner_ids == frozenset({"pickle"})
+    assert policy.exact_scanner_ids == frozenset({"pickle"})
+    assert policy.exclude_scanner_ids == frozenset({"zip"})
 
 
 def test_scan_file_exact_scanner_allows_pickle_detection(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- cache static scanner metadata and alias resolution on hot paths
- rehydrate normalized scanner-selection payloads without resolving aliases again
- add regression coverage that proves normalized payloads skip the slower alias path

## Why
On a synthetic `2000`-file directory scan, repeated scanner-selection normalization accounted for about `3.57s` of aggregate profile time before this change.

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_scanner_selection.py -q`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`

## Benchmarks
- `2000` empty `.dat` files: `3.740284s` -> `3.066438s`
- `500` tiny `.pkl` files: `1.543400s` -> `1.326489s`
