### PR TITLE
fix: scan nested ONNX external initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- scan ONNX external data initializers in nested graphs, functions, and training graphs
 - route renamed structured JAX/Orbax JSON checkpoints, conservatively report observable bounded-prefix threats, and fail closed for oversized identified metadata
 - classify Flax MessagePack recursion-limit analysis gaps as inconclusive coverage
 - classify incomplete JAX/Orbax metadata, pickle, and NumPy analysis as inconclusive coverage

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -144,6 +144,27 @@ def _iter_model_graphs(model: Any) -> Any:
         yield training_info.algorithm
 
 
+def _iter_graph_and_subgraphs(graph: Any) -> Any:
+    """Yield an ONNX graph and every graph nested below node attributes."""
+    yield graph
+    for node in getattr(graph, "node", []):
+        for attribute in getattr(node, "attribute", []):
+            for subgraph in _iter_attribute_graphs(attribute):
+                yield from _iter_graph_and_subgraphs(subgraph)
+
+
+def _iter_model_initializer_graphs(model: Any) -> Any:
+    """Yield every ONNX graph that can carry tensor initializers."""
+    yield from _iter_graph_and_subgraphs(model.graph)
+    for function in getattr(model, "functions", []):
+        for attribute in getattr(function, "attribute_proto", []):
+            for subgraph in _iter_attribute_graphs(attribute):
+                yield from _iter_graph_and_subgraphs(subgraph)
+    for training_info in getattr(model, "training_info", []):
+        yield from _iter_graph_and_subgraphs(training_info.initialization)
+        yield from _iter_graph_and_subgraphs(training_info.algorithm)
+
+
 def _model_declares_python_operator(model: Any) -> bool:
     """Return True when the parsed ONNX model actually declares a Python operator.
 
@@ -623,10 +644,12 @@ class OnnxScanner(BaseScanner):
         traversal_files: dict[str, list[str]] = {}  # file -> [tensor_names]
         safe_files: set[str] = set()
 
-        for tensor in model.graph.initializer:
-            self.check_interrupted()
+        for graph in _iter_model_initializer_graphs(model):
+            for tensor in getattr(graph, "initializer", []):
+                self.check_interrupted()
 
-            if tensor.data_location == onnx.TensorProto.EXTERNAL:
+                if tensor.data_location != onnx.TensorProto.EXTERNAL:
+                    continue
                 info = {entry.key: entry.value for entry in tensor.external_data}
                 location = info.get("location")
                 if not location:

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -157,6 +157,7 @@ def _iter_model_initializer_graphs(model: Any) -> Any:
     """Yield every ONNX graph that can carry tensor initializers."""
     yield from _iter_graph_and_subgraphs(model.graph)
     for function in getattr(model, "functions", []):
+        yield from _iter_graph_and_subgraphs(function)
         for attribute in getattr(function, "attribute_proto", []):
             for subgraph in _iter_attribute_graphs(attribute):
                 yield from _iter_graph_and_subgraphs(subgraph)

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -100,6 +100,55 @@ def create_python_onnx_model(tmp_path: Path) -> Path:
     return path
 
 
+def create_onnx_model_with_nested_external_initializer(
+    tmp_path: Path,
+    *,
+    external_path: str,
+    missing_external: bool = False,
+) -> Path:
+    tensor = helper.make_tensor("nested_W", TensorProto.FLOAT, [1], vals=[1.0])
+    tensor.data_location = onnx.TensorProto.EXTERNAL
+    entry = StringStringEntryProto()
+    entry.key = "location"
+    entry.value = external_path
+    tensor.external_data.append(entry)
+
+    then_branch = helper.make_graph(
+        [helper.make_node("Identity", ["nested_W"], ["Z"])],
+        "then_branch",
+        [],
+        [helper.make_tensor_value_info("Z", TensorProto.FLOAT, [1])],
+        initializer=[tensor],
+    )
+    else_tensor = helper.make_tensor("else_W", TensorProto.FLOAT, [1], vals=[0.0])
+    else_branch = helper.make_graph(
+        [helper.make_node("Identity", ["else_W"], ["Z"])],
+        "else_branch",
+        [],
+        [helper.make_tensor_value_info("Z", TensorProto.FLOAT, [1])],
+        initializer=[else_tensor],
+    )
+    condition = helper.make_tensor("cond", TensorProto.BOOL, [], vals=[True])
+    graph = helper.make_graph(
+        [helper.make_node("If", ["cond"], ["Y"], then_branch=then_branch, else_branch=else_branch)],
+        "graph",
+        [],
+        [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])],
+        initializer=[condition],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    path = tmp_path / "nested_external.onnx"
+    onnx.save(model, str(path))
+
+    if not missing_external:
+        external_file = tmp_path / external_path
+        external_file.parent.mkdir(parents=True, exist_ok=True)
+        external_file.write_bytes(struct.pack("f", 1.0))
+
+    return path
+
+
 def _failed_custom_domain_checks(result: Any) -> list[Any]:
     return [c for c in result.checks if c.name == "Custom Operator Domain Check" and c.status == CheckStatus.FAILED]
 
@@ -1010,6 +1059,58 @@ class TestCVE202427318NestedPathTraversal:
         assert len(cve_checks) > 0
         assert cve_checks[0].details["cwe"] == "CWE-22"
         assert cve_checks[0].details["cvss"] == 7.5
+
+    def test_nested_graph_initializer_traversal_detected(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model_with_nested_external_initializer(
+            tmp_path,
+            external_path="weights/../../../tmp/exfil",
+            missing_external=True,
+        )
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is False
+        cve_checks = [c for c in result.checks if c.details.get("cve_id") == "CVE-2024-27318"]
+        assert len(cve_checks) > 0
+        assert cve_checks[0].severity == IssueSeverity.CRITICAL
+        assert cve_checks[0].details["tensor"] == "nested_W"
+
+    def test_nested_graph_initializer_in_dir_dotdot_not_flagged(self, tmp_path: Path) -> None:
+        (tmp_path / "nested_weights.bin").write_bytes(struct.pack("f", 1.0))
+        model_path = create_onnx_model_with_nested_external_initializer(
+            tmp_path,
+            external_path="weights/../nested_weights.bin",
+            missing_external=True,
+        )
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is True
+        traversal_checks = [
+            c for c in result.checks if c.status == CheckStatus.FAILED and "traversal" in c.message.lower()
+        ]
+        assert traversal_checks == []
+        size_checks = [
+            c for c in result.checks if c.name == "External Data Size Validation" and c.status == CheckStatus.PASSED
+        ]
+        assert len(size_checks) > 0
+        assert size_checks[0].details["tensor"] == "nested_W"
+
+    def test_nested_graph_initializer_missing_external_data_reported(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model_with_nested_external_initializer(
+            tmp_path,
+            external_path="missing_nested_weights.bin",
+            missing_external=True,
+        )
+
+        result = OnnxScanner().scan(str(model_path))
+
+        missing_checks = [
+            c for c in result.checks if c.name == "External Data Reference Check" and c.status == CheckStatus.FAILED
+        ]
+        assert len(missing_checks) == 1
+        assert missing_checks[0].severity == IssueSeverity.WARNING
+        assert missing_checks[0].details["sample_tensors"] == ["nested_W"]
 
     def test_windows_absolute_path_is_flagged_on_posix_hosts(self, tmp_path: Path) -> None:
         model_path = create_onnx_model(

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -149,6 +149,76 @@ def create_onnx_model_with_nested_external_initializer(
     return path
 
 
+def create_onnx_model_with_function_body_external_initializer(
+    tmp_path: Path,
+    *,
+    external_path: str,
+    missing_external: bool = False,
+) -> Path:
+    tensor = onnx.TensorProto()
+    tensor.name = "function_W"
+    tensor.data_type = TensorProto.FLOAT
+    tensor.dims.append(1)
+    tensor.data_location = onnx.TensorProto.EXTERNAL
+    entry = StringStringEntryProto()
+    entry.key = "location"
+    entry.value = external_path
+    tensor.external_data.append(entry)
+
+    then_branch = helper.make_graph(
+        [helper.make_node("Identity", ["function_W"], ["Z"])],
+        "function_then_branch",
+        [],
+        [helper.make_tensor_value_info("Z", TensorProto.FLOAT, [1])],
+        initializer=[tensor],
+    )
+    else_branch = helper.make_graph(
+        [helper.make_node("Identity", ["X"], ["Z"])],
+        "function_else_branch",
+        [helper.make_tensor_value_info("X", TensorProto.FLOAT, [1])],
+        [helper.make_tensor_value_info("Z", TensorProto.FLOAT, [1])],
+    )
+    if_node = helper.make_node(
+        "If",
+        ["cond"],
+        ["Y"],
+        then_branch=then_branch,
+        else_branch=else_branch,
+    )
+    function = helper.make_function(
+        "local",
+        "SelectExternal",
+        ["cond", "X"],
+        ["Y"],
+        [if_node],
+        [helper.make_opsetid("", 13)],
+    )
+    condition = helper.make_tensor("cond", TensorProto.BOOL, [], vals=[True])
+    input_value = helper.make_tensor("X", TensorProto.FLOAT, [1], vals=[0.0])
+    graph = helper.make_graph(
+        [helper.make_node("SelectExternal", ["cond", "X"], ["Y"], domain="local")],
+        "graph",
+        [],
+        [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])],
+        initializer=[condition, input_value],
+    )
+    model = helper.make_model(
+        graph,
+        functions=[function],
+        opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid("local", 1)],
+    )
+    model.ir_version = 9
+    path = tmp_path / "function_body_external.onnx"
+    onnx.save(model, str(path))
+
+    if not missing_external:
+        external_file = tmp_path / external_path
+        external_file.parent.mkdir(parents=True, exist_ok=True)
+        external_file.write_bytes(struct.pack("f", 1.0))
+
+    return path
+
+
 def _failed_custom_domain_checks(result: Any) -> list[Any]:
     return [c for c in result.checks if c.name == "Custom Operator Domain Check" and c.status == CheckStatus.FAILED]
 
@@ -1111,6 +1181,39 @@ class TestCVE202427318NestedPathTraversal:
         assert len(missing_checks) == 1
         assert missing_checks[0].severity == IssueSeverity.WARNING
         assert missing_checks[0].details["sample_tensors"] == ["nested_W"]
+
+    def test_function_body_initializer_traversal_detected(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model_with_function_body_external_initializer(
+            tmp_path,
+            external_path="weights/../../../tmp/exfil",
+            missing_external=True,
+        )
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is False
+        cve_checks = [c for c in result.checks if c.details.get("cve_id") == "CVE-2024-27318"]
+        assert len(cve_checks) > 0
+        assert cve_checks[0].severity == IssueSeverity.CRITICAL
+        assert cve_checks[0].details["tensor"] == "function_W"
+
+    def test_function_body_initializer_in_dir_dotdot_not_flagged(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model_with_function_body_external_initializer(
+            tmp_path,
+            external_path="weights/../function_weights.bin",
+        )
+
+        result = OnnxScanner().scan(str(model_path))
+
+        traversal_checks = [
+            c for c in result.checks if c.status == CheckStatus.FAILED and "traversal" in c.message.lower()
+        ]
+        assert traversal_checks == []
+        size_checks = [
+            c for c in result.checks if c.name == "External Data Size Validation" and c.status == CheckStatus.PASSED
+        ]
+        assert len(size_checks) > 0
+        assert size_checks[0].details["tensor"] == "function_W"
 
     def test_windows_absolute_path_is_flagged_on_posix_hosts(self, tmp_path: Path) -> None:
         model_path = create_onnx_model(


### PR DESCRIPTION
## Summary

- Walk ONNX subgraphs when validating external_data initializers, not just the root graph.
- Add nested If-graph regressions for traversal, benign in-dir dotdot paths, and missing external data.

## Validation

- `PYTHONPATH=/private/tmp/modelaudit-fixes/f13 PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/python -m pytest tests/scanners/test_onnx_scanner.py -q`
- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/python -m ruff format modelaudit/scanners/onnx_scanner.py tests/scanners/test_onnx_scanner.py`
- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/python -m ruff check --fix modelaudit/scanners/onnx_scanner.py tests/scanners/test_onnx_scanner.py`
- `PYTHONPATH=/private/tmp/modelaudit-fixes/f13 /Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/python -m mypy modelaudit/scanners/onnx_scanner.py tests/scanners/test_onnx_scanner.py`
