### PR TITLE
fix: detect NeMo torch extension targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - route renamed structurally valid MXNet symbol graphs through existing suspicious-reference analysis
 - harden renamed MXNet symbol routing with fail-closed bounded ambiguity and XGBoost overlap handling
 - restore content routing for extensionless XGBoost UBJSON models and classify unavailable or undecodable XGBoost reads as inconclusive
+- detect NeMo Hydra targets that invoke PyTorch C++ extension loaders
 - route renamed TAR-backed NeMo archives with relative archive-root model configs through Hydra `_target_` analysis while retaining generic embedded-member checks
 - honor descriptor-owned header aliases during helper scanner selection for renamed HDF5, GGML, and compressed payloads
 - detect signature-valid Torch7 payloads even when renamed with misleading suffixes

--- a/modelaudit/scanners/nemo_scanner.py
+++ b/modelaudit/scanners/nemo_scanner.py
@@ -51,7 +51,6 @@ _SAFE_TARGET_PREFIXES = (
     "lightning.",
     "torch.optim.",
     "torch.nn.",
-    "torch.utils.",
     "transformers.",
     "omegaconf.",
     "hydra.",
@@ -60,6 +59,20 @@ _SAFE_TARGET_PREFIXES = (
     "numpy.",
     "dataclasses.",
 )
+
+# Exact safe _target_ values for utility namespaces that also contain unsafe
+# callables. Keep this list narrow instead of trusting whole namespaces.
+_SAFE_TARGETS = {
+    "torch.utils.data.BatchSampler",
+    "torch.utils.data.ConcatDataset",
+    "torch.utils.data.DataLoader",
+    "torch.utils.data.RandomSampler",
+    "torch.utils.data.SequentialSampler",
+    "torch.utils.data.Subset",
+    "torch.utils.data.TensorDataset",
+    "torch.utils.data.WeightedRandomSampler",
+    "torch.utils.data.distributed.DistributedSampler",
+}
 
 # Dangerous _target_ values that indicate exploitation
 _DANGEROUS_TARGETS = {
@@ -106,6 +119,11 @@ _DANGEROUS_TARGETS = {
     "torch.package.PackageImporter",
     "torch.package.PackageImporter.load_pickle",
     "torch.serialization.load",
+    "torch.utils.cpp_extension._import_module_from_library",
+    "torch.utils.cpp_extension._jit_compile",
+    "torch.utils.cpp_extension._run_ninja_build",
+    "torch.utils.cpp_extension.load",
+    "torch.utils.cpp_extension.load_inline",
     "torch.utils.model_zoo.load_url",
     "shutil.rmtree",
     "pathlib.Path.unlink",
@@ -1290,7 +1308,7 @@ class NemoScanner(BaseScanner):
             return
 
         # Trusted namespaces can still hide obviously dangerous leaf names.
-        if any(target.startswith(prefix) for prefix in _SAFE_TARGET_PREFIXES):
+        if target in _SAFE_TARGETS or any(target.startswith(prefix) for prefix in _SAFE_TARGET_PREFIXES):
             pattern = _find_suspicious_safe_prefixed_target_pattern(target)
             if pattern is not None:
                 self._add_suspicious_target_check(

--- a/modelaudit/scanners/nemo_scanner.py
+++ b/modelaudit/scanners/nemo_scanner.py
@@ -72,6 +72,14 @@ _SAFE_TARGETS = {
     "torch.utils.data.TensorDataset",
     "torch.utils.data.WeightedRandomSampler",
     "torch.utils.data.distributed.DistributedSampler",
+    "torch.utils.data.dataloader.DataLoader",
+    "torch.utils.data.dataset.ConcatDataset",
+    "torch.utils.data.dataset.Subset",
+    "torch.utils.data.dataset.TensorDataset",
+    "torch.utils.data.sampler.BatchSampler",
+    "torch.utils.data.sampler.RandomSampler",
+    "torch.utils.data.sampler.SequentialSampler",
+    "torch.utils.data.sampler.WeightedRandomSampler",
 }
 
 # Dangerous _target_ values that indicate exploitation

--- a/tests/scanners/test_nemo_scanner.py
+++ b/tests/scanners/test_nemo_scanner.py
@@ -1447,6 +1447,57 @@ class TestCVE202523304HydraTarget:
         assert cve_checks[0].severity == IssueSeverity.CRITICAL
         assert cve_checks[0].details["target"] == target
 
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "torch.utils.cpp_extension.load",
+            "torch.utils.cpp_extension.load_inline",
+            "torch.utils.cpp_extension._jit_compile",
+        ],
+    )
+    def test_torch_cpp_extension_targets_detected_as_dangerous(self, tmp_path: Path, target: str) -> None:
+        """Native extension JIT/load helpers must not be hidden by torch.utils allowlisting."""
+        config = {
+            "model": {
+                "_target_": target,
+                "name": "malicious_extension",
+                "cpp_sources": ['#include <cstdlib>\nint run() { return system("id"); }'],
+            },
+        }
+        path = _create_nemo_file(tmp_path, config)
+
+        result = NemoScanner().scan(str(path))
+
+        cve_checks = [
+            check
+            for check in result.checks
+            if check.name == "CVE-2025-23304: Dangerous Hydra _target_" and check.details.get("target") == target
+        ]
+        assert len(cve_checks) == 1
+        assert cve_checks[0].status == CheckStatus.FAILED
+        assert cve_checks[0].severity == IssueSeverity.CRITICAL
+        assert cve_checks[0].details["cve_id"] == "CVE-2025-23304"
+
+    def test_explicit_safe_torch_utils_data_target_remains_safe(self, tmp_path: Path) -> None:
+        """Legitimate torch.utils data helpers stay clean without trusting all torch.utils targets."""
+        config = {"loader": {"_target_": "torch.utils.data.DataLoader", "batch_size": 4}}
+        path = _create_nemo_file(tmp_path, config)
+
+        result = NemoScanner().scan(str(path))
+
+        assert not [
+            check
+            for check in result.checks
+            if check.name == "CVE-2025-23304: Dangerous Hydra _target_"
+            and check.details.get("target") == "torch.utils.data.DataLoader"
+        ]
+        assert any(
+            check.name == "Hydra _target_ Safety Check"
+            and check.status == CheckStatus.PASSED
+            and check.details.get("target") == "torch.utils.data.DataLoader"
+            for check in result.checks
+        )
+
     def test_numpy_load_without_pickle_is_safe_target(self, tmp_path: Path) -> None:
         """Default numpy.load calls should not be treated as pickle deserialization."""
         config = {"model": {"_target_": "numpy.load", "file": "weights.npy"}}

--- a/tests/scanners/test_nemo_scanner.py
+++ b/tests/scanners/test_nemo_scanner.py
@@ -1478,9 +1478,17 @@ class TestCVE202523304HydraTarget:
         assert cve_checks[0].severity == IssueSeverity.CRITICAL
         assert cve_checks[0].details["cve_id"] == "CVE-2025-23304"
 
-    def test_explicit_safe_torch_utils_data_target_remains_safe(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "torch.utils.data.DataLoader",
+            "torch.utils.data.dataloader.DataLoader",
+            "torch.utils.data.sampler.RandomSampler",
+        ],
+    )
+    def test_explicit_safe_torch_utils_data_target_remains_safe(self, tmp_path: Path, target: str) -> None:
         """Legitimate torch.utils data helpers stay clean without trusting all torch.utils targets."""
-        config = {"loader": {"_target_": "torch.utils.data.DataLoader", "batch_size": 4}}
+        config = {"loader": {"_target_": target, "batch_size": 4}}
         path = _create_nemo_file(tmp_path, config)
 
         result = NemoScanner().scan(str(path))
@@ -1488,13 +1496,12 @@ class TestCVE202523304HydraTarget:
         assert not [
             check
             for check in result.checks
-            if check.name == "CVE-2025-23304: Dangerous Hydra _target_"
-            and check.details.get("target") == "torch.utils.data.DataLoader"
+            if check.name == "CVE-2025-23304: Dangerous Hydra _target_" and check.details.get("target") == target
         ]
         assert any(
             check.name == "Hydra _target_ Safety Check"
             and check.status == CheckStatus.PASSED
-            and check.details.get("target") == "torch.utils.data.DataLoader"
+            and check.details.get("target") == target
             for check in result.checks
         )
 


### PR DESCRIPTION
## Summary

- remove the broad `torch.utils.` Hydra allowlist in NeMo configs
- explicitly allow known safe `torch.utils.data` targets
- flag PyTorch C++ extension loaders such as `load_inline` as CVE-2025-23304 dangerous targets

## Validation

- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/python -m pytest tests/scanners/test_nemo_scanner.py -q`
- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/ruff check modelaudit/scanners/nemo_scanner.py tests/scanners/test_nemo_scanner.py`
- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/mypy modelaudit/scanners/nemo_scanner.py tests/scanners/test_nemo_scanner.py`
