### PR TITLE
fix: avoid ambient TensorFlow proto imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - redact secret-shaped dictionary keys from embedded-secret detector finding contexts
 - redact compound credential names and malformed userinfo URLs in scanner evidence
 - restrict JFrog credential forwarding to explicitly trusted HTTPS hosts
+- avoid importing attacker-shadowed TensorFlow protobuf packages during static scanning
 - inspect every parsed GGUF chat template when duplicate or trailing malformed metadata could otherwise hide SSTI payloads
 - bound GGUF declared metadata and tensor collections, and cap reported tensor summaries, so oversized structures fail closed without exhausting scanner resources
 - redact secret-shaped dictionary keys from embedded-secret detector finding contexts

--- a/modelaudit/protos/__init__.py
+++ b/modelaudit/protos/__init__.py
@@ -67,13 +67,33 @@ def _trusted_tensorflow_roots() -> list[Path]:
     return roots
 
 
-def _module_is_under_root(module: types.ModuleType, root: Path) -> bool:
-    module_file = getattr(module, "__file__", None)
-    if module_file and _path_is_relative_to(Path(module_file).resolve(), root):
-        return True
+def _trusted_import_roots() -> list[Path]:
+    roots = _trusted_tensorflow_roots()
+    seen = set(roots)
+    for key in ("stdlib", "platstdlib"):
+        path_value = sysconfig.get_paths().get(key)
+        if path_value:
+            root = Path(path_value).resolve()
+            if root not in seen:
+                roots.append(root)
+                seen.add(root)
+    return roots
 
-    module_paths = getattr(module, "__path__", ())
-    return any(_path_is_relative_to(Path(module_path).resolve(), root) for module_path in module_paths)
+
+def _safe_import_paths(*preferred_roots: Path) -> list[str]:
+    roots = [*preferred_roots, *_trusted_import_roots()]
+    return list(dict.fromkeys(str(root) for root in roots))
+
+
+def _module_is_under_root(module: types.ModuleType, root: Path) -> bool:
+    with suppress(OSError, RuntimeError, TypeError, ValueError):
+        module_file = getattr(module, "__file__", None)
+        if module_file and _path_is_relative_to(Path(module_file).resolve(), root):
+            return True
+
+        module_paths = getattr(module, "__path__", ())
+        return any(_path_is_relative_to(Path(module_path).resolve(), root) for module_path in module_paths)
+    return False
 
 
 def _remove_tensorflow_modules_outside(root: Path) -> None:
@@ -110,14 +130,19 @@ def _setup_vendored_protos() -> bool:
     _USING_VENDORED = True
     logger.debug("Using vendored TensorFlow protos")
 
+    original_sys_path = list(sys.path)
     try:
+        sys.path[:] = _safe_import_paths(_PROTOS_PATH)
         from tensorflow.core.framework.graph_pb2 import GraphDef
         from tensorflow.core.protobuf.saved_model_pb2 import SavedModel
 
         return True
-    except ImportError as e:
-        logger.debug("Vendored TensorFlow protos failed to load: %s", e)
+    except Exception:
+        logger.debug("Vendored TensorFlow protos failed to load")
+        _USING_VENDORED = False
         return False
+    finally:
+        sys.path[:] = original_sys_path
 
 
 def _setup_trusted_tensorflow_protos() -> bool:
@@ -131,15 +156,15 @@ def _setup_trusted_tensorflow_protos() -> bool:
     original_sys_path = list(sys.path)
     _remove_tensorflow_modules_outside(trusted_root)
     try:
-        sys.path[:] = [str(trusted_root), *[entry for entry in sys.path if entry != str(trusted_root)]]
+        sys.path[:] = _safe_import_paths(trusted_root)
         from tensorflow.core.framework.graph_pb2 import GraphDef
         from tensorflow.core.protobuf.saved_model_pb2 import SavedModel
 
         _USING_VENDORED = False
-        logger.debug("Using TensorFlow protos from trusted installation root %s", trusted_root)
+        logger.debug("Using TensorFlow protos from a trusted installation root")
         return True
-    except ImportError as e:
-        logger.debug("Trusted TensorFlow protobuf import failed: %s", e)
+    except Exception:
+        logger.debug("Trusted TensorFlow protobuf import failed")
         return False
     finally:
         sys.path[:] = original_sys_path

--- a/modelaudit/protos/__init__.py
+++ b/modelaudit/protos/__init__.py
@@ -5,47 +5,110 @@ These are generated from TensorFlow's .proto files to enable SavedModel parsing
 without requiring the full TensorFlow package (and avoiding Keras CVE exposure).
 
 Strategy:
-1. If TensorFlow is installed, use its protos (no sys.path manipulation needed)
-2. If TensorFlow is NOT installed, fall back to vendored protos via sys.path
+1. Use native TensorFlow protos only from trusted installation roots.
+2. Otherwise, prefer vendored protobuf stubs for scanner-owned parsing.
+3. Never probe ambient `tensorflow` from CWD/PYTHONPATH shadow roots.
 
-This avoids conflicts when TensorFlow is present.
+This avoids executing attacker-shadowed TensorFlow packages from CWD/PYTHONPATH
+during static model scanning.
 """
 
 from __future__ import annotations
 
+import importlib.machinery
 import logging
+import site
 import sys
+import sysconfig
 import types
+from contextlib import suppress
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 _PROTOS_DIR = str(Path(__file__).parent)
+_PROTOS_PATH = Path(_PROTOS_DIR).resolve()
 _PROTOS_AVAILABLE: bool | None = None
 _USING_VENDORED = False
 
 
-def _check_tensorflow_protos() -> bool:
-    """Check if TensorFlow's protos are available (TensorFlow is installed)."""
-    try:
-        # Try importing from TensorFlow directly (without sys.path manipulation)
-        from tensorflow.core.framework.graph_pb2 import GraphDef
-        from tensorflow.core.protobuf.saved_model_pb2 import SavedModel
-
+def _path_is_relative_to(path: Path, root: Path) -> bool:
+    with suppress(ValueError):
+        path.relative_to(root)
         return True
-    except ImportError:
-        return False
+    return False
+
+
+def _trusted_tensorflow_roots() -> list[Path]:
+    roots: list[Path] = []
+    seen: set[Path] = set()
+
+    for key in ("purelib", "platlib"):
+        path_value = sysconfig.get_paths().get(key)
+        if path_value:
+            root = Path(path_value).resolve()
+            if root not in seen:
+                roots.append(root)
+                seen.add(root)
+
+    with suppress(Exception):
+        for site_path in site.getsitepackages():
+            root = Path(site_path).resolve()
+            if root not in seen:
+                roots.append(root)
+                seen.add(root)
+    with suppress(Exception):
+        user_site = site.getusersitepackages()
+        root = Path(user_site).resolve()
+        if root not in seen:
+            roots.append(root)
+            seen.add(root)
+
+    return roots
+
+
+def _module_is_under_root(module: types.ModuleType, root: Path) -> bool:
+    module_file = getattr(module, "__file__", None)
+    if module_file and _path_is_relative_to(Path(module_file).resolve(), root):
+        return True
+
+    module_paths = getattr(module, "__path__", ())
+    return any(_path_is_relative_to(Path(module_path).resolve(), root) for module_path in module_paths)
+
+
+def _remove_tensorflow_modules_outside(root: Path) -> None:
+    for module_name, module in list(sys.modules.items()):
+        if module_name != "tensorflow" and not module_name.startswith("tensorflow."):
+            continue
+        if not isinstance(module, types.ModuleType) or not _module_is_under_root(module, root):
+            sys.modules.pop(module_name, None)
+
+
+def _trusted_tensorflow_root() -> Path | None:
+    for root in _trusted_tensorflow_roots():
+        spec = importlib.machinery.PathFinder.find_spec("tensorflow", [str(root)])
+        if spec is None or spec.origin is None:
+            continue
+        if _path_is_relative_to(Path(spec.origin).resolve(), root):
+            return root
+    return None
+
+
+def _ensure_vendored_protos_first() -> None:
+    """Place vendored TensorFlow protobuf stubs before ambient import roots."""
+    with suppress(ValueError):
+        sys.path.remove(_PROTOS_DIR)
+    sys.path.insert(0, _PROTOS_DIR)
 
 
 def _setup_vendored_protos() -> bool:
-    """Set up vendored protos by adding to sys.path. Only call if TensorFlow not installed."""
+    """Set up vendored protos by adding them ahead of ambient sys.path roots."""
     global _USING_VENDORED
 
-    if _PROTOS_DIR not in sys.path:
-        # Add vendored protos to sys.path (only when TensorFlow isn't installed)
-        sys.path.insert(0, _PROTOS_DIR)
-        _USING_VENDORED = True
-        logger.debug("Using vendored TensorFlow protos (TensorFlow not installed)")
+    _remove_tensorflow_modules_outside(_PROTOS_PATH)
+    _ensure_vendored_protos_first()
+    _USING_VENDORED = True
+    logger.debug("Using vendored TensorFlow protos")
 
     try:
         from tensorflow.core.framework.graph_pb2 import GraphDef
@@ -57,20 +120,39 @@ def _setup_vendored_protos() -> bool:
         return False
 
 
+def _setup_trusted_tensorflow_protos() -> bool:
+    """Import TensorFlow protobuf stubs only from trusted installation roots."""
+    global _USING_VENDORED
+
+    trusted_root = _trusted_tensorflow_root()
+    if trusted_root is None:
+        return False
+
+    original_sys_path = list(sys.path)
+    _remove_tensorflow_modules_outside(trusted_root)
+    try:
+        sys.path[:] = [str(trusted_root), *[entry for entry in sys.path if entry != str(trusted_root)]]
+        from tensorflow.core.framework.graph_pb2 import GraphDef
+        from tensorflow.core.protobuf.saved_model_pb2 import SavedModel
+
+        _USING_VENDORED = False
+        logger.debug("Using TensorFlow protos from trusted installation root %s", trusted_root)
+        return True
+    except ImportError as e:
+        logger.debug("Trusted TensorFlow protobuf import failed: %s", e)
+        return False
+    finally:
+        sys.path[:] = original_sys_path
+
+
 def _check_vendored_protos() -> bool:
-    """Check if protos are available (either from TensorFlow or vendored)."""
+    """Check if safe TensorFlow protobuf stubs are available."""
     global _PROTOS_AVAILABLE
 
     if _PROTOS_AVAILABLE is not None:
         return _PROTOS_AVAILABLE
 
-    # Strategy: prefer TensorFlow's protos, fall back to vendored
-    if _check_tensorflow_protos():
-        _PROTOS_AVAILABLE = True
-        logger.debug("Using TensorFlow's native protos")
-    else:
-        _PROTOS_AVAILABLE = _setup_vendored_protos()
-
+    _PROTOS_AVAILABLE = _setup_trusted_tensorflow_protos() or _setup_vendored_protos()
     return _PROTOS_AVAILABLE
 
 
@@ -115,11 +197,11 @@ def get_graph_pb2() -> types.ModuleType:
 
 
 def is_using_vendored_protos() -> bool:
-    """Return True if using vendored protos, False if using TensorFlow's native protos."""
+    """Return True when vendored protos are active."""
     _check_vendored_protos()  # Ensure initialization
     return _USING_VENDORED
 
 
-# Initialize on import - sets up sys.path if TensorFlow not installed
-# This ensures that subsequent `from tensorflow.core...` imports work
+# Initialize on import so subsequent `from tensorflow.core...` imports resolve
+# to scanner-owned vendored stubs before ambient packages.
 _check_vendored_protos()

--- a/modelaudit/protos/__init__.py
+++ b/modelaudit/protos/__init__.py
@@ -57,12 +57,13 @@ def _trusted_tensorflow_roots() -> list[Path]:
             if root not in seen:
                 roots.append(root)
                 seen.add(root)
-    with suppress(Exception):
-        user_site = site.getusersitepackages()
-        root = Path(user_site).resolve()
-        if root not in seen:
-            roots.append(root)
-            seen.add(root)
+    if site.ENABLE_USER_SITE is True:
+        with suppress(Exception):
+            user_site = site.getusersitepackages()
+            root = Path(user_site).resolve()
+            if root not in seen:
+                roots.append(root)
+                seen.add(root)
 
     return roots
 

--- a/modelaudit/utils/tensorflow_compat.py
+++ b/modelaudit/utils/tensorflow_compat.py
@@ -275,8 +275,7 @@ def get_protobuf_classes() -> tuple[Any, Any]:
     """
     Get SavedModel and GraphDef protobuf classes.
 
-    Uses modelaudit.protos to initialize proto loading (TF-native first, vendored fallback),
-    then imports via tensorflow.core.* which resolves to whichever source is available.
+    Uses modelaudit.protos to initialize safe TensorFlow protobuf loading.
 
     Returns:
         Tuple of (SavedModel, GraphDef) classes
@@ -291,14 +290,13 @@ def get_protobuf_classes() -> tuple[Any, Any]:
             "Reinstall modelaudit or install TensorFlow with: pip install modelaudit[tensorflow]"
         )
 
-    from tensorflow.core.framework.graph_pb2 import GraphDef
-    from tensorflow.core.protobuf.saved_model_pb2 import SavedModel
+    import modelaudit.protos
 
-    return SavedModel, GraphDef
+    return modelaudit.protos.get_saved_model_class(), modelaudit.protos.get_graph_def_class()
 
 
 def has_tensorflow_protobuf_stubs() -> bool:
-    """Return True when TensorFlow protobuf stubs are available from native or vendored protos."""
+    """Return True when safe TensorFlow protobuf stubs are available."""
     global _HAS_PROTOBUF_STUBS
 
     if _HAS_PROTOBUF_STUBS is None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -243,6 +243,40 @@ print(json.dumps({
         assert tensorflow_file.is_relative_to(project_root / "modelaudit" / "protos")
 
 
+@pytest.mark.parametrize(
+    ("enable_user_site", "expected_trusted"),
+    [
+        pytest.param(False, False, id="disabled"),
+        pytest.param(None, False, id="security-disabled"),
+        pytest.param(True, True, id="enabled"),
+    ],
+)
+def test_tensorflow_trusted_root_honors_user_site_enablement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    enable_user_site: bool | None,
+    expected_trusted: bool,
+) -> None:
+    import modelaudit.protos
+
+    user_site = tmp_path / "user-site"
+    shadow_tensorflow = user_site / "tensorflow"
+    shadow_tensorflow.mkdir(parents=True)
+    (shadow_tensorflow / "__init__.py").write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(modelaudit.protos.sysconfig, "get_paths", lambda: {})
+    monkeypatch.setattr(modelaudit.protos.site, "getsitepackages", lambda: [])
+    monkeypatch.setattr(modelaudit.protos.site, "getusersitepackages", lambda: str(user_site))
+    monkeypatch.setattr(modelaudit.protos.site, "ENABLE_USER_SITE", enable_user_site)
+
+    trusted_root = modelaudit.protos._trusted_tensorflow_root()
+
+    if expected_trusted:
+        assert trusted_root == user_site.resolve()
+    else:
+        assert trusted_root is None
+
+
 def _build_malicious_tf_metagraph() -> bytes:
     _require_tf_protos()
     import modelaudit.protos  # noqa: F401

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -172,14 +172,27 @@ def _require_tf_protos() -> None:
 def test_tensorflow_protobuf_bootstrap_avoids_shadow_package(tmp_path: Path) -> None:
     shadow_root = tmp_path / "shadow"
     shadow_tensorflow = shadow_root / "tensorflow"
+    shadow_google = shadow_root / "google"
     shadow_tensorflow.mkdir(parents=True)
-    sentinel = tmp_path / "shadow_tensorflow_imported.txt"
+    shadow_google.mkdir()
+    tensorflow_sentinel = tmp_path / "shadow_tensorflow_imported.txt"
+    google_sentinel = tmp_path / "shadow_google_imported.txt"
     (shadow_tensorflow / "__init__.py").write_text(
         "\n".join(
             [
                 "import os",
                 "from pathlib import Path",
                 "Path(os.environ['SHADOW_TENSORFLOW_SENTINEL']).write_text('imported', encoding='utf-8')",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (shadow_google / "__init__.py").write_text(
+        "\n".join(
+            [
+                "import os",
+                "from pathlib import Path",
+                "Path(os.environ['SHADOW_GOOGLE_SENTINEL']).write_text('imported', encoding='utf-8')",
             ]
         ),
         encoding="utf-8",
@@ -192,7 +205,8 @@ def test_tensorflow_protobuf_bootstrap_avoids_shadow_package(tmp_path: Path) -> 
     if existing_pythonpath:
         pythonpath_entries.append(existing_pythonpath)
     env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
-    env["SHADOW_TENSORFLOW_SENTINEL"] = str(sentinel)
+    env["SHADOW_TENSORFLOW_SENTINEL"] = str(tensorflow_sentinel)
+    env["SHADOW_GOOGLE_SENTINEL"] = str(google_sentinel)
 
     script = """
 import importlib
@@ -218,7 +232,8 @@ print(json.dumps({
     )
 
     assert result.returncode == 0, result.stderr
-    assert not sentinel.exists()
+    assert not tensorflow_sentinel.exists()
+    assert not google_sentinel.exists()
     payload = json.loads(result.stdout)
     assert payload["available"] is True
     assert payload["saved_model_class"] == "SavedModel"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,6 +9,7 @@ import json
 import os
 import pickle
 import struct
+import subprocess
 import sys
 import zipfile
 from collections.abc import Callable, Iterator
@@ -166,6 +167,65 @@ def _build_malicious_pickle(*, protocol: int | None = None) -> bytes:
 def _require_tf_protos() -> None:
     if not _has_tf_protos():
         pytest.skip("TensorFlow protobuf stubs unavailable")
+
+
+def test_tensorflow_protobuf_bootstrap_avoids_shadow_package(tmp_path: Path) -> None:
+    shadow_root = tmp_path / "shadow"
+    shadow_tensorflow = shadow_root / "tensorflow"
+    shadow_tensorflow.mkdir(parents=True)
+    sentinel = tmp_path / "shadow_tensorflow_imported.txt"
+    (shadow_tensorflow / "__init__.py").write_text(
+        "\n".join(
+            [
+                "import os",
+                "from pathlib import Path",
+                "Path(os.environ['SHADOW_TENSORFLOW_SENTINEL']).write_text('imported', encoding='utf-8')",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    project_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    pythonpath_entries = [str(shadow_root), str(project_root)]
+    existing_pythonpath = env.get("PYTHONPATH")
+    if existing_pythonpath:
+        pythonpath_entries.append(existing_pythonpath)
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+    env["SHADOW_TENSORFLOW_SENTINEL"] = str(sentinel)
+
+    script = """
+import importlib
+import json
+import modelaudit.protos
+
+tensorflow_module = importlib.import_module("tensorflow")
+saved_model_cls = modelaudit.protos.get_saved_model_class()
+print(json.dumps({
+    "available": modelaudit.protos._check_vendored_protos(),
+    "using_vendored": modelaudit.protos.is_using_vendored_protos(),
+    "tensorflow_file": getattr(tensorflow_module, "__file__", ""),
+    "saved_model_class": saved_model_cls.__name__,
+}))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not sentinel.exists()
+    payload = json.loads(result.stdout)
+    assert payload["available"] is True
+    assert payload["saved_model_class"] == "SavedModel"
+    tensorflow_file = Path(payload["tensorflow_file"]).resolve()
+    assert not tensorflow_file.is_relative_to(shadow_root)
+    if payload["using_vendored"]:
+        assert tensorflow_file.is_relative_to(project_root / "modelaudit" / "protos")
 
 
 def _build_malicious_tf_metagraph() -> bytes:


### PR DESCRIPTION
## Summary

Fixes MA-DSS-C077 by preventing TensorFlow protobuf bootstrap from importing attacker-shadowed `tensorflow` packages during static scanning.

- load native TensorFlow protos only from Python-configured trusted installation roots
- fall back to ModelAudit's vendored protobuf stubs ahead of ambient CWD/PYTHONPATH roots
- purge non-trusted/non-vendored `tensorflow.*` modules before safe proto bootstrap
- centralize `get_protobuf_classes()` through `modelaudit.protos`

## False-positive / false-negative audit

- Malicious positive: a subprocess regression puts a shadow `tensorflow` package first on `PYTHONPATH`; importing `modelaudit.protos` must not execute its sentinel.
- Benign compatibility guard: trusted native TensorFlow installs can still provide protobuf stubs, and vendored stubs still backstop environments without TensorFlow.
- Scanner coverage guard: full SavedModel and MetaGraph scanner tests still pass with the safe bootstrap.

## Validation

- `PYTHONPATH=/private/tmp/modelaudit-c077:/private/tmp/modelaudit-c077/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/test_core.py::test_tensorflow_protobuf_bootstrap_avoids_shadow_package -q` -> 1 passed
- `PYTHONPATH=/private/tmp/modelaudit-c077:/private/tmp/modelaudit-c077/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/scanners/test_tf_savedmodel_scanner.py -q` -> 61 passed
- `PYTHONPATH=/private/tmp/modelaudit-c077:/private/tmp/modelaudit-c077/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/scanners/test_tf_metagraph_scanner.py tests/test_metadata_extractor.py::test_has_tensorflow_protobuf_stubs_fails_closed_on_probe_error -q` -> 26 passed
- `/Users/mdangelo/code/modelaudit/.venv/bin/ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> 399 files already formatted
- `/Users/mdangelo/code/modelaudit/.venv/bin/ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> all checks passed
- `/Users/mdangelo/code/modelaudit/.venv/bin/mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> success, 454 source files
- `PYTHONPATH=/private/tmp/modelaudit-c077:/private/tmp/modelaudit-c077/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest -n auto -m "not slow and not integration" --maxfail=1` -> 7711 passed, 16 skipped

Note: one interim full-suite run hit a local timing timeout in `test_concurrent_performance`; the isolated rerun skipped under the test's local-overhead guard, and the final full-suite rerun passed.
