### PR TITLE
fix: enforce huggingface file size budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - redact secret-shaped dictionary keys from embedded-secret detector finding contexts
 - redact compound credential names and malformed userinfo URLs in scanner evidence
 - restrict JFrog credential forwarding to explicitly trusted HTTPS hosts
+- enforce direct Hugging Face file `--max-size` budgets before downloading
 - inspect every parsed GGUF chat template when duplicate or trailing malformed metadata could otherwise hide SSTI payloads
 - bound GGUF declared metadata and tensor collections, and cap reported tensor summaries, so oversized structures fail closed without exhausting scanner resources
 - redact secret-shaped dictionary keys from embedded-secret detector finding contexts

--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -1153,7 +1153,11 @@ def _resolve_scan_source_for_path(
                 hf_cache_dir = Path(tempfile.mkdtemp(prefix="modelaudit_hf_"))
                 temp_dir = str(hf_cache_dir)
 
-            download_path = download_file_from_hf(path, cache_dir=hf_cache_dir)
+            download_path = download_file_from_hf(
+                path,
+                cache_dir=hf_cache_dir,
+                max_size=runtime.max_download_bytes,
+            )
             source_model_id, source_model_source = extract_model_id_from_path(path)
 
             if not runtime.cache_enabled and temp_dir is None:

--- a/modelaudit/utils/sources/huggingface.py
+++ b/modelaudit/utils/sources/huggingface.py
@@ -485,8 +485,15 @@ def download_file_from_hf(url: str, cache_dir: Path | None = None, max_size: int
     display_url = redact_huggingface_url_for_display(url)
 
     try:
+        download_revision = branch
         if max_size is not None:
-            path_info = HfApi().get_paths_info(repo_id, filename, revision=branch)
+            api = HfApi()
+            repo_info = api.repo_info(repo_id, revision=branch)
+            pinned_revision = getattr(repo_info, "sha", None)
+            if not isinstance(pinned_revision, str) or not pinned_revision:
+                raise ValueError(f"Unable to determine immutable revision for {display_url}; refusing capped download")
+
+            path_info = api.get_paths_info(repo_id, filename, revision=pinned_revision)
             file_metadata = path_info[0] if path_info else None
             file_size = getattr(file_metadata, "size", None)
             if file_size is None:
@@ -495,12 +502,13 @@ def download_file_from_hf(url: str, cache_dir: Path | None = None, max_size: int
                 raise ValueError(
                     f"File size ({_format_size(file_size)}) exceeds maximum allowed size ({_format_size(max_size)})"
                 )
+            download_revision = pinned_revision
 
         # Use hf_hub_download for single file downloads
         local_path = hf_hub_download(
             repo_id=repo_id,
             filename=filename,
-            revision=branch,
+            revision=download_revision,
             cache_dir=str(cache_dir) if cache_dir else None,
         )
         return Path(local_path)

--- a/modelaudit/utils/sources/huggingface.py
+++ b/modelaudit/utils/sources/huggingface.py
@@ -66,6 +66,16 @@ def _get_hf_cache_root() -> Path:
         return Path.home() / ".cache" / "huggingface" / "hub"
 
 
+def _format_size(size_bytes: int) -> str:
+    """Format a byte count for user-facing download budget errors."""
+    size = float(size_bytes)
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if size < 1024.0:
+            return f"{size:.1f} {unit}"
+        size /= 1024.0
+    return f"{size:.1f} PB"
+
+
 def _is_within_directory(base_dir: Path, target: Path) -> bool:
     """Return True when target resolves inside base_dir."""
     base_path = base_dir.resolve()
@@ -447,22 +457,24 @@ def download_model_streaming(
         ) from e
 
 
-def download_file_from_hf(url: str, cache_dir: Path | None = None) -> Path:
+def download_file_from_hf(url: str, cache_dir: Path | None = None, max_size: int | None = None) -> Path:
     """Download a single file from HuggingFace using direct file URL.
 
     Args:
         url: Direct HuggingFace file URL (e.g., https://huggingface.co/user/repo/resolve/main/file.bin)
         cache_dir: Optional cache directory for downloads
+        max_size: Optional maximum file size to download
 
     Returns:
         Path to the downloaded file
 
     Raises:
         ValueError: If URL is invalid
+        ValueError: If max_size is set and file size is unknown or exceeds it
         Exception: If download fails
     """
     try:
-        from huggingface_hub import hf_hub_download
+        from huggingface_hub import HfApi, hf_hub_download
     except ImportError as e:
         raise ImportError(
             "huggingface-hub package is required for HuggingFace URL support. "
@@ -473,6 +485,17 @@ def download_file_from_hf(url: str, cache_dir: Path | None = None) -> Path:
     display_url = redact_huggingface_url_for_display(url)
 
     try:
+        if max_size is not None:
+            path_info = HfApi().get_paths_info(repo_id, filename, revision=branch)
+            file_metadata = path_info[0] if path_info else None
+            file_size = getattr(file_metadata, "size", None)
+            if file_size is None:
+                raise ValueError(f"Unable to determine file size for {display_url}; refusing capped download")
+            if file_size > max_size:
+                raise ValueError(
+                    f"File size ({_format_size(file_size)}) exceeds maximum allowed size ({_format_size(max_size)})"
+                )
+
         # Use hf_hub_download for single file downloads
         local_path = hf_hub_download(
             repo_id=repo_id,

--- a/modelaudit/utils/sources/huggingface.py
+++ b/modelaudit/utils/sources/huggingface.py
@@ -463,7 +463,7 @@ def download_file_from_hf(url: str, cache_dir: Path | None = None, max_size: int
     Args:
         url: Direct HuggingFace file URL (e.g., https://huggingface.co/user/repo/resolve/main/file.bin)
         cache_dir: Optional cache directory for downloads
-        max_size: Optional maximum file size to download
+        max_size: Optional maximum file size to download; 0 disables the limit
 
     Returns:
         Path to the downloaded file
@@ -485,8 +485,12 @@ def download_file_from_hf(url: str, cache_dir: Path | None = None, max_size: int
     display_url = redact_huggingface_url_for_display(url)
 
     try:
+        if max_size is not None and max_size < 0:
+            raise ValueError("Maximum file size must be non-negative")
+
+        size_limit = max_size or None
         download_revision = branch
-        if max_size is not None:
+        if size_limit is not None:
             api = HfApi()
             repo_info = api.repo_info(repo_id, revision=branch)
             pinned_revision = getattr(repo_info, "sha", None)
@@ -496,11 +500,11 @@ def download_file_from_hf(url: str, cache_dir: Path | None = None, max_size: int
             path_info = api.get_paths_info(repo_id, filename, revision=pinned_revision)
             file_metadata = path_info[0] if path_info else None
             file_size = getattr(file_metadata, "size", None)
-            if file_size is None:
+            if not isinstance(file_size, int) or isinstance(file_size, bool) or file_size < 0:
                 raise ValueError(f"Unable to determine file size for {display_url}; refusing capped download")
-            if file_size > max_size:
+            if file_size > size_limit:
                 raise ValueError(
-                    f"File size ({_format_size(file_size)}) exceeds maximum allowed size ({_format_size(max_size)})"
+                    f"File size ({_format_size(file_size)}) exceeds maximum allowed size ({_format_size(size_limit)})"
                 )
             download_revision = pinned_revision
 
@@ -511,6 +515,19 @@ def download_file_from_hf(url: str, cache_dir: Path | None = None, max_size: int
             revision=download_revision,
             cache_dir=str(cache_dir) if cache_dir else None,
         )
-        return Path(local_path)
+        downloaded_path = Path(local_path)
+        if size_limit is not None:
+            try:
+                downloaded_size = downloaded_path.stat().st_size
+            except OSError as exc:
+                raise ValueError(
+                    f"Unable to verify downloaded file size for {display_url}; refusing capped download"
+                ) from exc
+            if downloaded_size > size_limit:
+                raise ValueError(
+                    f"Downloaded file size ({_format_size(downloaded_size)}) "
+                    f"exceeds maximum allowed size ({_format_size(size_limit)})"
+                )
+        return downloaded_path
     except Exception as e:
         raise Exception(f"Failed to download file from {display_url}: {redact_huggingface_urls_in_text(str(e))}") from e

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1056,12 +1056,15 @@ def test_scan_huggingface_file_download_failure_redacts_url(mock_download_file):
     assert "https://huggingface.co/test/model/resolve/main/file.bin" in output
 
 
+@pytest.mark.parametrize(("max_size", "expected_bytes"), [("2KB", 2048), ("0", 0)])
 @patch("modelaudit.cli.download_file_from_hf")
 @patch("modelaudit.cli.scan_model_directory_or_file")
 def test_scan_huggingface_file_passes_max_size_to_download(
     mock_scan: MagicMock,
     mock_download_file: MagicMock,
     tmp_path: Path,
+    max_size: str,
+    expected_bytes: int,
 ) -> None:
     """Direct HuggingFace file downloads should receive the CLI download budget before fetch."""
     downloaded_file = tmp_path / "model.bin"
@@ -1085,14 +1088,14 @@ def test_scan_huggingface_file_passes_max_size_to_download(
             "--format",
             "json",
             "--max-size",
-            "2KB",
+            max_size,
             "https://huggingface.co/test/model/resolve/main/model.bin",
         ],
     )
 
     assert result.exit_code == 0
     mock_download_file.assert_called_once()
-    assert mock_download_file.call_args.kwargs["max_size"] == 2048
+    assert mock_download_file.call_args.kwargs["max_size"] == expected_bytes
     assert mock_scan.call_args.args[0] == str(downloaded_file)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1019,6 +1019,46 @@ def test_scan_huggingface_file_download_failure_redacts_url(mock_download_file):
     assert "https://huggingface.co/test/model/resolve/main/file.bin" in output
 
 
+@patch("modelaudit.cli.download_file_from_hf")
+@patch("modelaudit.cli.scan_model_directory_or_file")
+def test_scan_huggingface_file_passes_max_size_to_download(
+    mock_scan: MagicMock,
+    mock_download_file: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Direct HuggingFace file downloads should receive the CLI download budget before fetch."""
+    downloaded_file = tmp_path / "model.bin"
+    downloaded_file.write_bytes(b"model")
+    mock_download_file.return_value = downloaded_file
+    mock_scan.return_value = create_mock_scan_result(
+        bytes_scanned=4,
+        issues=[],
+        files_scanned=1,
+        assets=[],
+        has_errors=False,
+        scanners=["test_scanner"],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "scan",
+            "--no-cache",
+            "--format",
+            "json",
+            "--max-size",
+            "2KB",
+            "https://huggingface.co/test/model/resolve/main/model.bin",
+        ],
+    )
+
+    assert result.exit_code == 0
+    mock_download_file.assert_called_once()
+    assert mock_download_file.call_args.kwargs["max_size"] == 2048
+    assert mock_scan.call_args.args[0] == str(downloaded_file)
+
+
 @patch("modelaudit.cli.is_huggingface_url")
 @patch("modelaudit.cli.download_model")
 @patch("modelaudit.cli.scan_model_directory_or_file")

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -802,6 +802,108 @@ class TestHuggingFaceFileURLs:
             cache_dir=str(cache_dir),
         )
 
+    @patch("huggingface_hub.HfApi")
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_file_with_max_size_preflights_before_download(
+        self,
+        mock_hf_hub_download: MagicMock,
+        mock_hf_api: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Direct file downloads should check size metadata before fetching capped files."""
+        mock_path = str(tmp_path / "downloaded_file.bin")
+        mock_hf_hub_download.return_value = mock_path
+        mock_hf_api.return_value.get_paths_info.return_value = [SimpleNamespace(size=1024)]
+
+        result = download_file_from_hf(
+            "https://huggingface.co/test/model/resolve/main/model.bin",
+            max_size=2048,
+        )
+
+        mock_hf_api.return_value.get_paths_info.assert_called_once_with("test/model", "model.bin", revision="main")
+        mock_hf_hub_download.assert_called_once()
+        assert result == Path(mock_path)
+
+    @patch("huggingface_hub.HfApi")
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_file_with_max_size_rejects_oversized_before_download(
+        self,
+        mock_hf_hub_download: MagicMock,
+        mock_hf_api: MagicMock,
+    ) -> None:
+        """Oversized direct files should not reach hf_hub_download."""
+        mock_hf_api.return_value.get_paths_info.return_value = [SimpleNamespace(size=11 * 1024 * 1024)]
+
+        with pytest.raises(Exception, match="exceeds maximum allowed size") as exc_info:
+            download_file_from_hf(
+                "https://huggingface.co/test/model/resolve/main/model.bin",
+                max_size=10 * 1024 * 1024,
+            )
+
+        assert "11.0 MB" in str(exc_info.value)
+        assert "10.0 MB" in str(exc_info.value)
+        mock_hf_hub_download.assert_not_called()
+
+    @patch("huggingface_hub.HfApi")
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_file_with_max_size_rejects_unknown_size_before_download(
+        self,
+        mock_hf_hub_download: MagicMock,
+        mock_hf_api: MagicMock,
+    ) -> None:
+        """Capped direct files fail closed when HuggingFace metadata has no size."""
+        mock_hf_api.return_value.get_paths_info.return_value = [SimpleNamespace(size=None)]
+
+        with pytest.raises(Exception, match="Unable to determine file size"):
+            download_file_from_hf(
+                "https://huggingface.co/test/model/resolve/main/model.bin",
+                max_size=10 * 1024 * 1024,
+            )
+
+        mock_hf_hub_download.assert_not_called()
+
+    @patch("huggingface_hub.HfApi")
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_file_with_max_size_redacts_metadata_errors(
+        self,
+        mock_hf_hub_download: MagicMock,
+        mock_hf_api: MagicMock,
+    ) -> None:
+        """Metadata preflight errors should not expose direct URL credentials."""
+        mock_hf_api.return_value.get_paths_info.side_effect = Exception(
+            "HEAD failed for https://huggingface.co/test/model/resolve/main/model.bin?token=hf_secret"
+        )
+
+        with pytest.raises(Exception, match="Failed to download file from") as exc_info:
+            download_file_from_hf(
+                "https://huggingface.co/test/model/resolve/main/model.bin?token=hf_secret",
+                max_size=10 * 1024 * 1024,
+            )
+
+        error = str(exc_info.value)
+        assert "hf_secret" not in error
+        assert "token=" not in error
+        assert "https://huggingface.co/test/model/resolve/main/model.bin" in error
+        mock_hf_hub_download.assert_not_called()
+
+    @patch("huggingface_hub.HfApi")
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_file_without_max_size_skips_metadata_preflight(
+        self,
+        mock_hf_hub_download: MagicMock,
+        mock_hf_api: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Uncapped direct file downloads keep existing behavior and skip metadata lookup."""
+        mock_path = str(tmp_path / "downloaded_file.bin")
+        mock_hf_hub_download.return_value = mock_path
+
+        result = download_file_from_hf("https://huggingface.co/test/model/resolve/main/model.bin")
+
+        mock_hf_api.assert_not_called()
+        mock_hf_hub_download.assert_called_once()
+        assert result == Path(mock_path)
+
     @patch("huggingface_hub.hf_hub_download")
     def test_download_file_failure(self, mock_hf_hub_download):
         """Test that file download failures are handled properly."""

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -813,6 +813,7 @@ class TestHuggingFaceFileURLs:
         """Direct file downloads should check size metadata before fetching capped files."""
         mock_path = str(tmp_path / "downloaded_file.bin")
         mock_hf_hub_download.return_value = mock_path
+        mock_hf_api.return_value.repo_info.return_value = SimpleNamespace(sha="abc123")
         mock_hf_api.return_value.get_paths_info.return_value = [SimpleNamespace(size=1024)]
 
         result = download_file_from_hf(
@@ -820,8 +821,14 @@ class TestHuggingFaceFileURLs:
             max_size=2048,
         )
 
-        mock_hf_api.return_value.get_paths_info.assert_called_once_with("test/model", "model.bin", revision="main")
-        mock_hf_hub_download.assert_called_once()
+        mock_hf_api.return_value.repo_info.assert_called_once_with("test/model", revision="main")
+        mock_hf_api.return_value.get_paths_info.assert_called_once_with("test/model", "model.bin", revision="abc123")
+        mock_hf_hub_download.assert_called_once_with(
+            repo_id="test/model",
+            filename="model.bin",
+            revision="abc123",
+            cache_dir=None,
+        )
         assert result == Path(mock_path)
 
     @patch("huggingface_hub.HfApi")
@@ -832,6 +839,7 @@ class TestHuggingFaceFileURLs:
         mock_hf_api: MagicMock,
     ) -> None:
         """Oversized direct files should not reach hf_hub_download."""
+        mock_hf_api.return_value.repo_info.return_value = SimpleNamespace(sha="abc123")
         mock_hf_api.return_value.get_paths_info.return_value = [SimpleNamespace(size=11 * 1024 * 1024)]
 
         with pytest.raises(Exception, match="exceeds maximum allowed size") as exc_info:
@@ -852,6 +860,7 @@ class TestHuggingFaceFileURLs:
         mock_hf_api: MagicMock,
     ) -> None:
         """Capped direct files fail closed when HuggingFace metadata has no size."""
+        mock_hf_api.return_value.repo_info.return_value = SimpleNamespace(sha="abc123")
         mock_hf_api.return_value.get_paths_info.return_value = [SimpleNamespace(size=None)]
 
         with pytest.raises(Exception, match="Unable to determine file size"):
@@ -870,6 +879,7 @@ class TestHuggingFaceFileURLs:
         mock_hf_api: MagicMock,
     ) -> None:
         """Metadata preflight errors should not expose direct URL credentials."""
+        mock_hf_api.return_value.repo_info.return_value = SimpleNamespace(sha="abc123")
         mock_hf_api.return_value.get_paths_info.side_effect = Exception(
             "HEAD failed for https://huggingface.co/test/model/resolve/main/model.bin?token=hf_secret"
         )
@@ -884,6 +894,25 @@ class TestHuggingFaceFileURLs:
         assert "hf_secret" not in error
         assert "token=" not in error
         assert "https://huggingface.co/test/model/resolve/main/model.bin" in error
+        mock_hf_hub_download.assert_not_called()
+
+    @patch("huggingface_hub.HfApi")
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_file_with_max_size_rejects_missing_immutable_revision(
+        self,
+        mock_hf_hub_download: MagicMock,
+        mock_hf_api: MagicMock,
+    ) -> None:
+        """Capped downloads fail closed instead of sizing and fetching a mutable branch."""
+        mock_hf_api.return_value.repo_info.return_value = SimpleNamespace(sha=None)
+
+        with pytest.raises(Exception, match="Unable to determine immutable revision"):
+            download_file_from_hf(
+                "https://huggingface.co/test/model/resolve/main/model.bin",
+                max_size=10 * 1024 * 1024,
+            )
+
+        mock_hf_api.return_value.get_paths_info.assert_not_called()
         mock_hf_hub_download.assert_not_called()
 
     @patch("huggingface_hub.HfApi")

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -810,15 +810,16 @@ class TestHuggingFaceFileURLs:
         mock_hf_api: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Direct file downloads should check size metadata before fetching capped files."""
-        mock_path = str(tmp_path / "downloaded_file.bin")
-        mock_hf_hub_download.return_value = mock_path
+        """Direct file downloads should allow files exactly at the capped boundary."""
+        downloaded_file = tmp_path / "downloaded_file.bin"
+        downloaded_file.write_bytes(b"x" * 1024)
+        mock_hf_hub_download.return_value = str(downloaded_file)
         mock_hf_api.return_value.repo_info.return_value = SimpleNamespace(sha="abc123")
         mock_hf_api.return_value.get_paths_info.return_value = [SimpleNamespace(size=1024)]
 
         result = download_file_from_hf(
             "https://huggingface.co/test/model/resolve/main/model.bin",
-            max_size=2048,
+            max_size=1024,
         )
 
         mock_hf_api.return_value.repo_info.assert_called_once_with("test/model", revision="main")
@@ -829,7 +830,7 @@ class TestHuggingFaceFileURLs:
             revision="abc123",
             cache_dir=None,
         )
-        assert result == Path(mock_path)
+        assert result == downloaded_file
 
     @patch("huggingface_hub.HfApi")
     @patch("huggingface_hub.hf_hub_download")
@@ -854,14 +855,16 @@ class TestHuggingFaceFileURLs:
 
     @patch("huggingface_hub.HfApi")
     @patch("huggingface_hub.hf_hub_download")
-    def test_download_file_with_max_size_rejects_unknown_size_before_download(
+    @pytest.mark.parametrize("file_size", [None, -1, "1024", True])
+    def test_download_file_with_max_size_rejects_invalid_size_before_download(
         self,
         mock_hf_hub_download: MagicMock,
         mock_hf_api: MagicMock,
+        file_size: object,
     ) -> None:
-        """Capped direct files fail closed when HuggingFace metadata has no size."""
+        """Capped direct files fail closed when HuggingFace metadata has no valid size."""
         mock_hf_api.return_value.repo_info.return_value = SimpleNamespace(sha="abc123")
-        mock_hf_api.return_value.get_paths_info.return_value = [SimpleNamespace(size=None)]
+        mock_hf_api.return_value.get_paths_info.return_value = [SimpleNamespace(size=file_size)]
 
         with pytest.raises(Exception, match="Unable to determine file size"):
             download_file_from_hf(
@@ -870,6 +873,46 @@ class TestHuggingFaceFileURLs:
             )
 
         mock_hf_hub_download.assert_not_called()
+
+    @patch("huggingface_hub.HfApi")
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_file_with_max_size_rejects_underreported_download(
+        self,
+        mock_hf_hub_download: MagicMock,
+        mock_hf_api: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Capped direct files should verify the returned cache file before scanning."""
+        downloaded_file = tmp_path / "downloaded_file.bin"
+        downloaded_file.write_bytes(b"oversized")
+        mock_hf_hub_download.return_value = str(downloaded_file)
+        mock_hf_api.return_value.repo_info.return_value = SimpleNamespace(sha="abc123")
+        mock_hf_api.return_value.get_paths_info.return_value = [SimpleNamespace(size=4)]
+
+        with pytest.raises(Exception, match=r"Downloaded file size .* exceeds maximum allowed size"):
+            download_file_from_hf(
+                "https://huggingface.co/test/model/resolve/main/model.bin",
+                max_size=4,
+            )
+
+    @patch("huggingface_hub.HfApi")
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_file_with_max_size_rejects_unverifiable_download(
+        self,
+        mock_hf_hub_download: MagicMock,
+        mock_hf_api: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Capped direct files fail closed if the downloaded cache path cannot be verified."""
+        mock_hf_hub_download.return_value = str(tmp_path / "missing.bin")
+        mock_hf_api.return_value.repo_info.return_value = SimpleNamespace(sha="abc123")
+        mock_hf_api.return_value.get_paths_info.return_value = [SimpleNamespace(size=4)]
+
+        with pytest.raises(Exception, match="Unable to verify downloaded file size"):
+            download_file_from_hf(
+                "https://huggingface.co/test/model/resolve/main/model.bin",
+                max_size=4,
+            )
 
     @patch("huggingface_hub.HfApi")
     @patch("huggingface_hub.hf_hub_download")
@@ -932,6 +975,44 @@ class TestHuggingFaceFileURLs:
         mock_hf_api.assert_not_called()
         mock_hf_hub_download.assert_called_once()
         assert result == Path(mock_path)
+
+    @patch("huggingface_hub.HfApi")
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_file_with_zero_max_size_skips_metadata_preflight(
+        self,
+        mock_hf_hub_download: MagicMock,
+        mock_hf_api: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """A zero maximum size should preserve ModelAudit's unlimited-size behavior."""
+        mock_path = str(tmp_path / "downloaded_file.bin")
+        mock_hf_hub_download.return_value = mock_path
+
+        result = download_file_from_hf(
+            "https://huggingface.co/test/model/resolve/main/model.bin",
+            max_size=0,
+        )
+
+        mock_hf_api.assert_not_called()
+        mock_hf_hub_download.assert_called_once()
+        assert result == Path(mock_path)
+
+    @patch("huggingface_hub.HfApi")
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_file_with_negative_max_size_rejected(
+        self,
+        mock_hf_hub_download: MagicMock,
+        mock_hf_api: MagicMock,
+    ) -> None:
+        """Negative direct-download limits should not silently disable enforcement."""
+        with pytest.raises(Exception, match="Maximum file size must be non-negative"):
+            download_file_from_hf(
+                "https://huggingface.co/test/model/resolve/main/model.bin",
+                max_size=-1,
+            )
+
+        mock_hf_api.assert_not_called()
+        mock_hf_hub_download.assert_not_called()
 
     @patch("huggingface_hub.hf_hub_download")
     def test_download_file_failure(self, mock_hf_hub_download):


### PR DESCRIPTION
## Summary

- pass the CLI `--max-size` download budget into direct Hugging Face file downloads
- preflight exact file metadata with `HfApi.get_paths_info()` before `hf_hub_download()` when a cap is set
- fail closed before download on oversized or unknown-size direct files, while preserving uncapped legacy behavior and URL redaction

## Validation

- `PYTHONPATH=/private/tmp/modelaudit-c012:/private/tmp/modelaudit-c012/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/utils/sources/test_huggingface.py::TestHuggingFaceFileURLs::test_download_file_success tests/utils/sources/test_huggingface.py::TestHuggingFaceFileURLs::test_download_file_with_cache_dir tests/utils/sources/test_huggingface.py::TestHuggingFaceFileURLs::test_download_file_with_max_size_preflights_before_download tests/utils/sources/test_huggingface.py::TestHuggingFaceFileURLs::test_download_file_with_max_size_rejects_oversized_before_download tests/utils/sources/test_huggingface.py::TestHuggingFaceFileURLs::test_download_file_with_max_size_rejects_unknown_size_before_download tests/utils/sources/test_huggingface.py::TestHuggingFaceFileURLs::test_download_file_with_max_size_redacts_metadata_errors tests/utils/sources/test_huggingface.py::TestHuggingFaceFileURLs::test_download_file_without_max_size_skips_metadata_preflight tests/test_cli.py::test_scan_huggingface_file_passes_max_size_to_download tests/test_cli.py::test_scan_huggingface_file_download_failure_redacts_url -q`
  - `9 passed`
- `PYTHONPATH=/private/tmp/modelaudit-c012:/private/tmp/modelaudit-c012/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/utils/sources/test_huggingface.py -q`
  - `59 passed`
- `PYTHONPATH=/private/tmp/modelaudit-c012:/private/tmp/modelaudit-c012/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/test_cli.py::test_scan_huggingface_file_passes_max_size_to_download tests/test_cli.py::test_scan_huggingface_file_download_failure_redacts_url tests/test_cli.py::test_scan_huggingface_url_success tests/test_cli.py::test_scan_huggingface_url_download_failure -q`
  - `4 passed`
- `CARGO_HOME=/private/tmp/modelaudit-cargo CARGO_TARGET_DIR=/private/tmp/modelaudit-c012-picklescan-target UV_CACHE_DIR=/private/tmp/modelaudit-uv-cache uv pip install --python /Users/mdangelo/code/modelaudit/.venv/bin/python -e packages/modelaudit-picklescan`
  - rebuilt native editable package for this worktree
- `/Users/mdangelo/code/modelaudit/.venv/bin/ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
  - `399 files already formatted`
- `/Users/mdangelo/code/modelaudit/.venv/bin/ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
  - `All checks passed`
- `PYTHONPATH=/private/tmp/modelaudit-c012:/private/tmp/modelaudit-c012/packages/modelaudit-picklescan/src /Users/mdangelo/code/modelaudit/.venv/bin/mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
  - `Success: no issues found in 454 source files`
- `PYTHONPATH=/private/tmp/modelaudit-c012:/private/tmp/modelaudit-c012/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest -n auto -m "not slow and not integration" --maxfail=1`
  - `7716 passed, 16 skipped, 21 warnings`
