### PR TITLE
fix: detect explicit dunder-call execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - preserve dangerous callable findings when embedded source captures a callable before a later safe overwrite
 - detect high-risk embedded Python callables invoked through explicit `.__call__` wrappers
 - avoid embedded Python execution findings after statically certain safe `setattr` replacement
+- avoid embedded Python execution findings after statically certain namespace-mapping replacement
+- preserve embedded Python execution findings when a replacement receiver is conditional, aliased, or a runtime argument
 - fail closed when nested NeMo checkpoint or referenced-artifact analysis is explicitly incomplete
 - preserve concrete nested security findings from checkpoint and referenced artifacts inside NeMo archives
 - keep PyTorch ZIP path traversal findings attributed to archive safety rules regardless of member names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - route signature-confirmed CNTK and LightGBM artifacts with misleading filenames through security analysis
 - share trusted-content routing across direct, nested, and helper scans so renamed specialized archives retain their format-specific analysis
 - preserve dangerous callable findings when embedded source captures a callable before a later safe overwrite
+- detect high-risk embedded Python callables invoked through explicit `.__call__` wrappers
 - fail closed when nested NeMo checkpoint or referenced-artifact analysis is explicitly incomplete
 - preserve concrete nested security findings from checkpoint and referenced artifacts inside NeMo archives
 - keep PyTorch ZIP path traversal findings attributed to archive safety rules regardless of member names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - share trusted-content routing across direct, nested, and helper scans so renamed specialized archives retain their format-specific analysis
 - preserve dangerous callable findings when embedded source captures a callable before a later safe overwrite
 - detect high-risk embedded Python callables invoked through explicit `.__call__` wrappers
+- avoid embedded Python execution findings after statically certain safe `setattr` replacement
 - fail closed when nested NeMo checkpoint or referenced-artifact analysis is explicitly incomplete
 - preserve concrete nested security findings from checkpoint and referenced artifacts inside NeMo archives
 - keep PyTorch ZIP path traversal findings attributed to archive safety rules regardless of member names

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -735,12 +735,21 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
                 )
         return frozenset(effective_names) if effective_names else None
 
-    def _resolve_reference_names(self, node: ast.AST) -> frozenset[str] | None:
+    @staticmethod
+    def _invoked_callable_reference_name(name: str) -> str:
+        while name.endswith(".__call__"):
+            name = name.removesuffix(".__call__")
+        return name
+
+    def _resolve_invoked_reference_names(self, node: ast.AST) -> frozenset[str] | None:
         resolved_names = _resolve_static_reference_names(node, self.alias_scopes)
-        return self._effective_reference_names(resolved_names) if resolved_names is not None else None
+        if resolved_names is None:
+            return None
+        callable_names = frozenset(self._invoked_callable_reference_name(name) for name in resolved_names)
+        return self._effective_reference_names(callable_names)
 
     def _resolve_bound_value_names(self, node: ast.AST) -> _AliasValue:
-        return self._capture_callable_names(self._resolve_reference_names(node))
+        return self._capture_callable_names(self._resolve_invoked_reference_names(node))
 
     def _bind_static_reference_target_to_value(self, target: ast.AST, value: ast.AST) -> None:
         target_names = _resolve_static_assignment_target_names(target, self.alias_scopes)
@@ -1120,7 +1129,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             self.visit(statement)
 
     def visit_Call(self, node: ast.Call) -> None:
-        resolved_names = self._resolve_reference_names(node.func)
+        resolved_names = self._resolve_invoked_reference_names(node.func)
         if resolved_names is not None:
             for resolved_name in resolved_names:
                 if self._is_tracked_call_name(resolved_name):

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -712,6 +712,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             {self._static_attribute_mutation_alias_key("setattr"): frozenset({"setattr"})}
         ]
         self._class_scope_ids: set[int] = set()
+        self._static_expression_binding_suppression_depth = 0
         self.risky_calls: set[str] = set()
         self.tracked_call_names = tracked_call_names
 
@@ -937,6 +938,16 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         if target_names is None or len(target_names) != 1:
             return
         self._bind_static_reference_names_to_value(target_names, node.args[2])
+
+    def _static_expression_bindings_enabled(self) -> bool:
+        return self._static_expression_binding_suppression_depth == 0
+
+    def _visit_without_static_expression_bindings(self, node: ast.AST) -> None:
+        self._static_expression_binding_suppression_depth += 1
+        try:
+            self.visit(node)
+        finally:
+            self._static_expression_binding_suppression_depth -= 1
 
     def _bind_target_to_value(self, target: ast.AST, value: ast.AST) -> None:
         if isinstance(target, ast.Name):
@@ -1188,8 +1199,50 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
 
     def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
         self.visit(node.value)
-        self._bind_target_to_value(node.target, node.value)
+        if self._static_expression_bindings_enabled():
+            self._bind_target_to_value(node.target, node.value)
         self.visit(node.target)
+
+    def visit_BoolOp(self, node: ast.BoolOp) -> None:
+        next_value_is_certainly_evaluated = True
+        for value in node.values:
+            if next_value_is_certainly_evaluated:
+                self.visit(value)
+            else:
+                self._visit_without_static_expression_bindings(value)
+
+            constant_bool = self._constant_bool(value)
+            if isinstance(node.op, ast.And):
+                if constant_bool is False:
+                    return
+                if constant_bool is not True:
+                    next_value_is_certainly_evaluated = False
+            else:
+                if constant_bool is True:
+                    return
+                if constant_bool is not False:
+                    next_value_is_certainly_evaluated = False
+
+    def visit_IfExp(self, node: ast.IfExp) -> None:
+        self.visit(node.test)
+        constant_bool = self._constant_bool(node.test)
+        if constant_bool is True:
+            self.visit(node.body)
+            return
+        if constant_bool is False:
+            self.visit(node.orelse)
+            return
+
+        self._visit_without_static_expression_bindings(node.body)
+        self._visit_without_static_expression_bindings(node.orelse)
+
+    def visit_Compare(self, node: ast.Compare) -> None:
+        self.visit(node.left)
+        if not node.comparators:
+            return
+        self.visit(node.comparators[0])
+        for comparator in node.comparators[1:]:
+            self._visit_without_static_expression_bindings(comparator)
 
     def visit_Expr(self, node: ast.Expr) -> None:
         self.visit(node.value)
@@ -1308,7 +1361,8 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
                 if self._is_tracked_call_name(resolved_name):
                     self.risky_calls.add(resolved_name)
         self.generic_visit(node)
-        self._bind_static_setattr_mutation(node)
+        if self._static_expression_bindings_enabled():
+            self._bind_static_setattr_mutation(node)
 
 
 def statically_resolved_python_call_names_in_tree(tree: ast.AST, tracked_call_names: frozenset[str]) -> set[str]:

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -293,6 +293,8 @@ _NAMESPACE_MAPPING_ACCESSORS = {"get", "__getitem__", "pop", "setdefault"}
 _GLOBAL_NAMESPACE_HELPERS = {"globals", "builtins.globals"}
 _GLOBAL_NAMESPACE_MAPPING_MARKER = "<globals mapping>"
 _STATIC_REFERENCE_OVERRIDE_PREFIX = "<static reference override>:"
+_STATIC_MAPPING_MUTATION_ALIAS_PREFIX = "<static mapping mutation alias>:"
+_STATIC_UNCERTAIN_BINDING_PREFIX = "<uncertain static binding>:"
 _STATIC_DIRECT_MUTATION_ALIAS_PREFIX = "<static direct mutation alias>:"
 _STATIC_ATTRIBUTE_MUTATION_ALIAS_PREFIX = "<static attribute mutation alias>:"
 _CAPTURED_CALLABLE_REFERENCE_PREFIX = "<captured callable>:"
@@ -304,6 +306,20 @@ _STATIC_ATTRIBUTE_MUTATION_HELPERS = {
     "__builtins__.setattr",
     "builtins.setattr",
 }
+
+
+def _has_uncertain_static_binding(node: ast.AST, alias_scopes: _AliasScopes) -> bool:
+    """Return whether ``node`` uses a name whose identity diverged across branches."""
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Name):
+            continue
+        uncertainty_key = f"{_STATIC_UNCERTAIN_BINDING_PREFIX}{child.id}"
+        for aliases in reversed(alias_scopes):
+            if uncertainty_key in aliases:
+                if aliases[uncertainty_key] is None:
+                    return True
+                break
+    return False
 
 
 def _resolve_global_namespace_mappings(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
@@ -410,6 +426,38 @@ def _resolve_direct_global_builtin_mutator_names(node: ast.AST, alias_scopes: _A
         return None
 
     target_roots = _resolve_direct_global_builtin_namespace_roots(node.value, alias_scopes)
+    if target_roots is None:
+        return None
+    return frozenset(f"{target_root}.{node.attr}" for target_root in target_roots)
+
+
+def _resolve_certain_namespace_mutation_roots(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
+    """Resolve namespace mappings whose mutation target is statically certain."""
+    direct_builtin_roots = _resolve_direct_global_builtin_namespace_roots(node, alias_scopes)
+    if direct_builtin_roots is not None:
+        return direct_builtin_roots
+
+    is_explicit_namespace_mapping = isinstance(node, ast.Attribute) and node.attr == "__dict__"
+    if isinstance(node, ast.Call) and len(node.args) == 1 and not node.keywords:
+        helper_name = _resolve_call_name(node.func)
+        helper_names = _apply_aliases(helper_name, alias_scopes) if helper_name is not None else None
+        is_explicit_namespace_mapping = helper_names is not None and helper_names.issubset({"vars", "builtins.vars"})
+    alias_roots = _resolve_namespace_dict_roots(node, alias_scopes)
+    if not is_explicit_namespace_mapping and alias_roots is None:
+        return None
+    if _has_uncertain_static_binding(node, alias_scopes):
+        return None
+
+    target_roots = alias_roots if alias_roots is not None else _resolve_namespace_dict_roots(node, alias_scopes)
+    return target_roots if target_roots is not None and len(target_roots) == 1 else None
+
+
+def _resolve_static_mapping_mutator_names(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
+    """Resolve mutation methods bound from one certain namespace mapping."""
+    if not isinstance(node, ast.Attribute) or node.attr not in _STATIC_MAPPING_MUTATORS:
+        return None
+
+    target_roots = _resolve_certain_namespace_mutation_roots(node.value, alias_scopes)
     if target_roots is None:
         return None
     return frozenset(f"{target_root}.{node.attr}" for target_root in target_roots)
@@ -679,10 +727,14 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
 
     def _bind_name(self, name: str, resolved_names: _AliasValue) -> None:
         self.alias_scopes[-1][name] = resolved_names
-        if not name.startswith("<") and self._lookup_static_direct_mutation_alias(name) is not None:
-            self.alias_scopes[-1][self._static_direct_mutation_alias_key(name)] = None
-        if not name.startswith("<") and self._lookup_static_attribute_mutation_alias_entry(name) is not _MISSING_ALIAS:
-            self.alias_scopes[-1][self._static_attribute_mutation_alias_key(name)] = None
+        if not name.startswith("<"):
+            self.alias_scopes[-1][self._static_uncertain_binding_key(name)] = frozenset()
+            if self._lookup_static_mapping_mutation_alias(name) is not None:
+                self.alias_scopes[-1][self._static_mapping_mutation_alias_key(name)] = None
+            if self._lookup_static_direct_mutation_alias(name) is not None:
+                self.alias_scopes[-1][self._static_direct_mutation_alias_key(name)] = None
+            if self._lookup_static_attribute_mutation_alias_entry(name) is not _MISSING_ALIAS:
+                self.alias_scopes[-1][self._static_attribute_mutation_alias_key(name)] = None
 
     @staticmethod
     def _static_reference_override_key(reference_name: str) -> str:
@@ -691,6 +743,14 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
     @staticmethod
     def _static_direct_mutation_alias_key(name: str) -> str:
         return f"{_STATIC_DIRECT_MUTATION_ALIAS_PREFIX}{name}"
+
+    @staticmethod
+    def _static_mapping_mutation_alias_key(name: str) -> str:
+        return f"{_STATIC_MAPPING_MUTATION_ALIAS_PREFIX}{name}"
+
+    @staticmethod
+    def _static_uncertain_binding_key(name: str) -> str:
+        return f"{_STATIC_UNCERTAIN_BINDING_PREFIX}{name}"
 
     @staticmethod
     def _static_attribute_mutation_alias_key(name: str) -> str:
@@ -702,6 +762,22 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             if override_key in aliases:
                 return aliases[override_key]
         return frozenset({reference_name})
+
+    def _lookup_static_mapping_mutation_alias(self, name: str) -> _AliasValue:
+        alias_key = self._static_mapping_mutation_alias_key(name)
+        for aliases in reversed(self.alias_scopes):
+            if alias_key in aliases:
+                return aliases[alias_key]
+        return None
+
+    def _resolve_certain_static_mapping_mutator_names(self, node: ast.AST) -> frozenset[str] | None:
+        mutator_names = _resolve_static_mapping_mutator_names(node, self.alias_scopes)
+        if mutator_names is not None:
+            return mutator_names
+
+        if isinstance(node, ast.Name):
+            return self._lookup_static_mapping_mutation_alias(node.id)
+        return None
 
     def _lookup_static_direct_mutation_alias(self, name: str) -> _AliasValue:
         alias_key = self._static_direct_mutation_alias_key(name)
@@ -794,6 +870,8 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         return self._capture_callable_names(self._resolve_invoked_reference_names(node))
 
     def _bind_static_reference_target_to_value(self, target: ast.AST, value: ast.AST) -> None:
+        if _has_uncertain_static_binding(target, self.alias_scopes):
+            return
         target_names = _resolve_static_assignment_target_names(target, self.alias_scopes)
         if target_names is None:
             return
@@ -805,12 +883,12 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         for target_name in target_names:
             self._bind_name(self._static_reference_override_key(target_name), resolved_value_names)
 
-    def _bind_direct_builtin_namespace_mutation(self, node: ast.Call) -> None:
-        """Model unconditional mutations of a directly addressed builtin mapping."""
+    def _bind_static_mapping_mutation(self, node: ast.Call) -> None:
+        """Model unconditional writes through one certain namespace mapping."""
         if node.keywords:
             return
 
-        mutator_names = self._resolve_certain_direct_builtin_mutator_names(node.func)
+        mutator_names = self._resolve_certain_static_mapping_mutator_names(node.func)
         if mutator_names is None:
             return
         methods = {mutator_name.rsplit(".", maxsplit=1)[1] for mutator_name in mutator_names}
@@ -852,6 +930,9 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         if helper_names is None:
             return
 
+        if _has_uncertain_static_binding(node.args[0], self.alias_scopes):
+            return
+
         target_names = _resolve_static_attribute_names(node.args[0], node.args[1], self.alias_scopes)
         if target_names is None or len(target_names) != 1:
             return
@@ -859,7 +940,13 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
 
     def _bind_target_to_value(self, target: ast.AST, value: ast.AST) -> None:
         if isinstance(target, ast.Name):
+            value_binding_is_uncertain = _has_uncertain_static_binding(value, self.alias_scopes)
             self._bind_name(target.id, self._resolve_bound_value_names(value))
+            if value_binding_is_uncertain:
+                self.alias_scopes[-1][self._static_uncertain_binding_key(target.id)] = None
+            mutator_names = self._resolve_certain_static_mapping_mutator_names(value)
+            if mutator_names is not None:
+                self._bind_name(self._static_mapping_mutation_alias_key(target.id), mutator_names)
             direct_mutator_names = self._resolve_certain_direct_builtin_mutator_names(value)
             if direct_mutator_names is not None:
                 self._bind_name(self._static_direct_mutation_alias_key(target.id), direct_mutator_names)
@@ -896,15 +983,19 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
                 arg.arg,
                 self._resolve_bound_value_names(default) if default is not None else None,
             )
+            self.alias_scopes[-1][self._static_uncertain_binding_key(arg.arg)] = None
         for arg, default in zip(arguments.kwonlyargs, arguments.kw_defaults, strict=True):
             self._bind_name(
                 arg.arg,
                 self._resolve_bound_value_names(default) if default is not None else None,
             )
+            self.alias_scopes[-1][self._static_uncertain_binding_key(arg.arg)] = None
         if arguments.vararg is not None:
             self._bind_name(arguments.vararg.arg, None)
+            self.alias_scopes[-1][self._static_uncertain_binding_key(arguments.vararg.arg)] = None
         if arguments.kwarg is not None:
             self._bind_name(arguments.kwarg.arg, None)
+            self.alias_scopes[-1][self._static_uncertain_binding_key(arguments.kwarg.arg)] = None
 
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
@@ -963,13 +1054,28 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         current_scope = self.alias_scopes[-1]
         branch_names = {name for scope in branch_scopes for name in scope}
         for name in branch_names:
-            if name.startswith((_STATIC_DIRECT_MUTATION_ALIAS_PREFIX, _STATIC_ATTRIBUTE_MUTATION_ALIAS_PREFIX)):
-                certainty_base_value = current_scope.get(name, _MISSING_ALIAS)
-                values = [scope.get(name, certainty_base_value) for scope in branch_scopes]
-                first_value = values[0]
+            if name.startswith(_STATIC_UNCERTAIN_BINDING_PREFIX):
+                uncertainty_base_value = current_scope.get(name, frozenset())
+                uncertainty_values = [scope.get(name, uncertainty_base_value) for scope in branch_scopes]
+                current_scope[name] = (
+                    None
+                    if uncertainty_base_value is None or any(value is None for value in uncertainty_values)
+                    else frozenset()
+                )
+                continue
+            if name.startswith(
+                (
+                    _STATIC_MAPPING_MUTATION_ALIAS_PREFIX,
+                    _STATIC_DIRECT_MUTATION_ALIAS_PREFIX,
+                    _STATIC_ATTRIBUTE_MUTATION_ALIAS_PREFIX,
+                )
+            ):
+                certainty_base_value: _AliasValue | object = current_scope.get(name, _MISSING_ALIAS)
+                certainty_values = [scope.get(name, certainty_base_value) for scope in branch_scopes]
+                first_value = certainty_values[0]
                 current_scope[name] = (
                     first_value
-                    if isinstance(first_value, frozenset) and all(value == first_value for value in values)
+                    if isinstance(first_value, frozenset) and all(value == first_value for value in certainty_values)
                     else None
                 )
                 continue
@@ -980,11 +1086,15 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
                 )
             else:
                 base_value = current_scope.get(name, _MISSING_ALIAS)
-            values = [scope.get(name, base_value) for scope in branch_scopes]
-            concrete_aliases = frozenset(alias for value in values if isinstance(value, frozenset) for alias in value)
+            branch_values = [scope.get(name, base_value) for scope in branch_scopes]
+            if not name.startswith("<") and any(value != branch_values[0] for value in branch_values[1:]):
+                current_scope[self._static_uncertain_binding_key(name)] = None
+            concrete_aliases = frozenset(
+                alias for value in branch_values if isinstance(value, frozenset) for alias in value
+            )
             if concrete_aliases:
                 current_scope[name] = concrete_aliases
-            elif any(value is None for value in values):
+            elif any(value is None for value in branch_values):
                 current_scope[name] = None
 
     def _visit_child_scope_without_class_locals(self, body: list[ast.stmt]) -> None:
@@ -1053,6 +1163,8 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
 
     def visit_Assign(self, node: ast.Assign) -> None:
         self.visit(node.value)
+        if isinstance(node.value, ast.Call):
+            self._bind_static_mapping_mutation(node.value)
         for target in node.targets:
             self._bind_target_to_value(target, node.value)
             self.visit(target)
@@ -1062,6 +1174,8 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             self.visit(node.annotation)
         if node.value is not None:
             self.visit(node.value)
+            if isinstance(node.value, ast.Call):
+                self._bind_static_mapping_mutation(node.value)
             self._bind_target_to_value(node.target, node.value)
         else:
             self._shadow_binding_target(node.target)
@@ -1080,7 +1194,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
     def visit_Expr(self, node: ast.Expr) -> None:
         self.visit(node.value)
         if isinstance(node.value, ast.Call):
-            self._bind_direct_builtin_namespace_mutation(node.value)
+            self._bind_static_mapping_mutation(node.value)
 
     def _visit_loop(self, node: ast.For | ast.AsyncFor) -> None:
         self.visit(node.iter)

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -294,9 +294,16 @@ _GLOBAL_NAMESPACE_HELPERS = {"globals", "builtins.globals"}
 _GLOBAL_NAMESPACE_MAPPING_MARKER = "<globals mapping>"
 _STATIC_REFERENCE_OVERRIDE_PREFIX = "<static reference override>:"
 _STATIC_DIRECT_MUTATION_ALIAS_PREFIX = "<static direct mutation alias>:"
+_STATIC_ATTRIBUTE_MUTATION_ALIAS_PREFIX = "<static attribute mutation alias>:"
 _CAPTURED_CALLABLE_REFERENCE_PREFIX = "<captured callable>:"
 _BUILTIN_NAMESPACE_NAMES = {"__builtin__", "__builtins__"}
 _STATIC_MAPPING_MUTATORS = {"__setitem__", "update"}
+_STATIC_ATTRIBUTE_MUTATION_HELPERS = {
+    "setattr",
+    "__builtin__.setattr",
+    "__builtins__.setattr",
+    "builtins.setattr",
+}
 
 
 def _resolve_global_namespace_mappings(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
@@ -653,7 +660,9 @@ def _binding_names(target: ast.AST) -> Iterator[str]:
 
 class _HighRiskPythonCallVisitor(ast.NodeVisitor):
     def __init__(self, tracked_call_names: frozenset[str] | None = None) -> None:
-        self.alias_scopes: _AliasScopes = [{}]
+        self.alias_scopes: _AliasScopes = [
+            {self._static_attribute_mutation_alias_key("setattr"): frozenset({"setattr"})}
+        ]
         self._class_scope_ids: set[int] = set()
         self.risky_calls: set[str] = set()
         self.tracked_call_names = tracked_call_names
@@ -661,6 +670,9 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
     def _bind_import_name(self, local_name: str, import_name: str) -> None:
         effective_names = self._effective_reference_names(frozenset({import_name}))
         self._bind_name(local_name, self._capture_callable_names(effective_names))
+        helper_names = self._static_attribute_mutation_helper_names(effective_names)
+        if helper_names is not None:
+            self._bind_name(self._static_attribute_mutation_alias_key(local_name), helper_names)
 
     def _record_import(self, alias: ast.alias, import_name: str) -> None:
         self._bind_import_name(alias.asname or alias.name, import_name)
@@ -669,6 +681,8 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         self.alias_scopes[-1][name] = resolved_names
         if not name.startswith("<") and self._lookup_static_direct_mutation_alias(name) is not None:
             self.alias_scopes[-1][self._static_direct_mutation_alias_key(name)] = None
+        if not name.startswith("<") and self._lookup_static_attribute_mutation_alias_entry(name) is not _MISSING_ALIAS:
+            self.alias_scopes[-1][self._static_attribute_mutation_alias_key(name)] = None
 
     @staticmethod
     def _static_reference_override_key(reference_name: str) -> str:
@@ -677,6 +691,10 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
     @staticmethod
     def _static_direct_mutation_alias_key(name: str) -> str:
         return f"{_STATIC_DIRECT_MUTATION_ALIAS_PREFIX}{name}"
+
+    @staticmethod
+    def _static_attribute_mutation_alias_key(name: str) -> str:
+        return f"{_STATIC_ATTRIBUTE_MUTATION_ALIAS_PREFIX}{name}"
 
     def _lookup_static_reference_override(self, reference_name: str) -> _AliasValue:
         override_key = self._static_reference_override_key(reference_name)
@@ -692,6 +710,13 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
                 return aliases[alias_key]
         return None
 
+    def _lookup_static_attribute_mutation_alias_entry(self, name: str) -> _AliasValue | object:
+        alias_key = self._static_attribute_mutation_alias_key(name)
+        for aliases in reversed(self.alias_scopes):
+            if alias_key in aliases:
+                return aliases[alias_key]
+        return _MISSING_ALIAS
+
     def _resolve_certain_direct_builtin_mutator_names(self, node: ast.AST) -> frozenset[str] | None:
         direct_mutator_names = _resolve_direct_global_builtin_mutator_names(node, self.alias_scopes)
         if direct_mutator_names is not None:
@@ -699,6 +724,23 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         if isinstance(node, ast.Name):
             return self._lookup_static_direct_mutation_alias(node.id)
         return None
+
+    def _static_attribute_mutation_helper_names(self, resolved_names: _AliasValue) -> frozenset[str] | None:
+        if resolved_names is None:
+            return None
+        helper_names = frozenset(self._invoked_callable_reference_name(name) for name in resolved_names)
+        return helper_names if helper_names and helper_names.issubset(_STATIC_ATTRIBUTE_MUTATION_HELPERS) else None
+
+    def _resolve_certain_static_attribute_mutation_helper_names(self, node: ast.AST) -> frozenset[str] | None:
+        call_name = _resolve_call_name(node)
+        if call_name is not None:
+            helper_names = self._lookup_static_attribute_mutation_alias_entry(
+                self._invoked_callable_reference_name(call_name)
+            )
+            if helper_names is not _MISSING_ALIAS:
+                return helper_names if isinstance(helper_names, frozenset) else None
+
+        return self._static_attribute_mutation_helper_names(self._resolve_invoked_reference_names(node))
 
     def _is_tracked_call_name(self, name: str) -> bool:
         return (
@@ -801,12 +843,29 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         for target_names, value in mutations:
             self._bind_static_reference_names_to_value(target_names, value)
 
+    def _bind_static_setattr_mutation(self, node: ast.Call) -> None:
+        """Model certain builtin ``setattr`` writes to one resolved reference."""
+        if len(node.args) != 3 or node.keywords:
+            return
+
+        helper_names = self._resolve_certain_static_attribute_mutation_helper_names(node.func)
+        if helper_names is None:
+            return
+
+        target_names = _resolve_static_attribute_names(node.args[0], node.args[1], self.alias_scopes)
+        if target_names is None or len(target_names) != 1:
+            return
+        self._bind_static_reference_names_to_value(target_names, node.args[2])
+
     def _bind_target_to_value(self, target: ast.AST, value: ast.AST) -> None:
         if isinstance(target, ast.Name):
             self._bind_name(target.id, self._resolve_bound_value_names(value))
             direct_mutator_names = self._resolve_certain_direct_builtin_mutator_names(value)
             if direct_mutator_names is not None:
                 self._bind_name(self._static_direct_mutation_alias_key(target.id), direct_mutator_names)
+            attribute_mutation_names = self._resolve_certain_static_attribute_mutation_helper_names(value)
+            if attribute_mutation_names is not None:
+                self._bind_name(self._static_attribute_mutation_alias_key(target.id), attribute_mutation_names)
         elif isinstance(target, (ast.Attribute, ast.Subscript)):
             self._bind_static_reference_target_to_value(target, value)
         elif isinstance(target, ast.Starred):
@@ -904,7 +963,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         current_scope = self.alias_scopes[-1]
         branch_names = {name for scope in branch_scopes for name in scope}
         for name in branch_names:
-            if name.startswith(_STATIC_DIRECT_MUTATION_ALIAS_PREFIX):
+            if name.startswith((_STATIC_DIRECT_MUTATION_ALIAS_PREFIX, _STATIC_ATTRIBUTE_MUTATION_ALIAS_PREFIX)):
                 certainty_base_value = current_scope.get(name, _MISSING_ALIAS)
                 values = [scope.get(name, certainty_base_value) for scope in branch_scopes]
                 first_value = values[0]
@@ -1135,6 +1194,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
                 if self._is_tracked_call_name(resolved_name):
                     self.risky_calls.add(resolved_name)
         self.generic_visit(node)
+        self._bind_static_setattr_mutation(node)
 
 
 def statically_resolved_python_call_names_in_tree(tree: ast.AST, tracked_call_names: frozenset[str]) -> set[str]:

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -492,6 +492,9 @@ class TestJITScriptDetector:
                 b"globals()['__builtins__']['eval']('1 + 1')\n"
             ),
             (b"import builtins\nif replace_builtin:\n    setattr(builtins, 'eval', len)\nbuiltins.eval('1 + 1')\n"),
+            (b"import builtins\nreplace_builtin and setattr(builtins, 'eval', len)\nbuiltins.eval('1 + 1')\n"),
+            (b"import builtins\nFalse and setattr(builtins, 'eval', len)\nbuiltins.eval('1 + 1')\n"),
+            (b"import builtins\nsetattr(builtins, 'eval', len) if replace_builtin else None\nbuiltins.eval('1 + 1')\n"),
             (
                 b"import builtins\n"
                 b"assign = setattr\n"

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -258,7 +258,19 @@ class TestJITScriptDetector:
             (b"namespace = globals()\nlookup = namespace.get\nlookup('__builtins__')['ev' + 'al']('1 + 1')\n"),
             b"lookup = globals()['__builtins__'].get\nlookup('ev' + 'al')('1 + 1')\n",
             b"lookup = globals()['__builtins__'].__getitem__\nlookup('ev' + 'al')('1 + 1')\n",
+            b"eval.__call__('1 + 1')\n",
+            b"run = globals()['__builtins__']['eval']\nrun.__call__('1 + 1')\n",
             (b"run = globals()['__builtins__']['eval']\nglobals()['__builtins__']['eval'] = len\nrun('1 + 1')\n"),
+            (
+                b"run = globals()['__builtins__']['eval']\n"
+                b"globals()['__builtins__']['eval'] = len\n"
+                b"run.__call__('1 + 1')\n"
+            ),
+            (
+                b"invoke = globals()['__builtins__']['eval'].__call__\n"
+                b"globals()['__builtins__']['eval'] = len\n"
+                b"invoke('1 + 1')\n"
+            ),
             (
                 b"run = globals()['__builtins__']['eval']\n"
                 b"globals()['__builtins__'].__setitem__('eval', len)\n"
@@ -340,6 +352,12 @@ class TestJITScriptDetector:
                 b"replace('eval', len)\n"
                 b"run = globals()['__builtins__']['eval']\n"
                 b"run([])\n"
+            ),
+            (b"globals()['__builtins__']['eval'] = len\nrun = globals()['__builtins__']['eval']\nrun.__call__([])\n"),
+            (
+                b"globals()['__builtins__']['eval'] = len\n"
+                b"invoke = globals()['__builtins__']['eval'].__call__\n"
+                b"invoke([])\n"
             ),
             b"def payload():\n    eval = len\n    return eval([])\n",
             (

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -362,6 +362,18 @@ class TestJITScriptDetector:
             b"import builtins\nsetattr(builtins, 'eval', len)\nbuiltins.eval([])\n",
             b"import builtins\nresult = setattr(builtins, 'eval', len)\nbuiltins.eval([])\n",
             (b"import builtins as bi\nfrom builtins import setattr as assign\nassign(bi, 'eval', len)\nbi.eval([])\n"),
+            b"import builtins\nbuiltins.__dict__.update({'eval': len})\nbuiltins.eval([])\n",
+            b"import builtins\nmapping = builtins.__dict__\nmapping.update({'eval': len})\nbuiltins.eval([])\n",
+            (
+                b"import builtins\n"
+                b"if cond:\n"
+                b"    target = builtins\n"
+                b"else:\n"
+                b"    target = builtins\n"
+                b"target.__dict__.update({'eval': len})\n"
+                b"builtins.eval([])\n"
+            ),
+            b"import builtins\nreplace = builtins.__dict__.update\nreplace({'eval': len})\nbuiltins.eval([])\n",
             b"def payload():\n    eval = len\n    return eval([])\n",
             (
                 b"def payload():\n"
@@ -410,6 +422,13 @@ class TestJITScriptDetector:
                 b"globals()['__builtins__']['eval']('pass')\n"
             ),
             b"import builtins\nsetattr(builtins, 'eval', builtins.exec)\nbuiltins.eval('pass')\n",
+            b"import builtins\nbuiltins.__dict__.update({'eval': builtins.exec})\nbuiltins.eval('pass')\n",
+            (
+                b"import builtins\n"
+                b"mapping = builtins.__dict__\n"
+                b"mapping.update({'eval': builtins.exec})\n"
+                b"builtins.eval('pass')\n"
+            ),
             b"import builtins\nprint(setattr(builtins, 'eval', builtins.exec))\nbuiltins.eval('pass')\n",
         ],
     )
@@ -501,6 +520,66 @@ class TestJITScriptDetector:
                 b"except Exception:\n"
                 b"    pass\n"
                 b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"if replace_builtin:\n"
+                b"    builtins.__dict__.update({'eval': len})\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"replace = builtins.__dict__.update\n"
+                b"replace = lambda values: None\n"
+                b"replace({'eval': len})\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"if swap:\n"
+                b"    builtins = make_namespace()\n"
+                b"builtins.__dict__.update({'eval': len})\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"if swap:\n"
+                b"    builtins = make_namespace()\n"
+                b"setattr(builtins, 'eval', len)\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"if swap:\n"
+                b"    builtins = make_namespace()\n"
+                b"builtins.eval = len\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"if swap:\n"
+                b"    builtins = make_namespace()\n"
+                b"namespace = builtins\n"
+                b"namespace.__dict__.update({'eval': len})\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"def invoke(namespace=builtins):\n"
+                b"    namespace.__dict__.update({'eval': len})\n"
+                b"    return builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"def invoke(namespace=builtins):\n"
+                b"    setattr(namespace, 'eval', len)\n"
+                b"    return builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"def invoke(namespace=builtins):\n"
+                b"    namespace.eval = len\n"
+                b"    return builtins.eval('1 + 1')\n"
             ),
         ],
     )

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -359,6 +359,9 @@ class TestJITScriptDetector:
                 b"invoke = globals()['__builtins__']['eval'].__call__\n"
                 b"invoke([])\n"
             ),
+            b"import builtins\nsetattr(builtins, 'eval', len)\nbuiltins.eval([])\n",
+            b"import builtins\nresult = setattr(builtins, 'eval', len)\nbuiltins.eval([])\n",
+            (b"import builtins as bi\nfrom builtins import setattr as assign\nassign(bi, 'eval', len)\nbi.eval([])\n"),
             b"def payload():\n    eval = len\n    return eval([])\n",
             (
                 b"def payload():\n"
@@ -406,6 +409,8 @@ class TestJITScriptDetector:
                 b"globals()['__builtins__']['exec'] = len\n"
                 b"globals()['__builtins__']['eval']('pass')\n"
             ),
+            b"import builtins\nsetattr(builtins, 'eval', builtins.exec)\nbuiltins.eval('pass')\n",
+            b"import builtins\nprint(setattr(builtins, 'eval', builtins.exec))\nbuiltins.eval('pass')\n",
         ],
     )
     def test_scan_model_detects_dangerous_builtin_reassignment(self, source: bytes) -> None:
@@ -466,6 +471,36 @@ class TestJITScriptDetector:
                 b"import helpers as replace\n"
                 b"replace({'eval': len})\n"
                 b"globals()['__builtins__']['eval']('1 + 1')\n"
+            ),
+            (b"import builtins\nif replace_builtin:\n    setattr(builtins, 'eval', len)\nbuiltins.eval('1 + 1')\n"),
+            (
+                b"import builtins\n"
+                b"assign = setattr\n"
+                b"if replace_builtin:\n"
+                b"    assign = lambda target, key, value: None\n"
+                b"assign(builtins, 'eval', len)\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"if replace_builtin:\n"
+                b"    setattr = lambda target, key, value: None\n"
+                b"setattr(builtins, 'eval', len)\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"setattr = lambda target, key, value: None\n"
+                b"setattr(builtins, 'eval', len)\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"try:\n"
+                b"    setattr(builtins, 'eval', len)\n"
+                b"except Exception:\n"
+                b"    pass\n"
+                b"builtins.eval('1 + 1')\n"
             ),
         ],
     )

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1052,6 +1052,7 @@ def test_pytorch_zip_scans_unmarked_python_blobs_in_archive_data(tmp_path: Path)
         b"namespace = globals()\nlookup = namespace.get\nlookup('__builtins__')['ev' + 'al']('1 + 1')\n",
         b"lookup = globals()['__builtins__'].get\nlookup('ev' + 'al')('1 + 1')\n",
         b"lookup = globals()['__builtins__'].__getitem__\nlookup('ev' + 'al')('1 + 1')\n",
+        (b"run = globals()['__builtins__']['eval']\nglobals()['__builtins__']['eval'] = len\nrun.__call__('1 + 1')\n"),
         (b"run = globals()['__builtins__']['eval']\nglobals()['__builtins__']['eval'] = len\nrun('1 + 1')\n"),
         (
             b"run = globals()['__builtins__']['eval']\n"
@@ -1154,6 +1155,7 @@ def test_pytorch_zip_scans_aliased_modeled_builtins_in_archive_data(
             b"globals()['__builtins__']['eval']([])\n"
         ),
         (b"globals()['__builtins__']['eval'] = len\nrun = globals()['__builtins__']['eval']\nrun([])\n"),
+        (b"globals()['__builtins__']['eval'] = len\nrun = globals()['__builtins__']['eval']\nrun.__call__([])\n"),
         (b"globals()['__builtins__'].__setitem__('eval', len)\nrun = globals()['__builtins__']['eval']\nrun([])\n"),
         (
             b"replace = globals()['__builtins__'].__setitem__\n"

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1144,6 +1144,7 @@ def test_pytorch_zip_scans_aliased_modeled_builtins_in_archive_data(
         b"mapping = {'eval': len}\nlookup = mapping.get\nlookup('eval')([])\n",
         b"globals()['__builtins__'].__setitem__('eval', len)\nglobals()['__builtins__']['eval']([])\n",
         b"globals()['__builtins__'].update({'eval': len})\nglobals()['__builtins__']['eval']([])\n",
+        b"import builtins\nbuiltins.__dict__.update({'eval': len})\nbuiltins.eval([])\n",
         (
             b"replace = globals()['__builtins__'].__setitem__\n"
             b"replace('eval', len)\n"
@@ -1219,6 +1220,7 @@ def test_pytorch_zip_ignores_benign_builtin_shaped_access_in_archive_data(tmp_pa
             b"setattr(globals()['__builtins__'], 'eval', __builtins__['exec'])\n"
             b"globals()['__builtins__']['eval']('pass')\n"
         ),
+        b"import builtins\nbuiltins.__dict__.update({'eval': builtins.exec})\nbuiltins.eval('pass')\n",
     ],
 )
 def test_pytorch_zip_detects_dangerous_builtin_reassignment_in_archive_data(tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1154,6 +1154,7 @@ def test_pytorch_zip_scans_aliased_modeled_builtins_in_archive_data(
             b"replace({'eval': len})\n"
             b"globals()['__builtins__']['eval']([])\n"
         ),
+        b"setattr(globals()['__builtins__'], 'eval', len)\nglobals()['__builtins__']['eval']([])\n",
         (b"globals()['__builtins__']['eval'] = len\nrun = globals()['__builtins__']['eval']\nrun([])\n"),
         (b"globals()['__builtins__']['eval'] = len\nrun = globals()['__builtins__']['eval']\nrun.__call__([])\n"),
         (b"globals()['__builtins__'].__setitem__('eval', len)\nrun = globals()['__builtins__']['eval']\nrun([])\n"),
@@ -1212,6 +1213,10 @@ def test_pytorch_zip_ignores_benign_builtin_shaped_access_in_archive_data(tmp_pa
         (
             b"replace = globals()['__builtins__'].update\n"
             b"replace({'eval': __builtins__['exec']})\n"
+            b"globals()['__builtins__']['eval']('pass')\n"
+        ),
+        (
+            b"setattr(globals()['__builtins__'], 'eval', __builtins__['exec'])\n"
             b"globals()['__builtins__']['eval']('pass')\n"
         ),
     ],

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -143,6 +143,8 @@ class TestTarScanner:
     @pytest.mark.parametrize(
         "payload",
         [
+            b"import os\nos.system.__call__('echo hidden')\n",
+            b"import os\ninvoke = os.system.__call__\nos.system = len\ninvoke('echo hidden')\n",
             b"import os\nrun = os.system\nos.system = len\nrun('echo hidden')\n",
             b"import os\nfrom os import system as run\nos.system = len\nrun('echo hidden')\n",
         ],
@@ -166,6 +168,8 @@ class TestTarScanner:
     @pytest.mark.parametrize(
         "payload",
         [
+            b"import os\nos.system = len\nos.system.__call__([])\n",
+            b"import os\nos.system = len\ninvoke = os.system.__call__\ninvoke([])\n",
             b"import os\nos.system = len\nrun = os.system\nrun([])\n",
             b"import os\nos.system = len\nfrom os import system as run\nrun([])\n",
         ],
@@ -234,6 +238,11 @@ class TestTarScanner:
             (b"namespace = globals()\nlookup = namespace.get\nlookup('__builtins__')['ev' + 'al']('1 + 1')\n"),
             b"lookup = globals()['__builtins__'].get\nlookup('ev' + 'al')('1 + 1')\n",
             b"lookup = globals()['__builtins__'].__getitem__\nlookup('ev' + 'al')('1 + 1')\n",
+            (
+                b"run = globals()['__builtins__']['eval']\n"
+                b"globals()['__builtins__']['eval'] = len\n"
+                b"run.__call__('1 + 1')\n"
+            ),
             (b"run = globals()['__builtins__']['eval']\nglobals()['__builtins__']['eval'] = len\nrun('1 + 1')\n"),
             (
                 b"run = globals()['__builtins__']['eval']\n"
@@ -301,6 +310,7 @@ class TestTarScanner:
                 b"globals()['__builtins__']['eval']([])\n"
             ),
             (b"globals()['__builtins__']['eval'] = len\nrun = globals()['__builtins__']['eval']\nrun([])\n"),
+            (b"globals()['__builtins__']['eval'] = len\nrun = globals()['__builtins__']['eval']\nrun.__call__([])\n"),
             (b"globals()['__builtins__'].__setitem__('eval', len)\nrun = globals()['__builtins__']['eval']\nrun([])\n"),
             (
                 b"replace = globals()['__builtins__'].__setitem__\n"

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -147,6 +147,13 @@ class TestTarScanner:
             b"import os\ninvoke = os.system.__call__\nos.system = len\ninvoke('echo hidden')\n",
             b"import os\nrun = os.system\nos.system = len\nrun('echo hidden')\n",
             b"import os\nfrom os import system as run\nos.system = len\nrun('echo hidden')\n",
+            b"import os\nrun = os.system\nsetattr(os, 'system', len)\nrun('echo hidden')\n",
+            (
+                b"import os\n"
+                b"setattr = lambda target, key, value: None\n"
+                b"setattr(os, 'system', len)\n"
+                b"os.system('echo hidden')\n"
+            ),
         ],
     )
     def test_scan_tar_preserves_captured_dangerous_callable_before_overwrite(
@@ -172,6 +179,9 @@ class TestTarScanner:
             b"import os\nos.system = len\ninvoke = os.system.__call__\ninvoke([])\n",
             b"import os\nos.system = len\nrun = os.system\nrun([])\n",
             b"import os\nos.system = len\nfrom os import system as run\nrun([])\n",
+            b"import os\nsetattr(os, 'system', len)\nos.system([])\n",
+            b"import os\nreplace = setattr\nreplace(os, 'system', len)\nos.system([])\n",
+            b"import os\nsetattr(os, 'system', len)\nrun = os.system\nrun([])\n",
         ],
     )
     def test_scan_tar_allows_callable_captured_after_safe_overwrite(self, tmp_path: Path, payload: bytes) -> None:
@@ -201,6 +211,21 @@ class TestTarScanner:
         assert len(python_checks) == 1
         assert python_checks[0].status == CheckStatus.FAILED
         assert python_checks[0].severity == IssueSeverity.WARNING
+        assert python_checks[0].details["reason"] == "high-risk calls: subprocess.run"
+
+    def test_scan_tar_reports_dangerous_setattr_replacement(self, tmp_path: Path) -> None:
+        archive_path = tmp_path / "model_bundle.tar"
+        payload = b"import os\nimport subprocess\nsetattr(os, 'system', subprocess.run)\nos.system(['id'])\n"
+        with tarfile.open(archive_path, "w") as archive:
+            info = tarfile.TarInfo("handler.py")
+            info.size = len(payload)
+            archive.addfile(info, tarfile.io.BytesIO(payload))  # type: ignore[attr-defined]
+
+        result = self.scanner.scan(str(archive_path))
+
+        python_checks = [check for check in result.checks if check.name == "Python Archive Member Security"]
+        assert len(python_checks) == 1
+        assert python_checks[0].status == CheckStatus.FAILED
         assert python_checks[0].details["reason"] == "high-risk calls: subprocess.run"
 
     def test_scan_tar_flags_builtins_getattr_keyword_call_dangerous_python_member(self, tmp_path: Path) -> None:

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -148,6 +148,31 @@ class TestTarScanner:
             b"import os\nrun = os.system\nos.system = len\nrun('echo hidden')\n",
             b"import os\nfrom os import system as run\nos.system = len\nrun('echo hidden')\n",
             b"import os\nrun = os.system\nsetattr(os, 'system', len)\nrun('echo hidden')\n",
+            b"import os\nrun = os.system\nos.__dict__.update({'system': len})\nrun('echo hidden')\n",
+            b"import os\nif replace:\n    os.__dict__.update({'system': len})\nos.system('echo hidden')\n",
+            (
+                b"import os\nif swap:\n    os = make_module()\n"
+                b"os.__dict__.update({'system': len})\nos.system('echo hidden')\n"
+            ),
+            b"import os\nif swap:\n    os = make_module()\nsetattr(os, 'system', len)\nos.system('echo hidden')\n",
+            b"import os\nif swap:\n    os = make_module()\nos.system = len\nos.system('echo hidden')\n",
+            (
+                b"import os\nif swap:\n    os = make_module()\ntarget = os\n"
+                b"target.__dict__.update({'system': len})\nos.system('echo hidden')\n"
+            ),
+            (
+                b"import os\nif swap:\n    os = make_module()\ntarget = os\n"
+                b"setattr(target, 'system', len)\nos.system('echo hidden')\n"
+            ),
+            (
+                b"import os\nif swap:\n    os = make_module()\ntarget = os\n"
+                b"target.system = len\nos.system('echo hidden')\n"
+            ),
+            (
+                b"import os\ndef hide(target=os):\n"
+                b"    target.__dict__.update({'system': len})\n"
+                b"    os.system('echo hidden')\n"
+            ),
             (
                 b"import os\n"
                 b"setattr = lambda target, key, value: None\n"
@@ -182,6 +207,11 @@ class TestTarScanner:
             b"import os\nsetattr(os, 'system', len)\nos.system([])\n",
             b"import os\nreplace = setattr\nreplace(os, 'system', len)\nos.system([])\n",
             b"import os\nsetattr(os, 'system', len)\nrun = os.system\nrun([])\n",
+            b"import os\nos.__dict__.__setitem__('system', len)\nos.system([])\n",
+            b"import os\nos.__dict__.update({'system': len})\nos.system([])\n",
+            b"import os\nvars(os).update({'system': len})\nos.system([])\n",
+            b"import os\nreplace = os.__dict__.update\nreplace({'system': len})\nos.system([])\n",
+            b"import os\nos.__dict__.update({'system': len})\nrun = os.system\nrun([])\n",
         ],
     )
     def test_scan_tar_allows_callable_captured_after_safe_overwrite(self, tmp_path: Path, payload: bytes) -> None:
@@ -213,9 +243,15 @@ class TestTarScanner:
         assert python_checks[0].severity == IssueSeverity.WARNING
         assert python_checks[0].details["reason"] == "high-risk calls: subprocess.run"
 
-    def test_scan_tar_reports_dangerous_setattr_replacement(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            b"import os\nimport subprocess\nsetattr(os, 'system', subprocess.run)\nos.system(['id'])\n",
+            b"import os\nimport subprocess\nos.__dict__.update({'system': subprocess.run})\nos.system(['id'])\n",
+        ],
+    )
+    def test_scan_tar_reports_dangerous_setattr_replacement(self, tmp_path: Path, payload: bytes) -> None:
         archive_path = tmp_path / "model_bundle.tar"
-        payload = b"import os\nimport subprocess\nsetattr(os, 'system', subprocess.run)\nos.system(['id'])\n"
         with tarfile.open(archive_path, "w") as archive:
             info = tarfile.TarInfo("handler.py")
             info.size = len(payload)
@@ -324,6 +360,7 @@ class TestTarScanner:
             b"mapping = {'eval': len}\nlookup = mapping.get\nlookup('eval')([])\n",
             b"globals()['__builtins__'].__setitem__('eval', len)\nglobals()['__builtins__']['eval']([])\n",
             b"globals()['__builtins__'].update({'eval': len})\nglobals()['__builtins__']['eval']([])\n",
+            b"import builtins\nbuiltins.__dict__.update({'eval': len})\nbuiltins.eval([])\n",
             (
                 b"replace = globals()['__builtins__'].__setitem__\n"
                 b"replace('eval', len)\n"
@@ -357,34 +394,45 @@ class TestTarScanner:
         assert not any(check.name == "Python Archive Member Security" for check in result.checks)
 
     @pytest.mark.parametrize(
-        "payload",
+        ("payload", "dangerous_name"),
         [
             (
                 b"namespace = globals()\n"
                 b"namespace['__builtins__']['eval'] = __builtins__['exec']\n"
-                b"namespace['__builtins__']['eval']('pass')\n"
+                b"namespace['__builtins__']['eval']('pass')\n",
+                "__builtins__.exec",
             ),
             (
                 b"globals()['__builtins__'].__setitem__('eval', __builtins__['exec'])\n"
-                b"globals()['__builtins__']['eval']('pass')\n"
+                b"globals()['__builtins__']['eval']('pass')\n",
+                "__builtins__.exec",
             ),
             (
                 b"globals()['__builtins__'].update({'eval': __builtins__['exec']})\n"
-                b"globals()['__builtins__']['eval']('pass')\n"
+                b"globals()['__builtins__']['eval']('pass')\n",
+                "__builtins__.exec",
             ),
             (
                 b"replace = globals()['__builtins__'].__setitem__\n"
                 b"replace('eval', __builtins__['exec'])\n"
-                b"globals()['__builtins__']['eval']('pass')\n"
+                b"globals()['__builtins__']['eval']('pass')\n",
+                "__builtins__.exec",
             ),
             (
                 b"replace = globals()['__builtins__'].update\n"
                 b"replace({'eval': __builtins__['exec']})\n"
-                b"globals()['__builtins__']['eval']('pass')\n"
+                b"globals()['__builtins__']['eval']('pass')\n",
+                "__builtins__.exec",
+            ),
+            (
+                b"import builtins\nbuiltins.__dict__.update({'eval': builtins.exec})\nbuiltins.eval('pass')\n",
+                "builtins.exec",
             ),
         ],
     )
-    def test_scan_tar_reports_dangerous_builtin_reassignment(self, tmp_path: Path, payload: bytes) -> None:
+    def test_scan_tar_reports_dangerous_builtin_reassignment(
+        self, tmp_path: Path, payload: bytes, dangerous_name: str
+    ) -> None:
         archive_path = tmp_path / "model_bundle.tar"
         with tarfile.open(archive_path, "w") as archive:
             info = tarfile.TarInfo("handler.py")
@@ -397,7 +445,7 @@ class TestTarScanner:
         assert len(python_checks) == 1
         assert python_checks[0].status == CheckStatus.FAILED
         assert python_checks[0].rule_code == "S104"
-        assert python_checks[0].details["reason"] == "high-risk calls: __builtins__.exec"
+        assert python_checks[0].details["reason"] == f"high-risk calls: {dangerous_name}"
 
     def test_scan_tar_flags_aliased_getattr_helper_dangerous_python_member(self, tmp_path: Path) -> None:
         """Aliased getattr helpers and module aliases should still resolve risky calls."""

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -288,6 +288,12 @@ def test_scan_detects_keyword_getattr_wrapped_handler_execution_primitive(
         (
             b"def handle(data, context):\n"
             b"    run = globals()['__builtins__']['eval']\n"
+            b"    globals()['__builtins__']['eval'] = len\n"
+            b"    return run.__call__('1 + 1')\n"
+        ),
+        (
+            b"def handle(data, context):\n"
+            b"    run = globals()['__builtins__']['eval']\n"
             b"    globals()['__builtins__'].__setitem__('eval', len)\n"
             b"    return run('1 + 1')\n"
         ),
@@ -388,6 +394,12 @@ def test_scan_detects_implicit_builtins_handler_execution_primitive(
             b"    globals()['__builtins__']['eval'] = len\n"
             b"    run = globals()['__builtins__']['eval']\n"
             b"    return run([])\n"
+        ),
+        (
+            b"def handle(data, context):\n"
+            b"    globals()['__builtins__']['eval'] = len\n"
+            b"    run = globals()['__builtins__']['eval']\n"
+            b"    return run.__call__([])\n"
         ),
         (
             b"def handle(data, context):\n"

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -391,6 +391,11 @@ def test_scan_detects_implicit_builtins_handler_execution_primitive(
         ),
         (
             b"def handle(data, context):\n"
+            b"    setattr(globals()['__builtins__'], 'eval', len)\n"
+            b"    return globals()['__builtins__']['eval']([])\n"
+        ),
+        (
+            b"def handle(data, context):\n"
             b"    globals()['__builtins__']['eval'] = len\n"
             b"    run = globals()['__builtins__']['eval']\n"
             b"    return run([])\n"
@@ -462,6 +467,11 @@ def test_scan_allows_benign_builtin_shaped_handler_source(tmp_path: Path, handle
             b"def handle(data, context):\n"
             b"    replace = globals()['__builtins__'].update\n"
             b"    replace({'eval': __builtins__['exec']})\n"
+            b"    return globals()['__builtins__']['eval']('pass')\n"
+        ),
+        (
+            b"def handle(data, context):\n"
+            b"    setattr(globals()['__builtins__'], 'eval', __builtins__['exec'])\n"
             b"    return globals()['__builtins__']['eval']('pass')\n"
         ),
     ],

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -378,6 +378,12 @@ def test_scan_detects_implicit_builtins_handler_execution_primitive(
             b"    return globals()['__builtins__']['eval']([])\n"
         ),
         (
+            b"import builtins\n"
+            b"def handle(data, context):\n"
+            b"    builtins.__dict__.update({'eval': len})\n"
+            b"    return builtins.eval([])\n"
+        ),
+        (
             b"def handle(data, context):\n"
             b"    replace = globals()['__builtins__'].__setitem__\n"
             b"    replace('eval', len)\n"
@@ -439,44 +445,59 @@ def test_scan_allows_benign_builtin_shaped_handler_source(tmp_path: Path, handle
 
 
 @pytest.mark.parametrize(
-    "handler_source",
+    ("handler_source", "dangerous_name"),
     [
         (
             b"def handle(data, context):\n"
             b"    namespace = globals()\n"
             b"    namespace['__builtins__']['eval'] = __builtins__['exec']\n"
-            b"    return namespace['__builtins__']['eval']('pass')\n"
+            b"    return namespace['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
         ),
         (
             b"def handle(data, context):\n"
             b"    globals()['__builtins__'].__setitem__('eval', __builtins__['exec'])\n"
-            b"    return globals()['__builtins__']['eval']('pass')\n"
+            b"    return globals()['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
         ),
         (
             b"def handle(data, context):\n"
             b"    globals()['__builtins__'].update({'eval': __builtins__['exec']})\n"
-            b"    return globals()['__builtins__']['eval']('pass')\n"
+            b"    return globals()['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
         ),
         (
             b"def handle(data, context):\n"
             b"    replace = globals()['__builtins__'].__setitem__\n"
             b"    replace('eval', __builtins__['exec'])\n"
-            b"    return globals()['__builtins__']['eval']('pass')\n"
+            b"    return globals()['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
         ),
         (
             b"def handle(data, context):\n"
             b"    replace = globals()['__builtins__'].update\n"
             b"    replace({'eval': __builtins__['exec']})\n"
-            b"    return globals()['__builtins__']['eval']('pass')\n"
+            b"    return globals()['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
         ),
         (
             b"def handle(data, context):\n"
             b"    setattr(globals()['__builtins__'], 'eval', __builtins__['exec'])\n"
-            b"    return globals()['__builtins__']['eval']('pass')\n"
+            b"    return globals()['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
+        ),
+        (
+            b"import builtins\n"
+            b"def handle(data, context):\n"
+            b"    builtins.__dict__.update({'eval': builtins.exec})\n"
+            b"    return builtins.eval('pass')\n",
+            "builtins.exec",
         ),
     ],
 )
-def test_scan_detects_dangerous_builtin_reassignment_in_handler_source(tmp_path: Path, handler_source: bytes) -> None:
+def test_scan_detects_dangerous_builtin_reassignment_in_handler_source(
+    tmp_path: Path, handler_source: bytes, dangerous_name: str
+) -> None:
     manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
     mar_path = _create_mar_archive(
         tmp_path,
@@ -489,7 +510,7 @@ def test_scan_detects_dangerous_builtin_reassignment_in_handler_source(tmp_path:
     handler_failures = _failed_checks(result, "TorchServe Handler Static Analysis")
 
     assert len(handler_failures) == 1
-    assert "__builtins__.exec" in handler_failures[0].message
+    assert dangerous_name in handler_failures[0].message
 
 
 def test_scan_detects_dunder_call_getattr_wrapped_handler_execution_primitive(tmp_path: Path) -> None:

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -162,6 +162,10 @@ def test_scan_zip_flags_aliased_dangerous_python_member(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     "source",
     [
+        "import os\nos.system.__call__('echo hidden')\n",
+        "import os\nrun = os.system\nrun.__call__('echo hidden')\n",
+        "import os\ngetattr(os.system, '__call__')('echo hidden')\n",
+        "import os\ninvoke = os.system.__call__\nos.system = len\ninvoke('echo hidden')\n",
         "import os\nrun = os.system\nos.system = len\nrun('echo hidden')\n",
         "import os\nfrom os import system as run\nos.system = len\nrun('echo hidden')\n",
         "import os\nfrom os import *\nos.system = len\nsystem('echo hidden')\n",
@@ -187,6 +191,9 @@ def test_scan_zip_preserves_captured_dangerous_callable_before_overwrite(tmp_pat
 @pytest.mark.parametrize(
     "source",
     [
+        "import os\nos.system = len\nos.system.__call__([])\n",
+        "import os\nos.system = len\ngetattr(os.system, '__call__')([])\n",
+        "import os\nos.system = len\ninvoke = os.system.__call__\ninvoke([])\n",
         "import os\nos.system = len\nrun = os.system\nrun([])\n",
         "import os\nos.system = len\nfrom os import system as run\nrun([])\n",
         "import os\nos.system = len\nfrom os import *\nsystem([])\n",
@@ -272,6 +279,7 @@ def test_scan_zip_flags_builtins_getattr_keyword_call_dangerous_python_member(tm
         "namespace = globals()\nlookup = namespace.get\nlookup('__builtins__')['ev' + 'al']('1 + 1')\n",
         "lookup = globals()['__builtins__'].get\nlookup('ev' + 'al')('1 + 1')\n",
         "lookup = globals()['__builtins__'].__getitem__\nlookup('ev' + 'al')('1 + 1')\n",
+        ("run = globals()['__builtins__']['eval']\nglobals()['__builtins__']['eval'] = len\nrun.__call__('1 + 1')\n"),
         "run = globals()['__builtins__']['eval']\nglobals()['__builtins__']['eval'] = len\nrun('1 + 1')\n",
         ("run = globals()['__builtins__']['eval']\nglobals()['__builtins__'].__setitem__('eval', len)\nrun('1 + 1')\n"),
         (
@@ -325,6 +333,7 @@ def test_scan_zip_flags_implicit_builtins_dangerous_python_member(tmp_path: Path
         ),
         ("replace = globals()['__builtins__'].update\nreplace({'eval': len})\nglobals()['__builtins__']['eval']([])\n"),
         "globals()['__builtins__']['eval'] = len\nrun = globals()['__builtins__']['eval']\nrun([])\n",
+        ("globals()['__builtins__']['eval'] = len\nrun = globals()['__builtins__']['eval']\nrun.__call__([])\n"),
         ("globals()['__builtins__'].__setitem__('eval', len)\nrun = globals()['__builtins__']['eval']\nrun([])\n"),
         (
             "replace = globals()['__builtins__'].__setitem__\n"

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -170,6 +170,13 @@ def test_scan_zip_flags_aliased_dangerous_python_member(tmp_path: Path) -> None:
         "import os\nfrom os import system as run\nos.system = len\nrun('echo hidden')\n",
         "import os\nfrom os import *\nos.system = len\nsystem('echo hidden')\n",
         ("import os\ndef run(action=os.system):\n    os.system = len\n    action('echo hidden')\n"),
+        "import os\nrun = os.system\nsetattr(os, 'system', len)\nrun('echo hidden')\n",
+        (
+            "import os\n"
+            "setattr = lambda target, key, value: None\n"
+            "setattr(os, 'system', len)\n"
+            "os.system('echo hidden')\n"
+        ),
     ],
 )
 def test_scan_zip_preserves_captured_dangerous_callable_before_overwrite(tmp_path: Path, source: str) -> None:
@@ -198,6 +205,11 @@ def test_scan_zip_preserves_captured_dangerous_callable_before_overwrite(tmp_pat
         "import os\nos.system = len\nfrom os import system as run\nrun([])\n",
         "import os\nos.system = len\nfrom os import *\nsystem([])\n",
         ("import os\nos.system = len\ndef run(action=os.system):\n    action([])\n"),
+        "import os\nsetattr(os, 'system', len)\nos.system([])\n",
+        "import os\nreplace = setattr\nreplace(os, 'system', len)\nos.system([])\n",
+        "import os\nresult = setattr(os, 'system', len)\nos.system([])\n",
+        "import os\nresult: None = setattr(os, 'system', len)\nos.system([])\n",
+        "import os\nsetattr(os, 'system', len)\nrun = os.system\nrun([])\n",
     ],
 )
 def test_scan_zip_allows_callable_captured_after_safe_overwrite(tmp_path: Path, source: str) -> None:
@@ -224,6 +236,29 @@ def test_scan_zip_flags_from_import_dangerous_python_member(tmp_path: Path) -> N
     ]
     assert len(python_checks) == 1
     assert python_checks[0].severity == IssueSeverity.WARNING
+    assert python_checks[0].details["reason"] == "high-risk calls: subprocess.run"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "import os\nimport subprocess\nsetattr(os, 'system', subprocess.run)\nos.system(['id'])\n",
+        "import os\nimport subprocess\nresult = setattr(os, 'system', subprocess.run)\nos.system(['id'])\n",
+    ],
+)
+def test_scan_zip_reports_dangerous_setattr_replacement(tmp_path: Path, source: str) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", source)
+
+    result = ZipScanner().scan(str(archive_path))
+
+    python_checks = [
+        check
+        for check in result.checks
+        if check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED
+    ]
+    assert len(python_checks) == 1
     assert python_checks[0].details["reason"] == "high-risk calls: subprocess.run"
 
 

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -171,6 +171,34 @@ def test_scan_zip_flags_aliased_dangerous_python_member(tmp_path: Path) -> None:
         "import os\nfrom os import *\nos.system = len\nsystem('echo hidden')\n",
         ("import os\ndef run(action=os.system):\n    os.system = len\n    action('echo hidden')\n"),
         "import os\nrun = os.system\nsetattr(os, 'system', len)\nrun('echo hidden')\n",
+        "import os\nrun = os.system\nos.__dict__.update({'system': len})\nrun('echo hidden')\n",
+        (
+            "import os\n"
+            "replace = os.__dict__.update\n"
+            "replace = lambda values: None\n"
+            "replace({'system': len})\n"
+            "os.system('echo hidden')\n"
+        ),
+        "import os\nif replace:\n    os.__dict__.update({'system': len})\nos.system('echo hidden')\n",
+        "import os\nif swap:\n    os = make_module()\nos.__dict__.update({'system': len})\nos.system('echo hidden')\n",
+        "import os\nif swap:\n    os = make_module()\nsetattr(os, 'system', len)\nos.system('echo hidden')\n",
+        "import os\nif swap:\n    os = make_module()\nos.system = len\nos.system('echo hidden')\n",
+        (
+            "import os\nif swap:\n    os = make_module()\ntarget = os\n"
+            "target.__dict__.update({'system': len})\nos.system('echo hidden')\n"
+        ),
+        (
+            "import os\nif swap:\n    os = make_module()\ntarget = os\n"
+            "setattr(target, 'system', len)\nos.system('echo hidden')\n"
+        ),
+        ("import os\nif swap:\n    os = make_module()\ntarget = os\ntarget.system = len\nos.system('echo hidden')\n"),
+        (
+            "import os\ndef hide(target=os):\n"
+            "    target.__dict__.update({'system': len})\n"
+            "    os.system('echo hidden')\n"
+        ),
+        ("import os\ndef hide(target=os):\n    setattr(target, 'system', len)\n    os.system('echo hidden')\n"),
+        ("import os\ndef hide(target=os):\n    target.system = len\n    os.system('echo hidden')\n"),
         (
             "import os\n"
             "setattr = lambda target, key, value: None\n"
@@ -210,6 +238,12 @@ def test_scan_zip_preserves_captured_dangerous_callable_before_overwrite(tmp_pat
         "import os\nresult = setattr(os, 'system', len)\nos.system([])\n",
         "import os\nresult: None = setattr(os, 'system', len)\nos.system([])\n",
         "import os\nsetattr(os, 'system', len)\nrun = os.system\nrun([])\n",
+        "import os\nos.__dict__.__setitem__('system', len)\nos.system([])\n",
+        "import os\nos.__dict__.update({'system': len})\nos.system([])\n",
+        "import os\nvars(os).update({'system': len})\nos.system([])\n",
+        "import os\nreplace = os.__dict__.update\nreplace({'system': len})\nos.system([])\n",
+        "import os\nresult = os.__dict__.update({'system': len})\nos.system([])\n",
+        "import os\nos.__dict__.update({'system': len})\nrun = os.system\nrun([])\n",
     ],
 )
 def test_scan_zip_allows_callable_captured_after_safe_overwrite(tmp_path: Path, source: str) -> None:
@@ -244,6 +278,8 @@ def test_scan_zip_flags_from_import_dangerous_python_member(tmp_path: Path) -> N
     [
         "import os\nimport subprocess\nsetattr(os, 'system', subprocess.run)\nos.system(['id'])\n",
         "import os\nimport subprocess\nresult = setattr(os, 'system', subprocess.run)\nos.system(['id'])\n",
+        "import os\nimport subprocess\nos.__dict__.update({'system': subprocess.run})\nos.system(['id'])\n",
+        "import os\nimport subprocess\nos.__dict__.__setitem__('system', subprocess.run)\nos.system(['id'])\n",
     ],
 )
 def test_scan_zip_reports_dangerous_setattr_replacement(tmp_path: Path, source: str) -> None:
@@ -367,6 +403,8 @@ def test_scan_zip_flags_implicit_builtins_dangerous_python_member(tmp_path: Path
             "globals()['__builtins__']['eval']([])\n"
         ),
         ("replace = globals()['__builtins__'].update\nreplace({'eval': len})\nglobals()['__builtins__']['eval']([])\n"),
+        "import builtins\nbuiltins.__dict__.update({'eval': len})\nbuiltins.eval([])\n",
+        "import builtins\nreplace = builtins.__dict__.update\nreplace({'eval': len})\nbuiltins.eval([])\n",
         "globals()['__builtins__']['eval'] = len\nrun = globals()['__builtins__']['eval']\nrun([])\n",
         ("globals()['__builtins__']['eval'] = len\nrun = globals()['__builtins__']['eval']\nrun.__call__([])\n"),
         ("globals()['__builtins__'].__setitem__('eval', len)\nrun = globals()['__builtins__']['eval']\nrun([])\n"),
@@ -389,34 +427,43 @@ def test_scan_zip_allows_benign_builtin_shaped_source(tmp_path: Path, source: st
 
 
 @pytest.mark.parametrize(
-    "source",
+    ("source", "dangerous_name"),
     [
         (
             "namespace = globals()\n"
             "namespace['__builtins__']['eval'] = __builtins__['exec']\n"
-            "namespace['__builtins__']['eval']('pass')\n"
+            "namespace['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
         ),
         (
             "globals()['__builtins__'].__setitem__('eval', __builtins__['exec'])\n"
-            "globals()['__builtins__']['eval']('pass')\n"
+            "globals()['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
         ),
         (
             "globals()['__builtins__'].update({'eval': __builtins__['exec']})\n"
-            "globals()['__builtins__']['eval']('pass')\n"
+            "globals()['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
         ),
         (
             "replace = globals()['__builtins__'].__setitem__\n"
             "replace('eval', __builtins__['exec'])\n"
-            "globals()['__builtins__']['eval']('pass')\n"
+            "globals()['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
         ),
         (
             "replace = globals()['__builtins__'].update\n"
             "replace({'eval': __builtins__['exec']})\n"
-            "globals()['__builtins__']['eval']('pass')\n"
+            "globals()['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
+        ),
+        (
+            "import builtins\nbuiltins.__dict__.update({'eval': builtins.exec})\nbuiltins.eval('pass')\n",
+            "builtins.exec",
         ),
     ],
 )
-def test_scan_zip_reports_dangerous_builtin_reassignment(tmp_path: Path, source: str) -> None:
+def test_scan_zip_reports_dangerous_builtin_reassignment(tmp_path: Path, source: str, dangerous_name: str) -> None:
     archive_path = tmp_path / "model_bundle.zip"
     with zipfile.ZipFile(archive_path, "w") as archive:
         archive.writestr("handler.py", source)
@@ -430,7 +477,7 @@ def test_scan_zip_reports_dangerous_builtin_reassignment(tmp_path: Path, source:
     ]
     assert len(python_checks) == 1
     assert python_checks[0].rule_code == "S104"
-    assert python_checks[0].details["reason"] == "high-risk calls: __builtins__.exec"
+    assert python_checks[0].details["reason"] == f"high-risk calls: {dangerous_name}"
 
 
 def test_scan_zip_flags_aliased_getattr_helper_dangerous_python_member(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- detect high-risk Python callables invoked through explicit `.__call__` wrappers
- preserve correct overwrite/capture behavior for saved callable wrappers
- add malicious and benign parity coverage across JIT, ZIP, TAR, PyTorch ZIP, and TorchServe consumers

## Root Cause

Static source analysis already unwrapped a few special forms such as `getattr(os, 'system').__call__(...)`, but ordinary resolved callable references retained a trailing `.__call__` component. As a result, payloads such as `os.system.__call__('id')`, `run.__call__('id')` after `run = os.system`, and saved builtin execution wrappers were not matched to their underlying high-risk call target.

## Changes

- canonicalize trailing `.__call__` components on statically resolved invocation targets before risk matching and overwrite evaluation
- apply the same canonicalization while capturing callable values, so `invoke = os.system.__call__` retains the underlying callable identity across later member overwrites
- keep known-safe post-overwrite wrappers clean by resolving overwrite state before reporting
- record the user-visible detection fix in `CHANGELOG.md`

## Security Regression Coverage

Positive cases cover direct `eval.__call__`, direct/aliased/`getattr`-resolved `os.system.__call__`, saved builtin and module wrappers after later safe overwrites, and the existing JIT/archive consumer surfaces.

Negative controls cover wrapper invocation and wrapper capture performed only after `eval` or `os.system` has been statically replaced with `len`, guarding against renewed false positives.

## Validation

- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest tests/detectors/test_jit_script_detector.py tests/scanners/test_pytorch_zip_scanner.py tests/scanners/test_zip_scanner.py tests/scanners/test_tar_scanner.py tests/scanners/test_torchserve_mar_scanner.py -q` (`640 passed, 92 skipped`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`5121 passed, 1038 skipped`)

## Stack

This draft PR is stacked on #1353, which is green in hosted CI and preserves findings for dangerous callable objects captured before later overwrites.