### PR TITLE
fix: detect disguised TorchServe extra files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - detect Python operators declared in nested ONNX graphs and functions
 - distinguish ASCII-serialized Torch7 artifacts from plain PyTorch source text
 - classify bounded, unreadable, or unparseable TorchServe MAR analysis gaps as inconclusive rather than security findings
+- detect manifest-declared TorchServe extra files disguised with executable content
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -14,32 +14,11 @@ from .base import IssueSeverity
 if TYPE_CHECKING:
     from .base import ScanResult
 
-_EXECUTABLE_ARCHIVE_MEMBER_SUFFIXES = (
-    ".sh",
-    ".bash",
-    ".cmd",
-    ".exe",
-    ".dll",
-    ".so",
-    ".dylib",
-    ".scr",
-    ".com",
-    ".bat",
-    ".ps1",
-)
 _EXECUTABLE_ARCHIVE_MEMBER_MAGIC_READ_BYTES = 1024
 _PORTABLE_EXECUTABLE_POINTER_OFFSET = 0x3C
 _PORTABLE_EXECUTABLE_MIN_HEADER_OFFSET = 0x40
 _PORTABLE_EXECUTABLE_MAX_HEADER_OFFSET = 1024 * 1024
 _PORTABLE_EXECUTABLE_SIGNATURE = b"PE\x00\x00"
-_EXECUTABLE_ARCHIVE_MEMBER_MAGIC_PREFIXES = (
-    b"\x7fELF",
-    b"\xfe\xed\xfa\xce",
-    b"\xfe\xed\xfa\xcf",
-    b"\xcf\xfa\xed\xfe",
-    b"\xce\xfa\xed\xfe",
-    b"#!",
-)
 _MACHO_FAT_MAGIC_32_BE = b"\xca\xfe\xba\xbe"
 _MACHO_FAT_MAGIC_32_LE = b"\xbe\xba\xfe\xca"
 _MACHO_FAT_MAGIC_64_BE = b"\xca\xfe\xba\xbf"
@@ -123,10 +102,25 @@ _MISSING_ALIAS = object()
 
 def is_executable_archive_member_name(member_name: str) -> bool:
     """Return True when an archive member name has an executable/native-library suffix."""
+    return executable_archive_member_name_rule_code(member_name) is not None
+
+
+def executable_archive_member_name_rule_code(member_name: str) -> str | None:
+    """Return the executable rule code implied by an archive member name."""
     normalized_name = member_name.lower()
-    return normalized_name.endswith(_EXECUTABLE_ARCHIVE_MEMBER_SUFFIXES) or bool(
-        _VERSIONED_SHARED_OBJECT_SUFFIX_RE.search(normalized_name)
-    )
+    if normalized_name.endswith((".exe", ".dll", ".scr", ".com")):
+        return "S501"
+    if normalized_name.endswith(".so") or _VERSIONED_SHARED_OBJECT_SUFFIX_RE.search(normalized_name):
+        return "S502"
+    if normalized_name.endswith(".dylib"):
+        return "S503"
+    if normalized_name.endswith((".sh", ".bash")):
+        return "S504"
+    if normalized_name.endswith((".bat", ".cmd")):
+        return "S505"
+    if normalized_name.endswith(".ps1"):
+        return "S506"
+    return None
 
 
 def _looks_like_portable_executable(prefix: bytes, *, path: str) -> bool:
@@ -174,17 +168,33 @@ def _looks_like_macho_fat_binary(prefix: bytes) -> bool:
 
 def is_executable_archive_member_content(path: str) -> bool:
     """Return True when a member begins with a strong executable signature."""
+    return executable_archive_member_content_rule_code(path) is not None
+
+
+def executable_archive_member_content_rule_code(path: str) -> str | None:
+    """Return the executable rule code implied by an archive member's content."""
     try:
         with open(path, "rb") as member_file:
             prefix = member_file.read(_EXECUTABLE_ARCHIVE_MEMBER_MAGIC_READ_BYTES)
     except OSError:
-        return False
+        return None
 
-    if prefix.startswith(_EXECUTABLE_ARCHIVE_MEMBER_MAGIC_PREFIXES):
-        return True
+    if _looks_like_portable_executable(prefix, path=path):
+        return "S501"
+    if prefix.startswith(b"\x7fELF"):
+        return "S502"
+    if prefix.startswith((b"\xfe\xed\xfa\xce", b"\xfe\xed\xfa\xcf", b"\xcf\xfa\xed\xfe", b"\xce\xfa\xed\xfe")):
+        return "S503"
     if _looks_like_macho_fat_binary(prefix):
-        return True
-    return _looks_like_portable_executable(prefix, path=path)
+        return "S503"
+    if prefix.startswith(b"#!"):
+        return "S504"
+    return None
+
+
+def executable_archive_member_rule_code(member_name: str, path: str) -> str | None:
+    """Return the best executable rule code for an archive member."""
+    return executable_archive_member_content_rule_code(path) or executable_archive_member_name_rule_code(member_name)
 
 
 def is_python_archive_member_name(member_name: str) -> bool:

--- a/modelaudit/scanners/torchserve_mar_scanner.py
+++ b/modelaudit/scanners/torchserve_mar_scanner.py
@@ -21,6 +21,7 @@ from ..scanner_results import INCONCLUSIVE_SCAN_OUTCOME, mark_inconclusive_scan_
 from ..utils import is_absolute_archive_path, is_critical_system_path, sanitize_archive_path
 from ..utils.helpers.assets import asset_from_scan_result
 from ._archive_locations import rewrite_extracted_member_location
+from .archive_member_security import is_executable_archive_member_content, is_executable_archive_member_name
 from .base import BaseScanner, IssueSeverity, ScanResult
 
 CRITICAL_SYSTEM_PATHS = [
@@ -1395,6 +1396,11 @@ class TorchServeMarScanner(BaseScanner):
             for path in manifest_context.get("serialized_paths", [])
             if self._is_path_like_reference("serializedFile", path)
         }
+        extra_file_refs = {
+            self._normalize_member_name(path)
+            for field, path in manifest_context.get("path_references", [])
+            if field == "extraFiles" and self._is_path_like_reference(field, path)
+        }
         archive_member_names = {
             self._normalize_member_name(info.filename)
             for info in member_infos
@@ -1586,6 +1592,20 @@ class TorchServeMarScanner(BaseScanner):
 
             try:
                 from .. import core
+
+                if normalized_member in extra_file_refs and (
+                    is_executable_archive_member_name(normalized_member)
+                    or is_executable_archive_member_content(temp_path)
+                ):
+                    result.add_check(
+                        name="TorchServe Executable Extra File Detection",
+                        passed=False,
+                        message=f"Executable file found in TorchServe MAR extraFiles member: {member_name}",
+                        severity=IssueSeverity.WARNING,
+                        rule_code="S603",
+                        location=f"{archive_path}:{member_name}",
+                        details={"entry": member_name, "manifest_field": "extraFiles"},
+                    )
 
                 nested_config = dict(self.config)
                 nested_config["_mar_depth"] = current_depth + 1

--- a/modelaudit/scanners/torchserve_mar_scanner.py
+++ b/modelaudit/scanners/torchserve_mar_scanner.py
@@ -21,7 +21,7 @@ from ..scanner_results import INCONCLUSIVE_SCAN_OUTCOME, mark_inconclusive_scan_
 from ..utils import is_absolute_archive_path, is_critical_system_path, sanitize_archive_path
 from ..utils.helpers.assets import asset_from_scan_result
 from ._archive_locations import rewrite_extracted_member_location
-from .archive_member_security import is_executable_archive_member_content, is_executable_archive_member_name
+from .archive_member_security import executable_archive_member_rule_code
 from .base import BaseScanner, IssueSeverity, ScanResult
 
 CRITICAL_SYSTEM_PATHS = [
@@ -1593,16 +1593,18 @@ class TorchServeMarScanner(BaseScanner):
             try:
                 from .. import core
 
-                if normalized_member in extra_file_refs and (
-                    is_executable_archive_member_name(normalized_member)
-                    or is_executable_archive_member_content(temp_path)
-                ):
+                executable_rule_code = (
+                    executable_archive_member_rule_code(normalized_member, temp_path)
+                    if normalized_member in extra_file_refs
+                    else None
+                )
+                if executable_rule_code is not None:
                     result.add_check(
                         name="TorchServe Executable Extra File Detection",
                         passed=False,
                         message=f"Executable file found in TorchServe MAR extraFiles member: {member_name}",
                         severity=IssueSeverity.WARNING,
-                        rule_code="S603",
+                        rule_code=executable_rule_code,
                         location=f"{archive_path}:{member_name}",
                         details={"entry": member_name, "manifest_field": "extraFiles"},
                     )

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -201,6 +201,85 @@ def test_scan_benign_mar_with_safe_handler(tmp_path: Path) -> None:
     assert len(handler_failures) == 0
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"\x7fELF" + b"\x00" * 64,
+        b"MZ" + b"\x00" * 58 + (64).to_bytes(4, "little") + b"PE\x00\x00" + b"\x00" * 16,
+    ],
+)
+def test_scan_flags_content_disguised_executable_extra_file(tmp_path: Path, payload: bytes) -> None:
+    manifest = {
+        "model": {
+            "handler": "handler.py",
+            "serializedFile": "weights.bin",
+            "extraFiles": "native/payload.dat",
+        },
+    }
+    mar_path = _create_mar_archive(
+        tmp_path,
+        manifest=manifest,
+        entries={
+            "handler.py": b"def handle(data, context):\n    return data\n",
+            "weights.bin": b"weights",
+            "native/payload.dat": payload,
+        },
+        filename="disguised_executable_extra_file.mar",
+    )
+
+    result = TorchServeMarScanner().scan(str(mar_path))
+    aggregate = core.scan_model_directory_or_file(str(mar_path), cache_enabled=False)
+
+    executable_checks = _failed_checks(result, "TorchServe Executable Extra File Detection")
+    assert len(executable_checks) == 1
+    assert executable_checks[0].rule_code == "S603"
+    assert executable_checks[0].details["entry"] == "native/payload.dat"
+    assert core.determine_exit_code(aggregate) == 1
+
+
+def test_scan_allows_benign_ordinary_named_extra_file(tmp_path: Path) -> None:
+    manifest = {
+        "model": {
+            "handler": "handler.py",
+            "serializedFile": "weights.bin",
+            "extraFiles": "native/payload.dat",
+        },
+    }
+    mar_path = _create_mar_archive(
+        tmp_path,
+        manifest=manifest,
+        entries={
+            "handler.py": b"def handle(data, context):\n    return data\n",
+            "weights.bin": b"weights",
+            "native/payload.dat": b"compiled feature metadata\n",
+        },
+        filename="benign_extra_file.mar",
+    )
+
+    result = TorchServeMarScanner().scan(str(mar_path))
+    aggregate = core.scan_model_directory_or_file(str(mar_path), cache_enabled=False)
+
+    assert _failed_checks(result, "TorchServe Executable Extra File Detection") == []
+    assert core.determine_exit_code(aggregate) == 0
+
+
+def test_scan_does_not_classify_serialized_weight_signature_as_extra_file(tmp_path: Path) -> None:
+    manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.dat"}}
+    mar_path = _create_mar_archive(
+        tmp_path,
+        manifest=manifest,
+        entries={
+            "handler.py": b"def handle(data, context):\n    return data\n",
+            "weights.dat": b"\x7fELF" + b"\x00" * 64,
+        },
+        filename="serialized_weight_signature.mar",
+    )
+
+    result = TorchServeMarScanner().scan(str(mar_path))
+
+    assert _failed_checks(result, "TorchServe Executable Extra File Detection") == []
+
+
 def test_scan_flags_duplicate_handler_member_even_when_benign_copy_is_last(tmp_path: Path) -> None:
     manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
     mar_path = _create_mar_archive(

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -202,13 +202,15 @@ def test_scan_benign_mar_with_safe_handler(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    "payload",
+    ("payload", "expected_rule_code"),
     [
-        b"\x7fELF" + b"\x00" * 64,
-        b"MZ" + b"\x00" * 58 + (64).to_bytes(4, "little") + b"PE\x00\x00" + b"\x00" * 16,
+        (b"\x7fELF" + b"\x00" * 64, "S502"),
+        (b"MZ" + b"\x00" * 58 + (64).to_bytes(4, "little") + b"PE\x00\x00" + b"\x00" * 16, "S501"),
     ],
 )
-def test_scan_flags_content_disguised_executable_extra_file(tmp_path: Path, payload: bytes) -> None:
+def test_scan_flags_content_disguised_executable_extra_file(
+    tmp_path: Path, payload: bytes, expected_rule_code: str
+) -> None:
     manifest = {
         "model": {
             "handler": "handler.py",
@@ -232,8 +234,37 @@ def test_scan_flags_content_disguised_executable_extra_file(tmp_path: Path, payl
 
     executable_checks = _failed_checks(result, "TorchServe Executable Extra File Detection")
     assert len(executable_checks) == 1
-    assert executable_checks[0].rule_code == "S603"
+    assert executable_checks[0].rule_code == expected_rule_code
     assert executable_checks[0].details["entry"] == "native/payload.dat"
+    assert core.determine_exit_code(aggregate) == 1
+
+
+def test_scan_flags_name_disguised_executable_extra_file(tmp_path: Path) -> None:
+    manifest = {
+        "model": {
+            "handler": "handler.py",
+            "serializedFile": "weights.bin",
+            "extraFiles": "native/payload.so",
+        },
+    }
+    mar_path = _create_mar_archive(
+        tmp_path,
+        manifest=manifest,
+        entries={
+            "handler.py": b"def handle(data, context):\n    return data\n",
+            "weights.bin": b"weights",
+            "native/payload.so": b"compiled sidecar metadata\n",
+        },
+        filename="name_disguised_executable_extra_file.mar",
+    )
+
+    result = TorchServeMarScanner().scan(str(mar_path))
+    aggregate = core.scan_model_directory_or_file(str(mar_path), cache_enabled=False)
+
+    executable_checks = _failed_checks(result, "TorchServe Executable Extra File Detection")
+    assert len(executable_checks) == 1
+    assert executable_checks[0].rule_code == "S502"
+    assert executable_checks[0].details["entry"] == "native/payload.so"
     assert core.determine_exit_code(aggregate) == 1
 
 


### PR DESCRIPTION
## Summary
- inspect manifest-declared TorchServe `extraFiles` for executable names and strong executable signatures
- detect ordinary-suffix native sidecars that otherwise route as unknown
- preserve model-aware treatment of `serializedFile` bytes to avoid treating weight content as an extra-file executable

## Stack
- Stacked on #1297 (`mdangelo/codex/fix-torchserve-incomplete-outcomes`), which owns TorchServe incomplete-outcome and cache-safety hardening and is green in CI.

## Root Cause
`TorchServeMarScanner` extracts members and delegates ordinary non-Python payloads through normal model-format routing. A manifest-declared `extraFiles` member such as `native/payload.dat` containing ELF or valid PE content routed to `unknown` and returned a clean aggregate result, although the package declares that sidecar for deployed model execution.

## Reproduction
Before this change, valid MAR files declaring `extraFiles: native/payload.dat` returned aggregate exit code `0` for both ELF and valid PE payload content, identical to a benign `.dat` control. After the change, both malicious cases report `S603` and exit `1`, while the benign extra-file control remains exit `0`. A `serializedFile` starting with signature-like bytes is deliberately not classified as an extra-file executable.

## Validation
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest tests/scanners/test_torchserve_mar_scanner.py tests/scanners/test_zip_scanner.py tests/test_core.py --maxfail=1 -q` (`321 passed`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`4752 passed, 971 skipped`)
- `npx prettier --check CHANGELOG.md`
- `git diff --check`