### PR TITLE
perf: reuse call graph analysis in directory scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - detect Python operators declared in nested ONNX graphs and functions
 - distinguish ASCII-serialized Torch7 artifacts from plain PyTorch source text
 
+### Performance Improvements
+
+- share fresh pickle call-graph source analysis across files in one directory scan
+
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance Improvements
 
-- share fresh pickle call-graph source analysis across files in one directory scan
+- reuse source-validated pickle call-graph analysis across multiple directory dispatches when supported by installed picklescan
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 

--- a/docs/agents/performance-audit.md
+++ b/docs/agents/performance-audit.md
@@ -119,17 +119,17 @@ These are the main measured areas that still deserve attention:
 
 ## Recent Wins Worth Preserving
 
-| Area                                   | Why it mattered                                               |
-| -------------------------------------- | ------------------------------------------------------------- |
-| scanner-selection reuse                | removed repeated registry and alias work in large directories |
-| Hugging Face bookkeeping short-circuit | avoided expensive non-HF path checks on ordinary folders      |
-| nearby-license reuse                   | cut repeated sibling-directory scans                          |
-| report-scoped call-graph cache sharing | reduced repeated AST work in pickle-heavy scans               |
-| scan-scoped call-graph cache sharing   | reuses one fresh installed-source snapshot in directory scans |
-| bounded ordinary license-header reads  | removed long scans over huge non-license text files           |
-| cache-key hash reuse                   | avoided one duplicate full-file hash on cache miss            |
-| ONNX raw-buffer reuse                  | avoided rereading successful ONNX scans                       |
-| native-only pickle validation          | kept a validation path from doing full enrichment work        |
+| Area                                   | Why it mattered                                                               |
+| -------------------------------------- | ----------------------------------------------------------------------------- |
+| scanner-selection reuse                | removed repeated registry and alias work in large directories                 |
+| Hugging Face bookkeeping short-circuit | avoided expensive non-HF path checks on ordinary folders                      |
+| nearby-license reuse                   | cut repeated sibling-directory scans                                          |
+| report-scoped call-graph cache sharing | reduced repeated AST work in pickle-heavy scans                               |
+| scan-scoped call-graph cache sharing   | reuses source-validated installed-source analysis across directory dispatches |
+| bounded ordinary license-header reads  | removed long scans over huge non-license text files                           |
+| cache-key hash reuse                   | avoided one duplicate full-file hash on cache miss                            |
+| ONNX raw-buffer reuse                  | avoided rereading successful ONNX scans                                       |
+| native-only pickle validation          | kept a validation path from doing full enrichment work                        |
 
 ## Decision Checklist
 

--- a/docs/agents/performance-audit.md
+++ b/docs/agents/performance-audit.md
@@ -125,6 +125,7 @@ These are the main measured areas that still deserve attention:
 | Hugging Face bookkeeping short-circuit | avoided expensive non-HF path checks on ordinary folders      |
 | nearby-license reuse                   | cut repeated sibling-directory scans                          |
 | report-scoped call-graph cache sharing | reduced repeated AST work in pickle-heavy scans               |
+| scan-scoped call-graph cache sharing   | reuses one fresh installed-source snapshot in directory scans |
 | bounded ordinary license-header reads  | removed long scans over huge non-license text files           |
 | cache-key hash reuse                   | avoided one duplicate full-file hash on cache miss            |
 | ONNX raw-buffer reuse                  | avoided rereading successful ONNX scans                       |
@@ -146,7 +147,7 @@ Before landing a performance change, record:
 Priority 1:
 
 - unify or reuse remaining hashing passes
-- replace report-scoped call-graph sharing with safe source-aware invalidation
+- extend scan-scoped call-graph reuse only with source-refresh regression coverage
 - measure duplicate-aware reuse only for scanners proven path-independent
 
 Priority 2:

--- a/docs/agents/picklescan-package-split.md
+++ b/docs/agents/picklescan-package-split.md
@@ -41,7 +41,9 @@ modelaudit/
 - `modelaudit.scanners.pickle_scanner.PickleScanner` is a thin ModelAudit
   adapter around the Rust-backed standalone package.
 - Wrapper scanners in `modelaudit` pass embedded pickle streams into
-  `modelaudit-picklescan`; archive parsing stays in `modelaudit`.
+  `modelaudit-picklescan`; the root package owns rich archive/container
+  orchestration, while standalone `scan_file()` also recognizes PyTorch ZIP
+  checkpoints for standalone callers.
 - The root `modelaudit` wheel depends on the `modelaudit-picklescan`
   distribution instead of bundling its pure Python package files. This keeps
   wheel installs aligned with the native extension that the scanner requires.
@@ -53,13 +55,23 @@ modelaudit/
 The standalone package exposes a small native surface:
 
 ```python
-from modelaudit_picklescan import PickleScanner, ScanOptions, scan_bytes, scan_file, scan_stream
+from modelaudit_picklescan import (
+    PickleScanner,
+    ScanOptions,
+    scan_bytes,
+    scan_file,
+    scan_stream,
+    shared_source_sensitive_caches,
+)
 
 report = scan_file("weights.pkl")
 report = scan_bytes(payload, source="weights.pkl")
 
 scanner = PickleScanner(options=ScanOptions(timeout_s=30.0, max_opcodes=1_000_000))
 report = scanner.scan_stream(stream, source="archive.pt:data.pkl", size=pickle_size)
+
+with shared_source_sensitive_caches():
+    reports = [scan_file(path) for path in related_paths]
 ```
 
 Resource controls include opcode and wall-clock limits, post-budget tail bytes,
@@ -86,6 +98,10 @@ Report semantics keep these concepts separate:
 - Embedded-pickle wrapper scanners (`pytorch_zip`, `joblib`, `numpy`, and
   `executorch`) call the public `scan_stream(..., source=...)` API and preserve
   archive-member context in result locations/details.
+- A multi-file root scan enters one `shared_source_sensitive_caches()` scope
+  while dispatching artifacts, reusing an installed-source snapshot for
+  call-graph enrichment. A later scan operation starts with fresh source
+  analysis so rewritten dangerous code is not hidden by stale cache state.
 - CI lints, type-checks, tests, builds, and smoke-installs both the root
   `modelaudit` distribution and the standalone `modelaudit-picklescan`
   distribution. Root wheel smoke tests install the local standalone wheel via
@@ -129,5 +145,5 @@ uvx twine check /tmp/modelaudit-picklescan-dist/*
   safety decision and scan-completeness contract must stay aligned.
 - Inconclusive analysis is represented as first-class status/metadata, not as a
   hidden success boolean.
-- Per-scan state stays isolated so one scan cannot leak source/location context
-  into the next.
+- Per-scan state stays isolated: related artifacts may reuse one installed-source
+  snapshot inside an explicit scope, while the next outer scope starts fresh.

--- a/docs/agents/picklescan-package-split.md
+++ b/docs/agents/picklescan-package-split.md
@@ -74,6 +74,10 @@ with shared_source_sensitive_caches():
     reports = [scan_file(path) for path in related_paths]
 ```
 
+Before returning each later report, the shared scope revalidates bounded
+analyzed source. A change observed at that validation point fails closed as
+inconclusive instead of returning an earlier clean result.
+
 Resource controls include opcode and wall-clock limits, post-budget tail bytes,
 string-literal scan characters, nested-pickle bytes, and nested scan depth.
 
@@ -98,10 +102,11 @@ Report semantics keep these concepts separate:
 - Embedded-pickle wrapper scanners (`pytorch_zip`, `joblib`, `numpy`, and
   `executorch`) call the public `scan_stream(..., source=...)` API and preserve
   archive-member context in result locations/details.
-- A multi-file root scan enters one `shared_source_sensitive_caches()` scope
-  while dispatching artifacts, reusing an installed-source snapshot for
-  call-graph enrichment. A later scan operation starts with fresh source
-  analysis so rewritten dangerous code is not hidden by stale cache state.
+- When a root scan has multiple dispatch entries and the installed standalone
+  package exposes `shared_source_sensitive_caches()`, it reuses source-validated
+  call-graph analysis across those entries. Changed sources are refreshed
+  before a later report, and changes observed by final validation fail closed;
+  older supported installs scan correctly without this optimization.
 - CI lints, type-checks, tests, builds, and smoke-installs both the root
   `modelaudit` distribution and the standalone `modelaudit-picklescan`
   distribution. Root wheel smoke tests install the local standalone wheel via
@@ -145,5 +150,5 @@ uvx twine check /tmp/modelaudit-picklescan-dist/*
   safety decision and scan-completeness contract must stay aligned.
 - Inconclusive analysis is represented as first-class status/metadata, not as a
   hidden success boolean.
-- Per-scan state stays isolated: related artifacts may reuse one installed-source
-  snapshot inside an explicit scope, while the next outer scope starts fresh.
+- Per-scan state stays isolated: scoped reuse revalidates analyzed source before
+  each later report, and the next outer scope starts fresh.

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -6,11 +6,19 @@ import logging
 import os
 import time
 from collections.abc import Iterator
-from contextlib import ExitStack, suppress
+from contextlib import ExitStack, contextmanager, suppress
 from pathlib import Path
 from typing import Any
 
-from modelaudit_picklescan import shared_source_sensitive_caches
+try:
+    from modelaudit_picklescan import shared_source_sensitive_caches
+except ImportError:
+
+    @contextmanager
+    def shared_source_sensitive_caches() -> Iterator[None]:
+        """Preserve compatibility with older independently versioned picklescan installs."""
+        yield
+
 
 import modelaudit.core_results as core_results
 from modelaudit.integrations.license_checker import (

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -6,9 +6,11 @@ import logging
 import os
 import time
 from collections.abc import Iterator
-from contextlib import suppress
+from contextlib import ExitStack, suppress
 from pathlib import Path
 from typing import Any
+
+from modelaudit_picklescan import shared_source_sensitive_caches
 
 import modelaudit.core_results as core_results
 from modelaudit.integrations.license_checker import (
@@ -472,6 +474,7 @@ def scan_model_directory_or_file(
     # Track file hashes for aggregate hash computation
     file_hashes: list[str] = []
     nearby_license_cache: dict[str, list[str]] = {}
+    pickle_source_snapshot_stack = ExitStack()
 
     phase_timings: dict[str, float] | None = {} if bool(kwargs.get("profile_timings")) else None
 
@@ -777,6 +780,9 @@ def scan_model_directory_or_file(
                         duplicate_paths_by_hash.setdefault(content_hash, []).append(file_path)
                 recorded_content_hashes: set[str] = set()
 
+                if len(scan_entries) > 1:
+                    pickle_source_snapshot_stack.enter_context(shared_source_sensitive_caches())
+
                 for representative_file, scanned_file_paths, shard_family_key in scan_entries:
                     # Check for interrupts
                     check_interrupted()
@@ -1075,6 +1081,8 @@ def scan_model_directory_or_file(
             details={"exception_type": type(e).__name__},
         )
         _add_error_asset_to_results(results, path)
+    finally:
+        pickle_source_snapshot_stack.close()
 
     # Final timing is handled by finalize_statistics()
 

--- a/modelaudit/utils/file/handlers.py
+++ b/modelaudit/utils/file/handlers.py
@@ -13,6 +13,7 @@ import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import suppress
+from contextvars import copy_context
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -403,7 +404,9 @@ class ParallelShardHandler:
 
         with ThreadPoolExecutor(max_workers=min(MAX_PARALLEL_WORKERS, total_shards)) as executor:
             # Submit all shard scans
-            future_to_shard = {executor.submit(self._scan_single_shard, shard): shard for shard in shards}
+            future_to_shard = {
+                executor.submit(copy_context().run, self._scan_single_shard, shard): shard for shard in shards
+            }
 
             # Process results as they complete
             for future in as_completed(future_to_shard):

--- a/packages/modelaudit-picklescan/AGENTS.md
+++ b/packages/modelaudit-picklescan/AGENTS.md
@@ -6,7 +6,7 @@ Scoped agent guide for work inside `packages/modelaudit-picklescan/`. The root [
 
 `modelaudit-picklescan` is the Rust-backed pickle scanner that ships as an independent PyPI package. The root `modelaudit` wheel depends on it at runtime via a hard `modelaudit-picklescan>=0.1.0,<0.2.0` pin in the root `pyproject.toml`.
 
-- **Public API** — exported from `src/modelaudit_picklescan/__init__.py`: `PickleScanner`, `ScanOptions`, `scan_file`, `scan_bytes`, `scan_stream`, `PickleReport`, `Finding`, `Notice`, `ScanError`, `Severity`, `ScanStatus`, `SafetyVerdict`, `CoverageSummary`. Treat these names as a stable surface.
+- **Public API** — exported from `src/modelaudit_picklescan/__init__.py`: `PickleScanner`, `ScanOptions`, `scan_file`, `scan_bytes`, `scan_stream`, `shared_source_sensitive_caches`, `PickleReport`, `Finding`, `Notice`, `ScanError`, `Severity`, `ScanStatus`, `SafetyVerdict`, `CoverageSummary`. Treat these names as a stable surface.
 - **Rust engine** — `rust/src/` compiled to `modelaudit_picklescan._rust` via maturin + PyO3. Rust 1.83+, edition 2021.
 - **Zero Python runtime deps** — the wheel is intentionally self-contained.
 - **Typed** — ships `py.typed`. Public models are frozen dataclasses with `to_dict()`.

--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -60,6 +60,10 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - detect dangerous positional lookups inside `str.format` replacement fields
 - recognize PyTorch ZIP archives that contain only hidden pickle members
 
+### Performance Improvements
+
+- expose a bounded source-analysis cache scope for multi-artifact scan operations
+
 ## [0.1.3](https://github.com/promptfoo/modelaudit/compare/modelaudit-picklescan-v0.1.2...modelaudit-picklescan-v0.1.3) (2026-04-27)
 
 ### Bug Fixes

--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -62,7 +62,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance Improvements
 
-- expose a bounded source-analysis cache scope for multi-artifact scan operations
+- expose a bounded, source-validated analysis cache scope for multi-artifact scan operations
 
 ## [0.1.3](https://github.com/promptfoo/modelaudit/compare/modelaudit-picklescan-v0.1.2...modelaudit-picklescan-v0.1.3) (2026-04-27)
 

--- a/packages/modelaudit-picklescan/Cargo.lock
+++ b/packages/modelaudit-picklescan/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "modelaudit-picklescan-rust"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "pyo3",
 ]

--- a/packages/modelaudit-picklescan/README.md
+++ b/packages/modelaudit-picklescan/README.md
@@ -106,8 +106,9 @@ Three convenience entry points, each returning a `PickleReport`:
 For long-running services, construct `PickleScanner(options=...)` once and reuse it across calls.
 
 When scanning a related batch of files, use `shared_source_sensitive_caches()` to
-reuse one installed-source snapshot for call-graph enrichment while keeping
-later scan batches isolated:
+reuse bounded call-graph source analysis. Analyzed source content is validated
+before each later report; changes observed at final validation fail closed as
+inconclusive, and later scan batches remain isolated:
 
 ```python
 from modelaudit_picklescan import scan_file, shared_source_sensitive_caches

--- a/packages/modelaudit-picklescan/README.md
+++ b/packages/modelaudit-picklescan/README.md
@@ -91,6 +91,7 @@ Use **[`modelaudit`](https://pypi.org/project/modelaudit/)** if you want the ful
 from modelaudit_picklescan import (
     PickleScanner, ScanOptions,
     scan_file, scan_bytes, scan_stream,
+    shared_source_sensitive_caches,
     PickleReport, Finding, Notice, ScanError,
     Severity, ScanStatus, SafetyVerdict, CoverageSummary,
 )
@@ -103,6 +104,17 @@ Three convenience entry points, each returning a `PickleReport`:
 - `scan_stream(stream, *, source="<stream>", size=None, options=None)` — scan a binary file-like object; falls back to bounded spooling when `size` is unknown.
 
 For long-running services, construct `PickleScanner(options=...)` once and reuse it across calls.
+
+When scanning a related batch of files, use `shared_source_sensitive_caches()` to
+reuse one installed-source snapshot for call-graph enrichment while keeping
+later scan batches isolated:
+
+```python
+from modelaudit_picklescan import scan_file, shared_source_sensitive_caches
+
+with shared_source_sensitive_caches():
+    reports = [scan_file(path) for path in model_paths]
+```
 
 ### Resource controls — `ScanOptions`
 

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/__init__.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/__init__.py
@@ -1,6 +1,7 @@
 """Standalone pickle scanning API."""
 
 from .api import PickleScanner, scan_bytes, scan_file, scan_stream
+from .call_graph import shared_source_sensitive_caches
 from .options import ScanOptions
 from .report import CoverageSummary, Finding, Notice, PickleReport, SafetyVerdict, ScanError, ScanStatus, Severity
 
@@ -18,4 +19,5 @@ __all__ = [
     "scan_bytes",
     "scan_file",
     "scan_stream",
+    "shared_source_sensitive_caches",
 ]

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -14,7 +14,9 @@ from .call_graph import (
     CallGraphFinding,
     StartupHookWriteFinding,
     UnanalyzedCallGraphReference,
+    _begin_shared_source_report,
     _CallGraphAnalysisLimitError,
+    _ensure_shared_source_snapshot_stable,
     find_dangerous_call_graphs,
     find_startup_hook_write_call_graphs,
     find_unanalyzed_callable_call_graph_references,
@@ -1008,9 +1010,10 @@ def _report_from_native_dict(raw_report: Mapping[str, Any]) -> PickleReport:
 def _with_call_graph_findings(report: PickleReport) -> PickleReport:
     import_references = report.metadata.get("import_references")
     callable_invocations = report.metadata.get("callable_invocations", ())
-    call_graph_limit_exceeded = has_unanalyzed_call_graph_import_references(import_references)
     enrichment_errors: list[tuple[str, Exception]] = []
     with shared_source_sensitive_caches():
+        report_generation = _begin_shared_source_report()
+        call_graph_limit_exceeded = has_unanalyzed_call_graph_import_references(import_references)
         try:
             call_graph_findings = find_dangerous_call_graphs(import_references, callable_invocations)
         except _CallGraphAnalysisLimitError as error:
@@ -1035,6 +1038,10 @@ def _with_call_graph_findings(report: PickleReport) -> PickleReport:
         except Exception as error:
             unanalyzed_references = ()
             enrichment_errors.append(("python_call_graph_source_unavailable", error))
+        try:
+            _ensure_shared_source_snapshot_stable(report_generation)
+        except _CallGraphAnalysisLimitError as error:
+            enrichment_errors.append(("python_call_graph_source_stability", error))
 
     updated_report = (
         _with_unanalyzed_call_graph_notices(report, unanalyzed_references) if unanalyzed_references else report

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import hashlib
 import os
 import sys
 import sysconfig
@@ -11,11 +12,11 @@ from collections import deque
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import lru_cache
 from importlib.machinery import EXTENSION_SUFFIXES, BuiltinImporter, FrozenImporter, ModuleSpec, PathFinder
 from pathlib import Path
-from typing import Protocol, TypeVar, cast
+from typing import Any, Protocol, TypeVar, cast
 
 # Bound per-pass import/callable fan-out for untrusted inputs. The 32-reference
 # cap has kept call-graph enrichment useful while preventing pathological scan
@@ -55,6 +56,10 @@ _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH: ContextVar[int] = ContextVar(
     "_SHARED_SOURCE_SENSITIVE_CACHE_DEPTH",
     default=0,
 )
+_SHARED_SOURCE_SENSITIVE_SNAPSHOT: ContextVar[_SharedSourceSnapshot | None] = ContextVar(
+    "_SHARED_SOURCE_SENSITIVE_SNAPSHOT",
+    default=None,
+)
 _SHARED_SOURCE_SENSITIVE_CACHE_LOCK = threading.RLock()
 _CachedFunctionT = TypeVar("_CachedFunctionT", bound=Callable[..., object])
 
@@ -82,6 +87,15 @@ class _CallGraphAnalysisLimitError(RuntimeError):
         self.partial_findings = partial_findings
         self.partial_startup_hook_write_findings = partial_startup_hook_write_findings
         self.partial_path = partial_path
+
+
+@dataclass
+class _SharedSourceSnapshot:
+    search_context: tuple[str, ...]
+    fingerprints: dict[str, bytes | None] = field(default_factory=dict)
+    generation: int = 0
+    reusable: bool = True
+    lock: Any = field(default_factory=threading.RLock)
 
 
 def _register_source_sensitive_cache(function: _CachedFunctionT) -> _CachedFunctionT:
@@ -554,23 +568,36 @@ def find_unanalyzed_callable_call_graph_references(
 
 @contextmanager
 def shared_source_sensitive_caches() -> Iterator[None]:
-    """Share one fresh installed-source snapshot across related scan work."""
+    """Share source analysis until a bounded source snapshot changes."""
     depth = _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.get()
     if depth > 0:
-        token = _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.set(depth + 1)
-        try:
-            yield
-        finally:
-            _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.reset(token)
+        snapshot = _SHARED_SOURCE_SENSITIVE_SNAPSHOT.get()
+        if snapshot is None:
+            token = _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.set(depth + 1)
+            try:
+                yield
+            finally:
+                _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.reset(token)
+        else:
+            with snapshot.lock:
+                token = _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.set(depth + 1)
+                try:
+                    yield
+                finally:
+                    _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.reset(token)
         return
 
     with _SHARED_SOURCE_SENSITIVE_CACHE_LOCK:
         _clear_source_sensitive_caches_now()
+        snapshot_token = _SHARED_SOURCE_SENSITIVE_SNAPSHOT.set(
+            _SharedSourceSnapshot(search_context=_source_search_context())
+        )
         token = _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.set(1)
         try:
             yield
         finally:
             _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.reset(token)
+            _SHARED_SOURCE_SENSITIVE_SNAPSHOT.reset(snapshot_token)
 
 
 @_register_source_sensitive_cache
@@ -863,15 +890,104 @@ def has_unanalyzed_call_graph_import_references(import_references: object) -> bo
 
 
 def _clear_source_sensitive_caches() -> None:
-    with _SHARED_SOURCE_SENSITIVE_CACHE_LOCK:
-        if _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.get() > 0:
+    if _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.get() > 0:
+        snapshot = _SHARED_SOURCE_SENSITIVE_SNAPSHOT.get()
+        if snapshot is None:
             return
+        with snapshot.lock:
+            if _shared_source_snapshot_is_current(snapshot):
+                return
+            _clear_source_sensitive_caches_now()
+            _reset_shared_source_snapshot(snapshot)
+        return
+
+    with _SHARED_SOURCE_SENSITIVE_CACHE_LOCK:
         _clear_source_sensitive_caches_now()
 
 
 def _clear_source_sensitive_caches_now() -> None:
     for function in _SOURCE_SENSITIVE_CACHED_FUNCTIONS:
         function.cache_clear()
+
+
+def _source_search_context() -> tuple[str, ...]:
+    return tuple(str(Path(entry or os.getcwd()).absolute()) for entry in sys.path)
+
+
+def _source_candidate_fingerprint(path: Path) -> tuple[bool, bytes | None]:
+    if not path.is_file():
+        return True, None
+    try:
+        with path.open("rb") as source_file:
+            source = source_file.read(_MAX_SOURCE_BYTES + 1)
+    except OSError:
+        return False, None
+    if len(source) > _MAX_SOURCE_BYTES:
+        return False, None
+    return True, hashlib.sha256(source).digest()
+
+
+def _reset_shared_source_snapshot(snapshot: _SharedSourceSnapshot) -> None:
+    snapshot.search_context = _source_search_context()
+    snapshot.fingerprints.clear()
+    snapshot.generation += 1
+    snapshot.reusable = True
+
+
+def _shared_source_snapshot_is_current(snapshot: _SharedSourceSnapshot) -> bool:
+    if not snapshot.reusable or snapshot.search_context != _source_search_context():
+        return False
+    for path, expected_fingerprint in snapshot.fingerprints.items():
+        reusable, fingerprint = _source_candidate_fingerprint(Path(path))
+        if not reusable or fingerprint != expected_fingerprint:
+            return False
+    return True
+
+
+def _begin_shared_source_report() -> int | None:
+    snapshot = _SHARED_SOURCE_SENSITIVE_SNAPSHOT.get()
+    if snapshot is None:
+        return None
+    with snapshot.lock:
+        if not _shared_source_snapshot_is_current(snapshot):
+            _clear_source_sensitive_caches_now()
+            _reset_shared_source_snapshot(snapshot)
+        return snapshot.generation
+
+
+def _ensure_shared_source_snapshot_stable(report_generation: int | None) -> None:
+    snapshot = _SHARED_SOURCE_SENSITIVE_SNAPSHOT.get()
+    if snapshot is None or report_generation is None:
+        return
+    with snapshot.lock:
+        if snapshot.generation != report_generation:
+            raise _CallGraphAnalysisLimitError("source changed during shared call-graph analysis")
+        if _shared_source_snapshot_is_current(snapshot):
+            return
+        _clear_source_sensitive_caches_now()
+        _reset_shared_source_snapshot(snapshot)
+    raise _CallGraphAnalysisLimitError("source changed during shared call-graph analysis")
+
+
+def _track_shared_source_candidates(parts: tuple[str, ...]) -> None:
+    snapshot = _SHARED_SOURCE_SENSITIVE_SNAPSHOT.get()
+    if snapshot is None:
+        return
+    candidates: set[Path] = set()
+    for entry in sys.path:
+        root = Path(entry or os.getcwd())
+        candidates.add(root.joinpath(*parts).with_suffix(".py").absolute())
+        candidates.add(root.joinpath(*parts, "__init__.py").absolute())
+    with snapshot.lock:
+        if snapshot.search_context != _source_search_context():
+            snapshot.reusable = False
+            return
+        for candidate in candidates:
+            reusable, fingerprint = _source_candidate_fingerprint(candidate)
+            if not reusable:
+                snapshot.reusable = False
+                return
+            snapshot.fingerprints[str(candidate)] = fingerprint
 
 
 def _call_graph_source_unavailable_reason(module_name: str) -> str | None:
@@ -3368,6 +3484,7 @@ def _resolve_module_source(module_name: str) -> Path | None:
     parts = module_name.split(".")
     if not parts or any(not part or "/" in part or "\\" in part for part in parts):
         return None
+    _track_shared_source_candidates(tuple(parts))
     for entry in sys.path:
         root = Path(entry or os.getcwd())
         current = root

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -555,11 +555,18 @@ def find_unanalyzed_callable_call_graph_references(
 @contextmanager
 def shared_source_sensitive_caches() -> Iterator[None]:
     """Share one fresh installed-source snapshot across related scan work."""
-    with _SHARED_SOURCE_SENSITIVE_CACHE_LOCK:
-        depth = _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.get()
-        if depth == 0:
-            _clear_source_sensitive_caches_now()
+    depth = _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.get()
+    if depth > 0:
         token = _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.set(depth + 1)
+        try:
+            yield
+        finally:
+            _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.reset(token)
+        return
+
+    with _SHARED_SOURCE_SENSITIVE_CACHE_LOCK:
+        _clear_source_sensitive_caches_now()
+        token = _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.set(1)
         try:
             yield
         finally:

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -554,7 +554,7 @@ def find_unanalyzed_callable_call_graph_references(
 
 @contextmanager
 def shared_source_sensitive_caches() -> Iterator[None]:
-    """Share one fresh cache generation across related enrichment passes."""
+    """Share one fresh installed-source snapshot across related scan work."""
     with _SHARED_SOURCE_SENSITIVE_CACHE_LOCK:
         depth = _SHARED_SOURCE_SENSITIVE_CACHE_DEPTH.get()
         if depth == 0:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import pytest
 
+import modelaudit_picklescan.api as api_module
 import modelaudit_picklescan.call_graph as call_graph
 from modelaudit_picklescan import PickleReport, SafetyVerdict, ScanOptions, ScanStatus, Severity, scan_bytes
 from modelaudit_picklescan.api import _RUST_EXTENSION_MODULE
@@ -134,6 +135,7 @@ def test_shared_source_sensitive_caches_allows_inherited_worker_scopes(
 
     def enter_worker_scope() -> None:
         with call_graph.shared_source_sensitive_caches():
+            call_graph._clear_source_sensitive_caches()
             worker_entered.set()
 
     monkeypatch.setattr(call_graph, "_clear_source_sensitive_caches_now", fake_clear)
@@ -151,6 +153,39 @@ def test_shared_source_sensitive_caches_allows_inherited_worker_scopes(
         pass
 
     assert clear_count == 2
+
+
+def test_shared_source_sensitive_caches_serializes_inherited_worker_work() -> None:
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_entered = threading.Event()
+
+    def hold_first_scope() -> None:
+        with call_graph.shared_source_sensitive_caches():
+            first_entered.set()
+            release_first.wait(timeout=1)
+
+    def enter_second_scope() -> None:
+        with call_graph.shared_source_sensitive_caches():
+            second_entered.set()
+
+    with call_graph.shared_source_sensitive_caches():
+        first_context = copy_context()
+        second_context = copy_context()
+        first_worker = threading.Thread(target=first_context.run, args=(hold_first_scope,))
+        second_worker = threading.Thread(target=second_context.run, args=(enter_second_scope,))
+        first_worker.start()
+        assert first_entered.wait(timeout=1)
+        second_worker.start()
+        second_was_blocked = not second_entered.wait(timeout=0.05)
+        release_first.set()
+        assert second_entered.wait(timeout=1)
+        first_worker.join(timeout=1)
+        second_worker.join(timeout=1)
+
+    assert second_was_blocked
+    assert not first_worker.is_alive()
+    assert not second_worker.is_alive()
 
 
 def test_shared_source_sensitive_caches_serializes_independent_scopes(
@@ -215,6 +250,132 @@ def test_shared_source_sensitive_caches_refreshes_between_outer_scopes(
     assert safe_report.verdict == SafetyVerdict.CLEAN
     assert dangerous_report.verdict == SafetyVerdict.MALICIOUS
     assert _has_critical_call_graph_finding(dangerous_report, module_name, "invoke", "os.system")
+
+
+def test_shared_source_sensitive_caches_refreshes_changed_source_within_scope(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    module_name = "modelaudit_tp_scoped_changed_call_graph_source"
+    module_path = module_dir / f"{module_name}.py"
+    module_path.write_text("def invoke(command):\n    return command\n", encoding="utf-8")
+    monkeypatch.syspath_prepend(str(module_dir))
+    importlib.invalidate_caches()
+    _clear_call_graph_caches()
+    payload = _global_call_payload(module_name, "invoke", _unicode_operand("echo changed"))
+
+    try:
+        with call_graph.shared_source_sensitive_caches():
+            safe_report = scan_bytes(payload, source="scoped-changed-safe.pkl")
+            module_path.write_text(
+                "import os\n\ndef invoke(command):\n    return os.system(command)\n",
+                encoding="utf-8",
+            )
+            importlib.invalidate_caches()
+            dangerous_report = scan_bytes(payload, source="scoped-changed-dangerous.pkl")
+    finally:
+        _clear_call_graph_caches()
+
+    assert safe_report.verdict == SafetyVerdict.CLEAN
+    assert dangerous_report.verdict == SafetyVerdict.MALICIOUS
+    assert _has_critical_call_graph_finding(dangerous_report, module_name, "invoke", "os.system")
+
+
+def test_shared_source_sensitive_caches_fails_closed_when_final_validation_observes_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    module_name = "modelaudit_tp_scoped_inflight_call_graph_source"
+    module_path = module_dir / f"{module_name}.py"
+    module_path.write_text("def invoke(command):\n    return command\n", encoding="utf-8")
+    monkeypatch.syspath_prepend(str(module_dir))
+    importlib.invalidate_caches()
+    _clear_call_graph_caches()
+    payload = _global_call_payload(module_name, "invoke", _unicode_operand("echo inflight"))
+
+    try:
+        with call_graph.shared_source_sensitive_caches():
+            safe_report = scan_bytes(payload, source="scoped-inflight-safe.pkl")
+            real_ensure_stable = api_module._ensure_shared_source_snapshot_stable
+            source_rewritten = False
+
+            def rewrite_before_completion_check(report_generation: int | None) -> None:
+                nonlocal source_rewritten
+                if not source_rewritten:
+                    module_path.write_text(
+                        "import os\n\ndef invoke(command):\n    return os.system(command)\n",
+                        encoding="utf-8",
+                    )
+                    importlib.invalidate_caches()
+                    source_rewritten = True
+                real_ensure_stable(report_generation)
+
+            monkeypatch.setattr(api_module, "_ensure_shared_source_snapshot_stable", rewrite_before_completion_check)
+            changed_report = scan_bytes(payload, source="scoped-inflight-changed.pkl")
+    finally:
+        _clear_call_graph_caches()
+
+    assert safe_report.verdict == SafetyVerdict.CLEAN
+    assert source_rewritten is True
+    assert changed_report.status == ScanStatus.INCONCLUSIVE
+    assert changed_report.verdict == SafetyVerdict.UNKNOWN
+    assert any(error.details.get("analysis") == "python_call_graph_source_stability" for error in changed_report.errors)
+
+
+def test_shared_source_sensitive_caches_fails_closed_after_mid_report_refresh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    module_name = "modelaudit_tp_scoped_mid_report_call_graph_source"
+    module_path = module_dir / f"{module_name}.py"
+    module_path.write_text("def invoke(command):\n    return command\n", encoding="utf-8")
+    monkeypatch.syspath_prepend(str(module_dir))
+    importlib.invalidate_caches()
+    _clear_call_graph_caches()
+    payload = _global_call_payload(module_name, "invoke", _unicode_operand("echo mid-report"))
+
+    try:
+        with call_graph.shared_source_sensitive_caches():
+            safe_report = scan_bytes(payload, source="scoped-mid-report-safe.pkl")
+            real_startup_findings = api_module.find_startup_hook_write_call_graphs
+            source_rewritten = False
+
+            def rewrite_before_later_subpass(
+                import_references: object,
+                callable_invocations: object | None = None,
+                *,
+                callable_invocations_complete: bool = True,
+            ) -> tuple[call_graph.StartupHookWriteFinding, ...]:
+                nonlocal source_rewritten
+                if not source_rewritten:
+                    module_path.write_text(
+                        "import os\n\ndef invoke(command):\n    return os.system(command)\n",
+                        encoding="utf-8",
+                    )
+                    importlib.invalidate_caches()
+                    source_rewritten = True
+                return real_startup_findings(
+                    import_references,
+                    callable_invocations,
+                    callable_invocations_complete=callable_invocations_complete,
+                )
+
+            monkeypatch.setattr(api_module, "find_startup_hook_write_call_graphs", rewrite_before_later_subpass)
+            changed_report = scan_bytes(payload, source="scoped-mid-report-changed.pkl")
+    finally:
+        _clear_call_graph_caches()
+
+    assert safe_report.verdict == SafetyVerdict.CLEAN
+    assert source_rewritten is True
+    assert changed_report.status == ScanStatus.INCONCLUSIVE
+    assert changed_report.verdict == SafetyVerdict.UNKNOWN
+    assert any(error.details.get("analysis") == "python_call_graph_source_stability" for error in changed_report.errors)
 
 
 def _env_without_pythonpath() -> dict[str, str]:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -10,7 +10,9 @@ import pickle
 import py_compile
 import subprocess
 import sys
+import threading
 import zipfile
+from contextvars import copy_context
 from importlib.machinery import ModuleSpec
 from importlib.util import find_spec
 from pathlib import Path
@@ -117,6 +119,67 @@ def test_shared_source_sensitive_caches_clears_once_per_scope(monkeypatch: pytes
 
     call_graph._clear_source_sensitive_caches()
 
+    assert clear_count == 2
+
+
+def test_shared_source_sensitive_caches_allows_inherited_worker_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_count = 0
+    worker_entered = threading.Event()
+
+    def fake_clear() -> None:
+        nonlocal clear_count
+        clear_count += 1
+
+    def enter_worker_scope() -> None:
+        with call_graph.shared_source_sensitive_caches():
+            worker_entered.set()
+
+    monkeypatch.setattr(call_graph, "_clear_source_sensitive_caches_now", fake_clear)
+
+    with call_graph.shared_source_sensitive_caches():
+        worker_context = copy_context()
+        worker = threading.Thread(target=worker_context.run, args=(enter_worker_scope,))
+        worker.start()
+        assert worker_entered.wait(timeout=1)
+        worker.join(timeout=1)
+        assert not worker.is_alive()
+        assert clear_count == 1
+
+    with call_graph.shared_source_sensitive_caches():
+        pass
+
+    assert clear_count == 2
+
+
+def test_shared_source_sensitive_caches_serializes_independent_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_count = 0
+    worker_started = threading.Event()
+    worker_entered = threading.Event()
+
+    def fake_clear() -> None:
+        nonlocal clear_count
+        clear_count += 1
+
+    def enter_worker_scope() -> None:
+        worker_started.set()
+        with call_graph.shared_source_sensitive_caches():
+            worker_entered.set()
+
+    monkeypatch.setattr(call_graph, "_clear_source_sensitive_caches_now", fake_clear)
+
+    with call_graph.shared_source_sensitive_caches():
+        worker = threading.Thread(target=enter_worker_scope)
+        worker.start()
+        assert worker_started.wait(timeout=1)
+        assert not worker_entered.wait(timeout=0.05)
+
+    assert worker_entered.wait(timeout=1)
+    worker.join(timeout=1)
+    assert not worker.is_alive()
     assert clear_count == 2
 
 

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -120,6 +120,40 @@ def test_shared_source_sensitive_caches_clears_once_per_scope(monkeypatch: pytes
     assert clear_count == 2
 
 
+def test_shared_source_sensitive_caches_refreshes_between_outer_scopes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    module_name = "modelaudit_tp_scoped_rewritten_call_graph_source"
+    module_path = module_dir / f"{module_name}.py"
+    module_path.write_text("def invoke(command):\n    return command\n", encoding="utf-8")
+    monkeypatch.syspath_prepend(str(module_dir))
+    importlib.invalidate_caches()
+    _clear_call_graph_caches()
+    payload = _global_call_payload(module_name, "invoke", _unicode_operand("echo rewritten"))
+
+    try:
+        with call_graph.shared_source_sensitive_caches():
+            safe_report = scan_bytes(payload, source="scoped-source-safe.pkl")
+
+        module_path.write_text(
+            "import os\n\ndef invoke(command):\n    return os.system(command)\n",
+            encoding="utf-8",
+        )
+        importlib.invalidate_caches()
+
+        with call_graph.shared_source_sensitive_caches():
+            dangerous_report = scan_bytes(payload, source="scoped-source-dangerous.pkl")
+    finally:
+        _clear_call_graph_caches()
+
+    assert safe_report.verdict == SafetyVerdict.CLEAN
+    assert dangerous_report.verdict == SafetyVerdict.MALICIOUS
+    assert _has_critical_call_graph_finding(dangerous_report, module_name, "invoke", "os.system")
+
+
 def _env_without_pythonpath() -> dict[str, str]:
     return {key: value for key, value in os.environ.items() if key != "PYTHONPATH"}
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -75,6 +75,54 @@ def test_multi_file_directory_scan_shares_one_pickle_source_snapshot(
     assert any(issue.rule_code == "DANGEROUS_CALL_GRAPH" for issue in result.issues)
 
 
+def test_multi_file_directory_scan_refreshes_changed_pickle_source_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    module_name = "modelaudit_tp_directory_changed_call_graph_target"
+    module_path = module_dir / f"{module_name}.py"
+    module_path.write_text("def invoke(command):\n    return command\n", encoding="utf-8")
+    monkeypatch.syspath_prepend(str(module_dir))
+    importlib.invalidate_caches()
+    safe_module = importlib.import_module(module_name)
+    safe_invoke = safe_module.invoke
+    model_dir = tmp_path / "models"
+    model_dir.mkdir()
+
+    class Payload:
+        def __reduce__(self) -> tuple[Any, tuple[str]]:
+            return (safe_invoke, ("echo changed-directory-scan",))
+
+    for index in range(2):
+        (model_dir / f"model-{index}.pkl").write_bytes(pickle.dumps(Payload()))
+
+    source_rewritten = False
+
+    def rewrite_before_second_scan(message: str, _percentage: float) -> None:
+        nonlocal source_rewritten
+        if "Scanning file 2/2" not in message or source_rewritten:
+            return
+        module_path.write_text(
+            "import os\n\ndef invoke(command):\n    return os.system(command)\n",
+            encoding="utf-8",
+        )
+        importlib.invalidate_caches()
+        source_rewritten = True
+
+    result = core_module.scan_model_directory_or_file(
+        str(model_dir),
+        cache_scan_results=False,
+        progress_callback=rewrite_before_second_scan,
+    )
+
+    assert source_rewritten is True
+    assert result.success is True
+    assert result.files_scanned == 2
+    assert any(issue.rule_code == "DANGEROUS_CALL_GRAPH" for issue in result.issues)
+
+
 def _build_malicious_pickle() -> bytes:
     """Build a tiny pickle payload that exercises nested dangerous-opcode scanning."""
     import os as os_module

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import base64
 import gzip
+import importlib
 import json
 import pickle
 import zipfile
 from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +25,54 @@ from modelaudit.utils.helpers.secure_hasher import compute_aggregate_hash
 from tests.helpers import create_mock_gguf, create_mock_onnx, create_mock_pytorch_zip
 
 _SYSTEM_GLOBAL_NAMES = ("os.system", "posix.system", "nt.system")
+
+
+def test_multi_file_directory_scan_shares_one_pickle_source_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = tmp_path / "modules"
+    module_dir.mkdir()
+    module_name = "modelaudit_tp_directory_call_graph_target"
+    (module_dir / f"{module_name}.py").write_text(
+        "import os\n\ndef invoke(command):\n    return os.system(command)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(module_dir))
+    importlib.invalidate_caches()
+    dangerous_module = importlib.import_module(module_name)
+    dangerous_invoke = dangerous_module.invoke
+    model_dir = tmp_path / "models"
+    model_dir.mkdir()
+
+    class Payload:
+        def __reduce__(self) -> tuple[Any, tuple[str]]:
+            return (dangerous_invoke, ("echo cached-directory-scan",))
+
+    for index in range(2):
+        (model_dir / f"model-{index}.pkl").write_bytes(pickle.dumps(Payload()))
+    scopes_entered = 0
+    scopes_exited = 0
+    real_snapshot = core_module.shared_source_sensitive_caches
+
+    @contextmanager
+    def fake_snapshot() -> Iterator[None]:
+        nonlocal scopes_entered, scopes_exited
+        scopes_entered += 1
+        with real_snapshot():
+            try:
+                yield
+            finally:
+                scopes_exited += 1
+
+    monkeypatch.setattr(core_module, "shared_source_sensitive_caches", fake_snapshot)
+
+    result = core_module.scan_model_directory_or_file(str(model_dir), cache_scan_results=False)
+
+    assert result.success is True
+    assert result.files_scanned == 2
+    assert (scopes_entered, scopes_exited) == (1, 1)
+    assert any(issue.rule_code == "DANGEROUS_CALL_GRAPH" for issue in result.issues)
 
 
 def _build_malicious_pickle() -> bytes:

--- a/tests/utils/file/test_advanced_file_handler.py
+++ b/tests/utils/file/test_advanced_file_handler.py
@@ -2,6 +2,7 @@
 
 import os
 import tempfile
+from contextvars import ContextVar
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -55,6 +56,27 @@ class IncompleteShardScanner:
             location=shard_path,
         )
         result.finish(success=False)
+        return result
+
+
+_SHARD_SCAN_CONTEXT: ContextVar[str] = ContextVar("_SHARD_SCAN_CONTEXT", default="missing")
+
+
+class ContextRecordingShardScanner:
+    """Scanner that records worker context for propagation tests."""
+
+    name = "context_recording_shard_scanner"
+
+    def scan(self, shard_path: str) -> ScanResult:
+        result = ScanResult(scanner_name=self.name)
+        result.add_check(
+            name="Shard Context",
+            passed=True,
+            message=Path(shard_path).name,
+            severity=IssueSeverity.INFO,
+            details={"context_value": _SHARD_SCAN_CONTEXT.get()},
+        )
+        result.finish(success=True)
         return result
 
 
@@ -480,6 +502,28 @@ class TestAdvancedFileHandler:
         shard_checks = [check for check in result.checks if check.name == "Shard Scan"]
         assert len(shard_checks) == 1
         assert shard_checks[0].severity == IssueSeverity.INFO
+
+    def test_parallel_shards_inherit_scan_context(self, tmp_path: Path) -> None:
+        """Shard workers preserve an enclosing source-sensitive scan snapshot."""
+        shard_path = tmp_path / "model-00001-of-00001.safetensors"
+        shard_path.write_bytes(b"safe")
+        handler = ParallelShardHandler(
+            {
+                "shards": [str(shard_path)],
+                "total_shards": 1,
+                "total_size": shard_path.stat().st_size,
+            },
+            ContextRecordingShardScanner,
+        )
+        token = _SHARD_SCAN_CONTEXT.set("directory-snapshot")
+        try:
+            result = handler.scan_shards()
+        finally:
+            _SHARD_SCAN_CONTEXT.reset(token)
+
+        context_checks = [check for check in result.checks if check.name == "Shard Context"]
+        assert len(context_checks) == 1
+        assert context_checks[0].details["context_value"] == "directory-snapshot"
 
     def test_sharded_model_preserves_unsuccessful_shard_result(self, tmp_path: Path) -> None:
         """Non-critical shard failures must not be overwritten after aggregate merge."""


### PR DESCRIPTION
## Summary

- reuse one fresh `modelaudit-picklescan` installed-source analysis snapshot while a multi-file directory scan dispatches artifacts
- keep the cache boundary explicit and fresh across outer scan operations, with regressions for dangerous source rewrites and cached multi-file detection
- correct the package-boundary documentation for standalone PyTorch ZIP handling and synchronize the stale picklescan `Cargo.lock` package version

## Root cause

Call-graph enrichment already cached repeated AST analysis inside one pickle report, but a directory scan discarded that work between related artifact reports. Pickle-heavy repository scans repeatedly re-analyzed the same installed Python globals. The optimization is scoped to multi-file directory dispatch only; single-file and streaming paths retain their existing lifetime.

## Safety and behavior

- Added a standalone regression that scans clean source in one cache scope, rewrites it to call `os.system`, and verifies a later scope still reports `DANGEROUS_CALL_GRAPH`.
- Added a root integration regression with two pickle artifacts reaching `os.system` only through Python call-graph enrichment, verifying directory cache reuse still reports the dangerous path.
- Updated maintainer docs to state that related artifacts share an installed-source snapshot only within an explicit scope and later outer scopes begin fresh.

## Performance evidence

On the same local interpreter and rebuilt native extension, scanning `tests/assets` with caching disabled retained exactly `files=90`, `issues=103`, `checks=439`, `success=True` while wall time changed from `6.621s` before the change to `5.697s` after the integrated directory-scan scope (about 14% faster). The checked-in benchmark workloads also pass; CI can provide the authoritative base/head comparison.

## Validation

- `uv run --active --no-sync ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run --active --no-sync ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run --active --no-sync mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`451` source files clean)
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run --active --no-sync pytest -n auto -m "not slow and not integration" --maxfail=1` (`5698 passed, 16 skipped`)
- `cargo check --locked --manifest-path packages/modelaudit-picklescan/Cargo.toml`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run --active --no-sync --with pytest-benchmark pytest tests/benchmarks/test_scan_benchmarks.py tests/benchmarks/test_picklescan_benchmarks.py --benchmark-json=/tmp/modelaudit-callgraph-scan-cache-benchmark.json -q` (`12 passed`)

`--no-sync` uses the already-rebuilt active environment because normal macOS resolution attempts the unsupported TensorRT wheel before tests execute.
