### PR TITLE
fix: share builtin namespace source detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - detect statically obscured high-risk calls in TorchServe handler source
 - avoid classifying SafeTensors documentation examples as executable metadata payloads
 - detect statically obscured builtin execution calls in embedded JIT source analysis
+- share intrinsic builtin namespace execution detection across embedded Python entrypoints
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -89,6 +89,10 @@ DANGEROUS_BUILTINS = [
     "reload",
     "file",
 ]
+_BUILTIN_NAMESPACE_PREFIXES = ("__builtin__.", "__builtins__.", "builtins.")
+_JIT_DANGEROUS_BUILTIN_CALL_NAMES = frozenset(DANGEROUS_BUILTINS).union(
+    f"{prefix}{builtin}" for prefix in _BUILTIN_NAMESPACE_PREFIXES for builtin in DANGEROUS_BUILTINS
+)
 
 # Dangerous module imports
 DANGEROUS_IMPORTS = [
@@ -205,17 +209,16 @@ def _resolve_dangerous_builtin_reference(node: ast.AST) -> str | None:
 
 def _resolve_alias_aware_dangerous_builtins(tree: ast.AST) -> set[str]:
     """Return dangerous builtins reached through shared bounded source resolution."""
-    from modelaudit.scanners.archive_member_security import high_risk_python_calls_in_tree
+    from modelaudit.scanners.archive_member_security import statically_resolved_python_call_names_in_tree
 
-    builtin_prefixes = ("__builtin__.", "__builtins__.", "builtins.")
     dangerous_builtins: set[str] = set()
-    for call in high_risk_python_calls_in_tree(tree):
-        if call.name in DANGEROUS_BUILTINS:
-            dangerous_builtins.add(call.name)
+    for call_name in statically_resolved_python_call_names_in_tree(tree, _JIT_DANGEROUS_BUILTIN_CALL_NAMES):
+        if call_name in DANGEROUS_BUILTINS:
+            dangerous_builtins.add(call_name)
             continue
-        for prefix in builtin_prefixes:
-            if call.name.startswith(prefix):
-                builtin_name = call.name.removeprefix(prefix)
+        for prefix in _BUILTIN_NAMESPACE_PREFIXES:
+            if call_name.startswith(prefix):
+                builtin_name = call_name.removeprefix(prefix)
                 if builtin_name in DANGEROUS_BUILTINS:
                     dangerous_builtins.add(builtin_name)
                 break

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -203,6 +203,25 @@ def _resolve_dangerous_builtin_reference(node: ast.AST) -> str | None:
     return name if name in DANGEROUS_BUILTINS else None
 
 
+def _resolve_alias_aware_dangerous_builtins(tree: ast.AST) -> set[str]:
+    """Return dangerous builtins reached through shared bounded source resolution."""
+    from modelaudit.scanners.archive_member_security import high_risk_python_calls_in_tree
+
+    builtin_prefixes = ("__builtin__.", "__builtins__.", "builtins.")
+    dangerous_builtins: set[str] = set()
+    for call in high_risk_python_calls_in_tree(tree):
+        if call.name in DANGEROUS_BUILTINS:
+            dangerous_builtins.add(call.name)
+            continue
+        for prefix in builtin_prefixes:
+            if call.name.startswith(prefix):
+                builtin_name = call.name.removeprefix(prefix)
+                if builtin_name in DANGEROUS_BUILTINS:
+                    dangerous_builtins.add(builtin_name)
+                break
+    return dangerous_builtins
+
+
 # Patterns that indicate code execution attempts
 CODE_EXECUTION_PATTERNS = [
     # Direct execution patterns
@@ -267,6 +286,8 @@ class JITScriptDetector:
     @staticmethod
     def _ast_contains_dangerous_python(tree: ast.AST) -> bool:
         """Return whether parsed Python contains modeled dangerous operations."""
+        if _resolve_alias_aware_dangerous_builtins(tree):
+            return True
 
         def is_dangerous_import(module_name: str) -> bool:
             return any(
@@ -761,6 +782,29 @@ class JITScriptDetector:
         visitor = DangerousNodeVisitor()
         visitor.visit(tree)
         findings.extend(visitor.findings)
+
+        reported_builtins = {
+            finding.builtin
+            for finding in findings
+            if finding.type == "ast_dangerous_call" and finding.builtin is not None
+        }
+        for dangerous_builtin in sorted(_resolve_alias_aware_dangerous_builtins(tree) - reported_builtins):
+            findings.append(
+                create_jit_finding(
+                    message=f"AST analysis: Dangerous function call '{dangerous_builtin}'",
+                    severity="CRITICAL",
+                    context=context,
+                    pattern=None,
+                    recommendation="Remove dangerous function calls to prevent code execution",
+                    confidence=0.9,
+                    framework=framework,
+                    code_snippet=None,
+                    type="ast_dangerous_call",
+                    operation=None,
+                    builtin=dangerous_builtin,
+                    import_=None,
+                )
+            )
 
         return findings
 

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -459,9 +459,11 @@ def _is_high_risk_python_call_name(name: str) -> bool:
     return name in _HIGH_RISK_PYTHON_CALLS or name.startswith("subprocess.")
 
 
-def _wildcard_import_aliases(module: str) -> Iterator[tuple[str, str]]:
+def _wildcard_import_aliases(
+    module: str, tracked_call_names: frozenset[str] | None = None
+) -> Iterator[tuple[str, str]]:
     prefix = f"{module}."
-    for call_name in sorted(_HIGH_RISK_PYTHON_CALLS):
+    for call_name in sorted(_HIGH_RISK_PYTHON_CALLS if tracked_call_names is None else tracked_call_names):
         if not call_name.startswith(prefix):
             continue
         exported_name = call_name.removeprefix(prefix).split(".", maxsplit=1)[0]
@@ -479,10 +481,11 @@ def _binding_names(target: ast.AST) -> Iterator[str]:
 
 
 class _HighRiskPythonCallVisitor(ast.NodeVisitor):
-    def __init__(self) -> None:
+    def __init__(self, tracked_call_names: frozenset[str] | None = None) -> None:
         self.alias_scopes: _AliasScopes = [{}]
         self._class_scope_ids: set[int] = set()
         self.risky_calls: set[str] = set()
+        self.tracked_call_names = tracked_call_names
 
     def _record_import(self, alias: ast.alias, import_name: str) -> None:
         self.alias_scopes[-1][alias.asname or alias.name] = frozenset({import_name})
@@ -540,7 +543,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             return
         for alias in node.names:
             if alias.name == "*":
-                for local_name, import_name in _wildcard_import_aliases(node.module):
+                for local_name, import_name in _wildcard_import_aliases(node.module, self.tracked_call_names):
                     self._bind_name(local_name, frozenset({import_name}))
                 continue
             self._record_import(alias, f"{node.module}.{alias.name}")
@@ -795,9 +798,20 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         resolved_names = _resolve_static_reference_names(node.func, self.alias_scopes)
         if resolved_names is not None:
             for resolved_name in resolved_names:
-                if _is_high_risk_python_call_name(resolved_name):
+                if (
+                    resolved_name in self.tracked_call_names
+                    if self.tracked_call_names is not None
+                    else _is_high_risk_python_call_name(resolved_name)
+                ):
                     self.risky_calls.add(resolved_name)
         self.generic_visit(node)
+
+
+def statically_resolved_python_call_names_in_tree(tree: ast.AST, tracked_call_names: frozenset[str]) -> set[str]:
+    """Return caller-selected static call targets resolved from an AST."""
+    visitor = _HighRiskPythonCallVisitor(tracked_call_names)
+    visitor.visit(tree)
+    return visitor.risky_calls
 
 
 def high_risk_python_calls_in_tree(tree: ast.AST) -> set[HighRiskPythonCall]:

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -59,6 +59,12 @@ _VERSIONED_SHARED_OBJECT_SUFFIX_RE = re.compile(r"\.so(?:\.[0-9]+)+$")
 _PYTHON_ARCHIVE_MEMBER_SUFFIXES = (".py", ".pyw")
 _HIGH_RISK_PYTHON_CALLS = {
     "__import__",
+    "__builtin__.__import__",
+    "__builtin__.eval",
+    "__builtin__.exec",
+    "__builtins__.__import__",
+    "__builtins__.eval",
+    "__builtins__.exec",
     "builtins.__import__",
     "builtins.eval",
     "builtins.exec",
@@ -82,7 +88,13 @@ _HIGH_RISK_PYTHON_CALLS = {
 # (eval/exec) just because the scanner hard-coded a single fallback.
 _HIGH_RISK_PYTHON_CALL_RULE_CODES: dict[str, str] = {
     "__import__": "S106",
+    "__builtin__.__import__": "S106",
+    "__builtins__.__import__": "S106",
     "builtins.__import__": "S106",
+    "__builtin__.eval": "S104",
+    "__builtin__.exec": "S104",
+    "__builtins__.eval": "S104",
+    "__builtins__.exec": "S104",
     "builtins.eval": "S104",
     "builtins.exec": "S104",
     "eval": "S104",
@@ -370,6 +382,11 @@ def _resolve_namespace_dict_roots(node: ast.AST, alias_scopes: _AliasScopes) -> 
             for resolved_name in resolved_namespace_names
             if resolved_name.endswith(".__dict__")
         }
+        roots.update(
+            resolved_name
+            for resolved_name in resolved_namespace_names
+            if resolved_name in {"__builtin__", "__builtins__"}
+        )
         if roots:
             return frozenset(roots)
 

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -245,6 +245,9 @@ class TestJITScriptDetector:
             b"__builtins__.__dict__['ev' + 'al']('1 + 1')\n",
             b"__builtins__.__dict__.get('ev' + 'al')('1 + 1')\n",
             b"__builtins__.__dict__.__getitem__('eval')('1 + 1')\n",
+            b"import builtins\nbuiltins.eval('1 + 1')\n",
+            b"import builtins as bi\ngetattr(bi, 'ev' + 'al')('1 + 1')\n",
+            b"from builtins import eval as run\nrun('1 + 1')\n",
         ],
     )
     def test_scan_model_detects_unmarked_static_builtin_indirection(self, source: bytes) -> None:
@@ -254,9 +257,15 @@ class TestJITScriptDetector:
 
         assert any(f.type == "ast_dangerous_call" and f.builtin == "eval" for f in findings)
 
-    def test_scan_model_ignores_ordinary_static_callback_mapping(self) -> None:
+    @pytest.mark.parametrize(
+        "source",
+        [
+            b"callbacks = {'eval': len}\ncallbacks['eval']([])\n",
+            b"import builtins as bi\nbi.len([1])\n",
+        ],
+    )
+    def test_scan_model_ignores_benign_builtin_shaped_access(self, source: bytes) -> None:
         detector = JITScriptDetector()
-        source = b"callbacks = {'eval': len}\ncallbacks['eval']([])\n"
 
         findings = detector.scan_model(source, "pytorch", "payload.bin")
 

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -258,6 +258,21 @@ class TestJITScriptDetector:
         assert any(f.type == "ast_dangerous_call" and f.builtin == "eval" for f in findings)
 
     @pytest.mark.parametrize(
+        ("source", "builtin"),
+        [
+            (b"import builtins as bi\nbi.open('result.txt', 'w')\n", "open"),
+            (b"import builtins as bi\ngetattr(bi, 'op' + 'en')('result.txt', 'w')\n", "open"),
+            (b"from builtins import compile as build\nbuild('x = 1', '<x>', 'exec')\n", "compile"),
+        ],
+    )
+    def test_scan_model_detects_aliased_modeled_builtin_operations(self, source: bytes, builtin: str) -> None:
+        detector = JITScriptDetector()
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(f.type == "ast_dangerous_call" and f.builtin == builtin for f in findings)
+
+    @pytest.mark.parametrize(
         "source",
         [
             b"callbacks = {'eval': len}\ncallbacks['eval']([])\n",

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1066,6 +1066,39 @@ def test_pytorch_zip_scans_static_builtin_indirection_in_archive_data(tmp_path: 
 
 
 @pytest.mark.parametrize(
+    ("payload", "builtin"),
+    [
+        (b"import builtins as bi\nbi.open('result.txt', 'w')\n", "open"),
+        (b"import builtins as bi\ngetattr(bi, 'op' + 'en')('result.txt', 'w')\n", "open"),
+        (b"from builtins import compile as build\nbuild('x = 1', '<x>', 'exec')\n", "compile"),
+    ],
+)
+def test_pytorch_zip_scans_aliased_modeled_builtins_in_archive_data(
+    tmp_path: Path,
+    payload: bytes,
+    builtin: str,
+) -> None:
+    zip_path = tmp_path / "model.pt"
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        zipf.writestr("archive/version", "3")
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("archive/data/payload.bin", payload)
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    jit_failures = [
+        check
+        for check in result.checks
+        if check.name == "JIT/Script Code Execution Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert any(
+        check.location == f"{zip_path}:archive/data/payload.bin"
+        and f"Dangerous function call '{builtin}'" in check.message
+        for check in jit_failures
+    )
+
+
+@pytest.mark.parametrize(
     "payload",
     [
         b"callbacks = {'eval': len}\ncallbacks['eval']([])\n",

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1040,6 +1040,8 @@ def test_pytorch_zip_scans_unmarked_python_blobs_in_archive_data(tmp_path: Path)
         b"getattr(__builtins__, 'eval')('1 + 1')\n",
         b"__builtins__['ev' + 'al']('1 + 1')\n",
         b"__builtins__.__dict__.get('eval')('1 + 1')\n",
+        b"import builtins as bi\nbi.eval('1 + 1')\n",
+        b"from builtins import eval as run\nrun('1 + 1')\n",
     ],
 )
 def test_pytorch_zip_scans_static_builtin_indirection_in_archive_data(tmp_path: Path, payload: bytes) -> None:
@@ -1063,13 +1065,20 @@ def test_pytorch_zip_scans_static_builtin_indirection_in_archive_data(tmp_path: 
     )
 
 
-def test_pytorch_zip_ignores_ordinary_callback_mapping_in_archive_data(tmp_path: Path) -> None:
-    """An ordinary application lookup with a builtin-shaped key must remain benign."""
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"callbacks = {'eval': len}\ncallbacks['eval']([])\n",
+        b"import builtins as bi\nbi.len([1])\n",
+    ],
+)
+def test_pytorch_zip_ignores_benign_builtin_shaped_access_in_archive_data(tmp_path: Path, payload: bytes) -> None:
+    """Ordinary mappings and harmless builtin use must remain benign."""
     zip_path = tmp_path / "model.pt"
     with zipfile.ZipFile(zip_path, "w") as zipf:
         zipf.writestr("archive/version", "3")
         zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
-        zipf.writestr("archive/data/payload.bin", b"callbacks = {'eval': len}\ncallbacks['eval']([])\n")
+        zipf.writestr("archive/data/payload.bin", payload)
 
     result = PyTorchZipScanner().scan(str(zip_path))
 

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -200,9 +200,15 @@ class TestTarScanner:
         assert python_checks[0].rule_code == "S104"
         assert python_checks[0].details["reason"] == "high-risk calls: __builtins__.eval"
 
-    def test_scan_tar_allows_ordinary_builtin_shaped_mapping(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            b"callbacks = {'eval': len}\ncallbacks['eval']([])\n",
+            b"import builtins as bi\nbi.open('labels.json', 'r')\n",
+        ],
+    )
+    def test_scan_tar_allows_benign_builtin_shaped_source(self, tmp_path: Path, payload: bytes) -> None:
         archive_path = tmp_path / "model_bundle.tar"
-        payload = b"callbacks = {'eval': len}\ncallbacks['eval']([])\n"
         with tarfile.open(archive_path, "w") as archive:
             info = tarfile.TarInfo("handler.py")
             info.size = len(payload)

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -177,6 +177,41 @@ class TestTarScanner:
         assert python_checks[0].rule_code == "S101"
         assert python_checks[0].details["reason"] == "high-risk calls: os.system"
 
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            b"__builtins__['ev' + 'al']('1 + 1')\n",
+            b"getattr(__builtins__, 'eval')('1 + 1')\n",
+            b"__builtins__.__dict__.get('eval')('1 + 1')\n",
+        ],
+    )
+    def test_scan_tar_flags_implicit_builtins_dangerous_python_member(self, tmp_path: Path, payload: bytes) -> None:
+        archive_path = tmp_path / "model_bundle.tar"
+        with tarfile.open(archive_path, "w") as archive:
+            info = tarfile.TarInfo("handler.py")
+            info.size = len(payload)
+            archive.addfile(info, tarfile.io.BytesIO(payload))  # type: ignore[attr-defined]
+
+        result = self.scanner.scan(str(archive_path))
+
+        python_checks = [check for check in result.checks if check.name == "Python Archive Member Security"]
+        assert len(python_checks) == 1
+        assert python_checks[0].status == CheckStatus.FAILED
+        assert python_checks[0].rule_code == "S104"
+        assert python_checks[0].details["reason"] == "high-risk calls: __builtins__.eval"
+
+    def test_scan_tar_allows_ordinary_builtin_shaped_mapping(self, tmp_path: Path) -> None:
+        archive_path = tmp_path / "model_bundle.tar"
+        payload = b"callbacks = {'eval': len}\ncallbacks['eval']([])\n"
+        with tarfile.open(archive_path, "w") as archive:
+            info = tarfile.TarInfo("handler.py")
+            info.size = len(payload)
+            archive.addfile(info, tarfile.io.BytesIO(payload))  # type: ignore[attr-defined]
+
+        result = self.scanner.scan(str(archive_path))
+
+        assert not any(check.name == "Python Archive Member Security" for check in result.checks)
+
     def test_scan_tar_flags_aliased_getattr_helper_dangerous_python_member(self, tmp_path: Path) -> None:
         """Aliased getattr helpers and module aliases should still resolve risky calls."""
         archive_path = tmp_path / "model_bundle.tar"

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -262,15 +262,20 @@ def test_scan_detects_implicit_builtins_handler_execution_primitive(
     assert "__builtins__.eval" in handler_failures[0].message
 
 
-def test_scan_allows_ordinary_builtin_shaped_handler_mapping(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "handler_source",
+    [
+        b"def handle(data, context):\n    callbacks = {'eval': len}\n    return callbacks['eval']([])\n",
+        b"import builtins as bi\ndef handle(data, context):\n    return bi.open('labels.json', 'r')\n",
+    ],
+)
+def test_scan_allows_benign_builtin_shaped_handler_source(tmp_path: Path, handler_source: bytes) -> None:
     manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
     mar_path = _create_mar_archive(
         tmp_path,
         manifest=manifest,
         entries={
-            "handler.py": (
-                b"def handle(data, context):\n    callbacks = {'eval': len}\n    return callbacks['eval']([])\n"
-            ),
+            "handler.py": handler_source,
             "weights.bin": b"weights",
         },
         filename="benign_builtin_mapping_handler.mar",

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -234,6 +234,53 @@ def test_scan_detects_keyword_getattr_wrapped_handler_execution_primitive(
     assert "os.system" in handler_failures[0].message
 
 
+@pytest.mark.parametrize(
+    "handler_source",
+    [
+        b"def handle(data, context):\n    return __builtins__['ev' + 'al']('1 + 1')\n",
+        b"def handle(data, context):\n    return getattr(__builtins__, 'eval')('1 + 1')\n",
+        b"def handle(data, context):\n    return __builtins__.__dict__.get('eval')('1 + 1')\n",
+    ],
+)
+def test_scan_detects_implicit_builtins_handler_execution_primitive(
+    tmp_path: Path,
+    handler_source: bytes,
+) -> None:
+    manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
+    mar_path = _create_mar_archive(
+        tmp_path,
+        manifest=manifest,
+        entries={"handler.py": handler_source, "weights.bin": b"weights"},
+        filename="implicit_builtins_handler.mar",
+    )
+
+    result = TorchServeMarScanner().scan(str(mar_path))
+    handler_failures = _failed_checks(result, "TorchServe Handler Static Analysis")
+
+    assert len(handler_failures) == 1
+    assert handler_failures[0].severity == IssueSeverity.CRITICAL
+    assert "__builtins__.eval" in handler_failures[0].message
+
+
+def test_scan_allows_ordinary_builtin_shaped_handler_mapping(tmp_path: Path) -> None:
+    manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
+    mar_path = _create_mar_archive(
+        tmp_path,
+        manifest=manifest,
+        entries={
+            "handler.py": (
+                b"def handle(data, context):\n    callbacks = {'eval': len}\n    return callbacks['eval']([])\n"
+            ),
+            "weights.bin": b"weights",
+        },
+        filename="benign_builtin_mapping_handler.mar",
+    )
+
+    result = TorchServeMarScanner().scan(str(mar_path))
+
+    assert _failed_checks(result, "TorchServe Handler Static Analysis") == []
+
+
 def test_scan_detects_dunder_call_getattr_wrapped_handler_execution_primitive(tmp_path: Path) -> None:
     manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
     mar_path = _create_mar_archive(

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -204,6 +204,41 @@ def test_scan_zip_flags_builtins_getattr_keyword_call_dangerous_python_member(tm
     assert python_checks[0].details["reason"] == "high-risk calls: os.system"
 
 
+@pytest.mark.parametrize(
+    "source",
+    [
+        "__builtins__['ev' + 'al']('1 + 1')\n",
+        "getattr(__builtins__, 'eval')('1 + 1')\n",
+        "__builtins__.__dict__.get('eval')('1 + 1')\n",
+    ],
+)
+def test_scan_zip_flags_implicit_builtins_dangerous_python_member(tmp_path: Path, source: str) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", source)
+
+    result = ZipScanner().scan(str(archive_path))
+
+    python_checks = [
+        check
+        for check in result.checks
+        if check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED
+    ]
+    assert len(python_checks) == 1
+    assert python_checks[0].rule_code == "S104"
+    assert python_checks[0].details["reason"] == "high-risk calls: __builtins__.eval"
+
+
+def test_scan_zip_allows_ordinary_builtin_shaped_mapping(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", "callbacks = {'eval': len}\ncallbacks['eval']([])\n")
+
+    result = ZipScanner().scan(str(archive_path))
+
+    assert not any(check.name == "Python Archive Member Security" for check in result.checks)
+
+
 def test_scan_zip_flags_aliased_getattr_helper_dangerous_python_member(tmp_path: Path) -> None:
     archive_path = tmp_path / "model_bundle.zip"
     source = (

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -229,10 +229,17 @@ def test_scan_zip_flags_implicit_builtins_dangerous_python_member(tmp_path: Path
     assert python_checks[0].details["reason"] == "high-risk calls: __builtins__.eval"
 
 
-def test_scan_zip_allows_ordinary_builtin_shaped_mapping(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "source",
+    [
+        "callbacks = {'eval': len}\ncallbacks['eval']([])\n",
+        "import builtins as bi\nbi.open('labels.json', 'r')\n",
+    ],
+)
+def test_scan_zip_allows_benign_builtin_shaped_source(tmp_path: Path, source: str) -> None:
     archive_path = tmp_path / "model_bundle.zip"
     with zipfile.ZipFile(archive_path, "w") as archive:
-        archive.writestr("handler.py", "callbacks = {'eval': len}\ncallbacks['eval']([])\n")
+        archive.writestr("handler.py", source)
 
     result = ZipScanner().scan(str(archive_path))
 


### PR DESCRIPTION
## What changed
- extend the bounded embedded-Python resolver to recognize intrinsic `__builtins__` and `__builtin__` namespace execution targets
- expose caller-selected static call resolution so JIT can reuse alias/scope handling under its own existing dangerous-builtin policy
- add malicious and benign controls across ZIP, TAR, TorchServe MAR, direct JIT, and PyTorch ZIP source-member paths
- record the user-visible detection improvement under `[Unreleased]`

## Why
Multiple adjacent false-negative gaps remained after #1344:

- generic ZIP/TAR Python-member analysis and TorchServe handler analysis caught `import builtins as bi; bi.eval(...)`, but missed equivalent intrinsic forms such as `__builtins__['eval'](...)` and `getattr(__builtins__, 'eval')(...)`
- JIT analysis for raw embedded PyTorch ZIP source members caught intrinsic `eval` forms from #1344, but still missed explicit alias-aware forms already recognized by shared analysis, such as `import builtins as bi; bi.eval(...)`
- JIT already flags direct `open(...)` and `compile(...)`, yet skipped equivalent `builtins.open(...)`, `getattr(builtins, 'open')(...)`, and aliased `builtins.compile(...)` forms

## Impact
Embedded Python entrypoints now agree on statically resolvable builtin execution indirection where their policies overlap. JIT retains its stricter existing dangerous-builtin policy through aliases, while generic archive and TorchServe handling remain scoped to their pre-existing high-risk call policy: ordinary mappings keyed `"eval"`, harmless `builtins.len(...)`, and generic read-only `builtins.open(..., 'r')` controls remain clean.

## Root cause
The shared source resolver modeled imported `builtins` aliases and static module namespace dispatch but did not classify Python's intrinsic builtin namespace as a mapping root or high-risk call prefix. JIT separately maintained dangerous builtin policy without an API for applying the resolver's bounded alias and static-lookup resolution to its larger configured target set.

## Validation
- affected modules: `PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest tests/detectors/test_jit_script_detector.py tests/scanners/test_pytorch_zip_scanner.py tests/scanners/test_zip_scanner.py tests/scanners/test_tar_scanner.py tests/scanners/test_torchserve_mar_scanner.py -q` (`473 passed, 40 skipped`)
- executable probes confirm intrinsic `eval` and explicit aliased JIT `eval`/`open`/`compile` payloads are detected, while JIT `builtins.len` and generic ZIP/TAR/TorchServe read-only `builtins.open` controls remain clean
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`Success: no issues found in 453 source files`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`4949 passed, 986 skipped`)

## Stack
Draft PR stacked on #1344 so the initial PyTorch JIT repair and this cross-entrypoint parity extension can be reviewed independently.