### PR TITLE
fix: detect embedded pty process launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - detect JIT-scanned embedded Python `os.posix_spawn*` and `os.startfile` process-launch calls while suppressing certain safe replacements
 - detect JIT-scanned embedded Python `subprocess.check_call`, `getoutput`, and `getstatusoutput` calls while suppressing certain safe replacements
 - detect embedded Python `asyncio.create_subprocess_exec` and `asyncio.create_subprocess_shell` process-launch calls
+- detect embedded Python `pty.spawn` launches and report statically resolved JIT process-launch aliases
 - preserve embedded Python execution findings when a replacement receiver is conditional, aliased, or a runtime argument
 - fail closed when nested NeMo checkpoint or referenced-artifact analysis is explicitly incomplete
 - preserve concrete nested security findings from checkpoint and referenced artifacts inside NeMo archives

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -153,20 +153,22 @@ def _resolve_alias_aware_dangerous_builtins(tree: ast.AST) -> set[str]:
     return dangerous_builtins
 
 
-def _resolve_alias_aware_process_calls(tree: ast.AST) -> tuple[set[str], set[str]]:
-    """Return OS and subprocess process launches reached through static resolution."""
+def _resolve_alias_aware_process_calls(tree: ast.AST) -> tuple[set[str], set[str], set[str]]:
+    """Return OS, subprocess, and pseudo-terminal launches reached through static resolution."""
     from modelaudit.scanners.archive_member_security import high_risk_python_calls_in_tree
 
     calls = high_risk_python_calls_in_tree(tree)
     return (
         {call.name for call in calls if call.rule_code == "S101"},
         {call.name for call in calls if call.rule_code == "S103"},
+        {call.name for call in calls if call.rule_code == "S111"},
     )
 
 
 # Patterns that indicate code execution attempts
 _SUBPROCESS_CODE_EXECUTION_DESCRIPTION = "Subprocess execution detected"
 _OS_CODE_EXECUTION_DESCRIPTION = "OS command execution detected"
+_PTY_CODE_EXECUTION_DESCRIPTION = "Pseudo-terminal process execution detected"
 CODE_EXECUTION_PATTERNS = [
     # Direct execution patterns
     (rb"exec\s*\(", "exec() call detected"),
@@ -180,6 +182,7 @@ CODE_EXECUTION_PATTERNS = [
     ),
     (rb"asyncio\.create_subprocess_(?:exec|shell)", _SUBPROCESS_CODE_EXECUTION_DESCRIPTION),
     (rb"os\.(system|popen|exec\w*|spawn\w*|posix_spawnp?|startfile)", _OS_CODE_EXECUTION_DESCRIPTION),
+    (rb"pty\.spawn", _PTY_CODE_EXECUTION_DESCRIPTION),
     # Network patterns
     (rb"socket\.(socket|create_connection)", "Socket creation detected"),
     (rb"urllib\.(request|urlopen)", "URL request detected"),
@@ -243,8 +246,8 @@ class JITScriptDetector:
         """Return whether parsed Python contains modeled dangerous operations."""
         if _resolve_alias_aware_dangerous_builtins(tree):
             return True
-        os_process_calls, subprocess_calls = _resolve_alias_aware_process_calls(tree)
-        if os_process_calls or subprocess_calls:
+        os_process_calls, subprocess_calls, pty_process_calls = _resolve_alias_aware_process_calls(tree)
+        if os_process_calls or subprocess_calls or pty_process_calls:
             return True
 
         def is_dangerous_import(module_name: str) -> bool:
@@ -568,10 +571,13 @@ class JITScriptDetector:
         bounded_dangerous_builtins: set[str] | None = None
         bounded_os_process_calls: set[str] | None = None
         bounded_subprocess_calls: set[str] | None = None
+        bounded_pty_process_calls: set[str] | None = None
         try:
             bounded_tree = ast.parse(textwrap.dedent(bounded.decode("utf-8")))
             bounded_dangerous_builtins = _resolve_alias_aware_dangerous_builtins(bounded_tree)
-            bounded_os_process_calls, bounded_subprocess_calls = _resolve_alias_aware_process_calls(bounded_tree)
+            bounded_os_process_calls, bounded_subprocess_calls, bounded_pty_process_calls = (
+                _resolve_alias_aware_process_calls(bounded_tree)
+            )
         except (SyntaxError, UnicodeDecodeError, ValueError):
             pass
 
@@ -635,6 +641,24 @@ class JITScriptDetector:
                 # Failed to process this code snippet
                 continue
 
+        def add_code_execution_pattern_finding(description: str) -> None:
+            findings.append(
+                create_jit_finding(
+                    message=description,
+                    severity="CRITICAL",
+                    context=context,
+                    pattern=description,
+                    recommendation="This pattern indicates potential code execution - review carefully",
+                    confidence=0.8,
+                    framework=framework,
+                    code_snippet=None,
+                    type="code_execution_pattern",
+                    operation=None,
+                    builtin=None,
+                    import_=None,
+                )
+            )
+
         # Check for common code execution patterns in binary
         for pattern, description in CODE_EXECUTION_PATTERNS:
             builtin_name = _BUILTIN_CODE_EXECUTION_PATTERN_NAMES.get(description)
@@ -656,23 +680,24 @@ class JITScriptDetector:
                 and not bounded_os_process_calls
             ):
                 continue
+            if (
+                description == _PTY_CODE_EXECUTION_DESCRIPTION
+                and bounded_pty_process_calls is not None
+                and not bounded_pty_process_calls
+            ):
+                continue
             if re.search(pattern, bounded):  # Limit search size
-                findings.append(
-                    create_jit_finding(
-                        message=description,
-                        severity="CRITICAL",
-                        context=context,
-                        pattern=description,
-                        recommendation="This pattern indicates potential code execution - review carefully",
-                        confidence=0.8,
-                        framework=framework,
-                        code_snippet=None,
-                        type="code_execution_pattern",
-                        operation=None,
-                        builtin=None,
-                        import_=None,
-                    )
-                )
+                add_code_execution_pattern_finding(description)
+
+        reported_patterns = {finding.pattern for finding in findings if finding.type == "code_execution_pattern"}
+        for calls, description in (
+            (bounded_os_process_calls, _OS_CODE_EXECUTION_DESCRIPTION),
+            (bounded_subprocess_calls, _SUBPROCESS_CODE_EXECUTION_DESCRIPTION),
+            (bounded_pty_process_calls, _PTY_CODE_EXECUTION_DESCRIPTION),
+        ):
+            if calls and description not in reported_patterns:
+                add_code_execution_pattern_finding(description)
+                reported_patterns.add(description)
 
         return findings
 

--- a/modelaudit/rule_catalog.py
+++ b/modelaudit/rule_catalog.py
@@ -86,6 +86,13 @@ RULE_CATALOG: tuple[RuleCatalogEntry, ...] = (
         patterns=(r"import\s+ctypes", r"from\s+ctypes\s+import", r"ctypes\."),
     ),
     RuleCatalogEntry(
+        code="S111",
+        name="pty process spawn usage",
+        severity="CRITICAL",
+        description="Pseudo-terminal process spawning via pty.spawn",
+        patterns=(r"pty\.spawn\s*\(",),
+    ),
+    RuleCatalogEntry(
         code="S115",
         name="Builtins code-execution access",
         severity="HIGH",

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -88,6 +88,7 @@ _ASYNCIO_PROCESS_EXECUTION_CALLS = frozenset(
         "asyncio.create_subprocess_shell",
     }
 )
+_PTY_PROCESS_EXECUTION_CALLS = frozenset({"pty.spawn"})
 _HIGH_RISK_PYTHON_CALLS = {
     "__import__",
     "__builtin__.__import__",
@@ -111,6 +112,7 @@ _HIGH_RISK_PYTHON_CALLS = {
     "subprocess.run",
     *_OS_PROCESS_EXECUTION_CALLS,
     *_ASYNCIO_PROCESS_EXECUTION_CALLS,
+    *_PTY_PROCESS_EXECUTION_CALLS,
 }
 # Retain broad subprocess coverage while excluding public APIs that only construct data.
 _KNOWN_NON_EXECUTING_SUBPROCESS_CALLS = {
@@ -143,6 +145,7 @@ _HIGH_RISK_PYTHON_CALL_RULE_CODES: dict[str, str] = {
     "pickle.loads": "S213",
     **dict.fromkeys(_OS_PROCESS_EXECUTION_CALLS, "S101"),
     **dict.fromkeys(_ASYNCIO_PROCESS_EXECUTION_CALLS, "S103"),
+    **dict.fromkeys(_PTY_PROCESS_EXECUTION_CALLS, "S111"),
 }
 _HIGH_RISK_PYTHON_CALL_PREFIX_RULE_CODES: tuple[tuple[str, str], ...] = (("subprocess.", "S103"),)
 _FALLBACK_HIGH_RISK_RULE_CODE = "S104"

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -242,6 +242,7 @@ class TestJITScriptDetector:
             b"def payload():\n    return os.posix_spawn('/bin/sh', ['sh'], {})\n",
             b"def payload():\n    return os.posix_spawnp('sh', ['sh'], {})\n",
             b"def payload():\n    return os.startfile('payload.exe')\n",
+            b"def payload():\n    from os import spawnv as run\n    return run(0, '/bin/sh', ['sh'])\n",
         ],
     )
     def test_scan_model_detects_unmarked_os_process_launch(self, source: bytes) -> None:
@@ -289,6 +290,7 @@ class TestJITScriptDetector:
             b"def payload():\n    return subprocess.check_call(['id'])\n",
             b"def payload():\n    return subprocess.getoutput('id')\n",
             b"def payload():\n    return subprocess.getstatusoutput('id')\n",
+            b"def payload():\n    from subprocess import check_call as run\n    return run(['id'])\n",
         ],
     )
     def test_scan_model_detects_unmarked_subprocess_process_launch(self, source: bytes) -> None:
@@ -335,6 +337,10 @@ class TestJITScriptDetector:
         [
             b"async def payload():\n    return await asyncio.create_subprocess_exec('/bin/sh', '-c', 'id')\n",
             b"async def payload():\n    return await asyncio.create_subprocess_shell('id')\n",
+            (
+                b"async def payload():\n    from asyncio import create_subprocess_shell as run\n"
+                b"    return await run('id')\n"
+            ),
         ],
     )
     def test_scan_model_detects_unmarked_asyncio_process_launch(self, source: bytes) -> None:
@@ -371,6 +377,42 @@ class TestJITScriptDetector:
 
         assert any(
             f.type == "code_execution_pattern" and f.pattern == "Subprocess execution detected" for f in findings
+        )
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            b"def payload():\n    return pty.spawn('/bin/sh')\n",
+            b"def payload():\n    from pty import spawn as run\n    return run('/bin/sh')\n",
+        ],
+    )
+    def test_scan_model_detects_unmarked_pty_process_launch(self, source: bytes) -> None:
+        detector = JITScriptDetector()
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Pseudo-terminal process execution detected"
+            for f in findings
+        )
+
+    def test_scan_model_ignores_certain_replaced_pty_process_launch(self) -> None:
+        detector = JITScriptDetector()
+        source = b"def payload():\n    pty.spawn = len\n    return pty.spawn([])\n"
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert findings == []
+
+    def test_scan_model_preserves_possible_pty_launch_after_conditional_replacement(self) -> None:
+        detector = JITScriptDetector()
+        source = b"def payload():\n    if replace:\n        pty.spawn = len\n    return pty.spawn('/bin/sh')\n"
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Pseudo-terminal process execution detected"
+            for f in findings
         )
 
     @pytest.mark.parametrize(

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1040,6 +1040,7 @@ def test_pytorch_zip_scans_unmarked_python_blobs_in_archive_data(tmp_path: Path)
         b"def payload():\n    return os.posix_spawn('/bin/sh', ['sh'], {})\n",
         b"def payload():\n    return os.posix_spawnp('sh', ['sh'], {})\n",
         b"def payload():\n    return os.startfile('payload.exe')\n",
+        b"def payload():\n    from os import spawnv as run\n    return run(0, '/bin/sh', ['sh'])\n",
     ],
 )
 def test_pytorch_zip_scans_unmarked_os_process_launch_in_archive_data(tmp_path: Path, payload: bytes) -> None:
@@ -1091,6 +1092,7 @@ def test_pytorch_zip_ignores_certain_replaced_os_process_launch_in_archive_data(
         b"def payload():\n    return subprocess.check_call(['id'])\n",
         b"def payload():\n    return subprocess.getoutput('id')\n",
         b"def payload():\n    return subprocess.getstatusoutput('id')\n",
+        b"def payload():\n    from subprocess import check_call as run\n    return run(['id'])\n",
     ],
 )
 def test_pytorch_zip_scans_unmarked_subprocess_launch_in_archive_data(tmp_path: Path, payload: bytes) -> None:
@@ -1145,6 +1147,7 @@ def test_pytorch_zip_ignores_nonexecuting_or_replaced_subprocess_launch_in_archi
     [
         b"async def payload():\n    return await asyncio.create_subprocess_exec('/bin/sh', '-c', 'id')\n",
         b"async def payload():\n    return await asyncio.create_subprocess_shell('id')\n",
+        (b"async def payload():\n    from asyncio import create_subprocess_shell as run\n    return await run('id')\n"),
     ],
 )
 def test_pytorch_zip_scans_unmarked_asyncio_process_launch_in_archive_data(tmp_path: Path, payload: bytes) -> None:
@@ -1186,6 +1189,50 @@ def test_pytorch_zip_ignores_certain_replaced_asyncio_process_launch_in_archive_
     tmp_path: Path, payload: bytes
 ) -> None:
     zip_path = tmp_path / "model.pt"
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        zipf.writestr("archive/version", "3")
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("archive/data/payload.bin", payload)
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    assert not any(
+        check.name == "JIT/Script Code Execution Detection" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"def payload():\n    return pty.spawn('/bin/sh')\n",
+        b"def payload():\n    from pty import spawn as run\n    return run('/bin/sh')\n",
+    ],
+)
+def test_pytorch_zip_scans_unmarked_pty_process_launch_in_archive_data(tmp_path: Path, payload: bytes) -> None:
+    zip_path = tmp_path / "model.pt"
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        zipf.writestr("archive/version", "3")
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("archive/data/payload.bin", payload)
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    jit_failures = [
+        check
+        for check in result.checks
+        if check.name == "JIT/Script Code Execution Detection" and check.status == CheckStatus.FAILED
+    ]
+    assert any(
+        check.location == f"{zip_path}:archive/data/payload.bin"
+        and "Pseudo-terminal process execution detected" in check.message
+        for check in jit_failures
+    )
+
+
+def test_pytorch_zip_ignores_certain_replaced_pty_process_launch_in_archive_data(tmp_path: Path) -> None:
+    zip_path = tmp_path / "model.pt"
+    payload = b"def payload():\n    pty.spawn = len\n    return pty.spawn([])\n"
     with zipfile.ZipFile(zip_path, "w") as zipf:
         zipf.writestr("archive/version", "3")
         zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -197,6 +197,30 @@ class TestTarScanner:
         assert python_checks[0].details["reason"] == f"high-risk calls: {dangerous_name}"
 
     @pytest.mark.parametrize(
+        ("payload", "dangerous_name"),
+        [
+            (b"import pty\npty.spawn('/bin/sh')\n", "pty.spawn"),
+            (b"from pty import spawn as run\nrun('/bin/sh')\n", "pty.spawn"),
+        ],
+    )
+    def test_scan_tar_flags_pty_process_launch_python_member(
+        self, tmp_path: Path, payload: bytes, dangerous_name: str
+    ) -> None:
+        archive_path = tmp_path / "model_bundle.tar"
+        with tarfile.open(archive_path, "w") as archive:
+            info = tarfile.TarInfo("handler.py")
+            info.size = len(payload)
+            archive.addfile(info, tarfile.io.BytesIO(payload))  # type: ignore[attr-defined]
+
+        result = self.scanner.scan(str(archive_path))
+
+        python_checks = [check for check in result.checks if check.name == "Python Archive Member Security"]
+        assert len(python_checks) == 1
+        assert python_checks[0].status == CheckStatus.FAILED
+        assert python_checks[0].rule_code == "S111"
+        assert python_checks[0].details["reason"] == f"high-risk calls: {dangerous_name}"
+
+    @pytest.mark.parametrize(
         "payload",
         [
             b"import os\nos.system.__call__('echo hidden')\n",
@@ -298,6 +322,7 @@ class TestTarScanner:
             b"import os\nos.__dict__.update({'spawnv': len})\nos.spawnv([])\n",
             b"import os\nsetattr(os, 'posix_spawn', len)\nos.posix_spawn([])\n",
             b"import asyncio\nasyncio.create_subprocess_shell = len\nasyncio.create_subprocess_shell([])\n",
+            b"import pty\npty.spawn = len\npty.spawn([])\n",
         ],
     )
     def test_scan_tar_allows_callable_captured_after_safe_overwrite(self, tmp_path: Path, payload: bytes) -> None:
@@ -344,6 +369,7 @@ class TestTarScanner:
                 b"import asyncio\nimport subprocess\nasyncio.create_subprocess_exec = subprocess.run\n"
                 b"asyncio.create_subprocess_exec(['id'])\n"
             ),
+            b"import pty\nimport subprocess\npty.spawn = subprocess.run\npty.spawn(['id'])\n",
         ],
     )
     def test_scan_tar_reports_dangerous_setattr_replacement(self, tmp_path: Path, payload: bytes) -> None:
@@ -1001,6 +1027,7 @@ class TestTarScanner:
                 "S103",
                 "subprocess.getstatusoutput",
             ),
+            (b"import pty\npty.spawn('/bin/sh')\n", "S111", "pty.spawn"),
             (b"import importlib\nimportlib.import_module('os')\n", "S107", "importlib.import_module"),
             (b"eval('1 + 1')\n", "S104", "eval"),
             (b"import pickle\npickle.loads(b'\\x80\\x04N.')\n", "S213", "pickle.loads"),

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -355,6 +355,47 @@ def test_scan_allows_replaced_asyncio_process_launch_handler_api(tmp_path: Path)
 
 
 @pytest.mark.parametrize(
+    ("handler_source", "dangerous_name"),
+    [
+        (b"import pty\ndef handle(data, context):\n    return pty.spawn('/bin/sh')\n", "pty.spawn"),
+        (b"from pty import spawn as run\ndef handle(data, context):\n    return run('/bin/sh')\n", "pty.spawn"),
+    ],
+)
+def test_scan_detects_pty_process_launch_handler_execution_primitive(
+    tmp_path: Path, handler_source: bytes, dangerous_name: str
+) -> None:
+    manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
+    mar_path = _create_mar_archive(
+        tmp_path,
+        manifest=manifest,
+        entries={"handler.py": handler_source, "weights.bin": b"weights"},
+        filename="pty_process_launch_handler.mar",
+    )
+
+    result = TorchServeMarScanner().scan(str(mar_path))
+    handler_failures = _failed_checks(result, "TorchServe Handler Static Analysis")
+
+    assert len(handler_failures) == 1
+    assert handler_failures[0].severity == IssueSeverity.CRITICAL
+    assert dangerous_name in handler_failures[0].message
+
+
+def test_scan_allows_replaced_pty_process_launch_handler_api(tmp_path: Path) -> None:
+    handler_source = b"import pty\ndef handle(data, context):\n    pty.spawn = len\n    return pty.spawn([])\n"
+    manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
+    mar_path = _create_mar_archive(
+        tmp_path,
+        manifest=manifest,
+        entries={"handler.py": handler_source, "weights.bin": b"weights"},
+        filename="safe_replaced_pty_process_launch_handler.mar",
+    )
+
+    result = TorchServeMarScanner().scan(str(mar_path))
+
+    assert _failed_checks(result, "TorchServe Handler Static Analysis") == []
+
+
+@pytest.mark.parametrize(
     "handler_source",
     [
         b"def handle(data, context):\n    return __builtins__['ev' + 'al']('1 + 1')\n",

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -269,6 +269,48 @@ def test_scan_zip_preserves_possible_asyncio_launch_after_conditional_overwrite(
 
 
 @pytest.mark.parametrize(
+    ("source", "dangerous_name"),
+    [
+        ("import pty\npty.spawn('/bin/sh')\n", "pty.spawn"),
+        ("from pty import spawn as run\nrun('/bin/sh')\n", "pty.spawn"),
+    ],
+)
+def test_scan_zip_flags_pty_process_launch_python_member(tmp_path: Path, source: str, dangerous_name: str) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", source)
+
+    result = ZipScanner().scan(str(archive_path))
+
+    python_checks = [
+        check
+        for check in result.checks
+        if check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED
+    ]
+    assert len(python_checks) == 1
+    assert python_checks[0].rule_code == "S111"
+    assert python_checks[0].details["reason"] == f"high-risk calls: {dangerous_name}"
+
+
+def test_scan_zip_preserves_possible_pty_launch_after_conditional_overwrite(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    source = "import pty\nif replace:\n    pty.spawn = len\npty.spawn('/bin/sh')\n"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", source)
+
+    result = ZipScanner().scan(str(archive_path))
+
+    python_checks = [
+        check
+        for check in result.checks
+        if check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED
+    ]
+    assert len(python_checks) == 1
+    assert python_checks[0].rule_code == "S111"
+    assert python_checks[0].details["reason"] == "high-risk calls: pty.spawn"
+
+
+@pytest.mark.parametrize(
     "source",
     [
         "import os\nos.system.__call__('echo hidden')\n",
@@ -416,6 +458,7 @@ def test_scan_zip_preserves_captured_dangerous_callable_before_overwrite(tmp_pat
         "import os\nos.__dict__.update({'spawnv': len})\nos.spawnv([])\n",
         "import os\nsetattr(os, 'posix_spawn', len)\nos.posix_spawn([])\n",
         "import asyncio\nasyncio.create_subprocess_shell = len\nasyncio.create_subprocess_shell([])\n",
+        "import pty\npty.spawn = len\npty.spawn([])\n",
     ],
 )
 def test_scan_zip_allows_callable_captured_after_safe_overwrite(tmp_path: Path, source: str) -> None:
@@ -471,6 +514,7 @@ def test_scan_zip_flags_from_import_dangerous_python_member(tmp_path: Path) -> N
             "import asyncio\nimport subprocess\nasyncio.create_subprocess_exec = subprocess.run\n"
             "asyncio.create_subprocess_exec(['id'])\n"
         ),
+        "import pty\nimport subprocess\npty.spawn = subprocess.run\npty.spawn(['id'])\n",
     ],
 )
 def test_scan_zip_reports_dangerous_setattr_replacement(tmp_path: Path, source: str) -> None:
@@ -1284,6 +1328,7 @@ def test_scan_zip_ignores_benign_python_file_operations(tmp_path: Path) -> None:
         ("import subprocess\nsubprocess.run(['echo'], check=False)\n", "S103", "subprocess.run"),
         ("import subprocess\nsubprocess.getoutput('echo hidden')\n", "S103", "subprocess.getoutput"),
         ("import subprocess\nsubprocess.getstatusoutput('echo hidden')\n", "S103", "subprocess.getstatusoutput"),
+        ("import pty\npty.spawn('/bin/sh')\n", "S111", "pty.spawn"),
         ("import importlib\nimportlib.import_module('os')\n", "S107", "importlib.import_module"),
         ("eval('1 + 1')\n", "S104", "eval"),
         ("import pickle\npickle.loads(b'\\x80\\x04N.')\n", "S213", "pickle.loads"),

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -41,6 +41,12 @@ class TestRuleRegistry:
         assert rule.name == "os module import"
         assert rule.default_severity == Severity.CRITICAL
 
+    def test_get_pty_spawn_rule(self) -> None:
+        rule = RuleRegistry.get_rule("S111")
+        assert rule is not None
+        assert rule.name == "pty process spawn usage"
+        assert rule.default_severity == Severity.CRITICAL
+
     def test_get_nonexistent_rule(self):
         """Test getting a rule that doesn't exist."""
         rule = RuleRegistry.get_rule("S9999")
@@ -93,6 +99,7 @@ class TestRuleRegistry:
         assert all(100 <= int(code[1:]) <= 199 for code in rules)
         assert "S101" in rules
         assert "S110" in rules
+        assert "S111" in rules
         assert "S201" not in rules  # Pickle rule, not in range
 
         # Get pickle rules (S200-S299)
@@ -469,6 +476,7 @@ class TestRulePatterns:
             ("import runpy", "S108"),
             ("import webbrowser", "S109"),
             ("import ctypes", "S110"),
+            ("pty.spawn('/bin/sh')", "S111"),
         ]
 
         for message, expected_code in test_cases:


### PR DESCRIPTION
## Summary
- detect embedded Python `pty.spawn` pseudo-terminal launches through shared archive analysis as `S111`
- report statically resolved JIT/PyTorch ZIP process-launch aliases, including `pty`, `asyncio`, `subprocess`, and `os` APIs
- register the already-referenced `S111` rule and cover malicious, safe-replacement, conditional-replacement, and rebinding cases

## Why
`pty.spawn('/bin/sh')` launches a child program and was already treated as critical in suspicious-symbol, NeMo target, rule-mapper, and whitelist policy, but shared Python member analysis and JIT/PyTorch ZIP source analysis produced no finding for it. Runtime probes reproduced the miss for both direct and aliased `pty.spawn` calls.

While adding that missing primitive, direct behavior probes showed a related JIT gap: shared static resolution recognized aliased process launches, but JIT emitted a finding only when the original dotted API name still appeared in bytes. This PR lets JIT reporting consume the resolved call sets when aliases hide literal names.

Deterministic replacements to safe callables remain suppressed, while conditional replacements and dangerous rebinding continue to fail closed.

## Validation
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest tests/test_rules.py tests/detectors/test_jit_script_detector.py tests/scanners/test_pytorch_zip_scanner.py tests/scanners/test_zip_scanner.py tests/scanners/test_tar_scanner.py tests/scanners/test_torchserve_mar_scanner.py -q --maxfail=1` (`1146 passed`)
- `npx prettier --check CHANGELOG.md` (`All matched files use Prettier code style!`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`398 files left unchanged`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`All checks passed!`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`Success: no issues found in 453 source files`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`6518 passed, 15 skipped`)

## Stack
- Stacked on #1368 (`ci: run retained memory guard in benchmarks`), which has completed hosted CI successfully.