### PR TITLE
fix: resolve jit subprocess launch calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - avoid embedded Python process-execution findings for known non-executing `subprocess` formatting and result/error APIs
 - detect embedded Python `os.exec*`, `os.spawn*`, `os.posix_spawn*`, and `os.startfile` process-launch calls
 - detect JIT-scanned embedded Python `os.posix_spawn*` and `os.startfile` process-launch calls while suppressing certain safe replacements
+- detect JIT-scanned embedded Python `subprocess.check_call`, `getoutput`, and `getstatusoutput` calls while suppressing certain safe replacements
 - preserve embedded Python execution findings when a replacement receiver is conditional, aliased, or a runtime argument
 - fail closed when nested NeMo checkpoint or referenced-artifact analysis is explicitly incomplete
 - preserve concrete nested security findings from checkpoint and referenced artifacts inside NeMo archives

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -153,14 +153,19 @@ def _resolve_alias_aware_dangerous_builtins(tree: ast.AST) -> set[str]:
     return dangerous_builtins
 
 
-def _resolve_alias_aware_os_process_calls(tree: ast.AST) -> set[str]:
-    """Return operating-system process launches reached through static resolution."""
+def _resolve_alias_aware_process_calls(tree: ast.AST) -> tuple[set[str], set[str]]:
+    """Return OS and subprocess process launches reached through static resolution."""
     from modelaudit.scanners.archive_member_security import high_risk_python_calls_in_tree
 
-    return {call.name for call in high_risk_python_calls_in_tree(tree) if call.rule_code == "S101"}
+    calls = high_risk_python_calls_in_tree(tree)
+    return (
+        {call.name for call in calls if call.rule_code == "S101"},
+        {call.name for call in calls if call.rule_code == "S103"},
+    )
 
 
 # Patterns that indicate code execution attempts
+_SUBPROCESS_CODE_EXECUTION_DESCRIPTION = "Subprocess execution detected"
 _OS_CODE_EXECUTION_DESCRIPTION = "OS command execution detected"
 CODE_EXECUTION_PATTERNS = [
     # Direct execution patterns
@@ -169,7 +174,10 @@ CODE_EXECUTION_PATTERNS = [
     (rb"compile\s*\(", "compile() call detected"),
     (rb"__import__\s*\(", "__import__() call detected"),
     # Subprocess patterns
-    (rb"subprocess\.(call|run|Popen|check_output)", "Subprocess execution detected"),
+    (
+        rb"subprocess\.(call|run|Popen|check_call|check_output|getoutput|getstatusoutput)",
+        _SUBPROCESS_CODE_EXECUTION_DESCRIPTION,
+    ),
     (rb"os\.(system|popen|exec\w*|spawn\w*|posix_spawnp?|startfile)", _OS_CODE_EXECUTION_DESCRIPTION),
     # Network patterns
     (rb"socket\.(socket|create_connection)", "Socket creation detected"),
@@ -232,7 +240,10 @@ class JITScriptDetector:
     @staticmethod
     def _ast_contains_dangerous_python(tree: ast.AST) -> bool:
         """Return whether parsed Python contains modeled dangerous operations."""
-        if _resolve_alias_aware_dangerous_builtins(tree) or _resolve_alias_aware_os_process_calls(tree):
+        if _resolve_alias_aware_dangerous_builtins(tree):
+            return True
+        os_process_calls, subprocess_calls = _resolve_alias_aware_process_calls(tree)
+        if os_process_calls or subprocess_calls:
             return True
 
         def is_dangerous_import(module_name: str) -> bool:
@@ -269,10 +280,6 @@ class JITScriptDetector:
                     "requests.post",
                     "requests.put",
                     "requests.delete",
-                    "subprocess.call",
-                    "subprocess.run",
-                    "subprocess.Popen",
-                    "subprocess.check_output",
                 }:
                     return True
         return False
@@ -559,10 +566,11 @@ class JITScriptDetector:
         matches = [bounded] if include_full_source else re.findall(python_code_pattern, bounded)
         bounded_dangerous_builtins: set[str] | None = None
         bounded_os_process_calls: set[str] | None = None
+        bounded_subprocess_calls: set[str] | None = None
         try:
             bounded_tree = ast.parse(textwrap.dedent(bounded.decode("utf-8")))
             bounded_dangerous_builtins = _resolve_alias_aware_dangerous_builtins(bounded_tree)
-            bounded_os_process_calls = _resolve_alias_aware_os_process_calls(bounded_tree)
+            bounded_os_process_calls, bounded_subprocess_calls = _resolve_alias_aware_process_calls(bounded_tree)
         except (SyntaxError, UnicodeDecodeError, ValueError):
             pass
 
@@ -633,6 +641,12 @@ class JITScriptDetector:
                 builtin_name is not None
                 and bounded_dangerous_builtins is not None
                 and builtin_name not in bounded_dangerous_builtins
+            ):
+                continue
+            if (
+                description == _SUBPROCESS_CODE_EXECUTION_DESCRIPTION
+                and bounded_subprocess_calls is not None
+                and not bounded_subprocess_calls
             ):
                 continue
             if (

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -286,6 +286,53 @@ class TestJITScriptDetector:
     @pytest.mark.parametrize(
         "source",
         [
+            b"def payload():\n    return subprocess.check_call(['id'])\n",
+            b"def payload():\n    return subprocess.getoutput('id')\n",
+            b"def payload():\n    return subprocess.getstatusoutput('id')\n",
+        ],
+    )
+    def test_scan_model_detects_unmarked_subprocess_process_launch(self, source: bytes) -> None:
+        detector = JITScriptDetector()
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Subprocess execution detected" for f in findings
+        )
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            b"def payload():\n    subprocess.run = len\n    return subprocess.run([])\n",
+            b"def payload():\n    subprocess.check_call = len\n    return subprocess.check_call([])\n",
+            b"def payload():\n    subprocess.getoutput = len\n    return subprocess.getoutput([])\n",
+        ],
+    )
+    def test_scan_model_ignores_certain_replaced_subprocess_process_launch(self, source: bytes) -> None:
+        detector = JITScriptDetector()
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert findings == []
+
+    def test_scan_model_preserves_possible_subprocess_launch_after_conditional_replacement(self) -> None:
+        detector = JITScriptDetector()
+        source = (
+            b"def payload():\n"
+            b"    if replace:\n"
+            b"        subprocess.check_call = len\n"
+            b"    return subprocess.check_call(['id'])\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Subprocess execution detected" for f in findings
+        )
+
+    @pytest.mark.parametrize(
+        "source",
+        [
             b"getattr(__builtins__, 'eval')('1 + 1')\n",
             b"__builtins__['eval']('1 + 1')\n",
             b"getattr(__builtins__, 'ev' + 'al')('1 + 1')\n",

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1088,6 +1088,61 @@ def test_pytorch_zip_ignores_certain_replaced_os_process_launch_in_archive_data(
 @pytest.mark.parametrize(
     "payload",
     [
+        b"def payload():\n    return subprocess.check_call(['id'])\n",
+        b"def payload():\n    return subprocess.getoutput('id')\n",
+        b"def payload():\n    return subprocess.getstatusoutput('id')\n",
+    ],
+)
+def test_pytorch_zip_scans_unmarked_subprocess_launch_in_archive_data(tmp_path: Path, payload: bytes) -> None:
+    zip_path = tmp_path / "model.pt"
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        zipf.writestr("archive/version", "3")
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("archive/data/payload.bin", payload)
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    jit_failures = [
+        check
+        for check in result.checks
+        if check.name == "JIT/Script Code Execution Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert any(
+        check.location == f"{zip_path}:archive/data/payload.bin" and "Subprocess execution detected" in check.message
+        for check in jit_failures
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"def payload():\n    subprocess.run = len\n    return subprocess.run([])\n",
+        b"def payload():\n    subprocess.check_call = len\n    return subprocess.check_call([])\n",
+        b"def payload():\n    subprocess.getoutput = len\n    return subprocess.getoutput([])\n",
+        b"def payload():\n    return subprocess.CompletedProcess([], 0)\n",
+        b"def payload():\n    return subprocess.list2cmdline(['input'])\n",
+    ],
+)
+def test_pytorch_zip_ignores_nonexecuting_or_replaced_subprocess_launch_in_archive_data(
+    tmp_path: Path, payload: bytes
+) -> None:
+    zip_path = tmp_path / "model.pt"
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        zipf.writestr("archive/version", "3")
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("archive/data/payload.bin", payload)
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    assert not any(
+        check.name == "JIT/Script Code Execution Detection" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
         b"getattr(__builtins__, 'eval')('1 + 1')\n",
         b"__builtins__['ev' + 'al']('1 + 1')\n",
         b"__builtins__.__dict__.get('eval')('1 + 1')\n",


### PR DESCRIPTION
## Summary
- detect JIT-scanned `subprocess.check_call`, `subprocess.getoutput`, and `subprocess.getstatusoutput` calls
- route JIT subprocess decisions through the shared static `S103` resolver alongside OS process calls
- suppress deterministic safe replacements and keep non-executing subprocess APIs benign

## Why
PyTorch ZIP JIT analysis previously found an unimported `subprocess.run(...)` source member, but returned no JIT finding for equivalent `subprocess.check_call(...)`, `subprocess.getoutput(...)`, or `subprocess.getstatusoutput(...)` calls. At the same time, `subprocess.run = len; subprocess.run([])` was still reported as execution because JIT used raw signatures instead of the existing resolver policy.

The archive source resolver already models the missing process-launch helpers as `S103`, excludes non-executing `CompletedProcess`/`list2cmdline` APIs, and handles certain versus conditional replacements. This PR makes JIT consume that contract in one process-call traversal rather than growing another partial list.

## Validation
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest tests/detectors/test_jit_script_detector.py tests/scanners/test_pytorch_zip_scanner.py -q --maxfail=1` (`365 passed`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`398 files left unchanged`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`All checks passed!`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`Success: no issues found in 453 source files`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` in the `all-ci` environment (`6470 passed, 15 skipped`)

## Stack
- Stacked on #1364 (`fix: detect jit os process launches`), which has completed hosted CI successfully.