### PR TITLE
perf: reuse pmml suspicious patterns

### DIFF
--- a/modelaudit/scanners/pmml_scanner.py
+++ b/modelaudit/scanners/pmml_scanner.py
@@ -33,6 +33,7 @@ SUSPICIOUS_PATTERNS = [
     r"__import__",
     r"\bsystem\s*\(",
 ]
+_COMPILED_SUSPICIOUS_PATTERNS = tuple((pattern, re.compile(pattern, re.IGNORECASE)) for pattern in SUSPICIOUS_PATTERNS)
 URL_PATTERNS = ["http://", "https://", "file://", "ftp://"]
 BENIGN_DOCUMENTATION_URL_PATTERNS = frozenset({"http://", "https://"})
 DANGEROUS_ENTITIES = ["<!DOCTYPE", "<!ENTITY", "<!ELEMENT", "<!ATTLIST"]
@@ -366,8 +367,8 @@ class PmmlScanner(BaseScanner):
 
             # Special attention to Extension elements which can contain arbitrary content
             if tag_name == "extension":
-                for pattern in SUSPICIOUS_PATTERNS:
-                    if re.search(pattern, combined, re.IGNORECASE):
+                for pattern, compiled_pattern in _COMPILED_SUSPICIOUS_PATTERNS:
+                    if compiled_pattern.search(combined):
                         result.add_check(
                             name="Extension Element Security Check",
                             passed=False,

--- a/tests/scanners/test_pmml_scanner.py
+++ b/tests/scanners/test_pmml_scanner.py
@@ -1,5 +1,8 @@
 from pathlib import Path
 
+import pytest
+
+import modelaudit.scanners.pmml_scanner as pmml_scanner_module
 from modelaudit.scanners.base import IssueSeverity
 from modelaudit.scanners.pmml_scanner import PmmlScanner
 
@@ -91,6 +94,31 @@ def test_pmml_scanner_system_call_is_flagged(tmp_path: Path) -> None:
 </PMML>"""
     path = tmp_path / "system_call.pmml"
     path.write_text(pmml, encoding="utf-8")
+
+    result = PmmlScanner().scan(str(path))
+
+    assert result.success is True
+    assert any(issue.details.get("pattern") == r"\bsystem\s*\(" for issue in result.issues)
+
+
+def test_pmml_scanner_reuses_compiled_extension_patterns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pmml = """<?xml version='1.0'?>
+<PMML version='4.4'>
+  <Header>
+    <Extension>system('id')</Extension>
+  </Header>
+  <DataDictionary numberOfFields='0'/>
+</PMML>"""
+    path = tmp_path / "compiled_patterns.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    def fail_re_search(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("PMML extension matching should reuse compiled suspicious patterns")
+
+    monkeypatch.setattr(pmml_scanner_module.re, "search", fail_re_search)
 
     result = PmmlScanner().scan(str(path))
 


### PR DESCRIPTION
## Summary
- compile the static PMML extension suspicious-pattern bank once at import time
- reuse those compiled regexes while scanning extension text
- add focused coverage proving extension detection no longer depends on per-scan `re.search()` calls

## Benchmarks
Synthetic PMML with `5,000` benign `<Extension>` elements:
- before: median 0.057360s
- after: median 0.051372s
- speedup: 1.12x on the whole synthetic scan

Exact extension-pattern loop, `20,000` benign payloads:
- before: median 0.497881s
- after: median 0.469647s
- speedup: 1.06x

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/scanners/pmml_scanner.py tests/scanners/test_pmml_scanner.py`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_pmml_scanner.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`

Environment notes from the full repo validation lane:
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy ...` currently crashes inside `mypy 1.20.0` on `backports.zstd.ZstdDecompressor` before checking repo code.
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` again failed only in the same unrelated performance sentinels on untouched code under the local all-extras environment:
  - `tests/test_real_world_dill_joblib.py::TestPerformanceBenchmarks::test_validation_performance_impact`
  - `tests/test_performance_benchmarks.py::TestPerformanceBenchmarks::test_concurrent_performance`
