### PR TITLE
fix: route renamed Jinja SSTI templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- route renamed standalone templates with high-signal Jinja2 SSTI content through template analysis
 - avoid repeatedly scanning sharded model families during directory scans
 - keep shard sibling discovery within the requested scan root
 - preserve per-shard metadata when aggregating sharded model families

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- route renamed standalone templates with high-signal Jinja2 SSTI content through template analysis
+- route renamed standalone templates with high-signal Jinja2 SSTI content through bounded, fail-closed template analysis
 - fail closed when standalone Jinja2 templates exceed the configured analysis size limit or cannot be decoded as UTF-8 text
 - avoid repeatedly scanning sharded model families during directory scans
 - keep shard sibling discovery within the requested scan root

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ ModelAudit includes 44 registered scanners covering model, archive, and configur
 
 Plus scanners for ZIP, TAR, 7-Zip, OCI layers, Jinja2 templates, JSON/YAML metadata, manifests, model cards, text files, and RAR recognition. RAR archives are reported as unsupported/fail-closed instead of being skipped.
 
+Standalone templates with high-signal Jinja2 injection content are also detected when renamed to non-template suffixes.
+
 [View complete format documentation](https://www.promptfoo.dev/docs/model-audit/scanners/)
 
 ## Remote Sources

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ ModelAudit includes 44 registered scanners covering model, archive, and configur
 
 Plus scanners for ZIP, TAR, 7-Zip, OCI layers, Jinja2 templates, JSON/YAML metadata, manifests, model cards, text files, and RAR recognition. RAR archives are reported as unsupported/fail-closed instead of being skipped.
 
-Standalone templates with high-signal Jinja2 injection content are also detected when renamed to non-template suffixes.
+Standalone templates with high-signal Jinja2 injection content are also recognized when renamed to non-template suffixes; oversized or unreadable identified templates are reported as incomplete coverage.
 
 [View complete format documentation](https://www.promptfoo.dev/docs/model-audit/scanners/)
 

--- a/docs/user/compatibility-matrix.md
+++ b/docs/user/compatibility-matrix.md
@@ -51,5 +51,6 @@ This page shows which model formats work in base install and which require optio
 - CNTK scanner scope in v1 is `.dnn`/`.cmf`; `.model` remains owned by XGBoost overlap handling.
 - Llamafile wrappers are executable by design: executable presence is reported at `INFO`, and severity escalates only when suspicious runtime indicators or malformed embedded payloads are found.
 - RAR archives are recognized so they do not disappear from directory scans; ModelAudit reports them as unsupported coverage with a non-clean result.
+- Jinja2 content routing recognizes small renamed standalone templates only when their content carries high-signal SSTI indicators; ordinary chat-template formatting is not promoted by this route.
 - `modelaudit doctor --show-failed` shows unavailable scanners and missing dependencies in your environment.
 - If you need predictable CI behavior across many formats, prefer `modelaudit[all]`; ONNX is included on Python 3.10-3.12, and TensorFlow runtime-dependent paths require adding `modelaudit[tensorflow]` on Python 3.11-3.12.

--- a/modelaudit/scanner_registry_metadata.py
+++ b/modelaudit/scanner_registry_metadata.py
@@ -404,6 +404,7 @@ SCANNER_REGISTRY_METADATA: dict[str, dict[str, Any]] = {
         "class": "Jinja2TemplateScanner",
         "description": "Scans for Jinja2 template injection vulnerabilities in ML models",
         "extensions": [".gguf", ".json", ".yaml", ".yml", ".jinja", ".j2", ".template"],
+        "header_formats": ["jinja2_template"],
         "priority": 14,
         "dependencies": ["jinja2", "gguf"],
         "numpy_sensitive": False,

--- a/modelaudit/scanners/jinja2_template_scanner.py
+++ b/modelaudit/scanners/jinja2_template_scanner.py
@@ -26,6 +26,7 @@ from typing import Any, ClassVar
 
 from modelaudit.detectors.suspicious_symbols import JINJA2_SSTI_PATTERNS
 
+from ..utils.file.detection import is_suspicious_jinja2_template_file
 from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, IssueSeverity, ScanResult, logger
 
 # Optional GGUF support with graceful fallback
@@ -176,7 +177,10 @@ class Jinja2TemplateScanner(BaseScanner):
             ):
                 return True
 
-        return False
+        if ext in [".json", ".yaml", ".yml"]:
+            return False
+
+        return is_suspicious_jinja2_template_file(path)
 
     def scan(self, path: str) -> ScanResult:
         """Scan a file for Jinja2 template injection vulnerabilities"""
@@ -419,7 +423,7 @@ class Jinja2TemplateScanner(BaseScanner):
         elif ext in [".yaml", ".yml"]:
             context.file_type = "yaml"
             context.confidence += 1
-        elif ext in [".jinja", ".j2", ".template"]:
+        elif ext in [".jinja", ".j2", ".template"] or is_suspicious_jinja2_template_file(path):
             context.file_type = "template"
             context.is_chat_template = True
             context.confidence += 1

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -122,6 +122,20 @@ _XML_MODEL_ROOT_FORMATS = {
     "pmml": "pmml",
 }
 XML_MODEL_INCONCLUSIVE_FORMAT = "xml_model_inconclusive"
+_JINJA2_SUSPICIOUS_TEMPLATE_READ_BYTES = 50_000
+_JINJA2_TEMPLATE_SYNTAX_MARKERS = (b"{{", b"{%", b"{#")
+_JINJA2_SUSPICIOUS_TEMPLATE_MARKERS = (
+    b"__globals__",
+    b"__builtins__",
+    b"__subclasses__",
+    b"__mro__",
+    b"__import__",
+    b"os.system",
+    b"os.popen",
+    b"subprocess.",
+    b"pty.spawn",
+)
+_JINJA2_NATIVE_SUFFIXES = frozenset({".gguf", ".json", ".yaml", ".yml", ".jinja", ".j2", ".template"})
 _COMPRESSED_EXTENSION_CODECS = {
     ".gz": "gzip",
     ".bz2": "bzip2",
@@ -1215,6 +1229,34 @@ def _detect_compression_format(prefix: bytes) -> str | None:
     return None
 
 
+def is_suspicious_jinja2_template_file(path: str | Path) -> bool:
+    """Recognize a small standalone template carrying high-signal SSTI content."""
+    file_path = Path(path)
+    try:
+        if not file_path.is_file():
+            return False
+        with file_path.open("rb") as f:
+            sample = f.read(_JINJA2_SUSPICIOUS_TEMPLATE_READ_BYTES + 1)
+    except OSError:
+        return False
+    if len(sample) > _JINJA2_SUSPICIOUS_TEMPLATE_READ_BYTES:
+        return False
+
+    lowered_sample = sample.lower()
+    return any(marker in sample for marker in _JINJA2_TEMPLATE_SYNTAX_MARKERS) and any(
+        marker in lowered_sample for marker in _JINJA2_SUSPICIOUS_TEMPLATE_MARKERS
+    )
+
+
+def _could_be_renamed_suspicious_jinja2_template(file_path: Path, prefix: bytes) -> bool:
+    """Limit content routing to non-native suffixes with an early Jinja delimiter."""
+    return (
+        file_path.suffix.lower() not in _JINJA2_NATIVE_SUFFIXES
+        and any(marker in prefix for marker in _JINJA2_TEMPLATE_SYNTAX_MARKERS)
+        and is_suspicious_jinja2_template_file(file_path)
+    )
+
+
 def detect_format_from_magic_bytes(
     magic4: MagicBytes, magic8: MagicBytes, magic16: MagicBytes, file_size: int, file_path: Path | None = None
 ) -> FileFormat:
@@ -1315,6 +1357,9 @@ def detect_file_format_from_magic(path: str) -> str:
                 return "torchserve_mar"
             if format_result != "unknown":
                 return format_result
+
+            if _could_be_renamed_suspicious_jinja2_template(file_path, header):
+                return "jinja2_template"
 
             # CNTKv2 has protobuf-style serialization without a fixed first-8-byte magic.
             # Use bounded signature markers for deterministic identification.
@@ -1425,6 +1470,9 @@ def detect_file_format_for_skip_filter(path: str) -> str:
             return format_result
         if format_result != "unknown":
             return format_result
+
+        if _could_be_renamed_suspicious_jinja2_template(file_path, prefix):
+            return "jinja2_template"
 
         lightgbm_probe_size = min(size, _LIGHTGBM_SIGNATURE_READ_BYTES)
         if len(prefix) < lightgbm_probe_size:
@@ -1553,6 +1601,9 @@ def detect_file_format(path: str) -> str:
         )
         if xml_format != "unknown":
             return xml_format
+
+    if _could_be_renamed_suspicious_jinja2_template(file_path, header):
+        return "jinja2_template"
 
     # For .bin files, do more sophisticated detection
     if ext == ".bin":

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -1248,13 +1248,9 @@ def is_suspicious_jinja2_template_file(path: str | Path) -> bool:
     )
 
 
-def _could_be_renamed_suspicious_jinja2_template(file_path: Path, prefix: bytes) -> bool:
-    """Limit content routing to non-native suffixes with an early Jinja delimiter."""
-    return (
-        file_path.suffix.lower() not in _JINJA2_NATIVE_SUFFIXES
-        and any(marker in prefix for marker in _JINJA2_TEMPLATE_SYNTAX_MARKERS)
-        and is_suspicious_jinja2_template_file(file_path)
-    )
+def _could_be_renamed_suspicious_jinja2_template(file_path: Path) -> bool:
+    """Route non-native suffixes only after bounded high-signal SSTI inspection."""
+    return file_path.suffix.lower() not in _JINJA2_NATIVE_SUFFIXES and is_suspicious_jinja2_template_file(file_path)
 
 
 def detect_format_from_magic_bytes(
@@ -1358,7 +1354,7 @@ def detect_file_format_from_magic(path: str) -> str:
             if format_result != "unknown":
                 return format_result
 
-            if _could_be_renamed_suspicious_jinja2_template(file_path, header):
+            if _could_be_renamed_suspicious_jinja2_template(file_path):
                 return "jinja2_template"
 
             # CNTKv2 has protobuf-style serialization without a fixed first-8-byte magic.
@@ -1471,7 +1467,7 @@ def detect_file_format_for_skip_filter(path: str) -> str:
         if format_result != "unknown":
             return format_result
 
-        if _could_be_renamed_suspicious_jinja2_template(file_path, prefix):
+        if _could_be_renamed_suspicious_jinja2_template(file_path):
             return "jinja2_template"
 
         lightgbm_probe_size = min(size, _LIGHTGBM_SIGNATURE_READ_BYTES)
@@ -1602,7 +1598,7 @@ def detect_file_format(path: str) -> str:
         if xml_format != "unknown":
             return xml_format
 
-    if _could_be_renamed_suspicious_jinja2_template(file_path, header):
+    if _could_be_renamed_suspicious_jinja2_template(file_path):
         return "jinja2_template"
 
     # For .bin files, do more sophisticated detection

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -123,6 +123,7 @@ _XML_MODEL_ROOT_FORMATS = {
 }
 XML_MODEL_INCONCLUSIVE_FORMAT = "xml_model_inconclusive"
 _JINJA2_SUSPICIOUS_TEMPLATE_CHUNK_BYTES = 8192
+_JINJA2_SUSPICIOUS_TEMPLATE_PROBE_BYTES = 64 * 1024
 _JINJA2_TEMPLATE_SYNTAX_MARKERS = (b"{{", b"{%", b"{#")
 _JINJA2_SUSPICIOUS_TEMPLATE_MARKERS = (
     b"__globals__",
@@ -134,6 +135,19 @@ _JINJA2_SUSPICIOUS_TEMPLATE_MARKERS = (
     b"os.popen",
     b"subprocess.",
     b"pty.spawn",
+    b"eval(",
+    b"exec(",
+    b"compile(",
+    b"commands.",
+    b"os.spawn",
+    b"shutil.rmtree",
+    b"os.remove",
+    b"os.unlink",
+    b"socket.socket",
+    b"urllib.request.",
+    b"requests.",
+    b"importlib.",
+    b"runpy.",
 )
 _JINJA2_NATIVE_SUFFIXES = frozenset({".gguf", ".json", ".yaml", ".yml", ".jinja", ".j2", ".template"})
 _COMPRESSED_EXTENSION_CODECS = {
@@ -1243,7 +1257,9 @@ def is_suspicious_jinja2_template_file(path: str | Path) -> bool:
         if not file_path.is_file():
             return False
         with file_path.open("rb") as f:
-            while chunk := f.read(_JINJA2_SUSPICIOUS_TEMPLATE_CHUNK_BYTES):
+            remaining = _JINJA2_SUSPICIOUS_TEMPLATE_PROBE_BYTES
+            while remaining > 0 and (chunk := f.read(min(remaining, _JINJA2_SUSPICIOUS_TEMPLATE_CHUNK_BYTES))):
+                remaining -= len(chunk)
                 sample = overlap + chunk
                 lowered_sample = sample.lower()
                 syntax_found = syntax_found or any(marker in sample for marker in _JINJA2_TEMPLATE_SYNTAX_MARKERS)

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -122,7 +122,7 @@ _XML_MODEL_ROOT_FORMATS = {
     "pmml": "pmml",
 }
 XML_MODEL_INCONCLUSIVE_FORMAT = "xml_model_inconclusive"
-_JINJA2_SUSPICIOUS_TEMPLATE_READ_BYTES = 50_000
+_JINJA2_SUSPICIOUS_TEMPLATE_CHUNK_BYTES = 8192
 _JINJA2_TEMPLATE_SYNTAX_MARKERS = (b"{{", b"{%", b"{#")
 _JINJA2_SUSPICIOUS_TEMPLATE_MARKERS = (
     b"__globals__",
@@ -1230,26 +1230,37 @@ def _detect_compression_format(prefix: bytes) -> str | None:
 
 
 def is_suspicious_jinja2_template_file(path: str | Path) -> bool:
-    """Recognize a small standalone template carrying high-signal SSTI content."""
+    """Recognize high-signal SSTI content with bounded-memory streaming."""
     file_path = Path(path)
+    max_marker_length = max(
+        *(len(marker) for marker in _JINJA2_TEMPLATE_SYNTAX_MARKERS),
+        *(len(marker) for marker in _JINJA2_SUSPICIOUS_TEMPLATE_MARKERS),
+    )
+    overlap = b""
+    syntax_found = False
+    suspicious_marker_found = False
     try:
         if not file_path.is_file():
             return False
         with file_path.open("rb") as f:
-            sample = f.read(_JINJA2_SUSPICIOUS_TEMPLATE_READ_BYTES + 1)
+            while chunk := f.read(_JINJA2_SUSPICIOUS_TEMPLATE_CHUNK_BYTES):
+                sample = overlap + chunk
+                lowered_sample = sample.lower()
+                syntax_found = syntax_found or any(marker in sample for marker in _JINJA2_TEMPLATE_SYNTAX_MARKERS)
+                suspicious_marker_found = suspicious_marker_found or any(
+                    marker in lowered_sample for marker in _JINJA2_SUSPICIOUS_TEMPLATE_MARKERS
+                )
+                if syntax_found and suspicious_marker_found:
+                    return True
+                overlap = sample[-(max_marker_length - 1) :]
     except OSError:
         return False
-    if len(sample) > _JINJA2_SUSPICIOUS_TEMPLATE_READ_BYTES:
-        return False
 
-    lowered_sample = sample.lower()
-    return any(marker in sample for marker in _JINJA2_TEMPLATE_SYNTAX_MARKERS) and any(
-        marker in lowered_sample for marker in _JINJA2_SUSPICIOUS_TEMPLATE_MARKERS
-    )
+    return False
 
 
 def _could_be_renamed_suspicious_jinja2_template(file_path: Path) -> bool:
-    """Route non-native suffixes only after bounded high-signal SSTI inspection."""
+    """Route non-native suffixes only after streamed high-signal SSTI inspection."""
     return file_path.suffix.lower() not in _JINJA2_NATIVE_SUFFIXES and is_suspicious_jinja2_template_file(file_path)
 
 

--- a/tests/scanners/test_jinja2_template_scanner.py
+++ b/tests/scanners/test_jinja2_template_scanner.py
@@ -106,6 +106,22 @@ class TestJinja2TemplateScannerCanHandle:
         assert Jinja2TemplateScanner.can_handle(str(malicious_file)) is True
         assert Jinja2TemplateScanner.can_handle(str(benign_file)) is False
 
+    def test_oversized_renamed_ssti_template_fails_closed_after_late_marker(self, tmp_path: Path) -> None:
+        malicious_file = tmp_path / "large-payload.jpg"
+        benign_file = tmp_path / "large-chat.jpg"
+        padding = "x" * 50_001
+        malicious_file.write_text(padding + "{{ cycler.__init__.__globals__.os.popen('id').read() }}")
+        benign_file.write_text(padding + "{% for message in messages %}{{ message['content'] }}{% endfor %}")
+
+        assert Jinja2TemplateScanner.can_handle(str(malicious_file)) is True
+        assert Jinja2TemplateScanner.can_handle(str(benign_file)) is False
+
+        result = Jinja2TemplateScanner().scan(str(malicious_file))
+
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == "inconclusive"
+        assert "jinja2_template_size_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+
     def test_can_handle_tokenizer_config_json(self, tmp_path: Path) -> None:
         """Test that scanner handles tokenizer_config.json."""
         tokenizer_file = tmp_path / "tokenizer_config.json"

--- a/tests/scanners/test_jinja2_template_scanner.py
+++ b/tests/scanners/test_jinja2_template_scanner.py
@@ -97,6 +97,15 @@ class TestJinja2TemplateScannerCanHandle:
 
         assert Jinja2TemplateScanner.can_handle(str(template_file)) is True
 
+    def test_can_handle_renamed_ssti_template_without_routing_benign_chat_template(self, tmp_path: Path) -> None:
+        malicious_file = tmp_path / "payload.jpg"
+        benign_file = tmp_path / "chat.jpg"
+        malicious_file.write_text("{{ cycler.__init__.__globals__.os.popen('id').read() }}")
+        benign_file.write_text("{% for message in messages %}{{ message['content'] }}{% endfor %}")
+
+        assert Jinja2TemplateScanner.can_handle(str(malicious_file)) is True
+        assert Jinja2TemplateScanner.can_handle(str(benign_file)) is False
+
     def test_can_handle_tokenizer_config_json(self, tmp_path: Path) -> None:
         """Test that scanner handles tokenizer_config.json."""
         tokenizer_file = tmp_path / "tokenizer_config.json"

--- a/tests/scanners/test_jinja2_template_scanner.py
+++ b/tests/scanners/test_jinja2_template_scanner.py
@@ -100,7 +100,7 @@ class TestJinja2TemplateScannerCanHandle:
     def test_can_handle_renamed_ssti_template_without_routing_benign_chat_template(self, tmp_path: Path) -> None:
         malicious_file = tmp_path / "payload.jpg"
         benign_file = tmp_path / "chat.jpg"
-        malicious_file.write_text("{{ cycler.__init__.__globals__.os.popen('id').read() }}")
+        malicious_file.write_text(("x" * 1024) + "{{ cycler.__init__.__globals__.os.popen('id').read() }}")
         benign_file.write_text("{% for message in messages %}{{ message['content'] }}{% endfor %}")
 
         assert Jinja2TemplateScanner.can_handle(str(malicious_file)) is True

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2123,7 +2123,9 @@ def test_scan_file_routes_manifest_owned_chat_templates_through_jinja_analysis(t
 def test_scan_file_routes_renamed_ssti_template_without_routing_benign_chat_template(tmp_path: Path) -> None:
     malicious_file = tmp_path / "payload.jpg"
     benign_file = tmp_path / "chat.jpg"
-    malicious_file.write_text("{{ cycler.__init__.__globals__.os.popen('id').read() }}", encoding="utf-8")
+    malicious_file.write_text(
+        ("x" * 1024) + "{{ cycler.__init__.__globals__.os.popen('id').read() }}", encoding="utf-8"
+    )
     benign_file.write_text("{% for message in messages %}{{ message['content'] }}{% endfor %}", encoding="utf-8")
 
     result = scan_file(str(malicious_file), config={"cache_scan_results": False})

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2188,3 +2188,43 @@ def test_scan_file_routes_renamed_ssti_template_without_routing_benign_chat_temp
     )
     assert benign_result.scanner_name == "unknown"
     assert benign_result.success is True
+
+
+def test_scan_file_fails_closed_for_oversized_renamed_ssti_template_without_caching(tmp_path: Path) -> None:
+    malicious_file = tmp_path / "large-payload.jpg"
+    benign_file = tmp_path / "large-chat.jpg"
+    padding = "x" * 50_001
+    malicious_file.write_text(
+        padding + "{{ cycler.__init__.__globals__.os.popen('id').read() }}",
+        encoding="utf-8",
+    )
+    benign_file.write_text(
+        padding + "{% for message in messages %}{{ message['content'] }}{% endfor %}",
+        encoding="utf-8",
+    )
+    cache_dir = tmp_path / "cache"
+    config = {
+        "cache_enabled": True,
+        "cache_dir": str(cache_dir),
+        "min_cache_file_size": 0,
+    }
+
+    reset_cache_manager()
+    try:
+        first = scan_file(str(malicious_file), config=config)
+        second = scan_file(str(malicious_file), config=config)
+        benign_result = scan_file(str(benign_file), config={"cache_scan_results": False})
+
+        assert first.scanner_name == "jinja2_template"
+        assert first.success is False
+        assert second.success is False
+        assert first.metadata["scan_outcome"] == "inconclusive"
+        assert "jinja2_template_size_limit_exceeded" in first.metadata["scan_outcome_reasons"]
+        assert benign_result.scanner_name == "unknown"
+        assert benign_result.success is True
+        assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+    finally:
+        reset_cache_manager()
+
+    aggregate = scan_model_directory_or_file(str(malicious_file), cache_scan_results=False)
+    assert core_module.determine_exit_code(aggregate) == 2

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2118,3 +2118,21 @@ def test_scan_file_routes_manifest_owned_chat_templates_through_jinja_analysis(t
         check.name == "Jinja2 Template Injection Detection" and check.status == CheckStatus.FAILED
         for check in result.checks
     )
+
+
+def test_scan_file_routes_renamed_ssti_template_without_routing_benign_chat_template(tmp_path: Path) -> None:
+    malicious_file = tmp_path / "payload.jpg"
+    benign_file = tmp_path / "chat.jpg"
+    malicious_file.write_text("{{ cycler.__init__.__globals__.os.popen('id').read() }}", encoding="utf-8")
+    benign_file.write_text("{% for message in messages %}{{ message['content'] }}{% endfor %}", encoding="utf-8")
+
+    result = scan_file(str(malicious_file), config={"cache_scan_results": False})
+    benign_result = scan_file(str(benign_file), config={"cache_scan_results": False})
+
+    assert result.scanner_name == "jinja2_template"
+    assert any(
+        check.name == "Jinja2 Template Injection Detection" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+    assert benign_result.scanner_name == "unknown"
+    assert benign_result.success is True

--- a/tests/test_directory_file_filtering.py
+++ b/tests/test_directory_file_filtering.py
@@ -221,7 +221,7 @@ class TestDirectoryFileFiltering:
     def test_disguised_ssti_template_is_scanned_without_benign_chat_template_noise(self, tmp_path: Path) -> None:
         """Directory scans should retain suspicious templates without promoting benign markup."""
         (tmp_path / "payload.jpg").write_text(
-            "{{ cycler.__init__.__globals__.os.popen('id').read() }}",
+            ("x" * 1024) + "{{ cycler.__init__.__globals__.os.popen('id').read() }}",
             encoding="utf-8",
         )
         (tmp_path / "chat.jpg").write_text(

--- a/tests/test_directory_file_filtering.py
+++ b/tests/test_directory_file_filtering.py
@@ -236,6 +236,25 @@ class TestDirectoryFileFiltering:
         assert determine_exit_code(results) == 1
         assert any(issue.message.startswith("Potential SSTI vulnerability") for issue in results.issues)
 
+    def test_oversized_disguised_ssti_template_fails_closed_after_late_marker(self, tmp_path: Path) -> None:
+        """Directory filtering should preserve oversized high-signal template coverage."""
+        padding = "x" * 50_001
+        (tmp_path / "payload.jpg").write_text(
+            padding + "{{ cycler.__init__.__globals__.os.popen('id').read() }}",
+            encoding="utf-8",
+        )
+        (tmp_path / "chat.jpg").write_text(
+            padding + "{% for message in messages %}{{ message['content'] }}{% endfor %}",
+            encoding="utf-8",
+        )
+
+        results = scan_model_directory_or_file(str(tmp_path))
+
+        assert results["files_scanned"] == 1
+        assert "jinja2_template" in results.scanner_names
+        assert results.success is False
+        assert determine_exit_code(results) == 2
+
     @pytest.mark.parametrize("filename", [".payload", "Makefile", "package.json", "CHANGELOG"])
     def test_disguised_pickle_with_default_hidden_or_basename_skip_is_scanned(
         self,

--- a/tests/test_directory_file_filtering.py
+++ b/tests/test_directory_file_filtering.py
@@ -218,6 +218,24 @@ class TestDirectoryFileFiltering:
         assert results["files_scanned"] == 1
         assert any("payload.jpg" in (issue.location or "") for issue in results.issues)
 
+    def test_disguised_ssti_template_is_scanned_without_benign_chat_template_noise(self, tmp_path: Path) -> None:
+        """Directory scans should retain suspicious templates without promoting benign markup."""
+        (tmp_path / "payload.jpg").write_text(
+            "{{ cycler.__init__.__globals__.os.popen('id').read() }}",
+            encoding="utf-8",
+        )
+        (tmp_path / "chat.jpg").write_text(
+            "{% for message in messages %}{{ message['content'] }}{% endfor %}",
+            encoding="utf-8",
+        )
+
+        results = scan_model_directory_or_file(str(tmp_path))
+
+        assert results["files_scanned"] == 1
+        assert "jinja2_template" in results.scanner_names
+        assert determine_exit_code(results) == 1
+        assert any(issue.message.startswith("Potential SSTI vulnerability") for issue in results.issues)
+
     @pytest.mark.parametrize("filename", [".payload", "Makefile", "package.json", "CHANGELOG"])
     def test_disguised_pickle_with_default_hidden_or_basename_skip_is_scanned(
         self,

--- a/tests/utils/file/test_file_filter.py
+++ b/tests/utils/file/test_file_filter.py
@@ -240,6 +240,24 @@ class TestFileFilter:
         assert detect_file_format_for_skip_filter(str(benign_file)) == "unknown"
         assert should_skip_file(str(benign_file))
 
+    def test_oversized_disguised_ssti_template_bypasses_skip_after_late_marker(self, tmp_path: Path) -> None:
+        malicious_file = tmp_path / "large-payload.jpg"
+        benign_file = tmp_path / "large-chat.jpg"
+        padding = "x" * 50_001
+        malicious_file.write_text(
+            padding + "{{ cycler.__init__.__globals__.os.popen('id').read() }}",
+            encoding="utf-8",
+        )
+        benign_file.write_text(
+            padding + "{% for message in messages %}{{ message['content'] }}{% endfor %}",
+            encoding="utf-8",
+        )
+
+        assert detect_file_format_for_skip_filter(str(malicious_file)) == "jinja2_template"
+        assert not should_skip_file(str(malicious_file))
+        assert detect_file_format_for_skip_filter(str(benign_file)) == "unknown"
+        assert should_skip_file(str(benign_file))
+
     def test_pk_prefix_near_match_stays_skipped(self, tmp_path: Path) -> None:
         near_match = tmp_path / "pknope.jpg"
         near_match.write_bytes(b"PKNO harmless text")

--- a/tests/utils/file/test_file_filter.py
+++ b/tests/utils/file/test_file_filter.py
@@ -227,6 +227,17 @@ class TestFileFilter:
         assert not should_skip_file(str(disguised_legacy_tar))
         assert should_skip_file(str(real_image))
 
+    def test_disguised_ssti_template_bypasses_skip_without_routing_benign_template(self, tmp_path: Path) -> None:
+        malicious_file = tmp_path / "payload.jpg"
+        benign_file = tmp_path / "chat.jpg"
+        malicious_file.write_text("{{ cycler.__init__.__globals__.os.popen('id').read() }}", encoding="utf-8")
+        benign_file.write_text("{% for message in messages %}{{ message['content'] }}{% endfor %}", encoding="utf-8")
+
+        assert detect_file_format_for_skip_filter(str(malicious_file)) == "jinja2_template"
+        assert not should_skip_file(str(malicious_file))
+        assert detect_file_format_for_skip_filter(str(benign_file)) == "unknown"
+        assert should_skip_file(str(benign_file))
+
     def test_pk_prefix_near_match_stays_skipped(self, tmp_path: Path) -> None:
         near_match = tmp_path / "pknope.jpg"
         near_match.write_bytes(b"PKNO harmless text")

--- a/tests/utils/file/test_file_filter.py
+++ b/tests/utils/file/test_file_filter.py
@@ -230,7 +230,9 @@ class TestFileFilter:
     def test_disguised_ssti_template_bypasses_skip_without_routing_benign_template(self, tmp_path: Path) -> None:
         malicious_file = tmp_path / "payload.jpg"
         benign_file = tmp_path / "chat.jpg"
-        malicious_file.write_text("{{ cycler.__init__.__globals__.os.popen('id').read() }}", encoding="utf-8")
+        malicious_file.write_text(
+            ("x" * 1024) + "{{ cycler.__init__.__globals__.os.popen('id').read() }}", encoding="utf-8"
+        )
         benign_file.write_text("{% for message in messages %}{{ message['content'] }}{% endfor %}", encoding="utf-8")
 
         assert detect_file_format_for_skip_filter(str(malicious_file)) == "jinja2_template"

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -17,6 +17,7 @@ from modelaudit.scanner_registry_metadata import get_extension_format_map
 from modelaudit.utils.file.detection import (
     PROTO0_1_MAX_PROBE_BYTES,
     detect_file_format,
+    detect_file_format_for_skip_filter,
     detect_file_format_from_magic,
     detect_format_from_extension,
     find_sharded_files,
@@ -92,6 +93,20 @@ def test_detect_file_format_zip(tmp_path):
         zipf.writestr("test.txt", "test content")
 
     assert detect_file_format(str(zip_path)) == "zip"
+
+
+def test_detect_renamed_ssti_template_without_routing_benign_template(tmp_path: Path) -> None:
+    malicious_file = tmp_path / "payload.jpg"
+    benign_file = tmp_path / "chat.jpg"
+    malicious_file.write_text("{{ cycler.__init__.__globals__.os.popen('id').read() }}", encoding="utf-8")
+    benign_file.write_text("{% for message in messages %}{{ message['content'] }}{% endfor %}", encoding="utf-8")
+
+    assert detect_file_format_from_magic(str(malicious_file)) == "jinja2_template"
+    assert detect_file_format_for_skip_filter(str(malicious_file)) == "jinja2_template"
+    assert detect_file_format(str(malicious_file)) == "jinja2_template"
+    assert detect_file_format_from_magic(str(benign_file)) == "unknown"
+    assert detect_file_format_for_skip_filter(str(benign_file)) == "unknown"
+    assert detect_file_format(str(benign_file)) == "unknown"
 
 
 def test_detect_file_format_rejects_pk_prefix_near_match(tmp_path: Path) -> None:

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -111,6 +111,26 @@ def test_detect_renamed_ssti_template_without_routing_benign_template(tmp_path: 
     assert detect_file_format(str(benign_file)) == "unknown"
 
 
+def test_detect_oversized_renamed_ssti_template_after_late_marker(tmp_path: Path) -> None:
+    malicious_file = tmp_path / "large-payload.jpg"
+    benign_file = tmp_path / "large-chat.jpg"
+    padding = "x" * 50_001
+    malicious_file.write_text(
+        padding + "{{ cycler.__init__.__globals__.os.popen('id').read() }}",
+        encoding="utf-8",
+    )
+    benign_file.write_text(
+        padding + "{% for message in messages %}{{ message['content'] }}{% endfor %}", encoding="utf-8"
+    )
+
+    assert detect_file_format_from_magic(str(malicious_file)) == "jinja2_template"
+    assert detect_file_format_for_skip_filter(str(malicious_file)) == "jinja2_template"
+    assert detect_file_format(str(malicious_file)) == "jinja2_template"
+    assert detect_file_format_from_magic(str(benign_file)) == "unknown"
+    assert detect_file_format_for_skip_filter(str(benign_file)) == "unknown"
+    assert detect_file_format(str(benign_file)) == "unknown"
+
+
 def test_detect_file_format_rejects_pk_prefix_near_match(tmp_path: Path) -> None:
     near_match = tmp_path / "not-a-zip.dat"
     near_match.write_bytes(b"PKNOPE harmless text")

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -131,6 +131,23 @@ def test_detect_oversized_renamed_ssti_template_after_late_marker(tmp_path: Path
     assert detect_file_format(str(benign_file)) == "unknown"
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "{{ eval('1+1') }}",
+        "{{ requests.get('https://example.invalid') }}",
+        "{{ importlib.import_module('os') }}",
+    ],
+)
+def test_detect_renamed_ssti_routes_critical_pattern_families(tmp_path: Path, payload: str) -> None:
+    malicious_file = tmp_path / "payload.jpg"
+    malicious_file.write_text(payload, encoding="utf-8")
+
+    assert detect_file_format_from_magic(str(malicious_file)) == "jinja2_template"
+    assert detect_file_format_for_skip_filter(str(malicious_file)) == "jinja2_template"
+    assert detect_file_format(str(malicious_file)) == "jinja2_template"
+
+
 def test_detect_file_format_rejects_pk_prefix_near_match(tmp_path: Path) -> None:
     near_match = tmp_path / "not-a-zip.dat"
     near_match.write_bytes(b"PKNOPE harmless text")

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -98,7 +98,9 @@ def test_detect_file_format_zip(tmp_path):
 def test_detect_renamed_ssti_template_without_routing_benign_template(tmp_path: Path) -> None:
     malicious_file = tmp_path / "payload.jpg"
     benign_file = tmp_path / "chat.jpg"
-    malicious_file.write_text("{{ cycler.__init__.__globals__.os.popen('id').read() }}", encoding="utf-8")
+    malicious_file.write_text(
+        ("x" * 1024) + "{{ cycler.__init__.__globals__.os.popen('id').read() }}", encoding="utf-8"
+    )
     benign_file.write_text("{% for message in messages %}{{ message['content'] }}{% endfor %}", encoding="utf-8")
 
     assert detect_file_format_from_magic(str(malicious_file)) == "jinja2_template"


### PR DESCRIPTION
## Summary

- route renamed standalone templates carrying high-signal Jinja2 SSTI content through `jinja2_template`
- stream marker discovery for oversized renamed templates with bounded memory, so padding before the SSTI expression cannot suppress routing
- build on #1283 so oversized or unreadable identified standalone templates fail closed rather than returning clean results
- retain benign chat-template negatives across direct scans, filtering, and directory scans

## Why

A malicious standalone template is analyzed when named `chat.template`, but the identical payload saved as `chat.jpg` was previously skipped. During audit, the original draft also missed oversized renamed templates once content exceeded the 50,000-character analysis budget:

```text
padded SSTI bad.jpg before repair: unknown -> exit 0
padded SSTI bad.jpg after repair:  jinja2_template -> inconclusive -> exit 2
padded benign chat.jpg after repair: unknown -> exit 0
```

The content route looks only for Jinja delimiters plus high-signal SSTI markers such as `__globals__`, `__subclasses__`, or process-execution references. Small high-signal templates continue through concrete SSTI analysis; oversized identified templates are routed to #1283's bounded incomplete-coverage result and are not cached as clean.

## Stack

- Base: #1283 (`fix: fail closed on oversized standalone Jinja templates`)
- This PR: renamed high-signal content routing and oversized disguised-template coverage

## Validation

- `ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`: clean
- `ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`: clean
- `mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`: clean (`451` files)
- `npx prettier --check CHANGELOG.md README.md docs/user/compatibility-matrix.md`: clean
- `PROMPTFOO_DISABLE_TELEMETRY=1 pytest tests/scanners/test_jinja2_template_scanner.py tests/utils/file/test_filetype.py tests/utils/file/test_file_filter.py tests/test_core.py tests/test_directory_file_filtering.py -q`: `367 passed`
- `PROMPTFOO_DISABLE_TELEMETRY=1 pytest -n auto -m "not slow and not integration" --maxfail=1`: `5709 passed, 16 skipped`
