### PR TITLE
perf: dedupe repeated metadata urls

### DIFF
--- a/modelaudit/scanners/metadata_scanner.py
+++ b/modelaudit/scanners/metadata_scanner.py
@@ -180,6 +180,7 @@ class MetadataScanner(BaseScanner):
             self._check_timeout()
             if url in seen:
                 continue
+            seen.add(url)
             parsed = urlparse(url)
             matched_domain = None
             matched_component = None
@@ -200,7 +201,6 @@ class MetadataScanner(BaseScanner):
             if matched_domain is None:
                 continue
 
-            seen.add(url)
             safe_url = _redact_url_for_display(url)
             self._add_issue_check(
                 result,

--- a/tests/scanners/test_metadata_scanner.py
+++ b/tests/scanners/test_metadata_scanner.py
@@ -2,9 +2,11 @@
 
 import tempfile
 from pathlib import Path
+from urllib.parse import ParseResult
 
 import pytest
 
+from modelaudit.scanners import metadata_scanner
 from modelaudit.scanners.base import CheckStatus, IssueSeverity
 from modelaudit.scanners.metadata_scanner import MetadataScanner
 
@@ -75,6 +77,29 @@ class TestMetadataScanner:
         }
         assert any("bit.ly" in issue.message for issue in result.issues)
         assert any("ngrok.io" in issue.message for issue in result.issues)
+
+    def test_repeated_benign_urls_are_parsed_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Skip duplicate benign URLs before reparsing them."""
+        scanner = MetadataScanner()
+        result = scanner._create_result()
+        parse_calls = 0
+        real_urlparse = metadata_scanner.urlparse
+
+        def tracking_urlparse(url: str) -> ParseResult:
+            nonlocal parse_calls
+            parse_calls += 1
+            return real_urlparse(url)
+
+        monkeypatch.setattr(metadata_scanner, "urlparse", tracking_urlparse)
+
+        scanner._check_suspicious_urls_in_text(
+            "\n".join(["https://huggingface.co/example/model"] * 3),
+            "README.md",
+            result,
+        )
+
+        assert parse_calls == 1
+        assert result.issues == []
 
     def test_scan_detects_suspicious_subdomain_hosts(self):
         """Test suspicious domains are detected through subdomain matching."""


### PR DESCRIPTION
## Summary
- mark metadata URLs as seen before parsing so repeated benign links are skipped too
- preserve suspicious URL findings while avoiding duplicate parse work for repeated ordinary URLs
- add a focused regression proving repeated benign links parse once

## Benchmark
Synthetic README text containing `20,000` copies of the same benign URL, median of 9 samples in a controlled same-process A/B:

- prior late-dedupe path: `0.034692s`
- early URL dedupe path: `0.005104s`

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest tests/scanners/test_metadata_scanner.py::TestMetadataScanner::test_repeated_benign_urls_are_parsed_once -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
