### PR TITLE
perf: skip directory pre-count without progress

### DIFF
--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -441,22 +441,24 @@ def scan_model_directory_or_file(
             if progress_callback:
                 progress_callback(f"Scanning directory: {path}", 0.0)
 
-            # Scan all files in the directory
-            # Use lazy file counting for better performance on large directories
+            # Scan all files in the directory. File counts are only needed for
+            # progress percentages, so avoid the extra tree walk when callers do
+            # not request progress updates.
             total_files = None  # Will be set to actual count if directory is small
             processed_files = 0
             limit_reached = False
 
-            # Quick check: count files only if directory seems reasonable in size
-            # This avoids the expensive rglob() on large directories
-            try:
-                # Do a quick count of immediate children first
-                immediate_children = len(list(Path(path).iterdir()))
-                if immediate_children < 1000:  # Only count if not too many immediate children
-                    total_files = sum(1 for _ in Path(path).rglob("*") if _.is_file())
-            except (OSError, PermissionError):
-                # If we can't count, just proceed without progress percentage
-                total_files = None
+            if progress_callback:
+                # Quick check: count files only if directory seems reasonable in size.
+                # This avoids the expensive rglob() on large directories.
+                try:
+                    # Do a quick count of immediate children first.
+                    immediate_children = len(list(Path(path).iterdir()))
+                    if immediate_children < 1000:  # Only count if not too many immediate children.
+                        total_files = sum(1 for _ in Path(path).rglob("*") if _.is_file())
+                except (OSError, PermissionError):
+                    # If we can't count, just proceed without progress percentage.
+                    total_files = None
 
             base_dir = Path(path).resolve()
             hf_cache_root = _find_hf_cache_root(base_dir)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,6 +7,7 @@ import gzip
 import json
 import pickle
 import zipfile
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -1339,6 +1340,26 @@ def test_scan_file_routes_model_config_json_to_manifest_scanner(tmp_path: Path) 
 
     assert result.scanner_name == "manifest"
     assert result.success is True
+
+
+def test_scan_directory_without_progress_skips_file_counting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = tmp_path / "model.pkl"
+    model_path.write_bytes(b"\x80\x04N.")
+
+    def fail_rglob(self: Path, pattern: str) -> Iterator[Path]:
+        raise AssertionError(f"unexpected rglob({pattern!r}) for {self}")
+
+    monkeypatch.setattr(Path, "rglob", fail_rglob)
+
+    result = scan_model_directory_or_file(
+        str(tmp_path),
+        cache_scan_results=False,
+    )
+
+    assert result.files_scanned == 1
 
 
 def test_scan_file_routes_manifest_owned_chat_templates_through_jinja_analysis(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- avoid the directory `rglob()` pre-count when callers did not request progress callbacks
- preserve the existing progress-percentage path when callbacks are present
- add a regression test proving no-progress directory scans no longer call `Path.rglob()`

## Benchmarks
- synthetic 10,000-file tree pre-count pass removed: `0.094856s` median (`100` directories x `100` skipped files)
- end-to-end no-progress scan timing was too noisy to use as the headline number because the remaining `os.walk()` work dominates the run

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_core.py::test_scan_directory_without_progress_skips_file_counting tests/test_integration.py::test_scan_directory_with_multiple_models -q`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` *(repo-wide run hit the known timing-sensitive `tests/test_real_world_dill_joblib.py::TestPerformanceBenchmarks::test_validation_performance_impact` flake under xdist: `0.0083699s > 0.003s`)*
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_real_world_dill_joblib.py::TestPerformanceBenchmarks::test_validation_performance_impact -q`