### PR TITLE
perf: reuse prefiltered sarif issues

### DIFF
--- a/modelaudit/integrations/sarif_formatter.py
+++ b/modelaudit/integrations/sarif_formatter.py
@@ -58,11 +58,11 @@ def _create_run(
     issues = _primary_sarif_issues(issues)
 
     # Create rules from unique issue types
-    rules = _create_rules(issues)
+    rules = _create_rules(issues, prefiltered=True)
     rule_indices = {rule["id"]: idx for idx, rule in enumerate(rules)}
 
     # Create results from issues
-    results = _create_results(issues, rule_indices)
+    results = _create_results(issues, rule_indices, prefiltered=True)
 
     # Create artifacts from scanned files
     artifacts = _create_artifacts(audit_result)
@@ -148,9 +148,10 @@ def _exit_code_description(audit_result: ModelAuditResultModel, exit_code: int) 
     return "Errors occurred during scanning"
 
 
-def _create_rules(issues: list) -> list[dict[str, Any]]:
+def _create_rules(issues: list, *, prefiltered: bool = False) -> list[dict[str, Any]]:
     """Create SARIF rules from unique issue types."""
-    issues = _primary_sarif_issues(issues)
+    if not prefiltered:
+        issues = _primary_sarif_issues(issues)
     rules = []
     seen_rules = set()
 
@@ -191,12 +192,18 @@ def _create_rules(issues: list) -> list[dict[str, Any]]:
     return rules
 
 
-def _create_results(issues: list, rule_indices: dict[str, int] | None = None) -> list[dict[str, Any]]:
+def _create_results(
+    issues: list,
+    rule_indices: dict[str, int] | None = None,
+    *,
+    prefiltered: bool = False,
+) -> list[dict[str, Any]]:
     """Create SARIF results from issues."""
-    issues = _primary_sarif_issues(issues)
+    if not prefiltered:
+        issues = _primary_sarif_issues(issues)
     results = []
     if rule_indices is None:
-        rule_indices = {rule["id"]: idx for idx, rule in enumerate(_create_rules(issues))}
+        rule_indices = {rule["id"]: idx for idx, rule in enumerate(_create_rules(issues, prefiltered=prefiltered))}
 
     for issue in issues:
         rule_id = _get_rule_id(issue)

--- a/tests/integrations/test_sarif_formatter.py
+++ b/tests/integrations/test_sarif_formatter.py
@@ -3,6 +3,9 @@
 import json
 import time
 
+import pytest
+
+import modelaudit.integrations.sarif_formatter as sarif_formatter
 from modelaudit.integrations.sarif_formatter import (
     _create_artifacts,
     _create_results,
@@ -134,6 +137,35 @@ class TestCreateRun:
         assert driver["name"] == "ModelAudit"
         assert "version" in driver
         assert "rules" in driver
+
+    def test_primary_issue_filter_runs_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Prefiltered issues should not be filtered again while building one run."""
+        result = create_initial_audit_result()
+        result.issues = [
+            Issue(
+                message="Primary dangerous call",
+                severity=IssueSeverity.CRITICAL,
+                location="/test/file.pkl",
+                details={"pickle_rule_code": "DANGEROUS_CALL"},
+                rule_code="S104",
+                timestamp=time.time(),
+            )
+        ]
+        result.finalize_statistics()
+
+        call_count = 0
+        original_primary_sarif_issues = sarif_formatter._primary_sarif_issues
+
+        def counting_primary_sarif_issues(issues: list[Issue]) -> list[Issue]:
+            nonlocal call_count
+            call_count += 1
+            return original_primary_sarif_issues(issues)
+
+        monkeypatch.setattr(sarif_formatter, "_primary_sarif_issues", counting_primary_sarif_issues)
+
+        _create_run(result, ["/test"], verbose=False)
+
+        assert call_count == 1
 
     def test_invocation_properties(self):
         """Test invocation includes scan properties."""


### PR DESCRIPTION
## Summary
- reuse the primary SARIF issue filter result inside `_create_run()` instead of recomputing it in rule/result builders
- preserve standalone helper semantics with an explicit `prefiltered` flag
- add a regression proving one SARIF run only invokes the primary-issue filter once

## Benchmark
Synthetic 100,000-issue list with 25% compatibility-only supporting rows, 20 iterations per sample, median of 7 repeats:

- current three-pass filter path: `0.636097s`
- one-pass prefiltered path: `0.222424s`
- duplicated-filter slice: `2.86x` faster

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest tests/integrations/test_sarif_formatter.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check modelaudit/integrations/sarif_formatter.py tests/integrations/test_sarif_formatter.py`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` *(blocked by the existing `mypy 1.20.0` internal error in this checkout)*
- `PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest -n auto -m "not slow and not integration" --maxfail=1` *(reproduces the existing environment-sensitive timing sentinel failures in `test_validation_performance_impact` and `test_directory_scanning_performance`)*
