### PR TITLE
fix: detect static TorchServe call indirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - avoid reporting ordinary `sklearn` references in Skops model-card prose as unsafe joblib fallback evidence
 - detect high-risk Python archive-member calls dispatched through static namespace and attribute lookup indirection
 - inspect nested PMML extension attributes for code-shaped execution indicators
+- detect statically obscured high-risk calls in TorchServe handler source
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -783,6 +783,15 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
 
+def high_risk_python_calls_in_tree(tree: ast.AST) -> set[HighRiskPythonCall]:
+    """Return the set of high-risk Python calls resolvable from an AST."""
+    visitor = _HighRiskPythonCallVisitor()
+    visitor.visit(tree)
+    return {
+        HighRiskPythonCall(name=name, rule_code=_rule_code_for_high_risk_call(name)) for name in visitor.risky_calls
+    }
+
+
 def high_risk_python_calls_in_source(source_bytes: bytes) -> set[HighRiskPythonCall]:
     """Return the set of high-risk Python calls resolvable from ``source_bytes``.
 
@@ -798,11 +807,7 @@ def high_risk_python_calls_in_source(source_bytes: bytes) -> set[HighRiskPythonC
     except (SyntaxError, ValueError) as exc:
         raise PythonArchiveMemberParseError(str(exc)) from exc
 
-    visitor = _HighRiskPythonCallVisitor()
-    visitor.visit(tree)
-    return {
-        HighRiskPythonCall(name=name, rule_code=_rule_code_for_high_risk_call(name)) for name in visitor.risky_calls
-    }
+    return high_risk_python_calls_in_tree(tree)
 
 
 _PYTHON_MEMBER_CHECK_NAME = "Python Archive Member Security"

--- a/modelaudit/scanners/torchserve_mar_scanner.py
+++ b/modelaudit/scanners/torchserve_mar_scanner.py
@@ -21,6 +21,7 @@ from ..scanner_results import INCONCLUSIVE_SCAN_OUTCOME, mark_inconclusive_scan_
 from ..utils import is_absolute_archive_path, is_critical_system_path, sanitize_archive_path
 from ..utils.helpers.assets import asset_from_scan_result
 from ._archive_locations import rewrite_extracted_member_location
+from .archive_member_security import high_risk_python_calls_in_tree
 from .base import BaseScanner, IssueSeverity, ScanResult
 
 CRITICAL_SYSTEM_PATHS = [
@@ -47,25 +48,6 @@ POPULAR_ML_PACKAGE_TYPOS = {
     "trransformers": "transformers",
 }
 TRUSTED_PYPI_HOSTS = {"pypi.org", "files.pythonhosted.org", "test.pypi.org"}
-
-HIGH_RISK_CALLS = {
-    "__import__",
-    "builtins.__import__",
-    "builtins.eval",
-    "builtins.exec",
-    "eval",
-    "exec",
-    "importlib.import_module",
-    "os.popen",
-    "os.system",
-    "pickle.load",
-    "pickle.loads",
-    "subprocess.call",
-    "subprocess.check_call",
-    "subprocess.check_output",
-    "subprocess.Popen",
-    "subprocess.run",
-}
 
 SAFE_IMPORT_TIME_CALLS = {
     "logging.getLogger",
@@ -1233,42 +1215,6 @@ class TorchServeMarScanner(BaseScanner):
             return resolved_head
         return ".".join([resolved_head, *tail])
 
-    def _resolve_getattr_call_name(self, node: ast.AST, aliases: dict[str, str]) -> str | None:
-        if isinstance(node, ast.Attribute) and node.attr == "__call__":
-            return self._resolve_getattr_call_name(node.value, aliases)
-
-        if not isinstance(node, ast.Call):
-            return None
-
-        helper_name = self._resolve_call_name(node.func)
-        if helper_name is None:
-            return None
-
-        resolved_helper_name = self._apply_alias(helper_name, aliases)
-        if resolved_helper_name not in {"getattr", "builtins.getattr"}:
-            return None
-
-        target_root_node: ast.AST | None = node.args[0] if node.args else None
-        attr_name_node: ast.AST | None = node.args[1] if len(node.args) >= 2 else None
-        for keyword in node.keywords:
-            if keyword.arg == "object" and target_root_node is None:
-                target_root_node = keyword.value
-            elif keyword.arg == "name" and attr_name_node is None:
-                attr_name_node = keyword.value
-
-        if target_root_node is None or attr_name_node is None:
-            return None
-
-        target_root = self._resolve_call_name(target_root_node)
-        if target_root is None:
-            return None
-
-        if not isinstance(attr_name_node, ast.Constant) or not isinstance(attr_name_node.value, str):
-            return None
-
-        resolved_target_root = self._apply_alias(target_root, aliases)
-        return f"{resolved_target_root}.{attr_name_node.value}"
-
     def _parse_python_source(self, source_bytes: bytes) -> tuple[ast.Module | None, str | None]:
         try:
             source = source_bytes.decode("utf-8")
@@ -1283,27 +1229,7 @@ class TorchServeMarScanner(BaseScanner):
         return tree, None
 
     def _find_high_risk_calls_from_tree(self, tree: ast.AST) -> set[str]:
-        aliases = self._collect_import_aliases(tree)
-        risky_calls: set[str] = set()
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-
-            call_name = self._resolve_call_name(node.func)
-            resolved_name = (
-                self._apply_alias(call_name, aliases)
-                if call_name is not None
-                else self._resolve_getattr_call_name(node.func, aliases)
-            )
-            if resolved_name is None:
-                continue
-            if resolved_name in HIGH_RISK_CALLS:
-                risky_calls.add(resolved_name)
-                continue
-            if resolved_name.startswith("subprocess."):
-                risky_calls.add(resolved_name)
-
-        return risky_calls
+        return {call.name for call in high_risk_python_calls_in_tree(tree)}
 
     def _find_high_risk_calls(self, source_bytes: bytes) -> tuple[set[str], str | None]:
         tree, parse_error = self._parse_python_source(source_bytes)

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -412,6 +412,50 @@ def test_non_handler_python_analysis_detects_malicious_utils_module(tmp_path: Pa
     )
 
 
+def test_non_handler_python_analysis_detects_static_namespace_call_indirection(tmp_path: Path) -> None:
+    manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
+    mar_path = _create_mar_archive(
+        tmp_path,
+        manifest=manifest,
+        entries={
+            "handler.py": b"import utils\n\ndef handle(data, context):\n    return utils.transform(data)\n",
+            "utils.py": b"import os\n\ndef transform(data):\n    return os.__dict__['system']('echo hidden')\n",
+            "weights.bin": b"weights",
+        },
+        filename="static_namespace_utils.mar",
+    )
+
+    result = TorchServeMarScanner().scan(str(mar_path))
+    non_handler_failures = _failed_checks(result, "MAR Non-Handler Python Analysis")
+
+    assert any(
+        failure.severity == IssueSeverity.WARNING and "high-risk calls: os.system" in failure.message
+        for failure in non_handler_failures
+    )
+
+
+def test_non_handler_python_analysis_does_not_flag_ordinary_mapping_call(tmp_path: Path) -> None:
+    manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
+    mar_path = _create_mar_archive(
+        tmp_path,
+        manifest=manifest,
+        entries={
+            "handler.py": b"import utils\n\ndef handle(data, context):\n    return utils.transform(data)\n",
+            "utils.py": (
+                b"def safe(value):\n    return value\n\n"
+                b"def transform(data):\n    calls = {'system': safe}\n    return calls['system'](data)\n"
+            ),
+            "weights.bin": b"weights",
+        },
+        filename="benign_mapping_utils.mar",
+    )
+
+    result = TorchServeMarScanner().scan(str(mar_path))
+    non_handler_failures = _failed_checks(result, "MAR Non-Handler Python Analysis")
+
+    assert non_handler_failures == []
+
+
 def test_non_handler_python_analysis_flags_duplicate_module_even_when_benign_copy_is_last(tmp_path: Path) -> None:
     manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
     mar_path = _create_mar_archive(
@@ -1444,6 +1488,53 @@ def handle(data, context):
     assert len(handler_failures) >= 1
     assert handler_failures[0].severity == IssueSeverity.CRITICAL
     assert "subprocess.run" in handler_failures[0].message
+
+
+@pytest.mark.parametrize(
+    "handler_source",
+    [
+        b"import os\n\ndef handle(data, context):\n    return os.__dict__['system']('echo hidden')\n",
+        b"import os\n\ndef handle(data, context):\n    return os.__getattribute__('system')('echo hidden')\n",
+    ],
+)
+def test_handler_analysis_detects_static_namespace_call_indirection(tmp_path: Path, handler_source: bytes) -> None:
+    manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
+    mar_path = _create_mar_archive(
+        tmp_path,
+        manifest=manifest,
+        entries={"handler.py": handler_source, "weights.bin": b"weights"},
+        filename="static_namespace_handler.mar",
+    )
+
+    result = TorchServeMarScanner().scan(str(mar_path))
+    handler_failures = _failed_checks(result, "TorchServe Handler Static Analysis")
+
+    assert any(
+        failure.severity == IssueSeverity.CRITICAL and "os.system" in failure.message for failure in handler_failures
+    )
+
+
+def test_handler_analysis_does_not_flag_ordinary_mapping_call(tmp_path: Path) -> None:
+    handler_code = b"""
+def safe(value):
+    return value
+
+def handle(data, context):
+    calls = {"system": safe}
+    return calls["system"](data)
+"""
+    manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
+    mar_path = _create_mar_archive(
+        tmp_path,
+        manifest=manifest,
+        entries={"handler.py": handler_code, "weights.bin": b"weights"},
+        filename="benign_mapping_handler.mar",
+    )
+
+    result = TorchServeMarScanner().scan(str(mar_path))
+    handler_failures = _failed_checks(result, "TorchServe Handler Static Analysis")
+
+    assert handler_failures == []
 
 
 def test_manifest_read_is_bounded(tmp_path: Path) -> None:


### PR DESCRIPTION
## What changed

- expose the shared scoped high-risk Python call resolver for already parsed ASTs and use it for TorchServe MAR Python source analysis
- remove TorchServe's narrower duplicate risky-call matching logic
- add malicious and benign regressions for both manifest-selected handlers and imported helper modules
- record the security detection repair in the unreleased changelog

## Why

TorchServe MAR analysis did not report high-risk calls hidden behind statically resolvable module namespace access. A manifest-selected handler containing:

```python
import os

def handle(data, context):
    return os.__dict__["system"]("echo hidden")
```

or `os.__getattribute__("system")("echo hidden")` produced no `TorchServe Handler Static Analysis` failure, while the equivalent direct `os.system(...)` call was detected.

## Impact and root cause

TorchServe maintained a separate AST call-name resolver from generic archive-member analysis. Its resolver recognized ordinary and limited `getattr` forms but not static namespace and dunder attribute indirection already handled by the shared archive resolver. As a result, malicious handler or helper Python source in a `.mar` could evade the execution-primitive finding.

This change reuses the shared scope-aware resolver over TorchServe's existing parsed AST, preserving its bounded reads, parsing behavior, and reporting paths. An ordinary application dictionary call such as `calls["system"](data)` remains clean in both handler and helper-module coverage.

After the change, the reproduced static namespace and dunder attribute payloads are reported as `os.system`; benign ordinary-mapping controls produce no handler or helper-module finding.

## Validation

- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`4921 passed, 972 skipped`)
- focused TorchServe/ZIP/TAR suites (`315 passed`)
- direct MAR reproducer for direct call, two static-indirection payloads, and benign ordinary-mapping control

Stacked on #1341.