### PR TITLE
perf: reuse onnx model bytes for parsing

### DIFF
--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -240,13 +240,38 @@ class OnnxScanner(BaseScanner):
             result.finish(success=False)
             return result
 
+        # Read raw bytes first so successful scans can parse and run raw
+        # detectors from the same buffer. If this read fails, fall back to
+        # ONNX's path-based loader so structural analysis still has a chance
+        # to complete while raw detector coverage stays explicitly incomplete.
+        model_data: bytes | None = None
+        try:
+            self.check_interrupted()
+            with open(path, "rb") as f:
+                model_data = f.read()
+            self.check_interrupted()
+        except Exception as e:
+            logger.warning("Raw ONNX detector input read failed: %s", e)
+            self._mark_raw_detection_incomplete(
+                result,
+                path,
+                detector="raw_file_read",
+                reason="file_read_failed",
+                message=f"Raw ONNX detector input read failed: {e!s}",
+                details={"exception": str(e), "exception_type": type(e).__name__},
+            )
+
         try:
             import onnx
 
-            # Check for interrupts before starting the potentially long-running load
+            # Check for interrupts before starting the potentially long-running load.
             self.check_interrupted()
-            model = onnx.load(path, load_external_data=False)
-            # Check for interrupts after loading completes
+            model = (
+                onnx.load(path, load_external_data=False)
+                if model_data is None
+                else onnx.load_model_from_string(model_data)
+            )
+            # Check for interrupts after loading completes.
             self.check_interrupted()
             result.bytes_scanned = file_size
         except KeyboardInterrupt:
@@ -272,24 +297,7 @@ class OnnxScanner(BaseScanner):
             },
         )
 
-        # Read the raw bytes once, then keep detector coverage separate so a
-        # failure in one detector does not masquerade as a clean pass.
-        try:
-            self.check_interrupted()
-            with open(path, "rb") as f:
-                model_data = f.read()
-            self.check_interrupted()
-        except Exception as e:
-            logger.warning("Raw ONNX detector input read failed: %s", e)
-            self._mark_raw_detection_incomplete(
-                result,
-                path,
-                detector="raw_file_read",
-                reason="file_read_failed",
-                message=f"Raw ONNX detector input read failed: {e!s}",
-                details={"exception": str(e), "exception_type": type(e).__name__},
-            )
-        else:
+        if model_data is not None:
             check_jit = self._get_bool_config("check_jit_script", True)
             if check_jit:
                 try:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -121,6 +121,31 @@ def test_onnx_scanner_basic_model(tmp_path):
     assert not any(i.severity in (IssueSeverity.INFO, IssueSeverity.WARNING) for i in result.issues)
 
 
+def test_onnx_scanner_reuses_raw_bytes_for_model_parse(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Successful scans should parse from the raw detector buffer."""
+    model_path = create_onnx_model(tmp_path)
+    parsed_payloads: list[bytes] = []
+    real_load_model_from_string = onnx.load_model_from_string
+
+    def fail_path_loader(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("path-based ONNX parsing should not run after the raw read succeeds")
+
+    def tracking_load_model_from_string(payload: bytes) -> Any:
+        parsed_payloads.append(payload)
+        return real_load_model_from_string(payload)
+
+    monkeypatch.setattr(onnx, "load", fail_path_loader)
+    monkeypatch.setattr(onnx, "load_model_from_string", tracking_load_model_from_string)
+
+    result = OnnxScanner({"check_jit_script": False, "check_network_comm": False}).scan(str(model_path))
+
+    assert result.success
+    assert parsed_payloads == [model_path.read_bytes()]
+
+
 def test_onnx_scanner_custom_op(tmp_path: Path) -> None:
     model_path = create_onnx_model(tmp_path, custom=True)
     result = OnnxScanner().scan(str(model_path))

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -146,6 +146,42 @@ def test_onnx_scanner_reuses_raw_bytes_for_model_parse(
     assert parsed_payloads == [model_path.read_bytes()]
 
 
+def test_onnx_scanner_raw_read_failure_falls_back_to_path_parse(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Raw-detector read failures should keep structural parsing but fail closed."""
+    model_path = create_onnx_model(tmp_path)
+    real_load = onnx.load
+    raw_read_attempts = 0
+    path_loads: list[str] = []
+
+    def fail_first_raw_read(file: Any, mode: str = "r", *args: Any, **kwargs: Any) -> Any:
+        nonlocal raw_read_attempts
+        if mode == "rb" and raw_read_attempts == 0:
+            raw_read_attempts += 1
+            raise OSError("simulated raw read failure")
+        return open(file, mode, *args, **kwargs)
+
+    def tracking_path_loader(path: str, *, load_external_data: bool) -> Any:
+        path_loads.append(path)
+        return real_load(path, load_external_data=load_external_data)
+
+    monkeypatch.setattr("modelaudit.scanners.onnx_scanner.open", fail_first_raw_read, raising=False)
+    monkeypatch.setattr(onnx, "load", tracking_path_loader)
+
+    result = OnnxScanner({"check_jit_script": False, "check_network_comm": False}).scan(str(model_path))
+    coverage_checks = [check for check in result.checks if check.name == "Raw Detector Analysis Coverage"]
+
+    assert path_loads == [str(model_path)]
+    assert result.success is False
+    assert result.bytes_scanned > 0
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert len(coverage_checks) == 1
+    assert coverage_checks[0].details["detector"] == "raw_file_read"
+    assert coverage_checks[0].details["coverage_gap"] == "file_read_failed"
+
+
 def test_onnx_scanner_custom_op(tmp_path: Path) -> None:
     model_path = create_onnx_model(tmp_path, custom=True)
     result = OnnxScanner().scan(str(model_path))


### PR DESCRIPTION
## Summary
- read ONNX bytes once, then reuse that buffer for both protobuf parsing and raw-byte detectors
- preserve the existing path-based fallback when the initial raw-byte read fails
- add regression coverage proving successful scans parse from the already-read buffer

## Benchmarks
Synthetic 64 MiB ONNX model, 5 rounds x 3 scans per round:
- before: median 0.023632s
- after: median 0.013408s
- speedup: 1.76x on the measured I/O slice

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_onnx_scanner.py`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`

Full non-slow suite note:
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
- Fails in two unrelated performance sentinels on untouched code after the optional `all-ci` environment was installed locally:
  - `tests/test_performance_benchmarks.py::TestPerformanceBenchmarks::test_directory_scanning_performance`
  - `tests/test_real_world_dill_joblib.py::TestPerformanceBenchmarks::test_validation_performance_impact`
- The ONNX-focused suite passes, and the isolated directory benchmark passed on rerun.
