### PR TITLE
fix: require ETags for cloud cache hits

### DIFF
--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -6,7 +6,7 @@ import os
 import re
 import shutil
 import tempfile
-from collections.abc import Callable, Collection, Coroutine, Iterator
+from collections.abc import Callable, Collection, Coroutine, Iterator, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -101,6 +101,17 @@ def _cloud_url_basename(url: str) -> str:
     except Exception:
         path = url
     return Path(path).name
+
+
+def _metadata_etag(metadata: Mapping[str, Any] | None) -> str | None:
+    """Extract a stable object validator from fsspec-style metadata."""
+    if not metadata:
+        return None
+    for key in ("etag", "ETag", "Etag", "e_tag", "version_id", "VersionId", "generation"):
+        value = metadata.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return None
 
 
 def _cloud_url_without_query(url: str) -> str:
@@ -309,13 +320,17 @@ async def analyze_cloud_target(url: str) -> dict[str, Any]:
 
         # Check if it's a file or directory
         if info.get("type") == "file" or (info.get("type") != "directory" and "size" in info):
-            return {
+            file_metadata: dict[str, Any] = {
                 "type": "file",
                 "size": info.get("size", 0),
                 "name": _cloud_url_basename(url),
                 "estimated_time": estimate_download_time(info.get("size", 0)),
                 "human_size": format_size(info.get("size", 0)),
             }
+            etag = _metadata_etag(info)
+            if etag is not None:
+                file_metadata["etag"] = etag
+            return file_metadata
 
         # It's a directory, list contents
         files = []
@@ -329,14 +344,21 @@ async def analyze_cloud_target(url: str) -> dict[str, Any]:
                 item_info = fs.info(item)
                 if item_info.get("type") == "file" or "size" in item_info:
                     size = item_info.get("size", 0)
-                    files.append(
-                        {"path": item, "name": _cloud_url_basename(item), "size": size, "human_size": format_size(size)}
-                    )
+                    file_metadata = {
+                        "path": item,
+                        "name": _cloud_url_basename(item),
+                        "size": size,
+                        "human_size": format_size(size),
+                    }
+                    etag = _metadata_etag(item_info)
+                    if etag is not None:
+                        file_metadata["etag"] = etag
+                    files.append(file_metadata)
                     total_size += size
             except Exception:
                 continue
 
-        return {
+        directory_metadata: dict[str, Any] = {
             "type": "directory",
             "file_count": len(files),
             "total_size": total_size,
@@ -344,6 +366,10 @@ async def analyze_cloud_target(url: str) -> dict[str, Any]:
             "files": files,
             "estimated_time": estimate_download_time(total_size),
         }
+        etag = _metadata_etag(info)
+        if etag is not None:
+            directory_metadata["etag"] = etag
+        return directory_metadata
     except Exception as e:
         # If we can't get info, assume it's a file
         return {"type": "unknown", "error": redact_cloud_error_for_display(e, url)}
@@ -632,14 +658,6 @@ def download_from_cloud(
     # Initialize cache
     cache = GCSCache(cache_dir) if use_cache else None
 
-    # Check cache first
-    if cache:
-        cached_path = cache.get_cached_path(url)
-        if cached_path:
-            if show_progress:
-                click.echo(f"✓ Using cached version from {cached_path}")
-            return cached_path
-
     # Analyze target
     metadata = _run_coroutine_sync(lambda: analyze_cloud_target(url))
 
@@ -647,6 +665,14 @@ def download_from_cloud(
     if "error" in metadata or metadata.get("type") == "unknown":
         error_msg = redact_cloud_error_for_display(metadata.get("error", "Unknown cloud target type"), url)
         raise ValueError(f"Failed to analyze cloud target {redact_url_for_display(url)}: {error_msg}")
+
+    etag = _metadata_etag(metadata)
+    if cache:
+        cached_path = cache.get_cached_path(url, etag=etag)
+        if cached_path:
+            if show_progress:
+                click.echo(f"✓ Using cached version from {cached_path}")
+            return cached_path
 
     # Check if we can use streaming analysis
     if stream_analyze and metadata.get("type") == "file":
@@ -781,13 +807,13 @@ def download_from_cloud(
 
             # Cache the download
             if cache:
-                cache.cache_file(url, local_file)  # Cache the actual file, not the directory
+                cache.cache_file(url, local_file, etag=etag)  # Cache the actual file, not the directory
 
             return local_file  # Return the actual file path for single files
 
         # Cache the download (for directories)
         if cache:
-            cache.cache_file(url, download_path)
+            cache.cache_file(url, download_path, etag=etag)
 
         return download_path
     except Exception:

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -467,8 +467,12 @@ class GCSCache:
                 self._save_metadata()
                 return None
 
-            # Check if etag matches (if provided)
-            if etag and cached.get("etag") != etag:
+            cached_etag = cached.get("etag")
+            if etag is None or not cached_etag:
+                self._save_metadata()
+                return None
+
+            if cached_etag != etag:
                 return None
 
             # Update last accessed time

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -630,6 +630,17 @@ def _build_safe_local_path(base_url: str, file_url: str, download_path: Path) ->
     return local_path
 
 
+def _clear_directory_contents(path: Path) -> None:
+    """Remove stale cache directory contents without deleting the directory itself."""
+    if not path.exists():
+        return
+    for child in path.iterdir():
+        if child.is_dir():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+
+
 def download_from_cloud(
     url: str,
     cache_dir: Path | None = None,
@@ -745,6 +756,9 @@ def download_from_cloud(
 
         # Download based on type
         if metadata["type"] == "directory":
+            if cache:
+                _clear_directory_contents(download_path)
+
             # Handle directory download
             raw_files = metadata.get("files")
             if raw_files is None:

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -208,6 +208,36 @@ def test_download_from_cloud_reuses_cache_with_matching_etag(mock_fs: MagicMock,
     assert mock_fs.call_count == 3
 
 
+@patch("fsspec.filesystem")
+def test_download_from_cloud_clears_stale_directory_cache(mock_fs: MagicMock, tmp_path: Path) -> None:
+    url = "s3://bucket/models"
+    cache = GCSCache(cache_dir=tmp_path / "cache")
+    stale_dir = tmp_path / "stale"
+    stale_dir.mkdir()
+    (stale_dir / "old-model.bin").write_bytes(b"old")
+    cache.cache_file(url, stale_dir, etag="etag-v1")
+
+    fs_meta = make_fs_mock()
+    fs_meta.info.return_value = {"type": "directory", "ETag": "etag-v2"}
+    fs_meta.glob.return_value = ["s3://bucket/models/new-model.bin"]
+    fs_meta.info.side_effect = [
+        {"type": "directory", "ETag": "etag-v2"},
+        {"type": "file", "size": 3, "ETag": "file-etag-v2"},
+    ]
+
+    fs = make_fs_mock()
+    fs.info.return_value = {"type": "file", "size": 3}
+    fs.get.side_effect = lambda _src, dst: Path(dst).write_bytes(b"new")
+
+    mock_fs.side_effect = [fs_meta, fs]
+
+    result = download_from_cloud(url, cache_dir=tmp_path / "cache", show_progress=False, selective=False)
+
+    assert isinstance(result, Path)
+    assert not (result / "old-model.bin").exists()
+    assert (result / "new-model.bin").read_bytes() == b"new"
+
+
 @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
 @patch("modelaudit.utils.sources.cloud_storage.check_disk_space")
 @patch("fsspec.filesystem")

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -162,6 +162,7 @@ def test_download_from_cloud(mock_fs: MagicMock, tmp_path: Path) -> None:
 
     fs = make_fs_mock()
     fs.info.return_value = {"type": "file", "size": 1024}
+    fs.get.side_effect = lambda _src, dst: Path(dst).write_bytes(b"data")
 
     mock_fs.side_effect = [fs_meta, fs]
 
@@ -179,6 +180,32 @@ def test_download_from_cloud(mock_fs: MagicMock, tmp_path: Path) -> None:
     assert result.name == "model.pt"
 
     # Note: fsspec filesystems don't need explicit cleanup according to implementation
+
+
+@patch("fsspec.filesystem")
+def test_download_from_cloud_reuses_cache_with_matching_etag(mock_fs: MagicMock, tmp_path: Path) -> None:
+    url = "s3://bucket/model.pt"
+
+    first_meta = make_fs_mock()
+    first_meta.info.return_value = {"type": "file", "size": 4, "ETag": "etag-v1"}
+
+    downloader = make_fs_mock()
+    downloader.info.return_value = {"type": "file", "size": 4, "ETag": "etag-v1"}
+    downloader.get.side_effect = lambda _src, dst: Path(dst).write_bytes(b"data")
+
+    second_meta = make_fs_mock()
+    second_meta.info.return_value = {"type": "file", "size": 4, "ETag": "etag-v1"}
+
+    mock_fs.side_effect = [first_meta, downloader, second_meta]
+
+    first = download_from_cloud(url, cache_dir=tmp_path, show_progress=False)
+    second = download_from_cloud(url, cache_dir=tmp_path, show_progress=False)
+
+    assert isinstance(first, Path)
+    assert second == first
+    assert first.read_bytes() == b"data"
+    downloader.get.assert_called_once()
+    assert mock_fs.call_count == 3
 
 
 @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -741,13 +741,90 @@ class TestCloudCacheSafety:
         source_file = sibling_dir / "artifact.bin"
         source_file.write_bytes(b"artifact")
 
-        cache.cache_file("s3://bucket/model.bin", source_file)
+        url = "s3://bucket/model.bin"
+        cache.cache_file(url, source_file, etag="etag-v1")
 
-        cached_path = cache.get_cached_path("s3://bucket/model.bin")
+        cached_path = cache.get_cached_path(url, etag="etag-v1")
         assert cached_path is not None
         assert cached_path.resolve() != source_file.resolve()
         assert cached_path.resolve().is_relative_to(cache.cache_dir.resolve())
         assert source_file.exists()
+
+    def test_cache_without_etag_is_stale_miss(self, tmp_path: Path) -> None:
+        """Cache entries without validators must not be reused as fresh remote objects."""
+        cache = GCSCache(cache_dir=tmp_path / "cache")
+        source_file = tmp_path / "artifact.bin"
+        source_file.write_bytes(b"artifact")
+        url = "s3://bucket/model.bin"
+
+        cache.cache_file(url, source_file)
+
+        assert cache.get_cached_path(url) is None
+        assert cache.get_cached_path(url, etag="etag-v1") is None
+
+    def test_cache_with_matching_etag_hits(self, tmp_path: Path) -> None:
+        cache = GCSCache(cache_dir=tmp_path / "cache")
+        source_file = tmp_path / "artifact.bin"
+        source_file.write_bytes(b"artifact")
+        url = "s3://bucket/model.bin"
+
+        cache.cache_file(url, source_file, etag="etag-v1")
+
+        cached_path = cache.get_cached_path(url, etag="etag-v1")
+
+        assert cached_path is not None
+        assert cached_path.read_bytes() == b"artifact"
+
+    def test_cache_with_mismatched_etag_misses(self, tmp_path: Path) -> None:
+        cache = GCSCache(cache_dir=tmp_path / "cache")
+        source_file = tmp_path / "artifact.bin"
+        source_file.write_bytes(b"artifact")
+        url = "s3://bucket/model.bin"
+
+        cache.cache_file(url, source_file, etag="etag-v1")
+
+        assert cache.get_cached_path(url, etag="etag-v2") is None
+
+    def test_legacy_cache_without_etag_is_stale_miss_and_migrates_metadata(self, tmp_path: Path) -> None:
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        cached_file = cache_dir / "aa" / "bb" / "model.bin"
+        cached_file.parent.mkdir(parents=True)
+        cached_file.write_bytes(b"artifact")
+        signed_url = (
+            "https://user:pass@bucket.s3.amazonaws.com/path/model.bin"
+            "?X-Amz-Credential=secret&X-Amz-Signature=sig#fragment"
+        )
+
+        cache = GCSCache(cache_dir=cache_dir)
+        cache_key = cache.get_cache_key(signed_url)
+        cache.metadata_file.write_text(
+            json.dumps(
+                {
+                    cache_key: {
+                        "url": signed_url,
+                        "path": str(cached_file),
+                        "size": cached_file.stat().st_size,
+                        "cached_at": "2026-01-01T00:00:00",
+                        "last_accessed": "2026-01-01T00:00:00",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        cache = GCSCache(cache_dir=cache_dir)
+
+        assert cache.get_cached_path(signed_url) is None
+        raw_metadata = cache.metadata_file.read_text(encoding="utf-8")
+        metadata = json.loads(raw_metadata)
+        entry = metadata[cache_key]
+        assert "url" not in entry
+        assert entry["url_sha256"] == cache_key
+        assert entry["url_display"] == "https://bucket.s3.amazonaws.com/path/model.bin"
+        assert "X-Amz-Credential" not in raw_metadata
+        assert "X-Amz-Signature" not in raw_metadata
+        assert "user:pass" not in raw_metadata
 
     def test_clean_old_cache_does_not_delete_outside_cache(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture


### PR DESCRIPTION
## Summary

- Require an explicit matching ETag before returning a cloud cache entry as fresh.
- Treat no-validator cache entries as stale misses, including legacy entries without `etag`.
- Preserve metadata sanitization by rewriting legacy raw-URL metadata on stale no-validator lookups.
- Add focused regressions for no ETag, matching ETag, mismatched ETag, and legacy metadata migration.

## Validation

- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run --active --no-sync --with-editable . pytest tests/utils/sources/test_cloud_storage.py -q`
- `uv run --active --no-sync --with-editable . ruff format --check modelaudit/utils/sources/cloud_storage.py tests/utils/sources/test_cloud_storage.py`
- `uv run --active --no-sync --with-editable . ruff check modelaudit/utils/sources/cloud_storage.py tests/utils/sources/test_cloud_storage.py`
- `uv run --active --no-sync --with-editable . mypy modelaudit/utils/sources/cloud_storage.py tests/utils/sources/test_cloud_storage.py`
