### PR TITLE
fix: model namespace mapping deletions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - model deterministic mapping-helper replacements when their helper and receiver remain certain
 - avoid embedded Python execution findings after a certain discarded namespace-map removal
 - avoid embedded Python execution findings after certain key-specific namespace deletion
+- avoid embedded Python execution findings after certain namespace-map clearing or certain map mutator calls themselves
 - preserve embedded Python execution findings when a replacement receiver is conditional, aliased, or a runtime argument
 - fail closed when nested NeMo checkpoint or referenced-artifact analysis is explicitly incomplete
 - preserve concrete nested security findings from checkpoint and referenced artifacts inside NeMo archives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - avoid embedded Python execution findings after a certain discarded namespace-map removal
 - avoid embedded Python execution findings after certain key-specific namespace deletion
 - avoid embedded Python execution findings after certain namespace-map clearing or certain map mutator calls themselves
+- preserve embedded Python execution findings after reloads or rebuilt child namespaces undo certain namespace removals
 - preserve embedded Python execution findings when a replacement receiver is conditional, aliased, or a runtime argument
 - fail closed when nested NeMo checkpoint or referenced-artifact analysis is explicitly incomplete
 - preserve concrete nested security findings from checkpoint and referenced artifacts inside NeMo archives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - model reflective and saved namespace-map replacements when their receiver remains certain
 - model deterministic mapping-helper replacements when their helper and receiver remain certain
 - avoid embedded Python execution findings after a certain discarded namespace-map removal
+- avoid embedded Python execution findings after certain key-specific namespace deletion
 - preserve embedded Python execution findings when a replacement receiver is conditional, aliased, or a runtime argument
 - fail closed when nested NeMo checkpoint or referenced-artifact analysis is explicitly incomplete
 - preserve concrete nested security findings from checkpoint and referenced artifacts inside NeMo archives

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -296,9 +296,13 @@ _STATIC_REFERENCE_OVERRIDE_PREFIX = "<static reference override>:"
 _STATIC_CLEARED_NAMESPACE_PREFIX = "<static cleared namespace>:"
 _STATIC_MAPPING_MUTATION_ALIAS_PREFIX = "<static mapping mutation alias>:"
 _STATIC_UNCERTAIN_BINDING_PREFIX = "<uncertain static binding>:"
+_STATIC_GLOBAL_BUILTINS_REBOUND_KEY = "<static global builtins rebound>"
 _CAPTURED_CALLABLE_REFERENCE_PREFIX = "<captured callable>:"
 _BUILTIN_NAMESPACE_NAMES = {"__builtin__", "__builtins__"}
 _BUILTIN_NAMESPACE_ROOT_EQUIVALENTS = frozenset({"__builtin__", "__builtins__", "builtins"})
+_GLOBAL_BUILTIN_NAMESPACE_REFERENCES = frozenset(
+    f"{_GLOBAL_NAMESPACE_MAPPING_MARKER}.{namespace_name}" for namespace_name in _BUILTIN_NAMESPACE_NAMES
+).union(f"{namespace_name}.__dict__" for namespace_name in _BUILTIN_NAMESPACE_NAMES)
 _STATIC_MAPPING_MUTATORS = {"__delitem__", "__setitem__", "clear", "pop", "update"}
 _STATIC_ATTRIBUTE_MUTATION_HELPERS = {
     "setattr",
@@ -320,6 +324,7 @@ _STATIC_MAPPING_FUNCTION_MUTATORS = {
     "operator.delitem": "__delitem__",
     "operator.setitem": "__setitem__",
 }
+_STATIC_RELOAD_HELPERS = {"importlib.reload"}
 
 
 def _has_uncertain_static_binding(node: ast.AST, alias_scopes: _AliasScopes) -> bool:
@@ -701,26 +706,42 @@ def _binding_names(target: ast.AST) -> Iterator[str]:
             yield from _binding_names(element)
 
 
-def _equivalent_static_namespace_roots(namespace_root: str) -> frozenset[str]:
+def _equivalent_static_namespace_roots(
+    namespace_root: str,
+    alias_scopes: _AliasScopes | None = None,
+) -> frozenset[str]:
     if namespace_root in _BUILTIN_NAMESPACE_ROOT_EQUIVALENTS:
+        if alias_scopes is not None:
+            for aliases in reversed(alias_scopes):
+                if _STATIC_GLOBAL_BUILTINS_REBOUND_KEY in aliases:
+                    if aliases[_STATIC_GLOBAL_BUILTINS_REBOUND_KEY] is None:
+                        return frozenset({namespace_root})
+                    break
         return _BUILTIN_NAMESPACE_ROOT_EQUIVALENTS
     return frozenset({namespace_root})
 
 
-def _equivalent_static_reference_names(reference_name: str) -> frozenset[str]:
+def _equivalent_static_reference_names(
+    reference_name: str,
+    alias_scopes: _AliasScopes | None = None,
+) -> frozenset[str]:
     namespace_root, separator, attribute_name = reference_name.partition(".")
     if not separator:
         return frozenset({reference_name})
     return frozenset(
-        f"{equivalent_root}.{attribute_name}" for equivalent_root in _equivalent_static_namespace_roots(namespace_root)
+        f"{equivalent_root}.{attribute_name}"
+        for equivalent_root in _equivalent_static_namespace_roots(namespace_root, alias_scopes)
     )
 
 
-def _static_reference_namespace_roots(reference_name: str) -> frozenset[str]:
+def _static_reference_namespace_roots(
+    reference_name: str,
+    alias_scopes: _AliasScopes | None = None,
+) -> frozenset[str]:
     parts = reference_name.split(".")
     namespace_roots: set[str] = set()
     for index in range(1, len(parts)):
-        namespace_roots.update(_equivalent_static_namespace_roots(".".join(parts[:index])))
+        namespace_roots.update(_equivalent_static_namespace_roots(".".join(parts[:index]), alias_scopes))
     return frozenset(namespace_roots)
 
 
@@ -762,11 +783,74 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         return f"{_STATIC_UNCERTAIN_BINDING_PREFIX}{name}"
 
     def _lookup_static_reference_override(self, reference_name: str) -> _AliasValue:
-        override_key = self._static_reference_override_key(reference_name)
         for aliases in reversed(self.alias_scopes):
+            override_names = self._lookup_static_reference_override_in_scope(aliases, reference_name)
+            if override_names is not _MISSING_ALIAS:
+                return override_names if isinstance(override_names, frozenset) else None
+            for namespace_root in _static_reference_namespace_roots(reference_name, self.alias_scopes):
+                clear_key = self._static_cleared_namespace_key(namespace_root)
+                if clear_key in aliases and aliases[clear_key] is None:
+                    return None
+        return frozenset({reference_name})
+
+    def _lookup_static_reference_override_in_scope(
+        self,
+        aliases: _AliasScope,
+        reference_name: str,
+    ) -> _AliasValue | object:
+        override_key = self._static_reference_override_key(reference_name)
+        if override_key in aliases:
+            return aliases[override_key]
+
+        equivalent_reference_names = _equivalent_static_reference_names(reference_name, self.alias_scopes)
+        for equivalent_reference_name in sorted(equivalent_reference_names - {reference_name}):
+            override_key = self._static_reference_override_key(equivalent_reference_name)
             if override_key in aliases:
                 return aliases[override_key]
-            for namespace_root in _static_reference_namespace_roots(reference_name):
+
+        parts = reference_name.split(".")
+        for index in range(len(parts) - 1, 0, -1):
+            prefix = ".".join(parts[:index])
+            suffix = ".".join(parts[index:])
+            prefix_override_key = self._static_reference_override_key(prefix)
+            if prefix_override_key in aliases:
+                override_names = aliases[prefix_override_key]
+                if override_names is None:
+                    return None
+                return frozenset(f"{override_name}.{suffix}" for override_name in override_names)
+
+            equivalent_prefixes = _equivalent_static_reference_names(prefix, self.alias_scopes)
+            for equivalent_prefix in sorted(equivalent_prefixes - {prefix}):
+                override_key = self._static_reference_override_key(equivalent_prefix)
+                if override_key not in aliases:
+                    continue
+                override_names = aliases[override_key]
+                if override_names is None:
+                    return None
+                return frozenset(f"{override_name}.{suffix}" for override_name in override_names)
+
+        return _MISSING_ALIAS
+
+    def _lookup_exact_static_reference_override(self, reference_name: str) -> _AliasValue:
+        parts = reference_name.split(".")
+        namespace_roots = [".".join(parts[:index]) for index in range(1, len(parts))]
+        for aliases in reversed(self.alias_scopes):
+            override_key = self._static_reference_override_key(reference_name)
+            if override_key in aliases:
+                return aliases[override_key]
+
+            for index in range(len(parts) - 1, 0, -1):
+                prefix = ".".join(parts[:index])
+                suffix = ".".join(parts[index:])
+                prefix_override_key = self._static_reference_override_key(prefix)
+                if prefix_override_key not in aliases:
+                    continue
+                override_names = aliases[prefix_override_key]
+                if override_names is None:
+                    return None
+                return frozenset(f"{override_name}.{suffix}" for override_name in override_names)
+
+            for namespace_root in namespace_roots:
                 clear_key = self._static_cleared_namespace_key(namespace_root)
                 if clear_key in aliases and aliases[clear_key] is None:
                     return None
@@ -849,28 +933,41 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
 
     def _bind_static_reference_names_to_value(self, target_names: frozenset[str], value: ast.AST) -> None:
         resolved_value_names = self._resolve_bound_value_names(value)
+        self._mark_global_builtin_namespace_rebound(target_names)
         for target_name in target_names:
-            for equivalent_target_name in _equivalent_static_reference_names(target_name):
+            for equivalent_target_name in _equivalent_static_reference_names(target_name, self.alias_scopes):
                 self._bind_name(self._static_reference_override_key(equivalent_target_name), resolved_value_names)
 
     def _bind_static_reference_names_as_removed(self, target_names: frozenset[str]) -> None:
+        self._mark_global_builtin_namespace_rebound(target_names)
         for target_name in target_names:
-            for equivalent_target_name in _equivalent_static_reference_names(target_name):
+            for equivalent_target_name in _equivalent_static_reference_names(target_name, self.alias_scopes):
                 self._bind_name(self._static_reference_override_key(equivalent_target_name), None)
+
+    def _mark_global_builtin_namespace_rebound(self, target_names: frozenset[str]) -> None:
+        if target_names & _GLOBAL_BUILTIN_NAMESPACE_REFERENCES:
+            self._bind_name(_STATIC_GLOBAL_BUILTINS_REBOUND_KEY, None)
 
     def _discard_static_reference_overrides_for_roots(self, namespace_roots: frozenset[str]) -> None:
         current_scope = self.alias_scopes[-1]
         for namespace_root in namespace_roots:
-            for equivalent_root in _equivalent_static_namespace_roots(namespace_root):
+            for equivalent_root in _equivalent_static_namespace_roots(namespace_root, self.alias_scopes):
                 reference_prefix = f"{_STATIC_REFERENCE_OVERRIDE_PREFIX}{equivalent_root}."
                 for key in list(current_scope):
                     if key.startswith(reference_prefix):
                         del current_scope[key]
 
+    def _discard_static_namespace_state_for_roots(self, namespace_roots: frozenset[str]) -> None:
+        current_scope = self.alias_scopes[-1]
+        self._discard_static_reference_overrides_for_roots(namespace_roots)
+        for namespace_root in namespace_roots:
+            for equivalent_root in _equivalent_static_namespace_roots(namespace_root, self.alias_scopes):
+                current_scope.pop(self._static_cleared_namespace_key(equivalent_root), None)
+
     def _bind_static_namespace_roots_as_cleared(self, namespace_roots: frozenset[str]) -> None:
         self._discard_static_reference_overrides_for_roots(namespace_roots)
         for namespace_root in namespace_roots:
-            for equivalent_root in _equivalent_static_namespace_roots(namespace_root):
+            for equivalent_root in _equivalent_static_namespace_roots(namespace_root, self.alias_scopes):
                 self._bind_name(self._static_cleared_namespace_key(equivalent_root), None)
 
     def _bind_static_reference_target_as_removed(self, target: ast.AST) -> None:
@@ -972,6 +1069,20 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         if target_names is None or len(target_names) != 1:
             return
         self._bind_static_reference_names_to_value(target_names, node.args[2])
+
+    def _bind_static_reload_mutation(self, node: ast.Call) -> None:
+        if len(node.args) != 1 or node.keywords:
+            return
+
+        helper_name = _resolve_call_name(node.func)
+        helper_names = _apply_aliases(helper_name, self.alias_scopes) if helper_name is not None else None
+        if helper_names is None or not (helper_names & _STATIC_RELOAD_HELPERS):
+            return
+
+        target_name = _resolve_call_name(node.args[0])
+        namespace_roots = _apply_aliases(target_name, self.alias_scopes) if target_name is not None else None
+        if namespace_roots is not None:
+            self._discard_static_namespace_state_for_roots(namespace_roots)
 
     def _bind_target_to_value(self, target: ast.AST, value: ast.AST) -> None:
         if isinstance(target, ast.Name):
@@ -1117,9 +1228,8 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
                 continue
             base_value: _AliasValue | object
             if name.startswith(_STATIC_REFERENCE_OVERRIDE_PREFIX):
-                base_value = self._lookup_static_reference_override(
-                    name.removeprefix(_STATIC_REFERENCE_OVERRIDE_PREFIX)
-                )
+                reference_name = name.removeprefix(_STATIC_REFERENCE_OVERRIDE_PREFIX)
+                base_value = self._lookup_exact_static_reference_override(reference_name)
             else:
                 base_value = current_scope.get(name, _MISSING_ALIAS)
             branch_values = [scope.get(name, base_value) for scope in branch_scopes]
@@ -1351,6 +1461,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             for resolved_name in resolved_names:
                 if self._is_tracked_call_name(resolved_name):
                     self.risky_calls.add(resolved_name)
+        self._bind_static_reload_mutation(node)
         self.generic_visit(node)
 
 

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -297,7 +297,7 @@ _STATIC_MAPPING_MUTATION_ALIAS_PREFIX = "<static mapping mutation alias>:"
 _STATIC_UNCERTAIN_BINDING_PREFIX = "<uncertain static binding>:"
 _CAPTURED_CALLABLE_REFERENCE_PREFIX = "<captured callable>:"
 _BUILTIN_NAMESPACE_NAMES = {"__builtin__", "__builtins__"}
-_STATIC_MAPPING_MUTATORS = {"__setitem__", "pop", "update"}
+_STATIC_MAPPING_MUTATORS = {"__delitem__", "__setitem__", "pop", "update"}
 _STATIC_ATTRIBUTE_MUTATION_HELPERS = {
     "setattr",
     "__builtin__.setattr",
@@ -307,10 +307,13 @@ _STATIC_ATTRIBUTE_MUTATION_HELPERS = {
 _STATIC_MAPPING_FUNCTION_MUTATORS = {
     "dict.__setitem__": "__setitem__",
     "builtins.dict.__setitem__": "__setitem__",
+    "dict.__delitem__": "__delitem__",
+    "builtins.dict.__delitem__": "__delitem__",
     "dict.update": "update",
     "builtins.dict.update": "update",
     "dict.pop": "pop",
     "builtins.dict.pop": "pop",
+    "operator.delitem": "__delitem__",
     "operator.setitem": "__setitem__",
 }
 
@@ -814,6 +817,17 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         for target_name in target_names:
             self._bind_name(self._static_reference_override_key(target_name), resolved_value_names)
 
+    def _bind_static_reference_names_as_removed(self, target_names: frozenset[str]) -> None:
+        for target_name in target_names:
+            self._bind_name(self._static_reference_override_key(target_name), None)
+
+    def _bind_static_reference_target_as_removed(self, target: ast.AST) -> None:
+        if _has_uncertain_static_binding(target, self.alias_scopes):
+            return
+        target_names = _resolve_static_assignment_target_names(target, self.alias_scopes)
+        if target_names is not None:
+            self._bind_static_reference_names_as_removed(target_names)
+
     def _bind_static_mapping_mutation(self, node: ast.Call, *, model_discarded_removals: bool = False) -> None:
         """Model unconditional writes through one certain namespace mapping."""
         if node.keywords:
@@ -853,6 +867,13 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             mutations.append(
                 (frozenset(f"{target_root}.{attr_name}" for target_root in target_roots), mutation_args[1])
             )
+        elif method == "__delitem__":
+            if len(mutation_args) != 1:
+                return
+            attr_name = _resolve_static_string(mutation_args[0])
+            if attr_name is None:
+                return
+            mutations.append((frozenset(f"{target_root}.{attr_name}" for target_root in target_roots), None))
         elif method == "update":
             if len(mutation_args) != 1 or not isinstance(mutation_args[0], ast.Dict):
                 return
@@ -875,8 +896,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
 
         for target_names, value in mutations:
             if value is None:
-                for target_name in target_names:
-                    self._bind_name(self._static_reference_override_key(target_name), None)
+                self._bind_static_reference_names_as_removed(target_names)
             else:
                 self._bind_static_reference_names_to_value(target_names, value)
 
@@ -1138,6 +1158,11 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         self.visit(node.value)
         self._bind_target_to_value(node.target, node.value)
         self.visit(node.target)
+
+    def visit_Delete(self, node: ast.Delete) -> None:
+        for target in node.targets:
+            self._bind_static_reference_target_as_removed(target)
+            self.visit(target)
 
     def visit_Expr(self, node: ast.Expr) -> None:
         self.visit(node.value)

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -293,11 +293,13 @@ _NAMESPACE_MAPPING_ACCESSORS = {"get", "__getitem__", "pop", "setdefault"}
 _GLOBAL_NAMESPACE_HELPERS = {"globals", "builtins.globals"}
 _GLOBAL_NAMESPACE_MAPPING_MARKER = "<globals mapping>"
 _STATIC_REFERENCE_OVERRIDE_PREFIX = "<static reference override>:"
+_STATIC_CLEARED_NAMESPACE_PREFIX = "<static cleared namespace>:"
 _STATIC_MAPPING_MUTATION_ALIAS_PREFIX = "<static mapping mutation alias>:"
 _STATIC_UNCERTAIN_BINDING_PREFIX = "<uncertain static binding>:"
 _CAPTURED_CALLABLE_REFERENCE_PREFIX = "<captured callable>:"
 _BUILTIN_NAMESPACE_NAMES = {"__builtin__", "__builtins__"}
-_STATIC_MAPPING_MUTATORS = {"__delitem__", "__setitem__", "pop", "update"}
+_BUILTIN_NAMESPACE_ROOT_EQUIVALENTS = frozenset({"__builtin__", "__builtins__", "builtins"})
+_STATIC_MAPPING_MUTATORS = {"__delitem__", "__setitem__", "clear", "pop", "update"}
 _STATIC_ATTRIBUTE_MUTATION_HELPERS = {
     "setattr",
     "__builtin__.setattr",
@@ -309,6 +311,8 @@ _STATIC_MAPPING_FUNCTION_MUTATORS = {
     "builtins.dict.__setitem__": "__setitem__",
     "dict.__delitem__": "__delitem__",
     "builtins.dict.__delitem__": "__delitem__",
+    "dict.clear": "clear",
+    "builtins.dict.clear": "clear",
     "dict.update": "update",
     "builtins.dict.update": "update",
     "dict.pop": "pop",
@@ -697,6 +701,29 @@ def _binding_names(target: ast.AST) -> Iterator[str]:
             yield from _binding_names(element)
 
 
+def _equivalent_static_namespace_roots(namespace_root: str) -> frozenset[str]:
+    if namespace_root in _BUILTIN_NAMESPACE_ROOT_EQUIVALENTS:
+        return _BUILTIN_NAMESPACE_ROOT_EQUIVALENTS
+    return frozenset({namespace_root})
+
+
+def _equivalent_static_reference_names(reference_name: str) -> frozenset[str]:
+    namespace_root, separator, attribute_name = reference_name.partition(".")
+    if not separator:
+        return frozenset({reference_name})
+    return frozenset(
+        f"{equivalent_root}.{attribute_name}" for equivalent_root in _equivalent_static_namespace_roots(namespace_root)
+    )
+
+
+def _static_reference_namespace_roots(reference_name: str) -> frozenset[str]:
+    parts = reference_name.split(".")
+    namespace_roots: set[str] = set()
+    for index in range(1, len(parts)):
+        namespace_roots.update(_equivalent_static_namespace_roots(".".join(parts[:index])))
+    return frozenset(namespace_roots)
+
+
 class _HighRiskPythonCallVisitor(ast.NodeVisitor):
     def __init__(self, tracked_call_names: frozenset[str] | None = None) -> None:
         self.alias_scopes: _AliasScopes = [{}]
@@ -723,6 +750,10 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         return f"{_STATIC_REFERENCE_OVERRIDE_PREFIX}{reference_name}"
 
     @staticmethod
+    def _static_cleared_namespace_key(namespace_root: str) -> str:
+        return f"{_STATIC_CLEARED_NAMESPACE_PREFIX}{namespace_root}"
+
+    @staticmethod
     def _static_mapping_mutation_alias_key(name: str) -> str:
         return f"{_STATIC_MAPPING_MUTATION_ALIAS_PREFIX}{name}"
 
@@ -735,6 +766,10 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         for aliases in reversed(self.alias_scopes):
             if override_key in aliases:
                 return aliases[override_key]
+            for namespace_root in _static_reference_namespace_roots(reference_name):
+                clear_key = self._static_cleared_namespace_key(namespace_root)
+                if clear_key in aliases and aliases[clear_key] is None:
+                    return None
         return frozenset({reference_name})
 
     def _lookup_static_mapping_mutation_alias(self, name: str) -> _AliasValue:
@@ -815,11 +850,28 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
     def _bind_static_reference_names_to_value(self, target_names: frozenset[str], value: ast.AST) -> None:
         resolved_value_names = self._resolve_bound_value_names(value)
         for target_name in target_names:
-            self._bind_name(self._static_reference_override_key(target_name), resolved_value_names)
+            for equivalent_target_name in _equivalent_static_reference_names(target_name):
+                self._bind_name(self._static_reference_override_key(equivalent_target_name), resolved_value_names)
 
     def _bind_static_reference_names_as_removed(self, target_names: frozenset[str]) -> None:
         for target_name in target_names:
-            self._bind_name(self._static_reference_override_key(target_name), None)
+            for equivalent_target_name in _equivalent_static_reference_names(target_name):
+                self._bind_name(self._static_reference_override_key(equivalent_target_name), None)
+
+    def _discard_static_reference_overrides_for_roots(self, namespace_roots: frozenset[str]) -> None:
+        current_scope = self.alias_scopes[-1]
+        for namespace_root in namespace_roots:
+            for equivalent_root in _equivalent_static_namespace_roots(namespace_root):
+                reference_prefix = f"{_STATIC_REFERENCE_OVERRIDE_PREFIX}{equivalent_root}."
+                for key in list(current_scope):
+                    if key.startswith(reference_prefix):
+                        del current_scope[key]
+
+    def _bind_static_namespace_roots_as_cleared(self, namespace_roots: frozenset[str]) -> None:
+        self._discard_static_reference_overrides_for_roots(namespace_roots)
+        for namespace_root in namespace_roots:
+            for equivalent_root in _equivalent_static_namespace_roots(namespace_root):
+                self._bind_name(self._static_cleared_namespace_key(equivalent_root), None)
 
     def _bind_static_reference_target_as_removed(self, target: ast.AST) -> None:
         if _has_uncertain_static_binding(target, self.alias_scopes):
@@ -874,6 +926,11 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             if attr_name is None:
                 return
             mutations.append((frozenset(f"{target_root}.{attr_name}" for target_root in target_roots), None))
+        elif method == "clear":
+            if mutation_args:
+                return
+            self._bind_static_namespace_roots_as_cleared(target_roots)
+            return
         elif method == "update":
             if len(mutation_args) != 1 or not isinstance(mutation_args[0], ast.Dict):
                 return
@@ -1025,7 +1082,20 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
     def _merge_conditional_branch_scopes(self, branch_scopes: list[_AliasScope]) -> None:
         current_scope = self.alias_scopes[-1]
         branch_names = {name for scope in branch_scopes for name in scope}
-        for name in branch_names:
+        cleared_namespace_names = {name for name in branch_names if name.startswith(_STATIC_CLEARED_NAMESPACE_PREFIX)}
+        remaining_branch_names = branch_names - cleared_namespace_names
+
+        for name in sorted(cleared_namespace_names):
+            cleared_base_value = current_scope.get(name, frozenset())
+            cleared_values = [scope.get(name, cleared_base_value) for scope in branch_scopes]
+            if all(value is None for value in cleared_values):
+                namespace_root = name.removeprefix(_STATIC_CLEARED_NAMESPACE_PREFIX)
+                self._discard_static_reference_overrides_for_roots(frozenset({namespace_root}))
+                current_scope[name] = None
+            else:
+                current_scope[name] = frozenset()
+
+        for name in sorted(remaining_branch_names):
             if name.startswith(_STATIC_UNCERTAIN_BINDING_PREFIX):
                 uncertainty_base_value = current_scope.get(name, frozenset())
                 uncertainty_values = [scope.get(name, uncertainty_base_value) for scope in branch_scopes]
@@ -1277,7 +1347,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
 
     def visit_Call(self, node: ast.Call) -> None:
         resolved_names = self._resolve_invoked_reference_names(node.func)
-        if resolved_names is not None:
+        if resolved_names is not None and self._resolve_certain_static_mapping_mutator_names(node.func) is None:
             for resolved_name in resolved_names:
                 if self._is_tracked_call_name(resolved_name):
                     self.risky_calls.add(resolved_name)

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -290,6 +290,8 @@ class TestJITScriptDetector:
             b"import builtins\nbuiltins.__dict__.pop('eval')('pass')\n",
             b"import builtins\nrun = builtins.__dict__.pop('eval')\nrun('pass')\n",
             b"import builtins\nif remove:\n    del builtins.__dict__['eval']\nbuiltins.eval('pass')\n",
+            b"import builtins\nrun = builtins.eval\nbuiltins.__dict__.clear()\nrun('pass')\n",
+            b"import builtins\nif remove:\n    builtins.__dict__.clear()\nbuiltins.eval('pass')\n",
         ],
     )
     def test_scan_model_detects_unmarked_static_builtin_indirection(self, source: bytes) -> None:
@@ -376,6 +378,9 @@ class TestJITScriptDetector:
             b"import builtins\ndel builtins.__dict__['eval']\nbuiltins.eval([])\n",
             b"import builtins\nbuiltins.__dict__.__delitem__('eval')\nbuiltins.eval([])\n",
             b"import builtins\nimport operator\noperator.delitem(builtins.__dict__, 'eval')\nbuiltins.eval([])\n",
+            b"import builtins\nbuiltins.__dict__.clear()\nbuiltins.eval([])\n",
+            b"import builtins\nclear = builtins.__dict__.clear\nclear()\nbuiltins.eval([])\n",
+            b"import builtins\ndict.clear(builtins.__dict__)\nbuiltins.eval([])\n",
             b"def payload():\n    eval = len\n    return eval([])\n",
             (
                 b"def payload():\n"
@@ -434,6 +439,10 @@ class TestJITScriptDetector:
             (
                 b"import builtins\nimport operator\n"
                 b"operator.setitem(builtins.__dict__, 'eval', builtins.exec)\nbuiltins.eval('pass')\n"
+            ),
+            (
+                b"import builtins\nrun = builtins.exec\nbuiltins.__dict__.clear()\n"
+                b"builtins.__dict__.update({'eval': run})\nbuiltins.eval('pass')\n"
             ),
         ],
     )

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -289,6 +289,7 @@ class TestJITScriptDetector:
             ),
             b"import builtins\nbuiltins.__dict__.pop('eval')('pass')\n",
             b"import builtins\nrun = builtins.__dict__.pop('eval')\nrun('pass')\n",
+            b"import builtins\nif remove:\n    del builtins.__dict__['eval']\nbuiltins.eval('pass')\n",
         ],
     )
     def test_scan_model_detects_unmarked_static_builtin_indirection(self, source: bytes) -> None:
@@ -372,6 +373,9 @@ class TestJITScriptDetector:
             b"import builtins\nimport operator\noperator.setitem(builtins.__dict__, 'eval', len)\nbuiltins.eval([])\n",
             b"import builtins\nbuiltins.__dict__.pop('eval')\nbuiltins.eval([])\n",
             b"import builtins\ndict.pop(builtins.__dict__, 'eval')\nbuiltins.eval([])\n",
+            b"import builtins\ndel builtins.__dict__['eval']\nbuiltins.eval([])\n",
+            b"import builtins\nbuiltins.__dict__.__delitem__('eval')\nbuiltins.eval([])\n",
+            b"import builtins\nimport operator\noperator.delitem(builtins.__dict__, 'eval')\nbuiltins.eval([])\n",
             b"def payload():\n    eval = len\n    return eval([])\n",
             (
                 b"def payload():\n"

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -6,6 +6,7 @@ import pytest
 
 from modelaudit.detectors import jit_script as jit_script_module
 from modelaudit.detectors.jit_script import JITScriptDetector, detect_jit_script_risks
+from modelaudit.scanners.archive_member_security import high_risk_python_calls_in_source
 
 
 class TestJITScriptDetector:
@@ -315,6 +316,38 @@ class TestJITScriptDetector:
         findings = detector.scan_model(source, "pytorch", "payload.bin")
 
         assert any(f.type == "ast_dangerous_call" and f.builtin == builtin for f in findings)
+
+    @pytest.mark.parametrize(
+        ("source", "builtin"),
+        [
+            (
+                b"import importlib\nimport os\ndel os.__dict__['system']\nimportlib.reload(os)\nos.system('id')\n",
+                "os.system",
+            ),
+            (
+                b"import importlib\nimport os\nos.__dict__.clear()\nimportlib.reload(os)\nos.system('id')\n",
+                "os.system",
+            ),
+            (
+                b"import os\nimport subprocess\n"
+                b"subprocess.__dict__.clear()\n"
+                b"subprocess.os = os\n"
+                b"subprocess.os.system('id')\n",
+                "os.system",
+            ),
+            (
+                b"import builtins\n"
+                b"globals()['__builtins__'] = {'eval': len}\n"
+                b"del globals()['__builtins__']['eval']\n"
+                b"builtins.eval('1 + 1')\n",
+                "builtins.eval",
+            ),
+        ],
+    )
+    def test_static_python_analysis_detects_rebuilt_namespace_calls(self, source: bytes, builtin: str) -> None:
+        calls = high_risk_python_calls_in_source(source)
+
+        assert any(call.name == builtin for call in calls)
 
     @pytest.mark.parametrize(
         "source",

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1073,6 +1073,8 @@ def test_pytorch_zip_scans_unmarked_python_blobs_in_archive_data(tmp_path: Path)
         b"import builtins\nbuiltins.__dict__.pop('eval')('pass')\n",
         b"import builtins\nrun = builtins.__dict__.pop('eval')\nrun('pass')\n",
         b"import builtins\nif remove:\n    del builtins.__dict__['eval']\nbuiltins.eval('pass')\n",
+        b"import builtins\nrun = builtins.eval\nbuiltins.__dict__.clear()\nrun('pass')\n",
+        b"import builtins\nif remove:\n    builtins.__dict__.clear()\nbuiltins.eval('pass')\n",
     ],
 )
 def test_pytorch_zip_scans_static_builtin_indirection_in_archive_data(tmp_path: Path, payload: bytes) -> None:
@@ -1155,6 +1157,8 @@ def test_pytorch_zip_scans_aliased_modeled_builtins_in_archive_data(
         b"import builtins\ndel builtins.__dict__['eval']\nbuiltins.eval([])\n",
         b"import builtins\nbuiltins.__dict__.__delitem__('eval')\nbuiltins.eval([])\n",
         b"import builtins\nimport operator\noperator.delitem(builtins.__dict__, 'eval')\nbuiltins.eval([])\n",
+        b"import builtins\nbuiltins.__dict__.clear()\nbuiltins.eval([])\n",
+        b"import builtins\ndict.clear(builtins.__dict__)\nbuiltins.eval([])\n",
         (
             b"replace = globals()['__builtins__'].__setitem__\n"
             b"replace('eval', len)\n"
@@ -1233,6 +1237,10 @@ def test_pytorch_zip_ignores_benign_builtin_shaped_access_in_archive_data(tmp_pa
         b"import builtins\nbuiltins.__dict__.update({'eval': builtins.exec})\nbuiltins.eval('pass')\n",
         b"import builtins\ngetattr(builtins, '__dict__').update({'eval': builtins.exec})\nbuiltins.eval('pass')\n",
         b"import builtins\ndict.update(builtins.__dict__, {'eval': builtins.exec})\nbuiltins.eval('pass')\n",
+        (
+            b"import builtins\nrun = builtins.exec\nbuiltins.__dict__.clear()\n"
+            b"builtins.__dict__.update({'eval': run})\nbuiltins.eval('pass')\n"
+        ),
     ],
 )
 def test_pytorch_zip_detects_dangerous_builtin_reassignment_in_archive_data(tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1072,6 +1072,7 @@ def test_pytorch_zip_scans_unmarked_python_blobs_in_archive_data(tmp_path: Path)
         ),
         b"import builtins\nbuiltins.__dict__.pop('eval')('pass')\n",
         b"import builtins\nrun = builtins.__dict__.pop('eval')\nrun('pass')\n",
+        b"import builtins\nif remove:\n    del builtins.__dict__['eval']\nbuiltins.eval('pass')\n",
     ],
 )
 def test_pytorch_zip_scans_static_builtin_indirection_in_archive_data(tmp_path: Path, payload: bytes) -> None:
@@ -1151,6 +1152,9 @@ def test_pytorch_zip_scans_aliased_modeled_builtins_in_archive_data(
         b"import builtins\ndict.update(builtins.__dict__, {'eval': len})\nbuiltins.eval([])\n",
         b"import builtins\nbuiltins.__dict__.pop('eval')\nbuiltins.eval([])\n",
         b"import builtins\ndict.pop(builtins.__dict__, 'eval')\nbuiltins.eval([])\n",
+        b"import builtins\ndel builtins.__dict__['eval']\nbuiltins.eval([])\n",
+        b"import builtins\nbuiltins.__dict__.__delitem__('eval')\nbuiltins.eval([])\n",
+        b"import builtins\nimport operator\noperator.delitem(builtins.__dict__, 'eval')\nbuiltins.eval([])\n",
         (
             b"replace = globals()['__builtins__'].__setitem__\n"
             b"replace('eval', len)\n"

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -183,6 +183,7 @@ class TestTarScanner:
             ),
             b"import os\nrun = os.__dict__.pop('system')\nrun('echo hidden')\n",
             b"import os\nif remove:\n    os.__dict__.pop('system')\nos.system('echo hidden')\n",
+            b"import os\nif remove:\n    del os.__dict__['system']\nos.system('echo hidden')\n",
             (
                 b"import os\n"
                 b"setattr = lambda target, key, value: None\n"
@@ -228,6 +229,9 @@ class TestTarScanner:
             b"import os\nimport operator\noperator.setitem(os.__dict__, 'system', len)\nos.system([])\n",
             b"import os\nos.__dict__.pop('system')\nos.system([])\n",
             b"import os\ndict.pop(os.__dict__, 'system')\nos.system([])\n",
+            b"import os\ndel os.__dict__['system']\nos.system([])\n",
+            b"import os\nos.__dict__.__delitem__('system')\nos.system([])\n",
+            b"import os\nimport operator\noperator.delitem(os.__dict__, 'system')\nos.system([])\n",
         ],
     )
     def test_scan_tar_allows_callable_captured_after_safe_overwrite(self, tmp_path: Path, payload: bytes) -> None:
@@ -344,6 +348,7 @@ class TestTarScanner:
             ),
             b"globals()['__builtins__'].pop('eval')('1 + 1')\n",
             b"run = globals()['__builtins__'].pop('eval')\nrun('1 + 1')\n",
+            b"if remove:\n    del globals()['__builtins__']['eval']\nglobals()['__builtins__']['eval']('1 + 1')\n",
         ],
     )
     def test_scan_tar_flags_implicit_builtins_dangerous_python_member(self, tmp_path: Path, payload: bytes) -> None:
@@ -404,6 +409,7 @@ class TestTarScanner:
                 b"run([])\n"
             ),
             b"globals()['__builtins__'].pop('eval')\nglobals()['__builtins__']['eval']([])\n",
+            b"del globals()['__builtins__']['eval']\nglobals()['__builtins__']['eval']([])\n",
         ],
     )
     def test_scan_tar_allows_benign_builtin_shaped_source(self, tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -184,6 +184,8 @@ class TestTarScanner:
             b"import os\nrun = os.__dict__.pop('system')\nrun('echo hidden')\n",
             b"import os\nif remove:\n    os.__dict__.pop('system')\nos.system('echo hidden')\n",
             b"import os\nif remove:\n    del os.__dict__['system']\nos.system('echo hidden')\n",
+            b"import os\nrun = os.system\nos.__dict__.clear()\nrun('echo hidden')\n",
+            b"import os\nif remove:\n    os.__dict__.clear()\nos.system('echo hidden')\n",
             (
                 b"import os\n"
                 b"setattr = lambda target, key, value: None\n"
@@ -232,6 +234,10 @@ class TestTarScanner:
             b"import os\ndel os.__dict__['system']\nos.system([])\n",
             b"import os\nos.__dict__.__delitem__('system')\nos.system([])\n",
             b"import os\nimport operator\noperator.delitem(os.__dict__, 'system')\nos.system([])\n",
+            b"import os\nos.__dict__.clear()\nos.system([])\n",
+            b"import os\ndict.clear(os.__dict__)\nos.system([])\n",
+            b"import subprocess\nsubprocess.__dict__.update({'run': len})\nsubprocess.run([])\n",
+            b"import subprocess\nsubprocess.__dict__.clear()\nsubprocess.run([])\n",
         ],
     )
     def test_scan_tar_allows_callable_captured_after_safe_overwrite(self, tmp_path: Path, payload: bytes) -> None:
@@ -288,6 +294,36 @@ class TestTarScanner:
         assert len(python_checks) == 1
         assert python_checks[0].status == CheckStatus.FAILED
         assert python_checks[0].details["reason"] == "high-risk calls: subprocess.run"
+
+    @pytest.mark.parametrize(
+        ("payload", "dangerous_name"),
+        [
+            (
+                b"import os\nimport subprocess\nsubprocess.__dict__.update({'run': os.system})\nsubprocess.run('id')\n",
+                "os.system",
+            ),
+            (
+                b"import subprocess\nrun = subprocess.Popen\nsubprocess.__dict__.clear()\n"
+                b"subprocess.__dict__.update({'run': run})\nsubprocess.run([])\n",
+                "subprocess.Popen",
+            ),
+        ],
+    )
+    def test_scan_tar_reports_dangerous_subprocess_mapping_replacement(
+        self, tmp_path: Path, payload: bytes, dangerous_name: str
+    ) -> None:
+        archive_path = tmp_path / "model_bundle.tar"
+        with tarfile.open(archive_path, "w") as archive:
+            info = tarfile.TarInfo("handler.py")
+            info.size = len(payload)
+            archive.addfile(info, tarfile.io.BytesIO(payload))  # type: ignore[attr-defined]
+
+        result = self.scanner.scan(str(archive_path))
+
+        python_checks = [check for check in result.checks if check.name == "Python Archive Member Security"]
+        assert len(python_checks) == 1
+        assert python_checks[0].status == CheckStatus.FAILED
+        assert python_checks[0].details["reason"] == f"high-risk calls: {dangerous_name}"
 
     def test_scan_tar_flags_builtins_getattr_keyword_call_dangerous_python_member(self, tmp_path: Path) -> None:
         """Keyword-based getattr indirection should still resolve to the risky call name."""
@@ -349,6 +385,8 @@ class TestTarScanner:
             b"globals()['__builtins__'].pop('eval')('1 + 1')\n",
             b"run = globals()['__builtins__'].pop('eval')\nrun('1 + 1')\n",
             b"if remove:\n    del globals()['__builtins__']['eval']\nglobals()['__builtins__']['eval']('1 + 1')\n",
+            b"run = globals()['__builtins__']['eval']\nglobals()['__builtins__'].clear()\nrun('1 + 1')\n",
+            b"if remove:\n    globals()['__builtins__'].clear()\nglobals()['__builtins__']['eval']('1 + 1')\n",
         ],
     )
     def test_scan_tar_flags_implicit_builtins_dangerous_python_member(self, tmp_path: Path, payload: bytes) -> None:
@@ -410,6 +448,8 @@ class TestTarScanner:
             ),
             b"globals()['__builtins__'].pop('eval')\nglobals()['__builtins__']['eval']([])\n",
             b"del globals()['__builtins__']['eval']\nglobals()['__builtins__']['eval']([])\n",
+            b"globals()['__builtins__'].clear()\nglobals()['__builtins__']['eval']([])\n",
+            b"import builtins\nbuiltins.__dict__.clear()\nbuiltins.eval([])\n",
         ],
     )
     def test_scan_tar_allows_benign_builtin_shaped_source(self, tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -318,6 +318,18 @@ def test_scan_detects_keyword_getattr_wrapped_handler_execution_primitive(
             b"        del globals()['__builtins__']['eval']\n"
             b"    return globals()['__builtins__']['eval']('1 + 1')\n"
         ),
+        (
+            b"def handle(data, context):\n"
+            b"    run = globals()['__builtins__']['eval']\n"
+            b"    globals()['__builtins__'].clear()\n"
+            b"    return run('1 + 1')\n"
+        ),
+        (
+            b"def handle(data, context):\n"
+            b"    if remove:\n"
+            b"        globals()['__builtins__'].clear()\n"
+            b"    return globals()['__builtins__']['eval']('1 + 1')\n"
+        ),
     ],
 )
 def test_scan_detects_implicit_builtins_handler_execution_primitive(
@@ -432,6 +444,13 @@ def test_scan_detects_implicit_builtins_handler_execution_primitive(
             b"def handle(data, context):\n"
             b"    import operator\n"
             b"    operator.delitem(builtins.__dict__, 'eval')\n"
+            b"    return builtins.eval([])\n"
+        ),
+        (b"import builtins\ndef handle(data, context):\n    builtins.__dict__.clear()\n    return builtins.eval([])\n"),
+        (
+            b"import builtins\n"
+            b"def handle(data, context):\n"
+            b"    dict.clear(builtins.__dict__)\n"
             b"    return builtins.eval([])\n"
         ),
         (
@@ -555,6 +574,15 @@ def test_scan_allows_benign_builtin_shaped_handler_source(tmp_path: Path, handle
             b"import builtins\n"
             b"def handle(data, context):\n"
             b"    dict.update(builtins.__dict__, {'eval': builtins.exec})\n"
+            b"    return builtins.eval('pass')\n",
+            "builtins.exec",
+        ),
+        (
+            b"import builtins\n"
+            b"def handle(data, context):\n"
+            b"    run = builtins.exec\n"
+            b"    builtins.__dict__.clear()\n"
+            b"    builtins.__dict__.update({'eval': run})\n"
             b"    return builtins.eval('pass')\n",
             "builtins.exec",
         ),

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -312,6 +312,12 @@ def test_scan_detects_keyword_getattr_wrapped_handler_execution_primitive(
         ),
         (b"def handle(data, context):\n    return globals()['__builtins__'].pop('eval')('1 + 1')\n"),
         (b"def handle(data, context):\n    run = globals()['__builtins__'].pop('eval')\n    return run('1 + 1')\n"),
+        (
+            b"def handle(data, context):\n"
+            b"    if remove:\n"
+            b"        del globals()['__builtins__']['eval']\n"
+            b"    return globals()['__builtins__']['eval']('1 + 1')\n"
+        ),
     ],
 )
 def test_scan_detects_implicit_builtins_handler_execution_primitive(
@@ -407,6 +413,25 @@ def test_scan_detects_implicit_builtins_handler_execution_primitive(
             b"import builtins\n"
             b"def handle(data, context):\n"
             b"    dict.pop(builtins.__dict__, 'eval')\n"
+            b"    return builtins.eval([])\n"
+        ),
+        (
+            b"import builtins\n"
+            b"def handle(data, context):\n"
+            b"    del builtins.__dict__['eval']\n"
+            b"    return builtins.eval([])\n"
+        ),
+        (
+            b"import builtins\n"
+            b"def handle(data, context):\n"
+            b"    builtins.__dict__.__delitem__('eval')\n"
+            b"    return builtins.eval([])\n"
+        ),
+        (
+            b"import builtins\n"
+            b"def handle(data, context):\n"
+            b"    import operator\n"
+            b"    operator.delitem(builtins.__dict__, 'eval')\n"
             b"    return builtins.eval([])\n"
         ),
         (

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -221,6 +221,12 @@ def test_scan_zip_flags_aliased_dangerous_python_member(tmp_path: Path) -> None:
         ),
         "import os\nrun = os.__dict__.pop('system')\nrun('echo hidden')\n",
         "import os\nif remove:\n    os.__dict__.pop('system')\nos.system('echo hidden')\n",
+        "import os\nif remove:\n    del os.__dict__['system']\nos.system('echo hidden')\n",
+        "import os\nif remove:\n    os.__dict__.__delitem__('system')\nos.system('echo hidden')\n",
+        (
+            "import os\nimport operator\nif remove:\n"
+            "    operator.delitem(os.__dict__, 'system')\nos.system('echo hidden')\n"
+        ),
         ("import os\ndef hide(target=os):\n    setattr(target, 'system', len)\n    os.system('echo hidden')\n"),
         ("import os\ndef hide(target=os):\n    target.system = len\n    os.system('echo hidden')\n"),
         (
@@ -281,6 +287,12 @@ def test_scan_zip_preserves_captured_dangerous_callable_before_overwrite(tmp_pat
         "import os\nos.__dict__.pop('system')\nos.system([])\n",
         "import os\nremove = os.__dict__.pop\nremove('system')\nos.system([])\n",
         "import os\ndict.pop(os.__dict__, 'system')\nos.system([])\n",
+        "import os\ndel os.__dict__['system']\nos.system([])\n",
+        "import os\ndel os.system\nos.system([])\n",
+        "import os\nos.__dict__.__delitem__('system')\nos.system([])\n",
+        "import os\nremove = os.__dict__.__delitem__\nremove('system')\nos.system([])\n",
+        "import os\ndict.__delitem__(os.__dict__, 'system')\nos.system([])\n",
+        "import os\nimport operator\noperator.delitem(os.__dict__, 'system')\nos.system([])\n",
     ],
 )
 def test_scan_zip_allows_callable_captured_after_safe_overwrite(tmp_path: Path, source: str) -> None:
@@ -413,6 +425,7 @@ def test_scan_zip_flags_builtins_getattr_keyword_call_dangerous_python_member(tm
         ),
         "globals()['__builtins__'].pop('eval')('1 + 1')\n",
         "run = globals()['__builtins__'].pop('eval')\nrun('1 + 1')\n",
+        "if remove:\n    del globals()['__builtins__']['eval']\nglobals()['__builtins__']['eval']('1 + 1')\n",
     ],
 )
 def test_scan_zip_flags_implicit_builtins_dangerous_python_member(tmp_path: Path, source: str) -> None:
@@ -465,6 +478,8 @@ def test_scan_zip_flags_implicit_builtins_dangerous_python_member(tmp_path: Path
         ),
         "globals()['__builtins__'].pop('eval')\nglobals()['__builtins__']['eval']([])\n",
         "remove = globals()['__builtins__'].pop\nremove('eval')\nglobals()['__builtins__']['eval']([])\n",
+        "del globals()['__builtins__']['eval']\nglobals()['__builtins__']['eval']([])\n",
+        "globals()['__builtins__'].__delitem__('eval')\nglobals()['__builtins__']['eval']([])\n",
     ],
 )
 def test_scan_zip_allows_benign_builtin_shaped_source(tmp_path: Path, source: str) -> None:

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -227,6 +227,9 @@ def test_scan_zip_flags_aliased_dangerous_python_member(tmp_path: Path) -> None:
             "import os\nimport operator\nif remove:\n"
             "    operator.delitem(os.__dict__, 'system')\nos.system('echo hidden')\n"
         ),
+        "import os\nrun = os.system\nos.__dict__.clear()\nrun('echo hidden')\n",
+        "import os\nif remove:\n    os.__dict__.clear()\nos.system('echo hidden')\n",
+        "import os\nif swap:\n    os = make_module()\nos.__dict__.clear()\nos.system('echo hidden')\n",
         ("import os\ndef hide(target=os):\n    setattr(target, 'system', len)\n    os.system('echo hidden')\n"),
         ("import os\ndef hide(target=os):\n    target.system = len\n    os.system('echo hidden')\n"),
         (
@@ -293,6 +296,32 @@ def test_scan_zip_preserves_captured_dangerous_callable_before_overwrite(tmp_pat
         "import os\nremove = os.__dict__.__delitem__\nremove('system')\nos.system([])\n",
         "import os\ndict.__delitem__(os.__dict__, 'system')\nos.system([])\n",
         "import os\nimport operator\noperator.delitem(os.__dict__, 'system')\nos.system([])\n",
+        "import os\nos.__dict__.clear()\nos.system([])\n",
+        "import os\nvars(os).clear()\nos.system([])\n",
+        "import os\nclear = os.__dict__.clear\nclear()\nos.system([])\n",
+        "import os\ndict.clear(os.__dict__)\nos.system([])\n",
+        (
+            "import os\n"
+            "if clear:\n"
+            "    os.__dict__.clear()\n"
+            "    os.__dict__['system'] = len\n"
+            "else:\n"
+            "    os.__dict__.clear()\n"
+            "os.system([])\n"
+        ),
+        (
+            "import os\n"
+            "import subprocess\n"
+            "os.__dict__['system'] = subprocess.run\n"
+            "if clear:\n"
+            "    os.__dict__.clear()\n"
+            "else:\n"
+            "    os.__dict__.clear()\n"
+            "os.system([])\n"
+        ),
+        "import subprocess\nsubprocess.__dict__.update({'run': len})\nsubprocess.run([])\n",
+        "import subprocess\nsubprocess.__dict__.pop('run')\nsubprocess.run([])\n",
+        "import subprocess\nsubprocess.__dict__.clear()\nsubprocess.run([])\n",
     ],
 )
 def test_scan_zip_allows_callable_captured_after_safe_overwrite(tmp_path: Path, source: str) -> None:
@@ -339,6 +368,10 @@ def test_scan_zip_flags_from_import_dangerous_python_member(tmp_path: Path) -> N
             "import os\nimport operator\nimport subprocess\n"
             "operator.setitem(os.__dict__, 'system', subprocess.run)\nos.system(['id'])\n"
         ),
+        (
+            "import os\nimport subprocess\nos.__dict__.clear()\n"
+            "os.__dict__.update({'system': subprocess.run})\nos.system(['id'])\n"
+        ),
     ],
 )
 def test_scan_zip_reports_dangerous_setattr_replacement(tmp_path: Path, source: str) -> None:
@@ -355,6 +388,39 @@ def test_scan_zip_reports_dangerous_setattr_replacement(tmp_path: Path, source: 
     ]
     assert len(python_checks) == 1
     assert python_checks[0].details["reason"] == "high-risk calls: subprocess.run"
+
+
+@pytest.mark.parametrize(
+    ("source", "dangerous_name"),
+    [
+        (
+            "import os\nimport subprocess\nsubprocess.__dict__.update({'run': os.system})\nsubprocess.run('id')\n",
+            "os.system",
+        ),
+        (
+            "import subprocess\nrun = subprocess.Popen\nsubprocess.__dict__.clear()\n"
+            "subprocess.__dict__.update({'run': run})\nsubprocess.run([])\n",
+            "subprocess.Popen",
+        ),
+        ("import subprocess\nsubprocess.__dict__.pop('run')(['id'])\n", "subprocess.run"),
+    ],
+)
+def test_scan_zip_reports_dangerous_subprocess_mapping_replacement(
+    tmp_path: Path, source: str, dangerous_name: str
+) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", source)
+
+    result = ZipScanner().scan(str(archive_path))
+
+    python_checks = [
+        check
+        for check in result.checks
+        if check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED
+    ]
+    assert len(python_checks) == 1
+    assert python_checks[0].details["reason"] == f"high-risk calls: {dangerous_name}"
 
 
 def test_scan_zip_flags_wildcard_import_dangerous_python_member(tmp_path: Path) -> None:
@@ -426,6 +492,8 @@ def test_scan_zip_flags_builtins_getattr_keyword_call_dangerous_python_member(tm
         "globals()['__builtins__'].pop('eval')('1 + 1')\n",
         "run = globals()['__builtins__'].pop('eval')\nrun('1 + 1')\n",
         "if remove:\n    del globals()['__builtins__']['eval']\nglobals()['__builtins__']['eval']('1 + 1')\n",
+        "run = globals()['__builtins__']['eval']\nglobals()['__builtins__'].clear()\nrun('1 + 1')\n",
+        "if remove:\n    globals()['__builtins__'].clear()\nglobals()['__builtins__']['eval']('1 + 1')\n",
     ],
 )
 def test_scan_zip_flags_implicit_builtins_dangerous_python_member(tmp_path: Path, source: str) -> None:
@@ -480,6 +548,10 @@ def test_scan_zip_flags_implicit_builtins_dangerous_python_member(tmp_path: Path
         "remove = globals()['__builtins__'].pop\nremove('eval')\nglobals()['__builtins__']['eval']([])\n",
         "del globals()['__builtins__']['eval']\nglobals()['__builtins__']['eval']([])\n",
         "globals()['__builtins__'].__delitem__('eval')\nglobals()['__builtins__']['eval']([])\n",
+        "globals()['__builtins__'].clear()\nglobals()['__builtins__']['eval']([])\n",
+        "import builtins\nbuiltins.__dict__.clear()\nbuiltins.eval([])\n",
+        "import builtins\ndict.clear(builtins.__dict__)\nbuiltins.eval([])\n",
+        "import builtins\nbuiltins.__dict__.clear()\nglobals()['__builtins__']['eval']([])\n",
     ],
 )
 def test_scan_zip_allows_benign_builtin_shaped_source(tmp_path: Path, source: str) -> None:
@@ -525,6 +597,11 @@ def test_scan_zip_allows_benign_builtin_shaped_source(tmp_path: Path, source: st
         ),
         (
             "import builtins\nbuiltins.__dict__.update({'eval': builtins.exec})\nbuiltins.eval('pass')\n",
+            "builtins.exec",
+        ),
+        (
+            "import builtins\nrun = builtins.exec\nbuiltins.__dict__.clear()\n"
+            "globals()['__builtins__']['eval'] = run\nbuiltins.eval('pass')\n",
             "builtins.exec",
         ),
     ],


### PR DESCRIPTION
## Summary
- model statically certain key deletion via `del`, bound/unbound `__delitem__`, and `operator.delitem`
- avoid later embedded-source execution findings when the referenced dangerous key is definitely absent
- preserve findings for conditional and dynamically rebound deletion targets

## Why
After deterministic `pop()` removal was covered in #1359, the same static-analysis contract still reported impossible later calls after explicit key deletion forms such as `del os.__dict__['system']` and `operator.delitem(os.__dict__, 'system')`. These are key-specific operations with a precise safety effect, so they can be modeled without assuming that an unknown collection has been cleared.

Whole-map `clear()` semantics are intentionally out of scope for this PR because they require separate root-wide invalidation reasoning.

## Validation
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest tests/detectors/test_jit_script_detector.py tests/scanners/test_zip_scanner.py tests/scanners/test_tar_scanner.py tests/scanners/test_pytorch_zip_scanner.py tests/scanners/test_torchserve_mar_scanner.py -q --maxfail=1` (`788 passed, 130 skipped`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`Success: no issues found in 453 source files`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`5269 passed, 1076 skipped`)

## Stack
- Stacked on #1359 (`fix: model discarded namespace mapping removals`), which has completed hosted CI successfully.
