### PR TITLE
fix(manifest): fail closed on cloud URL read errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - preserve HuggingFace snapshot shard paths while grouping cache-backed families
 - stop flagging a false-positive ONNX Python operator when tensor weight bytes coincidentally spell `PyOp`
 - classify unavailable manifest and ML text reads as inconclusive rather than security findings, including routing, preflight, and stale cache transitions
+- classify unavailable manifest cloud-reference inspection as inconclusive rather than reporting complete coverage
 - detect Python operators declared in nested ONNX graphs, functions, and function-default graphs
 - distinguish ASCII-serialized Torch7 artifacts from plain PyTorch source text
 - classify unavailable Paddle, NumPy, PyTorch binary, and SavedModel reads as inconclusive rather than security findings

--- a/modelaudit/scanners/manifest_scanner.py
+++ b/modelaudit/scanners/manifest_scanner.py
@@ -756,6 +756,10 @@ class ManifestScanner(BaseScanner):
 
     def _finish_manifest_result(self, result: ScanResult) -> None:
         """Fail closed for inconclusive manifests unless real security findings were recovered."""
+        if scan_result_has_operational_error(result):
+            result.finish(success=False)
+            return
+
         if result.metadata.get("scan_outcome") == INCONCLUSIVE_SCAN_OUTCOME and not _scan_result_has_security_findings(
             result
         ):

--- a/modelaudit/scanners/manifest_scanner.py
+++ b/modelaudit/scanners/manifest_scanner.py
@@ -1153,6 +1153,15 @@ class ManifestScanner(BaseScanner):
 
         except TimeoutError:
             raise
+        except (OSError, UnicodeError) as e:
+            self._record_read_failure(
+                result,
+                path,
+                e,
+                reason="manifest_cloud_storage_read_failed",
+                check_name="Cloud Storage URL Detection",
+                message="Unable to load manifest text for cloud storage URL analysis",
+            )
         except Exception as e:
             logger.debug(f"Error checking cloud storage URLs in {path}: {e}")
 

--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -325,6 +325,41 @@ def test_manifest_parser_read_failure_bypasses_stale_clean_cache(
         reset_cache_manager()
 
 
+def test_manifest_cloud_storage_read_failure_is_inconclusive_after_parse_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_file = tmp_path / "config.json"
+    test_file.write_text(
+        json.dumps({"model_type": "bert", "weights": "https://bucket.s3.amazonaws.com/malware/model.bin"}),
+        encoding="utf-8",
+    )
+    scanner = ManifestScanner()
+    original_read = scanner._read_manifest_text
+    read_count = 0
+
+    def fail_cloud_url_read_once(path: str) -> str:
+        nonlocal read_count
+        read_count += 1
+        if read_count == 1:
+            raise OSError("simulated cloud storage URL read failure")
+        return original_read(path)
+
+    monkeypatch.setattr(scanner, "_read_manifest_text", fail_cloud_url_read_once)
+
+    result = scanner.scan(str(test_file))
+
+    assert result.success is False
+    assert result.metadata.get("scan_outcome") == INCONCLUSIVE_SCAN_OUTCOME
+    assert result.metadata.get("operational_error_reason") == "manifest_cloud_storage_read_failed"
+    assert any(
+        check.name == "Cloud Storage URL Detection"
+        and check.severity == IssueSeverity.INFO
+        and check.details.get("scan_outcome_reason") == "manifest_cloud_storage_read_failed"
+        for check in result.checks
+    )
+
+
 def test_manifest_scanner_case_insensitive_blacklist(tmp_path):
     """Test that blacklist matching is case-insensitive."""
     test_file = tmp_path / "inference_config.json"

--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -334,20 +334,20 @@ def test_manifest_cloud_storage_read_failure_is_inconclusive_after_parse_retry(
         json.dumps({"model_type": "bert", "weights": "https://bucket.s3.amazonaws.com/malware/model.bin"}),
         encoding="utf-8",
     )
-    scanner = ManifestScanner()
-    original_read = scanner._read_manifest_text
-    read_count = 0
+    original_read = ManifestScanner._read_manifest_text
+    read_counts: dict[int, int] = {}
 
-    def fail_cloud_url_read_once(path: str) -> str:
-        nonlocal read_count
-        read_count += 1
-        if read_count == 1:
+    def fail_cloud_url_read_once(self: ManifestScanner, path: str) -> str:
+        scanner_id = id(self)
+        read_counts[scanner_id] = read_counts.get(scanner_id, 0) + 1
+        if read_counts[scanner_id] == 1:
             raise OSError("simulated cloud storage URL read failure")
-        return original_read(path)
+        return original_read(self, path)
 
-    monkeypatch.setattr(scanner, "_read_manifest_text", fail_cloud_url_read_once)
+    monkeypatch.setattr(ManifestScanner, "_read_manifest_text", fail_cloud_url_read_once)
 
-    result = scanner.scan(str(test_file))
+    result = ManifestScanner().scan(str(test_file))
+    aggregate = scan_model_directory_or_file(str(test_file), cache_enabled=False)
 
     assert result.success is False
     assert result.metadata.get("scan_outcome") == INCONCLUSIVE_SCAN_OUTCOME
@@ -358,6 +358,118 @@ def test_manifest_cloud_storage_read_failure_is_inconclusive_after_parse_retry(
         and check.details.get("scan_outcome_reason") == "manifest_cloud_storage_read_failed"
         for check in result.checks
     )
+    assert (
+        aggregate.file_metadata[str(test_file)].get("operational_error_reason") == "manifest_cloud_storage_read_failed"
+    )
+    assert determine_exit_code(aggregate) == 2
+
+
+def test_manifest_cloud_storage_read_failure_remains_unsuccessful_with_recovered_finding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_file = tmp_path / "config.json"
+    test_file.write_text(
+        json.dumps(
+            {
+                "model_type": "bert",
+                "weights": "https://bucket.s3.amazonaws.com/releases/model.bin",
+                "checksum": "0" * 40,
+            }
+        ),
+        encoding="utf-8",
+    )
+    original_read = ManifestScanner._read_manifest_text
+    read_counts: dict[int, int] = {}
+
+    def fail_cloud_url_read_once(self: ManifestScanner, path: str) -> str:
+        scanner_id = id(self)
+        read_counts[scanner_id] = read_counts.get(scanner_id, 0) + 1
+        if read_counts[scanner_id] == 1:
+            raise OSError("simulated cloud storage URL read failure")
+        return original_read(self, path)
+
+    monkeypatch.setattr(ManifestScanner, "_read_manifest_text", fail_cloud_url_read_once)
+
+    result = ManifestScanner().scan(str(test_file))
+    aggregate = scan_model_directory_or_file(str(test_file), cache_enabled=False)
+
+    assert result.success is False
+    assert result.metadata.get("operational_error_reason") == "manifest_cloud_storage_read_failed"
+    assert any(
+        check.name == "Weak Hash Detection" and check.severity == IssueSeverity.WARNING for check in result.checks
+    )
+    assert any(issue.severity == IssueSeverity.WARNING for issue in aggregate.issues)
+    assert determine_exit_code(aggregate) == 2
+
+
+def test_manifest_cloud_storage_read_failure_bypasses_stale_clean_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_file = tmp_path / "config.json"
+    test_file.write_text(
+        json.dumps(
+            {
+                "model_type": "bert",
+                "weights": "https://bucket.s3.amazonaws.com/releases/model.bin",
+                "padding": "x" * 11_000,
+            }
+        ),
+        encoding="utf-8",
+    )
+    cache_dir = tmp_path / "cache"
+
+    reset_cache_manager()
+    try:
+        with monkeypatch.context() as warm_cache:
+            warm_cache.setattr(
+                cache_decorator,
+                "should_bypass_cache_for_read_failure_aware_file",
+                lambda _path: False,
+            )
+            warm_result = scan_file(
+                str(test_file),
+                config={
+                    "cache_enabled": True,
+                    "cache_dir": str(cache_dir),
+                    "min_cache_file_size": 0,
+                },
+            )
+
+        assert warm_result.success is True
+        cached_entries = get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"]
+        assert cached_entries > 0
+
+        original_read = ManifestScanner._read_manifest_text
+        read_counts: dict[int, int] = {}
+
+        def fail_cloud_url_read_once(self: ManifestScanner, path: str) -> str:
+            scanner_id = id(self)
+            read_counts[scanner_id] = read_counts.get(scanner_id, 0) + 1
+            if read_counts[scanner_id] == 1:
+                raise OSError("simulated cloud storage URL read failure after cache warm")
+            return original_read(self, path)
+
+        monkeypatch.setattr(ManifestScanner, "_read_manifest_text", fail_cloud_url_read_once)
+
+        aggregate = scan_model_directory_or_file(
+            str(test_file),
+            cache_enabled=True,
+            cache_dir=str(cache_dir),
+            min_cache_file_size=0,
+        )
+
+        assert determine_exit_code(aggregate) == 2
+        assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in aggregate.issues)
+        assert aggregate.file_metadata[str(test_file)].get("scan_outcome") == INCONCLUSIVE_SCAN_OUTCOME
+        assert (
+            aggregate.file_metadata[str(test_file)].get("operational_error_reason")
+            == "manifest_cloud_storage_read_failed"
+        )
+        assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == cached_entries
+    finally:
+        reset_cache_manager()
 
 
 def test_manifest_scanner_case_insensitive_blacklist(tmp_path):


### PR DESCRIPTION
## Summary
- mark manifest cloud-storage URL read failures as operationally incomplete
- preserve later manifest analysis while preventing clean success after skipped cloud-reference coverage
- add a transient-read regression and changelog entry

## Root Cause
The manifest read-failure hardening covered blacklist and structured parsing reads, but `_check_cloud_storage_urls()` still swallowed `OSError` and `UnicodeError`. A transient first read failure followed by successful parsing could report complete coverage while skipping cloud-reference analysis.

## Validation
- Regression failed before the source fix: `tests/scanners/test_manifest_scanner.py::test_manifest_cloud_storage_read_failure_is_inconclusive_after_parse_retry` returned `result.success == True`.
- `PYTHONPATH=/Users/mdangelo/.codex/worktrees/251a/modelaudit UV_CACHE_DIR=/tmp/modelaudit-uv-cache UV_PROJECT_ENVIRONMENT=/Users/mdangelo/code/modelaudit/.venv PROMPTFOO_DISABLE_TELEMETRY=1 uv run --no-sync pytest tests/scanners/test_manifest_scanner.py -q` (`68 passed`)
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache UV_PROJECT_ENVIRONMENT=/Users/mdangelo/code/modelaudit/.venv uv run --no-sync ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache UV_PROJECT_ENVIRONMENT=/Users/mdangelo/code/modelaudit/.venv uv run --no-sync ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache UV_PROJECT_ENVIRONMENT=/Users/mdangelo/code/modelaudit/.venv uv run --no-sync ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache UV_PROJECT_ENVIRONMENT=/Users/mdangelo/code/modelaudit/.venv uv run --no-sync ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache UV_PROJECT_ENVIRONMENT=/Users/mdangelo/code/modelaudit/.venv uv run --no-sync mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`Success: no issues found in 453 source files`)
- Attempted the full required `pytest -n auto -m "not slow and not integration" --maxfail=1` lane with this worktree pinned on `PYTHONPATH` and normal cache write access. It was terminated while draining at 80% after recording only unchanged time-budget failures: `test_debug_command_is_fast` and `test_directory_scanning_performance`.

## Environment Note
Fresh `uv` sync is not usable on this Darwin host because the TensorRT placeholder dependency has no macOS arm64 wheel. Validation therefore used the existing compatible virtualenv with `--no-sync`; its editable `modelaudit-picklescan` native extension was rebuilt from this checkout before tests.
