### PR TITLE
ci: run retained memory guard in benchmarks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -16,4 +16,7 @@ Python CI ignores documentation-only PRs, which are handled by the documentation
 
 The performance workflow compares workload-oriented benchmarks between the PR
 base and head, posts a sticky summary comment on same-repo PRs, uploads JSON and
-Markdown artifacts, and reports regressions without blocking the PR.
+Markdown artifacts, and reports comparative regressions without blocking the
+PR. It separately runs the retained-memory stability guard from
+`tests/test_performance_benchmarks.py`, which fails the workflow if repeat scans
+retain excessive memory.

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -9,6 +9,7 @@ on:
       - "tests/helpers/**"
       - "tests/conftest.py"
       - "tests/test_benchmark_report.py"
+      - "tests/test_performance_benchmarks.py"
       - "scripts/benchmark_report.py"
       - "pyproject.toml"
       - "uv.lock"
@@ -23,6 +24,7 @@ on:
       - "tests/helpers/**"
       - "tests/conftest.py"
       - "tests/test_benchmark_report.py"
+      - "tests/test_performance_benchmarks.py"
       - "scripts/benchmark_report.py"
       - "pyproject.toml"
       - "uv.lock"
@@ -152,6 +154,14 @@ jobs:
             --summary-file "$BENCHMARK_ARTIFACT_DIR/benchmark-current.md"
           cat "$BENCHMARK_ARTIFACT_DIR/benchmark-current.md" >> "$BENCHMARK_ARTIFACT_DIR/benchmark-summary.md"
           cat "$BENCHMARK_ARTIFACT_DIR/benchmark-summary.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run retained-memory stability guard
+        env:
+          PROMPTFOO_DISABLE_TELEMETRY: "1"
+        run: |
+          uv run --locked --with psutil pytest \
+            tests/test_performance_benchmarks.py::TestPerformanceBenchmarks::test_memory_usage_stability \
+            -q
 
       - name: Comment benchmark summary on PR
         if: >

--- a/docs/agents/performance-audit.md
+++ b/docs/agents/performance-audit.md
@@ -32,6 +32,7 @@ The PR benchmark lane lives in:
 
 - `tests/benchmarks/test_scan_benchmarks.py`
 - `tests/benchmarks/test_picklescan_benchmarks.py`
+- `tests/test_performance_benchmarks.py` (`test_memory_usage_stability` guard only)
 - `.github/workflows/perf.yml`
 - `scripts/benchmark_report.py`
 
@@ -65,7 +66,10 @@ user-relevant workload or guards a security-critical hot path.
 
 The GitHub Actions performance workflow runs the benchmark suite on the PR base
 and head, posts a sticky summary comment, and uploads JSON plus Markdown
-artifacts. It is advisory: it reports regressions without blocking the PR.
+artifacts. It also runs the retained-memory stability guard from
+`tests/test_performance_benchmarks.py`; older timing-sensitive tests in that
+module remain outside the PR lane. The comparative benchmark report is
+advisory, while a failed retained-memory guard fails the workflow.
 
 ### Local Benchmark Run
 


### PR DESCRIPTION
## Summary
- trigger the Performance Benchmarks workflow when `tests/test_performance_benchmarks.py` changes
- execute only its stabilized `test_memory_usage_stability` RSS guard in the performance lane, with `psutil` explicitly available
- document that comparative benchmark reporting is advisory while retained-memory regression failure is blocking

## Why
Validation of #1367 exposed that edits to `tests/test_performance_benchmarks.py` neither trigger `perf.yml` nor run under ordinary PR Python CI, because the file is marked `performance` and PR matrix jobs exclude performance tests. That leaves a retained-memory regression guard unexercised by hosted PR checks.

The older timing-sensitive assertions in that module were intentionally kept out of the PR lane. This PR adds only the now steady-state `test_memory_usage_stability` check from #1367, so memory-retention regressions are enforced without reviving flaky timing gates.

## Validation
- `npx prettier --check .github/workflows/perf.yml docs/agents/performance-audit.md .github/workflows/README.md` (`All matched files use Prettier code style!`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked --with psutil pytest tests/test_performance_benchmarks.py::TestPerformanceBenchmarks::test_memory_usage_stability -q` (`1 passed in 70.96s`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`398 files left unchanged`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`All checks passed!`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`Success: no issues found in 453 source files`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`6490 passed, 15 skipped`)

## Stack
- Stacked on #1367 (`test: stabilize memory growth benchmark`), which has completed hosted CI successfully.