### PR TITLE
fix: enforce cloud download size caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - redact secret-shaped dictionary keys from embedded-secret detector finding contexts
 - redact compound credential names and malformed userinfo URLs in scanner evidence
 - restrict JFrog credential forwarding to explicitly trusted HTTPS hosts
+- enforce automatic cloud download size limits when remote size metadata is missing or late-bound
 - inspect every parsed GGUF chat template when duplicate or trailing malformed metadata could otherwise hide SSTI payloads
 - bound GGUF declared metadata and tensor collections, and cap reported tensor summaries, so oversized structures fail closed without exhausting scanner resources
 - redact secret-shaped dictionary keys from embedded-secret detector finding contexts

--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -530,6 +530,10 @@ def _resolve_scan_runtime_config(
     if max_size is not None:
         with contextlib.suppress(ValueError):
             max_download_bytes = parse_size_string(max_size)
+    else:
+        configured_max_file_size = config_values.get("max_file_size", 0)
+        if isinstance(configured_max_file_size, int) and configured_max_file_size > 0:
+            max_download_bytes = configured_max_file_size
 
     scanner_selection = config_values.get(SCANNER_SELECTION_CONFIG_KEY)
     scanner_policy = policy_from_config(config_values)

--- a/modelaudit/utils/helpers/auto_defaults.py
+++ b/modelaudit/utils/helpers/auto_defaults.py
@@ -24,13 +24,16 @@ def detect_input_type(path: str) -> str:
     """
     # Cloud storage detection
     hostname = _get_hostname(path)
-    if path.startswith(("s3://", "gs://", "az://")) or hostname.endswith(".blob.core.windows.net"):
-        if path.startswith("s3://"):
-            return "cloud_s3"
-        elif path.startswith("gs://"):
-            return "cloud_gcs"
-        else:
-            return "cloud_azure"
+    if (
+        path.startswith(("s3://", "r2://"))
+        or hostname.endswith(".s3.amazonaws.com")
+        or hostname.endswith(".r2.cloudflarestorage.com")
+    ):
+        return "cloud_s3"
+    if path.startswith(("gs://", "gcs://")) or hostname == "storage.googleapis.com":
+        return "cloud_gcs"
+    if path.startswith("az://") or hostname.endswith(".blob.core.windows.net"):
+        return "cloud_azure"
 
     # HuggingFace detection
     if path.startswith(("hf://", "https://huggingface.co/", "https://hf.co/")):

--- a/modelaudit/utils/helpers/retry.py
+++ b/modelaudit/utils/helpers/retry.py
@@ -31,6 +31,7 @@ def exponential_backoff(
     exponential_base: float = 2.0,
     jitter: bool = True,
     retry_on: tuple[type[Exception], ...] | None = None,
+    do_not_retry_on: tuple[type[Exception], ...] | None = None,
     verbose: bool = False,
     sanitize_error: Callable[[Exception], object] | None = None,
 ) -> Callable[..., T]:
@@ -45,6 +46,7 @@ def exponential_backoff(
         exponential_base: Base for exponential backoff calculation
         jitter: Add random jitter to delays to prevent thundering herd
         retry_on: Tuple of exception types to retry on (None = all exceptions)
+        do_not_retry_on: Tuple of exception types that must fail immediately
         verbose: Show retry messages to user
 
     Returns:
@@ -59,6 +61,9 @@ def exponential_backoff(
             try:
                 return func(*args, **kwargs)
             except Exception as e:
+                if do_not_retry_on and isinstance(e, do_not_retry_on):
+                    raise
+
                 # Check if we should retry this exception
                 if retry_on and not isinstance(e, retry_on):
                     raise
@@ -107,6 +112,7 @@ def retry_with_backoff(
     exponential_base: float = 2.0,
     jitter: bool = True,
     retry_on: tuple[type[Exception], ...] | None = None,
+    do_not_retry_on: tuple[type[Exception], ...] | None = None,
     verbose: bool = False,
     sanitize_error: Callable[[Exception], object] | None = None,
 ) -> Callable[[Callable[..., T]], Callable[..., T]]:
@@ -129,6 +135,7 @@ def retry_with_backoff(
             exponential_base=exponential_base,
             jitter=jitter,
             retry_on=retry_on,
+            do_not_retry_on=do_not_retry_on,
             verbose=verbose,
             sanitize_error=sanitize_error,
         )

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -700,7 +700,15 @@ def download_from_cloud(
         return f"stream://{url}"
 
     # Check size limits
-    size = metadata.get("total_size", metadata.get("size", 0))
+    try:
+        size = _parse_size_value(metadata.get("total_size", metadata.get("size", 0)))
+    except (TypeError, ValueError) as exc:
+        if max_size:
+            raise ValueError(
+                "Unable to enforce maximum cloud download size for "
+                f"{redact_url_for_display(url)}: invalid size metadata"
+            ) from exc
+        size = 0
     if max_size and size > max_size:
         raise ValueError(f"File size ({format_size(size)}) exceeds maximum allowed size ({format_size(max_size)})")
 
@@ -750,9 +758,18 @@ def download_from_cloud(
                     )
 
         if object_size is not None:
+            if max_size and object_size > max_size:
+                raise ValueError(
+                    f"File size ({format_size(object_size)}) exceeds maximum allowed size ({format_size(max_size)})"
+                )
             has_space, message = check_disk_space(download_path, object_size)
             if not has_space:
                 raise Exception(f"Cannot download from {redact_url_for_display(url)}: {message}")
+        elif max_size:
+            raise ValueError(
+                "Unable to enforce maximum cloud download size for "
+                f"{redact_url_for_display(url)} because the object size could not be determined"
+            )
 
         # Download based on type
         if metadata["type"] == "directory":

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -641,6 +641,31 @@ def _clear_directory_contents(path: Path) -> None:
             child.unlink()
 
 
+def _selected_cloud_download_size(fs: Any, files: list[dict[str, Any]], max_size: int) -> int:
+    """Return the late-bound size of selected objects, failing closed on unknown sizes."""
+    total_size = 0
+    for file_info in files:
+        file_url = str(file_info["path"])
+        try:
+            file_size = get_cloud_object_size(fs, file_url, strict=True)
+        except ValueError as exc:
+            raise ValueError(
+                "Unable to enforce maximum cloud download size for selected object "
+                f"{redact_url_for_display(file_url)} because its size could not be determined"
+            ) from exc
+        if file_size is None:
+            raise ValueError(
+                "Unable to enforce maximum cloud download size for selected object "
+                f"{redact_url_for_display(file_url)} because its size could not be determined"
+            )
+        total_size += file_size
+        if total_size > max_size:
+            raise ValueError(
+                f"File size ({format_size(total_size)}) exceeds maximum allowed size ({format_size(max_size)})"
+            )
+    return total_size
+
+
 def download_from_cloud(
     url: str,
     cache_dir: Path | None = None,
@@ -703,13 +728,13 @@ def download_from_cloud(
     try:
         size = _parse_size_value(metadata.get("total_size", metadata.get("size", 0)))
     except (TypeError, ValueError) as exc:
-        if max_size:
+        if max_size and not (metadata["type"] == "directory" and selective):
             raise ValueError(
                 "Unable to enforce maximum cloud download size for "
                 f"{redact_url_for_display(url)}: invalid size metadata"
             ) from exc
         size = 0
-    if max_size and size > max_size:
+    if max_size and size > max_size and not (metadata["type"] == "directory" and selective):
         raise ValueError(f"File size ({format_size(size)}) exceeds maximum allowed size ({format_size(max_size)})")
 
     # Show warning for large files
@@ -738,24 +763,55 @@ def download_from_cloud(
         # fsspec filesystems don't need explicit cleanup - use directly without 'with' statement
         fs = fsspec.filesystem(fs_protocol, **fs_args)
 
+        files: list[dict[str, Any]] | None = None
+        if metadata["type"] == "directory":
+            raw_files = metadata.get("files")
+            if raw_files is None:
+                files = []
+            elif isinstance(raw_files, list):
+                files = raw_files
+            else:
+                raise ValueError(f"Invalid metadata for 'files': expected list, got {type(raw_files).__name__}")
+
+            if selective:
+                # Filter to only scannable files before enforcing acquisition budgets.
+                files = filter_scannable_files(files, scannable_extensions=scannable_extensions)
+                if show_progress:
+                    total = metadata.get("file_count", 0)
+                    if files:
+                        click.echo(f"Found {len(files)} scannable files out of {total} total files")
+                    else:
+                        click.echo(f"No scannable files found out of {total} total files")
+
+            if not files:
+                raise ValueError("No scannable model files found in directory")
+
         # Check available disk space before downloading
         object_size: int | None
-        try:
-            object_size = get_cloud_object_size(fs, url, strict=True)
-        except ValueError as exc:
-            # Fall back to metadata-derived size when available. If no reliable size is
-            # available, continue without a pre-download disk check (legacy behavior).
-            if size > 0:
-                object_size = int(size)
-                if show_progress:
-                    click.echo(f"⚠️  Falling back to metadata size estimate for disk check: {exc}")
-            else:
-                object_size = None
-                if show_progress:
-                    click.echo(
-                        "⚠️  Unable to determine download size for "
-                        f"{redact_url_for_display(url)}; continuing without disk check: {exc}"
-                    )
+        if max_size and files is not None:
+            object_size = _selected_cloud_download_size(fs, files, max_size)
+        else:
+            try:
+                object_size = get_cloud_object_size(fs, url, strict=True)
+            except ValueError as exc:
+                if max_size:
+                    raise ValueError(
+                        "Unable to enforce maximum cloud download size for "
+                        f"{redact_url_for_display(url)} because the object size could not be determined"
+                    ) from exc
+                # Fall back to metadata-derived size when available. If no reliable size is
+                # available, continue without a pre-download disk check (legacy behavior).
+                if size > 0:
+                    object_size = int(size)
+                    if show_progress:
+                        click.echo(f"⚠️  Falling back to metadata size estimate for disk check: {exc}")
+                else:
+                    object_size = None
+                    if show_progress:
+                        click.echo(
+                            "⚠️  Unable to determine download size for "
+                            f"{redact_url_for_display(url)}; continuing without disk check: {exc}"
+                        )
 
         if object_size is not None:
             if max_size and object_size > max_size:
@@ -776,27 +832,7 @@ def download_from_cloud(
             if cache:
                 _clear_directory_contents(download_path)
 
-            # Handle directory download
-            raw_files = metadata.get("files")
-            if raw_files is None:
-                files = []
-            elif isinstance(raw_files, list):
-                files = raw_files
-            else:
-                raise ValueError(f"Invalid metadata for 'files': expected list, got {type(raw_files).__name__}")
-
-            if selective:
-                # Filter to only scannable files
-                files = filter_scannable_files(files, scannable_extensions=scannable_extensions)
-                if show_progress:
-                    total = metadata.get("file_count", 0)
-                    if files:
-                        click.echo(f"Found {len(files)} scannable files out of {total} total files")
-                    else:
-                        click.echo(f"No scannable files found out of {total} total files")
-
-            if not files:
-                raise ValueError("No scannable model files found in directory")
+            assert files is not None
 
             # Download files
             for file_info in files:
@@ -891,9 +927,18 @@ def download_from_cloud_streaming(
         error_msg = metadata.get("error", "Unknown cloud target type")
         raise ValueError(f"Failed to analyze cloud target {redact_url_for_display(url)}: {error_msg}")
 
-    # Check size limits
-    size = metadata.get("total_size", metadata.get("size", 0))
-    if max_size and size > max_size:
+    # Check size limits. Selective directory downloads are capped after filtering
+    # so unrelated prefix contents do not reject a bounded acquisition.
+    try:
+        size = _parse_size_value(metadata.get("total_size", metadata.get("size", 0)))
+    except (TypeError, ValueError) as exc:
+        if max_size and not (metadata["type"] == "directory" and selective):
+            raise ValueError(
+                "Unable to enforce maximum cloud download size for "
+                f"{redact_url_for_display(url)}: invalid size metadata"
+            ) from exc
+        size = 0
+    if max_size and size > max_size and not (metadata["type"] == "directory" and selective):
         raise ValueError(f"Total size ({format_size(size)}) exceeds maximum allowed size ({format_size(max_size)})")
 
     # Get filesystem
@@ -921,6 +966,9 @@ def download_from_cloud_streaming(
     else:
         # Single file
         files = [{"path": url, "name": _cloud_url_basename(url), "size": metadata.get("size", 0)}]
+
+    if max_size:
+        _selected_cloud_download_size(fs, files, max_size)
 
     # Create temp directory for downloads
     temp_dir = Path(tempfile.mkdtemp(prefix="modelaudit_stream_"))

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -23,6 +23,7 @@ from ..helpers.disk_space import check_disk_space
 
 logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
+_CLOUD_DOWNLOAD_CHUNK_BYTES = 1024 * 1024
 
 _SENSITIVE_QUERY_PARAM_RE = re.compile(
     (
@@ -666,6 +667,36 @@ def _selected_cloud_download_size(fs: Any, files: list[dict[str, Any]], max_size
     return total_size
 
 
+class _CloudDownloadBudgetExceeded(ValueError):
+    """Raised when a cloud transfer exceeds its bounded acquisition budget."""
+
+
+def _download_cloud_object(fs: Any, file_url: str, local_path: Path, max_bytes: int | None) -> int:
+    """Download one cloud object while enforcing an optional transfer budget."""
+    if max_bytes is None:
+        fs.get(file_url, str(local_path))
+        return 0
+
+    bytes_written = 0
+    try:
+        with fs.open(file_url, "rb") as remote_file, local_path.open("wb") as local_file:
+            while True:
+                chunk = remote_file.read(min(_CLOUD_DOWNLOAD_CHUNK_BYTES, max_bytes - bytes_written + 1))
+                if not chunk:
+                    return bytes_written
+                if not isinstance(chunk, bytes):
+                    raise TypeError("cloud filesystem returned non-bytes content")
+                bytes_written += len(chunk)
+                if bytes_written > max_bytes:
+                    raise _CloudDownloadBudgetExceeded(
+                        f"Cloud download exceeds maximum allowed size ({format_size(max_bytes)})"
+                    )
+                local_file.write(chunk)
+    except Exception:
+        local_path.unlink(missing_ok=True)
+        raise
+
+
 def download_from_cloud(
     url: str,
     cache_dir: Path | None = None,
@@ -835,6 +866,7 @@ def download_from_cloud(
             assert files is not None
 
             # Download files
+            remaining_download_bytes = max_size
             for file_info in files:
                 file_url = file_info["path"]
                 local_path = _build_safe_local_path(url, file_url, download_path)
@@ -845,13 +877,16 @@ def download_from_cloud(
 
                 @retry_with_backoff(
                     max_retries=3,
+                    do_not_retry_on=(_CloudDownloadBudgetExceeded,),
                     verbose=show_progress,
                     sanitize_error=_cloud_error_sanitizer(file_url),
                 )
-                def download_file(url=file_url, path=local_path):
-                    fs.get(url, str(path))
+                def download_file(url=file_url, path=local_path, budget=remaining_download_bytes):
+                    return _download_cloud_object(fs, url, path, budget)
 
-                download_file()
+                downloaded_bytes = download_file()
+                if remaining_download_bytes is not None:
+                    remaining_download_bytes -= downloaded_bytes
         else:
             # Single file download
             file_name = _cloud_url_basename(url)
@@ -859,11 +894,12 @@ def download_from_cloud(
 
             @retry_with_backoff(
                 max_retries=3,
+                do_not_retry_on=(_CloudDownloadBudgetExceeded,),
                 verbose=show_progress,
                 sanitize_error=_cloud_error_sanitizer(url),
             )
             def download_single_file():
-                fs.get(url, str(local_file))
+                return _download_cloud_object(fs, url, local_file, max_size)
 
             if show_progress and size > 100 * 1024 * 1024 * 1024:  # Show progress for files > 100GB
                 with yaspin(text=f"Downloading {file_name}") as spinner:
@@ -976,6 +1012,7 @@ def download_from_cloud_streaming(
     try:
         # Download files one at a time
         total_files = len(files)
+        remaining_download_bytes = max_size
         for i, file_info in enumerate(files):
             file_url = file_info["path"]
             file_name = file_info.get("name") or _cloud_url_basename(file_url)
@@ -990,13 +1027,16 @@ def download_from_cloud_streaming(
 
             @retry_with_backoff(
                 max_retries=3,
+                do_not_retry_on=(_CloudDownloadBudgetExceeded,),
                 verbose=show_progress,
                 sanitize_error=_cloud_error_sanitizer(file_url),
             )
-            def download_file(url=file_url, path=local_path):
-                fs.get(url, str(path))
+            def download_file(url=file_url, path=local_path, budget=remaining_download_bytes):
+                return _download_cloud_object(fs, url, path, budget)
 
-            download_file()
+            downloaded_bytes = download_file()
+            if remaining_download_bytes is not None:
+                remaining_download_bytes -= downloaded_bytes
 
             yield (local_path, is_last)
 

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -714,9 +714,29 @@ class _CloudDownloadBudgetExceeded(ValueError):
     """Raised when a cloud transfer exceeds its bounded acquisition budget."""
 
 
-def _download_cloud_object(fs: Any, file_url: str, local_path: Path, max_bytes: int | None) -> int:
+class _CloudDownloadBudget:
+    """Track a cloud acquisition budget across objects and retry attempts."""
+
+    def __init__(self, max_bytes: int):
+        self.max_bytes = max_bytes
+        self.remaining_bytes = max_bytes
+
+    def read_size(self) -> int:
+        """Return a bounded read size that can detect one byte over budget."""
+        return min(_CLOUD_DOWNLOAD_CHUNK_BYTES, self.remaining_bytes + 1)
+
+    def consume(self, byte_count: int) -> None:
+        """Charge transferred bytes to the shared acquisition budget."""
+        if byte_count > self.remaining_bytes:
+            raise _CloudDownloadBudgetExceeded(
+                f"Cloud download exceeds maximum allowed size ({format_size(self.max_bytes)})"
+            )
+        self.remaining_bytes -= byte_count
+
+
+def _download_cloud_object(fs: Any, file_url: str, local_path: Path, budget: _CloudDownloadBudget | None) -> int:
     """Download one cloud object while enforcing an optional transfer budget."""
-    if max_bytes is None:
+    if budget is None:
         fs.get(file_url, str(local_path))
         return 0
 
@@ -724,16 +744,13 @@ def _download_cloud_object(fs: Any, file_url: str, local_path: Path, max_bytes: 
     try:
         with fs.open(file_url, "rb") as remote_file, local_path.open("wb") as local_file:
             while True:
-                chunk = remote_file.read(min(_CLOUD_DOWNLOAD_CHUNK_BYTES, max_bytes - bytes_written + 1))
+                chunk = remote_file.read(budget.read_size())
                 if not chunk:
                     return bytes_written
                 if not isinstance(chunk, bytes):
                     raise TypeError("cloud filesystem returned non-bytes content")
+                budget.consume(len(chunk))
                 bytes_written += len(chunk)
-                if bytes_written > max_bytes:
-                    raise _CloudDownloadBudgetExceeded(
-                        f"Cloud download exceeds maximum allowed size ({format_size(max_bytes)})"
-                    )
                 local_file.write(chunk)
     except Exception:
         local_path.unlink(missing_ok=True)
@@ -909,7 +926,7 @@ def download_from_cloud(
             assert files is not None
 
             # Download files
-            remaining_download_bytes = max_size
+            download_budget = _CloudDownloadBudget(max_size) if max_size else None
             for file_info in files:
                 file_url = file_info["path"]
                 local_path = _build_safe_local_path(url, file_url, download_path)
@@ -924,16 +941,15 @@ def download_from_cloud(
                     verbose=show_progress,
                     sanitize_error=_cloud_error_sanitizer(file_url),
                 )
-                def download_file(url=file_url, path=local_path, budget=remaining_download_bytes):
+                def download_file(url=file_url, path=local_path, budget=download_budget):
                     return _download_cloud_object(fs, url, path, budget)
 
-                downloaded_bytes = download_file()
-                if remaining_download_bytes is not None:
-                    remaining_download_bytes -= downloaded_bytes
+                download_file()
         else:
             # Single file download
             file_name = _cloud_url_basename(url)
             local_file = download_path / file_name
+            download_budget = _CloudDownloadBudget(max_size) if max_size else None
 
             @retry_with_backoff(
                 max_retries=3,
@@ -942,7 +958,7 @@ def download_from_cloud(
                 sanitize_error=_cloud_error_sanitizer(url),
             )
             def download_single_file():
-                return _download_cloud_object(fs, url, local_file, max_size)
+                return _download_cloud_object(fs, url, local_file, download_budget)
 
             if show_progress and size > 100 * 1024 * 1024 * 1024:  # Show progress for files > 100GB
                 with yaspin(text=f"Downloading {file_name}") as spinner:
@@ -1055,7 +1071,7 @@ def download_from_cloud_streaming(
     try:
         # Download files one at a time
         total_files = len(files)
-        remaining_download_bytes = max_size
+        download_budget = _CloudDownloadBudget(max_size) if max_size else None
         for i, file_info in enumerate(files):
             file_url = file_info["path"]
             file_name = file_info.get("name") or _cloud_url_basename(file_url)
@@ -1074,12 +1090,10 @@ def download_from_cloud_streaming(
                 verbose=show_progress,
                 sanitize_error=_cloud_error_sanitizer(file_url),
             )
-            def download_file(url=file_url, path=local_path, budget=remaining_download_bytes):
+            def download_file(url=file_url, path=local_path, budget=download_budget):
                 return _download_cloud_object(fs, url, path, budget)
 
-            downloaded_bytes = download_file()
-            if remaining_download_bytes is not None:
-                remaining_download_bytes -= downloaded_bytes
+            download_file()
 
             yield (local_path, is_last)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -778,9 +778,20 @@ def test_scan_max_file_size(tmp_path):
     assert "500" in result.output or "File too large" in result.output  # Should mention the max file size or error
 
 
-def test_cloud_auto_size_limit_applies_to_download_budget(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "cloud_url",
+    [
+        "s3://bucket/model.bin",
+        "r2://bucket/model.bin",
+        "gcs://bucket/model.bin",
+        "https://bucket.s3.amazonaws.com/model.bin",
+        "https://storage.googleapis.com/bucket/model.bin",
+        "https://account.r2.cloudflarestorage.com/bucket/model.bin",
+    ],
+)
+def test_cloud_auto_size_limit_applies_to_download_budget(tmp_path: Path, cloud_url: str) -> None:
     runtime = _resolve_scan_runtime_config(
-        ["s3://bucket/model.bin"],
+        [cloud_url],
         format="json",
         output=None,
         timeout=None,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ from click.testing import CliRunner
 
 from modelaudit import __version__
 from modelaudit.cache.trusted_config_store import TrustedConfigStore
-from modelaudit.cli import _summarize_progress_tree, cli, expand_paths, format_text_output
+from modelaudit.cli import _resolve_scan_runtime_config, _summarize_progress_tree, cli, expand_paths, format_text_output
 from modelaudit.core import scan_model_directory_or_file
 from modelaudit.models import ModelAuditResultModel, create_initial_audit_result
 from modelaudit.utils.tensorflow_compat import has_tensorflow_protobuf_stubs as _has_tf_protos
@@ -776,6 +776,32 @@ def test_scan_max_file_size(tmp_path):
     assert result.output  # Should have some output
     # Note: JSON output format doesn't include file paths
     assert "500" in result.output or "File too large" in result.output  # Should mention the max file size or error
+
+
+def test_cloud_auto_size_limit_applies_to_download_budget(tmp_path: Path) -> None:
+    runtime = _resolve_scan_runtime_config(
+        ["s3://bucket/model.bin"],
+        format="json",
+        output=None,
+        timeout=None,
+        max_size=None,
+        cache_dir=str(tmp_path / "cache"),
+        progress=False,
+        no_cache=False,
+        no_whitelist=False,
+        stream=False,
+        strict=False,
+        verbose=False,
+        quiet=True,
+        scanners=(),
+        exclude_scanners=(),
+        suppress=(),
+        severity=(),
+        scan_start_time=0.0,
+    )
+
+    assert runtime.max_file_size == 50 * 1024 * 1024 * 1024
+    assert runtime.max_download_bytes == runtime.max_file_size
 
 
 def test_format_text_output():

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -751,10 +751,12 @@ class TestCloudPathSecurity:
 
     @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
     @patch("fsspec.filesystem")
+    @pytest.mark.parametrize("metadata_size", [0, 1])
     def test_download_with_max_size_fails_when_size_cannot_be_determined(
         self,
         mock_fs_class: MagicMock,
         mock_analyze: AsyncMock,
+        metadata_size: int,
     ) -> None:
         fs = make_fs_mock()
         fs.info.side_effect = RuntimeError("permission denied")
@@ -762,15 +764,89 @@ class TestCloudPathSecurity:
 
         mock_analyze.return_value = {
             "type": "file",
-            "size": 0,
+            "size": metadata_size,
             "name": "model.bin",
-            "human_size": "0 B",
+            "human_size": f"{metadata_size} B",
             "estimated_time": "instant",
         }
 
         with pytest.raises(ValueError, match="Unable to enforce maximum cloud download size"):
             download_from_cloud(
                 "s3://bucket/model.bin",
+                max_size=1024,
+                use_cache=False,
+                show_progress=False,
+            )
+
+        fs.get.assert_not_called()
+
+    @pytest.mark.parametrize("prefix_size", [2048, "unknown"])
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_download_with_max_size_applies_to_selected_directory_files(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+        tmp_path: Path,
+        prefix_size: int | str,
+    ) -> None:
+        fs = make_fs_mock()
+        fs.info.return_value = {"type": "file", "size": 512}
+        mock_fs_class.return_value = fs
+
+        model_url = "s3://bucket/models/model.pkl"
+        mock_analyze.return_value = {
+            "type": "directory",
+            "file_count": 2,
+            "total_size": prefix_size,
+            "human_size": "2.0 KB",
+            "estimated_time": "instant",
+            "files": [
+                {"path": model_url, "name": "model.pkl", "size": 512, "human_size": "512 B"},
+                {"path": "s3://bucket/models/preview.png", "name": "preview.png", "size": 1536, "human_size": "1.5 KB"},
+            ],
+        }
+
+        result = download_from_cloud(
+            "s3://bucket/models",
+            cache_dir=tmp_path,
+            max_size=1024,
+            use_cache=False,
+            show_progress=False,
+        )
+
+        assert result == tmp_path
+        fs.info.assert_called_once_with(model_url)
+        fs.get.assert_called_once()
+        assert fs.get.call_args.args[0] == model_url
+
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_download_with_max_size_rejects_selected_directory_total_over_limit(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        fs = make_fs_mock()
+        fs.info.return_value = {"type": "file", "size": 600}
+        mock_fs_class.return_value = fs
+        mock_analyze.return_value = {
+            "type": "directory",
+            "file_count": 2,
+            "total_size": 1200,
+            "human_size": "1.2 KB",
+            "estimated_time": "instant",
+            "files": [
+                {"path": "s3://bucket/models/model-1.pkl", "name": "model-1.pkl", "size": 600, "human_size": "600 B"},
+                {"path": "s3://bucket/models/model-2.pkl", "name": "model-2.pkl", "size": 600, "human_size": "600 B"},
+            ],
+        }
+
+        with pytest.raises(ValueError, match="exceeds maximum allowed size"):
+            download_from_cloud(
+                "s3://bucket/models",
+                cache_dir=tmp_path,
                 max_size=1024,
                 use_cache=False,
                 show_progress=False,
@@ -843,6 +919,68 @@ class TestCloudPathSecurity:
             )
 
         fs.get.assert_not_called()
+
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_streaming_download_with_max_size_fails_when_size_cannot_be_determined(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+    ) -> None:
+        fs = make_fs_mock()
+        fs.info.side_effect = RuntimeError("permission denied")
+        mock_fs_class.return_value = fs
+        mock_analyze.return_value = {
+            "type": "file",
+            "size": 0,
+            "name": "model.bin",
+            "human_size": "0 B",
+            "estimated_time": "instant",
+        }
+
+        with pytest.raises(ValueError, match="Unable to enforce maximum cloud download size"):
+            list(download_from_cloud_streaming("s3://bucket/model.bin", max_size=1024, show_progress=False))
+
+        fs.get.assert_not_called()
+
+    @pytest.mark.parametrize("prefix_size", [2048, "unknown"])
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_streaming_download_with_max_size_applies_to_selected_directory_files(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+        prefix_size: int | str,
+    ) -> None:
+        fs = make_fs_mock()
+        fs.info.return_value = {"type": "file", "size": 512}
+        mock_fs_class.return_value = fs
+
+        model_url = "s3://bucket/models/model.pkl"
+        mock_analyze.return_value = {
+            "type": "directory",
+            "file_count": 2,
+            "total_size": prefix_size,
+            "human_size": "2.0 KB",
+            "estimated_time": "instant",
+            "files": [
+                {"path": model_url, "name": "model.pkl", "size": 512, "human_size": "512 B"},
+                {"path": "s3://bucket/models/preview.png", "name": "preview.png", "size": 1536, "human_size": "1.5 KB"},
+            ],
+        }
+
+        streamed = list(
+            download_from_cloud_streaming(
+                "s3://bucket/models",
+                max_size=1024,
+                show_progress=False,
+            )
+        )
+
+        assert len(streamed) == 1
+        fs.info.assert_called_once_with(model_url)
+        fs.get.assert_called_once()
+        assert fs.get.call_args.args[0] == model_url
 
 
 class TestCloudCacheSafety:

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -36,6 +36,15 @@ def make_fs_mock() -> MagicMock:
     return fs
 
 
+class _FailAfterPayload(BytesIO):
+    """Return the payload once, then simulate a transient transport failure."""
+
+    def read(self, size: int | None = -1) -> bytes:
+        if self.tell() == len(self.getvalue()):
+            raise OSError("connection reset")
+        return super().read(size)
+
+
 def configure_partial_metadata_failure(fs: MagicMock, url: str) -> tuple[str, str]:
     model_url = f"{url.rstrip('/')}/model.bin"
     hidden_url = f"{url.rstrip('/')}/evil.pkl?X-Amz-Signature=secret"
@@ -935,6 +944,37 @@ class TestCloudPathSecurity:
 
     @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
     @patch("fsspec.filesystem")
+    def test_download_with_zero_max_size_remains_uncapped(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        fs = make_fs_mock()
+        fs.info.side_effect = RuntimeError("permission denied")
+        mock_fs_class.return_value = fs
+        mock_analyze.return_value = {
+            "type": "file",
+            "size": 0,
+            "name": "model.bin",
+            "human_size": "0 B",
+            "estimated_time": "instant",
+        }
+
+        result = download_from_cloud(
+            "s3://bucket/model.bin",
+            cache_dir=tmp_path,
+            max_size=0,
+            use_cache=False,
+            show_progress=False,
+        )
+
+        assert result == tmp_path / "model.bin"
+        fs.get.assert_called_once_with("s3://bucket/model.bin", str(result))
+        fs.open.assert_not_called()
+
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
     @pytest.mark.parametrize("metadata_size", [0, 1])
     def test_download_with_max_size_fails_when_size_cannot_be_determined(
         self,
@@ -1072,6 +1112,41 @@ class TestCloudPathSecurity:
         fs.get.assert_not_called()
         assert not (tmp_path / "model.bin").exists()
 
+    @patch("modelaudit.utils.helpers.retry.time.sleep")
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_download_with_max_size_counts_failed_attempts_against_budget(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+        mock_sleep: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        fs = make_fs_mock()
+        fs.info.return_value = {"type": "file", "size": 3}
+        fs.open.side_effect = lambda *_args: _FailAfterPayload(b"abc")
+        mock_fs_class.return_value = fs
+        mock_analyze.return_value = {
+            "type": "file",
+            "size": 3,
+            "name": "model.bin",
+            "human_size": "3 B",
+            "estimated_time": "instant",
+        }
+
+        with pytest.raises(ValueError, match="Cloud download exceeds maximum allowed size"):
+            download_from_cloud(
+                "s3://bucket/model.bin",
+                cache_dir=tmp_path,
+                max_size=4,
+                use_cache=False,
+                show_progress=False,
+            )
+
+        assert fs.open.call_count == 2
+        mock_sleep.assert_called_once()
+        assert not (tmp_path / "model.bin").exists()
+
     @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
     @patch("fsspec.filesystem")
     def test_download_with_max_size_rejects_late_object_size_over_limit(
@@ -1161,6 +1236,29 @@ class TestCloudPathSecurity:
 
         fs.get.assert_not_called()
 
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_streaming_download_with_zero_max_size_remains_uncapped(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+    ) -> None:
+        fs = make_fs_mock()
+        mock_fs_class.return_value = fs
+        mock_analyze.return_value = {
+            "type": "file",
+            "size": 0,
+            "name": "model.bin",
+            "human_size": "0 B",
+            "estimated_time": "instant",
+        }
+
+        streamed = list(download_from_cloud_streaming("s3://bucket/model.bin", max_size=0, show_progress=False))
+
+        assert len(streamed) == 1
+        fs.get.assert_called_once()
+        fs.open.assert_not_called()
+
     @pytest.mark.parametrize("prefix_size", [2048, "unknown"])
     @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
     @patch("fsspec.filesystem")
@@ -1225,6 +1323,33 @@ class TestCloudPathSecurity:
 
         fs.open.assert_called_once_with("s3://bucket/model.bin", "rb")
         fs.get.assert_not_called()
+
+    @patch("modelaudit.utils.helpers.retry.time.sleep")
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_streaming_download_with_max_size_counts_failed_attempts_against_budget(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        fs = make_fs_mock()
+        fs.info.return_value = {"type": "file", "size": 3}
+        fs.open.side_effect = lambda *_args: _FailAfterPayload(b"abc")
+        mock_fs_class.return_value = fs
+        mock_analyze.return_value = {
+            "type": "file",
+            "size": 3,
+            "name": "model.bin",
+            "human_size": "3 B",
+            "estimated_time": "instant",
+        }
+
+        with pytest.raises(ValueError, match="Cloud download exceeds maximum allowed size"):
+            list(download_from_cloud_streaming("s3://bucket/model.bin", max_size=4, show_progress=False))
+
+        assert fs.open.call_count == 2
+        mock_sleep.assert_called_once()
 
 
 class TestCloudCacheSafety:

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import stat
+from io import BytesIO
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -792,6 +793,7 @@ class TestCloudPathSecurity:
     ) -> None:
         fs = make_fs_mock()
         fs.info.return_value = {"type": "file", "size": 512}
+        fs.open.return_value = BytesIO(b"model")
         mock_fs_class.return_value = fs
 
         model_url = "s3://bucket/models/model.pkl"
@@ -817,8 +819,8 @@ class TestCloudPathSecurity:
 
         assert result == tmp_path
         fs.info.assert_called_once_with(model_url)
-        fs.get.assert_called_once()
-        assert fs.get.call_args.args[0] == model_url
+        fs.open.assert_called_once_with(model_url, "rb")
+        fs.get.assert_not_called()
 
     @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
     @patch("fsspec.filesystem")
@@ -853,6 +855,39 @@ class TestCloudPathSecurity:
             )
 
         fs.get.assert_not_called()
+
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_download_with_max_size_rejects_underreported_transfer_without_retry(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        fs = make_fs_mock()
+        fs.info.return_value = {"type": "file", "size": 4}
+        fs.open.return_value = BytesIO(b"oversized")
+        mock_fs_class.return_value = fs
+        mock_analyze.return_value = {
+            "type": "file",
+            "size": 4,
+            "name": "model.bin",
+            "human_size": "4 B",
+            "estimated_time": "instant",
+        }
+
+        with pytest.raises(ValueError, match="Cloud download exceeds maximum allowed size"):
+            download_from_cloud(
+                "s3://bucket/model.bin",
+                cache_dir=tmp_path,
+                max_size=4,
+                use_cache=False,
+                show_progress=False,
+            )
+
+        fs.open.assert_called_once_with("s3://bucket/model.bin", "rb")
+        fs.get.assert_not_called()
+        assert not (tmp_path / "model.bin").exists()
 
     @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
     @patch("fsspec.filesystem")
@@ -954,6 +989,7 @@ class TestCloudPathSecurity:
     ) -> None:
         fs = make_fs_mock()
         fs.info.return_value = {"type": "file", "size": 512}
+        fs.open.return_value = BytesIO(b"model")
         mock_fs_class.return_value = fs
 
         model_url = "s3://bucket/models/model.pkl"
@@ -979,8 +1015,33 @@ class TestCloudPathSecurity:
 
         assert len(streamed) == 1
         fs.info.assert_called_once_with(model_url)
-        fs.get.assert_called_once()
-        assert fs.get.call_args.args[0] == model_url
+        fs.open.assert_called_once_with(model_url, "rb")
+        fs.get.assert_not_called()
+
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_streaming_download_with_max_size_rejects_underreported_transfer_without_retry(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+    ) -> None:
+        fs = make_fs_mock()
+        fs.info.return_value = {"type": "file", "size": 4}
+        fs.open.return_value = BytesIO(b"oversized")
+        mock_fs_class.return_value = fs
+        mock_analyze.return_value = {
+            "type": "file",
+            "size": 4,
+            "name": "model.bin",
+            "human_size": "4 B",
+            "estimated_time": "instant",
+        }
+
+        with pytest.raises(ValueError, match="Cloud download exceeds maximum allowed size"):
+            list(download_from_cloud_streaming("s3://bucket/model.bin", max_size=4, show_progress=False))
+
+        fs.open.assert_called_once_with("s3://bucket/model.bin", "rb")
+        fs.get.assert_not_called()
 
 
 class TestCloudCacheSafety:

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -751,6 +751,64 @@ class TestCloudPathSecurity:
 
     @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
     @patch("fsspec.filesystem")
+    def test_download_with_max_size_fails_when_size_cannot_be_determined(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+    ) -> None:
+        fs = make_fs_mock()
+        fs.info.side_effect = RuntimeError("permission denied")
+        mock_fs_class.return_value = fs
+
+        mock_analyze.return_value = {
+            "type": "file",
+            "size": 0,
+            "name": "model.bin",
+            "human_size": "0 B",
+            "estimated_time": "instant",
+        }
+
+        with pytest.raises(ValueError, match="Unable to enforce maximum cloud download size"):
+            download_from_cloud(
+                "s3://bucket/model.bin",
+                max_size=1024,
+                use_cache=False,
+                show_progress=False,
+            )
+
+        fs.get.assert_not_called()
+
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_download_with_max_size_rejects_late_object_size_over_limit(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+    ) -> None:
+        fs = make_fs_mock()
+        fs.info.return_value = {"type": "file", "size": 2048}
+        mock_fs_class.return_value = fs
+
+        mock_analyze.return_value = {
+            "type": "file",
+            "size": 0,
+            "name": "model.bin",
+            "human_size": "0 B",
+            "estimated_time": "instant",
+        }
+
+        with pytest.raises(ValueError, match="exceeds maximum allowed size"):
+            download_from_cloud(
+                "s3://bucket/model.bin",
+                max_size=1024,
+                use_cache=False,
+                show_progress=False,
+            )
+
+        fs.get.assert_not_called()
+
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
     def test_streaming_download_rejects_path_traversal(
         self,
         mock_fs_class: MagicMock,


### PR DESCRIPTION
## Summary

Fixes MA-DSS-C007 by enforcing cloud download size caps before non-streaming cloud acquisition.

- propagate the automatic cloud `max_file_size` default into `max_download_bytes`
- parse cloud-reported size metadata before download size checks
- reject capped downloads when provider size cannot be determined
- re-check late `fs.info()` object size before `fs.get`

## False-positive / false-negative audit

- Malicious positive: capped downloads with missing/unknown remote size now fail before `fs.get`.
- Malicious positive: capped downloads where late provider metadata exceeds the cap now fail before `fs.get`.
- Benign compatibility guard: uncapped downloads still continue when size cannot be determined.
- CLI guard: cloud auto defaults now set the download acquisition budget to the advertised 50GB cloud limit.

## Validation

- `PYTHONPATH=/private/tmp/modelaudit-c007:/private/tmp/modelaudit-c007/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/utils/sources/test_cloud_storage.py::TestCloudPathSecurity::test_download_continues_when_size_cannot_be_determined tests/utils/sources/test_cloud_storage.py::TestCloudPathSecurity::test_download_with_max_size_fails_when_size_cannot_be_determined tests/utils/sources/test_cloud_storage.py::TestCloudPathSecurity::test_download_with_max_size_rejects_late_object_size_over_limit tests/test_cli.py::test_cloud_auto_size_limit_applies_to_download_budget -q` -> 4 passed
- `PYTHONPATH=/private/tmp/modelaudit-c007:/private/tmp/modelaudit-c007/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/utils/sources/test_cloud_storage.py -q` -> 48 passed
- `/Users/mdangelo/code/modelaudit/.venv/bin/ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> 399 files already formatted
- `/Users/mdangelo/code/modelaudit/.venv/bin/ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> all checks passed
- `/Users/mdangelo/code/modelaudit/.venv/bin/mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> success, 454 source files
- `PYTHONPATH=/private/tmp/modelaudit-c007:/private/tmp/modelaudit-c007/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest -n auto -m "not slow and not integration" --maxfail=1` -> 7713 passed, 16 skipped
