### PR TITLE
fix: preflight 7z extraction budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- preflight and stream-enforce cumulative SevenZip extraction budgets before writing oversized archives
 - route renamed structured JAX/Orbax JSON checkpoints, conservatively report observable bounded-prefix threats, and fail closed for oversized identified metadata
 - classify Flax MessagePack recursion-limit analysis gaps as inconclusive coverage
 - classify incomplete JAX/Orbax metadata, pickle, and NumPy analysis as inconclusive coverage

--- a/modelaudit/scanners/sevenzip_scanner.py
+++ b/modelaudit/scanners/sevenzip_scanner.py
@@ -904,7 +904,6 @@ class SevenZipScanner(BaseScanner):
         projected_cumulative_bytes = budget.cumulative_extract_bytes + known_extract_bytes
         if known_extract_bytes > 0 and projected_cumulative_bytes > self.max_total_extract_size:
             budget.abort_due_to_limit()
-            scan_complete = False
             self._add_cumulative_extraction_size_check(
                 result,
                 archive_path,

--- a/modelaudit/scanners/sevenzip_scanner.py
+++ b/modelaudit/scanners/sevenzip_scanner.py
@@ -36,6 +36,26 @@ class _HeaderProbeComplete(Exception):
     """Internal signal used to stop a header probe once enough bytes are captured."""
 
 
+class _ExtractionBudgetExceeded(Exception):
+    """Internal signal used to abort extraction before a configured byte budget is exceeded."""
+
+    def __init__(
+        self,
+        file_name: str,
+        *,
+        cumulative_bytes: int,
+        total_limit: int,
+        file_bytes: int,
+        file_limit: int,
+    ) -> None:
+        super().__init__(f"Extraction budget exceeded while extracting {file_name}")
+        self.file_name = file_name
+        self.cumulative_bytes = cumulative_bytes
+        self.total_limit = total_limit
+        self.file_bytes = file_bytes
+        self.file_limit = file_limit
+
+
 class _HeaderProbeBuffer:
     def __init__(self, limit: int, *, raise_on_limit: bool = True) -> None:
         self._limit = limit
@@ -78,6 +98,92 @@ class _HeaderProbeFactory:
 
     def get(self, filename: str) -> _HeaderProbeBuffer | None:
         return self.products.get(filename)
+
+
+class _BudgetedExtractionFile:
+    def __init__(
+        self,
+        path: Path,
+        file_name: str,
+        *,
+        budget: "_RecursiveScanBudget",
+        max_file_size: int,
+        max_total_size: int,
+    ) -> None:
+        self._file = path.open("wb")
+        self._file_name = file_name
+        self._budget = budget
+        self._max_file_size = max_file_size
+        self._max_total_size = max_total_size
+        self._written = 0
+
+    def write(self, data: bytes | bytearray) -> int:
+        chunk_size = len(data)
+        projected_file_size = self._written + chunk_size
+        projected_total_size = self._budget.cumulative_extract_bytes + chunk_size
+        if projected_file_size > self._max_file_size or projected_total_size > self._max_total_size:
+            raise _ExtractionBudgetExceeded(
+                self._file_name,
+                cumulative_bytes=projected_total_size,
+                total_limit=self._max_total_size,
+                file_bytes=projected_file_size,
+                file_limit=self._max_file_size,
+            )
+
+        self._file.write(data)
+        self._written = projected_file_size
+        self._budget.record_extract_bytes(chunk_size)
+        return chunk_size
+
+    def flush(self) -> None:
+        self._file.flush()
+
+    def close(self) -> None:
+        self._file.close()
+
+
+class _BudgetedExtractionFactory:
+    def __init__(
+        self,
+        target_dir: Path,
+        *,
+        budget: "_RecursiveScanBudget",
+        max_file_size: int,
+        max_total_size: int,
+    ) -> None:
+        self._target_dir = target_dir.resolve()
+        self._budget = budget
+        self._max_file_size = max_file_size
+        self._max_total_size = max_total_size
+        self.products: dict[str, _BudgetedExtractionFile] = {}
+        self.paths: dict[str, Path] = {}
+
+    def create(self, filename: str) -> _BudgetedExtractionFile:
+        target_path = (self._target_dir / filename).resolve()
+        try:
+            target_path.relative_to(self._target_dir)
+        except ValueError as exc:
+            raise ValueError(f"Refusing to extract 7z member outside target directory: {filename}") from exc
+
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        writer = _BudgetedExtractionFile(
+            target_path,
+            filename,
+            budget=self._budget,
+            max_file_size=self._max_file_size,
+            max_total_size=self._max_total_size,
+        )
+        self.products[filename] = writer
+        self.paths[filename] = target_path
+        return writer
+
+    def get_path(self, filename: str) -> Path:
+        return self.paths.get(filename, self._target_dir / filename)
+
+    def close(self) -> None:
+        for writer in self.products.values():
+            with suppress(Exception):
+                writer.close()
 
 
 @dataclass
@@ -763,7 +869,9 @@ class SevenZipScanner(BaseScanner):
     ) -> bool:
         """Extract scannable files and run appropriate scanners on them"""
         scan_complete = not budget.should_stop()
-        extractable_files = []
+        extractable_files: list[str] = []
+        member_sizes: dict[str, int | None] = {}
+        known_extract_bytes = 0
         for file_name in scannable_files:
             member_info = None
             with suppress(Exception):
@@ -786,20 +894,50 @@ class SevenZipScanner(BaseScanner):
                 continue
 
             extractable_files.append(file_name)
+            member_sizes[file_name] = member_size
+            if member_size is not None:
+                known_extract_bytes += member_size
 
         if not extractable_files or budget.should_stop():
             return scan_complete and not budget.should_stop()
 
+        projected_cumulative_bytes = budget.cumulative_extract_bytes + known_extract_bytes
+        if known_extract_bytes > 0 and projected_cumulative_bytes > self.max_total_extract_size:
+            budget.abort_due_to_limit()
+            scan_complete = False
+            self._add_cumulative_extraction_size_check(
+                result,
+                archive_path,
+                cumulative_bytes=projected_cumulative_bytes,
+            )
+            return False
+
+        use_budgeted_factory = any(member_sizes[file_name] is None for file_name in extractable_files)
+
         with tempfile.TemporaryDirectory(prefix="modelaudit_7z_") as tmp_dir:
+            extraction_factory: _BudgetedExtractionFactory | None = None
             try:
-                # Extract all scannable files at once to avoid py7zr state issues
-                archive.extract(path=tmp_dir, targets=extractable_files)
+                if use_budgeted_factory:
+                    extraction_factory = _BudgetedExtractionFactory(
+                        Path(tmp_dir),
+                        budget=budget,
+                        max_file_size=self.max_extract_size,
+                        max_total_size=self.max_total_extract_size,
+                    )
+                    archive.extract(targets=extractable_files, factory=extraction_factory)
+                else:
+                    # Extract all scannable files at once to avoid py7zr state issues
+                    archive.extract(path=tmp_dir, targets=extractable_files)
 
                 for file_name in extractable_files:
                     if budget.should_stop():
                         return False
                     try:
-                        extracted_path = os.path.join(tmp_dir, file_name)
+                        extracted_path = (
+                            str(extraction_factory.get_path(file_name))
+                            if extraction_factory is not None
+                            else os.path.join(tmp_dir, file_name)
+                        )
 
                         # Block symlinks — matches zip_scanner / pytorch_zip_scanner
                         if os.path.islink(extracted_path):
@@ -833,26 +971,17 @@ class SevenZipScanner(BaseScanner):
                                 continue
 
                             # Check cumulative extraction size
-                            cumulative_extract_bytes = budget.record_extract_bytes(extracted_size)
-                            if cumulative_extract_bytes > self.max_total_extract_size:
-                                budget.abort_due_to_limit()
-                                scan_complete = False
-                                result.add_check(
-                                    name="Cumulative Extraction Size",
-                                    passed=False,
-                                    message=(
-                                        f"Cumulative extracted bytes ({cumulative_extract_bytes}) "
-                                        f"exceed limit of {self.max_total_extract_size}"
-                                    ),
-                                    severity=IssueSeverity.CRITICAL,
-                                    location=archive_path,
-                                    details={
-                                        "cumulative_bytes": cumulative_extract_bytes,
-                                        "limit": self.max_total_extract_size,
-                                        "potential_threat": "zip_bomb",
-                                    },
-                                )
-                                return False
+                            if extraction_factory is None:
+                                cumulative_extract_bytes = budget.record_extract_bytes(extracted_size)
+                                if cumulative_extract_bytes > self.max_total_extract_size:
+                                    budget.abort_due_to_limit()
+                                    scan_complete = False
+                                    self._add_cumulative_extraction_size_check(
+                                        result,
+                                        archive_path,
+                                        cumulative_bytes=cumulative_extract_bytes,
+                                    )
+                                    return False
 
                             # Get appropriate scanner for the extracted file
                             nested_scan_success = self._scan_extracted_file(
@@ -891,6 +1020,25 @@ class SevenZipScanner(BaseScanner):
                             details={"error": str(e)},
                         )
 
+            except _ExtractionBudgetExceeded as e:
+                budget.abort_due_to_limit()
+                scan_complete = False
+                if e.file_bytes > e.file_limit:
+                    result.add_check(
+                        name="Extracted File Size",
+                        passed=False,
+                        message=f"Extracted file {e.file_name} is too large ({e.file_bytes} bytes)",
+                        severity=IssueSeverity.WARNING,
+                        location=f"{archive_path}:{e.file_name}",
+                        details={"extracted_size": e.file_bytes, "size_limit": e.file_limit},
+                    )
+                else:
+                    self._add_cumulative_extraction_size_check(
+                        result,
+                        archive_path,
+                        cumulative_bytes=e.cumulative_bytes,
+                    )
+
             except Exception as e:
                 scan_complete = False
                 result.add_check(
@@ -901,8 +1049,31 @@ class SevenZipScanner(BaseScanner):
                     location=archive_path,
                     details={"error": str(e)},
                 )
+            finally:
+                if extraction_factory is not None:
+                    extraction_factory.close()
 
         return scan_complete and not budget.should_stop()
+
+    def _add_cumulative_extraction_size_check(
+        self,
+        result: ScanResult,
+        archive_path: str,
+        *,
+        cumulative_bytes: int,
+    ) -> None:
+        result.add_check(
+            name="Cumulative Extraction Size",
+            passed=False,
+            message=(f"Cumulative extracted bytes ({cumulative_bytes}) exceed limit of {self.max_total_extract_size}"),
+            severity=IssueSeverity.CRITICAL,
+            location=archive_path,
+            details={
+                "cumulative_bytes": cumulative_bytes,
+                "limit": self.max_total_extract_size,
+                "potential_threat": "zip_bomb",
+            },
+        )
 
     @staticmethod
     def _get_archive_member_size(archive: Any, file_name: str) -> int | None:

--- a/tests/scanners/test_sevenzip_scanner.py
+++ b/tests/scanners/test_sevenzip_scanner.py
@@ -1964,9 +1964,117 @@ class TestSevenZipScannerHardening:
         assert not result.success
         assert cumulative_checks[0].severity == IssueSeverity.CRITICAL
         assert cumulative_checks[0].details["limit"] == limit
-        assert mock_scan_file.call_count == 1
-        scanned_file = Path(mock_scan_file.call_args.args[0])
-        assert scanned_file.name == "inner_a.pkl"
+        mock_scan_file.assert_not_called()
+
+    def test_known_cumulative_extraction_size_limit_preflights_before_extraction(
+        self,
+        scanner: SevenZipScanner,
+        temp_7z_file: str,
+    ) -> None:
+        scanner.max_total_extract_size = 100
+
+        with (
+            patch("modelaudit.scanners.sevenzip_scanner.HAS_PY7ZR", True),
+            patch("modelaudit.scanners.sevenzip_scanner.py7zr") as mock_py7zr,
+            patch.object(scanner, "_scan_extracted_file") as mock_scan_extracted_file,
+            patch("os.path.isfile", return_value=True),
+            patch("os.path.getsize", return_value=32),
+        ):
+            mock_archive = MagicMock()
+            mock_archive.getnames.return_value = ["a.pkl", "b.pkl"]
+            mock_archive.getinfo.side_effect = lambda _name: MagicMock(uncompressed=60, is_directory=False)
+            mock_py7zr.SevenZipFile.return_value.__enter__.return_value = mock_archive
+
+            result = scanner.scan(temp_7z_file)
+
+        cumulative_checks = [c for c in result.checks if c.name == "Cumulative Extraction Size"]
+        assert result.success is False
+        assert len(cumulative_checks) == 1
+        assert cumulative_checks[0].severity == IssueSeverity.CRITICAL
+        assert cumulative_checks[0].details["cumulative_bytes"] == 120
+        mock_archive.extract.assert_not_called()
+        mock_scan_extracted_file.assert_not_called()
+
+    def test_unknown_cumulative_extraction_size_limit_uses_budgeted_factory(
+        self,
+        scanner: SevenZipScanner,
+        temp_7z_file: str,
+    ) -> None:
+        scanner.max_total_extract_size = 100
+        extract_kwargs: dict[str, Any] = {}
+
+        def fake_extract(*_args: Any, **kwargs: Any) -> None:
+            extract_kwargs.update(kwargs)
+            factory = kwargs["factory"]
+            for target in kwargs["targets"]:
+                writer = factory.create(target)
+                writer.write(b"x" * 60)
+                writer.close()
+
+        with (
+            patch("modelaudit.scanners.sevenzip_scanner.HAS_PY7ZR", True),
+            patch("modelaudit.scanners.sevenzip_scanner.py7zr") as mock_py7zr,
+            patch.object(scanner, "_scan_extracted_file") as mock_scan_extracted_file,
+            patch("os.path.isfile", return_value=True),
+            patch("os.path.getsize", return_value=32),
+        ):
+            mock_archive = MagicMock()
+            mock_archive.getnames.return_value = ["a.pkl", "b.pkl"]
+            mock_archive.getinfo.side_effect = lambda _name: MagicMock(uncompressed=None, is_directory=False)
+            mock_archive.extract.side_effect = fake_extract
+            mock_py7zr.SevenZipFile.return_value.__enter__.return_value = mock_archive
+
+            result = scanner.scan(temp_7z_file)
+
+        cumulative_checks = [c for c in result.checks if c.name == "Cumulative Extraction Size"]
+        assert result.success is False
+        assert len(cumulative_checks) == 1
+        assert cumulative_checks[0].severity == IssueSeverity.CRITICAL
+        assert cumulative_checks[0].details["cumulative_bytes"] == 120
+        assert "factory" in extract_kwargs
+        assert "path" not in extract_kwargs
+        mock_scan_extracted_file.assert_not_called()
+
+    @pytest.mark.skipif(not HAS_PY7ZR, reason="py7zr not available")
+    def test_real_many_small_members_abort_before_extraction_budget_is_exceeded(self, tmp_path: Path) -> None:
+        archive_path = tmp_path / "many_small.7z"
+        members: list[tuple[Path, str]] = []
+        for index in range(4):
+            member_path = tmp_path / f"member_{index}.pkl"
+            self._write_pickle(member_path, {"payload": "x" * 64, "index": index})
+            members.append((member_path, f"member_{index}.pkl"))
+        self._write_7z_archive(archive_path, members)
+        limit = sum(path.stat().st_size for path, _name in members) - 1
+        scanner = SevenZipScanner(config={"max_7z_total_extract_size": limit})
+
+        with patch("modelaudit.core.scan_file", return_value=_mock_scan_result()) as mock_scan_file:
+            result = scanner.scan(str(archive_path))
+
+        cumulative_checks = [c for c in result.checks if c.name == "Cumulative Extraction Size"]
+        assert result.success is False
+        assert len(cumulative_checks) == 1
+        assert cumulative_checks[0].details["limit"] == limit
+        mock_scan_file.assert_not_called()
+
+    @pytest.mark.skipif(not HAS_PY7ZR, reason="py7zr not available")
+    def test_real_archive_under_cumulative_extraction_budget_scans_members(self, tmp_path: Path) -> None:
+        archive_path = tmp_path / "under_budget.7z"
+        members: list[tuple[Path, str]] = []
+        for index in range(2):
+            member_path = tmp_path / f"safe_{index}.pkl"
+            self._write_pickle(member_path, {"payload": "safe", "index": index})
+            members.append((member_path, f"safe_{index}.pkl"))
+        self._write_7z_archive(archive_path, members)
+        limit = sum(path.stat().st_size for path, _name in members)
+        scanner = SevenZipScanner(config={"max_7z_total_extract_size": limit})
+
+        with patch("modelaudit.core.scan_file", return_value=_mock_scan_result()) as mock_scan_file:
+            result = scanner.scan(str(archive_path))
+
+        cumulative_checks = [c for c in result.checks if c.name == "Cumulative Extraction Size"]
+        assert result.success is True
+        assert cumulative_checks == []
+        assert mock_scan_file.call_count == 2
 
     # -- depth bomb finish() --------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Preflight known 7z member uncompressed sizes before bulk extraction.
- Use a budgeted extraction factory for unknown-size members so writes abort before per-file or cumulative byte limits are exceeded.
- Add focused regressions for known-size preflight, unknown-size guarded extraction, real many-small-member archives, and a benign under-budget archive.

## Validation

- `PYTHONPATH=/private/tmp/modelaudit-fixes/f14 PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/python -m pytest tests/scanners/test_sevenzip_scanner.py -q`
- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/python -m ruff format modelaudit/scanners/sevenzip_scanner.py tests/scanners/test_sevenzip_scanner.py`
- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/python -m ruff check --fix modelaudit/scanners/sevenzip_scanner.py tests/scanners/test_sevenzip_scanner.py`
- `PYTHONPATH=/private/tmp/modelaudit-fixes/f14 /Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/python -m mypy modelaudit/scanners/sevenzip_scanner.py tests/scanners/test_sevenzip_scanner.py`
