### PR TITLE
test(deps): cover urllib3 lock floor

### DIFF
--- a/tests/test_dependency_lock.py
+++ b/tests/test_dependency_lock.py
@@ -6,6 +6,7 @@ from pathlib import Path
 ROOT_DIR = Path(__file__).resolve().parents[1]
 LOCKFILE = ROOT_DIR / "uv.lock"
 PATCHED_GITPYTHON_FLOOR = (3, 1, 50)
+PATCHED_URLLIB3_FLOOR = (2, 7, 0)
 
 
 def _lock_package_block(name: str) -> str:
@@ -46,6 +47,13 @@ def test_gitpython_lock_stays_on_patched_release_floor() -> None:
 
     assert _locked_version(gitpython_block) >= PATCHED_GITPYTHON_FLOOR
     assert "gitpython-3.1.49" not in gitpython_block
+
+
+def test_urllib3_lock_stays_on_patched_release_floor() -> None:
+    urllib3_block = _lock_package_block("urllib3")
+
+    assert _locked_version(urllib3_block) >= PATCHED_URLLIB3_FLOOR
+    assert "urllib3-2.6.3" not in urllib3_block
 
 
 def test_mlflow_skinny_transitive_gitpython_dependency_is_guarded() -> None:


### PR DESCRIPTION
Summary:
- add a uv.lock regression guard for urllib3 >= 2.7.0
- keep security-sensitive dependency lock coverage aligned with the recent lock bump

Tests:
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run pytest tests/test_dependency_lock.py -q
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/