### PR TITLE
perf: reuse call graph controlled names

### DIFF
--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -2085,18 +2085,16 @@ def _calls_in_function(
         **aliases,
         **_collect_function_import_aliases(function_node, module_name, is_package),
     }
-    function_aliases.update(
-        _collect_function_instance_aliases(
-            function_node,
-            call_nodes,
-            module_name,
-            function_aliases,
-            local_defs,
-            local_class_targets,
-            class_name=class_name,
-        )
+    instance_aliases, parameter_controlled_names = _collect_function_instance_aliases(
+        function_node,
+        call_nodes,
+        module_name,
+        function_aliases,
+        local_defs,
+        local_class_targets,
+        class_name=class_name,
     )
-    parameter_controlled_names: set[str] | None = None
+    function_aliases.update(instance_aliases)
     tcl_command_controlled_names: set[str] | None = None
     dynamic_getattr_callable_names: set[str] | None = None
     getattr_default_callable_names: dict[str, str] | None = None
@@ -2470,10 +2468,10 @@ def _collect_function_instance_aliases(
     local_class_targets: set[str],
     *,
     class_name: str | None,
-) -> dict[str, str]:
+) -> tuple[dict[str, str], set[str] | None]:
     receiver_names = _method_call_receiver_names(call_nodes)
     if not receiver_names:
-        return {}
+        return {}, None
 
     assignment_candidates = tuple(
         (node, target_names)
@@ -2482,7 +2480,7 @@ def _collect_function_instance_aliases(
         and (target_names := _assignment_alias_target_names(node) & receiver_names)
     )
     if not assignment_candidates:
-        return {}
+        return {}, None
 
     instance_aliases: dict[str, str] = {}
     controlled_names = _parameter_controlled_names(function_node)
@@ -2504,8 +2502,8 @@ def _collect_function_instance_aliases(
                 continue
             instance_aliases[target_name] = resolved
             if len(instance_aliases) >= _MAX_FUNCTION_INSTANCE_ALIASES:
-                return instance_aliases
-    return instance_aliases
+                return instance_aliases, controlled_names
+    return instance_aliases, controlled_names
 
 
 def _method_call_receiver_names(call_nodes: tuple[ast.Call, ...]) -> set[str]:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import importlib
 import io
 import os
@@ -8386,3 +8387,45 @@ if marker.read_text() != marker_content:
     )
     assert result.returncode == 0, result.stderr
     assert marker.read_text() == marker_content
+
+
+def test_calls_in_function_reuses_instance_alias_parameter_analysis(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = ast.parse(
+        """
+class Runner:
+    def execute(self, command):
+        pass
+
+def bridge(target, command):
+    runner = Runner(command)
+    runner.execute(command)
+    getattr(target, command)(command)
+"""
+    )
+    bridge = module.body[1]
+    assert isinstance(bridge, ast.FunctionDef)
+
+    calls = 0
+    original_parameter_controlled_names = call_graph._parameter_controlled_names
+
+    def counting_parameter_controlled_names(
+        function_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> set[str]:
+        nonlocal calls
+        calls += 1
+        return original_parameter_controlled_names(function_node)
+
+    monkeypatch.setattr(call_graph, "_parameter_controlled_names", counting_parameter_controlled_names)
+
+    resolved_calls = call_graph._calls_in_function(
+        bridge,
+        "benchmod",
+        False,
+        {},
+        {"Runner", "bridge"},
+        {"benchmod.Runner"},
+        {"benchmod.Runner": ("benchmod.Runner.execute",)},
+    )
+
+    assert "benchmod.Runner.execute" in resolved_calls
+    assert calls == 1


### PR DESCRIPTION
## Summary
- reuse the parameter-controlled name set when function-local instance-alias analysis already computed it
- avoid a second AST walk in functions that later need the same control-flow evidence for dynamic dispatch checks
- add a focused regression proving one analysis pass is reused within `_calls_in_function()`

## Benchmarks
- helper-shaped `_calls_in_function()` workload over 2,000 invocations:
  - before: `0.257836s` median, `2.0` controlled-name analyses per invocation
  - after: `0.213943s` median, `1.0` controlled-name analyses per invocation

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py::test_calls_in_function_reuses_instance_alias_parameter_analysis packages/modelaudit-picklescan/tests/test_call_graph_click.py::test_call_graph_resolves_function_local_class_instance_aliases packages/modelaudit-picklescan/tests/test_call_graph_tkinter.py::test_call_graph_marks_parameter_controlled_tcl_dispatchers -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/ --show-traceback` *(blocked by existing mypy 1.20.0 internal error on `backports.zstd.ZstdDecompressor`)*
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` *(currently fails only on the existing local directory-scan performance threshold: `34.61s` vs `<30.0s`)*