### PR TITLE
perf: bound directory progress pre-counts

### DIFF
--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -1,6 +1,7 @@
 """Core scanning engine for orchestrating model file security analysis."""
 
 import hashlib
+import itertools
 import logging
 import os
 import time
@@ -68,6 +69,14 @@ logger = logging.getLogger("modelaudit.core")
 
 _add_asset_to_results = core_results.add_asset_to_results
 _add_error_asset_to_results = core_results.add_error_asset_to_results
+_DIRECTORY_PRECOUNT_CHILD_LIMIT = 1000
+
+
+def _count_immediate_children_up_to(path: Path, limit: int) -> int:
+    """Count at most `limit` immediate children for directory-size heuristics."""
+    return sum(1 for _child in itertools.islice(path.iterdir(), limit))
+
+
 _add_issue_to_model = core_results.add_issue_to_model
 _add_scan_result_to_model = core_results.add_scan_result_to_model
 _consolidate_checks = core_results.consolidate_checks
@@ -451,8 +460,12 @@ def scan_model_directory_or_file(
             # This avoids the expensive rglob() on large directories
             try:
                 # Do a quick count of immediate children first
-                immediate_children = len(list(Path(path).iterdir()))
-                if immediate_children < 1000:  # Only count if not too many immediate children
+                immediate_children = _count_immediate_children_up_to(
+                    Path(path),
+                    _DIRECTORY_PRECOUNT_CHILD_LIMIT,
+                )
+                # Only run the recursive count for narrower roots.
+                if immediate_children < _DIRECTORY_PRECOUNT_CHILD_LIMIT:
                     total_files = sum(1 for _ in Path(path).rglob("*") if _.is_file())
             except (OSError, PermissionError):
                 # If we can't count, just proceed without progress percentage

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -77,6 +77,12 @@ def _count_immediate_children_up_to(path: Path, limit: int) -> int:
     return sum(1 for _child in itertools.islice(path.iterdir(), limit))
 
 
+def _count_files_up_to(path: Path, limit: int) -> int | None:
+    """Return an exact recursive file count only while it stays within `limit`."""
+    count = sum(1 for candidate in itertools.islice((item for item in path.rglob("*") if item.is_file()), limit + 1))
+    return None if count > limit else count
+
+
 _add_issue_to_model = core_results.add_issue_to_model
 _add_scan_result_to_model = core_results.add_scan_result_to_model
 _consolidate_checks = core_results.consolidate_checks
@@ -466,7 +472,7 @@ def scan_model_directory_or_file(
                 )
                 # Only run the recursive count for narrower roots.
                 if immediate_children < _DIRECTORY_PRECOUNT_CHILD_LIMIT:
-                    total_files = sum(1 for _ in Path(path).rglob("*") if _.is_file())
+                    total_files = _count_files_up_to(Path(path), _DIRECTORY_PRECOUNT_CHILD_LIMIT)
             except (OSError, PermissionError):
                 # If we can't count, just proceed without progress percentage
                 total_files = None

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,6 +7,7 @@ import gzip
 import json
 import pickle
 import zipfile
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -1339,6 +1340,23 @@ def test_scan_file_routes_model_config_json_to_manifest_scanner(tmp_path: Path) 
 
     assert result.scanner_name == "manifest"
     assert result.success is True
+
+
+def test_directory_child_probe_stops_at_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def bounded_iterdir(self: Path) -> Iterator[Path]:
+        for index in range(core_module._DIRECTORY_PRECOUNT_CHILD_LIMIT):
+            yield self / f"child_{index}"
+        raise AssertionError("directory child probe consumed past its limit")
+
+    monkeypatch.setattr(Path, "iterdir", bounded_iterdir)
+
+    assert (
+        core_module._count_immediate_children_up_to(
+            tmp_path,
+            core_module._DIRECTORY_PRECOUNT_CHILD_LIMIT,
+        )
+        == core_module._DIRECTORY_PRECOUNT_CHILD_LIMIT
+    )
 
 
 def test_scan_file_routes_manifest_owned_chat_templates_through_jinja_analysis(tmp_path: Path) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1359,6 +1359,26 @@ def test_directory_child_probe_stops_at_limit(monkeypatch: pytest.MonkeyPatch, t
     )
 
 
+def test_directory_file_probe_stops_after_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def bounded_rglob(self: Path, pattern: str) -> Iterator[Path]:
+        assert pattern == "*"
+        for index in range(core_module._DIRECTORY_PRECOUNT_CHILD_LIMIT + 1):
+            child = self / f"child_{index}.pkl"
+            child.touch()
+            yield child
+        raise AssertionError("directory file probe consumed past its limit")
+
+    monkeypatch.setattr(Path, "rglob", bounded_rglob)
+
+    assert (
+        core_module._count_files_up_to(
+            tmp_path,
+            core_module._DIRECTORY_PRECOUNT_CHILD_LIMIT,
+        )
+        is None
+    )
+
+
 def test_scan_file_routes_manifest_owned_chat_templates_through_jinja_analysis(tmp_path: Path) -> None:
     manifest_path = tmp_path / "config.json"
     manifest_path.write_text(


### PR DESCRIPTION
## Summary
- replace the eager `len(list(Path.iterdir()))` progress heuristic with a bounded top-level child probe
- cap recursive progress pre-counting once a tree already exceeds the existing `1000`-file threshold
- add regressions proving neither probe consumes past the bound

## Benchmarks
- synthetic wide directory with `20,000` immediate children, same-process A/B:
  - eager child-list materialization: `0.017017s` median
  - bounded child probe helper: `0.008936s` median
- synthetic deep directory with `20,000` nested files, same-process A/B:
  - full recursive count: `0.138195s` median
  - bounded recursive probe: `0.014900s` median

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_core.py::test_directory_child_probe_stops_at_limit tests/test_core.py::test_directory_file_probe_stops_after_limit tests/test_integration.py::test_scan_directory_with_multiple_models -q`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`