### PR TITLE
fix: harden legacy JAX checkpoint routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - scan dangerous RKNN safe-key metadata values instead of suppressing the whole key-value string
 - scan ONNX external data initializers in nested graphs, functions, and training graphs
 - route protocol-0 JAX checkpoint pickles through pickle opcode security checks
+- harden legacy JAX checkpoint pickle routing against bounded-prefix bypasses and benign sidecar false positives
 - detect dangerous Python calls retrieved or installed through module namespace dictionaries in ZIP and TAR members, while avoiding comprehension-local false positives
 - preflight and stream-enforce cumulative SevenZip extraction budgets before writing oversized archives
 - mark oversized structured JSON/YAML Jinja template fields as incomplete coverage instead of clean

--- a/modelaudit/scanners/jax_checkpoint_scanner.py
+++ b/modelaudit/scanners/jax_checkpoint_scanner.py
@@ -764,7 +764,7 @@ class JaxCheckpointScanner(BaseScanner):
             return False
 
         read_limit = max(len(header), min(self.max_pickle_scan_bytes, self._LEGACY_PICKLE_PREFIX_PROBE_BYTES))
-        with suppress(Exception):
+        with suppress(ValueError):
             file_size = os.path.getsize(path)
             with open(path, "rb") as source:
                 data = source.read(read_limit)
@@ -774,8 +774,7 @@ class JaxCheckpointScanner(BaseScanner):
             memo_indices: set[int] = set()
             next_memo_index = 0
             parsed_opcode = False
-            parsed_opcode_count = 0
-            saw_dangerous_global = False
+            observed_security_relevant_opcode = False
 
             def _memo_index(value: Any) -> int | None:
                 try:
@@ -818,14 +817,12 @@ class JaxCheckpointScanner(BaseScanner):
             try:
                 for opcode, arg, _pos in pickletools.genops(data):
                     parsed_opcode = True
-                    parsed_opcode_count += 1
                     if opcode.name == "GLOBAL" and isinstance(arg, str):
                         parsed_global = self._parse_pickle_global_reference(arg)
-                        if parsed_global is not None:
-                            module_name, global_name = parsed_global
-                            saw_dangerous_global = saw_dangerous_global or self._is_dangerous_pickle_global(
-                                module_name, global_name
-                            )
+                        if parsed_global is not None and self._is_dangerous_pickle_global(*parsed_global):
+                            observed_security_relevant_opcode = True
+                    elif opcode.name in {"STACK_GLOBAL", "REDUCE", "NEWOBJ", "NEWOBJ_EX", "OBJ", "INST"}:
+                        observed_security_relevant_opcode = True
                     if opcode.name in {"BINPUT", "LONG_BINPUT", "PUT"}:
                         if not stack:
                             return False
@@ -848,9 +845,9 @@ class JaxCheckpointScanner(BaseScanner):
                         return True
             except ValueError as e:
                 if "pickle exhausted before seeing STOP" in str(e):
-                    if parsed_opcode_count == 1 and not saw_dangerous_global:
-                        return False
-                    return parsed_opcode
+                    if file_size > len(data):
+                        return parsed_opcode or self._header_starts_with_legacy_pickle_opcode(header)
+                    return parsed_opcode and observed_security_relevant_opcode
                 if file_size > len(data) and self._is_truncated_pickle_parse_error(e):
                     return parsed_opcode or self._header_starts_with_legacy_pickle_opcode(header)
 
@@ -861,12 +858,9 @@ class JaxCheckpointScanner(BaseScanner):
         if not cls._header_starts_with_legacy_pickle_opcode(header):
             return False
 
-        with suppress(Exception):
-            with open(path, "rb") as source:
-                data = source.read(max(8192, len(header)))
-            return cls._contains_jax_indicator(data.decode("utf-8", errors="ignore"))
-
-        return False
+        with open(path, "rb") as source:
+            data = source.read(max(8192, len(header)))
+        return cls._contains_jax_indicator(data.decode("utf-8", errors="ignore"))
 
     @classmethod
     def _is_likely_jax_file(cls, path: str) -> bool:

--- a/tests/scanners/test_jax_checkpoint_scanner.py
+++ b/tests/scanners/test_jax_checkpoint_scanner.py
@@ -433,6 +433,102 @@ def test_empty_orbax_checkpoint_file_does_not_scan_as_pickle(tmp_path: Path) -> 
     assert "jax_pickle_scan_failed" not in result.metadata.get("scan_outcome_reasons", [])
 
 
+def test_orbax_plaintext_checkpoint_with_global_shaped_prefix_does_not_scan_as_pickle(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "plaintext_orbax"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "checkpoint").write_text("configuration\nmetadata\n", encoding="utf-8")
+
+    assert JaxCheckpointScanner.can_handle(str(checkpoint_dir))
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success
+    assert not any(check.name == "Pickle Checkpoint Scan" for check in result.checks)
+    assert "jax_pickle_scan_failed" not in result.metadata.get("scan_outcome_reasons", [])
+
+
+def test_orbax_legacy_probe_read_failure_is_inconclusive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkpoint_dir = tmp_path / "unreadable_legacy_orbax"
+    checkpoint_dir.mkdir()
+    checkpoint_file = checkpoint_dir / "checkpoint"
+    checkpoint_file.write_bytes(b"cposix\nsystem\np0\n(Vid\np1\ntp2\nRp3\n.")
+    original_open = builtins.open
+    checkpoint_open_count = 0
+
+    def fail_second_checkpoint_read(file: Any, *args: Any, **kwargs: Any) -> Any:
+        nonlocal checkpoint_open_count
+        if file == str(checkpoint_file) and args and args[0] == "rb":
+            checkpoint_open_count += 1
+            if checkpoint_open_count == 2:
+                raise OSError("simulated legacy pickle probe read failure")
+        return original_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", fail_second_checkpoint_read)
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success is False
+    assert "jax_checkpoint_file_scan_failed" in result.metadata.get("scan_outcome_reasons", [])
+    assert any(
+        check.name == "Checkpoint File Scan"
+        and check.details.get("scan_outcome_reason") == "jax_checkpoint_file_scan_failed"
+        for check in result.checks
+    )
+
+
+def test_single_file_legacy_indicator_read_failure_is_inconclusive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkpoint_file = tmp_path / "legacy_jax.checkpoint"
+    checkpoint_file.write_bytes(b"Vjax\n.")
+    scanner = JaxCheckpointScanner()
+
+    monkeypatch.setattr(scanner, "_has_structural_legacy_pickle_prefix", lambda _path, _header: True)
+
+    def fail_indicator_read(_path: str, _header: bytes) -> bool:
+        raise OSError("simulated JAX indicator read failure")
+
+    monkeypatch.setattr(scanner, "_legacy_pickle_header_has_jax_indicator", fail_indicator_read)
+
+    result = scanner.scan(str(checkpoint_file))
+
+    assert result.success is False
+    assert "jax_checkpoint_file_scan_failed" in result.metadata.get("scan_outcome_reasons", [])
+    assert any(
+        check.name == "Checkpoint File Scan"
+        and check.details.get("scan_outcome_reason") == "jax_checkpoint_file_scan_failed"
+        for check in result.checks
+    )
+
+
+def test_orbax_legacy_pickle_dangerous_global_after_probe_boundary_is_detected(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "orbax_probe_boundary"
+    checkpoint_dir.mkdir()
+    checkpoint_file = checkpoint_dir / "checkpoint"
+    harmless_prefix = b"N0" * (JaxCheckpointScanner._LEGACY_PICKLE_PREFIX_PROBE_BYTES // 2)
+    checkpoint_file.write_bytes(harmless_prefix + b"cposix\nsystem\n(Vid\ntR.")
+
+    assert JaxCheckpointScanner.can_handle(str(checkpoint_dir))
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert not any(
+        check.name == "Checkpoint Format Detection" and check.details.get("format") == "unknown"
+        for check in result.checks
+    )
+    assert any(
+        check.name == "Pickle Opcode Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details["global"] == "posix.system"
+        for check in result.checks
+    )
+
+
 def test_orbax_protocol_zero_persid_checkpoint_scans_pickle(tmp_path: Path) -> None:
     checkpoint_dir = tmp_path / "orbax_persid"
     checkpoint_dir.mkdir()
@@ -508,11 +604,12 @@ def test_eof_truncated_orbax_legacy_pickle_is_scanned_inconclusive(tmp_path: Pat
     assert "jax_pickle_scan_failed" in result.metadata.get("scan_outcome_reasons", [])
 
 
-def test_orbax_binbytes_prefix_scans_pickle(tmp_path: Path) -> None:
+@pytest.mark.parametrize("bytes_prefix", [b"B\x03\x00\x00\x00abc", b"C\x03abc"])
+def test_orbax_binbytes_prefix_scans_pickle(tmp_path: Path, bytes_prefix: bytes) -> None:
     checkpoint_dir = tmp_path / "orbax_binbytes"
     checkpoint_dir.mkdir()
     checkpoint_file = checkpoint_dir / "checkpoint"
-    checkpoint_file.write_bytes(b"B\x03\x00\x00\x00abccposix\nsystem\np0\n(Vid\np1\ntp2\nRp3\n.")
+    checkpoint_file.write_bytes(bytes_prefix + b"cposix\nsystem\np0\n(Vid\np1\ntp2\nRp3\n.")
 
     assert JaxCheckpointScanner.can_handle(str(checkpoint_dir))
 


### PR DESCRIPTION
## Summary
- fail closed when a valid markerless Orbax pickle places dangerous opcodes beyond the bounded legacy prefix probe
- avoid routing benign plaintext checkpoint sidecars as pickle failures while preserving dangerous EOF-truncated coverage
- propagate in-scan legacy probe read failures as inconclusive outcomes and cover `SHORT_BINBYTES` routing

## Context
Follow-up to merged #1383. During post-merge review, a valid harmless opcode prefix filling the 8 KiB structural probe could hide a later `GLOBAL posix.system` payload from JAX checkpoint scanning. The same pass also found missing fail-closed coverage for probe read failures and a broader plaintext sidecar false-positive shape.

## Validation
- `uv --no-config run --no-sync ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv --no-config run --no-sync ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv --no-config run --no-sync ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv --no-config run --no-sync mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `npx prettier --check CHANGELOG.md`
- `PYTHONDONTWRITEBYTECODE=1 PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --no-sync pytest -p no:cacheprovider tests/scanners/test_jax_checkpoint_scanner.py tests/scanners/test_rknn_scanner.py` (`118 passed`)
- `PYTHONDONTWRITEBYTECODE=1 PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --no-sync pytest -p no:cacheprovider -n auto -m 'not slow and not integration' --maxfail=1` (`6491 passed, 845 skipped`)

No database, migration, frontend, or design-system state is involved in this scanner-only follow-up.
