### PR TITLE
fix: bound jax and flax metadata scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- bound Flax MessagePack decoding/traversal and Orbax metadata JSON parsing so oversized JAX/Flax checkpoints fail closed
 - scan ONNX external data references in sparse initializers, tensor-valued attributes, and function defaults
 - avoid false-positive process-launch findings for parsed framed Python string literals
 - detect dangerous Python calls retrieved through module namespace dictionaries in ZIP and TAR members

--- a/modelaudit/scanners/flax_msgpack_scanner.py
+++ b/modelaudit/scanners/flax_msgpack_scanner.py
@@ -363,81 +363,65 @@ class FlaxMsgpackScanner(BaseScanner):
 
         return metadata
 
-    def _check_jax_specific_threats(self, obj: Any, result: ScanResult) -> None:
-        """Check for JAX/Flax specific security threats."""
+    def _check_jax_transform(
+        self,
+        key: str,
+        value: str,
+        location: str,
+        result: ScanResult,
+    ) -> None:
+        """Check one visible key/value pair for dangerous JAX transforms."""
+        for transform in _matching_jax_transforms(key.lower(), value):
+            result.add_check(
+                name="JAX Transform Security Check",
+                passed=False,
+                message=f"Suspicious JAX transform detected: {transform}",
+                severity=IssueSeverity.CRITICAL,
+                location=location,
+                details={
+                    "transform": transform,
+                    "context": value[:200],
+                },
+                rule_code="S1105",
+            )
 
-        def check_jax_transforms(data: Any, path: str = "") -> None:
-            """Check for potentially dangerous JAX transform usage."""
-            if isinstance(data, dict):
-                for key, value in data.items():
-                    key_str = str(key).lower()
-                    value_str = str(value)
+    @staticmethod
+    def _check_jax_array_metadata(value: dict[Any, Any], location: str, result: ScanResult) -> None:
+        """Check one visible dictionary for suspicious JAX array metadata."""
+        if "__jax_array__" in value:
+            result.add_check(
+                name="JAX Array Metadata Check",
+                passed=False,
+                message="Suspicious JAX array metadata detected",
+                severity=IssueSeverity.WARNING,
+                location=location,
+                details={"suspicious_key": "__jax_array__"},
+                rule_code="S905",
+            )
 
-                    for transform in _matching_jax_transforms(key_str, value_str):
-                        result.add_check(
-                            name="JAX Transform Security Check",
-                            passed=False,
-                            message=f"Suspicious JAX transform detected: {transform}",
-                            severity=IssueSeverity.CRITICAL,
-                            location=f"{path}/{key}",
-                            details={
-                                "transform": transform,
-                                "context": value_str[:200] if len(value_str) > 200 else value_str,
-                            },
-                            rule_code="S1105",  # JAX compilation risks
-                        )
-
-                    check_jax_transforms(value, f"{path}/{key}" if path else key)
-            elif isinstance(data, list | tuple):
-                for i, value in enumerate(data):
-                    check_jax_transforms(value, f"{path}[{i}]")
-
-        # Check for JAX-specific attack patterns
-        check_jax_transforms(obj)
-
-        # Check for fake JAX arrays or suspicious array metadata
-        def check_array_metadata(data: Any, path: str = "") -> None:
-            if isinstance(data, dict):
-                # Look for fake JAX array indicators
-                if "__jax_array__" in data:
-                    result.add_check(
-                        name="JAX Array Metadata Check",
-                        passed=False,
-                        message="Suspicious JAX array metadata detected",
-                        severity=IssueSeverity.WARNING,
-                        location=path,
-                        details={"suspicious_key": "__jax_array__"},
-                        rule_code="S905",
-                    )
-
-                # Check for unusual shape specifications that might indicate attacks
-                if "shape" in data and isinstance(data["shape"], list | tuple):
-                    shape = data["shape"]
-                    if any(dim < 0 for dim in shape if isinstance(dim, int)):
-                        result.add_check(
-                            name="Tensor Shape Validation",
-                            passed=False,
-                            message="Invalid tensor shape with negative dimensions",
-                            severity=IssueSeverity.INFO,
-                            location=path,
-                            details={"shape": shape},
-                            rule_code="S902",
-                        )
-                    elif any(dim > 10**9 for dim in shape if isinstance(dim, int)):
-                        result.add_check(
-                            name="Tensor Dimension Check",
-                            passed=False,
-                            message="Suspiciously large tensor dimensions",
-                            severity=IssueSeverity.WARNING,
-                            location=path,
-                            details={"shape": shape, "max_safe_dimension": 10**9},
-                            rule_code="S804",
-                        )
-
-                for key, value in data.items():
-                    check_array_metadata(value, f"{path}/{key}" if path else key)
-
-        check_array_metadata(obj)
+        shape = value.get("shape")
+        if not isinstance(shape, list | tuple):
+            return
+        if any(dim < 0 for dim in shape if isinstance(dim, int)):
+            result.add_check(
+                name="Tensor Shape Validation",
+                passed=False,
+                message="Invalid tensor shape with negative dimensions",
+                severity=IssueSeverity.INFO,
+                location=location,
+                details={"shape": shape},
+                rule_code="S902",
+            )
+        elif any(dim > 10**9 for dim in shape if isinstance(dim, int)):
+            result.add_check(
+                name="Tensor Dimension Check",
+                passed=False,
+                message="Suspiciously large tensor dimensions",
+                severity=IssueSeverity.WARNING,
+                location=location,
+                details={"shape": shape, "max_safe_dimension": 10**9},
+                rule_code="S804",
+            )
 
     def _check_suspicious_strings(
         self,
@@ -677,6 +661,7 @@ class FlaxMsgpackScanner(BaseScanner):
         result: ScanResult,
         depth: int = 0,
         traversal_state: dict[str, Any] | None = None,
+        check_string_jax_transform: bool = True,
     ) -> None:
         """Recursively analyze msgpack content for security threats and anomalies."""
         if traversal_state is None:
@@ -738,6 +723,9 @@ class FlaxMsgpackScanner(BaseScanner):
                 pass
 
         elif isinstance(value, str):
+            if check_string_jax_transform:
+                self._check_jax_transform("", value, location, result)
+
             # Check for suspicious string patterns
             self._check_suspicious_strings(value, location, result)
 
@@ -754,6 +742,8 @@ class FlaxMsgpackScanner(BaseScanner):
                 )
 
         elif isinstance(value, dict):
+            self._check_jax_array_metadata(value, location, result)
+
             if len(value) > self.max_items_per_container:
                 self._add_structure_budget_check(
                     result,
@@ -781,13 +771,26 @@ class FlaxMsgpackScanner(BaseScanner):
                 if index >= self.max_items_per_container:
                     break
                 key_str = str(k)
+                self._check_jax_transform(
+                    key_str,
+                    v if isinstance(v, str) else "",
+                    f"{location}/{key_str}",
+                    result,
+                )
                 self._check_suspicious_keys(key_str, v, f"{location}/{key_str}", result)
 
                 # Check if key itself contains suspicious patterns
                 if isinstance(k, str):
                     self._check_suspicious_strings(k, f"{location}[key:{k}]", result)
 
-                self._analyze_content(v, f"{location}/{key_str}", result, depth + 1, traversal_state)
+                self._analyze_content(
+                    v,
+                    f"{location}/{key_str}",
+                    result,
+                    depth + 1,
+                    traversal_state,
+                    check_string_jax_transform=not isinstance(v, str),
+                )
 
         elif isinstance(value, list | tuple):
             if len(value) > self.max_items_per_container:
@@ -1472,22 +1475,12 @@ class FlaxMsgpackScanner(BaseScanner):
                 # Validate Flax structure with enhanced analysis
                 self._validate_flax_structure(obj, result, ml_analysis=ml_analysis)
 
-                # Check for JAX/Flax specific security threats
-                self._check_jax_specific_threats(obj, result)
-
             # Perform deep security analysis
             traversal_state = self._new_content_traversal_state(max_nodes=max_nodes_per_object)
             self._analyze_content(obj, "root", result, traversal_state=traversal_state)
 
             for object_index, stream_obj in enumerate(objects[1:], start=1):
                 stream_location = f"root[msgpack_object_{object_index}]"
-                if self._check_preanalysis_structure_budget(
-                    stream_obj,
-                    result,
-                    location=stream_location,
-                    max_nodes=max_nodes_per_object,
-                ):
-                    self._check_jax_specific_threats(stream_obj, result)
                 self._analyze_content(
                     stream_obj,
                     stream_location,

--- a/modelaudit/scanners/flax_msgpack_scanner.py
+++ b/modelaudit/scanners/flax_msgpack_scanner.py
@@ -564,21 +564,29 @@ class FlaxMsgpackScanner(BaseScanner):
             },
         )
 
-    def _check_preanalysis_structure_budget(self, obj: Any, result: ScanResult, *, location: str) -> bool:
+    def _check_preanalysis_structure_budget(
+        self,
+        obj: Any,
+        result: ScanResult,
+        *,
+        location: str,
+        max_nodes: int | None = None,
+    ) -> bool:
         """Bound helper-analysis traversal before running ML/JAX metadata prechecks."""
         stack: list[tuple[Any, str, int]] = [(obj, location, 0)]
         visited_nodes = 0
+        node_limit = self.max_structure_nodes if max_nodes is None else max_nodes
 
         while stack:
             value, value_location, depth = stack.pop()
             visited_nodes += 1
-            if visited_nodes > self.max_structure_nodes:
+            if visited_nodes > node_limit:
                 self._add_structure_budget_check(
                     result,
                     location=value_location,
                     budget="node_count",
                     observed=visited_nodes,
-                    maximum=self.max_structure_nodes,
+                    maximum=node_limit,
                 )
                 return False
             if depth > self.max_recursion_depth:
@@ -655,8 +663,12 @@ class FlaxMsgpackScanner(BaseScanner):
 
         return " ".join(fragments).lower()
 
-    def _new_content_traversal_state(self) -> dict[str, Any]:
-        return {"nodes": 0, "node_budget_reported": False}
+    def _new_content_traversal_state(self, *, max_nodes: int | None = None) -> dict[str, Any]:
+        return {
+            "nodes": 0,
+            "max_nodes": self.max_structure_nodes if max_nodes is None else max_nodes,
+            "node_budget_reported": False,
+        }
 
     def _analyze_content(
         self,
@@ -670,14 +682,14 @@ class FlaxMsgpackScanner(BaseScanner):
         if traversal_state is None:
             traversal_state = self._new_content_traversal_state()
         traversal_state["nodes"] += 1
-        if traversal_state["nodes"] > self.max_structure_nodes:
+        if traversal_state["nodes"] > traversal_state["max_nodes"]:
             if not traversal_state["node_budget_reported"]:
                 self._add_structure_budget_check(
                     result,
                     location=location,
                     budget="node_count",
                     observed=traversal_state["nodes"],
-                    maximum=self.max_structure_nodes,
+                    maximum=traversal_state["max_nodes"],
                 )
                 traversal_state["node_budget_reported"] = True
             return
@@ -1254,6 +1266,90 @@ class FlaxMsgpackScanner(BaseScanner):
             rule_code="S902",
         )
 
+    def _unpack_bounded_msgpack_preview_value(
+        self,
+        unpacker: Any,
+        *,
+        depth: int,
+        state: dict[str, int],
+    ) -> tuple[Any, bool]:
+        """Decode a bounded visible prefix without materializing oversized containers."""
+        if depth > self.max_recursion_depth or state["nodes"] >= self.max_structure_nodes:
+            return None, False
+        state["nodes"] += 1
+
+        try:
+            map_length = unpacker.read_map_header()
+        except ValueError:
+            pass
+        else:
+            pairs: list[dict[Any, Any]] = []
+            for _ in range(min(map_length, self.max_items_per_container)):
+                key, key_complete = self._unpack_bounded_msgpack_preview_value(
+                    unpacker,
+                    depth=depth + 1,
+                    state=state,
+                )
+                if not key_complete:
+                    pairs.append({"<partial_key>": key})
+                    return pairs, False
+                value, value_complete = self._unpack_bounded_msgpack_preview_value(
+                    unpacker,
+                    depth=depth + 1,
+                    state=state,
+                )
+                try:
+                    pair = {key: value}
+                except TypeError:
+                    pair = {str(key): value}
+                pairs.append(pair)
+                if not value_complete:
+                    return pairs, False
+            return pairs, map_length <= self.max_items_per_container
+
+        try:
+            array_length = unpacker.read_array_header()
+        except ValueError:
+            pass
+        else:
+            items: list[Any] = []
+            for _ in range(min(array_length, self.max_items_per_container)):
+                value, value_complete = self._unpack_bounded_msgpack_preview_value(
+                    unpacker,
+                    depth=depth + 1,
+                    state=state,
+                )
+                items.append(value)
+                if not value_complete:
+                    return items, False
+            return items, array_length <= self.max_items_per_container
+
+        return unpacker.unpack(), True
+
+    def _scan_bounded_msgpack_decode_prefix(self, path: str, result: ScanResult) -> None:
+        """Preserve visible security findings when normal decoding hits a budget."""
+        state = {"nodes": 0}
+        try:
+            with open(path, "rb") as source:
+                unpacker = msgpack.Unpacker(
+                    source,
+                    read_size=self._msgpack_stream_read_size(),
+                    **self._msgpack_unpacker_kwargs(),
+                )
+                for object_index in range(self.max_msgpack_stream_objects):
+                    preview, complete = self._unpack_bounded_msgpack_preview_value(
+                        unpacker,
+                        depth=0,
+                        state=state,
+                    )
+                    if preview is not None:
+                        self._analyze_content(preview, f"root[bounded_decode_prefix_{object_index}]", result)
+                    if not complete:
+                        break
+        except Exception:
+            # The original decode failure is already surfaced as inconclusive.
+            return
+
     def _unpack_msgpack_objects_from_path(self, path: str, result: ScanResult) -> list[Any] | None:
         """Stream MessagePack from disk so scans do not allocate the whole file before decoding."""
         unpacker = msgpack.Unpacker(**self._msgpack_unpacker_kwargs())
@@ -1269,6 +1365,7 @@ class FlaxMsgpackScanner(BaseScanner):
                     has_incomplete_tail = drain_result
         except Exception as e:
             if self._is_msgpack_limit_error(e):
+                self._scan_bounded_msgpack_decode_prefix(path, result)
                 self._add_msgpack_decode_limit_check(result, path, e)
             else:
                 self._add_msgpack_parse_failure_check(result, path, e)
@@ -1359,7 +1456,13 @@ class FlaxMsgpackScanner(BaseScanner):
             if len(objects) > 1:
                 result.metadata["msgpack_object_count"] = len(objects)
 
-            preanalysis_complete = self._check_preanalysis_structure_budget(obj, result, location="root")
+            max_nodes_per_object = max(1, self.max_structure_nodes // len(objects))
+            preanalysis_complete = self._check_preanalysis_structure_budget(
+                obj,
+                result,
+                location="root",
+                max_nodes=max_nodes_per_object,
+            )
             ml_analysis: dict[str, Any] | None = None
             if preanalysis_complete:
                 # Extract JAX/Flax specific metadata and architecture information
@@ -1373,14 +1476,24 @@ class FlaxMsgpackScanner(BaseScanner):
                 self._check_jax_specific_threats(obj, result)
 
             # Perform deep security analysis
-            traversal_state = self._new_content_traversal_state()
+            traversal_state = self._new_content_traversal_state(max_nodes=max_nodes_per_object)
             self._analyze_content(obj, "root", result, traversal_state=traversal_state)
 
             for object_index, stream_obj in enumerate(objects[1:], start=1):
                 stream_location = f"root[msgpack_object_{object_index}]"
-                if self._check_preanalysis_structure_budget(stream_obj, result, location=stream_location):
+                if self._check_preanalysis_structure_budget(
+                    stream_obj,
+                    result,
+                    location=stream_location,
+                    max_nodes=max_nodes_per_object,
+                ):
                     self._check_jax_specific_threats(stream_obj, result)
-                self._analyze_content(stream_obj, stream_location, result, traversal_state=traversal_state)
+                self._analyze_content(
+                    stream_obj,
+                    stream_location,
+                    result,
+                    traversal_state=self._new_content_traversal_state(max_nodes=max_nodes_per_object),
+                )
 
             result.bytes_scanned = file_size
         except MemoryError:

--- a/modelaudit/scanners/flax_msgpack_scanner.py
+++ b/modelaudit/scanners/flax_msgpack_scanner.py
@@ -13,20 +13,9 @@ from ..utils.file.detection import has_inconclusive_renamed_flax_msgpack_routing
 try:
     import msgpack
 
-    # Try to import exceptions module - not available in all msgpack versions
-    try:
-        from msgpack import exceptions as msgpack_exceptions
-
-        HAS_MSGPACK_EXCEPTIONS = True
-    except (ImportError, AttributeError):
-        msgpack_exceptions = None  # type: ignore[assignment]
-        HAS_MSGPACK_EXCEPTIONS = False
-
     HAS_MSGPACK = True
 except Exception:  # pragma: no cover - optional dependency missing
     HAS_MSGPACK = False
-    HAS_MSGPACK_EXCEPTIONS = False
-    msgpack_exceptions = None  # type: ignore[assignment]
 
 from .base import BaseScanner, IssueSeverity, ScanResult
 
@@ -1168,10 +1157,9 @@ class FlaxMsgpackScanner(BaseScanner):
             "max_map_len": self.max_items_per_container,
         }
 
-    def _msgpack_unpackb_kwargs(self) -> dict[str, Any]:
-        kwargs = self._msgpack_unpacker_kwargs()
-        kwargs.pop("max_buffer_size", None)
-        return kwargs
+    def _msgpack_stream_read_size(self) -> int:
+        """Leave decoder-buffer headroom for an object split across filesystem reads."""
+        return min(self.chunk_size, max(self.max_msgpack_decode_bytes // 2, 1))
 
     @staticmethod
     def _is_msgpack_limit_error(error: Exception) -> bool:
@@ -1208,6 +1196,43 @@ class FlaxMsgpackScanner(BaseScanner):
         )
         result.finish(success=False)
 
+    def _add_msgpack_stream_object_limit_check(self, result: ScanResult, path: str, parsed_object_count: int) -> None:
+        result.add_check(
+            name="Msgpack Stream Object Limit",
+            passed=False,
+            message=f"Msgpack stream object count exceeds configured limit ({self.max_msgpack_stream_objects})",
+            severity=IssueSeverity.WARNING,
+            location=path,
+            details={
+                "max_msgpack_stream_objects": self.max_msgpack_stream_objects,
+                "parsed_object_count": parsed_object_count,
+            },
+            rule_code="S902",
+        )
+        result.metadata["operational_error"] = True
+        result.metadata["operational_error_reason"] = "msgpack_stream_object_limit_exceeded"
+        result.finish(success=False)
+
+    @staticmethod
+    def _is_msgpack_out_of_data(error: Exception) -> bool:
+        return type(error).__name__ == "OutOfData"
+
+    def _drain_msgpack_unpacker(self, unpacker: Any, objects: list[Any], result: ScanResult, path: str) -> bool | None:
+        """Append complete objects and report whether the unpacker consumed a partial tail."""
+        while True:
+            previous_offset = unpacker.tell()
+            try:
+                stream_obj = unpacker.unpack()
+            except Exception as error:
+                if self._is_msgpack_out_of_data(error):
+                    return unpacker.tell() > previous_offset
+                raise
+
+            if len(objects) >= self.max_msgpack_stream_objects:
+                self._add_msgpack_stream_object_limit_check(result, path, len(objects))
+                return None
+            objects.append(stream_obj)
+
     def _add_msgpack_stream_integrity_check(self, objects: list[Any], result: ScanResult, path: str) -> None:
         if len(objects) <= 1:
             return
@@ -1229,116 +1254,19 @@ class FlaxMsgpackScanner(BaseScanner):
             rule_code="S902",
         )
 
-    def _unpack_msgpack_objects(self, file_data: bytes, result: ScanResult, path: str) -> list[Any] | None:
-        """Unpack all msgpack objects in a bounded byte buffer and preserve trailing-object warnings."""
-        try:
-            return [msgpack.unpackb(file_data, **self._msgpack_unpackb_kwargs())]
-        except Exception as e:
-            if self._is_msgpack_limit_error(e):
-                self._add_msgpack_decode_limit_check(result, path, e)
-                return None
-
-            extra_data_detected = False
-            if (
-                HAS_MSGPACK_EXCEPTIONS
-                and msgpack_exceptions
-                and hasattr(msgpack_exceptions, "ExtraData")
-                and isinstance(e, msgpack_exceptions.ExtraData)
-            ):
-                extra_data_detected = True
-
-            if extra_data_detected:
-                unpacker = msgpack.Unpacker(**self._msgpack_unpacker_kwargs())
-                unpacker.feed(file_data)
-                try:
-                    objects: list[Any] = []
-                    for stream_obj in unpacker:
-                        if len(objects) >= self.max_msgpack_stream_objects:
-                            result.add_check(
-                                name="Msgpack Stream Object Limit",
-                                passed=False,
-                                message=(
-                                    "Msgpack stream object count exceeds configured limit "
-                                    f"({self.max_msgpack_stream_objects})"
-                                ),
-                                severity=IssueSeverity.WARNING,
-                                location=path,
-                                details={
-                                    "max_msgpack_stream_objects": self.max_msgpack_stream_objects,
-                                    "parsed_object_count": len(objects),
-                                },
-                                rule_code="S902",
-                            )
-                            result.metadata["operational_error"] = True
-                            result.metadata["operational_error_reason"] = "msgpack_stream_object_limit_exceeded"
-                            result.finish(success=False)
-                            return None
-                        objects.append(stream_obj)
-                except Exception as unpack_e:
-                    if self._is_msgpack_limit_error(unpack_e):
-                        self._add_msgpack_decode_limit_check(result, path, unpack_e)
-                    else:
-                        self._add_msgpack_parse_failure_check(result, path, unpack_e)
-                    return None
-
-                if objects:
-                    self._add_msgpack_stream_integrity_check(objects, result, path)
-                    return objects
-
-                result.add_check(
-                    name="Msgpack Parse Check",
-                    passed=False,
-                    message="Failed to parse msgpack data: stream contained trailing bytes but no decodable objects",
-                    severity=IssueSeverity.WARNING,
-                    location=path,
-                    details={"parse_error": "no decodable objects"},
-                    rule_code="S902",
-                )
-                result.finish(success=False)
-                return None
-
-            result.add_check(
-                name="Msgpack Format Validation",
-                passed=False,
-                message=f"Invalid msgpack format: {e!s}",
-                severity=IssueSeverity.INFO,
-                location=path,
-                details={"msgpack_error": str(e)},
-                rule_code="S902",
-            )
-            result.finish(success=False)
-            return None
-
     def _unpack_msgpack_objects_from_path(self, path: str, result: ScanResult) -> list[Any] | None:
         """Stream MessagePack from disk so scans do not allocate the whole file before decoding."""
         unpacker = msgpack.Unpacker(**self._msgpack_unpacker_kwargs())
         objects: list[Any] = []
+        has_incomplete_tail = False
         try:
             with open(path, "rb") as source:
-                while chunk := source.read(self.chunk_size):
+                while chunk := source.read(self._msgpack_stream_read_size()):
                     unpacker.feed(chunk)
-                    for stream_obj in unpacker:
-                        if len(objects) >= self.max_msgpack_stream_objects:
-                            result.add_check(
-                                name="Msgpack Stream Object Limit",
-                                passed=False,
-                                message=(
-                                    "Msgpack stream object count exceeds configured limit "
-                                    f"({self.max_msgpack_stream_objects})"
-                                ),
-                                severity=IssueSeverity.WARNING,
-                                location=path,
-                                details={
-                                    "max_msgpack_stream_objects": self.max_msgpack_stream_objects,
-                                    "parsed_object_count": len(objects),
-                                },
-                                rule_code="S902",
-                            )
-                            result.metadata["operational_error"] = True
-                            result.metadata["operational_error_reason"] = "msgpack_stream_object_limit_exceeded"
-                            result.finish(success=False)
-                            return None
-                        objects.append(stream_obj)
+                    drain_result = self._drain_msgpack_unpacker(unpacker, objects, result, path)
+                    if drain_result is None:
+                        return None
+                    has_incomplete_tail = drain_result
         except Exception as e:
             if self._is_msgpack_limit_error(e):
                 self._add_msgpack_decode_limit_check(result, path, e)
@@ -1346,6 +1274,9 @@ class FlaxMsgpackScanner(BaseScanner):
                 self._add_msgpack_parse_failure_check(result, path, e)
             return None
 
+        if has_incomplete_tail:
+            self._add_msgpack_parse_failure_check(result, path, ValueError("incomplete trailing msgpack object"))
+            return None
         if not objects:
             result.add_check(
                 name="Msgpack Parse Check",

--- a/modelaudit/scanners/flax_msgpack_scanner.py
+++ b/modelaudit/scanners/flax_msgpack_scanner.py
@@ -44,6 +44,10 @@ class FlaxMsgpackScanner(BaseScanner):
     name = "flax_msgpack"
     description = "Scans Flax/JAX msgpack checkpoints for security threats and integrity issues"
     RECURSION_LIMIT_INCONCLUSIVE_REASON: ClassVar[str] = "flax_msgpack_recursion_limit_exceeded"
+    STRUCTURE_BUDGET_INCONCLUSIVE_REASON: ClassVar[str] = "flax_msgpack_structure_budget_exceeded"
+    DECODE_LIMIT_INCONCLUSIVE_REASON: ClassVar[str] = "flax_msgpack_decode_limit_exceeded"
+    DEFAULT_MAX_STRUCTURE_NODES: ClassVar[int] = 200_000
+    DEFAULT_MAX_BOUNDED_TEXT_CHARS: ClassVar[int] = 1_000_000
     # Enhanced file extension support for JAX/Flax ecosystem
     supported_extensions: ClassVar[list[str]] = [
         ".msgpack",
@@ -61,6 +65,18 @@ class FlaxMsgpackScanner(BaseScanner):
         self.max_recursion_depth = self.config.get("max_recursion_depth", 100)
         self.max_items_per_container = self.config.get("max_items_per_container", 50000)  # Increased for large models
         self.max_msgpack_stream_objects = self.config.get("max_msgpack_stream_objects", 4096)
+        default_decode_limit = (
+            self.max_file_read_size if self.max_file_read_size > 0 else self.default_max_file_read_size
+        )
+        self.max_msgpack_decode_bytes = self._positive_int_config("max_msgpack_decode_bytes", default_decode_limit)
+        self.max_structure_nodes = self._positive_int_config(
+            "max_msgpack_structure_nodes",
+            self.DEFAULT_MAX_STRUCTURE_NODES,
+        )
+        self.max_bounded_text_chars = self._positive_int_config(
+            "max_msgpack_bounded_text_chars",
+            self.DEFAULT_MAX_BOUNDED_TEXT_CHARS,
+        )
 
         # Enhanced suspicious patterns for JAX/Flax specific threats
         self.suspicious_patterns = self.config.get(
@@ -206,6 +222,19 @@ class FlaxMsgpackScanner(BaseScanner):
             ],
         }
 
+    @staticmethod
+    def _positive_int_config_value(value: Any, default: int) -> int:
+        if isinstance(value, bool):
+            return default
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return default
+        return parsed if parsed > 0 else default
+
+    def _positive_int_config(self, key: str, default: int) -> int:
+        return self._positive_int_config_value(self.config.get(key, default), default)
+
     @classmethod
     def can_handle(cls, path: str) -> bool:
         if not os.path.isfile(path):
@@ -279,8 +308,8 @@ class FlaxMsgpackScanner(BaseScanner):
                 rule_code=None,  # Passing check
             )
 
-        # Analyze architecture patterns
-        obj_str = str(obj).lower()
+        # Analyze architecture patterns with a bounded text view.
+        obj_str = self._bounded_structure_text(obj)
         for _pattern_type, patterns in self.jax_patterns.items():
             found_patterns = [p for p in patterns if p in obj_str]
             if found_patterns:
@@ -498,14 +527,172 @@ class FlaxMsgpackScanner(BaseScanner):
         normalized = value.strip().lower()
         return normalized in self.dangerous_callable_names
 
+    def _add_incomplete_check(
+        self,
+        result: ScanResult,
+        *,
+        reason: str,
+        name: str,
+        message: str,
+        location: str,
+        details: dict[str, Any],
+    ) -> None:
+        mark_inconclusive_scan_result(result, reason)
+        check_details = {
+            **details,
+            "analysis_incomplete": True,
+            "scan_outcome_reason": reason,
+        }
+        result.add_check(
+            name=name,
+            passed=False,
+            message=message,
+            severity=IssueSeverity.INFO,
+            location=location,
+            details=check_details,
+            rule_code="S902",
+        )
+
+    def _add_structure_budget_check(
+        self,
+        result: ScanResult,
+        *,
+        location: str,
+        budget: str,
+        observed: int,
+        maximum: int,
+    ) -> None:
+        self._add_incomplete_check(
+            result,
+            reason=self.STRUCTURE_BUDGET_INCONCLUSIVE_REASON,
+            name="Flax MessagePack Structure Budget",
+            message=f"Flax MessagePack structure analysis exceeded the {budget} budget",
+            location=location,
+            details={
+                "budget": budget,
+                "observed": observed,
+                "max_allowed": maximum,
+            },
+        )
+
+    def _check_preanalysis_structure_budget(self, obj: Any, result: ScanResult, *, location: str) -> bool:
+        """Bound helper-analysis traversal before running ML/JAX metadata prechecks."""
+        stack: list[tuple[Any, str, int]] = [(obj, location, 0)]
+        visited_nodes = 0
+
+        while stack:
+            value, value_location, depth = stack.pop()
+            visited_nodes += 1
+            if visited_nodes > self.max_structure_nodes:
+                self._add_structure_budget_check(
+                    result,
+                    location=value_location,
+                    budget="node_count",
+                    observed=visited_nodes,
+                    maximum=self.max_structure_nodes,
+                )
+                return False
+            if depth > self.max_recursion_depth:
+                self._add_incomplete_check(
+                    result,
+                    reason=self.RECURSION_LIMIT_INCONCLUSIVE_REASON,
+                    name="Flax MessagePack Preanalysis Depth Limit",
+                    message=f"Maximum preanalysis recursion depth exceeded: {depth}",
+                    location=value_location,
+                    details={
+                        "depth": depth,
+                        "max_allowed": self.max_recursion_depth,
+                    },
+                )
+                return False
+
+            if isinstance(value, dict):
+                if len(value) > self.max_items_per_container:
+                    self._add_structure_budget_check(
+                        result,
+                        location=value_location,
+                        budget="dict_items",
+                        observed=len(value),
+                        maximum=self.max_items_per_container,
+                    )
+                    return False
+                for key, nested_value in value.items():
+                    key_text = str(key)
+                    stack.append((nested_value, f"{value_location}/{key_text}", depth + 1))
+            elif isinstance(value, list | tuple):
+                if len(value) > self.max_items_per_container:
+                    self._add_structure_budget_check(
+                        result,
+                        location=value_location,
+                        budget="sequence_items",
+                        observed=len(value),
+                        maximum=self.max_items_per_container,
+                    )
+                    return False
+                for index, nested_value in enumerate(value):
+                    stack.append((nested_value, f"{value_location}[{index}]", depth + 1))
+
+        return True
+
+    def _bounded_structure_text(self, obj: Any) -> str:
+        """Return a bounded lowercase text view for architecture heuristics."""
+        fragments: list[str] = []
+        total_chars = 0
+        stack: list[tuple[Any, int]] = [(obj, 0)]
+        visited_nodes = 0
+
+        while stack and total_chars < self.max_bounded_text_chars:
+            value, depth = stack.pop()
+            visited_nodes += 1
+            if visited_nodes > self.max_structure_nodes or depth > self.max_recursion_depth:
+                break
+
+            if isinstance(value, dict):
+                for key, nested_value in value.items():
+                    key_text = str(key)
+                    remaining = self.max_bounded_text_chars - total_chars
+                    if remaining <= 0:
+                        break
+                    fragments.append(key_text[:remaining])
+                    total_chars += min(len(key_text), remaining)
+                    stack.append((nested_value, depth + 1))
+            elif isinstance(value, list | tuple):
+                for nested_value in value:
+                    stack.append((nested_value, depth + 1))
+            elif isinstance(value, str):
+                remaining = self.max_bounded_text_chars - total_chars
+                fragments.append(value[:remaining])
+                total_chars += min(len(value), remaining)
+
+        return " ".join(fragments).lower()
+
+    def _new_content_traversal_state(self) -> dict[str, Any]:
+        return {"nodes": 0, "node_budget_reported": False}
+
     def _analyze_content(
         self,
         value: Any,
         location: str,
         result: ScanResult,
         depth: int = 0,
+        traversal_state: dict[str, Any] | None = None,
     ) -> None:
         """Recursively analyze msgpack content for security threats and anomalies."""
+        if traversal_state is None:
+            traversal_state = self._new_content_traversal_state()
+        traversal_state["nodes"] += 1
+        if traversal_state["nodes"] > self.max_structure_nodes:
+            if not traversal_state["node_budget_reported"]:
+                self._add_structure_budget_check(
+                    result,
+                    location=location,
+                    budget="node_count",
+                    observed=traversal_state["nodes"],
+                    maximum=self.max_structure_nodes,
+                )
+                traversal_state["node_budget_reported"] = True
+            return
+
         if depth > self.max_recursion_depth:
             mark_inconclusive_scan_result(result, self.RECURSION_LIMIT_INCONCLUSIVE_REASON)
             result.add_check(
@@ -567,6 +754,13 @@ class FlaxMsgpackScanner(BaseScanner):
 
         elif isinstance(value, dict):
             if len(value) > self.max_items_per_container:
+                self._add_structure_budget_check(
+                    result,
+                    location=location,
+                    budget="dict_items",
+                    observed=len(value),
+                    maximum=self.max_items_per_container,
+                )
                 result.add_check(
                     name="Dictionary Size Check",
                     passed=False,
@@ -577,10 +771,14 @@ class FlaxMsgpackScanner(BaseScanner):
                     details={
                         "item_count": len(value),
                         "max_allowed": self.max_items_per_container,
+                        "analysis_incomplete": True,
+                        "scan_outcome_reason": self.STRUCTURE_BUDGET_INCONCLUSIVE_REASON,
                     },
                 )
 
-            for k, v in value.items():
+            for index, (k, v) in enumerate(value.items()):
+                if index >= self.max_items_per_container:
+                    break
                 key_str = str(k)
                 self._check_suspicious_keys(key_str, v, f"{location}/{key_str}", result)
 
@@ -588,10 +786,17 @@ class FlaxMsgpackScanner(BaseScanner):
                 if isinstance(k, str):
                     self._check_suspicious_strings(k, f"{location}[key:{k}]", result)
 
-                self._analyze_content(v, f"{location}/{key_str}", result, depth + 1)
+                self._analyze_content(v, f"{location}/{key_str}", result, depth + 1, traversal_state)
 
         elif isinstance(value, list | tuple):
             if len(value) > self.max_items_per_container:
+                self._add_structure_budget_check(
+                    result,
+                    location=location,
+                    budget="sequence_items",
+                    observed=len(value),
+                    maximum=self.max_items_per_container,
+                )
                 result.add_check(
                     name="Array Size Check",
                     passed=False,
@@ -602,11 +807,15 @@ class FlaxMsgpackScanner(BaseScanner):
                     details={
                         "item_count": len(value),
                         "max_allowed": self.max_items_per_container,
+                        "analysis_incomplete": True,
+                        "scan_outcome_reason": self.STRUCTURE_BUDGET_INCONCLUSIVE_REASON,
                     },
                 )
 
             for i, v in enumerate(value):
-                self._analyze_content(v, f"{location}[{i}]", result, depth + 1)
+                if i >= self.max_items_per_container:
+                    break
+                self._analyze_content(v, f"{location}[{i}]", result, depth + 1, traversal_state)
 
         elif isinstance(value, int | float):
             # Check for suspicious numerical values that might indicate attacks
@@ -703,7 +912,7 @@ class FlaxMsgpackScanner(BaseScanner):
         # Check for hierarchical structure (multiple layers)
         layer_evidence = 0
         layer_keywords = ["layer", "block", "attention", "ffn", "mlp", "linear", "conv"]
-        obj_text_lower = str(obj).lower()
+        obj_text_lower = self._bounded_structure_text(obj)
 
         for keyword in layer_keywords:
             if keyword in obj_text_lower:
@@ -948,11 +1157,87 @@ class FlaxMsgpackScanner(BaseScanner):
                 rule_code="S902",
             )
 
+    def _msgpack_unpacker_kwargs(self) -> dict[str, Any]:
+        return {
+            "raw": False,
+            "strict_map_key": False,
+            "max_buffer_size": self.max_msgpack_decode_bytes,
+            "max_str_len": self.max_msgpack_decode_bytes,
+            "max_bin_len": self.max_msgpack_decode_bytes,
+            "max_array_len": self.max_items_per_container,
+            "max_map_len": self.max_items_per_container,
+        }
+
+    def _msgpack_unpackb_kwargs(self) -> dict[str, Any]:
+        kwargs = self._msgpack_unpacker_kwargs()
+        kwargs.pop("max_buffer_size", None)
+        return kwargs
+
+    @staticmethod
+    def _is_msgpack_limit_error(error: Exception) -> bool:
+        if type(error).__name__ == "BufferFull":
+            return True
+        message = str(error).lower()
+        return "exceeds max_" in message or "max_buffer_size" in message or "recursion" in message
+
+    def _add_msgpack_decode_limit_check(self, result: ScanResult, path: str, error: Exception) -> None:
+        self._add_incomplete_check(
+            result,
+            reason=self.DECODE_LIMIT_INCONCLUSIVE_REASON,
+            name="Msgpack Decode Budget",
+            message="Flax MessagePack decode exceeded configured size or container limits",
+            location=path,
+            details={
+                "error": str(error),
+                "error_type": type(error).__name__,
+                "max_msgpack_decode_bytes": self.max_msgpack_decode_bytes,
+                "max_items_per_container": self.max_items_per_container,
+            },
+        )
+        result.finish(success=False)
+
+    def _add_msgpack_parse_failure_check(self, result: ScanResult, path: str, error: Exception) -> None:
+        result.add_check(
+            name="Msgpack Parse Check",
+            passed=False,
+            message=f"Failed to parse msgpack data: {error}",
+            severity=IssueSeverity.WARNING,
+            location=path,
+            details={"parse_error": str(error)},
+            rule_code="S902",
+        )
+        result.finish(success=False)
+
+    def _add_msgpack_stream_integrity_check(self, objects: list[Any], result: ScanResult, path: str) -> None:
+        if len(objects) <= 1:
+            return
+        trailing_objects_are_container_like = all(
+            isinstance(stream_obj, (dict, list, tuple)) for stream_obj in objects[1:]
+        )
+        result.add_check(
+            name="Msgpack Stream Integrity Check",
+            passed=False,
+            message="Extra trailing data found after msgpack content",
+            severity=(IssueSeverity.INFO if trailing_objects_are_container_like else IssueSeverity.WARNING),
+            location=path,
+            details={
+                "has_trailing_data": True,
+                "trailing_object_count": len(objects) - 1,
+                "trailing_object_types": [type(stream_obj).__name__ for stream_obj in objects[1:9]],
+                "trailing_objects_are_container_like": trailing_objects_are_container_like,
+            },
+            rule_code="S902",
+        )
+
     def _unpack_msgpack_objects(self, file_data: bytes, result: ScanResult, path: str) -> list[Any] | None:
-        """Unpack all msgpack objects in the stream and preserve trailing-object warnings."""
+        """Unpack all msgpack objects in a bounded byte buffer and preserve trailing-object warnings."""
         try:
-            return [msgpack.unpackb(file_data, raw=False, strict_map_key=False)]
+            return [msgpack.unpackb(file_data, **self._msgpack_unpackb_kwargs())]
         except Exception as e:
+            if self._is_msgpack_limit_error(e):
+                self._add_msgpack_decode_limit_check(result, path, e)
+                return None
+
             extra_data_detected = False
             if (
                 HAS_MSGPACK_EXCEPTIONS
@@ -963,7 +1248,7 @@ class FlaxMsgpackScanner(BaseScanner):
                 extra_data_detected = True
 
             if extra_data_detected:
-                unpacker = msgpack.Unpacker(raw=False, strict_map_key=False)
+                unpacker = msgpack.Unpacker(**self._msgpack_unpacker_kwargs())
                 unpacker.feed(file_data)
                 try:
                     objects: list[Any] = []
@@ -990,36 +1275,14 @@ class FlaxMsgpackScanner(BaseScanner):
                             return None
                         objects.append(stream_obj)
                 except Exception as unpack_e:
-                    result.add_check(
-                        name="Msgpack Parse Check",
-                        passed=False,
-                        message=f"Failed to parse msgpack data: {unpack_e}",
-                        severity=IssueSeverity.WARNING,
-                        location=path,
-                        details={"parse_error": str(unpack_e)},
-                        rule_code="S902",
-                    )
-                    result.finish(success=False)
+                    if self._is_msgpack_limit_error(unpack_e):
+                        self._add_msgpack_decode_limit_check(result, path, unpack_e)
+                    else:
+                        self._add_msgpack_parse_failure_check(result, path, unpack_e)
                     return None
 
                 if objects:
-                    trailing_objects_are_container_like = all(
-                        isinstance(stream_obj, (dict, list, tuple)) for stream_obj in objects[1:]
-                    )
-                    result.add_check(
-                        name="Msgpack Stream Integrity Check",
-                        passed=False,
-                        message="Extra trailing data found after msgpack content",
-                        severity=(IssueSeverity.INFO if trailing_objects_are_container_like else IssueSeverity.WARNING),
-                        location=path,
-                        details={
-                            "has_trailing_data": True,
-                            "trailing_object_count": len(objects) - 1,
-                            "trailing_object_types": [type(stream_obj).__name__ for stream_obj in objects[1:9]],
-                            "trailing_objects_are_container_like": trailing_objects_are_container_like,
-                        },
-                        rule_code="S902",
-                    )
+                    self._add_msgpack_stream_integrity_check(objects, result, path)
                     return objects
 
                 result.add_check(
@@ -1045,6 +1308,59 @@ class FlaxMsgpackScanner(BaseScanner):
             )
             result.finish(success=False)
             return None
+
+    def _unpack_msgpack_objects_from_path(self, path: str, result: ScanResult) -> list[Any] | None:
+        """Stream MessagePack from disk so scans do not allocate the whole file before decoding."""
+        unpacker = msgpack.Unpacker(**self._msgpack_unpacker_kwargs())
+        objects: list[Any] = []
+        try:
+            with open(path, "rb") as source:
+                while chunk := source.read(self.chunk_size):
+                    unpacker.feed(chunk)
+                    for stream_obj in unpacker:
+                        if len(objects) >= self.max_msgpack_stream_objects:
+                            result.add_check(
+                                name="Msgpack Stream Object Limit",
+                                passed=False,
+                                message=(
+                                    "Msgpack stream object count exceeds configured limit "
+                                    f"({self.max_msgpack_stream_objects})"
+                                ),
+                                severity=IssueSeverity.WARNING,
+                                location=path,
+                                details={
+                                    "max_msgpack_stream_objects": self.max_msgpack_stream_objects,
+                                    "parsed_object_count": len(objects),
+                                },
+                                rule_code="S902",
+                            )
+                            result.metadata["operational_error"] = True
+                            result.metadata["operational_error_reason"] = "msgpack_stream_object_limit_exceeded"
+                            result.finish(success=False)
+                            return None
+                        objects.append(stream_obj)
+        except Exception as e:
+            if self._is_msgpack_limit_error(e):
+                self._add_msgpack_decode_limit_check(result, path, e)
+            else:
+                self._add_msgpack_parse_failure_check(result, path, e)
+            return None
+
+        if not objects:
+            result.add_check(
+                name="Msgpack Parse Check",
+                passed=False,
+                message="Failed to parse msgpack data: no decodable objects",
+                severity=IssueSeverity.WARNING,
+                location=path,
+                details={"parse_error": "no decodable objects"},
+                rule_code="S902",
+            )
+            result.finish(success=False)
+            return None
+
+        self._add_msgpack_stream_integrity_check(objects, result, path)
+        return objects
 
     def scan(self, path: str) -> ScanResult:
         path_check_result = self._check_path(path)
@@ -1098,11 +1414,7 @@ class FlaxMsgpackScanner(BaseScanner):
         try:
             self.current_file_path = path
 
-            # Read entire file to check for trailing data
-            with open(path, "rb") as f:
-                file_data = f.read()
-
-            objects = self._unpack_msgpack_objects(file_data, result, path)
+            objects = self._unpack_msgpack_objects_from_path(path, result)
             if objects is None:
                 return result
 
@@ -1116,22 +1428,28 @@ class FlaxMsgpackScanner(BaseScanner):
             if len(objects) > 1:
                 result.metadata["msgpack_object_count"] = len(objects)
 
-            # Extract JAX/Flax specific metadata and architecture information
-            ml_analysis = self._analyze_ml_structure(obj, result)
-            self._extract_jax_metadata(obj, result, ml_analysis=ml_analysis)
+            preanalysis_complete = self._check_preanalysis_structure_budget(obj, result, location="root")
+            ml_analysis: dict[str, Any] | None = None
+            if preanalysis_complete:
+                # Extract JAX/Flax specific metadata and architecture information
+                ml_analysis = self._analyze_ml_structure(obj, result)
+                self._extract_jax_metadata(obj, result, ml_analysis=ml_analysis)
 
-            # Validate Flax structure with enhanced analysis
-            self._validate_flax_structure(obj, result, ml_analysis=ml_analysis)
+                # Validate Flax structure with enhanced analysis
+                self._validate_flax_structure(obj, result, ml_analysis=ml_analysis)
 
-            # Check for JAX/Flax specific security threats
-            self._check_jax_specific_threats(obj, result)
+                # Check for JAX/Flax specific security threats
+                self._check_jax_specific_threats(obj, result)
 
             # Perform deep security analysis
-            self._analyze_content(obj, "root", result)
+            traversal_state = self._new_content_traversal_state()
+            self._analyze_content(obj, "root", result, traversal_state=traversal_state)
 
             for object_index, stream_obj in enumerate(objects[1:], start=1):
-                self._check_jax_specific_threats(stream_obj, result)
-                self._analyze_content(stream_obj, f"root[msgpack_object_{object_index}]", result)
+                stream_location = f"root[msgpack_object_{object_index}]"
+                if self._check_preanalysis_structure_budget(stream_obj, result, location=stream_location):
+                    self._check_jax_specific_threats(stream_obj, result)
+                self._analyze_content(stream_obj, stream_location, result, traversal_state=traversal_state)
 
             result.bytes_scanned = file_size
         except MemoryError:

--- a/modelaudit/scanners/flax_msgpack_scanner.py
+++ b/modelaudit/scanners/flax_msgpack_scanner.py
@@ -713,6 +713,8 @@ class FlaxMsgpackScanner(BaseScanner):
             # Try to decode as text to check for embedded code
             try:
                 decoded = value.decode("utf-8", errors="ignore")
+                if check_string_jax_transform:
+                    self._check_jax_transform("", decoded, location, result)
                 if len(decoded) > 50:  # Only check substantial text
                     self._check_suspicious_strings(
                         decoded,
@@ -1301,10 +1303,8 @@ class FlaxMsgpackScanner(BaseScanner):
                     depth=depth + 1,
                     state=state,
                 )
-                try:
-                    pair = {key: value}
-                except TypeError:
-                    pair = {str(key): value}
+                normalized_key = str(key) if isinstance(key, list | dict) else key
+                pair = {normalized_key: value}
                 pairs.append(pair)
                 if not value_complete:
                     return pairs, False
@@ -1459,12 +1459,11 @@ class FlaxMsgpackScanner(BaseScanner):
             if len(objects) > 1:
                 result.metadata["msgpack_object_count"] = len(objects)
 
-            max_nodes_per_object = max(1, self.max_structure_nodes // len(objects))
             preanalysis_complete = self._check_preanalysis_structure_budget(
                 obj,
                 result,
                 location="root",
-                max_nodes=max_nodes_per_object,
+                max_nodes=self.max_structure_nodes,
             )
             ml_analysis: dict[str, Any] | None = None
             if preanalysis_complete:
@@ -1476,16 +1475,17 @@ class FlaxMsgpackScanner(BaseScanner):
                 self._validate_flax_structure(obj, result, ml_analysis=ml_analysis)
 
             # Perform deep security analysis
-            traversal_state = self._new_content_traversal_state(max_nodes=max_nodes_per_object)
+            traversal_state = self._new_content_traversal_state(max_nodes=self.max_structure_nodes)
             self._analyze_content(obj, "root", result, traversal_state=traversal_state)
 
+            trailing_max_nodes_per_object = max(1, self.max_structure_nodes // max(1, len(objects) - 1))
             for object_index, stream_obj in enumerate(objects[1:], start=1):
                 stream_location = f"root[msgpack_object_{object_index}]"
                 self._analyze_content(
                     stream_obj,
                     stream_location,
                     result,
-                    traversal_state=self._new_content_traversal_state(max_nodes=max_nodes_per_object),
+                    traversal_state=self._new_content_traversal_state(max_nodes=trailing_max_nodes_per_object),
                 )
 
             result.bytes_scanned = file_size

--- a/modelaudit/scanners/jax_checkpoint_scanner.py
+++ b/modelaudit/scanners/jax_checkpoint_scanner.py
@@ -7,9 +7,10 @@ import os
 import pickletools
 import re
 from collections import OrderedDict
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import suppress
 from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -658,6 +659,7 @@ class JaxCheckpointScanner(BaseScanner):
         check_name: str = "JSON Pattern Security Check",
         message_prefix: str = "Suspicious pattern in bounded JSON checkpoint prefix",
         depth_check_name: str = "JSON Metadata Traversal Depth Limit",
+        on_string_value: Callable[[str, str], None] | None = None,
     ) -> None:
         """Scan decoded JSON string content visible inside the bounded prefix."""
         with open(path, "rb") as source:
@@ -682,6 +684,8 @@ class JaxCheckpointScanner(BaseScanner):
 
         finding_budget = _PatternFindingBudget(self.max_metadata_pattern_findings)
         for context, text_value in string_values:
+            if on_string_value is not None:
+                on_string_value(context, text_value)
             self._add_suspicious_pattern_checks(
                 text_value,
                 context=context,
@@ -991,6 +995,11 @@ class JaxCheckpointScanner(BaseScanner):
                             check_name="Orbax Pattern Security Check",
                             message_prefix="Suspicious pattern in bounded Orbax metadata prefix",
                             depth_check_name="Orbax Metadata Traversal Depth Limit",
+                            on_string_value=partial(
+                                self._check_bounded_orbax_restore_fn,
+                                path=str(metadata_path),
+                                result=result,
+                            ),
                         )
                         continue
 
@@ -1042,26 +1051,42 @@ class JaxCheckpointScanner(BaseScanner):
                     treat_legacy_pickle_header_as_checkpoint=True,
                 )
 
+    def _check_bounded_orbax_restore_fn(
+        self,
+        context: str,
+        text_value: str,
+        *,
+        path: str,
+        result: ScanResult,
+    ) -> None:
+        """Run the dedicated restore-function check when the root value is visible."""
+        if context == "orbax_metadata_bounded_prefix.restore_fn":
+            self._add_orbax_restore_fn_check(text_value, path, result)
+
+    def _add_orbax_restore_fn_check(self, restore_fn_value: Any, path: str, result: ScanResult) -> None:
+        """Report a visible Orbax restore function with dangerous values promoted."""
+        restore_fn_text = str(restore_fn_value)
+        restore_fn_is_dangerous = bool(self._DANGEROUS_RESTORE_FN_PATTERN.search(restore_fn_text))
+        result.add_check(
+            name="Orbax Restore Function Check",
+            passed=False,
+            message=(
+                "Dangerous restore function detected in Orbax metadata"
+                if restore_fn_is_dangerous
+                else "Custom restore function detected in Orbax metadata"
+            ),
+            severity=IssueSeverity.CRITICAL if restore_fn_is_dangerous else IssueSeverity.WARNING,
+            location=path,
+            details={"restore_fn": restore_fn_text[:200]},
+            rule_code="S302",
+        )
+
     def _analyze_orbax_metadata(self, metadata: dict[str, Any], path: str, result: ScanResult) -> None:
         """Analyze Orbax metadata for security issues."""
 
         # Check for suspicious restore functions
         if "restore_fn" in metadata:
-            restore_fn_value = str(metadata["restore_fn"])
-            restore_fn_is_dangerous = bool(self._DANGEROUS_RESTORE_FN_PATTERN.search(restore_fn_value))
-            result.add_check(
-                name="Orbax Restore Function Check",
-                passed=False,
-                message=(
-                    "Dangerous restore function detected in Orbax metadata"
-                    if restore_fn_is_dangerous
-                    else "Custom restore function detected in Orbax metadata"
-                ),
-                severity=IssueSeverity.CRITICAL if restore_fn_is_dangerous else IssueSeverity.WARNING,
-                location=path,
-                details={"restore_fn": restore_fn_value[:200]},
-                rule_code="S302",
-            )
+            self._add_orbax_restore_fn_check(metadata["restore_fn"], path, result)
 
         # Check for code injection in metadata
         pattern_finding_budget = _PatternFindingBudget(self.max_metadata_pattern_findings)

--- a/modelaudit/scanners/jax_checkpoint_scanner.py
+++ b/modelaudit/scanners/jax_checkpoint_scanner.py
@@ -226,6 +226,7 @@ class JaxCheckpointScanner(BaseScanner):
     _JSON_PREFIX_PATTERN_READ_FAILED_REASON: ClassVar[str] = "jax_json_checkpoint_prefix_pattern_read_failed"
     _METADATA_TRAVERSAL_LIMIT_REASON: ClassVar[str] = "jax_metadata_traversal_depth_limit"
     _PICKLE_SCAN_LIMIT_REASON: ClassVar[str] = "jax_pickle_scan_limit_exceeded"
+    _ORBAX_METADATA_SIZE_LIMIT_REASON: ClassVar[str] = "jax_orbax_metadata_analysis_size_limit"
     _LEGACY_PICKLE_INITIAL_OPCODES: ClassVar[bytes] = (
         b"()BCcFGIJKLMNPSTUVX]}\x82\x83\x84\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x95\x96\x97"
     )
@@ -520,6 +521,7 @@ class JaxCheckpointScanner(BaseScanner):
         cls,
         prefix_text: str,
         *,
+        root_context: str = "json_checkpoint_bounded_prefix",
         depth_cap_contexts: set[str] | None = None,
     ) -> Iterator[tuple[str, str]]:
         """Yield decoded visible JSON strings with bounded ancestor context."""
@@ -554,7 +556,7 @@ class JaxCheckpointScanner(BaseScanner):
                     return
                 kind = "object" if prefix_text[offset] == "{" else "array"
                 state = "key" if kind == "object" else "value"
-                frames.append(_BoundedJsonPrefixFrame(kind, "json_checkpoint_bounded_prefix", state))
+                frames.append(_BoundedJsonPrefixFrame(kind, root_context, state))
                 offset += 1
                 continue
 
@@ -647,7 +649,16 @@ class JaxCheckpointScanner(BaseScanner):
             frame.state = "key" if frame.kind == "object" else "value"
             offset += 1
 
-    def _scan_bounded_json_prefix_patterns(self, path: str, result: ScanResult) -> None:
+    def _scan_bounded_json_prefix_patterns(
+        self,
+        path: str,
+        result: ScanResult,
+        *,
+        context_root: str = "json_checkpoint_bounded_prefix",
+        check_name: str = "JSON Pattern Security Check",
+        message_prefix: str = "Suspicious pattern in bounded JSON checkpoint prefix",
+        depth_check_name: str = "JSON Metadata Traversal Depth Limit",
+    ) -> None:
         """Scan decoded JSON string content visible inside the bounded prefix."""
         with open(path, "rb") as source:
             prefix_text = source.read(JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES).decode("utf-8-sig", errors="ignore")
@@ -659,12 +670,13 @@ class JaxCheckpointScanner(BaseScanner):
         except (json.JSONDecodeError, RecursionError):
             string_values = self._iter_bounded_json_prefix_strings(
                 prefix_text,
+                root_context=context_root,
                 depth_cap_contexts=depth_cap_contexts,
             )
         else:
             string_values = self._iter_string_metadata(
                 parsed_root,
-                "json_checkpoint_bounded_prefix",
+                context_root,
                 depth_cap_contexts=depth_cap_contexts,
             )
 
@@ -673,15 +685,15 @@ class JaxCheckpointScanner(BaseScanner):
             self._add_suspicious_pattern_checks(
                 text_value,
                 context=context,
-                check_name="JSON Pattern Security Check",
-                message_prefix="Suspicious pattern in bounded JSON checkpoint prefix",
+                check_name=check_name,
+                message_prefix=message_prefix,
                 location=path,
                 result=result,
                 finding_budget=finding_budget,
             )
         self._add_metadata_traversal_depth_limit_checks(
             contexts=depth_cap_contexts,
-            check_name="JSON Metadata Traversal Depth Limit",
+            check_name=depth_check_name,
             location=path,
             result=result,
         )
@@ -952,6 +964,36 @@ class JaxCheckpointScanner(BaseScanner):
             metadata_path = path_obj / metadata_file
             if metadata_path.exists():
                 try:
+                    metadata_size = metadata_path.stat().st_size
+                    if metadata_size > JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES:
+                        mark_inconclusive_scan_result(result, self._ORBAX_METADATA_SIZE_LIMIT_REASON)
+                        result.add_check(
+                            name="Orbax Metadata Analysis Limit",
+                            passed=False,
+                            message=(
+                                "Orbax metadata analysis incomplete because the file exceeds the bounded parsing limit"
+                            ),
+                            severity=IssueSeverity.INFO,
+                            location=str(metadata_path),
+                            rule_code="S902",
+                            details={
+                                "file": metadata_file,
+                                "file_size": metadata_size,
+                                "max_json_analysis_bytes": JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES,
+                                "analysis_incomplete": True,
+                                "scan_outcome_reason": self._ORBAX_METADATA_SIZE_LIMIT_REASON,
+                            },
+                        )
+                        self._scan_bounded_json_prefix_patterns(
+                            str(metadata_path),
+                            result,
+                            context_root="orbax_metadata_bounded_prefix",
+                            check_name="Orbax Pattern Security Check",
+                            message_prefix="Suspicious pattern in bounded Orbax metadata prefix",
+                            depth_check_name="Orbax Metadata Traversal Depth Limit",
+                        )
+                        continue
+
                     with open(metadata_path, encoding="utf-8") as f:
                         metadata = json.load(f)
 

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -335,6 +335,25 @@ def test_flax_msgpack_scans_trailing_msgpack_objects(tmp_path: Path) -> None:
     )
 
 
+def test_flax_msgpack_preserves_trailing_scan_after_first_object_exhausts_node_budget(tmp_path: Path) -> None:
+    """A large first object must not starve a small malicious trailing object."""
+    path = tmp_path / "trailing_after_budget.msgpack"
+    payload = msgpack.packb({"params": list(range(8))}, use_bin_type=True)
+    payload += msgpack.packb("eval('x')", use_bin_type=True)
+    path.write_bytes(payload)
+
+    result = FlaxMsgpackScanner(config={"max_msgpack_structure_nodes": 4}).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert any(
+        issue.severity == IssueSeverity.CRITICAL
+        and issue.message == r"Suspicious code pattern detected: eval\s*\("
+        and issue.location == "root[msgpack_object_1]"
+        for issue in result.issues
+    )
+
+
 def test_flax_msgpack_benign_trailing_dict_object_is_info_only(tmp_path: Path) -> None:
     """Valid trailing dict objects should be scanned without warning-level stream noise."""
     path = tmp_path / "benign_two_objects.msgpack"
@@ -461,6 +480,54 @@ def test_flax_msgpack_decode_limit_is_inconclusive(tmp_path: Path) -> None:
         and check.details["analysis_incomplete"] is True
         for check in result.checks
     )
+
+
+@pytest.mark.parametrize(
+    "oversized_value",
+    [
+        ["eval('x')", "safe", "extra"],
+        {"payload": "eval('x')", "safe": "ok", "extra": "ok"},
+    ],
+)
+def test_flax_msgpack_decode_limit_scans_visible_oversized_container_prefix(
+    tmp_path: Path,
+    oversized_value: object,
+) -> None:
+    """Early malicious values remain visible when a container exceeds the decode cap."""
+    path = tmp_path / "oversized_container.msgpack"
+    create_msgpack_file(path, {"params": oversized_value})
+
+    result = FlaxMsgpackScanner(
+        config={
+            "max_items_per_container": 2,
+            "max_msgpack_decode_bytes": 1024,
+        }
+    ).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert FlaxMsgpackScanner.DECODE_LIMIT_INCONCLUSIVE_REASON in result.metadata["scan_outcome_reasons"]
+    assert any(
+        issue.severity == IssueSeverity.CRITICAL and issue.message == r"Suspicious code pattern detected: eval\s*\("
+        for issue in result.issues
+    )
+
+
+def test_flax_msgpack_decode_limit_does_not_join_adjacent_visible_strings(tmp_path: Path) -> None:
+    """Structurally separate values must not become a synthetic suspicious pattern."""
+    path = tmp_path / "oversized_benign_strings.msgpack"
+    create_msgpack_file(path, {"params": ["ev", "al(", "extra"]})
+
+    result = FlaxMsgpackScanner(
+        config={
+            "max_items_per_container": 2,
+            "max_msgpack_decode_bytes": 1024,
+        }
+    ).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert not any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
 
 
 def test_flax_msgpack_large_containers(tmp_path):

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -142,8 +142,8 @@ def test_flax_scan_reuses_ml_structure_analysis(
     assert analyze_calls == 1
 
 
-def test_flax_ml_structure_reuses_lowered_object_text() -> None:
-    """Layer-keyword analysis should stringify the checkpoint object once."""
+def test_flax_ml_structure_uses_bounded_text_without_whole_object_stringification() -> None:
+    """Layer-keyword analysis should not stringify the whole checkpoint object."""
 
     class StringCountingDict(dict[str, Any]):
         stringify_calls = 0
@@ -157,7 +157,7 @@ def test_flax_ml_structure_reuses_lowered_object_text() -> None:
 
     scanner._analyze_ml_structure(obj, scanner._create_result())
 
-    assert obj.stringify_calls == 1
+    assert obj.stringify_calls == 0
 
 
 def test_flax_msgpack_suspicious_content(tmp_path):
@@ -396,6 +396,43 @@ def test_flax_msgpack_caps_trailing_stream_object_count(tmp_path: Path) -> None:
     assert object_limit_checks[0].details["max_msgpack_stream_objects"] == 4
 
 
+def test_flax_msgpack_streaming_decode_does_not_call_unpackb(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Native scans should stream through Unpacker instead of full-buffer unpackb."""
+    path = tmp_path / "streamed.msgpack"
+    create_msgpack_file(path, {"params": {"w": [1, 2, 3]}})
+
+    def fail_unpackb(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("scan should not full-buffer decode through msgpack.unpackb")
+
+    monkeypatch.setattr(msgpack, "unpackb", fail_unpackb)
+
+    result = FlaxMsgpackScanner().scan(str(path))
+
+    assert result.success is True
+    assert result.metadata.get("top_level_type") == "dict"
+
+
+def test_flax_msgpack_decode_limit_is_inconclusive(tmp_path: Path) -> None:
+    """Oversized MessagePack members should fail closed before materializing content."""
+    path = tmp_path / "oversized_blob.msgpack"
+    create_msgpack_file(path, {"params": {"blob": b"x" * 512}})
+
+    result = FlaxMsgpackScanner(config={"max_msgpack_decode_bytes": 128}).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert FlaxMsgpackScanner.DECODE_LIMIT_INCONCLUSIVE_REASON in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Msgpack Decode Budget"
+        and check.status == CheckStatus.FAILED
+        and check.details["analysis_incomplete"] is True
+        for check in result.checks
+    )
+
+
 def test_flax_msgpack_large_containers(tmp_path):
     """Test detection of containers with excessive items."""
     path = tmp_path / "large.msgpack"
@@ -414,11 +451,10 @@ def test_flax_msgpack_large_containers(tmp_path):
     scanner = FlaxMsgpackScanner()
     result = scanner.scan(str(path))
 
-    info_issues = [issue for issue in result.issues if issue.severity == IssueSeverity.INFO]
-    assert len(info_issues) >= 2  # Should report both large containers at INFO level
-
-    issue_messages = [issue.message for issue in info_issues]
-    assert any("excessive items" in msg for msg in issue_messages)
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert FlaxMsgpackScanner.DECODE_LIMIT_INCONCLUSIVE_REASON in result.metadata["scan_outcome_reasons"]
+    assert any(check.name == "Msgpack Decode Budget" for check in result.checks)
 
 
 def test_flax_msgpack_deep_nesting_is_inconclusive(tmp_path: Path) -> None:
@@ -473,6 +509,32 @@ def test_flax_msgpack_renamed_hidden_pattern_beyond_recursion_limit_is_inconclus
         tmp_path / "hidden-payload-cache",
         max_recursion_depth=2,
     )
+
+
+def test_flax_msgpack_preanalysis_depth_limit_skips_unbounded_ml_helpers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deep structures should fail closed before ML metadata helpers recurse over them."""
+    path = tmp_path / "preanalysis_deep.msgpack"
+    nested: object = "benign"
+    for _ in range(6):
+        nested = {"nested": nested}
+    create_msgpack_file(path, {"params": nested})
+
+    scanner = FlaxMsgpackScanner(config={"max_recursion_depth": 2})
+
+    def fail_analyze(_obj: Any, _result: ScanResult) -> dict[str, Any]:
+        raise AssertionError("ML structure helper should be skipped once preanalysis depth is exhausted")
+
+    monkeypatch.setattr(scanner, "_analyze_ml_structure", fail_analyze)
+
+    result = scanner.scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert FlaxMsgpackScanner.RECURSION_LIMIT_INCONCLUSIVE_REASON in result.metadata["scan_outcome_reasons"]
+    assert any(check.name == "Flax MessagePack Preanalysis Depth Limit" for check in result.checks)
 
 
 def test_flax_msgpack_pattern_within_recursion_limit_remains_security_finding(tmp_path: Path) -> None:

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -513,6 +513,48 @@ def test_flax_msgpack_decode_limit_scans_visible_oversized_container_prefix(
     )
 
 
+def test_flax_msgpack_decode_limit_scans_visible_jax_transform_prefix(tmp_path: Path) -> None:
+    """Dedicated JAX checks must run on the visible prefix of oversized containers."""
+    path = tmp_path / "oversized_jax_transform.msgpack"
+    create_msgpack_file(path, {"params": [{"jit_compile": "safe"}, "safe", "extra"]})
+
+    result = FlaxMsgpackScanner(
+        config={
+            "max_items_per_container": 2,
+            "max_msgpack_decode_bytes": 1024,
+        }
+    ).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    jax_checks = [
+        check
+        for check in result.checks
+        if check.name == "JAX Transform Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details["transform"] == "jit_compile"
+    ]
+    assert len(jax_checks) == 1
+
+
+def test_flax_msgpack_decode_limit_does_not_join_adjacent_jax_transform_parts(tmp_path: Path) -> None:
+    """Separate visible keys and values must not synthesize a JAX transform."""
+    path = tmp_path / "oversized_jax_transform_parts.msgpack"
+    create_msgpack_file(path, {"params": [{"jit": "compile"}, "safe", "extra"]})
+
+    result = FlaxMsgpackScanner(
+        config={
+            "max_items_per_container": 2,
+            "max_msgpack_decode_bytes": 1024,
+        }
+    ).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert all(check.name != "JAX Transform Security Check" for check in result.checks)
+
+
 def test_flax_msgpack_decode_limit_does_not_join_adjacent_visible_strings(tmp_path: Path) -> None:
     """Structurally separate values must not become a synthetic suspicious pattern."""
     path = tmp_path / "oversized_benign_strings.msgpack"

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -354,6 +354,24 @@ def test_flax_msgpack_preserves_trailing_scan_after_first_object_exhausts_node_b
     )
 
 
+def test_flax_msgpack_trailing_objects_do_not_dilute_primary_scan_budget(tmp_path: Path) -> None:
+    """Many trailing objects must not shrink the primary checkpoint's security traversal."""
+    path = tmp_path / "primary_before_many_trailing.msgpack"
+    payload = msgpack.packb({"params": ["safe", "eval('x')"]}, use_bin_type=True)
+    payload += b"".join(msgpack.packb("safe", use_bin_type=True) for _ in range(3))
+    path.write_bytes(payload)
+
+    result = FlaxMsgpackScanner(config={"max_msgpack_structure_nodes": 4}).scan(str(path))
+
+    assert result.success is False
+    assert any(
+        issue.severity == IssueSeverity.CRITICAL
+        and issue.message == r"Suspicious code pattern detected: eval\s*\("
+        and issue.location == "root/params[1]"
+        for issue in result.issues
+    )
+
+
 def test_flax_msgpack_benign_trailing_dict_object_is_info_only(tmp_path: Path) -> None:
     """Valid trailing dict objects should be scanned without warning-level stream noise."""
     path = tmp_path / "benign_two_objects.msgpack"
@@ -536,6 +554,23 @@ def test_flax_msgpack_decode_limit_scans_visible_jax_transform_prefix(tmp_path: 
         and check.details["transform"] == "jit_compile"
     ]
     assert len(jax_checks) == 1
+
+
+def test_flax_msgpack_scans_byte_encoded_jax_transform_metadata(tmp_path: Path) -> None:
+    """Byte-valued JAX metadata must retain the dedicated transform check."""
+    path = tmp_path / "byte_jax_transform.msgpack"
+    create_msgpack_file(path, {"params": {"x": b"jit_compile"}})
+
+    result = FlaxMsgpackScanner().scan(str(path))
+
+    assert result.success is False
+    assert any(
+        check.name == "JAX Transform Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details["transform"] == "jit_compile"
+        for check in result.checks
+    )
 
 
 def test_flax_msgpack_decode_limit_does_not_join_adjacent_jax_transform_parts(tmp_path: Path) -> None:

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -375,6 +375,23 @@ def test_flax_msgpack_scalar_trailing_junk_stays_warning(tmp_path: Path) -> None
     assert stream_checks[0].details["trailing_objects_are_container_like"] is False
 
 
+def test_flax_msgpack_incomplete_trailing_object_fails_closed(tmp_path: Path) -> None:
+    """A partial trailing object must not disappear into the streaming unpacker buffer."""
+    path = tmp_path / "incomplete_trailing_object.msgpack"
+    payload = msgpack.packb({"params": {"w": [1, 2, 3]}}, use_bin_type=True) + b"\x81\xa1"
+    path.write_bytes(payload)
+
+    result = FlaxMsgpackScanner().scan(str(path))
+
+    assert result.success is False
+    assert any(
+        check.name == "Msgpack Parse Check"
+        and check.status == CheckStatus.FAILED
+        and check.details["parse_error"] == "incomplete trailing msgpack object"
+        for check in result.checks
+    )
+
+
 def test_flax_msgpack_caps_trailing_stream_object_count(tmp_path: Path) -> None:
     """Too many trailing msgpack objects should fail closed without materializing the full stream."""
     path = tmp_path / "many_objects.msgpack"
@@ -413,6 +430,19 @@ def test_flax_msgpack_streaming_decode_does_not_call_unpackb(
 
     assert result.success is True
     assert result.metadata.get("top_level_type") == "dict"
+
+
+def test_flax_msgpack_small_decode_buffer_accepts_stream_of_small_objects(tmp_path: Path) -> None:
+    """A bounded decoder should stream complete small objects without buffering the whole file."""
+    path = tmp_path / "small_stream_objects.msgpack"
+    payload = b"".join(msgpack.packb({"params": {"n": [index]}}, use_bin_type=True) for index in range(8))
+    path.write_bytes(payload)
+
+    result = FlaxMsgpackScanner(config={"max_msgpack_decode_bytes": 32}).scan(str(path))
+
+    assert result.success is True
+    assert result.metadata.get("msgpack_object_count") == 8
+    assert all(check.name != "Msgpack Decode Budget" for check in result.checks)
 
 
 def test_flax_msgpack_decode_limit_is_inconclusive(tmp_path: Path) -> None:

--- a/tests/scanners/test_jax_checkpoint_scanner.py
+++ b/tests/scanners/test_jax_checkpoint_scanner.py
@@ -2100,6 +2100,57 @@ def test_oversized_orbax_metadata_reports_visible_bounded_pattern(tmp_path: Path
     )
 
 
+def test_oversized_orbax_metadata_reports_visible_dangerous_restore_fn(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "oversized_orbax_restore_fn"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "type": "orbax_checkpoint",
+                "restore_fn": "os.system",
+                "padding": "x" * (JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES + 16),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "jax_orbax_metadata_analysis_size_limit" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Orbax Restore Function Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details["restore_fn"] == "os.system"
+        for check in result.checks
+    )
+
+
+def test_oversized_orbax_metadata_keeps_visible_benign_restore_fn_warning_only(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "oversized_orbax_benign_restore_fn"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "type": "orbax_checkpoint",
+                "restore_fn": "custom_deserialize",
+                "padding": "x" * (JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES + 16),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    restore_checks = [check for check in result.checks if check.name == "Orbax Restore Function Check"]
+    assert len(restore_checks) == 1
+    assert restore_checks[0].status == CheckStatus.FAILED
+    assert restore_checks[0].severity == IssueSeverity.WARNING
+    assert restore_checks[0].details["restore_fn"] == "custom_deserialize"
+
+
 def test_orbax_metadata_read_failure_is_inconclusive(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/scanners/test_jax_checkpoint_scanner.py
+++ b/tests/scanners/test_jax_checkpoint_scanner.py
@@ -2035,6 +2035,71 @@ def test_malformed_orbax_metadata_is_inconclusive(tmp_path: Path) -> None:
     )
 
 
+def test_oversized_orbax_metadata_fails_closed_without_json_load(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkpoint_dir = tmp_path / "oversized_orbax"
+    checkpoint_dir.mkdir()
+    padding = "x" * (JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES + 16)
+    (checkpoint_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "type": "orbax_checkpoint",
+                "padding": padding,
+                "payload": "jax.experimental.host_callback.call(os.system, 'id')",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fail_json_load(_stream: Any) -> Any:
+        raise AssertionError("oversized Orbax metadata must not be fully loaded")
+
+    monkeypatch.setattr("modelaudit.scanners.jax_checkpoint_scanner.json.load", fail_json_load)
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "jax_orbax_metadata_analysis_size_limit" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Orbax Metadata Analysis Limit"
+        and check.status == CheckStatus.FAILED
+        and check.details["analysis_incomplete"] is True
+        for check in result.checks
+    )
+    assert all(check.name != "Orbax Pattern Security Check" for check in result.checks)
+
+
+def test_oversized_orbax_metadata_reports_visible_bounded_pattern(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "oversized_orbax_visible"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "type": "orbax_checkpoint",
+                "payload": "jax.experimental.host_callback.call(os.system, 'id')",
+                "padding": "x" * (JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES + 16),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = JaxCheckpointScanner().scan(str(checkpoint_dir))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "jax_orbax_metadata_analysis_size_limit" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Orbax Pattern Security Check"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details["context"] == "orbax_metadata_bounded_prefix.payload"
+        for check in result.checks
+    )
+
+
 def test_orbax_metadata_read_failure_is_inconclusive(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Summary:\n- stream Flax MessagePack through bounded unpacker limits\n- cap Flax/JAX helper traversal and fail closed on oversize metadata\n- add C171/C173 regressions for oversized/deep fixtures and visible bounded-prefix findings\n\nValidation:\n- Flax + JAX focused suites: 146 passed\n- new C171/C173 regressions: 4 passed\n- ruff check/format, mypy, git diff --check