### PR TITLE
fix: register emitted dynamic code rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - detect JIT-scanned embedded Python `subprocess.check_call`, `getoutput`, and `getstatusoutput` calls while suppressing certain safe replacements
 - detect embedded Python `asyncio.create_subprocess_exec` and `asyncio.create_subprocess_shell` process-launch calls
 - detect embedded Python `pty.spawn` launches and report statically resolved JIT process-launch aliases
+- register emitted `S112`-`S114` dynamic-code rule identifiers so they can be listed and configured
 - preserve embedded Python execution findings when a replacement receiver is conditional, aliased, or a runtime argument
 - fail closed when nested NeMo checkpoint or referenced-artifact analysis is explicitly incomplete
 - preserve concrete nested security findings from checkpoint and referenced artifacts inside NeMo archives

--- a/modelaudit/rule_catalog.py
+++ b/modelaudit/rule_catalog.py
@@ -93,6 +93,27 @@ RULE_CATALOG: tuple[RuleCatalogEntry, ...] = (
         patterns=(r"pty\.spawn\s*\(",),
     ),
     RuleCatalogEntry(
+        code="S112",
+        name="interactive code execution usage",
+        severity="CRITICAL",
+        description="Interactive code execution via the code module",
+        patterns=(r"code\.(?:InteractiveConsole|InteractiveInterpreter)\b",),
+    ),
+    RuleCatalogEntry(
+        code="S113",
+        name="dynamic function construction usage",
+        severity="HIGH",
+        description="Runtime construction of code or function objects via types",
+        patterns=(r"types\.(?:CodeType|FunctionType)\b",),
+    ),
+    RuleCatalogEntry(
+        code="S114",
+        name="AST code parsing usage",
+        severity="MEDIUM",
+        description="Runtime parsing of executable Python syntax via ast",
+        patterns=(r"ast\.parse\s*\(",),
+    ),
+    RuleCatalogEntry(
         code="S115",
         name="Builtins code-execution access",
         severity="HIGH",

--- a/tests/scanners/test_rule_code_registry_consistency.py
+++ b/tests/scanners/test_rule_code_registry_consistency.py
@@ -9,29 +9,39 @@ SCANNERS_DIR = Path(__file__).resolve().parents[2] / "modelaudit" / "scanners"
 
 
 def _extract_literal_rule_codes(path: Path) -> set[str]:
-    """Extract literal `rule_code=\"S...\"` values from scanner source."""
+    """Extract scanner-emitted literal rule codes from assignments and mapping helpers."""
     tree = ast.parse(path.read_text(encoding="utf-8"))
     codes: set[str] = set()
 
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
-        if not isinstance(node.func, ast.Attribute):
-            continue
 
-        for keyword in node.keywords:
-            if keyword.arg != "rule_code":
-                continue
-            if isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, str):
-                normalized = keyword.value.value.strip().upper()
-                if normalized.startswith("S"):
-                    codes.add(normalized)
+        if isinstance(node.func, ast.Attribute):
+            for keyword in node.keywords:
+                if keyword.arg != "rule_code":
+                    continue
+                if isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, str):
+                    normalized = keyword.value.value.strip().upper()
+                    if normalized.startswith("S"):
+                        codes.add(normalized)
+
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "_rule"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            normalized = node.args[0].value.strip().upper()
+            if normalized.startswith("S"):
+                codes.add(normalized)
 
     return codes
 
 
 def test_scanner_literal_rule_codes_are_registered() -> None:
-    """All literal scanner rule codes should exist in RuleRegistry."""
+    """All literal scanner rule assignments and mapper returns should be registered."""
     known_codes = set(RuleRegistry.get_all_rules().keys())
     unknown_by_file: dict[str, list[str]] = {}
 

--- a/tests/scanners/test_rule_mapper.py
+++ b/tests/scanners/test_rule_mapper.py
@@ -6,6 +6,7 @@ from modelaudit.rules import RuleRegistry
 from modelaudit.scanners.rule_mapper import (
     get_embedded_code_rule_code,
     get_generic_rule_code,
+    get_import_rule_code,
     get_network_rule_code,
     get_secret_rule_code,
 )
@@ -23,6 +24,22 @@ def test_rule_mapper_returns_registered_codes() -> None:
     for code in sample_codes:
         assert code is not None
         assert RuleRegistry.get_rule(code) is not None
+
+
+@pytest.mark.parametrize(
+    ("module", "expected_rule_code"),
+    [
+        ("pty", "S111"),
+        ("code", "S112"),
+        ("types", "S113"),
+        ("ast", "S114"),
+    ],
+)
+def test_import_rule_mapper_returns_registered_code_execution_codes(module: str, expected_rule_code: str) -> None:
+    code = get_import_rule_code(module)
+
+    assert code == expected_rule_code
+    assert RuleRegistry.get_rule(code) is not None
 
 
 def test_generic_rule_prefers_network_codes_for_urls() -> None:

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -47,6 +47,16 @@ class TestRuleRegistry:
         assert rule.name == "pty process spawn usage"
         assert rule.default_severity == Severity.CRITICAL
 
+    @pytest.mark.parametrize(
+        ("rule_code", "expected_severity"),
+        [("S112", Severity.CRITICAL), ("S113", Severity.HIGH), ("S114", Severity.MEDIUM)],
+    )
+    def test_get_dynamic_python_construction_rules(self, rule_code: str, expected_severity: Severity) -> None:
+        rule = RuleRegistry.get_rule(rule_code)
+
+        assert rule is not None
+        assert rule.default_severity == expected_severity
+
     def test_get_nonexistent_rule(self):
         """Test getting a rule that doesn't exist."""
         rule = RuleRegistry.get_rule("S9999")
@@ -100,6 +110,7 @@ class TestRuleRegistry:
         assert "S101" in rules
         assert "S110" in rules
         assert "S111" in rules
+        assert "S114" in rules
         assert "S201" not in rules  # Pickle rule, not in range
 
         # Get pickle rules (S200-S299)
@@ -231,6 +242,12 @@ S301 = "HIGH"
         assert "S801" in config.suppress
         assert config.severity["S301"] == Severity.HIGH
         assert config.severity["S701"] == Severity.CRITICAL
+
+    def test_from_cli_args_accepts_import_mapper_rule_codes(self) -> None:
+        config = ModelAuditConfig.from_cli_args(suppress=["S112"], severity={"S113": "HIGH", "S114": "MEDIUM"})
+
+        assert config.suppress == {"S112"}
+        assert config.severity == {"S113": Severity.HIGH, "S114": Severity.MEDIUM}
 
     def test_from_cli_args_rejects_unknown_rule_codes(self):
         """Unknown CLI rule codes should fail fast."""
@@ -477,6 +494,9 @@ class TestRulePatterns:
             ("import webbrowser", "S109"),
             ("import ctypes", "S110"),
             ("pty.spawn('/bin/sh')", "S111"),
+            ("code.InteractiveConsole()", "S112"),
+            ("types.FunctionType(code, globals())", "S113"),
+            ("ast.parse(source)", "S114"),
         ]
 
         for message, expected_code in test_cases:


### PR DESCRIPTION
## Summary
- register the already-emitted `S112`, `S113`, and `S114` dynamic-Python rule identifiers in the public rule catalog
- keep matching narrow to executable-object signals (`code.InteractiveConsole`, `types.FunctionType`/`CodeType`, and `ast.parse`) instead of broad benign imports
- extend registry-consistency coverage to catch literal `_rule("S...")` mapper returns, not only `rule_code=` assignments

## Why
`get_import_rule_code()` returns `S112`, `S113`, and `S114`, and whitelist policy already treats those identifiers as non-downgradeable security findings. However, none of those identifiers existed in `RULE_CATALOG`: `RuleRegistry.get_rule()` returned `None`, `modelaudit rules` could not describe them, and `--suppress` / `--severity` rejected emitted findings as unknown rule codes.

The pre-existing consistency test did not catch this drift because it inspected only `rule_code="..."` arguments in scanner code; these identifiers are emitted through `_rule("...")` in `rule_mapper.py`.

## Validation
- behavior probe: `code`, `types`, and `ast` mapper results now each resolve in `RuleRegistry` and are accepted by `ModelAuditConfig.from_cli_args(suppress=[...])`
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest tests/test_rules.py tests/scanners/test_rule_mapper.py tests/scanners/test_rule_code_registry_consistency.py -q --maxfail=1` (`62 passed`)
- `npx prettier --check CHANGELOG.md` (`All matched files use Prettier code style!`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`398 files left unchanged`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`All checks passed!`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`Success: no issues found in 453 source files`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`6526 passed, 15 skipped`)

## Stack
- Stacked on #1369 (`fix: detect embedded pty process launches`), which has completed hosted CI successfully.