### PR TITLE
perf: reuse metagraph attr lowercase values

### DIFF
--- a/modelaudit/scanners/tf_metagraph_scanner.py
+++ b/modelaudit/scanners/tf_metagraph_scanner.py
@@ -232,6 +232,10 @@ def _extract_attr_strings(attrs: Any) -> list[_AttrString]:
     return strings
 
 
+def _attr_strings_with_lowered_values(attr_strings: Iterable[_AttrString]) -> tuple[tuple[_AttrString, str], ...]:
+    return tuple((attr_string, attr_string.attr_value.lower()) for attr_string in attr_strings)
+
+
 class TensorFlowMetaGraphScanner(BaseScanner):
     """Scanner for TensorFlow MetaGraph protobuf files (.meta)."""
 
@@ -397,12 +401,14 @@ class TensorFlowMetaGraphScanner(BaseScanner):
                 continue
 
             attr_strings = _extract_attr_strings(ctx.attrs)
-            has_decode_hint = any(_DECODE_HINT_RE.search(attr.attr_value.lower()) for attr in attr_strings)
+            attr_strings_with_lowered_values = _attr_strings_with_lowered_values(attr_strings)
+            has_decode_hint = any(
+                _DECODE_HINT_RE.search(attr_lower) for _attr_string, attr_lower in attr_strings_with_lowered_values
+            )
 
-            for attr_string in attr_strings:
+            for attr_string, attr_lower in attr_strings_with_lowered_values:
                 attr_name = attr_string.attr_name
                 attr_val = attr_string.attr_value
-                attr_lower = attr_val.lower()
 
                 if _LIBRARY_OR_PATH_RE.search(attr_val):
                     suspicious_signal_categories.add("dynamic_library_or_path")

--- a/tests/scanners/test_tf_metagraph_scanner.py
+++ b/tests/scanners/test_tf_metagraph_scanner.py
@@ -13,6 +13,8 @@ from modelaudit.scanners.tf_metagraph_scanner import (
     _MAX_PARSE_BYTES,
     DISCOVERY_ASSUMPTIONS,
     TensorFlowMetaGraphScanner,
+    _attr_strings_with_lowered_values,
+    _AttrString,
 )
 from modelaudit.utils.tensorflow_compat import has_tensorflow_protobuf_stubs as _has_tf_protos
 
@@ -73,6 +75,22 @@ def _build_metagraph(
                 collection.bytes_list.value.append(value)
 
     return cast(bytes, metagraph.SerializeToString())
+
+
+def test_tf_metagraph_attr_lowering_reuses_shared_values() -> None:
+    class CountingStr(str):
+        lower_calls = 0
+
+        def lower(self) -> str:
+            type(self).lower_calls += 1
+            return super().lower()
+
+    attr_value = CountingStr("BASE64 payload")
+
+    lowered_values = _attr_strings_with_lowered_values((_AttrString("payload", attr_value, len(attr_value)),))
+
+    assert lowered_values == ((_AttrString("payload", attr_value, len(attr_value)), "base64 payload"),)
+    assert CountingStr.lower_calls == 1
 
 
 def test_tf_metagraph_scanner_can_handle_strict(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- reuse lowered TensorFlow MetaGraph executable-attribute values within one node scan
- avoid lowercasing the same bounded attr payload once for decode-hint probing and again for the main signal loop
- add a focused regression proving attr values are lowered once

## Benchmark
Bounded worst-case executable-node payload (`64` attrs at the scanner's `32 KiB` attr cap), `200` iterations:

| version | median time |
| --- | ---: |
| before | 9.785893s |
| after | 9.487525s |

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest tests/scanners/test_tf_metagraph_scanner.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/scanners/tf_metagraph_scanner.py tests/scanners/test_tf_metagraph_scanner.py`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/scanners/tf_metagraph_scanner.py tests/scanners/test_tf_metagraph_scanner.py`

## Notes
- repo-wide `mypy` still hits the existing `mypy 1.20.0` internal error on `backports.zstd.ZstdDecompressor`
- the broad non-slow pytest lane still trips timing-sensitive perf assertions in this environment (`test_validation_performance_impact`, `test_concurrent_performance`)
