### PR TITLE
perf: reuse nearby license discovery

### DIFF
--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -358,6 +358,7 @@ def scan_model_directory_or_file(
     }
     # Track file hashes for aggregate hash computation
     file_hashes: list[str] = []
+    nearby_license_cache: dict[str, list[str]] = {}
 
     # Configure scan options
     config = {
@@ -495,7 +496,10 @@ def scan_model_directory_or_file(
                         filename_lower = Path(file_path).name.lower()
                         if filename_lower in LICENSE_FILES:
                             try:
-                                license_metadata = collect_license_metadata(str(resolved_file))
+                                license_metadata = collect_license_metadata(
+                                    str(resolved_file),
+                                    nearby_license_cache=nearby_license_cache,
+                                )
                                 from .models import FileMetadataModel
 
                                 results.file_metadata[str(resolved_file)] = FileMetadataModel(**license_metadata)
@@ -649,7 +653,10 @@ def scan_model_directory_or_file(
                         _add_asset_to_results(results, representative_file, file_result)
 
                         # Add metadata for this path using Pydantic models
-                        license_metadata = collect_license_metadata(representative_file)
+                        license_metadata = collect_license_metadata(
+                            representative_file,
+                            nearby_license_cache=nearby_license_cache,
+                        )
                         combined_metadata = {**file_result.metadata, **license_metadata}
                         combined_metadata["content_hash"] = content_hash
                         duplicate_files = duplicate_paths_by_hash.get(content_hash, [])
@@ -741,7 +748,10 @@ def scan_model_directory_or_file(
                 _add_asset_to_results(results, target, file_result)
 
                 # Collect and apply license metadata for all files
-                license_metadata = collect_license_metadata(target)
+                license_metadata = collect_license_metadata(
+                    target,
+                    nearby_license_cache=nearby_license_cache,
+                )
                 if license_metadata:
                     from .models import FileMetadataModel
 
@@ -1319,6 +1329,7 @@ def scan_model_streaming(
     metadata_scanner_available: bool = scanner_selection.allows("metadata") and _registry.has_scanner_class(
         "MetadataScanner"
     )
+    nearby_license_cache: dict[str, list[str]] = {}
 
     base_dir = Path(scan_root).resolve() if scan_root is not None else None
     hf_cache_root = _find_hf_cache_root(base_dir) if base_dir is not None else None
@@ -1364,7 +1375,10 @@ def scan_model_streaming(
                     filename_lower = source_path.name.lower()
                     if filename_lower in LICENSE_FILES:
                         try:
-                            license_metadata = collect_license_metadata(str(scan_path))
+                            license_metadata = collect_license_metadata(
+                                str(scan_path),
+                                nearby_license_cache=nearby_license_cache,
+                            )
                             from .models import FileMetadataModel
 
                             results.file_metadata[report_path] = FileMetadataModel(**license_metadata)

--- a/modelaudit/integrations/license_checker.py
+++ b/modelaudit/integrations/license_checker.py
@@ -2,7 +2,7 @@ import itertools
 import json
 import os
 import re
-from collections.abc import Mapping
+from collections.abc import Mapping, MutableMapping
 from contextlib import suppress
 from pathlib import Path
 from typing import Any
@@ -737,7 +737,11 @@ def check_commercial_use_warnings(scan_results: dict[str, Any] | Any, *, strict:
     return warnings
 
 
-def collect_license_metadata(file_path: str) -> dict[str, Any]:
+def collect_license_metadata(
+    file_path: str,
+    *,
+    nearby_license_cache: MutableMapping[str, list[str]] | None = None,
+) -> dict[str, Any]:
     """
     Collect comprehensive license metadata for a file.
 
@@ -789,7 +793,14 @@ def collect_license_metadata(file_path: str) -> dict[str, Any]:
     # Find nearby license files
     if os.path.isfile(file_path):
         dir_path = str(Path(file_path).parent)
-        nearby_licenses = find_license_files(dir_path)
+        if nearby_license_cache is None:
+            nearby_licenses = find_license_files(dir_path)
+        else:
+            cached_nearby_licenses = nearby_license_cache.get(dir_path)
+            if cached_nearby_licenses is None:
+                cached_nearby_licenses = find_license_files(dir_path)
+                nearby_license_cache[dir_path] = cached_nearby_licenses
+            nearby_licenses = cached_nearby_licenses
         metadata["license_files_nearby"] = nearby_licenses
 
     return metadata

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,8 @@ def pytest_runtest_setup(item):
             "test_metadata_extractor.py",  # Metadata extractor helper routing and CLI tests
             "test_weak_hash_detection.py",  # Weak hash detection tests
             "test_cloud_url_detection.py",  # Cloud storage URL detection tests
+            "test_license_checker.py",  # License metadata and nearby-license caching tests
+            "test_license_integration.py",  # End-to-end license metadata integration tests
             "tests/utils/sources/test_cloud_storage.py",  # Cloud storage source tests
             "test_skops_scanner.py",  # Skops scanner CVE detection tests
             "test_keras_zip_scanner.py",  # Keras ZIP scanner tests

--- a/tests/integrations/test_license_checker.py
+++ b/tests/integrations/test_license_checker.py
@@ -3,6 +3,7 @@
 import json
 from pathlib import Path
 
+import pytest
 from pydantic import HttpUrl
 
 from modelaudit.integrations.license_checker import (
@@ -544,6 +545,32 @@ Bob,30
 
         assert metadata["is_dataset"] is True  # .pkl is both dataset and model extension
         assert metadata["is_model"] is True
+
+    def test_collect_license_metadata_reuses_nearby_license_cache(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Repeated same-directory metadata scans should reuse nearby-license discovery."""
+        first_file = tmp_path / "first.pkl"
+        second_file = tmp_path / "second.pkl"
+        first_file.write_bytes(b"first")
+        second_file.write_bytes(b"second")
+        calls = 0
+
+        def fake_find_license_files(directory: str) -> list[str]:
+            nonlocal calls
+            calls += 1
+            return [str(Path(directory) / "LICENSE")]
+
+        monkeypatch.setattr("modelaudit.integrations.license_checker.find_license_files", fake_find_license_files)
+        nearby_license_cache: dict[str, list[str]] = {}
+
+        first_metadata = collect_license_metadata(str(first_file), nearby_license_cache=nearby_license_cache)
+        second_metadata = collect_license_metadata(str(second_file), nearby_license_cache=nearby_license_cache)
+
+        assert calls == 1
+        assert first_metadata["license_files_nearby"] == second_metadata["license_files_nearby"]
 
 
 class TestIntegration:

--- a/tests/integrations/test_license_integration.py
+++ b/tests/integrations/test_license_integration.py
@@ -112,6 +112,27 @@ class TestLicenseIntegration:
         assert dataset_warning["severity"] == "info"
         assert "Verify data usage rights" in dataset_warning["message"]
 
+    def test_directory_scan_reuses_nearby_license_discovery(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Directory scans should reuse nearby-license discovery across sibling files."""
+        (tmp_path / "first.dat").write_text("first", encoding="utf-8")
+        (tmp_path / "second.dat").write_text("second", encoding="utf-8")
+        calls = 0
+
+        def fake_find_license_files(directory: str) -> list[str]:
+            nonlocal calls
+            calls += 1
+            return [str(Path(directory) / "LICENSE")]
+
+        monkeypatch.setattr("modelaudit.integrations.license_checker.find_license_files", fake_find_license_files)
+
+        scan_model_directory_or_file(str(tmp_path), skip_file_types=False, cache_enabled=False)
+
+        assert calls == 1
+
     def test_mixed_licenses_detection(self, test_data_dir: Any) -> None:
         """Test detection of mixed license scenarios."""
         mixed_dir = test_data_dir / "mixed_licenses"


### PR DESCRIPTION
## Summary
- cache nearby-license discovery within a scan and reuse it across sibling files
- thread the per-scan cache through regular and streaming scan paths
- add focused unit/integration coverage and include the license tests on reduced Python lanes

## Why
`collect_license_metadata()` was calling `find_license_files()` once per scanned file. In a synthetic directory with `2000` sibling files, that repeated same-directory walk dominated license time.

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/integrations/test_license_checker.py tests/integrations/test_license_integration.py -q -k 'reuses_nearby_license'`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`

## Benchmarks
- synthetic `2000`-file profile:
  - `find_license_files()`: about `5.479s` / `2000` calls -> `0.003s` / `1` call
  - `collect_license_metadata()`: about `5.694s` -> `0.153s`
