### PR TITLE
fix: avoid duplicate sharded directory scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+
+- avoid repeatedly scanning sharded model families during directory scans
+
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 
 ### Bug Fixes

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -43,6 +43,7 @@ from modelaudit.utils.file.detection import (
     validate_file_type_with_formats,
 )
 from modelaudit.utils.file.handlers import (
+    ShardedModelDetector,
     scan_advanced_large_file,
     should_use_advanced_handler,
 )
@@ -103,6 +104,9 @@ _XGBOOST_BINARY_EXTENSIONS = frozenset({".bst"})
 _XGBOOST_PICKLE_SPOOF_REASON = "xgboost_binary_pickle_spoof"
 _RECOGNIZED_FORMAT_SCANNER_UNAVAILABLE_REASON = "recognized_format_scanner_unavailable"
 _XML_MODEL_ROUTING_INCOMPLETE_REASON = "xml_model_routing_incomplete"
+_ShardFamilyKey = tuple[str, str, int | None]
+_ScanEntry = tuple[str, list[str], _ShardFamilyKey | None]
+_SHARD_FAMILY_CACHE_FINGERPRINT_CONFIG_KEY = "shard_family_cache_fingerprint"
 
 
 def _start_phase_timing(phase_timings: dict[str, float] | None) -> float | None:
@@ -122,6 +126,44 @@ def _finish_phase_timing(
 def _attach_phase_timings(results: ModelAuditResultModel, phase_timings: dict[str, float] | None) -> None:
     if phase_timings is not None:
         results.phase_timings = phase_timings  # type: ignore[attr-defined]
+
+
+def _shard_family_key_for_path(path: str) -> _ShardFamilyKey | None:
+    """Return a stable key for files that belong to the same local shard family."""
+    path_obj = Path(path)
+    shard_match = ShardedModelDetector.match_shard_filename(path_obj.name)
+    if shard_match is None:
+        return None
+
+    pattern = shard_match.get("pattern")
+    if not isinstance(pattern, str):
+        return None
+
+    expected_total = shard_match.get("expected_total_shards")
+    if not isinstance(expected_total, int):
+        expected_total = None
+
+    return (str(path_obj.parent), pattern, expected_total)
+
+
+def _build_shard_family_cache_fingerprint(
+    shard_family_key: _ShardFamilyKey,
+    scanned_file_paths: list[str],
+    content_hashes: dict[str, str],
+) -> dict[str, Any]:
+    """Fingerprint every present shard so representative cache entries stay valid."""
+    _parent_dir, pattern, expected_total_shards = shard_family_key
+    return {
+        "pattern": pattern,
+        "expected_total_shards": expected_total_shards,
+        "members": [
+            {
+                "path": str(Path(scanned_file_path).resolve()),
+                "content_hash": content_hashes.get(scanned_file_path),
+            }
+            for scanned_file_path in sorted(scanned_file_paths)
+        ],
+    }
 
 
 def _select_preferred_scanner_id(path: str, header_format: str, ext: str) -> str | None:
@@ -536,6 +578,8 @@ def scan_model_directory_or_file(
 
             # First pass: collect all file paths that need scanning
             files_to_scan: list[str] = []
+            shard_family_representatives: dict[_ShardFamilyKey, str] = {}
+            shard_family_paths: dict[_ShardFamilyKey, set[str]] = {}
             directory_discovery_started_at = _start_phase_timing(phase_timings)
             for root, _, files in os.walk(path, followlinks=False):
                 for file in files:
@@ -609,15 +653,41 @@ def scan_model_directory_or_file(
                             continue
 
                         # Add to files to scan list instead of scanning immediately
+                        shard_family_key = _shard_family_key_for_path(target_str)
+                        if shard_family_key is not None:
+                            family_paths = shard_family_paths.setdefault(shard_family_key, set())
+                            family_paths.add(target_str)
+                            if shard_family_key not in shard_family_representatives:
+                                shard_family_representatives[shard_family_key] = target_str
+                                shard_info = ShardedModelDetector.detect_shards(target_str)
+                                if shard_info is not None:
+                                    for shard_path in shard_info.get("shards", []):
+                                        if isinstance(shard_path, str):
+                                            family_paths.add(str(Path(shard_path).resolve()))
+                            continue
+
                         files_to_scan.append(target_str)
             _finish_phase_timing(phase_timings, "directory_discovery", directory_discovery_started_at)
 
-            # Second pass: scan every path independently. Some scanners depend on
-            # parent paths or sibling files, so content equality alone is not a
-            # safe proxy for scan-result equality.
-            if files_to_scan:
+            scan_entries: list[_ScanEntry] = [(file_path, [file_path], None) for file_path in files_to_scan]
+            for shard_family_key, representative_file in shard_family_representatives.items():
+                ordered_family_paths = sorted(shard_family_paths.get(shard_family_key, {representative_file}))
+                scan_entries.append((representative_file, ordered_family_paths, shard_family_key))
+
+            # Second pass: scan every non-shard path independently and every shard
+            # family once. Shard scans already expand to sibling shards in the
+            # advanced handler, so scanning each shard path would duplicate work.
+            if scan_entries:
+                hash_paths: list[str] = []
+                seen_hash_paths: set[str] = set()
+                for _representative_file, scanned_file_paths, _shard_family_key in scan_entries:
+                    for scanned_file_path in scanned_file_paths:
+                        if scanned_file_path not in seen_hash_paths:
+                            hash_paths.append(scanned_file_path)
+                            seen_hash_paths.add(scanned_file_path)
+
                 top_level_hashing_started_at = _start_phase_timing(phase_timings)
-                content_hashes = _hash_files_by_path(files_to_scan)
+                content_hashes = _hash_files_by_path(hash_paths)
                 _finish_phase_timing(phase_timings, "top_level_hashing", top_level_hashing_started_at)
                 duplicate_paths_by_hash: dict[str, list[str]] = {}
                 for file_path, content_hash in content_hashes.items():
@@ -625,13 +695,7 @@ def scan_model_directory_or_file(
                         duplicate_paths_by_hash.setdefault(content_hash, []).append(file_path)
                 recorded_content_hashes: set[str] = set()
 
-                for representative_file, content_hash in content_hashes.items():
-                    # Collect valid content hashes for aggregate hash computation
-                    # Skip "unhashable_" prefix entries (those are placeholder hashes for files that failed to hash)
-                    if not content_hash.startswith("unhashable_") and content_hash not in recorded_content_hashes:
-                        file_hashes.append(content_hash)
-                        recorded_content_hashes.add(content_hash)
-
+                for representative_file, scanned_file_paths, shard_family_key in scan_entries:
                     # Check for interrupts
                     check_interrupted()
 
@@ -641,14 +705,17 @@ def scan_model_directory_or_file(
 
                     # Update progress
                     if progress_callback:
+                        scan_label = Path(representative_file).name
+                        if len(scanned_file_paths) > 1:
+                            scan_label = f"{scan_label} ({len(scanned_file_paths)} shards)"
                         if total_files is not None and total_files > 0:
                             progress_callback(
-                                f"Scanning file {processed_files + 1}/{total_files}: {Path(representative_file).name}",
+                                f"Scanning file {processed_files + 1}/{total_files}: {scan_label}",
                                 processed_files / total_files * 100,
                             )
                         else:
                             progress_callback(
-                                f"Scanning file {processed_files + 1}: {Path(representative_file).name}",
+                                f"Scanning file {processed_files + 1}: {scan_label}",
                                 0.0,
                             )
 
@@ -658,7 +725,17 @@ def scan_model_directory_or_file(
 
                         file_scan_started_at = _start_phase_timing(phase_timings)
                         try:
-                            file_result = scan_file(representative_file, config)
+                            file_config = config
+                            if shard_family_key is not None:
+                                file_config = dict(config)
+                                file_config[_SHARD_FAMILY_CACHE_FINGERPRINT_CONFIG_KEY] = (
+                                    _build_shard_family_cache_fingerprint(
+                                        shard_family_key,
+                                        scanned_file_paths,
+                                        content_hashes,
+                                    )
+                                )
+                            file_result = scan_file(representative_file, file_config)
                         finally:
                             _finish_phase_timing(phase_timings, "file_scan_dispatch", file_scan_started_at)
 
@@ -667,8 +744,17 @@ def scan_model_directory_or_file(
                         if _scan_result_has_operational_error(file_result):
                             scan_metadata["has_operational_errors"] = True
                         results.bytes_scanned += file_result.bytes_scanned
-                        results.files_scanned += 1
-                        processed_files += 1
+                        results.files_scanned += len(scanned_file_paths)
+                        processed_files += len(scanned_file_paths)
+                        for scanned_file_path in scanned_file_paths:
+                            path_content_hash = content_hashes.get(scanned_file_path)
+                            if (
+                                path_content_hash is not None
+                                and not path_content_hash.startswith("unhashable_")
+                                and path_content_hash not in recorded_content_hashes
+                            ):
+                                file_hashes.append(path_content_hash)
+                                recorded_content_hashes.add(path_content_hash)
 
                         # Add scanner to tracking list (different from scanner_names)
                         scanner_name = file_result.scanner_name
@@ -734,32 +820,38 @@ def scan_model_directory_or_file(
 
                                     results.checks.append(Check(**check_dict))
 
-                        _add_asset_to_results(results, representative_file, file_result)
+                        for scanned_file_path in scanned_file_paths:
+                            _add_asset_to_results(results, scanned_file_path, file_result)
                         _finish_phase_timing(phase_timings, "result_merge", result_merge_started_at)
 
                         # Add metadata for this path using Pydantic models
-                        license_metadata_started_at = _start_phase_timing(phase_timings)
-                        try:
-                            license_metadata = collect_license_metadata(
-                                representative_file,
-                                nearby_license_cache=nearby_license_cache,
-                            )
-                        finally:
-                            _finish_phase_timing(phase_timings, "license_metadata", license_metadata_started_at)
-                        combined_metadata = {**file_result.metadata, **license_metadata}
-                        combined_metadata["content_hash"] = content_hash
-                        duplicate_files = duplicate_paths_by_hash.get(content_hash, [])
-                        combined_metadata["duplicate_files"] = duplicate_files if len(duplicate_files) > 1 else None
-
-                        # Convert ml_context if present
-                        if "ml_context" in combined_metadata and isinstance(combined_metadata["ml_context"], dict):
-                            from .models import MLContextModel
-
-                            combined_metadata["ml_context"] = MLContextModel(**combined_metadata["ml_context"])
-
                         from .models import FileMetadataModel
 
-                        results.file_metadata[representative_file] = FileMetadataModel(**combined_metadata)
+                        for scanned_file_path in scanned_file_paths:
+                            license_metadata_started_at = _start_phase_timing(phase_timings)
+                            try:
+                                license_metadata = collect_license_metadata(
+                                    scanned_file_path,
+                                    nearby_license_cache=nearby_license_cache,
+                                )
+                            finally:
+                                _finish_phase_timing(phase_timings, "license_metadata", license_metadata_started_at)
+                            combined_metadata = {**file_result.metadata, **license_metadata}
+                            path_content_hash = content_hashes.get(scanned_file_path)
+                            if path_content_hash is not None:
+                                combined_metadata["content_hash"] = path_content_hash
+                                duplicate_files = duplicate_paths_by_hash.get(path_content_hash, [])
+                                combined_metadata["duplicate_files"] = (
+                                    duplicate_files if len(duplicate_files) > 1 else None
+                                )
+
+                            # Convert ml_context if present
+                            if "ml_context" in combined_metadata and isinstance(combined_metadata["ml_context"], dict):
+                                from .models import MLContextModel
+
+                                combined_metadata["ml_context"] = MLContextModel(**combined_metadata["ml_context"])
+
+                            results.file_metadata[scanned_file_path] = FileMetadataModel(**combined_metadata)
 
                         if max_total_size > 0 and results.bytes_scanned > max_total_size:
                             _add_issue_to_model(
@@ -783,7 +875,8 @@ def scan_model_directory_or_file(
                             location=representative_file,
                             details={"exception_type": type(e).__name__},
                         )
-                        _add_error_asset_to_results(results, representative_file)
+                        for scanned_file_path in scanned_file_paths:
+                            _add_error_asset_to_results(results, scanned_file_path)
 
             # Final progress update for directory scan
             if progress_callback and not limit_reached and total_files is not None and total_files > 0:

--- a/modelaudit/utils/file/handlers.py
+++ b/modelaudit/utils/file/handlers.py
@@ -90,6 +90,31 @@ class ShardedModelDetector:
     ]
 
     @classmethod
+    def match_shard_filename(cls, file_name: str) -> dict[str, int | str | None] | None:
+        """Return shard metadata for a filename when it matches a known shard pattern."""
+        for pattern in cls.SHARD_PATTERNS:
+            match = re.fullmatch(pattern, file_name)
+            if not match:
+                continue
+
+            current_shard_index: int | None = None
+            expected_total_shards: int | None = None
+            if match.lastindex:
+                with suppress(IndexError, ValueError):
+                    current_shard_index = int(match.group(1))
+            if (match.lastindex or 0) >= 2:
+                with suppress(IndexError, ValueError):
+                    expected_total_shards = int(match.group(2))
+
+            return {
+                "pattern": pattern,
+                "current_shard_index": current_shard_index,
+                "expected_total_shards": expected_total_shards,
+            }
+
+        return None
+
+    @classmethod
     def detect_shards(cls, file_path: str) -> dict[str, Any] | None:
         """
         Detect if a file is part of a sharded model.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -15,9 +15,11 @@ import pytest
 
 from modelaudit import core as core_module
 from modelaudit.cache import get_cache_manager, reset_cache_manager
+from modelaudit.cache.optimized_config import normalize_material_scan_config
 from modelaudit.core import scan_file, scan_model_directory_or_file
 from modelaudit.scanners import flax_msgpack_scanner, jinja2_template_scanner
 from modelaudit.scanners.base import CheckStatus, IssueSeverity, ScanResult
+from modelaudit.utils.helpers.secure_hasher import compute_aggregate_hash
 from tests.helpers import create_mock_gguf, create_mock_onnx, create_mock_pytorch_zip
 
 _SYSTEM_GLOBAL_NAMES = ("os.system", "posix.system", "nt.system")
@@ -79,6 +81,155 @@ def _assert_system_pickle_detected(result: ScanResult, entry_name: str) -> None:
         and any(global_name in issue.message.lower() for global_name in _SYSTEM_GLOBAL_NAMES)
         for issue in result.issues
     ), f"Expected S201 finding for {entry_name}, got: {[(i.location, i.message, i.details) for i in result.issues]}"
+
+
+def _mock_sharded_scan_result(bytes_scanned: int, *, missing_shards: int = 0) -> ScanResult:
+    """Return a ScanResult shaped like the advanced sharded-model handler."""
+    result = ScanResult(scanner_name="safetensors")
+    result.bytes_scanned = bytes_scanned
+    result.add_check(
+        name="Mock Shard Scan",
+        passed=True,
+        message="Mock shard family scanned",
+        severity=IssueSeverity.INFO,
+    )
+    if missing_shards:
+        result.add_check(
+            name="Sharded Model Coverage Check",
+            passed=False,
+            message=f"Missing {missing_shards} expected model shard(s); scan coverage is incomplete.",
+            severity=IssueSeverity.INFO,
+            details={
+                "expected_total_shards": 3,
+                "present_total_shards": 2,
+                "missing_shard_count": missing_shards,
+                "analysis_incomplete": True,
+                "scan_outcome": "inconclusive",
+                "scan_outcome_reason": "missing_model_shards",
+            },
+        )
+        result.metadata["analysis_incomplete"] = True
+        result.metadata["scan_outcome"] = "inconclusive"
+        result.metadata["scan_outcome_reasons"] = ["missing_model_shards"]
+    result.finish(success=missing_shards == 0)
+    return result
+
+
+def test_directory_scan_scans_sharded_model_family_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shards: list[Path] = []
+    for shard_index in range(1, 4):
+        shard_path = tmp_path / f"model-{shard_index:05d}-of-00003.safetensors"
+        shard_path.write_bytes(f"shard-{shard_index}".encode())
+        shards.append(shard_path.resolve())
+    family_size = sum(shard.stat().st_size for shard in shards)
+    calls: list[str] = []
+
+    def fake_scan_file(path: str, config: dict[str, Any] | None = None) -> ScanResult:
+        calls.append(path)
+        return _mock_sharded_scan_result(family_size)
+
+    monkeypatch.setattr(core_module, "scan_file", fake_scan_file)
+
+    result = core_module.scan_model_directory_or_file(str(tmp_path), cache_scan_results=False)
+
+    assert len(calls) == 1
+    assert Path(calls[0]).name in {shard.name for shard in shards}
+    assert result.files_scanned == len(shards)
+    assert result.bytes_scanned == family_size
+    assert set(result.file_metadata) == {str(shard) for shard in shards}
+    assert {asset.path for asset in result.assets} == {str(shard) for shard in shards}
+
+
+def test_directory_scan_reports_incomplete_sharded_model_family_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shards: list[Path] = []
+    for shard_index in range(1, 3):
+        shard_path = tmp_path / f"model-{shard_index:05d}-of-00003.safetensors"
+        shard_path.write_bytes(f"shard-{shard_index}".encode())
+        shards.append(shard_path.resolve())
+    family_size = sum(shard.stat().st_size for shard in shards)
+    calls: list[str] = []
+
+    def fake_scan_file(path: str, config: dict[str, Any] | None = None) -> ScanResult:
+        calls.append(path)
+        return _mock_sharded_scan_result(family_size, missing_shards=1)
+
+    monkeypatch.setattr(core_module, "scan_file", fake_scan_file)
+
+    result = core_module.scan_model_directory_or_file(str(tmp_path), cache_scan_results=False)
+
+    coverage_checks = [check for check in result.checks if check.name == "Sharded Model Coverage Check"]
+    assert len(calls) == 1
+    assert result.files_scanned == len(shards)
+    assert result.bytes_scanned == family_size
+    assert len(coverage_checks) == 1
+    assert coverage_checks[0].details["missing_shard_count"] == 1
+
+
+def test_directory_scan_sharded_family_cache_fingerprint_tracks_sibling_shards(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shards: list[Path] = []
+    for shard_index in range(1, 3):
+        shard_path = tmp_path / f"model-{shard_index:05d}-of-00002.safetensors"
+        shard_path.write_bytes(f"shard-{shard_index}".encode())
+        shards.append(shard_path.resolve())
+    captured_configs: list[dict[str, Any]] = []
+
+    def fake_scan_file(path: str, config: dict[str, Any] | None = None) -> ScanResult:
+        captured_configs.append(dict(config or {}))
+        return _mock_sharded_scan_result(sum(shard.stat().st_size for shard in shards))
+
+    monkeypatch.setattr(core_module, "scan_file", fake_scan_file)
+
+    core_module.scan_model_directory_or_file(str(tmp_path))
+    first_material_config = normalize_material_scan_config(captured_configs[0])
+    first_fingerprint = first_material_config[core_module._SHARD_FAMILY_CACHE_FINGERPRINT_CONFIG_KEY]
+
+    shards[1].write_bytes(b"changed-shard-2")
+    captured_configs.clear()
+
+    core_module.scan_model_directory_or_file(str(tmp_path))
+    second_material_config = normalize_material_scan_config(captured_configs[0])
+    second_fingerprint = second_material_config[core_module._SHARD_FAMILY_CACHE_FINGERPRINT_CONFIG_KEY]
+
+    assert {member["path"] for member in first_fingerprint["members"]} == {str(shard) for shard in shards}
+    assert first_fingerprint != second_fingerprint
+
+
+def test_directory_scan_content_hash_excludes_files_skipped_by_total_size_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_files: list[Path] = []
+    for index in range(3):
+        model_path = tmp_path / f"model-{index}.safetensors"
+        model_path.write_bytes(f"model-{index}".encode())
+        model_files.append(model_path.resolve())
+    calls: list[str] = []
+
+    def fake_scan_file(path: str, config: dict[str, Any] | None = None) -> ScanResult:
+        calls.append(path)
+        result = ScanResult(scanner_name="safetensors")
+        result.bytes_scanned = 2
+        result.finish(success=True)
+        return result
+
+    monkeypatch.setattr(core_module, "scan_file", fake_scan_file)
+
+    result = core_module.scan_model_directory_or_file(str(tmp_path), max_total_size=1)
+
+    all_file_hashes = [core_module._calculate_file_hash(str(model_path)) for model_path in model_files]
+    scanned_file_hashes = [core_module._calculate_file_hash(path) for path in calls]
+    assert len(calls) == 1
+    assert result.content_hash == compute_aggregate_hash(scanned_file_hashes)
+    assert result.content_hash != compute_aggregate_hash(all_file_hashes)
 
 
 def test_scan_file_detects_malicious_zip_with_misleading_extension(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Deduplicate sharded model families during directory scans so a family is scanned once instead of once per shard.
- Preserve per-shard file counts, assets, and file metadata while counting family bytes only once.
- Keep shard-family cache entries valid by fingerprinting every present shard path/content hash.
- Keep aggregate `content_hash` limited to scan entries that actually ran when scans stop early.
- Add regression coverage for complete, incomplete, cache-sensitive, and early-stopped sharded/directory scans.

## Validation

- `PROMPTFOO_DISABLE_TELEMETRY=1 ./.venv/bin/python -m pytest tests/test_core.py -k "sharded or content_hash_excludes"`
- `./.venv/bin/ruff format --check modelaudit/core.py tests/test_core.py`
- `./.venv/bin/ruff check modelaudit/core.py tests/test_core.py`
- `./.venv/bin/mypy modelaudit/core.py tests/test_core.py`
- `git diff --check`

Note: local validation used the existing project virtualenv because `uv` is not installed in this environment.