### PR TITLE
perf: share getattr assignment candidates

### DIFF
--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -2100,6 +2100,7 @@ def _calls_in_function(
     tcl_command_controlled_names: set[str] | None = None
     dynamic_getattr_callable_names: set[str] | None = None
     getattr_default_callable_names: dict[str, str] | None = None
+    assignment_call_candidates: tuple[tuple[set[str], ast.Call], ...] | None = None
     may_use_getattr_dispatch = _may_use_getattr_dispatch(call_nodes, function_aliases)
     for node in call_nodes:
         if may_use_getattr_dispatch:
@@ -2117,8 +2118,10 @@ def _calls_in_function(
                 continue
             if isinstance(node.func, ast.Name):
                 if dynamic_getattr_callable_names is None:
+                    if assignment_call_candidates is None:
+                        assignment_call_candidates = _function_assignment_call_candidates(function_node)
                     dynamic_getattr_callable_names = _controlled_getattr_callable_names(
-                        function_node,
+                        assignment_call_candidates,
                         module_name,
                         function_aliases,
                         local_defs,
@@ -2131,8 +2134,10 @@ def _calls_in_function(
                     calls.append(_CONTROLLED_GETATTR_DISPATCH_SINK)
                     continue
                 if getattr_default_callable_names is None:
+                    if assignment_call_candidates is None:
+                        assignment_call_candidates = _function_assignment_call_candidates(function_node)
                     getattr_default_callable_names = _getattr_default_callable_names(
-                        function_node,
+                        assignment_call_candidates,
                         call_nodes,
                         module_name,
                         function_aliases,
@@ -2350,7 +2355,7 @@ def _is_controlled_direct_getattr_dispatch(
 
 
 def _controlled_getattr_callable_names(
-    function_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    assignment_call_candidates: tuple[tuple[set[str], ast.Call], ...],
     module_name: str,
     aliases: dict[str, str],
     local_defs: set[str],
@@ -2359,20 +2364,7 @@ def _controlled_getattr_callable_names(
     class_name: str | None,
 ) -> set[str]:
     callable_names: set[str] = set()
-    for node in ast.walk(function_node):
-        value: ast.AST | None
-        if isinstance(node, ast.Assign):
-            value = node.value
-            targets = set()
-            for target in node.targets:
-                targets.update(_assignment_target_names(target))
-        elif isinstance(node, ast.AnnAssign):
-            value = node.value
-            targets = _assignment_target_names(node.target)
-        else:
-            continue
-        if not isinstance(value, ast.Call):
-            continue
+    for targets, value in assignment_call_candidates:
         if _controlled_getattr_call(
             value,
             module_name,
@@ -2403,7 +2395,7 @@ def _controlled_getattr_call(
 
 
 def _getattr_default_callable_names(
-    function_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    assignment_call_candidates: tuple[tuple[set[str], ast.Call], ...],
     call_nodes: tuple[ast.Call, ...],
     module_name: str,
     aliases: dict[str, str],
@@ -2416,20 +2408,7 @@ def _getattr_default_callable_names(
         return {}
 
     callable_names: dict[str, str] = {}
-    for node in ast.walk(function_node):
-        value: ast.AST | None
-        if isinstance(node, ast.Assign):
-            value = node.value
-            targets = set()
-            for target in node.targets:
-                targets.update(_assignment_target_names(target))
-        elif isinstance(node, ast.AnnAssign):
-            value = node.value
-            targets = _assignment_target_names(node.target)
-        else:
-            continue
-        if not isinstance(value, ast.Call):
-            continue
+    for targets, value in assignment_call_candidates:
         target_names = targets & called_names
         if not target_names:
             continue
@@ -2445,6 +2424,27 @@ def _getattr_default_callable_names(
         for target_name in sorted(target_names):
             callable_names[target_name] = fallback_target
     return callable_names
+
+
+def _function_assignment_call_candidates(
+    function_node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> tuple[tuple[set[str], ast.Call], ...]:
+    candidates: list[tuple[set[str], ast.Call]] = []
+    for node in ast.walk(function_node):
+        value: ast.AST | None
+        if isinstance(node, ast.Assign):
+            value = node.value
+            targets = set()
+            for target in node.targets:
+                targets.update(_assignment_target_names(target))
+        elif isinstance(node, ast.AnnAssign):
+            value = node.value
+            targets = _assignment_target_names(node.target)
+        else:
+            continue
+        if isinstance(value, ast.Call):
+            candidates.append((targets, value))
+    return tuple(candidates)
 
 
 def _getattr_default_callable_target(

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import importlib
 import io
 import os
@@ -8386,3 +8387,40 @@ if marker.read_text() != marker_content:
     )
     assert result.returncode == 0, result.stderr
     assert marker.read_text() == marker_content
+
+
+def test_calls_in_function_reuses_getattr_assignment_candidates(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = ast.parse(
+        """
+def bridge(target, command, fallback):
+    callback = getattr(target, command, fallback)
+    callback(command)
+"""
+    )
+    bridge = module.body[0]
+    assert isinstance(bridge, ast.FunctionDef)
+
+    calls = 0
+    original_assignment_call_candidates = call_graph._function_assignment_call_candidates
+
+    def counting_assignment_call_candidates(
+        function_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> tuple[tuple[set[str], ast.Call], ...]:
+        nonlocal calls
+        calls += 1
+        return original_assignment_call_candidates(function_node)
+
+    monkeypatch.setattr(call_graph, "_function_assignment_call_candidates", counting_assignment_call_candidates)
+
+    resolved_calls = call_graph._calls_in_function(
+        bridge,
+        "benchmod",
+        False,
+        {},
+        {"bridge"},
+        set(),
+        {},
+    )
+
+    assert "builtins.getattr.__call__" in resolved_calls
+    assert calls == 1


### PR DESCRIPTION
## Summary
- reuse assignment-call candidates across controlled and fallback `getattr` dispatch analysis
- avoid a duplicate function-body walk when both branches are needed
- add a regression proving the candidate collector runs once

## Benchmark
Helper-shaped `bridge(target, command, fallback)` workload, same checkout before/after, 5,000 `_calls_in_function()` calls per sample:

| version | ast.walk calls / invocation | median time |
| --- | ---: | ---: |
| before | 8.0 | 0.439966s |
| after | 7.0 | 0.392207s |

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py packages/modelaudit-picklescan/tests/test_call_graph_click.py::test_call_graph_resolves_function_local_class_instance_aliases packages/modelaudit-picklescan/tests/test_call_graph_tkinter.py::test_call_graph_marks_parameter_controlled_tcl_dispatchers -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py`

## Notes
- repo-wide `mypy` still hits the existing `mypy 1.20.0` internal error on `backports.zstd.ZstdDecompressor`
- the broad non-slow pytest lane still trips existing timing-sensitive perf assertions in this environment (`test_validation_performance_impact`, `test_directory_scanning_performance`); the focused suite above is clean, and the unrelated isolated directory benchmark passed on rerun
