### PR TITLE
fix: classify unavailable Joblib reads correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- classify unavailable Joblib reads as inconclusive rather than security findings
 - avoid repeatedly scanning sharded model families during directory scans
 - keep shard sibling discovery within the requested scan root
 - preserve per-shard metadata when aggregating sharded model families

--- a/modelaudit/scanners/joblib_scanner.py
+++ b/modelaudit/scanners/joblib_scanner.py
@@ -13,6 +13,7 @@ from contextlib import suppress
 from typing import Any, ClassVar
 
 from ..detectors.cve_patterns import analyze_cve_patterns, enhance_scan_result_with_cve
+from ..scanner_results import mark_inconclusive_scan_result
 from ..scanner_selection import add_scanner_selection_skip_check, embedded_pickle_scanner
 from ..utils.file.detection import read_magic_bytes
 from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, IssueSeverity, ScanResult
@@ -500,6 +501,25 @@ class JoblibScanner(BaseScanner):
                     result.finish(success=False)
                     return result
                 self._scan_pickle_payload(decompressed, result, f"{path} (decompressed)")
+        except OSError as e:
+            mark_inconclusive_scan_result(result, "joblib_read_failed")
+            result.add_check(
+                name="Joblib File Read",
+                passed=False,
+                message=f"Unable to read joblib file for analysis: {e!s}",
+                severity=IssueSeverity.INFO,
+                location=path,
+                details={
+                    "exception": str(e),
+                    "exception_type": type(e).__name__,
+                    "analysis_incomplete": True,
+                    "scan_outcome_reason": "joblib_read_failed",
+                },
+                rule_code="S902",
+            )
+            self._record_joblib_operational_error(result, "joblib_read_failed")
+            result.finish(success=False)
+            return result
         except Exception as e:  # pragma: no cover
             result.add_check(
                 name="Joblib File Scan",

--- a/tests/scanners/test_joblib_scanner_codecs.py
+++ b/tests/scanners/test_joblib_scanner_codecs.py
@@ -8,7 +8,10 @@ import pickle
 import zlib
 from pathlib import Path
 
-from modelaudit.core import scan_file
+import pytest
+
+from modelaudit.core import determine_exit_code, scan_file, scan_model_directory_or_file
+from modelaudit.scanner_results import INCONCLUSIVE_SCAN_OUTCOME
 from modelaudit.scanners.base import Check, CheckStatus, IssueSeverity, ScanResult
 from modelaudit.scanners.joblib_scanner import JoblibScanner
 
@@ -71,6 +74,36 @@ def test_scan_accepts_raw_protocol0_int_pickle_joblib(tmp_path: Path) -> None:
     assert result.success is True
     assert _compression_failures(result) == []
     assert not _has_system_reduce_failure(result)
+
+
+def test_scan_reports_unavailable_joblib_read_as_inconclusive_not_security_finding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "safe.joblib"
+    path.write_bytes(pickle.dumps(7, protocol=4))
+
+    def fail_read(_self: JoblibScanner, _path: str) -> bytes:
+        raise OSError("simulated joblib read failure")
+
+    monkeypatch.setattr(JoblibScanner, "_read_file_safely", fail_read)
+
+    result = JoblibScanner().scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert result.metadata["scan_outcome_reasons"] == ["joblib_read_failed"]
+    assert result.metadata["operational_error_reason"] == "joblib_read_failed"
+    read_checks = [check for check in result.checks if check.name == "Joblib File Read"]
+    assert len(read_checks) == 1
+    assert read_checks[0].severity == IssueSeverity.INFO
+    assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
+
+    aggregate = scan_model_directory_or_file(str(path), cache_scan_results=False)
+
+    assert aggregate.success is False
+    assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in aggregate.issues)
+    assert determine_exit_code(aggregate) == 2
 
 
 def test_scan_fails_closed_when_numpy_wrapper_prefix_has_unknown_tail(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- classify Joblib input read failures as incomplete analysis rather than critical security findings
- preserve operational failure metadata while adding stable `joblib_read_failed` inconclusive reporting
- add direct and aggregate regression coverage without changing embedded pickle or compression-bomb detection

## Finding
A valid safe `.joblib` whose scanner content read raised `OSError` emitted a `CRITICAL` `S902` finding, despite having inspected no malicious bytes. The scan already behaved operationally for exit-code purposes, but the surfaced result falsely claimed a security finding.

The read-failure path now reports informational coverage loss and explicit inconclusive metadata. Real dangerous pickle reductions and decompression-limit handling remain unchanged.

## Validation
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`4742 passed, 971 skipped`)
- focused Joblib/core suite: `129 passed`
- `npx prettier --check CHANGELOG.md`
- `git diff --check`