### PR TITLE
perf: reuse compiled pmml extension patterns

### DIFF
--- a/modelaudit/scanners/pmml_scanner.py
+++ b/modelaudit/scanners/pmml_scanner.py
@@ -33,6 +33,7 @@ SUSPICIOUS_PATTERNS = [
     r"__import__",
     r"\bsystem\s*\(",
 ]
+_COMPILED_SUSPICIOUS_PATTERNS = tuple((pattern, re.compile(pattern)) for pattern in SUSPICIOUS_PATTERNS)
 URL_PATTERNS = ["http://", "https://", "file://", "ftp://"]
 BENIGN_DOCUMENTATION_URL_PATTERNS = frozenset({"http://", "https://"})
 DANGEROUS_ENTITIES = ["<!DOCTYPE", "<!ENTITY", "<!ELEMENT", "<!ATTLIST"]
@@ -366,8 +367,8 @@ class PmmlScanner(BaseScanner):
 
             # Special attention to Extension elements which can contain arbitrary content
             if tag_name == "extension":
-                for pattern in SUSPICIOUS_PATTERNS:
-                    if re.search(pattern, combined, re.IGNORECASE):
+                for pattern, compiled_pattern in _COMPILED_SUSPICIOUS_PATTERNS:
+                    if compiled_pattern.search(combined):
                         result.add_check(
                             name="Extension Element Security Check",
                             passed=False,

--- a/tests/scanners/test_pmml_scanner.py
+++ b/tests/scanners/test_pmml_scanner.py
@@ -98,6 +98,23 @@ def test_pmml_scanner_system_call_is_flagged(tmp_path: Path) -> None:
     assert any(issue.details.get("pattern") == r"\bsystem\s*\(" for issue in result.issues)
 
 
+def test_pmml_scanner_mixed_case_system_call_is_flagged(tmp_path: Path) -> None:
+    pmml = """<?xml version='1.0'?>
+<PMML version='4.4'>
+  <Header>
+    <Extension>SyStEm('id')</Extension>
+  </Header>
+  <DataDictionary numberOfFields='0'/>
+</PMML>"""
+    path = tmp_path / "mixed_case_system_call.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    result = PmmlScanner().scan(str(path))
+
+    assert result.success is True
+    assert any(issue.details.get("pattern") == r"\bsystem\s*\(" for issue in result.issues)
+
+
 def test_pmml_scanner_namespaced_extension_content(tmp_path: Path) -> None:
     """Test namespaced Extension and script tags are inspected."""
     pmml = """<?xml version='1.0'?>


### PR DESCRIPTION
## Summary
- compile PMML suspicious extension patterns once at module load
- search the already-lowered extension text case-sensitively instead of redoing ignore-case regex work
- add a mixed-case malicious extension regression to preserve detection behavior

## Benchmark
- synthetic 8 MiB no-match PMML extension text, five runs
- before: median 0.770225s
- after: median 0.460403s

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_pmml_scanner.py -q`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` *(hit unrelated timing-sensitive `tests/test_real_world_dill_joblib.py::TestPerformanceBenchmarks::test_validation_performance_impact` under xdist)*
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_real_world_dill_joblib.py::TestPerformanceBenchmarks::test_validation_performance_impact -q`