### PR TITLE
perf: reuse network library patterns

### DIFF
--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -311,6 +311,10 @@ class NetworkCommDetector:
         b"psycopg2",
         b"mysql.connector",
     ]
+    NETWORK_LIBRARY_PATTERNS: ClassVar[dict[bytes, tuple[bytes, ...]]] = {
+        lib: (b"import " + lib, b"from " + lib, lib + b".connect", lib + b".request", lib + b".__init__")
+        for lib in NETWORK_LIBRARIES
+    }
 
     # Network functions
     NETWORK_FUNCTIONS: ClassVar[list[bytes]] = [
@@ -783,10 +787,7 @@ class NetworkCommDetector:
     def _scan_network_libraries(self, data: bytes, context: str) -> None:
         """Scan for network library imports."""
         for lib in self.NETWORK_LIBRARIES:
-            # Look for import statements
-            patterns = [b"import " + lib, b"from " + lib, lib + b".connect", lib + b".request", lib + b".__init__"]
-
-            for pattern in patterns:
+            for pattern in self.NETWORK_LIBRARY_PATTERNS[lib]:
                 for match_index in _iter_pattern_matches(data, pattern):
                     if _is_doc_only_network_reference(
                         data,

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -4,6 +4,8 @@ import os
 from pathlib import Path
 from urllib.parse import urlparse
 
+import pytest
+
 from modelaudit.detectors.network_comm import NetworkCommDetector, detect_network_communication
 
 
@@ -205,6 +207,16 @@ class TestNetworkCommDetector:
         # Check severity levels
         critical = [f for f in lib_findings if f["severity"] == "CRITICAL"]
         assert len(critical) >= 2  # socket and paramiko are critical
+
+    def test_network_library_scan_uses_shared_patterns(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Derived library patterns should come from the shared class table."""
+        detector = NetworkCommDetector()
+        monkeypatch.setattr(NetworkCommDetector, "NETWORK_LIBRARIES", [b"socket"])
+        monkeypatch.setattr(NetworkCommDetector, "NETWORK_LIBRARY_PATTERNS", {b"socket": (b"CUSTOM_SOCKET_PATTERN",)})
+
+        detector._scan_network_libraries(b"CUSTOM_SOCKET_PATTERN", "payload.bin")
+
+        assert any(finding["library"] == "socket" for finding in detector.findings)
 
     def test_detect_network_functions(self) -> None:
         """Test detection of network function calls."""


### PR DESCRIPTION
## Summary
- materialize derived network-library byte-pattern tuples once on the detector class
- reuse those tuples during each network-library scan instead of rebuilding them per library per file
- add focused regression coverage for the shared pattern table

## Benchmark
Benign no-match network-library scan (`5,000` iterations, median of `5` same-process runs):
- before: `0.561651s`
- after: `0.389619s`

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/detectors/test_network_comm_detector.py -q`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`