### PR TITLE
perf: reuse jax probe file handle

### DIFF
--- a/modelaudit/scanners/jax_checkpoint_scanner.py
+++ b/modelaudit/scanners/jax_checkpoint_scanner.py
@@ -491,18 +491,15 @@ class JaxCheckpointScanner(BaseScanner):
         try:
             with open(path, "rb") as f:
                 header = f.read(512)
-
-            # Check for pickle formats with JAX indicators. Protocol 0 pickles
-            # are textual and can begin directly with a string opcode such as
-            # `Vjax`, so they do not have the binary protocol marker.
-            if header.startswith(b"\x80") or header[:1] in b"(cdgINRSUV":
-                # Read more to check for JAX-specific content
-                with suppress(Exception):
-                    with open(path, "rb") as f:
-                        data = f.read(8192)  # Read first 8KB
+                # Check for pickle formats with JAX indicators. Protocol 0
+                # pickles are textual and can begin directly with a string
+                # opcode such as `Vjax`, so they do not have the binary
+                # protocol marker.
+                if header.startswith(b"\x80") or header[:1] in b"(cdgINRSUV":
+                    with suppress(Exception):
+                        data = header + f.read(max(0, 8192 - len(header)))
                         data_str = data.decode("utf-8", errors="ignore").lower()
-
-                    return cls._contains_jax_indicator(data_str)
+                        return cls._contains_jax_indicator(data_str)
 
             decoded_header = header.decode("utf-8", errors="ignore").lower()
 

--- a/tests/scanners/test_jax_checkpoint_scanner.py
+++ b/tests/scanners/test_jax_checkpoint_scanner.py
@@ -1,7 +1,9 @@
+import builtins
 import json
 import os
 import pickle
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -231,6 +233,25 @@ def test_benign_jax_pickle_does_not_false_positive_on_opcode_letters(tmp_path: P
     assert result.success
     assert all(check.name != "Pickle Opcode Security Check" for check in result.checks)
     assert all(issue.severity != IssueSeverity.CRITICAL for issue in result.issues)
+
+
+def test_pickle_candidate_probe_reuses_open_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    checkpoint_path = tmp_path / "candidate.pickle"
+    checkpoint_path.write_bytes(pickle.dumps({"framework": "jax"}))
+
+    original_open = builtins.open
+    open_count = 0
+
+    def counting_open(file: Any, *args: Any, **kwargs: Any) -> Any:
+        nonlocal open_count
+        if file == str(checkpoint_path):
+            open_count += 1
+        return original_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", counting_open)
+
+    assert JaxCheckpointScanner._is_likely_jax_file(str(checkpoint_path)) is True
+    assert open_count == 1
 
 
 def test_malicious_pickle_global_opcode_is_detected(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- reuse the initial open file handle while probing pickle-shaped JAX checkpoint candidates
- avoid reopening and rereading the same prefix during routing
- add focused regression coverage proving one open on pickle candidates

## Benchmarks
- repeated pickle-candidate probe, `200` calls:
  - previous two-open path: `0.045949s` median
  - single-handle path: `0.026661s` median

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_jax_checkpoint_scanner.py -k "pickle_candidate_probe_reuses_open_file or benign_jax_pickle_does_not_false_positive_on_opcode_letters"`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`