### PR TITLE
perf: reuse cache key content hash on store

### DIFF
--- a/modelaudit/cache/adaptive_cache_keys.py
+++ b/modelaudit/cache/adaptive_cache_keys.py
@@ -63,17 +63,24 @@ class AdaptiveCacheKeyGenerator:
         self.fingerprint_cache = {}  # Brief cache for repeated operations
         self.cache_expiry = 5.0  # Cache fingerprints for 5 seconds
 
-    def generate_key_with_stat_reuse(self, file_path: str, stat_result: os.stat_result) -> str:
-        """Generate cache key reusing existing stat result for optimal performance."""
+    def generate_key_material_with_stat_reuse(
+        self, file_path: str, stat_result: os.stat_result
+    ) -> tuple[str, str | None]:
+        """Generate a cache key plus any content hash already needed for that key."""
         fingerprint = FileFingerprint.from_stat(file_path, stat_result)
 
         # Use content hash strategy based on file size
         if self._should_use_content_hash(stat_result.st_size):
             secure_key = fingerprint.secure_key(file_path, self.hasher)
-            return str(secure_key)
-        else:
-            quick_key = fingerprint.quick_key()
-            return str(quick_key)
+            return str(secure_key), fingerprint.content_hash
+
+        quick_key = fingerprint.quick_key()
+        return str(quick_key), None
+
+    def generate_key_with_stat_reuse(self, file_path: str, stat_result: os.stat_result) -> str:
+        """Generate cache key reusing existing stat result for optimal performance."""
+        cache_key, _content_hash = self.generate_key_material_with_stat_reuse(file_path, stat_result)
+        return cache_key
 
     def generate_key(self, file_path: str) -> str:
         """Generate cache key using an adaptive strategy."""

--- a/modelaudit/cache/scan_results_cache.py
+++ b/modelaudit/cache/scan_results_cache.py
@@ -223,7 +223,7 @@ class ScanResultsCache:
                 return False
 
             # Pass file_stat to avoid redundant calls
-            cache_key = self._generate_cache_key(
+            cache_key, content_hash = self._generate_cache_key_material(
                 file_path,
                 file_stat=file_stat,
                 version_context=version_context,
@@ -232,8 +232,8 @@ class ScanResultsCache:
             if not cache_key:
                 return False
 
-            # Use optimized hash method with stat reuse
-            file_hash = self.hasher.hash_file_with_stat(file_path, file_stat)
+            # Large-file cache keys already require this exact secure content hash.
+            file_hash = content_hash or self.hasher.hash_file_with_stat(file_path, file_stat)
             mtime_ns = getattr(file_stat, "st_mtime_ns", int(file_stat.st_mtime * 1_000_000_000))
 
             cache_entry = CacheEntry(
@@ -302,17 +302,34 @@ class ScanResultsCache:
         Returns:
             Cache key string or None if generation failed
         """
+        cache_key, _content_hash = self._generate_cache_key_material(
+            file_path,
+            file_stat=file_stat,
+            version_context=version_context,
+            version_info=version_info,
+        )
+        return cache_key
+
+    def _generate_cache_key_material(
+        self,
+        file_path: str,
+        file_stat: os.stat_result | None = None,
+        version_context: dict[str, Any] | None = None,
+        version_info: dict[str, Any] | None = None,
+    ) -> tuple[str | None, str | None]:
+        """Generate a cache key and surface any secure content hash already computed for it."""
         try:
             if file_stat is not None:
-                file_key = self.key_generator.generate_key_with_stat_reuse(file_path, file_stat)
+                file_key, content_hash = self.key_generator.generate_key_material_with_stat_reuse(file_path, file_stat)
             else:
                 file_key = self.key_generator.generate_key(file_path)
+                content_hash = None
 
             resolved_version_info = (
                 version_info if version_info is not None else self._get_version_info(version_context)
             )
             if resolved_version_info is None:
-                return None
+                return None, None
 
             # Create version fingerprint
             version_str = json.dumps(resolved_version_info, sort_keys=True)
@@ -323,11 +340,11 @@ class ScanResultsCache:
             clean_file_key = file_key.split(":")[-1]
             cache_key = f"{clean_file_key}_{version_hash}"
 
-            return cache_key
+            return cache_key, content_hash
 
         except Exception as e:
             logger.debug(f"Failed to generate cache key for {file_path}: {e}")
-            return None
+            return None, None
 
     def _get_cache_file_path(self, cache_key: str) -> Path:
         """

--- a/tests/cache/test_cache_correctness.py
+++ b/tests/cache/test_cache_correctness.py
@@ -534,7 +534,7 @@ def test_batch_store_counts_only_persisted_results(tmp_path: Path, monkeypatch: 
     batch_ops = BatchCacheOperations(cache_manager)
 
     assert cache_manager.cache is not None
-    monkeypatch.setattr(cache_manager.cache, "_generate_cache_key", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cache_manager.cache, "_generate_cache_key_material", lambda *args, **kwargs: (None, None))
 
     stored_count = batch_ops.batch_store(
         [
@@ -613,6 +613,31 @@ def test_cache_key_generation_avoids_full_hash_for_medium_files(
     cache_key = cache.generate_cache_key(str(file_path), version_context=build_cache_version_context({"timeout": 30}))
 
     assert cache_key is not None
+
+
+def test_large_file_store_reuses_cache_key_content_hash(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    file_path = _make_cacheable_file(tmp_path, name="large.bin")
+    file_path.write_bytes(b"x" * (11 * 1024 * 1024))
+    cache = ScanResultsCache(str(tmp_path / "scan-cache"))
+    version_context = build_cache_version_context({"timeout": 30})
+    expected_hash = "secure:" + ("a" * 64)
+    expected = {"checks": [], "issues": [], "metadata": {}, "scanner": "test", "success": True}
+
+    monkeypatch.setattr(cache.key_generator.hasher, "hash_file", lambda _path: expected_hash)
+
+    def fail_hash(_path: str, _stat: os.stat_result) -> str:
+        raise AssertionError("large-file cache store should reuse the cache-key content hash")
+
+    monkeypatch.setattr(cache.hasher, "hash_file_with_stat", fail_hash)
+
+    assert cache.store_result(str(file_path), expected, 10, version_context=version_context) is True
+
+    cache_key = cache.generate_cache_key(str(file_path), version_context=version_context)
+    assert cache_key is not None
+    cache_file_path = cache._get_cache_file_path(cache_key)
+    cache_entry = json.loads(cache_file_path.read_text(encoding="utf-8"))
+
+    assert cache_entry["file_info"]["hash"] == expected_hash
 
 
 def test_same_size_rewrite_with_high_resolution_mtime_invalidates_cache(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- reuse the secure large-file content hash already computed while building cache keys
- avoid an immediate second full-file hash during cache writes
- add regression coverage for the large-file store path

## Benchmark
- synthetic 64 MiB cache store, five runs
- before: median 0.126905s; key hash calls 5; store hash calls 5
- after: median 0.110148s; key hash calls 5; store hash calls 0

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/cache/test_cache_correctness.py -q`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`