### PR TITLE
test: sync python 3.13-slim digest constant with Dockerfiles

### DIFF
--- a/tests/test_docker_workflow.py
+++ b/tests/test_docker_workflow.py
@@ -9,7 +9,7 @@ import yaml
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _PINNED_PYTHON_IMAGE_RE = re.compile(r"^python:(?P<version>\d+\.\d+-slim)@sha256:(?P<digest>[0-9a-f]{64})$")
 _PYTHON_3_12_SLIM_DIGEST = "401f6e1a67dad31a1bd78e9ad22d0ee0a3b52154e6bd30e90be696bb6a3d7461"
-_PYTHON_3_13_SLIM_DIGEST = "dc1546eefcbe8caaa1f004f16ab76b204b5e1dbd58ff81b899f21cd40541232f"
+_PYTHON_3_13_SLIM_DIGEST = "e544a7fcbdf8555eceda66bf86cafb006c736339f76141918bcb812f3174c00a"
 
 
 def _load_docker_workflow() -> dict[str, Any]:


### PR DESCRIPTION
## Summary

`tests/test_docker_workflow.py::test_dockerfiles_use_current_python_base_digests` is **failing on `main`** and consequently on every open PR.

## Cause

The test pins the expected `python:3.13-slim` base-image digest in the `_PYTHON_3_13_SLIM_DIGEST` constant. The renovate digest bump #1257 advanced both `Dockerfile` and `Dockerfile.full` to:

```
python:3.13-slim@sha256:e544a7fcbdf8555eceda66bf86cafb006c736339f76141918bcb812f3174c00a
```

but did not update the test constant, which was left at the previous `sha256:dc1546ee...21cd40541232f`. The test then asserts the Dockerfiles match the stale constant and fails:

```
E   AssertionError: assert 'python:3.13-...b812f3174c00a' == 'python:3.13-...21cd40541232f'
E     - python:3.13-slim@sha256:dc1546eefcbe8caaa1f004f16ab76b204b5e1dbd58ff81b899f21cd40541232f
E     + python:3.13-slim@sha256:e544a7fcbdf8555eceda66bf86cafb006c736339f76141918bcb812f3174c00a
```

## Fix

Update `_PYTHON_3_13_SLIM_DIGEST` to the digest the Dockerfiles actually pin. One-line, test-only change. `_PYTHON_3_12_SLIM_DIGEST` already matches `Dockerfile.tensorflow`, so it is untouched.

`tests/test_docker_workflow.py` now passes (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
