### PR TITLE
perf: reuse lowered secret descriptions

### DIFF
--- a/modelaudit/scanners/metadata_scanner.py
+++ b/modelaudit/scanners/metadata_scanner.py
@@ -312,7 +312,7 @@ class MetadataScanner(BaseScanner):
 
                 # For well-known token formats (GitHub, OpenAI, AWS), we trust the pattern
                 # and don't need entropy checks - these have specific prefixes/formats
-                is_known_format = any(prefix in description.lower() for prefix in ["github", "openai", "aws", "slack"])
+                is_known_format = self._is_known_secret_format(description)
 
                 if is_known_format:
                     # Known format - report if not a placeholder
@@ -334,6 +334,7 @@ class MetadataScanner(BaseScanner):
                                 type="exposed_secret",
                             ),
                         )
+
                 else:
                     # Generic pattern - use entropy check to reduce false positives
                     entropy = self._calculate_entropy(secret_part)
@@ -358,3 +359,8 @@ class MetadataScanner(BaseScanner):
                                 type="exposed_secret",
                             ),
                         )
+
+    @staticmethod
+    def _is_known_secret_format(description: str) -> bool:
+        lowered_description = description.lower()
+        return any(prefix in lowered_description for prefix in ["github", "openai", "aws", "slack"])

--- a/tests/scanners/test_metadata_scanner.py
+++ b/tests/scanners/test_metadata_scanner.py
@@ -12,6 +12,19 @@ from modelaudit.scanners.metadata_scanner import MetadataScanner
 class TestMetadataScanner:
     """Test metadata scanner functionality."""
 
+    def test_known_secret_format_reuses_lowered_description(self) -> None:
+        class CountingDescription(str):
+            lower_calls = 0
+
+            def lower(self) -> str:
+                self.lower_calls += 1
+                return super().lower()
+
+        description = CountingDescription("OpenAI API Key")
+
+        assert MetadataScanner._is_known_secret_format(description) is True
+        assert description.lower_calls == 1
+
     def test_can_handle_text_metadata(self):
         """Test that scanner handles text metadata files only."""
         scanner = MetadataScanner()


### PR DESCRIPTION
## Summary
- lower metadata secret descriptions once while checking known token formats
- add a focused regression that proves the known-format probe reuses the normalized description

## Benchmark
- `100,000` secret descriptions, `50` probe passes
- old median: 3.509000s
- new median: 2.000413s
- speedup: 1.75x

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_metadata_scanner.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/scanners/metadata_scanner.py tests/scanners/test_metadata_scanner.py`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/scanners/metadata_scanner.py tests/scanners/test_metadata_scanner.py`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` *(fails with the existing mypy 1.20.0 internal error)*
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` *(fails only on the existing timing-sensitive `test_validation_performance_impact` and `test_directory_scanning_performance` sentinels in this environment)*