### PR TITLE
fix: scan duplicate executorch pickle members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - redact secret-shaped dictionary keys from embedded-secret detector finding contexts
 - redact compound credential names and malformed userinfo URLs in scanner evidence
 - restrict JFrog credential forwarding to explicitly trusted HTTPS hosts
+- scan every duplicate ExecuTorch pickle ZIP member instead of reopening by shadowable name
 - inspect every parsed GGUF chat template when duplicate or trailing malformed metadata could otherwise hide SSTI payloads
 - bound GGUF declared metadata and tensor collections, and cap reported tensor summaries, so oversized structures fail closed without exhausting scanner resources
 - redact secret-shaped dictionary keys from embedded-secret detector finding contexts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - redact secret-shaped dictionary keys from embedded-secret detector finding contexts
 - redact compound credential names and malformed userinfo URLs in scanner evidence
 - restrict JFrog credential forwarding to explicitly trusted HTTPS hosts
-- scan every duplicate ExecuTorch pickle ZIP member instead of reopening by shadowable name
+- scan duplicate and case-varied ExecuTorch pickle ZIP members without shadowable-name or metadata-routing bypasses
 - enforce automatic cloud download size limits when remote size metadata is missing or late-bound
 - avoid importing attacker-shadowed TensorFlow protobuf packages during static scanning
 - inspect every parsed GGUF chat template when duplicate or trailing malformed metadata could otherwise hide SSTI payloads

--- a/modelaudit/scanners/executorch_scanner.py
+++ b/modelaudit/scanners/executorch_scanner.py
@@ -151,7 +151,7 @@ class ExecuTorchScanner(BaseScanner):
                         continue
                     safe_entries.append(entry)
 
-                pickle_entries = [entry for entry in safe_entries if entry.filename.endswith(".pkl")]
+                pickle_entries = [entry for entry in safe_entries if entry.filename.casefold().endswith(".pkl")]
                 pickle_files = [entry.filename for entry in pickle_entries]
                 result.metadata["pickle_files"] = pickle_files
                 bytes_scanned = 0
@@ -180,7 +180,7 @@ class ExecuTorchScanner(BaseScanner):
 
                 for entry in safe_entries:
                     name = entry.filename
-                    if name.endswith(".py"):
+                    if name.casefold().endswith(".py"):
                         result.add_check(
                             name="Python File Detection",
                             passed=False,

--- a/modelaudit/scanners/executorch_scanner.py
+++ b/modelaudit/scanners/executorch_scanner.py
@@ -133,8 +133,9 @@ class ExecuTorchScanner(BaseScanner):
         try:
             self.current_file_path = path
             with zipfile.ZipFile(path, "r") as z:
-                safe_entries: list[str] = []
-                for name in z.namelist():
+                safe_entries: list[zipfile.ZipInfo] = []
+                for entry in z.infolist():
+                    name = entry.filename
                     temp_base = os.path.join(tempfile.gettempdir(), "extract")
                     _, is_safe = sanitize_archive_path(name, temp_base)
                     if not is_safe:
@@ -148,14 +149,15 @@ class ExecuTorchScanner(BaseScanner):
                             rule_code="S405",
                         )
                         continue
-                    safe_entries.append(name)
+                    safe_entries.append(entry)
 
-                pickle_files = [n for n in safe_entries if n.endswith(".pkl")]
+                pickle_entries = [entry for entry in safe_entries if entry.filename.endswith(".pkl")]
+                pickle_files = [entry.filename for entry in pickle_entries]
                 result.metadata["pickle_files"] = pickle_files
                 bytes_scanned = 0
 
-                for name in pickle_files:
-                    member_info = z.getinfo(name)
+                for member_info in pickle_entries:
+                    name = member_info.filename
                     bytes_scanned += member_info.file_size
                     if self.pickle_scanner is None:
                         add_scanner_selection_skip_check(
@@ -167,7 +169,7 @@ class ExecuTorchScanner(BaseScanner):
                         )
                         continue
 
-                    with z.open(name, "r") as file_like:
+                    with z.open(member_info, "r") as file_like:
                         sub_result = self.pickle_scanner.scan_stream(
                             cast(BinaryIO, file_like),
                             member_info.file_size,
@@ -176,7 +178,8 @@ class ExecuTorchScanner(BaseScanner):
                     apply_pickle_member_context(sub_result, archive_path=path, member_name=name)
                     result.merge(sub_result)
 
-                for name in safe_entries:
+                for entry in safe_entries:
+                    name = entry.filename
                     if name.endswith(".py"):
                         result.add_check(
                             name="Python File Detection",

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -1856,7 +1856,7 @@ def _read_zip_member_text(
     try:
         data = _read_zip_member_bounded(archive, member_info, max_bytes)
         return data.decode("utf-8", errors="strict").strip()
-    except (OSError, RuntimeError, UnicodeDecodeError, ValueError):
+    except (OSError, RuntimeError, UnicodeDecodeError, ValueError, zipfile.BadZipFile):
         return None
 
 
@@ -2020,7 +2020,7 @@ def is_executorch_archive(path: str) -> bool:
             for info in archive.infolist():
                 if not info.filename or info.is_dir():
                     continue
-                name = _normalize_archive_member_name(info.filename)
+                name = _normalize_archive_member_name(info.filename).casefold()
                 members_by_name.setdefault(name, []).append(info)
 
             for name in members_by_name:

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -2016,13 +2016,14 @@ def is_executorch_archive(path: str) -> bool:
 
     try:
         with zipfile.ZipFile(file_path, "r") as archive:
-            member_names = {
-                _normalize_archive_member_name(info.filename)
-                for info in archive.infolist()
-                if info.filename and not info.is_dir()
-            }
+            members_by_name: dict[str, list[zipfile.ZipInfo]] = {}
+            for info in archive.infolist():
+                if not info.filename or info.is_dir():
+                    continue
+                name = _normalize_archive_member_name(info.filename)
+                members_by_name.setdefault(name, []).append(info)
 
-            for name in member_names:
+            for name in members_by_name:
                 if name == "bytecode.pkl":
                     prefix = ""
                 elif name.endswith("/bytecode.pkl"):
@@ -2031,13 +2032,10 @@ def is_executorch_archive(path: str) -> bool:
                     continue
 
                 version_name = f"{prefix}/version" if prefix else "version"
-                version_info = archive.NameToInfo.get(version_name)
-                if version_info is None:
-                    continue
-
-                version_text = _read_zip_member_text(archive, version_info, _PYTORCH_ZIP_METADATA_MAX_BYTES)
-                if version_text is not None and re.fullmatch(r"\d+(?:\.\d+)?", version_text):
-                    return True
+                for version_info in members_by_name.get(version_name, []):
+                    version_text = _read_zip_member_text(archive, version_info, _PYTORCH_ZIP_METADATA_MAX_BYTES)
+                    if version_text is not None and re.fullmatch(r"\d+(?:\.\d+)?", version_text):
+                        return True
     except (OSError, RuntimeError, zipfile.BadZipFile, zipfile.LargeZipFile):
         return False
 

--- a/tests/scanners/test_executorch_scanner.py
+++ b/tests/scanners/test_executorch_scanner.py
@@ -1,4 +1,5 @@
 import pickle
+import struct
 import zipfile
 from pathlib import Path
 
@@ -42,6 +43,31 @@ def _pickle_payload_with_eval(source: str) -> bytes:
             return (eval, (source,))
 
     return pickle.dumps(EvalPayload())
+
+
+def _corrupt_zip_member_crc(zip_path: Path, member_index: int) -> None:
+    """Patch one ZIP member's local and central-directory CRC fields."""
+    with zipfile.ZipFile(zip_path, "r") as zip_file:
+        member_info = zip_file.infolist()[member_index]
+        central_directory_offset = zip_file.start_dir
+
+    archive_bytes = bytearray(zip_path.read_bytes())
+    local_crc_offset = member_info.header_offset + 14
+    original_crc = struct.unpack_from("<I", archive_bytes, local_crc_offset)[0]
+    corrupt_crc = (original_crc ^ 0xFFFFFFFF) & 0xFFFFFFFF
+    struct.pack_into("<I", archive_bytes, local_crc_offset, corrupt_crc)
+
+    cursor = central_directory_offset
+    while cursor < len(archive_bytes) and archive_bytes[cursor : cursor + 4] == b"PK\x01\x02":
+        local_header_offset = struct.unpack_from("<I", archive_bytes, cursor + 42)[0]
+        filename_len, extra_len, comment_len = struct.unpack_from("<HHH", archive_bytes, cursor + 28)
+        if local_header_offset == member_info.header_offset:
+            struct.pack_into("<I", archive_bytes, cursor + 16, corrupt_crc)
+            zip_path.write_bytes(archive_bytes)
+            return
+        cursor += 46 + filename_len + extra_len + comment_len
+
+    raise AssertionError(f"Unable to locate central directory entry at offset {member_info.header_offset}")
 
 
 def test_executorch_scanner_can_handle(tmp_path: Path) -> None:
@@ -339,6 +365,45 @@ def test_renamed_executorch_archive_duplicate_members_route_and_detect_shadowed_
     assert any(issue.severity == IssueSeverity.CRITICAL and "eval" in issue.message.lower() for issue in result.issues)
 
 
+def test_renamed_executorch_archive_unreadable_duplicate_version_does_not_hide_valid_marker(tmp_path: Path) -> None:
+    model_path = tmp_path / "duplicate-version-model.jpg"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("version", "corrupt")
+        zipf.writestr("bytecode.pkl", _pickle_payload_with_eval("print('evil')"))
+        zipf.writestr("version", "1")
+    _corrupt_zip_member_crc(model_path, 0)
+
+    assert ExecuTorchScanner.can_handle(str(model_path))
+
+    result = core.scan_file(str(model_path), config={"cache_scan_results": False})
+
+    assert result.scanner_name == "executorch"
+    assert any(issue.severity == IssueSeverity.CRITICAL and "eval" in issue.message.lower() for issue in result.issues)
+
+
+def test_renamed_executorch_archive_case_insensitive_members_route_and_detect_payload(tmp_path: Path) -> None:
+    model_path = tmp_path / "uppercase-members.jpg"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("VERSION", "1")
+        zipf.writestr("BYTECODE.PKL", _pickle_payload_with_eval("print('evil')"))
+
+    assert ExecuTorchScanner.can_handle(str(model_path))
+
+    result = core.scan_file(str(model_path), config={"cache_scan_results": False})
+
+    assert result.scanner_name == "executorch"
+    assert any(issue.severity == IssueSeverity.CRITICAL and "eval" in issue.message.lower() for issue in result.issues)
+
+
+def test_renamed_executorch_archive_case_insensitive_near_match_does_not_route(tmp_path: Path) -> None:
+    model_path = tmp_path / "uppercase-near-match.jpg"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("VERSION", "not-a-version")
+        zipf.writestr("BYTECODE.PKL", pickle.dumps({"weights": [1, 2, 3]}))
+
+    assert not ExecuTorchScanner.can_handle(str(model_path))
+
+
 def test_executorch_duplicate_pickle_members_scan_malicious_last_entry(tmp_path: Path) -> None:
     model_path = tmp_path / "duplicate-model-reversed.ptl"
     with zipfile.ZipFile(model_path, "w") as zipf:
@@ -349,6 +414,21 @@ def test_executorch_duplicate_pickle_members_scan_malicious_last_entry(tmp_path:
     result = ExecuTorchScanner().scan(str(model_path))
 
     assert result.metadata["pickle_files"] == ["model.pkl", "model.pkl"]
+    assert any(issue.severity == IssueSeverity.CRITICAL and "eval" in issue.message.lower() for issue in result.issues)
+
+
+def test_executorch_unreadable_duplicate_pickle_is_inconclusive_and_scans_later_member(tmp_path: Path) -> None:
+    model_path = tmp_path / "duplicate-corrupt-model.ptl"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("model.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("model.pkl", _pickle_payload_with_eval("print('evil')"))
+    _corrupt_zip_member_crc(model_path, 1)
+
+    result = ExecuTorchScanner().scan(str(model_path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
     assert any(issue.severity == IssueSeverity.CRITICAL and "eval" in issue.message.lower() for issue in result.issues)
 
 
@@ -364,3 +444,15 @@ def test_executorch_benign_duplicate_pickle_members_stay_clean(tmp_path: Path) -
     assert result.success is True
     assert result.metadata["pickle_files"] == ["model.pkl", "model.pkl"]
     assert not any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+
+
+def test_executorch_case_insensitive_python_suffix_is_flagged(tmp_path: Path) -> None:
+    model_path = tmp_path / "uppercase-python.ptl"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("bytecode.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("hooks.PY", "print('evil')")
+
+    result = ExecuTorchScanner().scan(str(model_path))
+
+    assert any(issue.rule_code == "S104" and issue.details.get("file") == "hooks.PY" for issue in result.issues)

--- a/tests/scanners/test_executorch_scanner.py
+++ b/tests/scanners/test_executorch_scanner.py
@@ -36,6 +36,14 @@ def create_executorch_archive(tmp_path: Path, *, malicious: bool = False) -> Pat
     return zip_path
 
 
+def _pickle_payload_with_eval(source: str) -> bytes:
+    class EvalPayload:
+        def __reduce__(self):
+            return (eval, (source,))
+
+    return pickle.dumps(EvalPayload())
+
+
 def test_executorch_scanner_can_handle(tmp_path: Path) -> None:
     path = create_executorch_archive(tmp_path)
     assert ExecuTorchScanner.can_handle(str(path))
@@ -295,3 +303,63 @@ def test_executorch_scanner_streams_pickle_members_without_zip_read(
     result = ExecuTorchScanner().scan(str(model_path))
 
     assert any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+
+
+def test_executorch_duplicate_pickle_members_scan_malicious_first_entry(tmp_path: Path) -> None:
+    model_path = tmp_path / "duplicate-model.ptl"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("model.pkl", _pickle_payload_with_eval("print('evil')"))
+        zipf.writestr("model.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+
+    result = ExecuTorchScanner().scan(str(model_path))
+
+    assert result.metadata["pickle_files"] == ["model.pkl", "model.pkl"]
+    assert any(issue.severity == IssueSeverity.CRITICAL and "eval" in issue.message.lower() for issue in result.issues)
+
+
+def test_renamed_executorch_archive_duplicate_pickle_routes_and_detects_shadowed_payload(tmp_path: Path) -> None:
+    model_path = tmp_path / "duplicate-model.jpg"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("bytecode.pkl", _pickle_payload_with_eval("print('evil')"))
+        zipf.writestr("bytecode.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+
+    file_result = core.scan_file(str(model_path), config={"cache_scan_results": False})
+    result = core.scan_model_directory_or_file(str(tmp_path), cache_scan_results=False)
+
+    assert file_result.scanner_name == "executorch"
+    assert any(
+        issue.severity == IssueSeverity.CRITICAL and "eval" in issue.message.lower() for issue in file_result.issues
+    )
+    assert result.files_scanned == 1
+    assert "executorch" in result.scanner_names
+    assert core.determine_exit_code(result) == 1
+    assert any(issue.severity == IssueSeverity.CRITICAL and "eval" in issue.message.lower() for issue in result.issues)
+
+
+def test_executorch_duplicate_pickle_members_scan_malicious_last_entry(tmp_path: Path) -> None:
+    model_path = tmp_path / "duplicate-model-reversed.ptl"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("model.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("model.pkl", _pickle_payload_with_eval("print('evil')"))
+
+    result = ExecuTorchScanner().scan(str(model_path))
+
+    assert result.metadata["pickle_files"] == ["model.pkl", "model.pkl"]
+    assert any(issue.severity == IssueSeverity.CRITICAL and "eval" in issue.message.lower() for issue in result.issues)
+
+
+def test_executorch_benign_duplicate_pickle_members_stay_clean(tmp_path: Path) -> None:
+    model_path = tmp_path / "duplicate-benign-model.ptl"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("model.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("model.pkl", pickle.dumps({"weights": [4, 5, 6]}))
+
+    result = ExecuTorchScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert result.metadata["pickle_files"] == ["model.pkl", "model.pkl"]
+    assert not any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)

--- a/tests/scanners/test_executorch_scanner.py
+++ b/tests/scanners/test_executorch_scanner.py
@@ -318,12 +318,13 @@ def test_executorch_duplicate_pickle_members_scan_malicious_first_entry(tmp_path
     assert any(issue.severity == IssueSeverity.CRITICAL and "eval" in issue.message.lower() for issue in result.issues)
 
 
-def test_renamed_executorch_archive_duplicate_pickle_routes_and_detects_shadowed_payload(tmp_path: Path) -> None:
+def test_renamed_executorch_archive_duplicate_members_route_and_detect_shadowed_payload(tmp_path: Path) -> None:
     model_path = tmp_path / "duplicate-model.jpg"
     with zipfile.ZipFile(model_path, "w") as zipf:
         zipf.writestr("version", "1")
         zipf.writestr("bytecode.pkl", _pickle_payload_with_eval("print('evil')"))
         zipf.writestr("bytecode.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("version", "not-a-version")
 
     file_result = core.scan_file(str(model_path), config={"cache_scan_results": False})
     result = core.scan_model_directory_or_file(str(tmp_path), cache_scan_results=False)


### PR DESCRIPTION
## Summary

- scan ExecuTorch ZIP entries by `ZipInfo` so duplicate pickle member names are not reopened through the shadowable ZIP name map
- add malicious-first, malicious-last, benign-duplicate, and renamed content-routed archive regressions
- update changelog

## Validation

- `PYTHONPATH=/private/tmp/modelaudit-c009:/private/tmp/modelaudit-c009/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/scanners/test_executorch_scanner.py::test_executorch_duplicate_pickle_members_scan_malicious_first_entry tests/scanners/test_executorch_scanner.py::test_renamed_executorch_archive_duplicate_pickle_routes_and_detects_shadowed_payload tests/scanners/test_executorch_scanner.py::test_executorch_duplicate_pickle_members_scan_malicious_last_entry tests/scanners/test_executorch_scanner.py::test_executorch_benign_duplicate_pickle_members_stay_clean tests/scanners/test_executorch_scanner.py::test_executorch_scanner_streams_pickle_members_without_zip_read -q`
  - `5 passed, 4 warnings`
- `PYTHONPATH=/private/tmp/modelaudit-c009:/private/tmp/modelaudit-c009/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/scanners/test_executorch_scanner.py -q`
  - `21 passed, 4 warnings`
- `/Users/mdangelo/code/modelaudit/.venv/bin/ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
  - `399 files already formatted`
- `/Users/mdangelo/code/modelaudit/.venv/bin/ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
  - `All checks passed`
- `PYTHONPATH=/private/tmp/modelaudit-c009:/private/tmp/modelaudit-c009/packages/modelaudit-picklescan/src /Users/mdangelo/code/modelaudit/.venv/bin/mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
  - `Success: no issues found in 454 source files`
- `PYTHONPATH=/private/tmp/modelaudit-c009:/private/tmp/modelaudit-c009/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest -n auto -m "not slow and not integration" --maxfail=1`
  - `7714 passed, 16 skipped, 25 warnings`
