### PR TITLE
perf: reuse savedmodel function patterns

### DIFF
--- a/modelaudit/scanners/tf_savedmodel_scanner.py
+++ b/modelaudit/scanners/tf_savedmodel_scanner.py
@@ -85,6 +85,17 @@ _PYFUNC_DANGEROUS_REFERENCE_TOKENS = frozenset(
         "webbrowser",
     }
 )
+_SUSPICIOUS_FUNCTION_NAME_PATTERNS = (
+    ("eval", re.compile(r"(?:^|[^a-z0-9])eval(?:[^a-z0-9]|$)")),
+    ("exec", re.compile(r"(?:^|[^a-z0-9])exec(?:[^a-z0-9]|$)")),
+    ("compile", re.compile(r"(?:^|[^a-z0-9])compile(?:[^a-z0-9]|$)")),
+    ("__import__", re.compile(r"(?:^|[^a-z0-9])__import__(?:[^a-z0-9]|$)")),
+    ("system", re.compile(r"(?:^|[^a-z0-9])system(?:[^a-z0-9]|$)")),
+    ("popen", re.compile(r"(?:^|[^a-z0-9])popen(?:[^a-z0-9]|$)")),
+    ("subprocess", re.compile(r"(?:^|[^a-z0-9])subprocess(?:[^a-z0-9]|$)")),
+    ("pickle", re.compile(r"(?:^|[^a-z0-9])pickle(?:[^a-z0-9]|$)")),
+    ("marshal", re.compile(r"(?:^|[^a-z0-9])marshal(?:[^a-z0-9]|$)")),
+)
 
 
 def _looks_like_pe_executable(content_head: bytes) -> bool:
@@ -980,20 +991,8 @@ class TensorFlowSavedModelScanner(BaseScanner):
     @staticmethod
     def _match_suspicious_function_name(func_name: str) -> str | None:
         """Return the suspicious token matched in a function name, if any."""
-        suspicious_patterns = (
-            ("eval", re.compile(r"(?:^|[^a-z0-9])eval(?:[^a-z0-9]|$)")),
-            ("exec", re.compile(r"(?:^|[^a-z0-9])exec(?:[^a-z0-9]|$)")),
-            ("compile", re.compile(r"(?:^|[^a-z0-9])compile(?:[^a-z0-9]|$)")),
-            ("__import__", re.compile(r"(?:^|[^a-z0-9])__import__(?:[^a-z0-9]|$)")),
-            ("system", re.compile(r"(?:^|[^a-z0-9])system(?:[^a-z0-9]|$)")),
-            ("popen", re.compile(r"(?:^|[^a-z0-9])popen(?:[^a-z0-9]|$)")),
-            ("subprocess", re.compile(r"(?:^|[^a-z0-9])subprocess(?:[^a-z0-9]|$)")),
-            ("pickle", re.compile(r"(?:^|[^a-z0-9])pickle(?:[^a-z0-9]|$)")),
-            ("marshal", re.compile(r"(?:^|[^a-z0-9])marshal(?:[^a-z0-9]|$)")),
-        )
-
         lowered_func_name = func_name.lower()
-        for pattern_name, pattern in suspicious_patterns:
+        for pattern_name, pattern in _SUSPICIOUS_FUNCTION_NAME_PATTERNS:
             if pattern.search(lowered_func_name):
                 return pattern_name
         return None

--- a/tests/scanners/test_tf_savedmodel_scanner.py
+++ b/tests/scanners/test_tf_savedmodel_scanner.py
@@ -6,6 +6,7 @@ from typing import Any, Protocol, TypedDict
 
 import pytest
 
+import modelaudit.scanners.tf_savedmodel_scanner as tf_savedmodel_scanner
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.scanners.base import IssueSeverity
 from modelaudit.scanners.tf_savedmodel_scanner import _ASSET_PROBE_BYTES, TensorFlowSavedModelScanner
@@ -64,6 +65,18 @@ def test_tf_savedmodel_scanner_can_handle(tmp_path: Path) -> None:
         assert TensorFlowSavedModelScanner.can_handle(str(tf_dir)) is False
         assert TensorFlowSavedModelScanner.can_handle(str(regular_dir)) is False
         assert TensorFlowSavedModelScanner.can_handle(str(test_file)) is False
+
+
+def test_suspicious_function_name_reuses_precompiled_patterns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Function-name matching should not rebuild static regexes per call."""
+
+    def fail_compile(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("unexpected regex compilation")
+
+    monkeypatch.setattr(tf_savedmodel_scanner.re, "compile", fail_compile)
+
+    assert TensorFlowSavedModelScanner._match_suspicious_function_name("safe_function_name") is None
+    assert TensorFlowSavedModelScanner._match_suspicious_function_name("module.eval") == "eval"
 
 
 def create_tf_savedmodel(tmp_path: Path, *, malicious: bool = False) -> Path:

--- a/tests/scanners/test_tf_savedmodel_scanner.py
+++ b/tests/scanners/test_tf_savedmodel_scanner.py
@@ -6,7 +6,6 @@ from typing import Any, Protocol, TypedDict
 
 import pytest
 
-import modelaudit.scanners.tf_savedmodel_scanner as tf_savedmodel_scanner
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.scanners.base import IssueSeverity
 from modelaudit.scanners.tf_savedmodel_scanner import _ASSET_PROBE_BYTES, TensorFlowSavedModelScanner
@@ -73,7 +72,7 @@ def test_suspicious_function_name_reuses_precompiled_patterns(monkeypatch: pytes
     def fail_compile(*_args: Any, **_kwargs: Any) -> None:
         raise AssertionError("unexpected regex compilation")
 
-    monkeypatch.setattr(tf_savedmodel_scanner.re, "compile", fail_compile)
+    monkeypatch.setattr("modelaudit.scanners.tf_savedmodel_scanner.re.compile", fail_compile)
 
     assert TensorFlowSavedModelScanner._match_suspicious_function_name("safe_function_name") is None
     assert TensorFlowSavedModelScanner._match_suspicious_function_name("module.eval") == "eval"


### PR DESCRIPTION
## Summary
- hoist static TensorFlow SavedModel suspicious-function regexes out of the per-name hot path
- preserve existing matching semantics while avoiding repeated compilation
- add focused coverage that fails if helper calls rebuild the patterns again

## Benchmark
`100,000` safe function-name checks, same-process controlled A/B:
- before: `1.497486s` median
- after: `0.563691s` median

## Validation
- `uv run pytest tests/scanners/test_tf_savedmodel_scanner.py -q -k suspicious_function_name_reuses_precompiled_patterns`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_real_world_dill_joblib.py -q -k validation_performance_impact`

## Notes
- The full `pytest -n auto -m "not slow and not integration" --maxfail=1` lane hit the existing timing-sensitive `test_validation_performance_impact` threshold twice under parallel load (`4.258 ms` / `5.527 ms` vs a `3 ms` bound); that test passed immediately when rerun directly and this branch does not touch picklescan code.