### PR TITLE
fix: detect global builtin namespace execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - detect statically obscured builtin execution calls in embedded JIT source analysis
 - share intrinsic builtin namespace execution detection across embedded Python entrypoints
 - route signature-confirmed RKNN artifacts with misleading filenames through security analysis
+- detect embedded Python builtin execution recovered through static global namespace lookups
 
 ## [0.2.45](https://github.com/promptfoo/modelaudit/compare/v0.2.44...v0.2.45) (2026-05-03)
 

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -289,18 +289,55 @@ def _resolve_static_string(node: ast.AST) -> str | None:
     return "".join(parts)
 
 
+_NAMESPACE_MAPPING_ACCESSORS = {"get", "__getitem__", "pop", "setdefault"}
+_GLOBAL_NAMESPACE_HELPERS = {"globals", "builtins.globals"}
+_BUILTIN_NAMESPACE_NAMES = {"__builtin__", "__builtins__"}
+
+
+def _resolve_global_builtin_namespace_roots(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
+    """Resolve a statically addressed builtin namespace obtained from ``globals()``."""
+    namespace_node: ast.AST
+    attr_name_node: ast.AST
+    if isinstance(node, ast.Subscript):
+        namespace_node = node.value
+        attr_name_node = node.slice
+    elif (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in _NAMESPACE_MAPPING_ACCESSORS
+        and node.args
+    ):
+        namespace_node = node.func.value
+        attr_name_node = node.args[0]
+    else:
+        return None
+
+    attr_name = _resolve_static_string(attr_name_node)
+    if attr_name not in _BUILTIN_NAMESPACE_NAMES:
+        return None
+    if not isinstance(namespace_node, ast.Call) or namespace_node.args or namespace_node.keywords:
+        return None
+
+    helper_name = _resolve_call_name(namespace_node.func)
+    resolved_helper_names = _apply_aliases(helper_name, alias_scopes) if helper_name is not None else None
+    if resolved_helper_names is None or not (resolved_helper_names & _GLOBAL_NAMESPACE_HELPERS):
+        return None
+    return frozenset({attr_name})
+
+
 def _resolve_static_attribute_names(
     target_root_node: ast.AST, attr_name_node: ast.AST, alias_scopes: _AliasScopes
 ) -> frozenset[str] | None:
-    target_root = _resolve_call_name(target_root_node)
-    if target_root is None:
-        return None
-
     attr_name = _resolve_static_string(attr_name_node)
     if attr_name is None:
         return None
 
-    resolved_target_roots = _apply_aliases(target_root, alias_scopes)
+    resolved_target_roots = _resolve_global_builtin_namespace_roots(target_root_node, alias_scopes)
+    if resolved_target_roots is None:
+        target_root = _resolve_call_name(target_root_node)
+        if target_root is None:
+            return None
+        resolved_target_roots = _apply_aliases(target_root, alias_scopes)
     if resolved_target_roots is None:
         return None
     return frozenset(f"{resolved_target_root}.{attr_name}" for resolved_target_root in resolved_target_roots)
@@ -360,6 +397,10 @@ def _resolve_dunder_getattribute_call_names(node: ast.AST, alias_scopes: _AliasS
 
 
 def _resolve_namespace_dict_roots(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
+    global_builtin_roots = _resolve_global_builtin_namespace_roots(node, alias_scopes)
+    if global_builtin_roots is not None:
+        return global_builtin_roots
+
     target_root_node: ast.AST | None = None
     namespace_node = node
     if isinstance(namespace_node, ast.Attribute) and namespace_node.attr == "__dict__":
@@ -371,6 +412,9 @@ def _resolve_namespace_dict_roots(node: ast.AST, alias_scopes: _AliasScopes) -> 
             target_root_node = namespace_node.args[0]
 
     if target_root_node is not None:
+        global_builtin_roots = _resolve_global_builtin_namespace_roots(target_root_node, alias_scopes)
+        if global_builtin_roots is not None:
+            return global_builtin_roots
         target_root = _resolve_call_name(target_root_node)
         return _apply_aliases(target_root, alias_scopes) if target_root is not None else None
 
@@ -383,9 +427,7 @@ def _resolve_namespace_dict_roots(node: ast.AST, alias_scopes: _AliasScopes) -> 
             if resolved_name.endswith(".__dict__")
         }
         roots.update(
-            resolved_name
-            for resolved_name in resolved_namespace_names
-            if resolved_name in {"__builtin__", "__builtins__"}
+            resolved_name for resolved_name in resolved_namespace_names if resolved_name in _BUILTIN_NAMESPACE_NAMES
         )
         if roots:
             return frozenset(roots)
@@ -402,9 +444,6 @@ def _resolve_namespace_dict_roots(node: ast.AST, alias_scopes: _AliasScopes) -> 
         if resolved_name.endswith(".__dict__")
     }
     return frozenset(roots) if roots else None
-
-
-_NAMESPACE_MAPPING_ACCESSORS = {"get", "__getitem__", "pop", "setdefault"}
 
 
 def _resolve_namespace_dict_call_names(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -292,6 +292,27 @@ def _resolve_static_string(node: ast.AST) -> str | None:
 _NAMESPACE_MAPPING_ACCESSORS = {"get", "__getitem__", "pop", "setdefault"}
 _GLOBAL_NAMESPACE_HELPERS = {"globals", "builtins.globals"}
 _BUILTIN_NAMESPACE_NAMES = {"__builtin__", "__builtins__"}
+_GLOBAL_NAMESPACE_MAPPING_NAME = "<globals>"
+
+
+def _resolve_global_namespace_mapping_names(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
+    """Resolve the module global namespace mapping returned by zero-argument ``globals()``."""
+    if isinstance(node, ast.Call) and not node.args and not node.keywords:
+        helper_name = _resolve_call_name(node.func)
+        resolved_helper_names = _apply_aliases(helper_name, alias_scopes) if helper_name is not None else None
+        if resolved_helper_names is not None and resolved_helper_names & _GLOBAL_NAMESPACE_HELPERS:
+            return frozenset({_GLOBAL_NAMESPACE_MAPPING_NAME})
+
+    namespace_name = _resolve_call_name(node)
+    resolved_namespace_names = _apply_aliases(namespace_name, alias_scopes) if namespace_name is not None else None
+    if resolved_namespace_names is None:
+        return None
+    global_namespace_names = {
+        resolved_namespace_name
+        for resolved_namespace_name in resolved_namespace_names
+        if resolved_namespace_name == _GLOBAL_NAMESPACE_MAPPING_NAME
+    }
+    return frozenset(global_namespace_names) if global_namespace_names else None
 
 
 def _resolve_global_builtin_namespace_roots(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
@@ -315,12 +336,7 @@ def _resolve_global_builtin_namespace_roots(node: ast.AST, alias_scopes: _AliasS
     attr_name = _resolve_static_string(attr_name_node)
     if attr_name not in _BUILTIN_NAMESPACE_NAMES:
         return None
-    if not isinstance(namespace_node, ast.Call) or namespace_node.args or namespace_node.keywords:
-        return None
-
-    helper_name = _resolve_call_name(namespace_node.func)
-    resolved_helper_names = _apply_aliases(helper_name, alias_scopes) if helper_name is not None else None
-    if resolved_helper_names is None or not (resolved_helper_names & _GLOBAL_NAMESPACE_HELPERS):
+    if _resolve_global_namespace_mapping_names(namespace_node, alias_scopes) is None:
         return None
     return frozenset({attr_name})
 
@@ -481,6 +497,16 @@ def _resolve_static_reference_names(node: ast.AST, alias_scopes: _AliasScopes) -
     call_name = _resolve_call_name(node)
     if call_name is not None:
         return _apply_aliases(call_name, alias_scopes)
+    global_namespace_names = _resolve_global_namespace_mapping_names(node, alias_scopes)
+    if global_namespace_names is not None:
+        return global_namespace_names
+    global_builtin_roots = _resolve_global_builtin_namespace_roots(node, alias_scopes)
+    if global_builtin_roots is not None:
+        return global_builtin_roots
+    if isinstance(node, ast.Attribute):
+        attribute_names = _resolve_static_attribute_names(node.value, ast.Constant(node.attr), alias_scopes)
+        if attribute_names is not None:
+            return attribute_names
     getattr_names = _resolve_getattr_call_names(node, alias_scopes)
     if getattr_names is not None:
         return getattr_names

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -248,6 +248,9 @@ class TestJITScriptDetector:
             b"import builtins\nbuiltins.eval('1 + 1')\n",
             b"import builtins as bi\ngetattr(bi, 'ev' + 'al')('1 + 1')\n",
             b"from builtins import eval as run\nrun('1 + 1')\n",
+            b"globals()['__builtins__']['ev' + 'al']('1 + 1')\n",
+            b"globals().get('__builtins__').get('eval')('1 + 1')\n",
+            b"getattr(globals()['__builtins__'], 'eval')('1 + 1')\n",
         ],
     )
     def test_scan_model_detects_unmarked_static_builtin_indirection(self, source: bytes) -> None:
@@ -277,6 +280,8 @@ class TestJITScriptDetector:
         [
             b"callbacks = {'eval': len}\ncallbacks['eval']([])\n",
             b"import builtins as bi\nbi.len([1])\n",
+            b"globals()['__builtins__']['len']([1])\n",
+            b"globals = lambda: {'__builtins__': {'eval': len}}\nglobals()['__builtins__']['eval']([])\n",
         ],
     )
     def test_scan_model_ignores_benign_builtin_shaped_access(self, source: bytes) -> None:

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -251,6 +251,9 @@ class TestJITScriptDetector:
             b"globals()['__builtins__']['ev' + 'al']('1 + 1')\n",
             b"globals().get('__builtins__').get('eval')('1 + 1')\n",
             b"getattr(globals()['__builtins__'], 'eval')('1 + 1')\n",
+            b"globals()['__builtins__'].eval('1 + 1')\n",
+            b"builtins_ref = globals()['__builtins__']\ngetattr(builtins_ref, 'eval')('1 + 1')\n",
+            b"global_namespace = globals()\nglobal_namespace['__builtins__']['eval']('1 + 1')\n",
         ],
     )
     def test_scan_model_detects_unmarked_static_builtin_indirection(self, source: bytes) -> None:
@@ -282,6 +285,7 @@ class TestJITScriptDetector:
             b"import builtins as bi\nbi.len([1])\n",
             b"globals()['__builtins__']['len']([1])\n",
             b"globals = lambda: {'__builtins__': {'eval': len}}\nglobals()['__builtins__']['eval']([])\n",
+            b"global_namespace = {'__builtins__': {'eval': len}}\nglobal_namespace['__builtins__']['eval']([])\n",
         ],
     )
     def test_scan_model_ignores_benign_builtin_shaped_access(self, source: bytes) -> None:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1045,6 +1045,9 @@ def test_pytorch_zip_scans_unmarked_python_blobs_in_archive_data(tmp_path: Path)
         b"globals()['__builtins__']['ev' + 'al']('1 + 1')\n",
         b"globals().get('__builtins__').get('eval')('1 + 1')\n",
         b"getattr(globals()['__builtins__'], 'eval')('1 + 1')\n",
+        b"globals()['__builtins__'].eval('1 + 1')\n",
+        b"builtins_ref = globals()['__builtins__']\ngetattr(builtins_ref, 'eval')('1 + 1')\n",
+        b"global_namespace = globals()\nglobal_namespace['__builtins__']['eval']('1 + 1')\n",
     ],
 )
 def test_pytorch_zip_scans_static_builtin_indirection_in_archive_data(tmp_path: Path, payload: bytes) -> None:
@@ -1108,6 +1111,7 @@ def test_pytorch_zip_scans_aliased_modeled_builtins_in_archive_data(
         b"import builtins as bi\nbi.len([1])\n",
         b"globals()['__builtins__']['len']([1])\n",
         b"globals = lambda: {'__builtins__': {'eval': len}}\nglobals()['__builtins__']['eval']([])\n",
+        b"global_namespace = {'__builtins__': {'eval': len}}\nglobal_namespace['__builtins__']['eval']([])\n",
     ],
 )
 def test_pytorch_zip_ignores_benign_builtin_shaped_access_in_archive_data(tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1042,6 +1042,9 @@ def test_pytorch_zip_scans_unmarked_python_blobs_in_archive_data(tmp_path: Path)
         b"__builtins__.__dict__.get('eval')('1 + 1')\n",
         b"import builtins as bi\nbi.eval('1 + 1')\n",
         b"from builtins import eval as run\nrun('1 + 1')\n",
+        b"globals()['__builtins__']['ev' + 'al']('1 + 1')\n",
+        b"globals().get('__builtins__').get('eval')('1 + 1')\n",
+        b"getattr(globals()['__builtins__'], 'eval')('1 + 1')\n",
     ],
 )
 def test_pytorch_zip_scans_static_builtin_indirection_in_archive_data(tmp_path: Path, payload: bytes) -> None:
@@ -1103,6 +1106,8 @@ def test_pytorch_zip_scans_aliased_modeled_builtins_in_archive_data(
     [
         b"callbacks = {'eval': len}\ncallbacks['eval']([])\n",
         b"import builtins as bi\nbi.len([1])\n",
+        b"globals()['__builtins__']['len']([1])\n",
+        b"globals = lambda: {'__builtins__': {'eval': len}}\nglobals()['__builtins__']['eval']([])\n",
     ],
 )
 def test_pytorch_zip_ignores_benign_builtin_shaped_access_in_archive_data(tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -183,6 +183,9 @@ class TestTarScanner:
             b"__builtins__['ev' + 'al']('1 + 1')\n",
             b"getattr(__builtins__, 'eval')('1 + 1')\n",
             b"__builtins__.__dict__.get('eval')('1 + 1')\n",
+            b"globals()['__builtins__']['ev' + 'al']('1 + 1')\n",
+            b"globals().get('__builtins__').get('eval')('1 + 1')\n",
+            b"getattr(globals()['__builtins__'], 'eval')('1 + 1')\n",
         ],
     )
     def test_scan_tar_flags_implicit_builtins_dangerous_python_member(self, tmp_path: Path, payload: bytes) -> None:
@@ -205,6 +208,8 @@ class TestTarScanner:
         [
             b"callbacks = {'eval': len}\ncallbacks['eval']([])\n",
             b"import builtins as bi\nbi.open('labels.json', 'r')\n",
+            b"globals()['__builtins__']['len']([1])\n",
+            b"globals = lambda: {'__builtins__': {'eval': len}}\nglobals()['__builtins__']['eval']([])\n",
         ],
     )
     def test_scan_tar_allows_benign_builtin_shaped_source(self, tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -186,6 +186,9 @@ class TestTarScanner:
             b"globals()['__builtins__']['ev' + 'al']('1 + 1')\n",
             b"globals().get('__builtins__').get('eval')('1 + 1')\n",
             b"getattr(globals()['__builtins__'], 'eval')('1 + 1')\n",
+            b"globals()['__builtins__'].eval('1 + 1')\n",
+            b"builtins_ref = globals()['__builtins__']\ngetattr(builtins_ref, 'eval')('1 + 1')\n",
+            b"global_namespace = globals()\nglobal_namespace['__builtins__']['eval']('1 + 1')\n",
         ],
     )
     def test_scan_tar_flags_implicit_builtins_dangerous_python_member(self, tmp_path: Path, payload: bytes) -> None:
@@ -210,6 +213,7 @@ class TestTarScanner:
             b"import builtins as bi\nbi.open('labels.json', 'r')\n",
             b"globals()['__builtins__']['len']([1])\n",
             b"globals = lambda: {'__builtins__': {'eval': len}}\nglobals()['__builtins__']['eval']([])\n",
+            b"global_namespace = {'__builtins__': {'eval': len}}\nglobal_namespace['__builtins__']['eval']([])\n",
         ],
     )
     def test_scan_tar_allows_benign_builtin_shaped_source(self, tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -240,6 +240,9 @@ def test_scan_detects_keyword_getattr_wrapped_handler_execution_primitive(
         b"def handle(data, context):\n    return __builtins__['ev' + 'al']('1 + 1')\n",
         b"def handle(data, context):\n    return getattr(__builtins__, 'eval')('1 + 1')\n",
         b"def handle(data, context):\n    return __builtins__.__dict__.get('eval')('1 + 1')\n",
+        b"def handle(data, context):\n    return globals()['__builtins__']['ev' + 'al']('1 + 1')\n",
+        b"def handle(data, context):\n    return globals().get('__builtins__').get('eval')('1 + 1')\n",
+        b"def handle(data, context):\n    return getattr(globals()['__builtins__'], 'eval')('1 + 1')\n",
     ],
 )
 def test_scan_detects_implicit_builtins_handler_execution_primitive(
@@ -267,6 +270,12 @@ def test_scan_detects_implicit_builtins_handler_execution_primitive(
     [
         b"def handle(data, context):\n    callbacks = {'eval': len}\n    return callbacks['eval']([])\n",
         b"import builtins as bi\ndef handle(data, context):\n    return bi.open('labels.json', 'r')\n",
+        b"def handle(data, context):\n    return globals()['__builtins__']['len']([1])\n",
+        (
+            b"def handle(data, context):\n"
+            b"    globals = lambda: {'__builtins__': {'eval': len}}\n"
+            b"    return globals()['__builtins__']['eval']([])\n"
+        ),
     ],
 )
 def test_scan_allows_benign_builtin_shaped_handler_source(tmp_path: Path, handler_source: bytes) -> None:

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -243,6 +243,17 @@ def test_scan_detects_keyword_getattr_wrapped_handler_execution_primitive(
         b"def handle(data, context):\n    return globals()['__builtins__']['ev' + 'al']('1 + 1')\n",
         b"def handle(data, context):\n    return globals().get('__builtins__').get('eval')('1 + 1')\n",
         b"def handle(data, context):\n    return getattr(globals()['__builtins__'], 'eval')('1 + 1')\n",
+        b"def handle(data, context):\n    return globals()['__builtins__'].eval('1 + 1')\n",
+        (
+            b"def handle(data, context):\n"
+            b"    builtins_ref = globals()['__builtins__']\n"
+            b"    return getattr(builtins_ref, 'eval')('1 + 1')\n"
+        ),
+        (
+            b"def handle(data, context):\n"
+            b"    global_namespace = globals()\n"
+            b"    return global_namespace['__builtins__']['eval']('1 + 1')\n"
+        ),
     ],
 )
 def test_scan_detects_implicit_builtins_handler_execution_primitive(
@@ -275,6 +286,11 @@ def test_scan_detects_implicit_builtins_handler_execution_primitive(
             b"def handle(data, context):\n"
             b"    globals = lambda: {'__builtins__': {'eval': len}}\n"
             b"    return globals()['__builtins__']['eval']([])\n"
+        ),
+        (
+            b"def handle(data, context):\n"
+            b"    global_namespace = {'__builtins__': {'eval': len}}\n"
+            b"    return global_namespace['__builtins__']['eval']([])\n"
         ),
     ],
 )

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -218,6 +218,9 @@ def test_scan_zip_flags_builtins_getattr_keyword_call_dangerous_python_member(tm
         "__builtins__['ev' + 'al']('1 + 1')\n",
         "getattr(__builtins__, 'eval')('1 + 1')\n",
         "__builtins__.__dict__.get('eval')('1 + 1')\n",
+        "globals()['__builtins__']['ev' + 'al']('1 + 1')\n",
+        "globals().get('__builtins__').get('eval')('1 + 1')\n",
+        "getattr(globals()['__builtins__'], 'eval')('1 + 1')\n",
     ],
 )
 def test_scan_zip_flags_implicit_builtins_dangerous_python_member(tmp_path: Path, source: str) -> None:
@@ -242,6 +245,8 @@ def test_scan_zip_flags_implicit_builtins_dangerous_python_member(tmp_path: Path
     [
         "callbacks = {'eval': len}\ncallbacks['eval']([])\n",
         "import builtins as bi\nbi.open('labels.json', 'r')\n",
+        "globals()['__builtins__']['len']([1])\n",
+        "globals = lambda: {'__builtins__': {'eval': len}}\nglobals()['__builtins__']['eval']([])\n",
     ],
 )
 def test_scan_zip_allows_benign_builtin_shaped_source(tmp_path: Path, source: str) -> None:

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -221,6 +221,9 @@ def test_scan_zip_flags_builtins_getattr_keyword_call_dangerous_python_member(tm
         "globals()['__builtins__']['ev' + 'al']('1 + 1')\n",
         "globals().get('__builtins__').get('eval')('1 + 1')\n",
         "getattr(globals()['__builtins__'], 'eval')('1 + 1')\n",
+        "globals()['__builtins__'].eval('1 + 1')\n",
+        "builtins_ref = globals()['__builtins__']\ngetattr(builtins_ref, 'eval')('1 + 1')\n",
+        "global_namespace = globals()\nglobal_namespace['__builtins__']['eval']('1 + 1')\n",
     ],
 )
 def test_scan_zip_flags_implicit_builtins_dangerous_python_member(tmp_path: Path, source: str) -> None:
@@ -247,6 +250,7 @@ def test_scan_zip_flags_implicit_builtins_dangerous_python_member(tmp_path: Path
         "import builtins as bi\nbi.open('labels.json', 'r')\n",
         "globals()['__builtins__']['len']([1])\n",
         "globals = lambda: {'__builtins__': {'eval': len}}\nglobals()['__builtins__']['eval']([])\n",
+        "global_namespace = {'__builtins__': {'eval': len}}\nglobal_namespace['__builtins__']['eval']([])\n",
     ],
 )
 def test_scan_zip_allows_benign_builtin_shaped_source(tmp_path: Path, source: str) -> None:


### PR DESCRIPTION
## What changed
- extend shared embedded-Python static resolution to recognize literal builtin-namespace recovery through unshadowed zero-argument `globals()` lookups
- detect subscript, mapping-accessor, and `getattr` calls such as `globals()['__builtins__']['ev' + 'al'](...)`
- add positive and benign-shadowing regression coverage for generic ZIP, TAR, TorchServe handlers, PyTorch ZIP embedded source, and direct JIT analysis
- record the detection repair in the unreleased changelog

## Why
Embedded Python could recover dangerous builtins through `globals()['__builtins__']` using only compile-time strings. That is an executable, statically resolvable path, but the shared resolver previously modeled imported/implicit builtin namespaces only. Generic archives and JIT-driven scanner paths therefore missed `eval` execution expressed through this global namespace lookup.

## Impact
ModelAudit now catches this builtin execution indirection consistently across five source-analysis entrypoints. The resolution remains bounded and conservative: ordinary global lookups, harmless `len` access, and a locally shadowed `globals` callback mapping remain clean in regression coverage.

## Root cause
The shared namespace resolver handled module `__dict__`, `vars(module)`, and intrinsic/imported builtin roots, but did not connect the literal `__builtins__` value obtained from the actual `globals()` namespace back to the modeled builtin root.

## Validation
- executable before/after repro across ZIP, TAR, TorchServe MAR, PyTorch ZIP, and direct JIT analysis, with benign `len` and shadowed-`globals` controls
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest tests/detectors/test_jit_script_detector.py tests/scanners/test_pytorch_zip_scanner.py tests/scanners/test_zip_scanner.py tests/scanners/test_tar_scanner.py tests/scanners/test_torchserve_mar_scanner.py -q` (`495 passed, 45 skipped`)
- `uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`Success: no issues found in 453 source files`)
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`4976 passed, 991 skipped`)