### PR TITLE
perf: cache manifest trusted-url lookups

### DIFF
--- a/modelaudit/scanners/manifest_scanner.py
+++ b/modelaudit/scanners/manifest_scanner.py
@@ -419,6 +419,19 @@ TRUSTED_URL_EXACT_DOMAINS = {
     "sourceforge.net",
     "streamlit.io",
 }
+_NORMALIZED_TRUSTED_URL_DOMAINS: Final[frozenset[str]] = frozenset(
+    domain.lower().rstrip(".") for domain in TRUSTED_URL_DOMAINS
+)
+_NORMALIZED_TRUSTED_URL_EXACT_DOMAINS: Final[frozenset[str]] = frozenset(
+    domain.lower().rstrip(".") for domain in TRUSTED_URL_EXACT_DOMAINS
+)
+_TRUSTED_URL_SUBDOMAIN_SUFFIXES: Final[tuple[str, ...]] = tuple(
+    dict.fromkeys(
+        normalized_domain
+        for domain in TRUSTED_URL_DOMAINS
+        if (normalized_domain := domain.lower().rstrip(".")) not in _NORMALIZED_TRUSTED_URL_EXACT_DOMAINS
+    )
+)
 
 # Regex to find URLs in text
 URL_PATTERN = re.compile(r'https?://[^\s<>"\']+[^\s<>"\',.]')
@@ -485,15 +498,10 @@ def _is_trusted_url_domain(url: str) -> bool:
     if _is_trusted_s3_endpoint_host(host):
         return True
 
-    for domain in TRUSTED_URL_DOMAINS:
-        trusted = domain.lower().rstrip(".")
-        if host == trusted:
-            return True
-        if trusted in TRUSTED_URL_EXACT_DOMAINS:
-            continue
-        if host.endswith(f".{trusted}"):
-            return True
-    return False
+    if host in _NORMALIZED_TRUSTED_URL_DOMAINS:
+        return True
+
+    return any(host.endswith(f".{trusted}") for trusted in _TRUSTED_URL_SUBDOMAIN_SUFFIXES)
 
 
 class ManifestScanner(BaseScanner):

--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
+from modelaudit.scanners import manifest_scanner
 from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity, ScanResult
 from modelaudit.scanners.manifest_scanner import _PARSE_FAILED, ManifestScanner, _is_trusted_url_domain
 
@@ -1024,6 +1025,10 @@ class TestIsTrustedUrlDomain:
     def test_exact_trusted_domain(self) -> None:
         assert _is_trusted_url_domain("https://github.com/repo") is True
         assert _is_trusted_url_domain("https://huggingface.co/model") is True
+
+    def test_exact_trusted_domain_skips_suffix_scan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(manifest_scanner, "_TRUSTED_URL_SUBDOMAIN_SUFFIXES", ())
+        assert _is_trusted_url_domain("https://github.com/repo") is True
 
     def test_s3_endpoint_host_patterns_trusted(self) -> None:
         assert _is_trusted_url_domain("https://bucket.s3.amazonaws.com/model.bin") is True


### PR DESCRIPTION
## Summary
- pre-normalize manifest trusted-url domains once at import time
- use an exact-host set before falling back to subdomain suffix checks
- add regression coverage for the exact-host fast path

## Benchmarks
- `20,000` exact trusted URL checks: `0.342448s` -> `0.059979s`
- `20,000` untrusted URL checks: `0.359739s` -> `0.247666s`
- `20,000` trusted subdomain checks: `0.090956s` -> `0.082338s`

## Validation
- `uv run pytest tests/scanners/test_manifest_scanner.py -q -k "exact_trusted_domain or subdomain_of_trusted_domain or exact_match_domains_block_subdomains or untrusted_domain"`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` *(one local timing guard failed once at `0.00421s < 0.003s`, then passed when rerun in isolation)*
- `uv run pytest tests/test_real_world_dill_joblib.py -q -k validation_performance_impact`