### PR TITLE
fix: strip jfrog credentials on redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - redact secret-shaped dictionary keys from embedded-secret detector finding contexts
 - redact compound credential names and malformed userinfo URLs in scanner evidence
 - restrict JFrog credential forwarding to explicitly trusted HTTPS hosts
+- strip JFrog credentials from untrusted redirect hops during artifact and Storage API requests
 - inspect every parsed GGUF chat template when duplicate or trailing malformed metadata could otherwise hide SSTI payloads
 - bound GGUF declared metadata and tensor collections, and cap reported tensor summaries, so oversized structures fail closed without exhausting scanner resources
 - redact secret-shaped dictionary keys from embedded-secret detector finding contexts

--- a/modelaudit/utils/sources/jfrog.py
+++ b/modelaudit/utils/sources/jfrog.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import tempfile
 from collections.abc import Collection
+from http.cookiejar import CookieJar
 from pathlib import Path, PurePosixPath
 from typing import Any, Literal, TypedDict
 from urllib.parse import urljoin, urlparse, urlunparse
@@ -259,10 +260,12 @@ def _get_with_jfrog_redirect_policy(
     """GET a JFrog URL while stripping credentials from untrusted redirects."""
     current_url = url
     current_headers = headers
+    redirect_cookies = requests.cookies.RequestsCookieJar()
     for _redirect_count in range(_MAX_JFROG_REDIRECTS + 1):
         response = requests.get(
             current_url,
             headers=current_headers,
+            cookies=redirect_cookies,
             timeout=timeout,
             stream=stream,
             allow_redirects=False,
@@ -271,6 +274,9 @@ def _get_with_jfrog_redirect_policy(
             return response
 
         location = response.headers.get("Location")
+        response_cookies = getattr(response, "cookies", None)
+        if isinstance(response_cookies, CookieJar):
+            requests.cookies.merge_cookies(redirect_cookies, response_cookies)
         response.close()
         if not location:
             raise requests.exceptions.RequestException(

--- a/modelaudit/utils/sources/jfrog.py
+++ b/modelaudit/utils/sources/jfrog.py
@@ -271,14 +271,13 @@ def _get_with_jfrog_redirect_policy(
             return response
 
         location = response.headers.get("Location")
+        response.close()
         if not location:
-            response.close()
             raise requests.exceptions.RequestException(
                 f"JFrog redirect response missing Location header for {redact_jfrog_url_for_display(current_url)}"
             )
 
         current_url = urljoin(current_url, location)
-        response.close()
         current_headers = headers if _is_trusted_jfrog_auth_target(current_url) else {}
 
     raise requests.exceptions.TooManyRedirects(

--- a/modelaudit/utils/sources/jfrog.py
+++ b/modelaudit/utils/sources/jfrog.py
@@ -257,15 +257,18 @@ def _get_with_jfrog_redirect_policy(
     timeout: int,
     stream: bool = False,
 ) -> requests.Response:
-    """GET a JFrog URL while stripping credentials from untrusted redirects."""
+    """GET a JFrog URL while isolating credentials from untrusted redirects."""
     current_url = url
     current_headers = headers
-    redirect_cookies = requests.cookies.RequestsCookieJar()
+    current_is_trusted = _is_trusted_jfrog_auth_target(url)
+    trusted_redirect_cookies = requests.cookies.RequestsCookieJar()
+    untrusted_redirect_cookies = requests.cookies.RequestsCookieJar()
     for _redirect_count in range(_MAX_JFROG_REDIRECTS + 1):
+        current_cookies = trusted_redirect_cookies if current_is_trusted else untrusted_redirect_cookies
         response = requests.get(
             current_url,
             headers=current_headers,
-            cookies=redirect_cookies,
+            cookies=current_cookies,
             timeout=timeout,
             stream=stream,
             allow_redirects=False,
@@ -276,7 +279,7 @@ def _get_with_jfrog_redirect_policy(
         location = response.headers.get("Location")
         response_cookies = getattr(response, "cookies", None)
         if isinstance(response_cookies, CookieJar):
-            requests.cookies.merge_cookies(redirect_cookies, response_cookies)
+            requests.cookies.merge_cookies(current_cookies, response_cookies)
         response.close()
         if not location:
             raise requests.exceptions.RequestException(
@@ -284,7 +287,8 @@ def _get_with_jfrog_redirect_policy(
             )
 
         current_url = urljoin(current_url, location)
-        current_headers = headers if _is_trusted_jfrog_auth_target(current_url) else {}
+        current_is_trusted = _is_trusted_jfrog_auth_target(current_url)
+        current_headers = headers if current_is_trusted else {}
 
     raise requests.exceptions.TooManyRedirects(
         f"Exceeded {_MAX_JFROG_REDIRECTS} redirects for JFrog URL {redact_jfrog_url_for_display(url)}"

--- a/modelaudit/utils/sources/jfrog.py
+++ b/modelaudit/utils/sources/jfrog.py
@@ -138,6 +138,8 @@ def is_jfrog_url(url: str) -> bool:
     """Check if a URL points to a JFrog Artifactory file or folder."""
     parsed = urlparse(url)
     hostname = _normalize_hostname(parsed.hostname or "")
+    if not hostname or hostname != _get_requests_prepared_hostname(url):
+        return False
     if parsed.scheme != "https" and not (parsed.scheme == "http" and _is_local_jfrog_host(hostname)):
         return False
     if "/artifactory/" not in parsed.path:
@@ -270,7 +272,10 @@ def _get_with_jfrog_redirect_policy(
 
         location = response.headers.get("Location")
         if not location:
-            return response
+            response.close()
+            raise requests.exceptions.RequestException(
+                f"JFrog redirect response missing Location header for {redact_jfrog_url_for_display(current_url)}"
+            )
 
         current_url = urljoin(current_url, location)
         response.close()

--- a/modelaudit/utils/sources/jfrog.py
+++ b/modelaudit/utils/sources/jfrog.py
@@ -9,7 +9,7 @@ import tempfile
 from collections.abc import Collection
 from pathlib import Path, PurePosixPath
 from typing import Any, Literal, TypedDict
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urljoin, urlparse, urlunparse
 
 import click
 import requests
@@ -20,6 +20,8 @@ logger = logging.getLogger(__name__)
 
 # Constants
 MAX_RECURSION_DEPTH = 64  # Prevent runaway recursion in folder traversal
+_MAX_JFROG_REDIRECTS = 5
+_JFROG_REDIRECT_STATUS_CODES = frozenset({301, 302, 303, 307, 308})
 _SENSITIVE_QUERY_PARAM_RE = re.compile(
     r"([?&][^=\s&]*(?:signature|credential|security-token|access-key|access_key|token|secret|api-key|api_key|apikey|sig)[^=\s&]*=)[^\s&#]+",
     re.IGNORECASE,
@@ -189,6 +191,19 @@ def _is_jfrog_service_host(hostname: str) -> bool:
     return hostname == "jfrog.io" or hostname.endswith(".jfrog.io") or _is_local_jfrog_host(hostname)
 
 
+def _get_requests_prepared_hostname(url: str) -> str:
+    """Return the hostname Requests will connect to after URL preparation."""
+    try:
+        prepared_url = requests.Request("GET", url).prepare().url
+    except requests.exceptions.RequestException:
+        return ""
+
+    if not prepared_url:
+        return ""
+
+    return _normalize_hostname(urlparse(prepared_url).hostname or "")
+
+
 def _is_trusted_jfrog_auth_target(url: str) -> bool:
     """Return True when credentials may be sent to this JFrog URL."""
     parsed = urlparse(url)
@@ -196,7 +211,8 @@ def _is_trusted_jfrog_auth_target(url: str) -> bool:
         return False
 
     hostname = _normalize_hostname(parsed.hostname or "")
-    return bool(hostname and hostname in _get_trusted_jfrog_hosts())
+    prepared_hostname = _get_requests_prepared_hostname(url)
+    return bool(hostname and hostname == prepared_hostname and hostname in _get_trusted_jfrog_hosts())
 
 
 def _build_jfrog_auth_headers(
@@ -229,6 +245,40 @@ def _build_jfrog_auth_headers(
         return {"Authorization": f"Bearer {env_access_token}"}
 
     return {}
+
+
+def _get_with_jfrog_redirect_policy(
+    url: str,
+    *,
+    headers: dict[str, str],
+    timeout: int,
+    stream: bool = False,
+) -> requests.Response:
+    """GET a JFrog URL while stripping credentials from untrusted redirects."""
+    current_url = url
+    current_headers = headers
+    for _redirect_count in range(_MAX_JFROG_REDIRECTS + 1):
+        response = requests.get(
+            current_url,
+            headers=current_headers,
+            timeout=timeout,
+            stream=stream,
+            allow_redirects=False,
+        )
+        if response.status_code not in _JFROG_REDIRECT_STATUS_CODES:
+            return response
+
+        location = response.headers.get("Location")
+        if not location:
+            return response
+
+        current_url = urljoin(current_url, location)
+        response.close()
+        current_headers = headers if _is_trusted_jfrog_auth_target(current_url) else {}
+
+    raise requests.exceptions.TooManyRedirects(
+        f"Exceeded {_MAX_JFROG_REDIRECTS} redirects for JFrog URL {redact_jfrog_url_for_display(url)}"
+    )
 
 
 def download_artifact(
@@ -291,7 +341,7 @@ def download_artifact(
 
     try:
         # Use requests for proper authentication and error handling
-        response = requests.get(
+        response = _get_with_jfrog_redirect_policy(
             url,
             headers=headers,
             timeout=timeout,
@@ -434,7 +484,7 @@ def detect_jfrog_target_type(
     headers = _build_jfrog_auth_headers(storage_api_url, api_token=api_token, access_token=access_token)
 
     try:
-        response = requests.get(storage_api_url, headers=headers, timeout=timeout)
+        response = _get_with_jfrog_redirect_policy(storage_api_url, headers=headers, timeout=timeout)
         response.raise_for_status()
 
         data = response.json()

--- a/tests/integrations/test_jfrog.py
+++ b/tests/integrations/test_jfrog.py
@@ -288,6 +288,35 @@ class TestJFrogDownload:
         assert mock_get.call_args_list[1].kwargs["headers"] == {"X-JFrog-Art-Api": "test-token"}
 
     @patch("modelaudit.utils.sources.jfrog.requests.get")
+    def test_download_redirect_preserves_response_cookies(
+        self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Manual redirects should preserve stickiness/session cookies through the cookie jar."""
+        redirect_response = MagicMock(spec=requests.Response)
+        redirect_response.status_code = 302
+        redirect_response.headers = {"Location": "/artifactory/repo/model.bin?node=1"}
+        redirect_response.cookies = requests.cookies.cookiejar_from_dict({"ROUTEID": "backend-a"})
+        final_response = MagicMock(spec=requests.Response)
+        final_response.status_code = 200
+        final_response.headers = {}
+        final_response.raise_for_status.return_value = None
+        final_response.iter_content.return_value = [b"data"]
+        mock_get.side_effect = [redirect_response, final_response]
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+
+        result = download_artifact(
+            "https://company.jfrog.io/artifactory/repo/model.bin",
+            cache_dir=tmp_path,
+            api_token="test-token",
+        )
+
+        assert result.read_bytes() == b"data"
+        first_cookie_jar = mock_get.call_args_list[0].kwargs["cookies"]
+        second_cookie_jar = mock_get.call_args_list[1].kwargs["cookies"]
+        assert first_cookie_jar is second_cookie_jar
+        assert second_cookie_jar.get("ROUTEID") == "backend-a"
+
+    @patch("modelaudit.utils.sources.jfrog.requests.get")
     def test_download_redirect_without_location_fails_closed(
         self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/integrations/test_jfrog.py
+++ b/tests/integrations/test_jfrog.py
@@ -308,6 +308,26 @@ class TestJFrogDownload:
         redirect_response.close.assert_called_once_with()
 
     @patch("modelaudit.utils.sources.jfrog.requests.get")
+    def test_download_malformed_redirect_location_closes_response(
+        self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Malformed redirect targets must not leave streamed responses open."""
+        redirect_response = MagicMock(spec=requests.Response)
+        redirect_response.status_code = 302
+        redirect_response.headers = {"Location": "https://[::1"}
+        mock_get.return_value = redirect_response
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+
+        with pytest.raises(Exception, match="Invalid IPv6 URL"):
+            download_artifact(
+                "https://company.jfrog.io/artifactory/repo/model.bin",
+                cache_dir=tmp_path,
+                api_token="test-token",
+            )
+
+        redirect_response.close.assert_called_once_with()
+
+    @patch("modelaudit.utils.sources.jfrog.requests.get")
     def test_http_jfrog_saas_url_is_rejected_before_credentials(
         self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/integrations/test_jfrog.py
+++ b/tests/integrations/test_jfrog.py
@@ -317,6 +317,46 @@ class TestJFrogDownload:
         assert second_cookie_jar.get("ROUTEID") == "backend-a"
 
     @patch("modelaudit.utils.sources.jfrog.requests.get")
+    def test_download_redirect_isolates_cookies_across_trust_boundaries(
+        self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Trusted JFrog cookies must not cross an untrusted redirect hop."""
+        trusted_redirect = MagicMock(spec=requests.Response)
+        trusted_redirect.status_code = 302
+        trusted_redirect.headers = {"Location": "https://evil.example/artifacts/model.bin"}
+        trusted_redirect.cookies = requests.cookies.cookiejar_from_dict({"JFROG_SESSION": "trusted-session"})
+        untrusted_redirect = MagicMock(spec=requests.Response)
+        untrusted_redirect.status_code = 302
+        untrusted_redirect.headers = {"Location": "https://company.jfrog.io/artifactory/repo/model.bin?node=1"}
+        untrusted_redirect.cookies = requests.cookies.cookiejar_from_dict({"EVIL_SESSION": "untrusted-session"})
+        final_response = MagicMock(spec=requests.Response)
+        final_response.status_code = 200
+        final_response.headers = {}
+        final_response.raise_for_status.return_value = None
+        final_response.iter_content.return_value = [b"data"]
+        mock_get.side_effect = [trusted_redirect, untrusted_redirect, final_response]
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+
+        result = download_artifact(
+            "https://company.jfrog.io/artifactory/repo/model.bin",
+            cache_dir=tmp_path,
+            api_token="test-token",
+        )
+
+        assert result.read_bytes() == b"data"
+        trusted_cookie_jar = mock_get.call_args_list[0].kwargs["cookies"]
+        untrusted_cookie_jar = mock_get.call_args_list[1].kwargs["cookies"]
+        returning_trusted_cookie_jar = mock_get.call_args_list[2].kwargs["cookies"]
+        assert trusted_cookie_jar is returning_trusted_cookie_jar
+        assert trusted_cookie_jar is not untrusted_cookie_jar
+        assert trusted_cookie_jar.get("JFROG_SESSION") == "trusted-session"
+        assert trusted_cookie_jar.get("EVIL_SESSION") is None
+        assert untrusted_cookie_jar.get("JFROG_SESSION") is None
+        assert untrusted_cookie_jar.get("EVIL_SESSION") == "untrusted-session"
+        assert mock_get.call_args_list[1].kwargs["headers"] == {}
+        assert mock_get.call_args_list[2].kwargs["headers"] == {"X-JFrog-Art-Api": "test-token"}
+
+    @patch("modelaudit.utils.sources.jfrog.requests.get")
     def test_download_redirect_without_location_fails_closed(
         self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -462,7 +502,12 @@ class TestJFrogDownload:
         assert mock_get.call_args[1]["headers"] == {"Authorization": "Bearer explicit-access-token"}
 
     @patch("modelaudit.utils.sources.jfrog.requests.get")
-    def test_no_authentication(self, mock_get, tmp_path, caplog):
+    def test_no_authentication(
+        self,
+        mock_get: MagicMock,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         """Test anonymous access when no authentication is provided."""
         mock_response = mock_get.return_value
         mock_response.status_code = 200

--- a/tests/integrations/test_jfrog.py
+++ b/tests/integrations/test_jfrog.py
@@ -65,6 +65,7 @@ class TestJFrogDownload:
     def test_download_success(self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         # Mock successful response
         mock_response = mock_get.return_value
+        mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
         mock_response.iter_content.return_value = [b"data"]
         monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
@@ -80,6 +81,7 @@ class TestJFrogDownload:
         call_args = mock_get.call_args
         assert "X-JFrog-Art-Api" in call_args[1]["headers"]
         assert call_args[1]["headers"]["X-JFrog-Art-Api"] == "test-token"
+        assert call_args[1]["allow_redirects"] is False
 
     def test_invalid_url(self):
         with pytest.raises(ValueError):
@@ -99,6 +101,7 @@ class TestJFrogDownload:
     def test_authentication_methods(self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test different authentication methods."""
         mock_response = mock_get.return_value
+        mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
         mock_response.iter_content.return_value = [b"data"]
         monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
@@ -123,6 +126,7 @@ class TestJFrogDownload:
     ) -> None:
         """Explicit caller credentials should not be shadowed by ambient env tokens."""
         mock_response = mock_get.return_value
+        mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
         mock_response.iter_content.return_value = [b"data"]
         monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
@@ -141,6 +145,7 @@ class TestJFrogDownload:
     def test_environment_variables(self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test authentication via environment variables."""
         mock_response = mock_get.return_value
+        mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
         mock_response.iter_content.return_value = [b"data"]
         monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
@@ -164,6 +169,7 @@ class TestJFrogDownload:
     ) -> None:
         """Credentials should not be sent to arbitrary JFrog SaaS tenants."""
         mock_response = mock_get.return_value
+        mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
         mock_response.iter_content.return_value = [b"data"]
         monkeypatch.setenv("JFROG_API_TOKEN", "env-api-token")
@@ -184,6 +190,112 @@ class TestJFrogDownload:
         assert "env-api-token" not in caplog.text
 
     @patch("modelaudit.utils.sources.jfrog.requests.get")
+    def test_parser_confused_initial_jfrog_url_receives_no_credentials(
+        self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Credential trust must match the host Requests will actually contact."""
+        mock_response = mock_get.return_value
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_response.iter_content.return_value = [b"data"]
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+
+        with caplog.at_level(logging.WARNING, logger="modelaudit.utils.sources.jfrog"):
+            result = download_artifact(
+                "https://evil.example\\@company.jfrog.io/artifactory/repo/model.bin",
+                cache_dir=tmp_path,
+                api_token="test-token",
+            )
+
+        assert result.read_bytes() == b"data"
+        assert mock_get.call_args.kwargs["headers"] == {}
+        assert mock_get.call_args.kwargs["allow_redirects"] is False
+        assert "Skipping JFrog credentials" in caplog.text
+        assert "test-token" not in caplog.text
+
+    @patch("modelaudit.utils.sources.jfrog.requests.get")
+    def test_untrusted_download_redirect_strips_credentials(
+        self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """API tokens must not be forwarded to an untrusted redirect target."""
+        redirect_response = MagicMock(spec=requests.Response)
+        redirect_response.status_code = 302
+        redirect_response.headers = {"Location": "https://evil.example/artifacts/model.bin"}
+        final_response = MagicMock(spec=requests.Response)
+        final_response.status_code = 200
+        final_response.headers = {}
+        final_response.raise_for_status.return_value = None
+        final_response.iter_content.return_value = [b"data"]
+        mock_get.side_effect = [redirect_response, final_response]
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+
+        result = download_artifact(
+            "https://company.jfrog.io/artifactory/repo/model.bin",
+            cache_dir=tmp_path,
+            api_token="test-token",
+        )
+
+        assert result.read_bytes() == b"data"
+        assert mock_get.call_args_list[0].kwargs["headers"] == {"X-JFrog-Art-Api": "test-token"}
+        assert mock_get.call_args_list[1].args[0] == "https://evil.example/artifacts/model.bin"
+        assert mock_get.call_args_list[1].kwargs["headers"] == {}
+        assert all(call.kwargs["allow_redirects"] is False for call in mock_get.call_args_list)
+
+    @patch("modelaudit.utils.sources.jfrog.requests.get")
+    def test_parser_confused_redirect_strips_credentials(
+        self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Redirect trust must use the effective Requests destination host."""
+        redirect_response = MagicMock(spec=requests.Response)
+        redirect_response.status_code = 302
+        redirect_response.headers = {"Location": "https://evil.example\\@company.jfrog.io/artifacts/model.bin"}
+        final_response = MagicMock(spec=requests.Response)
+        final_response.status_code = 200
+        final_response.headers = {}
+        final_response.raise_for_status.return_value = None
+        final_response.iter_content.return_value = [b"data"]
+        mock_get.side_effect = [redirect_response, final_response]
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+
+        result = download_artifact(
+            "https://company.jfrog.io/artifactory/repo/model.bin",
+            cache_dir=tmp_path,
+            api_token="test-token",
+        )
+
+        assert result.read_bytes() == b"data"
+        assert mock_get.call_args_list[0].kwargs["headers"] == {"X-JFrog-Art-Api": "test-token"}
+        assert mock_get.call_args_list[1].args[0] == "https://evil.example\\@company.jfrog.io/artifacts/model.bin"
+        assert mock_get.call_args_list[1].kwargs["headers"] == {}
+        assert all(call.kwargs["allow_redirects"] is False for call in mock_get.call_args_list)
+
+    @patch("modelaudit.utils.sources.jfrog.requests.get")
+    def test_trusted_download_redirect_preserves_credentials(
+        self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Credentials can be reused when a redirect target is explicitly trusted."""
+        redirect_response = MagicMock(spec=requests.Response)
+        redirect_response.status_code = 307
+        redirect_response.headers = {"Location": "/artifactory/repo/model.bin?download=1"}
+        final_response = MagicMock(spec=requests.Response)
+        final_response.status_code = 200
+        final_response.headers = {}
+        final_response.raise_for_status.return_value = None
+        final_response.iter_content.return_value = [b"data"]
+        mock_get.side_effect = [redirect_response, final_response]
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+
+        result = download_artifact(
+            "https://company.jfrog.io/artifactory/repo/model.bin",
+            cache_dir=tmp_path,
+            api_token="test-token",
+        )
+
+        assert result.read_bytes() == b"data"
+        assert mock_get.call_args_list[1].args[0] == ("https://company.jfrog.io/artifactory/repo/model.bin?download=1")
+        assert mock_get.call_args_list[1].kwargs["headers"] == {"X-JFrog-Art-Api": "test-token"}
+
+    @patch("modelaudit.utils.sources.jfrog.requests.get")
     def test_http_jfrog_saas_url_is_rejected_before_credentials(
         self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -201,6 +313,7 @@ class TestJFrogDownload:
     ) -> None:
         """Storage API probing should share the same credential forwarding policy."""
         mock_response = mock_get.return_value
+        mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
         mock_response.json.return_value = {"repo": "public-repo", "path": "/model.bin", "size": 12}
         monkeypatch.setenv("JFROG_API_TOKEN", "env-api-token")
@@ -214,11 +327,66 @@ class TestJFrogDownload:
         assert mock_get.call_args[1]["headers"] == {}
 
     @patch("modelaudit.utils.sources.jfrog.requests.get")
+    def test_storage_api_untrusted_redirect_strips_credentials(
+        self, mock_get: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Storage API redirects must not forward credentials to untrusted hosts."""
+        redirect_response = MagicMock(spec=requests.Response)
+        redirect_response.status_code = 302
+        redirect_response.headers = {"Location": "https://evil.example/storage/model.bin"}
+        final_response = MagicMock(spec=requests.Response)
+        final_response.status_code = 200
+        final_response.headers = {}
+        final_response.raise_for_status.return_value = None
+        final_response.json.return_value = {"repo": "repo", "path": "/model.bin", "size": 12}
+        mock_get.side_effect = [redirect_response, final_response]
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+
+        result = detect_jfrog_target_type(
+            "https://company.jfrog.io/artifactory/repo/model.bin",
+            api_token="test-token",
+        )
+
+        assert result["type"] == "file"
+        assert mock_get.call_args_list[0].kwargs["headers"] == {"X-JFrog-Art-Api": "test-token"}
+        assert mock_get.call_args_list[1].args[0] == "https://evil.example/storage/model.bin"
+        assert mock_get.call_args_list[1].kwargs["headers"] == {}
+        assert all(call.kwargs["allow_redirects"] is False for call in mock_get.call_args_list)
+
+    @patch("modelaudit.utils.sources.jfrog.requests.get")
+    def test_storage_api_parser_confused_redirect_strips_credentials(
+        self, mock_get: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Storage API redirects share the effective-destination host check."""
+        redirect_response = MagicMock(spec=requests.Response)
+        redirect_response.status_code = 302
+        redirect_response.headers = {"Location": "https://evil.example\\@company.jfrog.io/storage/model.bin"}
+        final_response = MagicMock(spec=requests.Response)
+        final_response.status_code = 200
+        final_response.headers = {}
+        final_response.raise_for_status.return_value = None
+        final_response.json.return_value = {"repo": "repo", "path": "/model.bin", "size": 12}
+        mock_get.side_effect = [redirect_response, final_response]
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+
+        result = detect_jfrog_target_type(
+            "https://company.jfrog.io/artifactory/repo/model.bin",
+            api_token="test-token",
+        )
+
+        assert result["type"] == "file"
+        assert mock_get.call_args_list[0].kwargs["headers"] == {"X-JFrog-Art-Api": "test-token"}
+        assert mock_get.call_args_list[1].args[0] == "https://evil.example\\@company.jfrog.io/storage/model.bin"
+        assert mock_get.call_args_list[1].kwargs["headers"] == {}
+        assert all(call.kwargs["allow_redirects"] is False for call in mock_get.call_args_list)
+
+    @patch("modelaudit.utils.sources.jfrog.requests.get")
     def test_storage_api_explicit_access_token_precedes_environment_api_token(
         self, mock_get: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Explicit Storage API access tokens should not be shadowed by env API tokens."""
         mock_response = mock_get.return_value
+        mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
         mock_response.json.return_value = {"repo": "repo", "path": "/model.bin", "size": 12}
         monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
@@ -236,6 +404,7 @@ class TestJFrogDownload:
     def test_no_authentication(self, mock_get, tmp_path, caplog):
         """Test anonymous access when no authentication is provided."""
         mock_response = mock_get.return_value
+        mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
         mock_response.iter_content.return_value = [b"data"]
 

--- a/tests/integrations/test_jfrog.py
+++ b/tests/integrations/test_jfrog.py
@@ -191,27 +191,19 @@ class TestJFrogDownload:
 
     @patch("modelaudit.utils.sources.jfrog.requests.get")
     def test_parser_confused_initial_jfrog_url_receives_no_credentials(
-        self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+        self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Credential trust must match the host Requests will actually contact."""
-        mock_response = mock_get.return_value
-        mock_response.status_code = 200
-        mock_response.raise_for_status.return_value = None
-        mock_response.iter_content.return_value = [b"data"]
+        """Parser-confused initial URLs must be rejected before any request is sent."""
         monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
 
-        with caplog.at_level(logging.WARNING, logger="modelaudit.utils.sources.jfrog"):
-            result = download_artifact(
+        with pytest.raises(ValueError, match="Not a JFrog URL"):
+            download_artifact(
                 "https://evil.example\\@company.jfrog.io/artifactory/repo/model.bin",
                 cache_dir=tmp_path,
                 api_token="test-token",
             )
 
-        assert result.read_bytes() == b"data"
-        assert mock_get.call_args.kwargs["headers"] == {}
-        assert mock_get.call_args.kwargs["allow_redirects"] is False
-        assert "Skipping JFrog credentials" in caplog.text
-        assert "test-token" not in caplog.text
+        mock_get.assert_not_called()
 
     @patch("modelaudit.utils.sources.jfrog.requests.get")
     def test_untrusted_download_redirect_strips_credentials(
@@ -294,6 +286,26 @@ class TestJFrogDownload:
         assert result.read_bytes() == b"data"
         assert mock_get.call_args_list[1].args[0] == ("https://company.jfrog.io/artifactory/repo/model.bin?download=1")
         assert mock_get.call_args_list[1].kwargs["headers"] == {"X-JFrog-Art-Api": "test-token"}
+
+    @patch("modelaudit.utils.sources.jfrog.requests.get")
+    def test_download_redirect_without_location_fails_closed(
+        self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Redirect responses without a target must not be scanned as artifact bodies."""
+        redirect_response = MagicMock(spec=requests.Response)
+        redirect_response.status_code = 302
+        redirect_response.headers = {}
+        mock_get.return_value = redirect_response
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+
+        with pytest.raises(Exception, match="JFrog redirect response missing Location header"):
+            download_artifact(
+                "https://company.jfrog.io/artifactory/repo/model.bin",
+                cache_dir=tmp_path,
+                api_token="test-token",
+            )
+
+        redirect_response.close.assert_called_once_with()
 
     @patch("modelaudit.utils.sources.jfrog.requests.get")
     def test_http_jfrog_saas_url_is_rejected_before_credentials(


### PR DESCRIPTION
## Summary
- route JFrog artifact and Storage API GETs through a manual redirect policy with automatic redirects disabled
- strip auth headers from untrusted redirect targets while preserving credentials for explicitly trusted HTTPS JFrog targets
- require Requests' prepared URL host to match urlparse's host before sending JFrog credentials, closing malformed-authority parser confusion

## Validation
- CARGO_HOME=/private/tmp/modelaudit-cargo CARGO_TARGET_DIR=/private/tmp/modelaudit-c018-picklescan-target UV_CACHE_DIR=/private/tmp/modelaudit-uv-cache uv pip install --python /Users/mdangelo/code/modelaudit/.venv/bin/python -e packages/modelaudit-picklescan
- PYTHONPATH=/private/tmp/modelaudit-c018:/private/tmp/modelaudit-c018/packages/modelaudit-picklescan/src /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/integrations/test_jfrog.py tests/integrations/test_jfrog_integration.py -q -> 50 passed, 2 skipped
- /Users/mdangelo/code/modelaudit/.venv/bin/ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/ -> 399 files already formatted
- /Users/mdangelo/code/modelaudit/.venv/bin/ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/ -> All checks passed
- PYTHONPATH=/private/tmp/modelaudit-c018:/private/tmp/modelaudit-c018/packages/modelaudit-picklescan/src /Users/mdangelo/code/modelaudit/.venv/bin/mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/ -> Success: no issues found in 454 source files
- PYTHONPATH=/private/tmp/modelaudit-c018:/private/tmp/modelaudit-c018/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest -n auto -m "not slow and not integration" --maxfail=1 -> 7710 passed, 16 skipped, 22 warnings

## Notes
- Fixes MA-DSS-C018 from the Codex Security scan.