### PR TITLE
test(docker): cover python base digest updates

### DIFF
--- a/tests/test_docker_workflow.py
+++ b/tests/test_docker_workflow.py
@@ -8,6 +8,8 @@ import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _PINNED_PYTHON_IMAGE_RE = re.compile(r"^python:(?P<version>\d+\.\d+-slim)@sha256:(?P<digest>[0-9a-f]{64})$")
+_PYTHON_3_12_SLIM_DIGEST = "401f6e1a67dad31a1bd78e9ad22d0ee0a3b52154e6bd30e90be696bb6a3d7461"
+_PYTHON_3_13_SLIM_DIGEST = "dc1546eefcbe8caaa1f004f16ab76b204b5e1dbd58ff81b899f21cd40541232f"
 
 
 def _load_docker_workflow() -> dict[str, Any]:
@@ -71,6 +73,15 @@ def test_dockerfiles_pin_python_base_images_by_digest() -> None:
 
     tensorflow_from = _dockerfile_lines("Dockerfile.tensorflow")[0].removeprefix("FROM ")
     _assert_pinned_python_image(tensorflow_from, "3.12-slim")
+
+
+def test_dockerfiles_use_current_python_base_digests() -> None:
+    python_3_13_image = f"python:3.13-slim@sha256:{_PYTHON_3_13_SLIM_DIGEST}"
+    python_3_12_image = f"python:3.12-slim@sha256:{_PYTHON_3_12_SLIM_DIGEST}"
+
+    assert _python_image_from_arg("Dockerfile") == python_3_13_image
+    assert _python_image_from_arg("Dockerfile.full") == python_3_13_image
+    assert _dockerfile_lines("Dockerfile.tensorflow")[0] == f"FROM {python_3_12_image}"
 
 
 def test_docker_success_job_waits_for_full_image_result() -> None:


### PR DESCRIPTION
## Summary
- add a Docker workflow regression for the current Python 3.12 and 3.13 slim image digests touched by recent Renovate updates
- keep the lightweight and full Dockerfiles tied to the same Python 3.13 base image digest

## Validation
- env UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run --no-sync pytest tests/test_docker_workflow.py -q
- env UV_CACHE_DIR=/tmp/modelaudit-uv-cache UV_PROJECT_ENVIRONMENT=/Users/mdangelo/code/modelaudit/.venv uv run --no-sync ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- env UV_CACHE_DIR=/tmp/modelaudit-uv-cache UV_PROJECT_ENVIRONMENT=/Users/mdangelo/code/modelaudit/.venv uv run --no-sync ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- env UV_CACHE_DIR=/tmp/modelaudit-uv-cache UV_PROJECT_ENVIRONMENT=/Users/mdangelo/code/modelaudit/.venv uv run --no-sync mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- env UV_CACHE_DIR=/tmp/modelaudit-uv-cache UV_PROJECT_ENVIRONMENT=/Users/mdangelo/code/modelaudit/.venv uv run --no-sync ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- env UV_CACHE_DIR=/tmp/modelaudit-uv-cache UV_PROJECT_ENVIRONMENT=/Users/mdangelo/code/modelaudit/.venv uv run --no-sync ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/

Full non-slow pytest was rerun after rebuilding the local picklescan Rust extension; it reached 5557 passed / 13 skipped and failed only local timing thresholds in tests/test_performance_benchmarks.py::TestPerformanceBenchmarks::test_directory_scanning_performance and tests/test_debug_command.py::TestDebugCommand::test_debug_command_is_fast. Both timing tests also failed isolated in this local environment.