### PR TITLE
fix: scan hidden sevenzip member risks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - detect Python operators declared in nested ONNX graphs and functions
 - distinguish ASCII-serialized Torch7 artifacts from plain PyTorch source text
 - detect executable PyTorch ZIP sidecars hidden behind ordinary filenames while excluding raw tensor-storage bytes
+- scan 7-Zip Python members and content-disguised executable sidecars through shared archive security checks
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -701,20 +701,21 @@ def scan_archive_member_for_known_risks(
     result: ScanResult,
     max_python_analysis_bytes: int,
     python_analysis_incomplete_reason: str,
+    analyze_python_source: bool = True,
 ) -> None:
     """Inspect generic archive members that nested dispatch would otherwise ignore.
 
     ``archive_kind`` is a short label (``"ZIP"`` / ``"TAR"``) used only for the
     human-readable message text. The dispatcher (1) routes Python-looking
-    members through bounded AST analysis, (2) flags native/script executable-
-    suffix members, and (3) leaves everything else to the caller's normal
-    nested routing.
+    members through bounded AST analysis unless content routing already owns
+    the member, (2) flags native/script executable-suffix members, and (3)
+    leaves everything else to the caller's normal nested routing.
     """
     normalized_name = member_name.replace("\\", "/").lstrip("/")
     normalized_lower = normalized_name.lower()
     location = f"{archive_path}:{member_name}"
 
-    if is_python_archive_member_name(normalized_lower):
+    if is_python_archive_member_name(normalized_lower) and analyze_python_source:
         if total_size > max_python_analysis_bytes:
             mark_archive_scan_incomplete(result, python_analysis_incomplete_reason)
             result.add_check(

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -691,6 +691,23 @@ _PYTHON_MEMBER_CHECK_NAME = "Python Archive Member Security"
 _EXECUTABLE_MEMBER_CHECK_NAME = "Executable Archive Member Detection"
 
 
+def _add_executable_archive_member_check(
+    *,
+    archive_kind: str,
+    archive_path: str,
+    member_name: str,
+    result: ScanResult,
+) -> None:
+    result.add_check(
+        name=_EXECUTABLE_MEMBER_CHECK_NAME,
+        passed=False,
+        message=f"Executable file found in {archive_kind} archive: {member_name}",
+        severity=IssueSeverity.WARNING,
+        location=f"{archive_path}:{member_name}",
+        details={"entry": member_name},
+    )
+
+
 def scan_archive_member_for_known_risks(
     *,
     archive_kind: str,
@@ -737,6 +754,15 @@ def scan_archive_member_for_known_risks(
             with open(tmp_path, "rb") as member_file:
                 calls = high_risk_python_calls_in_source(member_file.read())
         except PythonArchiveMemberParseError as exc:
+            if is_executable_archive_member_content(tmp_path):
+                _add_executable_archive_member_check(
+                    archive_kind=archive_kind,
+                    archive_path=archive_path,
+                    member_name=member_name,
+                    result=result,
+                )
+                return
+
             mark_archive_scan_incomplete(result, python_analysis_incomplete_reason)
             result.add_check(
                 name=_PYTHON_MEMBER_CHECK_NAME,
@@ -775,11 +801,9 @@ def scan_archive_member_for_known_risks(
         return
 
     if is_executable_archive_member_name(normalized_lower) or is_executable_archive_member_content(tmp_path):
-        result.add_check(
-            name=_EXECUTABLE_MEMBER_CHECK_NAME,
-            passed=False,
-            message=f"Executable file found in {archive_kind} archive: {member_name}",
-            severity=IssueSeverity.WARNING,
-            location=location,
-            details={"entry": member_name},
+        _add_executable_archive_member_check(
+            archive_kind=archive_kind,
+            archive_path=archive_path,
+            member_name=member_name,
+            result=result,
         )

--- a/modelaudit/scanners/sevenzip_scanner.py
+++ b/modelaudit/scanners/sevenzip_scanner.py
@@ -451,14 +451,16 @@ class SevenZipScanner(BaseScanner):
 
             # Filter for scannable model files from safe entries only
             scannable_files = self._identify_scannable_files(safe_file_names)
-            member_security_files = self._identify_named_member_security_files(safe_file_names)
+            named_security_files = self._identify_named_member_security_files(safe_file_names)
+            # Nested model targets still need generic executable-content inspection.
+            member_security_files = list(dict.fromkeys([*scannable_files, *named_security_files]))
             nested_archive_files, probed_security_files, probes_complete = (
                 self._identify_probed_nested_and_security_files(
                     archive,
                     safe_file_names,
                     path,
                     result,
-                    named_security_files=frozenset(member_security_files),
+                    named_security_files=frozenset(named_security_files),
                 )
             )
             member_security_files.extend(probed_security_files)
@@ -540,7 +542,7 @@ class SevenZipScanner(BaseScanner):
             candidate_extensions = self._candidate_archive_extensions(file_name)
             if (
                 any(extension in supported_extensions for extension in candidate_extensions)
-                or file_name in named_security_files
+                and file_name not in named_security_files
             ):
                 continue
 
@@ -566,7 +568,7 @@ class SevenZipScanner(BaseScanner):
                     f"Nested member probe limit ({self.max_extensionless_probes}) "
                     f"reached; remaining unsupported members were not inspected"
                 ),
-                severity=IssueSeverity.WARNING,
+                severity=IssueSeverity.INFO,
                 location=archive_path,
                 details={"limit": self.max_extensionless_probes},
             )
@@ -605,7 +607,7 @@ class SevenZipScanner(BaseScanner):
                     name=f"Nested 7z Probe: {file_name}",
                     passed=False,
                     message=f"Failed to inspect nested archive candidate {file_name}: {e}",
-                    severity=IssueSeverity.WARNING,
+                    severity=IssueSeverity.INFO,
                     location=f"{archive_path}:{file_name}",
                     details={"error": str(e)},
                 )

--- a/modelaudit/scanners/sevenzip_scanner.py
+++ b/modelaudit/scanners/sevenzip_scanner.py
@@ -19,6 +19,12 @@ from ._archive_config import get_archive_depth
 from ._archive_locations import rewrite_extracted_member_location
 from ._archive_outcomes import mark_archive_scan_incomplete, member_scan_incomplete
 from .archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY
+from .archive_member_security import (
+    has_executable_archive_member_signature,
+    is_executable_archive_member_name,
+    is_python_archive_member_name,
+    scan_archive_member_for_known_risks,
+)
 from .base import BaseScanner, IssueSeverity, ScanResult
 
 # Try to import py7zr with graceful fallback
@@ -100,6 +106,12 @@ class _RecursiveScanBudget:
         return self.limit_exceeded
 
 
+@dataclass(frozen=True)
+class _NestedMemberProbeResult:
+    detected_format: str | None
+    executable_content: bool = False
+
+
 class SevenZipScanner(BaseScanner):
     """Scanner for 7-Zip archive files (.7z)
 
@@ -111,7 +123,8 @@ class SevenZipScanner(BaseScanner):
     description = "Scans 7-Zip archives for malicious model files"
     supported_extensions: ClassVar[list[str]] = [".7z"]
     _SEVENZIP_MAGIC: ClassVar[bytes] = b"7z\xbc\xaf\x27\x1c"
-    _NESTED_MEMBER_PROBE_BYTES: ClassVar[int] = 512
+    _NESTED_MEMBER_PROBE_BYTES: ClassVar[int] = 1024
+    _MAX_PYTHON_MEMBER_ANALYSIS_BYTES: ClassVar[int] = 10 * 1024 * 1024
 
     _MAX_EXTENSIONLESS_PROBES: ClassVar[int] = 100
     _MAX_TOTAL_EXTRACT_SIZE: ClassVar[int] = 5 * 1024 * 1024 * 1024  # 5 GB
@@ -438,17 +451,23 @@ class SevenZipScanner(BaseScanner):
 
             # Filter for scannable model files from safe entries only
             scannable_files = self._identify_scannable_files(safe_file_names)
-            nested_archive_files, probes_complete = self._identify_extensionless_nested_7z_files(
-                archive,
-                safe_file_names,
-                path,
-                result,
+            member_security_files = self._identify_named_member_security_files(safe_file_names)
+            nested_archive_files, probed_security_files, probes_complete = (
+                self._identify_probed_nested_and_security_files(
+                    archive,
+                    safe_file_names,
+                    path,
+                    result,
+                    named_security_files=frozenset(member_security_files),
+                )
             )
-            scannable_files.extend(nested_archive_files)
+            member_security_files.extend(probed_security_files)
+            nested_scan_targets = list(dict.fromkeys([*scannable_files, *nested_archive_files]))
+            extraction_targets = list(dict.fromkeys([*nested_scan_targets, *member_security_files]))
             if not probes_complete:
                 scan_complete = False
 
-            if not scannable_files:
+            if not extraction_targets:
                 result.add_check(
                     name="Archive Content Check",
                     passed=True,
@@ -460,17 +479,20 @@ class SevenZipScanner(BaseScanner):
                 scan_complete = (
                     self._extract_and_scan_files(
                         archive,
-                        scannable_files,
+                        extraction_targets,
                         path,
                         result,
                         depth,
                         budget=budget,
+                        member_security_files=frozenset(member_security_files),
+                        nested_scan_files=frozenset(nested_scan_targets),
                     )
                     and scan_complete
                 )
 
             result.metadata["total_files"] = len(file_names)
-            result.metadata["scannable_files"] = len(scannable_files)
+            result.metadata["scannable_files"] = len(nested_scan_targets)
+            result.metadata["security_files"] = len(set(member_security_files))
             result.metadata["unsafe_entries"] = len(file_names) - len(safe_file_names)
             result.metadata["file_size"] = os.path.getsize(path)
 
@@ -490,17 +512,36 @@ class SevenZipScanner(BaseScanner):
 
         return scannable_files
 
-    def _identify_extensionless_nested_7z_files(
-        self, archive: Any, file_names: list[str], archive_path: str, result: ScanResult
-    ) -> tuple[list[str], bool]:
-        """Inspect likely disguised nested members and keep only confirmed scannable payloads."""
+    @staticmethod
+    def _identify_named_member_security_files(file_names: list[str]) -> list[str]:
+        """Return archive members whose names require generic security inspection."""
+        return [
+            file_name
+            for file_name in file_names
+            if is_python_archive_member_name(file_name) or is_executable_archive_member_name(file_name)
+        ]
+
+    def _identify_probed_nested_and_security_files(
+        self,
+        archive: Any,
+        file_names: list[str],
+        archive_path: str,
+        result: ScanResult,
+        *,
+        named_security_files: frozenset[str] = frozenset(),
+    ) -> tuple[list[str], list[str], bool]:
+        """Probe unsupported members for nested formats and hidden executables."""
         nested_archives: list[str] = []
+        executable_members: list[str] = []
         probes_complete = True
         probe_candidates: list[tuple[int, int, str]] = []
         supported_extensions = self._supported_nested_core_extensions()
         for index, file_name in enumerate(file_names):
             candidate_extensions = self._candidate_archive_extensions(file_name)
-            if any(extension in supported_extensions for extension in candidate_extensions):
+            if (
+                any(extension in supported_extensions for extension in candidate_extensions)
+                or file_name in named_security_files
+            ):
                 continue
 
             member_info = None
@@ -533,14 +574,19 @@ class SevenZipScanner(BaseScanner):
         probe_candidates.sort(key=lambda item: (-item[0], item[1]))
         probe_targets = [file_name for _, _, file_name in probe_candidates[: self.max_extensionless_probes]]
         if not probe_targets:
-            return nested_archives, probes_complete
+            return nested_archives, executable_members, probes_complete
 
         try:
             probe_results = self._probe_extensionless_members(archive, probe_targets)
             for file_name in probe_targets:
-                if probe_results.get(file_name):
+                probe_result = probe_results.get(file_name)
+                if probe_result is None:
+                    continue
+                if probe_result.detected_format is not None:
                     nested_archives.append(file_name)
-            return nested_archives, probes_complete
+                if probe_result.executable_content:
+                    executable_members.append(file_name)
+            return nested_archives, executable_members, probes_complete
         except Exception:
             # Fall back to per-member probing if the fast path fails against a
             # particular archive layout or py7zr behavior.
@@ -548,8 +594,11 @@ class SevenZipScanner(BaseScanner):
 
         for file_name in probe_targets:
             try:
-                if self._member_probe_detected_format(archive, file_name) is not None:
+                probe_result = self._member_probe_result(archive, file_name)
+                if probe_result.detected_format is not None:
                     nested_archives.append(file_name)
+                if probe_result.executable_content:
+                    executable_members.append(file_name)
             except Exception as e:
                 probes_complete = False
                 result.add_check(
@@ -561,7 +610,7 @@ class SevenZipScanner(BaseScanner):
                     details={"error": str(e)},
                 )
 
-        return nested_archives, probes_complete
+        return nested_archives, executable_members, probes_complete
 
     @classmethod
     def _nested_probe_priority(cls, file_name: str) -> int:
@@ -586,9 +635,9 @@ class SevenZipScanner(BaseScanner):
 
         return priority
 
-    def _probe_extensionless_members(self, archive: Any, file_names: list[str]) -> dict[str, str | None]:
-        """Probe disguised members while stopping each extraction at the header budget."""
-        return {file_name: self._member_probe_detected_format(archive, file_name) for file_name in file_names}
+    def _probe_extensionless_members(self, archive: Any, file_names: list[str]) -> dict[str, _NestedMemberProbeResult]:
+        """Probe disguised members while stopping each extraction at bounded prefixes."""
+        return {file_name: self._member_probe_result(archive, file_name) for file_name in file_names}
 
     @classmethod
     def _probe_has_7z_magic(cls, probe: Any | None) -> bool:
@@ -637,9 +686,9 @@ class SevenZipScanner(BaseScanner):
             return None
         return detected_format
 
-    def _member_probe_detected_format(self, archive: Any, file_name: str) -> str | None:
-        """Read only enough bytes to confirm whether a member has a scannable nested format."""
-        probe_factory = _HeaderProbeFactory(limit=self._NESTED_MEMBER_PROBE_BYTES)
+    def _read_member_probe_prefix(self, archive: Any, file_name: str, limit: int) -> bytes:
+        """Extract a bounded prefix from one member without writing to disk."""
+        probe_factory = _HeaderProbeFactory(limit=limit)
 
         try:
             with suppress(_HeaderProbeComplete):
@@ -651,7 +700,31 @@ class SevenZipScanner(BaseScanner):
         probe = probe_factory.get(file_name)
         if probe is None:
             probe = next(iter(probe_factory.products.values()), None)
-        return self._probe_detected_format(probe)
+        if probe is None:
+            return b""
+        probe.seek(0)
+        return probe.read(limit)
+
+    def _member_probe_result(self, archive: Any, file_name: str) -> _NestedMemberProbeResult:
+        """Classify a member through bounded format and executable-content probes."""
+        prefix = self._read_member_probe_prefix(archive, file_name, self._NESTED_MEMBER_PROBE_BYTES)
+        detected_format = self._probe_detected_format(io.BytesIO(prefix))
+        if detected_format is not None:
+            return _NestedMemberProbeResult(detected_format=detected_format)
+
+        def read_prefix(limit: int) -> bytes:
+            if limit <= len(prefix) or not prefix.startswith(b"MZ"):
+                return prefix[:limit]
+            return self._read_member_probe_prefix(archive, file_name, limit)
+
+        return _NestedMemberProbeResult(
+            detected_format=None,
+            executable_content=has_executable_archive_member_signature(read_prefix),
+        )
+
+    def _member_probe_detected_format(self, archive: Any, file_name: str) -> str | None:
+        """Read only enough bytes to confirm whether a member has a scannable nested format."""
+        return self._member_probe_result(archive, file_name).detected_format
 
     def _check_path_traversal(self, file_names: list[str], archive_path: str, result: ScanResult) -> list[str]:
         """Check for path traversal vulnerabilities and return only safe entries."""
@@ -709,9 +782,13 @@ class SevenZipScanner(BaseScanner):
         result: ScanResult,
         depth: int,
         budget: _RecursiveScanBudget,
+        member_security_files: frozenset[str] = frozenset(),
+        nested_scan_files: frozenset[str] | None = None,
     ) -> bool:
         """Extract scannable files and run appropriate scanners on them"""
         scan_complete = not budget.should_stop()
+        if nested_scan_files is None:
+            nested_scan_files = frozenset(scannable_files)
         extractable_files = []
         for file_name in scannable_files:
             member_info = None
@@ -802,6 +879,23 @@ class SevenZipScanner(BaseScanner):
                                     },
                                 )
                                 return False
+
+                            if file_name in member_security_files:
+                                scan_archive_member_for_known_risks(
+                                    archive_kind="7z",
+                                    archive_path=archive_path,
+                                    member_name=file_name,
+                                    tmp_path=extracted_path,
+                                    total_size=extracted_size,
+                                    result=result,
+                                    max_python_analysis_bytes=self._MAX_PYTHON_MEMBER_ANALYSIS_BYTES,
+                                    python_analysis_incomplete_reason="sevenzip_python_member_analysis_incomplete",
+                                )
+                                if member_scan_incomplete(result):
+                                    scan_complete = False
+
+                            if file_name not in nested_scan_files:
+                                continue
 
                             # Get appropriate scanner for the extracted file
                             nested_scan_success = self._scan_extracted_file(

--- a/modelaudit/scanners/sevenzip_scanner.py
+++ b/modelaudit/scanners/sevenzip_scanner.py
@@ -892,6 +892,7 @@ class SevenZipScanner(BaseScanner):
                                     result=result,
                                     max_python_analysis_bytes=self._MAX_PYTHON_MEMBER_ANALYSIS_BYTES,
                                     python_analysis_incomplete_reason="sevenzip_python_member_analysis_incomplete",
+                                    analyze_python_source=file_name not in nested_scan_files,
                                 )
                                 if member_scan_incomplete(result):
                                     scan_complete = False

--- a/tests/scanners/test_sevenzip_scanner.py
+++ b/tests/scanners/test_sevenzip_scanner.py
@@ -22,9 +22,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.scanners.archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY
 from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity, ScanResult
-from modelaudit.scanners.sevenzip_scanner import HAS_PY7ZR, SevenZipScanner, _RecursiveScanBudget
+from modelaudit.scanners.sevenzip_scanner import (
+    HAS_PY7ZR,
+    SevenZipScanner,
+    _NestedMemberProbeResult,
+    _RecursiveScanBudget,
+)
 
 # Skip all tests if py7zr is not available for asset generation
 pytest_plugins: list[str] = []
@@ -1362,7 +1368,7 @@ class TestSevenZipScannerHardening:
             patch.object(
                 scanner,
                 "_probe_extensionless_members",
-                return_value=dict.fromkeys(extensionless_members[:3], False),
+                return_value={name: _NestedMemberProbeResult(None) for name in extensionless_members[:3]},
             ) as mock_probe,
             patch("os.path.getsize", return_value=32),
         ):
@@ -1392,7 +1398,11 @@ class TestSevenZipScannerHardening:
         with (
             patch("modelaudit.scanners.sevenzip_scanner.HAS_PY7ZR", True),
             patch("modelaudit.scanners.sevenzip_scanner.py7zr") as mock_py7zr,
-            patch.object(scanner, "_probe_extensionless_members", return_value={"payload.jpg": "zip"}) as mock_probe,
+            patch.object(
+                scanner,
+                "_probe_extensionless_members",
+                return_value={"payload.jpg": _NestedMemberProbeResult("zip")},
+            ) as mock_probe,
             patch.object(scanner, "_extract_and_scan_files", return_value=True) as mock_extract,
             patch("os.path.getsize", return_value=32),
         ):
@@ -1420,7 +1430,11 @@ class TestSevenZipScannerHardening:
         with (
             patch("modelaudit.scanners.sevenzip_scanner.HAS_PY7ZR", True),
             patch("modelaudit.scanners.sevenzip_scanner.py7zr") as mock_py7zr,
-            patch.object(scanner, "_probe_extensionless_members", return_value={"payload.jpg": "zip"}),
+            patch.object(
+                scanner,
+                "_probe_extensionless_members",
+                return_value={"payload.jpg": _NestedMemberProbeResult("zip")},
+            ),
             patch("os.path.getsize", return_value=32),
         ):
             mock_archive = MagicMock()
@@ -1458,8 +1472,8 @@ class TestSevenZipScannerHardening:
         fake_archive = FakeArchive()
 
         assert scanner._probe_extensionless_members(fake_archive, ["payload_a.jpg", "payload_b.jpg"]) == {
-            "payload_a.jpg": "zip",
-            "payload_b.jpg": "zip",
+            "payload_a.jpg": _NestedMemberProbeResult("zip"),
+            "payload_b.jpg": _NestedMemberProbeResult("zip"),
         }
         assert fake_archive.targets == [["payload_a.jpg"], ["payload_b.jpg"]]
         assert fake_archive.reset_count == 2
@@ -1538,6 +1552,105 @@ class TestSevenZipScannerHardening:
         assert result.success is True
         assert result.metadata["scannable_files"] == 0
         assert not result.issues
+
+    @pytest.mark.skipif(not HAS_PY7ZR, reason="py7zr not available")
+    def test_high_risk_python_member_is_scanned_through_shared_archive_security(self, tmp_path: Path) -> None:
+        """Python source members must not bypass the AST archive-member detector."""
+        import py7zr  # type: ignore[import-untyped]
+
+        archive_path = tmp_path / "python_sidecar.7z"
+        source_path = tmp_path / "setup.py"
+        source_path.write_bytes(b"import os\nos.system('echo hidden')\n")
+        with py7zr.SevenZipFile(archive_path, "w") as archive:
+            archive.write(source_path, "assets/setup.py")
+
+        result = SevenZipScanner().scan(str(archive_path))
+        security_checks = [
+            check
+            for check in result.checks
+            if check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED
+        ]
+
+        assert len(security_checks) == 1
+        assert "high-risk calls: os.system" in security_checks[0].message
+        assert security_checks[0].rule_code == "S101"
+        aggregate = scan_model_directory_or_file(str(archive_path), cache_scan_results=False)
+        assert determine_exit_code(aggregate) == 1
+
+    @pytest.mark.skipif(not HAS_PY7ZR, reason="py7zr not available")
+    def test_benign_python_and_ordinary_members_stay_clean(self, tmp_path: Path) -> None:
+        """Scanning generic member types must not turn inert sidecars into findings."""
+        import py7zr  # type: ignore[import-untyped]
+
+        archive_path = tmp_path / "benign_sidecars.7z"
+        source_path = tmp_path / "setup.py"
+        notes_path = tmp_path / "readme.dat"
+        source_path.write_bytes(b"def transform(value):\n    return value\n")
+        notes_path.write_bytes(b"ordinary model notes")
+        with py7zr.SevenZipFile(archive_path, "w") as archive:
+            archive.write(source_path, "assets/setup.py")
+            archive.write(notes_path, "assets/readme.dat")
+
+        result = SevenZipScanner().scan(str(archive_path))
+
+        assert result.success is True
+        assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
+
+    @pytest.mark.skipif(not HAS_PY7ZR, reason="py7zr not available")
+    def test_unparseable_python_member_marks_scan_inconclusive(self, tmp_path: Path) -> None:
+        """Unparseable Python source must fail closed instead of silently clearing coverage."""
+        import py7zr  # type: ignore[import-untyped]
+
+        archive_path = tmp_path / "unparseable_python.7z"
+        source_path = tmp_path / "broken.py"
+        source_path.write_bytes(b"def broken(:\n")
+        with py7zr.SevenZipFile(archive_path, "w") as archive:
+            archive.write(source_path, "assets/broken.py")
+
+        result = SevenZipScanner().scan(str(archive_path))
+
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "sevenzip_python_member_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+        parse_checks = [
+            check
+            for check in result.checks
+            if check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED
+        ]
+        assert len(parse_checks) == 1
+        assert parse_checks[0].severity == IssueSeverity.INFO
+        aggregate = scan_model_directory_or_file(str(archive_path), cache_scan_results=False)
+        assert determine_exit_code(aggregate) == 2
+
+    @pytest.mark.skipif(not HAS_PY7ZR, reason="py7zr not available")
+    def test_disguised_executable_members_are_detected_by_content(self, tmp_path: Path) -> None:
+        """Executable bytes must not disappear behind inert member suffixes."""
+        import py7zr  # type: ignore[import-untyped]
+
+        distant_pe_header = bytearray(b"\x00" * 2052)
+        distant_pe_header[:2] = b"MZ"
+        distant_pe_header[0x3C:0x40] = (2048).to_bytes(4, "little")
+        distant_pe_header[2048:2052] = b"PE\x00\x00"
+        archive_path = tmp_path / "executable_sidecars.7z"
+        elf_path = tmp_path / "payload.dat"
+        pe_path = tmp_path / "loader.txt"
+        elf_path.write_bytes(b"\x7fELF\x02\x01\x01\x00" + (b"\x00" * 64))
+        pe_path.write_bytes(bytes(distant_pe_header))
+        with py7zr.SevenZipFile(archive_path, "w") as archive:
+            archive.write(elf_path, "assets/payload.dat")
+            archive.write(pe_path, "assets/loader.txt")
+
+        result = SevenZipScanner().scan(str(archive_path))
+        security_messages = {
+            check.message
+            for check in result.checks
+            if check.name == "Executable Archive Member Detection" and check.status == CheckStatus.FAILED
+        }
+
+        assert "Executable file found in 7z archive: assets/payload.dat" in security_messages
+        assert "Executable file found in 7z archive: assets/loader.txt" in security_messages
+        aggregate = scan_model_directory_or_file(str(archive_path), cache_scan_results=False)
+        assert determine_exit_code(aggregate) == 1
 
     # -- cumulative entry count -----------------------------------------------
 

--- a/tests/scanners/test_sevenzip_scanner.py
+++ b/tests/scanners/test_sevenzip_scanner.py
@@ -1385,6 +1385,7 @@ class TestSevenZipScannerHardening:
             limit_checks = [c for c in result.checks if "Probe Limit" in c.name]
             assert len(limit_checks) == 1
             assert limit_checks[0].status == CheckStatus.FAILED
+            assert limit_checks[0].severity == IssueSeverity.INFO
 
     def test_disguised_nested_zip_member_is_routed_for_scan(
         self,
@@ -1578,6 +1579,34 @@ class TestSevenZipScannerHardening:
         assert determine_exit_code(aggregate) == 1
 
     @pytest.mark.skipif(not HAS_PY7ZR, reason="py7zr not available")
+    def test_python_named_pickle_still_reaches_nested_pickle_scanning(self, tmp_path: Path) -> None:
+        """A pickle disguised as Python source must not stop at AST inspection."""
+        import py7zr  # type: ignore[import-untyped]
+
+        class MaliciousClass:
+            def __reduce__(self) -> tuple[Any, tuple[str]]:
+                import os as os_module
+
+                return (os_module.system, ("echo disguised_python_pickle",))
+
+        payload_path = tmp_path / "payload.pkl"
+        archive_path = tmp_path / "python_named_pickle.7z"
+        self._write_pickle(payload_path, MaliciousClass())
+        with py7zr.SevenZipFile(archive_path, "w") as archive:
+            archive.write(payload_path, "assets/payload.py")
+
+        result = SevenZipScanner().scan(str(archive_path))
+
+        assert any(
+            issue.location
+            and f"{archive_path}:assets/payload.py" in issue.location
+            and "system" in issue.message.lower()
+            for issue in result.issues
+        )
+        aggregate = scan_model_directory_or_file(str(archive_path), cache_scan_results=False)
+        assert determine_exit_code(aggregate) == 1
+
+    @pytest.mark.skipif(not HAS_PY7ZR, reason="py7zr not available")
     def test_benign_python_and_ordinary_members_stay_clean(self, tmp_path: Path) -> None:
         """Scanning generic member types must not turn inert sidecars into findings."""
         import py7zr  # type: ignore[import-untyped]
@@ -1634,11 +1663,14 @@ class TestSevenZipScannerHardening:
         archive_path = tmp_path / "executable_sidecars.7z"
         elf_path = tmp_path / "payload.dat"
         pe_path = tmp_path / "loader.txt"
+        supported_path = tmp_path / "declared.pkl"
         elf_path.write_bytes(b"\x7fELF\x02\x01\x01\x00" + (b"\x00" * 64))
         pe_path.write_bytes(bytes(distant_pe_header))
+        supported_path.write_bytes(b"\x7fELF\x02\x01\x01\x00" + (b"\x00" * 64))
         with py7zr.SevenZipFile(archive_path, "w") as archive:
             archive.write(elf_path, "assets/payload.dat")
             archive.write(pe_path, "assets/loader.txt")
+            archive.write(supported_path, "assets/declared.pkl")
 
         result = SevenZipScanner().scan(str(archive_path))
         security_messages = {
@@ -1649,6 +1681,7 @@ class TestSevenZipScannerHardening:
 
         assert "Executable file found in 7z archive: assets/payload.dat" in security_messages
         assert "Executable file found in 7z archive: assets/loader.txt" in security_messages
+        assert "Executable file found in 7z archive: assets/declared.pkl" in security_messages
         aggregate = scan_model_directory_or_file(str(archive_path), cache_scan_results=False)
         assert determine_exit_code(aggregate) == 1
 

--- a/tests/scanners/test_sevenzip_scanner.py
+++ b/tests/scanners/test_sevenzip_scanner.py
@@ -1607,6 +1607,25 @@ class TestSevenZipScannerHardening:
         assert determine_exit_code(aggregate) == 1
 
     @pytest.mark.skipif(not HAS_PY7ZR, reason="py7zr not available")
+    def test_benign_python_named_pickle_does_not_mark_python_analysis_incomplete(self, tmp_path: Path) -> None:
+        """A nested pickle owned by content routing must not be parsed as Python source."""
+        import py7zr  # type: ignore[import-untyped]
+
+        payload_path = tmp_path / "payload.pkl"
+        archive_path = tmp_path / "benign_python_named_pickle.7z"
+        self._write_pickle(payload_path, {"safe": True})
+        with py7zr.SevenZipFile(archive_path, "w") as archive:
+            archive.write(payload_path, "assets/payload.py")
+
+        result = SevenZipScanner().scan(str(archive_path))
+
+        assert result.success is True
+        assert result.metadata.get("analysis_incomplete") is not True
+        assert not any(check.name == "Python Archive Member Security" for check in result.checks)
+        aggregate = scan_model_directory_or_file(str(archive_path), cache_scan_results=False)
+        assert determine_exit_code(aggregate) == 0
+
+    @pytest.mark.skipif(not HAS_PY7ZR, reason="py7zr not available")
     def test_benign_python_and_ordinary_members_stay_clean(self, tmp_path: Path) -> None:
         """Scanning generic member types must not turn inert sidecars into findings."""
         import py7zr  # type: ignore[import-untyped]

--- a/tests/scanners/test_sevenzip_scanner.py
+++ b/tests/scanners/test_sevenzip_scanner.py
@@ -1683,13 +1683,16 @@ class TestSevenZipScannerHardening:
         elf_path = tmp_path / "payload.dat"
         pe_path = tmp_path / "loader.txt"
         supported_path = tmp_path / "declared.pkl"
+        python_named_path = tmp_path / "payload.py"
         elf_path.write_bytes(b"\x7fELF\x02\x01\x01\x00" + (b"\x00" * 64))
         pe_path.write_bytes(bytes(distant_pe_header))
         supported_path.write_bytes(b"\x7fELF\x02\x01\x01\x00" + (b"\x00" * 64))
+        python_named_path.write_bytes(b"\x7fELF\x02\x01\x01\x00" + (b"\x00" * 64))
         with py7zr.SevenZipFile(archive_path, "w") as archive:
             archive.write(elf_path, "assets/payload.dat")
             archive.write(pe_path, "assets/loader.txt")
             archive.write(supported_path, "assets/declared.pkl")
+            archive.write(python_named_path, "assets/payload.py")
 
         result = SevenZipScanner().scan(str(archive_path))
         security_messages = {
@@ -1701,6 +1704,7 @@ class TestSevenZipScannerHardening:
         assert "Executable file found in 7z archive: assets/payload.dat" in security_messages
         assert "Executable file found in 7z archive: assets/loader.txt" in security_messages
         assert "Executable file found in 7z archive: assets/declared.pkl" in security_messages
+        assert "Executable file found in 7z archive: assets/payload.py" in security_messages
         aggregate = scan_model_directory_or_file(str(archive_path), cache_scan_results=False)
         assert determine_exit_code(aggregate) == 1
 


### PR DESCRIPTION
## Stack

- Stacked on #1318 (`fix: detect disguised PyTorch ZIP executables`) to reuse its bounded shared executable-signature reader.
- Review this PR as the SevenZip delta plus the shared archive-member helper adjustment for Python-named executable bytes; after #1318 merges it can be retargeted to `main`.
- PR #1296 addressed pre-existing SevenZip probe-limit outcome severity; this PR preserves that INFO severity on the new/retouched SevenZip probe-limit and probe-failure paths so incomplete probes yield exit code `2` unless real findings are present.

## Summary

- route Python and executable-named SevenZip members through the shared generic archive security checker already used by ZIP/TAR
- extend existing bounded unsupported-member probes to retain ELF/PE/Mach-O/script executable content hidden behind ordinary names such as `.dat`, `.txt`, or `.py`
- keep generic security members separate from nested model dispatch and preserve bounded probing, extraction, and incomplete-analysis behavior
- record the user-visible detection improvement under `[Unreleased]`

## Root Cause

`SevenZipScanner` previously extracted only nested model candidates selected by registered extension or model-format prefix probing. Generic archive members were otherwise ignored. A valid 7z containing `assets/setup.py` with `os.system(...)`, or `assets/payload.dat` containing ELF bytes, returned clean with `scannable_files=0` and aggregate exit code `0`; equivalent ZIP/TAR members already receive shared security inspection.

## Behavior Verified

- high-risk `assets/setup.py` now produces `Python Archive Member Security` with rule code `S101` and aggregate exit code `1`
- ELF and distant-header PE members named `.dat` / `.txt` now produce `Executable Archive Member Detection` and aggregate exit code `1`
- ELF bytes named `.py` now produce the executable-member finding instead of only an inconclusive Python parse
- benign Python plus inert ordinary sidecars remain clean
- unparseable Python members now mark SevenZip analysis inconclusive and aggregate exit code `2` instead of reporting clean coverage
- metadata separates generic `security_files` from nested model `scannable_files`, avoiding unnecessary nested dispatch for security-only sidecars

## Validation

- `PROMPTFOO_DISABLE_TELEMETRY=1 .venv/bin/pytest tests/scanners/test_sevenzip_scanner.py -q --maxfail=1` (`72 passed, 2 skipped`)
- `PROMPTFOO_DISABLE_TELEMETRY=1 .venv/bin/pytest tests/scanners/test_zip_scanner.py tests/scanners/test_tar_scanner.py -q --maxfail=1` (`175 passed, 1 warning`)
- `.venv/bin/ruff format --check modelaudit/scanners/archive_member_security.py modelaudit/scanners/sevenzip_scanner.py tests/scanners/test_sevenzip_scanner.py`
- `.venv/bin/ruff check modelaudit/scanners/archive_member_security.py modelaudit/scanners/sevenzip_scanner.py tests/scanners/test_sevenzip_scanner.py`
- `.venv/bin/mypy modelaudit/scanners/archive_member_security.py modelaudit/scanners/sevenzip_scanner.py tests/scanners/test_sevenzip_scanner.py`
