### PR TITLE
fix: model namespace mapping mutation helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - avoid embedded Python execution findings after statically certain safe `setattr` replacement
 - avoid embedded Python execution findings after statically certain namespace-mapping replacement
 - model reflective and saved namespace-map replacements when their receiver remains certain
+- model deterministic mapping-helper replacements when their helper and receiver remain certain
 - preserve embedded Python execution findings when a replacement receiver is conditional, aliased, or a runtime argument
 - fail closed when nested NeMo checkpoint or referenced-artifact analysis is explicitly incomplete
 - preserve concrete nested security findings from checkpoint and referenced artifacts inside NeMo archives

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -304,6 +304,13 @@ _STATIC_ATTRIBUTE_MUTATION_HELPERS = {
     "__builtins__.setattr",
     "builtins.setattr",
 }
+_STATIC_MAPPING_FUNCTION_MUTATORS = {
+    "dict.__setitem__": "__setitem__",
+    "builtins.dict.__setitem__": "__setitem__",
+    "dict.update": "update",
+    "builtins.dict.update": "update",
+    "operator.setitem": "__setitem__",
+}
 
 
 def _has_uncertain_static_binding(node: ast.AST, alias_scopes: _AliasScopes) -> bool:
@@ -811,26 +818,43 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             return
 
         mutator_names = self._resolve_certain_static_mapping_mutator_names(node.func)
-        if mutator_names is None:
-            return
-        methods = {mutator_name.rsplit(".", maxsplit=1)[1] for mutator_name in mutator_names}
-        if len(methods) != 1:
-            return
-        method = next(iter(methods))
-        target_roots = frozenset(mutator_name.rsplit(".", maxsplit=1)[0] for mutator_name in mutator_names)
+        mutation_args = node.args
+        if mutator_names is not None:
+            methods = {mutator_name.rsplit(".", maxsplit=1)[1] for mutator_name in mutator_names}
+            if len(methods) != 1:
+                return
+            method = next(iter(methods))
+            target_roots = frozenset(mutator_name.rsplit(".", maxsplit=1)[0] for mutator_name in mutator_names)
+        else:
+            if _has_uncertain_static_binding(node.func, self.alias_scopes) or not node.args:
+                return
+            helper_names = self._resolve_invoked_reference_names(node.func)
+            if helper_names is None:
+                return
+            helper_methods = {_STATIC_MAPPING_FUNCTION_MUTATORS.get(helper_name) for helper_name in helper_names}
+            if None in helper_methods or len(helper_methods) != 1:
+                return
+            method = next(helper_method for helper_method in helper_methods if helper_method is not None)
+            resolved_target_roots = _resolve_certain_namespace_mutation_roots(node.args[0], self.alias_scopes)
+            if resolved_target_roots is None:
+                return
+            target_roots = resolved_target_roots
+            mutation_args = node.args[1:]
 
         mutations: list[tuple[frozenset[str], ast.AST]] = []
         if method == "__setitem__":
-            if len(node.args) != 2:
+            if len(mutation_args) != 2:
                 return
-            attr_name = _resolve_static_string(node.args[0])
+            attr_name = _resolve_static_string(mutation_args[0])
             if attr_name is None:
                 return
-            mutations.append((frozenset(f"{target_root}.{attr_name}" for target_root in target_roots), node.args[1]))
+            mutations.append(
+                (frozenset(f"{target_root}.{attr_name}" for target_root in target_roots), mutation_args[1])
+            )
         elif method == "update":
-            if len(node.args) != 1 or not isinstance(node.args[0], ast.Dict):
+            if len(mutation_args) != 1 or not isinstance(mutation_args[0], ast.Dict):
                 return
-            for attr_name_node, value_node in zip(node.args[0].keys, node.args[0].values, strict=True):
+            for attr_name_node, value_node in zip(mutation_args[0].keys, mutation_args[0].values, strict=True):
                 if attr_name_node is None:
                     return
                 attr_name = _resolve_static_string(attr_name_node)

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -366,6 +366,8 @@ class TestJITScriptDetector:
             b"import builtins\nreplace = builtins.__dict__.update\nreplace({'eval': len})\nbuiltins.eval([])\n",
             b"import builtins\ngetattr(builtins, '__dict__').update({'eval': len})\nbuiltins.eval([])\n",
             b"import builtins\nnamespace = builtins.__dict__\nnamespace.update({'eval': len})\nbuiltins.eval([])\n",
+            b"import builtins\ndict.update(builtins.__dict__, {'eval': len})\nbuiltins.eval([])\n",
+            b"import builtins\nimport operator\noperator.setitem(builtins.__dict__, 'eval', len)\nbuiltins.eval([])\n",
             b"def payload():\n    eval = len\n    return eval([])\n",
             (
                 b"def payload():\n"
@@ -419,6 +421,11 @@ class TestJITScriptDetector:
             (
                 b"import builtins\nnamespace = builtins.__dict__\n"
                 b"namespace.update({'eval': builtins.exec})\nbuiltins.eval('pass')\n"
+            ),
+            b"import builtins\ndict.update(builtins.__dict__, {'eval': builtins.exec})\nbuiltins.eval('pass')\n",
+            (
+                b"import builtins\nimport operator\n"
+                b"operator.setitem(builtins.__dict__, 'eval', builtins.exec)\nbuiltins.eval('pass')\n"
             ),
         ],
     )
@@ -557,6 +564,14 @@ class TestJITScriptDetector:
                 b"def invoke(namespace=builtins.__dict__):\n"
                 b"    namespace.update({'eval': len})\n"
                 b"    return builtins.eval('1 + 1')\n"
+            ),
+            (
+                b"import builtins\n"
+                b"replace = dict.update\n"
+                b"if swap:\n"
+                b"    replace = lambda target, values: None\n"
+                b"replace(builtins.__dict__, {'eval': len})\n"
+                b"builtins.eval('1 + 1')\n"
             ),
             (
                 b"import builtins\n"

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1146,6 +1146,7 @@ def test_pytorch_zip_scans_aliased_modeled_builtins_in_archive_data(
         b"globals()['__builtins__'].update({'eval': len})\nglobals()['__builtins__']['eval']([])\n",
         b"import builtins\nbuiltins.__dict__.update({'eval': len})\nbuiltins.eval([])\n",
         b"import builtins\ngetattr(builtins, '__dict__').update({'eval': len})\nbuiltins.eval([])\n",
+        b"import builtins\ndict.update(builtins.__dict__, {'eval': len})\nbuiltins.eval([])\n",
         (
             b"replace = globals()['__builtins__'].__setitem__\n"
             b"replace('eval', len)\n"
@@ -1223,6 +1224,7 @@ def test_pytorch_zip_ignores_benign_builtin_shaped_access_in_archive_data(tmp_pa
         ),
         b"import builtins\nbuiltins.__dict__.update({'eval': builtins.exec})\nbuiltins.eval('pass')\n",
         b"import builtins\ngetattr(builtins, '__dict__').update({'eval': builtins.exec})\nbuiltins.eval('pass')\n",
+        b"import builtins\ndict.update(builtins.__dict__, {'eval': builtins.exec})\nbuiltins.eval('pass')\n",
     ],
 )
 def test_pytorch_zip_detects_dangerous_builtin_reassignment_in_archive_data(tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -178,6 +178,10 @@ class TestTarScanner:
                 b"namespace.update({'system': len})\nos.system('echo hidden')\n"
             ),
             (
+                b"import os\nreplace = dict.update\nif swap:\n    replace = lambda target, values: None\n"
+                b"replace(os.__dict__, {'system': len})\nos.system('echo hidden')\n"
+            ),
+            (
                 b"import os\n"
                 b"setattr = lambda target, key, value: None\n"
                 b"setattr(os, 'system', len)\n"
@@ -218,6 +222,8 @@ class TestTarScanner:
             b"import os\nos.__dict__.update({'system': len})\nrun = os.system\nrun([])\n",
             b"import os\ngetattr(os, '__dict__').update({'system': len})\nos.system([])\n",
             b"import os\nnamespace = os.__dict__\nnamespace.update({'system': len})\nos.system([])\n",
+            b"import os\ndict.update(os.__dict__, {'system': len})\nos.system([])\n",
+            b"import os\nimport operator\noperator.setitem(os.__dict__, 'system', len)\nos.system([])\n",
         ],
     )
     def test_scan_tar_allows_callable_captured_after_safe_overwrite(self, tmp_path: Path, payload: bytes) -> None:
@@ -258,6 +264,7 @@ class TestTarScanner:
                 b"import os\nimport subprocess\n"
                 b"getattr(os, '__dict__').update({'system': subprocess.run})\nos.system(['id'])\n"
             ),
+            b"import os\nimport subprocess\ndict.update(os.__dict__, {'system': subprocess.run})\nos.system(['id'])\n",
         ],
     )
     def test_scan_tar_reports_dangerous_setattr_replacement(self, tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -390,6 +390,12 @@ def test_scan_detects_implicit_builtins_handler_execution_primitive(
             b"    return builtins.eval([])\n"
         ),
         (
+            b"import builtins\n"
+            b"def handle(data, context):\n"
+            b"    dict.update(builtins.__dict__, {'eval': len})\n"
+            b"    return builtins.eval([])\n"
+        ),
+        (
             b"def handle(data, context):\n"
             b"    replace = globals()['__builtins__'].__setitem__\n"
             b"    replace('eval', len)\n"
@@ -503,6 +509,13 @@ def test_scan_allows_benign_builtin_shaped_handler_source(tmp_path: Path, handle
             b"import builtins\n"
             b"def handle(data, context):\n"
             b"    getattr(builtins, '__dict__').update({'eval': builtins.exec})\n"
+            b"    return builtins.eval('pass')\n",
+            "builtins.exec",
+        ),
+        (
+            b"import builtins\n"
+            b"def handle(data, context):\n"
+            b"    dict.update(builtins.__dict__, {'eval': builtins.exec})\n"
             b"    return builtins.eval('pass')\n",
             "builtins.exec",
         ),

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -210,6 +210,15 @@ def test_scan_zip_flags_aliased_dangerous_python_member(tmp_path: Path) -> None:
             "    namespace.update({'system': len})\n"
             "    os.system('echo hidden')\n"
         ),
+        (
+            "import os\nreplace = dict.update\nif swap:\n    replace = lambda target, values: None\n"
+            "replace(os.__dict__, {'system': len})\nos.system('echo hidden')\n"
+        ),
+        (
+            "import os\ndef hide(namespace=os.__dict__):\n"
+            "    dict.update(namespace, {'system': len})\n"
+            "    os.system('echo hidden')\n"
+        ),
         ("import os\ndef hide(target=os):\n    setattr(target, 'system', len)\n    os.system('echo hidden')\n"),
         ("import os\ndef hide(target=os):\n    target.system = len\n    os.system('echo hidden')\n"),
         (
@@ -263,6 +272,10 @@ def test_scan_zip_preserves_captured_dangerous_callable_before_overwrite(tmp_pat
         "import os\nnamespace = os.__dict__\nnamespace.update({'system': len})\nos.system([])\n",
         "import os\nnamespace = getattr(os, '__dict__')\nnamespace.update({'system': len})\nos.system([])\n",
         "import os\nreplace = getattr(os, '__dict__').update\nreplace({'system': len})\nos.system([])\n",
+        "import os\ndict.update(os.__dict__, {'system': len})\nos.system([])\n",
+        "import os\ndict.__setitem__(os.__dict__, 'system', len)\nos.system([])\n",
+        "import os\nimport operator\noperator.setitem(os.__dict__, 'system', len)\nos.system([])\n",
+        "import os\nfrom operator import setitem as replace\nreplace(os.__dict__, 'system', len)\nos.system([])\n",
     ],
 )
 def test_scan_zip_allows_callable_captured_after_safe_overwrite(tmp_path: Path, source: str) -> None:
@@ -303,6 +316,11 @@ def test_scan_zip_flags_from_import_dangerous_python_member(tmp_path: Path) -> N
         (
             "import os\nimport subprocess\nnamespace = os.__dict__\n"
             "namespace.update({'system': subprocess.run})\nos.system(['id'])\n"
+        ),
+        "import os\nimport subprocess\ndict.update(os.__dict__, {'system': subprocess.run})\nos.system(['id'])\n",
+        (
+            "import os\nimport operator\nimport subprocess\n"
+            "operator.setitem(os.__dict__, 'system', subprocess.run)\nos.system(['id'])\n"
         ),
     ],
 )


### PR DESCRIPTION
## Summary
- model deterministic namespace-map writes performed through `dict.update`, `dict.__setitem__`, and `operator.setitem`
- apply existing safe replacement suppression and dangerous replacement reattribution to those helper forms
- preserve findings when a helper is conditionally rebound or the namespace receiver is runtime-dependent

## Root cause
Embedded Python analysis modeled mutations invoked as bound mapping methods, but not the equivalent deterministic helper-call forms. A safe call such as `dict.update(os.__dict__, {'system': len})` therefore remained a false positive, while replacing the same slot with `subprocess.run` was reported under stale `os.system` attribution.

The implementation feeds recognized helper calls into the same bounded literal-key mutation logic as bound methods and reuses the receiver certainty contract from #1356/#1357. It intentionally does not model removal operations such as `pop`, where returned-call behavior and absent attributes require a distinct treatment.

## Security regression coverage
- benign `dict.update`, `dict.__setitem__`, `operator.setitem`, and imported `operator.setitem` alias cases
- dangerous helper replacements attributed to `subprocess.run` or `builtins.exec`
- conditional helper-rebinding and runtime-receiver positives remain findings
- coverage through ZIP, TAR, standalone JIT, PyTorch ZIP JIT, and TorchServe MAR paths

## Validation
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`Success: no issues found in 453 source files`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`5219 passed, 1068 skipped`)

## Stack
This draft is stacked on #1357 (`fix: model resolved namespace mapping mutations`).