### PR TITLE
fix: fail closed on empty Hugging Face repo listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - preserve per-shard metadata when aggregating sharded model families
 - prevent picklescan call-graph alias cycles from hanging scans
 - preserve HuggingFace snapshot shard paths while grouping cache-backed families
+- fail closed when Hugging Face repository listings contain no recognized scannable files instead of downloading the full repository
 - stop flagging a false-positive ONNX Python operator when tensor weight bytes coincidentally spell `PyOp`
 - classify unavailable manifest and ML text reads as inconclusive rather than security findings, including routing, preflight, and stale cache transitions
 - classify unavailable manifest cloud-reference inspection as inconclusive rather than reporting complete coverage

--- a/modelaudit/utils/sources/huggingface.py
+++ b/modelaudit/utils/sources/huggingface.py
@@ -51,7 +51,7 @@ def _get_model_extensions() -> set[str]:
 def _build_extension_allow_patterns() -> list[str]:
     """Build conservative glob patterns for scannable files."""
     extensions = _get_model_extensions()
-    suffix_globs = {_case_insensitive_suffix_glob(ext) for ext in extensions}
+    suffix_globs = {_case_insensitive_suffix_glob(ext) for ext in extensions if ext}
     patterns = {f"*{suffix}" for suffix in suffix_globs}
     patterns.update(f"**/*{suffix}" for suffix in suffix_globs)
     return sorted(patterns)
@@ -65,7 +65,7 @@ def _case_insensitive_suffix_glob(extension: str) -> str:
 def _is_scannable_hf_file(filename: str, extensions: set[str]) -> bool:
     """Return whether a listed Hugging Face file has a supported suffix."""
     filename_lower = filename.lower()
-    return any(filename_lower.endswith(ext.lower()) for ext in extensions)
+    return any(filename_lower.endswith(ext.lower()) for ext in extensions if ext)
 
 
 def _raise_no_scannable_hf_files(repo_id: str) -> None:

--- a/modelaudit/utils/sources/huggingface.py
+++ b/modelaudit/utils/sources/huggingface.py
@@ -56,6 +56,13 @@ def _build_extension_allow_patterns() -> list[str]:
     return sorted(patterns)
 
 
+def _raise_no_scannable_hf_files(repo_id: str) -> None:
+    raise Exception(
+        f"Refusing to download full snapshot for {repo_id}: "
+        "repository listing contains no recognized ModelAudit-scannable files"
+    )
+
+
 def _get_hf_cache_root() -> Path:
     """Return the HuggingFace hub cache root."""
     try:
@@ -309,12 +316,10 @@ def download_model(url: str, cache_dir: Path | None = None, show_progress: bool 
                     f"Refusing to download full snapshot for {repo_id}: no selective allowlist patterns available"
                 )
             download_kwargs["allow_patterns"] = extension_allow_patterns
-
-        if "allow_patterns" in download_kwargs:
-            local_path = snapshot_download(**download_kwargs)  # type: ignore[call-arg]
         else:
-            # Fallback: download everything if no model files identified
-            local_path = snapshot_download(**download_kwargs)  # type: ignore[call-arg]
+            _raise_no_scannable_hf_files(repo_id)
+
+        local_path = snapshot_download(**download_kwargs)  # type: ignore[call-arg]
 
         # Verify we actually got model files
         downloaded_path = Path(local_path)
@@ -408,9 +413,7 @@ def download_model_streaming(
         model_files = [f for f in repo_files if any(f.endswith(ext) for ext in model_extensions)]
 
         if not model_files:
-            # Fallback: download all files if no recognized extensions found
-            # This maintains parity with download_model() behavior
-            model_files = repo_files
+            _raise_no_scannable_hf_files(repo_id)
 
         # Setup cache directory
         download_path = None

--- a/modelaudit/utils/sources/huggingface.py
+++ b/modelaudit/utils/sources/huggingface.py
@@ -51,9 +51,21 @@ def _get_model_extensions() -> set[str]:
 def _build_extension_allow_patterns() -> list[str]:
     """Build conservative glob patterns for scannable files."""
     extensions = _get_model_extensions()
-    patterns = {f"*{ext}" for ext in extensions}
-    patterns.update(f"**/*{ext}" for ext in extensions)
+    suffix_globs = {_case_insensitive_suffix_glob(ext) for ext in extensions}
+    patterns = {f"*{suffix}" for suffix in suffix_globs}
+    patterns.update(f"**/*{suffix}" for suffix in suffix_globs)
     return sorted(patterns)
+
+
+def _case_insensitive_suffix_glob(extension: str) -> str:
+    """Build a fnmatch suffix glob that preserves mixed-case remote files."""
+    return "".join(f"[{char.lower()}{char.upper()}]" if char.isalpha() else char for char in extension)
+
+
+def _is_scannable_hf_file(filename: str, extensions: set[str]) -> bool:
+    """Return whether a listed Hugging Face file has a supported suffix."""
+    filename_lower = filename.lower()
+    return any(filename_lower.endswith(ext.lower()) for ext in extensions)
 
 
 def _raise_no_scannable_hf_files(repo_id: str) -> None:
@@ -287,7 +299,7 @@ def download_model(url: str, cache_dir: Path | None = None, show_progress: bool 
 
         # Find model files in the repository (using centralized model extensions)
         model_extensions = _get_model_extensions()
-        model_files = [f for f in repo_files if any(f.endswith(ext) for ext in model_extensions)]
+        model_files = [f for f in repo_files if _is_scannable_hf_file(f, model_extensions)]
 
         # Download strategy:
         # - When cache_dir is provided: Use local_dir to place files directly there (safer)
@@ -324,7 +336,9 @@ def download_model(url: str, cache_dir: Path | None = None, show_progress: bool 
         # Verify we actually got model files
         downloaded_path = Path(local_path)
         model_extensions = _get_model_extensions()
-        found_models = any(downloaded_path.glob(f"*{ext}") for ext in model_extensions)
+        found_models = any(
+            path.is_file() and _is_scannable_hf_file(path.name, model_extensions) for path in downloaded_path.rglob("*")
+        )
 
         if not found_models and not any(downloaded_path.glob("config.json")):
             # If no model files and no config, warn the user
@@ -410,7 +424,7 @@ def download_model_streaming(
 
         # Filter for model files
         model_extensions = _get_model_extensions()
-        model_files = [f for f in repo_files if any(f.endswith(ext) for ext in model_extensions)]
+        model_files = [f for f in repo_files if _is_scannable_hf_file(f, model_extensions)]
 
         if not model_files:
             _raise_no_scannable_hf_files(repo_id)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -999,6 +999,34 @@ def test_scan_huggingface_url_download_failure(mock_download, mock_is_hf_url):
     assert "Download failed" in result.output
 
 
+@patch("modelaudit.utils.sources.huggingface.get_model_size", return_value=None)
+@patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={"", ".bin"})
+@patch("modelaudit.utils.sources.huggingface._list_repo_files_with_timeout", return_value=(["notes.unknown"], None))
+@patch("huggingface_hub.snapshot_download")
+@patch("modelaudit.cli.scan_model_directory_or_file")
+def test_scan_huggingface_no_scannable_listing_fails_closed(
+    mock_scan: MagicMock,
+    mock_snapshot_download: MagicMock,
+    _mock_list_repo_files: MagicMock,
+    _mock_get_extensions: MagicMock,
+    _mock_get_model_size: MagicMock,
+) -> None:
+    """Unsupported-only repositories should exit 2 without downloading or scanning."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["scan", "--no-cache", "--format", "json", "https://huggingface.co/test/model"],
+    )
+
+    parsed = parse_click_json_output(result.output)
+    assert result.exit_code == 2
+    assert parsed["has_errors"] is True
+    assert parsed["files_scanned"] == 0
+    assert "repository listing contains no recognized ModelAudit-scannable files" in result.output
+    mock_snapshot_download.assert_not_called()
+    mock_scan.assert_not_called()
+
+
 @patch("modelaudit.cli.download_file_from_hf")
 def test_scan_huggingface_file_download_failure_redacts_url(mock_download_file):
     """Redact direct-file URL secrets from CLI download failures."""
@@ -1547,6 +1575,29 @@ def test_scan_huggingface_streaming_download_failure(mock_download_streaming, mo
     # Should fail with error code 2
     assert result.exit_code == 2
     assert "Error" in result.output
+
+
+@patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={"", ".bin"})
+@patch("modelaudit.utils.sources.huggingface._list_repo_files_with_timeout", return_value=(["notes.unknown"], None))
+@patch("huggingface_hub.hf_hub_download")
+def test_scan_huggingface_streaming_no_scannable_listing_fails_closed(
+    mock_hf_hub_download: MagicMock,
+    _mock_list_repo_files: MagicMock,
+    _mock_get_extensions: MagicMock,
+) -> None:
+    """Lazy streaming listing failures should exit 2 instead of reporting a clean scan."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["scan", "--stream", "--no-cache", "--format", "json", "hf://test/model"],
+    )
+
+    parsed = parse_click_json_output(result.output)
+    assert result.exit_code == 2
+    assert parsed["has_errors"] is True
+    assert parsed["files_scanned"] == 0
+    assert "repository listing contains no recognized ModelAudit-scannable files" in result.output
+    mock_hf_hub_download.assert_not_called()
 
 
 @patch("modelaudit.cli.is_huggingface_url")

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -1,5 +1,6 @@
 """Tests for HuggingFace URL handling."""
 
+from fnmatch import fnmatch
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -321,7 +322,13 @@ class TestModelDownload:
         download_model("https://huggingface.co/test/model")
 
         allow_patterns = mock_snapshot_download.call_args.kwargs["allow_patterns"]
-        assert allow_patterns == ["**/*.bin", "**/*.json", "*.bin", "*.json"]
+        assert allow_patterns == [
+            "**/*.[bB][iI][nN]",
+            "**/*.[jJ][sS][oO][nN]",
+            "*.[bB][iI][nN]",
+            "*.[jJ][sS][oO][nN]",
+        ]
+        assert any(fnmatch("MODEL.BiN", pattern) for pattern in allow_patterns)
 
     @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".bin"})
     @patch("huggingface_hub.snapshot_download")
@@ -345,7 +352,8 @@ class TestModelDownload:
             download_model("https://huggingface.co/test/model")
 
         allow_patterns = mock_snapshot_download.call_args.kwargs["allow_patterns"]
-        assert allow_patterns == ["**/*.bin", "*.bin"]
+        assert allow_patterns == ["**/*.[bB][iI][nN]", "*.[bB][iI][nN]"]
+        assert any(fnmatch("MODEL.BiN", pattern) for pattern in allow_patterns)
 
     @patch("huggingface_hub.HfApi.repo_info")
     def test_list_repo_files_timeout_uses_hfapi_timeout(self, mock_repo_info: MagicMock) -> None:
@@ -397,6 +405,30 @@ class TestModelDownload:
             download_model("https://huggingface.co/test/model")
 
         mock_snapshot_download.assert_not_called()
+
+    @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".safetensors"})
+    @patch(
+        "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
+        return_value=(["nested/MODEL.SaFeTeNsOrS"], None),
+    )
+    @patch("huggingface_hub.snapshot_download")
+    def test_download_model_listing_accepts_mixed_case_scannable_suffix(
+        self,
+        mock_snapshot_download: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        _mock_get_extensions: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Supported remote suffixes should match local case-insensitive routing."""
+        download_path = tmp_path / "download"
+        model_path = download_path / "nested" / "MODEL.SaFeTeNsOrS"
+        model_path.parent.mkdir(parents=True)
+        model_path.write_bytes(b"weights")
+        mock_snapshot_download.return_value = str(download_path)
+
+        download_model("https://huggingface.co/test/model")
+
+        assert mock_snapshot_download.call_args.kwargs["allow_patterns"] == ["nested/MODEL.SaFeTeNsOrS"]
 
     @patch("huggingface_hub.snapshot_download")
     @patch("shutil.rmtree")
@@ -461,6 +493,28 @@ class TestModelDownloadStreaming:
             cache_dir=str(tmp_path / "huggingface"),
             local_dir=str(tmp_path / "huggingface" / "test" / "model"),
         )
+
+    @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".safetensors"})
+    @patch(
+        "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
+        return_value=(["MODEL.SaFeTeNsOrS"], None),
+    )
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_model_streaming_accepts_mixed_case_scannable_suffix(
+        self,
+        mock_hf_hub_download: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        _mock_get_extensions: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Streaming downloads should recognize mixed-case supported suffixes."""
+        downloaded_file = tmp_path / "MODEL.SaFeTeNsOrS"
+        mock_hf_hub_download.return_value = str(downloaded_file)
+
+        results = list(download_model_streaming("https://huggingface.co/test/model"))
+
+        assert results == [(downloaded_file, True)]
+        mock_hf_hub_download.assert_called_once_with(repo_id="test/model", filename="MODEL.SaFeTeNsOrS")
 
     @patch(
         "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -360,21 +360,43 @@ class TestModelDownload:
 
     @patch("modelaudit.utils.sources.huggingface._list_repo_files_with_timeout", return_value=(["notes.unknown"], None))
     @patch("huggingface_hub.snapshot_download")
-    def test_download_model_listing_success_without_scannable_files_keeps_full_snapshot_fallback(
+    def test_download_model_listing_success_without_scannable_files_fails_closed(
         self,
         mock_snapshot_download: MagicMock,
         _mock_list_repo_files: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """A successful listing with no scannable files should preserve the existing full-snapshot fallback."""
+        """A successful listing with no scannable files must not fall back to a full snapshot."""
         download_path = tmp_path / "download"
         download_path.mkdir()
         (download_path / "config.json").write_text("{}")
         mock_snapshot_download.return_value = str(download_path)
 
-        download_model("https://huggingface.co/test/model")
+        with pytest.raises(
+            Exception,
+            match="Refusing to download full snapshot for test/model: "
+            "repository listing contains no recognized ModelAudit-scannable files",
+        ):
+            download_model("https://huggingface.co/test/model")
 
-        assert "allow_patterns" not in mock_snapshot_download.call_args.kwargs
+        mock_snapshot_download.assert_not_called()
+
+    @patch("modelaudit.utils.sources.huggingface._list_repo_files_with_timeout", return_value=([], None))
+    @patch("huggingface_hub.snapshot_download")
+    def test_download_model_empty_listing_fails_closed(
+        self,
+        mock_snapshot_download: MagicMock,
+        _mock_list_repo_files: MagicMock,
+    ) -> None:
+        """An empty successful listing should not trigger a full-snapshot download."""
+        with pytest.raises(
+            Exception,
+            match="Refusing to download full snapshot for test/model: "
+            "repository listing contains no recognized ModelAudit-scannable files",
+        ):
+            download_model("https://huggingface.co/test/model")
+
+        mock_snapshot_download.assert_not_called()
 
     @patch("huggingface_hub.snapshot_download")
     @patch("shutil.rmtree")
@@ -470,6 +492,47 @@ class TestModelDownloadStreaming:
         with pytest.raises(
             Exception,
             match="Failed listing files in repository test/model: repository listing unavailable",
+        ):
+            list(download_model_streaming("https://huggingface.co/test/model"))
+
+        mock_hf_hub_download.assert_not_called()
+
+    @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".bin"})
+    @patch(
+        "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
+        return_value=(["README.md", "notes.txt"], None),
+    )
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_model_streaming_listing_success_without_scannable_files_fails_closed(
+        self,
+        mock_hf_hub_download: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        _mock_get_extensions: MagicMock,
+    ) -> None:
+        """Streaming mode must not download every repo file when no scannable files are listed."""
+        with pytest.raises(
+            Exception,
+            match="Refusing to download full snapshot for test/model: "
+            "repository listing contains no recognized ModelAudit-scannable files",
+        ):
+            list(download_model_streaming("https://huggingface.co/test/model"))
+
+        mock_hf_hub_download.assert_not_called()
+
+    @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".bin"})
+    @patch("modelaudit.utils.sources.huggingface._list_repo_files_with_timeout", return_value=([], None))
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_model_streaming_empty_listing_fails_closed(
+        self,
+        mock_hf_hub_download: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        _mock_get_extensions: MagicMock,
+    ) -> None:
+        """An empty successful listing should not make streaming mode download all repo files."""
+        with pytest.raises(
+            Exception,
+            match="Refusing to download full snapshot for test/model: "
+            "repository listing contains no recognized ModelAudit-scannable files",
         ):
             list(download_model_streaming("https://huggingface.co/test/model"))
 

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -300,7 +300,7 @@ class TestModelDownload:
         mock_snapshot_download.assert_called_once()
         assert mock_snapshot_download.call_args.kwargs["local_dir"] == str(existing_path)
 
-    @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".bin", ".json"})
+    @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={"", ".bin", ".json"})
     @patch(
         "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
         return_value=(None, "repo listing failed"),
@@ -366,35 +366,65 @@ class TestModelDownload:
         assert error is None
         mock_repo_info.assert_called_once_with("test/model", timeout=7, files_metadata=False)
 
+    @patch("modelaudit.utils.sources.huggingface.get_model_size", return_value=None)
+    @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={"", ".bin"})
     @patch("modelaudit.utils.sources.huggingface._list_repo_files_with_timeout", return_value=(["notes.unknown"], None))
     @patch("huggingface_hub.snapshot_download")
     def test_download_model_listing_success_without_scannable_files_fails_closed(
         self,
         mock_snapshot_download: MagicMock,
         _mock_list_repo_files: MagicMock,
+        _mock_get_extensions: MagicMock,
+        _mock_get_model_size: MagicMock,
         tmp_path: Path,
     ) -> None:
         """A successful listing with no scannable files must not fall back to a full snapshot."""
-        download_path = tmp_path / "download"
-        download_path.mkdir()
-        (download_path / "config.json").write_text("{}")
-        mock_snapshot_download.return_value = str(download_path)
+        cache_dir = tmp_path / "cache"
+        download_path = cache_dir / "huggingface" / "test" / "model"
 
         with pytest.raises(
             Exception,
             match="Refusing to download full snapshot for test/model: "
             "repository listing contains no recognized ModelAudit-scannable files",
         ):
-            download_model("https://huggingface.co/test/model")
+            download_model("https://huggingface.co/test/model", cache_dir=cache_dir)
 
         mock_snapshot_download.assert_not_called()
+        assert not download_path.exists()
 
+    @patch("modelaudit.utils.sources.huggingface.get_model_size", return_value=None)
+    @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={"", ".bin"})
+    @patch("modelaudit.utils.sources.huggingface._list_repo_files_with_timeout", return_value=(["notes.unknown"], None))
+    @patch("huggingface_hub.snapshot_download")
+    def test_download_model_listing_without_scannable_files_preserves_existing_cache(
+        self,
+        mock_snapshot_download: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        _mock_get_extensions: MagicMock,
+        _mock_get_model_size: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Fail-closed listing checks must not delete a user's preexisting cache."""
+        cache_dir = tmp_path / "cache"
+        download_path = cache_dir / "huggingface" / "test" / "model"
+        download_path.mkdir(parents=True)
+        cached_file = download_path / "cached.bin"
+        cached_file.write_bytes(b"cached")
+
+        with pytest.raises(Exception, match="repository listing contains no recognized ModelAudit-scannable files"):
+            download_model("https://huggingface.co/test/model", cache_dir=cache_dir)
+
+        mock_snapshot_download.assert_not_called()
+        assert cached_file.read_bytes() == b"cached"
+
+    @patch("modelaudit.utils.sources.huggingface.get_model_size", return_value=None)
     @patch("modelaudit.utils.sources.huggingface._list_repo_files_with_timeout", return_value=([], None))
     @patch("huggingface_hub.snapshot_download")
     def test_download_model_empty_listing_fails_closed(
         self,
         mock_snapshot_download: MagicMock,
         _mock_list_repo_files: MagicMock,
+        _mock_get_model_size: MagicMock,
     ) -> None:
         """An empty successful listing should not trigger a full-snapshot download."""
         with pytest.raises(
@@ -406,6 +436,7 @@ class TestModelDownload:
 
         mock_snapshot_download.assert_not_called()
 
+    @patch("modelaudit.utils.sources.huggingface.get_model_size", return_value=None)
     @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".safetensors"})
     @patch(
         "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
@@ -417,6 +448,7 @@ class TestModelDownload:
         mock_snapshot_download: MagicMock,
         _mock_list_repo_files: MagicMock,
         _mock_get_extensions: MagicMock,
+        _mock_get_model_size: MagicMock,
         tmp_path: Path,
     ) -> None:
         """Supported remote suffixes should match local case-insensitive routing."""
@@ -467,7 +499,7 @@ class TestModelDownload:
 class TestModelDownloadStreaming:
     """Test streaming model downloads from HuggingFace."""
 
-    @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".bin"})
+    @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={"", ".bin"})
     @patch(
         "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
         return_value=(["pytorch_model.bin", "README.md"], None),


### PR DESCRIPTION
## Summary
- fail closed when a Hugging Face repository listing succeeds but contains no ModelAudit-scannable files
- remove the normal full-snapshot fallback and streaming all-files fallback for no-recognized-model listings
- add regressions for unsupported-only and empty listings in normal and streaming paths

## Validation
- PYTHONPATH=/private/tmp/modelaudit-c013:/private/tmp/modelaudit-c013/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/utils/sources/test_huggingface.py::TestModelDownload::test_download_model_listing_success_without_scannable_files_fails_closed tests/utils/sources/test_huggingface.py::TestModelDownload::test_download_model_empty_listing_fails_closed tests/utils/sources/test_huggingface.py::TestModelDownload::test_download_model_listing_error_uses_extension_allow_patterns tests/utils/sources/test_huggingface.py::TestModelDownloadStreaming::test_download_model_streaming_downloads_scannable_files_only tests/utils/sources/test_huggingface.py::TestModelDownloadStreaming::test_download_model_streaming_listing_success_without_scannable_files_fails_closed tests/utils/sources/test_huggingface.py::TestModelDownloadStreaming::test_download_model_streaming_empty_listing_fails_closed -q
- PYTHONPATH=/private/tmp/modelaudit-c013:/private/tmp/modelaudit-c013/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/utils/sources/test_huggingface.py -q
- CARGO_HOME=/private/tmp/modelaudit-cargo CARGO_TARGET_DIR=/private/tmp/modelaudit-c013-picklescan-target UV_CACHE_DIR=/private/tmp/modelaudit-uv-cache uv pip install --python /Users/mdangelo/code/modelaudit/.venv/bin/python -e packages/modelaudit-picklescan
- /Users/mdangelo/code/modelaudit/.venv/bin/ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- /Users/mdangelo/code/modelaudit/.venv/bin/ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PYTHONPATH=/private/tmp/modelaudit-c013:/private/tmp/modelaudit-c013/packages/modelaudit-picklescan/src /Users/mdangelo/code/modelaudit/.venv/bin/mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- PYTHONPATH=/private/tmp/modelaudit-c013:/private/tmp/modelaudit-c013/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest -n auto -m "not slow and not integration" --maxfail=1