### PR TITLE
perf: reuse manifest text within scans

### DIFF
--- a/modelaudit/scanners/manifest_scanner.py
+++ b/modelaudit/scanners/manifest_scanner.py
@@ -723,6 +723,8 @@ class ManifestScanner(BaseScanner):
             )
             result.finish(success=False)
             return result
+        finally:
+            self._manifest_text_cache.clear()
 
         self._finish_manifest_result(result)
         return result

--- a/modelaudit/scanners/manifest_scanner.py
+++ b/modelaudit/scanners/manifest_scanner.py
@@ -604,6 +604,7 @@ class ManifestScanner(BaseScanner):
         result = self._create_result()
         file_size = self.get_file_size(path)
         result.metadata["file_size"] = file_size
+        self._manifest_text_cache: dict[str, str] = {}
 
         try:
             # Store the file path for use in issue locations
@@ -754,8 +755,7 @@ class ManifestScanner(BaseScanner):
             return
 
         try:
-            with open(path, encoding="utf-8") as f:
-                content = f.read().lower()
+            content = self._read_manifest_text(path).lower()
 
             found_blacklisted = False
             for pattern in self.blacklist_patterns:
@@ -807,8 +807,7 @@ class ManifestScanner(BaseScanner):
     ) -> Any:
         """Parse the file based on its extension"""
         try:
-            with open(path, encoding="utf-8") as f:
-                content = f.read()
+            content = self._read_manifest_text(path)
 
             stripped_content = content.strip()
 
@@ -1010,8 +1009,7 @@ class ManifestScanner(BaseScanner):
         - Supply chain risks from external resources
         """
         try:
-            with open(path, encoding="utf-8") as f:
-                content = f.read()
+            content = self._read_manifest_text(path)
 
             self._check_timeout()
             seen_urls: set[str] = set()
@@ -1060,6 +1058,18 @@ class ManifestScanner(BaseScanner):
             raise
         except Exception as e:
             logger.debug(f"Error checking cloud storage URLs in {path}: {e}")
+
+    def _read_manifest_text(self, path: str) -> str:
+        cached_content = getattr(self, "_manifest_text_cache", {}).get(path)
+        if cached_content is not None:
+            return cached_content
+
+        with open(path, encoding="utf-8") as f:
+            content = f.read()
+
+        if hasattr(self, "_manifest_text_cache"):
+            self._manifest_text_cache[path] = content
+        return content
 
     def _check_suspicious_urls(self, content: Any, result: ScanResult) -> None:
         """Check for untrusted URLs in config values using allowlist approach.

--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -1,6 +1,8 @@
+import builtins
 import json
 import logging
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -48,6 +50,38 @@ def test_manifest_scanner_blacklist(tmp_path):
         issue.details.get("blacklisted_term", "") for issue in blacklist_issues if hasattr(issue, "details")
     ]
     assert "unsafe" in blacklisted_terms
+
+
+def test_manifest_scanner_reuses_manifest_text_during_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_file = tmp_path / "manifest.json"
+    test_file.write_text(
+        json.dumps(
+            {
+                "model_name": "safe-model",
+                "description": "ordinary manifest",
+                "source": _https_url("huggingface.co"),
+            }
+        )
+    )
+
+    original_open = builtins.open
+    open_count = 0
+
+    def counting_open(file: Any, *args: Any, **kwargs: Any) -> Any:
+        nonlocal open_count
+        if file == str(test_file) and kwargs.get("encoding") == "utf-8":
+            open_count += 1
+        return original_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", counting_open)
+
+    result = ManifestScanner(config={"blacklist_patterns": ["blocked"]}).scan(str(test_file))
+
+    assert result.success is True
+    assert open_count == 1
 
 
 def test_manifest_scanner_case_insensitive_blacklist(tmp_path):

--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -84,6 +84,17 @@ def test_manifest_scanner_reuses_manifest_text_during_scan(
     assert open_count == 1
 
 
+def test_manifest_scanner_clears_manifest_text_after_scan(tmp_path: Path) -> None:
+    test_file = tmp_path / "manifest.json"
+    test_file.write_text(json.dumps({"model_name": "safe-model"}))
+    scanner = ManifestScanner(config={"blacklist_patterns": ["blocked"]})
+
+    result = scanner.scan(str(test_file))
+
+    assert result.scanner is scanner
+    assert scanner._manifest_text_cache == {}
+
+
 def test_manifest_scanner_case_insensitive_blacklist(tmp_path):
     """Test that blacklist matching is case-insensitive."""
     test_file = tmp_path / "inference_config.json"


### PR DESCRIPTION
## Summary
- cache decoded manifest text for the lifetime of one manifest scan
- reuse that text across blacklist, cloud URL, and parse passes instead of reopening the same file three times
- add focused regression coverage that proves one physical text read during a scan

## Benchmarks
- same-process `8 MiB` manifest A/B:
  - forced uncached reads: `0.673513s` median
  - per-scan text cache: `0.423788s` median

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_manifest_scanner.py -k "reuses_manifest_text_during_scan or manifest_scanner_blacklist or manifest_scanner_no_blacklist_clean_file"`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`