### PR TITLE
fix: terminate call-graph alias fixpoint on oscillating rebinds (#1247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - keep shard sibling discovery within the requested scan root
 - preserve per-shard metadata when aggregating sharded model families
 - reject plain PyTorch source text from Torch7 content routing
+- prevent picklescan call-graph alias cycles from hanging scans
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 

--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -51,6 +51,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- prevent call-graph alias cycles from hanging scans
 - detect nested brace-format lookups that reach tracked `defaultdict` factories
 - avoid `str.format` false positives when a `ChainMap` shadows a `defaultdict`
 - block `statistics.quantiles` call-iterator consumption in call-graph analysis

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -1024,6 +1024,9 @@ def _with_call_graph_findings(report: PickleReport) -> PickleReport:
                 import_references,
                 callable_invocations,
             )
+        except _CallGraphAnalysisLimitError as error:
+            startup_hook_write_findings = error.partial_startup_hook_write_findings
+            enrichment_errors.append(("python_call_graph_startup_hook_write", error))
         except Exception as error:
             startup_hook_write_findings = ()
             enrichment_errors.append(("python_call_graph_startup_hook_write", error))

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -14,6 +14,7 @@ from .call_graph import (
     CallGraphFinding,
     StartupHookWriteFinding,
     UnanalyzedCallGraphReference,
+    _CallGraphAnalysisLimitError,
     find_dangerous_call_graphs,
     find_startup_hook_write_call_graphs,
     find_unanalyzed_callable_call_graph_references,
@@ -1012,6 +1013,9 @@ def _with_call_graph_findings(report: PickleReport) -> PickleReport:
     with shared_source_sensitive_caches():
         try:
             call_graph_findings = find_dangerous_call_graphs(import_references, callable_invocations)
+        except _CallGraphAnalysisLimitError as error:
+            call_graph_findings = error.partial_findings
+            enrichment_errors.append(("python_call_graph", error))
         except Exception as error:
             call_graph_findings = ()
             enrichment_errors.append(("python_call_graph", error))

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1664,15 +1664,16 @@ def _collect_assignment_aliases(
 ) -> dict[str, str]:
     node_list = tuple(nodes)
     assignment_aliases: dict[str, str] = {}
-    # Track every (target, resolved) pair already applied. A target can be
-    # reassigned across passes (e.g. distinct `if`/`else` branches both bind
-    # the same name), so the fixpoint may oscillate without ever growing the
-    # dict. Re-applying a previously seen pair must not count as progress, or
-    # the loop never terminates (see imaplib/http.server/nntplib stdlib hangs).
-    seen_assignments: set[tuple[str, str]] = set()
+    # A source-flattened branch may rebind one name indefinitely. Track full
+    # states so each distinct state gets a propagation pass before a cycle ends.
+    seen_states: set[tuple[tuple[str, str], ...]] = set()
 
     changed = True
     while changed and len(assignment_aliases) < _MAX_ASSIGNMENT_ALIASES:
+        state = tuple(sorted(assignment_aliases.items()))
+        if state in seen_states:
+            break
+        seen_states.add(state)
         changed = False
         scoped_aliases = {**aliases, **assignment_aliases}
         for node in node_list:
@@ -1690,9 +1691,7 @@ def _collect_assignment_aliases(
                 if assignment_aliases.get(target_name) == resolved:
                     continue
                 assignment_aliases[target_name] = resolved
-                if (target_name, resolved) not in seen_assignments:
-                    seen_assignments.add((target_name, resolved))
-                    changed = True
+                changed = True
                 if len(assignment_aliases) >= _MAX_ASSIGNMENT_ALIASES:
                     break
     return assignment_aliases

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1717,10 +1717,15 @@ def _contains_current_loop_break(nodes: Iterable[ast.stmt]) -> bool:
     return any(contains_break(node) for node in nodes)
 
 
-def _conditionally_rebound_assignment_nodes(nodes: Iterable[ast.AST]) -> dict[str, set[int]]:
+def _conditionally_rebound_assignment_nodes(
+    nodes: Iterable[ast.AST],
+    *,
+    propagate_reads: bool,
+) -> dict[str, set[int]]:
     """Return alternate-path assignment nodes grouped by ambiguously rebound name."""
+    node_list = tuple(nodes)
     ambiguous_assignment_nodes: dict[str, set[int]] = {}
-    for node in nodes:
+    for node in node_list:
         branch_bodies: tuple[Iterable[ast.stmt], ...]
         if isinstance(node, ast.If):
             branch_bodies = (node.body, node.orelse)
@@ -1751,6 +1756,24 @@ def _conditionally_rebound_assignment_nodes(nodes: Iterable[ast.AST]) -> dict[st
                     target_nodes.update(previous_assignments.get(target_name, set()))
             branch_assignments.append(assignments)
             seen_targets.update(branch_targets)
+
+    if not propagate_reads:
+        return ambiguous_assignment_nodes
+
+    active_ambiguous_targets: set[str] = set()
+    for node in node_list:
+        target_names = _assignment_alias_target_names(node)
+        if not target_names:
+            continue
+        reads_ambiguous_target = bool(_assignment_alias_read_names(node) & active_ambiguous_targets)
+        for target_name in target_names:
+            conditional_node_ids = ambiguous_assignment_nodes.get(target_name, set())
+            if id(node) in conditional_node_ids or reads_ambiguous_target:
+                if reads_ambiguous_target:
+                    ambiguous_assignment_nodes.setdefault(target_name, set()).add(id(node))
+                active_ambiguous_targets.add(target_name)
+            else:
+                active_ambiguous_targets.discard(target_name)
     return ambiguous_assignment_nodes
 
 
@@ -1765,7 +1788,12 @@ def _collect_assignment_aliases(
 ) -> dict[str, str]:
     node_list = tuple(nodes)
     assignment_aliases: dict[str, str] = {}
-    conditionally_rebound_node_ids = _conditionally_rebound_assignment_nodes(node_list)
+    source_path = _resolve_module_source(module_name)
+    enforce_transient_rebinding = source_path is None or not _is_library_source_path(str(source_path))
+    conditionally_rebound_node_ids = _conditionally_rebound_assignment_nodes(
+        node_list,
+        propagate_reads=enforce_transient_rebinding,
+    )
     seen_states: set[tuple[tuple[str, str], ...]] = {()}
     passes = 0
 
@@ -1779,6 +1807,7 @@ def _collect_assignment_aliases(
         state = tuple(sorted(assignment_aliases.items()))
         changed = False
         last_changed_node_ids: dict[str, int] = {}
+        last_resolved_node_ids: dict[str, int] = {}
         scoped_aliases = {**aliases, **assignment_aliases}
         for node in node_list:
             resolved = _assignment_alias_value(
@@ -1792,6 +1821,7 @@ def _collect_assignment_aliases(
             if resolved is None:
                 continue
             for target_name in _assignment_alias_target_names(node):
+                last_resolved_node_ids[target_name] = id(node)
                 if assignment_aliases.get(target_name) == resolved:
                     continue
                 assignment_aliases[target_name] = resolved
@@ -1801,9 +1831,10 @@ def _collect_assignment_aliases(
                     break
         next_state = tuple(sorted(assignment_aliases.items()))
         if next_state == state:
+            final_node_ids = last_resolved_node_ids if enforce_transient_rebinding else last_changed_node_ids
             if any(
                 node_id in conditionally_rebound_node_ids.get(target_name, set())
-                for target_name, node_id in last_changed_node_ids.items()
+                for target_name, node_id in final_node_ids.items()
             ):
                 raise _CallGraphAnalysisLimitError(
                     "assignment alias analysis encountered ambiguous conditional rebinding"
@@ -1877,6 +1908,12 @@ def _assignment_alias_target_names(node: ast.AST) -> set[str]:
         return targets
     if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
         return {node.target.id}
+    return set()
+
+
+def _assignment_alias_read_names(node: ast.AST) -> set[str]:
+    if isinstance(node, ast.Assign | ast.AnnAssign) and node.value is not None:
+        return {child.id for child in ast.walk(node.value) if isinstance(child, ast.Name)}
     return set()
 
 

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -70,6 +70,15 @@ _SOURCE_SENSITIVE_CACHED_FUNCTIONS: set[_CacheClearable] = set()
 class _CallGraphAnalysisLimitError(RuntimeError):
     """Raised when bounded call-graph enrichment cannot complete safely."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        partial_findings: tuple[CallGraphFinding, ...] = (),
+    ) -> None:
+        super().__init__(message)
+        self.partial_findings = partial_findings
+
 
 def _register_source_sensitive_cache(function: _CachedFunctionT) -> _CachedFunctionT:
     _SOURCE_SENSITIVE_CACHED_FUNCTIONS.add(cast(_CacheClearable, function))
@@ -325,48 +334,51 @@ def find_dangerous_call_graphs(
         if str(reference.get("module", "")) and str(reference.get("name", ""))
     }
 
-    for reference in _iter_call_graph_references(import_references, callable_references, invoked_references):
-        module = str(reference.get("module", ""))
-        name = str(reference.get("name", ""))
-        if not module or not name:
-            continue
+    try:
+        for reference in _iter_call_graph_references(import_references, callable_references, invoked_references):
+            module = str(reference.get("module", ""))
+            name = str(reference.get("name", ""))
+            if not module or not name:
+                continue
 
-        entrypoints = _call_graph_entrypoints_for_reference(module, name, reference)
-        if not entrypoints:
-            continue
-        allow_invoked_non_lifecycle_entrypoint = _is_explicit_method_import_reference(name)
-        sink_path = _first_matching_path(entrypoints, _find_sink_path)
-        if sink_path is None:
-            for positional_arg_count in positional_arg_counts.get((module, name), ()):
-                sink_path = _first_matching_path(
-                    entrypoints,
-                    _invoked_import_execution_path_callback(
-                        positional_arg_count,
-                        allow_non_lifecycle_entrypoint=allow_invoked_non_lifecycle_entrypoint,
-                    ),
+            entrypoints = _call_graph_entrypoints_for_reference(module, name, reference)
+            if not entrypoints:
+                continue
+            allow_invoked_non_lifecycle_entrypoint = _is_explicit_method_import_reference(name)
+            sink_path = _first_matching_path(entrypoints, _find_sink_path)
+            if sink_path is None:
+                for positional_arg_count in positional_arg_counts.get((module, name), ()):
+                    sink_path = _first_matching_path(
+                        entrypoints,
+                        _invoked_import_execution_path_callback(
+                            positional_arg_count,
+                            allow_non_lifecycle_entrypoint=allow_invoked_non_lifecycle_entrypoint,
+                        ),
+                    )
+                    if sink_path is not None:
+                        break
+            if sink_path is None:
+                continue
+
+            finding_key = (module, name, sink_path)
+            if finding_key in seen_findings:
+                continue
+            seen_findings.add(finding_key)
+
+            sink = sink_path[-1]
+            findings.append(
+                CallGraphFinding(
+                    module=module,
+                    name=name,
+                    import_reference=f"{module}.{name}",
+                    sink=sink,
+                    call_path=sink_path,
                 )
-                if sink_path is not None:
-                    break
-        if sink_path is None:
-            continue
-
-        finding_key = (module, name, sink_path)
-        if finding_key in seen_findings:
-            continue
-        seen_findings.add(finding_key)
-
-        sink = sink_path[-1]
-        findings.append(
-            CallGraphFinding(
-                module=module,
-                name=name,
-                import_reference=f"{module}.{name}",
-                sink=sink,
-                call_path=sink_path,
             )
-        )
-        if len(findings) >= _MAX_IMPORT_REFERENCES:
-            break
+            if len(findings) >= _MAX_IMPORT_REFERENCES:
+                break
+    except _CallGraphAnalysisLimitError as error:
+        raise _CallGraphAnalysisLimitError(str(error), partial_findings=tuple(findings)) from error
     return tuple(findings)
 
 

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -336,8 +336,9 @@ def find_dangerous_call_graphs(
         if str(reference.get("module", "")) and str(reference.get("name", ""))
     }
 
-    try:
-        for reference in _iter_call_graph_references(import_references, callable_references, invoked_references):
+    analysis_limit_error: _CallGraphAnalysisLimitError | None = None
+    for reference in _iter_call_graph_references(import_references, callable_references, invoked_references):
+        try:
             module = str(reference.get("module", ""))
             name = str(reference.get("name", ""))
             if not module or not name:
@@ -379,8 +380,14 @@ def find_dangerous_call_graphs(
             )
             if len(findings) >= _MAX_IMPORT_REFERENCES:
                 break
-    except _CallGraphAnalysisLimitError as error:
-        raise _CallGraphAnalysisLimitError(str(error), partial_findings=tuple(findings)) from error
+        except _CallGraphAnalysisLimitError as error:
+            if analysis_limit_error is None:
+                analysis_limit_error = error
+    if analysis_limit_error is not None:
+        raise _CallGraphAnalysisLimitError(
+            str(analysis_limit_error),
+            partial_findings=tuple(findings),
+        ) from analysis_limit_error
     return tuple(findings)
 
 
@@ -399,6 +406,7 @@ def find_startup_hook_write_call_graphs(
         for reference in _iter_callable_invocation_references(callable_invocations)
     }
     require_invocations = callable_invocations is not None and callable_invocations_complete
+    analysis_limit_error: _CallGraphAnalysisLimitError | None = None
     for reference in _iter_import_references(import_references):
         module = str(reference.get("module", ""))
         name = str(reference.get("name", ""))
@@ -435,12 +443,16 @@ def find_startup_hook_write_call_graphs(
                     )
                 )
         except _CallGraphAnalysisLimitError as error:
-            raise _CallGraphAnalysisLimitError(
-                str(error),
-                partial_startup_hook_write_findings=_materialize_startup_hook_write_findings(openers, writers),
-            ) from error
+            if analysis_limit_error is None:
+                analysis_limit_error = error
 
-    return _materialize_startup_hook_write_findings(openers, writers)
+    findings = _materialize_startup_hook_write_findings(openers, writers)
+    if analysis_limit_error is not None:
+        raise _CallGraphAnalysisLimitError(
+            str(analysis_limit_error),
+            partial_startup_hook_write_findings=findings,
+        ) from analysis_limit_error
+    return findings
 
 
 def _materialize_startup_hook_write_findings(
@@ -1689,9 +1701,9 @@ def _local_class_node_from_target(
     return local_class_nodes.get(class_name)
 
 
-def _conditionally_rebound_assignment_targets(nodes: Iterable[ast.AST]) -> set[str]:
-    """Return names assigned in multiple flattened alternate control-flow paths."""
-    ambiguous_targets: set[str] = set()
+def _conditionally_rebound_assignment_nodes(nodes: Iterable[ast.AST]) -> dict[str, set[int]]:
+    """Return alternate-path assignment nodes grouped by ambiguously rebound name."""
+    ambiguous_assignment_nodes: dict[str, set[int]] = {}
     for node in nodes:
         branch_bodies: tuple[Iterable[ast.stmt], ...]
         if isinstance(node, ast.If):
@@ -1708,16 +1720,22 @@ def _conditionally_rebound_assignment_targets(nodes: Iterable[ast.AST]) -> set[s
         else:
             continue
 
+        branch_assignments: list[dict[str, set[int]]] = []
         seen_targets: set[str] = set()
         for branch_body in branch_bodies:
-            branch_targets = {
-                target_name
-                for statement in _definition_scope_statements(branch_body)
-                for target_name in _assignment_alias_target_names(statement)
-            }
-            ambiguous_targets.update(seen_targets & branch_targets)
+            assignments: dict[str, set[int]] = {}
+            for statement in _definition_scope_statements(branch_body):
+                for target_name in _assignment_alias_target_names(statement):
+                    assignments.setdefault(target_name, set()).add(id(statement))
+            branch_targets = set(assignments)
+            for target_name in seen_targets & branch_targets:
+                target_nodes = ambiguous_assignment_nodes.setdefault(target_name, set())
+                target_nodes.update(assignments[target_name])
+                for previous_assignments in branch_assignments:
+                    target_nodes.update(previous_assignments.get(target_name, set()))
+            branch_assignments.append(assignments)
             seen_targets.update(branch_targets)
-    return ambiguous_targets
+    return ambiguous_assignment_nodes
 
 
 def _collect_assignment_aliases(
@@ -1731,7 +1749,7 @@ def _collect_assignment_aliases(
 ) -> dict[str, str]:
     node_list = tuple(nodes)
     assignment_aliases: dict[str, str] = {}
-    conditionally_rebound_targets = _conditionally_rebound_assignment_targets(node_list)
+    conditionally_rebound_node_ids = _conditionally_rebound_assignment_nodes(node_list)
     seen_states: set[tuple[tuple[str, str], ...]] = {()}
     passes = 0
 
@@ -1744,7 +1762,7 @@ def _collect_assignment_aliases(
         passes += 1
         state = tuple(sorted(assignment_aliases.items()))
         changed = False
-        changed_targets: set[str] = set()
+        last_changed_node_ids: dict[str, int] = {}
         scoped_aliases = {**aliases, **assignment_aliases}
         for node in node_list:
             resolved = _assignment_alias_value(
@@ -1762,12 +1780,15 @@ def _collect_assignment_aliases(
                     continue
                 assignment_aliases[target_name] = resolved
                 changed = True
-                changed_targets.add(target_name)
+                last_changed_node_ids[target_name] = id(node)
                 if len(assignment_aliases) >= _MAX_ASSIGNMENT_ALIASES:
                     break
         next_state = tuple(sorted(assignment_aliases.items()))
         if next_state == state:
-            if changed_targets & conditionally_rebound_targets:
+            if any(
+                node_id in conditionally_rebound_node_ids.get(target_name, set())
+                for target_name, node_id in last_changed_node_ids.items()
+            ):
                 raise _CallGraphAnalysisLimitError(
                     "assignment alias analysis encountered ambiguous conditional rebinding"
                 )

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -515,6 +515,8 @@ def _first_matching_path(
     for entrypoint in entrypoints:
         try:
             path = path_for(entrypoint)
+        except _CallGraphAnalysisLimitError:
+            raise
         except Exception:
             continue
         if path is not None:
@@ -1685,7 +1687,7 @@ def _collect_assignment_aliases(
         passes += 1
         state = tuple(sorted(assignment_aliases.items()))
         if state in seen_states:
-            break
+            raise _CallGraphAnalysisLimitError("assignment alias analysis entered a propagation cycle")
         seen_states.add(state)
         changed = False
         scoped_aliases = {**aliases, **assignment_aliases}

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -30,6 +30,7 @@ _MAX_CALL_GRAPH_DEPTH = 4
 _MAX_VISITED_FUNCTIONS = 64
 _MAX_CALLS_PER_FUNCTION = 128
 _MAX_ASSIGNMENT_ALIASES = 128
+_MAX_ASSIGNMENT_ALIAS_PASSES = 256
 _MAX_FUNCTION_INSTANCE_ALIASES = 32
 _MAX_CLASS_INSTANCE_ALIASES = 128
 _MAX_INHERITED_CLASS_METHODS = 128
@@ -64,6 +65,10 @@ class _CacheClearable(Protocol):
 
 
 _SOURCE_SENSITIVE_CACHED_FUNCTIONS: set[_CacheClearable] = set()
+
+
+class _CallGraphAnalysisLimitError(RuntimeError):
+    """Raised when bounded call-graph enrichment cannot complete safely."""
 
 
 def _register_source_sensitive_cache(function: _CachedFunctionT) -> _CachedFunctionT:
@@ -497,6 +502,8 @@ def shared_source_sensitive_caches() -> Iterator[None]:
 def _safe_call_graph_entrypoints(function_name: str) -> tuple[str, ...]:
     try:
         return _call_graph_entrypoints(function_name)
+    except _CallGraphAnalysisLimitError:
+        raise
     except Exception:
         return ()
 
@@ -1667,9 +1674,15 @@ def _collect_assignment_aliases(
     # A source-flattened branch may rebind one name indefinitely. Track full
     # states so each distinct state gets a propagation pass before a cycle ends.
     seen_states: set[tuple[tuple[str, str], ...]] = set()
+    passes = 0
 
     changed = True
     while changed and len(assignment_aliases) < _MAX_ASSIGNMENT_ALIASES:
+        if passes >= _MAX_ASSIGNMENT_ALIAS_PASSES:
+            raise _CallGraphAnalysisLimitError(
+                f"assignment alias analysis exceeded {_MAX_ASSIGNMENT_ALIAS_PASSES} propagation passes"
+            )
+        passes += 1
         state = tuple(sorted(assignment_aliases.items()))
         if state in seen_states:
             break

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1689,6 +1689,37 @@ def _local_class_node_from_target(
     return local_class_nodes.get(class_name)
 
 
+def _conditionally_rebound_assignment_targets(nodes: Iterable[ast.AST]) -> set[str]:
+    """Return names assigned in multiple flattened alternate control-flow paths."""
+    ambiguous_targets: set[str] = set()
+    for node in nodes:
+        branch_bodies: tuple[Iterable[ast.stmt], ...]
+        if isinstance(node, ast.If):
+            branch_bodies = (node.body, node.orelse)
+        elif isinstance(node, ast.Try):
+            branch_bodies = (
+                (*node.body, *node.orelse),
+                *(handler.body for handler in node.handlers),
+            )
+        elif isinstance(node, ast.For | ast.AsyncFor | ast.While):
+            branch_bodies = (node.body, node.orelse)
+        elif isinstance(node, ast.Match):
+            branch_bodies = tuple(case.body for case in node.cases)
+        else:
+            continue
+
+        seen_targets: set[str] = set()
+        for branch_body in branch_bodies:
+            branch_targets = {
+                target_name
+                for statement in _definition_scope_statements(branch_body)
+                for target_name in _assignment_alias_target_names(statement)
+            }
+            ambiguous_targets.update(seen_targets & branch_targets)
+            seen_targets.update(branch_targets)
+    return ambiguous_targets
+
+
 def _collect_assignment_aliases(
     nodes: Iterable[ast.AST],
     module_name: str,
@@ -1700,8 +1731,7 @@ def _collect_assignment_aliases(
 ) -> dict[str, str]:
     node_list = tuple(nodes)
     assignment_aliases: dict[str, str] = {}
-    # A source-flattened branch may rebind one name during every pass while its
-    # final state stays stable. Only completed-pass state cycles are incomplete.
+    conditionally_rebound_targets = _conditionally_rebound_assignment_targets(node_list)
     seen_states: set[tuple[tuple[str, str], ...]] = {()}
     passes = 0
 
@@ -1714,6 +1744,7 @@ def _collect_assignment_aliases(
         passes += 1
         state = tuple(sorted(assignment_aliases.items()))
         changed = False
+        changed_targets: set[str] = set()
         scoped_aliases = {**aliases, **assignment_aliases}
         for node in node_list:
             resolved = _assignment_alias_value(
@@ -1731,10 +1762,15 @@ def _collect_assignment_aliases(
                     continue
                 assignment_aliases[target_name] = resolved
                 changed = True
+                changed_targets.add(target_name)
                 if len(assignment_aliases) >= _MAX_ASSIGNMENT_ALIASES:
                     break
         next_state = tuple(sorted(assignment_aliases.items()))
         if next_state == state:
+            if changed_targets & conditionally_rebound_targets:
+                raise _CallGraphAnalysisLimitError(
+                    "assignment alias analysis encountered ambiguous conditional rebinding"
+                )
             break
         if next_state in seen_states:
             raise _CallGraphAnalysisLimitError("assignment alias analysis entered a propagation cycle")

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -2087,6 +2087,8 @@ def _assignment_alias_read_names(node: ast.AST) -> set[str]:
     if not isinstance(node, ast.Assign | ast.AnnAssign) or node.value is None:
         return set()
     value = node.value
+    if isinstance(value, ast.Call):
+        value = value.func
     while isinstance(value, ast.Attribute):
         value = value.value
     if isinstance(value, ast.Name):

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -338,19 +338,29 @@ def find_dangerous_call_graphs(
 
     analysis_limit_error: _CallGraphAnalysisLimitError | None = None
     for reference in _iter_call_graph_references(import_references, callable_references, invoked_references):
-        try:
-            module = str(reference.get("module", ""))
-            name = str(reference.get("name", ""))
-            if not module or not name:
-                continue
+        module = str(reference.get("module", ""))
+        name = str(reference.get("name", ""))
+        if not module or not name:
+            continue
 
+        try:
             entrypoints = _call_graph_entrypoints_for_reference(module, name, reference)
-            if not entrypoints:
-                continue
-            allow_invoked_non_lifecycle_entrypoint = _is_explicit_method_import_reference(name)
+        except _CallGraphAnalysisLimitError as error:
+            if analysis_limit_error is None:
+                analysis_limit_error = error
+            continue
+        if not entrypoints:
+            continue
+        allow_invoked_non_lifecycle_entrypoint = _is_explicit_method_import_reference(name)
+        try:
             sink_path = _first_matching_path(entrypoints, _find_sink_path)
-            if sink_path is None:
-                for positional_arg_count in positional_arg_counts.get((module, name), ()):
+        except _CallGraphAnalysisLimitError as error:
+            if analysis_limit_error is None:
+                analysis_limit_error = error
+            sink_path = None
+        if sink_path is None:
+            for positional_arg_count in positional_arg_counts.get((module, name), ()):
+                try:
                     sink_path = _first_matching_path(
                         entrypoints,
                         _invoked_import_execution_path_callback(
@@ -358,31 +368,32 @@ def find_dangerous_call_graphs(
                             allow_non_lifecycle_entrypoint=allow_invoked_non_lifecycle_entrypoint,
                         ),
                     )
-                    if sink_path is not None:
-                        break
-            if sink_path is None:
-                continue
+                except _CallGraphAnalysisLimitError as error:
+                    if analysis_limit_error is None:
+                        analysis_limit_error = error
+                    continue
+                if sink_path is not None:
+                    break
+        if sink_path is None:
+            continue
 
-            finding_key = (module, name, sink_path)
-            if finding_key in seen_findings:
-                continue
-            seen_findings.add(finding_key)
+        finding_key = (module, name, sink_path)
+        if finding_key in seen_findings:
+            continue
+        seen_findings.add(finding_key)
 
-            sink = sink_path[-1]
-            findings.append(
-                CallGraphFinding(
-                    module=module,
-                    name=name,
-                    import_reference=f"{module}.{name}",
-                    sink=sink,
-                    call_path=sink_path,
-                )
+        sink = sink_path[-1]
+        findings.append(
+            CallGraphFinding(
+                module=module,
+                name=name,
+                import_reference=f"{module}.{name}",
+                sink=sink,
+                call_path=sink_path,
             )
-            if len(findings) >= _MAX_IMPORT_REFERENCES:
-                break
-        except _CallGraphAnalysisLimitError as error:
-            if analysis_limit_error is None:
-                analysis_limit_error = error
+        )
+        if len(findings) >= _MAX_IMPORT_REFERENCES:
+            break
     if analysis_limit_error is not None:
         raise _CallGraphAnalysisLimitError(
             str(analysis_limit_error),
@@ -418,33 +429,50 @@ def find_startup_hook_write_call_graphs(
 
         try:
             entrypoints = _safe_call_graph_entrypoints(f"{module}.{name}")
-            if not entrypoints:
-                continue
-            if _first_matching_path(entrypoints, _find_sink_path) is not None:
-                continue
-            open_path = _first_matching_path(entrypoints, _find_file_open_path)
-            if open_path is not None:
-                openers.append(
-                    _ImportCallPath(
-                        module=module,
-                        name=name,
-                        import_reference=f"{module}.{name}",
-                        call_path=open_path,
-                    )
-                )
-            write_path = _first_matching_path(entrypoints, _find_file_write_path)
-            if write_path is not None:
-                writers.append(
-                    _ImportCallPath(
-                        module=module,
-                        name=name,
-                        import_reference=f"{module}.{name}",
-                        call_path=write_path,
-                    )
-                )
         except _CallGraphAnalysisLimitError as error:
             if analysis_limit_error is None:
                 analysis_limit_error = error
+            continue
+        if not entrypoints:
+            continue
+        try:
+            has_sink_path = _first_matching_path(entrypoints, _find_sink_path) is not None
+        except _CallGraphAnalysisLimitError as error:
+            if analysis_limit_error is None:
+                analysis_limit_error = error
+            has_sink_path = False
+        if has_sink_path:
+            continue
+        try:
+            open_path = _first_matching_path(entrypoints, _find_file_open_path)
+        except _CallGraphAnalysisLimitError as error:
+            if analysis_limit_error is None:
+                analysis_limit_error = error
+            open_path = None
+        if open_path is not None:
+            openers.append(
+                _ImportCallPath(
+                    module=module,
+                    name=name,
+                    import_reference=f"{module}.{name}",
+                    call_path=open_path,
+                )
+            )
+        try:
+            write_path = _first_matching_path(entrypoints, _find_file_write_path)
+        except _CallGraphAnalysisLimitError as error:
+            if analysis_limit_error is None:
+                analysis_limit_error = error
+            write_path = None
+        if write_path is not None:
+            writers.append(
+                _ImportCallPath(
+                    module=module,
+                    name=name,
+                    import_reference=f"{module}.{name}",
+                    call_path=write_path,
+                )
+            )
 
     findings = _materialize_startup_hook_write_findings(openers, writers)
     if analysis_limit_error is not None:
@@ -1744,21 +1772,10 @@ def _conditionally_rebound_assignment_nodes(
         else:
             continue
 
-        branch_assignments: list[dict[str, set[int]]] = []
-        seen_targets: set[str] = set()
         for branch_body in branch_bodies:
-            assignments: dict[str, set[int]] = {}
             for statement in _definition_scope_statements(branch_body):
                 for target_name in _assignment_alias_target_names(statement):
-                    assignments.setdefault(target_name, set()).add(id(statement))
-            branch_targets = set(assignments)
-            for target_name in seen_targets & branch_targets:
-                target_nodes = ambiguous_assignment_nodes.setdefault(target_name, set())
-                target_nodes.update(assignments[target_name])
-                for previous_assignments in branch_assignments:
-                    target_nodes.update(previous_assignments.get(target_name, set()))
-            branch_assignments.append(assignments)
-            seen_targets.update(branch_targets)
+                    ambiguous_assignment_nodes.setdefault(target_name, set()).add(id(statement))
 
     if not propagate_reads:
         return ambiguous_assignment_nodes

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -76,10 +76,12 @@ class _CallGraphAnalysisLimitError(RuntimeError):
         *,
         partial_findings: tuple[CallGraphFinding, ...] = (),
         partial_startup_hook_write_findings: tuple[StartupHookWriteFinding, ...] = (),
+        partial_path: tuple[str, ...] | None = None,
     ) -> None:
         super().__init__(message)
         self.partial_findings = partial_findings
         self.partial_startup_hook_write_findings = partial_startup_hook_write_findings
+        self.partial_path = partial_path
 
 
 def _register_source_sensitive_cache(function: _CachedFunctionT) -> _CachedFunctionT:
@@ -357,7 +359,7 @@ def find_dangerous_call_graphs(
         except _CallGraphAnalysisLimitError as error:
             if analysis_limit_error is None:
                 analysis_limit_error = error
-            sink_path = None
+            sink_path = error.partial_path
         if sink_path is None:
             for positional_arg_count in positional_arg_counts.get((module, name), ()):
                 try:
@@ -371,7 +373,7 @@ def find_dangerous_call_graphs(
                 except _CallGraphAnalysisLimitError as error:
                     if analysis_limit_error is None:
                         analysis_limit_error = error
-                    continue
+                    sink_path = error.partial_path
                 if sink_path is not None:
                     break
         if sink_path is None:
@@ -440,7 +442,7 @@ def find_startup_hook_write_call_graphs(
         except _CallGraphAnalysisLimitError as error:
             if analysis_limit_error is None:
                 analysis_limit_error = error
-            has_sink_path = False
+            has_sink_path = error.partial_path is not None
         if has_sink_path:
             continue
         try:
@@ -448,7 +450,7 @@ def find_startup_hook_write_call_graphs(
         except _CallGraphAnalysisLimitError as error:
             if analysis_limit_error is None:
                 analysis_limit_error = error
-            open_path = None
+            open_path = error.partial_path
         if open_path is not None:
             openers.append(
                 _ImportCallPath(
@@ -463,7 +465,7 @@ def find_startup_hook_write_call_graphs(
         except _CallGraphAnalysisLimitError as error:
             if analysis_limit_error is None:
                 analysis_limit_error = error
-            write_path = None
+            write_path = error.partial_path
         if write_path is not None:
             writers.append(
                 _ImportCallPath(
@@ -579,15 +581,24 @@ def _first_matching_path(
     entrypoints: Iterable[str],
     path_for: Callable[[str], tuple[str, ...] | None],
 ) -> tuple[str, ...] | None:
+    analysis_limit_error: _CallGraphAnalysisLimitError | None = None
     for entrypoint in entrypoints:
         try:
             path = path_for(entrypoint)
-        except _CallGraphAnalysisLimitError:
-            raise
+        except _CallGraphAnalysisLimitError as error:
+            if analysis_limit_error is None:
+                analysis_limit_error = error
+            continue
         except Exception:
             continue
         if path is not None:
+            if analysis_limit_error is not None:
+                raise _CallGraphAnalysisLimitError(
+                    str(analysis_limit_error), partial_path=path
+                ) from analysis_limit_error
             return path
+    if analysis_limit_error is not None:
+        raise analysis_limit_error
     return None
 
 
@@ -1773,10 +1784,34 @@ def _conditionally_rebound_assignment_nodes(
         else:
             continue
 
-        for branch_body in branch_bodies:
+        branch_statement_bodies = tuple(tuple(branch_body) for branch_body in branch_bodies)
+        for branch_body in branch_statement_bodies:
             for statement in _definition_scope_statements(branch_body):
                 for target_name in _assignment_alias_target_names(statement):
                     ambiguous_assignment_nodes.setdefault(target_name, set()).add(id(statement))
+
+        terminal_assignments: list[dict[str, ast.Assign | ast.AnnAssign]] = []
+        for branch_body in branch_statement_bodies:
+            if not branch_body or not isinstance(branch_body[-1], ast.Assign | ast.AnnAssign):
+                terminal_assignments.append({})
+                continue
+            terminal_statement = branch_body[-1]
+            if terminal_statement.value is None:
+                terminal_assignments.append({})
+                continue
+            terminal_assignments.append(
+                dict.fromkeys(_assignment_alias_target_names(terminal_statement), terminal_statement)
+            )
+        if isinstance(node, ast.If) and terminal_assignments:
+            terminal_targets = set.intersection(*(set(assignments) for assignments in terminal_assignments))
+            for target_name in terminal_targets:
+                statements = tuple(assignments[target_name] for assignments in terminal_assignments)
+                values = tuple(statement.value for statement in statements if statement.value is not None)
+                if (
+                    len(values) == len(statements)
+                    and len({ast.dump(value, include_attributes=False) for value in values}) == 1
+                ):
+                    ambiguous_assignment_nodes[target_name].difference_update(id(statement) for statement in statements)
 
     if not propagate_reads:
         return ambiguous_assignment_nodes, propagated_assignment_nodes

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1701,6 +1701,22 @@ def _local_class_node_from_target(
     return local_class_nodes.get(class_name)
 
 
+def _contains_current_loop_break(nodes: Iterable[ast.stmt]) -> bool:
+    """Return whether this loop body can break without entering a nested scope or loop."""
+
+    def contains_break(node: ast.AST) -> bool:
+        if isinstance(node, ast.Break):
+            return True
+        if isinstance(
+            node,
+            ast.For | ast.AsyncFor | ast.While | ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda | ast.ClassDef,
+        ):
+            return False
+        return any(contains_break(child) for child in ast.iter_child_nodes(node))
+
+    return any(contains_break(node) for node in nodes)
+
+
 def _conditionally_rebound_assignment_nodes(nodes: Iterable[ast.AST]) -> dict[str, set[int]]:
     """Return alternate-path assignment nodes grouped by ambiguously rebound name."""
     ambiguous_assignment_nodes: dict[str, set[int]] = {}
@@ -1713,7 +1729,7 @@ def _conditionally_rebound_assignment_nodes(nodes: Iterable[ast.AST]) -> dict[st
                 (*node.body, *node.orelse),
                 *(handler.body for handler in node.handlers),
             )
-        elif isinstance(node, ast.For | ast.AsyncFor | ast.While):
+        elif isinstance(node, ast.For | ast.AsyncFor | ast.While) and _contains_current_loop_break(node.body):
             branch_bodies = (node.body, node.orelse)
         elif isinstance(node, ast.Match):
             branch_bodies = tuple(case.body for case in node.cases)

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1865,7 +1865,8 @@ def _resolved_terminal_assignment_nodes(
                     continue
                 if any(
                     any(
-                        dependency_statement.lineno >= statement.lineno
+                        (dependency_statement.lineno, dependency_statement.col_offset)
+                        >= (statement.lineno, statement.col_offset)
                         for dependency_statement, statement in zip(
                             deterministic_statements[dependency],
                             statements,

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -75,9 +75,11 @@ class _CallGraphAnalysisLimitError(RuntimeError):
         message: str,
         *,
         partial_findings: tuple[CallGraphFinding, ...] = (),
+        partial_startup_hook_write_findings: tuple[StartupHookWriteFinding, ...] = (),
     ) -> None:
         super().__init__(message)
         self.partial_findings = partial_findings
+        self.partial_startup_hook_write_findings = partial_startup_hook_write_findings
 
 
 def _register_source_sensitive_cache(function: _CachedFunctionT) -> _CachedFunctionT:
@@ -406,32 +408,45 @@ def find_startup_hook_write_call_graphs(
             continue
         seen.add((module, name))
 
-        entrypoints = _safe_call_graph_entrypoints(f"{module}.{name}")
-        if not entrypoints:
-            continue
-        if _first_matching_path(entrypoints, _find_sink_path) is not None:
-            continue
-        open_path = _first_matching_path(entrypoints, _find_file_open_path)
-        if open_path is not None:
-            openers.append(
-                _ImportCallPath(
-                    module=module,
-                    name=name,
-                    import_reference=f"{module}.{name}",
-                    call_path=open_path,
+        try:
+            entrypoints = _safe_call_graph_entrypoints(f"{module}.{name}")
+            if not entrypoints:
+                continue
+            if _first_matching_path(entrypoints, _find_sink_path) is not None:
+                continue
+            open_path = _first_matching_path(entrypoints, _find_file_open_path)
+            if open_path is not None:
+                openers.append(
+                    _ImportCallPath(
+                        module=module,
+                        name=name,
+                        import_reference=f"{module}.{name}",
+                        call_path=open_path,
+                    )
                 )
-            )
-        write_path = _first_matching_path(entrypoints, _find_file_write_path)
-        if write_path is not None:
-            writers.append(
-                _ImportCallPath(
-                    module=module,
-                    name=name,
-                    import_reference=f"{module}.{name}",
-                    call_path=write_path,
+            write_path = _first_matching_path(entrypoints, _find_file_write_path)
+            if write_path is not None:
+                writers.append(
+                    _ImportCallPath(
+                        module=module,
+                        name=name,
+                        import_reference=f"{module}.{name}",
+                        call_path=write_path,
+                    )
                 )
-            )
+        except _CallGraphAnalysisLimitError as error:
+            raise _CallGraphAnalysisLimitError(
+                str(error),
+                partial_startup_hook_write_findings=_materialize_startup_hook_write_findings(openers, writers),
+            ) from error
 
+    return _materialize_startup_hook_write_findings(openers, writers)
+
+
+def _materialize_startup_hook_write_findings(
+    openers: list[_ImportCallPath],
+    writers: list[_ImportCallPath],
+) -> tuple[StartupHookWriteFinding, ...]:
     if not openers or not writers:
         return ()
 

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1769,6 +1769,15 @@ def _is_exhaustive_match(node: ast.Match) -> bool:
 _TerminalAssignmentGroup = tuple[str, tuple[ast.Assign | ast.AnnAssign, ...]]
 
 
+def _can_complete_normally(branch_body: Iterable[ast.stmt]) -> bool:
+    statements = tuple(branch_body)
+    return not statements or not isinstance(statements[-1], ast.Raise | ast.Return)
+
+
+def _contains_assignment_alias(branch_body: Iterable[ast.stmt]) -> bool:
+    return any(_assignment_alias_target_names(statement) for statement in _definition_scope_statements(branch_body))
+
+
 def _terminal_assignment_groups(
     branch_bodies: tuple[tuple[ast.stmt, ...], ...],
 ) -> tuple[_TerminalAssignmentGroup, ...]:
@@ -1800,16 +1809,38 @@ def _conditionally_rebound_assignment_nodes(
     ambiguous_assignment_nodes: dict[str, set[int]] = {}
     terminal_assignment_group_sets: list[tuple[_TerminalAssignmentGroup, ...]] = []
     for node in node_list:
+        alternate_bodies: tuple[Iterable[ast.stmt], ...]
         branch_bodies: tuple[Iterable[ast.stmt], ...]
+        terminating_bodies: tuple[Iterable[ast.stmt], ...]
         deterministic_terminal_bodies: tuple[Iterable[ast.stmt], ...] | None = None
         if isinstance(node, ast.If):
-            branch_bodies = (node.body, node.orelse)
+            alternate_bodies = (node.body, node.orelse)
+            terminating_bodies = tuple(
+                branch_body for branch_body in alternate_bodies if not _can_complete_normally(branch_body)
+            )
+            branch_bodies = tuple(
+                branch_body for branch_body in alternate_bodies if _can_complete_normally(branch_body)
+            )
+            if any(_contains_assignment_alias(branch_body) for branch_body in terminating_bodies):
+                branch_bodies = alternate_bodies
+            if len(branch_bodies) < 2:
+                continue
             deterministic_terminal_bodies = branch_bodies
         elif isinstance(node, ast.Try) and node.handlers:
-            branch_bodies = (
+            alternate_bodies = (
                 (*node.body, *node.orelse),
                 *(handler.body for handler in node.handlers),
             )
+            terminating_bodies = tuple(
+                branch_body for branch_body in alternate_bodies if not _can_complete_normally(branch_body)
+            )
+            branch_bodies = tuple(
+                branch_body for branch_body in alternate_bodies if _can_complete_normally(branch_body)
+            )
+            if any(_contains_assignment_alias(branch_body) for branch_body in terminating_bodies):
+                branch_bodies = alternate_bodies
+            if len(branch_bodies) < 2:
+                continue
             deterministic_terminal_bodies = branch_bodies
         elif isinstance(node, ast.For | ast.AsyncFor | ast.While) and _contains_current_loop_break(node.body):
             branch_bodies = (node.body, node.orelse)
@@ -1838,6 +1869,7 @@ def _conditionally_rebound_assignment_nodes(
 
 
 def _resolved_terminal_assignment_nodes(
+    nodes: tuple[ast.AST, ...],
     terminal_assignment_group_sets: tuple[tuple[_TerminalAssignmentGroup, ...], ...],
     ambiguous_assignment_nodes: dict[str, set[int]],
     module_name: str,
@@ -1848,55 +1880,72 @@ def _resolved_terminal_assignment_nodes(
     class_name: str | None,
 ) -> dict[str, set[int]]:
     deterministic_node_ids: dict[str, set[int]] = {}
-    ambiguous_target_names = set(ambiguous_assignment_nodes)
-    for terminal_assignment_groups in terminal_assignment_group_sets:
-        unresolved_groups = list(terminal_assignment_groups)
-        deterministic_targets: set[str] = set()
-        deterministic_statements: dict[str, tuple[ast.Assign | ast.AnnAssign, ...]] = {}
-        while unresolved_groups:
-            deferred_groups: list[_TerminalAssignmentGroup] = []
-            resolved_group = False
-            for target_name, statements in unresolved_groups:
-                conditional_dependencies: set[str] = set()
-                for statement in statements:
-                    conditional_dependencies.update(_assignment_value_read_names(statement) & ambiguous_target_names)
-                if conditional_dependencies - deterministic_targets:
-                    deferred_groups.append((target_name, statements))
-                    continue
-                if any(
-                    any(
-                        (dependency_statement.lineno, dependency_statement.col_offset)
-                        >= (statement.lineno, statement.col_offset)
-                        for dependency_statement, statement in zip(
-                            deterministic_statements[dependency],
-                            statements,
-                            strict=True,
-                        )
-                    )
-                    for dependency in conditional_dependencies
+    while True:
+        effective_ambiguous_node_ids = {
+            target_name: node_ids - deterministic_node_ids.get(target_name, set())
+            for target_name, node_ids in ambiguous_assignment_nodes.items()
+            if node_ids - deterministic_node_ids.get(target_name, set())
+        }
+        active_ambiguous_targets: set[str] = set()
+        ambiguous_before_statement: dict[int, set[str]] = {}
+        for node in nodes:
+            target_names = _assignment_alias_target_names(node)
+            if not target_names:
+                continue
+            ambiguous_before_statement[id(node)] = set(active_ambiguous_targets)
+            for target_name in target_names:
+                if id(node) in effective_ambiguous_node_ids.get(target_name, set()):
+                    active_ambiguous_targets.add(target_name)
+                else:
+                    active_ambiguous_targets.discard(target_name)
+
+        changed = False
+        for terminal_assignment_groups in terminal_assignment_group_sets:
+            branch_count = len(terminal_assignment_groups[0][1])
+            resolved_by_branch: list[dict[str, str]] = []
+            for branch_index in range(branch_count):
+                branch_statements = {
+                    id(statements[branch_index]): statements[branch_index]
+                    for _, statements in terminal_assignment_groups
+                }
+                branch_aliases = dict(aliases)
+                branch_local_targets: set[str] = set()
+                branch_resolved: dict[str, str] = {}
+                for statement in sorted(
+                    branch_statements.values(),
+                    key=lambda statement: (statement.lineno, statement.col_offset),
                 ):
-                    continue
-                resolved_values = tuple(
-                    _assignment_alias_value(
+                    blocked_dependencies = (
+                        _assignment_value_read_names(statement)
+                        & ambiguous_before_statement.get(id(statement), set()) - branch_local_targets
+                    )
+                    if blocked_dependencies:
+                        continue
+                    resolved = _assignment_alias_value(
                         statement,
                         module_name,
-                        aliases,
+                        branch_aliases,
                         local_defs,
                         local_class_targets,
                         class_name=class_name,
                     )
-                    for statement in statements
-                )
+                    if resolved is None:
+                        continue
+                    for target_name in _assignment_alias_target_names(statement):
+                        branch_aliases[target_name] = resolved
+                        branch_local_targets.add(target_name)
+                        branch_resolved[target_name] = resolved
+                resolved_by_branch.append(branch_resolved)
+
+            for target_name, statements in terminal_assignment_groups:
+                resolved_values = tuple(resolved.get(target_name) for resolved in resolved_by_branch)
                 if None not in resolved_values and len(set(resolved_values)) == 1:
-                    deterministic_node_ids.setdefault(target_name, set()).update(
-                        id(statement) for statement in statements
-                    )
-                    deterministic_targets.add(target_name)
-                    deterministic_statements[target_name] = statements
-                    resolved_group = True
-            if not resolved_group:
-                break
-            unresolved_groups = deferred_groups
+                    node_ids = deterministic_node_ids.setdefault(target_name, set())
+                    prior_count = len(node_ids)
+                    node_ids.update(id(statement) for statement in statements)
+                    changed = changed or len(node_ids) != prior_count
+        if not changed:
+            break
     return deterministic_node_ids
 
 
@@ -1984,6 +2033,7 @@ def _collect_assignment_aliases(
         next_state = tuple(sorted(assignment_aliases.items()))
         if next_state == state:
             deterministic_node_ids = _resolved_terminal_assignment_nodes(
+                node_list,
                 terminal_assignment_group_sets,
                 conditionally_rebound_node_ids,
                 module_name,
@@ -2100,7 +2150,55 @@ def _assignment_alias_read_names(node: ast.AST) -> set[str]:
 def _assignment_value_read_names(node: ast.Assign | ast.AnnAssign) -> set[str]:
     if node.value is None:
         return set()
-    return {child.id for child in ast.walk(node.value) if isinstance(child, ast.Name)}
+
+    names: set[str] = set()
+
+    def binding_names(target: ast.AST) -> set[str]:
+        return {child.id for child in ast.walk(target) if isinstance(child, ast.Name)}
+
+    def visit(value: ast.AST, bound_names: set[str]) -> None:
+        if isinstance(value, ast.Name):
+            if isinstance(value.ctx, ast.Load) and value.id not in bound_names:
+                names.add(value.id)
+            return
+        if isinstance(value, ast.Lambda):
+            for default in (
+                *value.args.defaults,
+                *(default for default in value.args.kw_defaults if default is not None),
+            ):
+                visit(default, bound_names)
+            lambda_bound_names = {
+                argument.arg
+                for argument in (
+                    *value.args.posonlyargs,
+                    *value.args.args,
+                    *value.args.kwonlyargs,
+                )
+            }
+            if value.args.vararg is not None:
+                lambda_bound_names.add(value.args.vararg.arg)
+            if value.args.kwarg is not None:
+                lambda_bound_names.add(value.args.kwarg.arg)
+            visit(value.body, bound_names | lambda_bound_names)
+            return
+        if isinstance(value, ast.ListComp | ast.SetComp | ast.GeneratorExp | ast.DictComp):
+            comprehension_bound_names = set(bound_names)
+            for generator in value.generators:
+                visit(generator.iter, comprehension_bound_names)
+                comprehension_bound_names.update(binding_names(generator.target))
+                for condition in generator.ifs:
+                    visit(condition, comprehension_bound_names)
+            if isinstance(value, ast.DictComp):
+                visit(value.key, comprehension_bound_names)
+                visit(value.value, comprehension_bound_names)
+            else:
+                visit(value.elt, comprehension_bound_names)
+            return
+        for child in ast.iter_child_nodes(value):
+            visit(child, bound_names)
+
+    visit(node.value, set())
+    return names
 
 
 def _is_local_class_member_alias(resolved: str, local_class_targets: set[str]) -> bool:

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1759,28 +1759,64 @@ def _contains_current_loop_break(nodes: Iterable[ast.stmt]) -> bool:
     return any(contains_break(node) for node in nodes)
 
 
+def _is_exhaustive_match(node: ast.Match) -> bool:
+    return any(
+        isinstance(case.pattern, ast.MatchAs) and case.pattern.pattern is None and case.guard is None
+        for case in node.cases
+    )
+
+
+_TerminalAssignmentGroup = tuple[str, tuple[ast.Assign | ast.AnnAssign, ...]]
+
+
+def _terminal_assignment_groups(
+    branch_bodies: tuple[tuple[ast.stmt, ...], ...],
+) -> tuple[_TerminalAssignmentGroup, ...]:
+    terminal_assignments: list[dict[str, ast.Assign | ast.AnnAssign]] = []
+    for branch_body in branch_bodies:
+        suffix_assignments: dict[str, ast.Assign | ast.AnnAssign] = {}
+        for statement in reversed(branch_body):
+            if not isinstance(statement, ast.Assign | ast.AnnAssign) or statement.value is None:
+                break
+            for target_name in _assignment_alias_target_names(statement):
+                suffix_assignments.setdefault(target_name, statement)
+        terminal_assignments.append(suffix_assignments)
+    if not terminal_assignments:
+        return ()
+    terminal_targets = set.intersection(*(set(assignments) for assignments in terminal_assignments))
+    return tuple(
+        (target_name, tuple(assignments[target_name] for assignments in terminal_assignments))
+        for target_name in sorted(terminal_targets)
+    )
+
+
 def _conditionally_rebound_assignment_nodes(
     nodes: Iterable[ast.AST],
-    *,
-    propagate_reads: bool,
-) -> tuple[dict[str, set[int]], dict[str, set[int]]]:
+) -> tuple[dict[str, set[int]], tuple[tuple[_TerminalAssignmentGroup, ...], ...]]:
     """Return alternate-path assignment nodes grouped by ambiguously rebound name."""
     node_list = tuple(nodes)
     ambiguous_assignment_nodes: dict[str, set[int]] = {}
-    propagated_assignment_nodes: dict[str, set[int]] = {}
+    terminal_assignment_group_sets: list[tuple[_TerminalAssignmentGroup, ...]] = []
     for node in node_list:
         branch_bodies: tuple[Iterable[ast.stmt], ...]
+        deterministic_terminal_bodies: tuple[Iterable[ast.stmt], ...] | None = None
         if isinstance(node, ast.If):
             branch_bodies = (node.body, node.orelse)
-        elif isinstance(node, ast.Try):
+            deterministic_terminal_bodies = branch_bodies
+        elif isinstance(node, ast.Try) and node.handlers:
             branch_bodies = (
                 (*node.body, *node.orelse),
                 *(handler.body for handler in node.handlers),
             )
+            deterministic_terminal_bodies = branch_bodies
         elif isinstance(node, ast.For | ast.AsyncFor | ast.While) and _contains_current_loop_break(node.body):
             branch_bodies = (node.body, node.orelse)
+            if node.body and isinstance(node.body[-1], ast.Break) and not _contains_current_loop_break(node.body[:-1]):
+                deterministic_terminal_bodies = (node.body[:-1], node.orelse)
         elif isinstance(node, ast.Match):
             branch_bodies = tuple(case.body for case in node.cases)
+            if _is_exhaustive_match(node):
+                deterministic_terminal_bodies = branch_bodies
         else:
             continue
 
@@ -1790,48 +1826,108 @@ def _conditionally_rebound_assignment_nodes(
                 for target_name in _assignment_alias_target_names(statement):
                     ambiguous_assignment_nodes.setdefault(target_name, set()).add(id(statement))
 
-        terminal_assignments: list[dict[str, ast.Assign | ast.AnnAssign]] = []
-        for branch_body in branch_statement_bodies:
-            if not branch_body or not isinstance(branch_body[-1], ast.Assign | ast.AnnAssign):
-                terminal_assignments.append({})
-                continue
-            terminal_statement = branch_body[-1]
-            if terminal_statement.value is None:
-                terminal_assignments.append({})
-                continue
-            terminal_assignments.append(
-                dict.fromkeys(_assignment_alias_target_names(terminal_statement), terminal_statement)
+        if deterministic_terminal_bodies is not None:
+            groups = _terminal_assignment_groups(
+                tuple(tuple(branch_body) for branch_body in deterministic_terminal_bodies)
             )
-        if isinstance(node, ast.If) and terminal_assignments:
-            terminal_targets = set.intersection(*(set(assignments) for assignments in terminal_assignments))
-            for target_name in terminal_targets:
-                statements = tuple(assignments[target_name] for assignments in terminal_assignments)
-                values = tuple(statement.value for statement in statements if statement.value is not None)
-                if (
-                    len(values) == len(statements)
-                    and len({ast.dump(value, include_attributes=False) for value in values}) == 1
+            if groups:
+                terminal_assignment_group_sets.append(groups)
+    return ambiguous_assignment_nodes, tuple(terminal_assignment_group_sets)
+
+
+def _resolved_terminal_assignment_nodes(
+    terminal_assignment_group_sets: tuple[tuple[_TerminalAssignmentGroup, ...], ...],
+    ambiguous_assignment_nodes: dict[str, set[int]],
+    module_name: str,
+    aliases: dict[str, str],
+    local_defs: set[str],
+    local_class_targets: set[str],
+    *,
+    class_name: str | None,
+) -> dict[str, set[int]]:
+    deterministic_node_ids: dict[str, set[int]] = {}
+    ambiguous_target_names = set(ambiguous_assignment_nodes)
+    for terminal_assignment_groups in terminal_assignment_group_sets:
+        unresolved_groups = list(terminal_assignment_groups)
+        deterministic_targets: set[str] = set()
+        deterministic_statements: dict[str, tuple[ast.Assign | ast.AnnAssign, ...]] = {}
+        while unresolved_groups:
+            deferred_groups: list[_TerminalAssignmentGroup] = []
+            resolved_group = False
+            for target_name, statements in unresolved_groups:
+                conditional_dependencies: set[str] = set()
+                for statement in statements:
+                    conditional_dependencies.update(_assignment_value_read_names(statement) & ambiguous_target_names)
+                if conditional_dependencies - deterministic_targets:
+                    deferred_groups.append((target_name, statements))
+                    continue
+                if any(
+                    any(
+                        dependency_statement.lineno >= statement.lineno
+                        for dependency_statement, statement in zip(
+                            deterministic_statements[dependency],
+                            statements,
+                            strict=True,
+                        )
+                    )
+                    for dependency in conditional_dependencies
                 ):
-                    ambiguous_assignment_nodes[target_name].difference_update(id(statement) for statement in statements)
+                    continue
+                resolved_values = tuple(
+                    _assignment_alias_value(
+                        statement,
+                        module_name,
+                        aliases,
+                        local_defs,
+                        local_class_targets,
+                        class_name=class_name,
+                    )
+                    for statement in statements
+                )
+                if None not in resolved_values and len(set(resolved_values)) == 1:
+                    deterministic_node_ids.setdefault(target_name, set()).update(
+                        id(statement) for statement in statements
+                    )
+                    deterministic_targets.add(target_name)
+                    deterministic_statements[target_name] = statements
+                    resolved_group = True
+            if not resolved_group:
+                break
+            unresolved_groups = deferred_groups
+    return deterministic_node_ids
 
+
+def _propagated_ambiguous_assignment_nodes(
+    nodes: tuple[ast.AST, ...],
+    ambiguous_assignment_nodes: dict[str, set[int]],
+    deterministic_node_ids: dict[str, set[int]],
+    *,
+    propagate_reads: bool,
+) -> tuple[dict[str, set[int]], dict[str, set[int]]]:
+    effective_ambiguous_node_ids = {
+        target_name: node_ids - deterministic_node_ids.get(target_name, set())
+        for target_name, node_ids in ambiguous_assignment_nodes.items()
+        if node_ids - deterministic_node_ids.get(target_name, set())
+    }
+    propagated_assignment_nodes: dict[str, set[int]] = {}
     if not propagate_reads:
-        return ambiguous_assignment_nodes, propagated_assignment_nodes
-
+        return effective_ambiguous_node_ids, propagated_assignment_nodes
     active_ambiguous_targets: set[str] = set()
-    for node in node_list:
+    for node in nodes:
         target_names = _assignment_alias_target_names(node)
         if not target_names:
             continue
         reads_ambiguous_target = bool(_assignment_alias_read_names(node) & active_ambiguous_targets)
         for target_name in target_names:
-            conditional_node_ids = ambiguous_assignment_nodes.get(target_name, set())
+            conditional_node_ids = effective_ambiguous_node_ids.get(target_name, set())
             if id(node) in conditional_node_ids or reads_ambiguous_target:
                 if reads_ambiguous_target:
-                    ambiguous_assignment_nodes.setdefault(target_name, set()).add(id(node))
+                    effective_ambiguous_node_ids.setdefault(target_name, set()).add(id(node))
                     propagated_assignment_nodes.setdefault(target_name, set()).add(id(node))
                 active_ambiguous_targets.add(target_name)
             else:
                 active_ambiguous_targets.discard(target_name)
-    return ambiguous_assignment_nodes, propagated_assignment_nodes
+    return effective_ambiguous_node_ids, propagated_assignment_nodes
 
 
 def _collect_assignment_aliases(
@@ -1846,10 +1942,7 @@ def _collect_assignment_aliases(
     node_list = tuple(nodes)
     assignment_aliases: dict[str, str] = {}
     source_path = _resolve_module_source(module_name)
-    conditionally_rebound_node_ids, propagated_rebound_node_ids = _conditionally_rebound_assignment_nodes(
-        node_list,
-        propagate_reads=source_path is None or not _is_stdlib_source_path(str(source_path)),
-    )
+    conditionally_rebound_node_ids, terminal_assignment_group_sets = _conditionally_rebound_assignment_nodes(node_list)
     seen_states: set[tuple[tuple[str, str], ...]] = {()}
     passes = 0
 
@@ -1887,8 +1980,25 @@ def _collect_assignment_aliases(
                     break
         next_state = tuple(sorted(assignment_aliases.items()))
         if next_state == state:
+            deterministic_node_ids = _resolved_terminal_assignment_nodes(
+                terminal_assignment_group_sets,
+                conditionally_rebound_node_ids,
+                module_name,
+                {**aliases, **assignment_aliases},
+                local_defs,
+                local_class_targets,
+                class_name=class_name,
+            )
+            effective_conditionally_rebound_node_ids, propagated_rebound_node_ids = (
+                _propagated_ambiguous_assignment_nodes(
+                    node_list,
+                    conditionally_rebound_node_ids,
+                    deterministic_node_ids,
+                    propagate_reads=source_path is None or not _is_stdlib_source_path(str(source_path)),
+                )
+            )
             changed_conditionally = any(
-                node_id in conditionally_rebound_node_ids.get(target_name, set())
+                node_id in effective_conditionally_rebound_node_ids.get(target_name, set())
                 for target_name, node_id in last_changed_node_ids.items()
             )
             resolved_from_conditional_read = any(
@@ -1980,6 +2090,12 @@ def _assignment_alias_read_names(node: ast.AST) -> set[str]:
     if isinstance(value, ast.Name):
         return {value.id}
     return set()
+
+
+def _assignment_value_read_names(node: ast.Assign | ast.AnnAssign) -> set[str]:
+    if node.value is None:
+        return set()
+    return {child.id for child in ast.walk(node.value) if isinstance(child, ast.Name)}
 
 
 def _is_local_class_member_alias(resolved: str, local_class_targets: set[str]) -> bool:

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1664,6 +1664,12 @@ def _collect_assignment_aliases(
 ) -> dict[str, str]:
     node_list = tuple(nodes)
     assignment_aliases: dict[str, str] = {}
+    # Track every (target, resolved) pair already applied. A target can be
+    # reassigned across passes (e.g. distinct `if`/`else` branches both bind
+    # the same name), so the fixpoint may oscillate without ever growing the
+    # dict. Re-applying a previously seen pair must not count as progress, or
+    # the loop never terminates (see imaplib/http.server/nntplib stdlib hangs).
+    seen_assignments: set[tuple[str, str]] = set()
 
     changed = True
     while changed and len(assignment_aliases) < _MAX_ASSIGNMENT_ALIASES:
@@ -1684,7 +1690,9 @@ def _collect_assignment_aliases(
                 if assignment_aliases.get(target_name) == resolved:
                     continue
                 assignment_aliases[target_name] = resolved
-                changed = True
+                if (target_name, resolved) not in seen_assignments:
+                    seen_assignments.add((target_name, resolved))
+                    changed = True
                 if len(assignment_aliases) >= _MAX_ASSIGNMENT_ALIASES:
                     break
     return assignment_aliases

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1776,6 +1776,8 @@ def _terminal_assignment_groups(
     for branch_body in branch_bodies:
         suffix_assignments: dict[str, ast.Assign | ast.AnnAssign] = {}
         for statement in reversed(branch_body):
+            if isinstance(statement, ast.Expr | ast.Pass):
+                continue
             if not isinstance(statement, ast.Assign | ast.AnnAssign) or statement.value is None:
                 break
             for target_name in _assignment_alias_target_names(statement):

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -775,7 +775,10 @@ def _is_skippable_torch_extension_global_reference(module: str, name: str) -> bo
     source_path = _resolve_module_source(module)
     if source_path is not None and not _is_library_source_path(str(source_path)):
         return False
-    return not _has_static_torch_extension_global_target(module, name)
+    try:
+        return not _has_static_torch_extension_global_target(module, name)
+    except _CallGraphAnalysisLimitError:
+        return False
 
 
 @_register_source_sensitive_cache

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1752,10 +1752,11 @@ def _conditionally_rebound_assignment_nodes(
     nodes: Iterable[ast.AST],
     *,
     propagate_reads: bool,
-) -> dict[str, set[int]]:
+) -> tuple[dict[str, set[int]], dict[str, set[int]]]:
     """Return alternate-path assignment nodes grouped by ambiguously rebound name."""
     node_list = tuple(nodes)
     ambiguous_assignment_nodes: dict[str, set[int]] = {}
+    propagated_assignment_nodes: dict[str, set[int]] = {}
     for node in node_list:
         branch_bodies: tuple[Iterable[ast.stmt], ...]
         if isinstance(node, ast.If):
@@ -1778,7 +1779,7 @@ def _conditionally_rebound_assignment_nodes(
                     ambiguous_assignment_nodes.setdefault(target_name, set()).add(id(statement))
 
     if not propagate_reads:
-        return ambiguous_assignment_nodes
+        return ambiguous_assignment_nodes, propagated_assignment_nodes
 
     active_ambiguous_targets: set[str] = set()
     for node in node_list:
@@ -1791,10 +1792,11 @@ def _conditionally_rebound_assignment_nodes(
             if id(node) in conditional_node_ids or reads_ambiguous_target:
                 if reads_ambiguous_target:
                     ambiguous_assignment_nodes.setdefault(target_name, set()).add(id(node))
+                    propagated_assignment_nodes.setdefault(target_name, set()).add(id(node))
                 active_ambiguous_targets.add(target_name)
             else:
                 active_ambiguous_targets.discard(target_name)
-    return ambiguous_assignment_nodes
+    return ambiguous_assignment_nodes, propagated_assignment_nodes
 
 
 def _collect_assignment_aliases(
@@ -1809,10 +1811,9 @@ def _collect_assignment_aliases(
     node_list = tuple(nodes)
     assignment_aliases: dict[str, str] = {}
     source_path = _resolve_module_source(module_name)
-    enforce_transient_rebinding = source_path is None or not _is_library_source_path(str(source_path))
-    conditionally_rebound_node_ids = _conditionally_rebound_assignment_nodes(
+    conditionally_rebound_node_ids, propagated_rebound_node_ids = _conditionally_rebound_assignment_nodes(
         node_list,
-        propagate_reads=enforce_transient_rebinding,
+        propagate_reads=source_path is None or not _is_stdlib_source_path(str(source_path)),
     )
     seen_states: set[tuple[tuple[str, str], ...]] = {()}
     passes = 0
@@ -1851,11 +1852,15 @@ def _collect_assignment_aliases(
                     break
         next_state = tuple(sorted(assignment_aliases.items()))
         if next_state == state:
-            final_node_ids = last_resolved_node_ids if enforce_transient_rebinding else last_changed_node_ids
-            if any(
+            changed_conditionally = any(
                 node_id in conditionally_rebound_node_ids.get(target_name, set())
-                for target_name, node_id in final_node_ids.items()
-            ):
+                for target_name, node_id in last_changed_node_ids.items()
+            )
+            resolved_from_conditional_read = any(
+                node_id in propagated_rebound_node_ids.get(target_name, set())
+                for target_name, node_id in last_resolved_node_ids.items()
+            )
+            if changed_conditionally or resolved_from_conditional_read:
                 raise _CallGraphAnalysisLimitError(
                     "assignment alias analysis encountered ambiguous conditional rebinding"
                 )
@@ -1932,8 +1937,13 @@ def _assignment_alias_target_names(node: ast.AST) -> set[str]:
 
 
 def _assignment_alias_read_names(node: ast.AST) -> set[str]:
-    if isinstance(node, ast.Assign | ast.AnnAssign) and node.value is not None:
-        return {child.id for child in ast.walk(node.value) if isinstance(child, ast.Name)}
+    if not isinstance(node, ast.Assign | ast.AnnAssign) or node.value is None:
+        return set()
+    value = node.value
+    while isinstance(value, ast.Attribute):
+        value = value.value
+    if isinstance(value, ast.Name):
+        return {value.id}
     return set()
 
 

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1766,7 +1766,8 @@ def _is_exhaustive_match(node: ast.Match) -> bool:
     )
 
 
-_TerminalAssignmentGroup = tuple[str, tuple[ast.Assign | ast.AnnAssign, ...]]
+_TerminalAssignment = ast.Assign | ast.AnnAssign
+_TerminalAssignmentGroup = tuple[str, tuple[_TerminalAssignment | None, ...]]
 
 
 def _can_complete_normally(branch_body: Iterable[ast.stmt]) -> bool:
@@ -1774,16 +1775,19 @@ def _can_complete_normally(branch_body: Iterable[ast.stmt]) -> bool:
     return not statements or not isinstance(statements[-1], ast.Raise | ast.Return)
 
 
-def _contains_assignment_alias(branch_body: Iterable[ast.stmt]) -> bool:
-    return any(_assignment_alias_target_names(statement) for statement in _definition_scope_statements(branch_body))
+def _assignment_alias_targets(branch_body: Iterable[ast.stmt]) -> set[str]:
+    targets: set[str] = set()
+    for statement in _definition_scope_statements(branch_body):
+        targets.update(_assignment_alias_target_names(statement))
+    return targets
 
 
 def _terminal_assignment_groups(
     branch_bodies: tuple[tuple[ast.stmt, ...], ...],
 ) -> tuple[_TerminalAssignmentGroup, ...]:
-    terminal_assignments: list[dict[str, ast.Assign | ast.AnnAssign]] = []
+    terminal_assignments: list[dict[str, _TerminalAssignment]] = []
     for branch_body in branch_bodies:
-        suffix_assignments: dict[str, ast.Assign | ast.AnnAssign] = {}
+        suffix_assignments: dict[str, _TerminalAssignment] = {}
         for statement in reversed(branch_body):
             if isinstance(statement, ast.Expr | ast.Pass):
                 continue
@@ -1794,9 +1798,9 @@ def _terminal_assignment_groups(
         terminal_assignments.append(suffix_assignments)
     if not terminal_assignments:
         return ()
-    terminal_targets = set.intersection(*(set(assignments) for assignments in terminal_assignments))
+    terminal_targets = set().union(*(set(assignments) for assignments in terminal_assignments))
     return tuple(
-        (target_name, tuple(assignments[target_name] for assignments in terminal_assignments))
+        (target_name, tuple(assignments.get(target_name) for assignments in terminal_assignments))
         for target_name in sorted(terminal_targets)
     )
 
@@ -1821,7 +1825,11 @@ def _conditionally_rebound_assignment_nodes(
             branch_bodies = tuple(
                 branch_body for branch_body in alternate_bodies if _can_complete_normally(branch_body)
             )
-            if any(_contains_assignment_alias(branch_body) for branch_body in terminating_bodies):
+            continuing_targets = set().union(*(_assignment_alias_targets(branch_body) for branch_body in branch_bodies))
+            terminating_targets = set().union(
+                *(_assignment_alias_targets(branch_body) for branch_body in terminating_bodies)
+            )
+            if continuing_targets & terminating_targets:
                 branch_bodies = alternate_bodies
             if len(branch_bodies) < 2:
                 continue
@@ -1837,7 +1845,11 @@ def _conditionally_rebound_assignment_nodes(
             branch_bodies = tuple(
                 branch_body for branch_body in alternate_bodies if _can_complete_normally(branch_body)
             )
-            if any(_contains_assignment_alias(branch_body) for branch_body in terminating_bodies):
+            continuing_targets = set().union(*(_assignment_alias_targets(branch_body) for branch_body in branch_bodies))
+            terminating_targets = set().union(
+                *(_assignment_alias_targets(branch_body) for branch_body in terminating_bodies)
+            )
+            if continuing_targets & terminating_targets:
                 branch_bodies = alternate_bodies
             if len(branch_bodies) < 2:
                 continue
@@ -1880,6 +1892,32 @@ def _resolved_terminal_assignment_nodes(
     class_name: str | None,
 ) -> dict[str, set[int]]:
     deterministic_node_ids: dict[str, set[int]] = {}
+
+    def incoming_alias_value(
+        target_name: str,
+        statements: tuple[_TerminalAssignment | None, ...],
+        effective_ambiguous_node_ids: dict[str, set[int]],
+    ) -> tuple[bool, str | None]:
+        statement_ids = {id(statement) for statement in statements if statement is not None}
+        first_index = min(index for index, node in enumerate(nodes) if id(node) in statement_ids)
+        found_prior_assignment = False
+        incoming_value: str | None = None
+        for node in nodes[:first_index]:
+            if target_name not in _assignment_alias_target_names(node):
+                continue
+            if id(node) in effective_ambiguous_node_ids.get(target_name, set()):
+                continue
+            found_prior_assignment = True
+            incoming_value = _assignment_alias_value(
+                node,
+                module_name,
+                aliases,
+                local_defs,
+                local_class_targets,
+                class_name=class_name,
+            )
+        return found_prior_assignment, incoming_value
+
     while True:
         effective_ambiguous_node_ids = {
             target_name: node_ids - deterministic_node_ids.get(target_name, set())
@@ -1904,10 +1942,11 @@ def _resolved_terminal_assignment_nodes(
             branch_count = len(terminal_assignment_groups[0][1])
             resolved_by_branch: list[dict[str, str]] = []
             for branch_index in range(branch_count):
-                branch_statements = {
-                    id(statements[branch_index]): statements[branch_index]
-                    for _, statements in terminal_assignment_groups
-                }
+                branch_statements: dict[int, _TerminalAssignment] = {}
+                for _, statements in terminal_assignment_groups:
+                    statement = statements[branch_index]
+                    if statement is not None:
+                        branch_statements[id(statement)] = statement
                 branch_aliases = dict(aliases)
                 branch_local_targets: set[str] = set()
                 branch_resolved: dict[str, str] = {}
@@ -1938,11 +1977,34 @@ def _resolved_terminal_assignment_nodes(
                 resolved_by_branch.append(branch_resolved)
 
             for target_name, statements in terminal_assignment_groups:
-                resolved_values = tuple(resolved.get(target_name) for resolved in resolved_by_branch)
-                if None not in resolved_values and len(set(resolved_values)) == 1:
+                present_values = tuple(
+                    resolved_by_branch[index].get(target_name)
+                    for index, statement in enumerate(statements)
+                    if statement is not None
+                )
+                if None in present_values:
+                    continue
+                resolved_values = list(present_values)
+                if any(statement is None for statement in statements):
+                    present_statements = tuple(statement for statement in statements if statement is not None)
+                    if any(
+                        target_name in ambiguous_before_statement.get(id(statement), set())
+                        for statement in present_statements
+                    ):
+                        continue
+                    found_incoming, incoming_value = incoming_alias_value(
+                        target_name,
+                        statements,
+                        effective_ambiguous_node_ids,
+                    )
+                    if found_incoming:
+                        if incoming_value is None:
+                            continue
+                        resolved_values.append(incoming_value)
+                if resolved_values and len(set(resolved_values)) == 1:
                     node_ids = deterministic_node_ids.setdefault(target_name, set())
                     prior_count = len(node_ids)
-                    node_ids.update(id(statement) for statement in statements)
+                    node_ids.update(id(statement) for statement in statements if statement is not None)
                     changed = changed or len(node_ids) != prior_count
         if not changed:
             break

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1673,9 +1673,9 @@ def _collect_assignment_aliases(
 ) -> dict[str, str]:
     node_list = tuple(nodes)
     assignment_aliases: dict[str, str] = {}
-    # A source-flattened branch may rebind one name indefinitely. Track full
-    # states so each distinct state gets a propagation pass before a cycle ends.
-    seen_states: set[tuple[tuple[str, str], ...]] = set()
+    # A source-flattened branch may rebind one name during every pass while its
+    # final state stays stable. Only completed-pass state cycles are incomplete.
+    seen_states: set[tuple[tuple[str, str], ...]] = {()}
     passes = 0
 
     changed = True
@@ -1686,9 +1686,6 @@ def _collect_assignment_aliases(
             )
         passes += 1
         state = tuple(sorted(assignment_aliases.items()))
-        if state in seen_states:
-            raise _CallGraphAnalysisLimitError("assignment alias analysis entered a propagation cycle")
-        seen_states.add(state)
         changed = False
         scoped_aliases = {**aliases, **assignment_aliases}
         for node in node_list:
@@ -1709,6 +1706,12 @@ def _collect_assignment_aliases(
                 changed = True
                 if len(assignment_aliases) >= _MAX_ASSIGNMENT_ALIASES:
                     break
+        next_state = tuple(sorted(assignment_aliases.items()))
+        if next_state == state:
+            break
+        if next_state in seen_states:
+            raise _CallGraphAnalysisLimitError("assignment alias analysis entered a propagation cycle")
+        seen_states.add(next_state)
     return assignment_aliases
 
 

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -1376,8 +1376,9 @@ def test_scan_file_detects_hidden_pytorch_zip_pickle_member_without_data_pickle(
 
 def test_scan_file_leaves_hidden_pickle_like_zip_without_pytorch_metadata_unrecognized(tmp_path: Path) -> None:
     archive_path = tmp_path / "hidden-only.zip"
+    entry = zipfile.ZipInfo("archive/payload", (1980, 1, 1, 0, 0, 0))
     with zipfile.ZipFile(archive_path, "w") as archive:
-        archive.writestr("archive/payload", pickle.dumps({"weights": [1, 2, 3]}, protocol=4))
+        archive.writestr(entry, pickle.dumps({"weights": [1, 2, 3]}, protocol=4))
 
     report = scan_file(archive_path)
 

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -36,7 +36,11 @@ from modelaudit_picklescan import (
     scan_bytes,
     scan_file,
 )
-from modelaudit_picklescan.call_graph import find_startup_hook_write_call_graphs
+from modelaudit_picklescan.call_graph import (
+    CallGraphFinding,
+    _CallGraphAnalysisLimitError,
+    find_startup_hook_write_call_graphs,
+)
 
 
 def _expected_system_global() -> str:
@@ -3510,6 +3514,48 @@ def test_scan_bytes_marks_call_graph_enrichment_failures_incomplete(monkeypatch:
         and error.details["analysis"] == "python_call_graph"
         and error.details["analysis_incomplete"] is True
         for error in report.errors
+    )
+
+
+def test_with_call_graph_findings_preserves_critical_findings_before_limit_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    partial_finding = CallGraphFinding(
+        module="click",
+        name="edit",
+        import_reference="click.edit",
+        sink="os.system",
+        call_path=("click.edit", "os.system"),
+    )
+
+    def raise_call_graph_limit(*_args: object, **_kwargs: object) -> tuple[CallGraphFinding, ...]:
+        raise _CallGraphAnalysisLimitError(
+            "assignment alias analysis entered a propagation cycle",
+            partial_findings=(partial_finding,),
+        )
+
+    monkeypatch.setattr(package_api, "find_dangerous_call_graphs", raise_call_graph_limit)
+    report = PickleReport(
+        source="partial-call-graph-findings.pkl",
+        status=ScanStatus.COMPLETE,
+        verdict=SafetyVerdict.CLEAN,
+        metadata={"import_references": ()},
+    )
+
+    updated = package_api._with_call_graph_findings(report)
+
+    assert updated.status == ScanStatus.INCONCLUSIVE
+    assert updated.verdict == SafetyVerdict.MALICIOUS
+    assert updated.metadata["analysis_incomplete"] is True
+    call_graph_findings = [finding for finding in updated.findings if finding.rule_code == "DANGEROUS_CALL_GRAPH"]
+    assert len(call_graph_findings) == 1
+    assert call_graph_findings[0].details["module"] == "click"
+    assert call_graph_findings[0].details["name"] == "edit"
+    assert any(
+        error.category == "call_graph_analysis_error"
+        and error.exception_type == "_CallGraphAnalysisLimitError"
+        and error.details["analysis_incomplete"] is True
+        for error in updated.errors
     )
 
 

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -38,6 +38,7 @@ from modelaudit_picklescan import (
 )
 from modelaudit_picklescan.call_graph import (
     CallGraphFinding,
+    StartupHookWriteFinding,
     _CallGraphAnalysisLimitError,
     find_startup_hook_write_call_graphs,
 )
@@ -3590,6 +3591,55 @@ def test_with_call_graph_findings_marks_startup_hook_enrichment_failures_incompl
         and error.exception_type == "RuntimeError"
         and error.details["analysis"] == "python_call_graph_startup_hook_write"
         and error.details["analysis_incomplete"] is True
+        for error in updated.errors
+    )
+
+
+def test_with_call_graph_findings_preserves_startup_hook_findings_before_limit_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    partial_finding = StartupHookWriteFinding(
+        opener_module="click",
+        opener_name="open_file",
+        writer_module="click",
+        writer_name="echo",
+        opener_import_reference="click.open_file",
+        writer_import_reference="click.echo",
+        open_sink="builtins.open",
+        write_sink="binary_file.write",
+        opener_call_path=("click.open_file", "builtins.open"),
+        writer_call_path=("click.echo", "binary_file.write"),
+    )
+
+    def raise_startup_hook_limit(*_args: object, **_kwargs: object) -> tuple[StartupHookWriteFinding, ...]:
+        raise _CallGraphAnalysisLimitError(
+            "assignment alias analysis entered a propagation cycle",
+            partial_startup_hook_write_findings=(partial_finding,),
+        )
+
+    monkeypatch.setattr(package_api, "find_startup_hook_write_call_graphs", raise_startup_hook_limit)
+    report = PickleReport(
+        source="partial-startup-hook-findings.pkl",
+        status=ScanStatus.COMPLETE,
+        verdict=SafetyVerdict.CLEAN,
+        metadata={"import_references": ()},
+    )
+
+    updated = package_api._with_call_graph_findings(report)
+
+    assert updated.status == ScanStatus.INCONCLUSIVE
+    assert updated.verdict == SafetyVerdict.MALICIOUS
+    assert updated.metadata["analysis_incomplete"] is True
+    startup_findings = [
+        finding for finding in updated.findings if finding.rule_code == "DANGEROUS_CALL_GRAPH_FILE_WRITE"
+    ]
+    assert len(startup_findings) == 1
+    assert startup_findings[0].details["opener_name"] == "open_file"
+    assert startup_findings[0].details["name"] == "echo"
+    assert any(
+        error.category == "call_graph_analysis_error"
+        and error.exception_type == "_CallGraphAnalysisLimitError"
+        and error.details["analysis"] == "python_call_graph_startup_hook_write"
         for error in updated.errors
     )
 

--- a/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
@@ -107,6 +107,47 @@ else:
     m = B()
 """
 
+_UNCONDITIONAL_OVERWRITE_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+class Final:
+    pass
+
+
+if cond:
+    m = A()
+else:
+    m = B()
+m = Final()
+"""
+
+_TRY_FINALLY_REBIND_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+class Final:
+    pass
+
+
+try:
+    m = A()
+except Exception:
+    m = B()
+finally:
+    m = Final()
+"""
+
 
 def _run_with_timeout(target: object, timeout: float = 10.0) -> None:
     thread = threading.Thread(target=target)  # type: ignore[arg-type]
@@ -146,11 +187,23 @@ def test_collect_assignment_aliases_fails_closed_on_stable_branch_rebind(source:
     assert result == {"limited": True}
 
 
-def test_collect_assignment_aliases_converges_on_sequential_rebind() -> None:
-    tree = ast.parse(_SEQUENTIAL_REBIND_SOURCE)
+@pytest.mark.parametrize(
+    ("source", "expected_target"),
+    (
+        (_SEQUENTIAL_REBIND_SOURCE, "testmod.B"),
+        (_UNCONDITIONAL_OVERWRITE_SOURCE, "testmod.Final"),
+        (_TRY_FINALLY_REBIND_SOURCE, "testmod.Final"),
+    ),
+    ids=("sequential", "unconditional-overwrite", "try-finally-overwrite"),
+)
+def test_collect_assignment_aliases_converges_on_deterministic_final_rebind(
+    source: str,
+    expected_target: str,
+) -> None:
+    tree = ast.parse(source)
     statements = _module_level_statements(tree)
     local_defs = _collect_local_defs(statements)
-    local_class_targets = {"testmod.A", "testmod.B"}
+    local_class_targets = {"testmod.A", "testmod.B", "testmod.Final"}
 
     aliases = _collect_assignment_aliases(
         statements,
@@ -160,7 +213,7 @@ def test_collect_assignment_aliases_converges_on_sequential_rebind() -> None:
         local_class_targets,
     )
 
-    assert aliases["m"] == "testmod.B"
+    assert aliases["m"] == expected_target
 
 
 def test_collect_assignment_aliases_fails_closed_on_cyclic_dependency_propagation() -> None:
@@ -282,6 +335,47 @@ def test_assignment_alias_limit_preserves_prior_call_graph_findings(
     )
 
 
+def test_assignment_alias_limit_preserves_later_call_graph_findings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    references = (
+        {"module": "limited", "name": "entry"},
+        {"module": "dangerous", "name": "entry"},
+    )
+
+    def _iter_references(
+        _import_references: object,
+        _callable_references: tuple[dict[str, object], ...],
+        _invoked_references: set[tuple[str, str]],
+    ) -> tuple[dict[str, str], ...]:
+        return references
+
+    def _entrypoints(module: str, name: str, _reference: dict[str, object]) -> tuple[str, ...]:
+        return (f"{module}.{name}",)
+
+    def _path(entrypoints: Iterable[str], _path_for: object) -> tuple[str, ...] | None:
+        if tuple(entrypoints) == ("limited.entry",):
+            raise _CallGraphAnalysisLimitError("assignment alias limit")
+        return ("dangerous.entry", "builtins.exec")
+
+    monkeypatch.setattr("modelaudit_picklescan.call_graph._iter_call_graph_references", _iter_references)
+    monkeypatch.setattr("modelaudit_picklescan.call_graph._call_graph_entrypoints_for_reference", _entrypoints)
+    monkeypatch.setattr("modelaudit_picklescan.call_graph._first_matching_path", _path)
+
+    with pytest.raises(_CallGraphAnalysisLimitError, match="assignment alias limit") as exc_info:
+        find_dangerous_call_graphs(())
+
+    assert exc_info.value.partial_findings == (
+        CallGraphFinding(
+            module="dangerous",
+            name="entry",
+            import_reference="dangerous.entry",
+            sink="builtins.exec",
+            call_path=("dangerous.entry", "builtins.exec"),
+        ),
+    )
+
+
 def test_assignment_alias_limit_preserves_prior_startup_hook_findings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -289,6 +383,51 @@ def test_assignment_alias_limit_preserves_prior_startup_hook_findings(
         {"module": "opener", "name": "entry"},
         {"module": "writer", "name": "entry"},
         {"module": "limited", "name": "entry"},
+    )
+
+    def _entrypoints(function_name: str) -> tuple[str, ...]:
+        if function_name == "limited.entry":
+            raise _CallGraphAnalysisLimitError("assignment alias limit")
+        return (function_name,)
+
+    def _path(entrypoints: Iterable[str], path_for: object) -> tuple[str, ...] | None:
+        entrypoint = next(iter(entrypoints))
+        path_name = getattr(path_for, "__name__", "")
+        if path_name == "_find_file_open_path" and entrypoint == "opener.entry":
+            return ("opener.entry", "builtins.open")
+        if path_name == "_find_file_write_path" and entrypoint == "writer.entry":
+            return ("writer.entry", "binary_file.write")
+        return None
+
+    monkeypatch.setattr("modelaudit_picklescan.call_graph._safe_call_graph_entrypoints", _entrypoints)
+    monkeypatch.setattr("modelaudit_picklescan.call_graph._first_matching_path", _path)
+
+    with pytest.raises(_CallGraphAnalysisLimitError, match="assignment alias limit") as exc_info:
+        find_startup_hook_write_call_graphs(references)
+
+    assert exc_info.value.partial_startup_hook_write_findings == (
+        StartupHookWriteFinding(
+            opener_module="opener",
+            opener_name="entry",
+            writer_module="writer",
+            writer_name="entry",
+            opener_import_reference="opener.entry",
+            writer_import_reference="writer.entry",
+            open_sink="builtins.open",
+            write_sink="binary_file.write",
+            opener_call_path=("opener.entry", "builtins.open"),
+            writer_call_path=("writer.entry", "binary_file.write"),
+        ),
+    )
+
+
+def test_assignment_alias_limit_preserves_later_startup_hook_findings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    references = (
+        {"module": "limited", "name": "entry"},
+        {"module": "opener", "name": "entry"},
+        {"module": "writer", "name": "entry"},
     )
 
     def _entrypoints(function_name: str) -> tuple[str, ...]:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
@@ -38,6 +38,22 @@ else:
     m = B()
 """
 
+_DEPENDENT_CYCLE_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+a = A()
+a = b
+b = B()
+b = a
+c = a
+"""
+
 
 def _run_with_timeout(target: object, timeout: float = 10.0) -> None:
     thread = threading.Thread(target=target)  # type: ignore[arg-type]
@@ -71,6 +87,28 @@ def test_collect_assignment_aliases_terminates_on_branch_rebind() -> None:
     # The rebinding name still resolves to one of the two local classes; the
     # exact branch is order-dependent, but the loop must converge.
     assert aliases.get("m") in {"testmod.A", "testmod.B"}
+
+
+def test_collect_assignment_aliases_terminates_after_cyclic_dependency_propagation() -> None:
+    tree = ast.parse(_DEPENDENT_CYCLE_SOURCE)
+    statements = _module_level_statements(tree)
+    local_defs = _collect_local_defs(statements)
+    local_class_targets = {"testmod.A", "testmod.B"}
+
+    result: dict[str, dict[str, str]] = {}
+
+    def _collect() -> None:
+        result["aliases"] = _collect_assignment_aliases(
+            statements,
+            "testmod",
+            {},
+            local_defs,
+            local_class_targets,
+        )
+
+    _run_with_timeout(_collect)
+
+    assert result["aliases"].get("c") in local_class_targets
 
 
 def _stack_global_payload(module: str, name: str) -> bytes:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
@@ -127,16 +127,36 @@ class A:
     pass
 
 
-class B:
+class Final:
     pass
 
 
 m = A()
 for value in values:
-    m = B()
+    m = Final()
     break
 else:
-    m = B()
+    m = Final()
+exposed = m
+"""
+
+_LOOP_EARLY_BREAK_BEFORE_TERMINAL_REBIND_SOURCE = """\
+class A:
+    pass
+
+
+class Final:
+    pass
+
+
+m = A()
+for value in values:
+    if cond:
+        break
+    m = Final()
+    break
+else:
+    m = Final()
 exposed = m
 """
 
@@ -235,6 +255,54 @@ match value:
 exposed = m
 """
 
+_CONDITIONALLY_REBOUND_TERMINAL_DEPENDENCY_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+class Final:
+    pass
+
+
+if cond:
+    F = A
+else:
+    F = B
+if cond:
+    m = F()
+else:
+    m = F()
+F = Final
+exposed = m
+"""
+
+_BRANCH_READ_BEFORE_MATCHING_TERMINAL_OVERWRITE_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+class Final:
+    pass
+
+
+if cond:
+    m = A()
+    exposed = m
+    m = Final()
+else:
+    m = B()
+    exposed = m
+    m = Final()
+"""
+
 _MATCHING_BRANCH_OVERWRITE_SOURCE = """\
 class A:
     pass
@@ -254,6 +322,77 @@ if cond:
 else:
     m = B()
     m = Final()
+exposed = m
+"""
+
+_RESOLVED_MATCHING_BRANCH_OVERWRITE_SOURCE = """\
+class Final:
+    pass
+
+
+F = Final
+if cond:
+    m = F()
+else:
+    m = Final()
+exposed = m
+"""
+
+_MATCHING_TRY_EXCEPT_OVERWRITE_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+class Final:
+    pass
+
+
+try:
+    m = A()
+    m = Final()
+except Exception:
+    m = B()
+    m = Final()
+exposed = m
+"""
+
+_EXHAUSTIVE_MATCH_OVERWRITE_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+class Final:
+    pass
+
+
+match value:
+    case 1:
+        m = A()
+        m = Final()
+        exposed = m
+    case _:
+        m = B()
+        m = Final()
+        exposed = m
+"""
+
+_TRY_FINALLY_NO_HANDLER_SOURCE = """\
+class Final:
+    pass
+
+
+try:
+    m = Final()
+finally:
+    cleanup()
 exposed = m
 """
 
@@ -294,26 +433,30 @@ def _run_with_timeout(target: object, timeout: float = 10.0) -> None:
         _OSCILLATING_MODULE_SOURCE,
         _TRY_REBIND_SOURCE,
         _LOOP_ELSE_REBIND_SOURCE,
-        _LOOP_MATCHING_TERMINAL_REBIND_SOURCE,
+        _LOOP_EARLY_BREAK_BEFORE_TERMINAL_REBIND_SOURCE,
         _READ_BEFORE_UNCONDITIONAL_OVERWRITE_SOURCE,
         _ONE_SIDED_REBIND_SOURCE,
         _NONEXHAUSTIVE_MATCH_OVERWRITE_SOURCE,
+        _CONDITIONALLY_REBOUND_TERMINAL_DEPENDENCY_SOURCE,
+        _BRANCH_READ_BEFORE_MATCHING_TERMINAL_OVERWRITE_SOURCE,
     ),
     ids=(
         "if-else",
         "try-except",
         "loop-else",
-        "loop-matching-terminal",
+        "loop-early-break",
         "read-before-overwrite",
         "one-sided-rebind",
         "match-no-default",
+        "conditional-terminal-dependency",
+        "branch-read-before-terminal-overwrite",
     ),
 )
 def test_collect_assignment_aliases_fails_closed_on_stable_branch_rebind(source: str) -> None:
     tree = ast.parse(source)
     statements = _module_level_statements(tree)
     local_defs = _collect_local_defs(statements)
-    local_class_targets = {"testmod.A", "testmod.B"}
+    local_class_targets = {"testmod.A", "testmod.B", "testmod.Final"}
 
     result: dict[str, bool] = {}
 
@@ -380,8 +523,27 @@ def test_collect_assignment_aliases_allows_alias_read_after_deterministic_overwr
     assert aliases["exposed"] == "testmod.Final"
 
 
-def test_collect_assignment_aliases_allows_matching_terminal_branch_overwrites() -> None:
-    tree = ast.parse(_MATCHING_BRANCH_OVERWRITE_SOURCE)
+@pytest.mark.parametrize(
+    "source",
+    (
+        _MATCHING_BRANCH_OVERWRITE_SOURCE,
+        _RESOLVED_MATCHING_BRANCH_OVERWRITE_SOURCE,
+        _MATCHING_TRY_EXCEPT_OVERWRITE_SOURCE,
+        _EXHAUSTIVE_MATCH_OVERWRITE_SOURCE,
+        _LOOP_MATCHING_TERMINAL_REBIND_SOURCE,
+        _TRY_FINALLY_NO_HANDLER_SOURCE,
+    ),
+    ids=(
+        "if-else",
+        "if-semantic-resolution",
+        "try-except",
+        "exhaustive-match",
+        "loop-terminal-break",
+        "try-finally-no-handler",
+    ),
+)
+def test_collect_assignment_aliases_allows_matching_terminal_branch_overwrites(source: str) -> None:
+    tree = ast.parse(source)
     statements = _module_level_statements(tree)
     local_defs = _collect_local_defs(statements)
 

--- a/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
@@ -107,6 +107,21 @@ else:
     m = B()
 """
 
+_LOOP_ELSE_COMPLETION_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+for value in values:
+    m = A()
+else:
+    m = B()
+"""
+
 _UNCONDITIONAL_OVERWRITE_SOURCE = """\
 class A:
     pass
@@ -191,10 +206,11 @@ def test_collect_assignment_aliases_fails_closed_on_stable_branch_rebind(source:
     ("source", "expected_target"),
     (
         (_SEQUENTIAL_REBIND_SOURCE, "testmod.B"),
+        (_LOOP_ELSE_COMPLETION_SOURCE, "testmod.B"),
         (_UNCONDITIONAL_OVERWRITE_SOURCE, "testmod.Final"),
         (_TRY_FINALLY_REBIND_SOURCE, "testmod.Final"),
     ),
-    ids=("sequential", "unconditional-overwrite", "try-finally-overwrite"),
+    ids=("sequential", "loop-else-completion", "unconditional-overwrite", "try-finally-overwrite"),
 )
 def test_collect_assignment_aliases_converges_on_deterministic_final_rebind(
     source: str,

--- a/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
@@ -62,6 +62,51 @@ b = a
 c = a
 """
 
+_SEQUENTIAL_REBIND_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+m = A()
+m = B()
+"""
+
+_TRY_REBIND_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+try:
+    m = A()
+    operation()
+except Exception:
+    m = B()
+"""
+
+_LOOP_ELSE_REBIND_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+for value in values:
+    m = A()
+    break
+else:
+    m = B()
+"""
+
 
 def _run_with_timeout(target: object, timeout: float = 10.0) -> None:
     thread = threading.Thread(target=target)  # type: ignore[arg-type]
@@ -72,26 +117,50 @@ def _run_with_timeout(target: object, timeout: float = 10.0) -> None:
         pytest.fail(f"call-graph analysis did not terminate within {timeout}s")
 
 
-def test_collect_assignment_aliases_converges_on_stable_branch_rebind() -> None:
-    tree = ast.parse(_OSCILLATING_MODULE_SOURCE)
+@pytest.mark.parametrize(
+    "source",
+    (_OSCILLATING_MODULE_SOURCE, _TRY_REBIND_SOURCE, _LOOP_ELSE_REBIND_SOURCE),
+    ids=("if-else", "try-except", "loop-else"),
+)
+def test_collect_assignment_aliases_fails_closed_on_stable_branch_rebind(source: str) -> None:
+    tree = ast.parse(source)
     statements = _module_level_statements(tree)
     local_defs = _collect_local_defs(statements)
     local_class_targets = {"testmod.A", "testmod.B"}
 
-    result: dict[str, dict[str, str]] = {}
+    result: dict[str, bool] = {}
 
     def _collect() -> None:
-        result["aliases"] = _collect_assignment_aliases(
-            statements,
-            "testmod",
-            {},
-            local_defs,
-            local_class_targets,
-        )
+        with pytest.raises(_CallGraphAnalysisLimitError, match="ambiguous conditional rebinding"):
+            _collect_assignment_aliases(
+                statements,
+                "testmod",
+                {},
+                local_defs,
+                local_class_targets,
+            )
+        result["limited"] = True
 
     _run_with_timeout(_collect)
 
-    assert result["aliases"]["m"] == "testmod.B"
+    assert result == {"limited": True}
+
+
+def test_collect_assignment_aliases_converges_on_sequential_rebind() -> None:
+    tree = ast.parse(_SEQUENTIAL_REBIND_SOURCE)
+    statements = _module_level_statements(tree)
+    local_defs = _collect_local_defs(statements)
+    local_class_targets = {"testmod.A", "testmod.B"}
+
+    aliases = _collect_assignment_aliases(
+        statements,
+        "testmod",
+        {},
+        local_defs,
+        local_class_targets,
+    )
+
+    assert aliases["m"] == "testmod.B"
 
 
 def test_collect_assignment_aliases_fails_closed_on_cyclic_dependency_propagation() -> None:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
@@ -325,6 +325,30 @@ else:
 exposed = m
 """
 
+_MATCHING_BRANCH_EPILOGUE_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+class Final:
+    pass
+
+
+if cond:
+    m = A()
+    m = Final()
+    log()
+else:
+    m = B()
+    m = Final()
+    log()
+exposed = m
+"""
+
 _RESOLVED_MATCHING_BRANCH_OVERWRITE_SOURCE = """\
 class Final:
     pass
@@ -527,6 +551,7 @@ def test_collect_assignment_aliases_allows_alias_read_after_deterministic_overwr
     "source",
     (
         _MATCHING_BRANCH_OVERWRITE_SOURCE,
+        _MATCHING_BRANCH_EPILOGUE_SOURCE,
         _RESOLVED_MATCHING_BRANCH_OVERWRITE_SOURCE,
         _MATCHING_TRY_EXCEPT_OVERWRITE_SOURCE,
         _EXHAUSTIVE_MATCH_OVERWRITE_SOURCE,
@@ -535,6 +560,7 @@ def test_collect_assignment_aliases_allows_alias_read_after_deterministic_overwr
     ),
     ids=(
         "if-else",
+        "if-expression-epilogue",
         "if-semantic-resolution",
         "try-except",
         "exhaustive-match",

--- a/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
@@ -67,28 +67,26 @@ def _run_with_timeout(target: object, timeout: float = 10.0) -> None:
         pytest.fail(f"call-graph analysis did not terminate within {timeout}s")
 
 
-def test_collect_assignment_aliases_fails_closed_on_branch_rebind() -> None:
+def test_collect_assignment_aliases_converges_on_stable_branch_rebind() -> None:
     tree = ast.parse(_OSCILLATING_MODULE_SOURCE)
     statements = _module_level_statements(tree)
     local_defs = _collect_local_defs(statements)
     local_class_targets = {"testmod.A", "testmod.B"}
 
-    result: dict[str, bool] = {}
+    result: dict[str, dict[str, str]] = {}
 
     def _collect() -> None:
-        with pytest.raises(_CallGraphAnalysisLimitError, match="entered a propagation cycle"):
-            _collect_assignment_aliases(
-                statements,
-                "testmod",
-                {},
-                local_defs,
-                local_class_targets,
-            )
-        result["limited"] = True
+        result["aliases"] = _collect_assignment_aliases(
+            statements,
+            "testmod",
+            {},
+            local_defs,
+            local_class_targets,
+        )
 
     _run_with_timeout(_collect)
 
-    assert result == {"limited": True}
+    assert result["aliases"]["m"] == "testmod.B"
 
 
 def test_collect_assignment_aliases_fails_closed_on_cyclic_dependency_propagation() -> None:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
@@ -479,6 +479,44 @@ else:
 exposed = m
 """
 
+_MATCHING_ONE_SIDED_REBIND_SOURCE = """\
+class Final:
+    pass
+
+
+m = Final()
+if cond:
+    m = Final()
+exposed = m
+"""
+
+_UNBOUND_ONE_SIDED_REBIND_SOURCE = """\
+class Final:
+    pass
+
+
+if cond:
+    m = Final()
+exposed = m
+"""
+
+_TERMINATING_UNRELATED_ALIAS_SOURCE = """\
+class A:
+    pass
+
+
+class Final:
+    pass
+
+
+if cond:
+    unused = A()
+    raise ImportError
+else:
+    m = Final()
+exposed = m
+"""
+
 _MATCHING_TRY_EXCEPT_OVERWRITE_SOURCE = """\
 class A:
     pass
@@ -679,6 +717,9 @@ def test_collect_assignment_aliases_allows_alias_read_after_deterministic_overwr
         _MUTUALLY_DEPENDENT_TERMINAL_ALIAS_SOURCE,
         _TERMINATING_ALTERNATIVE_SOURCE,
         _SCOPED_TERMINAL_DEPENDENCY_SOURCE,
+        _MATCHING_ONE_SIDED_REBIND_SOURCE,
+        _UNBOUND_ONE_SIDED_REBIND_SOURCE,
+        _TERMINATING_UNRELATED_ALIAS_SOURCE,
         _MATCHING_TRY_EXCEPT_OVERWRITE_SOURCE,
         _EXHAUSTIVE_MATCH_OVERWRITE_SOURCE,
         _LOOP_MATCHING_TERMINAL_REBIND_SOURCE,
@@ -693,6 +734,9 @@ def test_collect_assignment_aliases_allows_alias_read_after_deterministic_overwr
         "mutually-dependent-terminal-alias",
         "terminating-alternative",
         "scoped-terminal-dependency",
+        "matching-one-sided-rebind",
+        "unbound-one-sided-rebind",
+        "terminating-unrelated-alias",
         "try-except",
         "exhaustive-match",
         "loop-terminal-break",

--- a/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
@@ -15,14 +15,15 @@ from importlib.util import find_spec
 
 import pytest
 
-import modelaudit_picklescan.call_graph as call_graph
 from modelaudit_picklescan import PickleReport, Severity, scan_bytes
 from modelaudit_picklescan.api import _RUST_EXTENSION_MODULE
 from modelaudit_picklescan.call_graph import (
     _CallGraphAnalysisLimitError,
     _collect_assignment_aliases,
     _collect_local_defs,
+    _first_matching_path,
     _module_level_statements,
+    _safe_call_graph_entrypoints,
 )
 
 _OSCILLATING_MODULE_SOURCE = """\
@@ -66,51 +67,52 @@ def _run_with_timeout(target: object, timeout: float = 10.0) -> None:
         pytest.fail(f"call-graph analysis did not terminate within {timeout}s")
 
 
-def test_collect_assignment_aliases_terminates_on_branch_rebind() -> None:
+def test_collect_assignment_aliases_fails_closed_on_branch_rebind() -> None:
     tree = ast.parse(_OSCILLATING_MODULE_SOURCE)
     statements = _module_level_statements(tree)
     local_defs = _collect_local_defs(statements)
     local_class_targets = {"testmod.A", "testmod.B"}
 
-    result: dict[str, dict[str, str]] = {}
+    result: dict[str, bool] = {}
 
     def _collect() -> None:
-        result["aliases"] = _collect_assignment_aliases(
-            statements,
-            "testmod",
-            {},
-            local_defs,
-            local_class_targets,
-        )
+        with pytest.raises(_CallGraphAnalysisLimitError, match="entered a propagation cycle"):
+            _collect_assignment_aliases(
+                statements,
+                "testmod",
+                {},
+                local_defs,
+                local_class_targets,
+            )
+        result["limited"] = True
 
     _run_with_timeout(_collect)
 
-    aliases = result["aliases"]
-    # The rebinding name still resolves to one of the two local classes; the
-    # exact branch is order-dependent, but the loop must converge.
-    assert aliases.get("m") in {"testmod.A", "testmod.B"}
+    assert result == {"limited": True}
 
 
-def test_collect_assignment_aliases_terminates_after_cyclic_dependency_propagation() -> None:
+def test_collect_assignment_aliases_fails_closed_on_cyclic_dependency_propagation() -> None:
     tree = ast.parse(_DEPENDENT_CYCLE_SOURCE)
     statements = _module_level_statements(tree)
     local_defs = _collect_local_defs(statements)
     local_class_targets = {"testmod.A", "testmod.B"}
 
-    result: dict[str, dict[str, str]] = {}
+    result: dict[str, bool] = {}
 
     def _collect() -> None:
-        result["aliases"] = _collect_assignment_aliases(
-            statements,
-            "testmod",
-            {},
-            local_defs,
-            local_class_targets,
-        )
+        with pytest.raises(_CallGraphAnalysisLimitError, match="entered a propagation cycle"):
+            _collect_assignment_aliases(
+                statements,
+                "testmod",
+                {},
+                local_defs,
+                local_class_targets,
+            )
+        result["limited"] = True
 
     _run_with_timeout(_collect)
 
-    assert result["aliases"].get("c") in local_class_targets
+    assert result == {"limited": True}
 
 
 def test_collect_assignment_aliases_fails_closed_on_long_period_cycles() -> None:
@@ -152,11 +154,19 @@ def test_assignment_alias_limit_is_not_hidden_by_safe_entrypoint_wrapper(monkeyp
     def _raise_limit(_function_name: str) -> tuple[str, ...]:
         raise _CallGraphAnalysisLimitError("assignment alias limit")
 
-    monkeypatch.setattr(call_graph, "_call_graph_entrypoints", _raise_limit)
-    call_graph._safe_call_graph_entrypoints.cache_clear()
+    monkeypatch.setattr("modelaudit_picklescan.call_graph._call_graph_entrypoints", _raise_limit)
+    _safe_call_graph_entrypoints.cache_clear()
 
     with pytest.raises(_CallGraphAnalysisLimitError, match="assignment alias limit"):
-        call_graph._safe_call_graph_entrypoints("long_period.module")
+        _safe_call_graph_entrypoints("long_period.module")
+
+
+def test_assignment_alias_limit_is_not_hidden_by_path_search() -> None:
+    def _raise_limit(_entrypoint: str) -> tuple[str, ...] | None:
+        raise _CallGraphAnalysisLimitError("assignment alias limit")
+
+    with pytest.raises(_CallGraphAnalysisLimitError, match="assignment alias limit"):
+        _first_matching_path(("wrapper.entrypoint",), _raise_limit)
 
 
 def _stack_global_payload(module: str, name: str) -> bytes:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
@@ -201,6 +201,27 @@ exposed = m
 m = Final()
 """
 
+_CALL_READ_BEFORE_UNCONDITIONAL_OVERWRITE_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+class Final:
+    pass
+
+
+if cond:
+    m = A()
+else:
+    m = B()
+exposed = m()
+m = Final()
+"""
+
 _OVERWRITE_BEFORE_READ_SOURCE = """\
 class A:
     pass
@@ -459,6 +480,7 @@ def _run_with_timeout(target: object, timeout: float = 10.0) -> None:
         _LOOP_ELSE_REBIND_SOURCE,
         _LOOP_EARLY_BREAK_BEFORE_TERMINAL_REBIND_SOURCE,
         _READ_BEFORE_UNCONDITIONAL_OVERWRITE_SOURCE,
+        _CALL_READ_BEFORE_UNCONDITIONAL_OVERWRITE_SOURCE,
         _ONE_SIDED_REBIND_SOURCE,
         _NONEXHAUSTIVE_MATCH_OVERWRITE_SOURCE,
         _CONDITIONALLY_REBOUND_TERMINAL_DEPENDENCY_SOURCE,
@@ -470,6 +492,7 @@ def _run_with_timeout(target: object, timeout: float = 10.0) -> None:
         "loop-else",
         "loop-early-break",
         "read-before-overwrite",
+        "call-read-before-overwrite",
         "one-sided-rebind",
         "match-no-default",
         "conditional-terminal-dependency",

--- a/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
@@ -15,9 +15,11 @@ from importlib.util import find_spec
 
 import pytest
 
+import modelaudit_picklescan.call_graph as call_graph
 from modelaudit_picklescan import PickleReport, Severity, scan_bytes
 from modelaudit_picklescan.api import _RUST_EXTENSION_MODULE
 from modelaudit_picklescan.call_graph import (
+    _CallGraphAnalysisLimitError,
     _collect_assignment_aliases,
     _collect_local_defs,
     _module_level_statements,
@@ -109,6 +111,52 @@ def test_collect_assignment_aliases_terminates_after_cyclic_dependency_propagati
     _run_with_timeout(_collect)
 
     assert result["aliases"].get("c") in local_class_targets
+
+
+def test_collect_assignment_aliases_fails_closed_on_long_period_cycles() -> None:
+    periods = (7, 11, 13, 17, 19)
+    source_lines: list[str] = []
+    local_class_targets: set[str] = set()
+    for ring_index, period in enumerate(periods):
+        for position in range(period):
+            class_name = f"Ring{ring_index}Class{position}"
+            variable_name = f"ring_{ring_index}_{position}"
+            source_lines.extend((f"class {class_name}:", "    pass", "", f"{variable_name} = {class_name}()", ""))
+            local_class_targets.add(f"testmod.{class_name}")
+        for position in range(period):
+            next_position = (position + 1) % period
+            source_lines.append(f"ring_{ring_index}_{position} = ring_{ring_index}_{next_position}")
+
+    tree = ast.parse("\n".join(source_lines))
+    statements = _module_level_statements(tree)
+    local_defs = _collect_local_defs(statements)
+    result: dict[str, bool] = {}
+
+    def _collect() -> None:
+        with pytest.raises(_CallGraphAnalysisLimitError):
+            _collect_assignment_aliases(
+                statements,
+                "testmod",
+                {},
+                local_defs,
+                local_class_targets,
+            )
+        result["limited"] = True
+
+    _run_with_timeout(_collect)
+
+    assert result == {"limited": True}
+
+
+def test_assignment_alias_limit_is_not_hidden_by_safe_entrypoint_wrapper(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise_limit(_function_name: str) -> tuple[str, ...]:
+        raise _CallGraphAnalysisLimitError("assignment alias limit")
+
+    monkeypatch.setattr(call_graph, "_call_graph_entrypoints", _raise_limit)
+    call_graph._safe_call_graph_entrypoints.cache_clear()
+
+    with pytest.raises(_CallGraphAnalysisLimitError, match="assignment alias limit"):
+        call_graph._safe_call_graph_entrypoints("long_period.module")
 
 
 def _stack_global_payload(module: str, name: str) -> bytes:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
@@ -383,6 +383,18 @@ else:
 exposed = m
 """
 
+_SAME_LINE_RESOLVED_MATCHING_BRANCH_OVERWRITE_SOURCE = """\
+class Final:
+    pass
+
+
+if cond:
+    F = Final; m = F()
+else:
+    F = Final; m = F()
+exposed = m
+"""
+
 _MATCHING_TRY_EXCEPT_OVERWRITE_SOURCE = """\
 class A:
     pass
@@ -576,6 +588,7 @@ def test_collect_assignment_aliases_allows_alias_read_after_deterministic_overwr
         _MATCHING_BRANCH_OVERWRITE_SOURCE,
         _MATCHING_BRANCH_EPILOGUE_SOURCE,
         _RESOLVED_MATCHING_BRANCH_OVERWRITE_SOURCE,
+        _SAME_LINE_RESOLVED_MATCHING_BRANCH_OVERWRITE_SOURCE,
         _MATCHING_TRY_EXCEPT_OVERWRITE_SOURCE,
         _EXHAUSTIVE_MATCH_OVERWRITE_SOURCE,
         _LOOP_MATCHING_TERMINAL_REBIND_SOURCE,
@@ -585,6 +598,7 @@ def test_collect_assignment_aliases_allows_alias_read_after_deterministic_overwr
         "if-else",
         "if-expression-epilogue",
         "if-semantic-resolution",
+        "if-same-line-semantic-resolution",
         "try-except",
         "exhaustive-match",
         "loop-terminal-break",

--- a/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
@@ -222,6 +222,24 @@ exposed = m()
 m = Final()
 """
 
+_TERMINATING_ALIAS_BRANCH_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+if cond:
+    m = A()
+    consumed = m
+    raise ImportError
+else:
+    m = B()
+exposed = m
+"""
+
 _OVERWRITE_BEFORE_READ_SOURCE = """\
 class A:
     pass
@@ -395,6 +413,72 @@ else:
 exposed = m
 """
 
+_OVERWRITTEN_TERMINAL_DEPENDENCY_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+class Final:
+    pass
+
+
+if cond:
+    F = A
+else:
+    F = B
+F = Final
+if cond:
+    m = F()
+else:
+    m = F()
+exposed = m
+"""
+
+_MUTUALLY_DEPENDENT_TERMINAL_ALIAS_SOURCE = """\
+class Final:
+    pass
+
+
+if cond:
+    m = Final()
+    exposed = m
+else:
+    exposed = Final()
+    m = exposed
+"""
+
+_TERMINATING_ALTERNATIVE_SOURCE = """\
+class Final:
+    pass
+
+
+if cond:
+    m = Final()
+else:
+    raise ImportError
+exposed = m
+"""
+
+_SCOPED_TERMINAL_DEPENDENCY_SOURCE = """\
+class Final:
+    pass
+
+
+if cond:
+    F = first_value
+else:
+    F = second_value
+if cond:
+    m = Final([F for F in values])
+else:
+    m = Final(lambda F: F)
+exposed = m
+"""
+
 _MATCHING_TRY_EXCEPT_OVERWRITE_SOURCE = """\
 class A:
     pass
@@ -493,6 +577,7 @@ def _run_with_timeout(target: object, timeout: float = 10.0) -> None:
         _LOOP_EARLY_BREAK_BEFORE_TERMINAL_REBIND_SOURCE,
         _READ_BEFORE_UNCONDITIONAL_OVERWRITE_SOURCE,
         _CALL_READ_BEFORE_UNCONDITIONAL_OVERWRITE_SOURCE,
+        _TERMINATING_ALIAS_BRANCH_SOURCE,
         _ONE_SIDED_REBIND_SOURCE,
         _NONEXHAUSTIVE_MATCH_OVERWRITE_SOURCE,
         _CONDITIONALLY_REBOUND_TERMINAL_DEPENDENCY_SOURCE,
@@ -505,6 +590,7 @@ def _run_with_timeout(target: object, timeout: float = 10.0) -> None:
         "loop-early-break",
         "read-before-overwrite",
         "call-read-before-overwrite",
+        "terminating-alias-branch",
         "one-sided-rebind",
         "match-no-default",
         "conditional-terminal-dependency",
@@ -589,6 +675,10 @@ def test_collect_assignment_aliases_allows_alias_read_after_deterministic_overwr
         _MATCHING_BRANCH_EPILOGUE_SOURCE,
         _RESOLVED_MATCHING_BRANCH_OVERWRITE_SOURCE,
         _SAME_LINE_RESOLVED_MATCHING_BRANCH_OVERWRITE_SOURCE,
+        _OVERWRITTEN_TERMINAL_DEPENDENCY_SOURCE,
+        _MUTUALLY_DEPENDENT_TERMINAL_ALIAS_SOURCE,
+        _TERMINATING_ALTERNATIVE_SOURCE,
+        _SCOPED_TERMINAL_DEPENDENCY_SOURCE,
         _MATCHING_TRY_EXCEPT_OVERWRITE_SOURCE,
         _EXHAUSTIVE_MATCH_OVERWRITE_SOURCE,
         _LOOP_MATCHING_TERMINAL_REBIND_SOURCE,
@@ -599,6 +689,10 @@ def test_collect_assignment_aliases_allows_alias_read_after_deterministic_overwr
         "if-expression-epilogue",
         "if-semantic-resolution",
         "if-same-line-semantic-resolution",
+        "overwritten-terminal-dependency",
+        "mutually-dependent-terminal-alias",
+        "terminating-alternative",
+        "scoped-terminal-dependency",
         "try-except",
         "exhaustive-match",
         "loop-terminal-break",

--- a/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
@@ -142,6 +142,48 @@ else:
 m = Final()
 """
 
+_READ_BEFORE_UNCONDITIONAL_OVERWRITE_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+class Final:
+    pass
+
+
+if cond:
+    m = A()
+else:
+    m = B()
+exposed = m
+m = Final()
+"""
+
+_OVERWRITE_BEFORE_READ_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+class Final:
+    pass
+
+
+if cond:
+    m = A()
+else:
+    m = B()
+m = Final()
+exposed = m
+"""
+
 _TRY_FINALLY_REBIND_SOURCE = """\
 class A:
     pass
@@ -175,8 +217,13 @@ def _run_with_timeout(target: object, timeout: float = 10.0) -> None:
 
 @pytest.mark.parametrize(
     "source",
-    (_OSCILLATING_MODULE_SOURCE, _TRY_REBIND_SOURCE, _LOOP_ELSE_REBIND_SOURCE),
-    ids=("if-else", "try-except", "loop-else"),
+    (
+        _OSCILLATING_MODULE_SOURCE,
+        _TRY_REBIND_SOURCE,
+        _LOOP_ELSE_REBIND_SOURCE,
+        _READ_BEFORE_UNCONDITIONAL_OVERWRITE_SOURCE,
+    ),
+    ids=("if-else", "try-except", "loop-else", "read-before-overwrite"),
 )
 def test_collect_assignment_aliases_fails_closed_on_stable_branch_rebind(source: str) -> None:
     tree = ast.parse(source)
@@ -230,6 +277,23 @@ def test_collect_assignment_aliases_converges_on_deterministic_final_rebind(
     )
 
     assert aliases["m"] == expected_target
+
+
+def test_collect_assignment_aliases_allows_alias_read_after_deterministic_overwrite() -> None:
+    tree = ast.parse(_OVERWRITE_BEFORE_READ_SOURCE)
+    statements = _module_level_statements(tree)
+    local_defs = _collect_local_defs(statements)
+
+    aliases = _collect_assignment_aliases(
+        statements,
+        "testmod",
+        {},
+        local_defs,
+        {"testmod.A", "testmod.B", "testmod.Final"},
+    )
+
+    assert aliases["m"] == "testmod.Final"
+    assert aliases["exposed"] == "testmod.Final"
 
 
 def test_collect_assignment_aliases_fails_closed_on_cyclic_dependency_propagation() -> None:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
@@ -184,6 +184,21 @@ m = Final()
 exposed = m
 """
 
+_ONE_SIDED_REBIND_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+m = A()
+if cond:
+    m = B()
+exposed = m
+"""
+
 _TRY_FINALLY_REBIND_SOURCE = """\
 class A:
     pass
@@ -222,8 +237,9 @@ def _run_with_timeout(target: object, timeout: float = 10.0) -> None:
         _TRY_REBIND_SOURCE,
         _LOOP_ELSE_REBIND_SOURCE,
         _READ_BEFORE_UNCONDITIONAL_OVERWRITE_SOURCE,
+        _ONE_SIDED_REBIND_SOURCE,
     ),
-    ids=("if-else", "try-except", "loop-else", "read-before-overwrite"),
+    ids=("if-else", "try-except", "loop-else", "read-before-overwrite", "one-sided-rebind"),
 )
 def test_collect_assignment_aliases_fails_closed_on_stable_branch_rebind(source: str) -> None:
     tree = ast.parse(source)
@@ -456,6 +472,50 @@ def test_assignment_alias_limit_preserves_later_call_graph_findings(
     )
 
 
+def test_assignment_alias_limit_preserves_invoked_finding_after_sink_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reference = {"module": "invoked", "name": "entry"}
+    path_calls = 0
+
+    def _iter_references(
+        _import_references: object,
+        _callable_references: tuple[dict[str, object], ...],
+        _invoked_references: set[tuple[str, str]],
+    ) -> tuple[dict[str, str], ...]:
+        return (reference,)
+
+    def _entrypoints(module: str, name: str, _reference: dict[str, object]) -> tuple[str, ...]:
+        return (f"{module}.{name}",)
+
+    def _path(_entrypoints: Iterable[str], _path_for: object) -> tuple[str, ...] | None:
+        nonlocal path_calls
+        path_calls += 1
+        if path_calls == 1:
+            raise _CallGraphAnalysisLimitError("assignment alias limit")
+        return ("invoked.entry", "builtins.exec")
+
+    monkeypatch.setattr("modelaudit_picklescan.call_graph._iter_call_graph_references", _iter_references)
+    monkeypatch.setattr("modelaudit_picklescan.call_graph._call_graph_entrypoints_for_reference", _entrypoints)
+    monkeypatch.setattr("modelaudit_picklescan.call_graph._first_matching_path", _path)
+
+    with pytest.raises(_CallGraphAnalysisLimitError, match="assignment alias limit") as exc_info:
+        find_dangerous_call_graphs(
+            (),
+            ({"module": "invoked", "name": "entry", "positional_arg_count": 1},),
+        )
+
+    assert exc_info.value.partial_findings == (
+        CallGraphFinding(
+            module="invoked",
+            name="entry",
+            import_reference="invoked.entry",
+            sink="builtins.exec",
+            call_path=("invoked.entry", "builtins.exec"),
+        ),
+    )
+
+
 def test_assignment_alias_limit_preserves_prior_startup_hook_findings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -518,6 +578,50 @@ def test_assignment_alias_limit_preserves_later_startup_hook_findings(
     def _path(entrypoints: Iterable[str], path_for: object) -> tuple[str, ...] | None:
         entrypoint = next(iter(entrypoints))
         path_name = getattr(path_for, "__name__", "")
+        if path_name == "_find_file_open_path" and entrypoint == "opener.entry":
+            return ("opener.entry", "builtins.open")
+        if path_name == "_find_file_write_path" and entrypoint == "writer.entry":
+            return ("writer.entry", "binary_file.write")
+        return None
+
+    monkeypatch.setattr("modelaudit_picklescan.call_graph._safe_call_graph_entrypoints", _entrypoints)
+    monkeypatch.setattr("modelaudit_picklescan.call_graph._first_matching_path", _path)
+
+    with pytest.raises(_CallGraphAnalysisLimitError, match="assignment alias limit") as exc_info:
+        find_startup_hook_write_call_graphs(references)
+
+    assert exc_info.value.partial_startup_hook_write_findings == (
+        StartupHookWriteFinding(
+            opener_module="opener",
+            opener_name="entry",
+            writer_module="writer",
+            writer_name="entry",
+            opener_import_reference="opener.entry",
+            writer_import_reference="writer.entry",
+            open_sink="builtins.open",
+            write_sink="binary_file.write",
+            opener_call_path=("opener.entry", "builtins.open"),
+            writer_call_path=("writer.entry", "binary_file.write"),
+        ),
+    )
+
+
+def test_assignment_alias_limit_preserves_startup_hook_findings_after_sink_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    references = (
+        {"module": "opener", "name": "entry"},
+        {"module": "writer", "name": "entry"},
+    )
+
+    def _entrypoints(function_name: str) -> tuple[str, ...]:
+        return (function_name,)
+
+    def _path(entrypoints: Iterable[str], path_for: object) -> tuple[str, ...] | None:
+        entrypoint = next(iter(entrypoints))
+        path_name = getattr(path_for, "__name__", "")
+        if path_name == "_find_sink_path":
+            raise _CallGraphAnalysisLimitError("assignment alias limit")
         if path_name == "_find_file_open_path" and entrypoint == "opener.entry":
             return ("opener.entry", "builtins.open")
         if path_name == "_find_file_write_path" and entrypoint == "writer.entry":

--- a/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
@@ -20,6 +20,7 @@ from modelaudit_picklescan import PickleReport, Severity, scan_bytes
 from modelaudit_picklescan.api import _RUST_EXTENSION_MODULE
 from modelaudit_picklescan.call_graph import (
     CallGraphFinding,
+    StartupHookWriteFinding,
     _CallGraphAnalysisLimitError,
     _collect_assignment_aliases,
     _collect_local_defs,
@@ -27,6 +28,7 @@ from modelaudit_picklescan.call_graph import (
     _module_level_statements,
     _safe_call_graph_entrypoints,
     find_dangerous_call_graphs,
+    find_startup_hook_write_call_graphs,
 )
 
 _OSCILLATING_MODULE_SOURCE = """\
@@ -207,6 +209,51 @@ def test_assignment_alias_limit_preserves_prior_call_graph_findings(
             import_reference="dangerous.entry",
             sink="builtins.exec",
             call_path=("dangerous.entry", "builtins.exec"),
+        ),
+    )
+
+
+def test_assignment_alias_limit_preserves_prior_startup_hook_findings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    references = (
+        {"module": "opener", "name": "entry"},
+        {"module": "writer", "name": "entry"},
+        {"module": "limited", "name": "entry"},
+    )
+
+    def _entrypoints(function_name: str) -> tuple[str, ...]:
+        if function_name == "limited.entry":
+            raise _CallGraphAnalysisLimitError("assignment alias limit")
+        return (function_name,)
+
+    def _path(entrypoints: Iterable[str], path_for: object) -> tuple[str, ...] | None:
+        entrypoint = next(iter(entrypoints))
+        path_name = getattr(path_for, "__name__", "")
+        if path_name == "_find_file_open_path" and entrypoint == "opener.entry":
+            return ("opener.entry", "builtins.open")
+        if path_name == "_find_file_write_path" and entrypoint == "writer.entry":
+            return ("writer.entry", "binary_file.write")
+        return None
+
+    monkeypatch.setattr("modelaudit_picklescan.call_graph._safe_call_graph_entrypoints", _entrypoints)
+    monkeypatch.setattr("modelaudit_picklescan.call_graph._first_matching_path", _path)
+
+    with pytest.raises(_CallGraphAnalysisLimitError, match="assignment alias limit") as exc_info:
+        find_startup_hook_write_call_graphs(references)
+
+    assert exc_info.value.partial_startup_hook_write_findings == (
+        StartupHookWriteFinding(
+            opener_module="opener",
+            opener_name="entry",
+            writer_module="writer",
+            writer_name="entry",
+            opener_import_reference="opener.entry",
+            writer_import_reference="writer.entry",
+            open_sink="builtins.open",
+            write_sink="binary_file.write",
+            opener_call_path=("opener.entry", "builtins.open"),
+            writer_call_path=("writer.entry", "binary_file.write"),
         ),
     )
 

--- a/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import ast
 import threading
+from collections.abc import Iterable
 from importlib.util import find_spec
 
 import pytest
@@ -18,12 +19,14 @@ import pytest
 from modelaudit_picklescan import PickleReport, Severity, scan_bytes
 from modelaudit_picklescan.api import _RUST_EXTENSION_MODULE
 from modelaudit_picklescan.call_graph import (
+    CallGraphFinding,
     _CallGraphAnalysisLimitError,
     _collect_assignment_aliases,
     _collect_local_defs,
     _first_matching_path,
     _module_level_statements,
     _safe_call_graph_entrypoints,
+    find_dangerous_call_graphs,
 )
 
 _OSCILLATING_MODULE_SOURCE = """\
@@ -165,6 +168,47 @@ def test_assignment_alias_limit_is_not_hidden_by_path_search() -> None:
 
     with pytest.raises(_CallGraphAnalysisLimitError, match="assignment alias limit"):
         _first_matching_path(("wrapper.entrypoint",), _raise_limit)
+
+
+def test_assignment_alias_limit_preserves_prior_call_graph_findings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    references = (
+        {"module": "dangerous", "name": "entry"},
+        {"module": "limited", "name": "entry"},
+    )
+
+    def _iter_references(
+        _import_references: object,
+        _callable_references: tuple[dict[str, object], ...],
+        _invoked_references: set[tuple[str, str]],
+    ) -> tuple[dict[str, str], ...]:
+        return references
+
+    def _entrypoints(module: str, name: str, _reference: dict[str, object]) -> tuple[str, ...]:
+        return (f"{module}.{name}",)
+
+    def _path(entrypoints: Iterable[str], _path_for: object) -> tuple[str, ...] | None:
+        if tuple(entrypoints) == ("limited.entry",):
+            raise _CallGraphAnalysisLimitError("assignment alias limit")
+        return ("dangerous.entry", "builtins.exec")
+
+    monkeypatch.setattr("modelaudit_picklescan.call_graph._iter_call_graph_references", _iter_references)
+    monkeypatch.setattr("modelaudit_picklescan.call_graph._call_graph_entrypoints_for_reference", _entrypoints)
+    monkeypatch.setattr("modelaudit_picklescan.call_graph._first_matching_path", _path)
+
+    with pytest.raises(_CallGraphAnalysisLimitError, match="assignment alias limit") as exc_info:
+        find_dangerous_call_graphs(())
+
+    assert exc_info.value.partial_findings == (
+        CallGraphFinding(
+            module="dangerous",
+            name="entry",
+            import_reference="dangerous.entry",
+            sink="builtins.exec",
+            call_path=("dangerous.entry", "builtins.exec"),
+        ),
+    )
 
 
 def _stack_global_payload(module: str, name: str) -> bytes:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
@@ -122,6 +122,24 @@ else:
     m = B()
 """
 
+_LOOP_MATCHING_TERMINAL_REBIND_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+m = A()
+for value in values:
+    m = B()
+    break
+else:
+    m = B()
+exposed = m
+"""
+
 _UNCONDITIONAL_OVERWRITE_SOURCE = """\
 class A:
     pass
@@ -199,6 +217,46 @@ if cond:
 exposed = m
 """
 
+_NONEXHAUSTIVE_MATCH_OVERWRITE_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+m = A()
+match value:
+    case 1:
+        m = B()
+    case 2:
+        m = B()
+exposed = m
+"""
+
+_MATCHING_BRANCH_OVERWRITE_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+class Final:
+    pass
+
+
+if cond:
+    m = A()
+    m = Final()
+else:
+    m = B()
+    m = Final()
+exposed = m
+"""
+
 _TRY_FINALLY_REBIND_SOURCE = """\
 class A:
     pass
@@ -236,10 +294,20 @@ def _run_with_timeout(target: object, timeout: float = 10.0) -> None:
         _OSCILLATING_MODULE_SOURCE,
         _TRY_REBIND_SOURCE,
         _LOOP_ELSE_REBIND_SOURCE,
+        _LOOP_MATCHING_TERMINAL_REBIND_SOURCE,
         _READ_BEFORE_UNCONDITIONAL_OVERWRITE_SOURCE,
         _ONE_SIDED_REBIND_SOURCE,
+        _NONEXHAUSTIVE_MATCH_OVERWRITE_SOURCE,
     ),
-    ids=("if-else", "try-except", "loop-else", "read-before-overwrite", "one-sided-rebind"),
+    ids=(
+        "if-else",
+        "try-except",
+        "loop-else",
+        "loop-matching-terminal",
+        "read-before-overwrite",
+        "one-sided-rebind",
+        "match-no-default",
+    ),
 )
 def test_collect_assignment_aliases_fails_closed_on_stable_branch_rebind(source: str) -> None:
     tree = ast.parse(source)
@@ -297,6 +365,23 @@ def test_collect_assignment_aliases_converges_on_deterministic_final_rebind(
 
 def test_collect_assignment_aliases_allows_alias_read_after_deterministic_overwrite() -> None:
     tree = ast.parse(_OVERWRITE_BEFORE_READ_SOURCE)
+    statements = _module_level_statements(tree)
+    local_defs = _collect_local_defs(statements)
+
+    aliases = _collect_assignment_aliases(
+        statements,
+        "testmod",
+        {},
+        local_defs,
+        {"testmod.A", "testmod.B", "testmod.Final"},
+    )
+
+    assert aliases["m"] == "testmod.Final"
+    assert aliases["exposed"] == "testmod.Final"
+
+
+def test_collect_assignment_aliases_allows_matching_terminal_branch_overwrites() -> None:
+    tree = ast.parse(_MATCHING_BRANCH_OVERWRITE_SOURCE)
     statements = _module_level_statements(tree)
     local_defs = _collect_local_defs(statements)
 
@@ -388,6 +473,18 @@ def test_assignment_alias_limit_is_not_hidden_by_path_search() -> None:
 
     with pytest.raises(_CallGraphAnalysisLimitError, match="assignment alias limit"):
         _first_matching_path(("wrapper.entrypoint",), _raise_limit)
+
+
+def test_assignment_alias_limit_retains_later_matching_entrypoint_path() -> None:
+    def _path(entrypoint: str) -> tuple[str, ...] | None:
+        if entrypoint == "constructor.__new__":
+            raise _CallGraphAnalysisLimitError("assignment alias limit")
+        return ("constructor.__init__", "builtins.exec")
+
+    with pytest.raises(_CallGraphAnalysisLimitError, match="assignment alias limit") as exc_info:
+        _first_matching_path(("constructor.__new__", "constructor.__init__"), _path)
+
+    assert exc_info.value.partial_path == ("constructor.__init__", "builtins.exec")
 
 
 def test_assignment_alias_limit_preserves_prior_call_graph_findings(
@@ -512,6 +609,44 @@ def test_assignment_alias_limit_preserves_invoked_finding_after_sink_limit(
             import_reference="invoked.entry",
             sink="builtins.exec",
             call_path=("invoked.entry", "builtins.exec"),
+        ),
+    )
+
+
+def test_assignment_alias_limit_preserves_later_entrypoint_finding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reference = {"module": "constructor", "name": "Type"}
+
+    def _iter_references(
+        _import_references: object,
+        _callable_references: tuple[dict[str, object], ...],
+        _invoked_references: set[tuple[str, str]],
+    ) -> tuple[dict[str, str], ...]:
+        return (reference,)
+
+    def _entrypoints(_module: str, _name: str, _reference: dict[str, object]) -> tuple[str, ...]:
+        return ("constructor.Type.__new__", "constructor.Type.__init__")
+
+    def _path(entrypoint: str) -> tuple[str, ...] | None:
+        if entrypoint.endswith(".__new__"):
+            raise _CallGraphAnalysisLimitError("assignment alias limit")
+        return ("constructor.Type.__init__", "builtins.exec")
+
+    monkeypatch.setattr("modelaudit_picklescan.call_graph._iter_call_graph_references", _iter_references)
+    monkeypatch.setattr("modelaudit_picklescan.call_graph._call_graph_entrypoints_for_reference", _entrypoints)
+    monkeypatch.setattr("modelaudit_picklescan.call_graph._find_sink_path", _path)
+
+    with pytest.raises(_CallGraphAnalysisLimitError, match="assignment alias limit") as exc_info:
+        find_dangerous_call_graphs(())
+
+    assert exc_info.value.partial_findings == (
+        CallGraphFinding(
+            module="constructor",
+            name="Type",
+            import_reference="constructor.Type",
+            sink="builtins.exec",
+            call_path=("constructor.Type.__init__", "builtins.exec"),
         ),
     )
 

--- a/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_assignment_alias_cycle.py
@@ -1,0 +1,104 @@
+"""Regression: assignment-alias fixpoint must terminate on oscillating binds.
+
+A module that binds the same name in both branches of an ``if``/``else``
+(e.g. the ``imaplib``/``http.server``/``nntplib`` stdlib ``__main__`` blocks)
+makes ``_collect_assignment_aliases`` oscillate the alias between two values
+without ever growing the dict. The dict-size guard never trips, so the
+fixpoint loop spins forever and the whole scan hangs (GitHub issue #1247).
+"""
+
+from __future__ import annotations
+
+import ast
+import threading
+from importlib.util import find_spec
+
+import pytest
+
+from modelaudit_picklescan import PickleReport, Severity, scan_bytes
+from modelaudit_picklescan.api import _RUST_EXTENSION_MODULE
+from modelaudit_picklescan.call_graph import (
+    _collect_assignment_aliases,
+    _collect_local_defs,
+    _module_level_statements,
+)
+
+_OSCILLATING_MODULE_SOURCE = """\
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+if cond:
+    m = A()
+else:
+    m = B()
+"""
+
+
+def _run_with_timeout(target: object, timeout: float = 10.0) -> None:
+    thread = threading.Thread(target=target)  # type: ignore[arg-type]
+    thread.daemon = True
+    thread.start()
+    thread.join(timeout)
+    if thread.is_alive():
+        pytest.fail(f"call-graph analysis did not terminate within {timeout}s")
+
+
+def test_collect_assignment_aliases_terminates_on_branch_rebind() -> None:
+    tree = ast.parse(_OSCILLATING_MODULE_SOURCE)
+    statements = _module_level_statements(tree)
+    local_defs = _collect_local_defs(statements)
+    local_class_targets = {"testmod.A", "testmod.B"}
+
+    result: dict[str, dict[str, str]] = {}
+
+    def _collect() -> None:
+        result["aliases"] = _collect_assignment_aliases(
+            statements,
+            "testmod",
+            {},
+            local_defs,
+            local_class_targets,
+        )
+
+    _run_with_timeout(_collect)
+
+    aliases = result["aliases"]
+    # The rebinding name still resolves to one of the two local classes; the
+    # exact branch is order-dependent, but the loop must converge.
+    assert aliases.get("m") in {"testmod.A", "testmod.B"}
+
+
+def _stack_global_payload(module: str, name: str) -> bytes:
+    def _operand(value: str) -> bytes:
+        data = value.encode()
+        return b"\x8c" + bytes([len(data)]) + data
+
+    return b"\x80\x04" + _operand(module) + _operand(name) + b"\x93" + _operand("proof_of_bypass") + b"\x85R."
+
+
+@pytest.mark.skipif(
+    find_spec(_RUST_EXTENSION_MODULE) is None,
+    reason="Rust picklescan extension is not built",
+)
+@pytest.mark.skipif(
+    find_spec("imaplib") is None,
+    reason="imaplib stdlib module is unavailable",
+)
+def test_scan_imaplib_reference_terminates_and_flags() -> None:
+    """The issue #1247 proof-of-concept must finish and stay flagged."""
+    payload = _stack_global_payload("imaplib", "test")
+    result: dict[str, PickleReport] = {}
+
+    def _scan() -> None:
+        result["report"] = scan_bytes(payload)
+
+    _run_with_timeout(_scan)
+
+    report = result["report"]
+    severities = {finding.severity for finding in report.findings}
+    assert Severity.CRITICAL in severities

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -2151,6 +2151,62 @@ else:
     )
 
 
+def test_scan_bytes_fails_closed_on_installed_package_alias_read_before_overwrite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = tmp_path / "site-packages"
+    module_dir.mkdir()
+    module_name = "installed_alias_read_before_overwrite"
+    (module_dir / f"{module_name}.py").write_text(
+        """\
+import os
+
+
+class Dangerous:
+    def __call__(self, command):
+        os.system(command)
+
+
+class Safe:
+    def __call__(self, command):
+        return command
+
+
+class Final:
+    def __call__(self, command):
+        return command
+
+
+if cond:
+    entry = Dangerous()
+else:
+    entry = Safe()
+exposed = entry
+entry = Final()
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(module_dir))
+    importlib.invalidate_caches()
+    _clear_call_graph_caches()
+
+    try:
+        report = scan_bytes(
+            _global_call_payload(module_name, "exposed", _unicode_operand("echo hidden-branch")),
+            source="installed-alias-read-before-overwrite.pkl",
+        )
+    finally:
+        _clear_call_graph_caches()
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.metadata["analysis_incomplete"] is True
+    assert any(
+        error.category == "call_graph_analysis_error" and error.exception_type == "_CallGraphAnalysisLimitError"
+        for error in report.errors
+    )
+
+
 def test_call_graph_analyzes_shadowed_torch_storage_persistent_id_reference(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -2102,6 +2102,55 @@ def test_scan_bytes_analyzes_shadowed_torch_extension_callable_invocation(
     assert _has_critical_call_graph_finding(report, "torch", "device", "os.system")
 
 
+def test_scan_bytes_fails_closed_when_shadowed_torch_extension_analysis_hits_alias_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    (module_dir / "torch.py").write_text(
+        """\
+import os
+
+
+class Dangerous:
+    def __call__(self, command):
+        os.system(command)
+
+
+class Safe:
+    def __call__(self, command):
+        return command
+
+
+if cond:
+    device = Dangerous()
+else:
+    device = Safe()
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(module_dir))
+    importlib.invalidate_caches()
+    _clear_call_graph_caches()
+
+    try:
+        report = scan_bytes(
+            _global_call_payload("torch", "device", _unicode_operand("echo shadowed-torch-device")),
+            source="shadowed-torch-device-alias-limit.pkl",
+        )
+    finally:
+        _clear_call_graph_caches()
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.metadata["analysis_incomplete"] is True
+    assert not any(error.category == "rust_engine_error" for error in report.errors)
+    assert any(
+        error.category == "call_graph_analysis_error" and error.exception_type == "_CallGraphAnalysisLimitError"
+        for error in report.errors
+    )
+
+
 def test_call_graph_analyzes_shadowed_torch_storage_persistent_id_reference(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,6 +192,7 @@ def pytest_runtest_setup(item):
             "test_call_graph_local_imports.py",  # standalone picklescan function-local import RCE regressions
             "test_call_graph_six.py",  # standalone picklescan six.moves alias RCE regressions
             "test_call_graph_tkinter.py",  # standalone picklescan Tcl call-graph RCE regressions
+            "test_call_graph_assignment_alias_cycle.py",  # standalone picklescan alias fixpoint termination regressions
             "test_dill_joblib_enhanced.py",  # Dill/joblib pickle routing regression tests
             "test_pickle_context_filtering.py",  # Pickle context filtering regression tests
             "test_xdist_status.py",  # xdist worker progress reporting tests


### PR DESCRIPTION
## Summary

Fixes #1247 — scanning a pickle that references `imaplib`, `http.server`, or `nntplib` caused `modelaudit` to hang forever, blocking every other file in a directory scan.

Huge thanks to @HalaAli198 for the exceptionally well-researched report. 🙏 The hex dump, the minimal 42-byte proof-of-concept, the public Hugging Face repros, the workaround (`--exclude-scanner pickle`), and the cross-reference to promptfoo/promptfoo#6266 made this fast to reproduce and diagnose. That is exactly the kind of issue maintainers dream of receiving.

## Root cause

The report attributed the hang to the compiled Rust scanner (`_rust.abi3.so`), which was a very reasonable inference given `--timeout` had no effect. A `faulthandler` traceback showed the hang is actually in **pure-Python call-graph analysis**, before the slow Rust path is even reached:

```
call_graph.py:1673  _collect_assignment_aliases   ← infinite loop
call_graph.py:1245  _analyze_module
...
api.py:1014         _with_call_graph_findings
```

When call-graph analysis imports such a module's **source**, it flattens every module-level statement — including both branches of the `if __name__ == '__main__'` block. `imaplib.py` binds the same name twice:

```python
M = IMAP4_stream(stream_command)   # imaplib.py:1619
M = IMAP4(host)                    # imaplib.py:1621
```

The alias fixpoint loop in `_collect_assignment_aliases` flips `M` between `imaplib.IMAP4` and `imaplib.IMAP4_stream` on every pass, always marking `changed = True`. The loop's only guard checks the alias dict **size**, which never grows past 1 — so it spins forever. `http.server` and `nntplib` hit the identical `__main__`-block rebind pattern.

## Fix

Track every `(target, resolved)` pair already applied. Re-applying a previously seen pair no longer counts as progress, so an oscillating bind converges once both values have been observed (~3 passes) instead of looping forever. The alias is still applied so later nodes resolve correctly, and detection severity is unchanged — all affected files still report **CRITICAL**.

## Verification

- All three reported modules and the issue's hex-dump PoC now scan in <0.15s and still report **CRITICAL**.
- New regression test `test_call_graph_assignment_alias_cycle.py`: a deterministic unit test for the oscillating-bind fixpoint plus an end-to-end `imaplib` PoC scan, both guarded by thread watchdogs that **fail rather than hang** on regression. Registered in the reduced-CI allowlist in `tests/conftest.py`.
- Full picklescan suite (1338 passed), main `test_pickle_scanner.py` (131 passed), `ruff format`/`check`, and `mypy` all clean.

## Note on `--timeout`

The report also observed that `--timeout` does not interrupt the hang. That is a separate architectural limitation: the timeout is checked cooperatively *between* scanners, so any CPU-bound single-threaded stretch (Rust or Python) cannot be preempted mid-call. Fixing the actual infinite loop resolves the reported denial-of-service; making long-running scans pre-emptible would be a larger, separate change worth tracking on its own.

Thanks again, @HalaAli198 — this was a genuinely valuable find, and the care you put into the report is much appreciated. Wishing you well, and happy (safe) scanning! 🛡️

🤖 Generated with [Claude Code](https://claude.com/claude-code)
