### PR TITLE
perf: reuse lowered jax context text

### DIFF
--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -1063,6 +1063,11 @@ def _is_legitimate_serialization_file(path: str) -> bool:
     return not report.has_security_findings and report.status.value != "error"
 
 
+def _contains_any_jax_indicator(text: str, indicators: tuple[str, ...]) -> bool:
+    lowered_text = text.lower()
+    return any(indicator in lowered_text for indicator in indicators)
+
+
 def _path_prefix_looks_like_pickle(path: str) -> bool:
     try:
         with open(path, "rb") as handle:
@@ -2449,7 +2454,7 @@ class PickleScanner(BaseScanner):
             path,
             decoded_text,
         )
-        has_jax_context = any(indicator in decoded_text.lower() for indicator in jax_scanner._JAX_INDICATORS)
+        has_jax_context = _contains_any_jax_indicator(decoded_text, jax_scanner._JAX_INDICATORS)
         has_jax_findings = any(
             check.name == "JAX Pattern Security Check" and check.status == CheckStatus.FAILED
             for check in jax_result.checks

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -16,6 +16,7 @@ from modelaudit.scanners.pickle_scanner import (
     ALWAYS_DANGEROUS_FUNCTIONS,
     ALWAYS_DANGEROUS_MODULES,
     PickleScanner,
+    _contains_any_jax_indicator,
     _is_dangerous_module,
     _is_legitimate_serialization_file,
     _looks_like_pickle,
@@ -1481,6 +1482,20 @@ def test_pickle_scanner_delegates_jax_specific_patterns_for_jax_pickles(tmp_path
         and check.details["pattern"] == r"jax\.experimental\.io_callback"
         for check in result.checks
     )
+
+
+def test_contains_any_jax_indicator_reuses_lowered_text() -> None:
+    class TrackingStr(str):
+        lower_calls = 0
+
+        def lower(self) -> str:
+            self.lower_calls += 1
+            return super().lower()
+
+    text = TrackingStr("jax")
+
+    assert _contains_any_jax_indicator(text, ("jax", "flax", "haiku")) is True
+    assert text.lower_calls == 1
 
 
 def test_pickle_scanner_delegates_jax_patterns_for_pkl_suffixes(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- lower delegated JAX scan text once before checking all framework indicators
- keep the existing JAX detection semantics while removing repeated work in the wrapper path
- add a focused regression proving the helper performs one lowercase pass

## Benchmark
Synthetic `8 MiB` non-JAX text, 10 checks per sample, median of 9 samples in a controlled same-process A/B:

- repeated lowercasing path: `0.212387s`
- shared lowercase text path: `0.103317s`

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest tests/scanners/test_pickle_scanner.py::test_contains_any_jax_indicator_reuses_lowered_text -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
