### PR TITLE
fix: harden structured Jinja size handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - harden legacy JAX checkpoint pickle routing against bounded-prefix bypasses and benign sidecar false positives
 - detect dangerous Python calls retrieved or installed through module namespace dictionaries in ZIP and TAR members, while avoiding comprehension-local false positives
 - preflight and stream-enforce cumulative SevenZip extraction budgets before writing oversized archives
-- mark oversized structured JSON/YAML Jinja template fields as incomplete coverage instead of clean
+- mark oversized structured JSON/YAML Jinja template fields and manifest-owned nested template containers as incomplete coverage instead of clean
 - redact capability tokens embedded in network URL path segments
 - redact secret-shaped dictionary keys from embedded-secret detector finding contexts
 - redact compound credential names and malformed userinfo URLs in scanner evidence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - harden legacy JAX checkpoint pickle routing against bounded-prefix bypasses and benign sidecar false positives
 - detect dangerous Python calls retrieved or installed through module namespace dictionaries in ZIP and TAR members, while avoiding comprehension-local false positives
 - preflight and stream-enforce cumulative SevenZip extraction budgets before writing oversized archives
-- mark oversized structured JSON/YAML Jinja template fields and manifest-owned nested template containers as incomplete coverage instead of clean
+- harden structured JSON/YAML/GGUF Jinja template extraction against oversized values, nested containers, and colliding template paths
 - redact capability tokens embedded in network URL path segments
 - redact secret-shaped dictionary keys from embedded-secret detector finding contexts
 - redact compound credential names and malformed userinfo URLs in scanner evidence

--- a/modelaudit/scanners/jinja2_template_scanner.py
+++ b/modelaudit/scanners/jinja2_template_scanner.py
@@ -19,6 +19,7 @@ Key Features:
 """
 
 import json
+import operator
 import os
 import re
 import warnings
@@ -531,47 +532,85 @@ class Jinja2TemplateScanner(BaseScanner):
 
         try:
             reader = GGUFReader(path)
+        except Exception as exc:
+            logger.debug("Error opening GGUF for template extraction: %s", exc)
+            extraction_failures.append(self._template_extraction_failure("gguf", "jinja2_gguf_parse_failed", exc))
+            return templates, extraction_failures
 
-            # Look for tokenizer.chat_template in metadata
-            for key, field in reader.fields.items():
-                if key == "tokenizer.chat_template" and hasattr(field, "parts") and hasattr(field, "data"):
-                    value = field.parts[field.data[0]]
-                    template_str = self._gguf_template_value_to_string(value, extraction_failures)
+        for key, field in reader.fields.items():
+            if not self._is_gguf_chat_template_key(key):
+                continue
 
-                    if template_str:
-                        self._add_template_candidate(
-                            template_str,
-                            templates,
-                            "tokenizer.chat_template",
-                            extraction_failures,
-                            "gguf",
-                        )
+            try:
+                if not hasattr(field, "parts") or not hasattr(field, "data") or len(field.data) == 0:
+                    raise ValueError("GGUF chat template field does not expose readable value data")
 
-        except Exception as e:
-            logger.debug(f"Error extracting GGUF templates: {e}")
+                value = field.parts[field.data[0]]
+                template_str = self._gguf_template_value_to_string(value, extraction_failures, key)
+                if template_str:
+                    self._add_template_candidate(
+                        template_str,
+                        templates,
+                        key,
+                        extraction_failures,
+                        "gguf",
+                    )
+            except Exception as exc:
+                logger.debug("Error extracting GGUF chat template %s: %s", key, exc)
+                self._add_gguf_template_decode_failure(extraction_failures, key, field, exc)
 
         return templates, extraction_failures
+
+    @staticmethod
+    def _is_gguf_chat_template_key(key: Any) -> bool:
+        return isinstance(key, str) and (key == "tokenizer.chat_template" or key.startswith("tokenizer.chat_template."))
+
+    @staticmethod
+    def _add_gguf_template_decode_failure(
+        extraction_failures: list[dict[str, Any]],
+        template_location: str,
+        value: Any,
+        error: Exception | None = None,
+    ) -> None:
+        if any(
+            failure.get("reason") == "jinja2_gguf_template_decode_failed"
+            and failure.get("template_location") == template_location
+            for failure in extraction_failures
+        ):
+            return
+
+        failure = {
+            "format": "gguf",
+            "reason": "jinja2_gguf_template_decode_failed",
+            "template_location": template_location,
+            "value_type": type(value).__name__,
+        }
+        if error is not None:
+            failure["exception"] = str(error)
+            failure["exception_type"] = type(error).__name__
+        extraction_failures.append(failure)
 
     def _gguf_template_value_to_string(
         self,
         value: Any,
         extraction_failures: list[dict[str, Any]],
+        template_location: str,
     ) -> str | None:
         if isinstance(value, str):
             return value
 
         if isinstance(value, list | tuple):
-            return self._gguf_integer_sequence_to_string(value, extraction_failures)
+            return self._gguf_integer_sequence_to_string(value, extraction_failures, template_location)
 
         if isinstance(value, bytes | bytearray | memoryview):
-            return self._gguf_template_bytes_to_string(bytes(value), extraction_failures)
+            return self._gguf_template_bytes_to_string(bytes(value), extraction_failures, template_location)
 
         declared_size = self._gguf_declared_template_size(value)
         if declared_size is not None and declared_size > self.max_template_size:
             self._add_template_size_failure(
                 extraction_failures,
                 "gguf",
-                "tokenizer.chat_template",
+                template_location,
                 declared_size,
             )
             return None
@@ -584,7 +623,11 @@ class Jinja2TemplateScanner(BaseScanner):
                 logger.debug("Error decoding GGUF chat template bytes: %s", exc)
             else:
                 if isinstance(raw_value, bytes | bytearray | memoryview):
-                    return self._gguf_template_bytes_to_string(bytes(raw_value), extraction_failures)
+                    return self._gguf_template_bytes_to_string(
+                        bytes(raw_value),
+                        extraction_failures,
+                        template_location,
+                    )
 
         tolist = getattr(value, "tolist", None)
         if callable(tolist):
@@ -594,40 +637,62 @@ class Jinja2TemplateScanner(BaseScanner):
                 logger.debug("Error decoding GGUF chat template list: %s", exc)
             else:
                 if list_value is not value:
-                    recursive_value = self._gguf_template_value_to_string(list_value, extraction_failures)
+                    recursive_value = self._gguf_template_value_to_string(
+                        list_value,
+                        extraction_failures,
+                        template_location,
+                    )
                     if recursive_value is not None:
                         return recursive_value
 
-        return str(value)
+        self._add_gguf_template_decode_failure(extraction_failures, template_location, value)
+        return None
 
     def _gguf_integer_sequence_to_string(
         self,
         value: list[Any] | tuple[Any, ...],
         extraction_failures: list[dict[str, Any]],
+        template_location: str,
     ) -> str | None:
         if len(value) > self.max_template_size:
             self._add_template_size_failure(
                 extraction_failures,
                 "gguf",
-                "tokenizer.chat_template",
+                template_location,
                 len(value),
             )
             return None
 
-        return "".join(
-            chr(code_point) for code_point in value if isinstance(code_point, int) and 0 <= code_point <= 1114111
-        )
+        characters: list[str] = []
+        for raw_code_point in value:
+            if isinstance(raw_code_point, bool):
+                self._add_gguf_template_decode_failure(extraction_failures, template_location, value)
+                return None
+
+            try:
+                code_point = operator.index(raw_code_point)
+            except TypeError:
+                self._add_gguf_template_decode_failure(extraction_failures, template_location, value)
+                return None
+
+            if not 0 <= code_point <= 1114111:
+                self._add_gguf_template_decode_failure(extraction_failures, template_location, value)
+                return None
+            characters.append(chr(code_point))
+
+        return "".join(characters)
 
     def _gguf_template_bytes_to_string(
         self,
         value: bytes,
         extraction_failures: list[dict[str, Any]],
+        template_location: str,
     ) -> str | None:
         if len(value) > self.max_template_size:
             self._add_template_size_failure(
                 extraction_failures,
                 "gguf",
-                "tokenizer.chat_template",
+                template_location,
                 len(value),
             )
             return None
@@ -755,7 +820,7 @@ class Jinja2TemplateScanner(BaseScanner):
         config_format: str,
     ) -> None:
         if len(value) <= self.max_template_size:
-            templates[template_path] = value
+            self._record_template_candidate(templates, template_path, value)
             return
 
         self._add_template_size_failure(
@@ -764,6 +829,19 @@ class Jinja2TemplateScanner(BaseScanner):
             template_path,
             len(value),
         )
+
+    @staticmethod
+    def _record_template_candidate(templates: dict[str, str], template_path: str, value: str) -> None:
+        if template_path not in templates:
+            templates[template_path] = value
+            return
+
+        duplicate_index = len(templates) + 1
+        unique_path = f"{template_path} [duplicate {duplicate_index}]"
+        while unique_path in templates:
+            duplicate_index += 1
+            unique_path = f"{template_path} [duplicate {duplicate_index}]"
+        templates[unique_path] = value
 
     def _add_template_size_failure(
         self,

--- a/modelaudit/scanners/jinja2_template_scanner.py
+++ b/modelaudit/scanners/jinja2_template_scanner.py
@@ -131,6 +131,14 @@ def _scan_result_has_security_findings(result: ScanResult) -> bool:
     return any(issue.severity in (IssueSeverity.WARNING, IssueSeverity.CRITICAL) for issue in result.issues)
 
 
+def _nonnegative_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value >= 0:
+        return value
+    return None
+
+
 class Jinja2TemplateScanner(BaseScanner):
     """Scanner for Jinja2 template injection vulnerabilities in ML models"""
 
@@ -528,19 +536,7 @@ class Jinja2TemplateScanner(BaseScanner):
             for key, field in reader.fields.items():
                 if key == "tokenizer.chat_template" and hasattr(field, "parts") and hasattr(field, "data"):
                     value = field.parts[field.data[0]]
-                    if isinstance(value, list | tuple):
-                        if len(value) > self.max_template_size:
-                            self._add_template_size_failure(
-                                extraction_failures,
-                                "gguf",
-                                "tokenizer.chat_template",
-                                len(value),
-                            )
-                            continue
-                        # Convert list of integers to string
-                        template_str = "".join(chr(i) for i in value if isinstance(i, int) and 0 <= i <= 1114111)
-                    else:
-                        template_str = str(value)
+                    template_str = self._gguf_template_value_to_string(value, extraction_failures)
 
                     if template_str:
                         self._add_template_candidate(
@@ -555,6 +551,101 @@ class Jinja2TemplateScanner(BaseScanner):
             logger.debug(f"Error extracting GGUF templates: {e}")
 
         return templates, extraction_failures
+
+    def _gguf_template_value_to_string(
+        self,
+        value: Any,
+        extraction_failures: list[dict[str, Any]],
+    ) -> str | None:
+        if isinstance(value, str):
+            return value
+
+        if isinstance(value, list | tuple):
+            return self._gguf_integer_sequence_to_string(value, extraction_failures)
+
+        if isinstance(value, bytes | bytearray | memoryview):
+            return self._gguf_template_bytes_to_string(bytes(value), extraction_failures)
+
+        declared_size = self._gguf_declared_template_size(value)
+        if declared_size is not None and declared_size > self.max_template_size:
+            self._add_template_size_failure(
+                extraction_failures,
+                "gguf",
+                "tokenizer.chat_template",
+                declared_size,
+            )
+            return None
+
+        tobytes = getattr(value, "tobytes", None)
+        if callable(tobytes):
+            try:
+                raw_value = tobytes()
+            except Exception as exc:
+                logger.debug("Error decoding GGUF chat template bytes: %s", exc)
+            else:
+                if isinstance(raw_value, bytes | bytearray | memoryview):
+                    return self._gguf_template_bytes_to_string(bytes(raw_value), extraction_failures)
+
+        tolist = getattr(value, "tolist", None)
+        if callable(tolist):
+            try:
+                list_value = tolist()
+            except Exception as exc:
+                logger.debug("Error decoding GGUF chat template list: %s", exc)
+            else:
+                if list_value is not value:
+                    recursive_value = self._gguf_template_value_to_string(list_value, extraction_failures)
+                    if recursive_value is not None:
+                        return recursive_value
+
+        return str(value)
+
+    def _gguf_integer_sequence_to_string(
+        self,
+        value: list[Any] | tuple[Any, ...],
+        extraction_failures: list[dict[str, Any]],
+    ) -> str | None:
+        if len(value) > self.max_template_size:
+            self._add_template_size_failure(
+                extraction_failures,
+                "gguf",
+                "tokenizer.chat_template",
+                len(value),
+            )
+            return None
+
+        return "".join(
+            chr(code_point) for code_point in value if isinstance(code_point, int) and 0 <= code_point <= 1114111
+        )
+
+    def _gguf_template_bytes_to_string(
+        self,
+        value: bytes,
+        extraction_failures: list[dict[str, Any]],
+    ) -> str | None:
+        if len(value) > self.max_template_size:
+            self._add_template_size_failure(
+                extraction_failures,
+                "gguf",
+                "tokenizer.chat_template",
+                len(value),
+            )
+            return None
+
+        return value.decode("utf-8", errors="replace")
+
+    @staticmethod
+    def _gguf_declared_template_size(value: Any) -> int | None:
+        nbytes = _nonnegative_int(getattr(value, "nbytes", None))
+        if nbytes is not None:
+            return nbytes
+
+        size = _nonnegative_int(getattr(value, "size", None))
+        itemsize = _nonnegative_int(getattr(value, "itemsize", None))
+        if size is not None and itemsize is not None:
+            return size * itemsize
+
+        return size
 
     def _extract_json_templates(self, path: str) -> tuple[dict[str, str], list[dict[str, Any]]]:
         """Extract templates from JSON configuration files"""

--- a/modelaudit/scanners/jinja2_template_scanner.py
+++ b/modelaudit/scanners/jinja2_template_scanner.py
@@ -529,6 +529,14 @@ class Jinja2TemplateScanner(BaseScanner):
                 if key == "tokenizer.chat_template" and hasattr(field, "parts") and hasattr(field, "data"):
                     value = field.parts[field.data[0]]
                     if isinstance(value, list | tuple):
+                        if len(value) > self.max_template_size:
+                            self._add_template_size_failure(
+                                extraction_failures,
+                                "gguf",
+                                "tokenizer.chat_template",
+                                len(value),
+                            )
+                            continue
                         # Convert list of integers to string
                         template_str = "".join(chr(i) for i in value if isinstance(i, int) and 0 <= i <= 1114111)
                     else:

--- a/modelaudit/scanners/jinja2_template_scanner.py
+++ b/modelaudit/scanners/jinja2_template_scanner.py
@@ -70,6 +70,7 @@ _DETECTION_MESSAGE_LABELS = {
     "environment_access": "environment access",
     "sandbox_violation": "sandbox violation",
 }
+_MAX_REPORTED_TEMPLATE_LOCATIONS = 20
 _RAW_PARSE_FALLBACK_CONTEXT_BYTES = 1024
 _RAW_PARSE_FALLBACK_MAX_WINDOWS = 8
 _RAW_PARSE_FALLBACK_READ_BYTES = 256 * 1024
@@ -230,7 +231,7 @@ class Jinja2TemplateScanner(BaseScanner):
                         name="Template Extraction",
                         passed=False,
                         message=(
-                            "Template analysis incomplete because standalone template exceeds the size limit"
+                            "Template analysis incomplete because one or more extracted templates exceed the size limit"
                             if size_limited
                             else (
                                 "Template analysis incomplete because standalone template could not be read"
@@ -298,14 +299,19 @@ class Jinja2TemplateScanner(BaseScanner):
             "confidence": context.confidence,
         }
         bounded_templates: dict[str, str] = {}
-        oversized_template_locations: list[str] = []
+        oversized_failures: list[dict[str, Any]] = []
         for template_location, template_content in templates.items():
             if len(template_content) <= self.max_template_size:
                 bounded_templates[template_location] = template_content
             else:
-                oversized_template_locations.append(template_location)
+                self._add_template_size_failure(
+                    oversized_failures,
+                    "extracted",
+                    template_location,
+                    len(template_content),
+                )
 
-        if oversized_template_locations:
+        if oversized_failures:
             result.metadata[_INCONCLUSIVE_METADATA_KEY] = INCONCLUSIVE_SCAN_OUTCOME
             result.metadata[_INCONCLUSIVE_REASONS_METADATA_KEY] = ["jinja2_template_size_limit_exceeded"]
             result.add_check(
@@ -314,11 +320,7 @@ class Jinja2TemplateScanner(BaseScanner):
                 message="Template analysis incomplete because one or more extracted templates exceed the size limit",
                 severity=IssueSeverity.INFO,
                 location=path,
-                details={
-                    "reason": "jinja2_template_size_limit_exceeded",
-                    "max_template_size": self.max_template_size,
-                    "skipped_template_locations": oversized_template_locations,
-                },
+                details=oversized_failures[0],
             )
 
         if not bounded_templates:
@@ -494,7 +496,9 @@ class Jinja2TemplateScanner(BaseScanner):
 
         try:
             if context.file_type == "gguf" and HAS_GGUF:
-                templates.update(self._extract_gguf_templates(path))
+                extracted, failures = self._extract_gguf_templates(path)
+                templates.update(extracted)
+                extraction_failures.extend(failures)
             elif context.file_type in ["json", "tokenizer_config"]:
                 extracted, failures = self._extract_json_templates(path)
                 templates.update(extracted)
@@ -512,9 +516,10 @@ class Jinja2TemplateScanner(BaseScanner):
 
         return templates, extraction_failures
 
-    def _extract_gguf_templates(self, path: str) -> dict[str, str]:
+    def _extract_gguf_templates(self, path: str) -> tuple[dict[str, str], list[dict[str, Any]]]:
         """Extract chat templates from GGUF metadata"""
-        templates = {}
+        templates: dict[str, str] = {}
+        extraction_failures: list[dict[str, Any]] = []
 
         try:
             reader = GGUFReader(path)
@@ -529,13 +534,19 @@ class Jinja2TemplateScanner(BaseScanner):
                     else:
                         template_str = str(value)
 
-                    if template_str and len(template_str) <= self.max_template_size:
-                        templates["tokenizer.chat_template"] = template_str
+                    if template_str:
+                        self._add_template_candidate(
+                            template_str,
+                            templates,
+                            "tokenizer.chat_template",
+                            extraction_failures,
+                            "gguf",
+                        )
 
         except Exception as e:
             logger.debug(f"Error extracting GGUF templates: {e}")
 
-        return templates
+        return templates, extraction_failures
 
     def _extract_json_templates(self, path: str) -> tuple[dict[str, str], list[dict[str, Any]]]:
         """Extract templates from JSON configuration files"""
@@ -648,15 +659,56 @@ class Jinja2TemplateScanner(BaseScanner):
             templates[template_path] = value
             return
 
-        extraction_failures.append(
-            {
+        self._add_template_size_failure(
+            extraction_failures,
+            config_format,
+            template_path,
+            len(value),
+        )
+
+    def _add_template_size_failure(
+        self,
+        extraction_failures: list[dict[str, Any]],
+        config_format: str,
+        template_path: str,
+        template_size: int,
+    ) -> None:
+        for failure in extraction_failures:
+            if (
+                failure.get("format") == config_format
+                and failure.get("reason") == "jinja2_template_size_limit_exceeded"
+                and failure.get("max_template_size") == self.max_template_size
+            ):
+                break
+        else:
+            failure = {
                 "format": config_format,
                 "reason": "jinja2_template_size_limit_exceeded",
                 "max_template_size": self.max_template_size,
-                "skipped_template_locations": [template_path],
-                "template_size": len(value),
+                "skipped_template_locations": [],
+                "skipped_template_location_count": 0,
+                "skipped_template_locations_truncated": False,
+                "template_size": 0,
             }
-        )
+            extraction_failures.append(failure)
+
+        failure["skipped_template_location_count"] = int(failure["skipped_template_location_count"]) + 1
+        locations = failure["skipped_template_locations"]
+        if isinstance(locations, list) and len(locations) < _MAX_REPORTED_TEMPLATE_LOCATIONS:
+            locations.append(template_path)
+        else:
+            failure["skipped_template_locations_truncated"] = True
+        failure["template_size"] = max(int(failure["template_size"]), template_size)
+
+    def _legacy_template_size_failure(
+        self,
+        config_format: str,
+        template_path: str,
+        template_size: int,
+    ) -> dict[str, Any]:
+        extraction_failures: list[dict[str, Any]] = []
+        self._add_template_size_failure(extraction_failures, config_format, template_path, template_size)
+        return extraction_failures[0]
 
     def _extract_raw_template_fallback(self, path: str, templates: dict[str, str], template_key: str) -> None:
         for index, fallback_text in enumerate(self._raw_template_fallback_windows_from_file(path)):
@@ -824,12 +876,11 @@ class Jinja2TemplateScanner(BaseScanner):
 
             if len(content) > self.max_template_size:
                 extraction_failures.append(
-                    {
-                        "format": "template",
-                        "reason": "jinja2_template_size_limit_exceeded",
-                        "max_template_size": self.max_template_size,
-                        "skipped_template_locations": ["template_content"],
-                    }
+                    self._legacy_template_size_failure(
+                        "template",
+                        "template_content",
+                        len(content),
+                    )
                 )
             elif content:
                 templates["template_content"] = content

--- a/modelaudit/scanners/manifest_scanner.py
+++ b/modelaudit/scanners/manifest_scanner.py
@@ -980,16 +980,16 @@ class ManifestScanner(BaseScanner):
                 self._check_timeout()
                 child_path = f"{path}.{key}" if path else str(key)
                 if key in JINJA_TEMPLATE_FIELD_NAMES:
-                    templates.update(self._collect_jinja_template_container(item, child_path))
+                    self._merge_jinja_templates(templates, self._collect_jinja_template_container(item, child_path))
                     continue
-                templates.update(self._collect_jinja_template_fields(item, child_path))
+                self._merge_jinja_templates(templates, self._collect_jinja_template_fields(item, child_path))
             return templates
         if isinstance(value, list):
             list_templates: dict[str, str] = {}
             for index, item in enumerate(value):
                 self._check_timeout()
                 child_path = f"{path}[{index}]" if path else f"[{index}]"
-                list_templates.update(self._collect_jinja_template_fields(item, child_path))
+                self._merge_jinja_templates(list_templates, self._collect_jinja_template_fields(item, child_path))
             return list_templates
         return {}
 
@@ -1009,9 +1009,9 @@ class ManifestScanner(BaseScanner):
                 child_path = f"{path}.{key}"
                 if isinstance(item, str):
                     if item.strip() and self._looks_like_jinja(item):
-                        templates[child_path] = item
+                        self._record_jinja_template(templates, child_path, item)
                     continue
-                templates.update(self._collect_jinja_template_container(item, child_path))
+                self._merge_jinja_templates(templates, self._collect_jinja_template_container(item, child_path))
             return templates
 
         if isinstance(value, list):
@@ -1021,12 +1021,33 @@ class ManifestScanner(BaseScanner):
                 child_path = f"{path}[{index}]"
                 if isinstance(item, str):
                     if item.strip() and self._looks_like_jinja(item):
-                        list_templates[child_path] = item
+                        self._record_jinja_template(list_templates, child_path, item)
                     continue
-                list_templates.update(self._collect_jinja_template_container(item, child_path))
+                self._merge_jinja_templates(
+                    list_templates,
+                    self._collect_jinja_template_container(item, child_path),
+                )
             return list_templates
 
         return {}
+
+    @staticmethod
+    def _record_jinja_template(templates: dict[str, str], path: str, value: str) -> None:
+        if path not in templates:
+            templates[path] = value
+            return
+
+        duplicate_index = len(templates) + 1
+        unique_path = f"{path} [duplicate {duplicate_index}]"
+        while unique_path in templates:
+            duplicate_index += 1
+            unique_path = f"{path} [duplicate {duplicate_index}]"
+        templates[unique_path] = value
+
+    @classmethod
+    def _merge_jinja_templates(cls, templates: dict[str, str], collected: dict[str, str]) -> None:
+        for path, value in collected.items():
+            cls._record_jinja_template(templates, path, value)
 
     @staticmethod
     def _looks_like_jinja(value: str) -> bool:

--- a/modelaudit/scanners/manifest_scanner.py
+++ b/modelaudit/scanners/manifest_scanner.py
@@ -972,30 +972,32 @@ class ManifestScanner(BaseScanner):
 
         result.merge(Jinja2TemplateScanner(config=self.config).scan_extracted_templates(path, templates))
 
-    @classmethod
-    def _collect_jinja_template_fields(cls, value: Any, path: str = "") -> dict[str, str]:
+    def _collect_jinja_template_fields(self, value: Any, path: str = "") -> dict[str, str]:
+        self._check_timeout()
         if isinstance(value, dict):
             templates: dict[str, str] = {}
             for key, item in value.items():
+                self._check_timeout()
                 child_path = f"{path}.{key}" if path else str(key)
                 if key in JINJA_TEMPLATE_FIELD_NAMES:
-                    templates.update(cls._collect_jinja_template_container(item, child_path))
+                    templates.update(self._collect_jinja_template_container(item, child_path))
                     continue
-                templates.update(cls._collect_jinja_template_fields(item, child_path))
+                templates.update(self._collect_jinja_template_fields(item, child_path))
             return templates
         if isinstance(value, list):
             list_templates: dict[str, str] = {}
             for index, item in enumerate(value):
+                self._check_timeout()
                 child_path = f"{path}[{index}]" if path else f"[{index}]"
-                list_templates.update(cls._collect_jinja_template_fields(item, child_path))
+                list_templates.update(self._collect_jinja_template_fields(item, child_path))
             return list_templates
         return {}
 
-    @classmethod
-    def _collect_jinja_template_container(cls, value: Any, path: str) -> dict[str, str]:
+    def _collect_jinja_template_container(self, value: Any, path: str) -> dict[str, str]:
+        self._check_timeout()
         if isinstance(value, str):
             if value.strip() and (
-                path.rsplit(".", 1)[-1] in JINJA_TEMPLATE_FIELD_NAMES or cls._looks_like_jinja(value)
+                path.rsplit(".", 1)[-1] in JINJA_TEMPLATE_FIELD_NAMES or self._looks_like_jinja(value)
             ):
                 return {path: value}
             return {}
@@ -1003,23 +1005,25 @@ class ManifestScanner(BaseScanner):
         if isinstance(value, dict):
             templates: dict[str, str] = {}
             for key, item in value.items():
+                self._check_timeout()
                 child_path = f"{path}.{key}"
                 if isinstance(item, str):
-                    if item.strip() and cls._looks_like_jinja(item):
+                    if item.strip() and self._looks_like_jinja(item):
                         templates[child_path] = item
                     continue
-                templates.update(cls._collect_jinja_template_container(item, child_path))
+                templates.update(self._collect_jinja_template_container(item, child_path))
             return templates
 
         if isinstance(value, list):
             list_templates: dict[str, str] = {}
             for index, item in enumerate(value):
+                self._check_timeout()
                 child_path = f"{path}[{index}]"
                 if isinstance(item, str):
-                    if item.strip() and cls._looks_like_jinja(item):
+                    if item.strip() and self._looks_like_jinja(item):
                         list_templates[child_path] = item
                     continue
-                list_templates.update(cls._collect_jinja_template_container(item, child_path))
+                list_templates.update(self._collect_jinja_template_container(item, child_path))
             return list_templates
 
         return {}

--- a/modelaudit/scanners/manifest_scanner.py
+++ b/modelaudit/scanners/manifest_scanner.py
@@ -177,6 +177,7 @@ HASH_INTEGRITY_KEYS = [
 # Regex pattern for hexadecimal strings (used to detect hash values)
 HEX_PATTERN = re.compile(r"^[a-fA-F0-9]+$")
 JINJA_TEMPLATE_FIELD_NAMES = frozenset({"chat_template", "template", "jinja_template", "custom_chat_template"})
+JINJA_TEMPLATE_INDICATORS = ("{{", "{%", "{#")
 
 # Comprehensive allowlist of trusted domains for ML model configs
 # URLs from domains NOT in this list will be flagged as untrusted
@@ -977,17 +978,55 @@ class ManifestScanner(BaseScanner):
             templates: dict[str, str] = {}
             for key, item in value.items():
                 child_path = f"{path}.{key}" if path else str(key)
-                if key in JINJA_TEMPLATE_FIELD_NAMES and isinstance(item, str) and item.strip():
-                    templates[child_path] = item
+                if key in JINJA_TEMPLATE_FIELD_NAMES:
+                    templates.update(cls._collect_jinja_template_container(item, child_path))
+                    continue
                 templates.update(cls._collect_jinja_template_fields(item, child_path))
             return templates
         if isinstance(value, list):
-            templates = {}
+            list_templates: dict[str, str] = {}
             for index, item in enumerate(value):
                 child_path = f"{path}[{index}]" if path else f"[{index}]"
-                templates.update(cls._collect_jinja_template_fields(item, child_path))
-            return templates
+                list_templates.update(cls._collect_jinja_template_fields(item, child_path))
+            return list_templates
         return {}
+
+    @classmethod
+    def _collect_jinja_template_container(cls, value: Any, path: str) -> dict[str, str]:
+        if isinstance(value, str):
+            if value.strip() and (
+                path.rsplit(".", 1)[-1] in JINJA_TEMPLATE_FIELD_NAMES or cls._looks_like_jinja(value)
+            ):
+                return {path: value}
+            return {}
+
+        if isinstance(value, dict):
+            templates: dict[str, str] = {}
+            for key, item in value.items():
+                child_path = f"{path}.{key}"
+                if isinstance(item, str):
+                    if item.strip() and cls._looks_like_jinja(item):
+                        templates[child_path] = item
+                    continue
+                templates.update(cls._collect_jinja_template_container(item, child_path))
+            return templates
+
+        if isinstance(value, list):
+            list_templates: dict[str, str] = {}
+            for index, item in enumerate(value):
+                child_path = f"{path}[{index}]"
+                if isinstance(item, str):
+                    if item.strip() and cls._looks_like_jinja(item):
+                        list_templates[child_path] = item
+                    continue
+                list_templates.update(cls._collect_jinja_template_container(item, child_path))
+            return list_templates
+
+        return {}
+
+    @staticmethod
+    def _looks_like_jinja(value: str) -> bool:
+        return any(indicator in value for indicator in JINJA_TEMPLATE_INDICATORS)
 
     def _parse_ini_file(self, content: str) -> dict[str, Any]:
         """Parse INI-style manifests into nested dictionaries."""

--- a/tests/scanners/test_jinja2_template_scanner.py
+++ b/tests/scanners/test_jinja2_template_scanner.py
@@ -781,6 +781,83 @@ class TestJinja2TemplateScannerEdgeCases:
         assert failures[0]["reason"] == "jinja2_template_size_limit_exceeded"
         assert failures[0]["template_size"] == 65
 
+    def test_array_backed_gguf_oversized_chat_template_fails_before_stringifying(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class AbbreviatedArrayTemplate:
+            nbytes = 65
+
+            def __str__(self) -> str:
+                return "{{ content }}"
+
+            def tobytes(self) -> bytes:
+                raise AssertionError("oversized GGUF template must not be materialized")
+
+        class FakeGGUFReader:
+            def __init__(self, _path: str) -> None:
+                self.fields = {
+                    "tokenizer.chat_template": SimpleNamespace(
+                        parts=[AbbreviatedArrayTemplate()],
+                        data=[0],
+                    )
+                }
+
+        gguf_file = tmp_path / "model.gguf"
+        gguf_file.write_bytes(b"GGUF")
+        monkeypatch.setattr(jinja2_template_scanner, "HAS_GGUF", True)
+        monkeypatch.setattr(jinja2_template_scanner, "GGUFReader", FakeGGUFReader, raising=False)
+
+        result = Jinja2TemplateScanner({"max_template_size": 64}).scan(str(gguf_file))
+
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == "inconclusive"
+        assert "jinja2_template_size_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+        size_checks = [c for c in result.checks if c.name == "Template Size Limit"]
+        assert len(size_checks) == 1
+        assert size_checks[0].details["format"] == "gguf"
+        assert size_checks[0].details["skipped_template_locations"] == ["tokenizer.chat_template"]
+        assert size_checks[0].details["template_size"] == 65
+
+    def test_array_backed_gguf_chat_template_decodes_before_analysis(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        payload = "{{ lipsum.__globals__.os.popen('id') }}"
+        payload_bytes = payload.encode("utf-8")
+
+        class ArrayBackedTemplate:
+            nbytes = len(payload_bytes)
+
+            def __str__(self) -> str:
+                return "[123 123 ...]"
+
+            def tobytes(self) -> bytes:
+                return payload_bytes
+
+        class FakeGGUFReader:
+            def __init__(self, _path: str) -> None:
+                self.fields = {
+                    "tokenizer.chat_template": SimpleNamespace(
+                        parts=[ArrayBackedTemplate()],
+                        data=[0],
+                    )
+                }
+
+        gguf_file = tmp_path / "model.gguf"
+        gguf_file.write_bytes(b"GGUF")
+        monkeypatch.setattr(jinja2_template_scanner, "HAS_GGUF", True)
+        monkeypatch.setattr(jinja2_template_scanner, "GGUFReader", FakeGGUFReader, raising=False)
+
+        result = Jinja2TemplateScanner({"max_template_size": 128}).scan(str(gguf_file))
+
+        failed_checks = [check for check in result.checks if check.name == "Jinja2 Template Injection Detection"]
+        assert failed_checks
+        assert any(check.details.get("template_location") == "tokenizer.chat_template" for check in failed_checks)
+        assert not [check for check in result.checks if check.name == "Template Size Limit"]
+
     def test_small_json_chat_template_still_analyzed(self, tmp_path: Path) -> None:
         payload = "{{ lipsum.__globals__.os.popen('id') }}"
         tokenizer_file = tmp_path / "tokenizer_config.json"

--- a/tests/scanners/test_jinja2_template_scanner.py
+++ b/tests/scanners/test_jinja2_template_scanner.py
@@ -10,6 +10,7 @@ from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.scanners import jinja2_template_scanner
 from modelaudit.scanners.base import CheckStatus, IssueSeverity
 from modelaudit.scanners.jinja2_template_scanner import Jinja2TemplateScanner
+from tests.helpers import create_mock_gguf
 
 JINJA2_ASSETS_DIR = Path(__file__).resolve().parents[1] / "assets" / "samples" / "jinja2"
 MALICIOUS_JSON_FIXTURES = tuple(sorted((JINJA2_ASSETS_DIR / "malicious").glob("*.json"))) + tuple(
@@ -716,6 +717,41 @@ class TestJinja2TemplateScannerEdgeCases:
         assert "jinja2_template_size_limit_exceeded" in result.metadata["scan_outcome_reasons"]
         assert [c for c in result.checks if c.name == "Template Size Limit"]
         assert not [c for c in result.checks if c.name == "Jinja2 Template Injection Detection"]
+
+    def test_many_oversized_json_template_candidates_have_bounded_reporting(self, tmp_path: Path) -> None:
+        tokenizer_file = tmp_path / "tokenizer_config.json"
+        payload = "{{ message['content'] }}" + (" safe" * 32)
+        tokenizer_file.write_text(
+            json.dumps({f"template_candidate_{index}": payload for index in range(25)}),
+            encoding="utf-8",
+        )
+
+        result = Jinja2TemplateScanner({"max_template_size": 64}).scan(str(tokenizer_file))
+
+        size_checks = [c for c in result.checks if c.name == "Template Size Limit"]
+        assert result.success is False
+        assert len(size_checks) == 1
+        assert size_checks[0].details["skipped_template_location_count"] == 25
+        assert len(size_checks[0].details["skipped_template_locations"]) == 20
+        assert size_checks[0].details["skipped_template_locations_truncated"] is True
+        assert size_checks[0].details["template_size"] == len(payload)
+
+    def test_direct_gguf_oversized_chat_template_fails_closed(self, tmp_path: Path) -> None:
+        pytest.importorskip("gguf")
+        gguf_file = create_mock_gguf(
+            tmp_path / "large-template.gguf",
+            metadata={"tokenizer.chat_template": "{{ content }}" * 10000},
+        )
+
+        result = Jinja2TemplateScanner().scan(str(gguf_file))
+
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == "inconclusive"
+        assert "jinja2_template_size_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+        size_checks = [c for c in result.checks if c.name == "Template Size Limit"]
+        assert len(size_checks) == 1
+        assert size_checks[0].details["format"] == "gguf"
+        assert size_checks[0].details["skipped_template_locations"] == ["tokenizer.chat_template"]
 
     def test_small_json_chat_template_still_analyzed(self, tmp_path: Path) -> None:
         payload = "{{ lipsum.__globals__.os.popen('id') }}"

--- a/tests/scanners/test_jinja2_template_scanner.py
+++ b/tests/scanners/test_jinja2_template_scanner.py
@@ -738,6 +738,29 @@ class TestJinja2TemplateScannerEdgeCases:
         assert size_checks[0].details["skipped_template_locations_truncated"] is True
         assert size_checks[0].details["template_size"] == len(payload)
 
+    def test_json_template_path_collision_does_not_hide_malicious_candidate(self, tmp_path: Path) -> None:
+        malicious = "{{ lipsum.__globals__.os.popen('id') }}"
+        benign = "{{ message['content'] }}"
+        tokenizer_file = tmp_path / "tokenizer_config.json"
+        tokenizer_file.write_text(
+            json.dumps(
+                {
+                    "a.b": malicious,
+                    "a": {"b": benign},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = Jinja2TemplateScanner().scan(str(tokenizer_file))
+
+        failed_checks = [check for check in result.checks if check.name == "Jinja2 Template Injection Detection"]
+        assert failed_checks
+        assert any(check.details.get("template_location") == "a.b" for check in failed_checks)
+        summary = [check for check in result.checks if check.name == "Jinja2 SSTI Analysis Summary"]
+        assert len(summary) == 1
+        assert summary[0].details["templates_analyzed"] == 2
+
     def test_direct_gguf_oversized_chat_template_fails_closed(self, tmp_path: Path) -> None:
         pytest.importorskip("gguf")
         gguf_file = create_mock_gguf(
@@ -780,6 +803,110 @@ class TestJinja2TemplateScannerEdgeCases:
         assert len(failures) == 1
         assert failures[0]["reason"] == "jinja2_template_size_limit_exceeded"
         assert failures[0]["template_size"] == 65
+
+    def test_named_gguf_chat_template_is_decoded_and_analyzed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        payload = "{{ lipsum.__globals__.os.popen('id') }}"
+
+        class FakeGGUFReader:
+            def __init__(self, _path: str) -> None:
+                self.fields = {
+                    "tokenizer.chat_template.tool": SimpleNamespace(
+                        parts=[payload.encode("utf-8")],
+                        data=[0],
+                    )
+                }
+
+        gguf_file = tmp_path / "model.gguf"
+        gguf_file.write_bytes(b"GGUF")
+        monkeypatch.setattr(jinja2_template_scanner, "HAS_GGUF", True)
+        monkeypatch.setattr(jinja2_template_scanner, "GGUFReader", FakeGGUFReader, raising=False)
+
+        result = Jinja2TemplateScanner({"max_template_size": 128}).scan(str(gguf_file))
+
+        failed_checks = [check for check in result.checks if check.name == "Jinja2 Template Injection Detection"]
+        assert failed_checks
+        assert any(check.details.get("template_location") == "tokenizer.chat_template.tool" for check in failed_checks)
+
+    def test_unsupported_gguf_chat_template_value_fails_closed_without_stringifying(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class UnsupportedTemplateValue:
+            def __str__(self) -> str:
+                raise AssertionError("unsupported GGUF values must not be stringified")
+
+        class FakeGGUFReader:
+            def __init__(self, _path: str) -> None:
+                self.fields = {
+                    "tokenizer.chat_template": SimpleNamespace(
+                        parts=[UnsupportedTemplateValue()],
+                        data=[0],
+                    )
+                }
+
+        gguf_file = tmp_path / "model.gguf"
+        gguf_file.write_bytes(b"GGUF")
+        monkeypatch.setattr(jinja2_template_scanner, "HAS_GGUF", True)
+        monkeypatch.setattr(jinja2_template_scanner, "GGUFReader", FakeGGUFReader, raising=False)
+
+        result = Jinja2TemplateScanner().scan(str(gguf_file))
+
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == "inconclusive"
+        assert "jinja2_gguf_template_decode_failed" in result.metadata["scan_outcome_reasons"]
+        decode_checks = [check for check in result.checks if check.name == "Template Config Parsing"]
+        assert len(decode_checks) == 1
+        assert decode_checks[0].details["template_location"] == "tokenizer.chat_template"
+
+    def test_gguf_reader_failure_fails_closed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class FailingGGUFReader:
+            def __init__(self, _path: str) -> None:
+                raise ValueError("malformed GGUF metadata")
+
+        gguf_file = tmp_path / "model.gguf"
+        gguf_file.write_bytes(b"GGUF")
+        monkeypatch.setattr(jinja2_template_scanner, "HAS_GGUF", True)
+        monkeypatch.setattr(jinja2_template_scanner, "GGUFReader", FailingGGUFReader, raising=False)
+
+        result = Jinja2TemplateScanner().scan(str(gguf_file))
+
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == "inconclusive"
+        assert "jinja2_gguf_parse_failed" in result.metadata["scan_outcome_reasons"]
+        parse_checks = [check for check in result.checks if check.name == "Template Config Parsing"]
+        assert len(parse_checks) == 1
+        assert parse_checks[0].details["exception"] == "malformed GGUF metadata"
+
+    def test_malformed_named_gguf_template_does_not_hide_later_template(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        payload = "{{ lipsum.__globals__.os.popen('id') }}"
+
+        class FakeGGUFReader:
+            def __init__(self, _path: str) -> None:
+                self.fields = {
+                    "tokenizer.chat_template.bad": SimpleNamespace(parts=[], data=[]),
+                    "tokenizer.chat_template.tool": SimpleNamespace(parts=[payload.encode("utf-8")], data=[0]),
+                }
+
+        monkeypatch.setattr(jinja2_template_scanner, "GGUFReader", FakeGGUFReader, raising=False)
+
+        templates, failures = Jinja2TemplateScanner()._extract_gguf_templates("fake.gguf")
+
+        assert templates == {"tokenizer.chat_template.tool": payload}
+        assert len(failures) == 1
+        assert failures[0]["reason"] == "jinja2_gguf_template_decode_failed"
+        assert failures[0]["template_location"] == "tokenizer.chat_template.bad"
 
     def test_array_backed_gguf_oversized_chat_template_fails_before_stringifying(
         self,

--- a/tests/scanners/test_jinja2_template_scanner.py
+++ b/tests/scanners/test_jinja2_template_scanner.py
@@ -1,7 +1,9 @@
 """Tests for Jinja2TemplateScanner covering CVE-2024-34359 and SSTI detection."""
 
 import json
+from collections.abc import Iterator
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -752,6 +754,32 @@ class TestJinja2TemplateScannerEdgeCases:
         assert len(size_checks) == 1
         assert size_checks[0].details["format"] == "gguf"
         assert size_checks[0].details["skipped_template_locations"] == ["tokenizer.chat_template"]
+
+    def test_list_backed_gguf_oversized_chat_template_fails_before_iteration(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class ExplodingTemplateList(list[int]):
+            def __iter__(self) -> Iterator[int]:
+                raise AssertionError("oversized GGUF template must not be materialized")
+
+        class FakeGGUFReader:
+            def __init__(self, _path: str) -> None:
+                self.fields = {
+                    "tokenizer.chat_template": SimpleNamespace(
+                        parts=[ExplodingTemplateList([ord("a")] * 65)],
+                        data=[0],
+                    )
+                }
+
+        monkeypatch.setattr(jinja2_template_scanner, "GGUFReader", FakeGGUFReader, raising=False)
+
+        templates, failures = Jinja2TemplateScanner({"max_template_size": 64})._extract_gguf_templates("fake.gguf")
+
+        assert templates == {}
+        assert len(failures) == 1
+        assert failures[0]["reason"] == "jinja2_template_size_limit_exceeded"
+        assert failures[0]["template_size"] == 65
 
     def test_small_json_chat_template_still_analyzed(self, tmp_path: Path) -> None:
         payload = "{{ lipsum.__globals__.os.popen('id') }}"

--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -722,6 +722,76 @@ def test_manifest_scanner_delegates_malicious_chat_templates_to_jinja_analysis(t
     )
 
 
+def test_manifest_scanner_delegates_nested_chat_template_containers_to_jinja_analysis(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    payload = "{{ ''.__class__.__mro__[1].__subclasses__() }}"
+    config_path.write_text(
+        json.dumps(
+            {
+                "model_type": "llama",
+                "chat_template": {
+                    "default": payload,
+                    "description": "plain prose",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = ManifestScanner().scan(str(config_path))
+
+    assert any(
+        check.name == "Jinja2 Template Injection Detection"
+        and check.status == CheckStatus.FAILED
+        and check.details["template_location"] == "chat_template.default"
+        for check in result.checks
+    )
+
+
+def test_manifest_scanner_nested_oversized_chat_template_fails_closed(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    payload = "{{ message['content'] }}" + (" safe" * 32)
+    config_path.write_text(
+        json.dumps(
+            {
+                "model_type": "llama",
+                "chat_template": {
+                    "default": payload,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = ManifestScanner(config={"max_template_size": 64}).scan(str(config_path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == "inconclusive"
+    assert "jinja2_template_size_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    size_checks = [c for c in result.checks if c.name == "Template Size Limit"]
+    assert len(size_checks) == 1
+    assert size_checks[0].details["skipped_template_locations"] == ["chat_template.default"]
+
+
+def test_manifest_scanner_ignores_plain_nested_chat_template_container_strings(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "model_type": "llama",
+                "chat_template": {
+                    "description": "plain prose",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = ManifestScanner().scan(str(config_path))
+
+    assert not any(check.name.startswith("Jinja2") or check.name == "Template Size Limit" for check in result.checks)
+
+
 def test_manifest_scanner_keeps_benign_chat_templates_clean(tmp_path: Path) -> None:
     config_path = tmp_path / "config.json"
     config_path.write_text(

--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -748,6 +748,22 @@ def test_manifest_scanner_delegates_nested_chat_template_containers_to_jinja_ana
     )
 
 
+def test_manifest_scanner_nested_chat_template_collection_enforces_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    scanner = ManifestScanner()
+    timeout_calls = 0
+
+    def raise_during_nested_collection() -> None:
+        nonlocal timeout_calls
+        timeout_calls += 1
+        if timeout_calls == 4:
+            raise TimeoutError("embedded Jinja collection timed out")
+
+    monkeypatch.setattr(scanner, "_check_timeout", raise_during_nested_collection)
+
+    with pytest.raises(TimeoutError, match="embedded Jinja collection timed out"):
+        scanner._collect_jinja_template_fields({"chat_template": {"default": "{{ harmless }}"}})
+
+
 def test_manifest_scanner_nested_oversized_chat_template_fails_closed(tmp_path: Path) -> None:
     config_path = tmp_path / "config.json"
     payload = "{{ message['content'] }}" + (" safe" * 32)

--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -808,6 +808,33 @@ def test_manifest_scanner_ignores_plain_nested_chat_template_container_strings(t
     assert not any(check.name.startswith("Jinja2") or check.name == "Template Size Limit" for check in result.checks)
 
 
+def test_manifest_scanner_template_path_collision_does_not_hide_malicious_candidate(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    malicious = "{{ lipsum.__globals__.os.popen('id') }}"
+    benign = "{{ message['content'] }}"
+    config_path.write_text(
+        json.dumps(
+            {
+                "model_type": "llama",
+                "chat_template": {
+                    "a.b": malicious,
+                    "a": {"b": benign},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = ManifestScanner().scan(str(config_path))
+
+    failed_checks = [check for check in result.checks if check.name == "Jinja2 Template Injection Detection"]
+    assert failed_checks
+    assert any(check.details.get("template_location") == "chat_template.a.b" for check in failed_checks)
+    summary = [check for check in result.checks if check.name == "Jinja2 SSTI Analysis Summary"]
+    assert len(summary) == 1
+    assert summary[0].details["templates_analyzed"] == 2
+
+
 def test_manifest_scanner_keeps_benign_chat_templates_clean(tmp_path: Path) -> None:
     config_path = tmp_path / "config.json"
     config_path.write_text(


### PR DESCRIPTION
## Summary
- bound oversized structured Jinja size-limit reporting to one sampled failure
- fail closed for direct GGUF Jinja extraction when chat templates exceed the template cap
- delegate nested manifest-owned chat_template containers to Jinja analysis without scanning plain prose container strings

## Validation
- ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
- pytest tests/scanners/test_jinja2_template_scanner.py tests/scanners/test_manifest_scanner.py -q
- pytest -n auto -m "not slow and not integration" --maxfail=1

Note: local direct-GGUF Jinja regression skipped because the local venv lacks gguf; full suite otherwise passed after rebuilding modelaudit-picklescan for this worktree.