### PR TITLE
fix: model certain setattr source mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - share trusted-content routing across direct, nested, and helper scans so renamed specialized archives retain their format-specific analysis
 - preserve dangerous callable findings when embedded source captures a callable before a later safe overwrite
 - detect high-risk embedded Python callables invoked through explicit `.__call__` wrappers
+- avoid embedded Python execution findings after statically certain safe `setattr` replacement
 - fail closed when nested NeMo checkpoint or referenced-artifact analysis is explicitly incomplete
 - preserve concrete nested security findings from checkpoint and referenced artifacts inside NeMo archives
 - keep PyTorch ZIP path traversal findings attributed to archive safety rules regardless of member names

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -294,6 +294,7 @@ _GLOBAL_NAMESPACE_HELPERS = {"globals", "builtins.globals"}
 _GLOBAL_NAMESPACE_MAPPING_MARKER = "<globals mapping>"
 _STATIC_REFERENCE_OVERRIDE_PREFIX = "<static reference override>:"
 _STATIC_DIRECT_MUTATION_ALIAS_PREFIX = "<static direct mutation alias>:"
+_STATIC_ATTRIBUTE_MUTATION_ALIAS_PREFIX = "<static attribute mutation alias>:"
 _CAPTURED_CALLABLE_REFERENCE_PREFIX = "<captured callable>:"
 _BUILTIN_NAMESPACE_NAMES = {"__builtin__", "__builtins__"}
 _STATIC_MAPPING_MUTATORS = {"__setitem__", "update"}
@@ -659,7 +660,9 @@ def _binding_names(target: ast.AST) -> Iterator[str]:
 
 class _HighRiskPythonCallVisitor(ast.NodeVisitor):
     def __init__(self, tracked_call_names: frozenset[str] | None = None) -> None:
-        self.alias_scopes: _AliasScopes = [{}]
+        self.alias_scopes: _AliasScopes = [
+            {self._static_attribute_mutation_alias_key("setattr"): frozenset({"setattr"})}
+        ]
         self._class_scope_ids: set[int] = set()
         self.risky_calls: set[str] = set()
         self.tracked_call_names = tracked_call_names
@@ -667,6 +670,9 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
     def _bind_import_name(self, local_name: str, import_name: str) -> None:
         effective_names = self._effective_reference_names(frozenset({import_name}))
         self._bind_name(local_name, self._capture_callable_names(effective_names))
+        helper_names = self._static_attribute_mutation_helper_names(effective_names)
+        if helper_names is not None:
+            self._bind_name(self._static_attribute_mutation_alias_key(local_name), helper_names)
 
     def _record_import(self, alias: ast.alias, import_name: str) -> None:
         self._bind_import_name(alias.asname or alias.name, import_name)
@@ -675,6 +681,8 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         self.alias_scopes[-1][name] = resolved_names
         if not name.startswith("<") and self._lookup_static_direct_mutation_alias(name) is not None:
             self.alias_scopes[-1][self._static_direct_mutation_alias_key(name)] = None
+        if not name.startswith("<") and self._lookup_static_attribute_mutation_alias_entry(name) is not _MISSING_ALIAS:
+            self.alias_scopes[-1][self._static_attribute_mutation_alias_key(name)] = None
 
     @staticmethod
     def _static_reference_override_key(reference_name: str) -> str:
@@ -683,6 +691,10 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
     @staticmethod
     def _static_direct_mutation_alias_key(name: str) -> str:
         return f"{_STATIC_DIRECT_MUTATION_ALIAS_PREFIX}{name}"
+
+    @staticmethod
+    def _static_attribute_mutation_alias_key(name: str) -> str:
+        return f"{_STATIC_ATTRIBUTE_MUTATION_ALIAS_PREFIX}{name}"
 
     def _lookup_static_reference_override(self, reference_name: str) -> _AliasValue:
         override_key = self._static_reference_override_key(reference_name)
@@ -698,6 +710,13 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
                 return aliases[alias_key]
         return None
 
+    def _lookup_static_attribute_mutation_alias_entry(self, name: str) -> _AliasValue | object:
+        alias_key = self._static_attribute_mutation_alias_key(name)
+        for aliases in reversed(self.alias_scopes):
+            if alias_key in aliases:
+                return aliases[alias_key]
+        return _MISSING_ALIAS
+
     def _resolve_certain_direct_builtin_mutator_names(self, node: ast.AST) -> frozenset[str] | None:
         direct_mutator_names = _resolve_direct_global_builtin_mutator_names(node, self.alias_scopes)
         if direct_mutator_names is not None:
@@ -705,6 +724,23 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         if isinstance(node, ast.Name):
             return self._lookup_static_direct_mutation_alias(node.id)
         return None
+
+    def _static_attribute_mutation_helper_names(self, resolved_names: _AliasValue) -> frozenset[str] | None:
+        if resolved_names is None:
+            return None
+        helper_names = frozenset(self._invoked_callable_reference_name(name) for name in resolved_names)
+        return helper_names if helper_names and helper_names.issubset(_STATIC_ATTRIBUTE_MUTATION_HELPERS) else None
+
+    def _resolve_certain_static_attribute_mutation_helper_names(self, node: ast.AST) -> frozenset[str] | None:
+        call_name = _resolve_call_name(node)
+        if call_name is not None:
+            helper_names = self._lookup_static_attribute_mutation_alias_entry(
+                self._invoked_callable_reference_name(call_name)
+            )
+            if helper_names is not _MISSING_ALIAS:
+                return helper_names if isinstance(helper_names, frozenset) else None
+
+        return self._static_attribute_mutation_helper_names(self._resolve_invoked_reference_names(node))
 
     def _is_tracked_call_name(self, name: str) -> bool:
         return (
@@ -812,8 +848,8 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         if len(node.args) != 3 or node.keywords:
             return
 
-        helper_names = self._resolve_invoked_reference_names(node.func)
-        if helper_names is None or not helper_names.issubset(_STATIC_ATTRIBUTE_MUTATION_HELPERS):
+        helper_names = self._resolve_certain_static_attribute_mutation_helper_names(node.func)
+        if helper_names is None:
             return
 
         target_names = _resolve_static_attribute_names(node.args[0], node.args[1], self.alias_scopes)
@@ -827,6 +863,9 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             direct_mutator_names = self._resolve_certain_direct_builtin_mutator_names(value)
             if direct_mutator_names is not None:
                 self._bind_name(self._static_direct_mutation_alias_key(target.id), direct_mutator_names)
+            attribute_mutation_names = self._resolve_certain_static_attribute_mutation_helper_names(value)
+            if attribute_mutation_names is not None:
+                self._bind_name(self._static_attribute_mutation_alias_key(target.id), attribute_mutation_names)
         elif isinstance(target, (ast.Attribute, ast.Subscript)):
             self._bind_static_reference_target_to_value(target, value)
         elif isinstance(target, ast.Starred):
@@ -924,7 +963,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         current_scope = self.alias_scopes[-1]
         branch_names = {name for scope in branch_scopes for name in scope}
         for name in branch_names:
-            if name.startswith(_STATIC_DIRECT_MUTATION_ALIAS_PREFIX):
+            if name.startswith((_STATIC_DIRECT_MUTATION_ALIAS_PREFIX, _STATIC_ATTRIBUTE_MUTATION_ALIAS_PREFIX)):
                 certainty_base_value = current_scope.get(name, _MISSING_ALIAS)
                 values = [scope.get(name, certainty_base_value) for scope in branch_scopes]
                 first_value = values[0]
@@ -1014,8 +1053,6 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
 
     def visit_Assign(self, node: ast.Assign) -> None:
         self.visit(node.value)
-        if isinstance(node.value, ast.Call):
-            self._bind_static_setattr_mutation(node.value)
         for target in node.targets:
             self._bind_target_to_value(target, node.value)
             self.visit(target)
@@ -1025,8 +1062,6 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             self.visit(node.annotation)
         if node.value is not None:
             self.visit(node.value)
-            if isinstance(node.value, ast.Call):
-                self._bind_static_setattr_mutation(node.value)
             self._bind_target_to_value(node.target, node.value)
         else:
             self._shadow_binding_target(node.target)
@@ -1046,7 +1081,6 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         self.visit(node.value)
         if isinstance(node.value, ast.Call):
             self._bind_direct_builtin_namespace_mutation(node.value)
-            self._bind_static_setattr_mutation(node.value)
 
     def _visit_loop(self, node: ast.For | ast.AsyncFor) -> None:
         self.visit(node.iter)
@@ -1160,6 +1194,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
                 if self._is_tracked_call_name(resolved_name):
                     self.risky_calls.add(resolved_name)
         self.generic_visit(node)
+        self._bind_static_setattr_mutation(node)
 
 
 def statically_resolved_python_call_names_in_tree(tree: ast.AST, tracked_call_names: frozenset[str]) -> set[str]:

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -297,6 +297,12 @@ _STATIC_DIRECT_MUTATION_ALIAS_PREFIX = "<static direct mutation alias>:"
 _CAPTURED_CALLABLE_REFERENCE_PREFIX = "<captured callable>:"
 _BUILTIN_NAMESPACE_NAMES = {"__builtin__", "__builtins__"}
 _STATIC_MAPPING_MUTATORS = {"__setitem__", "update"}
+_STATIC_ATTRIBUTE_MUTATION_HELPERS = {
+    "setattr",
+    "__builtin__.setattr",
+    "__builtins__.setattr",
+    "builtins.setattr",
+}
 
 
 def _resolve_global_namespace_mappings(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
@@ -801,6 +807,20 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         for target_names, value in mutations:
             self._bind_static_reference_names_to_value(target_names, value)
 
+    def _bind_static_setattr_mutation(self, node: ast.Call) -> None:
+        """Model certain builtin ``setattr`` writes to one resolved reference."""
+        if len(node.args) != 3 or node.keywords:
+            return
+
+        helper_names = self._resolve_invoked_reference_names(node.func)
+        if helper_names is None or not helper_names.issubset(_STATIC_ATTRIBUTE_MUTATION_HELPERS):
+            return
+
+        target_names = _resolve_static_attribute_names(node.args[0], node.args[1], self.alias_scopes)
+        if target_names is None or len(target_names) != 1:
+            return
+        self._bind_static_reference_names_to_value(target_names, node.args[2])
+
     def _bind_target_to_value(self, target: ast.AST, value: ast.AST) -> None:
         if isinstance(target, ast.Name):
             self._bind_name(target.id, self._resolve_bound_value_names(value))
@@ -994,6 +1014,8 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
 
     def visit_Assign(self, node: ast.Assign) -> None:
         self.visit(node.value)
+        if isinstance(node.value, ast.Call):
+            self._bind_static_setattr_mutation(node.value)
         for target in node.targets:
             self._bind_target_to_value(target, node.value)
             self.visit(target)
@@ -1003,6 +1025,8 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             self.visit(node.annotation)
         if node.value is not None:
             self.visit(node.value)
+            if isinstance(node.value, ast.Call):
+                self._bind_static_setattr_mutation(node.value)
             self._bind_target_to_value(node.target, node.value)
         else:
             self._shadow_binding_target(node.target)
@@ -1022,6 +1046,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         self.visit(node.value)
         if isinstance(node.value, ast.Call):
             self._bind_direct_builtin_namespace_mutation(node.value)
+            self._bind_static_setattr_mutation(node.value)
 
     def _visit_loop(self, node: ast.For | ast.AsyncFor) -> None:
         self.visit(node.iter)

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -410,6 +410,7 @@ class TestJITScriptDetector:
                 b"globals()['__builtins__']['eval']('pass')\n"
             ),
             b"import builtins\nsetattr(builtins, 'eval', builtins.exec)\nbuiltins.eval('pass')\n",
+            b"import builtins\nprint(setattr(builtins, 'eval', builtins.exec))\nbuiltins.eval('pass')\n",
         ],
     )
     def test_scan_model_detects_dangerous_builtin_reassignment(self, source: bytes) -> None:
@@ -472,6 +473,21 @@ class TestJITScriptDetector:
                 b"globals()['__builtins__']['eval']('1 + 1')\n"
             ),
             (b"import builtins\nif replace_builtin:\n    setattr(builtins, 'eval', len)\nbuiltins.eval('1 + 1')\n"),
+            (
+                b"import builtins\n"
+                b"assign = setattr\n"
+                b"if replace_builtin:\n"
+                b"    assign = lambda target, key, value: None\n"
+                b"assign(builtins, 'eval', len)\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"if replace_builtin:\n"
+                b"    setattr = lambda target, key, value: None\n"
+                b"setattr(builtins, 'eval', len)\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
             (
                 b"import builtins\n"
                 b"setattr = lambda target, key, value: None\n"

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -359,6 +359,9 @@ class TestJITScriptDetector:
                 b"invoke = globals()['__builtins__']['eval'].__call__\n"
                 b"invoke([])\n"
             ),
+            b"import builtins\nsetattr(builtins, 'eval', len)\nbuiltins.eval([])\n",
+            b"import builtins\nresult = setattr(builtins, 'eval', len)\nbuiltins.eval([])\n",
+            (b"import builtins as bi\nfrom builtins import setattr as assign\nassign(bi, 'eval', len)\nbi.eval([])\n"),
             b"def payload():\n    eval = len\n    return eval([])\n",
             (
                 b"def payload():\n"
@@ -406,6 +409,7 @@ class TestJITScriptDetector:
                 b"globals()['__builtins__']['exec'] = len\n"
                 b"globals()['__builtins__']['eval']('pass')\n"
             ),
+            b"import builtins\nsetattr(builtins, 'eval', builtins.exec)\nbuiltins.eval('pass')\n",
         ],
     )
     def test_scan_model_detects_dangerous_builtin_reassignment(self, source: bytes) -> None:
@@ -466,6 +470,21 @@ class TestJITScriptDetector:
                 b"import helpers as replace\n"
                 b"replace({'eval': len})\n"
                 b"globals()['__builtins__']['eval']('1 + 1')\n"
+            ),
+            (b"import builtins\nif replace_builtin:\n    setattr(builtins, 'eval', len)\nbuiltins.eval('1 + 1')\n"),
+            (
+                b"import builtins\n"
+                b"setattr = lambda target, key, value: None\n"
+                b"setattr(builtins, 'eval', len)\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"try:\n"
+                b"    setattr(builtins, 'eval', len)\n"
+                b"except Exception:\n"
+                b"    pass\n"
+                b"builtins.eval('1 + 1')\n"
             ),
         ],
     )

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1154,6 +1154,7 @@ def test_pytorch_zip_scans_aliased_modeled_builtins_in_archive_data(
             b"replace({'eval': len})\n"
             b"globals()['__builtins__']['eval']([])\n"
         ),
+        b"setattr(globals()['__builtins__'], 'eval', len)\nglobals()['__builtins__']['eval']([])\n",
         (b"globals()['__builtins__']['eval'] = len\nrun = globals()['__builtins__']['eval']\nrun([])\n"),
         (b"globals()['__builtins__']['eval'] = len\nrun = globals()['__builtins__']['eval']\nrun.__call__([])\n"),
         (b"globals()['__builtins__'].__setitem__('eval', len)\nrun = globals()['__builtins__']['eval']\nrun([])\n"),
@@ -1212,6 +1213,10 @@ def test_pytorch_zip_ignores_benign_builtin_shaped_access_in_archive_data(tmp_pa
         (
             b"replace = globals()['__builtins__'].update\n"
             b"replace({'eval': __builtins__['exec']})\n"
+            b"globals()['__builtins__']['eval']('pass')\n"
+        ),
+        (
+            b"setattr(globals()['__builtins__'], 'eval', __builtins__['exec'])\n"
             b"globals()['__builtins__']['eval']('pass')\n"
         ),
     ],

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -147,6 +147,13 @@ class TestTarScanner:
             b"import os\ninvoke = os.system.__call__\nos.system = len\ninvoke('echo hidden')\n",
             b"import os\nrun = os.system\nos.system = len\nrun('echo hidden')\n",
             b"import os\nfrom os import system as run\nos.system = len\nrun('echo hidden')\n",
+            b"import os\nrun = os.system\nsetattr(os, 'system', len)\nrun('echo hidden')\n",
+            (
+                b"import os\n"
+                b"setattr = lambda target, key, value: None\n"
+                b"setattr(os, 'system', len)\n"
+                b"os.system('echo hidden')\n"
+            ),
         ],
     )
     def test_scan_tar_preserves_captured_dangerous_callable_before_overwrite(
@@ -172,6 +179,9 @@ class TestTarScanner:
             b"import os\nos.system = len\ninvoke = os.system.__call__\ninvoke([])\n",
             b"import os\nos.system = len\nrun = os.system\nrun([])\n",
             b"import os\nos.system = len\nfrom os import system as run\nrun([])\n",
+            b"import os\nsetattr(os, 'system', len)\nos.system([])\n",
+            b"import os\nreplace = setattr\nreplace(os, 'system', len)\nos.system([])\n",
+            b"import os\nsetattr(os, 'system', len)\nrun = os.system\nrun([])\n",
         ],
     )
     def test_scan_tar_allows_callable_captured_after_safe_overwrite(self, tmp_path: Path, payload: bytes) -> None:
@@ -201,6 +211,21 @@ class TestTarScanner:
         assert len(python_checks) == 1
         assert python_checks[0].status == CheckStatus.FAILED
         assert python_checks[0].severity == IssueSeverity.WARNING
+        assert python_checks[0].details["reason"] == "high-risk calls: subprocess.run"
+
+    def test_scan_tar_reports_dangerous_setattr_replacement(self, tmp_path: Path) -> None:
+        archive_path = tmp_path / "model_bundle.tar"
+        payload = b"import os\nimport subprocess\nsetattr(os, 'system', subprocess.run)\nos.system(['id'])\n"
+        with tarfile.open(archive_path, "w") as archive:
+            info = tarfile.TarInfo("handler.py")
+            info.size = len(payload)
+            archive.addfile(info, tarfile.io.BytesIO(payload))  # type: ignore[attr-defined]
+
+        result = self.scanner.scan(str(archive_path))
+
+        python_checks = [check for check in result.checks if check.name == "Python Archive Member Security"]
+        assert len(python_checks) == 1
+        assert python_checks[0].status == CheckStatus.FAILED
         assert python_checks[0].details["reason"] == "high-risk calls: subprocess.run"
 
     def test_scan_tar_flags_builtins_getattr_keyword_call_dangerous_python_member(self, tmp_path: Path) -> None:

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -391,6 +391,11 @@ def test_scan_detects_implicit_builtins_handler_execution_primitive(
         ),
         (
             b"def handle(data, context):\n"
+            b"    setattr(globals()['__builtins__'], 'eval', len)\n"
+            b"    return globals()['__builtins__']['eval']([])\n"
+        ),
+        (
+            b"def handle(data, context):\n"
             b"    globals()['__builtins__']['eval'] = len\n"
             b"    run = globals()['__builtins__']['eval']\n"
             b"    return run([])\n"
@@ -462,6 +467,11 @@ def test_scan_allows_benign_builtin_shaped_handler_source(tmp_path: Path, handle
             b"def handle(data, context):\n"
             b"    replace = globals()['__builtins__'].update\n"
             b"    replace({'eval': __builtins__['exec']})\n"
+            b"    return globals()['__builtins__']['eval']('pass')\n"
+        ),
+        (
+            b"def handle(data, context):\n"
+            b"    setattr(globals()['__builtins__'], 'eval', __builtins__['exec'])\n"
             b"    return globals()['__builtins__']['eval']('pass')\n"
         ),
     ],

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -170,6 +170,13 @@ def test_scan_zip_flags_aliased_dangerous_python_member(tmp_path: Path) -> None:
         "import os\nfrom os import system as run\nos.system = len\nrun('echo hidden')\n",
         "import os\nfrom os import *\nos.system = len\nsystem('echo hidden')\n",
         ("import os\ndef run(action=os.system):\n    os.system = len\n    action('echo hidden')\n"),
+        "import os\nrun = os.system\nsetattr(os, 'system', len)\nrun('echo hidden')\n",
+        (
+            "import os\n"
+            "setattr = lambda target, key, value: None\n"
+            "setattr(os, 'system', len)\n"
+            "os.system('echo hidden')\n"
+        ),
     ],
 )
 def test_scan_zip_preserves_captured_dangerous_callable_before_overwrite(tmp_path: Path, source: str) -> None:
@@ -198,6 +205,11 @@ def test_scan_zip_preserves_captured_dangerous_callable_before_overwrite(tmp_pat
         "import os\nos.system = len\nfrom os import system as run\nrun([])\n",
         "import os\nos.system = len\nfrom os import *\nsystem([])\n",
         ("import os\nos.system = len\ndef run(action=os.system):\n    action([])\n"),
+        "import os\nsetattr(os, 'system', len)\nos.system([])\n",
+        "import os\nreplace = setattr\nreplace(os, 'system', len)\nos.system([])\n",
+        "import os\nresult = setattr(os, 'system', len)\nos.system([])\n",
+        "import os\nresult: None = setattr(os, 'system', len)\nos.system([])\n",
+        "import os\nsetattr(os, 'system', len)\nrun = os.system\nrun([])\n",
     ],
 )
 def test_scan_zip_allows_callable_captured_after_safe_overwrite(tmp_path: Path, source: str) -> None:
@@ -224,6 +236,29 @@ def test_scan_zip_flags_from_import_dangerous_python_member(tmp_path: Path) -> N
     ]
     assert len(python_checks) == 1
     assert python_checks[0].severity == IssueSeverity.WARNING
+    assert python_checks[0].details["reason"] == "high-risk calls: subprocess.run"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "import os\nimport subprocess\nsetattr(os, 'system', subprocess.run)\nos.system(['id'])\n",
+        "import os\nimport subprocess\nresult = setattr(os, 'system', subprocess.run)\nos.system(['id'])\n",
+    ],
+)
+def test_scan_zip_reports_dangerous_setattr_replacement(tmp_path: Path, source: str) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", source)
+
+    result = ZipScanner().scan(str(archive_path))
+
+    python_checks = [
+        check
+        for check in result.checks
+        if check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED
+    ]
+    assert len(python_checks) == 1
     assert python_checks[0].details["reason"] == "high-risk calls: subprocess.run"
 
 


### PR DESCRIPTION
## Summary

- model statically certain builtin `setattr` writes in embedded Python source analysis
- remove false positives after proven safe replacements while improving dangerous replacement attribution
- retain findings for captured-before-write, conditional, exception-guarded, and shadowed-setter cases

## Root Cause

The source analyzer modeled direct assignments and selected builtin-mapping mutation methods, but ignored equivalent writes performed through builtin `setattr`. Consequently, safe code such as `setattr(os, 'system', len); os.system([])` or `setattr(builtins, 'eval', len); builtins.eval([])` still produced security findings. Dangerous writes were caught only as the old target name rather than the assigned callable identity.

## Changes

- recognize `setattr` only when the helper statically resolves to the builtin setter and the destination resolves to exactly one static member
- apply the modeled write for direct expression statements, assignment RHS calls, and annotated-assignment RHS calls, where execution of the call is certain in the modeled sequence
- reuse captured-callable and branch-merge semantics so a dangerous callable saved before a safe write remains reported and conditional/try-protected writes do not suppress potential execution
- record the public false-positive improvement in `CHANGELOG.md`

## Security Regression Coverage

Positive controls verify captured `os.system` remains reported across a later safe `setattr`, dangerous replacement is attributed to `subprocess.run` or `exec`, and shadowed, conditional, and exception-guarded setter calls do not suppress findings.

Negative controls verify safe unconditional `setattr` replacement is clean for `os.system` and builtin `eval`, including aliased setters, later callable capture, assignment-result calls, and annotated-assignment-result calls. The behavior is exercised through standalone JIT and ZIP/TAR/PyTorch ZIP/TorchServe consumers.

## Validation

- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest tests/detectors/test_jit_script_detector.py tests/scanners/test_pytorch_zip_scanner.py tests/scanners/test_zip_scanner.py tests/scanners/test_tar_scanner.py tests/scanners/test_torchserve_mar_scanner.py -q` (`659 passed, 99 skipped`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`5140 passed, 1045 skipped`)

## Stack

This draft PR is stacked on #1354, which is green in hosted CI and detects high-risk source callables invoked through explicit `.__call__` wrappers.