### PR TITLE
perf: reuse lowered layer type names

### DIFF
--- a/modelaudit/analysis/unified_context.py
+++ b/modelaudit/analysis/unified_context.py
@@ -143,21 +143,20 @@ class UnifiedMLContext:
         layer_type_counts: dict[str, int] = {}
         for pattern in self.layer_patterns:
             layer_type_counts[pattern.layer_type] = layer_type_counts.get(pattern.layer_type, 0) + 1
+        lowered_layer_types = tuple(str(layer.layer_type).lower() for layer in self.layer_patterns)
 
         # Transformer detection
         transformer_indicators = ["attention", "multi_head", "position", "embedding"]
         transformer_score = sum(
             1
             for indicator in transformer_indicators
-            if any(indicator in str(layer.layer_type).lower() for layer in self.layer_patterns)
+            if any(indicator in layer_type for layer_type in lowered_layer_types)
         )
 
         # CNN detection
         cnn_indicators = ["conv", "pool", "batch_norm"]
         cnn_score = sum(
-            1
-            for indicator in cnn_indicators
-            if any(indicator in str(layer.layer_type).lower() for layer in self.layer_patterns)
+            1 for indicator in cnn_indicators if any(indicator in layer_type for layer_type in lowered_layer_types)
         )
 
         # Determine architecture

--- a/tests/analysis/test_unified_context.py
+++ b/tests/analysis/test_unified_context.py
@@ -1,6 +1,7 @@
 """Tests for unified context module."""
 
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -226,6 +227,28 @@ class TestUnifiedMLContext:
         ]
         basic_context.analyze_architecture_patterns()
         assert basic_context.architecture == ModelArchitecture.CNN
+
+    def test_analyze_architecture_reuses_lowered_layer_types(self, basic_context: UnifiedMLContext) -> None:
+        """Architecture detection should normalize each layer type once."""
+
+        class CountingLayerType:
+            str_calls = 0
+
+            def __str__(self) -> str:
+                type(self).str_calls += 1
+                return "custom_layer"
+
+        basic_context.layer_patterns = [
+            LayerPattern(
+                layer_type=cast(str, CountingLayerType()),
+                parameter_names=[],
+                activation_functions=[],
+            )
+        ]
+
+        basic_context.analyze_architecture_patterns()
+
+        assert CountingLayerType.str_calls == 1
 
     def test_analyze_architecture_bert(self, basic_context):
         """Test BERT architecture detection."""


### PR DESCRIPTION
## Summary
- normalize layer-type strings once per architecture analysis
- reuse that lowered view across transformer and CNN indicator scans
- add a regression proving each layer type is stringified once

## Benchmark
`UnifiedMLContext.analyze_architecture_patterns()` over `1,000` synthetic layer names, `500` analyses:

| version | median time |
| --- | ---: |
| before | 1.268737s |
| after | 0.728951s |

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest tests/analysis/test_unified_context.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/analysis/unified_context.py tests/analysis/test_unified_context.py`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/analysis/unified_context.py tests/analysis/test_unified_context.py`

## Notes
- repo-wide `mypy` still hits the existing `mypy 1.20.0` internal error on `backports.zstd.ZstdDecompressor`
- the broad non-slow pytest lane still trips the timing-sensitive directory performance assertion in this environment
