### PR TITLE
fix: scan protocol zero JAX checkpoint pickles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- route protocol-0 JAX checkpoint pickles through pickle opcode security checks
 - route renamed structured JAX/Orbax JSON checkpoints, conservatively report observable bounded-prefix threats, and fail closed for oversized identified metadata
 - classify Flax MessagePack recursion-limit analysis gaps as inconclusive coverage
 - classify incomplete JAX/Orbax metadata, pickle, and NumPy analysis as inconclusive coverage

--- a/modelaudit/scanners/jax_checkpoint_scanner.py
+++ b/modelaudit/scanners/jax_checkpoint_scanner.py
@@ -886,7 +886,11 @@ class JaxCheckpointScanner(BaseScanner):
         checkpoint_files = list(path_obj.glob("checkpoint*"))
         for checkpoint_file in checkpoint_files:
             if checkpoint_file.is_file():
-                self._scan_checkpoint_file(str(checkpoint_file), result)
+                self._scan_checkpoint_file(
+                    str(checkpoint_file),
+                    result,
+                    treat_legacy_pickle_header_as_checkpoint=True,
+                )
 
     def _analyze_orbax_metadata(self, metadata: dict[str, Any], path: str, result: ScanResult) -> None:
         """Analyze Orbax metadata for security issues."""
@@ -943,7 +947,13 @@ class JaxCheckpointScanner(BaseScanner):
                 }
             )
 
-    def _scan_checkpoint_file(self, path: str, result: ScanResult) -> None:
+    def _scan_checkpoint_file(
+        self,
+        path: str,
+        result: ScanResult,
+        *,
+        treat_legacy_pickle_header_as_checkpoint: bool = False,
+    ) -> None:
         """Scan individual checkpoint file."""
         try:
             file_size = os.path.getsize(path)
@@ -963,7 +973,12 @@ class JaxCheckpointScanner(BaseScanner):
                 header = f.read(1024)
 
             # Check file format
-            if header.startswith(b"\x80") or self._legacy_pickle_header_has_jax_indicator(path, header):
+            legacy_pickle_header = header[:1] in self._LEGACY_PICKLE_INITIAL_OPCODES
+            if (
+                header.startswith(b"\x80")
+                or (legacy_pickle_header and treat_legacy_pickle_header_as_checkpoint)
+                or self._legacy_pickle_header_has_jax_indicator(path, header)
+            ):
                 self._scan_pickle_checkpoint(path, result)
             elif header.startswith(b"\x93NUMPY"):  # NumPy format
                 self._scan_numpy_checkpoint(path, result)

--- a/modelaudit/scanners/jax_checkpoint_scanner.py
+++ b/modelaudit/scanners/jax_checkpoint_scanner.py
@@ -226,6 +226,7 @@ class JaxCheckpointScanner(BaseScanner):
     _JSON_PREFIX_PATTERN_READ_FAILED_REASON: ClassVar[str] = "jax_json_checkpoint_prefix_pattern_read_failed"
     _METADATA_TRAVERSAL_LIMIT_REASON: ClassVar[str] = "jax_metadata_traversal_depth_limit"
     _PICKLE_SCAN_LIMIT_REASON: ClassVar[str] = "jax_pickle_scan_limit_exceeded"
+    _LEGACY_PICKLE_INITIAL_OPCODES: ClassVar[bytes] = b"(cdgINRSUV"
 
     def __init__(self, config: dict[str, Any] | None = None) -> None:
         """Initialize JAX checkpoint scanning limits and regex detectors."""
@@ -742,6 +743,18 @@ class JaxCheckpointScanner(BaseScanner):
         return any(list(path_obj.glob(pattern)) for pattern in jax_patterns)
 
     @classmethod
+    def _legacy_pickle_header_has_jax_indicator(cls, path: str, header: bytes) -> bool:
+        if header[:1] not in cls._LEGACY_PICKLE_INITIAL_OPCODES:
+            return False
+
+        with suppress(Exception):
+            with open(path, "rb") as source:
+                data = source.read(max(8192, len(header)))
+            return cls._contains_jax_indicator(data.decode("utf-8", errors="ignore"))
+
+        return False
+
+    @classmethod
     def _is_likely_jax_file(cls, path: str) -> bool:
         """Determine if a file is likely a JAX checkpoint."""
         try:
@@ -751,7 +764,7 @@ class JaxCheckpointScanner(BaseScanner):
                 # pickles are textual and can begin directly with a string
                 # opcode such as `Vjax`, so they do not have the binary
                 # protocol marker.
-                if header.startswith(b"\x80") or header[:1] in b"(cdgINRSUV":
+                if header.startswith(b"\x80") or header[:1] in cls._LEGACY_PICKLE_INITIAL_OPCODES:
                     with suppress(Exception):
                         data = header + f.read(max(0, 8192 - len(header)))
                         data_str = data.decode("utf-8", errors="ignore").lower()
@@ -950,7 +963,7 @@ class JaxCheckpointScanner(BaseScanner):
                 header = f.read(1024)
 
             # Check file format
-            if header.startswith(b"\x80"):  # Pickle format
+            if header.startswith(b"\x80") or self._legacy_pickle_header_has_jax_indicator(path, header):
                 self._scan_pickle_checkpoint(path, result)
             elif header.startswith(b"\x93NUMPY"):  # NumPy format
                 self._scan_numpy_checkpoint(path, result)

--- a/modelaudit/scanners/jax_checkpoint_scanner.py
+++ b/modelaudit/scanners/jax_checkpoint_scanner.py
@@ -226,7 +226,8 @@ class JaxCheckpointScanner(BaseScanner):
     _JSON_PREFIX_PATTERN_READ_FAILED_REASON: ClassVar[str] = "jax_json_checkpoint_prefix_pattern_read_failed"
     _METADATA_TRAVERSAL_LIMIT_REASON: ClassVar[str] = "jax_metadata_traversal_depth_limit"
     _PICKLE_SCAN_LIMIT_REASON: ClassVar[str] = "jax_pickle_scan_limit_exceeded"
-    _LEGACY_PICKLE_INITIAL_OPCODES: ClassVar[bytes] = b"(cdgINRSUV"
+    _LEGACY_PICKLE_INITIAL_OPCODES: ClassVar[bytes] = b"()cFGIJKLMNSTUVX]}"
+    _LEGACY_PICKLE_PREFIX_PROBE_BYTES: ClassVar[int] = 8192
 
     def __init__(self, config: dict[str, Any] | None = None) -> None:
         """Initialize JAX checkpoint scanning limits and regex detectors."""
@@ -743,8 +744,42 @@ class JaxCheckpointScanner(BaseScanner):
         return any(list(path_obj.glob(pattern)) for pattern in jax_patterns)
 
     @classmethod
+    def _header_starts_with_legacy_pickle_opcode(cls, header: bytes) -> bool:
+        return bool(header) and header[:1] in cls._LEGACY_PICKLE_INITIAL_OPCODES
+
+    @staticmethod
+    def _is_truncated_pickle_parse_error(error: ValueError) -> bool:
+        message = str(error)
+        return (
+            "pickle exhausted before seeing STOP" in message
+            or "not enough data" in message
+            or ("expected " in message and " bytes " in message and "remain" in message)
+        )
+
+    def _has_structural_legacy_pickle_prefix(self, path: str, header: bytes) -> bool:
+        if not self._header_starts_with_legacy_pickle_opcode(header):
+            return False
+
+        read_limit = max(len(header), min(self.max_pickle_scan_bytes, self._LEGACY_PICKLE_PREFIX_PROBE_BYTES))
+        with suppress(Exception):
+            file_size = os.path.getsize(path)
+            with open(path, "rb") as source:
+                data = source.read(read_limit)
+
+            parsed_opcode = False
+            try:
+                for opcode, _, _ in pickletools.genops(data):
+                    parsed_opcode = True
+                    if opcode.name == "STOP":
+                        return True
+            except ValueError as e:
+                return file_size > len(data) and parsed_opcode and self._is_truncated_pickle_parse_error(e)
+
+        return False
+
+    @classmethod
     def _legacy_pickle_header_has_jax_indicator(cls, path: str, header: bytes) -> bool:
-        if header[:1] not in cls._LEGACY_PICKLE_INITIAL_OPCODES:
+        if not cls._header_starts_with_legacy_pickle_opcode(header):
             return False
 
         with suppress(Exception):
@@ -764,7 +799,7 @@ class JaxCheckpointScanner(BaseScanner):
                 # pickles are textual and can begin directly with a string
                 # opcode such as `Vjax`, so they do not have the binary
                 # protocol marker.
-                if header.startswith(b"\x80") or header[:1] in cls._LEGACY_PICKLE_INITIAL_OPCODES:
+                if header.startswith(b"\x80") or cls._header_starts_with_legacy_pickle_opcode(header):
                     with suppress(Exception):
                         data = header + f.read(max(0, 8192 - len(header)))
                         data_str = data.decode("utf-8", errors="ignore").lower()
@@ -973,11 +1008,11 @@ class JaxCheckpointScanner(BaseScanner):
                 header = f.read(1024)
 
             # Check file format
-            legacy_pickle_header = header[:1] in self._LEGACY_PICKLE_INITIAL_OPCODES
+            legacy_pickle_header = self._has_structural_legacy_pickle_prefix(path, header)
             if (
                 header.startswith(b"\x80")
                 or (legacy_pickle_header and treat_legacy_pickle_header_as_checkpoint)
-                or self._legacy_pickle_header_has_jax_indicator(path, header)
+                or (legacy_pickle_header and self._legacy_pickle_header_has_jax_indicator(path, header))
             ):
                 self._scan_pickle_checkpoint(path, result)
             elif header.startswith(b"\x93NUMPY"):  # NumPy format

--- a/modelaudit/scanners/jax_checkpoint_scanner.py
+++ b/modelaudit/scanners/jax_checkpoint_scanner.py
@@ -774,6 +774,8 @@ class JaxCheckpointScanner(BaseScanner):
             memo_indices: set[int] = set()
             next_memo_index = 0
             parsed_opcode = False
+            parsed_opcode_count = 0
+            saw_dangerous_global = False
 
             def _memo_index(value: Any) -> int | None:
                 try:
@@ -816,6 +818,14 @@ class JaxCheckpointScanner(BaseScanner):
             try:
                 for opcode, arg, _pos in pickletools.genops(data):
                     parsed_opcode = True
+                    parsed_opcode_count += 1
+                    if opcode.name == "GLOBAL" and isinstance(arg, str):
+                        parsed_global = self._parse_pickle_global_reference(arg)
+                        if parsed_global is not None:
+                            module_name, global_name = parsed_global
+                            saw_dangerous_global = saw_dangerous_global or self._is_dangerous_pickle_global(
+                                module_name, global_name
+                            )
                     if opcode.name in {"BINPUT", "LONG_BINPUT", "PUT"}:
                         if not stack:
                             return False
@@ -838,6 +848,8 @@ class JaxCheckpointScanner(BaseScanner):
                         return True
             except ValueError as e:
                 if "pickle exhausted before seeing STOP" in str(e):
+                    if parsed_opcode_count == 1 and not saw_dangerous_global:
+                        return False
                     return parsed_opcode
                 if file_size > len(data) and self._is_truncated_pickle_parse_error(e):
                     return parsed_opcode or self._header_starts_with_legacy_pickle_opcode(header)

--- a/modelaudit/scanners/jax_checkpoint_scanner.py
+++ b/modelaudit/scanners/jax_checkpoint_scanner.py
@@ -227,7 +227,7 @@ class JaxCheckpointScanner(BaseScanner):
     _METADATA_TRAVERSAL_LIMIT_REASON: ClassVar[str] = "jax_metadata_traversal_depth_limit"
     _PICKLE_SCAN_LIMIT_REASON: ClassVar[str] = "jax_pickle_scan_limit_exceeded"
     _LEGACY_PICKLE_INITIAL_OPCODES: ClassVar[bytes] = (
-        b"()BCcFGIJKLMNPSTUVX]}\x82\x83\x84\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x96\x97"
+        b"()BCcFGIJKLMNPSTUVX]}\x82\x83\x84\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x95\x96\x97"
     )
     _LEGACY_PICKLE_PREFIX_PROBE_BYTES: ClassVar[int] = 8192
 

--- a/modelaudit/scanners/jax_checkpoint_scanner.py
+++ b/modelaudit/scanners/jax_checkpoint_scanner.py
@@ -226,7 +226,8 @@ class JaxCheckpointScanner(BaseScanner):
     _JSON_PREFIX_PATTERN_READ_FAILED_REASON: ClassVar[str] = "jax_json_checkpoint_prefix_pattern_read_failed"
     _METADATA_TRAVERSAL_LIMIT_REASON: ClassVar[str] = "jax_metadata_traversal_depth_limit"
     _PICKLE_SCAN_LIMIT_REASON: ClassVar[str] = "jax_pickle_scan_limit_exceeded"
-    _LEGACY_PICKLE_INITIAL_OPCODES: ClassVar[bytes] = b"()cFGIJKLMNSTUVX]}"
+    _LEGACY_PICKLE_INITIAL_OPCODES: ClassVar[bytes] = b"()cFGIJKLMNPSTUVX]}"
+    _LEGACY_PICKLE_LINE_ARGUMENT_OPCODES: ClassVar[bytes] = b"PSV"
     _LEGACY_PICKLE_PREFIX_PROBE_BYTES: ClassVar[int] = 8192
 
     def __init__(self, config: dict[str, Any] | None = None) -> None:
@@ -753,6 +754,7 @@ class JaxCheckpointScanner(BaseScanner):
         return (
             "pickle exhausted before seeing STOP" in message
             or "not enough data" in message
+            or "no newline found" in message
             or ("expected " in message and " bytes " in message and "remain" in message)
         )
 
@@ -766,14 +768,78 @@ class JaxCheckpointScanner(BaseScanner):
             with open(path, "rb") as source:
                 data = source.read(read_limit)
 
+            marker = object()
+            stack: list[object] = []
+            memo_indices: set[int] = set()
+            next_memo_index = 0
             parsed_opcode = False
+
+            def _memo_index(value: Any) -> int | None:
+                try:
+                    return int(value)
+                except (TypeError, ValueError):
+                    return None
+
+            def _apply_probe_stack_effect(opcode_info: Any) -> bool:
+                if opcode_info.name == "MARK":
+                    stack.append(marker)
+                    return True
+
+                stack_before = list(getattr(opcode_info, "stack_before", ()))
+                stack_after = list(getattr(opcode_info, "stack_after", ()))
+
+                if pickletools.markobject in stack_before:
+                    preserved_items_before_mark = stack_before.index(pickletools.markobject)
+                    if marker not in stack:
+                        return False
+                    marker_index = len(stack) - 1 - stack[::-1].index(marker)
+                    if marker_index < preserved_items_before_mark:
+                        return False
+                    del stack[marker_index:]
+                    if len(stack_after) > preserved_items_before_mark:
+                        stack.extend(object() for _ in range(len(stack_after) - preserved_items_before_mark))
+                    elif len(stack_after) < preserved_items_before_mark:
+                        remove_count = preserved_items_before_mark - len(stack_after)
+                        if len(stack) < remove_count:
+                            return False
+                        del stack[-remove_count:]
+                    return True
+
+                if len(stack) < len(stack_before):
+                    return False
+                if stack_before:
+                    del stack[-len(stack_before) :]
+                stack.extend(object() for _ in stack_after)
+                return True
+
             try:
-                for opcode, _, _ in pickletools.genops(data):
+                for opcode, arg, _pos in pickletools.genops(data):
                     parsed_opcode = True
+                    if opcode.name in {"BINPUT", "LONG_BINPUT", "PUT"}:
+                        if not stack:
+                            return False
+                        memo_index = _memo_index(arg)
+                        if memo_index is not None:
+                            memo_indices.add(memo_index)
+                            next_memo_index = max(next_memo_index, memo_index + 1)
+                    elif opcode.name == "MEMOIZE":
+                        if not stack:
+                            return False
+                        memo_indices.add(next_memo_index)
+                        next_memo_index += 1
+                    elif opcode.name in {"BINGET", "LONG_BINGET", "GET"}:
+                        memo_index = _memo_index(arg)
+                        if memo_index is None or memo_index not in memo_indices:
+                            return False
+                    if not _apply_probe_stack_effect(opcode):
+                        return False
                     if opcode.name == "STOP":
                         return True
             except ValueError as e:
-                return file_size > len(data) and parsed_opcode and self._is_truncated_pickle_parse_error(e)
+                if "pickle exhausted before seeing STOP" in str(e):
+                    return parsed_opcode
+                if file_size > len(data) and self._is_truncated_pickle_parse_error(e):
+                    return parsed_opcode or header[:1] in self._LEGACY_PICKLE_LINE_ARGUMENT_OPCODES
 
         return False
 

--- a/modelaudit/scanners/jax_checkpoint_scanner.py
+++ b/modelaudit/scanners/jax_checkpoint_scanner.py
@@ -226,8 +226,9 @@ class JaxCheckpointScanner(BaseScanner):
     _JSON_PREFIX_PATTERN_READ_FAILED_REASON: ClassVar[str] = "jax_json_checkpoint_prefix_pattern_read_failed"
     _METADATA_TRAVERSAL_LIMIT_REASON: ClassVar[str] = "jax_metadata_traversal_depth_limit"
     _PICKLE_SCAN_LIMIT_REASON: ClassVar[str] = "jax_pickle_scan_limit_exceeded"
-    _LEGACY_PICKLE_INITIAL_OPCODES: ClassVar[bytes] = b"()cFGIJKLMNPSTUVX]}"
-    _LEGACY_PICKLE_LINE_ARGUMENT_OPCODES: ClassVar[bytes] = b"PSV"
+    _LEGACY_PICKLE_INITIAL_OPCODES: ClassVar[bytes] = (
+        b"()BCcFGIJKLMNPSTUVX]}\x82\x83\x84\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x96\x97"
+    )
     _LEGACY_PICKLE_PREFIX_PROBE_BYTES: ClassVar[int] = 8192
 
     def __init__(self, config: dict[str, Any] | None = None) -> None:
@@ -839,7 +840,7 @@ class JaxCheckpointScanner(BaseScanner):
                 if "pickle exhausted before seeing STOP" in str(e):
                     return parsed_opcode
                 if file_size > len(data) and self._is_truncated_pickle_parse_error(e):
-                    return parsed_opcode or header[:1] in self._LEGACY_PICKLE_LINE_ARGUMENT_OPCODES
+                    return parsed_opcode or self._header_starts_with_legacy_pickle_opcode(header)
 
         return False
 

--- a/tests/scanners/test_jax_checkpoint_scanner.py
+++ b/tests/scanners/test_jax_checkpoint_scanner.py
@@ -517,6 +517,31 @@ def test_orbax_binbytes_prefix_scans_pickle(tmp_path: Path) -> None:
     )
 
 
+def test_orbax_frame_prefix_scans_pickle(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "orbax_frame"
+    checkpoint_dir.mkdir()
+    checkpoint_file = checkpoint_dir / "checkpoint"
+    frame_payload = b"cposix\nsystem\np0\n(Vid\np1\ntp2\nRp3\n."
+    checkpoint_file.write_bytes(b"\x95" + len(frame_payload).to_bytes(8, "little") + frame_payload)
+
+    assert JaxCheckpointScanner.can_handle(str(checkpoint_dir))
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success
+    assert not any(
+        check.name == "Checkpoint Format Detection" and check.details.get("format") == "unknown"
+        for check in result.checks
+    )
+    assert any(
+        check.name == "Pickle Opcode Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details["global"] == "posix.system"
+        for check in result.checks
+    )
+
+
 def test_orbax_truncated_binstring_prefix_scans_pickle(tmp_path: Path) -> None:
     checkpoint_dir = tmp_path / "orbax_long_binstring"
     checkpoint_dir.mkdir()

--- a/tests/scanners/test_jax_checkpoint_scanner.py
+++ b/tests/scanners/test_jax_checkpoint_scanner.py
@@ -493,6 +493,77 @@ def test_eof_truncated_orbax_legacy_pickle_is_scanned_inconclusive(tmp_path: Pat
     assert "jax_pickle_scan_failed" in result.metadata.get("scan_outcome_reasons", [])
 
 
+def test_orbax_binbytes_prefix_scans_pickle(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "orbax_binbytes"
+    checkpoint_dir.mkdir()
+    checkpoint_file = checkpoint_dir / "checkpoint"
+    checkpoint_file.write_bytes(b"B\x03\x00\x00\x00abccposix\nsystem\np0\n(Vid\np1\ntp2\nRp3\n.")
+
+    assert JaxCheckpointScanner.can_handle(str(checkpoint_dir))
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success
+    assert not any(
+        check.name == "Checkpoint Format Detection" and check.details.get("format") == "unknown"
+        for check in result.checks
+    )
+    assert any(
+        check.name == "Pickle Opcode Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details["global"] == "posix.system"
+        for check in result.checks
+    )
+
+
+def test_orbax_truncated_binstring_prefix_scans_pickle(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "orbax_long_binstring"
+    checkpoint_dir.mkdir()
+    checkpoint_file = checkpoint_dir / "checkpoint"
+    binary_string = b"A" * (JaxCheckpointScanner._LEGACY_PICKLE_PREFIX_PROBE_BYTES + 1)
+    checkpoint_file.write_bytes(
+        b"T" + len(binary_string).to_bytes(4, "little") + binary_string + b"cposix\nsystem\np0\n(Vid\np1\ntp2\nRp3\n."
+    )
+
+    assert JaxCheckpointScanner.can_handle(str(checkpoint_dir))
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success
+    assert not any(
+        check.name == "Checkpoint Format Detection" and check.details.get("format") == "unknown"
+        for check in result.checks
+    )
+    assert any(
+        check.name == "Pickle Opcode Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details["global"] == "posix.system"
+        for check in result.checks
+    )
+
+
+def test_orbax_truncated_numeric_prefix_is_scanned_inconclusive(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "orbax_long_numeric"
+    checkpoint_dir.mkdir()
+    checkpoint_file = checkpoint_dir / "checkpoint"
+    checkpoint_file.write_bytes(
+        b"I" + (b"9" * (JaxCheckpointScanner._LEGACY_PICKLE_PREFIX_PROBE_BYTES + 1)) + b"\n"
+        b"cposix\nsystem\np0\n(Vid\np1\ntp2\nRp3\n."
+    )
+
+    assert JaxCheckpointScanner.can_handle(str(checkpoint_dir))
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert not any(
+        check.name == "Checkpoint Format Detection" and check.details.get("format") == "unknown"
+        for check in result.checks
+    )
+    assert "jax_pickle_scan_failed" in result.metadata.get("scan_outcome_reasons", [])
+
+
 def test_benign_protocol_zero_jax_checkpoint_is_scanned_as_pickle(tmp_path: Path) -> None:
     pickle_path = tmp_path / "benign_protocol0_state.checkpoint"
     pickle_path.write_bytes(pickle.dumps({"framework": "jax", "params": {"dense": [1, 2, 3]}}, protocol=0))

--- a/tests/scanners/test_jax_checkpoint_scanner.py
+++ b/tests/scanners/test_jax_checkpoint_scanner.py
@@ -336,6 +336,28 @@ def test_protocol_zero_jax_checkpoint_pickle_global_opcode_is_detected(tmp_path:
     )
 
 
+def test_orbax_protocol_zero_checkpoint_without_jax_marker_scans_pickle(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "orbax_protocol0"
+    _write_orbax_metadata(checkpoint_dir, {"type": "orbax_checkpoint"})
+    checkpoint_file = checkpoint_dir / "checkpoint"
+    checkpoint_file.write_bytes(b"cposix\nsystem\np0\n(Vid\np1\ntp2\nRp3\n.")
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success
+    assert not any(
+        check.name == "Checkpoint Format Detection" and check.details.get("format") == "unknown"
+        for check in result.checks
+    )
+    assert any(
+        check.name == "Pickle Opcode Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details["global"] == "posix.system"
+        for check in result.checks
+    )
+
+
 def test_benign_protocol_zero_jax_checkpoint_is_scanned_as_pickle(tmp_path: Path) -> None:
     pickle_path = tmp_path / "benign_protocol0_state.checkpoint"
     pickle_path.write_bytes(pickle.dumps({"framework": "jax", "params": {"dense": [1, 2, 3]}}, protocol=0))

--- a/tests/scanners/test_jax_checkpoint_scanner.py
+++ b/tests/scanners/test_jax_checkpoint_scanner.py
@@ -360,6 +360,64 @@ def test_orbax_protocol_zero_checkpoint_without_jax_marker_scans_pickle(tmp_path
     )
 
 
+def test_orbax_protocol_one_checkpoint_without_jax_marker_scans_pickle(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "orbax_protocol1"
+    checkpoint_dir.mkdir()
+    checkpoint_file = checkpoint_dir / "checkpoint"
+    checkpoint_file.write_bytes(pickle.dumps({"payload": _MaliciousJaxState()}, protocol=1))
+
+    assert JaxCheckpointScanner.can_handle(str(checkpoint_dir))
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success
+    assert not any(
+        check.name == "Checkpoint Format Detection" and check.details.get("format") == "unknown"
+        for check in result.checks
+    )
+    assert any(
+        check.name == "Pickle Opcode Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details["global"] in {"os.system", "posix.system", "nt.system"}
+        for check in result.checks
+    )
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "configuration for jax checkpoint in a plain text sidecar",
+        "JAX checkpoint metadata in a plain text sidecar",
+    ],
+)
+def test_jax_text_checkpoint_with_legacy_opcode_prefix_does_not_scan_as_pickle(tmp_path: Path, text: str) -> None:
+    checkpoint_path = tmp_path / "plain_text.checkpoint"
+    checkpoint_path.write_text(text, encoding="utf-8")
+
+    assert JaxCheckpointScanner.can_handle(str(checkpoint_path))
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_path))
+
+    assert result.success
+    assert not any(check.name == "Pickle Checkpoint Scan" for check in result.checks)
+    assert "jax_pickle_scan_failed" not in result.metadata.get("scan_outcome_reasons", [])
+
+
+def test_empty_orbax_checkpoint_file_does_not_scan_as_pickle(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "empty_orbax"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "checkpoint").write_bytes(b"")
+
+    assert JaxCheckpointScanner.can_handle(str(checkpoint_dir))
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success
+    assert not any(check.name == "Pickle Checkpoint Scan" for check in result.checks)
+    assert "jax_pickle_scan_failed" not in result.metadata.get("scan_outcome_reasons", [])
+
+
 def test_benign_protocol_zero_jax_checkpoint_is_scanned_as_pickle(tmp_path: Path) -> None:
     pickle_path = tmp_path / "benign_protocol0_state.checkpoint"
     pickle_path.write_bytes(pickle.dumps({"framework": "jax", "params": {"dense": [1, 2, 3]}}, protocol=0))

--- a/tests/scanners/test_jax_checkpoint_scanner.py
+++ b/tests/scanners/test_jax_checkpoint_scanner.py
@@ -418,6 +418,81 @@ def test_empty_orbax_checkpoint_file_does_not_scan_as_pickle(tmp_path: Path) -> 
     assert "jax_pickle_scan_failed" not in result.metadata.get("scan_outcome_reasons", [])
 
 
+def test_orbax_protocol_zero_persid_checkpoint_scans_pickle(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "orbax_persid"
+    checkpoint_dir.mkdir()
+    checkpoint_file = checkpoint_dir / "checkpoint"
+    checkpoint_file.write_bytes(b"Popaque_id\ncposix\nsystem\np0\n(Vid\np1\ntp2\nRp3\n.")
+
+    assert JaxCheckpointScanner.can_handle(str(checkpoint_dir))
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success
+    assert not any(
+        check.name == "Checkpoint Format Detection" and check.details.get("format") == "unknown"
+        for check in result.checks
+    )
+    assert any(
+        check.name == "Pickle Opcode Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details["global"] == "posix.system"
+        for check in result.checks
+    )
+
+
+def test_orbax_protocol_zero_long_unicode_prefix_scans_pickle(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "orbax_long_unicode"
+    checkpoint_dir.mkdir()
+    checkpoint_file = checkpoint_dir / "checkpoint"
+    checkpoint_file.write_bytes(
+        b"V" + (b"A" * (JaxCheckpointScanner._LEGACY_PICKLE_PREFIX_PROBE_BYTES + 1)) + b"\n"
+        b"cposix\nsystem\np0\n(Vid\np1\ntp2\nRp3\n."
+    )
+
+    assert JaxCheckpointScanner.can_handle(str(checkpoint_dir))
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success
+    assert not any(
+        check.name == "Checkpoint Format Detection" and check.details.get("format") == "unknown"
+        for check in result.checks
+    )
+    assert any(
+        check.name == "Pickle Opcode Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details["global"] == "posix.system"
+        for check in result.checks
+    )
+
+
+def test_eof_truncated_orbax_legacy_pickle_is_scanned_inconclusive(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "orbax_eof_truncated"
+    checkpoint_dir.mkdir()
+    checkpoint_file = checkpoint_dir / "checkpoint"
+    checkpoint_file.write_bytes(b"cposix\nsystem\n")
+
+    assert JaxCheckpointScanner.can_handle(str(checkpoint_dir))
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert not any(
+        check.name == "Checkpoint Format Detection" and check.details.get("format") == "unknown"
+        for check in result.checks
+    )
+    assert any(
+        check.name == "Pickle Opcode Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details["global"] == "posix.system"
+        for check in result.checks
+    )
+    assert "jax_pickle_scan_failed" in result.metadata.get("scan_outcome_reasons", [])
+
+
 def test_benign_protocol_zero_jax_checkpoint_is_scanned_as_pickle(tmp_path: Path) -> None:
     pickle_path = tmp_path / "benign_protocol0_state.checkpoint"
     pickle_path.write_bytes(pickle.dumps({"framework": "jax", "params": {"dense": [1, 2, 3]}}, protocol=0))

--- a/tests/scanners/test_jax_checkpoint_scanner.py
+++ b/tests/scanners/test_jax_checkpoint_scanner.py
@@ -314,6 +314,46 @@ def test_malicious_pickle_global_opcode_is_detected(tmp_path: Path) -> None:
     )
 
 
+def test_protocol_zero_jax_checkpoint_pickle_global_opcode_is_detected(tmp_path: Path) -> None:
+    pickle_path = tmp_path / "malicious_protocol0_state.checkpoint"
+    pickle_path.write_bytes(pickle.dumps({"framework": "jax", "payload": _MaliciousJaxState()}, protocol=0))
+
+    assert JaxCheckpointScanner.can_handle(str(pickle_path))
+
+    result = JaxCheckpointScanner().scan(str(pickle_path))
+
+    assert result.success
+    assert not any(
+        check.name == "Checkpoint Format Detection" and check.details.get("format") == "unknown"
+        for check in result.checks
+    )
+    assert any(
+        check.name == "Pickle Opcode Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details["global"] in {"os.system", "posix.system", "nt.system"}
+        for check in result.checks
+    )
+
+
+def test_benign_protocol_zero_jax_checkpoint_is_scanned_as_pickle(tmp_path: Path) -> None:
+    pickle_path = tmp_path / "benign_protocol0_state.checkpoint"
+    pickle_path.write_bytes(pickle.dumps({"framework": "jax", "params": {"dense": [1, 2, 3]}}, protocol=0))
+
+    assert JaxCheckpointScanner.can_handle(str(pickle_path))
+
+    result = JaxCheckpointScanner().scan(str(pickle_path))
+
+    assert result.success
+    assert not any(
+        check.name == "Checkpoint Format Detection" and check.details.get("format") == "unknown"
+        for check in result.checks
+    )
+    assert not any(
+        check.name == "Pickle Opcode Security Check" and check.status == CheckStatus.FAILED for check in result.checks
+    )
+
+
 def test_stack_global_opcode_is_detected_after_interleaved_unhandled_stack_push(tmp_path: Path) -> None:
     pickle_path = tmp_path / "interleaved_empty_list_stack_global_state.pickle"
     payload = (

--- a/tests/scanners/test_jax_checkpoint_scanner.py
+++ b/tests/scanners/test_jax_checkpoint_scanner.py
@@ -404,6 +404,21 @@ def test_jax_text_checkpoint_with_legacy_opcode_prefix_does_not_scan_as_pickle(t
     assert "jax_pickle_scan_failed" not in result.metadata.get("scan_outcome_reasons", [])
 
 
+def test_orbax_text_checkpoint_sidecar_with_global_shape_does_not_scan_as_pickle(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "orbax_plain_text"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "metadata.json").write_text("{}", encoding="utf-8")
+    (checkpoint_dir / "checkpoint").write_text("configuration\nmetadata\n", encoding="utf-8")
+
+    assert JaxCheckpointScanner.can_handle(str(checkpoint_dir))
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success
+    assert not any(check.name == "Pickle Checkpoint Scan" for check in result.checks)
+    assert "jax_pickle_scan_failed" not in result.metadata.get("scan_outcome_reasons", [])
+
+
 def test_empty_orbax_checkpoint_file_does_not_scan_as_pickle(tmp_path: Path) -> None:
     checkpoint_dir = tmp_path / "empty_orbax"
     checkpoint_dir.mkdir()

--- a/tests/scanners/test_jax_checkpoint_scanner.py
+++ b/tests/scanners/test_jax_checkpoint_scanner.py
@@ -338,9 +338,11 @@ def test_protocol_zero_jax_checkpoint_pickle_global_opcode_is_detected(tmp_path:
 
 def test_orbax_protocol_zero_checkpoint_without_jax_marker_scans_pickle(tmp_path: Path) -> None:
     checkpoint_dir = tmp_path / "orbax_protocol0"
-    _write_orbax_metadata(checkpoint_dir, {"type": "orbax_checkpoint"})
+    checkpoint_dir.mkdir()
     checkpoint_file = checkpoint_dir / "checkpoint"
     checkpoint_file.write_bytes(b"cposix\nsystem\np0\n(Vid\np1\ntp2\nRp3\n.")
+
+    assert JaxCheckpointScanner.can_handle(str(checkpoint_dir))
 
     result = JaxCheckpointScanner().scan(str(checkpoint_dir))
 


### PR DESCRIPTION
## Summary

- route protocol-0 JAX checkpoint pickles into the pickle checkpoint scanner
- preserve benign protocol-0 JAX checkpoint handling without unknown-format success
- add malicious and benign protocol-0 checkpoint regressions

## Validation

- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/python -m pytest tests/scanners/test_jax_checkpoint_scanner.py -q`
- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/ruff format --check modelaudit/scanners/jax_checkpoint_scanner.py tests/scanners/test_jax_checkpoint_scanner.py`
- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/ruff check modelaudit/scanners/jax_checkpoint_scanner.py tests/scanners/test_jax_checkpoint_scanner.py`
- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/mypy modelaudit/scanners/jax_checkpoint_scanner.py tests/scanners/test_jax_checkpoint_scanner.py`
