### PR TITLE
fix: share trusted content routing across scan entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - route renamed ONNX protobuf models with prefixed unknown fields through content analysis and fail closed on unresolved or incomplete structure
 - preserve ambiguous budget-exhausted protobuf candidates for tentative analysis without misclassifying non-ONNX payloads
 - route signature-confirmed CNTK and LightGBM artifacts with misleading filenames through security analysis
+- share trusted-content routing across direct, nested, and helper scans so renamed specialized archives retain their format-specific analysis
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -17,7 +17,8 @@
 ## Routing & Coverage Invariants
 
 - Prefer trusted file structure and bounded content sniffing over extension-only routing, especially for ZIP-like containers and nested archives.
-- Keep scanner routing metadata descriptor-owned in `scanner_registry_metadata.py`; header-format aliases, content-routed extensions, extension-only format policy, and lazy class exports should come from that descriptor module, with `can_handle()` as the final content gate.
+- Keep scanner routing metadata descriptor-owned in `scanner_registry_metadata.py`; header-format aliases, content-routed extensions, extension-only format policy, and lazy class exports should come from that descriptor module.
+- Keep trusted content routing decisions shared in `scanners/routing.py` so top-level, nested archive, and registry helper flows cannot disagree. Use `can_handle()` as the final gate for suffix-selected candidates; a strict bounded content route may deliberately own a renamed file even when a legacy suffix-only gate declines it.
 - Source discovery filters should consume the registry-backed scannable extension set instead of carrying local allowlists.
 - For routing, prefiltering, or archive-recursion changes, add one malicious positive regression and one benign near-match negative regression.
 - If bounded routing cannot distinguish formats safely, preserve the candidate for tentative analysis; reject disproven or optional-analyzer-unsupported candidates cleanly, and report an inconclusive outcome once an established analysis path cannot complete.

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -30,6 +30,13 @@ from modelaudit.scanner_selection import (
 from modelaudit.scanners import _registry
 from modelaudit.scanners.archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY
 from modelaudit.scanners.base import FORMAT_VALIDATION_CONFIG_KEY, BaseScanner
+from modelaudit.scanners.routing import (
+    HEADER_FORMAT_TO_SCANNER_ID as _ROUTED_HEADER_FORMAT_TO_SCANNER_ID,
+)
+from modelaudit.scanners.routing import (
+    routed_scanner_can_handle,
+    select_routed_scanner_id,
+)
 from modelaudit.telemetry import record_file_type_detected, record_issue_found, record_scanner_used
 from modelaudit.utils import is_within_directory, resolve_dvc_file, should_skip_file
 from modelaudit.utils.file.detection import (
@@ -38,11 +45,6 @@ from modelaudit.utils.file.detection import (
     detect_file_format,
     detect_file_format_from_magic,
     detect_format_from_extension,
-    is_executorch_archive,
-    is_keras_zip_archive,
-    is_pytorch_zip_archive,
-    is_skops_archive,
-    is_torchserve_mar_archive,
     validate_file_type_with_formats,
 )
 from modelaudit.utils.file.handlers import (
@@ -100,9 +102,8 @@ _normalize_unclassified_scan_failure = core_results.normalize_unclassified_scan_
 determine_exit_code = core_results.determine_exit_code
 merge_scan_result = core_results.merge_scan_result
 
-HEADER_FORMAT_TO_SCANNER_ID = _registry.get_header_format_to_scanner_ids()
-_COMPRESSED_HEADER_FORMATS = frozenset({"compressed", "gzip", "bzip2", "xz", "lz4", "zlib"})
-_R_SERIALIZED_EXTENSIONS = frozenset({".rds", ".rda", ".rdata"})
+# Compatibility export consumed by asset-extraction tests and integrations.
+HEADER_FORMAT_TO_SCANNER_ID = _ROUTED_HEADER_FORMAT_TO_SCANNER_ID
 _XGBOOST_BINARY_EXTENSIONS = frozenset({".bst"})
 _XGBOOST_PICKLE_SPOOF_REASON = "xgboost_binary_pickle_spoof"
 _RECOGNIZED_FORMAT_SCANNER_UNAVAILABLE_REASON = "recognized_format_scanner_unavailable"
@@ -188,43 +189,7 @@ def _allowed_shard_paths_from_config(config: dict[str, Any]) -> list[str] | None
 
 def _select_preferred_scanner_id(path: str, header_format: str, ext: str) -> str | None:
     """Select a scanner by trusted file structure, not just suffix."""
-    if header_format == PROTOBUF_MODEL_CANDIDATE_FORMAT:
-        return "protobuf_model_candidate"
-
-    if header_format == "zip":
-        if is_torchserve_mar_archive(path):
-            return "torchserve_mar"
-        if is_keras_zip_archive(path, allow_config_only=ext == ".keras"):
-            return "keras_zip"
-        if is_pytorch_zip_archive(path):
-            return "pytorch_zip"
-        if is_executorch_archive(path):
-            return "executorch"
-        if is_skops_archive(path):
-            return "skops"
-        if ext == ".skops":
-            return "skops"
-        if ext == ".joblib":
-            return "joblib"
-        return "zip"
-
-    if ext == ".joblib" and header_format in _COMPRESSED_HEADER_FORMATS | {"pickle"}:
-        return "joblib"
-
-    if ext in _R_SERIALIZED_EXTENSIONS and header_format in _COMPRESSED_HEADER_FORMATS | {"r_serialized"}:
-        return "r_serialized"
-
-    if header_format == "tar" and ext == ".nemo":
-        return "nemo"
-
-    return _registry.get_scanner_id_for_header_format(header_format)
-
-
-def _is_direct_header_route(scanner_id: str, header_format: str) -> bool:
-    """Return whether the detected header directly maps to this scanner."""
-    if header_format == PROTOBUF_MODEL_CANDIDATE_FORMAT:
-        return scanner_id == "protobuf_model_candidate"
-    return header_format != "unknown" and HEADER_FORMAT_TO_SCANNER_ID.get(header_format) == scanner_id
+    return select_routed_scanner_id(path, header_format, extension=ext)
 
 
 def _preferred_scanner_can_handle(
@@ -234,19 +199,7 @@ def _preferred_scanner_can_handle(
     path: str,
 ) -> bool:
     """Honor trusted header routing even when scanner can_handle is suffix-gated."""
-    if scanner_class.can_handle(path):
-        return True
-
-    if os.path.exists(path) and _is_direct_header_route(scanner_id, header_format):
-        logger.debug(
-            "Using %s scanner for %s based on detected %s header despite can_handle rejection",
-            scanner_class.name,
-            path,
-            header_format,
-        )
-        return True
-
-    return False
+    return routed_scanner_can_handle(scanner_class, scanner_id, header_format, path)
 
 
 def _mark_xgboost_pickle_extension_spoof(result: ScanResult, path: str, ext: str) -> None:

--- a/modelaudit/scanner_registry_metadata.py
+++ b/modelaudit/scanner_registry_metadata.py
@@ -377,7 +377,7 @@ SCANNER_REGISTRY_METADATA: dict[str, dict[str, Any]] = {
     "cntk": {
         "module": "modelaudit.scanners.cntk_scanner",
         "class": "CntkScanner",
-        "description": "Scans CNTK .dnn/.cmf model artifacts",
+        "description": "Scans signature-confirmed CNTK model artifacts for load-time execution indicators",
         "extensions": [".dnn", ".cmf"],
         "priority": 18,
         "dependencies": [],

--- a/modelaudit/scanners/__init__.py
+++ b/modelaudit/scanners/__init__.py
@@ -10,6 +10,7 @@ from typing import Any
 from ..scanner_registry_metadata import get_scanner_registry_metadata
 from ..scanner_selection import ScannerSelectionPolicy, policy_from_config
 from .base import BaseScanner, Check, CheckStatus, Issue, IssueSeverity, ScanResult
+from .routing import routed_scanner_can_handle, select_routed_scanner_id
 
 logger = logging.getLogger(__name__)
 
@@ -273,14 +274,6 @@ class ScannerRegistry:
                 if scanner_class and scanner_class.can_handle(path):
                     return scanner_class
 
-        # Some ZIP-backed artifacts intentionally use pickle/checkpoint suffixes.
-        # If stricter extension-specific scanners all decline, fall back to the
-        # generic ZIP scanner so helper-level routing does not drop coverage.
-        if is_zip_file and (scanner_selection is None or scanner_selection.allows("zip")):
-            scanner_class = self._load_scanner("zip")
-            if scanner_class and scanner_class.can_handle(path):
-                return scanner_class
-
         try:
             from modelaudit.utils.file.detection import detect_file_format
 
@@ -288,16 +281,22 @@ class ScannerRegistry:
         except Exception:
             header_format = "unknown"
 
-        header_scanner_id = self.get_scanner_id_for_header_format(header_format)
+        header_scanner_id = select_routed_scanner_id(path, header_format, extension=file_ext)
         header_scanner_info = self._scanners.get(header_scanner_id or "")
         if (
             header_scanner_id
             and header_scanner_info
-            and header_format == header_scanner_id
             and (scanner_selection is None or scanner_selection.allows(header_scanner_id))
         ):
             scanner_class = self._load_scanner(header_scanner_id)
-            if scanner_class and (scanner_class.can_handle(path) or os.path.exists(path)):
+            if scanner_class and routed_scanner_can_handle(scanner_class, header_scanner_id, header_format, path):
+                return scanner_class
+
+        # If structure-specific scanners decline a ZIP, preserve generic ZIP
+        # recursion so nested payload analysis is never dropped.
+        if is_zip_file and (scanner_selection is None or scanner_selection.allows("zip")):
+            scanner_class = self._load_scanner("zip")
+            if scanner_class and scanner_class.can_handle(path):
                 return scanner_class
 
         # Manifest-like config files sometimes intentionally use generic or

--- a/modelaudit/scanners/archive_dispatch.py
+++ b/modelaudit/scanners/archive_dispatch.py
@@ -1,11 +1,9 @@
 """Nested archive dispatch helpers used by recursive scanners."""
 
-import os
 from collections.abc import Callable
 from typing import Any
 
 from ..core_results import mark_operational_scan_error
-from ..scanner_registry_metadata import get_scanner_registry_metadata
 from ..scanner_results import IssueSeverity, ScanResult, mark_inconclusive_scan_result
 from ..scanner_selection import (
     SCANNER_SELECTION_PREFERRED_KIND,
@@ -19,32 +17,20 @@ from ..utils.file.detection import (
     XML_MODEL_INCONCLUSIVE_FORMAT,
     detect_file_format,
     detect_file_format_from_magic,
-    is_executorch_archive,
-    is_keras_zip_archive,
-    is_pytorch_zip_archive,
-    is_skops_archive,
-    is_torchserve_mar_archive,
 )
 from .base import FORMAT_VALIDATION_CONFIG_KEY
+from .routing import (
+    HEADER_FORMAT_TO_SCANNER_ID,
+    routed_scanner_can_handle,
+    select_routed_scanner_id,
+)
 
 NESTED_SCAN_CALLBACK_CONFIG_KEY = "_archive_nested_scan_callback"
 NestedScanCallback = Callable[[str, dict[str, Any] | None], ScanResult]
 
+# Compatibility export for registry and archive-dispatch tests.
+_HEADER_FORMAT_TO_SCANNER_ID = HEADER_FORMAT_TO_SCANNER_ID
 
-def _build_header_format_to_scanner_id() -> dict[str, str]:
-    metadata = get_scanner_registry_metadata()
-    header_format_to_scanner_id = {scanner_id: scanner_id for scanner_id in metadata}
-    for scanner_id, scanner_info in metadata.items():
-        for header_format in scanner_info.get("header_formats", ()):
-            header_format_to_scanner_id[str(header_format)] = scanner_id
-    return header_format_to_scanner_id
-
-
-_HEADER_FORMAT_TO_SCANNER_ID: dict[str, str] = _build_header_format_to_scanner_id()
-_COMPRESSED_HEADER_FORMATS: frozenset[str] = frozenset(
-    header_format for header_format, scanner_id in _HEADER_FORMAT_TO_SCANNER_ID.items() if scanner_id == "compressed"
-)
-_R_SERIALIZED_EXTENSIONS: frozenset[str] = frozenset({".rds", ".rda", ".rdata"})
 _RECOGNIZED_FORMAT_SCANNER_UNAVAILABLE_REASON = "recognized_format_scanner_unavailable"
 _XML_MODEL_ROUTING_INCOMPLETE_REASON = "xml_model_routing_incomplete"
 _PROTOBUF_MODEL_ROUTING_INCOMPLETE_REASON = "protobuf_model_routing_incomplete"
@@ -54,61 +40,17 @@ def _select_nested_scanner_id(path: str, *, header_format: str | None = None) ->
     """Select a scanner for extracted archive members using trusted file structure first."""
     if header_format is None:
         header_format = detect_file_format(path)
-    ext = os.path.splitext(path)[1].lower()
-
-    if header_format == PROTOBUF_MODEL_CANDIDATE_FORMAT:
-        return "protobuf_model_candidate"
-
-    if header_format == "zip":
-        if is_torchserve_mar_archive(path):
-            return "torchserve_mar"
-        if is_keras_zip_archive(path, allow_config_only=ext == ".keras"):
-            return "keras_zip"
-        if is_pytorch_zip_archive(path):
-            return "pytorch_zip"
-        if is_executorch_archive(path):
-            return "executorch"
-        if is_skops_archive(path):
-            return "skops"
-        if ext == ".skops":
-            return "skops"
-        if ext == ".joblib":
-            return "joblib"
-        return "zip"
-
-    if ext == ".joblib" and header_format in _COMPRESSED_HEADER_FORMATS | {"pickle"}:
-        return "joblib"
-
-    if ext in _R_SERIALIZED_EXTENSIONS and header_format in _COMPRESSED_HEADER_FORMATS | {"r_serialized"}:
-        return "r_serialized"
-
-    if header_format == "tar" and ext == ".nemo":
-        return "nemo"
-
-    return _HEADER_FORMAT_TO_SCANNER_ID.get(header_format)
-
-
-def _is_direct_header_route(scanner_id: str, header_format: str) -> bool:
-    """Return whether the detected header directly maps to this scanner."""
-    if header_format == PROTOBUF_MODEL_CANDIDATE_FORMAT:
-        return scanner_id == "protobuf_model_candidate"
-    return header_format != "unknown" and _HEADER_FORMAT_TO_SCANNER_ID.get(header_format) == scanner_id
+    return select_routed_scanner_id(path, header_format)
 
 
 def _nested_scanner_can_handle(scanner_class: type[Any], scanner_id: str, path: str) -> bool:
     """Honor trusted header routing even when temporary archive paths are suffix-gated."""
-    if scanner_class.can_handle(path):
-        return True
-
-    if not os.path.exists(path):
-        return False
-
     try:
         header_format = detect_file_format(path)
     except Exception:
         return False
 
-    return _is_direct_header_route(scanner_id, header_format)
+    return routed_scanner_can_handle(scanner_class, scanner_id, header_format, path)
 
 
 def _make_unavailable_recognized_format_result(path: str, format_: str, scanner_id: str | None) -> ScanResult:

--- a/modelaudit/scanners/routing.py
+++ b/modelaudit/scanners/routing.py
@@ -1,0 +1,83 @@
+"""Shared trusted-content routing policy for scanner selection."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from ..scanner_registry_metadata import get_scanner_registry_metadata
+from ..utils.file.detection import (
+    PROTOBUF_MODEL_CANDIDATE_FORMAT,
+    is_executorch_archive,
+    is_keras_zip_archive,
+    is_pytorch_zip_archive,
+    is_skops_archive,
+    is_torchserve_mar_archive,
+)
+
+
+def _build_header_format_to_scanner_id() -> dict[str, str]:
+    metadata = get_scanner_registry_metadata()
+    header_format_to_scanner_id = {scanner_id: scanner_id for scanner_id in metadata}
+    for scanner_id, scanner_info in metadata.items():
+        for header_format in scanner_info.get("header_formats", ()):
+            header_format_to_scanner_id[str(header_format)] = scanner_id
+    return header_format_to_scanner_id
+
+
+HEADER_FORMAT_TO_SCANNER_ID: dict[str, str] = _build_header_format_to_scanner_id()
+COMPRESSED_HEADER_FORMATS: frozenset[str] = frozenset(
+    header_format for header_format, scanner_id in HEADER_FORMAT_TO_SCANNER_ID.items() if scanner_id == "compressed"
+)
+R_SERIALIZED_EXTENSIONS: frozenset[str] = frozenset({".rds", ".rda", ".rdata"})
+
+
+def select_routed_scanner_id(path: str, header_format: str, *, extension: str | None = None) -> str | None:
+    """Select the scanner owned by a trusted bounded content route."""
+    ext = extension if extension is not None else os.path.splitext(path)[1].lower()
+
+    if header_format == PROTOBUF_MODEL_CANDIDATE_FORMAT:
+        return "protobuf_model_candidate"
+
+    if header_format == "zip":
+        if is_torchserve_mar_archive(path):
+            return "torchserve_mar"
+        if is_keras_zip_archive(path, allow_config_only=ext == ".keras"):
+            return "keras_zip"
+        if is_pytorch_zip_archive(path):
+            return "pytorch_zip"
+        if is_executorch_archive(path):
+            return "executorch"
+        if is_skops_archive(path):
+            return "skops"
+        if ext == ".skops":
+            return "skops"
+        if ext == ".joblib":
+            return "joblib"
+        return "zip"
+
+    if ext == ".joblib" and header_format in COMPRESSED_HEADER_FORMATS | {"pickle"}:
+        return "joblib"
+
+    if ext in R_SERIALIZED_EXTENSIONS and header_format in COMPRESSED_HEADER_FORMATS | {"r_serialized"}:
+        return "r_serialized"
+
+    if header_format == "tar" and ext == ".nemo":
+        return "nemo"
+
+    return HEADER_FORMAT_TO_SCANNER_ID.get(header_format)
+
+
+def is_direct_header_route(scanner_id: str, header_format: str) -> bool:
+    """Return whether a strict detected format directly identifies a scanner."""
+    if header_format == PROTOBUF_MODEL_CANDIDATE_FORMAT:
+        return scanner_id == "protobuf_model_candidate"
+    return header_format != "unknown" and HEADER_FORMAT_TO_SCANNER_ID.get(header_format) == scanner_id
+
+
+def routed_scanner_can_handle(scanner_class: type[Any], scanner_id: str, header_format: str, path: str) -> bool:
+    """Accept content-routed scanners after their own gate or direct strict detection."""
+    if scanner_class.can_handle(path):
+        return True
+
+    return os.path.exists(path) and is_direct_header_route(scanner_id, header_format)

--- a/tests/scanners/test_scanner_registry.py
+++ b/tests/scanners/test_scanner_registry.py
@@ -1,3 +1,4 @@
+import base64
 import bz2
 import gzip
 import io
@@ -12,6 +13,7 @@ from typing import Literal
 
 import pytest
 
+from modelaudit import core as core_module
 from modelaudit.config.constants import SCANNABLE_MODEL_EXTENSIONS
 from modelaudit.core import scan_file
 from modelaudit.scanner_registry_metadata import (
@@ -35,6 +37,7 @@ _REPRESENTATIVE_SCANNER_IDS = [
     "compressed",
     "tar",
     "tf_savedmodel",
+    "cntk",
     "metadata",
     "manifest",
 ]
@@ -77,6 +80,12 @@ def _assert_scanner_for_path(path: Path, expected_scanner_name: str) -> None:
 
     assert scanner_class is not None
     assert scanner_class.name == expected_scanner_name
+
+
+def _assert_shared_zip_route(path: Path, expected_scanner_name: str) -> None:
+    _assert_scanner_for_path(path, expected_scanner_name)
+    assert core_module._select_preferred_scanner_id(str(path), "zip", path.suffix.lower()) == expected_scanner_name
+    assert _select_nested_scanner_id(str(path), header_format="zip") == expected_scanner_name
 
 
 def test_scanner_registry_contains_all_scanners():
@@ -352,6 +361,28 @@ def test_select_nested_scanner_id_does_not_route_compressed_non_target_suffix_to
 
 
 @pytest.mark.parametrize(
+    ("header_format", "suffix", "scanner_id"),
+    [
+        ("gzip", ".joblib", "joblib"),
+        ("gzip", ".rds", "r_serialized"),
+        ("tar", ".nemo", "nemo"),
+        ("cntk", ".jpg", "cntk"),
+    ],
+)
+def test_top_level_and_nested_routing_share_non_zip_content_decisions(
+    tmp_path: Path,
+    header_format: str,
+    suffix: str,
+    scanner_id: str,
+) -> None:
+    model_path = tmp_path / f"model{suffix}"
+    model_path.write_bytes(b"content-route-contract")
+
+    assert core_module._select_preferred_scanner_id(str(model_path), header_format, suffix) == scanner_id
+    assert _select_nested_scanner_id(str(model_path), header_format=header_format) == scanner_id
+
+
+@pytest.mark.parametrize(
     ("header_format", "scanner_id"),
     [
         ("pickle", "pickle"),
@@ -394,6 +425,12 @@ def test_get_scanner_for_path_preserves_zip_backed_pytorch_suffix_collision_disp
     _assert_scanner_for_path(model_path, expected_scanner_name)
 
 
+def test_get_scanner_for_path_routes_renamed_pytorch_zip_by_shared_content_contract(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "model.jpg")
+
+    _assert_shared_zip_route(model_path, "pytorch_zip")
+
+
 @pytest.mark.parametrize(
     ("suffix", "expected_scanner_name"),
     [
@@ -422,28 +459,83 @@ def test_get_scanner_for_path_routes_raw_bin_payload_to_pytorch_binary(tmp_path:
 
 def test_get_scanner_for_path_routes_misnamed_keras_zip_by_content(tmp_path: Path) -> None:
     model_path = _write_zip_archive(
-        tmp_path / "model.zip",
+        tmp_path / "model.jpg",
         {
             "config.json": json.dumps({"class_name": "Sequential", "config": {"layers": []}}).encode("utf-8"),
             "metadata.json": json.dumps({"keras_version": "3.0.0"}).encode("utf-8"),
         },
     )
 
-    _assert_scanner_for_path(model_path, "keras_zip")
+    _assert_shared_zip_route(model_path, "keras_zip")
+
+
+def test_get_scanner_for_file_preserves_keras_lambda_analysis_for_renamed_archive(tmp_path: Path) -> None:
+    encoded_code = base64.b64encode(b"exec(\"print('malicious')\")").decode()
+    model_path = _write_zip_archive(
+        tmp_path / "lambda.jpg",
+        {
+            "config.json": json.dumps(
+                {
+                    "class_name": "Functional",
+                    "config": {
+                        "layers": [
+                            {
+                                "class_name": "Lambda",
+                                "name": "lambda_1",
+                                "config": {"function": [encoded_code, None, None], "function_type": "lambda"},
+                            }
+                        ]
+                    },
+                }
+            ).encode("utf-8"),
+            "metadata.json": json.dumps({"keras_version": "3.0.0"}).encode("utf-8"),
+        },
+    )
+
+    scanner = get_scanner_for_file(str(model_path))
+
+    assert scanner is not None
+    assert scanner.name == "keras_zip"
+    result = scanner.scan(str(model_path))
+    assert any("lambda" in issue.message.lower() for issue in result.issues)
+
+
+def test_get_scanner_for_file_preserves_keras_h5_analysis_for_renamed_model(tmp_path: Path) -> None:
+    h5py = pytest.importorskip("h5py")
+    model_path = tmp_path / "lambda-h5.jpg"
+    with h5py.File(model_path, "w") as handle:
+        handle.attrs["model_config"] = json.dumps(
+            {
+                "class_name": "Sequential",
+                "config": {
+                    "layers": [{"class_name": "Lambda", "config": {"function": "lambda x: x * 2"}}],
+                },
+            }
+        )
+        handle.attrs["keras_version"] = "3.11.2"
+
+    scanner = get_scanner_for_file(str(model_path))
+
+    assert scanner is not None
+    assert scanner.name == "keras_h5"
+    assert core_module._select_preferred_scanner_id(str(model_path), "hdf5", ".jpg") == "keras_h5"
+    assert _select_nested_scanner_id(str(model_path), header_format="hdf5") == "keras_h5"
+    result = scanner.scan(str(model_path))
+    assert any("CVE-2025-9905" in issue.message for issue in result.issues)
 
 
 def test_get_scanner_for_path_routes_generic_zip_without_keras_markers_to_zip(tmp_path: Path) -> None:
     model_path = _write_zip_archive(
-        tmp_path / "generic.zip",
+        tmp_path / "generic.jpg",
         {"config.json": json.dumps({"model_type": "bert"}).encode("utf-8")},
     )
 
-    _assert_scanner_for_path(model_path, "zip")
+    _assert_shared_zip_route(model_path, "zip")
 
 
 def test_get_scanner_for_path_routes_misnamed_skops_zip_by_schema_content(tmp_path: Path) -> None:
     model_path = _write_zip_archive(
-        tmp_path / "model.zip",
+        tmp_path / "model.jpg",
         {
             "schema.json": json.dumps(
                 {
@@ -457,12 +549,12 @@ def test_get_scanner_for_path_routes_misnamed_skops_zip_by_schema_content(tmp_pa
         },
     )
 
-    _assert_scanner_for_path(model_path, "skops")
+    _assert_shared_zip_route(model_path, "skops")
 
 
 def test_get_scanner_for_path_routes_generic_zip_without_skops_markers_to_zip(tmp_path: Path) -> None:
     model_path = _write_zip_archive(
-        tmp_path / "generic.zip",
+        tmp_path / "generic.jpg",
         {
             "schema.json": json.dumps(
                 {
@@ -475,7 +567,7 @@ def test_get_scanner_for_path_routes_generic_zip_without_skops_markers_to_zip(tm
         },
     )
 
-    _assert_scanner_for_path(model_path, "zip")
+    _assert_shared_zip_route(model_path, "zip")
 
 
 def test_get_scanner_for_file_routes_disguised_rar_by_header(tmp_path: Path) -> None:
@@ -498,9 +590,9 @@ def test_get_scanner_for_file_rejects_rar_suffix_without_magic(tmp_path: Path) -
     assert scanner is None
 
 
-def test_get_scanner_for_path_routes_valid_mar_archive_to_torchserve_mar(tmp_path: Path) -> None:
+def test_get_scanner_for_path_routes_renamed_mar_archive_to_torchserve_mar(tmp_path: Path) -> None:
     mar_path = _write_zip_archive(
-        tmp_path / "model.mar",
+        tmp_path / "model.jpg",
         {
             "MAR-INF/MANIFEST.json": json.dumps(
                 {"model": {"handler": "handler.py", "serializedFile": "model.bin"}}
@@ -510,7 +602,19 @@ def test_get_scanner_for_path_routes_valid_mar_archive_to_torchserve_mar(tmp_pat
         },
     )
 
-    _assert_scanner_for_path(mar_path, "torchserve_mar")
+    _assert_shared_zip_route(mar_path, "torchserve_mar")
+
+
+def test_get_scanner_for_path_routes_renamed_executorch_archive_by_content(tmp_path: Path) -> None:
+    model_path = _write_zip_archive(
+        tmp_path / "model.jpg",
+        {
+            "bytecode.pkl": pickle.dumps({"weights": [1, 2, 3]}),
+            "version": b"1",
+        },
+    )
+
+    _assert_shared_zip_route(model_path, "executorch")
 
 
 def test_get_scanner_for_path_routes_non_torchserve_mar_zip_to_zip(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- extract one trusted-content routing service used by top-level scanning, nested archive dispatch, and the public scanner registry helper
- prevent renamed specialist archives/models from being downgraded to generic ZIP or missed by helper routing, including Keras ZIP/HDF5, PyTorch ZIP, Skops, TorchServe MAR, and ExecuTorch coverage
- correct the routing architecture invariant and align the CNTK descriptor with its signature-confirmed behavior

## Root Cause And Security Impact
Before this change, structural routing was implemented independently in `core.py` and `archive_dispatch.py`, while `ScannerRegistry.get_scanner_for_path()` used a narrower route and could select the generic ZIP scanner before inspecting specialist content. In reproduction, a renamed malicious Keras Lambda archive selected `zip` through the public helper while direct and nested flows selected `keras_zip`; that bypassed Keras-specific analysis for helper consumers.

This PR consolidates the decision contract and adds regression coverage so renamed malicious Keras ZIP and HDF5 payloads retain their format-specific findings, while renamed benign ZIP near-matches continue to route to generic ZIP.

## Validation
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`Success: no issues found in 453 source files`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`4842 passed, 972 skipped`)

## Stack
Stacked on #1323 (`fix: route renamed CNTK and LightGBM models by content`).