### PR TITLE
fix: avoid framed process string false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - scan ONNX external data references in sparse initializers, tensor-valued attributes, and function defaults
+- avoid false-positive process-launch findings for parsed framed Python string literals
 - detect dangerous Python calls retrieved through module namespace dictionaries in ZIP and TAR members
 - detect embedded Python `os.exec*`, `os.spawn*`, `os.posix_spawn*`, and `os.startfile` process-launch calls in archives and JIT-scanned content
 - detect embedded Python `asyncio.create_subprocess_*` calls and resolved JIT `subprocess` launch aliases

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -209,6 +209,20 @@ def _candidate_embedded_python_snippets(
     return candidates
 
 
+def _complete_brace_truncated_line_candidate(
+    bounded: bytes,
+    span: tuple[int, int],
+) -> tuple[bytes, tuple[int, int]] | None:
+    """Extend a failed block candidate through a same-line closing brace."""
+    if span[1] >= len(bounded) or bounded[span[1] : span[1] + 1] != b"}":
+        return None
+    line_end = bounded.find(b"\n", span[1])
+    end = len(bounded) if line_end < 0 else line_end + 1
+    if end <= span[1]:
+        return None
+    return bounded[span[0] : end], (span[0], end)
+
+
 def _embedded_python_scan_windows(data: bytes) -> list[bytes]:
     if len(data) <= _EMBEDDED_PYTHON_SCAN_WINDOW_BYTES:
         return [data]
@@ -691,6 +705,18 @@ class JITScriptDetector:
         for match, span in matches[:10]:  # Analyze first 10 code snippets
             try:
                 code_str, byte_offsets = _decode_utf8_with_byte_offsets(match)
+                parsed_snippet = _parse_embedded_python_snippet(code_str)
+                if parsed_snippet is None or parsed_snippet[1] < len(code_str):
+                    completed_candidate = _complete_brace_truncated_line_candidate(bounded, span)
+                    if completed_candidate is not None:
+                        completed_match, completed_span = completed_candidate
+                        completed_code_str, completed_byte_offsets = _decode_utf8_with_byte_offsets(completed_match)
+                        completed_parsed_snippet = _parse_embedded_python_snippet(completed_code_str)
+                        if completed_parsed_snippet is not None:
+                            code_str = completed_code_str
+                            byte_offsets = completed_byte_offsets
+                            parsed_snippet = completed_parsed_snippet
+                            span = completed_span
 
                 # Check for dangerous imports
                 for dangerous_import in DANGEROUS_IMPORTS:
@@ -732,8 +758,7 @@ class JITScriptDetector:
                             )
                         )
 
-                # Try to parse as AST for deeper analysis.
-                parsed_snippet = _parse_embedded_python_snippet(code_str)
+                # Use the parsed source, including a completed same-line candidate when applicable.
                 if parsed_snippet is not None:
                     tree, parsed_chars = parsed_snippet
                     parsed_byte_length = byte_offsets[parsed_chars]
@@ -751,11 +776,11 @@ class JITScriptDetector:
         for pattern, description in CODE_EXECUTION_PATTERNS:
             raw_pattern_spans = [match.span() for match in re.finditer(pattern, bounded)]
             pattern_match = len(raw_pattern_spans) > 0
+            raw_match_only_in_parsed_snippets = bool(parsed_snippet_spans) and not _has_raw_match_outside_parsed_spans(
+                raw_pattern_spans, parsed_snippet_spans
+            )
             if description == _SUBPROCESS_CODE_EXECUTION_DESCRIPTION:
                 resolved_subprocess_call = any(code == "S103" for _, code in resolved_high_risk_calls)
-                raw_match_only_in_parsed_snippets = bool(
-                    parsed_snippet_spans
-                ) and not _has_raw_match_outside_parsed_spans(raw_pattern_spans, parsed_snippet_spans)
                 if resolved_subprocess_call:
                     pattern_match = True
                 elif bounded_high_risk_calls is not None or raw_match_only_in_parsed_snippets:
@@ -764,13 +789,10 @@ class JITScriptDetector:
                 resolved_os_process_call = any(code == "S101" for _, code in resolved_high_risk_calls)
                 if resolved_os_process_call:
                     pattern_match = True
-                elif bounded_high_risk_calls is not None:
+                elif bounded_high_risk_calls is not None or raw_match_only_in_parsed_snippets:
                     continue
             if description == _RUNPY_CODE_EXECUTION_DESCRIPTION:
                 resolved_runpy_call = any(code == "S108" for _, code in resolved_high_risk_calls)
-                raw_match_only_in_parsed_snippets = bool(
-                    parsed_snippet_spans
-                ) and not _has_raw_match_outside_parsed_spans(raw_pattern_spans, parsed_snippet_spans)
                 if resolved_runpy_call:
                     pattern_match = True
                 elif bounded_high_risk_calls is not None or raw_match_only_in_parsed_snippets:

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -280,6 +280,16 @@ class TestJITScriptDetector:
 
         assert findings == []
 
+    def test_scan_model_ignores_binary_framed_string_literal_os_process_launch(self) -> None:
+        detector = JITScriptDetector()
+        source = b"\x00\xffdef payload():\n    return \"os.posix_spawn('/bin/sh', ['sh'], {})\"\n}"
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert not any(
+            f.type == "code_execution_pattern" and f.pattern == "OS command execution detected" for f in findings
+        )
+
     def test_scan_model_ignores_string_literal_os_process_launch_with_unrelated_risk(self) -> None:
         detector = JITScriptDetector()
         source = (
@@ -328,7 +338,7 @@ class TestJITScriptDetector:
         source = (
             b"\x00\xffdef payload():\n"
             b"    import os\n"
-            b"    return getattr(os, 'posix_' + 'spawn')('/bin/sh', ['sh'], dict())\n"
+            b"    return getattr(os, 'posix_' + 'spawn')('/bin/sh', ['sh'], {})\n"
             b"}"
         )
 
@@ -350,6 +360,28 @@ class TestJITScriptDetector:
         findings = detector.scan_model(source, "pytorch", "payload.bin")
 
         assert any(
+            f.type == "code_execution_pattern" and f.pattern == "OS command execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_framed_module_import_alias_aware_os_process_launch(self) -> None:
+        detector = JITScriptDetector()
+        source = (
+            b"\x00\xffimport os\ndef payload():\n    return getattr(os, 'posix_' + 'spawn')('/bin/sh', ['sh'], {})\n}"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "OS command execution detected" for f in findings
+        )
+
+    def test_scan_model_allows_framed_benign_dict_literal_os_accessor(self) -> None:
+        detector = JITScriptDetector()
+        source = b"\x00\xffdef payload():\n    import os\n    return {'cwd': getattr(os, 'getcwd')()}\n}"
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert not any(
             f.type == "code_execution_pattern" and f.pattern == "OS command execution detected" for f in findings
         )
 

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1448,6 +1448,7 @@ def test_pytorch_zip_scans_unmarked_python_blobs_in_archive_data(tmp_path: Path)
         b"def payload():\n    return os.posix_spawnp('sh', ['sh'], {})\n",
         b"def payload():\n    return os.startfile('payload.exe')\n",
         b"def payload():\n    return getattr(os, 'posix_' + 'spawn')('/bin/sh', ['sh'], {})\n",
+        (b"\x00\xffimport os\ndef payload():\n    return getattr(os, 'posix_' + 'spawn')('/bin/sh', ['sh'], {})\n}"),
         b"def payload():\n    os.posix_spawn = len\n    return os.posix_spawn([])\n",
         b"def payload(data):\n    os.posix_spawn = pickle.loads\n    return os.posix_spawn(data)\n",
     ],
@@ -1469,6 +1470,42 @@ def test_pytorch_zip_scans_os_process_launch_source_conservatively(tmp_path: Pat
     assert any(
         check.location == f"{zip_path}:archive/data/payload.bin" and "OS command execution detected" in check.message
         for check in jit_failures
+    )
+
+
+def test_pytorch_zip_allows_framed_benign_dict_literal_os_accessor(tmp_path: Path) -> None:
+    zip_path = tmp_path / "model.pt"
+    payload = b"\x00\xffdef payload():\n    import os\n    return {'cwd': getattr(os, 'getcwd')()}\n}"
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        zipf.writestr("archive/version", "3")
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("archive/data/payload.bin", payload)
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    assert not any(
+        check.name == "JIT/Script Code Execution Detection"
+        and check.status == CheckStatus.FAILED
+        and "OS command execution detected" in check.message
+        for check in result.checks
+    )
+
+
+def test_pytorch_zip_ignores_binary_framed_string_literal_os_process_launch(tmp_path: Path) -> None:
+    zip_path = tmp_path / "model.pt"
+    payload = b"\x00\xffdef payload():\n    return \"os.posix_spawn('/bin/sh', ['sh'], {})\"\n}"
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        zipf.writestr("archive/version", "3")
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("archive/data/payload.bin", payload)
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    assert not any(
+        check.name == "JIT/Script Code Execution Detection"
+        and check.status == CheckStatus.FAILED
+        and "OS command execution detected" in check.message
+        for check in result.checks
     )
 
 


### PR DESCRIPTION
## Summary

- avoid false-positive OS process findings when a binary-framed parsed Python snippet contains a string literal such as `os.posix_spawn('/bin/sh', ['sh'], {})`
- preserve detection for framed executable `getattr(os, 'posix_' + 'spawn')(..., {})` payloads by retrying a brace-truncated snippet only through the same source line
- add direct detector and PyTorch ZIP regressions for malicious, benign-dict, and framed string-literal cases

## Review Notes

- This is a focused follow-up to the embedded Python/process-launch surface already landed on `main` through #1363, #1398, and #1372.
- An initial draft expanded every brace-truncated candidate and was rejected during independent review because it could copy overlapping suffixes. The final implementation leaves candidate collection unchanged and performs completion only inside the existing ten-snippet analysis cap.
- Direct resource probe: 1,000 benign `return {}` functions still produce 1,000 candidates totaling 21,000 bytes.
- No database, migration, frontend, or design-system state is involved.

## Validation

- malicious framed direct probes retain `OS command execution detected`; framed string-literal near matches produce no OS execution finding
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --no-sync pytest -p no:cacheprovider tests/detectors/test_jit_script_detector.py tests/scanners/test_pytorch_zip_scanner.py` (`232 passed`)
- broader JIT/archive/routing/core/filetype coverage (`1605 passed, 21 warnings`)
- `uv --no-config run --no-sync ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv --no-config run --no-sync ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv --no-config run --no-sync mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`454 source files`)
- `npx prettier --check CHANGELOG.md`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv --no-config run --no-sync pytest -p no:cacheprovider -n auto -m "not slow and not integration" --maxfail=1` (`6682 passed, 819 skipped, 21 warnings`)

The native `modelaudit-picklescan` extension was rebuilt locally before the full lane because current `main` now includes #1375 Rust changes.
