### PR TITLE
perf: reuse lowered c2 payload scan

### DIFF
--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -862,32 +862,35 @@ class NetworkCommDetector:
 
     def _scan_cc_patterns(self, data: bytes, context: str) -> None:
         """Scan for command & control patterns."""
+        lowered_data = data.lower()
         for pattern in self.cc_patterns:
-            if pattern in data.lower():
-                # Get context
-                idx = data.lower().find(pattern)
-                start = max(0, idx - 30)
-                end = min(len(data), idx + len(pattern) + 30)
-                snippet = data[start:end].decode("utf-8", errors="ignore")
+            idx = lowered_data.find(pattern)
+            if idx < 0:
+                continue
 
-                confidence = 0.8
-                severity = "CRITICAL"
+            # Get context
+            start = max(0, idx - 30)
+            end = min(len(data), idx + len(pattern) + 30)
+            snippet = data[start:end].decode("utf-8", errors="ignore")
 
-                # Very suspicious patterns
-                if pattern in [b"malware", b"backdoor", b"trojan", b"botnet"]:
-                    confidence = 0.95
+            confidence = 0.8
+            severity = "CRITICAL"
 
-                self.findings.append(
-                    {
-                        "type": "cc_pattern",
-                        "severity": severity,
-                        "confidence": confidence,
-                        "message": f"C&C pattern detected: {pattern.decode()}",
-                        "pattern": pattern.decode(),
-                        "snippet": snippet,
-                        "context": context,
-                    }
-                )
+            # Very suspicious patterns
+            if pattern in [b"malware", b"backdoor", b"trojan", b"botnet"]:
+                confidence = 0.95
+
+            self.findings.append(
+                {
+                    "type": "cc_pattern",
+                    "severity": severity,
+                    "confidence": confidence,
+                    "message": f"C&C pattern detected: {pattern.decode()}",
+                    "pattern": pattern.decode(),
+                    "snippet": snippet,
+                    "context": context,
+                }
+            )
 
     def _scan_suspicious_ports(self, data: bytes, context: str) -> None:
         """Scan for references to suspicious ports."""

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -356,6 +356,24 @@ class TestNetworkCommDetector:
         assert "backdoor" in patterns
         assert "botnet" in patterns
 
+    def test_cc_pattern_scan_reuses_lowered_payload(self) -> None:
+        """Reuse one lowercase payload view across all C&C pattern checks."""
+
+        class TrackingBytes(bytes):
+            lower_calls = 0
+
+            def lower(self) -> bytes:
+                self.lower_calls += 1
+                return super().lower()
+
+        detector = NetworkCommDetector()
+        data = TrackingBytes(b'payload = {"malware": True, "backdoor": True}')
+
+        detector._scan_cc_patterns(data, "payload.bin")
+
+        assert data.lower_calls == 1
+        assert {finding["pattern"] for finding in detector.findings} >= {"malware", "backdoor"}
+
     def test_benign_metadata_reference_keys_are_not_cc_patterns(self) -> None:
         """Common model metadata URL keys are not C&C indicators by themselves."""
         detector = NetworkCommDetector()


### PR DESCRIPTION
## Summary
- lower each payload once before scanning C2 indicators
- replace repeated membership + find passes with one `find()` on the lowered payload
- add a focused regression proving the C2 scan only lowercases once while preserving detections

## Benchmark
Synthetic `8 MiB` payload with no C2 matches, 10 scans per sample, median of 9 samples in a controlled same-process A/B:

- prior repeated lowercasing path: `0.246317s`
- shared lowercase payload path: `0.068608s`

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest tests/detectors/test_network_comm_detector.py::TestNetworkCommDetector::test_cc_pattern_scan_reuses_lowered_payload -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
