### PR TITLE
perf: reuse call graph module parses

### DIFF
--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -240,6 +240,13 @@ class _WildcardExportSummary:
 
 
 @dataclass(frozen=True)
+class _ModuleSourceContext:
+    source_path: Path
+    module_statements: tuple[ast.stmt, ...]
+    is_package: bool
+
+
+@dataclass(frozen=True)
 class _ClassSourceContext:
     module_name: str
     class_node: ast.ClassDef
@@ -720,6 +727,7 @@ def _clear_source_sensitive_caches() -> None:
         _resolve_wildcard_reexport_alias,
         _wildcard_export_summary,
         _resolve_class_target,
+        _module_source_context,
         _analyze_module,
         _source_function_context,
         _source_class_context,
@@ -1114,19 +1122,10 @@ def _resolve_wildcard_reexport_alias_inner(
 
 @lru_cache(maxsize=4096)
 def _wildcard_export_summary(module_name: str) -> _WildcardExportSummary | None:
-    source_path = _resolve_module_source(module_name)
-    if source_path is None:
+    context = _module_source_context(module_name)
+    if context is None:
         return None
-    try:
-        if source_path.stat().st_size > _MAX_SOURCE_BYTES:
-            return None
-        source = source_path.read_text(encoding="utf-8")
-        tree = ast.parse(source, filename=str(source_path))
-    except Exception:
-        return None
-
-    is_package = source_path.name == "__init__.py"
-    return _collect_module_export_summary(_module_level_statements(tree), module_name, is_package)
+    return _collect_module_export_summary(context.module_statements, module_name, context.is_package)
 
 
 @lru_cache(maxsize=4096)
@@ -1177,6 +1176,60 @@ def _split_function_name(function_name: str) -> tuple[str | None, str]:
 
 @lru_cache(maxsize=1024)
 def _analyze_module(module_name: str) -> _ModuleAnalysis | None:
+    context = _module_source_context(module_name)
+    if context is None:
+        return None
+
+    export_summary = _collect_module_export_summary(context.module_statements, module_name, context.is_package)
+    import_aliases = _collect_aliases(context.module_statements, module_name, context.is_package)
+    local_defs = _collect_local_defs(context.module_statements)
+    local_class_entrypoints = _collect_local_class_entrypoints(
+        context.module_statements,
+        module_name,
+        import_aliases,
+        local_defs,
+    )
+    local_class_targets = set(local_class_entrypoints)
+    aliases = {
+        **import_aliases,
+        **_collect_assignment_aliases(
+            context.module_statements,
+            module_name,
+            import_aliases,
+            local_defs,
+            local_class_targets,
+        ),
+    }
+    aliases.update(
+        _collect_class_instance_default_aliases(
+            context.module_statements,
+            module_name,
+            aliases,
+            local_defs,
+            local_class_targets,
+        )
+    )
+    calls_by_function, class_entrypoints = _collect_function_calls(
+        context.module_statements,
+        module_name,
+        context.is_package,
+        aliases,
+        local_defs,
+        local_class_targets,
+        local_class_entrypoints,
+    )
+    return _ModuleAnalysis(
+        module=module_name,
+        source_path=str(context.source_path),
+        aliases=aliases,
+        direct_names=export_summary.direct_names,
+        calls_by_function=calls_by_function,
+        class_entrypoints=class_entrypoints,
+    )
+
+
+@lru_cache(maxsize=4096)
+def _module_source_context(module_name: str) -> _ModuleSourceContext | None:
     source_path = _resolve_module_source(module_name)
     if source_path is None:
         return None
@@ -1190,49 +1243,7 @@ def _analyze_module(module_name: str) -> _ModuleAnalysis | None:
 
     is_package = source_path.name == "__init__.py"
     module_statements = _module_level_statements(tree)
-    export_summary = _collect_module_export_summary(module_statements, module_name, is_package)
-    import_aliases = _collect_aliases(module_statements, module_name, is_package)
-    local_defs = _collect_local_defs(module_statements)
-    local_class_entrypoints = _collect_local_class_entrypoints(
-        module_statements, module_name, import_aliases, local_defs
-    )
-    local_class_targets = set(local_class_entrypoints)
-    aliases = {
-        **import_aliases,
-        **_collect_assignment_aliases(
-            module_statements,
-            module_name,
-            import_aliases,
-            local_defs,
-            local_class_targets,
-        ),
-    }
-    aliases.update(
-        _collect_class_instance_default_aliases(
-            module_statements,
-            module_name,
-            aliases,
-            local_defs,
-            local_class_targets,
-        )
-    )
-    calls_by_function, class_entrypoints = _collect_function_calls(
-        module_statements,
-        module_name,
-        is_package,
-        aliases,
-        local_defs,
-        local_class_targets,
-        local_class_entrypoints,
-    )
-    return _ModuleAnalysis(
-        module=module_name,
-        source_path=str(source_path),
-        aliases=aliases,
-        direct_names=export_summary.direct_names,
-        calls_by_function=calls_by_function,
-        class_entrypoints=class_entrypoints,
-    )
+    return _ModuleSourceContext(source_path=source_path, module_statements=module_statements, is_package=is_package)
 
 
 def _module_level_statements(tree: ast.Module) -> tuple[ast.stmt, ...]:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import importlib
 import io
 import os
@@ -79,10 +80,36 @@ def _clear_call_graph_caches() -> None:
         "_resolve_module_source",
         "_safe_call_graph_entrypoints",
         "_wildcard_export_summary",
+        "_module_source_context",
     ):
         cache_clear = getattr(getattr(call_graph_module, function_name), "cache_clear", None)
         if cache_clear is not None:
             cache_clear()
+
+
+def test_wildcard_summary_and_analysis_share_module_parse(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_path = tmp_path / "module.py"
+    module_path.write_text("from dependency import *\n\ndef run():\n    return 1\n", encoding="utf-8")
+    parse_calls = 0
+    real_parse = call_graph.ast.parse
+
+    def tracking_parse(source: str, filename: str = "<unknown>") -> ast.Module:
+        nonlocal parse_calls
+        parse_calls += 1
+        return real_parse(source, filename=filename)
+
+    monkeypatch.setattr(
+        call_graph, "_resolve_module_source", lambda module_name: module_path if module_name == "module" else None
+    )
+    monkeypatch.setattr(call_graph.ast, "parse", tracking_parse)
+    _clear_call_graph_caches()
+
+    assert call_graph._wildcard_export_summary("module") is not None
+    assert call_graph._analyze_module("module") is not None
+    assert parse_calls == 1
 
 
 def _env_without_pythonpath() -> dict[str, str]:


### PR DESCRIPTION
## Summary
- share one cached module-source parse between wildcard export summaries and full call-graph module analysis
- keep the cache source-sensitive by clearing the new context with the existing call-graph caches
- add a focused regression proving both consumers parse a module once together

## Benchmark
Synthetic module with `200` local functions, `20` cache-cleared wildcard-summary plus full-analysis pairs per sample, median of 9 samples:

- duplicate parse path: `0.115265s`
- shared source-context path: `0.095118s`

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py::test_wildcard_summary_and_analysis_share_module_parse -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
