### PR TITLE
perf: reuse hashes for hardlinked files

### DIFF
--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -293,6 +293,7 @@ def _hash_files_by_path(file_paths: list[str]) -> dict[str, str]:
                         content_hashes[file_path] = cached_hash
                         continue
             except OSError:
+                # Fall back to direct hashing when stat is unavailable or the file changes mid-scan.
                 pass
 
             content_hashes[file_path] = _calculate_file_hash(file_path)

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -241,10 +241,29 @@ def _hash_files_by_path(file_paths: list[str]) -> dict[str, str]:
         hash get unique placeholder values so they still scan independently.
     """
     content_hashes: dict[str, str] = {}
+    hashes_by_inode: dict[tuple[int, int, int, int], str] = {}
 
     for file_path in file_paths:
         try:
+            inode_key: tuple[int, int, int, int] | None = None
+            try:
+                file_stat = os.stat(file_path)
+                if file_stat.st_nlink > 1:
+                    inode_key = (
+                        file_stat.st_dev,
+                        file_stat.st_ino,
+                        file_stat.st_size,
+                        file_stat.st_mtime_ns,
+                    )
+                    if cached_hash := hashes_by_inode.get(inode_key):
+                        content_hashes[file_path] = cached_hash
+                        continue
+            except OSError:
+                pass
+
             content_hashes[file_path] = _calculate_file_hash(file_path)
+            if inode_key is not None:
+                hashes_by_inode[inode_key] = content_hashes[file_path]
         except Exception as e:
             # Log error but continue with other files to prevent single I/O failure from aborting entire scan
             logger.warning(f"Failed to hash file {file_path}: {e}. Skipping deduplication for this file.")

--- a/tests/test_regular_scan_hash.py
+++ b/tests/test_regular_scan_hash.py
@@ -1,6 +1,7 @@
 """Tests for content hash generation in regular scan mode."""
 
 import hashlib
+import os
 import pickle
 import zipfile
 from pathlib import Path
@@ -241,6 +242,31 @@ class TestHashGenerationEdgeCases:
 
         assert result.content_hash is not None
         assert result.files_scanned == 1
+
+    def test_hash_files_by_path_reuses_hash_for_hardlinks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Hardlinked paths should reuse the same read during the hash prepass."""
+        from modelaudit import core
+
+        source = tmp_path / "source.pkl"
+        source.write_bytes(pickle.dumps({"hardlink": True}))
+        linked_path = tmp_path / "linked.pkl"
+        os.link(source, linked_path)
+
+        hashed_paths: list[str] = []
+        original_hash = core._calculate_file_hash
+
+        def spy_hash(path: str) -> str:
+            hashed_paths.append(path)
+            return original_hash(path)
+
+        monkeypatch.setattr(core, "_calculate_file_hash", spy_hash)
+
+        content_hashes = core._hash_files_by_path([str(source), str(linked_path)])
+
+        assert content_hashes[str(source)] == content_hashes[str(linked_path)]
+        assert hashed_paths == [str(source)]
 
     def test_unhashable_files_excluded_from_hash(self, tmp_path, monkeypatch):
         """Test that files failing to hash are excluded from aggregate hash."""


### PR DESCRIPTION
## Summary
- reuse directory prepass hashes for paths that point at the same hardlinked inode
- keep scan results path-specific while avoiding redundant byte reads
- add regression coverage for hardlink hash reuse

## Benchmarks
- 32 MiB file exposed through 16 hardlinked paths: `0.248s` median before -> `0.0203s` median after (5 runs)

## Validation
- `uv run pytest tests/test_regular_scan_hash.py -q`
- `uv run ruff format modelaudit/core.py tests/test_regular_scan_hash.py`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`