### PR TITLE
fix: treat Keras fixed-version prereleases as vulnerable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- treat prereleases of fixed Keras ZIP CVE-2026-1669 versions as vulnerable
 - route renamed structured JAX/Orbax JSON checkpoints, conservatively report observable bounded-prefix threats, and fail closed for oversized identified metadata
 - classify Flax MessagePack recursion-limit analysis gaps as inconclusive coverage
 - classify incomplete JAX/Orbax metadata, pickle, and NumPy analysis as inconclusive coverage

--- a/modelaudit/scanners/keras_zip_scanner.py
+++ b/modelaudit/scanners/keras_zip_scanner.py
@@ -2025,8 +2025,9 @@ class KerasZipScanner(BaseScanner):
         except ValueError:
             return False
 
-        suffix = (version_match.group(4) or "").lstrip("._-")
-        is_prerelease = bool(_KERAS_PRERELEASE_SUFFIX_PATTERN.match(suffix))
+        suffix = (version_match.group(4) or "").strip().lower()
+        public_suffix = suffix.lstrip("._-")
+        is_prerelease = not suffix.startswith("+") and bool(_KERAS_PRERELEASE_SUFFIX_PATTERN.match(public_suffix))
         parsed = (major, minor, patch)
         if (3, 0, 0) <= parsed < (3, 12, 1) or (3, 13, 0) <= parsed < (3, 13, 2):
             return True

--- a/modelaudit/scanners/keras_zip_scanner.py
+++ b/modelaudit/scanners/keras_zip_scanner.py
@@ -116,6 +116,8 @@ def _has_get_file_reference(values: list[str]) -> bool:
 _KERAS_METADATA_ENTRY = "metadata.json"
 _KERAS_METADATA_MAX_BYTES = 10 * 1024 * 1024
 _KERAS_WEIGHTS_ENTRY = "model.weights.h5"
+_KERAS_RELEASE_VERSION_PATTERN = re.compile(r"^\s*(\d+)\.(\d+)(?:\.(\d+))?([A-Za-z0-9.+_-]*)\s*$")
+_KERAS_PRERELEASE_SUFFIX_PATTERN = re.compile(r"(?i)^(?:a|alpha|b|beta|c|rc|pre|preview|dev)")
 
 
 def _redact_url_for_display(url: str) -> str:
@@ -2012,20 +2014,20 @@ class KerasZipScanner(BaseScanner):
     @staticmethod
     def _is_vulnerable_to_cve_2026_1669(version: str) -> bool:
         """Return True for Keras versions in the known CVE-2026-1669 affected ranges."""
-        parts = version.split(".", 2)
-        if len(parts) < 2:
+        version_match = _KERAS_RELEASE_VERSION_PATTERN.match(version)
+        if not version_match:
             return False
 
         try:
-            major = int(parts[0])
-            minor = int(parts[1])
-            patch = 0
-            if len(parts) == 3:
-                patch_digits = "".join(ch for ch in parts[2] if ch.isdigit())
-                if patch_digits:
-                    patch = int(patch_digits)
+            major = int(version_match.group(1))
+            minor = int(version_match.group(2))
+            patch = int(version_match.group(3) or 0)
         except ValueError:
             return False
 
+        suffix = (version_match.group(4) or "").lstrip("._-")
+        is_prerelease = bool(_KERAS_PRERELEASE_SUFFIX_PATTERN.match(suffix))
         parsed = (major, minor, patch)
-        return (3, 0, 0) <= parsed < (3, 12, 1) or (3, 13, 0) <= parsed < (3, 13, 2)
+        if (3, 0, 0) <= parsed < (3, 12, 1) or (3, 13, 0) <= parsed < (3, 13, 2):
+            return True
+        return parsed in {(3, 12, 1), (3, 13, 2)} and is_prerelease

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 import tempfile
 import zipfile
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
@@ -214,6 +215,16 @@ def pytest_runtest_setup(item):
         marker = item.get_closest_marker(marker_name)
         if marker is not None and not _check_framework(module_name):
             pytest.skip(f"{marker_name} is not installed")
+
+
+@pytest.fixture(autouse=True)
+def reset_rule_config_between_tests() -> Iterator[None]:
+    """Keep CLI rule suppressions from leaking between tests."""
+    from modelaudit.config import reset_config
+
+    reset_config()
+    yield
+    reset_config()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -188,7 +188,10 @@ class TestKerasZipScanner:
             for check in result.checks
         )
 
-    @pytest.mark.parametrize("keras_version", ["3.12.1rc1", "3.12.1a0", "3.12.1.dev0", "3.13.2rc1"])
+    @pytest.mark.parametrize(
+        "keras_version",
+        ["3.12.1rc1", "3.12.1a0", "3.12.1.dev0", "3.13.2rc1", "3.13.2dev0"],
+    )
     def test_embedded_hdf5_external_references_prerelease_fixes_are_vulnerable(
         self, tmp_path: Path, keras_version: str
     ) -> None:
@@ -208,7 +211,10 @@ class TestKerasZipScanner:
         assert cve_issues[0].details["keras_version"] == keras_version
         assert cve_issues[0].severity == IssueSeverity.WARNING
 
-    @pytest.mark.parametrize("keras_version", ["3.12.1", "3.12.1+cpu", "3.13.2", "3.13.2.post1"])
+    @pytest.mark.parametrize(
+        "keras_version",
+        ["3.12.1", "3.12.1+cpu", "3.12.1+rc1", "3.13.2", "3.13.2.post1", "3.13.2+dev0"],
+    )
     def test_embedded_hdf5_external_references_stable_fixed_versions_pass(
         self, tmp_path: Path, keras_version: str
     ) -> None:

--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -188,6 +188,44 @@ class TestKerasZipScanner:
             for check in result.checks
         )
 
+    @pytest.mark.parametrize("keras_version", ["3.12.1rc1", "3.12.1a0", "3.12.1.dev0", "3.13.2rc1"])
+    def test_embedded_hdf5_external_references_prerelease_fixes_are_vulnerable(
+        self, tmp_path: Path, keras_version: str
+    ) -> None:
+        """Prereleases of the fixed CVE-2026-1669 versions are still vulnerable."""
+        scanner = KerasZipScanner()
+        keras_path = create_configured_keras_zip(
+            tmp_path,
+            {"class_name": "Sequential", "config": {"layers": []}},
+            keras_version=keras_version,
+            weights_h5_path=create_external_link_weights_h5(tmp_path),
+        )
+
+        result = scanner.scan(str(keras_path))
+
+        cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2026-1669"]
+        assert len(cve_issues) == 1
+        assert cve_issues[0].details["keras_version"] == keras_version
+        assert cve_issues[0].severity == IssueSeverity.WARNING
+
+    @pytest.mark.parametrize("keras_version", ["3.12.1", "3.12.1+cpu", "3.13.2", "3.13.2.post1"])
+    def test_embedded_hdf5_external_references_stable_fixed_versions_pass(
+        self, tmp_path: Path, keras_version: str
+    ) -> None:
+        """Stable fixed CVE-2026-1669 versions should not emit warning noise."""
+        scanner = KerasZipScanner()
+        keras_path = create_configured_keras_zip(
+            tmp_path,
+            {"class_name": "Sequential", "config": {"layers": []}},
+            keras_version=keras_version,
+            weights_h5_path=create_external_link_weights_h5(tmp_path),
+        )
+
+        result = scanner.scan(str(keras_path))
+
+        assert not any(issue.details.get("cve_id") == "CVE-2026-1669" for issue in result.issues)
+        assert not any(issue.severity in (IssueSeverity.WARNING, IssueSeverity.CRITICAL) for issue in result.issues)
+
     def test_benign_embedded_weights_do_not_emit_warning_noise(self, tmp_path: Path) -> None:
         """Benign embedded weights should not produce warning or critical noise."""
         scanner = KerasZipScanner()


### PR DESCRIPTION
## Summary

- replace CVE-2026-1669 digit-concatenating Keras version parsing with prerelease-aware parsing
- treat `3.12.1rc1` / `3.13.2rc1` style fixed-version prereleases as vulnerable
- keep stable fixed releases and local/post-release versions quiet

## Validation

- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/python -m pytest tests/scanners/test_keras_zip_scanner.py -q`
- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/ruff check modelaudit/scanners/keras_zip_scanner.py tests/scanners/test_keras_zip_scanner.py`
- `/Users/mdangelo/.codex/worktrees/5b31/modelaudit/.venv/bin/mypy modelaudit/scanners/keras_zip_scanner.py tests/scanners/test_keras_zip_scanner.py`
