### PR TITLE
fix: block torch.load on vulnerable prereleases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- block weight distribution `torch.load` on PyTorch prerelease and unknown versions before deserialization
 - route renamed structured JAX/Orbax JSON checkpoints, conservatively report observable bounded-prefix threats, and fail closed for oversized identified metadata
 - classify Flax MessagePack recursion-limit analysis gaps as inconclusive coverage
 - classify incomplete JAX/Orbax metadata, pickle, and NumPy analysis as inconclusive coverage

--- a/modelaudit/scanners/weight_distribution_scanner.py
+++ b/modelaudit/scanners/weight_distribution_scanner.py
@@ -9,6 +9,10 @@ from typing import Any, ClassVar
 
 from .base import BaseScanner, IssueSeverity, ScanResult, logger
 
+_PATCHED_TORCH_WEIGHTS_ONLY_VERSION = (2, 6, 0)
+_TORCH_RELEASE_VERSION_PATTERN = re.compile(r"^\s*(\d+)(?:\.(\d+))?(?:\.(\d+))?")
+_TORCH_PRERELEASE_MARKER_PATTERN = re.compile(r"(?i)^(?:a|b|c|rc|alpha|beta|pre|preview|dev)")
+
 
 class WeightDistributionScanner(BaseScanner):
     """Scanner that detects anomalous weight distributions potentially indicating trojaned models"""
@@ -199,6 +203,19 @@ class WeightDistributionScanner(BaseScanner):
         result.finish(success=True)
         return result
 
+    @staticmethod
+    def _torch_weights_only_is_patched_version(version: object) -> bool:
+        version_text = str(version).strip()
+        match = _TORCH_RELEASE_VERSION_PATTERN.match(version_text)
+        if not match:
+            return False
+
+        release = tuple(int(part or 0) for part in match.groups())
+        suffix = version_text[match.end() :].lstrip("._-")
+        if _TORCH_PRERELEASE_MARKER_PATTERN.match(suffix):
+            return False
+        return release >= _PATCHED_TORCH_WEIGHTS_ONLY_VERSION
+
     def _extract_pytorch_weights(self, path: str) -> dict[str, Any]:
         """Extract weights from PyTorch model files"""
         try:
@@ -227,18 +244,14 @@ class WeightDistributionScanner(BaseScanner):
 
             if supports_weights_only:
                 load_kwargs["weights_only"] = True
-                version_match = re.match(r"^(\d+)\.(\d+)", str(torch_version))
-                is_patched_version = False
-                if version_match:
-                    major = int(version_match.group(1))
-                    minor = int(version_match.group(2))
-                    is_patched_version = (major, minor) >= (2, 6)
+                is_patched_version = self._torch_weights_only_is_patched_version(torch_version)
 
                 if not is_patched_version and not self.enable_unsafe_torch_load:
                     self.extraction_unsafe = True
                     self.extraction_unsafe_reason = (
-                        "Blocked torch.load: weights_only=True on PyTorch versions below 2.6 "
-                        "is vulnerable to RCE. Set enable_unsafe_torch_load=true to override."
+                        "Blocked torch.load: weights_only=True is only treated as safe on stable "
+                        "PyTorch 2.6.0 or newer. Prerelease, dev, and unknown versions may still "
+                        "be vulnerable to RCE. Set enable_unsafe_torch_load=true to override."
                     )
                     raise RuntimeError(self.extraction_unsafe_reason)
             elif not self.enable_unsafe_torch_load:

--- a/modelaudit/scanners/weight_distribution_scanner.py
+++ b/modelaudit/scanners/weight_distribution_scanner.py
@@ -12,6 +12,7 @@ from .base import BaseScanner, IssueSeverity, ScanResult, logger
 _PATCHED_TORCH_WEIGHTS_ONLY_VERSION = (2, 6, 0)
 _TORCH_RELEASE_VERSION_PATTERN = re.compile(r"^\s*(\d+)(?:\.(\d+))?(?:\.(\d+))?")
 _TORCH_PRERELEASE_MARKER_PATTERN = re.compile(r"(?i)^(?:a|b|c|rc|alpha|beta|pre|preview|dev)")
+_TORCH_STABLE_SUFFIX_PATTERN = re.compile(r"(?i)^post\d*(?:\+.*)?$")
 
 
 class WeightDistributionScanner(BaseScanner):
@@ -211,8 +212,11 @@ class WeightDistributionScanner(BaseScanner):
             return False
 
         release = tuple(int(part or 0) for part in match.groups())
-        suffix = version_text[match.end() :].lstrip("._-")
-        if _TORCH_PRERELEASE_MARKER_PATTERN.match(suffix):
+        suffix = version_text[match.end() :].strip()
+        normalized_suffix = suffix.lstrip("._-")
+        if _TORCH_PRERELEASE_MARKER_PATTERN.match(normalized_suffix):
+            return False
+        if suffix and not suffix.startswith("+") and _TORCH_STABLE_SUFFIX_PATTERN.fullmatch(normalized_suffix) is None:
             return False
         return release >= _PATCHED_TORCH_WEIGHTS_ONLY_VERSION
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,7 @@ def pytest_runtest_setup(item):
             "test_cntk_scanner.py",  # CNTK .dnn/.cmf scanner tests
             "test_rknn_scanner.py",  # RKNN scanner tests
             "test_torch7_scanner.py",  # Torch7 scanner tests
+            "test_weight_distribution_scanner.py",  # PyTorch weight extraction safety regressions
             "test_lightgbm_scanner.py",  # LightGBM native scanner tests
             "test_llamafile_scanner.py",  # Llamafile executable scanner tests
             "test_coreml_scanner.py",  # CoreML scanner tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,7 +148,6 @@ def pytest_runtest_setup(item):
             "test_cntk_scanner.py",  # CNTK .dnn/.cmf scanner tests
             "test_rknn_scanner.py",  # RKNN scanner tests
             "test_torch7_scanner.py",  # Torch7 scanner tests
-            "test_weight_distribution_scanner.py",  # PyTorch weight extraction safety regressions
             "test_lightgbm_scanner.py",  # LightGBM native scanner tests
             "test_llamafile_scanner.py",  # Llamafile executable scanner tests
             "test_coreml_scanner.py",  # CoreML scanner tests
@@ -204,9 +203,17 @@ def pytest_runtest_setup(item):
             "test_docker_workflow.py",  # Docker workflow regression tests
             "test_perf_workflow.py",  # Performance benchmark workflow regression tests
         ]
+        allowed_test_nodeids = [
+            "tests/scanners/test_weight_distribution_scanner.py::TestWeightDistributionScanner::test_blocks_torch_load_for_vulnerable_pytorch_prereleases",
+            "tests/scanners/test_weight_distribution_scanner.py::TestWeightDistributionScanner::test_allows_torch_load_for_stable_patched_pytorch",
+            "tests/scanners/test_weight_distribution_scanner.py::TestWeightDistributionScanner::test_blocks_torch_load_for_unknown_pytorch_version",
+            "tests/scanners/test_weight_distribution_scanner.py::TestWeightDistributionScanner::test_blocks_torch_load_for_unknown_patched_version_suffixes",
+        ]
 
         # Check if this is an allowed test file
-        if any(allowed_file in test_file for allowed_file in allowed_test_files):
+        if any(allowed_file in test_file for allowed_file in allowed_test_files) or any(
+            item.nodeid.startswith(allowed_nodeid) for allowed_nodeid in allowed_test_nodeids
+        ):
             pass  # Allow these tests to continue to framework check
         else:
             # Skip all other tests on Python 3.10/3.12/3.13 to prevent CI issues

--- a/tests/scanners/test_weight_distribution_scanner.py
+++ b/tests/scanners/test_weight_distribution_scanner.py
@@ -543,6 +543,112 @@ class TestWeightDistributionScanner:
         assert "Blocked torch.load" in scanner.extraction_unsafe_reason
         assert load_called is False
 
+    def test_blocks_torch_load_for_vulnerable_pytorch_prereleases(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Prerelease PyTorch versions must fail closed before torch.load."""
+        for torch_version in ["2.6.0rc1", "2.6.0a0", "2.6.0.dev20250101", "2.10.0a0"]:
+            load_called = False
+
+            fake_torch: Any = types.ModuleType("torch")
+            fake_torch.__version__ = torch_version
+
+            class FakeTensor:  # pragma: no cover - simple test double
+                pass
+
+            fake_torch.Tensor = FakeTensor
+            fake_torch.device = lambda value: value
+
+            def fake_load(_path: str, *, map_location: object, weights_only: bool) -> dict[str, object]:
+                nonlocal load_called
+                load_called = True
+                return {}
+
+            fake_torch.load = fake_load
+            monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+            model_path = tmp_path / f"blocked-{torch_version}.pt"
+            model_path.write_bytes(b"not-a-valid-pytorch-model")
+
+            scanner = WeightDistributionScanner()
+            weights = scanner._extract_pytorch_weights(str(model_path))
+
+            assert weights == {}
+            assert scanner.extraction_unsafe
+            assert scanner.extraction_unsafe_reason is not None
+            assert "stable PyTorch 2.6.0 or newer" in scanner.extraction_unsafe_reason
+            assert load_called is False
+
+    def test_allows_torch_load_for_stable_patched_pytorch(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        load_call: dict[str, object] = {}
+
+        fake_torch: Any = types.ModuleType("torch")
+        fake_torch.__version__ = "2.6.0+cpu"
+
+        class FakeTensor:  # pragma: no cover - simple test double
+            pass
+
+        fake_torch.Tensor = FakeTensor
+        fake_torch.device = lambda value: value
+
+        def fake_load(_path: str, *, map_location: object, weights_only: bool) -> dict[str, object]:
+            load_call["map_location"] = map_location
+            load_call["weights_only"] = weights_only
+            return {}
+
+        fake_torch.load = fake_load
+        monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+        model_path = tmp_path / "stable.pt"
+        model_path.write_bytes(b"not-a-valid-pytorch-model")
+
+        scanner = WeightDistributionScanner()
+        weights = scanner._extract_pytorch_weights(str(model_path))
+
+        assert weights == {}
+        assert scanner.extraction_unsafe is False
+        assert load_call == {"map_location": "cpu", "weights_only": True}
+
+    def test_blocks_torch_load_for_unknown_pytorch_version(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        load_called = False
+
+        fake_torch: Any = types.ModuleType("torch")
+        fake_torch.__version__ = "unknown"
+
+        class FakeTensor:  # pragma: no cover - simple test double
+            pass
+
+        fake_torch.Tensor = FakeTensor
+        fake_torch.device = lambda value: value
+
+        def fake_load(_path: str, *, map_location: object, weights_only: bool) -> dict[str, object]:
+            nonlocal load_called
+            load_called = True
+            return {}
+
+        fake_torch.load = fake_load
+        monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+        model_path = tmp_path / "unknown.pt"
+        model_path.write_bytes(b"not-a-valid-pytorch-model")
+
+        scanner = WeightDistributionScanner()
+        weights = scanner._extract_pytorch_weights(str(model_path))
+
+        assert weights == {}
+        assert scanner.extraction_unsafe
+        assert load_called is False
+
     def test_multiple_anomalies(self):
         """Test detection of multiple types of anomalies in one layer"""
         import numpy as np

--- a/tests/scanners/test_weight_distribution_scanner.py
+++ b/tests/scanners/test_weight_distribution_scanner.py
@@ -649,6 +649,42 @@ class TestWeightDistributionScanner:
         assert scanner.extraction_unsafe
         assert load_called is False
 
+    @pytest.mark.parametrize("torch_version", ["2.6.0-custom", "2.6.0-unknown", "2.10.0-custom"])
+    def test_blocks_torch_load_for_unknown_patched_version_suffixes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        torch_version: str,
+    ) -> None:
+        load_called = False
+
+        fake_torch: Any = types.ModuleType("torch")
+        fake_torch.__version__ = torch_version
+
+        class FakeTensor:  # pragma: no cover - simple test double
+            pass
+
+        fake_torch.Tensor = FakeTensor
+        fake_torch.device = lambda value: value
+
+        def fake_load(_path: str, *, map_location: object, weights_only: bool) -> dict[str, object]:
+            nonlocal load_called
+            load_called = True
+            return {}
+
+        fake_torch.load = fake_load
+        monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+        model_path = tmp_path / f"{torch_version}.pt"
+        model_path.write_bytes(b"not-a-valid-pytorch-model")
+
+        scanner = WeightDistributionScanner()
+        weights = scanner._extract_pytorch_weights(str(model_path))
+
+        assert weights == {}
+        assert scanner.extraction_unsafe
+        assert load_called is False
+
     def test_multiple_anomalies(self):
         """Test detection of multiple types of anomalies in one layer"""
         import numpy as np


### PR DESCRIPTION
## Summary

- Treat `torch.load(..., weights_only=True)` as safe only on stable PyTorch 2.6.0 or newer.
- Fail closed for prerelease, dev, and unknown PyTorch versions before calling `torch.load`.
- Add focused regressions for prerelease, unknown, and stable patched PyTorch versions.
- Add the weight distribution scanner tests to the reduced-lane allowlist so the safety regressions run in CI.

## Validation

- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run --active --no-sync --with-editable . pytest tests/scanners/test_weight_distribution_scanner.py -q`
- `uv run --active --no-sync --with-editable . ruff format --check modelaudit/scanners/weight_distribution_scanner.py tests/scanners/test_weight_distribution_scanner.py tests/conftest.py`
- `uv run --active --no-sync --with-editable . ruff check modelaudit/scanners/weight_distribution_scanner.py tests/scanners/test_weight_distribution_scanner.py tests/conftest.py`
- `uv run --active --no-sync --with-editable . mypy modelaudit/scanners/weight_distribution_scanner.py tests/scanners/test_weight_distribution_scanner.py tests/conftest.py`
