### PR TITLE
fix: fail closed on partial cloud metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - redact compound credential names and malformed userinfo URLs in scanner evidence
 - restrict JFrog credential forwarding to explicitly trusted HTTPS hosts
 - block weight distribution `torch.load` on PyTorch prerelease and unknown versions before deserialization
+- fail closed when cloud directory metadata cannot be read for every listed object
 - treat prereleases of fixed Keras ZIP CVE-2026-1669 versions as vulnerable
 - detect external references in weights-only Keras HDF5 layouts without Keras metadata
 - restrict JFrog credential forwarding to explicitly trusted HTTPS hosts

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -96,6 +96,15 @@ def _bound_cloud_metadata_error_display(message: str) -> str:
     return f"{message[: _MAX_CLOUD_METADATA_ERROR_DISPLAY_CHARS - 3]}..."
 
 
+def _cloud_metadata_error_sample(path: object, error: object) -> dict[str, str]:
+    """Return a bounded, credential-safe metadata failure sample."""
+    path_text = str(path)
+    return {
+        "path": _bound_cloud_metadata_error_display(redact_cloud_error_for_display(path_text, path_text)),
+        "error": _bound_cloud_metadata_error_display(redact_cloud_error_for_display(error, path_text)),
+    }
+
+
 def _cloud_error_sanitizer(source_url: str) -> Callable[[Exception], str]:
     def sanitize(exc: Exception) -> str:
         return redact_cloud_error_for_display(exc, source_url)
@@ -353,7 +362,10 @@ async def analyze_cloud_target(url: str) -> dict[str, Any]:
         for item in fs.glob(glob_pattern):
             try:
                 item_info = fs.info(item)
-                if item_info.get("type") == "file" or "size" in item_info:
+                item_type = item_info.get("type")
+                if item_type == "directory":
+                    continue
+                if item_type == "file" or "size" in item_info:
                     size = item_info.get("size", 0)
                     file_metadata = {
                         "path": item,
@@ -366,15 +378,12 @@ async def analyze_cloud_target(url: str) -> dict[str, Any]:
                         file_metadata["etag"] = etag
                     files.append(file_metadata)
                     total_size += size
+                else:
+                    raise ValueError("cloud provider returned incomplete metadata for listed object")
             except Exception as exc:
                 metadata_error_count += 1
                 if len(metadata_errors) < _MAX_CLOUD_METADATA_ERROR_SAMPLES:
-                    metadata_errors.append(
-                        {
-                            "path": _bound_cloud_metadata_error_display(redact_url_for_display(item)),
-                            "error": _bound_cloud_metadata_error_display(redact_cloud_error_for_display(exc, item)),
-                        }
-                    )
+                    metadata_errors.append(_cloud_metadata_error_sample(item, exc))
 
         if metadata_error_count:
             sample_errors = "; ".join(f"{entry['path']}: {entry['error']}" for entry in metadata_errors)

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -335,6 +335,7 @@ async def analyze_cloud_target(url: str) -> dict[str, Any]:
         # It's a directory, list contents
         files = []
         total_size = 0
+        metadata_errors: list[dict[str, str]] = []
 
         # List all files recursively
         # Ensure URL ends with / for proper globbing
@@ -355,8 +356,29 @@ async def analyze_cloud_target(url: str) -> dict[str, Any]:
                         file_metadata["etag"] = etag
                     files.append(file_metadata)
                     total_size += size
-            except Exception:
-                continue
+            except Exception as exc:
+                metadata_errors.append(
+                    {
+                        "path": redact_url_for_display(item),
+                        "error": redact_cloud_error_for_display(exc, item),
+                    }
+                )
+
+        if metadata_errors:
+            sample_errors = "; ".join(f"{entry['path']}: {entry['error']}" for entry in metadata_errors[:3])
+            if len(metadata_errors) > 3:
+                sample_errors = f"{sample_errors}; ..."
+            return {
+                "type": "unknown",
+                "analysis_incomplete": True,
+                "metadata_error_count": len(metadata_errors),
+                "metadata_errors": metadata_errors,
+                "error": (
+                    "Cloud directory analysis incomplete: metadata lookup failed for "
+                    f"{len(metadata_errors)} object(s) under {redact_url_for_display(url)}: "
+                    f"{sample_errors}"
+                ),
+            }
 
         directory_metadata: dict[str, Any] = {
             "type": "directory",

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -32,6 +32,8 @@ _SENSITIVE_QUERY_PARAM_RE = re.compile(
     re.IGNORECASE,
 )
 _URL_USERINFO_RE = re.compile(r"([a-z][a-z0-9+.-]*://)([^/@\s]+)@", re.IGNORECASE)
+_MAX_CLOUD_METADATA_ERROR_SAMPLES = 3
+_MAX_CLOUD_METADATA_ERROR_DISPLAY_CHARS = 512
 
 
 def _run_coroutine_sync(coro_factory: Callable[[], Coroutine[Any, Any, _T]]) -> _T:
@@ -85,6 +87,13 @@ def redact_cloud_error_for_display(message: object, source_url: str | None = Non
         redacted = redacted.replace(source_url, redact_url_for_display(source_url))
     redacted = _URL_USERINFO_RE.sub(r"\1<credentials-redacted>@", redacted)
     return _SENSITIVE_QUERY_PARAM_RE.sub(r"\1<redacted>", redacted)
+
+
+def _bound_cloud_metadata_error_display(message: str) -> str:
+    """Limit model-controlled cloud metadata diagnostics retained in memory."""
+    if len(message) <= _MAX_CLOUD_METADATA_ERROR_DISPLAY_CHARS:
+        return message
+    return f"{message[: _MAX_CLOUD_METADATA_ERROR_DISPLAY_CHARS - 3]}..."
 
 
 def _cloud_error_sanitizer(source_url: str) -> Callable[[Exception], str]:
@@ -335,6 +344,7 @@ async def analyze_cloud_target(url: str) -> dict[str, Any]:
         # It's a directory, list contents
         files = []
         total_size = 0
+        metadata_error_count = 0
         metadata_errors: list[dict[str, str]] = []
 
         # List all files recursively
@@ -357,25 +367,27 @@ async def analyze_cloud_target(url: str) -> dict[str, Any]:
                     files.append(file_metadata)
                     total_size += size
             except Exception as exc:
-                metadata_errors.append(
-                    {
-                        "path": redact_url_for_display(item),
-                        "error": redact_cloud_error_for_display(exc, item),
-                    }
-                )
+                metadata_error_count += 1
+                if len(metadata_errors) < _MAX_CLOUD_METADATA_ERROR_SAMPLES:
+                    metadata_errors.append(
+                        {
+                            "path": _bound_cloud_metadata_error_display(redact_url_for_display(item)),
+                            "error": _bound_cloud_metadata_error_display(redact_cloud_error_for_display(exc, item)),
+                        }
+                    )
 
-        if metadata_errors:
-            sample_errors = "; ".join(f"{entry['path']}: {entry['error']}" for entry in metadata_errors[:3])
-            if len(metadata_errors) > 3:
+        if metadata_error_count:
+            sample_errors = "; ".join(f"{entry['path']}: {entry['error']}" for entry in metadata_errors)
+            if metadata_error_count > len(metadata_errors):
                 sample_errors = f"{sample_errors}; ..."
             return {
                 "type": "unknown",
                 "analysis_incomplete": True,
-                "metadata_error_count": len(metadata_errors),
+                "metadata_error_count": metadata_error_count,
                 "metadata_errors": metadata_errors,
                 "error": (
                     "Cloud directory analysis incomplete: metadata lookup failed for "
-                    f"{len(metadata_errors)} object(s) under {redact_url_for_display(url)}: "
+                    f"{metadata_error_count} object(s) under {redact_url_for_display(url)}: "
                     f"{sample_errors}"
                 ),
             }

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -168,6 +168,35 @@ def test_analyze_cloud_target_directory_success(mock_fs: MagicMock) -> None:
 
 
 @patch("fsspec.filesystem")
+def test_analyze_cloud_target_directory_ignores_explicit_directory_metadata(
+    mock_fs: MagicMock,
+) -> None:
+    url = "s3://bucket/path/"
+    directory_url = "s3://bucket/path/nested/"
+    model_url = "s3://bucket/path/nested/model.bin"
+    fs = make_fs_mock()
+
+    def info_side_effect(path: str) -> dict[str, object]:
+        if path == url:
+            return {"type": "directory", "name": "bucket/path/"}
+        if path == directory_url:
+            return {"type": "directory", "size": 0}
+        if path == model_url:
+            return {"type": "file", "size": 2048}
+        raise FileNotFoundError(path)
+
+    fs.info.side_effect = info_side_effect
+    fs.glob.return_value = [directory_url, model_url]
+    mock_fs.return_value = fs
+
+    result = asyncio.run(analyze_cloud_target(url))
+
+    assert result["type"] == "directory"
+    assert result["file_count"] == 1
+    assert result["files"][0]["path"] == model_url
+
+
+@patch("fsspec.filesystem")
 def test_analyze_cloud_target_directory_fails_on_partial_metadata_error(
     mock_fs: MagicMock,
 ) -> None:
@@ -187,6 +216,52 @@ def test_analyze_cloud_target_directory_fails_on_partial_metadata_error(
     assert "X-Amz-Signature" not in serialized
     assert "secret" not in serialized
     assert hidden_url not in serialized
+
+
+@patch("fsspec.filesystem")
+def test_analyze_cloud_target_directory_fails_on_incomplete_listed_object_metadata(
+    mock_fs: MagicMock,
+) -> None:
+    url = "s3://bucket/path/"
+    hidden_path = "bucket/path/hidden.pkl"
+    fs = make_fs_mock()
+    fs.info.side_effect = lambda path: {"type": "directory"} if path == url else {}
+    fs.glob.return_value = [hidden_path]
+    mock_fs.return_value = fs
+
+    result = asyncio.run(analyze_cloud_target(url))
+
+    assert result["type"] == "unknown"
+    assert result["analysis_incomplete"] is True
+    assert result["metadata_error_count"] == 1
+    assert result["metadata_errors"][0]["path"] == hidden_path
+    assert "incomplete metadata" in result["metadata_errors"][0]["error"]
+
+
+@patch("fsspec.filesystem")
+def test_analyze_cloud_target_redacts_protocol_stripped_metadata_error_path(
+    mock_fs: MagicMock,
+) -> None:
+    url = "s3://bucket/path/"
+    hidden_path = "bucket/path/hidden.pkl?X-Amz-Signature=secret"
+    fs = make_fs_mock()
+
+    def info_side_effect(path: str) -> dict[str, object]:
+        if path == url:
+            return {"type": "directory"}
+        raise PermissionError(f"metadata denied for {path}")
+
+    fs.info.side_effect = info_side_effect
+    fs.glob.return_value = [hidden_path]
+    mock_fs.return_value = fs
+
+    result = asyncio.run(analyze_cloud_target(url))
+    serialized = json.dumps(result)
+
+    assert result["type"] == "unknown"
+    assert result["analysis_incomplete"] is True
+    assert result["metadata_errors"][0]["path"].endswith("X-Amz-Signature=<redacted>")
+    assert "secret" not in serialized
 
 
 @patch("fsspec.filesystem")

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -189,6 +189,37 @@ def test_analyze_cloud_target_directory_fails_on_partial_metadata_error(
     assert hidden_url not in serialized
 
 
+@patch("fsspec.filesystem")
+def test_analyze_cloud_target_bounds_partial_metadata_error_details(
+    mock_fs: MagicMock,
+) -> None:
+    url = "s3://bucket/path/"
+    failed_urls = [f"s3://bucket/path/evil-{index}.pkl?X-Amz-Signature=secret-{index}" for index in range(5)]
+    fs = make_fs_mock()
+
+    def info_side_effect(path: str) -> dict[str, object]:
+        if path == url:
+            return {"type": "directory", "name": "bucket/path/"}
+        raise PermissionError(f"metadata denied for {path}: {'x' * 1024}")
+
+    fs.info.side_effect = info_side_effect
+    fs.glob.return_value = failed_urls
+    mock_fs.return_value = fs
+
+    result = asyncio.run(analyze_cloud_target(url))
+    serialized = json.dumps(result)
+
+    assert result["type"] == "unknown"
+    assert result["analysis_incomplete"] is True
+    assert result["metadata_error_count"] == 5
+    assert len(result["metadata_errors"]) == 3
+    assert all(len(entry["error"]) <= 512 for entry in result["metadata_errors"])
+    assert result["error"].endswith("; ...")
+    assert "evil-4.pkl" not in serialized
+    assert "X-Amz-Signature" not in serialized
+    assert "secret-" not in serialized
+
+
 def test_filter_scannable_files_handles_signed_cloud_urls() -> None:
     files = [{"path": "s3://bucket/model.pkl?X-Amz-Signature=secret"}]
 

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -35,6 +35,24 @@ def make_fs_mock() -> MagicMock:
     return fs
 
 
+def configure_partial_metadata_failure(fs: MagicMock, url: str) -> tuple[str, str]:
+    model_url = f"{url.rstrip('/')}/model.bin"
+    hidden_url = f"{url.rstrip('/')}/evil.pkl?X-Amz-Signature=secret"
+
+    def info_side_effect(path: str) -> dict[str, object]:
+        if path == url:
+            return {"type": "directory", "name": "bucket/path/"}
+        if path == model_url:
+            return {"type": "file", "size": 2048}
+        if path == hidden_url:
+            raise PermissionError(f"metadata denied for {hidden_url}")
+        raise FileNotFoundError(path)
+
+    fs.info.side_effect = info_side_effect
+    fs.glob.return_value = [model_url, hidden_url]
+    return model_url, hidden_url
+
+
 def test_run_coroutine_sync_without_running_loop() -> None:
     """_run_coroutine_sync should use asyncio.run() when no loop is active."""
 
@@ -149,10 +167,69 @@ def test_analyze_cloud_target_directory_success(mock_fs: MagicMock) -> None:
     fs.glob.assert_called_once_with("s3://bucket/path/**")
 
 
+@patch("fsspec.filesystem")
+def test_analyze_cloud_target_directory_fails_on_partial_metadata_error(
+    mock_fs: MagicMock,
+) -> None:
+    url = "s3://bucket/path/"
+    fs = make_fs_mock()
+    _model_url, hidden_url = configure_partial_metadata_failure(fs, url)
+    mock_fs.return_value = fs
+
+    result = asyncio.run(analyze_cloud_target(url))
+    serialized = json.dumps(result)
+
+    assert result["type"] == "unknown"
+    assert result["analysis_incomplete"] is True
+    assert result["metadata_error_count"] == 1
+    assert "metadata lookup failed for 1 object" in result["error"]
+    assert "evil.pkl" in result["error"]
+    assert "X-Amz-Signature" not in serialized
+    assert "secret" not in serialized
+    assert hidden_url not in serialized
+
+
 def test_filter_scannable_files_handles_signed_cloud_urls() -> None:
     files = [{"path": "s3://bucket/model.pkl?X-Amz-Signature=secret"}]
 
     assert filter_scannable_files(files) == files
+
+
+@patch("fsspec.filesystem")
+def test_download_from_cloud_fails_closed_on_partial_directory_metadata_error(
+    mock_fs_class: MagicMock,
+    tmp_path: Path,
+) -> None:
+    url = "s3://bucket/path/"
+    fs = make_fs_mock()
+    configure_partial_metadata_failure(fs, url)
+    mock_fs_class.return_value = fs
+
+    with pytest.raises(ValueError, match="Cloud directory analysis incomplete"):
+        download_from_cloud(
+            url,
+            cache_dir=tmp_path,
+            use_cache=False,
+            selective=False,
+            show_progress=False,
+        )
+
+    fs.get.assert_not_called()
+
+
+@patch("fsspec.filesystem")
+def test_download_from_cloud_streaming_fails_closed_on_partial_directory_metadata_error(
+    mock_fs_class: MagicMock,
+) -> None:
+    url = "s3://bucket/path/"
+    fs = make_fs_mock()
+    configure_partial_metadata_failure(fs, url)
+    mock_fs_class.return_value = fs
+
+    with pytest.raises(ValueError, match="Cloud directory analysis incomplete"):
+        list(download_from_cloud_streaming(url, selective=False, show_progress=False))
+
+    fs.get.assert_not_called()
 
 
 @patch("fsspec.filesystem")


### PR DESCRIPTION
## Summary

Fixes `MA-DSS-C002`: cloud directory analysis no longer silently omits objects whose per-entry metadata lookup fails.

- records per-object metadata lookup failures during cloud directory inventory
- fails closed with an explicit incomplete/error result before normal or streaming downloads call `fs.get`
- redacts signed URL query material from the new error details
- adds malicious-positive regressions for analysis, normal download, and streaming download
- keeps existing benign directory enumeration/path-safety coverage green

## False-positive / false-negative audit

- False negative addressed: a listed malicious object with failing `fs.info()` can no longer be dropped while the remaining directory subset scans cleanly.
- False positive guard: normal directory metadata success still returns the same file inventory, and existing traversal rejection tests still pass.
- Scope note: this intentionally treats any listed-object metadata failure as incomplete coverage. That may fail closed for transient provider metadata errors, but avoids representing partial remote coverage as clean.

## Validation

- `PYTHONPATH=/private/tmp/modelaudit-c002 PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/utils/sources/test_cloud_storage.py::test_analyze_cloud_target_directory_success tests/utils/sources/test_cloud_storage.py::test_analyze_cloud_target_directory_fails_on_partial_metadata_error tests/utils/sources/test_cloud_storage.py::test_download_from_cloud_fails_closed_on_partial_directory_metadata_error tests/utils/sources/test_cloud_storage.py::test_download_from_cloud_streaming_fails_closed_on_partial_directory_metadata_error tests/utils/sources/test_cloud_storage.py::TestCloudPathSecurity::test_download_rejects_path_traversal tests/utils/sources/test_cloud_storage.py::TestCloudPathSecurity::test_streaming_download_rejects_path_traversal -q`
- `PYTHONPATH=/private/tmp/modelaudit-c002 PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/utils/sources/test_cloud_storage.py -q`
- `/Users/mdangelo/code/modelaudit/.venv/bin/ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `/Users/mdangelo/code/modelaudit/.venv/bin/ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `/Users/mdangelo/code/modelaudit/.venv/bin/mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PYTHONPATH=/private/tmp/modelaudit-c002:/private/tmp/modelaudit-c002/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest -n auto -m "not slow and not integration" --maxfail=1`

Full pytest result: `7713 passed, 16 skipped, 21 warnings`.
