### PR TITLE
fix: decode valid XGBoost UBJSON empty containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - stop flagging a false-positive ONNX Python operator when tensor weight bytes coincidentally spell `PyOp`
 - detect Python operators declared in nested ONNX graphs and functions
 - distinguish ASCII-serialized Torch7 artifacts from plain PyTorch source text
+- decode valid XGBoost UBJSON models that contain count-optimized empty containers
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 

--- a/modelaudit/scanners/xgboost_scanner.py
+++ b/modelaudit/scanners/xgboost_scanner.py
@@ -19,6 +19,7 @@ Security Focus:
 """
 
 import importlib.util
+import io
 import json
 import logging
 import os
@@ -28,7 +29,7 @@ import subprocess
 import sys
 import tempfile
 from contextlib import suppress
-from typing import Any, ClassVar, cast
+from typing import Any, BinaryIO, ClassVar, cast
 
 from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, IssueSeverity, ScanResult
 
@@ -208,6 +209,50 @@ def _json_file_has_xgboost_markers(path: str, max_bytes: int) -> bool:
                     expecting_key = True
 
     return False
+
+
+class _XGBoostUBJSONReadAdapter:
+    """Supply the lookahead py-ubjson expects after valid empty counted containers."""
+
+    _COUNT_WIDTHS: ClassVar[dict[bytes, int]] = {
+        b"U": 1,
+        b"i": 1,
+        b"I": 2,
+        b"l": 4,
+        b"L": 8,
+    }
+    _VIRTUAL_CONTAINER_END: ClassVar[dict[bytes, bytes]] = {b"[": b"]", b"{": b"}"}
+
+    def __init__(self, stream: BinaryIO) -> None:
+        self._stream = stream
+        self._recent_single_byte_reads = b""
+        self._virtual_container_end: bytes | None = None
+
+    def read(self, size: int = -1) -> bytes:
+        if self._virtual_container_end is not None:
+            if size != 1:
+                raise ValueError("Unexpected UBJSON decoder read after an empty counted container")
+            virtual_end = self._virtual_container_end
+            self._virtual_container_end = None
+            self._recent_single_byte_reads = b""
+            return virtual_end
+
+        data = self._stream.read(size)
+        prefix = self._recent_single_byte_reads
+        if len(prefix) == 3 and prefix[:2] in (b"[#", b"{#") and self._COUNT_WIDTHS.get(prefix[2:]) == size:
+            self._recent_single_byte_reads = b""
+            if data == b"\0" * size:
+                self._virtual_container_end = self._VIRTUAL_CONTAINER_END[prefix[:1]]
+            return data
+
+        if size == 1 and len(data) == 1:
+            self._recent_single_byte_reads = (self._recent_single_byte_reads + data)[-3:]
+        else:
+            self._recent_single_byte_reads = b""
+        return data
+
+    def tell(self) -> int:
+        return self._stream.tell()
 
 
 class XGBoostScanner(BaseScanner):
@@ -464,8 +509,11 @@ class XGBoostScanner(BaseScanner):
         try:
             import ubjson
 
-            with open(path, "rb") as f:
-                model_data = ubjson.loadb(f.read())
+            payload = self._read_file_safely(path)
+            try:
+                model_data = ubjson.loadb(payload)
+            except ubjson.DecoderException:
+                model_data = ubjson.load(_XGBoostUBJSONReadAdapter(io.BytesIO(payload)))
 
             result.add_check(
                 name="UBJ Decoding",

--- a/tests/scanners/test_xgboost_scanner.py
+++ b/tests/scanners/test_xgboost_scanner.py
@@ -164,6 +164,16 @@ def _xgboost_ubjson_probe() -> bytes:
     return b"{L" + (b"\0" * 8) + b"learner" + b"learner_model_param" + b"version"
 
 
+def _use_xgboost_counted_empty_arrays(payload: bytes) -> bytes:
+    counted_empty_array = b"[#L" + (b"\0" * 8)
+    adapted = payload.replace(b"feature_names[]", b"feature_names" + counted_empty_array).replace(
+        b"feature_types[]", b"feature_types" + counted_empty_array
+    )
+    assert counted_empty_array in adapted
+    assert adapted != payload
+    return adapted
+
+
 class TestXGBoostScannerBasic:
     """Test basic XGBoost scanner functionality."""
 
@@ -722,6 +732,35 @@ class TestXGBoostUBJScanning:
             result = xgboost_scanner.scan(str(ubj_file))
 
         assert any("Error analyzing XGBoost UBJ model" in str(issue.message) for issue in result.issues)
+
+    def test_count_optimized_empty_arrays_are_decoded(self, temp_dir: Path, valid_xgboost_json: dict[str, Any]) -> None:
+        ubjson = pytest.importorskip("ubjson", reason="ubjson not installed")
+        valid_xgboost_json["learner"]["feature_names"] = []
+        valid_xgboost_json["learner"]["feature_types"] = []
+        model_file = temp_dir / "empty_features.ubj"
+        model_file.write_bytes(_use_xgboost_counted_empty_arrays(ubjson.dumpb(valid_xgboost_json)))
+
+        result = XGBoostScanner().scan(str(model_file))
+
+        assert result.success is True
+        assert any(check.name == "UBJ Decoding" and check.status == CheckStatus.PASSED for check in result.checks)
+
+    def test_count_optimized_empty_arrays_still_report_malicious_content(
+        self, temp_dir: Path, valid_xgboost_json: dict[str, Any]
+    ) -> None:
+        ubjson = pytest.importorskip("ubjson", reason="ubjson not installed")
+        valid_xgboost_json["learner"]["feature_names"] = []
+        valid_xgboost_json["learner"]["feature_types"] = []
+        valid_xgboost_json["learner"]["malicious_code"] = "os.system('touch pwned')"
+        model_file = temp_dir / "malicious_empty_features.ubj"
+        model_file.write_bytes(_use_xgboost_counted_empty_arrays(ubjson.dumpb(valid_xgboost_json)))
+
+        result = XGBoostScanner().scan(str(model_file))
+
+        assert result.success is False
+        assert any(
+            check.name == "JSON Content Analysis" and check.status == CheckStatus.FAILED for check in result.checks
+        )
 
 
 class TestXGBoostBinaryScanning:


### PR DESCRIPTION
## Summary
- retry UBJSON decoding through a bounded read adapter only when the normal decoder rejects an input
- repair `py-ubjson` handling of valid zero-length counted nested containers emitted by XGBoost 3.2 without invoking XGBoost on untrusted model bytes
- add clean and malicious count-optimized regressions and record the behavior fix in the changelog

## Finding
A valid model produced by declared dependency `xgboost==3.2.0` contains count-optimized empty arrays such as `feature_names`. Under `py-ubjson==0.16.1`, `XGBoostScanner` reported it as an inconclusive critical UBJSON decode error (`Integer marker expected`) because the decoder consumes the next object key after a zero-length counted nested container.

The fallback supplies only the virtual container terminator needed for that decoder read-ahead, after a normal decode failure. It remains within the scanner read-size boundary and still runs full JSON-content checks; a matching payload containing `os.system(...)` remains a failed critical finding.

## Validation
- `uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`4743 passed, 971 skipped`)
- `uv --no-config run --locked pytest tests/scanners/test_xgboost_scanner.py -q -m "not integration"` (`81 passed, 2 deselected`)
- `uv --no-config run --locked pytest tests/scanners/test_xgboost_scanner.py -q -m integration` (`2 passed`)

`--no-config --locked` avoids a workstation-global `UV_EXCLUDE_NEWER` setting rewriting the committed lockfile during validation.