### PR TITLE
fix: detect Keras weights-only external HDF5 refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- detect external references in weights-only Keras HDF5 layouts without Keras metadata
 - route renamed structured JAX/Orbax JSON checkpoints, conservatively report observable bounded-prefix threats, and fail closed for oversized identified metadata
 - classify Flax MessagePack recursion-limit analysis gaps as inconclusive coverage
 - classify incomplete JAX/Orbax metadata, pickle, and NumPy analysis as inconclusive coverage

--- a/modelaudit/scanners/keras_h5_scanner.py
+++ b/modelaudit/scanners/keras_h5_scanner.py
@@ -348,22 +348,91 @@ class KerasH5Scanner(BaseScanner):
         if any(str(key).lower() in cls._KERAS_WEIGHT_ROOT_GROUPS for key in h5_file):
             return True
 
-        if any(str(key).lower() in cls._KERAS_WEIGHT_ROOT_ATTRS for key in h5_file.attrs):
+        if cls._has_legacy_weights_layout(h5_file):
             return True
 
         return Path(path).name.lower().endswith(".weights.h5") and cls._has_keras3_weights_layout(h5_file)
 
-    @staticmethod
-    def _has_keras3_weights_layout(h5_file: Any) -> bool:
+    @classmethod
+    def _has_legacy_weights_layout(cls, h5_file: Any) -> bool:
+        layer_names = cls._decode_hdf5_names(h5_file.attrs.get("layer_names"))
+        if not layer_names:
+            return False
+
+        for layer_name in layer_names:
+            link = h5_file.get(layer_name, getlink=True)
+            if isinstance(link, h5py.ExternalLink):
+                return True
+            if not isinstance(link, h5py.HardLink):
+                continue
+
+            layer = h5_file.get(layer_name, getlink=False)
+            if isinstance(layer, h5py.Group) and "weight_names" in layer.attrs:
+                return True
+
+        return False
+
+    @classmethod
+    def _has_keras3_weights_layout(cls, h5_file: Any) -> bool:
         """Detect Keras 3 H5IOStore weights-only layouts without generic HDF5 overreach."""
-        if "vars" in h5_file:
+        if cls._has_group_or_external_link(h5_file, "vars"):
             return True
 
-        layers = h5_file.get("layers")
+        layers_link = h5_file.get("layers", getlink=True)
+        if isinstance(layers_link, h5py.ExternalLink):
+            return True
+        if not isinstance(layers_link, h5py.HardLink):
+            return False
+
+        layers = h5_file.get("layers", getlink=False)
         if not isinstance(layers, h5py.Group):
             return False
 
-        return any(isinstance(layer, h5py.Group) and "vars" in layer for layer in layers.values())
+        for layer_name in layers:
+            layer_link = layers.get(layer_name, getlink=True)
+            if isinstance(layer_link, h5py.ExternalLink):
+                return True
+            if not isinstance(layer_link, h5py.HardLink):
+                continue
+
+            layer = layers.get(layer_name, getlink=False)
+            if isinstance(layer, h5py.Group) and cls._has_group_or_external_link(layer, "vars"):
+                return True
+
+        return False
+
+    @staticmethod
+    def _has_group_or_external_link(group: Any, name: str) -> bool:
+        link = group.get(name, getlink=True)
+        if isinstance(link, h5py.ExternalLink):
+            return True
+        if not isinstance(link, h5py.HardLink):
+            return False
+        return isinstance(group.get(name, getlink=False), h5py.Group)
+
+    @staticmethod
+    def _decode_hdf5_names(value: Any) -> list[str]:
+        if value is None:
+            return []
+        if hasattr(value, "tolist"):
+            value = value.tolist()
+        if isinstance(value, bytes):
+            return [value.decode("utf-8", errors="ignore")]
+        if isinstance(value, str):
+            return [value]
+
+        try:
+            items = list(value)
+        except TypeError:
+            items = [value]
+
+        names = []
+        for item in items:
+            if isinstance(item, bytes):
+                names.append(item.decode("utf-8", errors="ignore"))
+            elif isinstance(item, str):
+                names.append(item)
+        return [name for name in names if name]
 
     def _check_hdf5_external_references(self, h5_file: Any, result: ScanResult, source_path: str) -> None:
         """Detect HDF5 external links/storage before any Keras-specific parsing short-circuits."""

--- a/modelaudit/scanners/keras_h5_scanner.py
+++ b/modelaudit/scanners/keras_h5_scanner.py
@@ -356,22 +356,7 @@ class KerasH5Scanner(BaseScanner):
         if any(str(key).lower() in cls._WEIGHTS_LIKE_ROOT_KEYS for key in h5_file):
             return True
 
-        if any(str(key).lower() in cls._WEIGHTS_LIKE_ROOT_KEYS for key in h5_file.attrs):
-            return True
-
-        found_weight_metadata = False
-
-        def visit(name: str, _obj: Any) -> None:
-            nonlocal found_weight_metadata
-            if found_weight_metadata:
-                return
-            normalized_parts = {part.lower() for part in name.replace("\\", "/").split("/") if part}
-            if normalized_parts & cls._WEIGHTS_LIKE_ROOT_KEYS:
-                found_weight_metadata = True
-
-        with suppress(Exception):
-            h5_file.visititems(visit)
-        return found_weight_metadata
+        return any(str(key).lower() in cls._WEIGHTS_LIKE_ROOT_KEYS for key in h5_file.attrs)
 
     def _check_hdf5_external_references(self, h5_file: Any, result: ScanResult, source_path: str) -> None:
         """Detect HDF5 external links/storage before any Keras-specific parsing short-circuits."""

--- a/modelaudit/scanners/keras_h5_scanner.py
+++ b/modelaudit/scanners/keras_h5_scanner.py
@@ -85,17 +85,8 @@ class KerasH5Scanner(BaseScanner):
             "system",
         }
     )
-    _WEIGHTS_LIKE_ROOT_KEYS: ClassVar[frozenset[str]] = frozenset(
-        {
-            "layer_names",
-            "layers",
-            "model_weights",
-            "optimizer_weights",
-            "vars",
-            "weights",
-            "weight_names",
-        }
-    )
+    _KERAS_WEIGHT_ROOT_GROUPS: ClassVar[frozenset[str]] = frozenset({"model_weights", "optimizer_weights"})
+    _KERAS_WEIGHT_ROOT_ATTRS: ClassVar[frozenset[str]] = frozenset({"layer_names", "weight_names"})
     _MODEL_CONTAINER_CLASSES: ClassVar[frozenset[str]] = frozenset({"Model", "Functional", "Sequential"})
     _WRAPPED_LAYER_SCAN_MODEL: ClassVar[dict[str, Any]] = {"class_name": "Sequential", "config": {"layers": []}}
 
@@ -353,10 +344,10 @@ class KerasH5Scanner(BaseScanner):
     @classmethod
     def _has_weights_like_hdf5_layout(cls, h5_file: Any) -> bool:
         """Return True for HDF5 layouts that resemble Keras weights-only files."""
-        if any(str(key).lower() in cls._WEIGHTS_LIKE_ROOT_KEYS for key in h5_file):
+        if any(str(key).lower() in cls._KERAS_WEIGHT_ROOT_GROUPS for key in h5_file):
             return True
 
-        return any(str(key).lower() in cls._WEIGHTS_LIKE_ROOT_KEYS for key in h5_file.attrs)
+        return any(str(key).lower() in cls._KERAS_WEIGHT_ROOT_ATTRS for key in h5_file.attrs)
 
     def _check_hdf5_external_references(self, h5_file: Any, result: ScanResult, source_path: str) -> None:
         """Detect HDF5 external links/storage before any Keras-specific parsing short-circuits."""

--- a/modelaudit/scanners/keras_h5_scanner.py
+++ b/modelaudit/scanners/keras_h5_scanner.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 from contextlib import suppress
+from pathlib import Path
 from typing import Any, ClassVar
 
 from modelaudit.detectors.suspicious_symbols import (
@@ -175,7 +176,7 @@ class KerasH5Scanner(BaseScanner):
                 if (
                     "model_config" in f.attrs
                     or "keras_version" in result.metadata
-                    or self._has_weights_like_hdf5_layout(f)
+                    or self._has_weights_like_hdf5_layout(f, path)
                 ):
                     self._check_hdf5_external_references(f, result, path)
 
@@ -342,12 +343,27 @@ class KerasH5Scanner(BaseScanner):
             return self._JSON_ATTRIBUTE_PARSE_FAILED
 
     @classmethod
-    def _has_weights_like_hdf5_layout(cls, h5_file: Any) -> bool:
+    def _has_weights_like_hdf5_layout(cls, h5_file: Any, path: str) -> bool:
         """Return True for HDF5 layouts that resemble Keras weights-only files."""
         if any(str(key).lower() in cls._KERAS_WEIGHT_ROOT_GROUPS for key in h5_file):
             return True
 
-        return any(str(key).lower() in cls._KERAS_WEIGHT_ROOT_ATTRS for key in h5_file.attrs)
+        if any(str(key).lower() in cls._KERAS_WEIGHT_ROOT_ATTRS for key in h5_file.attrs):
+            return True
+
+        return Path(path).name.lower().endswith(".weights.h5") and cls._has_keras3_weights_layout(h5_file)
+
+    @staticmethod
+    def _has_keras3_weights_layout(h5_file: Any) -> bool:
+        """Detect Keras 3 H5IOStore weights-only layouts without generic HDF5 overreach."""
+        if "vars" in h5_file:
+            return True
+
+        layers = h5_file.get("layers")
+        if not isinstance(layers, h5py.Group):
+            return False
+
+        return any(isinstance(layer, h5py.Group) and "vars" in layer for layer in layers.values())
 
     def _check_hdf5_external_references(self, h5_file: Any, result: ScanResult, source_path: str) -> None:
         """Detect HDF5 external links/storage before any Keras-specific parsing short-circuits."""

--- a/modelaudit/scanners/keras_h5_scanner.py
+++ b/modelaudit/scanners/keras_h5_scanner.py
@@ -85,6 +85,17 @@ class KerasH5Scanner(BaseScanner):
             "system",
         }
     )
+    _WEIGHTS_LIKE_ROOT_KEYS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "layer_names",
+            "layers",
+            "model_weights",
+            "optimizer_weights",
+            "vars",
+            "weights",
+            "weight_names",
+        }
+    )
     _MODEL_CONTAINER_CLASSES: ClassVar[frozenset[str]] = frozenset({"Model", "Functional", "Sequential"})
     _WRAPPED_LAYER_SCAN_MODEL: ClassVar[dict[str, Any]] = {"class_name": "Sequential", "config": {"layers": []}}
 
@@ -167,9 +178,14 @@ class KerasH5Scanner(BaseScanner):
                 if isinstance(keras_version_attr, str) and keras_version_attr.strip():
                     result.metadata["keras_version"] = keras_version_attr.strip()
 
-                # CVE-2026-1669 only applies to Keras weight loading. Skip generic HDF5
-                # files to avoid warning on benign non-Keras artifacts.
-                if "model_config" in f.attrs or "keras_version" in result.metadata:
+                # CVE-2026-1669 applies to weight loading too. Inspect full
+                # Keras files and weights-like HDF5 layouts while leaving
+                # unrelated generic HDF5 artifacts quiet.
+                if (
+                    "model_config" in f.attrs
+                    or "keras_version" in result.metadata
+                    or self._has_weights_like_hdf5_layout(f)
+                ):
                     self._check_hdf5_external_references(f, result, path)
 
                 # Check if this is a Keras model file
@@ -333,6 +349,29 @@ class KerasH5Scanner(BaseScanner):
                 rule_code="S902",
             )
             return self._JSON_ATTRIBUTE_PARSE_FAILED
+
+    @classmethod
+    def _has_weights_like_hdf5_layout(cls, h5_file: Any) -> bool:
+        """Return True for HDF5 layouts that resemble Keras weights-only files."""
+        if any(str(key).lower() in cls._WEIGHTS_LIKE_ROOT_KEYS for key in h5_file):
+            return True
+
+        if any(str(key).lower() in cls._WEIGHTS_LIKE_ROOT_KEYS for key in h5_file.attrs):
+            return True
+
+        found_weight_metadata = False
+
+        def visit(name: str, _obj: Any) -> None:
+            nonlocal found_weight_metadata
+            if found_weight_metadata:
+                return
+            normalized_parts = {part.lower() for part in name.replace("\\", "/").split("/") if part}
+            if normalized_parts & cls._WEIGHTS_LIKE_ROOT_KEYS:
+                found_weight_metadata = True
+
+        with suppress(Exception):
+            h5_file.visititems(visit)
+        return found_weight_metadata
 
     def _check_hdf5_external_references(self, h5_file: Any, result: ScanResult, source_path: str) -> None:
         """Detect HDF5 external links/storage before any Keras-specific parsing short-circuits."""

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -624,6 +624,32 @@ def test_keras_h5_scanner_skips_generic_hdf5_external_links_without_keras_metada
     assert not any(issue.severity in (IssueSeverity.WARNING, IssueSeverity.CRITICAL) for issue in result.issues)
 
 
+def test_keras_h5_scanner_flags_weights_only_external_link_without_keras_metadata(tmp_path: Path) -> None:
+    """Weights-only HDF5 files can still be Keras load inputs and must not skip external references."""
+    external_source = tmp_path / "external_source.h5"
+    with h5py.File(external_source, "w") as f:
+        f.create_dataset("payload", data=[1.0])
+
+    weights_path = tmp_path / "weights_only.h5"
+    with h5py.File(weights_path, "w") as f:
+        f["weights"] = h5py.ExternalLink(external_source.name, "/payload")
+
+    result = KerasH5Scanner().scan(str(weights_path))
+
+    cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2026-1669"]
+    assert len(cve_issues) == 1
+    assert cve_issues[0].severity == IssueSeverity.WARNING
+    assert cve_issues[0].details["parse_status"] == "unknown"
+    assert cve_issues[0].details["external_references"] == [
+        {
+            "kind": "ExternalLink",
+            "hdf5_path": "/weights",
+            "filename": "external_source.h5",
+            "path": "/payload",
+        },
+    ]
+
+
 def test_keras_h5_scanner_malicious_model(tmp_path):
     """Test scanning a malicious Keras H5 model."""
     model_path = create_mock_h5_file(tmp_path, malicious=True)

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -624,6 +624,20 @@ def test_keras_h5_scanner_skips_generic_hdf5_external_links_without_keras_metada
     assert not any(issue.severity in (IssueSeverity.WARNING, IssueSeverity.CRITICAL) for issue in result.issues)
 
 
+def test_keras_h5_scanner_skips_generic_nested_weight_like_groups(tmp_path: Path) -> None:
+    """Nested generic groups named vars/weights must not imply a Keras weights file."""
+    generic_path = tmp_path / "generic_nested.h5"
+    with h5py.File(generic_path, "w") as f:
+        experiment_vars = f.create_group("experiment").create_group("vars")
+        experiment_vars["linked"] = h5py.ExternalLink("external_source.h5", "/payload")
+
+    result = KerasH5Scanner().scan(str(generic_path))
+
+    assert result.success is True
+    assert not any(issue.details.get("cve_id") == "CVE-2026-1669" for issue in result.issues)
+    assert not any(issue.severity in (IssueSeverity.WARNING, IssueSeverity.CRITICAL) for issue in result.issues)
+
+
 def test_keras_h5_scanner_flags_weights_only_external_link_without_keras_metadata(tmp_path: Path) -> None:
     """Weights-only HDF5 files can still be Keras load inputs and must not skip external references."""
     external_source = tmp_path / "external_source.h5"

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -651,6 +651,21 @@ def test_keras_h5_scanner_skips_generic_root_weight_like_groups(tmp_path: Path) 
     assert not any(issue.severity in (IssueSeverity.WARNING, IssueSeverity.CRITICAL) for issue in result.issues)
 
 
+def test_keras_h5_scanner_skips_generic_layer_names_attr_without_weight_groups(tmp_path: Path) -> None:
+    """Generic HDF5 metadata named layer_names is not enough for Keras attribution."""
+    generic_path = tmp_path / "generic_layer_names.h5"
+    with h5py.File(generic_path, "w") as f:
+        f.attrs["layer_names"] = [b"experiment"]
+        f.create_group("experiment")
+        f["linked"] = h5py.ExternalLink("external_source.h5", "/payload")
+
+    result = KerasH5Scanner().scan(str(generic_path))
+
+    assert result.success is True
+    assert not any(issue.details.get("cve_id") == "CVE-2026-1669" for issue in result.issues)
+    assert not any(issue.severity in (IssueSeverity.WARNING, IssueSeverity.CRITICAL) for issue in result.issues)
+
+
 def test_keras_h5_scanner_flags_weights_only_external_link_without_keras_metadata(tmp_path: Path) -> None:
     """Weights-only HDF5 files can still be Keras load inputs and must not skip external references."""
     external_source = tmp_path / "external_source.h5"
@@ -701,6 +716,27 @@ def test_keras_h5_scanner_flags_keras3_weights_external_link_without_legacy_attr
             "kind": "ExternalLink",
             "hdf5_path": "/layers/dense/vars/0",
             "filename": "external_source.h5",
+            "path": "/payload",
+        },
+    ]
+
+
+def test_keras_h5_scanner_flags_keras3_weights_external_link_without_resolving_it(tmp_path: Path) -> None:
+    """Keras 3 layout probing should not follow attacker-controlled external links."""
+    weights_path = tmp_path / "model.weights.h5"
+    with h5py.File(weights_path, "w") as f:
+        layers = f.create_group("layers")
+        layers["dense"] = h5py.ExternalLink("missing_external_source.h5", "/payload")
+
+    result = KerasH5Scanner().scan(str(weights_path))
+
+    cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2026-1669"]
+    assert len(cve_issues) == 1
+    assert cve_issues[0].details["external_references"] == [
+        {
+            "kind": "ExternalLink",
+            "hdf5_path": "/layers/dense",
+            "filename": "missing_external_source.h5",
             "path": "/payload",
         },
     ]

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -638,6 +638,19 @@ def test_keras_h5_scanner_skips_generic_nested_weight_like_groups(tmp_path: Path
     assert not any(issue.severity in (IssueSeverity.WARNING, IssueSeverity.CRITICAL) for issue in result.issues)
 
 
+def test_keras_h5_scanner_skips_generic_root_weight_like_groups(tmp_path: Path) -> None:
+    """Generic root vars/weights groups are common outside Keras and should stay quiet."""
+    generic_path = tmp_path / "generic_root_vars.h5"
+    with h5py.File(generic_path, "w") as f:
+        f["vars"] = h5py.ExternalLink("external_source.h5", "/payload")
+
+    result = KerasH5Scanner().scan(str(generic_path))
+
+    assert result.success is True
+    assert not any(issue.details.get("cve_id") == "CVE-2026-1669" for issue in result.issues)
+    assert not any(issue.severity in (IssueSeverity.WARNING, IssueSeverity.CRITICAL) for issue in result.issues)
+
+
 def test_keras_h5_scanner_flags_weights_only_external_link_without_keras_metadata(tmp_path: Path) -> None:
     """Weights-only HDF5 files can still be Keras load inputs and must not skip external references."""
     external_source = tmp_path / "external_source.h5"
@@ -646,7 +659,10 @@ def test_keras_h5_scanner_flags_weights_only_external_link_without_keras_metadat
 
     weights_path = tmp_path / "weights_only.h5"
     with h5py.File(weights_path, "w") as f:
-        f["weights"] = h5py.ExternalLink(external_source.name, "/payload")
+        f.attrs["layer_names"] = [b"dense"]
+        dense = f.create_group("dense")
+        dense.attrs["weight_names"] = [b"kernel:0"]
+        dense["kernel:0"] = h5py.ExternalLink(external_source.name, "/payload")
 
     result = KerasH5Scanner().scan(str(weights_path))
 
@@ -657,7 +673,7 @@ def test_keras_h5_scanner_flags_weights_only_external_link_without_keras_metadat
     assert cve_issues[0].details["external_references"] == [
         {
             "kind": "ExternalLink",
-            "hdf5_path": "/weights",
+            "hdf5_path": "/dense/kernel:0",
             "filename": "external_source.h5",
             "path": "/payload",
         },

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -680,6 +680,32 @@ def test_keras_h5_scanner_flags_weights_only_external_link_without_keras_metadat
     ]
 
 
+def test_keras_h5_scanner_flags_keras3_weights_external_link_without_legacy_attrs(tmp_path: Path) -> None:
+    """Keras 3 .weights.h5 files use layers/*/vars rather than legacy attrs."""
+    external_source = tmp_path / "external_source.h5"
+    with h5py.File(external_source, "w") as f:
+        f.create_dataset("payload", data=[1.0])
+
+    weights_path = tmp_path / "model.weights.h5"
+    with h5py.File(weights_path, "w") as f:
+        vars_group = f.create_group("layers").create_group("dense").create_group("vars")
+        vars_group["0"] = h5py.ExternalLink(external_source.name, "/payload")
+
+    result = KerasH5Scanner().scan(str(weights_path))
+
+    cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2026-1669"]
+    assert len(cve_issues) == 1
+    assert cve_issues[0].details["parse_status"] == "unknown"
+    assert cve_issues[0].details["external_references"] == [
+        {
+            "kind": "ExternalLink",
+            "hdf5_path": "/layers/dense/vars/0",
+            "filename": "external_source.h5",
+            "path": "/payload",
+        },
+    ]
+
+
 def test_keras_h5_scanner_malicious_model(tmp_path):
     """Test scanning a malicious Keras H5 model."""
     model_path = create_mock_h5_file(tmp_path, malicious=True)


### PR DESCRIPTION
## Summary

- detect HDF5 external references in weights-only Keras-like layouts without requiring `model_config` or `keras_version`
- keep generic HDF5 files without Keras/weights markers quiet
- add a regression for weights-only external links

## Validation

- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/python -m pytest tests/scanners/test_keras_h5_scanner.py -q`
- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/ruff format --check modelaudit/scanners/keras_h5_scanner.py tests/scanners/test_keras_h5_scanner.py`
- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/ruff check modelaudit/scanners/keras_h5_scanner.py tests/scanners/test_keras_h5_scanner.py`
- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/mypy modelaudit/scanners/keras_h5_scanner.py tests/scanners/test_keras_h5_scanner.py`
