### PR TITLE
perf: reuse lowered ml operation names

### DIFF
--- a/modelaudit/analysis/ml_context_analyzer.py
+++ b/modelaudit/analysis/ml_context_analyzer.py
@@ -274,15 +274,16 @@ class MLContextAnalyzer:
                 return operation
 
         # Pattern-based matching for broader operations
+        function_call_lower = function_call.lower()
         for operation in self.ml_operations:
             if operation.framework == framework and (
                 (
                     operation.operation_type == "model_loading"
-                    and any(keyword in function_call.lower() for keyword in ["load", "restore", "checkpoint"])
+                    and any(keyword in function_call_lower for keyword in ["load", "restore", "checkpoint"])
                 )
                 or (
                     operation.operation_type == "tensor_ops"
-                    and any(keyword in function_call.lower() for keyword in ["tensor", "array", "constant"])
+                    and any(keyword in function_call_lower for keyword in ["tensor", "array", "constant"])
                 )
             ):
                 return operation

--- a/tests/analysis/test_ml_context_analyzer.py
+++ b/tests/analysis/test_ml_context_analyzer.py
@@ -192,6 +192,23 @@ class TestMLOperationPatterns:
         result = analyzer.analyze_context("model.fit(X, y)", ["sklearn", "RandomForestClassifier"])
         assert result.framework == MLFramework.SKLEARN
 
+    def test_identify_operation_reuses_lowered_function_call(self) -> None:
+        """Broad operation matching should lowercase a function call once."""
+        analyzer = MLContextAnalyzer()
+
+        class CountingStr(str):
+            lower_calls = 0
+
+            def lower(self) -> str:
+                type(self).lower_calls += 1
+                return super().lower()
+
+        operation = analyzer._identify_operation(CountingStr("torch.create_tensor_value"), MLFramework.PYTORCH)
+
+        assert operation is not None
+        assert operation.operation_type == "tensor_ops"
+        assert CountingStr.lower_calls == 1
+
 
 class TestFalsePositiveReduction:
     """Test false positive reduction scenarios."""


### PR DESCRIPTION
## Summary
- lowercase broad ML-operation candidates once per function call
- reuse that lowered string across model-loading and tensor-op fallback checks
- add a regression that exercises the second broad-match bucket and proves one lowercase pass

## Benchmark
Long synthetic function name matching the tensor-op fallback path, `100,000` `_identify_operation()` calls:

| version | median time |
| --- | ---: |
| before | 0.769627s |
| after | 0.682634s |

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest tests/analysis/test_ml_context_analyzer.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/analysis/ml_context_analyzer.py tests/analysis/test_ml_context_analyzer.py`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/analysis/ml_context_analyzer.py tests/analysis/test_ml_context_analyzer.py`

## Notes
- repo-wide `mypy` still hits the existing `mypy 1.20.0` internal error on `backports.zstd.ZstdDecompressor`
- the broad non-slow pytest lane still trips timing-sensitive perf assertions in this environment (`test_directory_scanning_performance`, `test_validation_performance_impact`)
