### PR TITLE
fix: harden asyncio subprocess review follow-up

### DIFF
--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -138,32 +138,48 @@ def _resolve_alias_aware_high_risk_calls(tree: ast.AST) -> set[tuple[str, str]]:
     return {(call.name, call.rule_code) for call in high_risk_python_calls_in_tree(tree)}
 
 
-def _parse_embedded_python_snippet(code_str: str) -> ast.AST | None:
+def _parse_embedded_python_snippet(code_str: str) -> tuple[ast.AST, int] | None:
     """Parse an extracted Python snippet, trimming trailing binary framing when needed."""
     try:
-        return ast.parse(code_str)
+        return ast.parse(code_str), len(code_str)
     except (SyntaxError, ValueError) as exc:
         initial_error = exc
 
-    lines = code_str.splitlines()
+    lines = code_str.splitlines(keepends=True)
+    candidate_lengths: list[int] = []
+    null_offset = code_str.find("\x00")
+    if null_offset > 0:
+        candidate_lengths.append(null_offset)
+
     candidate_ends: list[int] = []
     if isinstance(initial_error, SyntaxError) and initial_error.lineno is not None:
         candidate_ends.append(max(1, initial_error.lineno - 1))
     candidate_ends.extend(range(len(lines) - 1, max(0, len(lines) - _MAX_SNIPPET_PARSE_TRIM_ATTEMPTS - 1), -1))
 
-    seen_ends: set[int] = set()
     for end in candidate_ends:
-        if end <= 0 or end in seen_ends:
+        candidate_lengths.append(sum(len(line) for line in lines[:end]))
+
+    seen_lengths: set[int] = set()
+    for length in candidate_lengths:
+        if length <= 0 or length in seen_lengths:
             continue
-        seen_ends.add(end)
-        candidate = "\n".join(lines[:end])
+        seen_lengths.add(length)
+        candidate = code_str[:length]
         if candidate.strip() == "":
             continue
         try:
-            return ast.parse(f"{candidate}\n")
+            return ast.parse(f"{candidate}\n"), length
         except (SyntaxError, ValueError):
             continue
     return None
+
+
+def _has_raw_match_outside_parsed_spans(raw_spans: list[tuple[int, int]], parsed_spans: list[tuple[int, int]]) -> bool:
+    """Return whether any raw regex hit sits outside AST-validated source."""
+    for raw_start, raw_end in raw_spans:
+        if not any(parsed_start <= raw_start and raw_end <= parsed_end for parsed_start, parsed_end in parsed_spans):
+            return True
+    return False
 
 
 # Patterns that indicate code execution attempts
@@ -563,10 +579,14 @@ class JITScriptDetector:
 
         bounded = data if include_full_source else data[:1000000]
         python_code_pattern = rb"def\s+\w+\s*\([^)]*\):[^}]+|class\s+\w+[^}]+"
-        matches = [bounded] if include_full_source else re.findall(python_code_pattern, bounded)
+        matches = (
+            [(bounded, (0, len(bounded)))]
+            if include_full_source
+            else [(match.group(0), match.span()) for match in re.finditer(python_code_pattern, bounded)]
+        )
         bounded_high_risk_calls: set[tuple[str, str]] | None = None
         snippet_high_risk_calls: set[tuple[str, str]] = set()
-        snippet_parse_succeeded = False
+        parsed_snippet_spans: list[tuple[int, int]] = []
         try:
             bounded_tree = ast.parse(textwrap.dedent(bounded.decode("utf-8")))
             bounded_high_risk_calls = _resolve_alias_aware_high_risk_calls(bounded_tree)
@@ -575,7 +595,7 @@ class JITScriptDetector:
             # raw pattern detection active and fall back to extracted snippets.
             bounded_high_risk_calls = None
 
-        for match in matches[:10]:  # Analyze first 10 code snippets
+        for match, span in matches[:10]:  # Analyze first 10 code snippets
             try:
                 code_str = match.decode("utf-8", errors="ignore")
 
@@ -620,9 +640,11 @@ class JITScriptDetector:
                         )
 
                 # Try to parse as AST for deeper analysis.
-                tree = _parse_embedded_python_snippet(code_str)
-                if tree is not None:
-                    snippet_parse_succeeded = True
+                parsed_snippet = _parse_embedded_python_snippet(code_str)
+                if parsed_snippet is not None:
+                    tree, parsed_chars = parsed_snippet
+                    parsed_byte_length = len(code_str[:parsed_chars].encode("utf-8", errors="ignore"))
+                    parsed_snippet_spans.append((span[0], min(span[1], span[0] + parsed_byte_length)))
                     snippet_high_risk_calls.update(_resolve_alias_aware_high_risk_calls(tree))
                     ast_findings = self._analyze_ast(tree, framework, context)
                     findings.extend(ast_findings)
@@ -634,12 +656,16 @@ class JITScriptDetector:
         # Check for common code execution patterns in binary
         resolved_high_risk_calls = (bounded_high_risk_calls or set()) | snippet_high_risk_calls
         for pattern, description in CODE_EXECUTION_PATTERNS:
-            pattern_match = re.search(pattern, bounded) is not None
+            raw_pattern_spans = [match.span() for match in re.finditer(pattern, bounded)]
+            pattern_match = len(raw_pattern_spans) > 0
             if description == _SUBPROCESS_CODE_EXECUTION_DESCRIPTION:
                 resolved_subprocess_call = any(code == "S103" for _, code in resolved_high_risk_calls)
+                raw_match_only_in_parsed_snippets = bool(
+                    parsed_snippet_spans
+                ) and not _has_raw_match_outside_parsed_spans(raw_pattern_spans, parsed_snippet_spans)
                 if resolved_subprocess_call:
                     pattern_match = True
-                elif bounded_high_risk_calls is not None or snippet_parse_succeeded:
+                elif bounded_high_risk_calls is not None or raw_match_only_in_parsed_snippets:
                     continue
             if description == _OS_CODE_EXECUTION_DESCRIPTION:
                 resolved_os_process_call = any(code == "S101" for _, code in resolved_high_risk_calls)

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -128,6 +128,7 @@ def _compile_dangerous_import_patterns(dangerous_import: str) -> tuple[re.Patter
 _DANGEROUS_IMPORT_PATTERNS = {
     dangerous_import: _compile_dangerous_import_patterns(dangerous_import) for dangerous_import in DANGEROUS_IMPORTS
 }
+_MAX_SNIPPET_PARSE_TRIM_ATTEMPTS = 8
 
 
 def _resolve_alias_aware_high_risk_calls(tree: ast.AST) -> set[tuple[str, str]]:
@@ -141,11 +142,20 @@ def _parse_embedded_python_snippet(code_str: str) -> ast.AST | None:
     """Parse an extracted Python snippet, trimming trailing binary framing when needed."""
     try:
         return ast.parse(code_str)
-    except (SyntaxError, ValueError):
-        pass
+    except (SyntaxError, ValueError) as exc:
+        initial_error = exc
 
     lines = code_str.splitlines()
-    for end in range(len(lines) - 1, 0, -1):
+    candidate_ends: list[int] = []
+    if isinstance(initial_error, SyntaxError) and initial_error.lineno is not None:
+        candidate_ends.append(max(1, initial_error.lineno - 1))
+    candidate_ends.extend(range(len(lines) - 1, max(0, len(lines) - _MAX_SNIPPET_PARSE_TRIM_ATTEMPTS - 1), -1))
+
+    seen_ends: set[int] = set()
+    for end in candidate_ends:
+        if end <= 0 or end in seen_ends:
+            continue
+        seen_ends.add(end)
         candidate = "\n".join(lines[:end])
         if candidate.strip() == "":
             continue
@@ -556,6 +566,7 @@ class JITScriptDetector:
         matches = [bounded] if include_full_source else re.findall(python_code_pattern, bounded)
         bounded_high_risk_calls: set[tuple[str, str]] | None = None
         snippet_high_risk_calls: set[tuple[str, str]] = set()
+        snippet_parse_succeeded = False
         try:
             bounded_tree = ast.parse(textwrap.dedent(bounded.decode("utf-8")))
             bounded_high_risk_calls = _resolve_alias_aware_high_risk_calls(bounded_tree)
@@ -611,6 +622,7 @@ class JITScriptDetector:
                 # Try to parse as AST for deeper analysis.
                 tree = _parse_embedded_python_snippet(code_str)
                 if tree is not None:
+                    snippet_parse_succeeded = True
                     snippet_high_risk_calls.update(_resolve_alias_aware_high_risk_calls(tree))
                     ast_findings = self._analyze_ast(tree, framework, context)
                     findings.extend(ast_findings)
@@ -627,7 +639,7 @@ class JITScriptDetector:
                 resolved_subprocess_call = any(code == "S103" for _, code in resolved_high_risk_calls)
                 if resolved_subprocess_call:
                     pattern_match = True
-                elif bounded_high_risk_calls is not None:
+                elif bounded_high_risk_calls is not None or snippet_parse_succeeded:
                     continue
             if description == _OS_CODE_EXECUTION_DESCRIPTION:
                 resolved_os_process_call = any(code == "S101" for _, code in resolved_high_risk_calls)

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -182,6 +182,44 @@ def _has_raw_match_outside_parsed_spans(raw_spans: list[tuple[int, int]], parsed
     return False
 
 
+def _decode_utf8_with_byte_offsets(data: bytes) -> tuple[str, list[int]]:
+    """Decode UTF-8 like errors='ignore' while mapping decoded character offsets to byte offsets."""
+    chars: list[str] = []
+    byte_offsets = [0]
+    index = 0
+    while index < len(data):
+        byte = data[index]
+        if byte < 0x80:
+            chars.append(chr(byte))
+            index += 1
+            byte_offsets.append(index)
+            continue
+
+        if 0xC2 <= byte <= 0xDF:
+            length = 2
+        elif 0xE0 <= byte <= 0xEF:
+            length = 3
+        elif 0xF0 <= byte <= 0xF4:
+            length = 4
+        else:
+            index += 1
+            continue
+
+        chunk = data[index : index + length]
+        if len(chunk) != length or any((continuation & 0xC0) != 0x80 for continuation in chunk[1:]):
+            index += 1
+            continue
+        try:
+            chars.append(chunk.decode("utf-8"))
+        except UnicodeDecodeError:
+            index += 1
+            continue
+        index += length
+        byte_offsets.append(index)
+
+    return "".join(chars), byte_offsets
+
+
 # Patterns that indicate code execution attempts
 _SUBPROCESS_CODE_EXECUTION_DESCRIPTION = "Subprocess execution detected"
 _OS_CODE_EXECUTION_DESCRIPTION = "OS command execution detected"
@@ -597,7 +635,7 @@ class JITScriptDetector:
 
         for match, span in matches[:10]:  # Analyze first 10 code snippets
             try:
-                code_str = match.decode("utf-8", errors="ignore")
+                code_str, byte_offsets = _decode_utf8_with_byte_offsets(match)
 
                 # Check for dangerous imports
                 for dangerous_import in DANGEROUS_IMPORTS:
@@ -643,7 +681,7 @@ class JITScriptDetector:
                 parsed_snippet = _parse_embedded_python_snippet(code_str)
                 if parsed_snippet is not None:
                     tree, parsed_chars = parsed_snippet
-                    parsed_byte_length = len(code_str[:parsed_chars].encode("utf-8", errors="ignore"))
+                    parsed_byte_length = byte_offsets[parsed_chars]
                     parsed_snippet_spans.append((span[0], min(span[1], span[0] + parsed_byte_length)))
                     snippet_high_risk_calls.update(_resolve_alias_aware_high_risk_calls(tree))
                     ast_findings = self._analyze_ast(tree, framework, context)

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -1070,6 +1070,8 @@ def _wildcard_import_aliases(module: str) -> Iterator[tuple[str, str]]:
         if not call_name.startswith(prefix):
             continue
         exported_name = call_name.removeprefix(prefix).split(".", maxsplit=1)[0]
+        if module == "asyncio" and exported_name == "subprocess":
+            continue
         yield exported_name, f"{module}.{exported_name}"
 
 

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -425,6 +425,39 @@ class TestJITScriptDetector:
         assert tree is None
         assert parse_calls <= jit_script_module._MAX_SNIPPET_PARSE_TRIM_ATTEMPTS + 2
 
+    def test_scan_model_detects_binary_framed_long_tail_alias_aware_asyncio_subprocess_launch(self) -> None:
+        detector = JITScriptDetector()
+        tail = b"\n".join(b"tail" for _ in range(jit_script_module._MAX_SNIPPET_PARSE_TRIM_ATTEMPTS + 20))
+        source = (
+            b"\x00\xffdef payload():\n"
+            b"    from asyncio import create_subprocess_shell as launch\n"
+            b"    return launch('id')\n"
+            b"\x00" + tail
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Subprocess execution detected" for f in findings
+        )
+
+    def test_scan_model_preserves_raw_asyncio_match_in_unparsed_snippet_after_benign_parse(self) -> None:
+        detector = JITScriptDetector()
+        source = (
+            b"def benign():\n"
+            b"    return \"asyncio.create_subprocess_shell('id')\"\n"
+            b"}\n"
+            b"def payload():\n"
+            b"if True print('broken')\n"
+            b"asyncio.create_subprocess_shell('id')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Subprocess execution detected" for f in findings
+        )
+
     def test_scan_model_detects_embedded_snippet_alias_aware_asyncio_subprocess_launch(self) -> None:
         detector = JITScriptDetector()
         source = (

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -441,6 +441,17 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Subprocess execution detected" for f in findings
         )
 
+    def test_scan_model_detects_binary_framed_long_tail_alias_aware_os_process_launch(self) -> None:
+        detector = JITScriptDetector()
+        tail = b"\n".join(b"tail" for _ in range(jit_script_module._MAX_SNIPPET_PARSE_TRIM_ATTEMPTS + 20))
+        source = b"\x00\xffdef payload():\n    import os as o\n    return getattr(o, 'system')('id')\n\x00" + tail
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "OS command execution detected" for f in findings
+        )
+
     def test_scan_model_preserves_raw_asyncio_match_in_unparsed_snippet_after_benign_parse(self) -> None:
         detector = JITScriptDetector()
         source = (

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -408,6 +408,21 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Subprocess execution detected" for f in findings
         )
 
+    def test_scan_model_ignores_lossy_decoded_string_literal_asyncio_subprocess_launch(self) -> None:
+        detector = JITScriptDetector()
+        source = (
+            b"\x00\xffdef payload():\n"
+            b"    # ignored invalid bytes: "
+            + (b"\xff" * 64)
+            + b"\n    return \"asyncio.create_subprocess_shell('id')\"\n\x00\xffMODEL-FRAMING"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert not any(
+            f.type == "code_execution_pattern" and f.pattern == "Subprocess execution detected" for f in findings
+        )
+
     def test_parse_embedded_python_snippet_caps_trim_attempts(self, monkeypatch: pytest.MonkeyPatch) -> None:
         parse_calls = 0
 

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -1,5 +1,6 @@
 """Tests for JIT/Script code execution detection."""
 
+import ast
 from pathlib import Path
 
 import pytest
@@ -396,6 +397,33 @@ class TestJITScriptDetector:
         assert not any(
             f.type == "code_execution_pattern" and f.pattern == "Subprocess execution detected" for f in findings
         )
+
+    def test_scan_model_ignores_binary_framed_string_literal_asyncio_subprocess_launch(self) -> None:
+        detector = JITScriptDetector()
+        source = b"\x00\xffdef payload():\n    return \"asyncio.create_subprocess_shell('id')\"\n\x00\xffMODEL-FRAMING"
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert not any(
+            f.type == "code_execution_pattern" and f.pattern == "Subprocess execution detected" for f in findings
+        )
+
+    def test_parse_embedded_python_snippet_caps_trim_attempts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        parse_calls = 0
+
+        def fail_parse(_source: str) -> ast.AST:
+            nonlocal parse_calls
+            parse_calls += 1
+            raise SyntaxError("bad syntax", ("<embedded>", 1, 1, "bad"))
+
+        monkeypatch.setattr(jit_script_module.ast, "parse", fail_parse)
+
+        tree = jit_script_module._parse_embedded_python_snippet(
+            "def payload():\n" + "\n".join("bad" for _ in range(1000))
+        )
+
+        assert tree is None
+        assert parse_calls <= jit_script_module._MAX_SNIPPET_PARSE_TRIM_ATTEMPTS + 2
 
     def test_scan_model_detects_embedded_snippet_alias_aware_asyncio_subprocess_launch(self) -> None:
         detector = JITScriptDetector()

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -307,6 +307,24 @@ def test_scan_zip_flags_wildcard_import_dangerous_python_member(tmp_path: Path) 
     assert python_checks[0].details["reason"] == "high-risk calls: subprocess.run"
 
 
+def test_scan_zip_preserves_subprocess_after_asyncio_wildcard_import(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    source = "import subprocess\nfrom asyncio import *\nsubprocess.run(['echo', 'hidden'], check=False)\n"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", source)
+
+    result = ZipScanner().scan(str(archive_path))
+
+    python_checks = [
+        check
+        for check in result.checks
+        if check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED
+    ]
+    assert len(python_checks) == 1
+    assert python_checks[0].severity == IssueSeverity.WARNING
+    assert python_checks[0].details["reason"] == "high-risk calls: subprocess.run"
+
+
 def test_scan_zip_flags_builtins_getattr_keyword_call_dangerous_python_member(tmp_path: Path) -> None:
     archive_path = tmp_path / "model_bundle.zip"
     source = "import builtins as bi\nimport os\nbi.getattr(object=os, name='system').__call__('echo hidden')\n"


### PR DESCRIPTION
## Summary
- preserve real subprocess imports across asyncio star imports
- cap malformed embedded snippet trim attempts
- suppress raw asyncio string-literal matches after successful snippet parsing

## Test plan
- /Users/mdangelo/code/modelaudit/.venv/bin/python -m ruff format --check modelaudit/detectors/jit_script.py modelaudit/scanners/archive_member_security.py tests/detectors/test_jit_script_detector.py tests/scanners/test_zip_scanner.py
- /Users/mdangelo/code/modelaudit/.venv/bin/python -m ruff check modelaudit/detectors/jit_script.py modelaudit/scanners/archive_member_security.py tests/detectors/test_jit_script_detector.py tests/scanners/test_zip_scanner.py
- /Users/mdangelo/code/modelaudit/.venv/bin/python -m mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PROMPTFOO_DISABLE_TELEMETRY=1 pytest tests/detectors/test_jit_script_detector.py tests/scanners/test_zip_scanner.py tests/scanners/test_pytorch_zip_scanner.py tests/scanners/test_tar_scanner.py tests/scanners/test_torchserve_mar_scanner.py -q --maxfail=1