### PR TITLE
perf: reuse suspicious port names

### DIFF
--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -387,6 +387,27 @@ class NetworkCommDetector:
         ]
         for port in SUSPICIOUS_PORTS
     }
+    PORT_NAMES: ClassVar[dict[int, str]] = {
+        22: "SSH",
+        23: "Telnet",
+        135: "RPC",
+        139: "NetBIOS",
+        445: "SMB",
+        1337: "Common Backdoor",
+        1433: "MSSQL",
+        3128: "Proxy",
+        3306: "MySQL",
+        3389: "RDP",
+        4444: "Metasploit",
+        5432: "PostgreSQL",
+        5900: "VNC",
+        6379: "Redis",
+        8080: "HTTP Proxy",
+        8443: "HTTPS Alt",
+        9200: "Elasticsearch",
+        27017: "MongoDB",
+        31337: "Back Orifice",
+    }
 
     EXPLICIT_PORT_PATTERNS: ClassVar[dict[int, list[re.Pattern]]] = {
         port: [
@@ -1009,28 +1030,7 @@ class NetworkCommDetector:
 
     def _get_port_name(self, port: int) -> str:
         """Get common service name for a port."""
-        port_names = {
-            22: "SSH",
-            23: "Telnet",
-            135: "RPC",
-            139: "NetBIOS",
-            445: "SMB",
-            1337: "Common Backdoor",
-            1433: "MSSQL",
-            3128: "Proxy",
-            3306: "MySQL",
-            3389: "RDP",
-            4444: "Metasploit",
-            5432: "PostgreSQL",
-            5900: "VNC",
-            6379: "Redis",
-            8080: "HTTP Proxy",
-            8443: "HTTPS Alt",
-            9200: "Elasticsearch",
-            27017: "MongoDB",
-            31337: "Back Orifice",
-        }
-        return port_names.get(port, "Unknown")
+        return self.PORT_NAMES.get(port, "Unknown")
 
 
 def detect_network_communication(file_path: str, config: dict[str, Any] | None = None) -> list[dict[str, Any]]:

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -4,6 +4,8 @@ import os
 from pathlib import Path
 from urllib.parse import urlparse
 
+import pytest
+
 from modelaudit.detectors.network_comm import NetworkCommDetector, detect_network_communication
 
 
@@ -427,6 +429,14 @@ class TestNetworkCommDetector:
         duration = time.perf_counter() - start
 
         assert duration < 1.0
+
+    def test_port_name_lookup_uses_shared_mapping(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Port-name lookup should reuse the shared class mapping."""
+        detector = NetworkCommDetector()
+        monkeypatch.setattr(NetworkCommDetector, "PORT_NAMES", {9999: "Custom Service"})
+
+        assert detector._get_port_name(9999) == "Custom Service"
+        assert detector._get_port_name(22) == "Unknown"
 
     def test_blacklist_detection(self) -> None:
         """Test detection of blacklisted domains when configured."""


### PR DESCRIPTION
## Summary
- move the suspicious-port service-name mapping to shared detector state
- reuse that mapping for every suspicious-port finding instead of rebuilding it per hit
- add focused regression coverage for the shared lookup table

## Benchmark
Hit-heavy suspicious-port scan over every configured port (`20,000` iterations, median of `5` same-process runs, identical helper with only `_get_port_name()` swapped):
- before: `0.392935s`
- after: `0.231162s`

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/detectors/test_network_comm_detector.py -q`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`