### PR TITLE
fix: detect jit os process launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - avoid embedded Python execution findings after certain namespace-map clearing or certain map mutator calls themselves
 - avoid embedded Python process-execution findings for known non-executing `subprocess` formatting and result/error APIs
 - detect embedded Python `os.exec*`, `os.spawn*`, `os.posix_spawn*`, and `os.startfile` process-launch calls
+- detect JIT-scanned embedded Python `os.posix_spawn*` and `os.startfile` process-launch calls while suppressing certain safe replacements
 - preserve embedded Python execution findings when a replacement receiver is conditional, aliased, or a runtime argument
 - fail closed when nested NeMo checkpoint or referenced-artifact analysis is explicitly incomplete
 - preserve concrete nested security findings from checkpoint and referenced artifacts inside NeMo archives

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -635,13 +635,12 @@ class JITScriptDetector:
                 and builtin_name not in bounded_dangerous_builtins
             ):
                 continue
-            if (
-                description == _OS_CODE_EXECUTION_DESCRIPTION
-                and bounded_os_process_calls is not None
-                and not bounded_os_process_calls
-            ):
-                continue
-            if re.search(pattern, bounded):  # Limit search size
+            resolved_os_process_call = False
+            if description == _OS_CODE_EXECUTION_DESCRIPTION and bounded_os_process_calls is not None:
+                if not bounded_os_process_calls:
+                    continue
+                resolved_os_process_call = True
+            if resolved_os_process_call or re.search(pattern, bounded):  # Limit search size
                 findings.append(
                     create_jit_finding(
                         message=description,

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -153,7 +153,15 @@ def _resolve_alias_aware_dangerous_builtins(tree: ast.AST) -> set[str]:
     return dangerous_builtins
 
 
+def _resolve_alias_aware_os_process_calls(tree: ast.AST) -> set[str]:
+    """Return operating-system process launches reached through static resolution."""
+    from modelaudit.scanners.archive_member_security import high_risk_python_calls_in_tree
+
+    return {call.name for call in high_risk_python_calls_in_tree(tree) if call.rule_code == "S101"}
+
+
 # Patterns that indicate code execution attempts
+_OS_CODE_EXECUTION_DESCRIPTION = "OS command execution detected"
 CODE_EXECUTION_PATTERNS = [
     # Direct execution patterns
     (rb"exec\s*\(", "exec() call detected"),
@@ -162,7 +170,7 @@ CODE_EXECUTION_PATTERNS = [
     (rb"__import__\s*\(", "__import__() call detected"),
     # Subprocess patterns
     (rb"subprocess\.(call|run|Popen|check_output)", "Subprocess execution detected"),
-    (rb"os\.(system|popen|exec\w*|spawn\w*)", "OS command execution detected"),
+    (rb"os\.(system|popen|exec\w*|spawn\w*|posix_spawnp?|startfile)", _OS_CODE_EXECUTION_DESCRIPTION),
     # Network patterns
     (rb"socket\.(socket|create_connection)", "Socket creation detected"),
     (rb"urllib\.(request|urlopen)", "URL request detected"),
@@ -224,7 +232,7 @@ class JITScriptDetector:
     @staticmethod
     def _ast_contains_dangerous_python(tree: ast.AST) -> bool:
         """Return whether parsed Python contains modeled dangerous operations."""
-        if _resolve_alias_aware_dangerous_builtins(tree):
+        if _resolve_alias_aware_dangerous_builtins(tree) or _resolve_alias_aware_os_process_calls(tree):
             return True
 
         def is_dangerous_import(module_name: str) -> bool:
@@ -267,9 +275,6 @@ class JITScriptDetector:
                     "subprocess.check_output",
                 }:
                     return True
-                if operation.startswith("os.") and re.fullmatch(r"os\.(?:system|popen|exec\w*|spawn\w*)", operation):
-                    return True
-
         return False
 
     @staticmethod
@@ -553,9 +558,11 @@ class JITScriptDetector:
         python_code_pattern = rb"def\s+\w+\s*\([^)]*\):[^}]+|class\s+\w+[^}]+"
         matches = [bounded] if include_full_source else re.findall(python_code_pattern, bounded)
         bounded_dangerous_builtins: set[str] | None = None
+        bounded_os_process_calls: set[str] | None = None
         try:
             bounded_tree = ast.parse(textwrap.dedent(bounded.decode("utf-8")))
             bounded_dangerous_builtins = _resolve_alias_aware_dangerous_builtins(bounded_tree)
+            bounded_os_process_calls = _resolve_alias_aware_os_process_calls(bounded_tree)
         except (SyntaxError, UnicodeDecodeError, ValueError):
             pass
 
@@ -626,6 +633,12 @@ class JITScriptDetector:
                 builtin_name is not None
                 and bounded_dangerous_builtins is not None
                 and builtin_name not in bounded_dangerous_builtins
+            ):
+                continue
+            if (
+                description == _OS_CODE_EXECUTION_DESCRIPTION
+                and bounded_os_process_calls is not None
+                and not bounded_os_process_calls
             ):
                 continue
             if re.search(pattern, bounded):  # Limit search size

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -242,6 +242,7 @@ class TestJITScriptDetector:
             b"def payload():\n    return os.posix_spawn('/bin/sh', ['sh'], {})\n",
             b"def payload():\n    return os.posix_spawnp('sh', ['sh'], {})\n",
             b"def payload():\n    return os.startfile('payload.exe')\n",
+            b"def payload():\n    return getattr(os, 'posix_' + 'spawn')('/bin/sh', ['sh'], {})\n",
         ],
     )
     def test_scan_model_detects_unmarked_os_process_launch(self, source: bytes) -> None:

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -239,6 +239,53 @@ class TestJITScriptDetector:
     @pytest.mark.parametrize(
         "source",
         [
+            b"def payload():\n    return os.posix_spawn('/bin/sh', ['sh'], {})\n",
+            b"def payload():\n    return os.posix_spawnp('sh', ['sh'], {})\n",
+            b"def payload():\n    return os.startfile('payload.exe')\n",
+        ],
+    )
+    def test_scan_model_detects_unmarked_os_process_launch(self, source: bytes) -> None:
+        detector = JITScriptDetector()
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "OS command execution detected" for f in findings
+        )
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            b"def payload():\n    os.system = len\n    return os.system([])\n",
+            b"def payload():\n    os.posix_spawn = len\n    return os.posix_spawn([])\n",
+            b"def payload():\n    os.startfile = len\n    return os.startfile([])\n",
+        ],
+    )
+    def test_scan_model_ignores_certain_replaced_os_process_launch(self, source: bytes) -> None:
+        detector = JITScriptDetector()
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert findings == []
+
+    def test_scan_model_preserves_possible_os_process_launch_after_conditional_replacement(self) -> None:
+        detector = JITScriptDetector()
+        source = (
+            b"def payload():\n"
+            b"    if replace:\n"
+            b"        os.posix_spawn = len\n"
+            b"    return os.posix_spawn('/bin/sh', ['sh'], {})\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "OS command execution detected" for f in findings
+        )
+
+    @pytest.mark.parametrize(
+        "source",
+        [
             b"getattr(__builtins__, 'eval')('1 + 1')\n",
             b"__builtins__['eval']('1 + 1')\n",
             b"getattr(__builtins__, 'ev' + 'al')('1 + 1')\n",

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1040,6 +1040,7 @@ def test_pytorch_zip_scans_unmarked_python_blobs_in_archive_data(tmp_path: Path)
         b"def payload():\n    return os.posix_spawn('/bin/sh', ['sh'], {})\n",
         b"def payload():\n    return os.posix_spawnp('sh', ['sh'], {})\n",
         b"def payload():\n    return os.startfile('payload.exe')\n",
+        b"def payload():\n    return getattr(os, 'posix_' + 'spawn')('/bin/sh', ['sh'], {})\n",
     ],
 )
 def test_pytorch_zip_scans_unmarked_os_process_launch_in_archive_data(tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1037,6 +1037,57 @@ def test_pytorch_zip_scans_unmarked_python_blobs_in_archive_data(tmp_path: Path)
 @pytest.mark.parametrize(
     "payload",
     [
+        b"def payload():\n    return os.posix_spawn('/bin/sh', ['sh'], {})\n",
+        b"def payload():\n    return os.posix_spawnp('sh', ['sh'], {})\n",
+        b"def payload():\n    return os.startfile('payload.exe')\n",
+    ],
+)
+def test_pytorch_zip_scans_unmarked_os_process_launch_in_archive_data(tmp_path: Path, payload: bytes) -> None:
+    zip_path = tmp_path / "model.pt"
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        zipf.writestr("archive/version", "3")
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("archive/data/payload.bin", payload)
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    jit_failures = [
+        check
+        for check in result.checks
+        if check.name == "JIT/Script Code Execution Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert any(
+        check.location == f"{zip_path}:archive/data/payload.bin" and "OS command execution detected" in check.message
+        for check in jit_failures
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"def payload():\n    os.system = len\n    return os.system([])\n",
+        b"def payload():\n    os.posix_spawn = len\n    return os.posix_spawn([])\n",
+        b"def payload():\n    os.startfile = len\n    return os.startfile([])\n",
+    ],
+)
+def test_pytorch_zip_ignores_certain_replaced_os_process_launch_in_archive_data(tmp_path: Path, payload: bytes) -> None:
+    zip_path = tmp_path / "model.pt"
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        zipf.writestr("archive/version", "3")
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("archive/data/payload.bin", payload)
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    assert not any(
+        check.name == "JIT/Script Code Execution Detection" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
         b"getattr(__builtins__, 'eval')('1 + 1')\n",
         b"__builtins__['ev' + 'al']('1 + 1')\n",
         b"__builtins__.__dict__.get('eval')('1 + 1')\n",


### PR DESCRIPTION
## Summary
- detect JIT-scanned embedded Python calls to `os.posix_spawn*` and `os.startfile`
- reuse the shared static OS process-call resolver instead of relying only on text signatures
- suppress JIT process-execution findings after certain safe replacements while preserving conditional-call findings

## Why
PyTorch ZIP member JIT analysis recognized unmarked source that called `os.spawnv(...)`, but it returned no JIT finding for equivalent already-bound calls to `os.posix_spawn(...)`, `os.posix_spawnp(...)`, or Windows `os.startfile(...)`. These member payloads need not contain an `import os` statement, so import detection does not cover the bypass.

This PR uses the process-launch family introduced by #1363 through the shared alias/overwrite-aware resolver. That both closes the missing-detection path and improves the existing `os.system = len; os.system([])` case by avoiding a certain safe-replacement false positive. Conditional replacements continue to retain the security finding.

## Validation
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --python 3.11 --locked pytest tests/detectors/test_jit_script_detector.py tests/scanners/test_pytorch_zip_scanner.py -q --maxfail=1` (`350 passed`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config sync --python 3.11 --extra all-ci --locked`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`398 files left unchanged`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`All checks passed!`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`Success: no issues found in 453 source files`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` in the `all-ci` environment (`6454 passed, 16 skipped`)

## Stack
- Stacked on #1363 (`fix: detect archive os process launches`), which has completed hosted CI successfully.