### PR TITLE
fix: restrict JFrog credential forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- restrict JFrog credential forwarding to explicitly trusted HTTPS hosts
 - route renamed structured JAX/Orbax JSON checkpoints, conservatively report observable bounded-prefix threats, and fail closed for oversized identified metadata
 - classify Flax MessagePack recursion-limit analysis gaps as inconclusive coverage
 - classify incomplete JAX/Orbax metadata, pickle, and NumPy analysis as inconclusive coverage

--- a/modelaudit/utils/sources/jfrog.py
+++ b/modelaudit/utils/sources/jfrog.py
@@ -217,12 +217,12 @@ def _build_jfrog_auth_headers(
     if api_token:
         return {"X-JFrog-Art-Api": api_token}
 
+    if access_token:
+        return {"Authorization": f"Bearer {access_token}"}
+
     env_api_token = os.getenv("JFROG_API_TOKEN")
     if env_api_token:
         return {"X-JFrog-Art-Api": env_api_token}
-
-    if access_token:
-        return {"Authorization": f"Bearer {access_token}"}
 
     env_access_token = os.getenv("JFROG_ACCESS_TOKEN")
     if env_access_token:

--- a/modelaudit/utils/sources/jfrog.py
+++ b/modelaudit/utils/sources/jfrog.py
@@ -135,32 +135,44 @@ class JFrogFolderInfo(TypedDict):
 def is_jfrog_url(url: str) -> bool:
     """Check if a URL points to a JFrog Artifactory file or folder."""
     parsed = urlparse(url)
-    if parsed.scheme not in {"http", "https"}:
+    hostname = _normalize_hostname(parsed.hostname or "")
+    if parsed.scheme != "https" and not (parsed.scheme == "http" and _is_local_jfrog_host(hostname)):
         return False
-    hostname = (parsed.hostname or "").lower()
     if "/artifactory/" not in parsed.path:
         return False
-    return _is_trusted_jfrog_host(hostname)
+    return _is_jfrog_service_host(hostname) or hostname in _get_trusted_jfrog_hosts()
+
+
+def _normalize_hostname(hostname: str) -> str:
+    return hostname.strip().lower().rstrip(".")
+
+
+def _host_from_config_value(value: str) -> str:
+    """Normalize a configured host or base URL value to a hostname."""
+    candidate = value.strip()
+    if not candidate:
+        return ""
+
+    parsed = urlparse(candidate if "://" in candidate else f"//{candidate}")
+    return _normalize_hostname(parsed.hostname or candidate.split("/", 1)[0].split(":", 1)[0])
 
 
 def _get_trusted_jfrog_hosts() -> set[str]:
     """Return explicitly allowlisted JFrog hosts.
 
-    MODELAUDIT_JFROG_ALLOWED_HOSTS accepts a comma-separated list of hostnames.
+    MODELAUDIT_JFROG_ALLOWED_HOSTS accepts a comma-separated list of hostnames
+    or JFrog base URLs.
     This keeps automatic credential forwarding opt-in for self-hosted JFrog
     instances while rejecting arbitrary lookalike URLs.
     """
     raw_hosts = os.getenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "")
-    return {host.strip().lower() for host in raw_hosts.split(",") if host.strip()}
+    return {host for host in (_host_from_config_value(value) for value in raw_hosts.split(",")) if host}
 
 
-def _is_trusted_jfrog_host(hostname: str) -> bool:
-    """Return True when a hostname is trusted for JFrog authentication."""
+def _is_local_jfrog_host(hostname: str) -> bool:
+    """Return True when a hostname is local-only development infrastructure."""
     if not hostname:
         return False
-
-    if hostname == "jfrog.io" or hostname.endswith(".jfrog.io"):
-        return True
 
     if hostname == "localhost":
         return True
@@ -170,10 +182,53 @@ def _is_trusted_jfrog_host(hostname: str) -> bool:
     except ValueError:
         parsed_ip = None
 
-    if parsed_ip is not None and parsed_ip.is_loopback:
-        return True
+    return parsed_ip is not None and parsed_ip.is_loopback
 
-    return hostname in _get_trusted_jfrog_hosts()
+
+def _is_jfrog_service_host(hostname: str) -> bool:
+    return hostname == "jfrog.io" or hostname.endswith(".jfrog.io") or _is_local_jfrog_host(hostname)
+
+
+def _is_trusted_jfrog_auth_target(url: str) -> bool:
+    """Return True when credentials may be sent to this JFrog URL."""
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        return False
+
+    hostname = _normalize_hostname(parsed.hostname or "")
+    return bool(hostname and hostname in _get_trusted_jfrog_hosts())
+
+
+def _build_jfrog_auth_headers(
+    url: str,
+    *,
+    api_token: str | None,
+    access_token: str | None,
+) -> dict[str, str]:
+    """Build JFrog auth headers only for explicitly trusted HTTPS hosts."""
+    if not _is_trusted_jfrog_auth_target(url):
+        if api_token or access_token or os.getenv("JFROG_API_TOKEN") or os.getenv("JFROG_ACCESS_TOKEN"):
+            logger.warning(
+                "Skipping JFrog credentials for untrusted or insecure URL %s",
+                redact_jfrog_url_for_display(url),
+            )
+        return {}
+
+    if api_token:
+        return {"X-JFrog-Art-Api": api_token}
+
+    env_api_token = os.getenv("JFROG_API_TOKEN")
+    if env_api_token:
+        return {"X-JFrog-Art-Api": env_api_token}
+
+    if access_token:
+        return {"Authorization": f"Bearer {access_token}"}
+
+    env_access_token = os.getenv("JFROG_ACCESS_TOKEN")
+    if env_access_token:
+        return {"Authorization": f"Bearer {env_access_token}"}
+
+    return {}
 
 
 def download_artifact(
@@ -220,25 +275,7 @@ def download_artifact(
         dest_path = cache_dir / filename
         dest_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Prepare authentication headers
-    headers = {}
-
-    # 1. Check for API token (highest precedence)
-    if api_token:
-        headers["X-JFrog-Art-Api"] = api_token
-    else:
-        env_api_token = os.getenv("JFROG_API_TOKEN")
-        if env_api_token:
-            headers["X-JFrog-Art-Api"] = env_api_token
-
-    # 2. Check for access token (only if API token not found)
-    if "X-JFrog-Art-Api" not in headers:
-        if access_token:
-            headers["Authorization"] = f"Bearer {access_token}"
-        else:
-            env_access_token = os.getenv("JFROG_ACCESS_TOKEN")
-            if env_access_token:
-                headers["Authorization"] = f"Bearer {env_access_token}"
+    headers = _build_jfrog_auth_headers(url, api_token=api_token, access_token=access_token)
 
     # If no authentication is provided, proceed without auth (for public repos)
     if not headers:
@@ -394,21 +431,7 @@ def detect_jfrog_target_type(
     storage_api_url = get_storage_api_url(url)
     display_storage_api_url = redact_jfrog_url_for_display(storage_api_url)
 
-    # Prepare authentication headers
-    headers = {}
-    if api_token:
-        headers["X-JFrog-Art-Api"] = api_token
-    elif access_token:
-        headers["Authorization"] = f"Bearer {access_token}"
-    else:
-        # Check environment variables
-        env_api_token = os.getenv("JFROG_API_TOKEN")
-        if env_api_token:
-            headers["X-JFrog-Art-Api"] = env_api_token
-        else:
-            env_access_token = os.getenv("JFROG_ACCESS_TOKEN")
-            if env_access_token:
-                headers["Authorization"] = f"Bearer {env_access_token}"
+    headers = _build_jfrog_auth_headers(storage_api_url, api_token=api_token, access_token=access_token)
 
     try:
         response = requests.get(storage_api_url, headers=headers, timeout=timeout)

--- a/tests/integrations/test_jfrog.py
+++ b/tests/integrations/test_jfrog.py
@@ -36,6 +36,7 @@ class TestJFrogURLDetection:
             "https://example.com/model",
             "https://evil.example/artifactory/repo/model.bin",
             "https://my-jfrog.com/artifactory/libs-release/model.pt",
+            "http://attacker.jfrog.io/artifactory/repo/model.bin",
             "hf://model",
             "",
         ]
@@ -61,11 +62,12 @@ class TestJFrogDownload:
         assert "fragment" not in redacted
 
     @patch("modelaudit.utils.sources.jfrog.requests.get")
-    def test_download_success(self, mock_get, tmp_path):
+    def test_download_success(self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         # Mock successful response
         mock_response = mock_get.return_value
         mock_response.raise_for_status.return_value = None
         mock_response.iter_content.return_value = [b"data"]
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
 
         result = download_artifact(
             "https://company.jfrog.io/artifactory/repo/model.bin", cache_dir=tmp_path, api_token="test-token"
@@ -94,11 +96,12 @@ class TestJFrogDownload:
         mock_rmtree.assert_called()
 
     @patch("modelaudit.utils.sources.jfrog.requests.get")
-    def test_authentication_methods(self, mock_get, tmp_path):
+    def test_authentication_methods(self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test different authentication methods."""
         mock_response = mock_get.return_value
         mock_response.raise_for_status.return_value = None
         mock_response.iter_content.return_value = [b"data"]
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
 
         # Test API token
         download_artifact(
@@ -115,11 +118,12 @@ class TestJFrogDownload:
         assert call_args[1]["headers"]["Authorization"] == "Bearer test-access-token"
 
     @patch("modelaudit.utils.sources.jfrog.requests.get")
-    def test_environment_variables(self, mock_get, tmp_path, monkeypatch):
+    def test_environment_variables(self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test authentication via environment variables."""
         mock_response = mock_get.return_value
         mock_response.raise_for_status.return_value = None
         mock_response.iter_content.return_value = [b"data"]
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
 
         # Test JFROG_API_TOKEN
         monkeypatch.setenv("JFROG_API_TOKEN", "env-api-token")
@@ -133,6 +137,61 @@ class TestJFrogDownload:
         download_artifact("https://company.jfrog.io/artifactory/repo/model.bin", cache_dir=tmp_path)
         call_args = mock_get.call_args
         assert call_args[1]["headers"]["Authorization"] == "Bearer env-access-token"
+
+    @patch("modelaudit.utils.sources.jfrog.requests.get")
+    def test_unconfigured_jfrog_host_receives_no_credentials(
+        self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Credentials should not be sent to arbitrary JFrog SaaS tenants."""
+        mock_response = mock_get.return_value
+        mock_response.raise_for_status.return_value = None
+        mock_response.iter_content.return_value = [b"data"]
+        monkeypatch.setenv("JFROG_API_TOKEN", "env-api-token")
+        monkeypatch.setenv("JFROG_ACCESS_TOKEN", "env-access-token")
+
+        with caplog.at_level(logging.WARNING, logger="modelaudit.utils.sources.jfrog"):
+            download_artifact(
+                "https://attacker.jfrog.io/artifactory/repo/model.bin",
+                cache_dir=tmp_path,
+                api_token="explicit-api-token",
+                access_token="explicit-access-token",
+            )
+
+        call_args = mock_get.call_args
+        assert call_args[1]["headers"] == {}
+        assert "Skipping JFrog credentials" in caplog.text
+        assert "explicit-api-token" not in caplog.text
+        assert "env-api-token" not in caplog.text
+
+    @patch("modelaudit.utils.sources.jfrog.requests.get")
+    def test_http_jfrog_saas_url_is_rejected_before_credentials(
+        self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-local HTTP JFrog URLs must not receive credentials."""
+        monkeypatch.setenv("JFROG_API_TOKEN", "env-api-token")
+
+        with pytest.raises(ValueError, match="Not a JFrog URL"):
+            download_artifact("http://attacker.jfrog.io/artifactory/repo/model.bin", cache_dir=tmp_path)
+
+        mock_get.assert_not_called()
+
+    @patch("modelaudit.utils.sources.jfrog.requests.get")
+    def test_storage_api_skips_credentials_for_unconfigured_host(
+        self, mock_get: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Storage API probing should share the same credential forwarding policy."""
+        mock_response = mock_get.return_value
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"repo": "public-repo", "path": "/model.bin", "size": 12}
+        monkeypatch.setenv("JFROG_API_TOKEN", "env-api-token")
+
+        result = detect_jfrog_target_type(
+            "https://attacker.jfrog.io/artifactory/repo/model.bin",
+            api_token="explicit-api-token",
+        )
+
+        assert result["type"] == "file"
+        assert mock_get.call_args[1]["headers"] == {}
 
     @patch("modelaudit.utils.sources.jfrog.requests.get")
     def test_no_authentication(self, mock_get, tmp_path, caplog):

--- a/tests/integrations/test_jfrog.py
+++ b/tests/integrations/test_jfrog.py
@@ -118,6 +118,26 @@ class TestJFrogDownload:
         assert call_args[1]["headers"]["Authorization"] == "Bearer test-access-token"
 
     @patch("modelaudit.utils.sources.jfrog.requests.get")
+    def test_explicit_access_token_precedes_environment_api_token(
+        self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Explicit caller credentials should not be shadowed by ambient env tokens."""
+        mock_response = mock_get.return_value
+        mock_response.raise_for_status.return_value = None
+        mock_response.iter_content.return_value = [b"data"]
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+        monkeypatch.setenv("JFROG_API_TOKEN", "env-api-token")
+
+        download_artifact(
+            "https://company.jfrog.io/artifactory/repo/model.bin",
+            cache_dir=tmp_path,
+            access_token="explicit-access-token",
+        )
+
+        call_args = mock_get.call_args
+        assert call_args[1]["headers"] == {"Authorization": "Bearer explicit-access-token"}
+
+    @patch("modelaudit.utils.sources.jfrog.requests.get")
     def test_environment_variables(self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test authentication via environment variables."""
         mock_response = mock_get.return_value
@@ -192,6 +212,25 @@ class TestJFrogDownload:
 
         assert result["type"] == "file"
         assert mock_get.call_args[1]["headers"] == {}
+
+    @patch("modelaudit.utils.sources.jfrog.requests.get")
+    def test_storage_api_explicit_access_token_precedes_environment_api_token(
+        self, mock_get: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Explicit Storage API access tokens should not be shadowed by env API tokens."""
+        mock_response = mock_get.return_value
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"repo": "repo", "path": "/model.bin", "size": 12}
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+        monkeypatch.setenv("JFROG_API_TOKEN", "env-api-token")
+
+        result = detect_jfrog_target_type(
+            "https://company.jfrog.io/artifactory/repo/model.bin",
+            access_token="explicit-access-token",
+        )
+
+        assert result["type"] == "file"
+        assert mock_get.call_args[1]["headers"] == {"Authorization": "Bearer explicit-access-token"}
 
     @patch("modelaudit.utils.sources.jfrog.requests.get")
     def test_no_authentication(self, mock_get, tmp_path, caplog):


### PR DESCRIPTION
## Summary

- only forward JFrog credentials to explicitly configured HTTPS hosts
- reject non-local HTTP JFrog artifact URLs before requests are made
- share the credential policy between artifact downloads and Storage API probing

## Validation

- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/python -m pytest tests/integrations/test_jfrog.py -q`
- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/ruff check modelaudit/utils/sources/jfrog.py tests/integrations/test_jfrog.py`
- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/mypy modelaudit/utils/sources/jfrog.py tests/integrations/test_jfrog.py`
