### PR TITLE
perf: reuse jinja scanner patterns

### DIFF
--- a/modelaudit/scanners/jinja2_template_scanner.py
+++ b/modelaudit/scanners/jinja2_template_scanner.py
@@ -65,6 +65,25 @@ _RAW_PARSE_FALLBACK_MAX_WINDOWS = 8
 _RAW_PARSE_FALLBACK_READ_BYTES = 256 * 1024
 
 
+def _compile_all_patterns() -> dict[str, list[tuple[re.Pattern[str], str]]]:
+    """Compile the static SSTI regex set once for all scanner instances."""
+    compiled: dict[str, list[tuple[re.Pattern[str], str]]] = {}
+
+    for category, patterns in JINJA2_SSTI_PATTERNS.items():
+        compiled[category] = []
+        for pattern in patterns:
+            try:
+                compiled_pattern = re.compile(pattern, re.IGNORECASE | re.MULTILINE)
+                compiled[category].append((compiled_pattern, pattern))
+            except re.error as e:
+                logger.warning(f"Failed to compile regex pattern '{pattern}': {e}")
+
+    return compiled
+
+
+_COMPILED_JINJA2_SSTI_PATTERNS = _compile_all_patterns()
+
+
 class MLContext:
     """Context information about the ML model/file being scanned"""
 
@@ -117,23 +136,7 @@ class Jinja2TemplateScanner(BaseScanner):
         self.enable_sandbox_test = self.config.get("enable_sandbox_test", True) and HAS_JINJA2_SANDBOX
         self.skip_common_patterns = self.config.get("skip_common_patterns", True)  # Ignore common ML patterns
 
-        # Compile regex patterns for efficiency
-        self._compiled_patterns = self._compile_all_patterns()
-
-    def _compile_all_patterns(self) -> dict[str, list[tuple[re.Pattern, str]]]:
-        """Compile all regex patterns for efficient matching"""
-        compiled: dict[str, list[tuple[re.Pattern, str]]] = {}
-
-        for category, patterns in JINJA2_SSTI_PATTERNS.items():
-            compiled[category] = []
-            for pattern in patterns:
-                try:
-                    compiled_pattern = re.compile(pattern, re.IGNORECASE | re.MULTILINE)
-                    compiled[category].append((compiled_pattern, pattern))
-                except re.error as e:
-                    logger.warning(f"Failed to compile regex pattern '{pattern}': {e}")
-
-        return compiled
+        self._compiled_patterns = _COMPILED_JINJA2_SSTI_PATTERNS
 
     @classmethod
     def can_handle(cls, path: str) -> bool:

--- a/tests/scanners/test_jinja2_template_scanner.py
+++ b/tests/scanners/test_jinja2_template_scanner.py
@@ -60,6 +60,19 @@ def test_directory_scan_preserves_path_sensitive_yaml_routing(tmp_path: Path) ->
     assert not any(issue.location and str(misc_file) in issue.location for issue in result.issues)
 
 
+def test_jinja_scanner_reuses_precompiled_patterns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Scanner construction should reuse the shared static regex set."""
+
+    def fail_compile(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("unexpected regex compilation")
+
+    monkeypatch.setattr(jinja2_template_scanner.re, "compile", fail_compile)
+
+    scanner = Jinja2TemplateScanner()
+
+    assert scanner._compiled_patterns
+
+
 class TestJinja2TemplateScannerCanHandle:
     """Test the can_handle method."""
 


### PR DESCRIPTION
## Summary
- compile the static Jinja SSTI regex map once at module load
- reuse the shared pattern set across fresh scanner instances
- add focused coverage that catches accidental per-instance recompilation

## Benchmark
`2,000` `Jinja2TemplateScanner()` constructions, same-process controlled A/B:
- before: `0.078247s` median
- after: `0.000606s` median

## Validation
- `uv run pytest tests/scanners/test_jinja2_template_scanner.py -q -k jinja_scanner_reuses_precompiled_patterns`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`