### PR TITLE
perf: reuse lowered flax transform values

### DIFF
--- a/modelaudit/scanners/flax_msgpack_scanner.py
+++ b/modelaudit/scanners/flax_msgpack_scanner.py
@@ -27,6 +27,13 @@ except Exception:  # pragma: no cover - optional dependency missing
 
 from .base import BaseScanner, IssueSeverity, ScanResult
 
+_DANGEROUS_JAX_TRANSFORMS = ("jit_compile", "eval_jit", "exec_transform", "dynamic_eval", "runtime_eval")
+
+
+def _matching_jax_transforms(key_str: str, value_str: str) -> list[str]:
+    value_lower = value_str.lower()
+    return [transform for transform in _DANGEROUS_JAX_TRANSFORMS if transform in key_str or transform in value_lower]
+
 
 class FlaxMsgpackScanner(BaseScanner):
     """Scanner for Flax/JAX msgpack checkpoint files with enhanced security threat detection."""
@@ -334,23 +341,19 @@ class FlaxMsgpackScanner(BaseScanner):
                     key_str = str(key).lower()
                     value_str = str(value)
 
-                    # Check for suspicious JAX transform patterns
-                    dangerous_transforms = ["jit_compile", "eval_jit", "exec_transform", "dynamic_eval", "runtime_eval"]
-
-                    for transform in dangerous_transforms:
-                        if transform in key_str or transform in value_str.lower():
-                            result.add_check(
-                                name="JAX Transform Security Check",
-                                passed=False,
-                                message=f"Suspicious JAX transform detected: {transform}",
-                                severity=IssueSeverity.CRITICAL,
-                                location=f"{path}/{key}",
-                                details={
-                                    "transform": transform,
-                                    "context": value_str[:200] if len(value_str) > 200 else value_str,
-                                },
-                                rule_code="S1105",  # JAX compilation risks
-                            )
+                    for transform in _matching_jax_transforms(key_str, value_str):
+                        result.add_check(
+                            name="JAX Transform Security Check",
+                            passed=False,
+                            message=f"Suspicious JAX transform detected: {transform}",
+                            severity=IssueSeverity.CRITICAL,
+                            location=f"{path}/{key}",
+                            details={
+                                "transform": transform,
+                                "context": value_str[:200] if len(value_str) > 200 else value_str,
+                            },
+                            rule_code="S1105",  # JAX compilation risks
+                        )
 
                     check_jax_transforms(value, f"{path}/{key}" if path else key)
             elif isinstance(data, list | tuple):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,7 @@ def pytest_runtest_setup(item):
             "tests/utils/sources/test_cloud_storage.py",  # Cloud storage source tests
             "test_skops_scanner.py",  # Skops scanner CVE detection tests
             "test_keras_zip_scanner.py",  # Keras ZIP scanner tests
+            "test_flax_msgpack_scanner.py",  # Flax msgpack scanner performance and safety tests
             "test_nemo_scanner.py",  # NeMo scanner CVE-2025-23304 tests
             "test_numpy_scanner.py",  # NumPy scanner CVE-2019-6446 tests
             "test_onnx_scanner.py",  # ONNX scanner CVE-2025-51480 tests

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -10,7 +10,7 @@ pytest.importorskip("msgpack")
 import msgpack
 
 from modelaudit.scanners.base import CheckStatus, IssueSeverity
-from modelaudit.scanners.flax_msgpack_scanner import FlaxMsgpackScanner
+from modelaudit.scanners.flax_msgpack_scanner import FlaxMsgpackScanner, _matching_jax_transforms
 
 
 def create_msgpack_file(path: Path, data: Any) -> None:
@@ -28,6 +28,26 @@ def create_malicious_msgpack_file(path):
         "suspicious_blob": b"eval(compile('malicious code', 'string', 'exec'))" * 1000,
     }
     create_msgpack_file(path, malicious_data)
+
+
+class _LowerCountingText(str):
+    lower_calls: int
+
+    def __new__(cls, value: str) -> "_LowerCountingText":
+        instance = super().__new__(cls, value)
+        instance.lower_calls = 0
+        return instance
+
+    def lower(self) -> str:
+        self.lower_calls += 1
+        return super().lower()
+
+
+def test_matching_jax_transforms_reuses_lowered_value_text() -> None:
+    value = _LowerCountingText("dynamic_eval payload")
+
+    assert _matching_jax_transforms("weights", value) == ["dynamic_eval"]
+    assert value.lower_calls == 1
 
 
 def test_flax_msgpack_valid_checkpoint(tmp_path):


### PR DESCRIPTION
## Summary
- centralize Flax/JAX transform matching in one helper
- lowercase decoded value text once before testing all transform markers
- add a focused regression proving the helper performs one lowercase pass

## Benchmarks
Synthetic same-process `8 MiB` no-match value string, median of 9 samples with 10 scans/sample:
- repeated lowercasing path: `0.386153s`
- shared lowercase text: `0.210867s`

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_flax_msgpack_scanner.py::test_matching_jax_transforms_reuses_lowered_value_text tests/scanners/test_flax_msgpack_scanner.py::test_flax_msgpack_suspicious_content`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` *(hit the existing local timing-sensitive `tests/test_real_world_dill_joblib.py::TestPerformanceBenchmarks::test_validation_performance_impact` threshold once at `6.72ms < 3ms`; isolated rerun passed)*
