### PR TITLE
fix: keep shard siblings within scan root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - avoid repeatedly scanning sharded model families during directory scans
+- keep shard sibling discovery within the requested scan root
 - preserve per-shard metadata when aggregating sharded model families
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -167,6 +167,22 @@ def _build_shard_family_cache_fingerprint(
     }
 
 
+def _allowed_shard_paths_from_config(config: dict[str, Any]) -> list[str] | None:
+    """Return validated shard paths embedded in a grouped directory-scan config."""
+    fingerprint = config.get(_SHARD_FAMILY_CACHE_FINGERPRINT_CONFIG_KEY)
+    if not isinstance(fingerprint, dict):
+        return None
+
+    members = fingerprint.get("members")
+    if not isinstance(members, list):
+        return None
+
+    allowed_paths = [
+        str(member["path"]) for member in members if isinstance(member, dict) and isinstance(member.get("path"), str)
+    ]
+    return allowed_paths or None
+
+
 def _select_preferred_scanner_id(path: str, header_format: str, ext: str) -> str | None:
     """Select a scanner by trusted file structure, not just suffix."""
     if header_format == "zip":
@@ -1376,7 +1392,11 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
             if use_extreme_handler:
                 logger.debug(f"Large file optimization enabled: {path}")
                 result = scan_advanced_large_file(
-                    path, scanner, progress_callback, timeout * 2
+                    path,
+                    scanner,
+                    progress_callback,
+                    timeout * 2,
+                    allowed_shard_paths=_allowed_shard_paths_from_config(config),
                 )  # Double timeout for extreme files
             elif use_large_handler:
                 logger.debug(f"File size optimization: {path} ({file_size:,} bytes)")
@@ -1419,7 +1439,11 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
                 if use_extreme_handler:
                     logger.debug(f"Large file optimization enabled: {path}")
                     result = scan_advanced_large_file(
-                        path, scanner, progress_callback, timeout * 2
+                        path,
+                        scanner,
+                        progress_callback,
+                        timeout * 2,
+                        allowed_shard_paths=_allowed_shard_paths_from_config(config),
                     )  # Double timeout for extreme files
                 elif use_large_handler:
                     logger.debug(f"File size optimization: {path} ({file_size:,} bytes)")

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -664,7 +664,26 @@ def scan_model_directory_or_file(
                                 if shard_info is not None:
                                     for shard_path in shard_info.get("shards", []):
                                         if isinstance(shard_path, str):
-                                            family_paths.add(str(Path(shard_path).resolve()))
+                                            resolved_shard_path = str(Path(shard_path).resolve())
+                                            shard_in_base_dir = is_within_directory(str(base_dir), resolved_shard_path)
+                                            shard_in_hf_blobs = bool(
+                                                is_hf_cache
+                                                and hf_cache_root is not None
+                                                and is_within_directory(
+                                                    str(hf_cache_root / "blobs"),
+                                                    resolved_shard_path,
+                                                )
+                                            )
+                                            if shard_in_base_dir or shard_in_hf_blobs:
+                                                family_paths.add(resolved_shard_path)
+                                            else:
+                                                _add_issue_to_model(
+                                                    results,
+                                                    "Path traversal outside scanned directory",
+                                                    severity=IssueSeverity.CRITICAL.value,
+                                                    location=resolved_shard_path,
+                                                    details={"resolved_path": resolved_shard_path},
+                                                )
                             continue
 
                         files_to_scan.append(target_str)

--- a/modelaudit/utils/file/handlers.py
+++ b/modelaudit/utils/file/handlers.py
@@ -115,7 +115,12 @@ class ShardedModelDetector:
         return None
 
     @classmethod
-    def detect_shards(cls, file_path: str) -> dict[str, Any] | None:
+    def detect_shards(
+        cls,
+        file_path: str,
+        *,
+        allowed_paths: list[str] | None = None,
+    ) -> dict[str, Any] | None:
         """
         Detect if a file is part of a sharded model.
 
@@ -127,6 +132,7 @@ class ShardedModelDetector:
         """
         file_name = Path(file_path).name
         dir_path = Path(file_path).parent
+        allowed_path_set = {str(Path(path).resolve()) for path in allowed_paths} if allowed_paths is not None else None
 
         for pattern in cls.SHARD_PATTERNS:
             match = re.fullmatch(pattern, file_name)
@@ -140,6 +146,8 @@ class ShardedModelDetector:
                 for file in dir_path.glob("*"):
                     file_match = re.fullmatch(pattern, file.name)
                     if file_match:
+                        if allowed_path_set is not None and str(file.resolve()) not in allowed_path_set:
+                            continue
                         shard_info["shards"].append(str(file))
                         if file_match.lastindex:
                             with suppress(IndexError, ValueError):
@@ -431,6 +439,7 @@ class AdvancedFileHandler:
         scanner: Any,
         progress_callback: Callable[[str, float], None] | None = None,
         timeout: int = 7200,  # 2 hours for large models
+        allowed_shard_paths: list[str] | None = None,
     ):
         """
         Initialize advanced file handler.
@@ -448,7 +457,7 @@ class AdvancedFileHandler:
         self.start_time = time.time()
 
         # Check for sharded model
-        self.shard_info = ShardedModelDetector.detect_shards(file_path)
+        self.shard_info = ShardedModelDetector.detect_shards(file_path, allowed_paths=allowed_shard_paths)
 
         # Get file/model size
         if self.shard_info:
@@ -653,6 +662,7 @@ def scan_advanced_large_file(
     scanner: Any,
     progress_callback: Callable[[str, float], None] | None = None,
     timeout: int = 7200,
+    allowed_shard_paths: list[str] | None = None,
 ) -> "ScanResult":
     """
     Scan a large file with advanced handler.
@@ -673,7 +683,13 @@ def scan_advanced_large_file(
 
     # If caching is disabled, proceed with direct scan
     if not cache_enabled:
-        return _scan_advanced_large_file_internal(file_path, scanner, progress_callback, timeout)
+        return _scan_advanced_large_file_internal(
+            file_path,
+            scanner,
+            progress_callback,
+            timeout,
+            allowed_shard_paths=allowed_shard_paths,
+        )
 
     # Use cache manager for advanced large file scans
     try:
@@ -685,7 +701,13 @@ def scan_advanced_large_file(
 
         # Create wrapper function for cache manager
         def cached_advanced_scan_wrapper(fpath: str) -> dict:
-            result = _scan_advanced_large_file_internal(fpath, scanner, progress_callback, timeout)
+            result = _scan_advanced_large_file_internal(
+                fpath,
+                scanner,
+                progress_callback,
+                timeout,
+                allowed_shard_paths=allowed_shard_paths,
+            )
             return result.to_dict()
 
         # Get cached result or perform scan
@@ -703,7 +725,13 @@ def scan_advanced_large_file(
     except Exception as e:
         # If cache system fails, fall back to direct scanning
         logger.warning(f"Advanced file cache error for {file_path}: {e}. Falling back to direct scan.")
-        return _scan_advanced_large_file_internal(file_path, scanner, progress_callback, timeout)
+        return _scan_advanced_large_file_internal(
+            file_path,
+            scanner,
+            progress_callback,
+            timeout,
+            allowed_shard_paths=allowed_shard_paths,
+        )
 
 
 def _scan_advanced_large_file_internal(
@@ -711,6 +739,7 @@ def _scan_advanced_large_file_internal(
     scanner: Any,
     progress_callback: Callable[[str, float], None] | None = None,
     timeout: int = 7200,
+    allowed_shard_paths: list[str] | None = None,
 ) -> "ScanResult":
     """
     Internal implementation of advanced large file scanning (cache-agnostic).
@@ -724,5 +753,11 @@ def _scan_advanced_large_file_internal(
     Returns:
         ScanResult with findings
     """
-    handler = AdvancedFileHandler(file_path, scanner, progress_callback, timeout)
+    handler = AdvancedFileHandler(
+        file_path,
+        scanner,
+        progress_callback,
+        timeout,
+        allowed_shard_paths=allowed_shard_paths,
+    )
     return handler.scan()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -182,9 +182,11 @@ def test_directory_scan_rejects_shard_siblings_outside_scan_root(
     outside_shard.write_bytes(b"outside-shard")
     (model_dir / outside_shard.name).symlink_to(outside_shard)
     calls: list[str] = []
+    captured_configs: list[dict[str, Any]] = []
 
     def fake_scan_file(path: str, config: dict[str, Any] | None = None) -> ScanResult:
         calls.append(path)
+        captured_configs.append(dict(config or {}))
         return _mock_sharded_scan_result(first_shard.stat().st_size)
 
     monkeypatch.setattr(core_module, "scan_file", fake_scan_file)
@@ -195,6 +197,9 @@ def test_directory_scan_rejects_shard_siblings_outside_scan_root(
     assert len(calls) == 1
     assert outside_path not in result.file_metadata
     assert outside_path not in {asset.path for asset in result.assets}
+    material_config = normalize_material_scan_config(captured_configs[0])
+    fingerprint = material_config[core_module._SHARD_FAMILY_CACHE_FINGERPRINT_CONFIG_KEY]
+    assert outside_path not in {member["path"] for member in fingerprint["members"]}
     assert any(
         issue.message == "Path traversal outside scanned directory"
         and issue.location == outside_path

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -168,6 +168,41 @@ def test_directory_scan_preserves_per_shard_sizes(
     assert {asset.path: asset.size for asset in result.assets} == expected_sizes
 
 
+def test_directory_scan_rejects_shard_siblings_outside_scan_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    first_shard = model_dir / "model-00001-of-00002.safetensors"
+    first_shard.write_bytes(b"inside-shard")
+    outside_shard = outside_dir / "model-00002-of-00002.safetensors"
+    outside_shard.write_bytes(b"outside-shard")
+    (model_dir / outside_shard.name).symlink_to(outside_shard)
+    calls: list[str] = []
+
+    def fake_scan_file(path: str, config: dict[str, Any] | None = None) -> ScanResult:
+        calls.append(path)
+        return _mock_sharded_scan_result(first_shard.stat().st_size)
+
+    monkeypatch.setattr(core_module, "scan_file", fake_scan_file)
+
+    result = core_module.scan_model_directory_or_file(str(model_dir), cache_scan_results=False)
+    outside_path = str(outside_shard.resolve())
+
+    assert len(calls) == 1
+    assert outside_path not in result.file_metadata
+    assert outside_path not in {asset.path for asset in result.assets}
+    assert any(
+        issue.message == "Path traversal outside scanned directory"
+        and issue.location == outside_path
+        and issue.details["resolved_path"] == outside_path
+        for issue in result.issues
+    )
+
+
 def test_directory_scan_reports_incomplete_sharded_model_family_once(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/utils/file/test_advanced_file_handler.py
+++ b/tests/utils/file/test_advanced_file_handler.py
@@ -140,6 +140,22 @@ class TestShardedModelDetector:
         assert shard_info["shards"] == [str(shard_one)]
         assert shard_info["total_shards"] == 1
 
+    def test_detect_shards_respects_allowed_paths(self, tmp_path: Path) -> None:
+        """Directory scans should be able to constrain shard expansion to validated paths."""
+        shard_one = tmp_path / "model-00001-of-00002.safetensors"
+        shard_two = tmp_path / "model-00002-of-00002.safetensors"
+        shard_one.write_bytes(b"one")
+        shard_two.write_bytes(b"two")
+
+        shard_info = ShardedModelDetector.detect_shards(
+            str(shard_one),
+            allowed_paths=[str(shard_one.resolve())],
+        )
+
+        assert shard_info is not None
+        assert shard_info["shards"] == [str(shard_one)]
+        assert shard_info["total_shards"] == 1
+
     def test_no_shards_detected(self) -> None:
         """Test when file is not sharded."""
         with tempfile.NamedTemporaryFile(suffix=".bin") as f:
@@ -311,6 +327,24 @@ class TestAdvancedFileHandler:
         assert coverage_checks[0].details["missing_shard_count"] == 1
         assert coverage_checks[0].details["missing_shard_indices"] == [2]
         assert coverage_checks[0].details["missing_shard_indices_truncated"] is False
+
+    def test_sharded_model_honors_allowed_shard_paths(self, tmp_path: Path) -> None:
+        """Restricted shard scans must not expand beyond the validated allowlist."""
+        shard_one = tmp_path / "model-00001-of-00002.safetensors"
+        shard_two = tmp_path / "model-00002-of-00002.safetensors"
+        shard_one.write_bytes(b"one")
+        shard_two.write_bytes(b"two")
+
+        handler = AdvancedFileHandler(
+            str(shard_one),
+            CompletingShardScanner(),
+            allowed_shard_paths=[str(shard_one.resolve())],
+        )
+        result = handler.scan()
+
+        shard_detection = next(check for check in result.checks if check.name == "Sharded Model Detection")
+        assert shard_detection.details["shards"] == [str(shard_one)]
+        assert result.bytes_scanned == shard_one.stat().st_size
 
     def test_parallel_shard_errors_mark_scan_inconclusive(self, tmp_path: Path) -> None:
         """Shard scan exceptions are incomplete coverage, not security findings."""


### PR DESCRIPTION
## Summary
- revalidate shard siblings discovered during grouped scans against the requested scan root
- pass the validated shard allowlist into the advanced large-file handler so later shard expansion cannot rediscover out-of-root siblings
- continue allowing approved Hugging Face cache blob targets
- add regressions for both grouped directory scans and advanced shard detection

## Validation
- `uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m 'not slow and not integration' --maxfail=1`

Follow-up to #1231 for the post-open review finding on shard sibling containment. Carries forward @jessejam's original #1229 work with a co-authored follow-up commit.