### PR TITLE
perf: reuse flax suspicious patterns

### DIFF
--- a/modelaudit/scanners/flax_msgpack_scanner.py
+++ b/modelaudit/scanners/flax_msgpack_scanner.py
@@ -88,6 +88,9 @@ class FlaxMsgpackScanner(BaseScanner):
                 r"from\s+os\s+import\s+system",
             ],
         )
+        self._compiled_suspicious_patterns = tuple(
+            (pattern, re.compile(pattern, re.IGNORECASE), pattern.lower()) for pattern in self.suspicious_patterns
+        )
 
         self.suspicious_keys = self.config.get(
             "suspicious_keys",
@@ -411,14 +414,14 @@ class FlaxMsgpackScanner(BaseScanner):
         result: ScanResult,
     ) -> None:
         """Check string values for suspicious patterns that might indicate code injection."""
-        for pattern in self.suspicious_patterns:
-            if re.search(pattern, value, re.IGNORECASE):
+        for pattern, compiled_pattern, lowered_pattern in self._compiled_suspicious_patterns:
+            if compiled_pattern.search(value):
                 # Determine appropriate rule code based on pattern
-                if "eval" in pattern.lower():
+                if "eval" in lowered_pattern:
                     rule_code = "S104"  # eval/exec usage
-                elif "compile" in pattern.lower():
+                elif "compile" in lowered_pattern:
                     rule_code = "S105"  # compile usage
-                elif "import\\s+os" in pattern.lower() or "os\\.system" in pattern.lower():
+                elif "import\\s+os" in lowered_pattern or "os\\.system" in lowered_pattern:
                     rule_code = "S101"  # os module usage
                 else:
                     rule_code = "S999"  # Unknown/generic suspicious pattern

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -633,3 +633,12 @@ def test_flax_msgpack_custom_config(tmp_path):
 
     # Should still detect some issues but with different thresholds
     assert len(result.issues) > 0
+
+
+def test_flax_msgpack_custom_suspicious_patterns_still_match(tmp_path: Path) -> None:
+    path = tmp_path / "custom_pattern.msgpack"
+    create_msgpack_file(path, {"payload": "custom_threat"})
+
+    result = FlaxMsgpackScanner(config={"suspicious_patterns": [r"custom_threat"]}).scan(str(path))
+
+    assert any(issue.details.get("pattern") == r"custom_threat" for issue in result.issues)


### PR DESCRIPTION
## Summary
- compile configured Flax suspicious-string regexes once per scanner instance
- reuse the lowered pattern text when choosing rule codes
- add focused coverage that custom configured suspicious patterns still match

## Benchmarks
Benign-string-heavy helper workload, 5,000 strings x 7 rounds:
- before: median 0.272353s
- after: median 0.177386s
- speedup: 1.54x on the measured helper path

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/scanners/flax_msgpack_scanner.py tests/scanners/test_flax_msgpack_scanner.py`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_flax_msgpack_scanner.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`

Environment notes from the full repo validation lane:
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy ...` currently crashes inside `mypy 1.20.0` on `backports.zstd.ZstdDecompressor` before checking repo code.
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` reached the broad suite and failed in unrelated performance sentinels on untouched code under the local all-extras environment:
  - `tests/test_real_world_dill_joblib.py::TestPerformanceBenchmarks::test_validation_performance_impact`
  - `tests/test_performance_benchmarks.py::TestPerformanceBenchmarks::test_concurrent_performance`
