### PR TITLE
perf: reuse flax structure analysis

### DIFF
--- a/modelaudit/scanners/flax_msgpack_scanner.py
+++ b/modelaudit/scanners/flax_msgpack_scanner.py
@@ -231,7 +231,13 @@ class FlaxMsgpackScanner(BaseScanner):
 
         return False
 
-    def _extract_jax_metadata(self, obj: Any, result: ScanResult) -> dict[str, Any]:
+    def _extract_jax_metadata(
+        self,
+        obj: Any,
+        result: ScanResult,
+        *,
+        ml_analysis: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
         """Extract JAX/Flax specific metadata from the checkpoint."""
         metadata: dict[str, Any] = {
             "model_type": "unknown",
@@ -304,7 +310,8 @@ class FlaxMsgpackScanner(BaseScanner):
         metadata["parameter_count"] = count_parameters(obj)
 
         # Perform ML structure analysis to get confidence score
-        ml_analysis = self._analyze_ml_structure(obj, result)
+        if ml_analysis is None:
+            ml_analysis = self._analyze_ml_structure(obj, result)
 
         # Add confidence and ML analysis results to metadata
         metadata["confidence"] = ml_analysis["confidence"]
@@ -736,7 +743,13 @@ class FlaxMsgpackScanner(BaseScanner):
 
         return analysis
 
-    def _validate_flax_structure(self, obj: Any, result: ScanResult) -> None:
+    def _validate_flax_structure(
+        self,
+        obj: Any,
+        result: ScanResult,
+        *,
+        ml_analysis: dict[str, Any] | None = None,
+    ) -> None:
         """Validate that the msgpack structure looks like a legitimate Flax checkpoint using structural analysis."""
         if not isinstance(obj, dict):
             result.add_check(
@@ -843,7 +856,8 @@ class FlaxMsgpackScanner(BaseScanner):
             return
 
         # If no standard keys, perform deep structural analysis
-        ml_analysis = self._analyze_ml_structure(obj, result)
+        if ml_analysis is None:
+            ml_analysis = self._analyze_ml_structure(obj, result)
 
         if ml_analysis["is_ml_model"]:
             # High confidence legitimate ML model based on structural analysis
@@ -1068,10 +1082,11 @@ class FlaxMsgpackScanner(BaseScanner):
                 result.metadata["msgpack_object_count"] = len(objects)
 
             # Extract JAX/Flax specific metadata and architecture information
-            self._extract_jax_metadata(obj, result)
+            ml_analysis = self._analyze_ml_structure(obj, result)
+            self._extract_jax_metadata(obj, result, ml_analysis=ml_analysis)
 
             # Validate Flax structure with enhanced analysis
-            self._validate_flax_structure(obj, result)
+            self._validate_flax_structure(obj, result, ml_analysis=ml_analysis)
 
             # Check for JAX/Flax specific security threats
             self._check_jax_specific_threats(obj, result)

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -9,7 +9,7 @@ pytest.importorskip("msgpack")
 
 import msgpack
 
-from modelaudit.scanners.base import CheckStatus, IssueSeverity
+from modelaudit.scanners.base import CheckStatus, IssueSeverity, ScanResult
 from modelaudit.scanners.flax_msgpack_scanner import FlaxMsgpackScanner
 
 
@@ -56,6 +56,30 @@ def test_flax_msgpack_valid_checkpoint(tmp_path):
         )
         == 0
     )
+
+
+def test_flax_scan_reuses_ml_structure_analysis(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One scan should reuse the same deep ML-structure analysis result."""
+    path = tmp_path / "converted.msgpack"
+    create_msgpack_file(path, {"tensor": b"0" * 4096, "payload": "x" * 4096})
+
+    scanner = FlaxMsgpackScanner()
+    analyze_calls = 0
+    original_analyze = scanner._analyze_ml_structure
+
+    def count_analyze(obj: Any, result: ScanResult) -> dict[str, Any]:
+        nonlocal analyze_calls
+        analyze_calls += 1
+        return original_analyze(obj, result)
+
+    monkeypatch.setattr(scanner, "_analyze_ml_structure", count_analyze)
+
+    scanner.scan(str(path))
+
+    assert analyze_calls == 1
 
 
 def test_flax_msgpack_suspicious_content(tmp_path):


### PR DESCRIPTION
## Summary
- reuse one deep Flax ML-structure analysis across metadata extraction and format validation
- keep direct helper calls backward-compatible by falling back to local analysis when no precomputed result is provided
- add regression coverage proving a full scan analyzes one converted checkpoint once

## Benchmarks
- synthetic `8 MiB` object across metadata extraction plus format validation:
  - before: `0.351241s`
  - after: `0.182844s`

## Validation
- `uv run pytest tests/scanners/test_flax_msgpack_scanner.py -q -k "scan_reuses_ml_structure_analysis or valid_checkpoint"`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` *(one unrelated local timing guard failed after a machine stall: `test_debug_command_is_fast` measured `1034.76s`, then passed immediately in isolation)*
- `uv run pytest tests/test_debug_command.py -q -k debug_command_is_fast`