### PR TITLE
fix: harden standalone Keras H5 external reference analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fail closed when cloud directory metadata cannot be read for every listed object
 - treat prereleases of fixed Keras ZIP CVE-2026-1669 versions as vulnerable
 - detect external references in weights-only Keras HDF5 layouts without Keras metadata
+- bound standalone Keras HDF5 layout and external-reference analysis, and distrust artifact-controlled versions
 - restrict JFrog credential forwarding to explicitly trusted HTTPS hosts
 - classify unavailable metadata document reads and timed-out metadata scans as operationally incomplete rather than security findings
 - route renamed structured JAX/Orbax JSON checkpoints, conservatively report observable bounded-prefix threats, and fail closed for oversized identified metadata

--- a/modelaudit/scanners/keras_h5_scanner.py
+++ b/modelaudit/scanners/keras_h5_scanner.py
@@ -89,6 +89,9 @@ class KerasH5Scanner(BaseScanner):
     )
     _KERAS_WEIGHT_ROOT_GROUPS: ClassVar[frozenset[str]] = frozenset({"model_weights", "optimizer_weights"})
     _KERAS_WEIGHT_ROOT_ATTRS: ClassVar[frozenset[str]] = frozenset({"layer_names", "weight_names"})
+    _MAX_HDF5_LINK_VISITS: ClassVar[int] = 4096
+    _MAX_HDF5_EXTERNAL_REFERENCE_REPORTS: ClassVar[int] = 20
+    _MAX_HDF5_EXTERNAL_STORAGE_SEGMENT_REPORTS: ClassVar[int] = 20
     _MODEL_CONTAINER_CLASSES: ClassVar[frozenset[str]] = frozenset({"Model", "Functional", "Sequential"})
     _WRAPPED_LAYER_SCAN_MODEL: ClassVar[dict[str, Any]] = {"class_name": "Sequential", "config": {"layers": []}}
 
@@ -206,7 +209,7 @@ class KerasH5Scanner(BaseScanner):
                             details={"format": "generic_h5"},
                             rule_code=None,  # Passing check
                         )
-                    result.finish(success=True)  # Still success, just not a Keras file
+                    self._finish_scan_result(result)
                     return result
 
                 # Parse model config
@@ -434,17 +437,22 @@ class KerasH5Scanner(BaseScanner):
     def _check_hdf5_external_references(self, h5_file: Any, result: ScanResult, source_path: str) -> None:
         """Detect HDF5 external links/storage before any Keras-specific parsing short-circuits."""
         findings: list[dict[str, Any]] = []
+        external_reference_count = 0
+        external_storage_segments_truncated = False
 
         def visit(name: str, link: Any) -> None:
+            nonlocal external_reference_count, external_storage_segments_truncated
             if isinstance(link, h5py.ExternalLink):
-                findings.append(
-                    {
-                        "kind": "ExternalLink",
-                        "hdf5_path": f"/{name}".replace("//", "/"),
-                        "filename": link.filename,
-                        "path": link.path,
-                    },
-                )
+                external_reference_count += 1
+                if len(findings) < self._MAX_HDF5_EXTERNAL_REFERENCE_REPORTS:
+                    findings.append(
+                        {
+                            "kind": "ExternalLink",
+                            "hdf5_path": f"/{name}".replace("//", "/"),
+                            "filename": link.filename,
+                            "path": link.path,
+                        },
+                    )
                 return
 
             if not isinstance(link, h5py.HardLink):
@@ -454,18 +462,54 @@ class KerasH5Scanner(BaseScanner):
             if isinstance(obj, h5py.Dataset):
                 external_storage = obj.external
                 if external_storage:
-                    findings.append(
-                        {
-                            "kind": "external_storage",
-                            "hdf5_path": f"/{name}".replace("//", "/"),
-                            "segments": [
-                                {"filename": filename, "offset": int(offset), "size": int(size)}
-                                for filename, offset, size in external_storage
-                            ],
-                        },
-                    )
+                    external_reference_count += 1
+                    if len(findings) >= self._MAX_HDF5_EXTERNAL_REFERENCE_REPORTS:
+                        return
+                    segments = [
+                        {"filename": filename, "offset": int(offset), "size": int(size)}
+                        for filename, offset, size in external_storage[
+                            : self._MAX_HDF5_EXTERNAL_STORAGE_SEGMENT_REPORTS
+                        ]
+                    ]
+                    finding: dict[str, Any] = {
+                        "kind": "external_storage",
+                        "hdf5_path": f"/{name}".replace("//", "/"),
+                        "segments": segments,
+                    }
+                    if len(external_storage) > len(segments):
+                        external_storage_segments_truncated = True
+                        finding["segment_count"] = len(external_storage)
+                        finding["segments_truncated"] = True
+                    findings.append(finding)
 
-        self._visit_hdf5_links(h5_file, visit)
+        visited_link_count, link_visits_truncated = self._visit_hdf5_links(
+            h5_file,
+            visit,
+            max_links=self._MAX_HDF5_LINK_VISITS,
+        )
+        external_references_truncated = external_reference_count > len(findings)
+        if link_visits_truncated or external_references_truncated or external_storage_segments_truncated:
+            reason = "keras_h5_external_reference_analysis_limit_exceeded"
+            self._mark_inconclusive_scan_result(result, reason)
+            result.add_check(
+                name="HDF5 External Reference Analysis Limit",
+                passed=False,
+                message="Keras H5 external-reference analysis reached a configured safety limit",
+                severity=IssueSeverity.INFO,
+                location=source_path,
+                details={
+                    "analysis_incomplete": True,
+                    "scan_outcome_reason": reason,
+                    "visited_link_count": visited_link_count,
+                    "max_link_visits": self._MAX_HDF5_LINK_VISITS,
+                    "link_visits_truncated": link_visits_truncated,
+                    "external_reference_count": external_reference_count,
+                    "reported_external_reference_count": len(findings),
+                    "external_references_truncated": external_references_truncated,
+                    "external_storage_segments_truncated": external_storage_segments_truncated,
+                },
+                rule_code="S902",
+            )
 
         if not findings:
             return
@@ -483,6 +527,10 @@ class KerasH5Scanner(BaseScanner):
             "remediation": "Upgrade to Keras >= 3.12.1 or >= 3.13.2 and reject weights using HDF5 external references.",
             "external_references": findings,
         }
+        if external_references_truncated or external_storage_segments_truncated:
+            details["external_reference_count"] = external_reference_count
+            details["external_references_truncated"] = external_references_truncated
+            details["external_storage_segments_truncated"] = external_storage_segments_truncated
 
         vuln_status = self._is_vulnerable_to_cve_2026_1669(keras_version) if isinstance(keras_version, str) else None
         if vuln_status is True:
@@ -542,19 +590,36 @@ class KerasH5Scanner(BaseScanner):
         )
 
     @staticmethod
-    def _visit_hdf5_links(h5_file: Any, visit: Callable[[str, Any], None]) -> None:
+    def _visit_hdf5_links(
+        h5_file: Any,
+        visit: Callable[[str, Any], None],
+        *,
+        max_links: int,
+    ) -> tuple[int, bool]:
         """Visit links without resolving external targets on every supported h5py version."""
+        visited_link_count = 0
+
+        def bounded_visit(name: str, link: Any) -> bool | None:
+            nonlocal visited_link_count
+            visited_link_count += 1
+            if visited_link_count > max_links:
+                return True
+            visit(name, link)
+            return None
+
         if hasattr(h5_file, "visititems_links"):
-            h5_file.visititems_links(visit)
-            return
+            h5_file.visititems_links(bounded_visit)
+            return min(visited_link_count, max_links), visited_link_count > max_links
 
         visited_group_ids = {h5_file.id}
-
-        def walk(group: Any, prefix: str = "") -> None:
+        groups_to_visit = [(h5_file, "")]
+        while groups_to_visit:
+            group, prefix = groups_to_visit.pop()
             for child_name in group:
                 path = f"{prefix}/{child_name}" if prefix else str(child_name)
                 link = group.get(child_name, getlink=True)
-                visit(path, link)
+                if bounded_visit(path, link):
+                    return max_links, True
                 if not isinstance(link, h5py.HardLink):
                     continue
 
@@ -563,9 +628,9 @@ class KerasH5Scanner(BaseScanner):
                     continue
 
                 visited_group_ids.add(obj.id)
-                walk(obj, path)
+                groups_to_visit.append((obj, path))
 
-        walk(h5_file)
+        return visited_link_count, False
 
     def _scan_training_config(self, training_config: Any, result: ScanResult) -> None:
         """Inspect training_config for custom metrics and losses."""

--- a/modelaudit/scanners/keras_h5_scanner.py
+++ b/modelaudit/scanners/keras_h5_scanner.py
@@ -89,6 +89,7 @@ class KerasH5Scanner(BaseScanner):
     )
     _KERAS_WEIGHT_ROOT_GROUPS: ClassVar[frozenset[str]] = frozenset({"model_weights", "optimizer_weights"})
     _KERAS_WEIGHT_ROOT_ATTRS: ClassVar[frozenset[str]] = frozenset({"layer_names", "weight_names"})
+    _MAX_HDF5_LAYOUT_PROBE_ITEMS: ClassVar[int] = 4096
     _MAX_HDF5_LINK_VISITS: ClassVar[int] = 4096
     _MAX_HDF5_EXTERNAL_REFERENCE_REPORTS: ClassVar[int] = 20
     _MAX_HDF5_EXTERNAL_STORAGE_SEGMENT_REPORTS: ClassVar[int] = 20
@@ -359,7 +360,10 @@ class KerasH5Scanner(BaseScanner):
         if not layer_names:
             return False
 
-        for layer_name in layer_names:
+        for index, layer_name in enumerate(layer_names):
+            if index >= cls._MAX_HDF5_LAYOUT_PROBE_ITEMS:
+                return True
+
             link = h5_file.get(layer_name, getlink=True)
             if isinstance(link, h5py.ExternalLink):
                 return True
@@ -388,7 +392,10 @@ class KerasH5Scanner(BaseScanner):
         if not isinstance(layers, h5py.Group):
             return False
 
-        for layer_name in layers:
+        for index, layer_name in enumerate(layers):
+            if index >= cls._MAX_HDF5_LAYOUT_PROBE_ITEMS:
+                return True
+
             layer_link = layers.get(layer_name, getlink=True)
             if isinstance(layer_link, h5py.ExternalLink):
                 return True

--- a/modelaudit/scanners/keras_h5_scanner.py
+++ b/modelaudit/scanners/keras_h5_scanner.py
@@ -173,11 +173,7 @@ class KerasH5Scanner(BaseScanner):
                 # CVE-2026-1669 applies to weight loading too. Inspect full
                 # Keras files and weights-like HDF5 layouts while leaving
                 # unrelated generic HDF5 artifacts quiet.
-                if (
-                    "model_config" in f.attrs
-                    or "keras_version" in result.metadata
-                    or self._has_weights_like_hdf5_layout(f, path)
-                ):
+                if "model_config" in f.attrs or self._has_weights_like_hdf5_layout(f, path):
                     self._check_hdf5_external_references(f, result, path)
 
                 # Check if this is a Keras model file
@@ -504,21 +500,28 @@ class KerasH5Scanner(BaseScanner):
             )
             return
 
-        if vuln_status is False and isinstance(keras_version, str):
-            result.add_check(
-                name="HDF5 External Weight Reference Version Check",
-                passed=True,
-                message=(
-                    f"HDF5 external references detected in weights, but Keras {keras_version} is outside the known "
-                    "CVE-2026-1669 vulnerable ranges"
-                ),
-                location=location,
-                details={"keras_version": keras_version, "external_references": findings},
-            )
-            return
-
         if isinstance(keras_version, str):
             details["keras_version"] = keras_version
+            if vuln_status is False:
+                details["parse_status"] = "untrusted_artifact_version"
+                details["version_source"] = "hdf5_file_attribute"
+                result.add_check(
+                    name="HDF5 External Weight Reference Risk (Untrusted Version Metadata)",
+                    passed=False,
+                    message=(
+                        "HDF5 external references detected in standalone Keras H5 weights; "
+                        f"the file claims Keras {keras_version}, but artifact-controlled version metadata "
+                        "cannot prove the loader runtime is outside the CVE-2026-1669 vulnerable ranges"
+                    ),
+                    severity=IssueSeverity.WARNING,
+                    location=location,
+                    details=details
+                    | {
+                        "affected_versions": "Keras >= 3.0.0, < 3.12.1 and >= 3.13.0, < 3.13.2",
+                    },
+                    why=get_cve_2026_1669_explanation("hdf5_external_reference"),
+                )
+                return
 
         result.add_check(
             name="HDF5 External Weight Reference Risk (Version Unknown)",

--- a/modelaudit/scanners/keras_h5_scanner.py
+++ b/modelaudit/scanners/keras_h5_scanner.py
@@ -3,6 +3,7 @@
 import json
 import os
 import re
+from collections.abc import Callable
 from contextlib import suppress
 from pathlib import Path
 from typing import Any, ClassVar
@@ -446,6 +447,9 @@ class KerasH5Scanner(BaseScanner):
                 )
                 return
 
+            if not isinstance(link, h5py.HardLink):
+                return
+
             obj = h5_file.get(name, getlink=False)
             if isinstance(obj, h5py.Dataset):
                 external_storage = obj.external
@@ -461,10 +465,7 @@ class KerasH5Scanner(BaseScanner):
                         },
                     )
 
-        if hasattr(h5_file, "visititems_links"):
-            h5_file.visititems_links(visit)
-        else:  # pragma: no cover - compatibility fallback for older h5py
-            h5_file.visititems(lambda name, _obj: visit(name, h5_file.get(name, getlink=True)))
+        self._visit_hdf5_links(h5_file, visit)
 
         if not findings:
             return
@@ -539,6 +540,32 @@ class KerasH5Scanner(BaseScanner):
                 "parse_status": "unknown",
             },
         )
+
+    @staticmethod
+    def _visit_hdf5_links(h5_file: Any, visit: Callable[[str, Any], None]) -> None:
+        """Visit links without resolving external targets on every supported h5py version."""
+        if hasattr(h5_file, "visititems_links"):
+            h5_file.visititems_links(visit)
+            return
+
+        visited_group_ids = {h5_file.id}
+
+        def walk(group: Any, prefix: str = "") -> None:
+            for child_name in group:
+                path = f"{prefix}/{child_name}" if prefix else str(child_name)
+                link = group.get(child_name, getlink=True)
+                visit(path, link)
+                if not isinstance(link, h5py.HardLink):
+                    continue
+
+                obj = group.get(child_name, getlink=False)
+                if not isinstance(obj, h5py.Group) or obj.id in visited_group_ids:
+                    continue
+
+                visited_group_ids.add(obj.id)
+                walk(obj, path)
+
+        walk(h5_file)
 
     def _scan_training_config(self, training_config: Any, result: ScanResult) -> None:
         """Inspect training_config for custom metrics and losses."""

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -237,16 +237,27 @@ def test_keras_h5_scanner_detects_cve_2026_1669_external_storage(tmp_path: Path)
     ]
 
 
-def test_keras_h5_scanner_skips_cve_2026_1669_on_fixed_version(tmp_path: Path) -> None:
-    """Fixed Keras versions should not emit warning-level CVE-2026-1669 findings."""
-    model_path = create_h5_with_external_link(tmp_path, keras_version="3.13.2")
+@pytest.mark.parametrize(
+    "fixture_factory",
+    [create_h5_with_external_link, create_h5_with_external_storage],
+)
+def test_keras_h5_scanner_flags_external_references_despite_fixed_file_version(
+    tmp_path: Path,
+    fixture_factory: Any,
+) -> None:
+    """Standalone H5 files cannot use artifact-controlled keras_version to suppress external refs."""
+    model_path = fixture_factory(tmp_path, keras_version="3.13.2")
 
     scanner = KerasH5Scanner()
     result = scanner.scan(str(model_path))
 
-    assert not any(issue.details.get("cve_id") == "CVE-2026-1669" for issue in result.issues)
-    assert not any(issue.severity in (IssueSeverity.WARNING, IssueSeverity.CRITICAL) for issue in result.issues)
-    assert any(
+    cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2026-1669"]
+    assert len(cve_issues) == 1
+    assert cve_issues[0].severity == IssueSeverity.WARNING
+    assert cve_issues[0].details["keras_version"] == "3.13.2"
+    assert cve_issues[0].details["parse_status"] == "untrusted_artifact_version"
+    assert cve_issues[0].details["version_source"] == "hdf5_file_attribute"
+    assert not any(
         check.name == "HDF5 External Weight Reference Version Check" and check.status == CheckStatus.PASSED
         for check in result.checks
     )
@@ -624,6 +635,44 @@ def test_keras_h5_scanner_skips_generic_hdf5_external_links_without_keras_metada
     assert not any(issue.severity in (IssueSeverity.WARNING, IssueSeverity.CRITICAL) for issue in result.issues)
 
 
+def test_keras_h5_scanner_skips_generic_hdf5_external_link_with_only_keras_version(tmp_path: Path) -> None:
+    """A keras_version attribute alone must not classify a generic HDF5 file as Keras weights."""
+    generic_path = tmp_path / "generic_with_version.h5"
+    with h5py.File(generic_path, "w") as f:
+        f.attrs["keras_version"] = "3.13.2"
+        f["linked"] = h5py.ExternalLink("external_source.h5", "/payload")
+
+    result = KerasH5Scanner().scan(str(generic_path))
+
+    assert result.success is True
+    assert result.metadata["keras_version"] == "3.13.2"
+    assert not any(issue.details.get("cve_id") == "CVE-2026-1669" for issue in result.issues)
+    assert not any(issue.severity in (IssueSeverity.WARNING, IssueSeverity.CRITICAL) for issue in result.issues)
+
+
+def test_keras_h5_scanner_skips_generic_hdf5_external_storage_with_only_keras_version(tmp_path: Path) -> None:
+    """Artifact-controlled version metadata should not turn generic external storage into a Keras CVE."""
+    raw_storage = tmp_path / "generic.raw"
+    raw_storage.write_bytes(b"\x00" * 8)
+
+    generic_path = tmp_path / "generic_with_external_storage.h5"
+    with h5py.File(generic_path, "w") as f:
+        f.attrs["keras_version"] = "3.13.2"
+        f.create_dataset(
+            "external_values",
+            shape=(2,),
+            dtype="float32",
+            external=[(raw_storage.name, 0, 8)],
+        )
+
+    result = KerasH5Scanner().scan(str(generic_path))
+
+    assert result.success is True
+    assert result.metadata["keras_version"] == "3.13.2"
+    assert not any(issue.details.get("cve_id") == "CVE-2026-1669" for issue in result.issues)
+    assert not any(issue.severity in (IssueSeverity.WARNING, IssueSeverity.CRITICAL) for issue in result.issues)
+
+
 def test_keras_h5_scanner_skips_generic_nested_weight_like_groups(tmp_path: Path) -> None:
     """Nested generic groups named vars/weights must not imply a Keras weights file."""
     generic_path = tmp_path / "generic_nested.h5"
@@ -674,6 +723,7 @@ def test_keras_h5_scanner_flags_weights_only_external_link_without_keras_metadat
 
     weights_path = tmp_path / "weights_only.h5"
     with h5py.File(weights_path, "w") as f:
+        f.attrs["keras_version"] = "3.13.2"
         f.attrs["layer_names"] = [b"dense"]
         dense = f.create_group("dense")
         dense.attrs["weight_names"] = [b"kernel:0"]
@@ -684,7 +734,8 @@ def test_keras_h5_scanner_flags_weights_only_external_link_without_keras_metadat
     cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2026-1669"]
     assert len(cve_issues) == 1
     assert cve_issues[0].severity == IssueSeverity.WARNING
-    assert cve_issues[0].details["parse_status"] == "unknown"
+    assert cve_issues[0].details["keras_version"] == "3.13.2"
+    assert cve_issues[0].details["parse_status"] == "untrusted_artifact_version"
     assert cve_issues[0].details["external_references"] == [
         {
             "kind": "ExternalLink",
@@ -703,6 +754,7 @@ def test_keras_h5_scanner_flags_keras3_weights_external_link_without_legacy_attr
 
     weights_path = tmp_path / "model.weights.h5"
     with h5py.File(weights_path, "w") as f:
+        f.attrs["keras_version"] = "3.13.2"
         vars_group = f.create_group("layers").create_group("dense").create_group("vars")
         vars_group["0"] = h5py.ExternalLink(external_source.name, "/payload")
 
@@ -710,7 +762,8 @@ def test_keras_h5_scanner_flags_keras3_weights_external_link_without_legacy_attr
 
     cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2026-1669"]
     assert len(cve_issues) == 1
-    assert cve_issues[0].details["parse_status"] == "unknown"
+    assert cve_issues[0].details["keras_version"] == "3.13.2"
+    assert cve_issues[0].details["parse_status"] == "untrusted_artifact_version"
     assert cve_issues[0].details["external_references"] == [
         {
             "kind": "ExternalLink",

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -795,6 +795,72 @@ def test_keras_h5_scanner_flags_keras3_weights_external_link_without_resolving_i
     ]
 
 
+def test_keras_h5_scanner_legacy_h5py_traversal_flags_dangling_external_link(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """h5py before 3.11 must still inspect external links without resolving them."""
+    weights_path = tmp_path / "legacy.weights.h5"
+    with h5py.File(weights_path, "w") as f:
+        layers = f.create_group("layers")
+        layers["dense"] = h5py.ExternalLink("missing_external_source.h5", "/payload")
+
+    monkeypatch.delattr(h5py.Group, "visititems_links")
+
+    result = KerasH5Scanner().scan(str(weights_path))
+
+    cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2026-1669"]
+    assert len(cve_issues) == 1
+    assert cve_issues[0].details["external_references"] == [
+        {
+            "kind": "ExternalLink",
+            "hdf5_path": "/layers/dense",
+            "filename": "missing_external_source.h5",
+            "path": "/payload",
+        },
+    ]
+
+
+def test_keras_h5_scanner_external_reference_collection_does_not_resolve_soft_links(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SoftLink aliases must not be dereferenced while collecting external references."""
+    weights_path = tmp_path / "soft_alias.weights.h5"
+    with h5py.File(weights_path, "w") as f:
+        vars_group = f.create_group("layers").create_group("dense").create_group("vars")
+        vars_group["external_kernel"] = h5py.ExternalLink("missing_external_source.h5", "/payload")
+        vars_group["soft_alias"] = h5py.SoftLink("/layers/dense/vars/external_kernel")
+
+    original_get = h5py.Group.get
+
+    def guarded_get(
+        self: Any,
+        name: Any,
+        default: Any = None,
+        getclass: bool = False,
+        getlink: bool = False,
+    ) -> Any:
+        if str(name).endswith("soft_alias") and not getlink:
+            raise AssertionError("SoftLink target was followed")
+        return original_get(self, name, default=default, getclass=getclass, getlink=getlink)
+
+    monkeypatch.setattr(h5py.Group, "get", guarded_get)
+
+    result = KerasH5Scanner().scan(str(weights_path))
+
+    cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2026-1669"]
+    assert len(cve_issues) == 1
+    assert cve_issues[0].details["external_references"] == [
+        {
+            "kind": "ExternalLink",
+            "hdf5_path": "/layers/dense/vars/external_kernel",
+            "filename": "missing_external_source.h5",
+            "path": "/payload",
+        },
+    ]
+
+
 def test_keras_h5_scanner_malicious_model(tmp_path):
     """Test scanning a malicious Keras H5 model."""
     model_path = create_mock_h5_file(tmp_path, malicious=True)

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -715,6 +715,61 @@ def test_keras_h5_scanner_skips_generic_layer_names_attr_without_weight_groups(t
     assert not any(issue.severity in (IssueSeverity.WARNING, IssueSeverity.CRITICAL) for issue in result.issues)
 
 
+def test_keras_h5_scanner_bounds_legacy_layout_probe_before_external_reference_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Oversized legacy layout probes must route into bounded external-reference analysis."""
+    weights_path = tmp_path / "legacy_probe.h5"
+    with h5py.File(weights_path, "w") as f:
+        f.attrs["layer_names"] = [b"layer_0", b"layer_1", b"layer_2"]
+        for index in range(3):
+            f.create_group(f"layer_{index}")
+        f["external_payload"] = h5py.ExternalLink("missing_external_source.h5", "/payload")
+
+    monkeypatch.setattr(KerasH5Scanner, "_MAX_HDF5_LAYOUT_PROBE_ITEMS", 2)
+
+    result = KerasH5Scanner().scan(str(weights_path))
+
+    cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2026-1669"]
+    assert len(cve_issues) == 1
+    assert cve_issues[0].details["external_references"] == [
+        {
+            "kind": "ExternalLink",
+            "hdf5_path": "/external_payload",
+            "filename": "missing_external_source.h5",
+            "path": "/payload",
+        },
+    ]
+
+
+@pytest.mark.parametrize("layout", ["legacy", "keras3"])
+def test_keras_h5_scanner_layout_probe_limit_without_external_references_stays_clean(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    layout: str,
+) -> None:
+    """Layout probe exhaustion alone must not become a security finding or incomplete scan."""
+    weights_path = tmp_path / ("model.weights.h5" if layout == "keras3" else "legacy_probe.h5")
+    with h5py.File(weights_path, "w") as f:
+        if layout == "legacy":
+            f.attrs["layer_names"] = [b"layer_0", b"layer_1", b"layer_2"]
+            group = f
+        else:
+            group = f.create_group("layers")
+        for index in range(3):
+            group.create_group(f"layer_{index}")
+
+    monkeypatch.setattr(KerasH5Scanner, "_MAX_HDF5_LAYOUT_PROBE_ITEMS", 2)
+
+    result = KerasH5Scanner().scan(str(weights_path))
+
+    assert result.success is True
+    assert "scan_outcome" not in result.metadata
+    assert not any(issue.details.get("cve_id") == "CVE-2026-1669" for issue in result.issues)
+    assert not any(issue.severity in (IssueSeverity.WARNING, IssueSeverity.CRITICAL) for issue in result.issues)
+
+
 def test_keras_h5_scanner_flags_weights_only_external_link_without_keras_metadata(tmp_path: Path) -> None:
     """Weights-only HDF5 files can still be Keras load inputs and must not skip external references."""
     external_source = tmp_path / "external_source.h5"
@@ -769,6 +824,34 @@ def test_keras_h5_scanner_flags_keras3_weights_external_link_without_legacy_attr
             "kind": "ExternalLink",
             "hdf5_path": "/layers/dense/vars/0",
             "filename": "external_source.h5",
+            "path": "/payload",
+        },
+    ]
+
+
+def test_keras_h5_scanner_bounds_keras3_layout_probe_before_external_reference_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Oversized Keras 3 layout probes must route into bounded external-reference analysis."""
+    weights_path = tmp_path / "model.weights.h5"
+    with h5py.File(weights_path, "w") as f:
+        layers = f.create_group("layers")
+        for index in range(3):
+            layers.create_group(f"layer_{index}")
+        f["external_payload"] = h5py.ExternalLink("missing_external_source.h5", "/payload")
+
+    monkeypatch.setattr(KerasH5Scanner, "_MAX_HDF5_LAYOUT_PROBE_ITEMS", 2)
+
+    result = KerasH5Scanner().scan(str(weights_path))
+
+    cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2026-1669"]
+    assert len(cve_issues) == 1
+    assert cve_issues[0].details["external_references"] == [
+        {
+            "kind": "ExternalLink",
+            "hdf5_path": "/external_payload",
+            "filename": "missing_external_source.h5",
             "path": "/payload",
         },
     ]

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -861,6 +861,100 @@ def test_keras_h5_scanner_external_reference_collection_does_not_resolve_soft_li
     ]
 
 
+@pytest.mark.parametrize("legacy_h5py", [False, True])
+def test_keras_h5_scanner_external_reference_traversal_limit_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    legacy_h5py: bool,
+) -> None:
+    """External-reference traversal limits must fail closed without caching partial scans."""
+    weights_path = tmp_path / "traversal_limit.weights.h5"
+    with h5py.File(weights_path, "w") as f:
+        f.create_group("layers").create_group("dense").create_group("vars")
+
+    monkeypatch.setattr(KerasH5Scanner, "_MAX_HDF5_LINK_VISITS", 2)
+    if legacy_h5py:
+        monkeypatch.delattr(h5py.Group, "visititems_links")
+
+    result = KerasH5Scanner().scan(str(weights_path))
+
+    reason = "keras_h5_external_reference_analysis_limit_exceeded"
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert reason in result.metadata["scan_outcome_reasons"]
+    limit_checks = [check for check in result.checks if check.name == "HDF5 External Reference Analysis Limit"]
+    assert len(limit_checks) == 1
+    assert limit_checks[0].status == CheckStatus.FAILED
+    assert limit_checks[0].message == "Keras H5 external-reference analysis reached a configured safety limit"
+    assert limit_checks[0].details["visited_link_count"] == 2
+    assert limit_checks[0].details["link_visits_truncated"] is True
+
+    audit_result = scan_model_directory_or_file(str(weights_path), cache_enabled=False)
+    assert determine_exit_code(audit_result) == 2
+    _assert_inconclusive_keras_h5_scan_not_cached(weights_path, reason, tmp_path / f"cache-{legacy_h5py}")
+
+
+def test_keras_h5_scanner_external_reference_reports_are_bounded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reference reporting must stay bounded while preserving the security finding."""
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {"class_name": "Sequential", "config": {"layers": []}},
+    )
+    with h5py.File(model_path, "a") as f:
+        weights = f.require_group("model_weights")
+        for index in range(3):
+            weights[f"linked_{index}"] = h5py.ExternalLink("missing_external_source.h5", f"/payload/{index}")
+
+    monkeypatch.setattr(KerasH5Scanner, "_MAX_HDF5_EXTERNAL_REFERENCE_REPORTS", 2)
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    reason = "keras_h5_external_reference_analysis_limit_exceeded"
+    assert reason in result.metadata["scan_outcome_reasons"]
+    cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2026-1669"]
+    assert len(cve_issues) == 1
+    assert len(cve_issues[0].details["external_references"]) == 2
+    assert cve_issues[0].details["external_reference_count"] == 3
+    assert cve_issues[0].details["external_references_truncated"] is True
+
+    audit_result = scan_model_directory_or_file(str(model_path), cache_enabled=False)
+    assert determine_exit_code(audit_result) == 1
+
+
+def test_keras_h5_scanner_external_storage_segment_reports_are_bounded(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """External-storage diagnostics must not retain every attacker-controlled segment."""
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {"class_name": "Sequential", "config": {"layers": []}},
+    )
+    with h5py.File(model_path, "a") as f:
+        weights = f.require_group("model_weights")
+        weights.create_dataset(
+            "external_kernel",
+            shape=(3,),
+            dtype="float32",
+            external=[(f"weights-{index}.raw", 0, 4) for index in range(3)],
+        )
+
+    monkeypatch.setattr(KerasH5Scanner, "_MAX_HDF5_EXTERNAL_STORAGE_SEGMENT_REPORTS", 2)
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    reason = "keras_h5_external_reference_analysis_limit_exceeded"
+    assert reason in result.metadata["scan_outcome_reasons"]
+    cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2026-1669"]
+    assert len(cve_issues) == 1
+    external_reference = cve_issues[0].details["external_references"][0]
+    assert len(external_reference["segments"]) == 2
+    assert external_reference["segment_count"] == 3
+    assert external_reference["segments_truncated"] is True
+
+
 def test_keras_h5_scanner_malicious_model(tmp_path):
     """Test scanning a malicious Keras H5 model."""
     model_path = create_mock_h5_file(tmp_path, malicious=True)


### PR DESCRIPTION
## Summary

- distrust artifact-controlled standalone Keras H5 version metadata when external references are present
- inspect weights-only legacy and Keras 3 layouts without dereferencing attacker-controlled external or soft links
- bound external-reference traversal, reported references, storage segments, and pre-traversal layout probes
- preserve clean results for generic HDF5 near-matches and layout-probe exhaustion with no external references

## Audit improvements

The audit found that the external-reference walk was bounded, but legacy `layer_names` and Keras 3 `layers/*/vars` layout classification could still iterate attacker-sized structures first. The branch now caps those probes and conservatively routes budget exhaustion into the bounded external-reference analysis.

A 20,000-layer probe dropped from about `1.02s` to `0.20s` before the bounded scan begins.

## Validation

- combined standalone and ZIP Keras scanner suites: `254 passed`
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`399 files left unchanged`)
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`All checks passed`)
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`454 source files`)
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` (`7040 passed, 820 skipped`)
- final no-change lint and format checks passed