### PR TITLE
fix: mark oversized structured Jinja templates incomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- mark oversized structured JSON/YAML Jinja template fields as incomplete coverage instead of clean
 - route renamed structured JAX/Orbax JSON checkpoints, conservatively report observable bounded-prefix threats, and fail closed for oversized identified metadata
 - classify Flax MessagePack recursion-limit analysis gaps as inconclusive coverage
 - classify incomplete JAX/Orbax metadata, pickle, and NumPy analysis as inconclusive coverage

--- a/modelaudit/scanners/jinja2_template_scanner.py
+++ b/modelaudit/scanners/jinja2_template_scanner.py
@@ -60,6 +60,7 @@ _INCONCLUSIVE_METADATA_KEY = "scan_outcome"
 _INCONCLUSIVE_REASONS_METADATA_KEY = "scan_outcome_reasons"
 _JINJA_TEMPLATE_INDICATORS = ("{{", "{%", "{#")
 _JINJA_TEMPLATE_INDICATOR_BYTES = tuple(indicator.encode("utf-8") for indicator in _JINJA_TEMPLATE_INDICATORS)
+_TEMPLATE_FIELD_KEYS = frozenset({"chat_template", "template", "jinja_template", "custom_chat_template"})
 _RAW_PARSE_FALLBACK_CONTEXT_BYTES = 1024
 _RAW_PARSE_FALLBACK_MAX_WINDOWS = 8
 _RAW_PARSE_FALLBACK_READ_BYTES = 256 * 1024
@@ -534,7 +535,7 @@ class Jinja2TemplateScanner(BaseScanner):
                 data = json.load(f)
 
             # Recursively search for template fields
-            self._find_json_templates(data, templates, "")
+            self._find_json_templates(data, templates, "", extraction_failures, "json")
 
         except Exception as e:
             logger.debug(f"Error extracting JSON templates: {e}")
@@ -543,35 +544,47 @@ class Jinja2TemplateScanner(BaseScanner):
 
         return templates, extraction_failures
 
-    def _find_json_templates(self, data: Any, templates: dict[str, str], path: str) -> None:
+    def _find_json_templates(
+        self,
+        data: Any,
+        templates: dict[str, str],
+        path: str,
+        extraction_failures: list[dict[str, Any]],
+        config_format: str,
+    ) -> None:
         """Recursively find template strings in JSON data"""
         if isinstance(data, dict):
             for key, value in data.items():
                 current_path = f"{path}.{key}" if path else key
 
                 # Check for known template fields
-                if (
-                    key in ["chat_template", "template", "jinja_template", "custom_chat_template"]
-                    and isinstance(value, str)
-                    and value.strip()
-                    and len(value) <= self.max_template_size
-                ):
-                    templates[current_path] = value
+                if key in _TEMPLATE_FIELD_KEYS and isinstance(value, str) and value.strip():
+                    self._add_template_candidate(
+                        value,
+                        templates,
+                        current_path,
+                        extraction_failures,
+                        config_format,
+                    )
 
                 # Recursively check nested structures
                 elif isinstance(value, dict | list):
-                    self._find_json_templates(value, templates, current_path)
+                    self._find_json_templates(value, templates, current_path, extraction_failures, config_format)
 
                 # Check for template-like strings (contain Jinja2 syntax)
-                elif (
-                    isinstance(value, str) and self._looks_like_template(value) and len(value) <= self.max_template_size
-                ):
-                    templates[current_path] = value
+                elif isinstance(value, str) and self._looks_like_template(value):
+                    self._add_template_candidate(
+                        value,
+                        templates,
+                        current_path,
+                        extraction_failures,
+                        config_format,
+                    )
 
         elif isinstance(data, list):
             for i, item in enumerate(data):
                 current_path = f"{path}[{i}]" if path else f"[{i}]"
-                self._find_json_templates(item, templates, current_path)
+                self._find_json_templates(item, templates, current_path, extraction_failures, config_format)
 
     def _extract_yaml_templates(self, path: str) -> tuple[dict[str, str], list[dict[str, Any]]]:
         """Extract templates from YAML configuration files"""
@@ -594,7 +607,7 @@ class Jinja2TemplateScanner(BaseScanner):
                 data = yaml.safe_load(f)
 
             if data:
-                self._find_json_templates(data, templates, "")  # Reuse JSON logic
+                self._find_json_templates(data, templates, "", extraction_failures, "yaml")  # Reuse JSON logic
 
         except Exception as e:
             logger.debug(f"Error extracting YAML templates: {e}")
@@ -610,6 +623,28 @@ class Jinja2TemplateScanner(BaseScanner):
             "exception": str(error),
             "exception_type": type(error).__name__,
         }
+
+    def _add_template_candidate(
+        self,
+        value: str,
+        templates: dict[str, str],
+        template_path: str,
+        extraction_failures: list[dict[str, Any]],
+        config_format: str,
+    ) -> None:
+        if len(value) <= self.max_template_size:
+            templates[template_path] = value
+            return
+
+        extraction_failures.append(
+            {
+                "format": config_format,
+                "reason": "jinja2_template_size_limit_exceeded",
+                "max_template_size": self.max_template_size,
+                "skipped_template_locations": [template_path],
+                "template_size": len(value),
+            }
+        )
 
     def _extract_raw_template_fallback(self, path: str, templates: dict[str, str], template_key: str) -> None:
         for index, fallback_text in enumerate(self._raw_template_fallback_windows_from_file(path)):

--- a/modelaudit/scanners/jinja2_template_scanner.py
+++ b/modelaudit/scanners/jinja2_template_scanner.py
@@ -61,6 +61,15 @@ _INCONCLUSIVE_REASONS_METADATA_KEY = "scan_outcome_reasons"
 _JINJA_TEMPLATE_INDICATORS = ("{{", "{%", "{#")
 _JINJA_TEMPLATE_INDICATOR_BYTES = tuple(indicator.encode("utf-8") for indicator in _JINJA_TEMPLATE_INDICATORS)
 _TEMPLATE_FIELD_KEYS = frozenset({"chat_template", "template", "jinja_template", "custom_chat_template"})
+_DETECTION_MESSAGE_LABELS = {
+    "critical_injection": "critical injection",
+    "object_traversal": "object hierarchy access",
+    "global_access": "global namespace access",
+    "obfuscation": "obfuscation",
+    "control_flow": "control flow",
+    "environment_access": "environment access",
+    "sandbox_violation": "sandbox violation",
+}
 _RAW_PARSE_FALLBACK_CONTEXT_BYTES = 1024
 _RAW_PARSE_FALLBACK_MAX_WINDOWS = 8
 _RAW_PARSE_FALLBACK_READ_BYTES = 256 * 1024
@@ -340,7 +349,10 @@ class Jinja2TemplateScanner(BaseScanner):
                 result.add_check(
                     name="Jinja2 Template Injection Detection",
                     passed=False,
-                    message=f"Potential SSTI vulnerability detected: {detection.pattern_type}",
+                    message=(
+                        "Potential SSTI vulnerability detected: "
+                        f"{_DETECTION_MESSAGE_LABELS.get(detection.pattern_type, detection.pattern_type)}"
+                    ),
                     severity=severity,
                     location=detection.location or f"{path}:{template_location}",
                     details={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 import tempfile
 import zipfile
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
@@ -214,6 +215,16 @@ def pytest_runtest_setup(item):
         marker = item.get_closest_marker(marker_name)
         if marker is not None and not _check_framework(module_name):
             pytest.skip(f"{marker_name} is not installed")
+
+
+@pytest.fixture(autouse=True)
+def reset_rule_config_between_tests() -> Iterator[None]:
+    """Keep CLI rule suppressions from leaking between tests."""
+    from modelaudit.config import reset_config
+
+    reset_config()
+    yield
+    reset_config()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/scanners/test_jinja2_template_scanner.py
+++ b/tests/scanners/test_jinja2_template_scanner.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from modelaudit.config.rule_config import ModelAuditConfig, reset_config, set_config
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.scanners import jinja2_template_scanner
 from modelaudit.scanners.base import CheckStatus, IssueSeverity
@@ -728,6 +729,23 @@ class TestJinja2TemplateScannerEdgeCases:
         assert "scan_outcome" not in result.metadata
         assert not [c for c in result.checks if c.name == "Template Size Limit"]
         assert [c for c in result.checks if c.name == "Jinja2 Template Injection Detection"]
+
+    def test_path_traversal_suppression_does_not_hide_object_traversal_ssti(self, tmp_path: Path) -> None:
+        tokenizer_file = tmp_path / "tokenizer_config.json"
+        tokenizer_file.write_text(
+            json.dumps({"chat_template": "{{ ''.__class__.__mro__[1].__subclasses__() }}"}),
+            encoding="utf-8",
+        )
+
+        set_config(ModelAuditConfig(suppress={"S405"}))
+        try:
+            result = Jinja2TemplateScanner().scan(str(tokenizer_file))
+        finally:
+            reset_config()
+
+        failed_checks = [check for check in result.checks if check.name == "Jinja2 Template Injection Detection"]
+        assert any(check.details.get("pattern_type") == "object_traversal" for check in failed_checks)
+        assert not any(check.rule_code == "S405" for check in failed_checks)
 
     def test_invalid_utf8_standalone_template_returns_inconclusive_exit2(self, tmp_path: Path) -> None:
         """Unreadable standalone templates must not look clean."""

--- a/tests/scanners/test_jinja2_template_scanner.py
+++ b/tests/scanners/test_jinja2_template_scanner.py
@@ -655,6 +655,80 @@ class TestJinja2TemplateScannerEdgeCases:
         assert aggregate_result.success is False
         assert determine_exit_code(aggregate_result) == 2
 
+    def test_oversized_json_chat_template_fails_closed(self, tmp_path: Path) -> None:
+        default_limit = Jinja2TemplateScanner().max_template_size
+        payload = ("a" * (default_limit + 1)) + "{{ lipsum.__globals__.os.popen('id').read() }}"
+        tokenizer_file = tmp_path / "tokenizer_config.json"
+        tokenizer_file.write_text(json.dumps({"chat_template": payload}), encoding="utf-8")
+
+        scanner = Jinja2TemplateScanner({"max_template_size": 64})
+        result = scanner.scan(str(tokenizer_file))
+
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == "inconclusive"
+        assert "jinja2_template_size_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+        size_checks = [c for c in result.checks if c.name == "Template Size Limit"]
+        assert len(size_checks) == 1
+        assert size_checks[0].status == CheckStatus.FAILED
+        assert size_checks[0].severity == IssueSeverity.INFO
+        assert size_checks[0].details["skipped_template_locations"] == ["chat_template"]
+        assert size_checks[0].details["template_size"] == len(payload)
+        assert not [c for c in result.checks if c.message == "No Jinja2 templates found in file"]
+
+        aggregate_result = scan_model_directory_or_file(
+            str(tokenizer_file),
+            config={"max_template_size": 64, "cache_scan_results": False},
+        )
+        assert aggregate_result.success is False
+        assert determine_exit_code(aggregate_result) == 2
+
+    def test_oversized_yaml_chat_template_fails_closed(self, tmp_path: Path) -> None:
+        yaml = pytest.importorskip("yaml")
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        payload = ("a" * 96) + "{{ lipsum.__globals__.os.popen('id').read() }}"
+        yaml_file = model_dir / "config.yaml"
+        yaml_file.write_text(yaml.safe_dump({"chat_template": payload}), encoding="utf-8")
+
+        scanner = Jinja2TemplateScanner({"max_template_size": 64})
+        result = scanner.scan(str(yaml_file))
+
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == "inconclusive"
+        assert "jinja2_template_size_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+        size_checks = [c for c in result.checks if c.name == "Template Size Limit"]
+        assert len(size_checks) == 1
+        assert size_checks[0].details["format"] == "yaml"
+        assert size_checks[0].details["skipped_template_locations"] == ["chat_template"]
+        assert not [c for c in result.checks if c.message == "No Jinja2 templates found in file"]
+
+    def test_oversized_benign_json_template_is_inconclusive_without_security_finding(self, tmp_path: Path) -> None:
+        payload = "{{ message['content'] }}" + (" safe" * 32)
+        tokenizer_file = tmp_path / "tokenizer_config.json"
+        tokenizer_file.write_text(json.dumps({"chat_template": payload}), encoding="utf-8")
+
+        scanner = Jinja2TemplateScanner({"max_template_size": 64})
+        result = scanner.scan(str(tokenizer_file))
+
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == "inconclusive"
+        assert "jinja2_template_size_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+        assert [c for c in result.checks if c.name == "Template Size Limit"]
+        assert not [c for c in result.checks if c.name == "Jinja2 Template Injection Detection"]
+
+    def test_small_json_chat_template_still_analyzed(self, tmp_path: Path) -> None:
+        payload = "{{ lipsum.__globals__.os.popen('id') }}"
+        tokenizer_file = tmp_path / "tokenizer_config.json"
+        tokenizer_file.write_text(json.dumps({"chat_template": payload}), encoding="utf-8")
+
+        scanner = Jinja2TemplateScanner({"max_template_size": 128})
+        result = scanner.scan(str(tokenizer_file))
+
+        assert result.has_warnings or result.has_errors
+        assert "scan_outcome" not in result.metadata
+        assert not [c for c in result.checks if c.name == "Template Size Limit"]
+        assert [c for c in result.checks if c.name == "Jinja2 Template Injection Detection"]
+
     def test_invalid_utf8_standalone_template_returns_inconclusive_exit2(self, tmp_path: Path) -> None:
         """Unreadable standalone templates must not look clean."""
         template_file = tmp_path / "invalid.jinja"


### PR DESCRIPTION
## Summary

- Mark oversized JSON/YAML template candidates as incomplete coverage instead of dropping them silently.
- Reuse the existing template size-limit outcome so oversized structured configs do not report clean "no templates found" results.
- Add focused JSON/YAML regressions for oversized malicious templates, a benign oversized template, and a normal under-limit malicious template.

## Validation

- `PYTHONPATH=/private/tmp/modelaudit-fixes/f05 PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/python -m pytest tests/scanners/test_jinja2_template_scanner.py -q`
- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/python -m ruff format modelaudit/scanners/jinja2_template_scanner.py tests/scanners/test_jinja2_template_scanner.py`
- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/python -m ruff check --fix modelaudit/scanners/jinja2_template_scanner.py tests/scanners/test_jinja2_template_scanner.py`
- `PYTHONPATH=/private/tmp/modelaudit-fixes/f05 /Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/python -m mypy modelaudit/scanners/jinja2_template_scanner.py tests/scanners/test_jinja2_template_scanner.py`
