### PR TITLE
perf: reuse lowered license header text

### DIFF
--- a/modelaudit/integrations/license_checker.py
+++ b/modelaudit/integrations/license_checker.py
@@ -191,8 +191,13 @@ def _read_header_text(file_path: str, max_lines: int) -> str | None:
         return None
 
 
-def _content_has_prefilter_term(content: str, terms: tuple[str, ...]) -> bool:
-    lowered = content.lower()
+def _content_has_prefilter_term(
+    content: str,
+    terms: tuple[str, ...],
+    *,
+    lowered_content: str | None = None,
+) -> bool:
+    lowered = lowered_content if lowered_content is not None else content.lower()
     return any(term in lowered for term in terms)
 
 
@@ -256,9 +261,13 @@ DATASET_EXTENSIONS = {
 MODEL_EXTENSIONS = COMMON_MODEL_EXTENSIONS
 
 
-def _scan_license_headers_from_content(content: str) -> list[LicenseInfo]:
+def _scan_license_headers_from_content(
+    content: str,
+    *,
+    lowered_content: str | None = None,
+) -> list[LicenseInfo]:
     licenses: list[LicenseInfo] = []
-    if not _content_has_prefilter_term(content, _LICENSE_PREFILTER_TERMS):
+    if not _content_has_prefilter_term(content, _LICENSE_PREFILTER_TERMS, lowered_content=lowered_content):
         return licenses
 
     # Search for license patterns
@@ -296,9 +305,13 @@ def scan_for_license_headers(file_path: str, max_lines: int = 50) -> list[Licens
     return _scan_license_headers_from_content(content)
 
 
-def _extract_copyright_notices_from_content(content: str) -> list[CopyrightInfo]:
+def _extract_copyright_notices_from_content(
+    content: str,
+    *,
+    lowered_content: str | None = None,
+) -> list[CopyrightInfo]:
     copyrights: list[CopyrightInfo] = []
-    if not _content_has_prefilter_term(content, _COPYRIGHT_PREFILTER_TERMS):
+    if not _content_has_prefilter_term(content, _COPYRIGHT_PREFILTER_TERMS, lowered_content=lowered_content):
         return copyrights
 
     # Search for copyright patterns
@@ -762,8 +775,12 @@ def collect_license_metadata(file_path: str) -> dict[str, Any]:
 
     content = _read_header_text(file_path, max_lines=50)
 
+    lowered_content = content.lower() if content is not None else None
+
     # Scan for license headers
-    licenses = _scan_license_headers_from_content(content) if content is not None else []
+    licenses = (
+        _scan_license_headers_from_content(content, lowered_content=lowered_content) if content is not None else []
+    )
     metadata["license_info"] = [
         {
             "spdx_id": lic.spdx_id,
@@ -776,7 +793,9 @@ def collect_license_metadata(file_path: str) -> dict[str, Any]:
     ]
 
     # Extract copyright notices
-    copyrights = _extract_copyright_notices_from_content(content) if content is not None else []
+    copyrights = (
+        _extract_copyright_notices_from_content(content, lowered_content=lowered_content) if content is not None else []
+    )
     metadata["copyright_notices"] = [
         {
             "holder": cr.holder,

--- a/tests/integrations/test_license_checker.py
+++ b/tests/integrations/test_license_checker.py
@@ -3,8 +3,10 @@
 import json
 from pathlib import Path
 
+import pytest
 from pydantic import HttpUrl
 
+from modelaudit.integrations import license_checker
 from modelaudit.integrations.license_checker import (
     _LICENSE_HEADER_MAX_BYTES,
     CopyrightInfo,
@@ -544,6 +546,31 @@ Bob,30
 
         assert metadata["is_dataset"] is True  # .pkl is both dataset and model extension
         assert metadata["is_model"] is True
+
+    def test_collect_license_metadata_reuses_lowered_header(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Reuse one lowercase view across the shared metadata collectors."""
+
+        class TrackingStr(str):
+            lower_calls = 0
+
+            def lower(self) -> str:
+                self.lower_calls += 1
+                return super().lower()
+
+        test_file = tmp_path / "header.py"
+        test_file.write_text("placeholder")
+        content = TrackingStr("# SPDX-License-Identifier: MIT\n# Copyright 2024 Test Corp\n")
+        monkeypatch.setattr(license_checker, "_read_header_text", lambda *_args, **_kwargs: content)
+
+        metadata = collect_license_metadata(str(test_file))
+
+        assert content.lower_calls == 1
+        assert metadata["license_info"][0]["spdx_id"] == "MIT"
+        assert metadata["copyright_notices"][0]["holder"] == "Test Corp"
 
 
 class TestIntegration:


### PR DESCRIPTION
## Summary
- reuse one lowercase header view across license and copyright prefilters inside `collect_license_metadata()`
- keep standalone header/copyright helpers behaviorally unchanged for existing callers
- add a focused regression proving the shared metadata path only lowers the header once

## Benchmark
Synthetic long-header path, 8 MiB one-line file, 20 metadata collections per sample, median of 9 samples in a controlled same-process A/B:

- forced duplicate lowercasing: `0.687008s`
- shared lowercase view: `0.616486s`

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run --python 3.11 pytest tests/integrations/test_license_checker.py::TestLicenseMetadataCollection::test_collect_license_metadata_reuses_lowered_header -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
  - failed twice only at the existing timing-sensitive `tests/test_real_world_dill_joblib.py::TestPerformanceBenchmarks::test_validation_performance_impact` threshold (`3.48ms` and `3.11ms` observed vs `<3ms` required)
  - focused rerun of that test passed immediately
