### PR TITLE
fix: address AI quality findings

### DIFF
--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -32,6 +32,7 @@ _IMPORT_EXECUTION_SINK = "builtins.__import__"
 _IMPORT_EXECUTION_SAFE_MODULES = frozenset(sys.builtin_module_names)
 _PICKLE_CONSTRUCTOR_ENTRYPOINT_METHODS = ("__new__", "__init__")
 _PICKLE_LIFECYCLE_ENTRYPOINT_METHODS = ("__setstate__",)
+_PICKLE_LIFECYCLE_ENTRYPOINT_METHOD_SET = frozenset(_PICKLE_LIFECYCLE_ENTRYPOINT_METHODS)
 _PICKLE_ENTERED_IMPORT_EXECUTION_METHODS = (
     *_PICKLE_CONSTRUCTOR_ENTRYPOINT_METHODS,
     *_PICKLE_LIFECYCLE_ENTRYPOINT_METHODS,
@@ -57,6 +58,7 @@ _CLASS_ENTRYPOINT_METHODS = (
     *_PICKLE_LIFECYCLE_ENTRYPOINT_METHODS,
     "__init__",
 )
+_CLASS_ENTRYPOINT_METHOD_SET = frozenset(_CLASS_ENTRYPOINT_METHODS)
 _RCE_SINK_EXACT = frozenset(
     {
         "asyncio.create_subprocess_exec",
@@ -2219,7 +2221,10 @@ def _import_execution_calls(
     module_name: str,
     is_package: bool,
 ) -> tuple[str, ...]:
-    if _has_required_user_arguments(function_node) and function_node.name not in _PICKLE_LIFECYCLE_ENTRYPOINT_METHODS:
+    if (
+        _has_required_user_arguments(function_node)
+        and function_node.name not in _PICKLE_LIFECYCLE_ENTRYPOINT_METHOD_SET
+    ):
         return ()
     return _direct_import_execution_calls(function_node, module_name, is_package)
 
@@ -2295,7 +2300,7 @@ def _can_follow_import_execution_fallback(function_name: str, positional_arg_cou
 def _is_pickle_entered_import_execution_entrypoint(function_name: str) -> bool:
     _module_name, qualified_name = _split_source_qualified_name(function_name)
     class_name, _separator, method_name = qualified_name.rpartition(".")
-    if not class_name or method_name not in _CLASS_ENTRYPOINT_METHODS:
+    if not class_name or method_name not in _CLASS_ENTRYPOINT_METHOD_SET:
         return True
     return method_name in _PICKLE_ENTERED_IMPORT_EXECUTION_METHODS
 
@@ -2303,7 +2308,7 @@ def _is_pickle_entered_import_execution_entrypoint(function_name: str) -> bool:
 def _is_pickle_lifecycle_entrypoint(function_name: str) -> bool:
     _module_name, qualified_name = _split_source_qualified_name(function_name)
     class_name, _separator, method_name = qualified_name.rpartition(".")
-    return bool(class_name and method_name in _PICKLE_LIFECYCLE_ENTRYPOINT_METHODS)
+    return bool(class_name and method_name in _PICKLE_LIFECYCLE_ENTRYPOINT_METHOD_SET)
 
 
 def _can_enter_function_with_positional_args(

--- a/tests/integrations/test_license_checker.py
+++ b/tests/integrations/test_license_checker.py
@@ -23,20 +23,48 @@ from modelaudit.integrations.license_checker import (
     scan_for_license_headers,
 )
 
+MIT_HEADER = """# Copyright 2024 Example Corp
+# SPDX-License-Identifier: MIT
+# Licensed under the MIT License
+"""
+
+APACHE_HEADER = """# Licensed under the Apache License, Version 2.0
+# Copyright 2024 Apache Foundation
+"""
+
+AGPL_HEADER = """# Licensed under the GNU Affero General Public License
+# SPDX-License-Identifier: AGPL-3.0
+"""
+
+CC_BY_NC_HEADER = """Creative Commons Attribution NonCommercial License
+This work is licensed under CC BY-NC 4.0
+"""
+
+RAIL_HEADER = """# Released under the Responsible AI License
+# BigScience Open RAIL-M
+"""
+
+BIGSCIENCE_DATASET_NOTICE = """
+{
+  "_license": "BigScience Open RAIL-M",
+  "_notice": "Dataset released under BigScience Open RAIL-M"
+}
+"""
+
 
 class TestLicenseDetection:
     """Test license detection from file headers."""
 
-    def test_mit_license_detection(self, tmp_path):
+    def test_mit_license_detection(self, tmp_path: Path) -> None:
         """Test detection of MIT license."""
         test_file = tmp_path / "mit_file.py"
-        content = """# Copyright 2024 Example Corp
-# SPDX-License-Identifier: MIT
-# Licensed under the MIT License
-
+        content = (
+            MIT_HEADER
+            + """
 def example_function():
     pass
 """
+        )
         test_file.write_text(content)
 
         licenses = scan_for_license_headers(str(test_file))
@@ -48,14 +76,15 @@ def example_function():
         assert licenses[0].source == "file_header"
         assert licenses[0].confidence == 0.8
 
-    def test_apache_license_detection(self, tmp_path):
+    def test_apache_license_detection(self, tmp_path: Path) -> None:
         """Test detection of Apache 2.0 license."""
         test_file = tmp_path / "apache_file.py"
-        content = """# Licensed under the Apache License, Version 2.0
-# Copyright 2024 Apache Foundation
-
+        content = (
+            APACHE_HEADER
+            + """
 import numpy as np
 """
+        )
         test_file.write_text(content)
 
         licenses = scan_for_license_headers(str(test_file))
@@ -64,15 +93,16 @@ import numpy as np
         assert licenses[0].spdx_id == "Apache-2.0"
         assert licenses[0].commercial_allowed is True
 
-    def test_agpl_license_detection(self, tmp_path):
+    def test_agpl_license_detection(self, tmp_path: Path) -> None:
         """Test detection of AGPL license."""
         test_file = tmp_path / "agpl_file.py"
-        content = """# Licensed under the GNU Affero General Public License
-# SPDX-License-Identifier: AGPL-3.0
-
+        content = (
+            AGPL_HEADER
+            + """
 def network_service():
     pass
 """
+        )
         test_file.write_text(content)
 
         licenses = scan_for_license_headers(str(test_file))
@@ -83,14 +113,15 @@ def network_service():
         assert len(agpl_licenses) == 1
         assert agpl_licenses[0].commercial_allowed is True  # But with strong obligations
 
-    def test_cc_by_nc_license_detection(self, tmp_path):
+    def test_cc_by_nc_license_detection(self, tmp_path: Path) -> None:
         """Test detection of Creative Commons NonCommercial license."""
         test_file = tmp_path / "cc_nc_file.txt"
-        content = """Creative Commons Attribution NonCommercial License
-This work is licensed under CC BY-NC 4.0
-
+        content = (
+            CC_BY_NC_HEADER
+            + """
 Some dataset content here...
 """
+        )
         test_file.write_text(content)
 
         licenses = scan_for_license_headers(str(test_file))
@@ -99,14 +130,15 @@ Some dataset content here...
         assert licenses[0].spdx_id == "CC-BY-NC-4.0"
         assert licenses[0].commercial_allowed is False
 
-    def test_rail_license_detection(self, tmp_path):
+    def test_rail_license_detection(self, tmp_path: Path) -> None:
         """Test detection of RAIL license."""
         test_file = tmp_path / "rail_file.py"
-        content = """# Released under the Responsible AI License
-# BigScience Open RAIL-M
-def do_something():
+        content = (
+            RAIL_HEADER
+            + """def do_something():
     pass
 """
+        )
         test_file.write_text(content)
 
         licenses = scan_for_license_headers(str(test_file))
@@ -115,16 +147,10 @@ def do_something():
         spdx_ids = {lic.spdx_id for lic in licenses}
         assert "RAIL" in spdx_ids or "BigScience-OpenRAIL-M" in spdx_ids
 
-    def test_bigscience_dataset_notice_detection(self, tmp_path):
+    def test_bigscience_dataset_notice_detection(self, tmp_path: Path) -> None:
         """Test detection of BigScience dataset license notice."""
         dataset_file = tmp_path / "dataset.json"
-        content = """
-{
-  "_license": "BigScience Open RAIL-M",
-  "_notice": "Dataset released under BigScience Open RAIL-M"
-}
-"""
-        dataset_file.write_text(content)
+        dataset_file.write_text(BIGSCIENCE_DATASET_NOTICE)
 
         licenses = scan_for_license_headers(str(dataset_file))
 
@@ -164,7 +190,9 @@ def some_function():
         """Binary payloads should not be re-read as one huge text line."""
         test_file = tmp_path / "model.pt"
         test_file.write_bytes(
-            b"PK\x03\x04\x00" + b"A" * (_LICENSE_HEADER_MAX_BYTES * 2) + b"\nSPDX-License-Identifier: MIT\n",
+            b"PK\x03\x04\x00"  # ZIP local file header signature plus one extra binary byte.
+            + b"A" * (_LICENSE_HEADER_MAX_BYTES * 2)
+            + b"\nSPDX-License-Identifier: MIT\n",
         )
 
         content = _read_header_text(str(test_file), max_lines=50)
@@ -302,17 +330,14 @@ class TestUnlicensedDatasetDetection:
         assert len(unlicensed) == 1
         assert str(json_file) in unlicensed
 
-    def test_skip_small_single_files(self, tmp_path):
-        """Test that small single files are not flagged."""
+    def test_small_single_files_are_reported_by_raw_detection(self, tmp_path: Path) -> None:
+        """Raw detection reports unlicensed datasets before warning significance filtering."""
         small_json = tmp_path / "small.json"
-        small_json.write_text('{"test": "data"}')  # Small file
+        small_json.write_text('{"test": "data"}')
 
         unlicensed = detect_unlicensed_datasets([str(small_json)])
 
-        # Note: Small JSON files may still be flagged if they don't have license info
-        # This test verifies the behavior - small files in multi-file contexts are skipped
-        # but single small files may still be checked
-        assert len(unlicensed) <= 1  # May or may not be flagged depending on size threshold
+        assert unlicensed == [str(small_json)]
 
     def test_dataset_with_nearby_license(self, tmp_path):
         """Test dataset with license file in same directory."""
@@ -341,7 +366,7 @@ class TestUnlicensedDatasetDetection:
             nonlocal listing_count
             if path == tmp_path:
                 listing_count += 1
-            return original_iterdir(path)
+            yield from original_iterdir(path)
 
         monkeypatch.setattr(Path, "iterdir", counting_iterdir)
 
@@ -350,14 +375,15 @@ class TestUnlicensedDatasetDetection:
         assert unlicensed == files
         assert listing_count == 1
 
-    def test_ml_model_directory_skip(self, tmp_path):
+    def test_ml_model_directory_skip(self, tmp_path: Path) -> None:
         """Test that ML model files in model directories are skipped."""
         # Create ML model directory
         (tmp_path / "config.json").write_text('{"model_type": "gpt2"}')
         (tmp_path / "pytorch_model.bin").write_bytes(b"model weights")
+        # This would normally be flagged outside an ML model directory.
         (tmp_path / "data.pkl").write_bytes(
             b"some data",
-        )  # This would normally be flagged
+        )
 
         file_paths = [str(f) for f in tmp_path.glob("*")]
         unlicensed = detect_unlicensed_datasets(file_paths)

--- a/tests/integrations/test_license_integration.py
+++ b/tests/integrations/test_license_integration.py
@@ -45,11 +45,11 @@ class TestLicenseIntegration:
 
         # Should have no license warnings
         license_warnings = check_commercial_use_warnings(results)
-        [w for w in license_warnings if w.get("severity") != "debug"]
+        non_debug_warnings = [w for w in license_warnings if w.get("severity") != "debug"]
 
         # MIT is permissive, should not trigger warnings
-        agpl_warnings = [w for w in license_warnings if "AGPL" in w.get("message", "")]
-        nc_warnings = [w for w in license_warnings if "NonCommercial" in w.get("message", "")]
+        agpl_warnings = [w for w in non_debug_warnings if "AGPL" in w.get("message", "")]
+        nc_warnings = [w for w in non_debug_warnings if "NonCommercial" in w.get("message", "")]
 
         assert len(agpl_warnings) == 0, "MIT model should not trigger AGPL warnings"
         assert len(nc_warnings) == 0, "MIT model should not trigger non-commercial warnings"

--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -1097,6 +1097,7 @@ class TestIsTrustedUrlDomain:
         assert _is_trusted_url_domain("https://evil.gradio.app/p") is False
         assert _is_trusted_url_domain("https://evil.fastly.net/p") is False
         assert _is_trusted_url_domain("https://evil.azureedge.net/p") is False
+        # sourceforge.net is exact-match only; attacker-controlled subdomains stay untrusted.
         assert _is_trusted_url_domain("https://evil.sourceforge.net/p") is False
         assert _is_trusted_url_domain("https://evil.quay.io/p") is False
 
@@ -1109,6 +1110,7 @@ class TestIsTrustedUrlDomain:
         assert _is_trusted_url_domain("https://github.io/page") is True
         assert _is_trusted_url_domain("https://cloudfront.net/res") is True
         assert _is_trusted_url_domain("https://readthedocs.io/docs") is True
+        assert _is_trusted_url_domain("https://sourceforge.net/project") is True
 
     def test_userinfo_bypass_blocked(self) -> None:
         """URLs with userinfo (user@host) must NOT be trusted."""

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -20,12 +20,13 @@ from modelaudit.scanners.pickle_scanner import (
     _is_legitimate_serialization_file,
     _looks_like_pickle,
     _pickle_opcode_summary,
+    _rebuild_tensor_indicators_are_documentation_literals,
     is_suspicious_global,
 )
 from tests.helpers import create_mock_pytorch_zip
 
 EXPECTED_SYSTEM_GLOBAL = "nt.system" if os.name == "nt" else "posix.system"
-BYPASS_V4_REFERENCES: tuple[tuple[str, str, IssueSeverity], ...] = (
+BYPASS_V4_REFERENCES_TEST_CASES: tuple[tuple[str, str, IssueSeverity], ...] = (
     ("ctypes", "CDLL", IssueSeverity.CRITICAL),
     ("ctypes", "cast", IssueSeverity.CRITICAL),
     ("cProfile", "run", IssueSeverity.CRITICAL),
@@ -64,7 +65,8 @@ def _short_binunicode(data: bytes) -> bytes:
 
 
 def _binary_opcode_os_system_reduce_payload() -> bytes:
-    return _short_binunicode(b"os") + _short_binunicode(b"system") + b"\x93" + _short_binunicode(b"true") + b"\x85R."
+    # The command text is inert here; the scanner only needs a realistic GLOBAL/REDUCE payload shape.
+    return _short_binunicode(b"os") + _short_binunicode(b"system") + b"\x93" + _short_binunicode(b"echo") + b"\x85R."
 
 
 def _binary_opcode_stack_global_probe_decoy() -> bytes:
@@ -722,8 +724,8 @@ def test_comment_token_does_not_bypass_main_stack_global_detection(tmp_path: Pat
     )
 
 
-@pytest.mark.parametrize(("module", "func", "expected_severity"), BYPASS_V4_REFERENCES)
-def test_deleted_bypass_v4_generator_references_remain_covered(
+@pytest.mark.parametrize(("module", "func", "expected_severity"), BYPASS_V4_REFERENCES_TEST_CASES)
+def test_bypass_v4_references_still_detected(
     module: str,
     func: str,
     expected_severity: IssueSeverity,
@@ -1355,6 +1357,18 @@ def test_raw_cve_attributions_are_deduplicated_by_rule(
     assert len(result.metadata["cve_attributions"]) == 1
 
 
+def test_analyze_cve_patterns_deduplicates_attributions() -> None:
+    from modelaudit.detectors import cve_patterns
+
+    attributions = cve_patterns.analyze_cve_patterns(
+        "_rebuild_tensor SETITEM _rebuild_tensor SETITEM",
+    )
+    cve_ids = [attribution.cve_id for attribution in attributions]
+
+    assert cve_ids.count("CVE-2026-24747") == 1
+    assert len(cve_ids) == len(set(cve_ids))
+
+
 def test_raw_cve_comment_only_text_does_not_trigger_setitem(tmp_path: Path) -> None:
     path = tmp_path / "comment-only.pkl"
     path.write_bytes(
@@ -1376,6 +1390,16 @@ def test_raw_cve_rebuild_tensor_global_is_not_suppressed_by_documentation_litera
 
     assert any(issue.details.get("cve_id") == "CVE-2026-24747" for issue in result.issues)
     assert result.metadata["primary_cve"] == "CVE-2026-24747"
+
+
+def test_rebuild_tensor_documentation_literal_detector_behavior() -> None:
+    doc_only_payload = pickle.dumps({"doc": "# _rebuild_tensor\n# documentation only"}, protocol=4)
+    real_global_payload = (
+        b"(dS'doc'\nS'# _rebuild_tensor\\n# documentation only'\nsctorch\n_rebuild_tensor_v2\nS'value'\ns."
+    )
+
+    assert _rebuild_tensor_indicators_are_documentation_literals(doc_only_payload) is True
+    assert _rebuild_tensor_indicators_are_documentation_literals(real_global_payload) is False
 
 
 def test_raw_cve_rebuild_tensor_doc_filter_uses_rust_import_metadata(


### PR DESCRIPTION
## Summary
- address the current GitHub AI findings queue across call graph and test coverage
- keep ordered pickle entrypoint tuples while adding frozenset-backed membership checks
- tighten license, manifest, and pickle tests so they assert the actual behavior they cover

## Why
GitHub's AI findings page surfaced 14 issues across five recently changed files. Most were straightforward maintainability or clarity improvements; a few needed repo-aware adjustments so the fix matched the real behavior instead of the suggested patch literally.

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest tests/integrations/test_license_checker.py tests/integrations/test_license_integration.py tests/scanners/test_manifest_scanner.py tests/scanners/test_pickle_scanner.py --maxfail=1`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
- post-merge refresh check on the final head: `PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest tests/scanners/test_pickle_scanner.py tests/integrations/test_license_checker.py tests/integrations/test_license_integration.py tests/scanners/test_manifest_scanner.py --maxfail=1`