### PR TITLE
perf: cache parameter controlled names

### DIFF
--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -724,6 +724,7 @@ def _clear_source_sensitive_caches() -> None:
         _source_function_context,
         _source_class_context,
         _constructor_parameter_self_attribute_targets,
+        _parameter_controlled_names,
         _can_invoke_function_with_positional_args,
         _can_follow_import_execution_fallback,
         _resolve_module_source,
@@ -2602,6 +2603,7 @@ def _iter_call_nodes(function_node: ast.FunctionDef | ast.AsyncFunctionDef) -> t
     return tuple(calls)
 
 
+@lru_cache(maxsize=4096)
 def _parameter_controlled_names(function_node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
     controlled = _initial_parameter_controlled_names(function_node)
 

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import importlib
 import io
 import os
@@ -78,6 +79,7 @@ def _clear_call_graph_caches() -> None:
         "_resolve_function_target",
         "_resolve_module_source",
         "_safe_call_graph_entrypoints",
+        "_parameter_controlled_names",
         "_wildcard_export_summary",
     ):
         cache_clear = getattr(getattr(call_graph_module, function_name), "cache_clear", None)
@@ -87,6 +89,39 @@ def _clear_call_graph_caches() -> None:
 
 def _env_without_pythonpath() -> dict[str, str]:
     return {key: value for key, value in os.environ.items() if key != "PYTHONPATH"}
+
+
+def test_parameter_controlled_names_reuses_cached_analysis(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = ast.parse(
+        """
+def bridge(command):
+    alias = command
+    return alias
+"""
+    )
+    bridge = module.body[0]
+    assert isinstance(bridge, ast.FunctionDef)
+
+    calls = 0
+    original_initial_parameter_controlled_names = call_graph._initial_parameter_controlled_names
+
+    def counting_initial_parameter_controlled_names(
+        function_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> set[str]:
+        nonlocal calls
+        calls += 1
+        return original_initial_parameter_controlled_names(function_node)
+
+    monkeypatch.setattr(
+        call_graph,
+        "_initial_parameter_controlled_names",
+        counting_initial_parameter_controlled_names,
+    )
+    call_graph._parameter_controlled_names.cache_clear()
+
+    assert call_graph._parameter_controlled_names(bridge) == {"command", "alias"}
+    assert call_graph._parameter_controlled_names(bridge) == {"command", "alias"}
+    assert calls == 1
 
 
 def _sitebuiltins_helper_instance_call_payload() -> bytes:


### PR DESCRIPTION
## Summary
- cache `_parameter_controlled_names()` for repeated analysis of the same AST function node
- clear the new cache with the existing source-sensitive invalidation sweep
- add focused coverage proving repeated lookups reuse the fixed-point analysis

## Benchmarks
Repeated same-function control-flow analysis, `5,000` lookups x `5` passes per sample, median of 7 repeats:

- uncached helper: `0.900395s`
- cached helper: `0.000790s`
- helper loop: `1139.74x` faster

Matched cProfile run on `tests/assets/exploits/exploit_ultimate_50pct.pkl` from `origin/main`:

- before: `82.470s`
- after: `59.106s`
- profiled scan: `1.40x` faster

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py::test_parameter_controlled_names_reuses_cached_analysis -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` *(blocked by the existing `mypy 1.20.0` internal error in this checkout)*
- `PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest -n auto -m "not slow and not integration" --maxfail=1` *(reproduces the existing environment-sensitive timing sentinel failures in `test_validation_performance_impact` and `test_directory_scanning_performance`)*
