### PR TITLE
fix: address runpy review edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - detect embedded Python `os.exec*`, `os.spawn*`, `os.posix_spawn*`, and `os.startfile` process-launch calls in archives and JIT-scanned content
 - detect embedded Python `asyncio.create_subprocess_*` calls and resolved JIT `subprocess` launch aliases
 - detect embedded Python `runpy.run_module`, `runpy.run_path`, and `runpy._run_module_as_main` dynamic-module execution calls
+- preserve embedded Python runpy, webbrowser, and ctypes findings across continued imports, late aliases, and bounded tail-window extraction gaps
 - detect embedded Python `webbrowser` launches and `ctypes` native-library loads in archives and JIT-scanned content
 - scan dangerous RKNN safe-key metadata values instead of suppressing the whole key-value string
 - scan ONNX external data initializers in nested graphs, functions, and training graphs

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -132,14 +132,21 @@ _MAX_SNIPPET_PARSE_TRIM_ATTEMPTS = 8
 _MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS = 10
 _EMBEDDED_PYTHON_SCAN_WINDOW_BYTES = 1_000_000
 _EMBEDDED_PYTHON_START_MARKERS = (b"def ", b"async def ", b"class ", b"import ", b"from ")
-_PRIORITY_EMBEDDED_PYTHON_MARKERS = tuple(
-    marker.encode("utf-8")
-    for marker in (
-        *DANGEROUS_IMPORTS,
-        "asyncio",
-        "runpy",
-        "subprocess",
+_PRIORITY_EMBEDDED_PYTHON_MODULES = tuple(
+    sorted(
+        {marker.lower() for marker in (*DANGEROUS_IMPORTS, "asyncio", "runpy", "subprocess")},
+        key=len,
+        reverse=True,
     )
+)
+_PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN = b"|".join(
+    re.escape(marker.encode("utf-8")) for marker in _PRIORITY_EMBEDDED_PYTHON_MODULES
+)
+_PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN = re.compile(
+    rb"(?m)^\s*(?:"
+    rb"import\s+(?:[a-z_][\w.]*\s*,\s*)*(?:" + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN + rb")(?:[.\s,]|$)|"
+    rb"from\s+(?:" + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN + rb")(?:[.\s]|$)"
+    rb")"
 )
 _EMBEDDED_PYTHON_BLOCK_PATTERN = re.compile(rb"def\s+\w+\s*\([^)]*\):[^}]+|class\s+\w+[^}]+")
 _EMBEDDED_PYTHON_START_PATTERN = re.compile(
@@ -226,7 +233,7 @@ def _prioritized_embedded_python_snippets(
     selected_spans: set[tuple[int, int]] = set()
     for index, (candidate, span) in enumerate(candidates):
         candidate_prefix = candidate[:4096].lower()
-        has_priority_marker = any(marker in candidate_prefix for marker in _PRIORITY_EMBEDDED_PYTHON_MARKERS)
+        has_priority_marker = _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN.search(candidate_prefix) is not None
         if index >= _MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS and not has_priority_marker:
             continue
         if span in selected_spans:

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -382,15 +382,18 @@ def _priority_import_aliases(candidate: bytes) -> frozenset[bytes]:
                         )
                     else:
                         aliases.add((alias.asname or alias.name).encode("utf-8"))
-    aliases.update(_priority_assignment_aliases(source, tree))
+    aliases.update(_priority_assignment_aliases(source, tree, {alias.decode("utf-8") for alias in aliases}))
     return frozenset(aliases)
 
 
-def _priority_assignment_aliases(source: str, tree: ast.AST) -> set[bytes]:
+def _priority_assignment_aliases(source: str, tree: ast.AST, priority_aliases: set[str]) -> set[bytes]:
     aliases: set[bytes] = set()
-    targets = _assignment_targets_in_tree(tree)
-    for target in targets:
-        aliases.add(target.encode("utf-8"))
+    discovered_aliases = set(priority_aliases)
+    for target, value in _assignment_targets_and_values_in_tree(tree):
+        if _expression_is_priority_alias_reference(value, discovered_aliases):
+            aliases.add(target.encode("utf-8"))
+            discovered_aliases.add(target)
+            continue
         probe = f"{source}\n" + "\n".join(_priority_assignment_probe_calls(target))
         try:
             probe_tree = ast.parse(probe)
@@ -398,18 +401,44 @@ def _priority_assignment_aliases(source: str, tree: ast.AST) -> set[bytes]:
             continue
         if _resolve_alias_aware_high_risk_calls(probe_tree):
             aliases.add(target.encode("utf-8"))
+            discovered_aliases.add(target)
     return aliases
 
 
-def _assignment_targets_in_tree(tree: ast.AST) -> list[str]:
-    targets: list[str] = []
+def _assignment_targets_and_values_in_tree(tree: ast.AST) -> list[tuple[str, ast.AST]]:
+    targets_and_values: list[tuple[str, ast.AST]] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Assign):
             for target in node.targets:
-                targets.extend(_assignment_target_names(target))
-        elif isinstance(node, ast.AnnAssign) and node.value is not None:
-            targets.extend(_assignment_target_names(node.target))
-    return targets
+                targets_and_values.extend((name, node.value) for name in _assignment_target_names(target))
+        elif isinstance(node, (ast.AnnAssign, ast.NamedExpr)) and node.value is not None:
+            targets_and_values.extend((name, node.value) for name in _assignment_target_names(node.target))
+    return targets_and_values
+
+
+def _expression_is_priority_alias_reference(node: ast.AST, aliases: set[str]) -> bool:
+    if isinstance(node, ast.Name):
+        return node.id in aliases
+    if isinstance(node, ast.Attribute):
+        return _expression_is_priority_alias_reference(node.value, aliases)
+    if isinstance(node, ast.Subscript):
+        return _expression_is_priority_alias_reference(node.value, aliases)
+    if isinstance(node, ast.Call):
+        call_name = _simple_reference_name(node.func)
+        if call_name in {"getattr", "builtins.getattr"} and len(node.args) >= 2 and not node.keywords:
+            return _expression_is_priority_alias_reference(node.args[0], aliases)
+    return False
+
+
+def _simple_reference_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _simple_reference_name(node.value)
+        if parent is None:
+            return None
+        return f"{parent}.{node.attr}"
+    return None
 
 
 def _priority_assignment_probe_calls(target: str) -> list[str]:
@@ -464,12 +493,25 @@ def _priority_alias_usage_lines(
 
 
 def _line_uses_priority_alias(code_line: bytes, aliases: frozenset[bytes]) -> bool:
-    return any(re.search(rb"(?<![A-Za-z0-9_])" + re.escape(alias) + rb"\s*(?:\.|\()", code_line) for alias in aliases)
+    return any(
+        re.search(rb"(?<![A-Za-z0-9_])" + re.escape(alias) + rb"\s*(?:\.|\()", code_line)
+        or re.search(
+            rb"(?<![A-Za-z0-9_.])(?:builtins\.)?getattr\s*\(\s*" + re.escape(alias) + rb"\s*,",
+            code_line,
+        )
+        for alias in aliases
+    )
 
 
 def _line_calls_priority_alias(code_line: bytes, aliases: frozenset[bytes]) -> bool:
     return any(
         re.search(rb"(?<![A-Za-z0-9_])" + re.escape(alias) + rb"\s*(?:\(|\.[A-Za-z_]\w*\s*\()", code_line)
+        or re.search(
+            rb"(?<![A-Za-z0-9_.])(?:builtins\.)?getattr\s*\(\s*"
+            + re.escape(alias)
+            + rb"\s*,\s*['\"][A-Za-z_]\w*['\"]\s*\)\s*\(",
+            code_line,
+        )
         for alias in aliases
     )
 
@@ -734,6 +776,15 @@ def _is_priority_prefix_context_statement(context: bytes, statement: bytes) -> b
     return _is_priority_assignment_context(context, statement)
 
 
+def _is_prefix_context_shadow_statement(context: bytes, statement: bytes) -> bool:
+    if not context:
+        return False
+    context_names = _prefix_context_binding_names(context)
+    if not context_names:
+        return False
+    return not _statement_defined_names(statement).isdisjoint(context_names)
+
+
 def _statement_defined_names(statement: bytes) -> set[str]:
     statement_str, _byte_offsets = _decode_utf8_with_byte_offsets(statement)
     try:
@@ -823,7 +874,9 @@ def _extract_priority_prefix_context(data: bytes) -> bytes:
 
         statement = b"".join(statement_lines).rstrip() + b"\n"
         current_context = b"".join(context)
-        if not _is_priority_prefix_context_statement(current_context, statement):
+        if not _is_priority_prefix_context_statement(
+            current_context, statement
+        ) and not _is_prefix_context_shadow_statement(current_context, statement):
             multiline_quote = statement_line_quote
             index += 1
             continue
@@ -859,22 +912,23 @@ def _embedded_python_extraction_windows(data: bytes) -> list[tuple[bytes, bool]]
             insertion_index = bisect_right(tail_starts, priority_offset)
             if insertion_index:
                 priority_tail_starts.add(tail_starts[insertion_index - 1])
-        context_names = _prefix_context_binding_names(import_context)
-        for start in tail_starts:
-            probe = tail[start : start + _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES]
-            if any(
-                re.search(rb"(?<![A-Za-z0-9_])" + re.escape(name.encode()) + rb"\s*(?:\(|\.)", probe)
-                for name in context_names
-            ):
-                priority_tail_starts.add(start)
+        priority_tail_start_list = _bounded_priority_tail_starts(sorted(priority_tail_starts))
         selected_starts = [
             *tail_starts[:_MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS],
-            *sorted(priority_tail_starts),
+            *priority_tail_start_list,
             *tail_starts[-_MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS:],
         ]
         for start in dict.fromkeys(selected_starts):
             extraction_windows.append((import_context + b"\n" + tail[start:], True))
     return extraction_windows
+
+
+def _bounded_priority_tail_starts(tail_starts: list[int]) -> list[int]:
+    if len(tail_starts) <= _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPETS:
+        return tail_starts
+    head_count = _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPETS // 2
+    tail_count = _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPETS - head_count
+    return [*tail_starts[:head_count], *tail_starts[-tail_count:]]
 
 
 def _tail_starts_for_priority_alias_uses(

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -147,6 +147,14 @@ _PRIORITY_EMBEDDED_PYTHON_MODULES = tuple(
 _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN = b"|".join(
     re.escape(marker.encode("utf-8")) for marker in _PRIORITY_EMBEDDED_PYTHON_MODULES
 )
+_PRIORITY_WILDCARD_IMPORT_ALIASES = {
+    "asyncio": ("create_subprocess_exec", "create_subprocess_shell"),
+    "ctypes": ("CDLL", "LoadLibrary", "LibraryLoader", "cdll", "pydll", "windll"),
+    "os": ("popen", "spawnl", "spawnle", "spawnv", "spawnve", "system"),
+    "runpy": ("_run_module_as_main", "run_module", "run_path"),
+    "subprocess": ("Popen", "call", "check_call", "check_output", "getoutput", "getstatusoutput", "run"),
+    "webbrowser": ("get", "open", "open_new", "open_new_tab"),
+}
 _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN = re.compile(
     rb"(?m)^\s*(?:"
     rb"import\s+(?:[a-z_][\w.]*(?:\s+as\s+[a-z_]\w*)?\s*,(?:\s|\\\r?\n)*)*(?:"
@@ -335,7 +343,13 @@ def _priority_import_aliases(candidate: bytes) -> frozenset[bytes]:
         elif isinstance(statement, ast.ImportFrom) and statement.module is not None:
             root_name = statement.module.split(".", maxsplit=1)[0]
             if root_name in priority_modules:
-                aliases.update((alias.asname or alias.name).encode("utf-8") for alias in statement.names)
+                for alias in statement.names:
+                    if alias.name == "*":
+                        aliases.update(
+                            name.encode("utf-8") for name in _PRIORITY_WILDCARD_IMPORT_ALIASES.get(root_name, ())
+                        )
+                    else:
+                        aliases.add((alias.asname or alias.name).encode("utf-8"))
     aliases.update(_priority_assignment_aliases(source, tree))
     return frozenset(aliases)
 

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -152,18 +152,14 @@ _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN = re.compile(
     rb"from\s+(?:" + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN + rb")(?:[.\s]|\\\r?\n|$)"
     rb")"
 )
-_EMBEDDED_PYTHON_CONTEXT_STATEMENT_START_PATTERN = re.compile(
-    rb"(?<![A-Za-z0-9_'\".])(?:(?:import|from)\s+|[A-Za-z_]\w*\s*=)"
-)
-_PRIORITY_EMBEDDED_PYTHON_ALIAS_ASSIGNMENT_PATTERN = re.compile(rb"(?m)^\s*[a-z_]\w*\s*=\s*[a-z_]\w*(?:\.[a-z_]\w*)+")
-_DIRECT_PRIORITY_EMBEDDED_PYTHON_ALIAS_ASSIGNMENT_PATTERN = re.compile(
-    rb"(?m)^\s*[a-z_]\w*\s*=\s*(?:" + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN + rb")\."
-)
 _EMBEDDED_PYTHON_BLOCK_PATTERN = re.compile(rb"def\s+\w+\s*\([^)]*\):[^}]+|class\s+\w+[^}]+")
 _EMBEDDED_PYTHON_START_PATTERN = re.compile(
     rb"(?<![A-Za-z0-9_'\".])"
     rb"(?:(?:async\s+)?def\s+\w+|class\s+\w+|import\s+[A-Za-z_][\w.]*|"
     rb"from\s+[A-Za-z_][\w.]*(?:\s|\\\r?\n)+import)"
+)
+_EMBEDDED_PYTHON_CONTEXT_START_PATTERN = re.compile(
+    rb"(?<![A-Za-z0-9_'\".])(?:import\s+[A-Za-z_][\w.]*|from\s+[A-Za-z_][\w.]*|[A-Za-z_]\w*\s*=)"
 )
 
 
@@ -314,54 +310,87 @@ def _line_parenthesis_delta(line: bytes) -> int:
     return line.count(b"(") - line.count(b")")
 
 
-def _embedded_python_context_statement_start(line: bytes) -> int | None:
-    for match in _EMBEDDED_PYTHON_CONTEXT_STATEMENT_START_PATTERN.finditer(line):
-        prefix = line[: match.start()]
-        if prefix and prefix.strip() == b"":
-            continue
-        if prefix and any(0x20 <= byte < 0x7F for byte in prefix.strip()):
-            continue
-        return match.start()
+def _is_embedded_top_level_prefix(prefix: bytes) -> bool:
+    if not prefix:
+        return True
+    stripped_prefix = prefix.strip()
+    if stripped_prefix == b"":
+        return False
+    return not any(0x20 <= byte < 0x7F for byte in stripped_prefix)
+
+
+def _context_statement_start(line: bytes) -> int | None:
+    for match in _EMBEDDED_PYTHON_CONTEXT_START_PATTERN.finditer(line):
+        if _is_embedded_top_level_prefix(line[: match.start()]):
+            return match.start()
     return None
 
 
-def _is_priority_import_context_statement(statement: bytes, *, has_context: bool) -> bool:
-    lowered = statement.lower()
-    if _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN.search(lowered) is not None:
-        return True
-    if _DIRECT_PRIORITY_EMBEDDED_PYTHON_ALIAS_ASSIGNMENT_PATTERN.match(lowered) is not None:
-        return True
-    return has_context and _PRIORITY_EMBEDDED_PYTHON_ALIAS_ASSIGNMENT_PATTERN.match(lowered) is not None
+def _assignment_targets(tree: ast.AST) -> list[str]:
+    targets: list[str] = []
+    for statement in getattr(tree, "body", []):
+        if not isinstance(statement, ast.Assign):
+            continue
+        for target in statement.targets:
+            if isinstance(target, ast.Name):
+                targets.append(target.id)
+    return targets
 
 
-def _extract_priority_import_context(data: bytes) -> bytes:
-    """Return bounded dangerous import statements from a prefix window."""
+def _is_priority_assignment_context(context: bytes, statement: bytes) -> bool:
+    code_str, _byte_offsets = _decode_utf8_with_byte_offsets(context + statement)
+    statement_str, _statement_byte_offsets = _decode_utf8_with_byte_offsets(statement)
+    try:
+        statement_tree = ast.parse(statement_str)
+    except (SyntaxError, ValueError):
+        return False
+
+    targets = _assignment_targets(statement_tree)
+    if not targets:
+        return False
+
+    probe = code_str + "\n" + "\n".join(f"{target}()" for target in targets)
+    try:
+        probe_tree = ast.parse(probe)
+    except (SyntaxError, ValueError):
+        return False
+    return bool(_resolve_alias_aware_high_risk_calls(probe_tree))
+
+
+def _is_priority_prefix_context_statement(context: bytes, statement: bytes) -> bool:
+    if _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN.search(statement.lower()) is not None:
+        code_str, _byte_offsets = _decode_utf8_with_byte_offsets(statement)
+        try:
+            ast.parse(code_str)
+        except (SyntaxError, ValueError):
+            return False
+        return True
+    return _is_priority_assignment_context(context, statement)
+
+
+def _extract_priority_prefix_context(data: bytes) -> bytes:
+    """Return bounded top-level dangerous imports and aliases from a prefix window."""
     context: list[bytes] = []
     context_size = 0
     lines = data.splitlines(keepends=True)
     index = 0
     while index < len(lines):
-        statement_start = _embedded_python_context_statement_start(lines[index])
-        if statement_start is None:
+        start = _context_statement_start(lines[index])
+        if start is None:
             index += 1
             continue
 
-        statement_lines = [lines[index][statement_start:]]
+        statement_lines = [lines[index][start:]]
         paren_depth = _line_parenthesis_delta(statement_lines[0])
         while (_line_has_explicit_continuation(statement_lines[-1]) or paren_depth > 0) and index + 1 < len(lines):
             index += 1
-            continuation = lines[index].lstrip()
+            continuation = lines[index]
             statement_lines.append(continuation)
             paren_depth += _line_parenthesis_delta(continuation)
 
         statement = b"".join(statement_lines).rstrip() + b"\n"
-        if not _is_priority_import_context_statement(statement, has_context=bool(context)):
-            index += 1
-            continue
-        code_str, _byte_offsets = _decode_utf8_with_byte_offsets(statement)
-        try:
-            ast.parse(code_str)
-        except (SyntaxError, ValueError):
+        current_context = b"".join(context)
+        if not _is_priority_prefix_context_statement(current_context, statement):
             index += 1
             continue
         if context_size + len(statement) > _MAX_EMBEDDED_PYTHON_IMPORT_CONTEXT_BYTES:
@@ -380,7 +409,7 @@ def _embedded_python_extraction_windows(data: bytes) -> list[tuple[bytes, bool]]
 
     prefix, tail = windows
     extraction_windows = [(prefix, False), (tail, False)]
-    import_context = _extract_priority_import_context(prefix)
+    import_context = _extract_priority_prefix_context(prefix)
     if import_context:
         extraction_windows.append((import_context + b"\n" + tail, True))
     return extraction_windows
@@ -520,8 +549,7 @@ class JITScriptDetector:
             return False
         for window, include_full_source in _embedded_python_extraction_windows(data):
             for candidate, _span in _candidate_embedded_python_snippets(
-                window,
-                include_full_source=include_full_source,
+                window, include_full_source=include_full_source
             ):
                 code_str, _byte_offsets = _decode_utf8_with_byte_offsets(candidate)
                 parsed_snippet = _parse_embedded_python_snippet(code_str)

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -276,17 +276,28 @@ def _bounded_priority_embedded_python_candidate(
     priority_relative_offset = priority_offsets[index] - span[0]
     if priority_relative_offset >= _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES:
         line_start = candidate.rfind(b"\n", 0, priority_relative_offset) + 1
-        block_header_end = candidate.find(b"\n")
-        if block_header_end != -1 and candidate[:block_header_end].lstrip().startswith(
-            (b"def ", b"async def ", b"class ")
-        ):
-            bounded_end = min(len(candidate), line_start + _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES)
-            compact_candidate = candidate[: block_header_end + 1] + candidate[line_start:bounded_end]
-            return compact_candidate, (span[0], span[0] + len(compact_candidate))
     else:
         line_start = 0
     bounded_end = min(len(candidate), line_start + _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES)
-    return candidate[line_start:bounded_end], (span[0] + line_start, span[0] + bounded_end)
+    segments: list[bytes] = []
+    block_header_end = candidate.find(b"\n")
+    if (
+        block_header_end != -1
+        and line_start > block_header_end
+        and candidate[:block_header_end].lstrip().startswith((b"def ", b"async def ", b"class "))
+    ):
+        segments.append(candidate[: block_header_end + 1])
+    segments.append(candidate[line_start:bounded_end])
+
+    tail_start = max(bounded_end, len(candidate) - _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES)
+    tail_start = candidate.rfind(b"\n", 0, tail_start) + 1
+    if bounded_end < tail_start < len(candidate):
+        segments.append(candidate[tail_start:])
+
+    compact_candidate = b"\n".join(segment.rstrip(b"\n") for segment in segments if segment)
+    if len(segments) > 1:
+        return compact_candidate, (span[0], span[0] + len(compact_candidate))
+    return compact_candidate, (span[0] + line_start, span[0] + line_start + len(compact_candidate))
 
 
 def _prioritized_embedded_python_snippets(
@@ -544,6 +555,13 @@ def _embedded_python_extraction_windows(data: bytes) -> list[tuple[bytes, bool]]
     import_context = _extract_priority_prefix_context(prefix)
     if import_context:
         extraction_windows.append((import_context + b"\n" + tail, True))
+        tail_starts = [match.start() for match in _EMBEDDED_PYTHON_START_PATTERN.finditer(tail) if match.start() > 0]
+        selected_starts = [
+            *tail_starts[:_MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS],
+            *tail_starts[-_MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS:],
+        ]
+        for start in dict.fromkeys(selected_starts):
+            extraction_windows.append((import_context + b"\n" + tail[start:], True))
     return extraction_windows
 
 

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -144,7 +144,9 @@ _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN = b"|".join(
 )
 _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN = re.compile(
     rb"(?m)^\s*(?:"
-    rb"import\s+(?:[a-z_][\w.]*\s*,\s*)*(?:" + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN + rb")(?:[.\s,]|$)|"
+    rb"import\s+(?:[a-z_][\w.]*(?:\s+as\s+[a-z_]\w*)?\s*,\s*)*(?:"
+    + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN
+    + rb")(?:[.\s,]|$)|"
     rb"from\s+(?:" + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN + rb")(?:[.\s]|$)"
     rb")"
 )

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -154,8 +154,8 @@ _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN = re.compile(
     rb"from\s+(?:" + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN + rb")(?:[.\s]|\\\r?\n|$)"
     rb")"
 )
-_EMBEDDED_PYTHON_CONTEXT_ASSIGNMENT_LHS_PATTERN = rb"[A-Za-z_]\w*(?:\s*:[^=\n#]+)?"
-_EMBEDDED_PYTHON_BLOCK_PATTERN = re.compile(rb"def\s+\w+\s*\([^)]*\):[^}]+|class\s+\w+[^}]+")
+_EMBEDDED_PYTHON_CONTEXT_ASSIGNMENT_LHS_PATTERN = rb"(?:[A-Za-z_]\w*(?:\s*:[^=\n#]+)?|[\(\[][A-Za-z_][^=\n#]*[\)\]])"
+_EMBEDDED_PYTHON_BLOCK_PATTERN = re.compile(rb"def\s+\w+\s*\([^)]*\):[^}\x00]+|class\s+\w+[^}\x00]+")
 _EMBEDDED_PYTHON_START_PATTERN = re.compile(
     rb"(?<![A-Za-z0-9_'\".])"
     rb"(?:(?:async\s+)?def\s+\w+|class\s+\w+|import\s+[A-Za-z_][\w.]*|"
@@ -241,10 +241,9 @@ def _candidate_embedded_python_snippets(
     for start in start_offsets:
         if include_full_source and start == 0:
             continue
-        if (
-            any(block_start <= start < block_end for block_start, block_end in block_spans)
-            and start not in priority_starts
-        ):
+        if any(block_start < start < block_end for block_start, block_end in block_spans):
+            continue
+        if any(block_start == start for block_start, _block_end in block_spans) and start not in priority_starts:
             continue
         candidates.append((bounded[start:], (start, len(bounded))))
 
@@ -282,31 +281,47 @@ def _bounded_priority_embedded_python_candidate(
         ):
             bounded_end = min(len(candidate), line_start + _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES)
             compact_candidate = candidate[: block_header_end + 1] + candidate[line_start:bounded_end]
-            return _append_late_priority_alias_usage(candidate, compact_candidate, bounded_end, span[0])
+            return _append_late_priority_alias_usage(
+                candidate,
+                compact_candidate,
+                bounded_end,
+                span[0],
+                span[0] + line_start,
+                span[0] + bounded_end,
+            )
     else:
         line_start = 0
     bounded_end = min(len(candidate), line_start + _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES)
     bounded_candidate = candidate[line_start:bounded_end]
-    return _append_late_priority_alias_usage(candidate, bounded_candidate, bounded_end, span[0] + line_start)
+    return _append_late_priority_alias_usage(
+        candidate,
+        bounded_candidate,
+        bounded_end,
+        span[0],
+        span[0] + line_start,
+        span[0] + bounded_end,
+    )
 
 
 def _append_late_priority_alias_usage(
     candidate: bytes,
     bounded_candidate: bytes,
     search_start: int,
+    candidate_span_start: int,
     span_start: int,
+    span_end: int,
 ) -> tuple[bytes, tuple[int, int]]:
     aliases = _priority_import_aliases(bounded_candidate)
     if not aliases:
-        return bounded_candidate, (span_start, span_start + len(bounded_candidate))
+        return bounded_candidate, (span_start, span_end)
 
     usage_line = _priority_alias_usage_line(candidate, aliases, search_start)
     if usage_line is None:
-        return bounded_candidate, (span_start, span_start + len(bounded_candidate))
+        return bounded_candidate, (span_start, span_end)
 
     usage_start, usage_end = usage_line
     compact_candidate = bounded_candidate.rstrip() + b"\n" + candidate[usage_start:usage_end]
-    return compact_candidate, (span_start, span_start + len(compact_candidate))
+    return compact_candidate, (span_start, max(span_end, candidate_span_start + usage_end))
 
 
 def _priority_import_aliases(candidate: bytes) -> frozenset[bytes]:
@@ -510,8 +525,7 @@ def _assignment_targets(tree: ast.AST) -> list[str]:
     for statement in getattr(tree, "body", []):
         if isinstance(statement, ast.Assign):
             for target in statement.targets:
-                if isinstance(target, ast.Name):
-                    targets.append(target.id)
+                targets.extend(_assignment_target_names(target))
         elif (
             isinstance(statement, ast.AnnAssign)
             and statement.value is not None
@@ -519,6 +533,16 @@ def _assignment_targets(tree: ast.AST) -> list[str]:
         ):
             targets.append(statement.target.id)
     return targets
+
+
+def _assignment_target_names(target: ast.AST) -> list[str]:
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, ast.Starred):
+        return _assignment_target_names(target.value)
+    if isinstance(target, (ast.Tuple, ast.List)):
+        return [name for element in target.elts for name in _assignment_target_names(element)]
+    return []
 
 
 def _is_priority_assignment_context(context: bytes, statement: bytes) -> bool:
@@ -585,8 +609,11 @@ def _extract_priority_prefix_context(data: bytes) -> bytes:
             multiline_quote = statement_line_quote
             index += 1
             continue
-        if context_size + len(statement) > _MAX_EMBEDDED_PYTHON_IMPORT_CONTEXT_BYTES:
-            break
+        if len(statement) > _MAX_EMBEDDED_PYTHON_IMPORT_CONTEXT_BYTES:
+            index += 1
+            continue
+        while context and context_size + len(statement) > _MAX_EMBEDDED_PYTHON_IMPORT_CONTEXT_BYTES:
+            context_size -= len(context.pop(0))
         context.append(statement)
         context_size += len(statement)
         index += 1
@@ -815,6 +842,23 @@ class JITScriptDetector:
         patterns = _DANGEROUS_IMPORT_PATTERNS.get(dangerous_import)
         import_pattern, from_pattern = patterns or _compile_dangerous_import_patterns(dangerous_import)
         return import_pattern.search(source) is not None or from_pattern.search(source) is not None
+
+    @staticmethod
+    def _dangerous_imports_in_tree(tree: ast.AST) -> set[str]:
+        dangerous_imports: set[str] = set()
+        for node in ast.walk(tree):
+            imported_modules: list[str] = []
+            if isinstance(node, ast.Import):
+                imported_modules.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module is not None:
+                imported_modules.append(node.module)
+            for module_name in imported_modules:
+                dangerous_imports.update(
+                    dangerous_import
+                    for dangerous_import in DANGEROUS_IMPORTS
+                    if module_name == dangerous_import or module_name.startswith(f"{dangerous_import}.")
+                )
+        return dangerous_imports
 
     def scan_torchscript(self, data: bytes, context: str = "") -> list["JITScriptFinding"]:
         """Scan TorchScript model data for dangerous operations.
@@ -1117,9 +1161,14 @@ class JITScriptDetector:
                             parsed_snippet = completed_parsed_snippet
                             span = completed_span
 
+                parsed_imports = (
+                    self._dangerous_imports_in_tree(parsed_snippet[0]) if parsed_snippet is not None else None
+                )
                 # Check for dangerous imports
                 for dangerous_import in DANGEROUS_IMPORTS:
-                    if self._contains_dangerous_import(code_str, dangerous_import):
+                    if self._contains_dangerous_import(code_str, dangerous_import) and (
+                        parsed_imports is None or dangerous_import in parsed_imports
+                    ):
                         findings.append(
                             create_jit_finding(
                                 message=f"Dangerous import '{dangerous_import}' in embedded code",

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -131,6 +131,8 @@ _DANGEROUS_IMPORT_PATTERNS = {
 }
 _MAX_SNIPPET_PARSE_TRIM_ATTEMPTS = 8
 _MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS = 10
+_MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPETS = 16
+_MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES = 16_384
 _EMBEDDED_PYTHON_SCAN_WINDOW_BYTES = 1_000_000
 _MAX_EMBEDDED_PYTHON_IMPORT_CONTEXT_BYTES = 16_384
 _EMBEDDED_PYTHON_START_MARKERS = (b"def ", b"async def ", b"class ", b"import ", b"from ")
@@ -264,6 +266,23 @@ def _span_contains_priority_offset(span: tuple[int, int], priority_offsets: list
     return index < len(priority_offsets) and priority_offsets[index] < span[1]
 
 
+def _bounded_priority_embedded_python_candidate(
+    candidate: bytes,
+    span: tuple[int, int],
+    priority_offsets: list[int],
+) -> tuple[bytes, tuple[int, int]]:
+    index = bisect_left(priority_offsets, span[0])
+    if index >= len(priority_offsets) or priority_offsets[index] >= span[1]:
+        return candidate, span
+    priority_relative_offset = priority_offsets[index] - span[0]
+    if priority_relative_offset >= _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES:
+        line_start = candidate.rfind(b"\n", 0, priority_relative_offset) + 1
+    else:
+        line_start = 0
+    bounded_end = min(len(candidate), line_start + _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES)
+    return candidate[line_start:bounded_end], (span[0] + line_start, span[0] + bounded_end)
+
+
 def _prioritized_embedded_python_snippets(
     candidates: list[tuple[bytes, tuple[int, int]]],
     bounded: bytes | None = None,
@@ -271,14 +290,24 @@ def _prioritized_embedded_python_snippets(
     selected: list[tuple[bytes, tuple[int, int]]] = []
     selected_spans: set[tuple[int, int]] = set()
     priority_offsets = _priority_import_offsets(bounded) if bounded is not None else []
+    selected_priority_candidates = 0
     for index, (candidate, span) in enumerate(candidates):
         has_priority_marker = (
             _span_contains_priority_offset(span, priority_offsets)
             if bounded is not None
             else _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN.search(candidate.lower()) is not None
         )
-        if index >= _MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS and not has_priority_marker:
-            continue
+        if index >= _MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS:
+            if not has_priority_marker:
+                continue
+            if selected_priority_candidates >= _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPETS:
+                continue
+            if bounded is not None:
+                candidate, span = _bounded_priority_embedded_python_candidate(candidate, span, priority_offsets)
+            else:
+                candidate = candidate[:_MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES]
+                span = (span[0], span[0] + len(candidate))
+            selected_priority_candidates += 1
         if span in selected_spans:
             continue
         selected_spans.add(span)
@@ -306,11 +335,33 @@ def _embedded_python_scan_windows(data: bytes) -> list[bytes]:
     return [data[:_EMBEDDED_PYTHON_SCAN_WINDOW_BYTES], data[-_EMBEDDED_PYTHON_SCAN_WINDOW_BYTES:]]
 
 
+def _strip_python_comment_bytes(line: bytes) -> bytes:
+    quote: int | None = None
+    escaped = False
+    for index, byte in enumerate(line):
+        if escaped:
+            escaped = False
+            continue
+        if byte == ord("\\") and quote is not None:
+            escaped = True
+            continue
+        if byte in {ord("'"), ord('"')}:
+            if quote is None:
+                quote = byte
+            elif quote == byte:
+                quote = None
+            continue
+        if byte == ord("#") and quote is None:
+            return line[:index]
+    return line
+
+
 def _line_has_explicit_continuation(line: bytes) -> bool:
-    return line.rstrip().endswith(b"\\")
+    return _strip_python_comment_bytes(line).rstrip().endswith(b"\\")
 
 
 def _line_parenthesis_delta(line: bytes) -> int:
+    line = _strip_python_comment_bytes(line)
     return line.count(b"(") - line.count(b")")
 
 

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -171,13 +171,14 @@ _EMBEDDED_PYTHON_START_PATTERN = re.compile(
     rb"from\s+[A-Za-z_][\w.]*(?:\s|\\\r?\n)+import)"
 )
 _EMBEDDED_PYTHON_CONTEXT_START_PATTERN = re.compile(
-    rb"(?<![A-Za-z0-9_'\".])(?:import\s+[A-Za-z_][\w.]*|from\s+[A-Za-z_][\w.]*|"
+    rb"(?<![A-Za-z0-9_'\".])(?:if\s+True\s*:|import\s+[A-Za-z_][\w.]*|from\s+[A-Za-z_][\w.]*|"
     + _EMBEDDED_PYTHON_CONTEXT_ASSIGNMENT_LHS_PATTERN
     + rb"\s*=)"
 )
 _EMBEDDED_PYTHON_COMPOUND_CONTEXT_START_PATTERN = re.compile(
     rb"(?<![A-Za-z0-9_'\".])if\s+(?:True|1)\s*:\s*(?:import|from)\s+"
 )
+_EmbeddedPythonCandidate = tuple[bytes, tuple[int, int], tuple[tuple[int, int], ...]]
 
 
 def _resolve_alias_aware_high_risk_calls(tree: ast.AST) -> set[tuple[str, str]]:
@@ -227,8 +228,8 @@ def _candidate_embedded_python_snippets(
     bounded: bytes,
     *,
     include_full_source: bool = False,
-) -> list[tuple[bytes, tuple[int, int]]]:
-    candidates: list[tuple[bytes, tuple[int, int]]] = []
+) -> list[_EmbeddedPythonCandidate]:
+    candidates: list[_EmbeddedPythonCandidate] = []
     block_spans: list[tuple[int, int]] = []
     start_offsets = [match.start() for match in _EMBEDDED_PYTHON_START_PATTERN.finditer(bounded)]
     priority_starts: set[int] = set()
@@ -241,14 +242,15 @@ def _candidate_embedded_python_snippets(
             priority_starts.add(start_offsets[insertion_index - 2])
 
     if include_full_source:
-        candidates.append((bounded, (0, len(bounded))))
+        span = (0, len(bounded))
+        candidates.append((bounded, span, (span,)))
 
     for match in _EMBEDDED_PYTHON_BLOCK_PATTERN.finditer(bounded):
         span = match.span()
         if include_full_source and span[0] == 0:
             continue
         block_spans.append(span)
-        candidates.append((match.group(0), span))
+        candidates.append((match.group(0), span, (span,)))
 
     for start in start_offsets:
         if include_full_source and start == 0:
@@ -257,7 +259,8 @@ def _candidate_embedded_python_snippets(
             continue
         if any(block_start == start for block_start, _block_end in block_spans) and start not in priority_starts:
             continue
-        candidates.append((bounded[start:], (start, len(bounded))))
+        span = (start, len(bounded))
+        candidates.append((bounded[start:], span, (span,)))
 
     return candidates
 
@@ -280,10 +283,10 @@ def _bounded_priority_embedded_python_candidate(
     candidate: bytes,
     span: tuple[int, int],
     priority_offsets: list[int],
-) -> tuple[bytes, tuple[int, int]]:
+) -> _EmbeddedPythonCandidate:
     index = bisect_left(priority_offsets, span[0])
     if index >= len(priority_offsets) or priority_offsets[index] >= span[1]:
-        return candidate, span
+        return candidate, span, (span,)
     priority_relative_offset = priority_offsets[index] - span[0]
     if priority_relative_offset >= _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES:
         line_start = candidate.rfind(b"\n", 0, priority_relative_offset) + 1
@@ -318,11 +321,20 @@ def _bounded_priority_embedded_python_candidate(
     merged_ranges = _merge_candidate_segment_ranges(segment_ranges)
     compact_candidate = _compact_candidate_segments(candidate, merged_ranges)
     if not merged_ranges:
-        return compact_candidate, span
+        return compact_candidate, span, (span,)
 
     span_start = span[0] + merged_ranges[0][0]
     span_end = span[0] + max(end for _start, end in merged_ranges)
-    return compact_candidate, (span_start, span_end)
+    real_ranges = tuple((span[0] + start, span[0] + end) for start, end in merged_ranges)
+    return compact_candidate, (span_start, span_end), real_ranges
+
+
+def _is_priority_module_name(module_name: str) -> bool:
+    module_name = module_name.lower()
+    return any(
+        module_name == priority_module or module_name.startswith(f"{priority_module}.")
+        for priority_module in _PRIORITY_EMBEDDED_PYTHON_MODULES
+    )
 
 
 def _priority_import_aliases(candidate: bytes) -> frozenset[bytes]:
@@ -333,16 +345,15 @@ def _priority_import_aliases(candidate: bytes) -> frozenset[bytes]:
         return frozenset()
 
     aliases: set[bytes] = set()
-    priority_modules = set(_PRIORITY_EMBEDDED_PYTHON_MODULES)
     for statement in ast.walk(tree):
         if isinstance(statement, ast.Import):
             for alias in statement.names:
-                root_name = alias.name.split(".", maxsplit=1)[0]
-                if root_name in priority_modules:
+                if _is_priority_module_name(alias.name):
+                    root_name = alias.name.split(".", maxsplit=1)[0]
                     aliases.add((alias.asname or root_name).encode("utf-8"))
         elif isinstance(statement, ast.ImportFrom) and statement.module is not None:
             root_name = statement.module.split(".", maxsplit=1)[0]
-            if root_name in priority_modules:
+            if _is_priority_module_name(statement.module):
                 for alias in statement.names:
                     if alias.name == "*":
                         aliases.update(
@@ -373,6 +384,16 @@ def _priority_assignment_probe_calls(target: str) -> list[str]:
         f"{target}()",
         f"{target}.run_path('payload.py')",
         f"{target}.run_module('payload')",
+        f"{target}._run_module_as_main('payload')",
+        f"{target}.system('id')",
+        f"{target}.popen('id')",
+        f"{target}.run(['id'])",
+        f"{target}.Popen(['id'])",
+        f"{target}.call(['id'])",
+        f"{target}.check_call(['id'])",
+        f"{target}.check_output(['id'])",
+        f"{target}.getoutput('id')",
+        f"{target}.getstatusoutput('id')",
         f"{target}.open('https://example.invalid')",
         f"{target}.open_new('https://example.invalid')",
         f"{target}.open_new_tab('https://example.invalid')",
@@ -439,14 +460,14 @@ def _compact_candidate_segments(candidate: bytes, segment_ranges: list[tuple[int
 
 
 def _prioritized_embedded_python_snippets(
-    candidates: list[tuple[bytes, tuple[int, int]]],
+    candidates: list[_EmbeddedPythonCandidate],
     bounded: bytes | None = None,
-) -> list[tuple[bytes, tuple[int, int]]]:
-    selected: list[tuple[bytes, tuple[int, int]]] = []
+) -> list[_EmbeddedPythonCandidate]:
+    selected: list[_EmbeddedPythonCandidate] = []
     selected_spans: set[tuple[int, int]] = set()
     priority_offsets = _priority_import_offsets(bounded) if bounded is not None else []
     selected_priority_candidates = 0
-    for index, (candidate, span) in enumerate(candidates):
+    for index, (candidate, span, real_ranges) in enumerate(candidates):
         has_priority_marker = (
             _span_contains_priority_offset(span, priority_offsets)
             if bounded is not None
@@ -458,15 +479,18 @@ def _prioritized_embedded_python_snippets(
             if selected_priority_candidates >= _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPETS:
                 continue
             if bounded is not None:
-                candidate, span = _bounded_priority_embedded_python_candidate(candidate, span, priority_offsets)
+                candidate, span, real_ranges = _bounded_priority_embedded_python_candidate(
+                    candidate, span, priority_offsets
+                )
             else:
                 candidate = candidate[:_MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES]
                 span = (span[0], span[0] + len(candidate))
+                real_ranges = (span,)
             selected_priority_candidates += 1
         if span in selected_spans:
             continue
         selected_spans.add(span)
-        selected.append((candidate, span))
+        selected.append((candidate, span, real_ranges))
     return selected
 
 
@@ -622,12 +646,8 @@ def _assignment_targets(tree: ast.AST) -> list[str]:
         if isinstance(statement, ast.Assign):
             for target in statement.targets:
                 targets.extend(_assignment_target_names(target))
-        elif (
-            isinstance(statement, ast.AnnAssign)
-            and statement.value is not None
-            and isinstance(statement.target, ast.Name)
-        ):
-            targets.append(statement.target.id)
+        elif isinstance(statement, ast.AnnAssign) and statement.value is not None:
+            targets.extend(_assignment_target_names(statement.target))
     return targets
 
 
@@ -661,30 +681,84 @@ def _is_priority_assignment_context(context: bytes, statement: bytes) -> bool:
     return bool(_resolve_alias_aware_high_risk_calls(probe_tree))
 
 
+def _tree_imports_priority_module(tree: ast.AST) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import) and any(_is_priority_module_name(alias.name) for alias in node.names):
+            return True
+        if isinstance(node, ast.ImportFrom) and node.module is not None and _is_priority_module_name(node.module):
+            return True
+    return False
+
+
 def _is_priority_prefix_context_statement(context: bytes, statement: bytes) -> bool:
     code_str, _byte_offsets = _decode_utf8_with_byte_offsets(statement)
     try:
         tree = ast.parse(code_str)
     except (SyntaxError, ValueError):
-        tree = None
-    if tree is not None and _tree_imports_priority_module(tree):
+        return False
+    if _tree_imports_priority_module(tree):
         return True
     return _is_priority_assignment_context(context, statement)
 
 
-def _tree_imports_priority_module(tree: ast.AST) -> bool:
-    priority_modules = set(_PRIORITY_EMBEDDED_PYTHON_MODULES)
+def _statement_defined_names(statement: bytes) -> set[str]:
+    statement_str, _byte_offsets = _decode_utf8_with_byte_offsets(statement)
+    try:
+        tree = ast.parse(statement_str)
+    except (SyntaxError, ValueError):
+        return set()
+
+    names: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
-            if any(alias.name.split(".", maxsplit=1)[0].lower() in priority_modules for alias in node.names):
-                return True
-        elif (
-            isinstance(node, ast.ImportFrom)
-            and node.module is not None
-            and node.module.split(".", maxsplit=1)[0].lower() in priority_modules
-        ):
-            return True
-    return False
+            names.update(alias.asname or alias.name.split(".", maxsplit=1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            names.update(alias.asname or alias.name for alias in node.names)
+        elif isinstance(node, (ast.Assign, ast.AnnAssign, ast.NamedExpr)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                names.update(_assignment_target_names(target))
+    return names
+
+
+def _statement_referenced_names(statement: bytes) -> set[str]:
+    statement_str, _byte_offsets = _decode_utf8_with_byte_offsets(statement)
+    try:
+        tree = ast.parse(statement_str)
+    except (SyntaxError, ValueError):
+        return set()
+    return {node.id for node in ast.walk(tree) if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)}
+
+
+def _drop_context_statement_index(context: list[bytes]) -> int:
+    later_references: set[str] = set()
+    for index in range(len(context) - 1, -1, -1):
+        defined_names = _statement_defined_names(context[index])
+        if defined_names.isdisjoint(later_references):
+            return index
+        later_references.difference_update(defined_names)
+        later_references.update(_statement_referenced_names(context[index]))
+    return 0
+
+
+def _prefix_context_binding_names(context: bytes) -> set[str]:
+    code_str, _byte_offsets = _decode_utf8_with_byte_offsets(context)
+    try:
+        tree = ast.parse(code_str)
+    except (SyntaxError, ValueError):
+        return set()
+
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.asname or alias.name.split(".", maxsplit=1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            names.update(alias.asname or alias.name for alias in node.names)
+        elif isinstance(node, (ast.Assign, ast.AnnAssign, ast.NamedExpr)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                names.update(_assignment_target_names(target))
+    return names
 
 
 def _extract_priority_prefix_context(data: bytes) -> bytes:
@@ -724,7 +798,10 @@ def _extract_priority_prefix_context(data: bytes) -> bytes:
             index += 1
             continue
         while context and context_size + len(statement) > _MAX_EMBEDDED_PYTHON_IMPORT_CONTEXT_BYTES:
-            context_size -= len(context.pop(0))
+            drop_index = _drop_context_statement_index([*context, statement])
+            if drop_index >= len(context):
+                break
+            context_size -= len(context.pop(drop_index))
         context.append(statement)
         context_size += len(statement)
         index += 1
@@ -744,9 +821,22 @@ def _embedded_python_extraction_windows(data: bytes) -> list[tuple[bytes, bool]]
         extraction_windows.append((import_context + b"\n" + tail, True))
         tail_starts = [match.start() for match in _EMBEDDED_PYTHON_START_PATTERN.finditer(tail) if match.start() > 0]
         context_aliases = _priority_import_aliases(import_context)
+        priority_tail_starts = set(_tail_starts_for_priority_alias_uses(tail, tail_starts, context_aliases))
+        for priority_offset in _priority_import_offsets(tail):
+            insertion_index = bisect_right(tail_starts, priority_offset)
+            if insertion_index:
+                priority_tail_starts.add(tail_starts[insertion_index - 1])
+        context_names = _prefix_context_binding_names(import_context)
+        for start in tail_starts:
+            probe = tail[start : start + _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES]
+            if any(
+                re.search(rb"(?<![A-Za-z0-9_])" + re.escape(name.encode()) + rb"\s*(?:\(|\.)", probe)
+                for name in context_names
+            ):
+                priority_tail_starts.add(start)
         selected_starts = [
             *tail_starts[:_MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS],
-            *_tail_starts_for_priority_alias_uses(tail, tail_starts, context_aliases),
+            *sorted(priority_tail_starts),
             *tail_starts[-_MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS:],
         ]
         for start in dict.fromkeys(selected_starts):
@@ -775,6 +865,29 @@ def _has_raw_match_outside_parsed_spans(raw_spans: list[tuple[int, int]], parsed
         if not any(parsed_start <= raw_start and raw_end <= parsed_end for parsed_start, parsed_end in parsed_spans):
             return True
     return False
+
+
+def _parsed_real_spans(
+    real_ranges: tuple[tuple[int, int], ...],
+    parsed_byte_length: int,
+    compact_length: int,
+) -> list[tuple[int, int]]:
+    if parsed_byte_length >= compact_length:
+        return list(real_ranges)
+
+    remaining = parsed_byte_length
+    parsed_spans: list[tuple[int, int]] = []
+    for start, end in real_ranges:
+        if remaining <= 0:
+            break
+        segment_length = end - start
+        consumed = min(segment_length, remaining)
+        if consumed > 0:
+            parsed_spans.append((start, start + consumed))
+            remaining -= consumed
+        if remaining > 0:
+            remaining -= 1
+    return parsed_spans
 
 
 def _is_span_inside_parsed_spans(span: tuple[int, int], parsed_spans: list[tuple[int, int]]) -> bool:
@@ -902,7 +1015,7 @@ class JITScriptDetector:
         if not any(marker in data for marker in _EMBEDDED_PYTHON_START_MARKERS):
             return False
         for window, include_full_source in _embedded_python_extraction_windows(data):
-            for candidate, _span in _candidate_embedded_python_snippets(
+            for candidate, _span, _real_ranges in _candidate_embedded_python_snippets(
                 window, include_full_source=include_full_source
             ):
                 code_str, _byte_offsets = _decode_utf8_with_byte_offsets(candidate)
@@ -1272,7 +1385,7 @@ class JITScriptDetector:
             # raw pattern detection active and fall back to extracted snippets.
             bounded_high_risk_calls = None
 
-        for match, span in _prioritized_embedded_python_snippets(matches, bounded=bounded):
+        for match, span, real_ranges in _prioritized_embedded_python_snippets(matches, bounded=bounded):
             try:
                 if _is_span_inside_parsed_spans(span, parsed_snippet_spans):
                     continue
@@ -1289,6 +1402,7 @@ class JITScriptDetector:
                             byte_offsets = completed_byte_offsets
                             parsed_snippet = completed_parsed_snippet
                             span = completed_span
+                            real_ranges = (completed_span,)
 
                 parsed_imports = (
                     self._dangerous_imports_in_tree(parsed_snippet[0]) if parsed_snippet is not None else None
@@ -1339,10 +1453,7 @@ class JITScriptDetector:
                 if parsed_snippet is not None:
                     tree, parsed_chars = parsed_snippet
                     parsed_byte_length = byte_offsets[parsed_chars]
-                    parsed_end = (
-                        span[1] if span[1] - span[0] > len(match) + 1 else min(span[1], span[0] + parsed_byte_length)
-                    )
-                    parsed_snippet_spans.append((span[0], parsed_end))
+                    parsed_snippet_spans.extend(_parsed_real_spans(real_ranges, parsed_byte_length, len(match)))
                     snippet_high_risk_calls.update(_resolve_alias_aware_high_risk_calls(tree))
                     ast_findings = self._analyze_ast(tree, framework, context)
                     findings.extend(ast_findings)

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -152,6 +152,13 @@ _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN = re.compile(
     rb"from\s+(?:" + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN + rb")(?:[.\s]|\\\r?\n|$)"
     rb")"
 )
+_EMBEDDED_PYTHON_CONTEXT_STATEMENT_START_PATTERN = re.compile(
+    rb"(?<![A-Za-z0-9_'\".])(?:(?:import|from)\s+|[A-Za-z_]\w*\s*=)"
+)
+_PRIORITY_EMBEDDED_PYTHON_ALIAS_ASSIGNMENT_PATTERN = re.compile(rb"(?m)^\s*[a-z_]\w*\s*=\s*[a-z_]\w*(?:\.[a-z_]\w*)+")
+_DIRECT_PRIORITY_EMBEDDED_PYTHON_ALIAS_ASSIGNMENT_PATTERN = re.compile(
+    rb"(?m)^\s*[a-z_]\w*\s*=\s*(?:" + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN + rb")\."
+)
 _EMBEDDED_PYTHON_BLOCK_PATTERN = re.compile(rb"def\s+\w+\s*\([^)]*\):[^}]+|class\s+\w+[^}]+")
 _EMBEDDED_PYTHON_START_PATTERN = re.compile(
     rb"(?<![A-Za-z0-9_'\".])"
@@ -307,6 +314,26 @@ def _line_parenthesis_delta(line: bytes) -> int:
     return line.count(b"(") - line.count(b")")
 
 
+def _embedded_python_context_statement_start(line: bytes) -> int | None:
+    for match in _EMBEDDED_PYTHON_CONTEXT_STATEMENT_START_PATTERN.finditer(line):
+        prefix = line[: match.start()]
+        if prefix and prefix.strip() == b"":
+            continue
+        if prefix and any(0x20 <= byte < 0x7F for byte in prefix.strip()):
+            continue
+        return match.start()
+    return None
+
+
+def _is_priority_import_context_statement(statement: bytes, *, has_context: bool) -> bool:
+    lowered = statement.lower()
+    if _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN.search(lowered) is not None:
+        return True
+    if _DIRECT_PRIORITY_EMBEDDED_PYTHON_ALIAS_ASSIGNMENT_PATTERN.match(lowered) is not None:
+        return True
+    return has_context and _PRIORITY_EMBEDDED_PYTHON_ALIAS_ASSIGNMENT_PATTERN.match(lowered) is not None
+
+
 def _extract_priority_import_context(data: bytes) -> bytes:
     """Return bounded dangerous import statements from a prefix window."""
     context: list[bytes] = []
@@ -314,13 +341,13 @@ def _extract_priority_import_context(data: bytes) -> bytes:
     lines = data.splitlines(keepends=True)
     index = 0
     while index < len(lines):
-        stripped = lines[index].lstrip()
-        if not stripped.startswith((b"import ", b"from ")):
+        statement_start = _embedded_python_context_statement_start(lines[index])
+        if statement_start is None:
             index += 1
             continue
 
-        statement_lines = [stripped]
-        paren_depth = _line_parenthesis_delta(stripped)
+        statement_lines = [lines[index][statement_start:]]
+        paren_depth = _line_parenthesis_delta(statement_lines[0])
         while (_line_has_explicit_continuation(statement_lines[-1]) or paren_depth > 0) and index + 1 < len(lines):
             index += 1
             continuation = lines[index].lstrip()
@@ -328,7 +355,7 @@ def _extract_priority_import_context(data: bytes) -> bytes:
             paren_depth += _line_parenthesis_delta(continuation)
 
         statement = b"".join(statement_lines).rstrip() + b"\n"
-        if _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN.search(statement.lower()) is None:
+        if not _is_priority_import_context_statement(statement, has_context=bool(context)):
             index += 1
             continue
         code_str, _byte_offsets = _decode_utf8_with_byte_offsets(statement)
@@ -491,8 +518,11 @@ class JITScriptDetector:
         """Return whether a bounded binary blob has parseable dangerous Python framing."""
         if not any(marker in data for marker in _EMBEDDED_PYTHON_START_MARKERS):
             return False
-        for window in _embedded_python_scan_windows(data):
-            for candidate, _span in _candidate_embedded_python_snippets(window):
+        for window, include_full_source in _embedded_python_extraction_windows(data):
+            for candidate, _span in _candidate_embedded_python_snippets(
+                window,
+                include_full_source=include_full_source,
+            ):
                 code_str, _byte_offsets = _decode_utf8_with_byte_offsets(candidate)
                 parsed_snippet = _parse_embedded_python_snippet(code_str)
                 if parsed_snippet is None:

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -282,11 +282,71 @@ def _bounded_priority_embedded_python_candidate(
         ):
             bounded_end = min(len(candidate), line_start + _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES)
             compact_candidate = candidate[: block_header_end + 1] + candidate[line_start:bounded_end]
-            return compact_candidate, (span[0], span[0] + len(compact_candidate))
+            return _append_late_priority_alias_usage(candidate, compact_candidate, bounded_end, span[0])
     else:
         line_start = 0
     bounded_end = min(len(candidate), line_start + _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES)
-    return candidate[line_start:bounded_end], (span[0] + line_start, span[0] + bounded_end)
+    bounded_candidate = candidate[line_start:bounded_end]
+    return _append_late_priority_alias_usage(candidate, bounded_candidate, bounded_end, span[0] + line_start)
+
+
+def _append_late_priority_alias_usage(
+    candidate: bytes,
+    bounded_candidate: bytes,
+    search_start: int,
+    span_start: int,
+) -> tuple[bytes, tuple[int, int]]:
+    aliases = _priority_import_aliases(bounded_candidate)
+    if not aliases:
+        return bounded_candidate, (span_start, span_start + len(bounded_candidate))
+
+    usage_line = _priority_alias_usage_line(candidate, aliases, search_start)
+    if usage_line is None:
+        return bounded_candidate, (span_start, span_start + len(bounded_candidate))
+
+    usage_start, usage_end = usage_line
+    compact_candidate = bounded_candidate.rstrip() + b"\n" + candidate[usage_start:usage_end]
+    return compact_candidate, (span_start, span_start + len(compact_candidate))
+
+
+def _priority_import_aliases(candidate: bytes) -> frozenset[bytes]:
+    try:
+        source, _byte_offsets = _decode_utf8_with_byte_offsets(candidate)
+        tree = ast.parse(textwrap.dedent(source))
+    except (SyntaxError, ValueError):
+        return frozenset()
+
+    aliases: set[bytes] = set()
+    priority_modules = set(_PRIORITY_EMBEDDED_PYTHON_MODULES)
+    for statement in ast.walk(tree):
+        if isinstance(statement, ast.Import):
+            for alias in statement.names:
+                root_name = alias.name.split(".", maxsplit=1)[0]
+                if root_name in priority_modules:
+                    aliases.add((alias.asname or root_name).encode("utf-8"))
+        elif isinstance(statement, ast.ImportFrom) and statement.module is not None:
+            root_name = statement.module.split(".", maxsplit=1)[0]
+            if root_name in priority_modules:
+                aliases.update((alias.asname or alias.name).encode("utf-8") for alias in statement.names)
+    return frozenset(aliases)
+
+
+def _priority_alias_usage_line(
+    candidate: bytes, aliases: frozenset[bytes], search_start: int
+) -> tuple[int, int] | None:
+    line_start = search_start
+    while line_start < len(candidate):
+        line_end = candidate.find(b"\n", line_start)
+        if line_end == -1:
+            line_end = len(candidate)
+        else:
+            line_end += 1
+        line = candidate[line_start:line_end]
+        code_line = _python_code_without_comments_or_strings(line)
+        if any(re.search(rb"(?<![A-Za-z0-9_])" + re.escape(alias) + rb"\s*(?:\.|\()", code_line) for alias in aliases):
+            return line_start, min(line_end, line_start + _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES)
+        line_start = line_end
+    return None
 
 
 def _prioritized_embedded_python_snippets(
@@ -561,7 +621,13 @@ def _embedded_python_extraction_windows(data: bytes) -> list[tuple[bytes, bool]]
     import_context = _extract_priority_prefix_context(prefix)
     if import_context:
         extraction_windows.append((import_context + b"\n" + tail, True))
+        for start in _embedded_python_start_offsets(tail)[:_MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPETS]:
+            extraction_windows.append((import_context + b"\n" + tail[start:], False))
     return extraction_windows
+
+
+def _embedded_python_start_offsets(data: bytes) -> list[int]:
+    return [match.start() for match in _EMBEDDED_PYTHON_START_PATTERN.finditer(data)]
 
 
 def _has_raw_match_outside_parsed_spans(raw_spans: list[tuple[int, int]], parsed_spans: list[tuple[int, int]]) -> bool:

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -287,7 +287,28 @@ def _bounded_priority_embedded_python_candidate(
     index = bisect_left(priority_offsets, span[0])
     if index >= len(priority_offsets) or priority_offsets[index] >= span[1]:
         return candidate, span, (span,)
-    priority_relative_offset = priority_offsets[index] - span[0]
+    fallback_candidate: _EmbeddedPythonCandidate | None = None
+    for priority_offset in priority_offsets[index:]:
+        if priority_offset >= span[1]:
+            break
+        (
+            compact_candidate,
+            compact_span,
+            compact_real_ranges,
+            has_usage_lines,
+        ) = _bounded_priority_embedded_python_candidate_at_offset(candidate, span, priority_offset - span[0])
+        if has_usage_lines:
+            return compact_candidate, compact_span, compact_real_ranges
+        if fallback_candidate is None:
+            fallback_candidate = (compact_candidate, compact_span, compact_real_ranges)
+    return fallback_candidate or (candidate, span, (span,))
+
+
+def _bounded_priority_embedded_python_candidate_at_offset(
+    candidate: bytes,
+    span: tuple[int, int],
+    priority_relative_offset: int,
+) -> tuple[bytes, tuple[int, int], tuple[tuple[int, int], ...], bool]:
     if priority_relative_offset >= _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES:
         line_start = candidate.rfind(b"\n", 0, priority_relative_offset) + 1
     else:
@@ -321,12 +342,12 @@ def _bounded_priority_embedded_python_candidate(
     merged_ranges = _merge_candidate_segment_ranges(segment_ranges)
     compact_candidate = _compact_candidate_segments(candidate, merged_ranges)
     if not merged_ranges:
-        return compact_candidate, span, (span,)
+        return compact_candidate, span, (span,), bool(usage_lines)
 
     span_start = span[0] + merged_ranges[0][0]
     span_end = span[0] + max(end for _start, end in merged_ranges)
     real_ranges = tuple((span[0] + start, span[0] + end) for start, end in merged_ranges)
-    return compact_candidate, (span_start, span_end), real_ranges
+    return compact_candidate, (span_start, span_end), real_ranges, bool(usage_lines)
 
 
 def _is_priority_module_name(module_name: str) -> bool:
@@ -367,8 +388,9 @@ def _priority_import_aliases(candidate: bytes) -> frozenset[bytes]:
 
 def _priority_assignment_aliases(source: str, tree: ast.AST) -> set[bytes]:
     aliases: set[bytes] = set()
-    targets = _assignment_targets(tree)
+    targets = _assignment_targets_in_tree(tree)
     for target in targets:
+        aliases.add(target.encode("utf-8"))
         probe = f"{source}\n" + "\n".join(_priority_assignment_probe_calls(target))
         try:
             probe_tree = ast.parse(probe)
@@ -377,6 +399,17 @@ def _priority_assignment_aliases(source: str, tree: ast.AST) -> set[bytes]:
         if _resolve_alias_aware_high_risk_calls(probe_tree):
             aliases.add(target.encode("utf-8"))
     return aliases
+
+
+def _assignment_targets_in_tree(tree: ast.AST) -> list[str]:
+    targets: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                targets.extend(_assignment_target_names(target))
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            targets.extend(_assignment_target_names(node.target))
+    return targets
 
 
 def _priority_assignment_probe_calls(target: str) -> list[str]:

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -161,7 +161,8 @@ _EMBEDDED_PYTHON_START_PATTERN = re.compile(
     rb"from\s+[A-Za-z_][\w.]*(?:\s|\\\r?\n)+import)"
 )
 _EMBEDDED_PYTHON_CONTEXT_START_PATTERN = re.compile(
-    rb"(?<![A-Za-z0-9_'\".])(?:import\s+[A-Za-z_][\w.]*|from\s+[A-Za-z_][\w.]*|[A-Za-z_]\w*\s*=)"
+    rb"(?<![A-Za-z0-9_'\".])"
+    rb"(?:import\s+[A-Za-z_][\w.]*|from\s+[A-Za-z_][\w.]*|[A-Za-z_]\w*(?:\s*:[^=\n#]+)?\s*=)"
 )
 
 
@@ -338,45 +339,92 @@ def _embedded_python_scan_windows(data: bytes) -> list[bytes]:
     return [data[:_EMBEDDED_PYTHON_SCAN_WINDOW_BYTES], data[-_EMBEDDED_PYTHON_SCAN_WINDOW_BYTES:]]
 
 
-def _strip_python_comment_bytes(line: bytes) -> bytes:
-    quote: int | None = None
+def _python_structural_line_bytes(line: bytes) -> bytes:
+    structural = bytearray()
+    quote_marker: bytes | None = None
     escaped = False
-    for index, byte in enumerate(line):
-        if escaped:
-            escaped = False
+    index = 0
+    while index < len(line):
+        if quote_marker is not None:
+            if escaped:
+                escaped = False
+                index += 1
+                continue
+            if len(quote_marker) == 1 and line[index] == ord("\\"):
+                escaped = True
+                index += 1
+                continue
+            if line.startswith(quote_marker, index):
+                index += len(quote_marker)
+                quote_marker = None
+                continue
+            index += 1
             continue
-        if byte == ord("\\") and quote is not None:
-            escaped = True
+
+        byte = line[index]
+        if byte == ord("#"):
+            break
+        if line.startswith(b'"""', index) or line.startswith(b"'''", index):
+            quote_marker = line[index : index + 3]
+            index += 3
             continue
         if byte in {ord("'"), ord('"')}:
-            if quote is None:
-                quote = byte
-            elif quote == byte:
-                quote = None
+            quote_marker = bytes([byte])
+            index += 1
             continue
-        if byte == ord("#") and quote is None:
-            return line[:index]
-    return line
+        structural.append(byte)
+        index += 1
+    return bytes(structural)
+
+
+def _triple_quote_state_after_line(line: bytes, quote: bytes | None) -> bytes | None:
+    index = 0
+    while index < len(line):
+        if quote is not None:
+            end = line.find(quote, index)
+            if end == -1:
+                return quote
+            index = end + len(quote)
+            quote = None
+            continue
+
+        byte = line[index]
+        if byte == ord("#"):
+            return None
+        if line.startswith(b'"""', index) or line.startswith(b"'''", index):
+            quote = line[index : index + 3]
+            index += 3
+            continue
+        if byte in {ord("'"), ord('"')}:
+            single_quote = byte
+            index += 1
+            escaped = False
+            while index < len(line):
+                current = line[index]
+                if escaped:
+                    escaped = False
+                elif current == ord("\\"):
+                    escaped = True
+                elif current == single_quote:
+                    index += 1
+                    break
+                index += 1
+            continue
+        index += 1
+    return quote
 
 
 def _line_has_explicit_continuation(line: bytes) -> bool:
-    return _strip_python_comment_bytes(line).rstrip().endswith(b"\\")
+    return _python_structural_line_bytes(line).rstrip().endswith(b"\\")
 
 
 def _line_parenthesis_delta(line: bytes) -> int:
-    line = _strip_python_comment_bytes(line)
-    return line.count(b"(") - line.count(b")")
+    structural = _python_structural_line_bytes(line)
+    return structural.count(b"(") - structural.count(b")")
 
 
 def _multiline_string_state_after_line(line: bytes, quote: bytes | None) -> bytes | None:
-    code = _strip_python_comment_bytes(line)
-    if quote is not None:
-        return None if quote in code else quote
-    triple_quotes = [(offset, marker) for marker in (b'"""', b"'''") if (offset := code.find(marker)) != -1]
-    if not triple_quotes:
-        return None
-    quote_offset, marker = min(triple_quotes, key=lambda item: item[0])
-    return None if marker in code[quote_offset + len(marker) :] else marker
+    return _triple_quote_state_after_line(line, quote)
 
 
 def _is_embedded_top_level_prefix(prefix: bytes) -> bool:
@@ -398,11 +446,12 @@ def _context_statement_start(line: bytes) -> int | None:
 def _assignment_targets(tree: ast.AST) -> list[str]:
     targets: list[str] = []
     for statement in getattr(tree, "body", []):
-        if not isinstance(statement, ast.Assign):
-            continue
-        for target in statement.targets:
-            if isinstance(target, ast.Name):
-                targets.append(target.id)
+        if isinstance(statement, ast.Assign):
+            for target in statement.targets:
+                if isinstance(target, ast.Name):
+                    targets.append(target.id)
+        elif isinstance(statement, ast.AnnAssign) and isinstance(statement.target, ast.Name):
+            targets.append(statement.target.id)
     return targets
 
 

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -144,7 +144,7 @@ _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN = b"|".join(
 )
 _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN = re.compile(
     rb"(?m)^\s*(?:"
-    rb"import\s+(?:[a-z_][\w.]*(?:\s+as\s+[a-z_]\w*)?\s*,\s*)*(?:"
+    rb"import\s+(?:[a-z_][\w.]*(?:\s+as\s+[a-z_]\w*)?\s*,(?:\s|\\\r?\n)*)*(?:"
     + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN
     + rb")(?:[.\s,]|$)|"
     rb"from\s+(?:" + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN + rb")(?:[.\s]|$)"
@@ -265,12 +265,29 @@ def _embedded_python_scan_windows(data: bytes) -> list[bytes]:
     return [data[:_EMBEDDED_PYTHON_SCAN_WINDOW_BYTES], data[-_EMBEDDED_PYTHON_SCAN_WINDOW_BYTES:]]
 
 
+def _embedded_python_extraction_windows(data: bytes) -> list[tuple[bytes, bool]]:
+    windows = _embedded_python_scan_windows(data)
+    if len(windows) == 1:
+        return [(windows[0], False)]
+
+    # Keep top-of-source alias overwrites visible when checking bounded tail code.
+    prefix = windows[0]
+    first_python_start = _EMBEDDED_PYTHON_START_PATTERN.search(prefix)
+    if first_python_start is not None:
+        prefix = prefix[first_python_start.start() :]
+    return [(prefix + b"\n" + windows[1], True)]
+
+
 def _has_raw_match_outside_parsed_spans(raw_spans: list[tuple[int, int]], parsed_spans: list[tuple[int, int]]) -> bool:
     """Return whether any raw regex hit sits outside AST-validated source."""
     for raw_start, raw_end in raw_spans:
         if not any(parsed_start <= raw_start and raw_end <= parsed_end for parsed_start, parsed_end in parsed_spans):
             return True
     return False
+
+
+def _is_span_inside_parsed_spans(span: tuple[int, int], parsed_spans: list[tuple[int, int]]) -> bool:
+    return any(parsed_start <= span[0] and span[1] <= parsed_end for parsed_start, parsed_end in parsed_spans)
 
 
 def _decode_utf8_with_byte_offsets(data: bytes) -> tuple[str, list[int]]:
@@ -740,6 +757,8 @@ class JITScriptDetector:
 
         for match, span in _prioritized_embedded_python_snippets(matches):
             try:
+                if _is_span_inside_parsed_spans(span, parsed_snippet_spans):
+                    continue
                 code_str, byte_offsets = _decode_utf8_with_byte_offsets(match)
                 parsed_snippet = _parse_embedded_python_snippet(code_str)
                 if parsed_snippet is None or parsed_snippet[1] < len(code_str):
@@ -1227,8 +1246,15 @@ class JITScriptDetector:
                 )
             )
         elif self._looks_like_framed_dangerous_python_source(data):
-            for window in _embedded_python_scan_windows(data):
-                findings.extend(self._extract_and_check_python_code(window, "Generic Python", context))
+            for window, include_full_source in _embedded_python_extraction_windows(data):
+                findings.extend(
+                    self._extract_and_check_python_code(
+                        window,
+                        "Generic Python",
+                        context,
+                        include_full_source=include_full_source,
+                    )
+                )
 
         return findings
 

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -161,6 +161,7 @@ _PRIORITY_EMBEDDED_PYTHON_ALIAS_ASSIGNMENT_PATTERN = re.compile(rb"(?m)^\s*[a-z_
 _DIRECT_PRIORITY_EMBEDDED_PYTHON_ALIAS_ASSIGNMENT_PATTERN = re.compile(
     rb"(?m)^\s*[a-z_]\w*\s*=\s*(?:" + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN + rb")\."
 )
+_PRIORITY_EMBEDDED_PYTHON_SIMPLE_ALIAS_ASSIGNMENT_PATTERN = re.compile(rb"(?m)^\s*[a-z_]\w*\s*=\s*[a-z_]\w*")
 _EMBEDDED_PYTHON_BLOCK_PATTERN = re.compile(rb"def\s+\w+\s*\([^)]*\):[^}]+|class\s+\w+[^}]+")
 _EMBEDDED_PYTHON_START_PATTERN = re.compile(
     rb"(?<![A-Za-z0-9_'\".])"
@@ -277,6 +278,13 @@ def _bounded_priority_embedded_python_candidate(
     priority_relative_offset = priority_offsets[index] - span[0]
     if priority_relative_offset >= _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES:
         line_start = candidate.rfind(b"\n", 0, priority_relative_offset) + 1
+        block_header_end = candidate.find(b"\n")
+        if block_header_end != -1 and candidate[:block_header_end].lstrip().startswith(
+            (b"def ", b"async def ", b"class ")
+        ):
+            bounded_end = min(len(candidate), line_start + _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES)
+            compact_candidate = candidate[: block_header_end + 1] + candidate[line_start:bounded_end]
+            return compact_candidate, (span[0], span[0] + len(compact_candidate))
     else:
         line_start = 0
     bounded_end = min(len(candidate), line_start + _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES)
@@ -365,6 +373,17 @@ def _line_parenthesis_delta(line: bytes) -> int:
     return line.count(b"(") - line.count(b")")
 
 
+def _multiline_string_state_after_line(line: bytes, quote: bytes | None) -> bytes | None:
+    code = _strip_python_comment_bytes(line)
+    if quote is not None:
+        return None if quote in code else quote
+    triple_quotes = [(offset, marker) for marker in (b'"""', b"'''") if (offset := code.find(marker)) != -1]
+    if not triple_quotes:
+        return None
+    quote_offset, marker = min(triple_quotes, key=lambda item: item[0])
+    return None if marker in code[quote_offset + len(marker) :] else marker
+
+
 def _embedded_python_context_statement_start(line: bytes) -> int | None:
     for match in _EMBEDDED_PYTHON_CONTEXT_STATEMENT_START_PATTERN.finditer(line):
         prefix = line[: match.start()]
@@ -382,7 +401,10 @@ def _is_priority_import_context_statement(statement: bytes, *, has_context: bool
         return True
     if _DIRECT_PRIORITY_EMBEDDED_PYTHON_ALIAS_ASSIGNMENT_PATTERN.match(lowered) is not None:
         return True
-    return has_context and _PRIORITY_EMBEDDED_PYTHON_ALIAS_ASSIGNMENT_PATTERN.match(lowered) is not None
+    return has_context and (
+        _PRIORITY_EMBEDDED_PYTHON_ALIAS_ASSIGNMENT_PATTERN.match(lowered) is not None
+        or _PRIORITY_EMBEDDED_PYTHON_SIMPLE_ALIAS_ASSIGNMENT_PATTERN.match(lowered) is not None
+    )
 
 
 def _extract_priority_import_context(data: bytes) -> bytes:
@@ -391,12 +413,19 @@ def _extract_priority_import_context(data: bytes) -> bytes:
     context_size = 0
     lines = data.splitlines(keepends=True)
     index = 0
+    multiline_quote: bytes | None = None
     while index < len(lines):
+        if multiline_quote is not None:
+            multiline_quote = _multiline_string_state_after_line(lines[index], multiline_quote)
+            index += 1
+            continue
         statement_start = _embedded_python_context_statement_start(lines[index])
         if statement_start is None:
+            multiline_quote = _multiline_string_state_after_line(lines[index], None)
             index += 1
             continue
 
+        statement_line_quote = _multiline_string_state_after_line(lines[index], None)
         statement_lines = [lines[index][statement_start:]]
         paren_depth = _line_parenthesis_delta(statement_lines[0])
         while (_line_has_explicit_continuation(statement_lines[-1]) or paren_depth > 0) and index + 1 < len(lines):
@@ -407,12 +436,14 @@ def _extract_priority_import_context(data: bytes) -> bytes:
 
         statement = b"".join(statement_lines).rstrip() + b"\n"
         if not _is_priority_import_context_statement(statement, has_context=bool(context)):
+            multiline_quote = statement_line_quote
             index += 1
             continue
         code_str, _byte_offsets = _decode_utf8_with_byte_offsets(statement)
         try:
             ast.parse(code_str)
         except (SyntaxError, ValueError):
+            multiline_quote = statement_line_quote
             index += 1
             continue
         if context_size + len(statement) > _MAX_EMBEDDED_PYTHON_IMPORT_CONTEXT_BYTES:

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -12,6 +12,7 @@ Part of ModelAudit's critical security validation suite.
 import ast
 import re
 import textwrap
+from bisect import bisect_left, bisect_right
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -131,10 +132,11 @@ _DANGEROUS_IMPORT_PATTERNS = {
 _MAX_SNIPPET_PARSE_TRIM_ATTEMPTS = 8
 _MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS = 10
 _EMBEDDED_PYTHON_SCAN_WINDOW_BYTES = 1_000_000
+_MAX_EMBEDDED_PYTHON_IMPORT_CONTEXT_BYTES = 16_384
 _EMBEDDED_PYTHON_START_MARKERS = (b"def ", b"async def ", b"class ", b"import ", b"from ")
 _PRIORITY_EMBEDDED_PYTHON_MODULES = tuple(
     sorted(
-        {marker.lower() for marker in (*DANGEROUS_IMPORTS, "asyncio", "runpy", "subprocess")},
+        {marker.lower() for marker in (*DANGEROUS_IMPORTS, "asyncio", "ctypes", "runpy", "subprocess", "webbrowser")},
         key=len,
         reverse=True,
     )
@@ -147,13 +149,14 @@ _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN = re.compile(
     rb"import\s+(?:[a-z_][\w.]*(?:\s+as\s+[a-z_]\w*)?\s*,(?:\s|\\\r?\n)*)*(?:"
     + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN
     + rb")(?:[.\s,]|$)|"
-    rb"from\s+(?:" + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN + rb")(?:[.\s]|$)"
+    rb"from\s+(?:" + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN + rb")(?:[.\s]|\\\r?\n|$)"
     rb")"
 )
 _EMBEDDED_PYTHON_BLOCK_PATTERN = re.compile(rb"def\s+\w+\s*\([^)]*\):[^}]+|class\s+\w+[^}]+")
 _EMBEDDED_PYTHON_START_PATTERN = re.compile(
     rb"(?<![A-Za-z0-9_'\".])"
-    rb"(?:(?:async\s+)?def\s+\w+|class\s+\w+|import\s+[A-Za-z_][\w.]*|from\s+[A-Za-z_][\w.]*\s+import)"
+    rb"(?:(?:async\s+)?def\s+\w+|class\s+\w+|import\s+[A-Za-z_][\w.]*|"
+    rb"from\s+[A-Za-z_][\w.]*(?:\s|\\\r?\n)+import)"
 )
 
 
@@ -207,6 +210,16 @@ def _candidate_embedded_python_snippets(
 ) -> list[tuple[bytes, tuple[int, int]]]:
     candidates: list[tuple[bytes, tuple[int, int]]] = []
     block_spans: list[tuple[int, int]] = []
+    start_offsets = [match.start() for match in _EMBEDDED_PYTHON_START_PATTERN.finditer(bounded)]
+    priority_starts: set[int] = set()
+    for priority_offset in _priority_import_offsets(bounded):
+        insertion_index = bisect_right(start_offsets, priority_offset)
+        if insertion_index == 0:
+            continue
+        priority_starts.add(start_offsets[insertion_index - 1])
+        if insertion_index >= 2:
+            priority_starts.add(start_offsets[insertion_index - 2])
+
     if include_full_source:
         candidates.append((bounded, (0, len(bounded))))
 
@@ -217,25 +230,46 @@ def _candidate_embedded_python_snippets(
         block_spans.append(span)
         candidates.append((match.group(0), span))
 
-    for match in _EMBEDDED_PYTHON_START_PATTERN.finditer(bounded):
-        start = match.start()
+    for start in start_offsets:
         if include_full_source and start == 0:
             continue
-        if any(block_start <= start < block_end for block_start, block_end in block_spans):
+        if (
+            any(block_start <= start < block_end for block_start, block_end in block_spans)
+            and start not in priority_starts
+        ):
             continue
         candidates.append((bounded[start:], (start, len(bounded))))
 
     return candidates
 
 
+def _priority_import_offsets(bounded: bytes) -> list[int]:
+    lowered = bounded.lower()
+    return [
+        match.start()
+        for match in _EMBEDDED_PYTHON_START_PATTERN.finditer(lowered)
+        if _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN.match(lowered[match.start() :]) is not None
+    ]
+
+
+def _span_contains_priority_offset(span: tuple[int, int], priority_offsets: list[int]) -> bool:
+    index = bisect_left(priority_offsets, span[0])
+    return index < len(priority_offsets) and priority_offsets[index] < span[1]
+
+
 def _prioritized_embedded_python_snippets(
     candidates: list[tuple[bytes, tuple[int, int]]],
+    bounded: bytes | None = None,
 ) -> list[tuple[bytes, tuple[int, int]]]:
     selected: list[tuple[bytes, tuple[int, int]]] = []
     selected_spans: set[tuple[int, int]] = set()
+    priority_offsets = _priority_import_offsets(bounded) if bounded is not None else []
     for index, (candidate, span) in enumerate(candidates):
-        candidate_prefix = candidate[:4096].lower()
-        has_priority_marker = _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN.search(candidate_prefix) is not None
+        has_priority_marker = (
+            _span_contains_priority_offset(span, priority_offsets)
+            if bounded is not None
+            else _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN.search(candidate.lower()) is not None
+        )
         if index >= _MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS and not has_priority_marker:
             continue
         if span in selected_spans:
@@ -265,17 +299,64 @@ def _embedded_python_scan_windows(data: bytes) -> list[bytes]:
     return [data[:_EMBEDDED_PYTHON_SCAN_WINDOW_BYTES], data[-_EMBEDDED_PYTHON_SCAN_WINDOW_BYTES:]]
 
 
+def _line_has_explicit_continuation(line: bytes) -> bool:
+    return line.rstrip().endswith(b"\\")
+
+
+def _line_parenthesis_delta(line: bytes) -> int:
+    return line.count(b"(") - line.count(b")")
+
+
+def _extract_priority_import_context(data: bytes) -> bytes:
+    """Return bounded dangerous import statements from a prefix window."""
+    context: list[bytes] = []
+    context_size = 0
+    lines = data.splitlines(keepends=True)
+    index = 0
+    while index < len(lines):
+        stripped = lines[index].lstrip()
+        if not stripped.startswith((b"import ", b"from ")):
+            index += 1
+            continue
+
+        statement_lines = [stripped]
+        paren_depth = _line_parenthesis_delta(stripped)
+        while (_line_has_explicit_continuation(statement_lines[-1]) or paren_depth > 0) and index + 1 < len(lines):
+            index += 1
+            continuation = lines[index].lstrip()
+            statement_lines.append(continuation)
+            paren_depth += _line_parenthesis_delta(continuation)
+
+        statement = b"".join(statement_lines).rstrip() + b"\n"
+        if _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN.search(statement.lower()) is None:
+            index += 1
+            continue
+        code_str, _byte_offsets = _decode_utf8_with_byte_offsets(statement)
+        try:
+            ast.parse(code_str)
+        except (SyntaxError, ValueError):
+            index += 1
+            continue
+        if context_size + len(statement) > _MAX_EMBEDDED_PYTHON_IMPORT_CONTEXT_BYTES:
+            break
+        context.append(statement)
+        context_size += len(statement)
+        index += 1
+
+    return b"".join(context)
+
+
 def _embedded_python_extraction_windows(data: bytes) -> list[tuple[bytes, bool]]:
     windows = _embedded_python_scan_windows(data)
     if len(windows) == 1:
         return [(windows[0], False)]
 
-    # Keep top-of-source alias overwrites visible when checking bounded tail code.
-    prefix = windows[0]
-    first_python_start = _EMBEDDED_PYTHON_START_PATTERN.search(prefix)
-    if first_python_start is not None:
-        prefix = prefix[first_python_start.start() :]
-    return [(prefix + b"\n" + windows[1], True)]
+    prefix, tail = windows
+    extraction_windows = [(prefix, False), (tail, False)]
+    import_context = _extract_priority_import_context(prefix)
+    if import_context:
+        extraction_windows.append((import_context + b"\n" + tail, True))
+    return extraction_windows
 
 
 def _has_raw_match_outside_parsed_spans(raw_spans: list[tuple[int, int]], parsed_spans: list[tuple[int, int]]) -> bool:
@@ -762,7 +843,7 @@ class JITScriptDetector:
             # raw pattern detection active and fall back to extracted snippets.
             bounded_high_risk_calls = None
 
-        for match, span in _prioritized_embedded_python_snippets(matches):
+        for match, span in _prioritized_embedded_python_snippets(matches, bounded=bounded):
             try:
                 if _is_span_inside_parsed_spans(span, parsed_snippet_spans):
                     continue

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -129,8 +129,18 @@ _DANGEROUS_IMPORT_PATTERNS = {
     dangerous_import: _compile_dangerous_import_patterns(dangerous_import) for dangerous_import in DANGEROUS_IMPORTS
 }
 _MAX_SNIPPET_PARSE_TRIM_ATTEMPTS = 8
+_MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS = 10
 _EMBEDDED_PYTHON_SCAN_WINDOW_BYTES = 1_000_000
 _EMBEDDED_PYTHON_START_MARKERS = (b"def ", b"async def ", b"class ", b"import ", b"from ")
+_PRIORITY_EMBEDDED_PYTHON_MARKERS = tuple(
+    marker.encode("utf-8")
+    for marker in (
+        *DANGEROUS_IMPORTS,
+        "asyncio",
+        "runpy",
+        "subprocess",
+    )
+)
 _EMBEDDED_PYTHON_BLOCK_PATTERN = re.compile(rb"def\s+\w+\s*\([^)]*\):[^}]+|class\s+\w+[^}]+")
 _EMBEDDED_PYTHON_START_PATTERN = re.compile(
     rb"(?<![A-Za-z0-9_'\".])"
@@ -207,6 +217,23 @@ def _candidate_embedded_python_snippets(
         candidates.append((bounded[start:], (start, len(bounded))))
 
     return candidates
+
+
+def _prioritized_embedded_python_snippets(
+    candidates: list[tuple[bytes, tuple[int, int]]],
+) -> list[tuple[bytes, tuple[int, int]]]:
+    selected: list[tuple[bytes, tuple[int, int]]] = []
+    selected_spans: set[tuple[int, int]] = set()
+    for index, (candidate, span) in enumerate(candidates):
+        candidate_prefix = candidate[:4096].lower()
+        has_priority_marker = any(marker in candidate_prefix for marker in _PRIORITY_EMBEDDED_PYTHON_MARKERS)
+        if index >= _MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS and not has_priority_marker:
+            continue
+        if span in selected_spans:
+            continue
+        selected_spans.add(span)
+        selected.append((candidate, span))
+    return selected
 
 
 def _embedded_python_scan_windows(data: bytes) -> list[bytes]:
@@ -688,7 +715,7 @@ class JITScriptDetector:
             # raw pattern detection active and fall back to extracted snippets.
             bounded_high_risk_calls = None
 
-        for match, span in matches[:10]:  # Analyze first 10 code snippets
+        for match, span in _prioritized_embedded_python_snippets(matches):
             try:
                 code_str, byte_offsets = _decode_utf8_with_byte_offsets(match)
 
@@ -1169,7 +1196,8 @@ class JITScriptDetector:
                 )
             )
         elif self._looks_like_framed_dangerous_python_source(data):
-            findings.extend(self._extract_and_check_python_code(data, "Generic Python", context))
+            for window in _embedded_python_scan_windows(data):
+                findings.extend(self._extract_and_check_python_code(window, "Generic Python", context))
 
         return findings
 

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -133,6 +133,7 @@ _MAX_SNIPPET_PARSE_TRIM_ATTEMPTS = 8
 _MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS = 10
 _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPETS = 16
 _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES = 16_384
+_MAX_PRIORITY_ALIAS_USAGE_LINES = 8
 _EMBEDDED_PYTHON_SCAN_WINDOW_BYTES = 1_000_000
 _MAX_EMBEDDED_PYTHON_IMPORT_CONTEXT_BYTES = 16_384
 _EMBEDDED_PYTHON_START_MARKERS = (b"def ", b"async def ", b"class ", b"import ", b"from ")
@@ -165,6 +166,9 @@ _EMBEDDED_PYTHON_CONTEXT_START_PATTERN = re.compile(
     rb"(?<![A-Za-z0-9_'\".])(?:import\s+[A-Za-z_][\w.]*|from\s+[A-Za-z_][\w.]*|"
     + _EMBEDDED_PYTHON_CONTEXT_ASSIGNMENT_LHS_PATTERN
     + rb"\s*=)"
+)
+_EMBEDDED_PYTHON_COMPOUND_CONTEXT_START_PATTERN = re.compile(
+    rb"(?<![A-Za-z0-9_'\".])if\s+(?:True|1)\s*:\s*(?:import|from)\s+"
 )
 
 
@@ -294,8 +298,8 @@ def _bounded_priority_embedded_python_candidate(
     add_segment(line_start, bounded_end)
 
     aliases = _priority_import_aliases(_compact_candidate_segments(candidate, segment_ranges))
-    usage_line = _priority_alias_usage_line(candidate, aliases, bounded_end) if aliases else None
-    if usage_line is not None:
+    usage_lines = _priority_alias_usage_lines(candidate, aliases, bounded_end) if aliases else []
+    for usage_line in usage_lines:
         add_segment(*usage_line)
 
     tail_start = max(bounded_end, len(candidate) - _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES)
@@ -332,13 +336,44 @@ def _priority_import_aliases(candidate: bytes) -> frozenset[bytes]:
             root_name = statement.module.split(".", maxsplit=1)[0]
             if root_name in priority_modules:
                 aliases.update((alias.asname or alias.name).encode("utf-8") for alias in statement.names)
+    aliases.update(_priority_assignment_aliases(source, tree))
     return frozenset(aliases)
 
 
-def _priority_alias_usage_line(
+def _priority_assignment_aliases(source: str, tree: ast.AST) -> set[bytes]:
+    aliases: set[bytes] = set()
+    targets = _assignment_targets(tree)
+    for target in targets:
+        probe = f"{source}\n" + "\n".join(_priority_assignment_probe_calls(target))
+        try:
+            probe_tree = ast.parse(probe)
+        except (SyntaxError, ValueError):
+            continue
+        if _resolve_alias_aware_high_risk_calls(probe_tree):
+            aliases.add(target.encode("utf-8"))
+    return aliases
+
+
+def _priority_assignment_probe_calls(target: str) -> list[str]:
+    return [
+        f"{target}()",
+        f"{target}.run_path('payload.py')",
+        f"{target}.run_module('payload')",
+        f"{target}.open('https://example.invalid')",
+        f"{target}.open_new('https://example.invalid')",
+        f"{target}.open_new_tab('https://example.invalid')",
+        f"{target}.CDLL('payload')",
+        f"{target}.LoadLibrary('payload')",
+        f"{target}.__getitem__('payload')",
+    ]
+
+
+def _priority_alias_usage_lines(
     candidate: bytes, aliases: frozenset[bytes], search_start: int
-) -> tuple[int, int] | None:
+) -> list[tuple[int, int]]:
+    usage_lines: list[tuple[int, int]] = []
     line_start = search_start
+    multiline_quote: bytes | None = _multiline_string_state_after_line(candidate[:search_start], None)
     while line_start < len(candidate):
         line_end = candidate.find(b"\n", line_start)
         if line_end == -1:
@@ -346,11 +381,29 @@ def _priority_alias_usage_line(
         else:
             line_end += 1
         line = candidate[line_start:line_end]
+        if multiline_quote is not None:
+            multiline_quote = _multiline_string_state_after_line(line, multiline_quote)
+            line_start = line_end
+            continue
         code_line = _python_structural_line_bytes(line)
-        if any(re.search(rb"(?<![A-Za-z0-9_])" + re.escape(alias) + rb"\s*(?:\.|\()", code_line) for alias in aliases):
-            return line_start, min(line_end, line_start + _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES)
+        if _line_uses_priority_alias(code_line, aliases):
+            usage_lines.append((line_start, min(line_end, line_start + _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES)))
+            if _line_calls_priority_alias(code_line, aliases) or len(usage_lines) >= _MAX_PRIORITY_ALIAS_USAGE_LINES:
+                return usage_lines
+        multiline_quote = _multiline_string_state_after_line(line, multiline_quote)
         line_start = line_end
-    return None
+    return usage_lines
+
+
+def _line_uses_priority_alias(code_line: bytes, aliases: frozenset[bytes]) -> bool:
+    return any(re.search(rb"(?<![A-Za-z0-9_])" + re.escape(alias) + rb"\s*(?:\.|\()", code_line) for alias in aliases)
+
+
+def _line_calls_priority_alias(code_line: bytes, aliases: frozenset[bytes]) -> bool:
+    return any(
+        re.search(rb"(?<![A-Za-z0-9_])" + re.escape(alias) + rb"\s*(?:\(|\.[A-Za-z_]\w*\s*\()", code_line)
+        for alias in aliases
+    )
 
 
 def _merge_candidate_segment_ranges(segment_ranges: list[tuple[int, int]]) -> list[tuple[int, int]]:
@@ -465,7 +518,7 @@ def _triple_quote_state_after_line(line: bytes, quote: bytes | None) -> bytes | 
     index = 0
     while index < len(line):
         if quote is not None:
-            end = line.find(quote, index)
+            end = _find_unescaped_marker(line, quote, index)
             if end == -1:
                 return quote
             index = end + len(quote)
@@ -475,7 +528,7 @@ def _triple_quote_state_after_line(line: bytes, quote: bytes | None) -> bytes | 
         byte = line[index]
         if byte == ord("#"):
             return None
-        if line.startswith(b'"""', index) or line.startswith(b"'''", index):
+        if (line.startswith(b'"""', index) or line.startswith(b"'''", index)) and not _is_escaped_marker(line, index):
             quote = line[index : index + 3]
             index += 3
             continue
@@ -496,6 +549,24 @@ def _triple_quote_state_after_line(line: bytes, quote: bytes | None) -> bytes | 
             continue
         index += 1
     return quote
+
+
+def _find_unescaped_marker(line: bytes, marker: bytes, start: int) -> int:
+    index = line.find(marker, start)
+    while index != -1:
+        if not _is_escaped_marker(line, index):
+            return index
+        index = line.find(marker, index + 1)
+    return -1
+
+
+def _is_escaped_marker(line: bytes, index: int) -> bool:
+    backslashes = 0
+    position = index - 1
+    while position >= 0 and line[position] == ord("\\"):
+        backslashes += 1
+        position -= 1
+    return backslashes % 2 == 1
 
 
 def _line_has_explicit_continuation(line: bytes) -> bool:
@@ -523,6 +594,10 @@ def _is_embedded_top_level_prefix(prefix: bytes) -> bool:
 def _context_statement_start(line: bytes) -> int | None:
     for match in _EMBEDDED_PYTHON_CONTEXT_START_PATTERN.finditer(line):
         if _is_embedded_top_level_prefix(line[: match.start()]):
+            return match.start()
+    structural_line = _python_structural_line_bytes(line)
+    for match in _EMBEDDED_PYTHON_COMPOUND_CONTEXT_START_PATTERN.finditer(structural_line):
+        if _is_embedded_top_level_prefix(structural_line[: match.start()]):
             return match.start()
     return None
 
@@ -564,7 +639,7 @@ def _is_priority_assignment_context(context: bytes, statement: bytes) -> bool:
     if not targets:
         return False
 
-    probe = code_str + "\n" + "\n".join(f"{target}()" for target in targets)
+    probe = code_str + "\n" + "\n".join(call for target in targets for call in _priority_assignment_probe_calls(target))
     try:
         probe_tree = ast.parse(probe)
     except (SyntaxError, ValueError):
@@ -573,14 +648,29 @@ def _is_priority_assignment_context(context: bytes, statement: bytes) -> bool:
 
 
 def _is_priority_prefix_context_statement(context: bytes, statement: bytes) -> bool:
-    if _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN.search(statement.lower()) is not None:
-        code_str, _byte_offsets = _decode_utf8_with_byte_offsets(statement)
-        try:
-            ast.parse(code_str)
-        except (SyntaxError, ValueError):
-            return False
+    code_str, _byte_offsets = _decode_utf8_with_byte_offsets(statement)
+    try:
+        tree = ast.parse(code_str)
+    except (SyntaxError, ValueError):
+        tree = None
+    if tree is not None and _tree_imports_priority_module(tree):
         return True
     return _is_priority_assignment_context(context, statement)
+
+
+def _tree_imports_priority_module(tree: ast.AST) -> bool:
+    priority_modules = set(_PRIORITY_EMBEDDED_PYTHON_MODULES)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(alias.name.split(".", maxsplit=1)[0].lower() in priority_modules for alias in node.names):
+                return True
+        elif (
+            isinstance(node, ast.ImportFrom)
+            and node.module is not None
+            and node.module.split(".", maxsplit=1)[0].lower() in priority_modules
+        ):
+            return True
+    return False
 
 
 def _extract_priority_prefix_context(data: bytes) -> bytes:
@@ -639,13 +729,30 @@ def _embedded_python_extraction_windows(data: bytes) -> list[tuple[bytes, bool]]
     if import_context:
         extraction_windows.append((import_context + b"\n" + tail, True))
         tail_starts = [match.start() for match in _EMBEDDED_PYTHON_START_PATTERN.finditer(tail) if match.start() > 0]
+        context_aliases = _priority_import_aliases(import_context)
         selected_starts = [
             *tail_starts[:_MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS],
+            *_tail_starts_for_priority_alias_uses(tail, tail_starts, context_aliases),
             *tail_starts[-_MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS:],
         ]
         for start in dict.fromkeys(selected_starts):
             extraction_windows.append((import_context + b"\n" + tail[start:], True))
     return extraction_windows
+
+
+def _tail_starts_for_priority_alias_uses(
+    tail: bytes,
+    tail_starts: list[int],
+    aliases: frozenset[bytes],
+) -> list[int]:
+    selected_starts: list[int] = []
+    if not tail_starts or not aliases:
+        return selected_starts
+    for usage_start, _usage_end in _priority_alias_usage_lines(tail, aliases, 0):
+        start_index = bisect_right(tail_starts, usage_start) - 1
+        if start_index >= 0:
+            selected_starts.append(tail_starts[start_index])
+    return selected_starts
 
 
 def _has_raw_match_outside_parsed_spans(raw_spans: list[tuple[int, int]], parsed_spans: list[tuple[int, int]]) -> bool:

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -154,14 +154,24 @@ _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN = re.compile(
     rb"from\s+(?:" + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN + rb")(?:[.\s]|\\\r?\n|$)"
     rb")"
 )
+_EMBEDDED_PYTHON_CONTEXT_ASSIGNMENT_LHS_PATTERN = rb"[A-Za-z_]\w*(?:\s*:[^=\n]+)?"
+_PRIORITY_EMBEDDED_PYTHON_ASSIGNMENT_LHS_PATTERN = rb"[a-z_]\w*(?:\s*:[^=\n]+)?"
 _EMBEDDED_PYTHON_CONTEXT_STATEMENT_START_PATTERN = re.compile(
-    rb"(?<![A-Za-z0-9_'\".])(?:(?:import|from)\s+|[A-Za-z_]\w*\s*=)"
+    rb"(?<![A-Za-z0-9_'\".])(?:(?:import|from)\s+|" + _EMBEDDED_PYTHON_CONTEXT_ASSIGNMENT_LHS_PATTERN + rb"\s*=)"
 )
-_PRIORITY_EMBEDDED_PYTHON_ALIAS_ASSIGNMENT_PATTERN = re.compile(rb"(?m)^\s*[a-z_]\w*\s*=\s*[a-z_]\w*(?:\.[a-z_]\w*)+")
+_PRIORITY_EMBEDDED_PYTHON_ALIAS_ASSIGNMENT_PATTERN = re.compile(
+    rb"(?m)^\s*" + _PRIORITY_EMBEDDED_PYTHON_ASSIGNMENT_LHS_PATTERN + rb"\s*=\s*[a-z_]\w*(?:\.[a-z_]\w*)+"
+)
 _DIRECT_PRIORITY_EMBEDDED_PYTHON_ALIAS_ASSIGNMENT_PATTERN = re.compile(
-    rb"(?m)^\s*[a-z_]\w*\s*=\s*(?:" + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN + rb")\."
+    rb"(?m)^\s*"
+    + _PRIORITY_EMBEDDED_PYTHON_ASSIGNMENT_LHS_PATTERN
+    + rb"\s*=\s*(?:"
+    + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN
+    + rb")\."
 )
-_PRIORITY_EMBEDDED_PYTHON_SIMPLE_ALIAS_ASSIGNMENT_PATTERN = re.compile(rb"(?m)^\s*[a-z_]\w*\s*=\s*[a-z_]\w*")
+_PRIORITY_EMBEDDED_PYTHON_SIMPLE_ALIAS_ASSIGNMENT_PATTERN = re.compile(
+    rb"(?m)^\s*" + _PRIORITY_EMBEDDED_PYTHON_ASSIGNMENT_LHS_PATTERN + rb"\s*=\s*[a-z_]\w*"
+)
 _EMBEDDED_PYTHON_BLOCK_PATTERN = re.compile(rb"def\s+\w+\s*\([^)]*\):[^}]+|class\s+\w+[^}]+")
 _EMBEDDED_PYTHON_START_PATTERN = re.compile(
     rb"(?<![A-Za-z0-9_'\".])"
@@ -364,24 +374,88 @@ def _strip_python_comment_bytes(line: bytes) -> bytes:
     return line
 
 
+def _python_code_without_comments_or_strings(line: bytes) -> bytes:
+    code = bytearray(line)
+    quote: int | None = None
+    quote_size = 1
+    index = 0
+    while index < len(line):
+        byte = line[index]
+        if quote is not None:
+            code[index] = ord(" ")
+            if quote_size == 1 and byte == ord("\\"):
+                if index + 1 < len(line):
+                    code[index + 1] = ord(" ")
+                index += 2
+                continue
+            marker = bytes((quote,)) * quote_size
+            if line.startswith(marker, index):
+                code[index : index + quote_size] = b" " * quote_size
+                index += quote_size
+                quote = None
+                quote_size = 1
+                continue
+            if quote_size == 1 and byte == quote:
+                quote = None
+            index += 1
+            continue
+        if byte == ord("#"):
+            return bytes(code[:index])
+        if byte in {ord("'"), ord('"')}:
+            marker = bytes((byte,)) * 3
+            if line.startswith(marker, index):
+                code[index : index + 3] = b"   "
+                quote = byte
+                quote_size = 3
+                index += 3
+                continue
+            code[index] = ord(" ")
+            quote = byte
+            quote_size = 1
+        index += 1
+    return bytes(code)
+
+
 def _line_has_explicit_continuation(line: bytes) -> bool:
-    return _strip_python_comment_bytes(line).rstrip().endswith(b"\\")
+    return _python_code_without_comments_or_strings(line).rstrip().endswith(b"\\")
 
 
 def _line_parenthesis_delta(line: bytes) -> int:
-    line = _strip_python_comment_bytes(line)
+    line = _python_code_without_comments_or_strings(line)
     return line.count(b"(") - line.count(b")")
 
 
 def _multiline_string_state_after_line(line: bytes, quote: bytes | None) -> bytes | None:
-    code = _strip_python_comment_bytes(line)
+    code = line if quote is not None else _strip_python_comment_bytes(line)
     if quote is not None:
         return None if quote in code else quote
-    triple_quotes = [(offset, marker) for marker in (b'"""', b"'''") if (offset := code.find(marker)) != -1]
-    if not triple_quotes:
-        return None
-    quote_offset, marker = min(triple_quotes, key=lambda item: item[0])
-    return None if marker in code[quote_offset + len(marker) :] else marker
+    single_quote: int | None = None
+    escaped = False
+    index = 0
+    while index < len(code):
+        byte = code[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if single_quote is not None:
+            if byte == ord("\\"):
+                escaped = True
+            elif byte == single_quote:
+                single_quote = None
+            index += 1
+            continue
+        if byte in {ord("'"), ord('"')}:
+            marker = bytes((byte,)) * 3
+            if code.startswith(marker, index):
+                closing_offset = code.find(marker, index + len(marker))
+                if closing_offset == -1:
+                    return marker
+                index = closing_offset + len(marker)
+                continue
+            single_quote = byte
+        index += 1
+    return None
 
 
 def _embedded_python_context_statement_start(line: bytes) -> int | None:

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -1422,7 +1422,7 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
                     allow_module_locals_mapping=self._non_module_scope_depth == 0,
                 )
             elif name in _RUNPY_CODE_EXECUTION_CALLS:
-                base_value = frozenset({name})
+                base_value = current_scope[name] if name in current_scope else frozenset({name})
             else:
                 base_value = current_scope.get(name, frozenset({name}) if implicit_builtins else None)
             values = [scope.get(name, base_value) for scope in branch_scopes]

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -1323,23 +1323,23 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             allow_local_namespace_mapping=bool(self._comprehension_outer_scope_indices),
         )
 
+    def _bind_imported_static_members(self, local_name: str, import_name: str) -> None:
+        prefix = f"{import_name}."
+        for reference in _STATIC_OVERWRITABLE_HIGH_RISK_REFERENCES:
+            if not reference.startswith(prefix):
+                continue
+            self.alias_scopes[-1][f"{local_name}{reference.removeprefix(import_name)}"] = frozenset({reference})
+
     def _record_import(self, alias: ast.alias, import_name: str) -> None:
         local_name = alias.asname or alias.name
         self.alias_scopes[-1][local_name] = frozenset({import_name})
-        self._refresh_imported_static_members(local_name, import_name)
+        self._bind_imported_static_members(local_name, import_name)
 
     def _bind_name(self, name: str, resolved_names: _AliasValue) -> None:
         self.alias_scopes[-1][name] = resolved_names
 
     def _bind_name_in_scope(self, scope_index: int, name: str, resolved_names: _AliasValue) -> None:
         self.alias_scopes[scope_index][name] = resolved_names
-
-    def _refresh_imported_static_members(self, local_name: str, import_name: str) -> None:
-        for reference_name in _STATIC_OVERWRITABLE_HIGH_RISK_REFERENCES:
-            if reference_name != import_name and not reference_name.startswith(f"{import_name}."):
-                continue
-            suffix = reference_name.removeprefix(import_name)
-            self._bind_name(f"{local_name}{suffix}", frozenset({reference_name}))
 
     def _bind_module_namespace_key(self, key: str, resolved_names: _AliasValue) -> None:
         self._bind_name(f"{_MODULE_NAMESPACE_WRITE_PREFIX}{key}", resolved_names)

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -1330,15 +1330,25 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
                 continue
             self.alias_scopes[-1][f"{local_name}{reference.removeprefix(import_name)}"] = frozenset({reference})
 
+    def _clear_member_bindings(self, scope_index: int, local_name: str) -> None:
+        if "." in local_name or local_name.startswith(_MODULE_NAMESPACE_WRITE_PREFIX):
+            return
+        prefix = f"{local_name}."
+        scope = self.alias_scopes[scope_index]
+        for name in [name for name in scope if name.startswith(prefix)]:
+            scope.pop(name, None)
+
     def _record_import(self, alias: ast.alias, import_name: str) -> None:
         local_name = alias.asname or alias.name
-        self.alias_scopes[-1][local_name] = frozenset({import_name})
+        self._bind_name(local_name, frozenset({import_name}))
         self._bind_imported_static_members(local_name, import_name)
 
     def _bind_name(self, name: str, resolved_names: _AliasValue) -> None:
+        self._clear_member_bindings(-1, name)
         self.alias_scopes[-1][name] = resolved_names
 
     def _bind_name_in_scope(self, scope_index: int, name: str, resolved_names: _AliasValue) -> None:
+        self._clear_member_bindings(scope_index, name)
         self.alias_scopes[scope_index][name] = resolved_names
 
     def _bind_module_namespace_key(self, key: str, resolved_names: _AliasValue) -> None:

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -1354,11 +1354,25 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         self._bind_imported_static_members(local_name, import_name, preserve_existing=preserve_existing)
 
     def _bind_name(self, name: str, resolved_names: _AliasValue) -> None:
-        self._shadow_member_bindings(-1, name)
+        previous_names, _found = _lookup_bound_alias(name, self.alias_scopes)
+        preserves_module_binding = (
+            isinstance(previous_names, frozenset)
+            and isinstance(resolved_names, frozenset)
+            and bool(previous_names & resolved_names)
+        )
+        if not preserves_module_binding:
+            self._shadow_member_bindings(-1, name)
         self.alias_scopes[-1][name] = resolved_names
 
     def _bind_name_in_scope(self, scope_index: int, name: str, resolved_names: _AliasValue) -> None:
-        self._shadow_member_bindings(scope_index, name)
+        previous_names, _found = _lookup_bound_alias(name, self.alias_scopes[: scope_index + 1])
+        preserves_module_binding = (
+            isinstance(previous_names, frozenset)
+            and isinstance(resolved_names, frozenset)
+            and bool(previous_names & resolved_names)
+        )
+        if not preserves_module_binding:
+            self._shadow_member_bindings(scope_index, name)
         self.alias_scopes[scope_index][name] = resolved_names
 
     def _should_track_syntactic_static_reference(self, syntactic_name: str) -> bool:

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -1375,12 +1375,15 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
                         continue
                     self._bind_name(f"{root}.{key}", resolved_value)
         elif isinstance(target, ast.Attribute):
+            syntactic_name = _resolve_call_name(target)
             resolved_target_names = self._resolve_reference_names(target)
-            if resolved_target_names is None:
+            target_names = set(resolved_target_names or frozenset())
+            if syntactic_name in _STATIC_OVERWRITABLE_HIGH_RISK_REFERENCES:
+                target_names.add(syntactic_name)
+            if not target_names:
                 return
             resolved_value = self._resolve_binding_value_names(value)
-            syntactic_name = _resolve_call_name(target)
-            for target_name in resolved_target_names:
+            for target_name in target_names:
                 if target_name in _STATIC_OVERWRITABLE_HIGH_RISK_REFERENCES:
                     self._bind_name(target_name, resolved_value)
                     if syntactic_name is not None:

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -1323,12 +1323,15 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             allow_local_namespace_mapping=bool(self._comprehension_outer_scope_indices),
         )
 
-    def _bind_imported_static_members(self, local_name: str, import_name: str) -> None:
+    def _bind_imported_static_members(self, local_name: str, import_name: str, *, preserve_existing: bool) -> None:
         prefix = f"{import_name}."
         for reference in _STATIC_OVERWRITABLE_HIGH_RISK_REFERENCES:
             if not reference.startswith(prefix):
                 continue
-            self.alias_scopes[-1][f"{local_name}{reference.removeprefix(import_name)}"] = frozenset({reference})
+            local_reference = f"{local_name}{reference.removeprefix(import_name)}"
+            if preserve_existing and local_reference in self.alias_scopes[-1]:
+                continue
+            self.alias_scopes[-1][local_reference] = frozenset({reference})
 
     def _shadow_member_bindings(self, scope_index: int, local_name: str) -> None:
         if "." in local_name or local_name.startswith(_MODULE_NAMESPACE_WRITE_PREFIX):
@@ -1342,8 +1345,10 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
 
     def _record_import(self, alias: ast.alias, import_name: str) -> None:
         local_name = alias.asname or alias.name
+        previous_names, _found = _lookup_bound_alias(local_name, self.alias_scopes)
+        preserve_existing = isinstance(previous_names, frozenset) and import_name in previous_names
         self._bind_name(local_name, frozenset({import_name}))
-        self._bind_imported_static_members(local_name, import_name)
+        self._bind_imported_static_members(local_name, import_name, preserve_existing=preserve_existing)
 
     def _bind_name(self, name: str, resolved_names: _AliasValue) -> None:
         self._shadow_member_bindings(-1, name)

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -1325,14 +1325,29 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
 
     def _record_import(self, alias: ast.alias, import_name: str) -> None:
         local_name = alias.asname or alias.name
-        self.alias_scopes[-1][local_name] = frozenset({import_name})
+        self._bind_name(local_name, frozenset({import_name}))
         self._refresh_imported_static_members(local_name, import_name)
 
     def _bind_name(self, name: str, resolved_names: _AliasValue) -> None:
+        if "." not in name:
+            self._shadow_static_member_aliases(name)
         self.alias_scopes[-1][name] = resolved_names
 
     def _bind_name_in_scope(self, scope_index: int, name: str, resolved_names: _AliasValue) -> None:
+        if "." not in name:
+            self._shadow_static_member_aliases_in_scope(scope_index, name)
         self.alias_scopes[scope_index][name] = resolved_names
+
+    def _shadow_static_member_aliases(self, local_name: str) -> None:
+        self._shadow_static_member_aliases_in_scope(len(self.alias_scopes) - 1, local_name)
+
+    def _shadow_static_member_aliases_in_scope(self, scope_index: int, local_name: str) -> None:
+        prefix = f"{local_name}."
+        current_scope = self.alias_scopes[scope_index]
+        for scope in self.alias_scopes:
+            for key in scope:
+                if key.startswith(prefix):
+                    current_scope[key] = None
 
     def _refresh_imported_static_members(self, local_name: str, import_name: str) -> None:
         for reference_name in _STATIC_OVERWRITABLE_HIGH_RISK_REFERENCES:

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -1324,13 +1324,22 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         )
 
     def _record_import(self, alias: ast.alias, import_name: str) -> None:
-        self.alias_scopes[-1][alias.asname or alias.name] = frozenset({import_name})
+        local_name = alias.asname or alias.name
+        self.alias_scopes[-1][local_name] = frozenset({import_name})
+        self._refresh_imported_static_members(local_name, import_name)
 
     def _bind_name(self, name: str, resolved_names: _AliasValue) -> None:
         self.alias_scopes[-1][name] = resolved_names
 
     def _bind_name_in_scope(self, scope_index: int, name: str, resolved_names: _AliasValue) -> None:
         self.alias_scopes[scope_index][name] = resolved_names
+
+    def _refresh_imported_static_members(self, local_name: str, import_name: str) -> None:
+        for reference_name in _STATIC_OVERWRITABLE_HIGH_RISK_REFERENCES:
+            if reference_name != import_name and not reference_name.startswith(f"{import_name}."):
+                continue
+            suffix = reference_name.removeprefix(import_name)
+            self._bind_name(f"{local_name}{suffix}", frozenset({reference_name}))
 
     def _bind_module_namespace_key(self, key: str, resolved_names: _AliasValue) -> None:
         self._bind_name(f"{_MODULE_NAMESPACE_WRITE_PREFIX}{key}", resolved_names)

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -1328,7 +1328,10 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         for reference in _STATIC_OVERWRITABLE_HIGH_RISK_REFERENCES:
             if not reference.startswith(prefix):
                 continue
-            self.alias_scopes[-1][f"{local_name}{reference.removeprefix(import_name)}"] = frozenset({reference})
+            self.alias_scopes[-1][f"{local_name}{reference.removeprefix(import_name)}"] = _resolve_aliases(
+                reference,
+                self.alias_scopes,
+            )
 
     def _record_import(self, alias: ast.alias, import_name: str) -> None:
         local_name = alias.asname or alias.name
@@ -1344,6 +1347,11 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
         if "." not in name:
             self._shadow_static_member_aliases_in_scope(scope_index, name)
         self.alias_scopes[scope_index][name] = resolved_names
+
+    def _should_track_syntactic_static_reference(self, syntactic_name: str) -> bool:
+        root_name = syntactic_name.split(".", maxsplit=1)[0]
+        root_aliases, found = _lookup_bound_alias(root_name, self.alias_scopes)
+        return not found or root_aliases is not None
 
     def _shadow_static_member_aliases(self, local_name: str) -> None:
         self._shadow_static_member_aliases_in_scope(len(self.alias_scopes) - 1, local_name)
@@ -1402,7 +1410,10 @@ class _HighRiskPythonCallVisitor(ast.NodeVisitor):
             syntactic_name = _resolve_call_name(target)
             resolved_target_names = self._resolve_reference_names(target)
             target_names = set(resolved_target_names or frozenset())
-            if syntactic_name in _STATIC_OVERWRITABLE_HIGH_RISK_REFERENCES:
+            if (
+                syntactic_name in _STATIC_OVERWRITABLE_HIGH_RISK_REFERENCES
+                and self._should_track_syntactic_static_reference(syntactic_name)
+            ):
                 target_names.add(syntactic_name)
             if not target_names:
                 return

--- a/modelaudit/scanners/rule_mapper.py
+++ b/modelaudit/scanners/rule_mapper.py
@@ -123,10 +123,10 @@ def get_embedded_code_rule_code(code_type: str) -> str | None:
     """Get rule code for embedded code/executables."""
     code_lower = code_type.lower()
 
-    if "torchscript" in code_lower or "jit" in code_lower:
-        return _rule("S510")
-    elif "dynamic module execution" in code_lower or "runpy" in code_lower:
+    if "dynamic module execution" in code_lower or "runpy" in code_lower:
         return _rule("S108")
+    elif "torchscript" in code_lower or "jit" in code_lower:
+        return _rule("S510")
     elif (
         "windows" in code_lower
         or "pe executable" in code_lower

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -556,6 +556,30 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
+    def test_scan_model_detects_tail_window_runpy_execution(self) -> None:
+        detector = JITScriptDetector()
+        source = (
+            b"\x00" * (jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES + 16)
+            + b"\x00\xfffrom runpy import run_path as run\nrun('payload.py')\n\x00MODEL-FRAMING"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_late_priority_runpy_snippet_after_harmless_imports(self) -> None:
+        detector = JITScriptDetector()
+        leading_imports = b"".join(f"import harmless_{index}\n\x00".encode() for index in range(12))
+        source = b"\x00\xff" + leading_imports + b"from runpy import run_path as run\nrun('payload.py')\n"
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_scan_model_ignores_binary_framed_top_level_replaced_runpy_execution(self) -> None:
         detector = JITScriptDetector()
         source = b"\x00\xffimport runpy\nrunpy.run_path = len\nrunpy.run_path([])\n\x00MODEL-FRAMING"

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -636,10 +636,52 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
-    def test_scan_model_preserves_prefix_runpy_overwrite_in_tail_window(self) -> None:
+    @pytest.mark.parametrize(
+        "continued_import",
+        [
+            b"from runpy\\\n import run_path as run\n",
+            b"from runpy \\\n import run_path as run\n",
+            b"from runpy\\\r\n import run_path as run\r\n",
+            b"from runpy \\\r\n import run_path as run\r\n",
+        ],
+    )
+    def test_scan_model_detects_late_priority_runpy_continued_from_import(self, continued_import: bytes) -> None:
+        detector = JITScriptDetector()
+        leading_imports = b"".join(f"import harmless_{index}\n\x00".encode() for index in range(12))
+        source = b"\x00\xff" + leading_imports + continued_import + b"run('payload.py')\n"
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_late_priority_runpy_import_after_large_function_preamble(self) -> None:
+        detector = JITScriptDetector()
+        leading_blocks = b"".join(
+            f"def benign_{index}():\n    return {index}\n\x00".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+        padding = b"    # pad\n" * 600
+        source = (
+            b"\x00\xff"
+            + leading_blocks
+            + b"def payload():\n"
+            + padding
+            + b"    import runpy as rp\n"
+            + b"    return rp.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_reports_tail_runpy_after_prefix_overwrite_across_gap(self) -> None:
         detector = JITScriptDetector()
         filler_line = b"# filler\n"
-        filler = filler_line * (jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
         source = (
             b"\x00\xffimport runpy\n"
             b"runpy.run_path = len\n" + filler + b"def payload():\n    return runpy.run_path([])\n"
@@ -647,7 +689,60 @@ class TestJITScriptDetector:
 
         findings = detector.scan_model(source, "pytorch", "payload.bin")
 
-        assert not any(
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_reports_tail_runpy_when_omitted_middle_may_restore_overwrite(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b"\x00\xffimport runpy\n"
+            b"runpy.run_path = len\n"
+            + filler
+            + b"runpy.__dict__['run_path'] = runpy.run_module\n"
+            + filler
+            + b"def payload():\n    return runpy.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_reports_tail_runpy_when_safe_middle_state_is_omitted(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b"\x00\xffimport runpy\n"
+            + filler
+            + b"runpy.run_path = len\n"
+            + filler
+            + b"def payload():\n    return runpy.run_path([])\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_restored_runpy_execution_after_static_overwrite(self) -> None:
+        detector = JITScriptDetector()
+        source = (
+            b"def payload():\n"
+            b"    original = runpy.run_path\n"
+            b"    runpy.run_path = len\n"
+            b"    runpy.run_path = original\n"
+            b"    return runpy.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
@@ -661,7 +756,8 @@ class TestJITScriptDetector:
         os_candidate = (b"import os\n", (300, 301))
         aliased_runpy_candidate = (b"import harmless as h, runpy as rp\n", (350, 351))
         continued_runpy_candidate = (b"import harmless as h, \\\n    runpy as rp\n", (375, 376))
-        runpy_candidate = (b"from runpy import run_path\n", (400, 401))
+        continued_from_runpy_candidate = (b"from runpy\\\n import run_path\n", (400, 401))
+        runpy_candidate = (b"from runpy import run_path\n", (425, 426))
 
         selected = jit_script_module._prioritized_embedded_python_snippets(
             [
@@ -671,6 +767,7 @@ class TestJITScriptDetector:
                 os_candidate,
                 aliased_runpy_candidate,
                 continued_runpy_candidate,
+                continued_from_runpy_candidate,
                 runpy_candidate,
             ]
         )
@@ -680,6 +777,7 @@ class TestJITScriptDetector:
         assert os_candidate in selected
         assert aliased_runpy_candidate in selected
         assert continued_runpy_candidate in selected
+        assert continued_from_runpy_candidate in selected
         assert runpy_candidate in selected
 
     def test_scan_model_ignores_binary_framed_top_level_replaced_runpy_execution(self) -> None:
@@ -764,6 +862,33 @@ class TestJITScriptDetector:
         patterns = {finding.pattern for finding in findings if finding.type == "code_execution_pattern"}
         assert "Web browser launch detected" in patterns
         assert "Native library loading detected" in patterns
+
+    @pytest.mark.parametrize(
+        ("payload", "expected_pattern"),
+        [
+            (
+                b"def payload():\n    import webbrowser as wb\n    return wb.open('https://example.invalid')\n",
+                "Web browser launch detected",
+            ),
+            (
+                b"def payload():\n    import ctypes as ct\n    return ct.CDLL('libpayload.so')\n",
+                "Native library loading detected",
+            ),
+        ],
+    )
+    def test_scan_model_detects_late_priority_webbrowser_and_ctypes_aliases(
+        self, payload: bytes, expected_pattern: str
+    ) -> None:
+        detector = JITScriptDetector()
+        leading_blocks = b"".join(
+            f"def benign_{index}():\n    return {index}\n\x00".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+        source = b"\x00\xff" + leading_blocks + payload
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(f.type == "code_execution_pattern" and f.pattern == expected_pattern for f in findings)
 
     def test_scan_model_ignores_safe_webbrowser_get_overwrite(self) -> None:
         detector = JITScriptDetector()

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -580,6 +580,25 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
+    def test_priority_snippets_require_import_boundaries_after_cap(self) -> None:
+        leading_candidates = [
+            (f"import harmless_{index}\n".encode(), (index, index + 1))
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS)
+        ]
+        host_candidate = (b"import host_123\n", (100, 101))
+        system_candidate = (b"class System:\n    pass\n", (200, 201))
+        os_candidate = (b"import os\n", (300, 301))
+        runpy_candidate = (b"from runpy import run_path\n", (400, 401))
+
+        selected = jit_script_module._prioritized_embedded_python_snippets(
+            [*leading_candidates, host_candidate, system_candidate, os_candidate, runpy_candidate]
+        )
+
+        assert host_candidate not in selected
+        assert system_candidate not in selected
+        assert os_candidate in selected
+        assert runpy_candidate in selected
+
     def test_scan_model_ignores_binary_framed_top_level_replaced_runpy_execution(self) -> None:
         detector = JITScriptDetector()
         source = b"\x00\xffimport runpy\nrunpy.run_path = len\nrunpy.run_path([])\n\x00MODEL-FRAMING"

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -756,12 +756,53 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
+    def test_scan_model_detects_deep_priority_import_in_function_context(self) -> None:
+        detector = JITScriptDetector()
+        leading_blocks = b"".join(
+            f"def benign_{index}():\n    return {index}\n\x00".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+        padding_line = b"    # pad\n"
+        padding = padding_line * (
+            jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(padding_line) + 8
+        )
+        source = (
+            b"\x00\xff"
+            + leading_blocks
+            + b"def payload():\n"
+            + padding
+            + b"    import runpy as rp\n"
+            + b"    return rp.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_scan_model_detects_tail_alias_call_from_prefix_assignment_context(self) -> None:
         detector = JITScriptDetector()
         filler_line = b"# filler\n"
         filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
         source = (
             b"\x00\xffimport runpy\nrun = runpy.run_path\n" + filler + b"def payload():\n    return run('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_tail_one_hop_alias_after_prefix_from_import(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b"\x00\xfffrom runpy import run_path\nrun = run_path\n"
+            + filler
+            + b"def payload():\n    return run('payload.py')\n"
         )
 
         findings = detector.scan_model(source, "pytorch", "payload.bin")
@@ -777,6 +818,22 @@ class TestJITScriptDetector:
         source = (
             b"\x00\xffdef helper():\n"
             b"    import runpy as rp\n" + filler + b"def payload():\n    return rp.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert not any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_does_not_hoist_prefix_import_from_triple_quoted_string(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b'\x00\xfftext = """\nimport runpy as rp\n"""\n'
+            + filler
+            + b"def payload():\n    return rp.run_path('payload.py')\n"
         )
 
         findings = detector.scan_model(source, "pytorch", "payload.bin")

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -730,6 +730,47 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
+    def test_scan_model_detects_tail_alias_call_with_binary_framed_prefix_import(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = b"\x00\xffimport runpy as rp\n" + filler + b"def payload():\n    return rp.run_path('payload.py')\n"
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_tail_alias_call_from_prefix_assignment_context(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b"\x00\xffimport runpy\nrun = runpy.run_path\n" + filler + b"def payload():\n    return run('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_does_not_hoist_function_local_prefix_import_into_tail_context(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b"\x00\xffdef helper():\n"
+            b"    import runpy as rp\n" + filler + b"def payload():\n    return rp.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert not any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_scan_model_detects_restored_runpy_execution_after_static_overwrite(self) -> None:
         detector = JITScriptDetector()
         source = (

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -797,6 +797,24 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
+    def test_scan_model_detects_late_alias_call_after_bounded_priority_import(self) -> None:
+        detector = JITScriptDetector()
+        leading_blocks = b"".join(
+            f"def benign_{index}():\n    return {index}\n\x00".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+        padding_line = b"# pad\n"
+        padding = padding_line * (
+            jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(padding_line) + 8
+        )
+        source = b"\x00\xff" + leading_blocks + b"import runpy as rp\n" + padding + b"rp.run_path('payload.py')\n"
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_scan_model_detects_tail_runpy_alias_from_framed_prefix_assignment_context(self) -> None:
         detector = JITScriptDetector()
         filler_line = b"# filler\n"
@@ -835,6 +853,20 @@ class TestJITScriptDetector:
             b"\x00\xfffrom runpy import run_path\nrun = run_path\n"
             + filler
             + b"def payload():\n    return run('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_framed_tail_snippet_with_prefix_alias_context(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b"\x00\xffimport runpy as rp\n" + filler + b"\x00\xffdef payload():\n    return rp.run_path('payload.py')\n"
         )
 
         findings = detector.scan_model(source, "pytorch", "payload.bin")

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -756,6 +756,22 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
+    def test_scan_model_detects_tail_alias_call_with_string_parenthesis_in_prefix_import(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b'\x00\xffimport runpy as rp; marker = "("\n'
+            + filler
+            + b"def payload():\n    return rp.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_scan_model_detects_deep_priority_import_in_function_context(self) -> None:
         detector = JITScriptDetector()
         leading_blocks = b"".join(
@@ -795,6 +811,22 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
+    def test_scan_model_detects_tail_alias_call_from_prefix_annotated_assignment_context(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b"\x00\xffimport runpy\nrun: object = runpy.run_path\n"
+            + filler
+            + b"def payload():\n    return run('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_scan_model_detects_tail_one_hop_alias_after_prefix_from_import(self) -> None:
         detector = JITScriptDetector()
         filler_line = b"# filler\n"
@@ -803,6 +835,22 @@ class TestJITScriptDetector:
             b"\x00\xfffrom runpy import run_path\nrun = run_path\n"
             + filler
             + b"def payload():\n    return run('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_tail_import_after_quoted_triple_quote_marker(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b'\x00\xffmarker = \'"""\'\nimport runpy as rp\n'
+            + filler
+            + b"def payload():\n    return rp.run_path('payload.py')\n"
         )
 
         findings = detector.scan_model(source, "pytorch", "payload.bin")

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -923,6 +923,24 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
+    def test_scan_model_detects_late_wildcard_import_call_after_priority_window(self) -> None:
+        detector = JITScriptDetector()
+        leading_blocks = b"".join(
+            f"def benign_{index}():\n    return {index}\n}}\x00".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+        padding_line = b"# pad\n"
+        padding = padding_line * (
+            jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(padding_line) + 8
+        )
+        source = b"\x00\xff" + leading_blocks + b"from runpy import *\n" + padding + b"run_path('payload.py')\n"
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_scan_model_detects_middle_tail_alias_with_prefix_context(self) -> None:
         detector = JITScriptDetector()
         filler_line = b"# filler\n"

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -742,6 +742,20 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
+    def test_scan_model_detects_tail_alias_call_with_comment_parenthesis_in_prefix_import(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b"\x00\xffimport runpy as rp  # (\n" + filler + b"def payload():\n    return rp.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_scan_model_detects_tail_alias_call_from_prefix_assignment_context(self) -> None:
         detector = JITScriptDetector()
         filler_line = b"# filler\n"
@@ -815,11 +829,41 @@ class TestJITScriptDetector:
 
         assert host_candidate not in selected
         assert system_candidate not in selected
-        assert os_candidate in selected
-        assert aliased_runpy_candidate in selected
-        assert continued_runpy_candidate in selected
-        assert continued_from_runpy_candidate in selected
-        assert runpy_candidate in selected
+        selected_candidates = {candidate for candidate, _span in selected}
+        assert os_candidate[0] in selected_candidates
+        assert aliased_runpy_candidate[0] in selected_candidates
+        assert continued_runpy_candidate[0] in selected_candidates
+        assert continued_from_runpy_candidate[0] in selected_candidates
+        assert runpy_candidate[0] in selected_candidates
+
+    def test_priority_snippets_are_budgeted_and_bounded_after_default_cap(self) -> None:
+        leading_candidates = [
+            (f"import harmless_{index}\n".encode(), (index, index + 1))
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS)
+        ]
+        priority_payload = b"import os\n" + (b"# pad\n" * 4000)
+        priority_candidates = [
+            (
+                priority_payload,
+                (
+                    1_000 + index * len(priority_payload),
+                    1_000 + (index + 1) * len(priority_payload),
+                ),
+            )
+            for index in range(jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPETS + 4)
+        ]
+
+        selected = jit_script_module._prioritized_embedded_python_snippets([*leading_candidates, *priority_candidates])
+
+        assert len(selected) == (
+            jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS
+            + jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPETS
+        )
+        priority_selected = selected[jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS :]
+        assert all(
+            len(candidate) <= jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES
+            for candidate, _span in priority_selected
+        )
 
     def test_scan_model_ignores_binary_framed_top_level_replaced_runpy_execution(self) -> None:
         detector = JITScriptDetector()

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -659,7 +659,7 @@ class TestJITScriptDetector:
     def test_scan_model_detects_late_priority_runpy_import_after_large_function_preamble(self) -> None:
         detector = JITScriptDetector()
         leading_blocks = b"".join(
-            f"def benign_{index}():\n    return {index}\n\x00".encode()
+            f"def benign_{index}():\n    return {index}\n}}\x00".encode()
             for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
         )
         padding = b"    # pad\n" * 600
@@ -775,7 +775,7 @@ class TestJITScriptDetector:
     def test_scan_model_detects_deep_priority_import_in_function_context(self) -> None:
         detector = JITScriptDetector()
         leading_blocks = b"".join(
-            f"def benign_{index}():\n    return {index}\n\x00".encode()
+            f"def benign_{index}():\n    return {index}\n}}\x00".encode()
             for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
         )
         padding_line = b"    # pad\n"
@@ -800,7 +800,7 @@ class TestJITScriptDetector:
     def test_scan_model_detects_late_priority_alias_call_after_import_window(self) -> None:
         detector = JITScriptDetector()
         leading_blocks = b"".join(
-            f"def benign_{index}():\n    return {index}\n\x00".encode()
+            f"def benign_{index}():\n    return {index}\n}}\x00".encode()
             for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
         )
         padding_line = b"# pad\n"
@@ -812,6 +812,32 @@ class TestJITScriptDetector:
         findings = detector.scan_model(source, "pytorch", "payload.bin")
 
         assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_does_not_report_safe_late_priority_overwrite_from_compact_span(self) -> None:
+        detector = JITScriptDetector()
+        leading_blocks = b"".join(
+            f"def benign_{index}():\n    return {index}\n}}\x00".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+        padding_line = b"    # pad\n"
+        padding = padding_line * (
+            jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(padding_line) + 8
+        )
+        source = (
+            b"\x00\xff"
+            + leading_blocks
+            + b"def payload():\n"
+            + padding
+            + b"    import runpy\n"
+            + b"    runpy.run_path = len\n"
+            + b"    return runpy.run_path([])\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert not any(
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
@@ -843,12 +869,51 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
+    def test_scan_model_detects_tail_alias_after_noisy_prefix_context_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        detector = JITScriptDetector()
+        monkeypatch.setattr(jit_script_module, "_EMBEDDED_PYTHON_SCAN_WINDOW_BYTES", 4096)
+        long_alias = "unused_" + "x" * 900
+        noise = b"".join(f"import runpy as {long_alias}_{index}\n".encode() for index in range(20))
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b"\x00\xff"
+            + noise
+            + b"import runpy as rp\n"
+            + filler
+            + b"def payload():\n    return rp.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_scan_model_detects_tail_alias_call_from_prefix_annotated_assignment_context(self) -> None:
         detector = JITScriptDetector()
         filler_line = b"# filler\n"
         filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
         source = (
             b"\x00\xffimport runpy\nrun: object = runpy.run_path\n"
+            + filler
+            + b"def payload():\n    return run('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_tail_alias_call_from_prefix_unpack_assignment_context(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b"\x00\xffimport runpy\n(run,) = (runpy.run_path,)\n"
             + filler
             + b"def payload():\n    return run('payload.py')\n"
         )
@@ -903,6 +968,14 @@ class TestJITScriptDetector:
         assert not any(
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
+
+    def test_scan_model_does_not_parse_docstring_priority_import_as_statement(self) -> None:
+        detector = JITScriptDetector()
+        source = b'\x00\xffdef payload():\n    """\n    import os\n    """\n    return 1\n\x00MODEL-FRAMING'
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert not any(f.type in {"dangerous_import", "code_execution_pattern"} for f in findings)
 
     def test_scan_model_does_not_hoist_prefix_import_from_triple_quoted_string(self) -> None:
         detector = JITScriptDetector()

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -623,6 +623,34 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
+    def test_scan_model_detects_late_priority_runpy_continued_import_list_alias(self) -> None:
+        detector = JITScriptDetector()
+        leading_imports = b"".join(f"import harmless_{index}\n\x00".encode() for index in range(12))
+        source = (
+            b"\x00\xff" + leading_imports + b"import harmless as h, \\\n    runpy as rp\nrp.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_preserves_prefix_runpy_overwrite_in_tail_window(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b"\x00\xffimport runpy\n"
+            b"runpy.run_path = len\n" + filler + b"def payload():\n    return runpy.run_path([])\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert not any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_priority_snippets_require_import_boundaries_after_cap(self) -> None:
         leading_candidates = [
             (f"import harmless_{index}\n".encode(), (index, index + 1))
@@ -632,6 +660,7 @@ class TestJITScriptDetector:
         system_candidate = (b"class System:\n    pass\n", (200, 201))
         os_candidate = (b"import os\n", (300, 301))
         aliased_runpy_candidate = (b"import harmless as h, runpy as rp\n", (350, 351))
+        continued_runpy_candidate = (b"import harmless as h, \\\n    runpy as rp\n", (375, 376))
         runpy_candidate = (b"from runpy import run_path\n", (400, 401))
 
         selected = jit_script_module._prioritized_embedded_python_snippets(
@@ -641,6 +670,7 @@ class TestJITScriptDetector:
                 system_candidate,
                 os_candidate,
                 aliased_runpy_candidate,
+                continued_runpy_candidate,
                 runpy_candidate,
             ]
         )
@@ -649,6 +679,7 @@ class TestJITScriptDetector:
         assert system_candidate not in selected
         assert os_candidate in selected
         assert aliased_runpy_candidate in selected
+        assert continued_runpy_candidate in selected
         assert runpy_candidate in selected
 
     def test_scan_model_ignores_binary_framed_top_level_replaced_runpy_execution(self) -> None:

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -556,6 +556,23 @@ class TestJITScriptDetector:
 
         assert findings == []
 
+    def test_scan_model_ignores_runpy_member_after_module_alias_rebind(self) -> None:
+        detector = JITScriptDetector()
+        source = (
+            b"class Safe:\n"
+            b"    run_path = len\n"
+            b"def payload():\n"
+            b"    import runpy as rp\n"
+            b"    rp = Safe()\n"
+            b"    return rp.run_path([])\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert not any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_scan_model_preserves_possible_runpy_execution_after_conditional_replacement(self) -> None:
         detector = JITScriptDetector()
         source = (
@@ -894,6 +911,22 @@ class TestJITScriptDetector:
         filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
         source = (
             b'\x00\xffmarker = \'"""\'\nimport runpy as rp\n'
+            + filler
+            + b"def payload():\n    return rp.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_tail_import_after_comment_line_closes_triple_quote(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b'\x00\xfftext = """\n# closes """\nimport runpy as rp\n'
             + filler
             + b"def payload():\n    return rp.run_path('payload.py')\n"
         )

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -971,6 +971,28 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
+    def test_scan_model_detects_late_function_local_assignment_alias_after_priority_window(self) -> None:
+        detector = JITScriptDetector()
+        leading_blocks = b"".join(
+            f"def benign_{index}():\n    return {index}\n}}\x00".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+        padding_line = b"    # pad\n"
+        padding = padding_line * (
+            jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(padding_line) + 8
+        )
+        source = (
+            b"\x00\xff" + leading_blocks + b"def payload():\n"
+            b"    import runpy\n"
+            b"    run = runpy.run_path\n" + padding + b"    return run('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_scan_model_detects_late_wildcard_import_call_after_priority_window(self) -> None:
         detector = JITScriptDetector()
         leading_blocks = b"".join(
@@ -982,6 +1004,49 @@ class TestJITScriptDetector:
             jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(padding_line) + 8
         )
         source = b"\x00\xff" + leading_blocks + b"from runpy import *\n" + padding + b"run_path('payload.py')\n"
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_preserves_raw_runpy_hit_in_compacted_priority_gap(self) -> None:
+        detector = JITScriptDetector()
+        leading_blocks = b"".join(
+            f"def benign_{index}():\n    return {index}\n}}\x00".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+        padding_line = b"# pad\n"
+        padding = padding_line * (
+            jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(padding_line) + 8
+        )
+        source = b"\x00\xff" + leading_blocks + b"import os\n" + padding + b"runpy.run_path('payload.py')\n" + padding
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_later_priority_alias_pair_inside_same_block(self) -> None:
+        detector = JITScriptDetector()
+        leading_blocks = b"".join(
+            f"def benign_{index}():\n    return {index}\n}}\x00".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+        padding_line = b"    # pad\n"
+        padding = padding_line * (
+            jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(padding_line) + 8
+        )
+        source = (
+            b"\x00\xff" + leading_blocks + b"def payload():\n"
+            b"    import os\n"
+            + padding
+            + b"    import runpy as rp\n"
+            + padding
+            + b"    return rp.run_path('payload.py')\n"
+        )
 
         findings = detector.scan_model(source, "pytorch", "payload.bin")
 

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -612,6 +612,17 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
+    def test_scan_model_detects_late_priority_runpy_import_list_alias(self) -> None:
+        detector = JITScriptDetector()
+        leading_imports = b"".join(f"import harmless_{index}\n\x00".encode() for index in range(12))
+        source = b"\x00\xff" + leading_imports + b"import harmless as h, runpy as rp\nrp.run_path('payload.py')\n"
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_priority_snippets_require_import_boundaries_after_cap(self) -> None:
         leading_candidates = [
             (f"import harmless_{index}\n".encode(), (index, index + 1))
@@ -620,15 +631,24 @@ class TestJITScriptDetector:
         host_candidate = (b"import host_123\n", (100, 101))
         system_candidate = (b"class System:\n    pass\n", (200, 201))
         os_candidate = (b"import os\n", (300, 301))
+        aliased_runpy_candidate = (b"import harmless as h, runpy as rp\n", (350, 351))
         runpy_candidate = (b"from runpy import run_path\n", (400, 401))
 
         selected = jit_script_module._prioritized_embedded_python_snippets(
-            [*leading_candidates, host_candidate, system_candidate, os_candidate, runpy_candidate]
+            [
+                *leading_candidates,
+                host_candidate,
+                system_candidate,
+                os_candidate,
+                aliased_runpy_candidate,
+                runpy_candidate,
+            ]
         )
 
         assert host_candidate not in selected
         assert system_candidate not in selected
         assert os_candidate in selected
+        assert aliased_runpy_candidate in selected
         assert runpy_candidate in selected
 
     def test_scan_model_ignores_binary_framed_top_level_replaced_runpy_execution(self) -> None:

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -858,6 +858,147 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
+    def test_scan_model_ignores_late_priority_alias_use_inside_multiline_string(self) -> None:
+        detector = JITScriptDetector()
+        leading_blocks = b"".join(
+            f"def benign_{index}():\n    return {index}\n}}\x00".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+        padding_line = b"    # pad\n"
+        padding = padding_line * (
+            jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(padding_line) + 8
+        )
+        source = (
+            b"\x00\xff" + leading_blocks + b"def payload():\n"
+            b"    import runpy as rp\n" + padding + b'    text = """\n'
+            b"    rp.run_path('payload.py')\n"
+            b'    """\n'
+            b"    return 1\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert not any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_late_rebound_alias_call_after_priority_window(self) -> None:
+        detector = JITScriptDetector()
+        leading_blocks = b"".join(
+            f"def benign_{index}():\n    return {index}\n}}\x00".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+        padding_line = b"# pad\n"
+        padding = padding_line * (
+            jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(padding_line) + 8
+        )
+        source = (
+            b"\x00\xff" + leading_blocks + b"import runpy as rp\n" + padding + b"rp.run_path = runpy.run_module\n"
+            b"rp.run_path('payload')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_late_assignment_alias_call_after_priority_window(self) -> None:
+        detector = JITScriptDetector()
+        leading_blocks = b"".join(
+            f"def benign_{index}():\n    return {index}\n}}\x00".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+        padding_line = b"# pad\n"
+        padding = padding_line * (
+            jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(padding_line) + 8
+        )
+        source = (
+            b"\x00\xff" + leading_blocks + b"import runpy\nrun = runpy.run_path\n" + padding + b"run('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_middle_tail_alias_with_prefix_context(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        tail_prefix = b"".join(f"def benign_tail_{index}():\n    return {index}\n\x00".encode() for index in range(24))
+        tail_suffix = b"".join(f"def after_tail_{index}():\n    return {index}\n\x00".encode() for index in range(24))
+        source = (
+            b"\x00\xffimport runpy as rp\n"
+            + filler
+            + b"\x00\xff"
+            + tail_prefix
+            + b"def payload():\n    return rp.run_path('payload.py')\n\x00"
+            + tail_suffix
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_tail_alias_from_compound_prefix_import(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b"\x00\xffif True: import runpy as rp\n"
+            + filler
+            + b"def payload():\n    return rp.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_preserves_full_prefixed_tail_context(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        tail_padding_line = b"    # tail\n"
+        tail_padding = tail_padding_line * (
+            (jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES - 200) // len(tail_padding_line)
+        )
+        source = (
+            b"\x00\xffimport runpy as rp\n"
+            + filler
+            + b"\x00\xffdef payload():\n"
+            + tail_padding
+            + b"    return rp.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_ignores_escaped_triple_quote_prefix_import_context(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b'\x00\xfftext = """\n'
+            b'not closed \\"""\n'
+            b"import runpy as rp\n"
+            b'"""\n' + filler + b"def payload():\n    return rp.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert not any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_scan_model_detects_tail_runpy_alias_from_framed_prefix_assignment_context(self) -> None:
         detector = JITScriptDetector()
         filler_line = b"# filler\n"
@@ -917,6 +1058,20 @@ class TestJITScriptDetector:
             b"\x00\xffimport runpy\nrun: object = runpy.run_path\n"
             + filler
             + b"def payload():\n    return run('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_tail_module_alias_from_prefix_assignment_context(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b"\x00\xffimport runpy\nrp = runpy\n" + filler + b"def payload():\n    return rp.run_path('payload.py')\n"
         )
 
         findings = detector.scan_model(source, "pytorch", "payload.bin")

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -797,12 +797,44 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
+    def test_scan_model_detects_late_priority_alias_call_after_import_window(self) -> None:
+        detector = JITScriptDetector()
+        leading_blocks = b"".join(
+            f"def benign_{index}():\n    return {index}\n\x00".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+        padding_line = b"# pad\n"
+        padding = padding_line * (
+            jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(padding_line) + 8
+        )
+        source = b"\x00\xff" + leading_blocks + b"import runpy as rp\n" + padding + b"rp.run_path('payload.py')\n"
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_scan_model_detects_tail_runpy_alias_from_framed_prefix_assignment_context(self) -> None:
         detector = JITScriptDetector()
         filler_line = b"# filler\n"
         filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
         source = (
             b"\x00\xffimport runpy\nrun = runpy.run_path\n" + filler + b"def payload():\n    return run('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_framed_tail_alias_with_prefix_context(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b"\x00\xffimport runpy as rp\n" + filler + b"\x00\xffdef payload():\n    return rp.run_path('payload.py')\n"
         )
 
         findings = detector.scan_model(source, "pytorch", "payload.bin")

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -730,7 +730,7 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
-    def test_scan_model_detects_tail_alias_call_with_binary_framed_prefix_import(self) -> None:
+    def test_scan_model_detects_tail_runpy_alias_from_framed_prefix_import_context(self) -> None:
         detector = JITScriptDetector()
         filler_line = b"# filler\n"
         filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
@@ -742,7 +742,7 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
-    def test_scan_model_detects_tail_alias_call_from_prefix_assignment_context(self) -> None:
+    def test_scan_model_detects_tail_runpy_alias_from_framed_prefix_assignment_context(self) -> None:
         detector = JITScriptDetector()
         filler_line = b"# filler\n"
         filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
@@ -762,8 +762,22 @@ class TestJITScriptDetector:
         filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
         source = (
             b"\x00\xffdef helper():\n"
-            b"    import runpy as rp\n" + filler + b"def payload():\n    return rp.run_path('payload.py')\n"
+            b"    import runpy as rp\n" + filler + b"def payload():\n"
+            b"    import os\n"
+            b"    return rp.run_path('payload.py')\n"
         )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert not any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_does_not_use_commented_prefix_import_as_tail_context(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = b"\x00\xff# import runpy as rp\n" + filler + b"def payload():\n    return rp.run_path('payload.py')\n"
 
         findings = detector.scan_model(source, "pytorch", "payload.bin")
 

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -903,6 +903,54 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
+    def test_scan_model_preserves_raw_runpy_call_between_compact_priority_segments(self) -> None:
+        detector = JITScriptDetector()
+        leading_blocks = b"".join(
+            f"def benign_{index}():\n    return {index}\n}}\x00".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+        padding_before = b"# before\n" * (
+            jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(b"# before\n") + 8
+        )
+        padding_after = b"# after\n" * (
+            jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(b"# after\n") + 8
+        )
+        source = (
+            b"\x00\xff"
+            + leading_blocks
+            + b"import os\n"
+            + padding_before
+            + b"runpy.run_path('payload.py')\n"
+            + padding_after
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_late_alias_call_after_non_call_alias_use(self) -> None:
+        detector = JITScriptDetector()
+        leading_blocks = b"".join(
+            f"def benign_{index}():\n    return {index}\n}}\x00".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+        padding = b"# pad\n" * (jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(b"# pad\n") + 8)
+        source = (
+            b"\x00\xff"
+            + leading_blocks
+            + b"import runpy as rp\n"
+            + padding
+            + b"rp.other = 1\nrp.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_scan_model_detects_late_assignment_alias_call_after_priority_window(self) -> None:
         detector = JITScriptDetector()
         leading_blocks = b"".join(
@@ -1114,6 +1162,36 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
+    def test_scan_model_detects_tail_call_from_prefix_module_alias_context(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b"\x00\xffimport runpy\nrp = runpy\n" + filler + b"def payload():\n    return rp.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_tail_call_from_literal_true_compound_import_context(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b"\x00\xffif True: import runpy as rp\n"
+            + filler
+            + b"def payload():\n    return rp.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_scan_model_detects_tail_one_hop_alias_after_prefix_from_import(self) -> None:
         detector = JITScriptDetector()
         filler_line = b"# filler\n"
@@ -1136,6 +1214,27 @@ class TestJITScriptDetector:
         filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
         source = (
             b"\x00\xffimport runpy as rp\n" + filler + b"\x00\xffdef payload():\n    return rp.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_prefix_alias_call_after_middle_tail_start(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        harmless_tail = b"".join(
+            f"def harmless_{index}():\n    return {index}\n}}\x00".encode()
+            for index in range(2 * jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 4)
+        )
+        source = (
+            b"\x00\xffimport runpy as rp\n"
+            + filler
+            + harmless_tail
+            + b"def payload():\n    return rp.run_path('payload.py')\n"
         )
 
         findings = detector.scan_model(source, "pytorch", "payload.bin")
@@ -1181,12 +1280,49 @@ class TestJITScriptDetector:
 
         assert not any(f.type in {"dangerous_import", "code_execution_pattern"} for f in findings)
 
+    def test_scan_model_ignores_late_priority_alias_use_inside_multiline_string_with_trigger(self) -> None:
+        detector = JITScriptDetector()
+        leading_blocks = b"".join(
+            f"def benign_{index}():\n    return {index}\n}}\x00".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+        padding = b"# pad\n" * (jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(b"# pad\n") + 8)
+        source = (
+            b"\x00\xff"
+            + leading_blocks
+            + b"import runpy as rp\n"
+            + padding
+            + b'import os\ntext = """\nrp.run_path("payload.py")\n"""\n'
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert not any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_scan_model_does_not_hoist_prefix_import_from_triple_quoted_string(self) -> None:
         detector = JITScriptDetector()
         filler_line = b"# filler\n"
         filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
         source = (
             b'\x00\xfftext = """\nimport runpy as rp\n"""\n'
+            + filler
+            + b"def payload():\n    return rp.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert not any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_does_not_hoist_prefix_import_after_escaped_triple_quote(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b'\x00\xfftext = """\nnot close \\"""\nimport runpy as rp\n"""\n'
             + filler
             + b"def payload():\n    return rp.run_path('payload.py')\n"
         )
@@ -1246,17 +1382,22 @@ class TestJITScriptDetector:
         )
 
     def test_priority_snippets_require_import_boundaries_after_cap(self) -> None:
+        def candidate(
+            value: tuple[bytes, tuple[int, int]],
+        ) -> tuple[bytes, tuple[int, int], tuple[tuple[int, int], ...]]:
+            return value[0], value[1], (value[1],)
+
         leading_candidates = [
-            (f"import harmless_{index}\n".encode(), (index, index + 1))
+            candidate((f"import harmless_{index}\n".encode(), (index, index + 1)))
             for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS)
         ]
-        host_candidate = (b"import host_123\n", (100, 101))
-        system_candidate = (b"class System:\n    pass\n", (200, 201))
-        os_candidate = (b"import os\n", (300, 301))
-        aliased_runpy_candidate = (b"import harmless as h, runpy as rp\n", (350, 351))
-        continued_runpy_candidate = (b"import harmless as h, \\\n    runpy as rp\n", (375, 376))
-        continued_from_runpy_candidate = (b"from runpy\\\n import run_path\n", (400, 401))
-        runpy_candidate = (b"from runpy import run_path\n", (425, 426))
+        host_candidate = candidate((b"import host_123\n", (100, 101)))
+        system_candidate = candidate((b"class System:\n    pass\n", (200, 201)))
+        os_candidate = candidate((b"import os\n", (300, 301)))
+        aliased_runpy_candidate = candidate((b"import harmless as h, runpy as rp\n", (350, 351)))
+        continued_runpy_candidate = candidate((b"import harmless as h, \\\n    runpy as rp\n", (375, 376)))
+        continued_from_runpy_candidate = candidate((b"from runpy\\\n import run_path\n", (400, 401)))
+        runpy_candidate = candidate((b"from runpy import run_path\n", (425, 426)))
 
         selected = jit_script_module._prioritized_embedded_python_snippets(
             [
@@ -1271,9 +1412,9 @@ class TestJITScriptDetector:
             ]
         )
 
-        assert host_candidate not in selected
-        assert system_candidate not in selected
-        selected_candidates = {candidate for candidate, _span in selected}
+        selected_candidates = {candidate for candidate, _span, _real_ranges in selected}
+        assert host_candidate[0] not in selected_candidates
+        assert system_candidate[0] not in selected_candidates
         assert os_candidate[0] in selected_candidates
         assert aliased_runpy_candidate[0] in selected_candidates
         assert continued_runpy_candidate[0] in selected_candidates
@@ -1281,18 +1422,25 @@ class TestJITScriptDetector:
         assert runpy_candidate[0] in selected_candidates
 
     def test_priority_snippets_are_budgeted_and_bounded_after_default_cap(self) -> None:
+        def candidate(
+            value: tuple[bytes, tuple[int, int]],
+        ) -> tuple[bytes, tuple[int, int], tuple[tuple[int, int], ...]]:
+            return value[0], value[1], (value[1],)
+
         leading_candidates = [
-            (f"import harmless_{index}\n".encode(), (index, index + 1))
+            candidate((f"import harmless_{index}\n".encode(), (index, index + 1)))
             for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS)
         ]
         priority_payload = b"import os\n" + (b"# pad\n" * 4000)
         priority_candidates = [
-            (
-                priority_payload,
+            candidate(
                 (
-                    1_000 + index * len(priority_payload),
-                    1_000 + (index + 1) * len(priority_payload),
-                ),
+                    priority_payload,
+                    (
+                        1_000 + index * len(priority_payload),
+                        1_000 + (index + 1) * len(priority_payload),
+                    ),
+                )
             )
             for index in range(jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPETS + 4)
         ]
@@ -1306,7 +1454,7 @@ class TestJITScriptDetector:
         priority_selected = selected[jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS :]
         assert all(
             len(candidate) <= jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES
-            for candidate, _span in priority_selected
+            for candidate, _span, _real_ranges in priority_selected
         )
 
     def test_scan_model_ignores_binary_framed_top_level_replaced_runpy_execution(self) -> None:

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -971,6 +971,33 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
+    def test_scan_model_ignores_unrelated_assignment_alias_before_delayed_priority_call(self) -> None:
+        detector = JITScriptDetector()
+        leading_blocks = b"".join(
+            f"def benign_{index}():\n    return {index}\n}}\x00".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+        padding_line = b"# pad\n"
+        padding = padding_line * (
+            jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(padding_line) + 8
+        )
+        source = (
+            b"\x00\xff"
+            + leading_blocks
+            + b"import runpy as rp\nx = 1\n"
+            + padding
+            + b"x()\n"
+            + padding
+            + b"rp.run_path('payload.py')\n"
+            + padding
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_scan_model_detects_late_function_local_assignment_alias_after_priority_window(self) -> None:
         detector = JITScriptDetector()
         leading_blocks = b"".join(
@@ -985,6 +1012,31 @@ class TestJITScriptDetector:
             b"\x00\xff" + leading_blocks + b"def payload():\n"
             b"    import runpy\n"
             b"    run = runpy.run_path\n" + padding + b"    return run('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_late_getattr_priority_alias_call(self) -> None:
+        detector = JITScriptDetector()
+        leading_blocks = b"".join(
+            f"def benign_{index}():\n    return {index}\n}}\x00".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+        padding_line = b"# pad\n"
+        padding = padding_line * (
+            jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(padding_line) + 8
+        )
+        source = (
+            b"\x00\xff"
+            + leading_blocks
+            + b"import runpy as rp\n"
+            + padding
+            + b"getattr(rp, 'run_path')('payload.py')\n"
+            + padding
         )
 
         findings = detector.scan_model(source, "pytorch", "payload.bin")
@@ -1051,6 +1103,30 @@ class TestJITScriptDetector:
         findings = detector.scan_model(source, "pytorch", "payload.bin")
 
         assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_embedded_python_prefix_context_tail_starts_are_bounded(self) -> None:
+        prefix = b"\x00\xffimport runpy as rp\n" + b"# prefix\n" * 1024
+        tail_blocks = b"".join(
+            f'def harmless_{index}():\n    """rp.run_path(\'payload.py\')"""\n    return {index}\n'.encode()
+            for index in range(128)
+        )
+        data = prefix + (b"# middle\n" * 130_000) + tail_blocks
+
+        windows = jit_script_module._embedded_python_extraction_windows(data)
+
+        assert len(windows) <= 3 + (2 * jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS)
+
+    def test_scan_model_carries_prefix_alias_shadowing_into_tail_context(self) -> None:
+        detector = JITScriptDetector()
+        prefix = b"\x00\xffclass Safe:\n    run_path = len\nimport runpy as rp\nrp = Safe()\n" + b"# prefix\n" * 1024
+        tail = b"def payload():\n    return rp.run_path([])\n"
+        source = prefix + (b"# middle\n" * 130_000) + tail
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert not any(
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -811,6 +811,22 @@ class TestJITScriptDetector:
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 
+    def test_scan_model_detects_tail_alias_after_annotated_prefix_assignment(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b"\x00\xffimport runpy\nrun: object = runpy.run_path\n"
+            + filler
+            + b"def payload():\n    return run('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
     def test_scan_model_does_not_hoist_function_local_prefix_import_into_tail_context(self) -> None:
         detector = JITScriptDetector()
         filler_line = b"# filler\n"
@@ -853,6 +869,38 @@ class TestJITScriptDetector:
         findings = detector.scan_model(source, "pytorch", "payload.bin")
 
         assert not any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_tail_alias_with_parenthesis_inside_prefix_string(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b'\x00\xffimport runpy as rp; marker = "("\n'
+            + filler
+            + b"def payload():\n    return rp.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+
+    def test_scan_model_detects_real_prefix_import_after_single_quoted_triple_marker(self) -> None:
+        detector = JITScriptDetector()
+        filler_line = b"# filler\n"
+        filler = filler_line * (2 * jit_script_module._EMBEDDED_PYTHON_SCAN_WINDOW_BYTES // len(filler_line) + 1)
+        source = (
+            b'\x00\xffmarker = \'"""\'\nimport runpy as rp\n'
+            + filler
+            + b"def payload():\n    return rp.run_path('payload.py')\n"
+        )
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
 

--- a/tests/scanners/test_rule_mapper.py
+++ b/tests/scanners/test_rule_mapper.py
@@ -33,6 +33,7 @@ def test_generic_rule_prefers_network_codes_for_urls() -> None:
 def test_embedded_code_rule_maps_dynamic_module_execution_before_executable_text() -> None:
     """Dynamic module execution contains an "exe" prefix but belongs to runpy."""
     assert get_embedded_code_rule_code("Dynamic module execution detected") == "S108"
+    assert get_embedded_code_rule_code("TorchScript Dynamic module execution detected") == "S108"
 
 
 @pytest.mark.parametrize(

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -464,6 +464,19 @@ class TestTarScanner:
 
         assert not any(check.name == "Python Archive Member Security" for check in result.checks)
 
+    def test_scan_tar_ignores_runpy_member_after_module_alias_rebind(self, tmp_path: Path) -> None:
+        archive_path = tmp_path / "model_bundle.tar"
+        payload = b"class Safe:\n    run_path = len\nimport runpy as rp\nrp = Safe()\nrp.run_path([])\n"
+
+        with tarfile.open(archive_path, "w") as archive:
+            info = tarfile.TarInfo("handler.py")
+            info.size = len(payload)
+            archive.addfile(info, tarfile.io.BytesIO(payload))  # type: ignore[attr-defined]
+
+        result = self.scanner.scan(str(archive_path))
+
+        assert not any(check.name == "Python Archive Member Security" for check in result.checks)
+
     def test_scan_tar_ignores_safe_namespace_slot_rebinding(self, tmp_path: Path) -> None:
         """A safe final callable bound through a module dictionary should remain clean."""
         archive_path = tmp_path / "model_bundle.tar"

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -678,7 +678,7 @@ def test_scan_zip_preserves_restored_runpy_execution_after_static_overwrite(tmp_
     assert python_checks[0].details["reason"] == "high-risk calls: runpy.run_path"
 
 
-def test_scan_zip_clears_static_member_overwrite_after_module_import(tmp_path: Path) -> None:
+def test_scan_zip_preserves_runpy_execution_after_import_rebinds_module(tmp_path: Path) -> None:
     archive_path = tmp_path / "model_bundle.zip"
     source = (
         "class Dummy:\n    pass\nrunpy = Dummy()\nrunpy.run_path = len\nimport runpy\nrunpy.run_path('payload.py')\n"

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -698,6 +698,22 @@ def test_scan_zip_preserves_runpy_execution_after_import_rebinds_module(tmp_path
     assert python_checks[0].details["reason"] == "high-risk calls: runpy.run_path"
 
 
+def test_scan_zip_clears_imported_member_aliases_after_alias_rebind(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    source = "import runpy as rp\nrp = object()\nrp.run_path('safe')\n"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", source)
+
+    result = ZipScanner().scan(str(archive_path))
+
+    python_checks = [
+        check
+        for check in result.checks
+        if check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED
+    ]
+    assert python_checks == []
+
+
 def test_scan_zip_preserves_safe_runpy_overwrite_before_conditional(tmp_path: Path) -> None:
     archive_path = tmp_path / "model_bundle.zip"
     source = "import runpy\nrunpy.run_path = len\nif replace:\n    runpy.run_path = str\nrunpy.run_path([])\n"

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -624,6 +624,19 @@ def test_scan_zip_preserves_possible_runpy_execution_after_conditional_overwrite
     assert python_checks[0].details["reason"] == "high-risk calls: runpy.run_path"
 
 
+def test_scan_zip_preserves_safe_runpy_overwrite_before_conditional(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    source = "import runpy\nrunpy.run_path = len\nif replace:\n    runpy.run_path = str\nrunpy.run_path([])\n"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", source)
+
+    result = ZipScanner().scan(str(archive_path))
+
+    assert not any(
+        check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED for check in result.checks
+    )
+
+
 @pytest.mark.parametrize(
     "source",
     [

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -698,6 +698,19 @@ def test_scan_zip_clears_static_member_overwrite_after_module_import(tmp_path: P
     assert python_checks[0].details["reason"] == "high-risk calls: runpy.run_path"
 
 
+def test_scan_zip_clears_imported_static_members_after_alias_rebind(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    source = "import runpy as rp\nrp = object()\nrp.run_path('safe.py')\n"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", source)
+
+    result = ZipScanner().scan(str(archive_path))
+
+    assert not any(
+        check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED for check in result.checks
+    )
+
+
 def test_scan_zip_preserves_safe_runpy_overwrite_before_conditional(tmp_path: Path) -> None:
     archive_path = tmp_path / "model_bundle.zip"
     source = "import runpy\nrunpy.run_path = len\nif replace:\n    runpy.run_path = str\nrunpy.run_path([])\n"

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -654,6 +654,30 @@ def test_scan_zip_preserves_possible_runpy_execution_after_conditional_overwrite
     assert python_checks[0].details["reason"] == "high-risk calls: runpy.run_path"
 
 
+def test_scan_zip_preserves_restored_runpy_execution_after_static_overwrite(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    source = (
+        "import runpy\n"
+        "original = runpy.run_path\n"
+        "runpy.run_path = len\n"
+        "runpy.run_path = original\n"
+        "runpy.run_path('payload.py')\n"
+    )
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", source)
+
+    result = ZipScanner().scan(str(archive_path))
+
+    python_checks = [
+        check
+        for check in result.checks
+        if check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED
+    ]
+    assert len(python_checks) == 1
+    assert python_checks[0].rule_code == "S108"
+    assert python_checks[0].details["reason"] == "high-risk calls: runpy.run_path"
+
+
 def test_scan_zip_preserves_safe_runpy_overwrite_before_conditional(tmp_path: Path) -> None:
     archive_path = tmp_path / "model_bundle.zip"
     source = "import runpy\nrunpy.run_path = len\nif replace:\n    runpy.run_path = str\nrunpy.run_path([])\n"

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -678,6 +678,26 @@ def test_scan_zip_preserves_restored_runpy_execution_after_static_overwrite(tmp_
     assert python_checks[0].details["reason"] == "high-risk calls: runpy.run_path"
 
 
+def test_scan_zip_clears_static_member_overwrite_after_module_import(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    source = (
+        "class Dummy:\n    pass\nrunpy = Dummy()\nrunpy.run_path = len\nimport runpy\nrunpy.run_path('payload.py')\n"
+    )
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", source)
+
+    result = ZipScanner().scan(str(archive_path))
+
+    python_checks = [
+        check
+        for check in result.checks
+        if check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED
+    ]
+    assert len(python_checks) == 1
+    assert python_checks[0].rule_code == "S108"
+    assert python_checks[0].details["reason"] == "high-risk calls: runpy.run_path"
+
+
 def test_scan_zip_preserves_safe_runpy_overwrite_before_conditional(tmp_path: Path) -> None:
     archive_path = tmp_path / "model_bundle.zip"
     source = "import runpy\nrunpy.run_path = len\nif replace:\n    runpy.run_path = str\nrunpy.run_path([])\n"

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -724,6 +724,45 @@ def test_scan_zip_preserves_safe_module_member_overwrite_after_reimport(tmp_path
     )
 
 
+def test_scan_zip_preserves_runpy_member_after_harmless_reimport(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    source = "import runpy as rp\nimport runpy as rp\nrp.run_path('payload.py')\n"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", source)
+
+    result = ZipScanner().scan(str(archive_path))
+
+    python_checks = [
+        check
+        for check in result.checks
+        if check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED
+    ]
+    assert len(python_checks) == 1
+    assert python_checks[0].rule_code == "S108"
+    assert python_checks[0].details["reason"] == "high-risk calls: runpy.run_path"
+
+
+@pytest.mark.parametrize("rebinding", ["rp = rp", "rp = runpy"])
+def test_scan_zip_preserves_runpy_member_after_module_preserving_alias_assignment(
+    tmp_path: Path, rebinding: str
+) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    source = f"import runpy\nimport runpy as rp\n{rebinding}\nrp.run_path('payload.py')\n"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", source)
+
+    result = ZipScanner().scan(str(archive_path))
+
+    python_checks = [
+        check
+        for check in result.checks
+        if check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED
+    ]
+    assert len(python_checks) == 1
+    assert python_checks[0].rule_code == "S108"
+    assert python_checks[0].details["reason"] == "high-risk calls: runpy.run_path"
+
+
 def test_scan_zip_preserves_safe_runpy_overwrite_before_conditional(tmp_path: Path) -> None:
     archive_path = tmp_path / "model_bundle.zip"
     source = "import runpy\nrunpy.run_path = len\nif replace:\n    runpy.run_path = str\nrunpy.run_path([])\n"

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -711,6 +711,19 @@ def test_scan_zip_clears_imported_static_members_after_alias_rebind(tmp_path: Pa
     )
 
 
+def test_scan_zip_preserves_safe_module_member_overwrite_after_reimport(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    source = "import runpy as rp\nrp.run_path = len\nimport runpy as rp\nrp.run_path([])\n"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", source)
+
+    result = ZipScanner().scan(str(archive_path))
+
+    assert not any(
+        check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED for check in result.checks
+    )
+
+
 def test_scan_zip_preserves_safe_runpy_overwrite_before_conditional(tmp_path: Path) -> None:
     archive_path = tmp_path / "model_bundle.zip"
     source = "import runpy\nrunpy.run_path = len\nif replace:\n    runpy.run_path = str\nrunpy.run_path([])\n"

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -700,7 +700,7 @@ def test_scan_zip_preserves_runpy_execution_after_import_rebinds_module(tmp_path
 
 def test_scan_zip_clears_imported_static_members_after_alias_rebind(tmp_path: Path) -> None:
     archive_path = tmp_path / "model_bundle.zip"
-    source = "import runpy as rp\nrp = object()\nrp.run_path('safe.py')\n"
+    source = "class Safe:\n    run_path = len\nimport runpy as rp\nrp = Safe()\nrp.run_path([])\n"
     with zipfile.ZipFile(archive_path, "w") as archive:
         archive.writestr("handler.py", source)
 

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -711,6 +711,19 @@ def test_scan_zip_clears_imported_static_members_after_alias_rebind(tmp_path: Pa
     )
 
 
+def test_scan_zip_preserves_safe_member_overwrite_after_reimport(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model_bundle.zip"
+    source = "import runpy as rp\nrp.run_path = len\nimport runpy as rp\nrp.run_path([])\n"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("handler.py", source)
+
+    result = ZipScanner().scan(str(archive_path))
+
+    assert not any(
+        check.name == "Python Archive Member Security" and check.status == CheckStatus.FAILED for check in result.checks
+    )
+
+
 def test_scan_zip_preserves_safe_runpy_overwrite_before_conditional(tmp_path: Path) -> None:
     archive_path = tmp_path / "model_bundle.zip"
     source = "import runpy\nrunpy.run_path = len\nif replace:\n    runpy.run_path = str\nrunpy.run_path([])\n"


### PR DESCRIPTION
## Summary

- scans the same embedded Python tail windows that trigger framed-source detection
- prioritizes high-risk embedded snippets such as `runpy` even when they appear after the default snippet cap
- preserves safe `runpy` overwrites across conditional branch scope merges
- maps runpy/dynamic-module findings to S108 before generic embedded JIT text rules

## Validation

- `uv run --active --no-sync ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run --active --no-sync ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run --active --no-sync mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run --active --no-sync pytest tests/detectors/test_jit_script_detector.py::TestJITScriptDetector::test_scan_model_detects_tail_window_runpy_execution tests/detectors/test_jit_script_detector.py::TestJITScriptDetector::test_scan_model_detects_late_priority_runpy_snippet_after_harmless_imports tests/scanners/test_rule_mapper.py::test_embedded_code_rule_maps_dynamic_module_execution_before_executable_text tests/scanners/test_zip_scanner.py::test_scan_zip_preserves_safe_runpy_overwrite_before_conditional tests/scanners/test_zip_scanner.py::test_scan_zip_preserves_possible_runpy_execution_after_conditional_overwrite -q`
