### PR TITLE
perf: skip redundant jax scans for plain pickles

### DIFF
--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -23,6 +23,17 @@ from .picklescan_adapter import pickle_report_to_scan_result, scan_options_from_
 
 _NESTED_PICKLE_HEADER_SEARCH_LIMIT_BYTES = 64 * 1024
 _ROOT_RAW_SCAN_LIMIT_BYTES = 8 * 1024 * 1024
+_JAX_PICKLE_CONTEXT_INDICATORS = (
+    b"jax",
+    b"flax",
+    b"haiku",
+    b"orbax",
+    b"arrayimpl",
+    b"jaxlib",
+    b"device_array",
+)
+_DEFAULT_JAX_PICKLE_SCAN_LIMIT_BYTES = 16 * 1024 * 1024
+_MIN_JAX_PICKLE_SCAN_LIMIT_BYTES = 1024
 _ROOT_EXPENSIVE_RAW_SCAN_LIMIT_BYTES = 1 * 1024 * 1024
 _MAX_METADATA_PICKLE_READ_BYTES = 10 * 1024 * 1024
 _KNOWN_PICKLE_EXTENSIONS = frozenset({".pkl", ".pickle", ".dill", ".joblib"})
@@ -2432,11 +2443,22 @@ class PickleScanner(BaseScanner):
             return result
 
         self._add_root_legacy_metadata_detectors(result, path)
-        self._scan_jax_checkpoint_patterns_if_needed(path, file_size, result)
+        self._scan_jax_checkpoint_patterns_if_needed(path, file_size, raw_data, result)
         self._finish_after_wrapper_analysis(result, base_success=scan_result.success)
         return result
 
-    def _scan_jax_checkpoint_patterns_if_needed(self, path: str, file_size: int, result: ScanResult) -> None:
+    def _scan_jax_checkpoint_patterns_if_needed(
+        self,
+        path: str,
+        file_size: int,
+        raw_data: bytes,
+        result: ScanResult,
+    ) -> None:
+        if file_size <= len(raw_data) and file_size <= self._jax_pickle_scan_limit():
+            lowered_raw_data = raw_data.lower()
+            if not any(indicator in lowered_raw_data for indicator in _JAX_PICKLE_CONTEXT_INDICATORS):
+                return
+
         from .jax_checkpoint_scanner import JaxCheckpointScanner
 
         jax_scanner = JaxCheckpointScanner(config=self.config)
@@ -2473,3 +2495,11 @@ class PickleScanner(BaseScanner):
                 rule_code="S902",
             )
         result.merge(jax_result)
+
+    def _jax_pickle_scan_limit(self) -> int:
+        raw_value = self.config.get("jax_pickle_max_scan_bytes", _DEFAULT_JAX_PICKLE_SCAN_LIMIT_BYTES)
+        try:
+            parsed_value = int(raw_value)
+        except (TypeError, ValueError):
+            parsed_value = _DEFAULT_JAX_PICKLE_SCAN_LIMIT_BYTES
+        return max(parsed_value, _MIN_JAX_PICKLE_SCAN_LIMIT_BYTES)

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -1497,6 +1497,28 @@ def test_pickle_scanner_delegates_jax_patterns_for_pkl_suffixes(tmp_path: Path) 
     )
 
 
+def test_pickle_scanner_skips_jax_delegation_for_complete_non_jax_payloads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "plain_state.pkl"
+    payload = pickle.dumps({"payload": "ordinary pickle state"})
+    path.write_bytes(payload)
+
+    scanner = PickleScanner()
+    result = scanner._create_result()
+
+    def fail_if_called(path: str, text: str) -> ScanResult:
+        raise AssertionError("JAX checkpoint delegation should be skipped")
+
+    monkeypatch.setattr(
+        "modelaudit.scanners.jax_checkpoint_scanner.JaxCheckpointScanner.scan_pickle_pattern_text",
+        fail_if_called,
+    )
+
+    scanner._scan_jax_checkpoint_patterns_if_needed(str(path), len(payload), payload, result)
+
+
 def test_pickle_scanner_uses_jax_window_beyond_root_raw_scan_limit(tmp_path: Path) -> None:
     path = tmp_path / "late-jax.pkl"
     path.write_bytes(pickle.dumps({"padding": "a" * 256, "payload": "jax.experimental.io_callback"}))


### PR DESCRIPTION
## Summary
- skip JAX checkpoint delegation when the already-read root window covers the full pickle and proves there is no JAX context
- keep the existing conservative path for truncated windows and caller-configured narrow JAX scan limits
- add focused regression coverage for the new skip path while preserving late-JAX coverage

## Benchmarks
- synthetic `4 MiB` ordinary pickle:
  - unconditional delegation: `0.191007s` median
  - complete-window non-JAX skip: `0.065762s` median

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_pickle_scanner.py -k "skips_jax_delegation_for_complete_non_jax_payloads or delegates_jax_patterns_for_pkl_suffixes or uses_jax_window_beyond_root_raw_scan_limit or reports_info_only_jax_truncation_without_jax_context"`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`