### PR TITLE
perf: skip renormalizing scanner selection

### DIFF
--- a/modelaudit/scanner_selection.py
+++ b/modelaudit/scanner_selection.py
@@ -215,9 +215,33 @@ def policy_from_config(config: Mapping[str, Any] | None) -> ScannerSelectionPoli
     )
 
 
+def _is_normalized_scanner_selection_payload(selection: Any) -> bool:
+    """Return True for payloads already emitted by `ScannerSelectionPolicy.to_config()`."""
+    if not isinstance(selection, Mapping):
+        return False
+
+    scanners = selection.get("scanners")
+    exclude_scanners = selection.get("exclude_scanners")
+    enabled_scanner_ids = selection.get("enabled_scanner_ids")
+    return (
+        isinstance(selection.get("active"), bool)
+        and (scanners is None or isinstance(scanners, list))
+        and isinstance(exclude_scanners, list)
+        and isinstance(enabled_scanner_ids, list)
+    )
+
+
 def normalize_scanner_selection_config(config: Mapping[str, Any] | None) -> dict[str, Any]:
     """Return a mutable config with a normalized scanner selection payload."""
     normalized = dict(config or {})
+    raw_selection = normalized.get(SCANNER_SELECTION_CONFIG_KEY)
+    if (
+        "scanners" not in normalized
+        and "exclude_scanners" not in normalized
+        and _is_normalized_scanner_selection_payload(raw_selection)
+    ):
+        return normalized
+
     has_raw_selection = any(key in normalized for key in (SCANNER_SELECTION_CONFIG_KEY, "scanners", "exclude_scanners"))
     policy = policy_from_config(normalized)
     if policy.active or has_raw_selection:

--- a/tests/test_scanner_selection.py
+++ b/tests/test_scanner_selection.py
@@ -9,6 +9,7 @@ import zipfile
 from pathlib import Path
 from typing import Any
 
+import pytest
 from click.testing import CliRunner
 
 from modelaudit.cache import reset_cache_manager
@@ -17,6 +18,7 @@ from modelaudit.core import scan_file, scan_model_directory_or_file
 from modelaudit.scanner_registry_metadata import get_scanner_registry_metadata
 from modelaudit.scanner_selection import (
     collect_suppressed_preferred_scanners,
+    normalize_scanner_selection_config,
     resolve_scanner_ids,
     resolve_scanner_selection_policy,
     scanner_catalog,
@@ -85,6 +87,25 @@ def test_selection_policy_uses_allowlist_minus_exclusions() -> None:
     assert policy.enabled_scanner_ids == frozenset({"pickle"})
     assert policy.allows("pickle")
     assert not policy.allows("zip")
+
+
+def test_normalize_scanner_selection_config_reuses_normalized_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = normalize_scanner_selection_config(
+        {
+            "scanners": ["pickle"],
+            "exclude_scanners": ["zip"],
+            "cache_enabled": False,
+        }
+    )
+
+    def fail_policy_resolution(_: object) -> None:
+        raise AssertionError("already normalized config should not resolve policy again")
+
+    monkeypatch.setattr("modelaudit.scanner_selection.policy_from_config", fail_policy_resolution)
+
+    assert normalize_scanner_selection_config(config) == config
 
 
 def test_scan_file_exact_scanner_allows_pickle_detection(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- detect scanner-selection payloads that already match the normalized config shape
- return a copied config immediately when no raw top-level scanner inputs remain
- add a regression proving already-normalized configs do not resolve policy again

## Benchmarks
- `50,000` repeated already-normalized config calls: `5.097017s` median before -> `0.014622s` median after (5 runs)

## Validation
- `uv run pytest tests/test_scanner_selection.py -q`
- `uv run ruff format modelaudit/scanner_selection.py tests/test_scanner_selection.py`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`