### PR TITLE
perf: reuse lowered blacklist payload

### DIFF
--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -994,8 +994,9 @@ class NetworkCommDetector:
 
     def _check_blacklist(self, data: bytes, context: str) -> None:
         """Check against blacklisted domains/IPs."""
+        lowered_data = data.lower()
         for blacklisted in self.blacklisted_domains:
-            if blacklisted in data.lower():
+            if blacklisted in lowered_data:
                 self.findings.append(
                     {
                         "type": "blacklisted_domain",

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -997,6 +997,9 @@ class NetworkCommDetector:
 
     def _check_blacklist(self, data: bytes, context: str) -> None:
         """Check against blacklisted domains/IPs."""
+        if not self.blacklisted_domains:
+            return
+
         lowered_data = data.lower()
         for blacklisted in self.blacklisted_domains:
             if blacklisted in lowered_data:

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -485,6 +485,24 @@ class TestNetworkCommDetector:
         assert data.lower_calls == 1
         assert [finding["domain"] for finding in detector.findings] == ["blocked.example"]
 
+    def test_blacklist_scan_skips_lowering_without_configured_domains(self) -> None:
+        """Avoid touching payload bytes when no blacklist entries are configured."""
+
+        class TrackingBytes(bytes):
+            lower_calls = 0
+
+            def lower(self) -> bytes:
+                self.lower_calls += 1
+                return super().lower()
+
+        detector = NetworkCommDetector()
+        data = TrackingBytes(b"https://blocked.example/payload")
+
+        detector._check_blacklist(data, "payload.bin")
+
+        assert data.lower_calls == 0
+        assert detector.findings == []
+
     def test_custom_config(self) -> None:
         """Test custom configuration options."""
         config = {

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -449,6 +449,24 @@ class TestNetworkCommDetector:
         assert all(f["confidence"] == 1.0 for f in blacklist_findings)
         assert all(f["severity"] == "CRITICAL" for f in blacklist_findings)
 
+    def test_blacklist_scan_reuses_lowered_payload(self) -> None:
+        """Reuse one lowercase payload view across configured blacklist checks."""
+
+        class TrackingBytes(bytes):
+            lower_calls = 0
+
+            def lower(self) -> bytes:
+                self.lower_calls += 1
+                return super().lower()
+
+        detector = NetworkCommDetector({"custom_blacklist": [b"blocked.example", b"evil.example"]})
+        data = TrackingBytes(b"https://blocked.example/payload")
+
+        detector._check_blacklist(data, "payload.bin")
+
+        assert data.lower_calls == 1
+        assert [finding["domain"] for finding in detector.findings] == ["blocked.example"]
+
     def test_custom_config(self) -> None:
         """Test custom configuration options."""
         config = {


### PR DESCRIPTION
## Summary
- lower each payload once before checking all configured blacklist entries
- preserve existing blacklist matching semantics while removing repeated whole-payload conversions
- add a focused regression proving the blacklist path only lowercases once

## Benchmark
Synthetic `8 MiB` payload with no blacklist matches, `12` configured domains, 10 scans per sample, median of 9 samples in a controlled same-process A/B:

- repeated lowercasing path: `0.270927s`
- shared lowercase payload path: `0.085328s`

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest tests/detectors/test_network_comm_detector.py::TestNetworkCommDetector::test_blacklist_scan_reuses_lowered_payload -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
