### PR TITLE
perf: skip call graph enrichment in pickle validation

### DIFF
--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -14,8 +14,6 @@ from pathlib import Path
 from typing import Any, BinaryIO, ClassVar
 
 from modelaudit_picklescan import PickleScanner as StandalonePickleScanner
-from modelaudit_picklescan.api import _scan_pickle_payload_native
-from modelaudit_picklescan.options import ScanOptions
 
 from modelaudit.detectors.suspicious_symbols import SUSPICIOUS_GLOBALS
 from modelaudit.utils.helpers.code_validation import validate_python_syntax
@@ -1067,16 +1065,10 @@ def _is_legitimate_serialization_file(path: str) -> bool:
     if not path_obj.is_file():
         return False
     try:
-        payload = path_obj.read_bytes()
-        if not _looks_like_pickle(payload[:_NESTED_PICKLE_HEADER_SEARCH_LIMIT_BYTES]):
-            return False
-        report = _scan_pickle_payload_native(
-            payload,
-            source=str(path_obj),
-            options=ScanOptions(),
-            bytes_total=len(payload),
-            enrich_call_graph=False,
-        )
+        with path_obj.open("rb") as handle:
+            if not _looks_like_pickle(handle.read(_NESTED_PICKLE_HEADER_SEARCH_LIMIT_BYTES)):
+                return False
+        report = StandalonePickleScanner().scan_file(path_obj, enrich_call_graph=False)
     except Exception:
         return False
     return not report.has_security_findings and report.status.value != "error"

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from typing import Any, BinaryIO, ClassVar
 
 from modelaudit_picklescan import PickleScanner as StandalonePickleScanner
+from modelaudit_picklescan.api import _scan_pickle_payload_native
+from modelaudit_picklescan.options import ScanOptions
 
 from modelaudit.detectors.suspicious_symbols import SUSPICIOUS_GLOBALS
 from modelaudit.utils.helpers.code_validation import validate_python_syntax
@@ -1054,10 +1056,16 @@ def _is_legitimate_serialization_file(path: str) -> bool:
     if not path_obj.is_file():
         return False
     try:
-        with path_obj.open("rb") as handle:
-            if not _looks_like_pickle(handle.read(_NESTED_PICKLE_HEADER_SEARCH_LIMIT_BYTES)):
-                return False
-        report = StandalonePickleScanner().scan_file(path_obj)
+        payload = path_obj.read_bytes()
+        if not _looks_like_pickle(payload[:_NESTED_PICKLE_HEADER_SEARCH_LIMIT_BYTES]):
+            return False
+        report = _scan_pickle_payload_native(
+            payload,
+            source=str(path_obj),
+            options=ScanOptions(),
+            bytes_total=len(payload),
+            enrich_call_graph=False,
+        )
     except Exception:
         return False
     return not report.has_security_findings and report.status.value != "error"

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -900,6 +900,7 @@ def _scan_pickle_payload_native(
     options: ScanOptions,
     bytes_total: int | None = None,
     position_offset: int = 0,
+    enrich_call_graph: bool = True,
 ) -> PickleReport:
     native_bytes_total = _normalize_stream_size(bytes_total)
     native_position_offset = max(position_offset, 0)
@@ -915,7 +916,8 @@ def _scan_pickle_payload_native(
         )
         if not isinstance(raw_report, Mapping):
             raise TypeError(f"Rust scanner returned {type(raw_report).__name__}, expected mapping")
-        return _with_call_graph_findings(_report_from_native_dict(raw_report))
+        report = _report_from_native_dict(raw_report)
+        return _with_call_graph_findings(report) if enrich_call_graph else report
     except Exception as error:
         return _engine_error_report(
             source=source,

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -97,10 +97,22 @@ class PickleScanner:
     def __init__(self, options: ScanOptions | None = None) -> None:
         self.options = ScanOptions() if options is None else options
 
-    def scan_bytes(self, data: bytes | bytearray | memoryview, *, source: str = "<bytes>") -> PickleReport:
+    def scan_bytes(
+        self,
+        data: bytes | bytearray | memoryview,
+        *,
+        source: str = "<bytes>",
+        enrich_call_graph: bool = True,
+    ) -> PickleReport:
         """Scan a raw pickle byte payload."""
         payload = bytes(data)
-        return _scan_pickle_payload_native(payload, source=source, options=self.options, bytes_total=len(payload))
+        return _scan_pickle_payload_native(
+            payload,
+            source=source,
+            options=self.options,
+            bytes_total=len(payload),
+            enrich_call_graph=enrich_call_graph,
+        )
 
     def scan_stream(
         self,
@@ -108,6 +120,7 @@ class PickleScanner:
         *,
         source: str = "<stream>",
         size: int | None = None,
+        enrich_call_graph: bool = True,
     ) -> PickleReport:
         """Scan pickle bytes from the current position of a binary stream."""
         normalized_size = _normalize_stream_size(size)
@@ -131,6 +144,7 @@ class PickleScanner:
                     options=self.options,
                     bytes_total=error.bytes_read,
                     position_offset=position_offset,
+                    enrich_call_graph=enrich_call_graph,
                 )
                 return _with_short_read_error(
                     partial_report,
@@ -161,6 +175,7 @@ class PickleScanner:
             options=self.options,
             bytes_total=native_bytes_total,
             position_offset=position_offset,
+            enrich_call_graph=enrich_call_graph,
         )
         if stream_truncated:
             if normalized_size is None:
@@ -179,7 +194,7 @@ class PickleScanner:
             )
         return report
 
-    def scan_file(self, path: str | Path) -> PickleReport:
+    def scan_file(self, path: str | Path, *, enrich_call_graph: bool = True) -> PickleReport:
         """Scan a pickle file path, including pickle members in PyTorch ZIP containers."""
         source = str(path)
         path_obj = Path(path)
@@ -187,13 +202,23 @@ class PickleScanner:
         try:
             size = path_obj.stat().st_size
             if zipfile.is_zipfile(path_obj):
-                container_report = self._scan_pytorch_zip_file(path_obj, source=source, size=size)
+                container_report = self._scan_pytorch_zip_file(
+                    path_obj,
+                    source=source,
+                    size=size,
+                    enrich_call_graph=enrich_call_graph,
+                )
                 if container_report is not None:
                     return container_report
                 if _has_pytorch_checkpoint_suffix(path_obj):
                     return _unsupported_zip_report(source=source, size=size)
             with path_obj.open("rb") as handle:
-                return self.scan_stream(handle, source=source, size=size)
+                return self.scan_stream(
+                    handle,
+                    source=source,
+                    size=size,
+                    enrich_call_graph=enrich_call_graph,
+                )
         except OSError as error:
             return _io_error_report(
                 source=source,
@@ -213,7 +238,14 @@ class PickleScanner:
                 bytes_total=size,
             )
 
-    def _scan_pytorch_zip_file(self, path: Path, *, source: str, size: int) -> PickleReport | None:
+    def _scan_pytorch_zip_file(
+        self,
+        path: Path,
+        *,
+        source: str,
+        size: int,
+        enrich_call_graph: bool = True,
+    ) -> PickleReport | None:
         preflight_entry_count = _read_zip_entry_count(path, size)
         if preflight_entry_count is not None and preflight_entry_count > _MAX_PYTORCH_ZIP_ENTRIES:
             return _pytorch_zip_entry_limit_report(
@@ -271,6 +303,7 @@ class PickleScanner:
                                 cast(BinaryIO, member_stream),
                                 source=member_source,
                                 size=entry.file_size,
+                                enrich_call_graph=enrich_call_graph,
                             )
                         )
                 except Exception as error:
@@ -300,9 +333,10 @@ def scan_bytes(
     *,
     source: str = "<bytes>",
     options: ScanOptions | None = None,
+    enrich_call_graph: bool = True,
 ) -> PickleReport:
     """Convenience wrapper around :meth:`PickleScanner.scan_bytes`."""
-    return PickleScanner(options=options).scan_bytes(data, source=source)
+    return PickleScanner(options=options).scan_bytes(data, source=source, enrich_call_graph=enrich_call_graph)
 
 
 def scan_stream(
@@ -311,14 +345,25 @@ def scan_stream(
     source: str = "<stream>",
     size: int | None = None,
     options: ScanOptions | None = None,
+    enrich_call_graph: bool = True,
 ) -> PickleReport:
     """Convenience wrapper around :meth:`PickleScanner.scan_stream`."""
-    return PickleScanner(options=options).scan_stream(stream, source=source, size=size)
+    return PickleScanner(options=options).scan_stream(
+        stream,
+        source=source,
+        size=size,
+        enrich_call_graph=enrich_call_graph,
+    )
 
 
-def scan_file(path: str | Path, *, options: ScanOptions | None = None) -> PickleReport:
+def scan_file(
+    path: str | Path,
+    *,
+    options: ScanOptions | None = None,
+    enrich_call_graph: bool = True,
+) -> PickleReport:
     """Convenience wrapper around :meth:`PickleScanner.scan_file`."""
-    return PickleScanner(options=options).scan_file(path)
+    return PickleScanner(options=options).scan_file(path, enrich_call_graph=enrich_call_graph)
 
 
 def _read_zip_entry_count(path: Path, file_size: int) -> int | None:

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -1583,6 +1583,21 @@ def test_legitimate_serialization_file_uses_rust_scan(tmp_path: Path) -> None:
     assert _is_legitimate_serialization_file(str(text_path)) is False
 
 
+def test_legitimate_serialization_file_skips_call_graph_enrichment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    safe_path = tmp_path / "safe.joblib"
+    safe_path.write_bytes(b"\x80\x04cjoblib.numpy_pickle\nNumpyArrayWrapper\nq\x00.")
+
+    def fail_call_graph_enrichment(_report: object) -> object:
+        raise AssertionError("validation helper should use native Rust findings only")
+
+    monkeypatch.setattr("modelaudit_picklescan.api._with_call_graph_findings", fail_call_graph_enrichment)
+
+    assert _is_legitimate_serialization_file(str(safe_path)) is True
+
+
 def test_scan_missing_path_fails_closed(tmp_path: Path) -> None:
     path = tmp_path / "missing.pkl"
 

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -1635,6 +1635,21 @@ def test_legitimate_serialization_file_skips_call_graph_enrichment(
     assert _is_legitimate_serialization_file(str(safe_path)) is True
 
 
+def test_legitimate_serialization_file_keeps_bounded_file_reads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    safe_path = tmp_path / "safe.joblib"
+    safe_path.write_bytes(b"\x80\x04cjoblib.numpy_pickle\nNumpyArrayWrapper\nq\x00.")
+
+    def fail_read_bytes(_path: Path) -> bytes:
+        raise AssertionError("validation helper should preserve bounded scanner reads")
+
+    monkeypatch.setattr(Path, "read_bytes", fail_read_bytes)
+
+    assert _is_legitimate_serialization_file(str(safe_path)) is True
+
+
 def test_scan_missing_path_fails_closed(tmp_path: Path) -> None:
     path = tmp_path / "missing.pkl"
 


### PR DESCRIPTION
## Summary
- let the standalone native pickle helper optionally return the raw Rust report without Python call-graph enrichment
- make `_is_legitimate_serialization_file()` match its documented Rust-only contract
- add regression coverage that the validation helper does not invoke call-graph enrichment

## Benchmarks
Exact validation fixture used by `test_validation_performance_impact`:
- before: median `0.039207s` per call
- after: median `0.000067s` per call
- speedup: about `582x`

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/scanners/pickle_scanner.py packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py tests/scanners/test_pickle_scanner.py`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_pickle_scanner.py::test_legitimate_serialization_file_uses_rust_scan tests/scanners/test_pickle_scanner.py::test_legitimate_serialization_file_skips_call_graph_enrichment tests/test_real_world_dill_joblib.py::TestPerformanceBenchmarks::test_validation_performance_impact -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_dill_joblib_enhanced.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`

Full-lane notes:
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy --show-traceback ...` still crashes inside `mypy 1.20.0` on `backports.zstd.ZstdDecompressor` before checking repo code.
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` now passes the validation perf test that had been failing earlier and stops only at the unrelated directory scan threshold:
  - `tests/test_performance_benchmarks.py::TestPerformanceBenchmarks::test_directory_scanning_performance`
