### PR TITLE
perf: summarize CLI progress tree once

### DIFF
--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -924,10 +924,7 @@ def _create_path_progress_callback(
             total_bytes = os.path.getsize(actual_path)
             total_items = 1
         elif os.path.isdir(actual_path):
-            total_bytes = sum(
-                file_path.stat().st_size for file_path in Path(actual_path).rglob("*") if file_path.is_file()
-            )
-            total_items = len(list(Path(actual_path).rglob("*")))
+            total_bytes, total_items = _summarize_progress_tree(actual_path)
         else:
             total_bytes = 0
             total_items = 1
@@ -955,6 +952,17 @@ def _create_path_progress_callback(
             spinner.text = f"{message} ({percentage:.1f}%)"
 
     return enhanced_progress_callback
+
+
+def _summarize_progress_tree(path: str) -> tuple[int, int]:
+    """Return total file bytes and total descendant items with one tree walk."""
+    total_bytes = 0
+    total_items = 0
+    for item in Path(path).rglob("*"):
+        total_items += 1
+        if item.is_file():
+            total_bytes += item.stat().st_size
+    return total_bytes, total_items
 
 
 def _scan_local_or_downloaded_path(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ from click.testing import CliRunner
 
 from modelaudit import __version__
 from modelaudit.cache.trusted_config_store import TrustedConfigStore
-from modelaudit.cli import cli, expand_paths, format_text_output
+from modelaudit.cli import _summarize_progress_tree, cli, expand_paths, format_text_output
 from modelaudit.core import scan_model_directory_or_file
 from modelaudit.models import ModelAuditResultModel, create_initial_audit_result
 from tests.cli_output import parse_click_json_output
@@ -107,6 +107,27 @@ def test_cli_version():
     result = runner.invoke(cli, ["--version"])
     assert result.exit_code == 0
     assert __version__ in result.output
+
+
+def test_summarize_progress_tree_walks_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Directory progress totals should come from one recursive traversal."""
+    nested_dir = tmp_path / "nested"
+    nested_dir.mkdir()
+    (tmp_path / "root.bin").write_bytes(b"abc")
+    (nested_dir / "child.bin").write_bytes(b"de")
+
+    original_rglob = Path.rglob
+    rglob_calls = 0
+
+    def counting_rglob(path: Path, pattern: str) -> Any:
+        nonlocal rglob_calls
+        rglob_calls += 1
+        return original_rglob(path, pattern)
+
+    monkeypatch.setattr(Path, "rglob", counting_rglob)
+
+    assert _summarize_progress_tree(str(tmp_path)) == (5, 3)
+    assert rglob_calls == 1
 
 
 def test_scan_command_help():


### PR DESCRIPTION
## Summary
- collapse enhanced CLI progress directory summarization into one recursive traversal
- preserve current total-bytes and total-items behavior while avoiding a duplicate `rglob()` pass
- add focused coverage proving one traversal still produces the expected totals

## Benchmark
Synthetic tree with 20,000 files (`100` directories x `200` files), same-process controlled A/B:
- before: `0.553156s` median
- after: `0.413021s` median

## Validation
- `uv run pytest tests/test_cli.py -q -k summarize_progress_tree_walks_once`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`