### PR TITLE
perf: reuse lowered sarif messages

### DIFF
--- a/modelaudit/integrations/sarif_formatter.py
+++ b/modelaudit/integrations/sarif_formatter.py
@@ -338,19 +338,20 @@ def _get_rule_name(issue: Any) -> str:
 
 def _get_rule_short_description(issue: Any) -> str:
     """Get a short description for a rule."""
-    if "pickle" in issue.message.lower():
+    lowered_message = issue.message.lower()
+    if "pickle" in lowered_message:
         return "Potentially unsafe pickle operation detected"
-    elif "import" in issue.message.lower():
+    elif "import" in lowered_message:
         return "Dangerous import statement found"
-    elif "exec" in issue.message.lower() or "eval" in issue.message.lower():
+    elif "exec" in lowered_message or "eval" in lowered_message:
         return "Code execution vulnerability"
-    elif "network" in issue.message.lower():
+    elif "network" in lowered_message:
         return "Network communication detected"
-    elif "secret" in issue.message.lower() or "key" in issue.message.lower():
+    elif "secret" in lowered_message or "key" in lowered_message:
         return "Potential secrets or keys exposed"
-    elif "license" in issue.message.lower():
+    elif "license" in lowered_message:
         return "License compliance issue"
-    elif "blacklist" in issue.message.lower():
+    elif "blacklist" in lowered_message:
         return "Blacklisted model name detected"
     else:
         return str(issue.message[:100])

--- a/tests/integrations/test_sarif_formatter.py
+++ b/tests/integrations/test_sarif_formatter.py
@@ -2,6 +2,7 @@
 
 import json
 import time
+from types import SimpleNamespace
 
 from modelaudit.integrations.sarif_formatter import (
     _create_artifacts,
@@ -416,6 +417,22 @@ class TestHelperFunctions:
 
         desc = _get_rule_short_description(issue)
         assert "pickle" in desc.lower()
+
+    def test_get_rule_short_description_reuses_lowered_message(self):
+        """Short-description matching should normalize the issue message once."""
+
+        class CountingMessage(str):
+            lower_calls = 0
+
+            def lower(self) -> str:
+                self.lower_calls += 1
+                return super().lower()
+
+        message = CountingMessage("Potential exposed secret")
+        issue = SimpleNamespace(message=message)
+
+        assert _get_rule_short_description(issue) == "Potential secrets or keys exposed"
+        assert message.lower_calls == 1
 
     def test_get_rule_short_description_import(self):
         """Test short description for import issues."""


### PR DESCRIPTION
## Summary
- lower SARIF issue messages once while choosing short rule descriptions
- add a focused regression that proves the formatter reuses the normalized message

## Benchmark
- `100,000` issue messages, `50` classification passes
- old median: 1.469239s
- new median: 0.523130s
- speedup: 2.81x

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/integrations/test_sarif_formatter.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/integrations/sarif_formatter.py tests/integrations/test_sarif_formatter.py`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/integrations/sarif_formatter.py tests/integrations/test_sarif_formatter.py`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` *(fails with the existing mypy 1.20.0 internal error)*
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` *(fails only on the existing timing-sensitive `test_validation_performance_impact` and `test_directory_scanning_performance` sentinels in this environment)*