### PR TITLE
perf: reuse lowered metadata keys

### DIFF
--- a/modelaudit/metadata_extractor.py
+++ b/modelaudit/metadata_extractor.py
@@ -138,7 +138,8 @@ class ModelMetadataExtractor:
 
         # Add any keys containing 'security', 'suspicious', 'dangerous', etc.
         for key, value in metadata.items():
-            if any(term in key.lower() for term in ["security", "suspicious", "dangerous", "malicious", "risk"]):
+            key_lower = key.lower()
+            if any(term in key_lower for term in ["security", "suspicious", "dangerous", "malicious", "risk"]):
                 filtered[key] = value
 
         return filtered

--- a/tests/test_metadata_extractor.py
+++ b/tests/test_metadata_extractor.py
@@ -34,6 +34,20 @@ def test_has_tensorflow_protobuf_stubs_fails_closed_on_probe_error(monkeypatch: 
 class TestModelMetadataExtractor:
     """Test the ModelMetadataExtractor class."""
 
+    def test_filter_security_metadata_reuses_lowered_keys(self) -> None:
+        class CountingKey(str):
+            lower_calls = 0
+
+            def lower(self) -> str:
+                self.lower_calls += 1
+                return super().lower()
+
+        extractor = metadata_extractor_module.ModelMetadataExtractor()
+        key = CountingKey("risk_profile")
+
+        assert extractor._filter_security_metadata({key: True}) == {"risk_profile": True}
+        assert key.lower_calls == 1
+
     def test_extract_metadata_uses_scanner_helper_with_deserialization_config(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Summary
- lower metadata keys once while filtering security-relevant metadata
- add a focused regression that proves the key search reuses the normalized string

## Benchmark
- `50,000`-key metadata map, `100` filter passes
- old median: 1.357000s
- new median: 1.101180s
- speedup: 1.23x

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_metadata_extractor.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/metadata_extractor.py tests/test_metadata_extractor.py`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/metadata_extractor.py tests/test_metadata_extractor.py`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` *(fails with the existing mypy 1.20.0 internal error)*
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` *(fails only on the existing timing-sensitive `test_validation_performance_impact` and `test_directory_scanning_performance` sentinels in this environment)*