### PR TITLE
fix: avoid duplicate jit source findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - detect embedded Python `asyncio.create_subprocess_exec` and `asyncio.create_subprocess_shell` process-launch calls
 - detect embedded Python `pty.spawn` launches and report statically resolved JIT process-launch aliases
 - register emitted `S112`-`S114` dynamic-code rule identifiers so they can be listed and configured
+- avoid duplicate JIT findings when a complete embedded Python source payload is analyzed through multiple paths
 - preserve embedded Python execution findings when a replacement receiver is conditional, aliased, or a runtime argument
 - fail closed when nested NeMo checkpoint or referenced-artifact analysis is explicitly incomplete
 - preserve concrete nested security findings from checkpoint and referenced artifacts inside NeMo archives

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -295,12 +295,15 @@ class JITScriptDetector:
         import_pattern, from_pattern = patterns or _compile_dangerous_import_patterns(dangerous_import)
         return import_pattern.search(source) is not None or from_pattern.search(source) is not None
 
-    def scan_torchscript(self, data: bytes, context: str = "") -> list["JITScriptFinding"]:
+    def scan_torchscript(
+        self, data: bytes, context: str = "", *, scan_embedded_python: bool = True
+    ) -> list["JITScriptFinding"]:
         """Scan TorchScript model data for dangerous operations.
 
         Args:
             data: Binary model data
             context: Context string for reporting
+            scan_embedded_python: Whether to inspect embedded Python snippets in this pass.
 
         Returns:
             List of findings with details
@@ -354,7 +357,7 @@ class JITScriptDetector:
         # Look for embedded Python code even when framework markers are absent.
         # Scanner callers can hand us raw code-bearing blobs, and an attacker can
         # remove marker strings without removing the executable payload.
-        if b"def " in data or b"class " in data:
+        if scan_embedded_python and (b"def " in data or b"class " in data):
             code_findings = self._extract_and_check_python_code(data, "TorchScript", context)
             findings.extend(code_findings)
 
@@ -379,12 +382,15 @@ class JITScriptDetector:
 
         return findings
 
-    def scan_tensorflow(self, data: bytes, context: str = "") -> list["JITScriptFinding"]:
+    def scan_tensorflow(
+        self, data: bytes, context: str = "", *, scan_embedded_python: bool = True
+    ) -> list["JITScriptFinding"]:
         """Scan TensorFlow SavedModel for dangerous operations.
 
         Args:
             data: Binary model data or protobuf
             context: Context string for reporting
+            scan_embedded_python: Whether to inspect embedded Python snippets in this pass.
 
         Returns:
             List of findings with details
@@ -438,7 +444,7 @@ class JITScriptDetector:
                 )
 
             # Check for embedded Python code in SavedFunction
-            if b"python_function" in data or b"function_spec" in data:
+            if scan_embedded_python and (b"python_function" in data or b"function_spec" in data):
                 code_findings = self._extract_and_check_python_code(data, "TensorFlow", context)
                 findings.extend(code_findings)
 
@@ -1045,18 +1051,20 @@ class JITScriptDetector:
             elif b"onnx" in data or b"ai.onnx" in data:
                 model_type = "onnx"
 
+        dangerous_python_source = self._looks_like_dangerous_python_source(data)
+
         # Scan based on model type
         if model_type in ["pytorch", "torchscript"]:
-            findings.extend(self.scan_torchscript(data, context))
+            findings.extend(self.scan_torchscript(data, context, scan_embedded_python=not dangerous_python_source))
             findings.extend(self.scan_advanced_torchscript_vulnerabilities(data, context))
 
         if model_type in ["tensorflow", "tf", "keras"]:
-            findings.extend(self.scan_tensorflow(data, context))
+            findings.extend(self.scan_tensorflow(data, context, scan_embedded_python=not dangerous_python_source))
 
         if model_type == "onnx":
             findings.extend(self.scan_onnx(data, context))
 
-        if model_type == "pickle" and (b"def " in data or b"class " in data):
+        if model_type == "pickle" and not dangerous_python_source and (b"def " in data or b"class " in data):
             findings.extend(self._extract_and_check_python_code(data, "Generic Python", context))
 
         # Always check for generic dangerous patterns
@@ -1065,12 +1073,12 @@ class JITScriptDetector:
         # because that causes false positives (e.g. TorchScript patterns matching ONNX metadata)
         if model_type == "unknown":
             # Check all frameworks if type is unknown
-            findings.extend(self.scan_torchscript(data, context))
+            findings.extend(self.scan_torchscript(data, context, scan_embedded_python=not dangerous_python_source))
             findings.extend(self.scan_advanced_torchscript_vulnerabilities(data, context))
-            findings.extend(self.scan_tensorflow(data, context))
+            findings.extend(self.scan_tensorflow(data, context, scan_embedded_python=not dangerous_python_source))
             findings.extend(self.scan_onnx(data, context))
 
-        if self._looks_like_dangerous_python_source(data):
+        if dangerous_python_source:
             findings.extend(
                 self._extract_and_check_python_code(
                     data,

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -211,6 +211,43 @@ class TestJITScriptDetector:
         assert any(f.type == "dangerous_import" and f.import_ == "os" for f in findings)
         assert any(f.type == "dangerous_builtin" and f.builtin == "eval" for f in findings)
 
+    @pytest.mark.parametrize(
+        ("model_type", "data"),
+        [
+            ("pytorch", b"def payload():\n    import os\n    return os.system('id')\n"),
+            ("unknown", b"def payload():\n    import os\n    return os.system('id')\n"),
+            (
+                "tensorflow",
+                b"SavedFunction = True\npython_function = True\n"
+                b"def payload():\n    import os\n    return os.system('id')\n",
+            ),
+            ("pickle", b"def payload():\n    import os\n    return os.system('id')\n"),
+        ],
+    )
+    def test_scan_model_reports_complete_dangerous_python_source_once(self, model_type: str, data: bytes) -> None:
+        findings = JITScriptDetector().scan_model(data, model_type, "payload.bin")
+        identities = [
+            (finding.type, finding.message, finding.pattern, finding.operation, finding.builtin, finding.import_)
+            for finding in findings
+        ]
+
+        assert any(
+            finding.type == "code_execution_pattern" and finding.pattern == "OS command execution detected"
+            for finding in findings
+        )
+        assert len(identities) == len(set(identities))
+
+    def test_scan_model_keeps_dangerous_python_extraction_from_binary_torchscript_blob(self) -> None:
+        data = b"\x00binary model prefix\ndef payload():\n    import os\n    return os.system('id')\n"
+
+        findings = JITScriptDetector().scan_model(data, "pytorch", "payload.bin")
+
+        assert any(finding.type == "dangerous_import" and finding.import_ == "os" for finding in findings)
+        assert any(
+            finding.type == "code_execution_pattern" and finding.pattern == "OS command execution detected"
+            for finding in findings
+        )
+
     def test_scan_model_ignores_unmarked_benign_python_source(self) -> None:
         detector = JITScriptDetector()
         data = b"""

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1223,11 +1223,15 @@ def test_pytorch_zip_scans_unmarked_pty_process_launch_in_archive_data(tmp_path:
         for check in result.checks
         if check.name == "JIT/Script Code Execution Detection" and check.status == CheckStatus.FAILED
     ]
-    assert any(
-        check.location == f"{zip_path}:archive/data/payload.bin"
-        and "Pseudo-terminal process execution detected" in check.message
+    matching_failures = [
+        check
         for check in jit_failures
-    )
+        if (
+            check.location == f"{zip_path}:archive/data/payload.bin"
+            and "Pseudo-terminal process execution detected" in check.message
+        )
+    ]
+    assert len(matching_failures) == 1
 
 
 def test_pytorch_zip_ignores_certain_replaced_pty_process_launch_in_archive_data(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- analyze a complete dangerous Python source payload through the full-source JIT path only once
- keep framework-specific snippet extraction enabled for mixed binary blobs that cannot be parsed as complete Python source
- add duplicate-count regression coverage across PyTorch, TensorFlow, unknown, pickle, and PyTorch ZIP dispatch

## Why
`JITScriptDetector.scan_model()` analyzed the same complete Python source twice: once through framework-specific embedded-code extraction and again through its generic full-source fallback. A single source containing `os.system`, `subprocess`, `eval`, or `pty.spawn` therefore emitted identical findings twice, inflating downstream JIT check counts and summaries.

A runtime probe reproduced three logical `os.system` findings as six for PyTorch, TensorFlow, and unknown dispatch. This PR reuses the existing whole-source danger decision to disable only the redundant snippet pass when full-source parsing has already succeeded. It does not perform broad output deduplication, and it retains positive coverage for non-source binary payloads containing an embedded malicious function.

## Validation
- runtime probe: PyTorch, TensorFlow, unknown, and pickle source payloads now each emit one copy of the three modeled `os.system` findings; a binary-prefixed TorchScript blob remains detected
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest tests/detectors/test_jit_script_detector.py tests/scanners/test_pytorch_zip_scanner.py -q --maxfail=1` (`391 passed`)
- `npx prettier --check CHANGELOG.md` (`All matched files use Prettier code style!`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`398 files left unchanged`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`All checks passed!`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`Success: no issues found in 453 source files`)
- `env -u UV_EXCLUDE_NEWER -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1` (`6531 passed, 15 skipped`)

## Stack
- Stacked on #1370 (`fix: register emitted dynamic code rules`), which has completed hosted CI successfully.