### PR TITLE
fix(onnx): scan nested Python operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - prevent picklescan call-graph alias cycles from hanging scans
 - preserve HuggingFace snapshot shard paths while grouping cache-backed families
 - stop flagging a false-positive ONNX Python operator when tensor weight bytes coincidentally spell `PyOp`
+- detect Python operators declared in nested ONNX graphs and functions
 - distinguish ASCII-serialized Torch7 artifacts from plain PyTorch source text
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -462,51 +462,54 @@ class OnnxScanner(BaseScanner):
         custom_domains = set()
         python_ops_found = False
         safe_nodes = 0
+        nodes_checked = 0
 
-        for node in model.graph.node:
-            # Check for interrupts periodically during node processing
-            self.check_interrupted()
-            is_python_operator = _is_python_operator(node.op_type or "")
-            if node.domain and node.domain not in STANDARD_ONNX_DOMAINS:
-                custom_domains.add(node.domain)
+        for graph in _iter_model_graphs(model):
+            for node in _iter_graph_nodes(graph):
+                nodes_checked += 1
+                # Check for interrupts periodically during node processing.
+                self.check_interrupted()
+                is_python_operator = _is_python_operator(node.op_type or "")
+                if node.domain and node.domain not in STANDARD_ONNX_DOMAINS:
+                    custom_domains.add(node.domain)
 
-                # All custom domains are INFO - they're metadata, not executable code
-                # Security risk is in runtime environment (installing malicious operators)
-                # not in the ONNX file itself
-                result.add_check(
-                    name="Custom Operator Domain Check",
-                    passed=False,
-                    message=(
-                        f"Model references custom operator domain '{node.domain}'. "
-                        f"This is metadata only - ensure operators are from trusted sources before installation."
-                    ),
-                    severity=IssueSeverity.INFO,
-                    location=f"{path} (node: {node.name})",
-                    rule_code="S302",
-                    details={
-                        "op_type": node.op_type,
-                        "domain": node.domain,
-                        "security_note": (
-                            "Custom domains indicate dependencies on external operator implementations. "
-                            "ONNX files cannot execute code - risk is in runtime environment if malicious "
-                            "operators are installed. Verify operator packages before installation."
+                    # All custom domains are INFO - they're metadata, not executable code
+                    # Security risk is in runtime environment (installing malicious operators)
+                    # not in the ONNX file itself
+                    result.add_check(
+                        name="Custom Operator Domain Check",
+                        passed=False,
+                        message=(
+                            f"Model references custom operator domain '{node.domain}'. "
+                            f"This is metadata only - ensure operators are from trusted sources before installation."
                         ),
-                    },
-                )
+                        severity=IssueSeverity.INFO,
+                        location=f"{path} (node: {node.name})",
+                        rule_code="S302",
+                        details={
+                            "op_type": node.op_type,
+                            "domain": node.domain,
+                            "security_note": (
+                                "Custom domains indicate dependencies on external operator implementations. "
+                                "ONNX files cannot execute code - risk is in runtime environment if malicious "
+                                "operators are installed. Verify operator packages before installation."
+                            ),
+                        },
+                    )
 
-            if is_python_operator:
-                python_ops_found = True
-                result.add_check(
-                    name="Python Operator Detection",
-                    passed=False,
-                    message=f"Model uses Python operator '{node.op_type}'",
-                    severity=IssueSeverity.CRITICAL,
-                    location=f"{path} (node: {node.name})",
-                    rule_code="S902",
-                    details={"op_type": node.op_type, "domain": node.domain},
-                )
-            elif not node.domain or node.domain in STANDARD_ONNX_DOMAINS:
-                safe_nodes += 1
+                if is_python_operator:
+                    python_ops_found = True
+                    result.add_check(
+                        name="Python Operator Detection",
+                        passed=False,
+                        message=f"Model uses Python operator '{node.op_type}'",
+                        severity=IssueSeverity.CRITICAL,
+                        location=f"{path} (node: {node.name})",
+                        rule_code="S902",
+                        details={"op_type": node.op_type, "domain": node.domain},
+                    )
+                elif not node.domain or node.domain in STANDARD_ONNX_DOMAINS:
+                    safe_nodes += 1
 
         # Record successful checks for safe operators
         if safe_nodes > 0 and not custom_domains:
@@ -525,7 +528,7 @@ class OnnxScanner(BaseScanner):
                 passed=True,
                 message="No Python operators detected",
                 location=path,
-                details={"nodes_checked": len(model.graph.node)},
+                details={"nodes_checked": nodes_checked},
             )
 
         if custom_domains:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -508,6 +508,45 @@ def test_onnx_scanner_subgraph_pyop_still_flagged(tmp_path: Path) -> None:
     assert all(issue.severity == IssueSeverity.CRITICAL for issue in python_operator_issues)
 
 
+def test_onnx_scanner_subgraph_snake_python_op_still_flagged(tmp_path: Path) -> None:
+    """A nested structural Python op must not depend on the raw-byte detector."""
+    then_branch = helper.make_graph(
+        [helper.make_node("Python_Op", ["X"], ["Z"])],
+        "then",
+        [],
+        [helper.make_tensor_value_info("Z", TensorProto.FLOAT, [1])],
+    )
+    else_branch = helper.make_graph(
+        [helper.make_node("Identity", ["X"], ["Z"])],
+        "else",
+        [],
+        [helper.make_tensor_value_info("Z", TensorProto.FLOAT, [1])],
+    )
+    graph = helper.make_graph(
+        [helper.make_node("If", ["cond"], ["Y"], then_branch=then_branch, else_branch=else_branch)],
+        "graph",
+        [
+            helper.make_tensor_value_info("cond", TensorProto.BOOL, []),
+            helper.make_tensor_value_info("X", TensorProto.FLOAT, [1]),
+        ],
+        [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    model_path = tmp_path / "subgraph_snake_python_op.onnx"
+    onnx.save(model, str(model_path))
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is False
+    assert any(
+        check.name == "Python Operator Detection"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("op_type") == "Python_Op"
+        for check in result.checks
+    )
+
+
 @pytest.mark.parametrize("training_graph_field", ["initialization", "algorithm"])
 def test_onnx_scanner_training_graph_pyop_still_flagged(tmp_path: Path, training_graph_field: str) -> None:
     """A PyOp in either training graph must not be discarded as weight-data noise."""


### PR DESCRIPTION
## Summary

- inspect every declared ONNX graph scope when enforcing structural Python-operator checks
- add a regression for an underscored Python operator nested inside an `If` branch
- record the detection fix in the unreleased changelog

## Root Cause

The recent ONNX false-positive fix added recursive graph traversal when confirming raw-byte `python_operator` findings, but the graph-based `S902` check still visited only `model.graph.node`.

That creates a false-negative path: structural matching intentionally recognizes tokenized variants such as `Python_Op`, while the raw-byte detector only recognizes contiguous names such as `PythonOp`. A nested `Python_Op` therefore bypassed both checks and returned a successful scan.

## Fix

`OnnxScanner._check_custom_ops()` now uses the existing recursive ONNX traversal for top-level nodes, nested graph attributes, local functions, and training graphs. Its passing-check metadata now reports the full number of nodes examined.

## Validation

- Pre-fix proof: `pytest tests/scanners/test_onnx_scanner.py::test_onnx_scanner_subgraph_snake_python_op_still_flagged -q` failed because the scan returned `success=True`.
- `pytest tests/scanners/test_onnx_scanner.py -q` (`59 passed`)
- `ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 pytest -n auto -m "not slow and not integration" --maxfail=1` (`5696 passed, 16 skipped`)

For local validation, the existing shared environment required rebuilding the `modelaudit-picklescan` Rust extension after the recent mainline picklescan merge; the build's incidental `Cargo.lock` version drift was excluded from this PR.
