### PR TITLE
test(deps): cover gitpython lock floor

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,6 +104,7 @@ def pytest_runtest_setup(item):
             "test_core.py",
             "test_cli.py",
             "test_directory_file_filtering.py",  # Directory prefilter regression tests
+            "test_dependency_lock.py",  # Security-sensitive uv.lock dependency guardrails
             "test_bug1_confidence_exploit.py",  # Security bug test
             "test_gguf_scanner.py",  # GGUF scanner tests
             "test_jax_checkpoint_scanner.py",  # JAX checkpoint scanner tests

--- a/tests/test_dependency_lock.py
+++ b/tests/test_dependency_lock.py
@@ -1,0 +1,54 @@
+"""Regression tests for security-sensitive dependency lock entries."""
+
+import re
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+LOCKFILE = ROOT_DIR / "uv.lock"
+PATCHED_GITPYTHON_FLOOR = (3, 1, 50)
+
+
+def _lock_package_block(name: str) -> str:
+    for block in LOCKFILE.read_text().split("\n[[package]]\n"):
+        if re.search(rf'(?m)^name = "{re.escape(name)}"$', block):
+            return block
+
+    raise AssertionError(f"Package {name!r} is not present in uv.lock")
+
+
+def _locked_version(block: str) -> tuple[int, ...]:
+    match = re.search(r'(?m)^version = "([0-9]+(?:\.[0-9]+)*)"$', block)
+    if match is None:
+        raise AssertionError("Package block is missing a numeric version field")
+
+    return tuple(int(part) for part in match.group(1).split("."))
+
+
+def _dependency_names(block: str) -> set[str]:
+    dependencies: set[str] = set()
+    in_dependencies = False
+    for line in block.splitlines():
+        if line == "dependencies = [":
+            in_dependencies = True
+            continue
+        if in_dependencies and line == "]":
+            break
+        if in_dependencies:
+            match = re.search(r'\{ name = "([^"]+)"', line)
+            if match:
+                dependencies.add(match.group(1))
+
+    return dependencies
+
+
+def test_gitpython_lock_stays_on_patched_release_floor() -> None:
+    gitpython_block = _lock_package_block("gitpython")
+
+    assert _locked_version(gitpython_block) >= PATCHED_GITPYTHON_FLOOR
+    assert "gitpython-3.1.49" not in gitpython_block
+
+
+def test_mlflow_skinny_transitive_gitpython_dependency_is_guarded() -> None:
+    mlflow_skinny_block = _lock_package_block("mlflow-skinny")
+
+    assert "gitpython" in _dependency_names(mlflow_skinny_block)


### PR DESCRIPTION
## Summary
- add a focused uv.lock regression for the patched GitPython release floor
- guard that GitPython remains visible through the mlflow-skinny transitive dependency edge
- allow the dependency-lock regression in reduced Python CI lanes

## Validation
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_dependency_lock.py -q
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1