### PR TITLE
perf: cache call graph call nodes

### DIFF
--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -724,6 +724,7 @@ def _clear_source_sensitive_caches() -> None:
         _source_function_context,
         _source_class_context,
         _constructor_parameter_self_attribute_targets,
+        _iter_call_nodes,
         _can_invoke_function_with_positional_args,
         _can_follow_import_execution_fallback,
         _resolve_module_source,
@@ -2564,6 +2565,7 @@ def _function_instance_alias_value(
     return _resolve_class_target(call_target)
 
 
+@lru_cache(maxsize=4096)
 def _iter_call_nodes(function_node: ast.FunctionDef | ast.AsyncFunctionDef) -> tuple[ast.Call, ...]:
     calls: list[ast.Call] = []
 

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import importlib
 import io
 import os
@@ -13,6 +14,7 @@ import zipfile
 from importlib.machinery import ModuleSpec
 from importlib.util import find_spec
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -78,6 +80,7 @@ def _clear_call_graph_caches() -> None:
         "_resolve_function_target",
         "_resolve_module_source",
         "_safe_call_graph_entrypoints",
+        "_iter_call_nodes",
         "_wildcard_export_summary",
     ):
         cache_clear = getattr(getattr(call_graph_module, function_name), "cache_clear", None)
@@ -87,6 +90,37 @@ def _clear_call_graph_caches() -> None:
 
 def _env_without_pythonpath() -> dict[str, str]:
     return {key: value for key, value in os.environ.items() if key != "PYTHONPATH"}
+
+
+def test_iter_call_nodes_reuses_cached_walk(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = ast.parse(
+        """
+def bridge(target, command):
+    callback = getattr(target, command)
+    callback(command)
+"""
+    )
+    bridge = module.body[0]
+    assert isinstance(bridge, ast.FunctionDef)
+
+    visits = 0
+    original_visit = ast.NodeVisitor.visit
+
+    def counting_visit(self: ast.NodeVisitor, node: ast.AST) -> Any:
+        nonlocal visits
+        visits += 1
+        return original_visit(self, node)
+
+    monkeypatch.setattr(ast.NodeVisitor, "visit", counting_visit)
+    call_graph._iter_call_nodes.cache_clear()
+
+    first = call_graph._iter_call_nodes(bridge)
+    first_visit_count = visits
+    second = call_graph._iter_call_nodes(bridge)
+
+    assert first == second
+    assert first_visit_count > 0
+    assert visits == first_visit_count
 
 
 def _sitebuiltins_helper_instance_call_payload() -> bytes:


### PR DESCRIPTION
## Summary
- cache repeated `_iter_call_nodes()` AST walks by function node
- include the new cache in the existing source-sensitive invalidation sweep
- add a regression that proves the second lookup reuses the cached walk

## Benchmarks
- repeated same-function call-node walk, `5,000` lookups x `5` passes:
  - before: `1.000113s` median
  - after: `0.000891s` median
- matched cProfile run on `tests/assets/exploits/exploit_ultimate_50pct.pkl` from `origin/main`:
  - before: `82.470s`
  - after: `66.972s`

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py::test_iter_call_nodes_reuses_cached_walk -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py -q`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` *(hits existing mypy 1.20.0 internal error)*
- `PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest -n auto -m "not slow and not integration" --maxfail=1` *(reproduces the existing timing-sensitive directory-scan and validation-performance sentinels in this environment)*
