### PR TITLE
perf: reuse lowered keras metadata text

### DIFF
--- a/modelaudit/scanners/keras_utils.py
+++ b/modelaudit/scanners/keras_utils.py
@@ -2,7 +2,7 @@
 
 import base64
 import re
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from typing import Any
 
 from modelaudit.detectors.suspicious_symbols import (
@@ -127,6 +127,12 @@ def is_known_safe_keras_loss(identifier: Any) -> bool:
 def is_known_safe_keras_metric(identifier: Any) -> bool:
     """Return True when a serialized Keras metric identifier is known-safe."""
     return isinstance(identifier, str) and _normalize_keras_identifier(identifier) in _SAFE_KERAS_METRIC_IDENTIFIERS
+
+
+def find_case_insensitive_substrings(text: str, patterns: Iterable[str]) -> list[str]:
+    """Return configured substrings present in `text` using one lowercase pass."""
+    lowered = text.lower()
+    return [pattern for pattern in patterns if pattern in lowered]
 
 
 def iter_keras_serialized_identifiers(value: Any) -> Iterator[tuple[str, Any]]:
@@ -301,7 +307,7 @@ def check_lambda_dict_function(
         )
         return True
 
-    found_patterns = [p for p in _LAMBDA_DANGEROUS_PATTERNS if p in decoded_str.lower()]
+    found_patterns = find_case_insensitive_substrings(decoded_str, _LAMBDA_DANGEROUS_PATTERNS)
 
     if found_patterns:
         result.add_check(

--- a/modelaudit/scanners/keras_zip_scanner.py
+++ b/modelaudit/scanners/keras_zip_scanner.py
@@ -38,6 +38,7 @@ from .keras_utils import (
     check_custom_metric_config,
     check_lambda_dict_function,
     check_subclassed_model,
+    find_case_insensitive_substrings,
     is_known_safe_keras_layer_class,
 )
 
@@ -1790,10 +1791,7 @@ class KerasZipScanner(BaseScanner):
                         "webbrowser",
                     ]
 
-                    found_patterns = []
-                    for pattern in dangerous_patterns:
-                        if pattern in decoded_str.lower():
-                            found_patterns.append(pattern)
+                    found_patterns = find_case_insensitive_substrings(decoded_str, dangerous_patterns)
 
                     if found_patterns:
                         result.add_check(

--- a/modelaudit/scanners/tf_savedmodel_scanner.py
+++ b/modelaudit/scanners/tf_savedmodel_scanner.py
@@ -22,6 +22,7 @@ from modelaudit.utils.tensorflow_compat import has_tensorflow_protobuf_stubs
 
 from ..scanner_results import INCONCLUSIVE_SCAN_OUTCOME, mark_inconclusive_scan_result
 from .base import BaseScanner, IssueSeverity, ScanResult
+from .keras_utils import find_case_insensitive_substrings
 
 logger = logging.getLogger(__name__)
 
@@ -1187,10 +1188,7 @@ class TensorFlowSavedModelScanner(BaseScanner):
                                 "webbrowser",
                             ]
 
-                            found_patterns = []
-                            for pattern in dangerous_patterns:
-                                if pattern in decoded_str.lower():
-                                    found_patterns.append(pattern)
+                            found_patterns = find_case_insensitive_substrings(decoded_str, dangerous_patterns)
 
                             if found_patterns:
                                 result.add_check(
@@ -1275,8 +1273,9 @@ class TensorFlowSavedModelScanner(BaseScanner):
                     "marshal": "Unsafe deserialization",
                 }
 
+                present_patterns = set(find_case_insensitive_substrings(content_str, suspicious_patterns))
                 for pattern, description in suspicious_patterns.items():
-                    if pattern in content_str.lower():
+                    if pattern in present_patterns:
                         result.add_check(
                             name="Keras Metadata Pattern Check",
                             passed=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,7 @@ def pytest_runtest_setup(item):
             "tests/utils/sources/test_cloud_storage.py",  # Cloud storage source tests
             "test_skops_scanner.py",  # Skops scanner CVE detection tests
             "test_keras_zip_scanner.py",  # Keras ZIP scanner tests
+            "test_keras_utils.py",  # Shared Keras scanner helper tests
             "test_nemo_scanner.py",  # NeMo scanner CVE-2025-23304 tests
             "test_numpy_scanner.py",  # NumPy scanner CVE-2019-6446 tests
             "test_onnx_scanner.py",  # ONNX scanner CVE-2025-51480 tests

--- a/tests/scanners/test_keras_utils.py
+++ b/tests/scanners/test_keras_utils.py
@@ -1,0 +1,23 @@
+"""Tests for shared Keras scanner helpers."""
+
+from modelaudit.scanners.keras_utils import find_case_insensitive_substrings
+
+
+class _LowerCountingText(str):
+    lower_calls: int
+
+    def __new__(cls, value: str) -> "_LowerCountingText":
+        instance = super().__new__(cls, value)
+        instance.lower_calls = 0
+        return instance
+
+    def lower(self) -> str:
+        self.lower_calls += 1
+        return super().lower()
+
+
+def test_find_case_insensitive_substrings_reuses_lowered_text() -> None:
+    text = _LowerCountingText("Exec once, leave eval absent")
+
+    assert find_case_insensitive_substrings(text, ("exec", "eval", "marshal")) == ["exec", "eval"]
+    assert text.lower_calls == 1


### PR DESCRIPTION
## Summary
- add a shared Keras substring matcher that lowercases text once per scan
- reuse it across Keras dict-format Lambda handling, Keras ZIP Lambda handling, and TensorFlow SavedModel keras metadata checks
- add a focused regression proving the helper performs one lowercase pass

## Benchmarks
Synthetic same-process `8 MiB` no-match text, median of 9 samples with 10 scans/sample:
- decoded Lambda dangerous-pattern pass: `0.966723s -> 0.211598s`
- direct keras metadata suspicious-pattern pass: `0.580823s -> 0.233578s`

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_keras_utils.py tests/scanners/test_keras_zip_scanner.py::TestKerasZipScanner::test_lambda_layer_with_exec tests/scanners/test_tf_savedmodel_scanner.py::test_scan_keras_metadata_pb_lambda_exec_sets_success_false`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` *(hit the existing local timing-sensitive `tests/test_real_world_dill_joblib.py::TestPerformanceBenchmarks::test_validation_performance_impact` threshold once at `3.48ms < 3ms`; isolated rerun passed)*
