### PR TITLE
fix(ci): avoid performance gating in Windows nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,6 +76,6 @@ jobs:
         run: |
           cargo test --manifest-path packages/modelaudit-picklescan/Cargo.toml
 
-      - name: Run all tests
+      - name: Run all Windows tests except performance benchmarks
         run: |
-          uv run pytest -n auto --tb=short --durations=20
+          uv run pytest -n auto -m "not performance" --tb=short --durations=20

--- a/tests/test_perf_workflow.py
+++ b/tests/test_perf_workflow.py
@@ -6,21 +6,25 @@ from typing import Any
 import yaml
 
 
-def _load_perf_workflow() -> dict[str, Any]:
+def _load_workflow(filename: str) -> dict[str, Any]:
     current_path = Path(__file__).resolve()
     workflow_path = next(
         (
-            candidate_root / ".github" / "workflows" / "perf.yml"
+            candidate_root / ".github" / "workflows" / filename
             for candidate_root in [current_path.parent, *current_path.parents]
-            if (candidate_root / ".github" / "workflows" / "perf.yml").is_file()
+            if (candidate_root / ".github" / "workflows" / filename).is_file()
         ),
         None,
     )
     if workflow_path is None:
-        raise AssertionError("Could not locate .github/workflows/perf.yml from test file path")
+        raise AssertionError(f"Could not locate .github/workflows/{filename} from test file path")
     workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
     assert isinstance(workflow, dict)
     return workflow
+
+
+def _load_perf_workflow() -> dict[str, Any]:
+    return _load_workflow("perf.yml")
 
 
 def _benchmarks_job(workflow: dict[str, Any]) -> dict[str, Any]:
@@ -100,3 +104,19 @@ def test_perf_workflow_comments_only_on_same_repo_prs() -> None:
     assert "<!-- modelaudit-perf-benchmarks -->" in script
     assert "github.rest.issues.updateComment" in script
     assert "github.rest.issues.createComment" in script
+
+
+def test_nightly_windows_lane_defers_performance_benchmarks_to_linux() -> None:
+    workflow = _load_workflow("nightly.yml")
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+
+    linux_steps = jobs["full-matrix"]["steps"]
+    assert isinstance(linux_steps, list)
+    linux_run = _step_by_name(linux_steps, "Run all tests (fast + slow + integration + performance)")["run"]
+    assert '-m "not performance"' not in linux_run
+
+    windows_steps = jobs["windows-full"]["steps"]
+    assert isinstance(windows_steps, list)
+    windows_run = _step_by_name(windows_steps, "Run all Windows tests except performance benchmarks")["run"]
+    assert '-m "not performance"' in windows_run


### PR DESCRIPTION
## Summary
- exclude `performance`-marked tests from the Windows full nightly lane while retaining its functional, slow, and integration coverage
- keep performance coverage in the Linux nightly matrix and the dedicated benchmark workflow
- add a workflow contract test so Windows nightly does not regain timing-sensitive benchmark gating

## Root cause
The scheduled `Nightly CI` run [26324307724](https://github.com/promptfoo/modelaudit/actions/runs/26324307724) failed only in `Windows Full Tests (Python 3.11)`: `TestPerformanceBenchmarks.test_stress_performance` measured a 43.3% slowdown against its 30% wall-clock threshold. Every Linux nightly matrix job passed. Windows is already treated as a compatibility lane in ordinary CI, where performance tests are excluded, and comparable benchmark reporting is covered by `.github/workflows/perf.yml`.

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run --no-sync ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run --no-sync ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run --no-sync mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run --no-sync pytest tests/test_perf_workflow.py -q` (`4 passed`)
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run --no-sync pytest -n auto -m "not slow and not integration and not performance" --maxfail=1` (`5616 passed, 13 skipped`)

## Validation note
The repository's documented local selector without `not performance` was also attempted. It ran 5,605 tests before failing in the unrelated timing-sensitive `test_concurrent_performance` on this macOS host after its 60-second local timeout. A regular synced `uv run` additionally attempts a platform-incompatible TensorRT wheel on macOS arm64, so the successful checks above used the existing provisioned environment with `--no-sync`.