### PR TITLE
fix: inspect nested PMML extension attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - preserve SavedModel security findings from malformed content-routed payloads while reporting incomplete coverage
 - avoid reporting ordinary `sklearn` references in Skops model-card prose as unsafe joblib fallback evidence
 - detect high-risk Python archive-member calls dispatched through static namespace and attribute lookup indirection
+- inspect nested PMML extension attributes for code-shaped execution indicators
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 

--- a/modelaudit/scanners/pmml_scanner.py
+++ b/modelaudit/scanners/pmml_scanner.py
@@ -492,7 +492,7 @@ class PmmlScanner(BaseScanner):
         return cls._xml_namespace(tag) == root_namespace
 
     def _get_all_text_content(self, element: Any) -> tuple[str, bool]:
-        """Collect Extension text and report whether traversal hit the node budget."""
+        """Collect Extension text/attribute values and report bounded traversal truncation."""
         text_parts: list[str] = []
         stack = [element]
         nodes_seen = 0
@@ -514,6 +514,7 @@ class PmmlScanner(BaseScanner):
                 text_parts.append(current.text.strip())
             if current.tail:
                 text_parts.append(current.tail.strip())
+            text_parts.extend(str(value).strip() for value in current.attrib.values() if str(value).strip())
 
             try:
                 child_count = len(current)

--- a/tests/scanners/test_pmml_scanner.py
+++ b/tests/scanners/test_pmml_scanner.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from modelaudit.scanners.base import IssueSeverity
 from modelaudit.scanners.pmml_scanner import PmmlScanner
 
@@ -64,6 +66,42 @@ def test_pmml_scanner_suspicious_extension_content(tmp_path: Path) -> None:
     assert all(i.severity == IssueSeverity.WARNING for i in suspicious_issues)
 
 
+@pytest.mark.parametrize(
+    ("attribute_value", "expected_pattern"),
+    [
+        ("system('id')", r"\bsystem\s*\("),
+        (
+            "subprocess.run('id')",
+            r"\bsubprocess\s*\.\s*(?:popen|run|call|check_call|check_output|getoutput|getstatusoutput)\s*\(",
+        ),
+    ],
+    ids=["system", "subprocess"],
+)
+def test_pmml_scanner_nested_extension_attribute_code_is_flagged(
+    tmp_path: Path, attribute_value: str, expected_pattern: str
+) -> None:
+    pmml = f"""<?xml version='1.0'?>
+<PMML version='4.4'>
+  <Header>
+    <Extension>
+      <Payload handler="{attribute_value}"/>
+    </Extension>
+  </Header>
+  <DataDictionary numberOfFields='0'/>
+</PMML>"""
+    path = tmp_path / "nested_attribute_code.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    result = PmmlScanner().scan(str(path))
+
+    assert result.success is True
+    assert any(
+        issue.details.get("pattern") == expected_pattern
+        and issue.message == "Suspicious content in <Extension> element"
+        for issue in result.issues
+    )
+
+
 def test_pmml_scanner_benign_ecosystem_call_is_not_flagged(tmp_path: Path) -> None:
     pmml = """<?xml version='1.0'?>
 <PMML version='4.4'>
@@ -79,6 +117,23 @@ def test_pmml_scanner_benign_ecosystem_call_is_not_flagged(tmp_path: Path) -> No
 
     assert result.success is True
     assert not any(issue.details.get("pattern") == r"\bsystem\s*\(" for issue in result.issues)
+
+
+def test_pmml_scanner_benign_nested_extension_attribute_is_not_flagged(tmp_path: Path) -> None:
+    pmml = """<?xml version='1.0'?>
+<PMML version='4.4'>
+  <Header>
+    <Extension><Metric label="ecosystem()"/></Extension>
+  </Header>
+  <DataDictionary numberOfFields='0'/>
+</PMML>"""
+    path = tmp_path / "benign_nested_attribute.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    result = PmmlScanner().scan(str(path))
+
+    assert result.success is True
+    assert not any(issue.message == "Suspicious content in <Extension> element" for issue in result.issues)
 
 
 def test_pmml_scanner_system_call_is_flagged(tmp_path: Path) -> None:


### PR DESCRIPTION
## What changed

- include nested child attribute values in the bounded content gathered from PMML `<Extension>` elements
- add positive regressions for nested attribute values containing `system(...)` and `subprocess.run(...)`
- add a benign near-match regression for nested `ecosystem()` metadata
- record the security detection repair in the unreleased changelog

## Why

The PMML scanner already evaluates text, nested tag names, and attributes directly on an `<Extension>` element. However, code-shaped values on descendants inside an extension were omitted from the aggregate content scan. For example:

```xml
<Extension><Payload handler="system('id')"/></Extension>
```

and

```xml
<Extension><Payload handler="subprocess.run('id')"/></Extension>
```

produced no `Extension Element Security Check` finding and aggregate exit code `0`, even though equivalent attributes directly on `<Extension>` were detected.

## Impact and root cause

Nested extension elements are part of the same arbitrary vendor-extension payload surface as their parent. The existing bounded traversal visited those nodes but collected only their tag/text/tail content, silently dropping their attributes. This change collects descendant attribute values within that already bounded traversal and sends them through the existing code-shaped execution patterns. It does not introduce broader substring heuristics: a benign nested attribute such as `label="ecosystem()"` remains clean.

After the change, the reproduced nested `system(...)` and `subprocess.run(...)` attributes emit `S902` findings and aggregate exit code `1`; the benign nested attribute remains exit code `0`.

## Validation

- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`4916 passed, 972 skipped`)
- focused PMML suite (`43 passed`)
- direct PMML scanner plus aggregate exit-code reproduction for both malicious nested attributes and the benign control

Stacked on #1340.