### PR TITLE
perf: reuse lowered get_file values

### DIFF
--- a/modelaudit/scanners/keras_zip_scanner.py
+++ b/modelaudit/scanners/keras_zip_scanner.py
@@ -94,6 +94,22 @@ _URL_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
 _WINDOWS_ABSOLUTE_PATH_PATTERN = re.compile(r"^(?:[a-zA-Z]:[\\/]|\\\\)")
 _KERAS_CONFIG_ENTRY = "config.json"
 _KERAS_CONFIG_MAX_BYTES = 10 * 1024 * 1024
+
+
+def _has_get_file_reference(values: list[str]) -> bool:
+    """Return whether config string values reference a get_file callable."""
+    for value in values:
+        stripped_value = value.strip()
+        if _GET_FILE_PATTERN.fullmatch(stripped_value) is not None:
+            return True
+
+        stripped_value_lower = stripped_value.lower()
+        if stripped_value_lower.endswith(".get_file") or "keras.utils.get_file" in stripped_value_lower:
+            return True
+
+    return False
+
+
 _KERAS_METADATA_ENTRY = "metadata.json"
 _KERAS_METADATA_MAX_BYTES = 10 * 1024 * 1024
 _KERAS_WEIGHTS_ENTRY = "model.weights.h5"
@@ -1097,12 +1113,7 @@ class KerasZipScanner(BaseScanner):
                 key_lower = str(key).lower()
                 if key_lower in {"url", "origin", "args", "kwargs"}:
                     url_candidate_values.extend(self._extract_string_literals(value, include_dict_values=True))
-            has_get_file = any(
-                _GET_FILE_PATTERN.fullmatch(value.strip()) is not None
-                or value.strip().lower().endswith(".get_file")
-                or "keras.utils.get_file" in value.strip().lower()
-                for value in direct_string_values
-            )
+            has_get_file = _has_get_file_reference(direct_string_values)
             has_url = any(_URL_PATTERN.search(value) is not None for value in url_candidate_values)
             if not (has_get_file and has_url):
                 continue
@@ -1145,12 +1156,7 @@ class KerasZipScanner(BaseScanner):
                 if key_lower in {"url", "origin", "args", "kwargs"}:
                     url_candidate_values.extend(self._extract_string_literals(value, include_dict_values=True))
 
-            has_get_file = any(
-                _GET_FILE_PATTERN.fullmatch(value.strip()) is not None
-                or value.strip().lower().endswith(".get_file")
-                or "keras.utils.get_file" in value.strip().lower()
-                for value in direct_string_values
-            )
+            has_get_file = _has_get_file_reference(direct_string_values)
             if not has_get_file or not self._node_has_get_file_extract_true(node):
                 continue
 

--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -24,7 +24,7 @@ from modelaudit.cache import get_cache_manager, reset_cache_manager
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.scanners import keras_zip_scanner as keras_zip_scanner_module
 from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity
-from modelaudit.scanners.keras_zip_scanner import KerasZipScanner
+from modelaudit.scanners.keras_zip_scanner import KerasZipScanner, _has_get_file_reference
 
 try:
     import h5py
@@ -2207,6 +2207,22 @@ class TestCVE20251550ModuleReferences:
 
 class TestCVE20258747GetFileGadget:
     """Test CVE-2025-8747: keras.utils.get_file gadget bypass detection."""
+
+    def test_get_file_reference_reuses_lowered_value_text(self) -> None:
+        """Non-exact callable checks should lowercase each string once."""
+
+        class CountingValue(str):
+            lower_calls = 0
+
+            def strip(self) -> "CountingValue":
+                return self
+
+            def lower(self) -> str:
+                type(self).lower_calls += 1
+                return super().lower()
+
+        assert _has_get_file_reference([CountingValue("pkg.keras.utils.get_file")])
+        assert CountingValue.lower_calls == 1
 
     def _make_keras_zip(self, config_str: str, tmp_path: Path) -> str:
         """Helper to create a .keras ZIP with raw config string."""

--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -2214,7 +2214,7 @@ class TestCVE20258747GetFileGadget:
         class CountingValue(str):
             lower_calls = 0
 
-            def strip(self) -> "CountingValue":
+            def strip(self, chars: str | None = None, /) -> "CountingValue":
                 return self
 
             def lower(self) -> str:


### PR DESCRIPTION
## Summary
- centralize the Keras `get_file` callable matcher shared by the gadget and archive-extraction CVE checks
- lowercase each non-exact candidate value once instead of repeating `strip().lower()` across the predicate ladder
- add helper-level coverage proving the non-exact path performs one lowercase conversion

## Benchmark
Synthetic list of `200,001` candidate config values, 10 passes per sample, median of 7 repeats:

- repeated predicate ladder: `0.500627s`
- shared lowered value path: `0.320392s`
- matcher loop: `1.56x` faster

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest tests/scanners/test_keras_zip_scanner.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check modelaudit/scanners/keras_zip_scanner.py tests/scanners/test_keras_zip_scanner.py`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` *(blocked by the existing `mypy 1.20.0` internal error in this checkout)*
- `PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest -n auto -m "not slow and not integration" --maxfail=1` *(reproduces the existing environment-sensitive timing sentinel failures in `test_validation_performance_impact` and `test_directory_scanning_performance`)*
