### PR TITLE
perf: short-circuit hf bookkeeping checks

### DIFF
--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -906,25 +906,12 @@ def _is_huggingface_cache_file(path: str) -> bool:
     import os
 
     filename = os.path.basename(path)
-    path_obj = Path(path)
-
-    is_hf_bookkeeping_path = _is_hf_hub_bookkeeping_path(path_obj) or _is_hf_download_bookkeeping_path(path_obj)
+    if not (filename.endswith((".lock", ".metadata")) or filename in {".gitignore", ".gitattributes", "main", "HEAD"}):
+        return False
 
     # Only trust bookkeeping-shaped filenames when they actually live in a
     # recognized HuggingFace cache layout.
-    if filename.endswith(".lock"):
-        return is_hf_bookkeeping_path
-
-    # Only skip HuggingFace .metadata files in known cache/download layouts.
-    if filename.endswith(".metadata"):
-        return is_hf_bookkeeping_path
-
-    # Check for specific HuggingFace cache metadata files
-    # We no longer skip all HuggingFace cache files since we handle symlinks properly now
-
-    # Check for Git-related files that are commonly cached
-    if filename in [".gitignore", ".gitattributes"]:
-        return is_hf_bookkeeping_path
+    path_obj = Path(path)
 
     if filename in ["main", "HEAD"]:
         hf_cache_root = _find_hf_cache_root(path_obj)
@@ -937,6 +924,17 @@ def _is_huggingface_cache_file(path: str) -> bool:
             return False
 
         return bool(relative_parts and relative_parts[0] == "refs")
+
+    is_hf_bookkeeping_path = _is_hf_hub_bookkeeping_path(path_obj) or _is_hf_download_bookkeeping_path(path_obj)
+    if filename.endswith((".lock", ".metadata")):
+        return is_hf_bookkeeping_path
+
+    # Check for specific HuggingFace cache metadata files
+    # We no longer skip all HuggingFace cache files since we handle symlinks properly now
+
+    # Check for Git-related files that are commonly cached
+    if filename in [".gitignore", ".gitattributes"]:
+        return is_hf_bookkeeping_path
 
     return False
 

--- a/tests/test_directory_file_filtering.py
+++ b/tests/test_directory_file_filtering.py
@@ -489,6 +489,22 @@ class TestDirectoryFileFiltering:
         assert _is_huggingface_cache_file(str(hf_cache_metadata)) is True
         assert _is_huggingface_cache_file(str(hf_download_metadata)) is True
 
+    def test_non_bookkeeping_filenames_skip_hf_path_resolution(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Ordinary filenames should not pay HuggingFace bookkeeping path resolution costs."""
+        ordinary_model = tmp_path / "weights.dat"
+
+        def fail_if_called(*_args: object, **_kwargs: object) -> bool:
+            raise AssertionError("ordinary filenames should short-circuit before HF path resolution")
+
+        monkeypatch.setattr("modelaudit.core._is_hf_hub_bookkeeping_path", fail_if_called)
+        monkeypatch.setattr("modelaudit.core._is_hf_download_bookkeeping_path", fail_if_called)
+
+        assert _is_huggingface_cache_file(str(ordinary_model)) is False
+
     def test_bookkeeping_filenames_only_skip_inside_huggingface_cache(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Summary
- return early for filenames that can never be HuggingFace bookkeeping files
- keep the existing trust checks for bookkeeping-shaped names unchanged
- add regression coverage that ordinary filenames do not enter the expensive HF path helpers

## Why
`_is_huggingface_cache_file()` was doing path-resolution work for every scanned file before checking whether the basename could even be HuggingFace bookkeeping.

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_directory_file_filtering.py -q -k 'non_bookkeeping_filenames_skip_hf_path_resolution or huggingface'`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`

## Benchmarks
- ordinary `weights.dat` helper calls, `20,000` iterations: `2.504382s` -> `0.004380s`
- synthetic `2000`-file directory profile: HF helper family reduced to `0.009s` aggregate
