### PR TITLE
fix: bound Orbax directory checkpoint scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - scan dangerous RKNN safe-key metadata values instead of suppressing the whole key-value string
 - scan ONNX external data initializers in nested graphs, functions, and training graphs
 - route protocol-0 JAX checkpoint pickles through pickle opcode security checks
+- bound Orbax directory metadata parsing and checkpoint entry enumeration before scanning JAX checkpoints
 - harden legacy JAX checkpoint pickle routing against bounded-prefix bypasses and benign sidecar false positives
 - detect dangerous Python calls retrieved or installed through module namespace dictionaries in ZIP and TAR members, while avoiding comprehension-local false positives
 - preflight and stream-enforce cumulative SevenZip extraction budgets before writing oversized archives

--- a/modelaudit/scanners/jax_checkpoint_scanner.py
+++ b/modelaudit/scanners/jax_checkpoint_scanner.py
@@ -706,19 +706,18 @@ class JaxCheckpointScanner(BaseScanner):
 
         finding_budget = _PatternFindingBudget(self.max_metadata_pattern_findings)
         orbax_restore_context = f"{root_context}.restore_fn"
-        orbax_restore_fn_reported = False
+        first_orbax_restore_fn: str | None = None
+        dangerous_orbax_restore_fn: str | None = None
         for context, text_value in string_values:
-            if (
-                detect_orbax_restore_fn
-                and not orbax_restore_fn_reported
-                and (
-                    context == orbax_restore_context
-                    or context.startswith(f"{orbax_restore_context}.")
-                    or context.startswith(f"{orbax_restore_context}[")
-                )
+            if detect_orbax_restore_fn and (
+                context == orbax_restore_context
+                or context.startswith(f"{orbax_restore_context}.")
+                or context.startswith(f"{orbax_restore_context}[")
             ):
-                self._add_orbax_restore_fn_check(text_value, path, result)
-                orbax_restore_fn_reported = True
+                if first_orbax_restore_fn is None:
+                    first_orbax_restore_fn = text_value
+                if dangerous_orbax_restore_fn is None and self._DANGEROUS_RESTORE_FN_PATTERN.search(text_value):
+                    dangerous_orbax_restore_fn = text_value
             self._add_suspicious_pattern_checks(
                 text_value,
                 context=context,
@@ -728,6 +727,10 @@ class JaxCheckpointScanner(BaseScanner):
                 result=result,
                 finding_budget=finding_budget,
             )
+        if dangerous_orbax_restore_fn is not None:
+            self._add_orbax_restore_fn_check(dangerous_orbax_restore_fn, path, result)
+        elif first_orbax_restore_fn is not None:
+            self._add_orbax_restore_fn_check(first_orbax_restore_fn, path, result)
         self._add_metadata_traversal_depth_limit_checks(
             contexts=depth_cap_contexts,
             check_name=depth_limit_check_name,

--- a/modelaudit/scanners/jax_checkpoint_scanner.py
+++ b/modelaudit/scanners/jax_checkpoint_scanner.py
@@ -793,9 +793,15 @@ class JaxCheckpointScanner(BaseScanner):
             if (path_obj / orbax_file).exists():
                 return True
 
-        # Check for JAX checkpoint patterns
-        jax_patterns = ["step_*", "params_*", "state_*", "model_*"]
-        return any(next(path_obj.glob(pattern), None) is not None for pattern in jax_patterns)
+        # Probe once and route oversized directories into the scanner's
+        # fail-closed entry-limit handling.
+        jax_prefixes = ("step_", "params_", "state_", "model_")
+        for entry_index, entry in enumerate(path_obj.iterdir(), start=1):
+            if entry_index > cls.DEFAULT_MAX_ORBAX_DIRECTORY_ENTRIES:
+                return True
+            if entry.name.startswith(jax_prefixes):
+                return True
+        return False
 
     @classmethod
     def _header_starts_with_legacy_pickle_opcode(cls, header: bytes) -> bool:

--- a/modelaudit/scanners/jax_checkpoint_scanner.py
+++ b/modelaudit/scanners/jax_checkpoint_scanner.py
@@ -50,6 +50,14 @@ class _BoundedJsonPrefixFrame:
     next_index: int = 0
 
 
+@dataclass
+class _OrbaxDirectoryAccounting:
+    """Track files and bytes actually inspected by the Orbax directory scanner."""
+
+    bytes_scanned: int = 0
+    files_scanned: int = 0
+
+
 class JaxCheckpointScanner(BaseScanner):
     """Scanner for JAX checkpoint files in various formats (Orbax, pickle-based, etc.)."""
 
@@ -109,6 +117,8 @@ class JaxCheckpointScanner(BaseScanner):
     _UTF8_BOM: ClassVar[bytes] = b"\xef\xbb\xbf"
     DEFAULT_MAX_METADATA_PATTERN_FINDINGS: ClassVar[int] = 256
     DEFAULT_MAX_PICKLE_OPCODE_FINDINGS: ClassVar[int] = 256
+    DEFAULT_MAX_ORBAX_CHECKPOINT_FILES: ClassVar[int] = 4096
+    DEFAULT_MAX_ORBAX_DIRECTORY_ENTRIES: ClassVar[int] = 8192
     _DANGEROUS_PICKLE_GLOBALS: ClassVar[frozenset[tuple[str, str]]] = frozenset(
         {
             ("builtins", "__import__"),
@@ -224,6 +234,10 @@ class JaxCheckpointScanner(BaseScanner):
     DEFAULT_MAX_PICKLE_SCAN_BYTES: ClassVar[int] = 16 * 1024 * 1024
     _JSON_ANALYSIS_SIZE_LIMIT_REASON: ClassVar[str] = "jax_json_checkpoint_analysis_size_limit"
     _JSON_PREFIX_PATTERN_READ_FAILED_REASON: ClassVar[str] = "jax_json_checkpoint_prefix_pattern_read_failed"
+    _ORBAX_METADATA_ANALYSIS_SIZE_LIMIT_REASON: ClassVar[str] = "jax_orbax_metadata_analysis_size_limit"
+    _ORBAX_METADATA_PREFIX_PATTERN_READ_FAILED_REASON: ClassVar[str] = "jax_orbax_metadata_prefix_pattern_read_failed"
+    _ORBAX_DIRECTORY_ENTRY_COUNT_LIMIT_REASON: ClassVar[str] = "jax_orbax_directory_entry_count_limit"
+    _ORBAX_CHECKPOINT_FILE_COUNT_LIMIT_REASON: ClassVar[str] = "jax_orbax_checkpoint_file_count_limit"
     _METADATA_TRAVERSAL_LIMIT_REASON: ClassVar[str] = "jax_metadata_traversal_depth_limit"
     _PICKLE_SCAN_LIMIT_REASON: ClassVar[str] = "jax_pickle_scan_limit_exceeded"
     _LEGACY_PICKLE_INITIAL_OPCODES: ClassVar[bytes] = (
@@ -252,6 +266,16 @@ class JaxCheckpointScanner(BaseScanner):
         self.max_metadata_pattern_findings = self._get_int_config(
             "jax_metadata_max_pattern_findings",
             self.DEFAULT_MAX_METADATA_PATTERN_FINDINGS,
+            minimum=1,
+        )
+        self.max_orbax_checkpoint_files = self._get_int_config(
+            "jax_orbax_max_checkpoint_files",
+            self.DEFAULT_MAX_ORBAX_CHECKPOINT_FILES,
+            minimum=1,
+        )
+        self.max_orbax_directory_entries = self._get_int_config(
+            "jax_orbax_max_directory_entries",
+            self.DEFAULT_MAX_ORBAX_DIRECTORY_ENTRIES,
             minimum=1,
         )
 
@@ -520,6 +544,7 @@ class JaxCheckpointScanner(BaseScanner):
         cls,
         prefix_text: str,
         *,
+        root_context: str = "json_checkpoint_bounded_prefix",
         depth_cap_contexts: set[str] | None = None,
     ) -> Iterator[tuple[str, str]]:
         """Yield decoded visible JSON strings with bounded ancestor context."""
@@ -554,7 +579,7 @@ class JaxCheckpointScanner(BaseScanner):
                     return
                 kind = "object" if prefix_text[offset] == "{" else "array"
                 state = "key" if kind == "object" else "value"
-                frames.append(_BoundedJsonPrefixFrame(kind, "json_checkpoint_bounded_prefix", state))
+                frames.append(_BoundedJsonPrefixFrame(kind, root_context, state))
                 offset += 1
                 continue
 
@@ -647,7 +672,17 @@ class JaxCheckpointScanner(BaseScanner):
             frame.state = "key" if frame.kind == "object" else "value"
             offset += 1
 
-    def _scan_bounded_json_prefix_patterns(self, path: str, result: ScanResult) -> None:
+    def _scan_bounded_json_prefix_patterns(
+        self,
+        path: str,
+        result: ScanResult,
+        *,
+        root_context: str = "json_checkpoint_bounded_prefix",
+        check_name: str = "JSON Pattern Security Check",
+        message_prefix: str = "Suspicious pattern in bounded JSON checkpoint prefix",
+        depth_limit_check_name: str = "JSON Metadata Traversal Depth Limit",
+        detect_orbax_restore_fn: bool = False,
+    ) -> None:
         """Scan decoded JSON string content visible inside the bounded prefix."""
         with open(path, "rb") as source:
             prefix_text = source.read(JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES).decode("utf-8-sig", errors="ignore")
@@ -659,29 +694,43 @@ class JaxCheckpointScanner(BaseScanner):
         except (json.JSONDecodeError, RecursionError):
             string_values = self._iter_bounded_json_prefix_strings(
                 prefix_text,
+                root_context=root_context,
                 depth_cap_contexts=depth_cap_contexts,
             )
         else:
             string_values = self._iter_string_metadata(
                 parsed_root,
-                "json_checkpoint_bounded_prefix",
+                root_context,
                 depth_cap_contexts=depth_cap_contexts,
             )
 
         finding_budget = _PatternFindingBudget(self.max_metadata_pattern_findings)
+        orbax_restore_context = f"{root_context}.restore_fn"
+        orbax_restore_fn_reported = False
         for context, text_value in string_values:
+            if (
+                detect_orbax_restore_fn
+                and not orbax_restore_fn_reported
+                and (
+                    context == orbax_restore_context
+                    or context.startswith(f"{orbax_restore_context}.")
+                    or context.startswith(f"{orbax_restore_context}[")
+                )
+            ):
+                self._add_orbax_restore_fn_check(text_value, path, result)
+                orbax_restore_fn_reported = True
             self._add_suspicious_pattern_checks(
                 text_value,
                 context=context,
-                check_name="JSON Pattern Security Check",
-                message_prefix="Suspicious pattern in bounded JSON checkpoint prefix",
+                check_name=check_name,
+                message_prefix=message_prefix,
                 location=path,
                 result=result,
                 finding_budget=finding_budget,
             )
         self._add_metadata_traversal_depth_limit_checks(
             contexts=depth_cap_contexts,
-            check_name="JSON Metadata Traversal Depth Limit",
+            check_name=depth_limit_check_name,
             location=path,
             result=result,
         )
@@ -743,7 +792,7 @@ class JaxCheckpointScanner(BaseScanner):
 
         # Check for JAX checkpoint patterns
         jax_patterns = ["step_*", "params_*", "state_*", "model_*"]
-        return any(list(path_obj.glob(pattern)) for pattern in jax_patterns)
+        return any(next(path_obj.glob(pattern), None) is not None for pattern in jax_patterns)
 
     @classmethod
     def _header_starts_with_legacy_pickle_opcode(cls, header: bytes) -> bool:
@@ -941,9 +990,88 @@ class JaxCheckpointScanner(BaseScanner):
             for _, text_value in cls._iter_bounded_json_prefix_strings(prefix_text)
         )
 
-    def _scan_orbax_checkpoint(self, path: str, result: ScanResult) -> None:
+    def _add_orbax_metadata_read_failure(
+        self,
+        *,
+        result: ScanResult,
+        metadata_path: Path,
+        metadata_file: str,
+        error: Exception | str,
+    ) -> None:
+        """Record incomplete Orbax metadata coverage without treating it as a security finding."""
+        error_message = str(error)
+        mark_inconclusive_scan_result(result, "jax_orbax_metadata_read_failed")
+        result.add_check(
+            name="Orbax Metadata Read Check",
+            passed=False,
+            message=f"Error reading Orbax metadata: {error_message}",
+            severity=IssueSeverity.INFO,
+            location=str(metadata_path),
+            rule_code="S902",
+            details={
+                "error": error_message,
+                "file": metadata_file,
+                "analysis_incomplete": True,
+                "scan_outcome_reason": "jax_orbax_metadata_read_failed",
+            },
+        )
+
+    def _handle_oversized_orbax_metadata(
+        self,
+        *,
+        metadata_path: Path,
+        metadata_file: str,
+        file_size: int,
+        result: ScanResult,
+    ) -> None:
+        """Fail closed on oversized Orbax metadata while scanning a bounded visible prefix."""
+        mark_inconclusive_scan_result(result, self._ORBAX_METADATA_ANALYSIS_SIZE_LIMIT_REASON)
+        result.add_check(
+            name="Orbax Metadata Analysis Limit",
+            passed=False,
+            message="Orbax metadata analysis incomplete because the file exceeds the bounded parsing limit",
+            severity=IssueSeverity.INFO,
+            location=str(metadata_path),
+            rule_code="S902",
+            details={
+                "file": metadata_file,
+                "file_size": file_size,
+                "max_json_analysis_bytes": JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES,
+                "analysis_incomplete": True,
+                "scan_outcome_reason": self._ORBAX_METADATA_ANALYSIS_SIZE_LIMIT_REASON,
+            },
+        )
+        try:
+            self._scan_bounded_json_prefix_patterns(
+                str(metadata_path),
+                result,
+                root_context="orbax_metadata_bounded_prefix",
+                check_name="Orbax Pattern Security Check",
+                message_prefix="Suspicious pattern in bounded Orbax metadata prefix",
+                depth_limit_check_name="Orbax Metadata Traversal Depth Limit",
+                detect_orbax_restore_fn=True,
+            )
+        except OSError as e:
+            mark_operational_scan_error(result, self._ORBAX_METADATA_PREFIX_PATTERN_READ_FAILED_REASON)
+            result.add_check(
+                name="Orbax Metadata Bounded Prefix Pattern Scan",
+                passed=False,
+                message=f"Unable to inspect bounded Orbax metadata prefix: {e}",
+                severity=IssueSeverity.INFO,
+                location=str(metadata_path),
+                details={
+                    "file": metadata_file,
+                    "error_type": type(e).__name__,
+                    "analysis_incomplete": True,
+                    "scan_outcome_reason": self._ORBAX_METADATA_PREFIX_PATTERN_READ_FAILED_REASON,
+                },
+                rule_code="S902",
+            )
+
+    def _scan_orbax_checkpoint(self, path: str, result: ScanResult) -> _OrbaxDirectoryAccounting:
         """Scan Orbax checkpoint directory."""
         path_obj = Path(path)
+        accounting = _OrbaxDirectoryAccounting()
 
         # Check metadata files
         metadata_files = ["metadata.json", "orbax_checkpoint_metadata.json", "_CHECKPOINT"]
@@ -951,6 +1079,37 @@ class JaxCheckpointScanner(BaseScanner):
         for metadata_file in metadata_files:
             metadata_path = path_obj / metadata_file
             if metadata_path.exists():
+                if not metadata_path.is_file():
+                    self._add_orbax_metadata_read_failure(
+                        result=result,
+                        metadata_path=metadata_path,
+                        metadata_file=metadata_file,
+                        error="metadata path is not a regular file",
+                    )
+                    continue
+                try:
+                    file_size = metadata_path.stat().st_size
+                except OSError as e:
+                    self._add_orbax_metadata_read_failure(
+                        result=result,
+                        metadata_path=metadata_path,
+                        metadata_file=metadata_file,
+                        error=e,
+                    )
+                    continue
+
+                accounting.files_scanned += 1
+                accounting.bytes_scanned += min(file_size, JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES)
+
+                if file_size > JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES:
+                    self._handle_oversized_orbax_metadata(
+                        metadata_path=metadata_path,
+                        metadata_file=metadata_file,
+                        file_size=file_size,
+                        result=result,
+                    )
+                    continue
+
                 try:
                     with open(metadata_path, encoding="utf-8") as f:
                         metadata = json.load(f)
@@ -975,51 +1134,95 @@ class JaxCheckpointScanner(BaseScanner):
                         },
                     )
                 except Exception as e:
-                    mark_inconclusive_scan_result(result, "jax_orbax_metadata_read_failed")
-                    result.add_check(
-                        name="Orbax Metadata Read Check",
-                        passed=False,
-                        message=f"Error reading Orbax metadata: {e}",
-                        severity=IssueSeverity.INFO,
-                        location=str(metadata_path),
-                        rule_code="S902",
-                        details={
-                            "error": str(e),
-                            "analysis_incomplete": True,
-                            "scan_outcome_reason": "jax_orbax_metadata_read_failed",
-                        },
+                    self._add_orbax_metadata_read_failure(
+                        result=result,
+                        metadata_path=metadata_path,
+                        metadata_file=metadata_file,
+                        error=e,
                     )
 
         # Scan checkpoint files
-        checkpoint_files = list(path_obj.glob("checkpoint*"))
-        for checkpoint_file in checkpoint_files:
-            if checkpoint_file.is_file():
-                self._scan_checkpoint_file(
-                    str(checkpoint_file),
-                    result,
-                    treat_legacy_pickle_header_as_checkpoint=True,
+        directory_entries_seen = 0
+        checkpoint_files_seen = 0
+        for checkpoint_file in path_obj.iterdir():
+            directory_entries_seen += 1
+            if directory_entries_seen > self.max_orbax_directory_entries:
+                mark_inconclusive_scan_result(result, self._ORBAX_DIRECTORY_ENTRY_COUNT_LIMIT_REASON)
+                result.add_check(
+                    name="Orbax Directory Entry Count Limit",
+                    passed=False,
+                    message=(
+                        "Reached the maximum number of Orbax directory entries to inspect; "
+                        "additional entries were skipped"
+                    ),
+                    severity=IssueSeverity.INFO,
+                    location=path,
+                    details={
+                        "max_orbax_directory_entries": self.max_orbax_directory_entries,
+                        "analysis_incomplete": True,
+                        "scan_outcome_reason": self._ORBAX_DIRECTORY_ENTRY_COUNT_LIMIT_REASON,
+                    },
+                    rule_code="S902",
                 )
+                break
+            if not checkpoint_file.name.startswith("checkpoint") or not checkpoint_file.is_file():
+                continue
+            checkpoint_files_seen += 1
+            if checkpoint_files_seen > self.max_orbax_checkpoint_files:
+                mark_inconclusive_scan_result(result, self._ORBAX_CHECKPOINT_FILE_COUNT_LIMIT_REASON)
+                result.add_check(
+                    name="Orbax Checkpoint File Count Limit",
+                    passed=False,
+                    message=(
+                        "Reached the maximum number of Orbax checkpoint files to inspect; "
+                        "additional checkpoint entries were skipped"
+                    ),
+                    severity=IssueSeverity.INFO,
+                    location=path,
+                    details={
+                        "max_orbax_checkpoint_files": self.max_orbax_checkpoint_files,
+                        "analysis_incomplete": True,
+                        "scan_outcome_reason": self._ORBAX_CHECKPOINT_FILE_COUNT_LIMIT_REASON,
+                    },
+                    rule_code="S902",
+                )
+                break
+            with suppress(OSError):
+                accounting.bytes_scanned += checkpoint_file.stat().st_size
+            accounting.files_scanned += 1
+            self._scan_checkpoint_file(
+                str(checkpoint_file),
+                result,
+                treat_legacy_pickle_header_as_checkpoint=True,
+            )
+
+        result.metadata["orbax_files_inspected"] = accounting.files_scanned
+        result.metadata["directory_accounting_scope"] = "orbax_selected_files"
+        return accounting
+
+    def _add_orbax_restore_fn_check(self, restore_fn_value: str, path: str, result: ScanResult) -> None:
+        """Preserve Orbax restore hook reporting for full and bounded-prefix metadata scans."""
+        restore_fn_is_dangerous = bool(self._DANGEROUS_RESTORE_FN_PATTERN.search(restore_fn_value))
+        result.add_check(
+            name="Orbax Restore Function Check",
+            passed=False,
+            message=(
+                "Dangerous restore function detected in Orbax metadata"
+                if restore_fn_is_dangerous
+                else "Custom restore function detected in Orbax metadata"
+            ),
+            severity=IssueSeverity.CRITICAL if restore_fn_is_dangerous else IssueSeverity.WARNING,
+            location=path,
+            details={"restore_fn": restore_fn_value[:200]},
+            rule_code="S302",
+        )
 
     def _analyze_orbax_metadata(self, metadata: dict[str, Any], path: str, result: ScanResult) -> None:
         """Analyze Orbax metadata for security issues."""
 
         # Check for suspicious restore functions
         if "restore_fn" in metadata:
-            restore_fn_value = str(metadata["restore_fn"])
-            restore_fn_is_dangerous = bool(self._DANGEROUS_RESTORE_FN_PATTERN.search(restore_fn_value))
-            result.add_check(
-                name="Orbax Restore Function Check",
-                passed=False,
-                message=(
-                    "Dangerous restore function detected in Orbax metadata"
-                    if restore_fn_is_dangerous
-                    else "Custom restore function detected in Orbax metadata"
-                ),
-                severity=IssueSeverity.CRITICAL if restore_fn_is_dangerous else IssueSeverity.WARNING,
-                location=path,
-                details={"restore_fn": restore_fn_value[:200]},
-                rule_code="S302",
-            )
+            self._add_orbax_restore_fn_check(str(metadata["restore_fn"]), path, result)
 
         # Check for code injection in metadata
         pattern_finding_budget = _PatternFindingBudget(self.max_metadata_pattern_findings)
@@ -1566,12 +1769,9 @@ class JaxCheckpointScanner(BaseScanner):
                 result.metadata["checkpoint_type"] = "directory"
                 result.metadata["path_type"] = "directory"
 
-                self._scan_orbax_checkpoint(path, result)
-
-                # Calculate total size
-                total_size = sum(f.stat().st_size for f in Path(path).rglob("*") if f.is_file())
-                result.bytes_scanned = total_size
-                result.metadata["total_size"] = total_size
+                accounting = self._scan_orbax_checkpoint(path, result)
+                result.bytes_scanned = accounting.bytes_scanned
+                result.metadata["total_size"] = accounting.bytes_scanned
 
             else:
                 # Scan single file checkpoint

--- a/modelaudit/scanners/jax_checkpoint_scanner.py
+++ b/modelaudit/scanners/jax_checkpoint_scanner.py
@@ -119,6 +119,7 @@ class JaxCheckpointScanner(BaseScanner):
     DEFAULT_MAX_PICKLE_OPCODE_FINDINGS: ClassVar[int] = 256
     DEFAULT_MAX_ORBAX_CHECKPOINT_FILES: ClassVar[int] = 4096
     DEFAULT_MAX_ORBAX_DIRECTORY_ENTRIES: ClassVar[int] = 8192
+    _ORBAX_CHECKPOINT_ENTRY_PREFIXES: ClassVar[tuple[str, ...]] = ("step_", "params_", "state_", "model_")
     _DANGEROUS_PICKLE_GLOBALS: ClassVar[frozenset[tuple[str, str]]] = frozenset(
         {
             ("builtins", "__import__"),
@@ -238,6 +239,7 @@ class JaxCheckpointScanner(BaseScanner):
     _ORBAX_METADATA_PREFIX_PATTERN_READ_FAILED_REASON: ClassVar[str] = "jax_orbax_metadata_prefix_pattern_read_failed"
     _ORBAX_DIRECTORY_ENTRY_COUNT_LIMIT_REASON: ClassVar[str] = "jax_orbax_directory_entry_count_limit"
     _ORBAX_CHECKPOINT_FILE_COUNT_LIMIT_REASON: ClassVar[str] = "jax_orbax_checkpoint_file_count_limit"
+    _ORBAX_CHECKPOINT_ENTRY_UNINSPECTED_REASON: ClassVar[str] = "jax_orbax_checkpoint_entry_uninspected"
     _METADATA_TRAVERSAL_LIMIT_REASON: ClassVar[str] = "jax_metadata_traversal_depth_limit"
     _PICKLE_SCAN_LIMIT_REASON: ClassVar[str] = "jax_pickle_scan_limit_exceeded"
     _LEGACY_PICKLE_INITIAL_OPCODES: ClassVar[bytes] = (
@@ -786,7 +788,7 @@ class JaxCheckpointScanner(BaseScanner):
         path_obj = Path(path)
 
         # Orbax checkpoint indicators
-        orbax_files = ["checkpoint", "checkpoint_0", "metadata.json", "_CHECKPOINT", "orbax_checkpoint_metadata.json"]
+        orbax_files = ["metadata.json", "_CHECKPOINT", "orbax_checkpoint_metadata.json"]
 
         # Check for Orbax files
         for orbax_file in orbax_files:
@@ -795,13 +797,17 @@ class JaxCheckpointScanner(BaseScanner):
 
         # Probe once and route oversized directories into the scanner's
         # fail-closed entry-limit handling.
-        jax_prefixes = ("step_", "params_", "state_", "model_")
         for entry_index, entry in enumerate(path_obj.iterdir(), start=1):
             if entry_index > cls.DEFAULT_MAX_ORBAX_DIRECTORY_ENTRIES:
                 return True
-            if entry.name.startswith(jax_prefixes):
+            if cls._is_orbax_checkpoint_entry_name(entry.name):
                 return True
         return False
+
+    @classmethod
+    def _is_orbax_checkpoint_entry_name(cls, name: str) -> bool:
+        """Return whether a top-level entry has a recognized Orbax/JAX checkpoint name."""
+        return name == "checkpoint" or name.startswith(("checkpoint_", *cls._ORBAX_CHECKPOINT_ENTRY_PREFIXES))
 
     @classmethod
     def _header_starts_with_legacy_pickle_opcode(cls, header: bytes) -> bool:
@@ -1025,6 +1031,30 @@ class JaxCheckpointScanner(BaseScanner):
             },
         )
 
+    def _add_uninspected_orbax_checkpoint_entry(
+        self,
+        *,
+        result: ScanResult,
+        entry_path: Path,
+        entry_type: str,
+    ) -> None:
+        """Fail closed when a recognized checkpoint entry is not a regular file."""
+        mark_inconclusive_scan_result(result, self._ORBAX_CHECKPOINT_ENTRY_UNINSPECTED_REASON)
+        result.add_check(
+            name="Orbax Checkpoint Entry Coverage",
+            passed=False,
+            message="Recognized Orbax/JAX checkpoint entry is not a regular file and was not inspected",
+            severity=IssueSeverity.INFO,
+            location=str(entry_path),
+            rule_code="S902",
+            details={
+                "entry": entry_path.name,
+                "entry_type": entry_type,
+                "analysis_incomplete": True,
+                "scan_outcome_reason": self._ORBAX_CHECKPOINT_ENTRY_UNINSPECTED_REASON,
+            },
+        )
+
     def _handle_oversized_orbax_metadata(
         self,
         *,
@@ -1153,6 +1183,7 @@ class JaxCheckpointScanner(BaseScanner):
         # Scan checkpoint files
         directory_entries_seen = 0
         checkpoint_files_seen = 0
+        uninspected_checkpoint_entry_reported = False
         for checkpoint_file in path_obj.iterdir():
             directory_entries_seen += 1
             if directory_entries_seen > self.max_orbax_directory_entries:
@@ -1174,7 +1205,23 @@ class JaxCheckpointScanner(BaseScanner):
                     rule_code="S902",
                 )
                 break
-            if not checkpoint_file.name.startswith("checkpoint") or not checkpoint_file.is_file():
+            if not self._is_orbax_checkpoint_entry_name(checkpoint_file.name):
+                continue
+            if checkpoint_file.is_symlink() or not checkpoint_file.is_file():
+                if not uninspected_checkpoint_entry_reported:
+                    entry_type = (
+                        "symlink"
+                        if checkpoint_file.is_symlink()
+                        else "directory"
+                        if checkpoint_file.is_dir()
+                        else "non_regular"
+                    )
+                    self._add_uninspected_orbax_checkpoint_entry(
+                        result=result,
+                        entry_path=checkpoint_file,
+                        entry_type=entry_type,
+                    )
+                    uninspected_checkpoint_entry_reported = True
                 continue
             checkpoint_files_seen += 1
             if checkpoint_files_seen > self.max_orbax_checkpoint_files:

--- a/tests/scanners/test_jax_checkpoint_scanner.py
+++ b/tests/scanners/test_jax_checkpoint_scanner.py
@@ -2,6 +2,7 @@ import builtins
 import json
 import os
 import pickle
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -498,6 +499,27 @@ def test_orbax_directory_entry_count_limit_fails_closed(tmp_path: Path) -> None:
         and check.details["analysis_incomplete"] is True
         for check in result.checks
     )
+
+
+def test_orbax_directory_probe_routes_entry_limit_to_fail_closed_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkpoint_dir = tmp_path / "orbax_probe_limit"
+    checkpoint_dir.mkdir()
+    entries_yielded = 0
+
+    def synthetic_entries(path: Path) -> Iterator[Path]:
+        nonlocal entries_yielded
+        assert path == checkpoint_dir
+        for index in range(JaxCheckpointScanner.DEFAULT_MAX_ORBAX_DIRECTORY_ENTRIES + 1):
+            entries_yielded += 1
+            yield checkpoint_dir / f"unrelated_{index}.txt"
+
+    monkeypatch.setattr(Path, "iterdir", synthetic_entries)
+
+    assert JaxCheckpointScanner.can_handle(str(checkpoint_dir)) is True
+    assert entries_yielded == JaxCheckpointScanner.DEFAULT_MAX_ORBAX_DIRECTORY_ENTRIES + 1
 
 
 def test_orbax_checkpoint_file_count_limit_fails_closed(tmp_path: Path) -> None:

--- a/tests/scanners/test_jax_checkpoint_scanner.py
+++ b/tests/scanners/test_jax_checkpoint_scanner.py
@@ -376,6 +376,36 @@ def test_oversized_orbax_metadata_preserves_visible_nested_restore_fn_detection(
     )
 
 
+def test_oversized_orbax_metadata_reports_strongest_visible_nested_restore_fn(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "oversized_orbax_strongest_restore_fn"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "framework": "jax",
+                "type": "orbax_checkpoint",
+                "restore_fn": ["custom_deserialize", "eval"],
+                "padding": "x" * JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    restore_checks = [
+        check
+        for check in result.checks
+        if check.name == "Orbax Restore Function Check" and check.status == CheckStatus.FAILED
+    ]
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "jax_orbax_metadata_analysis_size_limit" in result.metadata["scan_outcome_reasons"]
+    assert len(restore_checks) == 1
+    assert restore_checks[0].severity == IssueSeverity.CRITICAL
+    assert restore_checks[0].details["restore_fn"] == "eval"
+
+
 def test_oversized_orbax_metadata_duplicate_restore_fn_reports_once(tmp_path: Path) -> None:
     checkpoint_dir = tmp_path / "oversized_orbax_duplicate_restore_fn"
     checkpoint_dir.mkdir()

--- a/tests/scanners/test_jax_checkpoint_scanner.py
+++ b/tests/scanners/test_jax_checkpoint_scanner.py
@@ -543,6 +543,58 @@ def test_orbax_checkpoint_file_count_limit_fails_closed(tmp_path: Path) -> None:
     )
 
 
+@pytest.mark.parametrize("checkpoint_filename", ["checkpoint_42", "params_0"])
+def test_orbax_prefixed_checkpoint_file_is_scanned(tmp_path: Path, checkpoint_filename: str) -> None:
+    checkpoint_dir = tmp_path / "orbax_prefixed_file"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / checkpoint_filename).write_bytes(b"cposix\nsystem\np0\n(Vid\np1\ntp2\nRp3\n.")
+
+    assert JaxCheckpointScanner.can_handle(str(checkpoint_dir))
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success
+    assert any(
+        check.name == "Pickle Opcode Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details["global"] == "posix.system"
+        for check in result.checks
+    )
+
+
+def test_orbax_nested_checkpoint_directory_fails_closed(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "orbax_nested_checkpoint"
+    nested_checkpoint_dir = checkpoint_dir / "step_0"
+    nested_checkpoint_dir.mkdir(parents=True)
+    (nested_checkpoint_dir / "checkpoint").write_bytes(b"cposix\nsystem\np0\n(Vid\np1\ntp2\nRp3\n.")
+
+    assert JaxCheckpointScanner.can_handle(str(checkpoint_dir))
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "jax_orbax_checkpoint_entry_uninspected" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Orbax Checkpoint Entry Coverage"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.INFO
+        and check.details["entry"] == "step_0"
+        and check.details["entry_type"] == "directory"
+        and check.details["analysis_incomplete"] is True
+        for check in result.checks
+    )
+
+
+def test_orbax_checkpoint_entry_near_match_does_not_route_directory(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "not_orbax"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "checkpointing_notes.txt").write_text("plain documentation", encoding="utf-8")
+
+    assert JaxCheckpointScanner.can_handle(str(checkpoint_dir)) is False
+
+
 class _SafeJaxState:
     def __init__(self) -> None:
         self.framework = "jax"

--- a/tests/scanners/test_jax_checkpoint_scanner.py
+++ b/tests/scanners/test_jax_checkpoint_scanner.py
@@ -245,6 +245,252 @@ def test_orbax_metadata_pattern_findings_are_capped_for_repeated_strings(tmp_pat
     assert limit_checks[0].details["max_metadata_pattern_findings"] == 3
 
 
+@pytest.mark.parametrize("metadata_filename", ["metadata.json", "orbax_checkpoint_metadata.json", "_CHECKPOINT"])
+def test_oversized_orbax_metadata_fails_closed_without_full_json_load(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    metadata_filename: str,
+) -> None:
+    checkpoint_dir = tmp_path / f"oversized_{metadata_filename.replace('.', '_')}"
+    checkpoint_dir.mkdir()
+    metadata_path = checkpoint_dir / metadata_filename
+    metadata_path.write_text(
+        json.dumps(
+            {
+                "framework": "jax",
+                "type": "orbax_checkpoint",
+                "padding": "x" * JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES,
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert metadata_path.stat().st_size > JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES
+
+    def fail_json_load(_stream: Any) -> Any:
+        raise AssertionError("oversized Orbax metadata should not be fully parsed")
+
+    monkeypatch.setattr("modelaudit.scanners.jax_checkpoint_scanner.json.load", fail_json_load)
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "jax_orbax_metadata_analysis_size_limit" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Orbax Metadata Analysis Limit"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.INFO
+        and check.details["file"] == metadata_filename
+        and check.details["file_size"] == metadata_path.stat().st_size
+        and check.details["max_json_analysis_bytes"] == JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES
+        and check.details["analysis_incomplete"] is True
+        for check in result.checks
+    )
+    assert not [check for check in result.checks if check.severity == IssueSeverity.CRITICAL]
+
+
+def test_oversized_orbax_metadata_reports_visible_bounded_pattern_before_failing_closed(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "oversized_orbax_prefix_signal"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "framework": "jax",
+                "type": "orbax_checkpoint",
+                "payload": "jax.experimental.host_callback.call(os.system, 'id')",
+                "padding": "x" * JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "jax_orbax_metadata_analysis_size_limit" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Orbax Pattern Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details["context"] == "orbax_metadata_bounded_prefix.payload"
+        for check in result.checks
+    )
+
+
+def test_oversized_orbax_metadata_preserves_visible_restore_fn_detection(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "oversized_orbax_restore_fn"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "framework": "jax",
+                "type": "orbax_checkpoint",
+                "restore_fn": "lambda x: eval(x)",
+                "padding": "x" * JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "jax_orbax_metadata_analysis_size_limit" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Orbax Restore Function Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details["restore_fn"] == "lambda x: eval(x)"
+        for check in result.checks
+    )
+
+
+def test_oversized_orbax_metadata_preserves_visible_nested_restore_fn_detection(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "oversized_orbax_nested_restore_fn"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "framework": "jax",
+                "type": "orbax_checkpoint",
+                "restore_fn": ["eval"],
+                "padding": "x" * JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "jax_orbax_metadata_analysis_size_limit" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Orbax Restore Function Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details["restore_fn"] == "eval"
+        for check in result.checks
+    )
+
+
+def test_oversized_orbax_metadata_duplicate_restore_fn_reports_once(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "oversized_orbax_duplicate_restore_fn"
+    checkpoint_dir.mkdir()
+    duplicate_restore_fields = ",".join('"restore_fn":"eval"' for _ in range(20))
+    (checkpoint_dir / "metadata.json").write_text(
+        (
+            '{"framework":"jax","type":"orbax_checkpoint",'
+            f'{duplicate_restore_fields},"padding":"{"x" * JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES}"'
+            "}"
+        ),
+        encoding="utf-8",
+    )
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    restore_checks = [
+        check
+        for check in result.checks
+        if check.name == "Orbax Restore Function Check" and check.status == CheckStatus.FAILED
+    ]
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "jax_orbax_metadata_analysis_size_limit" in result.metadata["scan_outcome_reasons"]
+    assert len(restore_checks) == 1
+    assert restore_checks[0].severity == IssueSeverity.CRITICAL
+    assert restore_checks[0].details["restore_fn"] == "eval"
+
+
+def test_oversized_orbax_doc_like_metadata_prefix_remains_benign(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "oversized_orbax_docs"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "framework": "jax",
+                "type": "orbax_checkpoint",
+                "docs": "The jax.experimental.io_callback API is described in Orbax user documentation",
+                "padding": "x" * JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "jax_orbax_metadata_analysis_size_limit" in result.metadata["scan_outcome_reasons"]
+    assert not [
+        check
+        for check in result.checks
+        if check.name == "Orbax Pattern Security Check" and check.severity == IssueSeverity.CRITICAL
+    ]
+
+
+def test_orbax_directory_accounting_uses_inspected_files_only(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "orbax_with_unrelated_descendant"
+    _write_orbax_metadata(checkpoint_dir, {"type": "orbax_checkpoint", "framework": "jax"})
+    nested_dir = checkpoint_dir / "nested"
+    nested_dir.mkdir()
+    unrelated_payload = nested_dir / "unrelated.bin"
+    unrelated_payload.write_bytes(b"x" * 4096)
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+    metadata_size = (checkpoint_dir / "metadata.json").stat().st_size
+
+    assert result.success is True
+    assert result.bytes_scanned == metadata_size
+    assert result.metadata["total_size"] == metadata_size
+    assert result.metadata["orbax_files_inspected"] == 1
+    assert result.metadata["directory_accounting_scope"] == "orbax_selected_files"
+    assert result.bytes_scanned < unrelated_payload.stat().st_size
+
+
+def test_orbax_directory_entry_count_limit_fails_closed(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "orbax_many_directory_entries"
+    _write_orbax_metadata(checkpoint_dir, {"type": "orbax_checkpoint", "framework": "jax"})
+    (checkpoint_dir / "unrelated.txt").write_text("not a checkpoint", encoding="utf-8")
+
+    result = JaxCheckpointScanner(config={"jax_orbax_max_directory_entries": 1}).scan(str(checkpoint_dir))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "jax_orbax_directory_entry_count_limit" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Orbax Directory Entry Count Limit"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.INFO
+        and check.details["max_orbax_directory_entries"] == 1
+        and check.details["analysis_incomplete"] is True
+        for check in result.checks
+    )
+
+
+def test_orbax_checkpoint_file_count_limit_fails_closed(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "orbax_many_checkpoints"
+    _write_orbax_metadata(checkpoint_dir, {"type": "orbax_checkpoint", "framework": "jax"})
+    (checkpoint_dir / "checkpoint_0").write_bytes(b"unknown checkpoint bytes")
+    (checkpoint_dir / "checkpoint_1").write_bytes(b"unknown checkpoint bytes")
+
+    result = JaxCheckpointScanner(config={"jax_orbax_max_checkpoint_files": 1}).scan(str(checkpoint_dir))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "jax_orbax_checkpoint_file_count_limit" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Orbax Checkpoint File Count Limit"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.INFO
+        and check.details["max_orbax_checkpoint_files"] == 1
+        and check.details["analysis_incomplete"] is True
+        for check in result.checks
+    )
+
+
 class _SafeJaxState:
     def __init__(self) -> None:
         self.framework = "jax"


### PR DESCRIPTION
## Summary
- bound Orbax metadata JSON parsing before full load and fail closed with bounded-prefix inspection when metadata is oversized
- preserve visible Orbax restore_fn and JAX/Orbax pattern findings in oversized metadata while capping duplicate restore_fn output
- replace recursive directory byte accounting with inspected-entry accounting and cap top-level Orbax checkpoint directory enumeration

## Validation
- rebuilt editable modelaudit-picklescan native extension for this worktree
- PYTHONPATH=/private/tmp/modelaudit-c017:/private/tmp/modelaudit-c017/packages/modelaudit-picklescan/src /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/scanners/test_jax_checkpoint_scanner.py -q -> 111 passed
- PYTHONPATH=/private/tmp/modelaudit-c017:/private/tmp/modelaudit-c017/packages/modelaudit-picklescan/src /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/scanners/test_jax_checkpoint_scanner.py tests/test_jax_flax_integration.py -q -> 119 passed
- /Users/mdangelo/code/modelaudit/.venv/bin/ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/ -> 399 files already formatted
- /Users/mdangelo/code/modelaudit/.venv/bin/ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/ -> All checks passed
- PYTHONPATH=/private/tmp/modelaudit-c017:/private/tmp/modelaudit-c017/packages/modelaudit-picklescan/src /Users/mdangelo/code/modelaudit/.venv/bin/mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/ -> Success: no issues found in 454 source files
- PYTHONPATH=/private/tmp/modelaudit-c017:/private/tmp/modelaudit-c017/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest -n auto -m "not slow and not integration" --maxfail=1 -k "not test_file_fingerprint_performance" -> 7720 passed, 16 skipped, 21 warnings
- PYTHONPATH=/private/tmp/modelaudit-c017:/private/tmp/modelaudit-c017/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/test_cache_optimizations.py::TestCacheOptimizationPerformance::test_file_fingerprint_performance -q -> 1 passed

## Notes
- The exact full pytest lane hit unrelated local timing variance twice in tests/test_cache_optimizations.py::TestCacheOptimizationPerformance::test_file_fingerprint_performance; the test passed in isolation, and the rest of the full lane passed with only that timing assertion excluded.
- Fixes MA-DSS-C017 from the Codex Security scan.