### PR TITLE
perf: bound ordinary license header reads

### DIFF
--- a/modelaudit/integrations/license_checker.py
+++ b/modelaudit/integrations/license_checker.py
@@ -181,9 +181,11 @@ def _read_header_text(file_path: str, max_lines: int) -> str | None:
     decoded_header = header_sample.decode("utf-8", errors="ignore")
     if not has_more_bytes:
         return "".join(decoded_header.splitlines(keepends=True)[:max_lines])
+    if not _is_explicit_license_file(file_path):
+        return decoded_header
 
-    # Likely text files should keep the original line-oriented behavior so
-    # long one-line headers are not silently truncated by the binary cap.
+    # Explicit license files keep the richer line-oriented behavior so long
+    # one-line license notices are not silently truncated by the byte cap.
     try:
         with open(file_path, encoding="utf-8", errors="ignore") as f:
             return "".join(itertools.islice(f, max_lines))
@@ -239,6 +241,11 @@ LICENSE_FILES = {
     "terms",
     "terms.txt",
 }
+
+
+def _is_explicit_license_file(file_path: str) -> bool:
+    return Path(file_path).name.lower() in LICENSE_FILES
+
 
 # Dataset file patterns that often lack proper licensing
 DATASET_EXTENSIONS = {

--- a/modelaudit/integrations/license_checker.py
+++ b/modelaudit/integrations/license_checker.py
@@ -182,7 +182,7 @@ def _read_header_text(file_path: str, max_lines: int) -> str | None:
     if not has_more_bytes:
         return "".join(decoded_header.splitlines(keepends=True)[:max_lines])
     if not _is_explicit_license_file(file_path):
-        return decoded_header
+        return "".join(decoded_header.splitlines(keepends=True)[:max_lines])
 
     # Explicit license files keep the richer line-oriented behavior so long
     # one-line license notices are not silently truncated by the byte cap.

--- a/tests/integrations/test_license_checker.py
+++ b/tests/integrations/test_license_checker.py
@@ -185,6 +185,22 @@ def some_function():
 
         assert [license_info.spdx_id for license_info in licenses] == ["MIT"]
 
+    def test_long_one_line_non_license_text_header_is_bounded(self, tmp_path: Path) -> None:
+        """Ordinary text-like payloads should not force a full-file line read."""
+        test_file = tmp_path / "payload.dat"
+        test_file.write_text(
+            "A" * (_LICENSE_HEADER_MAX_BYTES + 256) + " SPDX-License-Identifier: MIT\n",
+            encoding="utf-8",
+        )
+
+        content = _read_header_text(str(test_file), max_lines=1)
+        licenses = scan_for_license_headers(str(test_file), max_lines=1)
+
+        assert content is not None
+        assert len(content) <= _LICENSE_HEADER_MAX_BYTES
+        assert "SPDX-License-Identifier: MIT" not in content
+        assert licenses == []
+
 
 class TestCopyrightExtraction:
     """Test copyright notice extraction."""

--- a/tests/integrations/test_license_checker.py
+++ b/tests/integrations/test_license_checker.py
@@ -204,6 +204,23 @@ def some_function():
         assert "SPDX-License-Identifier: MIT" not in content
         assert licenses == []
 
+    def test_large_non_license_text_header_still_respects_max_lines(self, tmp_path: Path) -> None:
+        """Ordinary files should stay line-bounded even when the byte probe truncates."""
+        test_file = tmp_path / "payload.dat"
+        test_file.write_text(
+            "".join(f"line {index}\n" for index in range(10))
+            + "SPDX-License-Identifier: MIT\n"
+            + "A" * _LICENSE_HEADER_MAX_BYTES,
+            encoding="utf-8",
+        )
+
+        content = _read_header_text(str(test_file), max_lines=10)
+        licenses = scan_for_license_headers(str(test_file), max_lines=10)
+
+        assert content is not None
+        assert "SPDX-License-Identifier: MIT" not in content
+        assert licenses == []
+
 
 class TestCopyrightExtraction:
     """Test copyright notice extraction."""


### PR DESCRIPTION
## Summary
- bound long one-line header scans for ordinary non-license files at the existing header byte cap
- preserve the existing full line-oriented read for explicit license files like `notice.txt`
- add regression coverage for ordinary long one-line payloads

## Benchmarks
- synthetic 64 MiB one-line `payload.dat` through `scan_for_license_headers()`:
  - before: 0.166002s median
  - after: 0.000738s median

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/integrations/test_license_checker.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/integrations/test_license_integration.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/ --show-traceback` *(blocked by existing mypy 1.20.0 internal error on `backports.zstd.ZstdDecompressor`)*
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` *(currently fails on existing main-branch perf issues: native-only pickle validation is not yet on `main`, and concurrent directory scans time out while call-graph work remains unmerged)*