### PR TITLE
fix: detect static JIT builtin call indirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - inspect nested PMML extension attributes for code-shaped execution indicators
 - detect statically obscured high-risk calls in TorchServe handler source
 - avoid classifying SafeTensors documentation examples as executable metadata payloads
+- detect statically obscured builtin execution calls in embedded JIT source analysis
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -129,6 +129,80 @@ _DANGEROUS_IMPORT_PATTERNS = {
     dangerous_import: _compile_dangerous_import_patterns(dangerous_import) for dangerous_import in DANGEROUS_IMPORTS
 }
 
+_MAX_STATIC_BUILTIN_NAME_LENGTH = 128
+_MAX_STATIC_BUILTIN_NAME_NODES = 31
+
+
+def _resolve_static_string(node: ast.AST) -> str | None:
+    """Resolve a small constant-string expression without executing code."""
+    pending = [node]
+    parts: list[str] = []
+    visited = 0
+    total_length = 0
+
+    while pending:
+        current = pending.pop()
+        visited += 1
+        if visited > _MAX_STATIC_BUILTIN_NAME_NODES:
+            return None
+
+        if isinstance(current, ast.Constant) and isinstance(current.value, str):
+            parts.append(current.value)
+            total_length += len(current.value)
+            if total_length > _MAX_STATIC_BUILTIN_NAME_LENGTH:
+                return None
+        elif isinstance(current, ast.BinOp) and isinstance(current.op, ast.Add):
+            pending.extend((current.right, current.left))
+        else:
+            return None
+
+    return "".join(parts)
+
+
+def _is_builtins_namespace(node: ast.AST) -> bool:
+    """Return whether a node identifies Python's implicit builtins namespace."""
+    return (isinstance(node, ast.Name) and node.id == "__builtins__") or (
+        isinstance(node, ast.Attribute)
+        and node.attr == "__dict__"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "__builtins__"
+    )
+
+
+def _resolve_dangerous_builtin_reference(node: ast.AST) -> str | None:
+    """Resolve statically addressed dangerous builtin call targets."""
+    if isinstance(node, ast.Name):
+        return node.id if node.id in DANGEROUS_BUILTINS else None
+
+    if isinstance(node, ast.Attribute) and _is_builtins_namespace(node.value):
+        return node.attr if node.attr in DANGEROUS_BUILTINS else None
+
+    if isinstance(node, ast.Subscript) and _is_builtins_namespace(node.value):
+        name = _resolve_static_string(node.slice)
+        return name if name in DANGEROUS_BUILTINS else None
+
+    if not isinstance(node, ast.Call):
+        return None
+
+    lookup_name: ast.AST | None = None
+    if isinstance(node.func, ast.Name) and node.func.id == "getattr" and len(node.args) >= 2:
+        if _is_builtins_namespace(node.args[0]):
+            lookup_name = node.args[1]
+    elif (
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr in {"get", "__getitem__"}
+        and _is_builtins_namespace(node.func.value)
+        and node.args
+    ):
+        lookup_name = node.args[0]
+
+    if lookup_name is None:
+        return None
+
+    name = _resolve_static_string(lookup_name)
+    return name if name in DANGEROUS_BUILTINS else None
+
+
 # Patterns that indicate code execution attempts
 CODE_EXECUTION_PATTERNS = [
     # Direct execution patterns
@@ -216,7 +290,7 @@ class JITScriptDetector:
                 if node.module and is_dangerous_import(node.module):
                     return True
             elif isinstance(node, ast.Call):
-                if isinstance(node.func, ast.Name) and node.func.id in DANGEROUS_BUILTINS:
+                if _resolve_dangerous_builtin_reference(node.func) is not None:
                     return True
 
                 operation = dotted_name(node.func)
@@ -664,10 +738,11 @@ class JITScriptDetector:
 
             def visit_Call(self, node: ast.Call) -> None:
                 # Check for dangerous function calls
-                if isinstance(node.func, ast.Name) and node.func.id in DANGEROUS_BUILTINS:
+                dangerous_builtin = _resolve_dangerous_builtin_reference(node.func)
+                if dangerous_builtin is not None:
                     self.findings.append(
                         create_jit_finding(
-                            message=f"AST analysis: Dangerous function call '{node.func.id}'",
+                            message=f"AST analysis: Dangerous function call '{dangerous_builtin}'",
                             severity="CRITICAL",
                             context=context,
                             pattern=None,
@@ -677,7 +752,7 @@ class JITScriptDetector:
                             code_snippet=None,
                             type="ast_dangerous_call",
                             operation=None,
-                            builtin=node.func.id,
+                            builtin=dangerous_builtin,
                             import_=None,
                         )
                     )

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -236,6 +236,32 @@ class TestJITScriptDetector:
 
         assert any(f.type == "dangerous_import" and f.import_ == "os" for f in findings)
 
+    @pytest.mark.parametrize(
+        "source",
+        [
+            b"getattr(__builtins__, 'eval')('1 + 1')\n",
+            b"__builtins__['eval']('1 + 1')\n",
+            b"getattr(__builtins__, 'ev' + 'al')('1 + 1')\n",
+            b"__builtins__.__dict__['ev' + 'al']('1 + 1')\n",
+            b"__builtins__.__dict__.get('ev' + 'al')('1 + 1')\n",
+            b"__builtins__.__dict__.__getitem__('eval')('1 + 1')\n",
+        ],
+    )
+    def test_scan_model_detects_unmarked_static_builtin_indirection(self, source: bytes) -> None:
+        detector = JITScriptDetector()
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(f.type == "ast_dangerous_call" and f.builtin == "eval" for f in findings)
+
+    def test_scan_model_ignores_ordinary_static_callback_mapping(self) -> None:
+        detector = JITScriptDetector()
+        source = b"callbacks = {'eval': len}\ncallbacks['eval']([])\n"
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert findings == []
+
     def test_scan_model_detects_late_unmarked_module_scope_python_source(self) -> None:
         detector = JITScriptDetector()
         data = b"# pad\n" * 200000 + b"import os\nos.system('id')\n"

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1034,6 +1034,51 @@ def test_pytorch_zip_scans_unmarked_python_blobs_in_archive_data(tmp_path: Path)
     assert any(check.location == f"{zip_path}:archive/data/payload.bin" for check in jit_failures)
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"getattr(__builtins__, 'eval')('1 + 1')\n",
+        b"__builtins__['ev' + 'al']('1 + 1')\n",
+        b"__builtins__.__dict__.get('eval')('1 + 1')\n",
+    ],
+)
+def test_pytorch_zip_scans_static_builtin_indirection_in_archive_data(tmp_path: Path, payload: bytes) -> None:
+    """A disguised source member using the builtin namespace still receives JIT analysis."""
+    zip_path = tmp_path / "model.pt"
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        zipf.writestr("archive/version", "3")
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("archive/data/payload.bin", payload)
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    jit_failures = [
+        check
+        for check in result.checks
+        if check.name == "JIT/Script Code Execution Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert any(
+        check.location == f"{zip_path}:archive/data/payload.bin" and "Dangerous function call 'eval'" in check.message
+        for check in jit_failures
+    )
+
+
+def test_pytorch_zip_ignores_ordinary_callback_mapping_in_archive_data(tmp_path: Path) -> None:
+    """An ordinary application lookup with a builtin-shaped key must remain benign."""
+    zip_path = tmp_path / "model.pt"
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        zipf.writestr("archive/version", "3")
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("archive/data/payload.bin", b"callbacks = {'eval': len}\ncallbacks['eval']([])\n")
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    assert not any(
+        check.name == "JIT/Script Code Execution Detection" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+
+
 def test_pytorch_zip_ignores_non_source_eval_text_in_archive_data(tmp_path: Path) -> None:
     """Plain payload text containing a dangerous substring must not become a JIT false positive."""
     zip_path = tmp_path / "model.pt"


### PR DESCRIPTION
## What changed
- resolve bounded, statically addressed dangerous builtin call targets in embedded JIT/PyTorch source analysis
- cover `__builtins__[...]`, `getattr(__builtins__, ...)`, and `__builtins__.__dict__` lookup forms, including simple constant-string splitting and mapping-method access
- add detector-level and PyTorch ZIP regressions plus an ordinary callback-mapping negative control
- document the security fix under `[Unreleased]`

## Why
Raw source members embedded in a PyTorch ZIP could call dangerous builtins through Python's intrinsic `__builtins__` namespace and evade `JITScriptDetector`. A payload such as `getattr(__builtins__, 'eval')('1 + 1')` or `__builtins__['eval']('1 + 1')` produced no JIT security finding, while a direct `eval(...)` call was caught.

## Impact
Renamed or otherwise disguised source blobs inside PyTorch ZIP data members now retain code-execution detection when they use statically resolvable builtin indirection. The resolver remains deliberately narrow: ordinary mappings such as `callbacks['eval'](...)` are not treated as builtin execution targets.

## Root cause
The embedded-source gate and downstream AST reporting only recognized a dangerous builtin when `ast.Call.func` was a direct `ast.Name`. They did not model the intrinsic builtins namespace accessed by static subscript, attribute, or `getattr` lookup.

## Validation
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`Success: no issues found in 453 source files`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`4928 passed, 979 skipped`)
- focused detector/PyTorch ZIP regressions (`137 passed, 33 skipped`)
- executable probe confirms `getattr`, subscript, and `__builtins__.__dict__.get` forms now produce findings while an ordinary `callbacks['eval']` mapping remains clean

## Stack
Draft PR stacked on the SafeTensors false-positive repair branch from #1343 so each audit increment remains independently reviewable.