### PR TITLE
perf: add opt-in core phase timings

### DIFF
--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -90,6 +90,25 @@ _RECOGNIZED_FORMAT_SCANNER_UNAVAILABLE_REASON = "recognized_format_scanner_unava
 _XML_MODEL_ROUTING_INCOMPLETE_REASON = "xml_model_routing_incomplete"
 
 
+def _start_phase_timing(phase_timings: dict[str, float] | None) -> float | None:
+    return time.perf_counter() if phase_timings is not None else None
+
+
+def _finish_phase_timing(
+    phase_timings: dict[str, float] | None,
+    phase_name: str,
+    started_at: float | None,
+) -> None:
+    if phase_timings is None or started_at is None:
+        return
+    phase_timings[phase_name] = phase_timings.get(phase_name, 0.0) + (time.perf_counter() - started_at)
+
+
+def _attach_phase_timings(results: ModelAuditResultModel, phase_timings: dict[str, float] | None) -> None:
+    if phase_timings is not None:
+        results.phase_timings = phase_timings  # type: ignore[attr-defined]
+
+
 def _select_preferred_scanner_id(path: str, header_format: str, ext: str) -> str | None:
     """Select a scanner by trusted file structure, not just suffix."""
     if header_format == "zip":
@@ -359,7 +378,10 @@ def scan_model_directory_or_file(
     # Track file hashes for aggregate hash computation
     file_hashes: list[str] = []
 
+    phase_timings: dict[str, float] | None = {} if bool(kwargs.get("profile_timings")) else None
+
     # Configure scan options
+    scanner_selection_started_at = _start_phase_timing(phase_timings)
     config = {
         "blacklist_patterns": blacklist_patterns,
         "max_file_size": max_file_size,
@@ -376,6 +398,7 @@ def scan_model_directory_or_file(
         results.scanner_selection = scanner_selection.to_metadata()
 
     validate_scan_config(config)
+    _finish_phase_timing(phase_timings, "scanner_selection", scanner_selection_started_at)
 
     # Check if metadata scanner is available once (optimization - avoids loading scanner)
     metadata_scanner_available = scanner_selection.allows("metadata") and _registry.has_scanner_class("MetadataScanner")
@@ -420,12 +443,15 @@ def scan_model_directory_or_file(
 
             # Return early for streaming - finalize the model
             try:
+                streaming_scan_started_at = _start_phase_timing(phase_timings)
                 _consolidate_checks(results)
+                _finish_phase_timing(phase_timings, "result_consolidation", streaming_scan_started_at)
             except Exception as e:
                 logger.warning(f"Error consolidating checks ({type(e).__name__}): {e!s}", exc_info=e)
             results.has_errors = bool(scan_metadata.get("has_operational_errors", False))
             results.success = not _results_should_be_unsuccessful(results)
             results.finalize_statistics()
+            _attach_phase_timings(results, phase_timings)
             return results
 
         # Check if path exists (for non-streaming paths)
@@ -450,6 +476,7 @@ def scan_model_directory_or_file(
             # Quick check: count files only if directory seems reasonable in size
             # This avoids the expensive rglob() on large directories
             try:
+                directory_file_count_started_at = _start_phase_timing(phase_timings)
                 # Do a quick count of immediate children first
                 immediate_children = len(list(Path(path).iterdir()))
                 if immediate_children < 1000:  # Only count if not too many immediate children
@@ -457,6 +484,8 @@ def scan_model_directory_or_file(
             except (OSError, PermissionError):
                 # If we can't count, just proceed without progress percentage
                 total_files = None
+            finally:
+                _finish_phase_timing(phase_timings, "directory_file_count", directory_file_count_started_at)
 
             base_dir = Path(path).resolve()
             hf_cache_root = _find_hf_cache_root(base_dir)
@@ -465,6 +494,7 @@ def scan_model_directory_or_file(
 
             # First pass: collect all file paths that need scanning
             files_to_scan: list[str] = []
+            directory_discovery_started_at = _start_phase_timing(phase_timings)
             for root, _, files in os.walk(path, followlinks=False):
                 for file in files:
                     file_path = os.path.join(root, file)
@@ -495,7 +525,9 @@ def scan_model_directory_or_file(
                         filename_lower = Path(file_path).name.lower()
                         if filename_lower in LICENSE_FILES:
                             try:
+                                license_metadata_started_at = _start_phase_timing(phase_timings)
                                 license_metadata = collect_license_metadata(str(resolved_file))
+                                _finish_phase_timing(phase_timings, "license_metadata", license_metadata_started_at)
                                 from .models import FileMetadataModel
 
                                 results.file_metadata[str(resolved_file)] = FileMetadataModel(**license_metadata)
@@ -531,12 +563,15 @@ def scan_model_directory_or_file(
 
                         # Add to files to scan list instead of scanning immediately
                         files_to_scan.append(target_str)
+            _finish_phase_timing(phase_timings, "directory_discovery", directory_discovery_started_at)
 
             # Second pass: scan every path independently. Some scanners depend on
             # parent paths or sibling files, so content equality alone is not a
             # safe proxy for scan-result equality.
             if files_to_scan:
+                top_level_hashing_started_at = _start_phase_timing(phase_timings)
                 content_hashes = _hash_files_by_path(files_to_scan)
+                _finish_phase_timing(phase_timings, "top_level_hashing", top_level_hashing_started_at)
                 duplicate_paths_by_hash: dict[str, list[str]] = {}
                 for file_path, content_hash in content_hashes.items():
                     if not content_hash.startswith("unhashable_"):
@@ -574,7 +609,13 @@ def scan_model_directory_or_file(
                         # Check for interrupts before scanning each file
                         check_interrupted()
 
-                        file_result = scan_file(representative_file, config)
+                        file_scan_started_at = _start_phase_timing(phase_timings)
+                        try:
+                            file_result = scan_file(representative_file, config)
+                        finally:
+                            _finish_phase_timing(phase_timings, "file_scan_dispatch", file_scan_started_at)
+
+                        result_merge_started_at = _start_phase_timing(phase_timings)
                         _normalize_unclassified_scan_failure(file_result)
                         if _scan_result_has_operational_error(file_result):
                             scan_metadata["has_operational_errors"] = True
@@ -647,9 +688,12 @@ def scan_model_directory_or_file(
                                     results.checks.append(Check(**check_dict))
 
                         _add_asset_to_results(results, representative_file, file_result)
+                        _finish_phase_timing(phase_timings, "result_merge", result_merge_started_at)
 
                         # Add metadata for this path using Pydantic models
+                        license_metadata_started_at = _start_phase_timing(phase_timings)
                         license_metadata = collect_license_metadata(representative_file)
+                        _finish_phase_timing(phase_timings, "license_metadata", license_metadata_started_at)
                         combined_metadata = {**file_result.metadata, **license_metadata}
                         combined_metadata["content_hash"] = content_hash
                         duplicate_files = duplicate_paths_by_hash.get(content_hash, [])
@@ -728,20 +772,31 @@ def scan_model_directory_or_file(
                 # nested member results into their metadata, so scanner-emitted
                 # hashes are not always the bytes of this target.
                 try:
+                    top_level_hashing_started_at = _start_phase_timing(phase_timings)
                     file_hash = _calculate_file_hash(target)
                     file_hashes.append(file_hash)
                 except Exception as e:
                     logger.debug(f"Failed to hash file {target}: {e}")
+                finally:
+                    _finish_phase_timing(phase_timings, "top_level_hashing", top_level_hashing_started_at)
 
-                file_result = scan_file(target, config)
+                file_scan_started_at = _start_phase_timing(phase_timings)
+                try:
+                    file_result = scan_file(target, config)
+                finally:
+                    _finish_phase_timing(phase_timings, "file_scan_dispatch", file_scan_started_at)
 
                 # Use helper function to add scan result to Pydantic model
+                result_merge_started_at = _start_phase_timing(phase_timings)
                 _add_scan_result_to_model(results, scan_metadata, file_result, target)
 
                 _add_asset_to_results(results, target, file_result)
+                _finish_phase_timing(phase_timings, "result_merge", result_merge_started_at)
 
                 # Collect and apply license metadata for all files
+                license_metadata_started_at = _start_phase_timing(phase_timings)
                 license_metadata = collect_license_metadata(target)
+                _finish_phase_timing(phase_timings, "license_metadata", license_metadata_started_at)
                 if license_metadata:
                     from .models import FileMetadataModel
 
@@ -787,13 +842,17 @@ def scan_model_directory_or_file(
 
     # Consolidate checks for cleaner reporting
     try:
+        result_consolidation_started_at = _start_phase_timing(phase_timings)
         _consolidate_checks(results)
+        _finish_phase_timing(phase_timings, "result_consolidation", result_consolidation_started_at)
     except Exception as e:
         logger.warning(f"Error consolidating checks ({type(e).__name__}): {e!s}", exc_info=e)
 
     # Add license warnings if any
     try:
+        commercial_use_started_at = _start_phase_timing(phase_timings)
         license_warnings = check_commercial_use_warnings(results, strict=config.get("strict_license", False))
+        _finish_phase_timing(phase_timings, "commercial_use_warnings", commercial_use_started_at)
         for warning in license_warnings:
             _add_issue_to_model(
                 results,
@@ -816,12 +875,15 @@ def scan_model_directory_or_file(
     if file_hashes:
         from .utils.helpers.secure_hasher import compute_aggregate_hash
 
+        aggregate_hash_started_at = _start_phase_timing(phase_timings)
         results.content_hash = compute_aggregate_hash(file_hashes)
+        _finish_phase_timing(phase_timings, "aggregate_hash", aggregate_hash_started_at)
         logger.info(f"Computed aggregate content hash from {len(file_hashes)} file(s): {results.content_hash}")
 
     # Finalize statistics and return Pydantic model
     results.finalize_statistics()
     results.deduplicate_issues()
+    _attach_phase_timings(results, phase_timings)
     return results
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -222,6 +222,35 @@ def test_scan_directory_preserves_parseable_prefixed_zip_with_central_directory_
     )
 
 
+def test_scan_model_omits_phase_timings_by_default(tmp_path: Path) -> None:
+    payload = tmp_path / "payload.pkl"
+    payload.write_bytes(pickle.dumps({"weights": [1, 2, 3]}))
+
+    result = scan_model_directory_or_file(str(payload), cache_scan_results=False)
+
+    assert not hasattr(result, "phase_timings")
+
+
+def test_scan_model_emits_opt_in_phase_timings(tmp_path: Path) -> None:
+    payload = tmp_path / "payload.pkl"
+    payload.write_bytes(pickle.dumps({"weights": [1, 2, 3]}))
+
+    result = scan_model_directory_or_file(str(payload), cache_scan_results=False, profile_timings=True)
+    phase_timings = result.phase_timings  # type: ignore[attr-defined]
+
+    assert phase_timings.keys() >= {
+        "scanner_selection",
+        "top_level_hashing",
+        "file_scan_dispatch",
+        "result_merge",
+        "license_metadata",
+        "result_consolidation",
+        "commercial_use_warnings",
+        "aggregate_hash",
+    }
+    assert all(duration >= 0 for duration in phase_timings.values())
+
+
 def test_scan_file_detects_misnamed_gzip_wrapped_pickle_by_header(tmp_path: Path) -> None:
     disguised_gzip = tmp_path / "payload.jpg"
     disguised_gzip.write_bytes(gzip.compress(_build_malicious_pickle()))


### PR DESCRIPTION
## Summary
- add opt-in `profile_timings=True` support to expose coarse core scan phases without changing the default result shape
- record scanner selection, directory counting/discovery, hashing, scan dispatch, result merge, license metadata, consolidation, commercial-use warnings, and aggregate-hash time
- add focused regressions proving the field is absent by default and present when requested

## Benchmarks
Synthetic same-process directory scan with `25` tiny pickle files, median of 5 runs:
- default result path: `0.201428s`
- `profile_timings=True`: `0.189312s`

The difference is within noise; the point of this PR is observability, and the opt-in path shows no material overhead in the smoke benchmark.

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_core.py::test_scan_model_omits_phase_timings_by_default tests/test_core.py::test_scan_model_emits_opt_in_phase_timings`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` *(hit one unrelated local picklescan failure during the full xdist lane; the isolated rerun of `packages/modelaudit-picklescan/tests/test_api.py::test_scan_file_leaves_hidden_pickle_like_zip_without_pytorch_metadata_unrecognized` passed immediately)*
