### PR TITLE
fix: ignore nonexecuting subprocess APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - avoid embedded Python execution findings after a certain discarded namespace-map removal
 - avoid embedded Python execution findings after certain key-specific namespace deletion
 - avoid embedded Python execution findings after certain namespace-map clearing or certain map mutator calls themselves
+- avoid embedded Python process-execution findings for the non-executing `subprocess.list2cmdline` helper
 - preserve embedded Python execution findings when a replacement receiver is conditional, aliased, or a runtime argument
 - fail closed when nested NeMo checkpoint or referenced-artifact analysis is explicitly incomplete
 - preserve concrete nested security findings from checkpoint and referenced artifacts inside NeMo archives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - avoid embedded Python execution findings after a certain discarded namespace-map removal
 - avoid embedded Python execution findings after certain key-specific namespace deletion
 - avoid embedded Python execution findings after certain namespace-map clearing or certain map mutator calls themselves
-- avoid embedded Python process-execution findings for the non-executing `subprocess.list2cmdline` helper
+- avoid embedded Python process-execution findings for known non-executing `subprocess` formatting and result/error APIs
 - preserve embedded Python execution findings when a replacement receiver is conditional, aliased, or a runtime argument
 - fail closed when nested NeMo checkpoint or referenced-artifact analysis is explicitly incomplete
 - preserve concrete nested security findings from checkpoint and referenced artifacts inside NeMo archives

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -81,8 +81,14 @@ _HIGH_RISK_PYTHON_CALLS = {
     "subprocess.Popen",
     "subprocess.run",
 }
-# Retain broad subprocess coverage while excluding helpers that only transform data.
-_KNOWN_NON_EXECUTING_SUBPROCESS_CALLS = {"subprocess.list2cmdline"}
+# Retain broad subprocess coverage while excluding public APIs that only construct data.
+_KNOWN_NON_EXECUTING_SUBPROCESS_CALLS = {
+    "subprocess.CalledProcessError",
+    "subprocess.CompletedProcess",
+    "subprocess.SubprocessError",
+    "subprocess.TimeoutExpired",
+    "subprocess.list2cmdline",
+}
 
 # Map each high-risk call name to the rule code that best describes its risk
 # category. SARIF consumers, dashboards, and per-rule severity overrides rely

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -81,6 +81,8 @@ _HIGH_RISK_PYTHON_CALLS = {
     "subprocess.Popen",
     "subprocess.run",
 }
+# Retain broad subprocess coverage while excluding helpers that only transform data.
+_KNOWN_NON_EXECUTING_SUBPROCESS_CALLS = {"subprocess.list2cmdline"}
 
 # Map each high-risk call name to the rule code that best describes its risk
 # category. SARIF consumers, dashboards, and per-rule severity overrides rely
@@ -676,7 +678,9 @@ def _resolve_static_assignment_target_names(node: ast.AST, alias_scopes: _AliasS
 
 
 def _is_high_risk_python_call_name(name: str) -> bool:
-    return name in _HIGH_RISK_PYTHON_CALLS or name.startswith("subprocess.")
+    return name in _HIGH_RISK_PYTHON_CALLS or (
+        name.startswith("subprocess.") and name not in _KNOWN_NON_EXECUTING_SUBPROCESS_CALLS
+    )
 
 
 def _wildcard_import_aliases(

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -307,6 +307,11 @@ class TestTarScanner:
                 b"subprocess.__dict__.update({'run': run})\nsubprocess.run([])\n",
                 "subprocess.Popen",
             ),
+            (
+                b"import os\nimport subprocess\nsubprocess.__dict__.update({'list2cmdline': os.system})\n"
+                b"subprocess.list2cmdline(['id'])\n",
+                "os.system",
+            ),
         ],
     )
     def test_scan_tar_reports_dangerous_subprocess_mapping_replacement(
@@ -806,6 +811,22 @@ class TestTarScanner:
         assert not any(check.name == "Python Archive Member Security" for check in result.checks)
         assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
 
+    def test_scan_tar_ignores_nonexecuting_subprocess_helper(self, tmp_path: Path) -> None:
+        """subprocess.list2cmdline formats arguments without launching a process."""
+        archive_path = tmp_path / "model_bundle.tar"
+        source = b"import subprocess\nsubprocess.list2cmdline(['input file', '--quiet'])\n"
+
+        with tarfile.open(archive_path, "w") as archive:
+            info = tarfile.TarInfo("preprocess.py")
+            info.size = len(source)
+            archive.addfile(info, tarfile.io.BytesIO(source))  # type: ignore[attr-defined]
+
+        result = self.scanner.scan(str(archive_path))
+
+        assert result.success is True
+        assert not any(check.name == "Python Archive Member Security" for check in result.checks)
+        assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
+
     @pytest.mark.parametrize("dispatch", [b"handlers['system'](1.0)\n", b"handlers.get('system')(1.0)\n"])
     def test_scan_tar_ignores_benign_dictionary_dispatch_python_member(self, tmp_path: Path, dispatch: bytes) -> None:
         """Ordinary application dictionaries should not be treated as module namespaces."""
@@ -895,6 +916,12 @@ class TestTarScanner:
         [
             (b"import os\nos.system('echo hidden')\n", "S101", "os.system"),
             (b"import subprocess\nsubprocess.run(['echo'], check=False)\n", "S103", "subprocess.run"),
+            (b"import subprocess\nsubprocess.getoutput('echo hidden')\n", "S103", "subprocess.getoutput"),
+            (
+                b"import subprocess\nsubprocess.getstatusoutput('echo hidden')\n",
+                "S103",
+                "subprocess.getstatusoutput",
+            ),
             (b"import importlib\nimportlib.import_module('os')\n", "S107", "importlib.import_module"),
             (b"eval('1 + 1')\n", "S104", "eval"),
             (b"import pickle\npickle.loads(b'\\x80\\x04N.')\n", "S213", "pickle.loads"),

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -312,6 +312,11 @@ class TestTarScanner:
                 b"subprocess.list2cmdline(['id'])\n",
                 "os.system",
             ),
+            (
+                b"import os\nimport subprocess\nsubprocess.__dict__.update({'CompletedProcess': os.system})\n"
+                b"subprocess.CompletedProcess('id')\n",
+                "os.system",
+            ),
         ],
     )
     def test_scan_tar_reports_dangerous_subprocess_mapping_replacement(
@@ -811,10 +816,19 @@ class TestTarScanner:
         assert not any(check.name == "Python Archive Member Security" for check in result.checks)
         assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
 
-    def test_scan_tar_ignores_nonexecuting_subprocess_helper(self, tmp_path: Path) -> None:
-        """subprocess.list2cmdline formats arguments without launching a process."""
+    @pytest.mark.parametrize(
+        "source",
+        [
+            b"import subprocess\nsubprocess.list2cmdline(['input file', '--quiet'])\n",
+            b"import subprocess\nsubprocess.CompletedProcess([], 0)\n",
+            b"import subprocess\nsubprocess.SubprocessError('failed')\n",
+            b"import subprocess\nsubprocess.CalledProcessError(1, ['cmd'])\n",
+            b"import subprocess\nsubprocess.TimeoutExpired(['cmd'], 1)\n",
+        ],
+    )
+    def test_scan_tar_ignores_nonexecuting_subprocess_api(self, tmp_path: Path, source: bytes) -> None:
+        """Known data/result/error helpers must not be reported as process launches."""
         archive_path = tmp_path / "model_bundle.tar"
-        source = b"import subprocess\nsubprocess.list2cmdline(['input file', '--quiet'])\n"
 
         with tarfile.open(archive_path, "w") as archive:
             info = tarfile.TarInfo("preprocess.py")

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -514,13 +514,19 @@ def test_scan_allows_benign_builtin_shaped_handler_source(tmp_path: Path, handle
     assert _failed_checks(result, "TorchServe Handler Static Analysis") == []
 
 
-def test_scan_allows_nonexecuting_subprocess_handler_helper(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "expression",
+    [
+        b"subprocess.list2cmdline(['input file', '--quiet'])",
+        b"subprocess.CompletedProcess([], 0)",
+        b"subprocess.SubprocessError('failed')",
+        b"subprocess.CalledProcessError(1, ['cmd'])",
+        b"subprocess.TimeoutExpired(['cmd'], 1)",
+    ],
+)
+def test_scan_allows_nonexecuting_subprocess_handler_api(tmp_path: Path, expression: bytes) -> None:
     manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
-    handler_source = (
-        b"import subprocess\n"
-        b"def handle(data, context):\n"
-        b"    return subprocess.list2cmdline(['input file', '--quiet'])\n"
-    )
+    handler_source = b"import subprocess\ndef handle(data, context):\n    return " + expression + b"\n"
     mar_path = _create_mar_archive(
         tmp_path,
         manifest=manifest,
@@ -533,13 +539,14 @@ def test_scan_allows_nonexecuting_subprocess_handler_helper(tmp_path: Path) -> N
     assert _failed_checks(result, "TorchServe Handler Static Analysis") == []
 
 
-def test_scan_detects_rebound_nonexecuting_subprocess_handler_helper(tmp_path: Path) -> None:
+@pytest.mark.parametrize("api_name", [b"list2cmdline", b"CompletedProcess"])
+def test_scan_detects_rebound_nonexecuting_subprocess_handler_api(tmp_path: Path, api_name: bytes) -> None:
     manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
     handler_source = (
         b"import os\nimport subprocess\n"
         b"def handle(data, context):\n"
-        b"    subprocess.__dict__.update({'list2cmdline': os.system})\n"
-        b"    return subprocess.list2cmdline('id')\n"
+        b"    subprocess.__dict__.update({'" + api_name + b"': os.system})\n"
+        b"    return subprocess." + api_name + b"('id')\n"
     )
     mar_path = _create_mar_archive(
         tmp_path,

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -514,6 +514,47 @@ def test_scan_allows_benign_builtin_shaped_handler_source(tmp_path: Path, handle
     assert _failed_checks(result, "TorchServe Handler Static Analysis") == []
 
 
+def test_scan_allows_nonexecuting_subprocess_handler_helper(tmp_path: Path) -> None:
+    manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
+    handler_source = (
+        b"import subprocess\n"
+        b"def handle(data, context):\n"
+        b"    return subprocess.list2cmdline(['input file', '--quiet'])\n"
+    )
+    mar_path = _create_mar_archive(
+        tmp_path,
+        manifest=manifest,
+        entries={"handler.py": handler_source, "weights.bin": b"weights"},
+        filename="benign_subprocess_helper_handler.mar",
+    )
+
+    result = TorchServeMarScanner().scan(str(mar_path))
+
+    assert _failed_checks(result, "TorchServe Handler Static Analysis") == []
+
+
+def test_scan_detects_rebound_nonexecuting_subprocess_handler_helper(tmp_path: Path) -> None:
+    manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
+    handler_source = (
+        b"import os\nimport subprocess\n"
+        b"def handle(data, context):\n"
+        b"    subprocess.__dict__.update({'list2cmdline': os.system})\n"
+        b"    return subprocess.list2cmdline('id')\n"
+    )
+    mar_path = _create_mar_archive(
+        tmp_path,
+        manifest=manifest,
+        entries={"handler.py": handler_source, "weights.bin": b"weights"},
+        filename="rebound_subprocess_helper_handler.mar",
+    )
+
+    result = TorchServeMarScanner().scan(str(mar_path))
+    handler_failures = _failed_checks(result, "TorchServe Handler Static Analysis")
+
+    assert len(handler_failures) == 1
+    assert "os.system" in handler_failures[0].message
+
+
 @pytest.mark.parametrize(
     ("handler_source", "dangerous_name"),
     [

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -388,6 +388,11 @@ def test_scan_zip_reports_dangerous_setattr_replacement(tmp_path: Path, source: 
             "subprocess.list2cmdline(['id'])\n",
             "os.system",
         ),
+        (
+            "import os\nimport subprocess\nsubprocess.__dict__.update({'CompletedProcess': os.system})\n"
+            "subprocess.CompletedProcess('id')\n",
+            "os.system",
+        ),
         ("import subprocess\nsubprocess.__dict__.pop('run')(['id'])\n", "subprocess.run"),
     ],
 )
@@ -931,10 +936,20 @@ def test_scan_zip_ignores_benign_python_member(tmp_path: Path) -> None:
     assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
 
 
-def test_scan_zip_ignores_nonexecuting_subprocess_helper(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "source",
+    [
+        "import subprocess\nsubprocess.list2cmdline(['input file', '--quiet'])\n",
+        "import subprocess\nsubprocess.CompletedProcess([], 0)\n",
+        "import subprocess\nsubprocess.SubprocessError('failed')\n",
+        "import subprocess\nsubprocess.CalledProcessError(1, ['cmd'])\n",
+        "import subprocess\nsubprocess.TimeoutExpired(['cmd'], 1)\n",
+    ],
+)
+def test_scan_zip_ignores_nonexecuting_subprocess_api(tmp_path: Path, source: str) -> None:
     archive_path = tmp_path / "source_bundle.zip"
     with zipfile.ZipFile(archive_path, "w") as archive:
-        archive.writestr("preprocess.py", "import subprocess\nsubprocess.list2cmdline(['input file', '--quiet'])\n")
+        archive.writestr("preprocess.py", source)
 
     result = ZipScanner().scan(str(archive_path))
 

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -383,6 +383,11 @@ def test_scan_zip_reports_dangerous_setattr_replacement(tmp_path: Path, source: 
             "subprocess.__dict__.update({'run': run})\nsubprocess.run([])\n",
             "subprocess.Popen",
         ),
+        (
+            "import os\nimport subprocess\nsubprocess.__dict__.update({'list2cmdline': os.system})\n"
+            "subprocess.list2cmdline(['id'])\n",
+            "os.system",
+        ),
         ("import subprocess\nsubprocess.__dict__.pop('run')(['id'])\n", "subprocess.run"),
     ],
 )
@@ -926,6 +931,18 @@ def test_scan_zip_ignores_benign_python_member(tmp_path: Path) -> None:
     assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
 
 
+def test_scan_zip_ignores_nonexecuting_subprocess_helper(tmp_path: Path) -> None:
+    archive_path = tmp_path / "source_bundle.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("preprocess.py", "import subprocess\nsubprocess.list2cmdline(['input file', '--quiet'])\n")
+
+    result = ZipScanner().scan(str(archive_path))
+
+    assert result.success is True
+    assert not any(check.name == "Python Archive Member Security" for check in result.checks)
+    assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
+
+
 @pytest.mark.parametrize("dispatch", ["handlers['system'](1.0)", "handlers.get('system')(1.0)"])
 def test_scan_zip_ignores_benign_dictionary_dispatch_python_member(tmp_path: Path, dispatch: str) -> None:
     archive_path = tmp_path / "source_bundle.zip"
@@ -1132,6 +1149,8 @@ def test_scan_zip_ignores_benign_python_file_operations(tmp_path: Path) -> None:
         ("import os\nos.system('echo hidden')\n", "S101", "os.system"),
         ("import os\nos.popen('echo hidden')\n", "S101", "os.popen"),
         ("import subprocess\nsubprocess.run(['echo'], check=False)\n", "S103", "subprocess.run"),
+        ("import subprocess\nsubprocess.getoutput('echo hidden')\n", "S103", "subprocess.getoutput"),
+        ("import subprocess\nsubprocess.getstatusoutput('echo hidden')\n", "S103", "subprocess.getstatusoutput"),
         ("import importlib\nimportlib.import_module('os')\n", "S107", "importlib.import_module"),
         ("eval('1 + 1')\n", "S104", "eval"),
         ("import pickle\npickle.loads(b'\\x80\\x04N.')\n", "S213", "pickle.loads"),


### PR DESCRIPTION
## Summary
- exclude verified non-executing public `subprocess` APIs from embedded Python process-execution findings: `list2cmdline`, `CompletedProcess`, `SubprocessError`, `CalledProcessError`, and `TimeoutExpired`
- retain conservative `subprocess.*` detection for everything not explicitly proven non-executing, including `run`, `Popen`, `getoutput`, and `getstatusoutput`
- preserve dangerous attribution when an allowlisted attribute is statically rebound to `os.system`

## Why
Embedded source analysis currently treats any resolved `subprocess.*` call as process execution. Python's `subprocess.list2cmdline` only formats argument data, while its completed-result and error/timeout classes only construct data objects. Benign handlers using these public APIs therefore receive incorrect `S103` findings.

This PR uses a small exact allowlist rather than weakening the broad fallback. ZIP, TAR, and TorchServe tests cover benign calls and malicious rebinding of both a formatter and a constructor to `os.system`; ZIP/TAR tests retain `S103` findings for shell-executing `getoutput` and `getstatusoutput`.

## Validation
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest tests/scanners/test_zip_scanner.py tests/scanners/test_tar_scanner.py tests/scanners/test_torchserve_mar_scanner.py -q --maxfail=1` (`653 passed`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`Success: no issues found in 453 source files`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`5335 passed, 1082 skipped`)

## Stack
- Stacked on #1361 (`fix: model cleared namespace mappings`), which has completed hosted CI successfully.