### PR TITLE
perf: reuse jit import regexes

### DIFF
--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -115,6 +115,20 @@ DANGEROUS_IMPORTS = [
     "__builtins__",
 ]
 
+
+def _compile_dangerous_import_patterns(dangerous_import: str) -> tuple[re.Pattern[str], re.Pattern[str]]:
+    """Compile exact import/from-import regexes for one dangerous module name."""
+    escaped = re.escape(dangerous_import)
+    return (
+        re.compile(rf"(?m)^\s*import\s+{escaped}(?:[.\s,]|$)"),
+        re.compile(rf"(?m)^\s*from\s+{escaped}(?:[.\s]|$)"),
+    )
+
+
+_DANGEROUS_IMPORT_PATTERNS = {
+    dangerous_import: _compile_dangerous_import_patterns(dangerous_import) for dangerous_import in DANGEROUS_IMPORTS
+}
+
 # Patterns that indicate code execution attempts
 CODE_EXECUTION_PATTERNS = [
     # Direct execution patterns
@@ -231,10 +245,9 @@ class JITScriptDetector:
     @staticmethod
     def _contains_dangerous_import(source: str, dangerous_import: str) -> bool:
         """Return whether source imports the exact dangerous module or one of its submodules."""
-        escaped = re.escape(dangerous_import)
-        import_pattern = rf"(?m)^\s*import\s+{escaped}(?:[.\s,]|$)"
-        from_pattern = rf"(?m)^\s*from\s+{escaped}(?:[.\s]|$)"
-        return re.search(import_pattern, source) is not None or re.search(from_pattern, source) is not None
+        patterns = _DANGEROUS_IMPORT_PATTERNS.get(dangerous_import)
+        import_pattern, from_pattern = patterns or _compile_dangerous_import_patterns(dangerous_import)
+        return import_pattern.search(source) is not None or from_pattern.search(source) is not None
 
     def scan_torchscript(self, data: bytes, context: str = "") -> list["JITScriptFinding"]:
         """Scan TorchScript model data for dangerous operations.

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -2,6 +2,9 @@
 
 from pathlib import Path
 
+import pytest
+
+from modelaudit.detectors import jit_script as jit_script_module
 from modelaudit.detectors.jit_script import JITScriptDetector, detect_jit_script_risks
 
 
@@ -118,6 +121,16 @@ class TestJITScriptDetector:
         assert any("os" in getattr(f, "import_", "") for f in findings)
         assert any("subprocess" in getattr(f, "import_", "") for f in findings)
         assert any(f.severity == "CRITICAL" for f in findings)
+
+    def test_known_dangerous_import_reuses_compiled_patterns(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Known import checks should not rebuild regex source at call time."""
+
+        def fail_escape(_value: str) -> str:
+            raise AssertionError("known import checks should reuse compiled patterns")
+
+        monkeypatch.setattr(jit_script_module.re, "escape", fail_escape)
+
+        assert JITScriptDetector._contains_dangerous_import("import os\n", "os") is True
 
     def test_scan_torchscript_checks_unmarked_python_blobs(self) -> None:
         """Raw Python payloads should be analyzed even without TorchScript markers."""


### PR DESCRIPTION
## Summary
- precompile the fixed dangerous-import regex pairs once at module load
- keep the existing dynamic fallback for unexpected module names
- add regression coverage proving known imports reuse the shared patterns

## Benchmark
Safe embedded-source import checks across the fixed dangerous-import vocabulary (`10,000` loops, median of `5` same-process runs):
- before: `1.229623s`
- after: `1.087224s`

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/detectors/test_jit_script_detector.py -q`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` *(one unrelated local timing failure in `tests/test_real_world_dill_joblib.py::TestPerformanceBenchmarks::test_validation_performance_impact`; passed immediately in isolation)*
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_real_world_dill_joblib.py::TestPerformanceBenchmarks::test_validation_performance_impact -q`