### PR TITLE
perf: cache scanner selection policies

### DIFF
--- a/modelaudit/scanner_selection.py
+++ b/modelaudit/scanner_selection.py
@@ -101,6 +101,7 @@ def _scanner_aliases() -> dict[str, str]:
     aliases.setdefault(_alias_key("TensorFlowMetaGraphScanner"), "tf_metagraph")
     return aliases
 
+
 def resolve_scanner_ids(tokens: Iterable[str] | str | None) -> tuple[str, ...]:
     """Resolve scanner IDs, class names, and friendly aliases to canonical IDs."""
     metadata = _scanner_metadata()

--- a/modelaudit/scanner_selection.py
+++ b/modelaudit/scanner_selection.py
@@ -12,6 +12,7 @@ import difflib
 import os
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any, Literal
 
 from .scanner_registry_metadata import get_scanner_registry_metadata
@@ -93,10 +94,15 @@ def _scanner_aliases(metadata: Mapping[str, Mapping[str, Any]]) -> dict[str, str
     return aliases
 
 
+@lru_cache(maxsize=1)
+def _cached_scanner_aliases() -> dict[str, str]:
+    return _scanner_aliases(get_scanner_registry_metadata())
+
+
 def resolve_scanner_ids(tokens: Iterable[str] | str | None) -> tuple[str, ...]:
     """Resolve scanner IDs, class names, and friendly aliases to canonical IDs."""
     metadata = get_scanner_registry_metadata()
-    aliases = _scanner_aliases(metadata)
+    aliases = _cached_scanner_aliases()
     resolved: list[str] = []
     unknown: list[str] = []
 
@@ -165,6 +171,17 @@ def resolve_scanner_selection_policy(
     exclude_scanners: Iterable[str] | str | None = None,
 ) -> ScannerSelectionPolicy:
     """Resolve raw scanner selection inputs into a policy."""
+    return _resolve_scanner_selection_policy_cached(
+        tuple(split_scanner_tokens(scanners)),
+        tuple(split_scanner_tokens(exclude_scanners)),
+    )
+
+
+@lru_cache(maxsize=256)
+def _resolve_scanner_selection_policy_cached(
+    scanners: tuple[str, ...],
+    exclude_scanners: tuple[str, ...],
+) -> ScannerSelectionPolicy:
     metadata = get_scanner_registry_metadata()
     all_scanner_ids = frozenset(metadata.keys())
 

--- a/tests/test_scanner_selection.py
+++ b/tests/test_scanner_selection.py
@@ -87,6 +87,19 @@ def test_selection_policy_uses_allowlist_minus_exclusions() -> None:
     assert not policy.allows("zip")
 
 
+def test_selection_policy_reuses_normalized_cached_results() -> None:
+    list_policy = resolve_scanner_selection_policy(
+        scanners=["pickle", "zip"],
+        exclude_scanners=["zip"],
+    )
+    comma_policy = resolve_scanner_selection_policy(
+        scanners="pickle,zip",
+        exclude_scanners="zip",
+    )
+
+    assert list_policy is comma_policy
+
+
 def test_scan_file_exact_scanner_allows_pickle_detection(tmp_path: Path) -> None:
     path = tmp_path / "payload.pkl"
     path.write_bytes(_build_malicious_pickle())


### PR DESCRIPTION
## Summary
- precompute scanner aliases once from the static registry
- cache normalized immutable scanner-selection policies behind a bounded LRU
- add a regression proving equivalent list and comma-separated inputs reuse one policy

## Benchmarks
- `20,000` repeated `resolve_scanner_ids()` calls: `0.857873s` median before -> `0.288100s` median after
- `20,000` repeated equivalent policy resolutions: `2.038787s` median before -> `0.007434s` median after

## Validation
- `uv run pytest tests/test_scanner_selection.py -q`
- `uv run ruff format modelaudit/scanner_selection.py tests/test_scanner_selection.py`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`