### PR TITLE
perf: cache split call graph names

### DIFF
--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -720,6 +720,7 @@ def _clear_source_sensitive_caches() -> None:
         _resolve_wildcard_reexport_alias,
         _wildcard_export_summary,
         _resolve_class_target,
+        _split_function_name,
         _analyze_module,
         _source_function_context,
         _source_class_context,
@@ -1164,6 +1165,7 @@ def _class_entrypoints(class_name: str) -> tuple[str, ...]:
     return analysis.class_entrypoints.get(f"{module_name}.{qualified_name}", ())
 
 
+@lru_cache(maxsize=4096)
 def _split_function_name(function_name: str) -> tuple[str | None, str]:
     parts = function_name.split(".")
     for index in range(len(parts) - 1, 0, -1):

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -78,6 +78,7 @@ def _clear_call_graph_caches() -> None:
         "_resolve_function_target",
         "_resolve_module_source",
         "_safe_call_graph_entrypoints",
+        "_split_function_name",
         "_wildcard_export_summary",
     ):
         cache_clear = getattr(getattr(call_graph_module, function_name), "cache_clear", None)
@@ -87,6 +88,21 @@ def _clear_call_graph_caches() -> None:
 
 def _env_without_pythonpath() -> dict[str, str]:
     return {key: value for key, value in os.environ.items() if key != "PYTHONPATH"}
+
+
+def test_split_function_name_reuses_cached_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    analyze_calls: list[str] = []
+
+    def fake_analyze_module(module_name: str) -> object | None:
+        analyze_calls.append(module_name)
+        return object() if module_name == "pkg.mod" else None
+
+    monkeypatch.setattr(call_graph, "_analyze_module", fake_analyze_module)
+    call_graph._split_function_name.cache_clear()
+
+    assert call_graph._split_function_name("pkg.mod.func") == ("pkg.mod", "func")
+    assert call_graph._split_function_name("pkg.mod.func") == ("pkg.mod", "func")
+    assert analyze_calls == ["pkg.mod"]
 
 
 def _sitebuiltins_helper_instance_call_payload() -> bytes:


### PR DESCRIPTION
## Summary
- cache `_split_function_name()` so repeated call-graph lookups reuse the same dotted-name resolution
- clear the new cache with the existing source-sensitive invalidation sweep
- add focused coverage proving repeated resolution does not re-run module analysis

## Benchmarks
Repeated PyTorch reference split loop over 5 common names x 200, 100 passes per sample, median of 7 repeats:

- uncached helper: `0.030549s`
- cached helper: `0.003123s`
- helper loop: `9.78x` faster

Matched cProfile run on `tests/assets/exploits/exploit_ultimate_50pct.pkl`:

- before: `82.470s`
- after: `58.022s`
- profiled scan: `1.42x` faster

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` *(blocked by the existing `mypy 1.20.0` internal error in this checkout)*
- `PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest -n auto -m "not slow and not integration" --maxfail=1` *(reproduces the existing environment-sensitive `test_directory_scanning_performance` timing sentinel; the earlier bounded validation sentinel passed in this run)*
