### PR TITLE
fix: model resolved namespace mapping mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - preserve dangerous callable findings when embedded source captures a callable before a later safe overwrite
 - detect high-risk embedded Python callables invoked through explicit `.__call__` wrappers
 - avoid embedded Python execution findings after statically certain safe `setattr` replacement
+- avoid embedded Python execution findings after statically certain namespace-mapping replacement
+- preserve embedded Python execution findings when a replacement receiver is conditional, aliased, or a runtime argument
 - fail closed when nested NeMo checkpoint or referenced-artifact analysis is explicitly incomplete
 - preserve concrete nested security findings from checkpoint and referenced artifacts inside NeMo archives
 - keep PyTorch ZIP path traversal findings attributed to archive safety rules regardless of member names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - avoid embedded Python execution findings after statically certain safe `setattr` replacement
 - avoid embedded Python execution findings after statically certain namespace-mapping replacement
 - model reflective and saved namespace-map replacements when their receiver remains certain
+- model deterministic mapping-helper replacements when their helper and receiver remain certain
 - preserve embedded Python execution findings when a replacement receiver is conditional, aliased, or a runtime argument
 - fail closed when nested NeMo checkpoint or referenced-artifact analysis is explicitly incomplete
 - preserve concrete nested security findings from checkpoint and referenced artifacts inside NeMo archives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - detect high-risk embedded Python callables invoked through explicit `.__call__` wrappers
 - avoid embedded Python execution findings after statically certain safe `setattr` replacement
 - avoid embedded Python execution findings after statically certain namespace-mapping replacement
+- model reflective and saved namespace-map replacements when their receiver remains certain
 - preserve embedded Python execution findings when a replacement receiver is conditional, aliased, or a runtime argument
 - fail closed when nested NeMo checkpoint or referenced-artifact analysis is explicitly incomplete
 - preserve concrete nested security findings from checkpoint and referenced artifacts inside NeMo archives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - share trusted-content routing across direct, nested, and helper scans so renamed specialized archives retain their format-specific analysis
 - preserve dangerous callable findings when embedded source captures a callable before a later safe overwrite
 - detect high-risk embedded Python callables invoked through explicit `.__call__` wrappers
+- avoid embedded Python execution findings after statically certain safe `setattr` replacement
 - fail closed when nested NeMo checkpoint or referenced-artifact analysis is explicitly incomplete
 - preserve concrete nested security findings from checkpoint and referenced artifacts inside NeMo archives
 - keep PyTorch ZIP path traversal findings attributed to archive safety rules regardless of member names

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -424,13 +424,6 @@ def _resolve_certain_namespace_mutation_roots(node: ast.AST, alias_scopes: _Alia
     if direct_builtin_roots is not None:
         return direct_builtin_roots
 
-    is_explicit_namespace_mapping = isinstance(node, ast.Attribute) and node.attr == "__dict__"
-    if isinstance(node, ast.Call) and len(node.args) == 1 and not node.keywords:
-        helper_name = _resolve_call_name(node.func)
-        helper_names = _apply_aliases(helper_name, alias_scopes) if helper_name is not None else None
-        is_explicit_namespace_mapping = helper_names is not None and helper_names.issubset({"vars", "builtins.vars"})
-    if not is_explicit_namespace_mapping:
-        return None
     if _has_uncertain_static_binding(node, alias_scopes):
         return None
 

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -293,7 +293,8 @@ _NAMESPACE_MAPPING_ACCESSORS = {"get", "__getitem__", "pop", "setdefault"}
 _GLOBAL_NAMESPACE_HELPERS = {"globals", "builtins.globals"}
 _GLOBAL_NAMESPACE_MAPPING_MARKER = "<globals mapping>"
 _STATIC_REFERENCE_OVERRIDE_PREFIX = "<static reference override>:"
-_STATIC_DIRECT_MUTATION_ALIAS_PREFIX = "<static direct mutation alias>:"
+_STATIC_MAPPING_MUTATION_ALIAS_PREFIX = "<static mapping mutation alias>:"
+_STATIC_UNCERTAIN_BINDING_PREFIX = "<uncertain static binding>:"
 _CAPTURED_CALLABLE_REFERENCE_PREFIX = "<captured callable>:"
 _BUILTIN_NAMESPACE_NAMES = {"__builtin__", "__builtins__"}
 _STATIC_MAPPING_MUTATORS = {"__setitem__", "update"}
@@ -303,6 +304,20 @@ _STATIC_ATTRIBUTE_MUTATION_HELPERS = {
     "__builtins__.setattr",
     "builtins.setattr",
 }
+
+
+def _has_uncertain_static_binding(node: ast.AST, alias_scopes: _AliasScopes) -> bool:
+    """Return whether ``node`` uses a name whose identity diverged across branches."""
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Name):
+            continue
+        uncertainty_key = f"{_STATIC_UNCERTAIN_BINDING_PREFIX}{child.id}"
+        for aliases in reversed(alias_scopes):
+            if uncertainty_key in aliases:
+                if aliases[uncertainty_key] is None:
+                    return True
+                break
+    return False
 
 
 def _resolve_global_namespace_mappings(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
@@ -403,12 +418,32 @@ def _resolve_direct_global_builtin_namespace_roots(node: ast.AST, alias_scopes: 
     return frozenset({attr_name})
 
 
-def _resolve_direct_global_builtin_mutator_names(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
-    """Resolve mutator methods bound from a direct, unshadowed builtin mapping."""
+def _resolve_certain_namespace_mutation_roots(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
+    """Resolve namespace mappings whose mutation target is statically certain."""
+    direct_builtin_roots = _resolve_direct_global_builtin_namespace_roots(node, alias_scopes)
+    if direct_builtin_roots is not None:
+        return direct_builtin_roots
+
+    is_explicit_namespace_mapping = isinstance(node, ast.Attribute) and node.attr == "__dict__"
+    if isinstance(node, ast.Call) and len(node.args) == 1 and not node.keywords:
+        helper_name = _resolve_call_name(node.func)
+        helper_names = _apply_aliases(helper_name, alias_scopes) if helper_name is not None else None
+        is_explicit_namespace_mapping = helper_names is not None and helper_names.issubset({"vars", "builtins.vars"})
+    if not is_explicit_namespace_mapping:
+        return None
+    if _has_uncertain_static_binding(node, alias_scopes):
+        return None
+
+    target_roots = _resolve_namespace_dict_roots(node, alias_scopes)
+    return target_roots if target_roots is not None and len(target_roots) == 1 else None
+
+
+def _resolve_static_mapping_mutator_names(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
+    """Resolve mutation methods bound from one certain namespace mapping."""
     if not isinstance(node, ast.Attribute) or node.attr not in _STATIC_MAPPING_MUTATORS:
         return None
 
-    target_roots = _resolve_direct_global_builtin_namespace_roots(node.value, alias_scopes)
+    target_roots = _resolve_certain_namespace_mutation_roots(node.value, alias_scopes)
     if target_roots is None:
         return None
     return frozenset(f"{target_root}.{node.attr}" for target_root in target_roots)
@@ -673,16 +708,22 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
 
     def _bind_name(self, name: str, resolved_names: _AliasValue) -> None:
         self.alias_scopes[-1][name] = resolved_names
-        if not name.startswith("<") and self._lookup_static_direct_mutation_alias(name) is not None:
-            self.alias_scopes[-1][self._static_direct_mutation_alias_key(name)] = None
+        if not name.startswith("<"):
+            self.alias_scopes[-1][self._static_uncertain_binding_key(name)] = frozenset()
+            if self._lookup_static_mapping_mutation_alias(name) is not None:
+                self.alias_scopes[-1][self._static_mapping_mutation_alias_key(name)] = None
 
     @staticmethod
     def _static_reference_override_key(reference_name: str) -> str:
         return f"{_STATIC_REFERENCE_OVERRIDE_PREFIX}{reference_name}"
 
     @staticmethod
-    def _static_direct_mutation_alias_key(name: str) -> str:
-        return f"{_STATIC_DIRECT_MUTATION_ALIAS_PREFIX}{name}"
+    def _static_mapping_mutation_alias_key(name: str) -> str:
+        return f"{_STATIC_MAPPING_MUTATION_ALIAS_PREFIX}{name}"
+
+    @staticmethod
+    def _static_uncertain_binding_key(name: str) -> str:
+        return f"{_STATIC_UNCERTAIN_BINDING_PREFIX}{name}"
 
     def _lookup_static_reference_override(self, reference_name: str) -> _AliasValue:
         override_key = self._static_reference_override_key(reference_name)
@@ -691,19 +732,19 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
                 return aliases[override_key]
         return frozenset({reference_name})
 
-    def _lookup_static_direct_mutation_alias(self, name: str) -> _AliasValue:
-        alias_key = self._static_direct_mutation_alias_key(name)
+    def _lookup_static_mapping_mutation_alias(self, name: str) -> _AliasValue:
+        alias_key = self._static_mapping_mutation_alias_key(name)
         for aliases in reversed(self.alias_scopes):
             if alias_key in aliases:
                 return aliases[alias_key]
         return None
 
-    def _resolve_certain_direct_builtin_mutator_names(self, node: ast.AST) -> frozenset[str] | None:
-        direct_mutator_names = _resolve_direct_global_builtin_mutator_names(node, self.alias_scopes)
-        if direct_mutator_names is not None:
-            return direct_mutator_names
+    def _resolve_certain_static_mapping_mutator_names(self, node: ast.AST) -> frozenset[str] | None:
+        mutator_names = _resolve_static_mapping_mutator_names(node, self.alias_scopes)
+        if mutator_names is not None:
+            return mutator_names
         if isinstance(node, ast.Name):
-            return self._lookup_static_direct_mutation_alias(node.id)
+            return self._lookup_static_mapping_mutation_alias(node.id)
         return None
 
     def _is_tracked_call_name(self, name: str) -> bool:
@@ -758,6 +799,8 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         return self._capture_callable_names(self._resolve_invoked_reference_names(node))
 
     def _bind_static_reference_target_to_value(self, target: ast.AST, value: ast.AST) -> None:
+        if _has_uncertain_static_binding(target, self.alias_scopes):
+            return
         target_names = _resolve_static_assignment_target_names(target, self.alias_scopes)
         if target_names is None:
             return
@@ -769,12 +812,12 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         for target_name in target_names:
             self._bind_name(self._static_reference_override_key(target_name), resolved_value_names)
 
-    def _bind_direct_builtin_namespace_mutation(self, node: ast.Call) -> None:
-        """Model unconditional mutations of a directly addressed builtin mapping."""
+    def _bind_static_mapping_mutation(self, node: ast.Call) -> None:
+        """Model unconditional writes through one certain namespace mapping."""
         if node.keywords:
             return
 
-        mutator_names = self._resolve_certain_direct_builtin_mutator_names(node.func)
+        mutator_names = self._resolve_certain_static_mapping_mutator_names(node.func)
         if mutator_names is None:
             return
         methods = {mutator_name.rsplit(".", maxsplit=1)[1] for mutator_name in mutator_names}
@@ -811,6 +854,8 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         """Model certain builtin ``setattr`` writes to one resolved reference."""
         if len(node.args) != 3 or node.keywords:
             return
+        if _has_uncertain_static_binding(node.args[0], self.alias_scopes):
+            return
 
         helper_names = self._resolve_invoked_reference_names(node.func)
         if helper_names is None or not helper_names.issubset(_STATIC_ATTRIBUTE_MUTATION_HELPERS):
@@ -823,10 +868,13 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
 
     def _bind_target_to_value(self, target: ast.AST, value: ast.AST) -> None:
         if isinstance(target, ast.Name):
+            value_binding_is_uncertain = _has_uncertain_static_binding(value, self.alias_scopes)
             self._bind_name(target.id, self._resolve_bound_value_names(value))
-            direct_mutator_names = self._resolve_certain_direct_builtin_mutator_names(value)
-            if direct_mutator_names is not None:
-                self._bind_name(self._static_direct_mutation_alias_key(target.id), direct_mutator_names)
+            if value_binding_is_uncertain:
+                self.alias_scopes[-1][self._static_uncertain_binding_key(target.id)] = None
+            mutator_names = self._resolve_certain_static_mapping_mutator_names(value)
+            if mutator_names is not None:
+                self._bind_name(self._static_mapping_mutation_alias_key(target.id), mutator_names)
         elif isinstance(target, (ast.Attribute, ast.Subscript)):
             self._bind_static_reference_target_to_value(target, value)
         elif isinstance(target, ast.Starred):
@@ -857,15 +905,19 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
                 arg.arg,
                 self._resolve_bound_value_names(default) if default is not None else None,
             )
+            self.alias_scopes[-1][self._static_uncertain_binding_key(arg.arg)] = None
         for arg, default in zip(arguments.kwonlyargs, arguments.kw_defaults, strict=True):
             self._bind_name(
                 arg.arg,
                 self._resolve_bound_value_names(default) if default is not None else None,
             )
+            self.alias_scopes[-1][self._static_uncertain_binding_key(arg.arg)] = None
         if arguments.vararg is not None:
             self._bind_name(arguments.vararg.arg, None)
+            self.alias_scopes[-1][self._static_uncertain_binding_key(arguments.vararg.arg)] = None
         if arguments.kwarg is not None:
             self._bind_name(arguments.kwarg.arg, None)
+            self.alias_scopes[-1][self._static_uncertain_binding_key(arguments.kwarg.arg)] = None
 
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
@@ -924,13 +976,22 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         current_scope = self.alias_scopes[-1]
         branch_names = {name for scope in branch_scopes for name in scope}
         for name in branch_names:
-            if name.startswith(_STATIC_DIRECT_MUTATION_ALIAS_PREFIX):
-                certainty_base_value = current_scope.get(name, _MISSING_ALIAS)
-                values = [scope.get(name, certainty_base_value) for scope in branch_scopes]
-                first_value = values[0]
+            if name.startswith(_STATIC_UNCERTAIN_BINDING_PREFIX):
+                uncertainty_base_value = current_scope.get(name, frozenset())
+                uncertainty_values = [scope.get(name, uncertainty_base_value) for scope in branch_scopes]
+                current_scope[name] = (
+                    None
+                    if current_scope.get(name) is None or any(value is None for value in uncertainty_values)
+                    else frozenset()
+                )
+                continue
+            if name.startswith(_STATIC_MAPPING_MUTATION_ALIAS_PREFIX):
+                certainty_base_value: _AliasValue | object = current_scope.get(name, _MISSING_ALIAS)
+                certainty_values = [scope.get(name, certainty_base_value) for scope in branch_scopes]
+                first_value = certainty_values[0]
                 current_scope[name] = (
                     first_value
-                    if isinstance(first_value, frozenset) and all(value == first_value for value in values)
+                    if isinstance(first_value, frozenset) and all(value == first_value for value in certainty_values)
                     else None
                 )
                 continue
@@ -941,11 +1002,15 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
                 )
             else:
                 base_value = current_scope.get(name, _MISSING_ALIAS)
-            values = [scope.get(name, base_value) for scope in branch_scopes]
-            concrete_aliases = frozenset(alias for value in values if isinstance(value, frozenset) for alias in value)
+            branch_values = [scope.get(name, base_value) for scope in branch_scopes]
+            if not name.startswith("<") and any(value != branch_values[0] for value in branch_values[1:]):
+                current_scope[self._static_uncertain_binding_key(name)] = None
+            concrete_aliases = frozenset(
+                alias for value in branch_values if isinstance(value, frozenset) for alias in value
+            )
             if concrete_aliases:
                 current_scope[name] = concrete_aliases
-            elif any(value is None for value in values):
+            elif any(value is None for value in branch_values):
                 current_scope[name] = None
 
     def _visit_child_scope_without_class_locals(self, body: list[ast.stmt]) -> None:
@@ -1015,6 +1080,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
     def visit_Assign(self, node: ast.Assign) -> None:
         self.visit(node.value)
         if isinstance(node.value, ast.Call):
+            self._bind_static_mapping_mutation(node.value)
             self._bind_static_setattr_mutation(node.value)
         for target in node.targets:
             self._bind_target_to_value(target, node.value)
@@ -1026,6 +1092,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         if node.value is not None:
             self.visit(node.value)
             if isinstance(node.value, ast.Call):
+                self._bind_static_mapping_mutation(node.value)
                 self._bind_static_setattr_mutation(node.value)
             self._bind_target_to_value(node.target, node.value)
         else:
@@ -1045,7 +1112,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
     def visit_Expr(self, node: ast.Expr) -> None:
         self.visit(node.value)
         if isinstance(node.value, ast.Call):
-            self._bind_direct_builtin_namespace_mutation(node.value)
+            self._bind_static_mapping_mutation(node.value)
             self._bind_static_setattr_mutation(node.value)
 
     def _visit_loop(self, node: ast.For | ast.AsyncFor) -> None:

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -304,6 +304,13 @@ _STATIC_ATTRIBUTE_MUTATION_HELPERS = {
     "__builtins__.setattr",
     "builtins.setattr",
 }
+_STATIC_MAPPING_FUNCTION_MUTATORS = {
+    "dict.__setitem__": "__setitem__",
+    "builtins.dict.__setitem__": "__setitem__",
+    "dict.update": "update",
+    "builtins.dict.update": "update",
+    "operator.setitem": "__setitem__",
+}
 
 
 def _has_uncertain_static_binding(node: ast.AST, alias_scopes: _AliasScopes) -> bool:
@@ -811,26 +818,43 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             return
 
         mutator_names = self._resolve_certain_static_mapping_mutator_names(node.func)
-        if mutator_names is None:
-            return
-        methods = {mutator_name.rsplit(".", maxsplit=1)[1] for mutator_name in mutator_names}
-        if len(methods) != 1:
-            return
-        method = next(iter(methods))
-        target_roots = frozenset(mutator_name.rsplit(".", maxsplit=1)[0] for mutator_name in mutator_names)
+        mutation_args = node.args
+        if mutator_names is not None:
+            methods = {mutator_name.rsplit(".", maxsplit=1)[1] for mutator_name in mutator_names}
+            if len(methods) != 1:
+                return
+            method = next(iter(methods))
+            target_roots = frozenset(mutator_name.rsplit(".", maxsplit=1)[0] for mutator_name in mutator_names)
+        else:
+            if _has_uncertain_static_binding(node.func, self.alias_scopes) or not node.args:
+                return
+            helper_names = self._resolve_invoked_reference_names(node.func)
+            if helper_names is None:
+                return
+            helper_methods = {_STATIC_MAPPING_FUNCTION_MUTATORS.get(helper_name) for helper_name in helper_names}
+            if None in helper_methods or len(helper_methods) != 1:
+                return
+            method = next(helper_method for helper_method in helper_methods if helper_method is not None)
+            resolved_target_roots = _resolve_certain_namespace_mutation_roots(node.args[0], self.alias_scopes)
+            if resolved_target_roots is None:
+                return
+            target_roots = resolved_target_roots
+            mutation_args = node.args[1:]
 
         mutations: list[tuple[frozenset[str], ast.AST]] = []
         if method == "__setitem__":
-            if len(node.args) != 2:
+            if len(mutation_args) != 2:
                 return
-            attr_name = _resolve_static_string(node.args[0])
+            attr_name = _resolve_static_string(mutation_args[0])
             if attr_name is None:
                 return
-            mutations.append((frozenset(f"{target_root}.{attr_name}" for target_root in target_roots), node.args[1]))
+            mutations.append(
+                (frozenset(f"{target_root}.{attr_name}" for target_root in target_roots), mutation_args[1])
+            )
         elif method == "update":
-            if len(node.args) != 1 or not isinstance(node.args[0], ast.Dict):
+            if len(mutation_args) != 1 or not isinstance(mutation_args[0], ast.Dict):
                 return
-            for attr_name_node, value_node in zip(node.args[0].keys, node.args[0].values, strict=True):
+            for attr_name_node, value_node in zip(mutation_args[0].keys, mutation_args[0].values, strict=True):
                 if attr_name_node is None:
                     return
                 attr_name = _resolve_static_string(attr_name_node)

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -297,6 +297,12 @@ _STATIC_DIRECT_MUTATION_ALIAS_PREFIX = "<static direct mutation alias>:"
 _CAPTURED_CALLABLE_REFERENCE_PREFIX = "<captured callable>:"
 _BUILTIN_NAMESPACE_NAMES = {"__builtin__", "__builtins__"}
 _STATIC_MAPPING_MUTATORS = {"__setitem__", "update"}
+_STATIC_ATTRIBUTE_MUTATION_HELPERS = {
+    "setattr",
+    "__builtin__.setattr",
+    "__builtins__.setattr",
+    "builtins.setattr",
+}
 
 
 def _resolve_global_namespace_mappings(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
@@ -801,6 +807,20 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         for target_names, value in mutations:
             self._bind_static_reference_names_to_value(target_names, value)
 
+    def _bind_static_setattr_mutation(self, node: ast.Call) -> None:
+        """Model certain builtin ``setattr`` writes to one resolved reference."""
+        if len(node.args) != 3 or node.keywords:
+            return
+
+        helper_names = self._resolve_invoked_reference_names(node.func)
+        if helper_names is None or not helper_names.issubset(_STATIC_ATTRIBUTE_MUTATION_HELPERS):
+            return
+
+        target_names = _resolve_static_attribute_names(node.args[0], node.args[1], self.alias_scopes)
+        if target_names is None or len(target_names) != 1:
+            return
+        self._bind_static_reference_names_to_value(target_names, node.args[2])
+
     def _bind_target_to_value(self, target: ast.AST, value: ast.AST) -> None:
         if isinstance(target, ast.Name):
             self._bind_name(target.id, self._resolve_bound_value_names(value))
@@ -994,6 +1014,8 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
 
     def visit_Assign(self, node: ast.Assign) -> None:
         self.visit(node.value)
+        if isinstance(node.value, ast.Call):
+            self._bind_static_setattr_mutation(node.value)
         for target in node.targets:
             self._bind_target_to_value(target, node.value)
             self.visit(target)
@@ -1003,6 +1025,8 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             self.visit(node.annotation)
         if node.value is not None:
             self.visit(node.value)
+            if isinstance(node.value, ast.Call):
+                self._bind_static_setattr_mutation(node.value)
             self._bind_target_to_value(node.target, node.value)
         else:
             self._shadow_binding_target(node.target)
@@ -1022,6 +1046,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         self.visit(node.value)
         if isinstance(node.value, ast.Call):
             self._bind_direct_builtin_namespace_mutation(node.value)
+            self._bind_static_setattr_mutation(node.value)
 
     def _visit_loop(self, node: ast.For | ast.AsyncFor) -> None:
         self.visit(node.iter)

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -362,6 +362,8 @@ class TestJITScriptDetector:
             b"import builtins\nsetattr(builtins, 'eval', len)\nbuiltins.eval([])\n",
             b"import builtins\nresult = setattr(builtins, 'eval', len)\nbuiltins.eval([])\n",
             (b"import builtins as bi\nfrom builtins import setattr as assign\nassign(bi, 'eval', len)\nbi.eval([])\n"),
+            b"import builtins\nbuiltins.__dict__.update({'eval': len})\nbuiltins.eval([])\n",
+            b"import builtins\nreplace = builtins.__dict__.update\nreplace({'eval': len})\nbuiltins.eval([])\n",
             b"def payload():\n    eval = len\n    return eval([])\n",
             (
                 b"def payload():\n"
@@ -410,6 +412,7 @@ class TestJITScriptDetector:
                 b"globals()['__builtins__']['eval']('pass')\n"
             ),
             b"import builtins\nsetattr(builtins, 'eval', builtins.exec)\nbuiltins.eval('pass')\n",
+            b"import builtins\nbuiltins.__dict__.update({'eval': builtins.exec})\nbuiltins.eval('pass')\n",
         ],
     )
     def test_scan_model_detects_dangerous_builtin_reassignment(self, source: bytes) -> None:
@@ -485,6 +488,66 @@ class TestJITScriptDetector:
                 b"except Exception:\n"
                 b"    pass\n"
                 b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"if replace_builtin:\n"
+                b"    builtins.__dict__.update({'eval': len})\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"replace = builtins.__dict__.update\n"
+                b"replace = lambda values: None\n"
+                b"replace({'eval': len})\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"if swap:\n"
+                b"    builtins = make_namespace()\n"
+                b"builtins.__dict__.update({'eval': len})\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"if swap:\n"
+                b"    builtins = make_namespace()\n"
+                b"setattr(builtins, 'eval', len)\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"if swap:\n"
+                b"    builtins = make_namespace()\n"
+                b"builtins.eval = len\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"if swap:\n"
+                b"    builtins = make_namespace()\n"
+                b"namespace = builtins\n"
+                b"namespace.__dict__.update({'eval': len})\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"def invoke(namespace=builtins):\n"
+                b"    namespace.__dict__.update({'eval': len})\n"
+                b"    return builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"def invoke(namespace=builtins):\n"
+                b"    setattr(namespace, 'eval', len)\n"
+                b"    return builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"def invoke(namespace=builtins):\n"
+                b"    namespace.eval = len\n"
+                b"    return builtins.eval('1 + 1')\n"
             ),
         ],
     )

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -366,6 +366,8 @@ class TestJITScriptDetector:
             b"import builtins\nreplace = builtins.__dict__.update\nreplace({'eval': len})\nbuiltins.eval([])\n",
             b"import builtins\ngetattr(builtins, '__dict__').update({'eval': len})\nbuiltins.eval([])\n",
             b"import builtins\nnamespace = builtins.__dict__\nnamespace.update({'eval': len})\nbuiltins.eval([])\n",
+            b"import builtins\ndict.update(builtins.__dict__, {'eval': len})\nbuiltins.eval([])\n",
+            b"import builtins\nimport operator\noperator.setitem(builtins.__dict__, 'eval', len)\nbuiltins.eval([])\n",
             b"def payload():\n    eval = len\n    return eval([])\n",
             (
                 b"def payload():\n"
@@ -419,6 +421,11 @@ class TestJITScriptDetector:
             (
                 b"import builtins\nnamespace = builtins.__dict__\n"
                 b"namespace.update({'eval': builtins.exec})\nbuiltins.eval('pass')\n"
+            ),
+            b"import builtins\ndict.update(builtins.__dict__, {'eval': builtins.exec})\nbuiltins.eval('pass')\n",
+            (
+                b"import builtins\nimport operator\n"
+                b"operator.setitem(builtins.__dict__, 'eval', builtins.exec)\nbuiltins.eval('pass')\n"
             ),
         ],
     )
@@ -557,6 +564,14 @@ class TestJITScriptDetector:
                 b"def invoke(namespace=builtins.__dict__):\n"
                 b"    namespace.update({'eval': len})\n"
                 b"    return builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"replace = dict.update\n"
+                b"if swap:\n"
+                b"    replace = lambda target, values: None\n"
+                b"replace(builtins.__dict__, {'eval': len})\n"
+                b"builtins.eval('1 + 1')\n"
             ),
             (
                 b"import builtins\n"

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -364,6 +364,8 @@ class TestJITScriptDetector:
             (b"import builtins as bi\nfrom builtins import setattr as assign\nassign(bi, 'eval', len)\nbi.eval([])\n"),
             b"import builtins\nbuiltins.__dict__.update({'eval': len})\nbuiltins.eval([])\n",
             b"import builtins\nreplace = builtins.__dict__.update\nreplace({'eval': len})\nbuiltins.eval([])\n",
+            b"import builtins\ngetattr(builtins, '__dict__').update({'eval': len})\nbuiltins.eval([])\n",
+            b"import builtins\nnamespace = builtins.__dict__\nnamespace.update({'eval': len})\nbuiltins.eval([])\n",
             b"def payload():\n    eval = len\n    return eval([])\n",
             (
                 b"def payload():\n"
@@ -413,6 +415,11 @@ class TestJITScriptDetector:
             ),
             b"import builtins\nsetattr(builtins, 'eval', builtins.exec)\nbuiltins.eval('pass')\n",
             b"import builtins\nbuiltins.__dict__.update({'eval': builtins.exec})\nbuiltins.eval('pass')\n",
+            b"import builtins\ngetattr(builtins, '__dict__').update({'eval': builtins.exec})\nbuiltins.eval('pass')\n",
+            (
+                b"import builtins\nnamespace = builtins.__dict__\n"
+                b"namespace.update({'eval': builtins.exec})\nbuiltins.eval('pass')\n"
+            ),
         ],
     )
     def test_scan_model_detects_dangerous_builtin_reassignment(self, source: bytes) -> None:
@@ -535,6 +542,20 @@ class TestJITScriptDetector:
                 b"import builtins\n"
                 b"def invoke(namespace=builtins):\n"
                 b"    namespace.__dict__.update({'eval': len})\n"
+                b"    return builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"namespace = builtins.__dict__\n"
+                b"if swap:\n"
+                b"    namespace = make_mapping()\n"
+                b"namespace.update({'eval': len})\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"def invoke(namespace=builtins.__dict__):\n"
+                b"    namespace.update({'eval': len})\n"
                 b"    return builtins.eval('1 + 1')\n"
             ),
             (

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -359,6 +359,9 @@ class TestJITScriptDetector:
                 b"invoke = globals()['__builtins__']['eval'].__call__\n"
                 b"invoke([])\n"
             ),
+            b"import builtins\nsetattr(builtins, 'eval', len)\nbuiltins.eval([])\n",
+            b"import builtins\nresult = setattr(builtins, 'eval', len)\nbuiltins.eval([])\n",
+            (b"import builtins as bi\nfrom builtins import setattr as assign\nassign(bi, 'eval', len)\nbi.eval([])\n"),
             b"def payload():\n    eval = len\n    return eval([])\n",
             (
                 b"def payload():\n"
@@ -406,6 +409,7 @@ class TestJITScriptDetector:
                 b"globals()['__builtins__']['exec'] = len\n"
                 b"globals()['__builtins__']['eval']('pass')\n"
             ),
+            b"import builtins\nsetattr(builtins, 'eval', builtins.exec)\nbuiltins.eval('pass')\n",
         ],
     )
     def test_scan_model_detects_dangerous_builtin_reassignment(self, source: bytes) -> None:
@@ -466,6 +470,21 @@ class TestJITScriptDetector:
                 b"import helpers as replace\n"
                 b"replace({'eval': len})\n"
                 b"globals()['__builtins__']['eval']('1 + 1')\n"
+            ),
+            (b"import builtins\nif replace_builtin:\n    setattr(builtins, 'eval', len)\nbuiltins.eval('1 + 1')\n"),
+            (
+                b"import builtins\n"
+                b"setattr = lambda target, key, value: None\n"
+                b"setattr(builtins, 'eval', len)\n"
+                b"builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"try:\n"
+                b"    setattr(builtins, 'eval', len)\n"
+                b"except Exception:\n"
+                b"    pass\n"
+                b"builtins.eval('1 + 1')\n"
             ),
         ],
     )

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1144,6 +1144,7 @@ def test_pytorch_zip_scans_aliased_modeled_builtins_in_archive_data(
         b"mapping = {'eval': len}\nlookup = mapping.get\nlookup('eval')([])\n",
         b"globals()['__builtins__'].__setitem__('eval', len)\nglobals()['__builtins__']['eval']([])\n",
         b"globals()['__builtins__'].update({'eval': len})\nglobals()['__builtins__']['eval']([])\n",
+        b"import builtins\nbuiltins.__dict__.update({'eval': len})\nbuiltins.eval([])\n",
         (
             b"replace = globals()['__builtins__'].__setitem__\n"
             b"replace('eval', len)\n"
@@ -1219,6 +1220,7 @@ def test_pytorch_zip_ignores_benign_builtin_shaped_access_in_archive_data(tmp_pa
             b"setattr(globals()['__builtins__'], 'eval', __builtins__['exec'])\n"
             b"globals()['__builtins__']['eval']('pass')\n"
         ),
+        b"import builtins\nbuiltins.__dict__.update({'eval': builtins.exec})\nbuiltins.eval('pass')\n",
     ],
 )
 def test_pytorch_zip_detects_dangerous_builtin_reassignment_in_archive_data(tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1145,6 +1145,7 @@ def test_pytorch_zip_scans_aliased_modeled_builtins_in_archive_data(
         b"globals()['__builtins__'].__setitem__('eval', len)\nglobals()['__builtins__']['eval']([])\n",
         b"globals()['__builtins__'].update({'eval': len})\nglobals()['__builtins__']['eval']([])\n",
         b"import builtins\nbuiltins.__dict__.update({'eval': len})\nbuiltins.eval([])\n",
+        b"import builtins\ngetattr(builtins, '__dict__').update({'eval': len})\nbuiltins.eval([])\n",
         (
             b"replace = globals()['__builtins__'].__setitem__\n"
             b"replace('eval', len)\n"
@@ -1221,6 +1222,7 @@ def test_pytorch_zip_ignores_benign_builtin_shaped_access_in_archive_data(tmp_pa
             b"globals()['__builtins__']['eval']('pass')\n"
         ),
         b"import builtins\nbuiltins.__dict__.update({'eval': builtins.exec})\nbuiltins.eval('pass')\n",
+        b"import builtins\ngetattr(builtins, '__dict__').update({'eval': builtins.exec})\nbuiltins.eval('pass')\n",
     ],
 )
 def test_pytorch_zip_detects_dangerous_builtin_reassignment_in_archive_data(tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1154,6 +1154,7 @@ def test_pytorch_zip_scans_aliased_modeled_builtins_in_archive_data(
             b"replace({'eval': len})\n"
             b"globals()['__builtins__']['eval']([])\n"
         ),
+        b"setattr(globals()['__builtins__'], 'eval', len)\nglobals()['__builtins__']['eval']([])\n",
         (b"globals()['__builtins__']['eval'] = len\nrun = globals()['__builtins__']['eval']\nrun([])\n"),
         (b"globals()['__builtins__']['eval'] = len\nrun = globals()['__builtins__']['eval']\nrun.__call__([])\n"),
         (b"globals()['__builtins__'].__setitem__('eval', len)\nrun = globals()['__builtins__']['eval']\nrun([])\n"),
@@ -1212,6 +1213,10 @@ def test_pytorch_zip_ignores_benign_builtin_shaped_access_in_archive_data(tmp_pa
         (
             b"replace = globals()['__builtins__'].update\n"
             b"replace({'eval': __builtins__['exec']})\n"
+            b"globals()['__builtins__']['eval']('pass')\n"
+        ),
+        (
+            b"setattr(globals()['__builtins__'], 'eval', __builtins__['exec'])\n"
             b"globals()['__builtins__']['eval']('pass')\n"
         ),
     ],

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1146,6 +1146,7 @@ def test_pytorch_zip_scans_aliased_modeled_builtins_in_archive_data(
         b"globals()['__builtins__'].update({'eval': len})\nglobals()['__builtins__']['eval']([])\n",
         b"import builtins\nbuiltins.__dict__.update({'eval': len})\nbuiltins.eval([])\n",
         b"import builtins\ngetattr(builtins, '__dict__').update({'eval': len})\nbuiltins.eval([])\n",
+        b"import builtins\ndict.update(builtins.__dict__, {'eval': len})\nbuiltins.eval([])\n",
         (
             b"replace = globals()['__builtins__'].__setitem__\n"
             b"replace('eval', len)\n"
@@ -1223,6 +1224,7 @@ def test_pytorch_zip_ignores_benign_builtin_shaped_access_in_archive_data(tmp_pa
         ),
         b"import builtins\nbuiltins.__dict__.update({'eval': builtins.exec})\nbuiltins.eval('pass')\n",
         b"import builtins\ngetattr(builtins, '__dict__').update({'eval': builtins.exec})\nbuiltins.eval('pass')\n",
+        b"import builtins\ndict.update(builtins.__dict__, {'eval': builtins.exec})\nbuiltins.eval('pass')\n",
     ],
 )
 def test_pytorch_zip_detects_dangerous_builtin_reassignment_in_archive_data(tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -174,6 +174,10 @@ class TestTarScanner:
                 b"    os.system('echo hidden')\n"
             ),
             (
+                b"import os\nnamespace = os.__dict__\nif swap:\n    namespace = make_mapping()\n"
+                b"namespace.update({'system': len})\nos.system('echo hidden')\n"
+            ),
+            (
                 b"import os\n"
                 b"setattr = lambda target, key, value: None\n"
                 b"setattr(os, 'system', len)\n"
@@ -212,6 +216,8 @@ class TestTarScanner:
             b"import os\nvars(os).update({'system': len})\nos.system([])\n",
             b"import os\nreplace = os.__dict__.update\nreplace({'system': len})\nos.system([])\n",
             b"import os\nos.__dict__.update({'system': len})\nrun = os.system\nrun([])\n",
+            b"import os\ngetattr(os, '__dict__').update({'system': len})\nos.system([])\n",
+            b"import os\nnamespace = os.__dict__\nnamespace.update({'system': len})\nos.system([])\n",
         ],
     )
     def test_scan_tar_allows_callable_captured_after_safe_overwrite(self, tmp_path: Path, payload: bytes) -> None:
@@ -248,6 +254,10 @@ class TestTarScanner:
         [
             b"import os\nimport subprocess\nsetattr(os, 'system', subprocess.run)\nos.system(['id'])\n",
             b"import os\nimport subprocess\nos.__dict__.update({'system': subprocess.run})\nos.system(['id'])\n",
+            (
+                b"import os\nimport subprocess\n"
+                b"getattr(os, '__dict__').update({'system': subprocess.run})\nos.system(['id'])\n"
+            ),
         ],
     )
     def test_scan_tar_reports_dangerous_setattr_replacement(self, tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -178,6 +178,10 @@ class TestTarScanner:
                 b"namespace.update({'system': len})\nos.system('echo hidden')\n"
             ),
             (
+                b"import os\nreplace = dict.update\nif swap:\n    replace = lambda target, values: None\n"
+                b"replace(os.__dict__, {'system': len})\nos.system('echo hidden')\n"
+            ),
+            (
                 b"import os\n"
                 b"setattr = lambda target, key, value: None\n"
                 b"setattr(os, 'system', len)\n"
@@ -218,6 +222,8 @@ class TestTarScanner:
             b"import os\nos.__dict__.update({'system': len})\nrun = os.system\nrun([])\n",
             b"import os\ngetattr(os, '__dict__').update({'system': len})\nos.system([])\n",
             b"import os\nnamespace = os.__dict__\nnamespace.update({'system': len})\nos.system([])\n",
+            b"import os\ndict.update(os.__dict__, {'system': len})\nos.system([])\n",
+            b"import os\nimport operator\noperator.setitem(os.__dict__, 'system', len)\nos.system([])\n",
         ],
     )
     def test_scan_tar_allows_callable_captured_after_safe_overwrite(self, tmp_path: Path, payload: bytes) -> None:
@@ -258,6 +264,7 @@ class TestTarScanner:
                 b"import os\nimport subprocess\n"
                 b"getattr(os, '__dict__').update({'system': subprocess.run})\nos.system(['id'])\n"
             ),
+            b"import os\nimport subprocess\ndict.update(os.__dict__, {'system': subprocess.run})\nos.system(['id'])\n",
         ],
     )
     def test_scan_tar_reports_dangerous_setattr_replacement(self, tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -147,6 +147,13 @@ class TestTarScanner:
             b"import os\ninvoke = os.system.__call__\nos.system = len\ninvoke('echo hidden')\n",
             b"import os\nrun = os.system\nos.system = len\nrun('echo hidden')\n",
             b"import os\nfrom os import system as run\nos.system = len\nrun('echo hidden')\n",
+            b"import os\nrun = os.system\nsetattr(os, 'system', len)\nrun('echo hidden')\n",
+            (
+                b"import os\n"
+                b"setattr = lambda target, key, value: None\n"
+                b"setattr(os, 'system', len)\n"
+                b"os.system('echo hidden')\n"
+            ),
         ],
     )
     def test_scan_tar_preserves_captured_dangerous_callable_before_overwrite(
@@ -172,6 +179,9 @@ class TestTarScanner:
             b"import os\nos.system = len\ninvoke = os.system.__call__\ninvoke([])\n",
             b"import os\nos.system = len\nrun = os.system\nrun([])\n",
             b"import os\nos.system = len\nfrom os import system as run\nrun([])\n",
+            b"import os\nsetattr(os, 'system', len)\nos.system([])\n",
+            b"import os\nreplace = setattr\nreplace(os, 'system', len)\nos.system([])\n",
+            b"import os\nsetattr(os, 'system', len)\nrun = os.system\nrun([])\n",
         ],
     )
     def test_scan_tar_allows_callable_captured_after_safe_overwrite(self, tmp_path: Path, payload: bytes) -> None:
@@ -201,6 +211,21 @@ class TestTarScanner:
         assert len(python_checks) == 1
         assert python_checks[0].status == CheckStatus.FAILED
         assert python_checks[0].severity == IssueSeverity.WARNING
+        assert python_checks[0].details["reason"] == "high-risk calls: subprocess.run"
+
+    def test_scan_tar_reports_dangerous_setattr_replacement(self, tmp_path: Path) -> None:
+        archive_path = tmp_path / "model_bundle.tar"
+        payload = b"import os\nimport subprocess\nsetattr(os, 'system', subprocess.run)\nos.system(['id'])\n"
+        with tarfile.open(archive_path, "w") as archive:
+            info = tarfile.TarInfo("handler.py")
+            info.size = len(payload)
+            archive.addfile(info, tarfile.io.BytesIO(payload))  # type: ignore[attr-defined]
+
+        result = self.scanner.scan(str(archive_path))
+
+        python_checks = [check for check in result.checks if check.name == "Python Archive Member Security"]
+        assert len(python_checks) == 1
+        assert python_checks[0].status == CheckStatus.FAILED
         assert python_checks[0].details["reason"] == "high-risk calls: subprocess.run"
 
     def test_scan_tar_flags_builtins_getattr_keyword_call_dangerous_python_member(self, tmp_path: Path) -> None:

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -148,6 +148,31 @@ class TestTarScanner:
             b"import os\nrun = os.system\nos.system = len\nrun('echo hidden')\n",
             b"import os\nfrom os import system as run\nos.system = len\nrun('echo hidden')\n",
             b"import os\nrun = os.system\nsetattr(os, 'system', len)\nrun('echo hidden')\n",
+            b"import os\nrun = os.system\nos.__dict__.update({'system': len})\nrun('echo hidden')\n",
+            b"import os\nif replace:\n    os.__dict__.update({'system': len})\nos.system('echo hidden')\n",
+            (
+                b"import os\nif swap:\n    os = make_module()\n"
+                b"os.__dict__.update({'system': len})\nos.system('echo hidden')\n"
+            ),
+            b"import os\nif swap:\n    os = make_module()\nsetattr(os, 'system', len)\nos.system('echo hidden')\n",
+            b"import os\nif swap:\n    os = make_module()\nos.system = len\nos.system('echo hidden')\n",
+            (
+                b"import os\nif swap:\n    os = make_module()\ntarget = os\n"
+                b"target.__dict__.update({'system': len})\nos.system('echo hidden')\n"
+            ),
+            (
+                b"import os\nif swap:\n    os = make_module()\ntarget = os\n"
+                b"setattr(target, 'system', len)\nos.system('echo hidden')\n"
+            ),
+            (
+                b"import os\nif swap:\n    os = make_module()\ntarget = os\n"
+                b"target.system = len\nos.system('echo hidden')\n"
+            ),
+            (
+                b"import os\ndef hide(target=os):\n"
+                b"    target.__dict__.update({'system': len})\n"
+                b"    os.system('echo hidden')\n"
+            ),
             (
                 b"import os\n"
                 b"setattr = lambda target, key, value: None\n"
@@ -182,6 +207,11 @@ class TestTarScanner:
             b"import os\nsetattr(os, 'system', len)\nos.system([])\n",
             b"import os\nreplace = setattr\nreplace(os, 'system', len)\nos.system([])\n",
             b"import os\nsetattr(os, 'system', len)\nrun = os.system\nrun([])\n",
+            b"import os\nos.__dict__.__setitem__('system', len)\nos.system([])\n",
+            b"import os\nos.__dict__.update({'system': len})\nos.system([])\n",
+            b"import os\nvars(os).update({'system': len})\nos.system([])\n",
+            b"import os\nreplace = os.__dict__.update\nreplace({'system': len})\nos.system([])\n",
+            b"import os\nos.__dict__.update({'system': len})\nrun = os.system\nrun([])\n",
         ],
     )
     def test_scan_tar_allows_callable_captured_after_safe_overwrite(self, tmp_path: Path, payload: bytes) -> None:
@@ -213,9 +243,15 @@ class TestTarScanner:
         assert python_checks[0].severity == IssueSeverity.WARNING
         assert python_checks[0].details["reason"] == "high-risk calls: subprocess.run"
 
-    def test_scan_tar_reports_dangerous_setattr_replacement(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            b"import os\nimport subprocess\nsetattr(os, 'system', subprocess.run)\nos.system(['id'])\n",
+            b"import os\nimport subprocess\nos.__dict__.update({'system': subprocess.run})\nos.system(['id'])\n",
+        ],
+    )
+    def test_scan_tar_reports_dangerous_setattr_replacement(self, tmp_path: Path, payload: bytes) -> None:
         archive_path = tmp_path / "model_bundle.tar"
-        payload = b"import os\nimport subprocess\nsetattr(os, 'system', subprocess.run)\nos.system(['id'])\n"
         with tarfile.open(archive_path, "w") as archive:
             info = tarfile.TarInfo("handler.py")
             info.size = len(payload)
@@ -324,6 +360,7 @@ class TestTarScanner:
             b"mapping = {'eval': len}\nlookup = mapping.get\nlookup('eval')([])\n",
             b"globals()['__builtins__'].__setitem__('eval', len)\nglobals()['__builtins__']['eval']([])\n",
             b"globals()['__builtins__'].update({'eval': len})\nglobals()['__builtins__']['eval']([])\n",
+            b"import builtins\nbuiltins.__dict__.update({'eval': len})\nbuiltins.eval([])\n",
             (
                 b"replace = globals()['__builtins__'].__setitem__\n"
                 b"replace('eval', len)\n"
@@ -357,34 +394,45 @@ class TestTarScanner:
         assert not any(check.name == "Python Archive Member Security" for check in result.checks)
 
     @pytest.mark.parametrize(
-        "payload",
+        ("payload", "dangerous_name"),
         [
             (
                 b"namespace = globals()\n"
                 b"namespace['__builtins__']['eval'] = __builtins__['exec']\n"
-                b"namespace['__builtins__']['eval']('pass')\n"
+                b"namespace['__builtins__']['eval']('pass')\n",
+                "__builtins__.exec",
             ),
             (
                 b"globals()['__builtins__'].__setitem__('eval', __builtins__['exec'])\n"
-                b"globals()['__builtins__']['eval']('pass')\n"
+                b"globals()['__builtins__']['eval']('pass')\n",
+                "__builtins__.exec",
             ),
             (
                 b"globals()['__builtins__'].update({'eval': __builtins__['exec']})\n"
-                b"globals()['__builtins__']['eval']('pass')\n"
+                b"globals()['__builtins__']['eval']('pass')\n",
+                "__builtins__.exec",
             ),
             (
                 b"replace = globals()['__builtins__'].__setitem__\n"
                 b"replace('eval', __builtins__['exec'])\n"
-                b"globals()['__builtins__']['eval']('pass')\n"
+                b"globals()['__builtins__']['eval']('pass')\n",
+                "__builtins__.exec",
             ),
             (
                 b"replace = globals()['__builtins__'].update\n"
                 b"replace({'eval': __builtins__['exec']})\n"
-                b"globals()['__builtins__']['eval']('pass')\n"
+                b"globals()['__builtins__']['eval']('pass')\n",
+                "__builtins__.exec",
+            ),
+            (
+                b"import builtins\nbuiltins.__dict__.update({'eval': builtins.exec})\nbuiltins.eval('pass')\n",
+                "builtins.exec",
             ),
         ],
     )
-    def test_scan_tar_reports_dangerous_builtin_reassignment(self, tmp_path: Path, payload: bytes) -> None:
+    def test_scan_tar_reports_dangerous_builtin_reassignment(
+        self, tmp_path: Path, payload: bytes, dangerous_name: str
+    ) -> None:
         archive_path = tmp_path / "model_bundle.tar"
         with tarfile.open(archive_path, "w") as archive:
             info = tarfile.TarInfo("handler.py")
@@ -397,7 +445,7 @@ class TestTarScanner:
         assert len(python_checks) == 1
         assert python_checks[0].status == CheckStatus.FAILED
         assert python_checks[0].rule_code == "S104"
-        assert python_checks[0].details["reason"] == "high-risk calls: __builtins__.exec"
+        assert python_checks[0].details["reason"] == f"high-risk calls: {dangerous_name}"
 
     def test_scan_tar_flags_aliased_getattr_helper_dangerous_python_member(self, tmp_path: Path) -> None:
         """Aliased getattr helpers and module aliases should still resolve risky calls."""

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -391,6 +391,11 @@ def test_scan_detects_implicit_builtins_handler_execution_primitive(
         ),
         (
             b"def handle(data, context):\n"
+            b"    setattr(globals()['__builtins__'], 'eval', len)\n"
+            b"    return globals()['__builtins__']['eval']([])\n"
+        ),
+        (
+            b"def handle(data, context):\n"
             b"    globals()['__builtins__']['eval'] = len\n"
             b"    run = globals()['__builtins__']['eval']\n"
             b"    return run([])\n"
@@ -462,6 +467,11 @@ def test_scan_allows_benign_builtin_shaped_handler_source(tmp_path: Path, handle
             b"def handle(data, context):\n"
             b"    replace = globals()['__builtins__'].update\n"
             b"    replace({'eval': __builtins__['exec']})\n"
+            b"    return globals()['__builtins__']['eval']('pass')\n"
+        ),
+        (
+            b"def handle(data, context):\n"
+            b"    setattr(globals()['__builtins__'], 'eval', __builtins__['exec'])\n"
             b"    return globals()['__builtins__']['eval']('pass')\n"
         ),
     ],

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -390,6 +390,12 @@ def test_scan_detects_implicit_builtins_handler_execution_primitive(
             b"    return builtins.eval([])\n"
         ),
         (
+            b"import builtins\n"
+            b"def handle(data, context):\n"
+            b"    dict.update(builtins.__dict__, {'eval': len})\n"
+            b"    return builtins.eval([])\n"
+        ),
+        (
             b"def handle(data, context):\n"
             b"    replace = globals()['__builtins__'].__setitem__\n"
             b"    replace('eval', len)\n"
@@ -503,6 +509,13 @@ def test_scan_allows_benign_builtin_shaped_handler_source(tmp_path: Path, handle
             b"import builtins\n"
             b"def handle(data, context):\n"
             b"    getattr(builtins, '__dict__').update({'eval': builtins.exec})\n"
+            b"    return builtins.eval('pass')\n",
+            "builtins.exec",
+        ),
+        (
+            b"import builtins\n"
+            b"def handle(data, context):\n"
+            b"    dict.update(builtins.__dict__, {'eval': builtins.exec})\n"
             b"    return builtins.eval('pass')\n",
             "builtins.exec",
         ),

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -378,6 +378,12 @@ def test_scan_detects_implicit_builtins_handler_execution_primitive(
             b"    return globals()['__builtins__']['eval']([])\n"
         ),
         (
+            b"import builtins\n"
+            b"def handle(data, context):\n"
+            b"    builtins.__dict__.update({'eval': len})\n"
+            b"    return builtins.eval([])\n"
+        ),
+        (
             b"def handle(data, context):\n"
             b"    replace = globals()['__builtins__'].__setitem__\n"
             b"    replace('eval', len)\n"
@@ -439,44 +445,59 @@ def test_scan_allows_benign_builtin_shaped_handler_source(tmp_path: Path, handle
 
 
 @pytest.mark.parametrize(
-    "handler_source",
+    ("handler_source", "dangerous_name"),
     [
         (
             b"def handle(data, context):\n"
             b"    namespace = globals()\n"
             b"    namespace['__builtins__']['eval'] = __builtins__['exec']\n"
-            b"    return namespace['__builtins__']['eval']('pass')\n"
+            b"    return namespace['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
         ),
         (
             b"def handle(data, context):\n"
             b"    globals()['__builtins__'].__setitem__('eval', __builtins__['exec'])\n"
-            b"    return globals()['__builtins__']['eval']('pass')\n"
+            b"    return globals()['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
         ),
         (
             b"def handle(data, context):\n"
             b"    globals()['__builtins__'].update({'eval': __builtins__['exec']})\n"
-            b"    return globals()['__builtins__']['eval']('pass')\n"
+            b"    return globals()['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
         ),
         (
             b"def handle(data, context):\n"
             b"    replace = globals()['__builtins__'].__setitem__\n"
             b"    replace('eval', __builtins__['exec'])\n"
-            b"    return globals()['__builtins__']['eval']('pass')\n"
+            b"    return globals()['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
         ),
         (
             b"def handle(data, context):\n"
             b"    replace = globals()['__builtins__'].update\n"
             b"    replace({'eval': __builtins__['exec']})\n"
-            b"    return globals()['__builtins__']['eval']('pass')\n"
+            b"    return globals()['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
         ),
         (
             b"def handle(data, context):\n"
             b"    setattr(globals()['__builtins__'], 'eval', __builtins__['exec'])\n"
-            b"    return globals()['__builtins__']['eval']('pass')\n"
+            b"    return globals()['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
+        ),
+        (
+            b"import builtins\n"
+            b"def handle(data, context):\n"
+            b"    builtins.__dict__.update({'eval': builtins.exec})\n"
+            b"    return builtins.eval('pass')\n",
+            "builtins.exec",
         ),
     ],
 )
-def test_scan_detects_dangerous_builtin_reassignment_in_handler_source(tmp_path: Path, handler_source: bytes) -> None:
+def test_scan_detects_dangerous_builtin_reassignment_in_handler_source(
+    tmp_path: Path, handler_source: bytes, dangerous_name: str
+) -> None:
     manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
     mar_path = _create_mar_archive(
         tmp_path,
@@ -489,7 +510,7 @@ def test_scan_detects_dangerous_builtin_reassignment_in_handler_source(tmp_path:
     handler_failures = _failed_checks(result, "TorchServe Handler Static Analysis")
 
     assert len(handler_failures) == 1
-    assert "__builtins__.exec" in handler_failures[0].message
+    assert dangerous_name in handler_failures[0].message
 
 
 def test_scan_detects_dunder_call_getattr_wrapped_handler_execution_primitive(tmp_path: Path) -> None:

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -384,6 +384,12 @@ def test_scan_detects_implicit_builtins_handler_execution_primitive(
             b"    return builtins.eval([])\n"
         ),
         (
+            b"import builtins\n"
+            b"def handle(data, context):\n"
+            b"    getattr(builtins, '__dict__').update({'eval': len})\n"
+            b"    return builtins.eval([])\n"
+        ),
+        (
             b"def handle(data, context):\n"
             b"    replace = globals()['__builtins__'].__setitem__\n"
             b"    replace('eval', len)\n"
@@ -490,6 +496,13 @@ def test_scan_allows_benign_builtin_shaped_handler_source(tmp_path: Path, handle
             b"import builtins\n"
             b"def handle(data, context):\n"
             b"    builtins.__dict__.update({'eval': builtins.exec})\n"
+            b"    return builtins.eval('pass')\n",
+            "builtins.exec",
+        ),
+        (
+            b"import builtins\n"
+            b"def handle(data, context):\n"
+            b"    getattr(builtins, '__dict__').update({'eval': builtins.exec})\n"
             b"    return builtins.eval('pass')\n",
             "builtins.exec",
         ),

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -210,6 +210,15 @@ def test_scan_zip_flags_aliased_dangerous_python_member(tmp_path: Path) -> None:
             "    namespace.update({'system': len})\n"
             "    os.system('echo hidden')\n"
         ),
+        (
+            "import os\nreplace = dict.update\nif swap:\n    replace = lambda target, values: None\n"
+            "replace(os.__dict__, {'system': len})\nos.system('echo hidden')\n"
+        ),
+        (
+            "import os\ndef hide(namespace=os.__dict__):\n"
+            "    dict.update(namespace, {'system': len})\n"
+            "    os.system('echo hidden')\n"
+        ),
         ("import os\ndef hide(target=os):\n    setattr(target, 'system', len)\n    os.system('echo hidden')\n"),
         ("import os\ndef hide(target=os):\n    target.system = len\n    os.system('echo hidden')\n"),
         (
@@ -263,6 +272,10 @@ def test_scan_zip_preserves_captured_dangerous_callable_before_overwrite(tmp_pat
         "import os\nnamespace = os.__dict__\nnamespace.update({'system': len})\nos.system([])\n",
         "import os\nnamespace = getattr(os, '__dict__')\nnamespace.update({'system': len})\nos.system([])\n",
         "import os\nreplace = getattr(os, '__dict__').update\nreplace({'system': len})\nos.system([])\n",
+        "import os\ndict.update(os.__dict__, {'system': len})\nos.system([])\n",
+        "import os\ndict.__setitem__(os.__dict__, 'system', len)\nos.system([])\n",
+        "import os\nimport operator\noperator.setitem(os.__dict__, 'system', len)\nos.system([])\n",
+        "import os\nfrom operator import setitem as replace\nreplace(os.__dict__, 'system', len)\nos.system([])\n",
     ],
 )
 def test_scan_zip_allows_callable_captured_after_safe_overwrite(tmp_path: Path, source: str) -> None:
@@ -303,6 +316,11 @@ def test_scan_zip_flags_from_import_dangerous_python_member(tmp_path: Path) -> N
         (
             "import os\nimport subprocess\nnamespace = os.__dict__\n"
             "namespace.update({'system': subprocess.run})\nos.system(['id'])\n"
+        ),
+        "import os\nimport subprocess\ndict.update(os.__dict__, {'system': subprocess.run})\nos.system(['id'])\n",
+        (
+            "import os\nimport operator\nimport subprocess\n"
+            "operator.setitem(os.__dict__, 'system', subprocess.run)\nos.system(['id'])\n"
         ),
     ],
 )

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -197,6 +197,19 @@ def test_scan_zip_flags_aliased_dangerous_python_member(tmp_path: Path) -> None:
             "    target.__dict__.update({'system': len})\n"
             "    os.system('echo hidden')\n"
         ),
+        (
+            "import os\nresolve = getattr\nif swap:\n    resolve = make_resolver()\n"
+            "resolve(os, '__dict__').update({'system': len})\nos.system('echo hidden')\n"
+        ),
+        (
+            "import os\nnamespace = os.__dict__\nif swap:\n    namespace = make_mapping()\n"
+            "namespace.update({'system': len})\nos.system('echo hidden')\n"
+        ),
+        (
+            "import os\ndef hide(namespace=os.__dict__):\n"
+            "    namespace.update({'system': len})\n"
+            "    os.system('echo hidden')\n"
+        ),
         ("import os\ndef hide(target=os):\n    setattr(target, 'system', len)\n    os.system('echo hidden')\n"),
         ("import os\ndef hide(target=os):\n    target.system = len\n    os.system('echo hidden')\n"),
         (
@@ -244,6 +257,12 @@ def test_scan_zip_preserves_captured_dangerous_callable_before_overwrite(tmp_pat
         "import os\nreplace = os.__dict__.update\nreplace({'system': len})\nos.system([])\n",
         "import os\nresult = os.__dict__.update({'system': len})\nos.system([])\n",
         "import os\nos.__dict__.update({'system': len})\nrun = os.system\nrun([])\n",
+        "import os\ngetattr(os, '__dict__').update({'system': len})\nos.system([])\n",
+        "import os\nos.__getattribute__('__dict__').update({'system': len})\nos.system([])\n",
+        "import os\nobject.__getattribute__(os, '__dict__').update({'system': len})\nos.system([])\n",
+        "import os\nnamespace = os.__dict__\nnamespace.update({'system': len})\nos.system([])\n",
+        "import os\nnamespace = getattr(os, '__dict__')\nnamespace.update({'system': len})\nos.system([])\n",
+        "import os\nreplace = getattr(os, '__dict__').update\nreplace({'system': len})\nos.system([])\n",
     ],
 )
 def test_scan_zip_allows_callable_captured_after_safe_overwrite(tmp_path: Path, source: str) -> None:
@@ -280,6 +299,11 @@ def test_scan_zip_flags_from_import_dangerous_python_member(tmp_path: Path) -> N
         "import os\nimport subprocess\nresult = setattr(os, 'system', subprocess.run)\nos.system(['id'])\n",
         "import os\nimport subprocess\nos.__dict__.update({'system': subprocess.run})\nos.system(['id'])\n",
         "import os\nimport subprocess\nos.__dict__.__setitem__('system', subprocess.run)\nos.system(['id'])\n",
+        "import os\nimport subprocess\ngetattr(os, '__dict__').update({'system': subprocess.run})\nos.system(['id'])\n",
+        (
+            "import os\nimport subprocess\nnamespace = os.__dict__\n"
+            "namespace.update({'system': subprocess.run})\nos.system(['id'])\n"
+        ),
     ],
 )
 def test_scan_zip_reports_dangerous_setattr_replacement(tmp_path: Path, source: str) -> None:

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -170,6 +170,13 @@ def test_scan_zip_flags_aliased_dangerous_python_member(tmp_path: Path) -> None:
         "import os\nfrom os import system as run\nos.system = len\nrun('echo hidden')\n",
         "import os\nfrom os import *\nos.system = len\nsystem('echo hidden')\n",
         ("import os\ndef run(action=os.system):\n    os.system = len\n    action('echo hidden')\n"),
+        "import os\nrun = os.system\nsetattr(os, 'system', len)\nrun('echo hidden')\n",
+        (
+            "import os\n"
+            "setattr = lambda target, key, value: None\n"
+            "setattr(os, 'system', len)\n"
+            "os.system('echo hidden')\n"
+        ),
     ],
 )
 def test_scan_zip_preserves_captured_dangerous_callable_before_overwrite(tmp_path: Path, source: str) -> None:
@@ -198,6 +205,11 @@ def test_scan_zip_preserves_captured_dangerous_callable_before_overwrite(tmp_pat
         "import os\nos.system = len\nfrom os import system as run\nrun([])\n",
         "import os\nos.system = len\nfrom os import *\nsystem([])\n",
         ("import os\nos.system = len\ndef run(action=os.system):\n    action([])\n"),
+        "import os\nsetattr(os, 'system', len)\nos.system([])\n",
+        "import os\nreplace = setattr\nreplace(os, 'system', len)\nos.system([])\n",
+        "import os\nresult = setattr(os, 'system', len)\nos.system([])\n",
+        "import os\nresult: None = setattr(os, 'system', len)\nos.system([])\n",
+        "import os\nsetattr(os, 'system', len)\nrun = os.system\nrun([])\n",
     ],
 )
 def test_scan_zip_allows_callable_captured_after_safe_overwrite(tmp_path: Path, source: str) -> None:
@@ -224,6 +236,29 @@ def test_scan_zip_flags_from_import_dangerous_python_member(tmp_path: Path) -> N
     ]
     assert len(python_checks) == 1
     assert python_checks[0].severity == IssueSeverity.WARNING
+    assert python_checks[0].details["reason"] == "high-risk calls: subprocess.run"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "import os\nimport subprocess\nsetattr(os, 'system', subprocess.run)\nos.system(['id'])\n",
+        "import os\nimport subprocess\nresult = setattr(os, 'system', subprocess.run)\nos.system(['id'])\n",
+    ],
+)
+def test_scan_zip_reports_dangerous_setattr_replacement(tmp_path: Path, source: str) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", source)
+
+    result = ZipScanner().scan(str(archive_path))
+
+    python_checks = [
+        check
+        for check in result.checks
+        if check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED
+    ]
+    assert len(python_checks) == 1
     assert python_checks[0].details["reason"] == "high-risk calls: subprocess.run"
 
 

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -171,6 +171,34 @@ def test_scan_zip_flags_aliased_dangerous_python_member(tmp_path: Path) -> None:
         "import os\nfrom os import *\nos.system = len\nsystem('echo hidden')\n",
         ("import os\ndef run(action=os.system):\n    os.system = len\n    action('echo hidden')\n"),
         "import os\nrun = os.system\nsetattr(os, 'system', len)\nrun('echo hidden')\n",
+        "import os\nrun = os.system\nos.__dict__.update({'system': len})\nrun('echo hidden')\n",
+        (
+            "import os\n"
+            "replace = os.__dict__.update\n"
+            "replace = lambda values: None\n"
+            "replace({'system': len})\n"
+            "os.system('echo hidden')\n"
+        ),
+        "import os\nif replace:\n    os.__dict__.update({'system': len})\nos.system('echo hidden')\n",
+        "import os\nif swap:\n    os = make_module()\nos.__dict__.update({'system': len})\nos.system('echo hidden')\n",
+        "import os\nif swap:\n    os = make_module()\nsetattr(os, 'system', len)\nos.system('echo hidden')\n",
+        "import os\nif swap:\n    os = make_module()\nos.system = len\nos.system('echo hidden')\n",
+        (
+            "import os\nif swap:\n    os = make_module()\ntarget = os\n"
+            "target.__dict__.update({'system': len})\nos.system('echo hidden')\n"
+        ),
+        (
+            "import os\nif swap:\n    os = make_module()\ntarget = os\n"
+            "setattr(target, 'system', len)\nos.system('echo hidden')\n"
+        ),
+        ("import os\nif swap:\n    os = make_module()\ntarget = os\ntarget.system = len\nos.system('echo hidden')\n"),
+        (
+            "import os\ndef hide(target=os):\n"
+            "    target.__dict__.update({'system': len})\n"
+            "    os.system('echo hidden')\n"
+        ),
+        ("import os\ndef hide(target=os):\n    setattr(target, 'system', len)\n    os.system('echo hidden')\n"),
+        ("import os\ndef hide(target=os):\n    target.system = len\n    os.system('echo hidden')\n"),
         (
             "import os\n"
             "setattr = lambda target, key, value: None\n"
@@ -210,6 +238,12 @@ def test_scan_zip_preserves_captured_dangerous_callable_before_overwrite(tmp_pat
         "import os\nresult = setattr(os, 'system', len)\nos.system([])\n",
         "import os\nresult: None = setattr(os, 'system', len)\nos.system([])\n",
         "import os\nsetattr(os, 'system', len)\nrun = os.system\nrun([])\n",
+        "import os\nos.__dict__.__setitem__('system', len)\nos.system([])\n",
+        "import os\nos.__dict__.update({'system': len})\nos.system([])\n",
+        "import os\nvars(os).update({'system': len})\nos.system([])\n",
+        "import os\nreplace = os.__dict__.update\nreplace({'system': len})\nos.system([])\n",
+        "import os\nresult = os.__dict__.update({'system': len})\nos.system([])\n",
+        "import os\nos.__dict__.update({'system': len})\nrun = os.system\nrun([])\n",
     ],
 )
 def test_scan_zip_allows_callable_captured_after_safe_overwrite(tmp_path: Path, source: str) -> None:
@@ -244,6 +278,8 @@ def test_scan_zip_flags_from_import_dangerous_python_member(tmp_path: Path) -> N
     [
         "import os\nimport subprocess\nsetattr(os, 'system', subprocess.run)\nos.system(['id'])\n",
         "import os\nimport subprocess\nresult = setattr(os, 'system', subprocess.run)\nos.system(['id'])\n",
+        "import os\nimport subprocess\nos.__dict__.update({'system': subprocess.run})\nos.system(['id'])\n",
+        "import os\nimport subprocess\nos.__dict__.__setitem__('system', subprocess.run)\nos.system(['id'])\n",
     ],
 )
 def test_scan_zip_reports_dangerous_setattr_replacement(tmp_path: Path, source: str) -> None:
@@ -367,6 +403,8 @@ def test_scan_zip_flags_implicit_builtins_dangerous_python_member(tmp_path: Path
             "globals()['__builtins__']['eval']([])\n"
         ),
         ("replace = globals()['__builtins__'].update\nreplace({'eval': len})\nglobals()['__builtins__']['eval']([])\n"),
+        "import builtins\nbuiltins.__dict__.update({'eval': len})\nbuiltins.eval([])\n",
+        "import builtins\nreplace = builtins.__dict__.update\nreplace({'eval': len})\nbuiltins.eval([])\n",
         "globals()['__builtins__']['eval'] = len\nrun = globals()['__builtins__']['eval']\nrun([])\n",
         ("globals()['__builtins__']['eval'] = len\nrun = globals()['__builtins__']['eval']\nrun.__call__([])\n"),
         ("globals()['__builtins__'].__setitem__('eval', len)\nrun = globals()['__builtins__']['eval']\nrun([])\n"),
@@ -389,34 +427,43 @@ def test_scan_zip_allows_benign_builtin_shaped_source(tmp_path: Path, source: st
 
 
 @pytest.mark.parametrize(
-    "source",
+    ("source", "dangerous_name"),
     [
         (
             "namespace = globals()\n"
             "namespace['__builtins__']['eval'] = __builtins__['exec']\n"
-            "namespace['__builtins__']['eval']('pass')\n"
+            "namespace['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
         ),
         (
             "globals()['__builtins__'].__setitem__('eval', __builtins__['exec'])\n"
-            "globals()['__builtins__']['eval']('pass')\n"
+            "globals()['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
         ),
         (
             "globals()['__builtins__'].update({'eval': __builtins__['exec']})\n"
-            "globals()['__builtins__']['eval']('pass')\n"
+            "globals()['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
         ),
         (
             "replace = globals()['__builtins__'].__setitem__\n"
             "replace('eval', __builtins__['exec'])\n"
-            "globals()['__builtins__']['eval']('pass')\n"
+            "globals()['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
         ),
         (
             "replace = globals()['__builtins__'].update\n"
             "replace({'eval': __builtins__['exec']})\n"
-            "globals()['__builtins__']['eval']('pass')\n"
+            "globals()['__builtins__']['eval']('pass')\n",
+            "__builtins__.exec",
+        ),
+        (
+            "import builtins\nbuiltins.__dict__.update({'eval': builtins.exec})\nbuiltins.eval('pass')\n",
+            "builtins.exec",
         ),
     ],
 )
-def test_scan_zip_reports_dangerous_builtin_reassignment(tmp_path: Path, source: str) -> None:
+def test_scan_zip_reports_dangerous_builtin_reassignment(tmp_path: Path, source: str, dangerous_name: str) -> None:
     archive_path = tmp_path / "model_bundle.zip"
     with zipfile.ZipFile(archive_path, "w") as archive:
         archive.writestr("handler.py", source)
@@ -430,7 +477,7 @@ def test_scan_zip_reports_dangerous_builtin_reassignment(tmp_path: Path, source:
     ]
     assert len(python_checks) == 1
     assert python_checks[0].rule_code == "S104"
-    assert python_checks[0].details["reason"] == "high-risk calls: __builtins__.exec"
+    assert python_checks[0].details["reason"] == f"high-risk calls: {dangerous_name}"
 
 
 def test_scan_zip_flags_aliased_getattr_helper_dangerous_python_member(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- reuse existing namespace-map resolution when modeling statically certain mapping writes
- recognize safe or dangerous writes through reflective maps such as `getattr(os, '__dict__')`, `os.__getattribute__('__dict__')`, and stored `namespace = os.__dict__` aliases
- retain findings for conditional reflective helpers, conditionally replaced map aliases, and runtime-provided map parameters

## Root cause
The analyzer could already resolve dangerous reads dispatched through reflective or saved namespace mappings, but its mutation model accepted only direct `module.__dict__` and `vars(module)` receiver syntax. Consequently, equivalent statically certain safe replacement forms remained false positives, while dangerous replacements retained stale attribution.

This PR removes that redundant syntax restriction and relies on the certainty and uncertainty controls established in #1356: a mutation is modeled only when the existing resolver yields exactly one namespace root and no conditional, alias-propagated, or runtime-argument uncertainty is present.

## Security regression coverage
- safe reflective and saved-map replacements are clean
- dangerous reflective and saved-map replacements are attributed to `subprocess.run` or `builtins.exec`
- conditional helper, conditional map-alias, and defaulted map-parameter forms remain findings
- coverage through ZIP, TAR, standalone JIT, PyTorch ZIP JIT, and TorchServe MAR analysis paths

## Validation
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`Success: no issues found in 453 source files`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`5203 passed, 1063 skipped`)

## Stack
This draft is stacked on #1356 (`fix: model certain namespace mapping mutations`).