### PR TITLE
fix: fail closed on encoded nested probe cap

### DIFF
--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -51,6 +51,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- fail closed when encoded nested-pickle probe candidates exhaust the analysis cap
 - prevent call-graph alias cycles from hanging scans
 - detect nested brace-format lookups that reach tracked `defaultdict` factories
 - avoid `str.format` false positives when a `ChainMap` shadows a `defaultdict`

--- a/packages/modelaudit-picklescan/rust/src/nested.rs
+++ b/packages/modelaudit-picklescan/rust/src/nested.rs
@@ -12,6 +12,12 @@ pub(crate) struct NestedProbeOffsets {
     pub(crate) limit_exceeded: bool,
 }
 
+pub(crate) struct EncodedNestedProbeWindows {
+    pub(crate) windows: Vec<String>,
+    pub(crate) limit_exceeded: bool,
+    pub(crate) limit_exceeded_encoding: Option<&'static str>,
+}
+
 pub(crate) fn decode_possible_encoded_pickle(
     value: &str,
     max_nested_pickle_bytes: usize,
@@ -551,17 +557,31 @@ fn nested_pickle_probe_offsets_with_limit(
     }
 }
 
+#[cfg(test)]
 pub(crate) fn encoded_nested_literal_probe_windows(
     value: &str,
     max_window_chars: usize,
 ) -> Vec<String> {
+    encoded_nested_literal_probe_windows_with_limit(value, max_window_chars).windows
+}
+
+pub(crate) fn encoded_nested_literal_probe_windows_with_limit(
+    value: &str,
+    max_window_chars: usize,
+) -> EncodedNestedProbeWindows {
     let mut windows = Vec::new();
+    let mut limit_exceeded = false;
+    let mut limit_exceeded_encoding = None;
     let prefix_has_base64_pickle = base64_prefix_has_pickle_prefix(value);
     let prefix_has_hex_pickle = !prefix_has_base64_pickle && hex_prefix_has_pickle_prefix(value);
     if prefix_has_base64_pickle || prefix_has_hex_pickle {
         push_unique_window(&mut windows, take_chars(value, max_window_chars));
         if encoded_prefix_consumes_literal(value, prefix_has_base64_pickle, prefix_has_hex_pickle) {
-            return windows;
+            return EncodedNestedProbeWindows {
+                windows,
+                limit_exceeded,
+                limit_exceeded_encoding,
+            };
         }
     }
     let suffix_probe = take_last_chars(value, ENCODED_LITERAL_PROBE_CHARS);
@@ -572,15 +592,16 @@ pub(crate) fn encoded_nested_literal_probe_windows(
     let bytes = value.as_bytes();
     let mid_scan_len = bytes.len().min(MAX_ENCODED_LITERAL_MID_SCAN_BYTES);
     for index in 0..mid_scan_len {
-        if windows.len() >= MAX_NESTED_PAYLOAD_PROBES {
-            break;
-        }
-        let candidate_starts_encoded_pickle = starts_encoded_pickle_at(bytes, index);
-        if !candidate_starts_encoded_pickle {
+        let Some(candidate_encoding) = encoded_pickle_kind_at(bytes, index) else {
             continue;
-        }
+        };
         if !value.is_char_boundary(index) {
             continue;
+        }
+        if windows.len() >= MAX_NESTED_PAYLOAD_PROBES {
+            limit_exceeded = true;
+            limit_exceeded_encoding = Some(candidate_encoding);
+            break;
         }
         push_unique_window(
             &mut windows,
@@ -588,7 +609,11 @@ pub(crate) fn encoded_nested_literal_probe_windows(
         );
     }
 
-    windows
+    EncodedNestedProbeWindows {
+        windows,
+        limit_exceeded,
+        limit_exceeded_encoding,
+    }
 }
 
 pub(crate) fn encoded_nested_literal_probe_coverage_incomplete(value: &str) -> bool {
@@ -626,22 +651,29 @@ pub(crate) fn encoded_literal_may_contain_pickle(value: &str) -> bool {
 }
 
 fn starts_encoded_pickle_at(bytes: &[u8], index: usize) -> bool {
+    encoded_pickle_kind_at(bytes, index).is_some()
+}
+
+fn encoded_pickle_kind_at(bytes: &[u8], index: usize) -> Option<&'static str> {
     let suffix = &bytes[index..];
     let starts_base64_pickle =
         encoded_base64_first_byte(suffix).is_some_and(is_pickle_prefix_start_byte);
     let starts_hex_pickle = encoded_hex_first_byte(suffix).is_some_and(is_pickle_prefix_start_byte);
     if !starts_base64_pickle && !starts_hex_pickle {
-        return false;
+        return None;
     }
 
     let probe_len = suffix.len().min(ENCODED_LITERAL_PROBE_CHARS * 4);
     let Ok(probe) = std::str::from_utf8(&suffix[..probe_len]) else {
-        return false;
+        return None;
     };
     if starts_base64_pickle && base64_prefix_has_pickle_prefix(probe) {
-        return true;
+        return Some("base64");
     }
-    starts_hex_pickle && hex_prefix_has_pickle_prefix(probe)
+    if starts_hex_pickle && hex_prefix_has_pickle_prefix(probe) {
+        return Some("hex");
+    }
+    None
 }
 
 fn encoded_prefix_has_pickle_prefix(value: &str) -> bool {
@@ -1068,6 +1100,27 @@ mod tests {
 
         assert!(encoded_literal_may_contain_pickle(&value));
         assert!(windows.iter().any(|window| window.starts_with("gAR9Lg==")));
+    }
+
+    #[test]
+    fn encoded_probe_windows_report_limit_after_decoys_exhaust_cap() {
+        let mut value = String::new();
+        for index in 0..MAX_NESTED_PAYLOAD_PROBES {
+            value.push_str(&format!("gAR9Lg==-decoy-{index}|"));
+        }
+        let hidden_payload = "Y29zCnN5c3RlbQopUi4";
+        value.push_str(hidden_payload);
+        value.push_str(&"A".repeat(ENCODED_LITERAL_PROBE_CHARS + 1));
+
+        let probed = encoded_nested_literal_probe_windows_with_limit(&value, 64);
+
+        assert!(probed.limit_exceeded);
+        assert_eq!(probed.limit_exceeded_encoding, Some("base64"));
+        assert_eq!(probed.windows.len(), MAX_NESTED_PAYLOAD_PROBES);
+        assert!(!probed
+            .windows
+            .iter()
+            .any(|window| window.starts_with(hidden_payload)));
     }
 
     #[test]

--- a/packages/modelaudit-picklescan/rust/src/state.rs
+++ b/packages/modelaudit-picklescan/rust/src/state.rs
@@ -12,9 +12,10 @@ use crate::expansion::{
 use crate::nested::{
     decode_possible_encoded_pickle, detect_oversized_encoded_pickle_prefixes,
     encoded_literal_may_contain_pickle, encoded_nested_literal_probe_coverage_incomplete,
-    encoded_nested_literal_probe_windows, encoded_nested_window_char_limit, has_execution_opcode,
-    has_pickle_prefix, looks_like_pickle_payload, nested_pickle_probe_offsets,
-    pickle_payload_extent, truncated_pickle_prefix_requires_fail_closed, MAX_NESTED_PAYLOAD_PROBES,
+    encoded_nested_literal_probe_windows_with_limit, encoded_nested_window_char_limit,
+    has_execution_opcode, has_pickle_prefix, looks_like_pickle_payload,
+    nested_pickle_probe_offsets, pickle_payload_extent,
+    truncated_pickle_prefix_requires_fail_closed, MAX_NESTED_PAYLOAD_PROBES,
 };
 use crate::nested_surface::{
     encoded_nested_payload_finding, is_allowlisted_nested_constructor_ref,
@@ -4056,7 +4057,11 @@ impl<'a> ScanState<'a> {
             found_candidate |= self.scan_encoded_nested_pickle_candidate(value, position);
         }
 
-        for candidate in encoded_nested_literal_probe_windows(value, max_window_chars) {
+        let probe_windows =
+            encoded_nested_literal_probe_windows_with_limit(value, max_window_chars);
+        let probe_limit_exceeded = probe_windows.limit_exceeded;
+        let probe_limit_exceeded_encoding = probe_windows.limit_exceeded_encoding;
+        for candidate in probe_windows.windows {
             if found_candidate && candidate == value {
                 continue;
             }
@@ -4072,11 +4077,15 @@ impl<'a> ScanState<'a> {
             );
         }
 
+        if let Some(encoding) = probe_limit_exceeded_encoding {
+            self.record_nested_probe_limit_exceeded(encoding, string_char_len(value), position);
+        }
+
         if found_candidate {
             return;
         }
 
-        if probe_coverage_incomplete {
+        if probe_coverage_incomplete || probe_limit_exceeded {
             return;
         }
 
@@ -5454,6 +5463,16 @@ mod tests {
     use crate::report::{detail_string, detail_usize};
     use std::time::Duration;
 
+    fn encoded_probe_limit_decoy_literal() -> String {
+        let mut value = String::new();
+        for index in 0..MAX_NESTED_PAYLOAD_PROBES {
+            value.push_str(&format!("gAR9Lg==-decoy-{index}|"));
+        }
+        value.push_str("Y29zCnN5c3RlbQopUi4");
+        value.push_str(&"A".repeat(65));
+        value
+    }
+
     #[test]
     fn integer_stack_values_preserve_text_and_long_byte_operands() {
         for (arg, expected) in [
@@ -6119,6 +6138,50 @@ mod tests {
             .notices
             .iter()
             .any(|notice| notice.code == Some("nested_payload_truncated")));
+    }
+
+    #[test]
+    fn encoded_nested_probe_limit_fails_closed_after_decoys() {
+        let options = ScanOptions {
+            timeout_s: DEFAULT_TIMEOUT_S,
+            max_opcodes: DEFAULT_MAX_OPCODES,
+            post_budget_scan_bytes: DEFAULT_POST_BUDGET_SCAN_BYTES,
+            max_string_literal_scan_chars: DEFAULT_MAX_STRING_LITERAL_SCAN_CHARS,
+            max_nested_pickle_bytes: DEFAULT_MAX_NESTED_PICKLE_BYTES,
+            max_nested_depth: DEFAULT_MAX_NESTED_DEPTH,
+        };
+        let literal = encoded_probe_limit_decoy_literal();
+        let mut payload = b"\x80\x04X".to_vec();
+        payload.extend_from_slice(&(literal.len() as u32).to_le_bytes());
+        payload.extend_from_slice(literal.as_bytes());
+        payload.push(b'.');
+        let mut scan = ScanState::new(
+            "encoded-nested-probe-limit.pkl".to_string(),
+            &payload,
+            &options,
+            Some(payload.len()),
+            0,
+            0,
+            None,
+        );
+
+        scan.run();
+
+        assert_eq!(scan.status, ScanStatus::Inconclusive);
+        assert_eq!(scan.verdict, "malicious");
+        assert!(scan.findings.iter().any(|finding| {
+            finding.rule_code == Some("S601")
+                && detail_string(&finding.details, "encoding").as_deref() == Some("base64")
+                && detail_usize(&finding.details, "max_nested_payload_probes")
+                    == Some(MAX_NESTED_PAYLOAD_PROBES)
+                && finding.details.iter().any(|(key, value)| {
+                    key == "analysis_incomplete" && matches!(value, DetailValue::Bool(true))
+                })
+        }));
+        assert!(scan
+            .notices
+            .iter()
+            .any(|notice| notice.code == Some("nested_probe_limit")));
     }
 
     #[test]

--- a/packages/modelaudit-picklescan/tests/test_adversarial_pickle_oracle.py
+++ b/packages/modelaudit-picklescan/tests/test_adversarial_pickle_oracle.py
@@ -62,6 +62,11 @@ def _binunicode(data: bytes) -> bytes:
     return b"X" + len(data).to_bytes(4, "little") + data
 
 
+def _encoded_probe_limit_decoy_literal() -> str:
+    decoys = "".join(f"gAR9Lg==-decoy-{index}|" for index in range(64))
+    return f"{decoys}Y29zCnN5c3RlbQopUi4={'A' * 65}"
+
+
 def _text_operand(value: str) -> bytes:
     data = value.encode()
     if len(data) <= 0xFF:
@@ -136,6 +141,12 @@ MEMO_READS: dict[str, MemoOpcodeBuilder] = {
     "long-binget": lambda index: b"j" + index.to_bytes(4, "little"),
     "get": lambda index: b"g" + str(index).encode("ascii") + b"\n",
 }
+
+
+def _encoded_nested_probe_limit_payload() -> bytes:
+    decoys = "".join(f"gAR9Lg==-decoy-{index}|" for index in range(64))
+    literal = f"{decoys}Y29zCnN5c3RlbQopUi4{'A' * 65}".encode()
+    return b"\x80\x04" + _binunicode(literal) + b"."
 
 
 def _stack_global_call(
@@ -419,6 +430,17 @@ def _has_critical_call_graph_limit_finding(report: PickleReport) -> bool:
         finding.severity == Severity.CRITICAL
         and finding.rule_code == "DANGEROUS_CALL_GRAPH_LIMIT"
         and finding.details.get("analysis_incomplete") is True
+        for finding in report.findings
+    )
+
+
+def _has_encoded_nested_probe_limit_finding(report: PickleReport) -> bool:
+    return any(
+        finding.severity == Severity.CRITICAL
+        and finding.rule_code == "S601"
+        and finding.details.get("encoding") == "base64"
+        and finding.details.get("analysis_incomplete") is True
+        and finding.details.get("max_nested_payload_probes") == 64
         for finding in report.findings
     )
 
@@ -4781,6 +4803,18 @@ def test_call_graph_import_reference_limit_fails_closed() -> None:
     assert _has_critical_call_graph_limit_finding(updated)
 
 
+def test_scan_bytes_fails_closed_when_encoded_nested_probe_cap_is_exhausted() -> None:
+    report = scan_bytes(
+        _encoded_nested_probe_limit_payload(),
+        source="encoded-nested-probe-cap.pkl",
+    )
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert _has_encoded_nested_probe_limit_finding(report)
+    assert any(notice.code == "nested_probe_limit" for notice in report.notices)
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="proof uses POSIX shell")
 def test_scan_bytes_blocks_call_graph_exception_poisoning_rce(tmp_path: Path) -> None:
     marker = tmp_path / "call_graph_exception_poisoning_marker"
@@ -6065,6 +6099,26 @@ def test_scan_bytes_blocks_builtins_type_setitem_assignment_rce(tmp_path: Path) 
     result = pickle.loads(payload)
     assert result is None
     assert marker.exists()
+
+
+def test_scan_bytes_encoded_nested_probe_limit_fails_closed_after_decoys() -> None:
+    literal = _encoded_probe_limit_decoy_literal()
+    payload = b"\x80\x04" + _binunicode(literal.encode()) + b"."
+
+    report = scan_bytes(
+        payload,
+        source="encoded-nested-probe-limit.pkl",
+        options=ScanOptions(max_nested_pickle_bytes=16),
+    )
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    finding = next(finding for finding in report.findings if finding.rule_code == "S601")
+    assert finding.severity == Severity.CRITICAL
+    assert finding.details["encoding"] == "base64"
+    assert finding.details["max_nested_payload_probes"] == 64
+    assert finding.details["analysis_incomplete"] is True
+    assert any(notice.code == "nested_probe_limit" for notice in report.notices)
 
 
 def test_scan_bytes_blocks_builtins_staticmethod_descriptor_rce(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Track when encoded nested-pickle probe windows hit the candidate cap instead of silently stopping.
- Record an inconclusive critical nested-probe finding when encoded decoys exhaust the probe budget.
- Preserve the existing bounded scan behavior while carrying the detected encoded kind into findings.
- Add Rust window/state regressions and Python API oracle coverage for decoy-padded encoded payloads.

## Validation

- `cargo fmt --manifest-path Cargo.toml -- --check`
- `cargo test --manifest-path Cargo.toml encoded_probe_windows_report_limit_after_decoys_exhaust_cap`
- `cargo test --manifest-path Cargo.toml encoded_nested_probe_limit_fails_closed_after_decoys`
- `cargo clippy --manifest-path Cargo.toml --all-targets -- -D warnings`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run --with pytest pytest tests/test_adversarial_pickle_oracle.py::test_scan_bytes_fails_closed_when_encoded_nested_probe_cap_is_exhausted -q`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run --with pytest pytest tests/test_adversarial_pickle_oracle.py::test_scan_bytes_encoded_nested_probe_limit_fails_closed_after_decoys -q`
- `uv run --with ruff ruff format --check src tests/test_adversarial_pickle_oracle.py`
- `uv run --with ruff ruff check src tests/test_adversarial_pickle_oracle.py`
- `uv run --with mypy mypy src tests/test_adversarial_pickle_oracle.py`
