### PR TITLE
perf: share call graph caches within reports

### DIFF
--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -18,6 +18,7 @@ from .call_graph import (
     find_startup_hook_write_call_graphs,
     find_unanalyzed_callable_call_graph_references,
     has_unanalyzed_call_graph_import_references,
+    shared_source_sensitive_caches,
 )
 from .options import ScanOptions
 from .report import CoverageSummary, Finding, Notice, PickleReport, SafetyVerdict, ScanError, ScanStatus, Severity
@@ -961,24 +962,25 @@ def _with_call_graph_findings(report: PickleReport) -> PickleReport:
     callable_invocations = report.metadata.get("callable_invocations", ())
     call_graph_limit_exceeded = has_unanalyzed_call_graph_import_references(import_references)
     enrichment_errors: list[tuple[str, Exception]] = []
-    try:
-        call_graph_findings = find_dangerous_call_graphs(import_references, callable_invocations)
-    except Exception as error:
-        call_graph_findings = ()
-        enrichment_errors.append(("python_call_graph", error))
-    try:
-        startup_hook_write_findings = find_startup_hook_write_call_graphs(
-            import_references,
-            callable_invocations,
-        )
-    except Exception as error:
-        startup_hook_write_findings = ()
-        enrichment_errors.append(("python_call_graph_startup_hook_write", error))
-    try:
-        unanalyzed_references = find_unanalyzed_callable_call_graph_references(callable_invocations)
-    except Exception as error:
-        unanalyzed_references = ()
-        enrichment_errors.append(("python_call_graph_source_unavailable", error))
+    with shared_source_sensitive_caches():
+        try:
+            call_graph_findings = find_dangerous_call_graphs(import_references, callable_invocations)
+        except Exception as error:
+            call_graph_findings = ()
+            enrichment_errors.append(("python_call_graph", error))
+        try:
+            startup_hook_write_findings = find_startup_hook_write_call_graphs(
+                import_references,
+                callable_invocations,
+            )
+        except Exception as error:
+            startup_hook_write_findings = ()
+            enrichment_errors.append(("python_call_graph_startup_hook_write", error))
+        try:
+            unanalyzed_references = find_unanalyzed_callable_call_graph_references(callable_invocations)
+        except Exception as error:
+            unanalyzed_references = ()
+            enrichment_errors.append(("python_call_graph_source_unavailable", error))
 
     updated_report = (
         _with_unanalyzed_call_graph_notices(report, unanalyzed_references) if unanalyzed_references else report

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -7,7 +7,9 @@ import os
 import sys
 import sysconfig
 from collections import deque
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from functools import lru_cache
 from importlib.machinery import EXTENSION_SUFFIXES, BuiltinImporter, FrozenImporter, ModuleSpec, PathFinder
@@ -37,6 +39,10 @@ _PICKLE_ENTERED_IMPORT_EXECUTION_METHODS = (
 _INHERITED_CLASS_ENTRYPOINT_METHODS = (
     *_PICKLE_CONSTRUCTOR_ENTRYPOINT_METHODS,
     *_PICKLE_LIFECYCLE_ENTRYPOINT_METHODS,
+)
+_SHARED_SOURCE_SENSITIVE_CACHE_DEPTH: ContextVar[int] = ContextVar(
+    "_SHARED_SOURCE_SENSITIVE_CACHE_DEPTH",
+    default=0,
 )
 
 _CLASS_ENTRYPOINT_METHODS = (
@@ -436,6 +442,18 @@ def find_unanalyzed_callable_call_graph_references(
     return tuple(references)
 
 
+@contextmanager
+def shared_source_sensitive_caches() -> Iterator[None]:
+    """Share one fresh cache generation across related enrichment passes."""
+    if _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.get() == 0:
+        _clear_source_sensitive_caches_now()
+    token = _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.set(_SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.get() + 1)
+    try:
+        yield
+    finally:
+        _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.reset(token)
+
+
 @lru_cache(maxsize=4096)
 def _safe_call_graph_entrypoints(function_name: str) -> tuple[str, ...]:
     try:
@@ -708,6 +726,12 @@ def has_unanalyzed_call_graph_import_references(import_references: object) -> bo
 
 
 def _clear_source_sensitive_caches() -> None:
+    if _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.get() > 0:
+        return
+    _clear_source_sensitive_caches_now()
+
+
+def _clear_source_sensitive_caches_now() -> None:
     for function in (
         _safe_call_graph_entrypoints,
         _has_static_torch_extension_global_target,

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -85,6 +85,27 @@ def _clear_call_graph_caches() -> None:
             cache_clear()
 
 
+def test_shared_source_sensitive_caches_clears_once_per_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    clear_count = 0
+
+    def fake_clear() -> None:
+        nonlocal clear_count
+        clear_count += 1
+
+    monkeypatch.setattr(call_graph, "_clear_source_sensitive_caches_now", fake_clear)
+
+    with call_graph.shared_source_sensitive_caches():
+        call_graph._clear_source_sensitive_caches()
+        call_graph._clear_source_sensitive_caches()
+        call_graph._clear_source_sensitive_caches()
+
+    assert clear_count == 1
+
+    call_graph._clear_source_sensitive_caches()
+
+    assert clear_count == 2
+
+
 def _env_without_pythonpath() -> dict[str, str]:
     return {key: value for key, value in os.environ.items() if key != "PYTHONPATH"}
 


### PR DESCRIPTION
## Summary
- share one fresh source-sensitive call-graph cache generation across the three enrichment passes for a single pickle report
- keep direct public call-graph helpers fresh by default outside that report scope
- add focused regression coverage for scoped clearing behavior while preserving source-rewrite freshness coverage

## Benchmarks
- same-process `dill_func.pkl` A/B:
  - old three-clear behavior: `0.538389s` median
  - report-scoped sharing: `0.196939s` median

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py -k "shared_source_sensitive_caches_clears_once_per_scope or refreshes_call_graph_after_source_rewrite"`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest packages/modelaudit-picklescan/tests/test_api.py -k "with_call_graph_findings"`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`