### PR TITLE
fix: harden mixed Keras H5 Lambda analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - treat prereleases of fixed Keras ZIP CVE-2026-1669 versions as vulnerable
 - detect external references in weights-only Keras HDF5 layouts without Keras metadata
 - bound standalone Keras HDF5 layout and external-reference analysis, and distrust artifact-controlled versions
+- inspect mixed dict/list Keras HDF5 Lambda bytecode with bounded, marshal-aware analysis
 - restrict JFrog credential forwarding to explicitly trusted HTTPS hosts
 - classify unavailable metadata document reads and timed-out metadata scans as operationally incomplete rather than security findings
 - route renamed structured JAX/Orbax JSON checkpoints, conservatively report observable bounded-prefix threats, and fail closed for oversized identified metadata

--- a/modelaudit/scanners/keras_h5_scanner.py
+++ b/modelaudit/scanners/keras_h5_scanner.py
@@ -915,13 +915,12 @@ class KerasH5Scanner(BaseScanner):
         module_name = layer_config.get("module")
         function_name = layer_config.get("function_name")
 
-        if isinstance(function_str, dict) and check_lambda_dict_function(
+        dict_function_handled = isinstance(function_str, dict) and check_lambda_dict_function(
             function_str,
             result,
             self.current_file_path,
             layer_config.get("name", "lambda"),
-        ):
-            return
+        )
 
         # Check if there's actual Python code to validate
         if function_str and isinstance(function_str, str):
@@ -1013,7 +1012,7 @@ class KerasH5Scanner(BaseScanner):
                     why=get_pattern_explanation("lambda_layer"),
                     rule_code="S1103",
                 )
-            else:
+            elif not dict_function_handled:
                 # Safe module reference - record as passed
                 result.add_check(
                     name="Lambda Layer Module Reference Check",

--- a/modelaudit/scanners/keras_h5_scanner.py
+++ b/modelaudit/scanners/keras_h5_scanner.py
@@ -939,63 +939,62 @@ class KerasH5Scanner(BaseScanner):
                     },
                     rule_code=None,  # Passing check
                 )
-                return
-
-            # This might be serialized Python code
-            is_valid, error = validate_python_syntax(function_str)
-
-            if is_valid:
-                # It's valid Python! Check if it's dangerous
-                is_dangerous, risk_desc = is_code_potentially_dangerous(function_str, "low")
-
-                # Check if code is dangerous
-                if is_dangerous:
-                    result.add_check(
-                        name="Lambda Layer Code Analysis",
-                        passed=False,
-                        message="Lambda layer contains dangerous Python code",
-                        severity=IssueSeverity.CRITICAL,
-                        location=self.current_file_path,
-                        details={
-                            "layer_class": "Lambda",
-                            "code_analysis": risk_desc,
-                            "code_preview": function_str[:200] + "..." if len(function_str) > 200 else function_str,
-                        },
-                        rule_code="S507",  # Python embedded code
-                    )
-                else:
-                    # Valid Python but not dangerous - record as passed
-                    result.add_check(
-                        name="Lambda Layer Code Analysis",
-                        passed=True,
-                        message="Lambda layer contains safe Python code",
-                        location=self.current_file_path,
-                        details={
-                            "layer_class": "Lambda",
-                            "validation_status": "valid_python",
-                        },
-                        rule_code=None,  # Passing check
-                    )
             else:
-                # Not valid Python syntax - might be a configuration issue
-                # Only flag if it looks like attempted code execution
-                if any(keyword in str(layer_config) for keyword in ["eval", "exec", "compile", "__import__"]):
-                    result.add_check(
-                        name="Lambda Layer Suspicious Keywords Check",
-                        passed=False,
-                        message="Lambda layer contains suspicious configuration",
-                        severity=IssueSeverity.WARNING,
-                        location=self.current_file_path,
-                        details={
-                            "layer_class": "Lambda",
-                            "description": self.suspicious_layer_types["Lambda"],
-                            "layer_config": layer_config,
-                            "validation_error": error,
-                        },
-                        why=get_pattern_explanation("lambda_layer"),
-                        rule_code="S1103",
-                    )
-        elif module_name or function_name:
+                # This might be serialized Python code
+                is_valid, error = validate_python_syntax(function_str)
+
+                if is_valid:
+                    # It's valid Python! Check if it's dangerous
+                    is_dangerous, risk_desc = is_code_potentially_dangerous(function_str, "low")
+
+                    # Check if code is dangerous
+                    if is_dangerous:
+                        result.add_check(
+                            name="Lambda Layer Code Analysis",
+                            passed=False,
+                            message="Lambda layer contains dangerous Python code",
+                            severity=IssueSeverity.CRITICAL,
+                            location=self.current_file_path,
+                            details={
+                                "layer_class": "Lambda",
+                                "code_analysis": risk_desc,
+                                "code_preview": function_str[:200] + "..." if len(function_str) > 200 else function_str,
+                            },
+                            rule_code="S507",  # Python embedded code
+                        )
+                    else:
+                        # Valid Python but not dangerous - record as passed
+                        result.add_check(
+                            name="Lambda Layer Code Analysis",
+                            passed=True,
+                            message="Lambda layer contains safe Python code",
+                            location=self.current_file_path,
+                            details={
+                                "layer_class": "Lambda",
+                                "validation_status": "valid_python",
+                            },
+                            rule_code=None,  # Passing check
+                        )
+                else:
+                    # Not valid Python syntax - might be a configuration issue
+                    # Only flag if it looks like attempted code execution
+                    if any(keyword in str(layer_config) for keyword in ["eval", "exec", "compile", "__import__"]):
+                        result.add_check(
+                            name="Lambda Layer Suspicious Keywords Check",
+                            passed=False,
+                            message="Lambda layer contains suspicious configuration",
+                            severity=IssueSeverity.WARNING,
+                            location=self.current_file_path,
+                            details={
+                                "layer_class": "Lambda",
+                                "description": self.suspicious_layer_types["Lambda"],
+                                "layer_config": layer_config,
+                                "validation_error": error,
+                            },
+                            why=get_pattern_explanation("lambda_layer"),
+                            rule_code="S1103",
+                        )
+        if module_name or function_name:
             # Module/function reference - check for dangerous imports
             if self._is_lambda_module_reference_dangerous(module_name, function_name):
                 result.add_check(

--- a/modelaudit/scanners/keras_h5_scanner.py
+++ b/modelaudit/scanners/keras_h5_scanner.py
@@ -1107,7 +1107,12 @@ class KerasH5Scanner(BaseScanner):
                             why=get_pattern_explanation("lambda_layer"),
                             rule_code="S1103",
                         )
-        if module_name or function_name:
+        module_reference_values = (module_name, function_name)
+        has_invalid_module_reference = any(
+            value is not None and not isinstance(value, str) for value in module_reference_values
+        )
+        has_module_reference = any(isinstance(value, str) and bool(value.strip()) for value in module_reference_values)
+        if has_module_reference or has_invalid_module_reference:
             # Module/function reference - check for dangerous imports
             if self._is_lambda_module_reference_dangerous(module_name, function_name):
                 result.add_check(
@@ -1122,6 +1127,21 @@ class KerasH5Scanner(BaseScanner):
                         "function": function_name,
                     },
                     why=get_pattern_explanation("lambda_layer"),
+                    rule_code="S1103",
+                )
+            elif has_invalid_module_reference:
+                result.add_check(
+                    name="Lambda Layer Module Reference Check",
+                    passed=False,
+                    message="Lambda layer uses malformed module/function reference metadata",
+                    severity=IssueSeverity.WARNING,
+                    location=self.current_file_path,
+                    details={
+                        "layer_class": "Lambda",
+                        "module_type": type(module_name).__name__,
+                        "function_type": type(function_name).__name__,
+                    },
+                    why="Malformed Lambda module references cannot be safely classified.",
                     rule_code="S1103",
                 )
             elif not encoded_function_handled:

--- a/modelaudit/scanners/keras_h5_scanner.py
+++ b/modelaudit/scanners/keras_h5_scanner.py
@@ -27,6 +27,7 @@ from .keras_utils import (
     check_custom_loss_config,
     check_custom_metric_config,
     check_lambda_dict_function,
+    check_lambda_list_function,
     check_subclassed_model,
     is_known_safe_keras_layer_class,
 )
@@ -915,12 +916,22 @@ class KerasH5Scanner(BaseScanner):
         module_name = layer_config.get("module")
         function_name = layer_config.get("function_name")
 
-        dict_function_handled = isinstance(function_str, dict) and check_lambda_dict_function(
-            function_str,
-            result,
-            self.current_file_path,
-            layer_config.get("name", "lambda"),
-        )
+        layer_name = layer_config.get("name", "lambda")
+        encoded_function_handled = False
+        if isinstance(function_str, dict):
+            encoded_function_handled = check_lambda_dict_function(
+                function_str,
+                result,
+                self.current_file_path,
+                layer_name,
+            )
+        elif isinstance(function_str, list):
+            encoded_function_handled = check_lambda_list_function(
+                function_str,
+                result,
+                self.current_file_path,
+                layer_name,
+            )
 
         # Check if there's actual Python code to validate
         if function_str and isinstance(function_str, str):
@@ -1011,7 +1022,7 @@ class KerasH5Scanner(BaseScanner):
                     why=get_pattern_explanation("lambda_layer"),
                     rule_code="S1103",
                 )
-            elif not dict_function_handled:
+            elif not encoded_function_handled:
                 # Safe module reference - record as passed
                 result.add_check(
                     name="Lambda Layer Module Reference Check",

--- a/modelaudit/scanners/keras_h5_scanner.py
+++ b/modelaudit/scanners/keras_h5_scanner.py
@@ -915,6 +915,14 @@ class KerasH5Scanner(BaseScanner):
         module_name = layer_config.get("module")
         function_name = layer_config.get("function_name")
 
+        if isinstance(function_str, dict) and check_lambda_dict_function(
+            function_str,
+            result,
+            self.current_file_path,
+            layer_config.get("name", "lambda"),
+        ):
+            return
+
         # Check if there's actual Python code to validate
         if function_str and isinstance(function_str, str):
             # First check if it matches safe patterns
@@ -1019,9 +1027,6 @@ class KerasH5Scanner(BaseScanner):
                     },
                     rule_code=None,  # Passing check
                 )
-        elif isinstance(function_str, dict):
-            # Keras 3.x dict-format Lambda: {"class_name": "__lambda__", "config": {"code": ...}}
-            check_lambda_dict_function(function_str, result, self.current_file_path, layer_config.get("name", "lambda"))
         # Don't flag Lambda layers without code - they might just be placeholders
 
     @staticmethod

--- a/modelaudit/scanners/keras_utils.py
+++ b/modelaudit/scanners/keras_utils.py
@@ -36,7 +36,8 @@ _LAMBDA_DANGEROUS_PATTERNS: list[str] = [
     "ctypes",
 ]
 _MARSHALLED_CODE_FILENAME_RE = re.compile(r"(?i)(?:[A-Za-z]:)?[\\/][^\x00-\x1f\x7f\"'`<>|]+?\.py[co]?")
-_MAX_LAMBDA_DICT_CODE_B64_CHARS = 1024 * 1024
+_MARSHALLED_NAME_SEPARATOR_RE = r"(?:\.|[\x00-\x1f\x7f\ufffd]{1,16})"
+_MAX_LAMBDA_CODE_B64_CHARS = 1024 * 1024
 
 _EXTRA_SAFE_KERAS_LOSS_IDENTIFIERS: frozenset[str] = frozenset(
     {
@@ -141,10 +142,14 @@ def find_lambda_dangerous_patterns(text: str, patterns: Iterable[str]) -> list[s
     """Match dangerous Lambda bytecode text while ignoring marshalled source filenames."""
     sanitized = _MARSHALLED_CODE_FILENAME_RE.sub(" ", text)
     return [
-        pattern
-        for pattern in patterns
-        if re.search(rf"(?<![0-9A-Za-z_]){re.escape(pattern)}(?![0-9A-Za-z_])", sanitized, re.IGNORECASE)
+        pattern for pattern in patterns if re.search(_lambda_dangerous_pattern_regex(pattern), sanitized, re.IGNORECASE)
     ]
+
+
+def _lambda_dangerous_pattern_regex(pattern: str) -> str:
+    """Match dotted names across bounded marshal metadata without identifier substrings."""
+    pattern_body = _MARSHALLED_NAME_SEPARATOR_RE.join(re.escape(part) for part in pattern.split("."))
+    return rf"(?<![0-9A-Za-z_]){pattern_body}(?![0-9A-Za-z_])"
 
 
 def iter_keras_serialized_identifiers(value: Any) -> Iterator[tuple[str, Any]]:
@@ -300,7 +305,7 @@ def check_lambda_dict_function(
         )
         return True
 
-    if len(code_b64) > _MAX_LAMBDA_DICT_CODE_B64_CHARS:
+    if len(code_b64) > _MAX_LAMBDA_CODE_B64_CHARS:
         _add_lambda_code_size_limit_check(code_b64, result, location, layer_name, function_format="dict")
         return True
 
@@ -357,7 +362,7 @@ def check_lambda_list_function(
         )
         return True
 
-    if len(code_b64) > _MAX_LAMBDA_DICT_CODE_B64_CHARS:
+    if len(code_b64) > _MAX_LAMBDA_CODE_B64_CHARS:
         _add_lambda_code_size_limit_check(code_b64, result, location, layer_name, function_format="list")
         return True
 
@@ -396,7 +401,7 @@ def _add_lambda_code_size_limit_check(
             "function_format": function_format,
             "analysis_status": "code_size_limit_exceeded",
             "encoded_code_chars": len(code_b64),
-            "max_encoded_code_chars": _MAX_LAMBDA_DICT_CODE_B64_CHARS,
+            "max_encoded_code_chars": _MAX_LAMBDA_CODE_B64_CHARS,
         },
         why="Oversized Lambda bytecode was not decoded because it exceeds the bounded static-analysis limit.",
     )

--- a/modelaudit/scanners/keras_utils.py
+++ b/modelaudit/scanners/keras_utils.py
@@ -301,24 +301,117 @@ def check_lambda_dict_function(
         return True
 
     if len(code_b64) > _MAX_LAMBDA_DICT_CODE_B64_CHARS:
+        _add_lambda_code_size_limit_check(code_b64, result, location, layer_name, function_format="dict")
+        return True
+
+    _check_lambda_encoded_code(
+        code_b64,
+        result,
+        location,
+        layer_name,
+        function_format="dict",
+        bytecode_format="dict_bytecode",
+        format_label="dict-format",
+    )
+    return True
+
+
+def check_lambda_list_function(
+    function_data: list[Any],
+    result: ScanResult,
+    location: str,
+    layer_name: str,
+) -> bool:
+    """Check legacy Keras list-format Lambda function bytecode."""
+    if not function_data:
         result.add_check(
             name="Lambda Layer Detection",
             passed=False,
-            message=f"Lambda layer '{layer_name}' contains dict-format code that exceeds the bounded analysis limit",
+            message=f"Lambda layer '{layer_name}' uses list-format function with no encoded code field",
             severity=IssueSeverity.WARNING,
             location=location,
             details={
                 "layer_name": layer_name,
                 "layer_class": "Lambda",
-                "function_format": "dict",
-                "analysis_status": "code_size_limit_exceeded",
-                "encoded_code_chars": len(code_b64),
-                "max_encoded_code_chars": _MAX_LAMBDA_DICT_CODE_B64_CHARS,
+                "function_format": "list",
             },
-            why="Oversized Lambda bytecode was not decoded because it exceeds the bounded static-analysis limit.",
+            why="Lambda layers with list-format functions indicate encoded bytecode serialisation.",
         )
         return True
 
+    code_b64 = function_data[0]
+    if not code_b64 or not isinstance(code_b64, str):
+        result.add_check(
+            name="Lambda Layer Detection",
+            passed=False,
+            message=f"Lambda layer '{layer_name}' uses list-format function with no encoded code field",
+            severity=IssueSeverity.WARNING,
+            location=location,
+            details={
+                "layer_name": layer_name,
+                "layer_class": "Lambda",
+                "function_format": "list",
+                "code_type": type(code_b64).__name__,
+            },
+            why="Lambda layers with list-format functions indicate encoded bytecode serialisation.",
+        )
+        return True
+
+    if len(code_b64) > _MAX_LAMBDA_DICT_CODE_B64_CHARS:
+        _add_lambda_code_size_limit_check(code_b64, result, location, layer_name, function_format="list")
+        return True
+
+    _check_lambda_encoded_code(
+        code_b64,
+        result,
+        location,
+        layer_name,
+        function_format="list",
+        bytecode_format="list_bytecode",
+        format_label="list-format",
+    )
+    return True
+
+
+def _add_lambda_code_size_limit_check(
+    code_b64: str,
+    result: ScanResult,
+    location: str,
+    layer_name: str,
+    *,
+    function_format: str,
+) -> None:
+    result.add_check(
+        name="Lambda Layer Detection",
+        passed=False,
+        message=(
+            f"Lambda layer '{layer_name}' contains {function_format}-format code "
+            "that exceeds the bounded analysis limit"
+        ),
+        severity=IssueSeverity.WARNING,
+        location=location,
+        details={
+            "layer_name": layer_name,
+            "layer_class": "Lambda",
+            "function_format": function_format,
+            "analysis_status": "code_size_limit_exceeded",
+            "encoded_code_chars": len(code_b64),
+            "max_encoded_code_chars": _MAX_LAMBDA_DICT_CODE_B64_CHARS,
+        },
+        why="Oversized Lambda bytecode was not decoded because it exceeds the bounded static-analysis limit.",
+    )
+
+
+def _check_lambda_encoded_code(
+    code_b64: str,
+    result: ScanResult,
+    location: str,
+    layer_name: str,
+    *,
+    function_format: str,
+    bytecode_format: str,
+    format_label: str,
+) -> None:
     try:
         decoded = base64.b64decode(code_b64)
         decoded_str = decoded.decode("utf-8", errors="replace")
@@ -326,17 +419,17 @@ def check_lambda_dict_function(
         result.add_check(
             name="Lambda Layer Detection",
             passed=False,
-            message=f"Lambda layer '{layer_name}' contains non-decodable dict-format code",
+            message=f"Lambda layer '{layer_name}' contains non-decodable {function_format}-format code",
             severity=IssueSeverity.WARNING,
             location=location,
             details={
                 "layer_name": layer_name,
                 "layer_class": "Lambda",
-                "function_format": "dict",
+                "function_format": function_format,
             },
             why="Unable to decode Lambda bytecode for security analysis.",
         )
-        return True
+        return
 
     found_patterns = find_lambda_dangerous_patterns(decoded_str, _LAMBDA_DANGEROUS_PATTERNS)
 
@@ -353,7 +446,7 @@ def check_lambda_dict_function(
                 "layer_name": layer_name,
                 "layer_class": "Lambda",
                 "dangerous_patterns": found_patterns,
-                "function_format": "dict_bytecode",
+                "function_format": bytecode_format,
                 "code_preview": decoded_str[:200] + "..." if len(decoded_str) > 200 else decoded_str,
             },
             why=(
@@ -366,7 +459,7 @@ def check_lambda_dict_function(
             name="Lambda Layer Code Analysis",
             passed=False,
             message=(
-                f"Lambda layer '{layer_name}' contains embedded bytecode (dict-format) with no dangerous "
+                f"Lambda layer '{layer_name}' contains embedded bytecode ({format_label}) with no dangerous "
                 "text patterns detected"
             ),
             severity=IssueSeverity.WARNING,
@@ -374,15 +467,14 @@ def check_lambda_dict_function(
             details={
                 "layer_name": layer_name,
                 "layer_class": "Lambda",
-                "function_format": "dict_bytecode",
+                "function_format": bytecode_format,
                 "analysis_status": "opaque_bytecode",
             },
             why=(
-                "Keras 3.x Lambda layers embed compiled bytecode that will execute "
+                "Keras Lambda layers embed compiled bytecode that will execute "
                 "during model loading or inference; no high-risk text patterns were detected."
             ),
         )
-    return True
 
 
 def check_subclassed_model(

--- a/modelaudit/scanners/keras_utils.py
+++ b/modelaudit/scanners/keras_utils.py
@@ -36,6 +36,7 @@ _LAMBDA_DANGEROUS_PATTERNS: list[str] = [
     "ctypes",
 ]
 _MARSHALLED_CODE_FILENAME_RE = re.compile(r"(?i)(?:[A-Za-z]:)?[\\/][^\x00-\x1f\x7f\"'`<>|]+?\.py[co]?")
+_MAX_LAMBDA_DICT_CODE_B64_CHARS = 1024 * 1024
 
 _EXTRA_SAFE_KERAS_LOSS_IDENTIFIERS: frozenset[str] = frozenset(
     {
@@ -138,7 +139,12 @@ def find_case_insensitive_substrings(text: str, patterns: Iterable[str]) -> list
 
 def find_lambda_dangerous_patterns(text: str, patterns: Iterable[str]) -> list[str]:
     """Match dangerous Lambda bytecode text while ignoring marshalled source filenames."""
-    return find_case_insensitive_substrings(_MARSHALLED_CODE_FILENAME_RE.sub(" ", text), patterns)
+    sanitized = _MARSHALLED_CODE_FILENAME_RE.sub(" ", text)
+    return [
+        pattern
+        for pattern in patterns
+        if re.search(rf"(?<![0-9A-Za-z_]){re.escape(pattern)}(?![0-9A-Za-z_])", sanitized, re.IGNORECASE)
+    ]
 
 
 def iter_keras_serialized_identifiers(value: Any) -> Iterator[tuple[str, Any]]:
@@ -270,7 +276,7 @@ def check_lambda_dict_function(
                 "layer_class": "Lambda",
                 "function_format": "dict",
                 "parse_status": "invalid_config",
-                "function_dict": function_dict,
+                "config_type": type(config).__name__,
             },
             why="Malformed dict-format Lambda metadata is suspicious and prevents bytecode inspection.",
         )
@@ -291,6 +297,25 @@ def check_lambda_dict_function(
                 "function_format": "dict",
             },
             why="Lambda layers with dict-format functions indicate Keras 3.x bytecode serialisation.",
+        )
+        return True
+
+    if len(code_b64) > _MAX_LAMBDA_DICT_CODE_B64_CHARS:
+        result.add_check(
+            name="Lambda Layer Detection",
+            passed=False,
+            message=f"Lambda layer '{layer_name}' contains dict-format code that exceeds the bounded analysis limit",
+            severity=IssueSeverity.WARNING,
+            location=location,
+            details={
+                "layer_name": layer_name,
+                "layer_class": "Lambda",
+                "function_format": "dict",
+                "analysis_status": "code_size_limit_exceeded",
+                "encoded_code_chars": len(code_b64),
+                "max_encoded_code_chars": _MAX_LAMBDA_DICT_CODE_B64_CHARS,
+            },
+            why="Oversized Lambda bytecode was not decoded because it exceeds the bounded static-analysis limit.",
         )
         return True
 

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -1201,6 +1201,48 @@ def test_unrecognized_lambda_function_dict_still_uses_module_reference_check(tmp
     )
 
 
+def test_lambda_dict_bytecode_with_dangerous_module_fields_still_checks_module_reference(tmp_path: Path) -> None:
+    """Opaque dict bytecode must not suppress a dangerous sibling module/function reference."""
+    encoded_code = base64.b64encode(marshal.dumps((lambda x: x + 1).__code__)).decode()
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "name": "mixed_dangerous_module_model",
+                "layers": [
+                    {
+                        "class_name": "Lambda",
+                        "config": {
+                            "name": "mixed_dangerous_module",
+                            "function": {"class_name": "__lambda__", "config": {"code": encoded_code}},
+                            "module": "os",
+                            "function_name": "system",
+                        },
+                    }
+                ],
+            },
+        },
+    )
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    assert any(
+        issue.severity == IssueSeverity.WARNING
+        and "embedded bytecode" in issue.message
+        and "mixed_dangerous_module" in issue.message
+        for issue in result.issues
+    )
+    assert any(
+        check.name == "Lambda Layer Module Reference Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details.get("module") == "os"
+        and check.details.get("function") == "system"
+        for check in result.checks
+    )
+
+
 def test_keras_h5_scanner_empty_file(tmp_path):
     """Test scanning an empty file."""
     empty_path = tmp_path / "empty.h5"

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -13,6 +13,7 @@ import h5py
 
 from modelaudit.cache import get_cache_manager, reset_cache_manager
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
+from modelaudit.scanners import keras_utils
 from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity
 from modelaudit.scanners.keras_h5_scanner import KerasH5Scanner
 
@@ -1241,6 +1242,128 @@ def test_lambda_dict_bytecode_with_dangerous_module_fields_still_checks_module_r
         and check.details.get("function") == "system"
         for check in result.checks
     )
+
+
+def test_lambda_safe_string_with_dangerous_module_fields_still_checks_module_reference(tmp_path: Path) -> None:
+    """Safe-looking inline Lambda code must not suppress a dangerous sibling module reference."""
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "name": "mixed_safe_string_module_model",
+                "layers": [
+                    {
+                        "class_name": "Lambda",
+                        "config": {
+                            "name": "mixed_safe_string_module",
+                            "function": "lambda x: x / 255",
+                            "module": "os",
+                            "function_name": "system",
+                        },
+                    }
+                ],
+            },
+        },
+    )
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    assert any(
+        check.name == "Lambda Layer Code Analysis"
+        and check.status == CheckStatus.PASSED
+        and check.details.get("pattern_type") == "safe_normalization"
+        for check in result.checks
+    )
+    assert any(
+        check.name == "Lambda Layer Module Reference Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details.get("module") == "os"
+        and check.details.get("function") == "system"
+        for check in result.checks
+    )
+
+
+def test_lambda_dict_bytecode_does_not_match_dangerous_substrings_inside_identifiers(tmp_path: Path) -> None:
+    """Benign identifiers such as `opened` must not become critical `open` bytecode findings."""
+    encoded_code = base64.b64encode(b"def benign():\n    opened = 1\n    return opened\n").decode()
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "name": "benign_identifier_dict_lambda_model",
+                "layers": [
+                    {
+                        "class_name": "Lambda",
+                        "config": {
+                            "name": "benign_identifier_dict_lambda",
+                            "function": {"class_name": "__lambda__", "config": {"code": encoded_code}},
+                        },
+                    }
+                ],
+            },
+        },
+    )
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    assert not any(
+        check.name == "Lambda Layer Code Analysis"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        for check in result.checks
+    )
+    assert any(
+        check.name == "Lambda Layer Code Analysis"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.WARNING
+        and check.details.get("analysis_status") == "opaque_bytecode"
+        for check in result.checks
+    )
+
+
+def test_lambda_dict_oversized_code_is_not_decoded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Oversized encoded Lambda bytecode must fail closed before allocating a decoded copy."""
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "name": "oversized_dict_lambda_model",
+                "layers": [
+                    {
+                        "class_name": "Lambda",
+                        "config": {
+                            "name": "oversized_dict_lambda",
+                            "function": {"class_name": "__lambda__", "config": {"code": "A" * 9}},
+                        },
+                    }
+                ],
+            },
+        },
+    )
+
+    def fail_decode(_encoded: str) -> bytes:
+        raise AssertionError("oversized Lambda bytecode must not be decoded")
+
+    monkeypatch.setattr(keras_utils, "_MAX_LAMBDA_DICT_CODE_B64_CHARS", 8)
+    monkeypatch.setattr(keras_utils.base64, "b64decode", fail_decode)
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    oversized_checks = [
+        check
+        for check in result.checks
+        if check.name == "Lambda Layer Detection"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("analysis_status") == "code_size_limit_exceeded"
+    ]
+    assert len(oversized_checks) == 1
+    assert oversized_checks[0].severity == IssueSeverity.WARNING
+    assert oversized_checks[0].details["encoded_code_chars"] == 9
+    assert oversized_checks[0].details["max_encoded_code_chars"] == 8
 
 
 def test_keras_h5_scanner_empty_file(tmp_path):

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -1081,6 +1081,126 @@ def test_lambda_dict_bytecode_with_dangerous_pattern_still_critical(tmp_path: Pa
     assert {"eval", "__import__", "os.system"}.issubset(set(dangerous_checks[0].details["dangerous_patterns"]))
 
 
+def test_lambda_dict_bytecode_with_benign_module_fields_still_critical(tmp_path: Path) -> None:
+    """Dict-format Lambda bytecode must not be skipped by benign module/function metadata."""
+    encoded_code = base64.b64encode(b"import os\nos.system('id')\neval('__import__(\"os\")')").decode()
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "name": "mixed_dict_lambda_model",
+                "layers": [
+                    {
+                        "class_name": "Lambda",
+                        "config": {
+                            "name": "mixed_dict_lambda",
+                            "function": {"class_name": "__lambda__", "config": {"code": encoded_code}},
+                            "module": "keras.ops",
+                            "function_name": "identity",
+                        },
+                    }
+                ],
+            },
+        },
+    )
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    dangerous_checks = [
+        check
+        for check in result.checks
+        if check.name == "Lambda Layer Code Analysis"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details.get("layer_name") == "mixed_dict_lambda"
+    ]
+    assert len(dangerous_checks) == 1
+    assert {"eval", "__import__", "os.system"}.issubset(set(dangerous_checks[0].details["dangerous_patterns"]))
+    assert not any(
+        check.name == "Lambda Layer Module Reference Check"
+        and check.status == CheckStatus.PASSED
+        and check.details.get("module") == "keras.ops"
+        for check in result.checks
+    )
+
+
+def test_lambda_dict_bytecode_with_benign_module_fields_stays_warning(tmp_path: Path) -> None:
+    """Opaque dict-format Lambda bytecode should not become a passed module reference check."""
+    encoded_code = base64.b64encode(marshal.dumps((lambda x: x + 1).__code__)).decode()
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "name": "mixed_safe_dict_lambda_model",
+                "layers": [
+                    {
+                        "class_name": "Lambda",
+                        "config": {
+                            "name": "mixed_safe_dict_lambda",
+                            "function": {"class_name": "__lambda__", "config": {"code": encoded_code}},
+                            "module": "keras.ops",
+                            "function_name": "identity",
+                        },
+                    }
+                ],
+            },
+        },
+    )
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    bytecode_issues = [
+        issue
+        for issue in result.issues
+        if "embedded bytecode" in issue.message and "mixed_safe_dict_lambda" in issue.message
+    ]
+    assert len(bytecode_issues) == 1
+    assert bytecode_issues[0].severity == IssueSeverity.WARNING
+    assert not any(
+        check.name == "Lambda Layer Module Reference Check"
+        and check.status == CheckStatus.PASSED
+        and check.details.get("module") == "keras.ops"
+        for check in result.checks
+    )
+
+
+def test_unrecognized_lambda_function_dict_still_uses_module_reference_check(tmp_path: Path) -> None:
+    """Only recognized __lambda__ dictionaries should preempt module/function reference analysis."""
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "name": "unrecognized_dict_module_model",
+                "layers": [
+                    {
+                        "class_name": "Lambda",
+                        "config": {
+                            "name": "unrecognized_dict_module",
+                            "function": {"class_name": "SomeCallable", "config": {}},
+                            "module": "os",
+                            "function_name": "system",
+                        },
+                    }
+                ],
+            },
+        },
+    )
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    assert any(
+        check.name == "Lambda Layer Module Reference Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details.get("module") == "os"
+        and check.details.get("function") == "system"
+        for check in result.checks
+    )
+
+
 def test_keras_h5_scanner_empty_file(tmp_path):
     """Test scanning an empty file."""
     empty_path = tmp_path / "empty.h5"

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -1167,6 +1167,85 @@ def test_lambda_dict_bytecode_with_benign_module_fields_stays_warning(tmp_path: 
     )
 
 
+def test_lambda_list_bytecode_with_dangerous_pattern_is_critical(tmp_path: Path) -> None:
+    """Legacy list-format Lambda bytecode in H5 must be decoded and inspected."""
+    encoded_code = base64.b64encode(b"import os\nos.system('id')\neval('__import__(\"os\")')").decode()
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "name": "list_dict_lambda_model",
+                "layers": [
+                    {
+                        "class_name": "Lambda",
+                        "config": {
+                            "name": "dangerous_list_lambda",
+                            "function": [encoded_code, None, None],
+                        },
+                    }
+                ],
+            },
+        },
+    )
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    dangerous_checks = [
+        check
+        for check in result.checks
+        if check.name == "Lambda Layer Code Analysis"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details.get("layer_name") == "dangerous_list_lambda"
+    ]
+    assert len(dangerous_checks) == 1
+    assert dangerous_checks[0].details["function_format"] == "list_bytecode"
+    assert {"eval", "__import__", "os.system"}.issubset(set(dangerous_checks[0].details["dangerous_patterns"]))
+
+
+def test_lambda_list_bytecode_with_benign_module_fields_stays_warning(tmp_path: Path) -> None:
+    """Opaque list-format Lambda bytecode should not become a passed module reference check."""
+    encoded_code = base64.b64encode(marshal.dumps((lambda x: x + 1).__code__)).decode()
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "name": "mixed_safe_list_lambda_model",
+                "layers": [
+                    {
+                        "class_name": "Lambda",
+                        "config": {
+                            "name": "mixed_safe_list_lambda",
+                            "function": [encoded_code, None, None],
+                            "module": "keras.ops",
+                            "function_name": "identity",
+                        },
+                    }
+                ],
+            },
+        },
+    )
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    bytecode_issues = [
+        issue
+        for issue in result.issues
+        if "embedded bytecode" in issue.message and "mixed_safe_list_lambda" in issue.message
+    ]
+    assert len(bytecode_issues) == 1
+    assert bytecode_issues[0].severity == IssueSeverity.WARNING
+    assert bytecode_issues[0].details["function_format"] == "list_bytecode"
+    assert not any(
+        check.name == "Lambda Layer Module Reference Check"
+        and check.status == CheckStatus.PASSED
+        and check.details.get("module") == "keras.ops"
+        for check in result.checks
+    )
+
+
 def test_unrecognized_lambda_function_dict_still_uses_module_reference_check(tmp_path: Path) -> None:
     """Only recognized __lambda__ dictionaries should preempt module/function reference analysis."""
     model_path = create_custom_h5_file(

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -1344,7 +1344,8 @@ def test_lambda_dict_bytecode_without_dangerous_patterns_stays_warning(tmp_path:
 
 
 def test_lambda_dict_bytecode_with_dangerous_pattern_still_critical(tmp_path: Path) -> None:
-    encoded_code = base64.b64encode(b"import os\nos.system('id')\neval('__import__(\"os\")')").decode()
+    code = compile("import os\nos.system('id')\neval('__import__(\"os\")')", "<lambda>", "exec")
+    encoded_code = base64.b64encode(marshal.dumps(code)).decode()
     model_path = create_custom_h5_file(
         tmp_path,
         {
@@ -1380,7 +1381,8 @@ def test_lambda_dict_bytecode_with_dangerous_pattern_still_critical(tmp_path: Pa
 
 def test_lambda_dict_bytecode_with_benign_module_fields_still_critical(tmp_path: Path) -> None:
     """Dict-format Lambda bytecode must not be skipped by benign module/function metadata."""
-    encoded_code = base64.b64encode(b"import os\nos.system('id')\neval('__import__(\"os\")')").decode()
+    code = compile("import os\nos.system('id')\neval('__import__(\"os\")')", "<lambda>", "exec")
+    encoded_code = base64.b64encode(marshal.dumps(code)).decode()
     model_path = create_custom_h5_file(
         tmp_path,
         {
@@ -1463,9 +1465,46 @@ def test_lambda_dict_bytecode_with_benign_module_fields_stays_warning(tmp_path: 
     )
 
 
+def test_lambda_dict_malformed_config_does_not_echo_payload(tmp_path: Path) -> None:
+    """Malformed dict-format metadata should report its type without retaining attacker content."""
+    payload = "attacker-controlled-secret-payload"
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "name": "malformed_dict_lambda_model",
+                "layers": [
+                    {
+                        "class_name": "Lambda",
+                        "config": {
+                            "name": "malformed_dict_lambda",
+                            "function": {"class_name": "__lambda__", "config": payload},
+                        },
+                    }
+                ],
+            },
+        },
+    )
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    malformed_checks = [
+        check
+        for check in result.checks
+        if check.name == "Lambda Layer Detection"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("parse_status") == "invalid_config"
+    ]
+    assert len(malformed_checks) == 1
+    assert malformed_checks[0].details["config_type"] == "str"
+    assert payload not in str(malformed_checks[0].details)
+
+
 def test_lambda_list_bytecode_with_dangerous_pattern_is_critical(tmp_path: Path) -> None:
     """Legacy list-format Lambda bytecode in H5 must be decoded and inspected."""
-    encoded_code = base64.b64encode(b"import os\nos.system('id')\neval('__import__(\"os\")')").decode()
+    code = compile("import os\nos.system('id')\neval('__import__(\"os\")')", "<lambda>", "exec")
+    encoded_code = base64.b64encode(marshal.dumps(code)).decode()
     model_path = create_custom_h5_file(
         tmp_path,
         {
@@ -1542,6 +1581,41 @@ def test_lambda_list_bytecode_with_benign_module_fields_stays_warning(tmp_path: 
     )
 
 
+@pytest.mark.parametrize("function_data", [[], [None, None, None]])
+def test_lambda_list_missing_encoded_code_stays_warning(tmp_path: Path, function_data: list[Any]) -> None:
+    """Malformed list-format Lambda metadata must remain a security finding."""
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "name": "malformed_list_lambda_model",
+                "layers": [
+                    {
+                        "class_name": "Lambda",
+                        "config": {
+                            "name": "malformed_list_lambda",
+                            "function": function_data,
+                        },
+                    }
+                ],
+            },
+        },
+    )
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    malformed_checks = [
+        check
+        for check in result.checks
+        if check.name == "Lambda Layer Detection"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("function_format") == "list"
+    ]
+    assert len(malformed_checks) == 1
+    assert malformed_checks[0].severity == IssueSeverity.WARNING
+
+
 def test_unrecognized_lambda_function_dict_still_uses_module_reference_check(tmp_path: Path) -> None:
     """Only recognized __lambda__ dictionaries should preempt module/function reference analysis."""
     model_path = create_custom_h5_file(
@@ -1573,6 +1647,55 @@ def test_unrecognized_lambda_function_dict_still_uses_module_reference_check(tmp
         and check.severity == IssueSeverity.CRITICAL
         and check.details.get("module") == "os"
         and check.details.get("function") == "system"
+        for check in result.checks
+    )
+
+
+@pytest.mark.parametrize(
+    ("module_name", "function_name"),
+    [(["os"], None), (None, {"name": "system"})],
+)
+def test_lambda_malformed_module_reference_is_not_marked_safe(
+    tmp_path: Path,
+    module_name: Any,
+    function_name: Any,
+) -> None:
+    """Malformed mixed module/function metadata must not become a passed safety check."""
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "name": "malformed_module_reference_model",
+                "layers": [
+                    {
+                        "class_name": "Lambda",
+                        "config": {
+                            "name": "malformed_module_reference",
+                            "function": {"class_name": "SomeCallable", "config": {}},
+                            "module": module_name,
+                            "function_name": function_name,
+                        },
+                    }
+                ],
+            },
+        },
+    )
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    malformed_checks = [
+        check
+        for check in result.checks
+        if check.name == "Lambda Layer Module Reference Check"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("module_type") == type(module_name).__name__
+        and check.details.get("function_type") == type(function_name).__name__
+    ]
+    assert len(malformed_checks) == 1
+    assert malformed_checks[0].severity == IssueSeverity.WARNING
+    assert not any(
+        check.name == "Lambda Layer Module Reference Check" and check.status == CheckStatus.PASSED
         for check in result.checks
     )
 
@@ -1723,7 +1846,7 @@ def test_lambda_dict_oversized_code_is_not_decoded(tmp_path: Path, monkeypatch: 
     def fail_decode(_encoded: str) -> bytes:
         raise AssertionError("oversized Lambda bytecode must not be decoded")
 
-    monkeypatch.setattr(keras_utils, "_MAX_LAMBDA_DICT_CODE_B64_CHARS", 8)
+    monkeypatch.setattr(keras_utils, "_MAX_LAMBDA_CODE_B64_CHARS", 8)
     monkeypatch.setattr(keras_utils.base64, "b64decode", fail_decode)
 
     result = KerasH5Scanner().scan(str(model_path))
@@ -1737,6 +1860,49 @@ def test_lambda_dict_oversized_code_is_not_decoded(tmp_path: Path, monkeypatch: 
     ]
     assert len(oversized_checks) == 1
     assert oversized_checks[0].severity == IssueSeverity.WARNING
+    assert oversized_checks[0].details["encoded_code_chars"] == 9
+    assert oversized_checks[0].details["max_encoded_code_chars"] == 8
+
+
+def test_lambda_list_oversized_code_is_not_decoded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Oversized list-format Lambda bytecode must fail closed before allocating a decoded copy."""
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "name": "oversized_list_lambda_model",
+                "layers": [
+                    {
+                        "class_name": "Lambda",
+                        "config": {
+                            "name": "oversized_list_lambda",
+                            "function": ["A" * 9, None, None],
+                        },
+                    }
+                ],
+            },
+        },
+    )
+
+    def fail_decode(_encoded: str) -> bytes:
+        raise AssertionError("oversized Lambda bytecode must not be decoded")
+
+    monkeypatch.setattr(keras_utils, "_MAX_LAMBDA_CODE_B64_CHARS", 8)
+    monkeypatch.setattr(keras_utils.base64, "b64decode", fail_decode)
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    oversized_checks = [
+        check
+        for check in result.checks
+        if check.name == "Lambda Layer Detection"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("analysis_status") == "code_size_limit_exceeded"
+    ]
+    assert len(oversized_checks) == 1
+    assert oversized_checks[0].severity == IssueSeverity.WARNING
+    assert oversized_checks[0].details["function_format"] == "list"
     assert oversized_checks[0].details["encoded_code_chars"] == 9
     assert oversized_checks[0].details["max_encoded_code_chars"] == 8
 

--- a/tests/scanners/test_keras_utils.py
+++ b/tests/scanners/test_keras_utils.py
@@ -1,5 +1,7 @@
 """Tests for shared Keras scanner helpers."""
 
+import marshal
+
 from modelaudit.scanners.keras_utils import find_case_insensitive_substrings, find_lambda_dangerous_patterns
 
 
@@ -33,3 +35,22 @@ def test_find_lambda_dangerous_patterns_preserves_real_open_calls() -> None:
     text = "lambda body: open('/private/tmp/modelaudit-open-prs/payload.py')"
 
     assert find_lambda_dangerous_patterns(text, ("open", "exec")) == ["open"]
+
+
+def test_find_lambda_dangerous_patterns_ignores_substrings_inside_identifiers() -> None:
+    text = "opened executor evaluation ecosystem.systemic os + system osésystem"
+
+    assert find_lambda_dangerous_patterns(text, ("open", "exec", "eval", "os.system")) == []
+
+
+def test_find_lambda_dangerous_patterns_preserves_real_dotted_calls() -> None:
+    text = "lambda body: os.system('id')"
+
+    assert find_lambda_dangerous_patterns(text, ("os.system", "os.popen")) == ["os.system"]
+
+
+def test_find_lambda_dangerous_patterns_detects_marshaled_dotted_symbols() -> None:
+    code = compile("import os\nos.system('id')", "<lambda>", "exec")
+    text = marshal.dumps(code).decode("utf-8", errors="replace")
+
+    assert find_lambda_dangerous_patterns(text, ("open", "os.system", "os.popen")) == ["os.system"]


### PR DESCRIPTION
## Summary

- inspect recognized dict- and list-format Keras H5 Lambda bytecode before sibling module/function metadata can suppress it
- always evaluate dangerous sibling module references and report malformed non-string references instead of marking them safe
- bound encoded Lambda decoding and avoid echoing malformed attacker-controlled dict payloads
- detect genuine marshalled dotted calls such as `os.system` while suppressing identifier-substring and Unicode-identifier false positives

## Audit improvements

The audit found two concrete gaps beyond the original mixed-dict fix:

- the dangerous-bytecode tests used plain source bytes, so genuine marshalled `os.system(...)` remained only an opaque warning because marshal metadata separates `os` from `system`
- truthy non-string `module` / `function_name` values could fall through to a passed "module references are safe" check

Both are fixed with focused positive and negative regressions. The branch is also synced with merged #1421.

## Validation

- affected H5, Keras ZIP, shared Keras helper, and TensorFlow SavedModel suites: `336 passed`
- shared matcher remains bounded at about `0.35s` on a 1 MB adversarial probe
- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`399 files left unchanged` on final pass)
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`All checks passed`)
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` (`454 source files`)
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` (`7058 passed, 820 skipped`)
- final no-change lint and format checks passed