### PR TITLE
fix: confirm ONNX python_operator findings against the parsed graph (#1254)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - keep shard sibling discovery within the requested scan root
 - preserve per-shard metadata when aggregating sharded model families
 - reject plain PyTorch source text from Torch7 content routing
+- stop flagging a false-positive ONNX Python operator when tensor weight bytes coincidentally spell `PyOp`
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -125,6 +125,15 @@ def _iter_graph_nodes(graph: Any) -> Any:
                 yield from _iter_graph_nodes(subgraph)
 
 
+def _iter_model_graphs(model: Any) -> Any:
+    """Yield graph-bearing ONNX model fields that may declare operators."""
+    yield model.graph
+    yield from getattr(model, "functions", [])
+    for training_info in getattr(model, "training_info", []):
+        yield training_info.initialization
+        yield training_info.algorithm
+
+
 def _model_declares_python_operator(model: Any) -> bool:
     """Return True when the parsed ONNX model actually declares a Python operator.
 
@@ -133,8 +142,11 @@ def _model_declares_python_operator(model: Any) -> bool:
     with arbitrary tensor weight bytes. The parsed graph is the authoritative
     operator inventory, so it is consulted before trusting a raw-byte match.
     """
-    graphs = [model.graph, *getattr(model, "functions", [])]
-    return any(_is_python_operator(node.op_type or "") for graph in graphs for node in _iter_graph_nodes(graph))
+    return any(
+        _is_python_operator(node.op_type or "")
+        for graph in _iter_model_graphs(model)
+        for node in _iter_graph_nodes(graph)
+    )
 
 
 def _jit_finding_type(finding: Any) -> Any:

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -137,6 +137,11 @@ def _model_declares_python_operator(model: Any) -> bool:
     return any(_is_python_operator(node.op_type or "") for graph in graphs for node in _iter_graph_nodes(graph))
 
 
+def _jit_finding_type(finding: Any) -> Any:
+    """Return the detector finding type across dict and object results."""
+    return finding.get("type") if hasattr(finding, "get") else getattr(finding, "type", None)
+
+
 def _confirmed_python_operator_findings(findings: list[Any], model: Any) -> list[Any]:
     """Drop raw-byte ``python_operator`` findings the parsed graph does not confirm.
 
@@ -144,6 +149,9 @@ def _confirmed_python_operator_findings(findings: list[Any], model: Any) -> list
     false positive from the raw-byte regex colliding with tensor weight data.
     If the graph cannot be inspected, the finding is kept (fail closed).
     """
+    if not any(_jit_finding_type(finding) == "python_operator" for finding in findings):
+        return findings
+
     try:
         if _model_declares_python_operator(model):
             return findings
@@ -153,9 +161,7 @@ def _confirmed_python_operator_findings(findings: list[Any], model: Any) -> list
 
     confirmed: list[Any] = []
     for finding in findings:
-        # collect_jit_script_findings yields dicts; tolerate objects defensively.
-        finding_type = finding.get("type") if hasattr(finding, "get") else getattr(finding, "type", None)
-        if finding_type == "python_operator":
+        if _jit_finding_type(finding) == "python_operator":
             logger.debug("Suppressing unconfirmed raw-byte ONNX python_operator finding (no PyOp node in graph)")
             continue
         confirmed.append(finding)

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -110,6 +110,58 @@ def _is_python_operator(op_type: str) -> bool:
     return False
 
 
+def _iter_graph_nodes(graph: Any) -> Any:
+    """Yield every node in an ONNX graph or function, recursing into subgraphs."""
+    for node in graph.node:
+        yield node
+        for attribute in node.attribute:
+            subgraphs = list(attribute.graphs)
+            try:
+                if attribute.HasField("g"):
+                    subgraphs.append(attribute.g)
+            except (ValueError, AttributeError):  # pragma: no cover - proto edge case
+                pass
+            for subgraph in subgraphs:
+                yield from _iter_graph_nodes(subgraph)
+
+
+def _model_declares_python_operator(model: Any) -> bool:
+    """Return True when the parsed ONNX model actually declares a Python operator.
+
+    The raw-byte JIT detector matches short, case-insensitive operator-name
+    tokens (e.g. ``PyOp``) anywhere in the file, so on large models it collides
+    with arbitrary tensor weight bytes. The parsed graph is the authoritative
+    operator inventory, so it is consulted before trusting a raw-byte match.
+    """
+    graphs = [model.graph, *getattr(model, "functions", [])]
+    return any(_is_python_operator(node.op_type or "") for graph in graphs for node in _iter_graph_nodes(graph))
+
+
+def _confirmed_python_operator_findings(findings: list[Any], model: Any) -> list[Any]:
+    """Drop raw-byte ``python_operator`` findings the parsed graph does not confirm.
+
+    A ``python_operator`` finding with no matching node in the parsed graph is a
+    false positive from the raw-byte regex colliding with tensor weight data.
+    If the graph cannot be inspected, the finding is kept (fail closed).
+    """
+    try:
+        if _model_declares_python_operator(model):
+            return findings
+    except Exception as exc:  # pragma: no cover - defensive: keep finding if unsure
+        logger.debug("Unable to validate ONNX python operator finding against graph: %s", exc)
+        return findings
+
+    confirmed: list[Any] = []
+    for finding in findings:
+        # collect_jit_script_findings yields dicts; tolerate objects defensively.
+        finding_type = finding.get("type") if hasattr(finding, "get") else getattr(finding, "type", None)
+        if finding_type == "python_operator":
+            logger.debug("Suppressing unconfirmed raw-byte ONNX python_operator finding (no PyOp node in graph)")
+            continue
+        confirmed.append(finding)
+    return confirmed
+
+
 def _is_windows_absolute_path(path: str) -> bool:
     """Return True when a serialized path is absolute in Windows syntax."""
     return ntpath.isabs(path.replace("/", "\\"))
@@ -319,7 +371,7 @@ class OnnxScanner(BaseScanner):
                     )
                 else:
                     self.add_jit_script_findings(
-                        jit_findings,
+                        _confirmed_python_operator_findings(jit_findings, model),
                         result,
                         model_type="onnx",
                         context=path,

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -395,6 +395,104 @@ def test_onnx_scanner_uppercase_snake_python_near_match_not_flagged(tmp_path: Pa
     assert not [c for c in result.checks if c.name == "Python Operator Detection" and c.status == CheckStatus.FAILED]
 
 
+def _save_model_with_int8_weight(tmp_path: Path, weight_bytes: bytes, *, extra_node: Any = None) -> Path:
+    """Build a clean ai.onnx-only model whose int8 initializer holds ``weight_bytes``."""
+    weight = helper.make_tensor("W", TensorProto.INT8, [len(weight_bytes)], weight_bytes, raw=True)
+    scale = helper.make_tensor("scale", TensorProto.FLOAT, [], [1.0])
+    zero_point = helper.make_tensor("zp", TensorProto.INT8, [], [0])
+    nodes = [helper.make_node("DequantizeLinear", ["W", "scale", "zp"], ["Y"], name="dq")]
+    if extra_node is not None:
+        nodes.append(extra_node)
+    graph = helper.make_graph(
+        nodes,
+        "quant_graph",
+        [],
+        [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [len(weight_bytes)])],
+        initializer=[weight, scale, zero_point],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    path = tmp_path / "model.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def _python_operator_issues(result: Any) -> list[Any]:
+    return [
+        issue
+        for issue in result.issues
+        if issue.details.get("type") == "python_operator" or "Python operator" in issue.message
+    ]
+
+
+# Bytes "PyOp" (0x50 0x79 0x4F 0x70) bracketed by non-alphanumeric bytes: a
+# realistic byte run inside quantized int8 weight data that the raw-byte JIT
+# regex matches case-insensitively. See GitHub issue #1254.
+_PYOP_WEIGHT_BYTES = bytes([0x00, 0x50, 0x79, 0x4F, 0x70, 0x00, 0x01, 0x02])
+
+
+def test_onnx_scanner_pyop_bytes_in_weight_data_not_flagged(tmp_path: Path) -> None:
+    """A clean ai.onnx-only model is not flagged when weight bytes spell 'PyOp'."""
+    model_path = _save_model_with_int8_weight(tmp_path, _PYOP_WEIGHT_BYTES)
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert _python_operator_issues(result) == []
+
+
+def test_onnx_scanner_real_pyop_node_still_flagged_despite_weight_bytes(tmp_path: Path) -> None:
+    """A genuine PyOp node stays CRITICAL even when weight bytes also spell 'PyOp'."""
+    pyop_node = helper.make_node("PyOp", ["Y"], ["Z"], name="evil", domain="com.attacker")
+    model_path = _save_model_with_int8_weight(tmp_path, _PYOP_WEIGHT_BYTES, extra_node=pyop_node)
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is False
+    python_operator_issues = _python_operator_issues(result)
+    assert python_operator_issues
+    assert all(issue.severity == IssueSeverity.CRITICAL for issue in python_operator_issues)
+
+
+def test_onnx_scanner_subgraph_pyop_still_flagged(tmp_path: Path) -> None:
+    """A PyOp hidden inside an If-branch subgraph is still detected."""
+    then_branch = helper.make_graph(
+        [helper.make_node("PyOp", ["X"], ["Z"], domain="com.attacker")],
+        "then",
+        [],
+        [helper.make_tensor_value_info("Z", TensorProto.FLOAT, [1])],
+    )
+    else_branch = helper.make_graph(
+        [helper.make_node("Identity", ["X"], ["Z"])],
+        "else",
+        [],
+        [helper.make_tensor_value_info("Z", TensorProto.FLOAT, [1])],
+    )
+    if_node = helper.make_node("If", ["cond"], ["Y"], then_branch=then_branch, else_branch=else_branch)
+    graph = helper.make_graph(
+        [if_node],
+        "graph",
+        [
+            helper.make_tensor_value_info("cond", TensorProto.BOOL, []),
+            helper.make_tensor_value_info("X", TensorProto.FLOAT, [1]),
+        ],
+        [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])],
+    )
+    model = helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid("com.attacker", 1)],
+    )
+    model.ir_version = 8
+    model_path = tmp_path / "subgraph.onnx"
+    onnx.save(model, str(model_path))
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is False
+    python_operator_issues = _python_operator_issues(result)
+    assert python_operator_issues
+    assert all(issue.severity == IssueSeverity.CRITICAL for issue in python_operator_issues)
+
+
 class TestCVE202551480SavePathTraversal:
     """Tests for CVE-2025-51480: ONNX save_external_data arbitrary file overwrite."""
 

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -17,7 +17,7 @@ from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.detectors.jit_script import JITScriptDetector
 from modelaudit.detectors.network_comm import NetworkCommDetector
 from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity
-from modelaudit.scanners.onnx_scanner import OnnxScanner
+from modelaudit.scanners.onnx_scanner import OnnxScanner, _confirmed_python_operator_findings
 
 
 def create_onnx_model(
@@ -428,6 +428,21 @@ def _python_operator_issues(result: Any) -> list[Any]:
 # realistic byte run inside quantized int8 weight data that the raw-byte JIT
 # regex matches case-insensitively. See GitHub issue #1254.
 _PYOP_WEIGHT_BYTES = bytes([0x00, 0x50, 0x79, 0x4F, 0x70, 0x00, 0x01, 0x02])
+
+
+def test_onnx_scanner_skips_graph_confirmation_without_python_operator_candidate() -> None:
+    accessed: list[bool] = []
+
+    class UnreadableModel:
+        @property
+        def graph(self) -> Any:
+            accessed.append(True)
+            raise RuntimeError("graph should not be inspected")
+
+    findings = [{"type": "embedded_script", "content": "harmless"}]
+
+    assert _confirmed_python_operator_findings(findings, UnreadableModel()) == findings
+    assert accessed == []
 
 
 def test_onnx_scanner_pyop_bytes_in_weight_data_not_flagged(tmp_path: Path) -> None:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -508,6 +508,31 @@ def test_onnx_scanner_subgraph_pyop_still_flagged(tmp_path: Path) -> None:
     assert all(issue.severity == IssueSeverity.CRITICAL for issue in python_operator_issues)
 
 
+@pytest.mark.parametrize("training_graph_field", ["initialization", "algorithm"])
+def test_onnx_scanner_training_graph_pyop_still_flagged(tmp_path: Path, training_graph_field: str) -> None:
+    """A PyOp in either training graph must not be discarded as weight-data noise."""
+    model_path = _save_model_with_int8_weight(tmp_path, _PYOP_WEIGHT_BYTES)
+    model = onnx.load(str(model_path))
+    training_info = onnx.TrainingInfoProto()
+    getattr(training_info, training_graph_field).CopyFrom(
+        helper.make_graph(
+            [helper.make_node("PyOp", ["X"], ["Y"], domain="com.attacker")],
+            f"training_{training_graph_field}",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, [1])],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])],
+        )
+    )
+    model.training_info.append(training_info)
+    onnx.save(model, str(model_path))
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is False
+    python_operator_issues = _python_operator_issues(result)
+    assert python_operator_issues
+    assert all(issue.severity == IssueSeverity.CRITICAL for issue in python_operator_issues)
+
+
 class TestCVE202551480SavePathTraversal:
     """Tests for CVE-2025-51480: ONNX save_external_data arbitrary file overwrite."""
 


### PR DESCRIPTION
## Summary

Fixes #1254 — scanning a large, clean ONNX model could raise a **CRITICAL `python_operator` finding** even when the graph contains no `PyOp` node and no custom-domain operators. Reported against the official quantized `intfloat/multilingual-e5-base` embedding model.

Many thanks to @MFIB00 for an outstanding bug report. 🙏 Enumerating every `(domain, op_type)` pair, citing the SHA-256, linking the ONNX Runtime PyOp spec, and spelling out the real-world impact (a trusted, widely-downloaded model flagged CRITICAL) made the root cause unambiguous and gave us a precise reproduction target. This is exactly how a false-positive report should look.

## Reproduced on `main`

The reported finding (`type: python_operator`, `confidence: 0.9`, message *"Python operator in ONNX model - can execute arbitrary code"*) does **not** come from the ONNX scanner's graph-based operator check — that check correctly passes for this model. It comes from the raw-byte JIT detector (`jit_script.py:scan_onnx`), which searches the **entire file** for a short, case-insensitive operator-name regex:

```python
(?:PyFunc(?:Stateless)?|EagerPyFunc|PythonOp|PyOp)(?:V[0-9]+)?
```

The `PyOp` alternative is only **four characters**, matched **case-insensitively** — so each byte has 2/256 matching values. A 279 MB quantized model is hundreds of MB of arbitrary int8 tensor weight bytes, and a `[Pp][Yy][Oo][Pp]` run bracketed by non-alphanumeric bytes occurs **by chance**:

```
$ # raw 279 MB random buffers, exact regex from jit_script.py
trial 0: 1 matches [b'PYOP']
trial 2: 1 matches [b'PYOP']
trial 3: 1 matches [b'pyOP']
trial 4: 1 matches [b'Pyop']
trial 5: 1 matches [b'PYOp']
TOTAL across 8 trials of 279MB: 5
```

End-to-end: a **153-byte clean model** with only a standard `ai.onnx::DequantizeLinear` op and zero PyOp nodes — whose int8 initializer bytes happen to contain `P y O p` — reproduces the exact CRITICAL false positive from the issue.

## Fix

The parsed ONNX graph, not raw weight data, is the authoritative operator inventory — and the ONNX scanner already has the parsed model in hand. It now **cross-checks**: a raw-byte `python_operator` finding is dropped when the parsed graph declares no Python operator node. The graph is walked **completely** — including `If`/`Loop`/`Scan` subgraphs and local functions — so a genuine PyOp can't hide from the validation. If the graph cannot be inspected for any reason, the finding is **kept (fail closed)**.

Detection is fully preserved:

| Model | Before | After |
| --- | --- | --- |
| Clean model, weight bytes spell `PyOp` | 🔴 CRITICAL (false positive) | ✅ No issues |
| Genuine `PyOp` node | 🔴 CRITICAL | 🔴 CRITICAL |
| `PyOp` node + weight bytes also spell `PyOp` | 🔴 CRITICAL | 🔴 CRITICAL |
| `PyOp` hidden in an `If`-branch subgraph | 🔴 CRITICAL | 🔴 CRITICAL |

The graph-based `S902` "Python Operator Detection" check is untouched.

## Tests

Three regression tests added to `tests/scanners/test_onnx_scanner.py` (already in the reduced-CI allowlist):

- `test_onnx_scanner_pyop_bytes_in_weight_data_not_flagged` — clean model with `PyOp` weight bytes is not flagged.
- `test_onnx_scanner_real_pyop_node_still_flagged_despite_weight_bytes` — a genuine PyOp node stays CRITICAL even when weight bytes also collide.
- `test_onnx_scanner_subgraph_pyop_still_flagged` — a PyOp buried in an `If`-branch subgraph is still detected.

Full ONNX scanner suite passes (55 tests); `ruff` and `mypy` clean.

Thanks again, @MFIB00 — reports this thorough are a genuine gift to maintainers, and they directly make the scanner more trustworthy for everyone. Wishing you smooth, false-positive-free scanning ahead! 🛡️

🤖 Generated with [Claude Code](https://claude.com/claude-code)
