### PR TITLE
fix: detect embedded ctypes native loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - detect embedded Python `pty.spawn` launches and report statically resolved JIT process-launch aliases
 - detect embedded Python `runpy.run_module` and `runpy.run_path` dynamic-module execution calls
 - detect embedded Python `webbrowser.open`, `open_new`, and `open_new_tab` browser-launch calls
+- detect embedded Python `ctypes` DLL constructors and `LoadLibrary` native-loader calls
 - register emitted `S112`-`S114` dynamic-code rule identifiers so they can be listed and configured
 - avoid duplicate JIT findings when a complete embedded Python source payload is analyzed through multiple paths
 - preserve embedded Python execution findings when a replacement receiver is conditional, aliased, or a runtime argument

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -153,7 +153,9 @@ def _resolve_alias_aware_dangerous_builtins(tree: ast.AST) -> set[str]:
     return dangerous_builtins
 
 
-def _resolve_alias_aware_execution_calls(tree: ast.AST) -> tuple[set[str], set[str], set[str], set[str], set[str]]:
+def _resolve_alias_aware_execution_calls(
+    tree: ast.AST,
+) -> tuple[set[str], set[str], set[str], set[str], set[str], set[str]]:
     """Return modeled process and dynamic-module execution calls reached through static resolution."""
     from modelaudit.scanners.archive_member_security import high_risk_python_calls_in_tree
 
@@ -164,6 +166,7 @@ def _resolve_alias_aware_execution_calls(tree: ast.AST) -> tuple[set[str], set[s
         {call.name for call in calls if call.rule_code == "S111"},
         {call.name for call in calls if call.rule_code == "S108"},
         {call.name for call in calls if call.rule_code == "S109"},
+        {call.name for call in calls if call.rule_code == "S110"},
     )
 
 
@@ -173,6 +176,7 @@ _OS_CODE_EXECUTION_DESCRIPTION = "OS command execution detected"
 _PTY_CODE_EXECUTION_DESCRIPTION = "Pseudo-terminal process execution detected"
 _RUNPY_CODE_EXECUTION_DESCRIPTION = "Dynamic module execution detected"
 _WEBBROWSER_LAUNCH_DESCRIPTION = "Web browser launch detected"
+_CTYPES_NATIVE_LOADING_DESCRIPTION = "Native library loading detected"
 CODE_EXECUTION_PATTERNS = [
     # Direct execution patterns
     (rb"exec\s*\(", "exec() call detected"),
@@ -189,6 +193,10 @@ CODE_EXECUTION_PATTERNS = [
     (rb"pty\.spawn", _PTY_CODE_EXECUTION_DESCRIPTION),
     (rb"runpy\.(?:run_module|run_path)", _RUNPY_CODE_EXECUTION_DESCRIPTION),
     (rb"webbrowser\.open(?:_new(?:_tab)?)?", _WEBBROWSER_LAUNCH_DESCRIPTION),
+    (
+        rb"ctypes\.(?:(?:CDLL|OleDLL|PyDLL|WinDLL)|(?:cdll|oledll|pydll|windll)\.LoadLibrary)",
+        _CTYPES_NATIVE_LOADING_DESCRIPTION,
+    ),
     # Network patterns
     (rb"socket\.(socket|create_connection)", "Socket creation detected"),
     (rb"urllib\.(request|urlopen)", "URL request detected"),
@@ -252,15 +260,21 @@ class JITScriptDetector:
         """Return whether parsed Python contains modeled dangerous operations."""
         if _resolve_alias_aware_dangerous_builtins(tree):
             return True
-        os_process_calls, subprocess_calls, pty_process_calls, runpy_execution_calls, webbrowser_launch_calls = (
-            _resolve_alias_aware_execution_calls(tree)
-        )
+        (
+            os_process_calls,
+            subprocess_calls,
+            pty_process_calls,
+            runpy_execution_calls,
+            webbrowser_launch_calls,
+            ctypes_native_loading_calls,
+        ) = _resolve_alias_aware_execution_calls(tree)
         if (
             os_process_calls
             or subprocess_calls
             or pty_process_calls
             or runpy_execution_calls
             or webbrowser_launch_calls
+            or ctypes_native_loading_calls
         ):
             return True
 
@@ -594,6 +608,7 @@ class JITScriptDetector:
         bounded_pty_process_calls: set[str] | None = None
         bounded_runpy_execution_calls: set[str] | None = None
         bounded_webbrowser_launch_calls: set[str] | None = None
+        bounded_ctypes_native_loading_calls: set[str] | None = None
         try:
             bounded_tree = ast.parse(textwrap.dedent(bounded.decode("utf-8")))
             bounded_dangerous_builtins = _resolve_alias_aware_dangerous_builtins(bounded_tree)
@@ -603,6 +618,7 @@ class JITScriptDetector:
                 bounded_pty_process_calls,
                 bounded_runpy_execution_calls,
                 bounded_webbrowser_launch_calls,
+                bounded_ctypes_native_loading_calls,
             ) = _resolve_alias_aware_execution_calls(bounded_tree)
         except (SyntaxError, UnicodeDecodeError, ValueError):
             pass
@@ -724,6 +740,12 @@ class JITScriptDetector:
                 and not bounded_webbrowser_launch_calls
             ):
                 continue
+            if (
+                description == _CTYPES_NATIVE_LOADING_DESCRIPTION
+                and bounded_ctypes_native_loading_calls is not None
+                and not bounded_ctypes_native_loading_calls
+            ):
+                continue
             if re.search(pattern, bounded):  # Limit search size
                 add_code_execution_pattern_finding(description)
 
@@ -734,6 +756,7 @@ class JITScriptDetector:
             (bounded_pty_process_calls, _PTY_CODE_EXECUTION_DESCRIPTION),
             (bounded_runpy_execution_calls, _RUNPY_CODE_EXECUTION_DESCRIPTION),
             (bounded_webbrowser_launch_calls, _WEBBROWSER_LAUNCH_DESCRIPTION),
+            (bounded_ctypes_native_loading_calls, _CTYPES_NATIVE_LOADING_DESCRIPTION),
         ):
             if calls and description not in reported_patterns:
                 add_code_execution_pattern_finding(description)

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -194,7 +194,9 @@ CODE_EXECUTION_PATTERNS = [
     (rb"runpy\.(?:run_module|run_path)", _RUNPY_CODE_EXECUTION_DESCRIPTION),
     (rb"webbrowser\.open(?:_new(?:_tab)?)?", _WEBBROWSER_LAUNCH_DESCRIPTION),
     (
-        rb"ctypes\.(?:(?:CDLL|OleDLL|PyDLL|WinDLL)|(?:cdll|oledll|pydll|windll)\.LoadLibrary)",
+        rb"(?:_ctypes\.dlopen|ctypes\.(?:(?:CDLL|OleDLL|PyDLL|WinDLL)|"
+        rb"LibraryLoader\s*\([^)]*\)\.LoadLibrary|"
+        rb"(?:cdll|oledll|pydll|windll)\.(?:LoadLibrary|[A-Za-z_]\w*)))",
         _CTYPES_NATIVE_LOADING_DESCRIPTION,
     ),
     # Network patterns

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -102,6 +102,18 @@ _WEBBROWSER_LAUNCH_CALLS = frozenset(
         "webbrowser.open_new_tab",
     }
 )
+_CTYPES_NATIVE_LIBRARY_LOADING_CALLS = frozenset(
+    {
+        "ctypes.CDLL",
+        "ctypes.OleDLL",
+        "ctypes.PyDLL",
+        "ctypes.WinDLL",
+        "ctypes.cdll.LoadLibrary",
+        "ctypes.oledll.LoadLibrary",
+        "ctypes.pydll.LoadLibrary",
+        "ctypes.windll.LoadLibrary",
+    }
+)
 _HIGH_RISK_PYTHON_CALLS = {
     "__import__",
     "__builtin__.__import__",
@@ -128,6 +140,7 @@ _HIGH_RISK_PYTHON_CALLS = {
     *_PTY_PROCESS_EXECUTION_CALLS,
     *_RUNPY_CODE_EXECUTION_CALLS,
     *_WEBBROWSER_LAUNCH_CALLS,
+    *_CTYPES_NATIVE_LIBRARY_LOADING_CALLS,
 }
 # Retain broad subprocess coverage while excluding public APIs that only construct data.
 _KNOWN_NON_EXECUTING_SUBPROCESS_CALLS = {
@@ -163,6 +176,7 @@ _HIGH_RISK_PYTHON_CALL_RULE_CODES: dict[str, str] = {
     **dict.fromkeys(_PTY_PROCESS_EXECUTION_CALLS, "S111"),
     **dict.fromkeys(_RUNPY_CODE_EXECUTION_CALLS, "S108"),
     **dict.fromkeys(_WEBBROWSER_LAUNCH_CALLS, "S109"),
+    **dict.fromkeys(_CTYPES_NATIVE_LIBRARY_LOADING_CALLS, "S110"),
 }
 _HIGH_RISK_PYTHON_CALL_PREFIX_RULE_CODES: tuple[tuple[str, str], ...] = (("subprocess.", "S103"),)
 _FALLBACK_HIGH_RISK_RULE_CODE = "S104"

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -104,7 +104,9 @@ _WEBBROWSER_LAUNCH_CALLS = frozenset(
 )
 _CTYPES_NATIVE_LIBRARY_LOADING_CALLS = frozenset(
     {
+        "_ctypes.dlopen",
         "ctypes.CDLL",
+        "ctypes.LibraryLoader.LoadLibrary",
         "ctypes.OleDLL",
         "ctypes.PyDLL",
         "ctypes.WinDLL",
@@ -114,6 +116,16 @@ _CTYPES_NATIVE_LIBRARY_LOADING_CALLS = frozenset(
         "ctypes.windll.LoadLibrary",
     }
 )
+_CTYPES_LIBRARY_LOADER_CONSTRUCTORS = frozenset({"ctypes.LibraryLoader"})
+_CTYPES_LIBRARY_LOADER_OBJECTS = frozenset(
+    {
+        "ctypes.cdll",
+        "ctypes.oledll",
+        "ctypes.pydll",
+        "ctypes.windll",
+    }
+)
+_CTYPES_LIBRARY_LOADER_NON_LOADING_ATTRIBUTES = frozenset({"LoadLibrary"})
 _HIGH_RISK_PYTHON_CALLS = {
     "__import__",
     "__builtin__.__import__",
@@ -182,11 +194,27 @@ _HIGH_RISK_PYTHON_CALL_PREFIX_RULE_CODES: tuple[tuple[str, str], ...] = (("subpr
 _FALLBACK_HIGH_RISK_RULE_CODE = "S104"
 
 
+def _ctypes_loader_attribute_load_name(reference_name: str) -> str | None:
+    parts = reference_name.split(".")
+    if len(parts) < 3:
+        return None
+
+    loader_root = ".".join(parts[:2])
+    library_name = parts[2]
+    if loader_root not in _CTYPES_LIBRARY_LOADER_OBJECTS:
+        return None
+    if library_name.startswith("_") or library_name in _CTYPES_LIBRARY_LOADER_NON_LOADING_ATTRIBUTES:
+        return None
+    return f"{loader_root}.{library_name}"
+
+
 def _rule_code_for_high_risk_call(call_name: str) -> str:
     """Return the rule code that most accurately describes ``call_name``."""
     direct = _HIGH_RISK_PYTHON_CALL_RULE_CODES.get(call_name)
     if direct is not None:
         return direct
+    if _ctypes_loader_attribute_load_name(call_name) is not None:
+        return "S110"
     for prefix, code in _HIGH_RISK_PYTHON_CALL_PREFIX_RULE_CODES:
         if call_name.startswith(prefix):
             return code
@@ -330,6 +358,21 @@ def _apply_aliases(call_name: str, alias_scopes: _AliasScopes) -> frozenset[str]
         return resolved_heads
     suffix = ".".join(tail)
     return frozenset(f"{resolved_head}.{suffix}" for resolved_head in resolved_heads)
+
+
+def _resolve_ctypes_library_loader_instance_roots(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
+    if not isinstance(node, ast.Call):
+        return None
+
+    constructor_name = _resolve_call_name(node.func)
+    if constructor_name is None:
+        return None
+    resolved_constructor_names = _apply_aliases(constructor_name, alias_scopes)
+    if resolved_constructor_names is None:
+        return None
+
+    loader_roots = resolved_constructor_names & _CTYPES_LIBRARY_LOADER_CONSTRUCTORS
+    return frozenset(loader_roots) if loader_roots else None
 
 
 _MAX_STATIC_STRING_LENGTH = 1024
@@ -539,10 +582,12 @@ def _resolve_static_attribute_names(
 
     resolved_target_roots = _resolve_global_builtin_namespace_roots(target_root_node, alias_scopes)
     if resolved_target_roots is None:
-        target_root = _resolve_call_name(target_root_node)
-        if target_root is None:
-            return None
-        resolved_target_roots = _apply_aliases(target_root, alias_scopes)
+        resolved_target_roots = _resolve_ctypes_library_loader_instance_roots(target_root_node, alias_scopes)
+        if resolved_target_roots is None:
+            target_root = _resolve_call_name(target_root_node)
+            if target_root is None:
+                return None
+            resolved_target_roots = _apply_aliases(target_root, alias_scopes)
     if resolved_target_roots is None:
         return None
     return frozenset(f"{resolved_target_root}.{attr_name}" for resolved_target_root in resolved_target_roots)
@@ -726,6 +771,10 @@ def _resolve_static_reference_names(node: ast.AST, alias_scopes: _AliasScopes) -
     call_name = _resolve_call_name(node)
     if call_name is not None:
         return _apply_aliases(call_name, alias_scopes)
+    if isinstance(node, ast.Attribute):
+        attribute_names = _resolve_static_attribute_names(node.value, ast.Constant(value=node.attr), alias_scopes)
+        if attribute_names is not None:
+            return attribute_names
     getattr_names = _resolve_getattr_call_names(node, alias_scopes)
     if getattr_names is not None:
         return getattr_names
@@ -736,7 +785,9 @@ def _resolve_static_reference_names(node: ast.AST, alias_scopes: _AliasScopes) -
     if namespace_call_names is not None:
         return namespace_call_names
     namespace_roots = _resolve_namespace_dict_roots(node, alias_scopes)
-    return frozenset(f"{namespace_root}.__dict__" for namespace_root in namespace_roots) if namespace_roots else None
+    if namespace_roots:
+        return frozenset(f"{namespace_root}.__dict__" for namespace_root in namespace_roots)
+    return _resolve_ctypes_library_loader_instance_roots(node, alias_scopes)
 
 
 def _resolve_static_assignment_target_names(node: ast.AST, alias_scopes: _AliasScopes) -> frozenset[str] | None:
@@ -749,8 +800,10 @@ def _resolve_static_assignment_target_names(node: ast.AST, alias_scopes: _AliasS
 
 
 def _is_high_risk_python_call_name(name: str) -> bool:
-    return name in _HIGH_RISK_PYTHON_CALLS or (
-        name.startswith("subprocess.") and name not in _KNOWN_NON_EXECUTING_SUBPROCESS_CALLS
+    return (
+        name in _HIGH_RISK_PYTHON_CALLS
+        or (name.startswith("subprocess.") and name not in _KNOWN_NON_EXECUTING_SUBPROCESS_CALLS)
+        or (_ctypes_loader_attribute_load_name(name) is not None)
     )
 
 
@@ -779,6 +832,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
     def __init__(self, tracked_call_names: frozenset[str] | None = None) -> None:
         self.alias_scopes: _AliasScopes = [{}]
         self._class_scope_ids: set[int] = set()
+        self._suppress_attribute_load_detection_depth = 0
         self.risky_calls: set[str] = set()
         self.tracked_call_names = tracked_call_names
 
@@ -1047,6 +1101,13 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         for name in _binding_names(target):
             self._bind_name(name, None)
 
+    def _visit_assignment_target(self, target: ast.AST) -> None:
+        self._suppress_attribute_load_detection_depth += 1
+        try:
+            self.visit(target)
+        finally:
+            self._suppress_attribute_load_detection_depth -= 1
+
     def _bind_arguments(self, arguments: ast.arguments) -> None:
         positional_args = [*arguments.posonlyargs, *arguments.args]
         positional_default_start = len(positional_args) - len(arguments.defaults)
@@ -1242,7 +1303,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             self._bind_static_setattr_mutation(node.value)
         for target in node.targets:
             self._bind_target_to_value(target, node.value)
-            self.visit(target)
+            self._visit_assignment_target(target)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
         if node.annotation is not None:
@@ -1255,22 +1316,22 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             self._bind_target_to_value(node.target, node.value)
         else:
             self._shadow_binding_target(node.target)
-        self.visit(node.target)
+        self._visit_assignment_target(node.target)
 
     def visit_AugAssign(self, node: ast.AugAssign) -> None:
         self.visit(node.value)
         self._shadow_binding_target(node.target)
-        self.visit(node.target)
+        self._visit_assignment_target(node.target)
 
     def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
         self.visit(node.value)
         self._bind_target_to_value(node.target, node.value)
-        self.visit(node.target)
+        self._visit_assignment_target(node.target)
 
     def visit_Delete(self, node: ast.Delete) -> None:
         for target in node.targets:
             self._bind_static_reference_target_as_removed(target)
-            self.visit(target)
+            self._visit_assignment_target(target)
 
     def visit_Expr(self, node: ast.Expr) -> None:
         self.visit(node.value)
@@ -1290,7 +1351,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         self.alias_scopes.append(body_scope)
         try:
             self._shadow_binding_target(node.target)
-            self.visit(node.target)
+            self._visit_assignment_target(node.target)
             for statement in node.body:
                 self.visit(statement)
             body_scope = dict(body_scope)
@@ -1365,7 +1426,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             self.visit(item.context_expr)
             if item.optional_vars is not None:
                 self._shadow_binding_target(item.optional_vars)
-                self.visit(item.optional_vars)
+                self._visit_assignment_target(item.optional_vars)
         for statement in node.body:
             self.visit(statement)
 
@@ -1387,8 +1448,20 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         resolved_names = self._resolve_invoked_reference_names(node.func)
         if resolved_names is not None and self._resolve_certain_static_mapping_mutator_names(node.func) is None:
             for resolved_name in resolved_names:
-                if self._is_tracked_call_name(resolved_name):
-                    self.risky_calls.add(resolved_name)
+                risk_name = _ctypes_loader_attribute_load_name(resolved_name) or resolved_name
+                if self._is_tracked_call_name(risk_name):
+                    self.risky_calls.add(risk_name)
+        self.generic_visit(node)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if self._suppress_attribute_load_detection_depth == 0:
+            resolved_names = _resolve_static_reference_names(node, self.alias_scopes)
+            effective_names = self._effective_reference_names(resolved_names) if resolved_names is not None else None
+            if effective_names is not None:
+                for resolved_name in effective_names:
+                    load_name = _ctypes_loader_attribute_load_name(resolved_name)
+                    if load_name is not None and self._is_tracked_call_name(load_name):
+                        self.risky_calls.add(load_name)
         self.generic_visit(node)
 
 

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -536,6 +536,9 @@ class TestJITScriptDetector:
             b"def payload():\n    return ctypes.pydll.LoadLibrary('./payload.so')\n",
             b"def payload():\n    return ctypes.windll.LoadLibrary('payload.dll')\n",
             b"def payload():\n    from ctypes import CDLL as load\n    return load('./payload.so')\n",
+            b"def payload():\n    return ctypes.LibraryLoader(ctypes.CDLL).LoadLibrary('./payload.so')\n",
+            b"def payload():\n    return ctypes.cdll.msvcrt.printf(b'hi')\n",
+            b"def payload():\n    import _ctypes\n    return _ctypes.dlopen('libc.so.6')\n",
         ],
     )
     def test_scan_model_detects_unmarked_ctypes_native_loading(self, source: bytes) -> None:
@@ -552,6 +555,7 @@ class TestJITScriptDetector:
         [
             b"def payload():\n    ctypes.CDLL = len\n    return ctypes.CDLL([])\n",
             b"def payload():\n    ctypes.cdll.LoadLibrary = len\n    return ctypes.cdll.LoadLibrary([])\n",
+            b"def payload():\n    ctypes.cdll.msvcrt = len\n    return ctypes.cdll.msvcrt([])\n",
         ],
     )
     def test_scan_model_ignores_certain_replaced_ctypes_native_loading(self, source: bytes) -> None:

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -527,6 +527,53 @@ class TestJITScriptDetector:
     @pytest.mark.parametrize(
         "source",
         [
+            b"def payload():\n    return ctypes.CDLL('./payload.so')\n",
+            b"def payload():\n    return ctypes.OleDLL('payload.dll')\n",
+            b"def payload():\n    return ctypes.PyDLL('./payload.so')\n",
+            b"def payload():\n    return ctypes.WinDLL('payload.dll')\n",
+            b"def payload():\n    return ctypes.cdll.LoadLibrary('./payload.so')\n",
+            b"def payload():\n    return ctypes.oledll.LoadLibrary('payload.dll')\n",
+            b"def payload():\n    return ctypes.pydll.LoadLibrary('./payload.so')\n",
+            b"def payload():\n    return ctypes.windll.LoadLibrary('payload.dll')\n",
+            b"def payload():\n    from ctypes import CDLL as load\n    return load('./payload.so')\n",
+        ],
+    )
+    def test_scan_model_detects_unmarked_ctypes_native_loading(self, source: bytes) -> None:
+        detector = JITScriptDetector()
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Native library loading detected" for f in findings
+        )
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            b"def payload():\n    ctypes.CDLL = len\n    return ctypes.CDLL([])\n",
+            b"def payload():\n    ctypes.cdll.LoadLibrary = len\n    return ctypes.cdll.LoadLibrary([])\n",
+        ],
+    )
+    def test_scan_model_ignores_certain_replaced_ctypes_native_loading(self, source: bytes) -> None:
+        detector = JITScriptDetector()
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert findings == []
+
+    def test_scan_model_preserves_possible_ctypes_native_loading_after_conditional_replacement(self) -> None:
+        detector = JITScriptDetector()
+        source = b"def payload():\n    if replace:\n        ctypes.CDLL = len\n    return ctypes.CDLL('./payload.so')\n"
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Native library loading detected" for f in findings
+        )
+
+    @pytest.mark.parametrize(
+        "source",
+        [
             b"getattr(__builtins__, 'eval')('1 + 1')\n",
             b"__builtins__['eval']('1 + 1')\n",
             b"getattr(__builtins__, 'ev' + 'al')('1 + 1')\n",

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1345,6 +1345,61 @@ def test_pytorch_zip_ignores_certain_replaced_webbrowser_launch_in_archive_data(
 @pytest.mark.parametrize(
     "payload",
     [
+        b"def payload():\n    return ctypes.CDLL('./payload.so')\n",
+        b"def payload():\n    from ctypes import PyDLL as load\n    return load('./payload.so')\n",
+        b"def payload():\n    return ctypes.windll.LoadLibrary('payload.dll')\n",
+    ],
+)
+def test_pytorch_zip_scans_unmarked_ctypes_native_loading_in_archive_data(tmp_path: Path, payload: bytes) -> None:
+    zip_path = tmp_path / "model.pt"
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        zipf.writestr("archive/version", "3")
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("archive/data/payload.bin", payload)
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    jit_failures = [
+        check
+        for check in result.checks
+        if check.name == "JIT/Script Code Execution Detection" and check.status == CheckStatus.FAILED
+    ]
+    matching_failures = [
+        check
+        for check in jit_failures
+        if check.location == f"{zip_path}:archive/data/payload.bin"
+        and "Native library loading detected" in check.message
+    ]
+    assert len(matching_failures) == 1
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"def payload():\n    ctypes.CDLL = len\n    return ctypes.CDLL([])\n",
+        b"def payload():\n    ctypes.cdll.LoadLibrary = len\n    return ctypes.cdll.LoadLibrary([])\n",
+    ],
+)
+def test_pytorch_zip_ignores_certain_replaced_ctypes_native_loading_in_archive_data(
+    tmp_path: Path, payload: bytes
+) -> None:
+    zip_path = tmp_path / "model.pt"
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        zipf.writestr("archive/version", "3")
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("archive/data/payload.bin", payload)
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    assert not any(
+        check.name == "JIT/Script Code Execution Detection" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
         b"getattr(__builtins__, 'eval')('1 + 1')\n",
         b"__builtins__['ev' + 'al']('1 + 1')\n",
         b"__builtins__.__dict__.get('eval')('1 + 1')\n",

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1348,6 +1348,9 @@ def test_pytorch_zip_ignores_certain_replaced_webbrowser_launch_in_archive_data(
         b"def payload():\n    return ctypes.CDLL('./payload.so')\n",
         b"def payload():\n    from ctypes import PyDLL as load\n    return load('./payload.so')\n",
         b"def payload():\n    return ctypes.windll.LoadLibrary('payload.dll')\n",
+        b"def payload():\n    return ctypes.LibraryLoader(ctypes.CDLL).LoadLibrary('./payload.so')\n",
+        b"def payload():\n    return ctypes.cdll.msvcrt.printf(b'hi')\n",
+        b"def payload():\n    import _ctypes\n    return _ctypes.dlopen('libc.so.6')\n",
     ],
 )
 def test_pytorch_zip_scans_unmarked_ctypes_native_loading_in_archive_data(tmp_path: Path, payload: bytes) -> None:
@@ -1378,6 +1381,7 @@ def test_pytorch_zip_scans_unmarked_ctypes_native_loading_in_archive_data(tmp_pa
     [
         b"def payload():\n    ctypes.CDLL = len\n    return ctypes.CDLL([])\n",
         b"def payload():\n    ctypes.cdll.LoadLibrary = len\n    return ctypes.cdll.LoadLibrary([])\n",
+        b"def payload():\n    ctypes.cdll.msvcrt = len\n    return ctypes.cdll.msvcrt([])\n",
     ],
 )
 def test_pytorch_zip_ignores_certain_replaced_ctypes_native_loading_in_archive_data(

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -273,6 +273,31 @@ class TestTarScanner:
         assert python_checks[0].details["reason"] == f"high-risk calls: {dangerous_name}"
 
     @pytest.mark.parametrize(
+        ("payload", "dangerous_name"),
+        [
+            (b"import ctypes\nctypes.CDLL('./payload.so')\n", "ctypes.CDLL"),
+            (b"from ctypes import PyDLL as load\nload('./payload.so')\n", "ctypes.PyDLL"),
+            (b"import ctypes\nctypes.windll.LoadLibrary('payload.dll')\n", "ctypes.windll.LoadLibrary"),
+        ],
+    )
+    def test_scan_tar_flags_ctypes_native_loading_python_member(
+        self, tmp_path: Path, payload: bytes, dangerous_name: str
+    ) -> None:
+        archive_path = tmp_path / "model_bundle.tar"
+        with tarfile.open(archive_path, "w") as archive:
+            info = tarfile.TarInfo("handler.py")
+            info.size = len(payload)
+            archive.addfile(info, tarfile.io.BytesIO(payload))  # type: ignore[attr-defined]
+
+        result = self.scanner.scan(str(archive_path))
+
+        python_checks = [check for check in result.checks if check.name == "Python Archive Member Security"]
+        assert len(python_checks) == 1
+        assert python_checks[0].status == CheckStatus.FAILED
+        assert python_checks[0].rule_code == "S110"
+        assert python_checks[0].details["reason"] == f"high-risk calls: {dangerous_name}"
+
+    @pytest.mark.parametrize(
         "payload",
         [
             b"import os\nos.system.__call__('echo hidden')\n",
@@ -377,6 +402,8 @@ class TestTarScanner:
             b"import pty\npty.spawn = len\npty.spawn([])\n",
             b"import runpy\nrunpy.run_path = len\nrunpy.run_path([])\n",
             b"import webbrowser\nwebbrowser.open = len\nwebbrowser.open([])\n",
+            b"import ctypes\nctypes.CDLL = len\nctypes.CDLL([])\n",
+            b"import ctypes\nctypes.cdll.LoadLibrary = len\nctypes.cdll.LoadLibrary([])\n",
         ],
     )
     def test_scan_tar_allows_callable_captured_after_safe_overwrite(self, tmp_path: Path, payload: bytes) -> None:
@@ -1088,6 +1115,7 @@ class TestTarScanner:
                 "S109",
                 "webbrowser.open_new_tab",
             ),
+            (b"import ctypes\nctypes.CDLL('./payload.so')\n", "S110", "ctypes.CDLL"),
             (b"import importlib\nimportlib.import_module('os')\n", "S107", "importlib.import_module"),
             (b"eval('1 + 1')\n", "S104", "eval"),
             (b"import pickle\npickle.loads(b'\\x80\\x04N.')\n", "S213", "pickle.loads"),

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -278,6 +278,12 @@ class TestTarScanner:
             (b"import ctypes\nctypes.CDLL('./payload.so')\n", "ctypes.CDLL"),
             (b"from ctypes import PyDLL as load\nload('./payload.so')\n", "ctypes.PyDLL"),
             (b"import ctypes\nctypes.windll.LoadLibrary('payload.dll')\n", "ctypes.windll.LoadLibrary"),
+            (
+                b"import ctypes\nctypes.LibraryLoader(ctypes.CDLL).LoadLibrary('./payload.so')\n",
+                "ctypes.LibraryLoader.LoadLibrary",
+            ),
+            (b"import ctypes\nctypes.cdll.msvcrt.printf(b'hi')\n", "ctypes.cdll.msvcrt"),
+            (b"import _ctypes\n_ctypes.dlopen('libc.so.6')\n", "_ctypes.dlopen"),
         ],
     )
     def test_scan_tar_flags_ctypes_native_loading_python_member(
@@ -404,6 +410,7 @@ class TestTarScanner:
             b"import webbrowser\nwebbrowser.open = len\nwebbrowser.open([])\n",
             b"import ctypes\nctypes.CDLL = len\nctypes.CDLL([])\n",
             b"import ctypes\nctypes.cdll.LoadLibrary = len\nctypes.cdll.LoadLibrary([])\n",
+            b"import ctypes\nctypes.cdll.msvcrt = len\nctypes.cdll.msvcrt([])\n",
         ],
     )
     def test_scan_tar_allows_callable_captured_after_safe_overwrite(self, tmp_path: Path, payload: bytes) -> None:

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -497,6 +497,64 @@ def test_scan_allows_replaced_webbrowser_handler_api(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
+    ("handler_source", "dangerous_name"),
+    [
+        (b"import ctypes\ndef handle(data, context):\n    return ctypes.CDLL('./payload.so')\n", "ctypes.CDLL"),
+        (
+            b"from ctypes import PyDLL as load\ndef handle(data, context):\n    return load('./payload.so')\n",
+            "ctypes.PyDLL",
+        ),
+        (
+            b"import ctypes\ndef handle(data, context):\n    return ctypes.windll.LoadLibrary('payload.dll')\n",
+            "ctypes.windll.LoadLibrary",
+        ),
+    ],
+)
+def test_scan_detects_ctypes_native_loading_handler_primitive(
+    tmp_path: Path, handler_source: bytes, dangerous_name: str
+) -> None:
+    manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
+    mar_path = _create_mar_archive(
+        tmp_path,
+        manifest=manifest,
+        entries={"handler.py": handler_source, "weights.bin": b"weights"},
+        filename="ctypes_native_loading_handler.mar",
+    )
+
+    result = TorchServeMarScanner().scan(str(mar_path))
+    handler_failures = _failed_checks(result, "TorchServe Handler Static Analysis")
+
+    assert len(handler_failures) == 1
+    assert handler_failures[0].severity == IssueSeverity.CRITICAL
+    assert dangerous_name in handler_failures[0].message
+
+
+@pytest.mark.parametrize(
+    "handler_source",
+    [
+        b"import ctypes\ndef handle(data, context):\n    ctypes.CDLL = len\n    return ctypes.CDLL([])\n",
+        (
+            b"import ctypes\ndef handle(data, context):\n"
+            b"    ctypes.cdll.LoadLibrary = len\n"
+            b"    return ctypes.cdll.LoadLibrary([])\n"
+        ),
+    ],
+)
+def test_scan_allows_replaced_ctypes_native_loading_handler_api(tmp_path: Path, handler_source: bytes) -> None:
+    manifest = {"model": {"handler": "handler.py", "serializedFile": "weights.bin"}}
+    mar_path = _create_mar_archive(
+        tmp_path,
+        manifest=manifest,
+        entries={"handler.py": handler_source, "weights.bin": b"weights"},
+        filename="safe_replaced_ctypes_native_loading_handler.mar",
+    )
+
+    result = TorchServeMarScanner().scan(str(mar_path))
+
+    assert _failed_checks(result, "TorchServe Handler Static Analysis") == []
+
+
+@pytest.mark.parametrize(
     "handler_source",
     [
         b"def handle(data, context):\n    return __builtins__['ev' + 'al']('1 + 1')\n",

--- a/tests/scanners/test_torchserve_mar_scanner.py
+++ b/tests/scanners/test_torchserve_mar_scanner.py
@@ -508,6 +508,16 @@ def test_scan_allows_replaced_webbrowser_handler_api(tmp_path: Path) -> None:
             b"import ctypes\ndef handle(data, context):\n    return ctypes.windll.LoadLibrary('payload.dll')\n",
             "ctypes.windll.LoadLibrary",
         ),
+        (
+            b"import ctypes\ndef handle(data, context):\n"
+            b"    return ctypes.LibraryLoader(ctypes.CDLL).LoadLibrary('./payload.so')\n",
+            "ctypes.LibraryLoader.LoadLibrary",
+        ),
+        (
+            b"import ctypes\ndef handle(data, context):\n    return ctypes.cdll.msvcrt.printf(b'hi')\n",
+            "ctypes.cdll.msvcrt",
+        ),
+        (b"import _ctypes\ndef handle(data, context):\n    return _ctypes.dlopen('libc.so.6')\n", "_ctypes.dlopen"),
     ],
 )
 def test_scan_detects_ctypes_native_loading_handler_primitive(
@@ -537,6 +547,11 @@ def test_scan_detects_ctypes_native_loading_handler_primitive(
             b"import ctypes\ndef handle(data, context):\n"
             b"    ctypes.cdll.LoadLibrary = len\n"
             b"    return ctypes.cdll.LoadLibrary([])\n"
+        ),
+        (
+            b"import ctypes\ndef handle(data, context):\n"
+            b"    ctypes.cdll.msvcrt = len\n"
+            b"    return ctypes.cdll.msvcrt([])\n"
         ),
     ],
 )

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -407,6 +407,12 @@ def test_scan_zip_preserves_possible_webbrowser_launch_after_conditional_overwri
         ("import ctypes\nctypes.pydll.LoadLibrary('./payload.so')\n", "ctypes.pydll.LoadLibrary"),
         ("import ctypes\nctypes.windll.LoadLibrary('payload.dll')\n", "ctypes.windll.LoadLibrary"),
         ("from ctypes import CDLL as load\nload('./payload.so')\n", "ctypes.CDLL"),
+        (
+            "import ctypes\nctypes.LibraryLoader(ctypes.CDLL).LoadLibrary('./payload.so')\n",
+            "ctypes.LibraryLoader.LoadLibrary",
+        ),
+        ("import ctypes\nctypes.cdll.msvcrt.printf(b'hi')\n", "ctypes.cdll.msvcrt"),
+        ("import _ctypes\n_ctypes.dlopen('libc.so.6')\n", "_ctypes.dlopen"),
     ],
 )
 def test_scan_zip_flags_ctypes_native_loading_python_member(tmp_path: Path, source: str, dangerous_name: str) -> None:
@@ -597,6 +603,7 @@ def test_scan_zip_preserves_captured_dangerous_callable_before_overwrite(tmp_pat
         "import webbrowser\nwebbrowser.open = len\nwebbrowser.open([])\n",
         "import ctypes\nctypes.CDLL = len\nctypes.CDLL([])\n",
         "import ctypes\nctypes.cdll.LoadLibrary = len\nctypes.cdll.LoadLibrary([])\n",
+        "import ctypes\nctypes.cdll.msvcrt = len\nctypes.cdll.msvcrt([])\n",
     ],
 )
 def test_scan_zip_allows_callable_captured_after_safe_overwrite(tmp_path: Path, source: str) -> None:

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -396,6 +396,55 @@ def test_scan_zip_preserves_possible_webbrowser_launch_after_conditional_overwri
 
 
 @pytest.mark.parametrize(
+    ("source", "dangerous_name"),
+    [
+        ("import ctypes\nctypes.CDLL('./payload.so')\n", "ctypes.CDLL"),
+        ("import ctypes\nctypes.OleDLL('payload.dll')\n", "ctypes.OleDLL"),
+        ("import ctypes\nctypes.PyDLL('./payload.so')\n", "ctypes.PyDLL"),
+        ("import ctypes\nctypes.WinDLL('payload.dll')\n", "ctypes.WinDLL"),
+        ("import ctypes\nctypes.cdll.LoadLibrary('./payload.so')\n", "ctypes.cdll.LoadLibrary"),
+        ("import ctypes\nctypes.oledll.LoadLibrary('payload.dll')\n", "ctypes.oledll.LoadLibrary"),
+        ("import ctypes\nctypes.pydll.LoadLibrary('./payload.so')\n", "ctypes.pydll.LoadLibrary"),
+        ("import ctypes\nctypes.windll.LoadLibrary('payload.dll')\n", "ctypes.windll.LoadLibrary"),
+        ("from ctypes import CDLL as load\nload('./payload.so')\n", "ctypes.CDLL"),
+    ],
+)
+def test_scan_zip_flags_ctypes_native_loading_python_member(tmp_path: Path, source: str, dangerous_name: str) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", source)
+
+    result = ZipScanner().scan(str(archive_path))
+
+    python_checks = [
+        check
+        for check in result.checks
+        if check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED
+    ]
+    assert len(python_checks) == 1
+    assert python_checks[0].rule_code == "S110"
+    assert python_checks[0].details["reason"] == f"high-risk calls: {dangerous_name}"
+
+
+def test_scan_zip_preserves_possible_ctypes_native_loading_after_conditional_overwrite(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    source = "import ctypes\nif replace:\n    ctypes.CDLL = len\nctypes.CDLL('./payload.so')\n"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", source)
+
+    result = ZipScanner().scan(str(archive_path))
+
+    python_checks = [
+        check
+        for check in result.checks
+        if check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED
+    ]
+    assert len(python_checks) == 1
+    assert python_checks[0].rule_code == "S110"
+    assert python_checks[0].details["reason"] == "high-risk calls: ctypes.CDLL"
+
+
+@pytest.mark.parametrize(
     "source",
     [
         "import os\nos.system.__call__('echo hidden')\n",
@@ -546,6 +595,8 @@ def test_scan_zip_preserves_captured_dangerous_callable_before_overwrite(tmp_pat
         "import pty\npty.spawn = len\npty.spawn([])\n",
         "import runpy\nrunpy.run_path = len\nrunpy.run_path([])\n",
         "import webbrowser\nwebbrowser.open = len\nwebbrowser.open([])\n",
+        "import ctypes\nctypes.CDLL = len\nctypes.CDLL([])\n",
+        "import ctypes\nctypes.cdll.LoadLibrary = len\nctypes.cdll.LoadLibrary([])\n",
     ],
 )
 def test_scan_zip_allows_callable_captured_after_safe_overwrite(tmp_path: Path, source: str) -> None:
@@ -1418,6 +1469,7 @@ def test_scan_zip_ignores_benign_python_file_operations(tmp_path: Path) -> None:
         ("import pty\npty.spawn('/bin/sh')\n", "S111", "pty.spawn"),
         ("import runpy\nrunpy.run_path('payload.py')\n", "S108", "runpy.run_path"),
         ("import webbrowser\nwebbrowser.open_new_tab('https://evil.example')\n", "S109", "webbrowser.open_new_tab"),
+        ("import ctypes\nctypes.CDLL('./payload.so')\n", "S110", "ctypes.CDLL"),
         ("import importlib\nimportlib.import_module('os')\n", "S107", "importlib.import_module"),
         ("eval('1 + 1')\n", "S104", "eval"),
         ("import pickle\npickle.loads(b'\\x80\\x04N.')\n", "S213", "pickle.loads"),


### PR DESCRIPTION
## Summary
- detect embedded Python `ctypes` DLL constructor and loader-object `LoadLibrary` calls through shared archive analysis as `S110`
- surface direct and statically resolved aliased native-library loading in JIT/PyTorch ZIP scanning
- preserve deterministic safe-overwrite suppression for both constructors and nested loader methods while reporting conditional replacement paths

## Why
ModelAudit already registers `S110` for `ctypes`, identifies `ctypes.CDLL`/loader signatures in binary content, detects `ctypes` references in pickle paths, and treats `ctypes.CDLL` as suspicious in NeMo configuration. However, shared embedded Python member analysis and JIT/PyTorch ZIP source analysis returned no finding for `ctypes.CDLL`, `PyDLL`, `WinDLL`, `OleDLL`, loader-object `LoadLibrary` calls, or their aliases. This left embedded Python capable of loading native code unreported in ZIP, TAR, TorchServe MAR, and PyTorch ZIP/JIT content.

This PR models the full standard-library DLL-loading family as invocation-based `S110` behavior. It does not flag a bare `import ctypes`; certain safe replacements remain clean.

## Validation
- behavior probe: the four DLL constructors, `ctypes.cdll.LoadLibrary`, and aliases report `S110` plus JIT `Native library loading detected`; constructor and nested-loader safe replacements remain clean; conditional replacement reports
- focused scanner regression suite: `1194 passed, 18 warnings`
- `npx prettier --check CHANGELOG.md`: clean
- `uv --no-config run --locked ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`: clean
- `uv --no-config run --locked ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`: clean
- `uv --no-config run --locked mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`: `Success: no issues found in 453 source files`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --locked pytest -n auto -m "not slow and not integration" --maxfail=1`: `6615 passed, 15 skipped, 21 warnings`

## Stack
- Stacked on #1373 (`fix: detect embedded webbrowser launch calls`), which completed hosted CI successfully.