### PR TITLE
perf: reuse flax layer keyword text

### DIFF
--- a/modelaudit/scanners/flax_msgpack_scanner.py
+++ b/modelaudit/scanners/flax_msgpack_scanner.py
@@ -680,9 +680,10 @@ class FlaxMsgpackScanner(BaseScanner):
         # Check for hierarchical structure (multiple layers)
         layer_evidence = 0
         layer_keywords = ["layer", "block", "attention", "ffn", "mlp", "linear", "conv"]
+        obj_text_lower = str(obj).lower()
 
         for keyword in layer_keywords:
-            if keyword in str(obj).lower():
+            if keyword in obj_text_lower:
                 layer_evidence += 1
 
         if layer_evidence >= 2:

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -58,6 +58,24 @@ def test_flax_msgpack_valid_checkpoint(tmp_path):
     )
 
 
+def test_flax_ml_structure_reuses_lowered_object_text() -> None:
+    """Layer-keyword analysis should stringify the checkpoint object once."""
+
+    class StringCountingDict(dict[str, Any]):
+        stringify_calls = 0
+
+        def __str__(self) -> str:
+            self.stringify_calls += 1
+            return super().__str__()
+
+    obj = StringCountingDict({"tensor": b"0" * 4096, "payload": "x" * 4096})
+    scanner = FlaxMsgpackScanner()
+
+    scanner._analyze_ml_structure(obj, scanner._create_result())
+
+    assert obj.stringify_calls == 1
+
+
 def test_flax_msgpack_suspicious_content(tmp_path):
     """Test detection of suspicious patterns in msgpack content."""
     path = tmp_path / "suspicious.msgpack"


### PR DESCRIPTION
## Summary
- lower the Flax checkpoint object text once before layer-keyword checks
- avoid repeating `str(obj).lower()` for every hierarchical layer indicator
- add focused coverage that proves the object is stringified once during ML-structure analysis

## Benchmarks
- synthetic `8 MiB` object in `_analyze_ml_structure()`:
  - before: `0.076024s`
  - after: `0.015901s`

## Validation
- `uv run pytest tests/scanners/test_flax_msgpack_scanner.py -q -k "ml_structure_reuses_lowered_object_text or valid_checkpoint"`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` *(one local timing guard failed once at `0.00353s < 0.003s`, then passed when rerun in isolation)*
- `uv run pytest tests/test_real_world_dill_joblib.py -q -k validation_performance_impact`