### PR TITLE
fix: fail closed on embedded Python JIT budget gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - detect embedded Python `asyncio.create_subprocess_*` calls and resolved JIT `subprocess` launch aliases
 - detect embedded Python `runpy.run_module`, `runpy.run_path`, and `runpy._run_module_as_main` dynamic-module execution calls
 - preserve embedded Python runpy, webbrowser, and ctypes findings across continued imports, late aliases, and bounded tail-window extraction gaps
+- mark embedded Python/JIT byte and snippet budget exhaustion as incomplete coverage instead of clean scans
 - detect embedded Python `webbrowser` launches and `ctypes` native-library loads in archives and JIT-scanned content
 - resolve embedded `ctypes` loads through more CDLL-subclass construction forms (`__new__` returning inside `try`/`for`/`while`/`with`, `super()`/`*args` initializer forwarding) and indirect loader/controller bindings (conditional, boolean, walrus, and loop-bound expressions)
 - honor benign loader/controller member overwrites spelled as `setattr(..., **{})` or starred `setattr(*(...))`

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -142,6 +142,7 @@ _MAX_PRIORITY_ASSIGNMENT_PROBES = 48
 # Bound nested ``:``-header recursion when extracting an embedded statement so a
 # crafted deeply-indented blob cannot exhaust the interpreter stack.
 _MAX_BODY_STATEMENT_NESTING = 100
+_MAX_EMBEDDED_PYTHON_SOURCE_START_PROBES = 64
 _EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT = 1_000_000
 _EMBEDDED_PYTHON_SCAN_WINDOW_BYTES = 1_000_000
 _MAX_EMBEDDED_PYTHON_IMPORT_CONTEXT_BYTES = 16_384
@@ -193,6 +194,25 @@ _COMPOUND_HEADER_MATCH_PATTERN = re.compile(
     rb"\b(?:async\s+def|if|elif|else|for|while|try|except|finally|with|class|def)\b"
 )
 _EmbeddedPythonCandidate = tuple[bytes, tuple[int, int], tuple[tuple[int, int], ...]]
+
+
+def _has_source_like_embedded_python_start(data: bytes) -> bool:
+    """Return whether a Python start marker follows source indentation or binary framing."""
+    source_start_probes = 0
+    for match in _EMBEDDED_PYTHON_START_PATTERN.finditer(data):
+        cursor = match.start()
+        while cursor > 0 and data[cursor - 1] in b" \t\r":
+            cursor -= 1
+        if cursor > 0 and data[cursor - 1] != 0x0A and 0x20 <= data[cursor - 1] < 0x7F:
+            continue
+        source_start_probes += 1
+        if source_start_probes > _MAX_EMBEDDED_PYTHON_SOURCE_START_PROBES:
+            return True
+        candidate = data[match.start() : match.start() + _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES]
+        code_str, _byte_offsets = _decode_utf8_with_byte_offsets(candidate)
+        if _parse_embedded_python_snippet(code_str) is not None:
+            return True
+    return False
 
 
 def _resolve_alias_aware_high_risk_calls(tree: ast.AST) -> set[tuple[str, str]]:
@@ -1740,7 +1760,7 @@ class JITScriptDetector:
         # Look for embedded Python code even when framework markers are absent.
         # Scanner callers can hand us raw code-bearing blobs, and an attacker can
         # remove marker strings without removing the executable payload.
-        if _EMBEDDED_PYTHON_START_PATTERN.search(data) is not None:
+        if _has_source_like_embedded_python_start(data):
             code_findings = self._extract_and_check_python_code(data, "TorchScript", context)
             findings.extend(code_findings)
 
@@ -2477,7 +2497,7 @@ class JITScriptDetector:
         if model_type == "onnx":
             findings.extend(self.scan_onnx(data, context))
 
-        if model_type == "pickle" and _EMBEDDED_PYTHON_START_PATTERN.search(data) is not None:
+        if model_type == "pickle" and _has_source_like_embedded_python_start(data):
             findings.extend(self._extract_and_check_python_code(data, "Generic Python", context))
 
         # Always check for generic dangerous patterns

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -182,6 +182,12 @@ _EMBEDDED_PYTHON_START_PATTERN = re.compile(
     rb"(?:(?:async\s+)?def\s+\w+|class\s+\w+|import\s+[A-Za-z_][\w.]*|"
     rb"from\s+[A-Za-z_][\w.]*(?:\s|\\\r?\n)+import)"
 )
+_UNAMBIGUOUS_EMBEDDED_PYTHON_START_PATTERN = re.compile(
+    rb"(?:(?:async\s+)?def\s+\w+\s*[\[(]|"
+    rb"class\s+\w+\s*[\[(:]|"
+    rb"import\s+[A-Za-z_][\w.]*(?:\s*(?:,|as\b|\\\r?\n|\r?\n|$))|"
+    rb"from\s+[A-Za-z_][\w.]*(?:\s|\\\r?\n)+import(?:\s|\\\r?\n)+(?:\(|[A-Za-z_*]))"
+)
 _EMBEDDED_PYTHON_CONTEXT_START_PATTERN = re.compile(
     rb"(?<![A-Za-z0-9_'\".])(?:if\s+True\s*:|import\s+[A-Za-z_][\w.]*|from\s+[A-Za-z_][\w.]*|"
     + _EMBEDDED_PYTHON_CONTEXT_ASSIGNMENT_LHS_PATTERN
@@ -211,6 +217,8 @@ def _has_source_like_embedded_python_start(data: bytes, *, start_offset: int = 0
         candidate = data[match.start() : match.start() + _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES]
         code_str, _byte_offsets = _decode_utf8_with_byte_offsets(candidate)
         if _parse_embedded_python_snippet(code_str) is not None:
+            return True
+        if _UNAMBIGUOUS_EMBEDDED_PYTHON_START_PATTERN.match(candidate):
             return True
     return False
 

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -975,24 +975,27 @@ def _compact_candidate_segments(candidate: bytes, segment_ranges: list[tuple[int
 def _select_prioritized_embedded_python_snippets(
     candidates: list[_EmbeddedPythonCandidate],
     bounded: bytes | None = None,
-) -> tuple[list[_EmbeddedPythonCandidate], int]:
+) -> tuple[list[_EmbeddedPythonCandidate], list[tuple[int, int]]]:
     selected: list[_EmbeddedPythonCandidate] = []
     selected_spans: set[tuple[int, int]] = set()
     priority_offsets = _priority_import_offsets(bounded) if bounded is not None else []
+    selected_default_candidates = 0
     selected_priority_candidates = 0
-    omitted_budgeted_candidates = 0
-    for index, (candidate, span, real_ranges) in enumerate(candidates):
+    omitted_budgeted_spans: list[tuple[int, int]] = []
+    for candidate, span, real_ranges in candidates:
+        if span in selected_spans:
+            continue
         has_priority_marker = (
             _span_contains_priority_offset(span, priority_offsets)
             if bounded is not None
             else _PRIORITY_EMBEDDED_PYTHON_IMPORT_PATTERN.search(candidate.lower()) is not None
         )
-        if index >= _MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS:
+        if selected_default_candidates >= _MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS:
             if not has_priority_marker:
-                omitted_budgeted_candidates += 1
+                omitted_budgeted_spans.append(span)
                 continue
             if selected_priority_candidates >= _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPETS:
-                omitted_budgeted_candidates += 1
+                omitted_budgeted_spans.append(span)
                 continue
             if bounded is not None:
                 candidate, span, real_ranges = _bounded_priority_embedded_python_candidate(
@@ -1002,19 +1005,21 @@ def _select_prioritized_embedded_python_snippets(
                 candidate = candidate[:_MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES]
                 span = (span[0], span[0] + len(candidate))
                 real_ranges = (span,)
+            if span in selected_spans:
+                continue
             selected_priority_candidates += 1
-        if span in selected_spans:
-            continue
+        else:
+            selected_default_candidates += 1
         selected_spans.add(span)
         selected.append((candidate, span, real_ranges))
-    return selected, omitted_budgeted_candidates
+    return selected, omitted_budgeted_spans
 
 
 def _prioritized_embedded_python_snippets(
     candidates: list[_EmbeddedPythonCandidate],
     bounded: bytes | None = None,
 ) -> list[_EmbeddedPythonCandidate]:
-    selected, _omitted_budgeted_candidates = _select_prioritized_embedded_python_snippets(candidates, bounded)
+    selected, _omitted_budgeted_spans = _select_prioritized_embedded_python_snippets(candidates, bounded)
     return selected
 
 
@@ -1735,7 +1740,7 @@ class JITScriptDetector:
         # Look for embedded Python code even when framework markers are absent.
         # Scanner callers can hand us raw code-bearing blobs, and an attacker can
         # remove marker strings without removing the executable payload.
-        if b"def " in data or b"class " in data:
+        if _EMBEDDED_PYTHON_START_PATTERN.search(data) is not None:
             code_findings = self._extract_and_check_python_code(data, "TorchScript", context)
             findings.extend(code_findings)
 
@@ -1948,7 +1953,7 @@ class JITScriptDetector:
 
         bounded = data if include_full_source else data[:_EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT]
         matches = _candidate_embedded_python_snippets(bounded, include_full_source=include_full_source)
-        prioritized_matches, omitted_budgeted_candidates = _select_prioritized_embedded_python_snippets(
+        prioritized_matches, omitted_budgeted_spans = _select_prioritized_embedded_python_snippets(
             matches, bounded=bounded
         )
         if not include_full_source and len(data) > _EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT:
@@ -1961,20 +1966,6 @@ class JITScriptDetector:
                     max_scan_bytes=_EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT,
                 )
             )
-        if omitted_budgeted_candidates:
-            findings.append(
-                _embedded_python_analysis_incomplete_finding(
-                    framework=framework,
-                    context=context,
-                    reason=_EMBEDDED_PYTHON_SNIPPET_LIMIT_REASON,
-                    message=("Embedded Python/JIT analysis incomplete: candidate snippet budget was exceeded"),
-                    omitted_snippets=omitted_budgeted_candidates,
-                    candidates_count=len(matches),
-                )
-            )
-        if not prioritized_matches and omitted_budgeted_candidates:
-            return findings
-
         bounded_high_risk_calls: set[tuple[str, str]] | None = None
         snippet_high_risk_calls: set[tuple[str, str]] = set()
         parsed_snippet_spans: list[tuple[int, int]] = []
@@ -2062,6 +2053,21 @@ class JITScriptDetector:
             except Exception:
                 # Failed to process this code snippet
                 continue
+
+        uncovered_omitted_spans = [
+            span for span in omitted_budgeted_spans if not _is_span_inside_parsed_spans(span, parsed_snippet_spans)
+        ]
+        if uncovered_omitted_spans:
+            findings.append(
+                _embedded_python_analysis_incomplete_finding(
+                    framework=framework,
+                    context=context,
+                    reason=_EMBEDDED_PYTHON_SNIPPET_LIMIT_REASON,
+                    message=("Embedded Python/JIT analysis incomplete: candidate snippet budget was exceeded"),
+                    omitted_snippets=len(uncovered_omitted_spans),
+                    candidates_count=len(matches),
+                )
+            )
 
         # Check for common code execution patterns in binary
         resolved_high_risk_calls = (bounded_high_risk_calls or set()) | snippet_high_risk_calls
@@ -2471,7 +2477,7 @@ class JITScriptDetector:
         if model_type == "onnx":
             findings.extend(self.scan_onnx(data, context))
 
-        if model_type == "pickle" and (b"def " in data or b"class " in data):
+        if model_type == "pickle" and _EMBEDDED_PYTHON_START_PATTERN.search(data) is not None:
             findings.extend(self._extract_and_check_python_code(data, "Generic Python", context))
 
         # Always check for generic dangerous patterns

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -196,10 +196,10 @@ _COMPOUND_HEADER_MATCH_PATTERN = re.compile(
 _EmbeddedPythonCandidate = tuple[bytes, tuple[int, int], tuple[tuple[int, int], ...]]
 
 
-def _has_source_like_embedded_python_start(data: bytes) -> bool:
+def _has_source_like_embedded_python_start(data: bytes, *, start_offset: int = 0) -> bool:
     """Return whether a Python start marker follows source indentation or binary framing."""
     source_start_probes = 0
-    for match in _EMBEDDED_PYTHON_START_PATTERN.finditer(data):
+    for match in _EMBEDDED_PYTHON_START_PATTERN.finditer(data, start_offset):
         cursor = match.start()
         while cursor > 0 and data[cursor - 1] in b" \t\r":
             cursor -= 1
@@ -1976,7 +1976,23 @@ class JITScriptDetector:
         prioritized_matches, omitted_budgeted_spans = _select_prioritized_embedded_python_snippets(
             matches, bounded=bounded
         )
-        if not include_full_source and len(data) > _EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT:
+        has_bounded_source = _has_source_like_embedded_python_start(bounded)
+        has_source_beyond_bound = (
+            not include_full_source
+            and len(data) > _EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT
+            and _has_source_like_embedded_python_start(
+                data,
+                start_offset=max(
+                    0,
+                    _EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT - _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES,
+                ),
+            )
+        )
+        if (
+            not include_full_source
+            and len(data) > _EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT
+            and (has_bounded_source or has_source_beyond_bound)
+        ):
             findings.append(
                 _embedded_python_analysis_incomplete_finding(
                     framework=framework,
@@ -2486,19 +2502,39 @@ class JITScriptDetector:
             elif b"onnx" in data or b"ai.onnx" in data:
                 model_type = "onnx"
 
+        source_like_embedded_python = (
+            _has_source_like_embedded_python_start(data)
+            if model_type == "pickle"
+            or (
+                model_type in ["pytorch", "torchscript", "unknown"] and len(data) <= _EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT
+            )
+            else False
+        )
+        model_specific_embedded_python_fully_scanned = False
+
         # Scan based on model type
         if model_type in ["pytorch", "torchscript"]:
             findings.extend(self.scan_torchscript(data, context))
             findings.extend(self.scan_advanced_torchscript_vulnerabilities(data, context))
+            model_specific_embedded_python_fully_scanned = (
+                source_like_embedded_python and len(data) <= _EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT
+            )
 
         if model_type in ["tensorflow", "tf", "keras"]:
             findings.extend(self.scan_tensorflow(data, context))
+            model_specific_embedded_python_fully_scanned = (
+                len(data) <= _EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT
+                and (b"SavedFunction" in data or b"saved_model.pb" in data)
+                and (b"python_function" in data or b"function_spec" in data)
+                and _has_source_like_embedded_python_start(data)
+            )
 
         if model_type == "onnx":
             findings.extend(self.scan_onnx(data, context))
 
-        if model_type == "pickle" and _has_source_like_embedded_python_start(data):
+        if model_type == "pickle" and source_like_embedded_python:
             findings.extend(self._extract_and_check_python_code(data, "Generic Python", context))
+            model_specific_embedded_python_fully_scanned = len(data) <= _EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT
 
         # Always check for generic dangerous patterns
         # Only run fallback scanners if model type is truly unknown
@@ -2510,8 +2546,16 @@ class JITScriptDetector:
             findings.extend(self.scan_advanced_torchscript_vulnerabilities(data, context))
             findings.extend(self.scan_tensorflow(data, context))
             findings.extend(self.scan_onnx(data, context))
+            model_specific_embedded_python_fully_scanned = len(data) <= _EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT and (
+                source_like_embedded_python
+                or (
+                    (b"SavedFunction" in data or b"saved_model.pb" in data)
+                    and (b"python_function" in data or b"function_spec" in data)
+                    and _has_source_like_embedded_python_start(data)
+                )
+            )
 
-        if self._looks_like_dangerous_python_source(data):
+        if not model_specific_embedded_python_fully_scanned and self._looks_like_dangerous_python_source(data):
             findings.extend(
                 self._extract_and_check_python_code(
                     data,
@@ -2520,7 +2564,7 @@ class JITScriptDetector:
                     include_full_source=True,
                 )
             )
-        elif self._looks_like_framed_dangerous_python_source(data):
+        elif not model_specific_embedded_python_fully_scanned and self._looks_like_framed_dangerous_python_source(data):
             for window, include_full_source in _embedded_python_extraction_windows(data):
                 findings.extend(
                     self._extract_and_check_python_code(

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -142,8 +142,11 @@ _MAX_PRIORITY_ASSIGNMENT_PROBES = 48
 # Bound nested ``:``-header recursion when extracting an embedded statement so a
 # crafted deeply-indented blob cannot exhaust the interpreter stack.
 _MAX_BODY_STATEMENT_NESTING = 100
+_EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT = 1_000_000
 _EMBEDDED_PYTHON_SCAN_WINDOW_BYTES = 1_000_000
 _MAX_EMBEDDED_PYTHON_IMPORT_CONTEXT_BYTES = 16_384
+_EMBEDDED_PYTHON_BYTE_LIMIT_REASON = "jit_embedded_python_byte_limit"
+_EMBEDDED_PYTHON_SNIPPET_LIMIT_REASON = "jit_embedded_python_snippet_limit"
 _EMBEDDED_PYTHON_START_MARKERS = (b"def ", b"async def ", b"class ", b"import ", b"from ")
 _PRIORITY_EMBEDDED_PYTHON_MODULES = tuple(
     sorted(
@@ -969,14 +972,15 @@ def _compact_candidate_segments(candidate: bytes, segment_ranges: list[tuple[int
     return b"\n".join(candidate[start:end].rstrip(b"\n") for start, end in segment_ranges)
 
 
-def _prioritized_embedded_python_snippets(
+def _select_prioritized_embedded_python_snippets(
     candidates: list[_EmbeddedPythonCandidate],
     bounded: bytes | None = None,
-) -> list[_EmbeddedPythonCandidate]:
+) -> tuple[list[_EmbeddedPythonCandidate], int]:
     selected: list[_EmbeddedPythonCandidate] = []
     selected_spans: set[tuple[int, int]] = set()
     priority_offsets = _priority_import_offsets(bounded) if bounded is not None else []
     selected_priority_candidates = 0
+    omitted_budgeted_candidates = 0
     for index, (candidate, span, real_ranges) in enumerate(candidates):
         has_priority_marker = (
             _span_contains_priority_offset(span, priority_offsets)
@@ -985,8 +989,10 @@ def _prioritized_embedded_python_snippets(
         )
         if index >= _MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS:
             if not has_priority_marker:
+                omitted_budgeted_candidates += 1
                 continue
             if selected_priority_candidates >= _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPETS:
+                omitted_budgeted_candidates += 1
                 continue
             if bounded is not None:
                 candidate, span, real_ranges = _bounded_priority_embedded_python_candidate(
@@ -1001,6 +1007,14 @@ def _prioritized_embedded_python_snippets(
             continue
         selected_spans.add(span)
         selected.append((candidate, span, real_ranges))
+    return selected, omitted_budgeted_candidates
+
+
+def _prioritized_embedded_python_snippets(
+    candidates: list[_EmbeddedPythonCandidate],
+    bounded: bytes | None = None,
+) -> list[_EmbeddedPythonCandidate]:
+    selected, _omitted_budgeted_candidates = _select_prioritized_embedded_python_snippets(candidates, bounded)
     return selected
 
 
@@ -1364,6 +1378,44 @@ def _bounded_priority_tail_starts(tail_starts: list[int]) -> list[int]:
     head_count = _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPETS // 2
     tail_count = _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPETS - head_count
     return [*tail_starts[:head_count], *tail_starts[-tail_count:]]
+
+
+def _embedded_python_analysis_incomplete_finding(
+    *,
+    framework: str,
+    context: str,
+    reason: str,
+    message: str,
+    max_scan_bytes: int | None = None,
+    omitted_snippets: int | None = None,
+    candidates_count: int | None = None,
+) -> "JITScriptFinding":
+    details: dict[str, Any] = {
+        "analysis_incomplete": True,
+        "reason": reason,
+    }
+    if max_scan_bytes is not None:
+        details["max_scan_bytes"] = max_scan_bytes
+    if omitted_snippets is not None:
+        details["omitted_snippets"] = omitted_snippets
+    if candidates_count is not None:
+        details["candidate_snippets"] = candidates_count
+
+    return create_jit_finding(
+        message=message,
+        severity="INFO",
+        context=context,
+        pattern=None,
+        recommendation="Treat JIT/embedded Python coverage as inconclusive and review the model source.",
+        confidence=1.0,
+        details=details,
+        framework=framework,
+        code_snippet=None,
+        type="analysis_incomplete",
+        operation=None,
+        builtin=None,
+        import_=None,
+    )
 
 
 def _tail_starts_for_priority_alias_uses(
@@ -1894,8 +1946,35 @@ class JITScriptDetector:
         if not self.check_ast:
             return findings
 
-        bounded = data if include_full_source else data[:1000000]
+        bounded = data if include_full_source else data[:_EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT]
         matches = _candidate_embedded_python_snippets(bounded, include_full_source=include_full_source)
+        prioritized_matches, omitted_budgeted_candidates = _select_prioritized_embedded_python_snippets(
+            matches, bounded=bounded
+        )
+        if not include_full_source and len(data) > _EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT:
+            findings.append(
+                _embedded_python_analysis_incomplete_finding(
+                    framework=framework,
+                    context=context,
+                    reason=_EMBEDDED_PYTHON_BYTE_LIMIT_REASON,
+                    message=("Embedded Python/JIT analysis incomplete: payload exceeds the bounded byte scan window"),
+                    max_scan_bytes=_EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT,
+                )
+            )
+        if omitted_budgeted_candidates:
+            findings.append(
+                _embedded_python_analysis_incomplete_finding(
+                    framework=framework,
+                    context=context,
+                    reason=_EMBEDDED_PYTHON_SNIPPET_LIMIT_REASON,
+                    message=("Embedded Python/JIT analysis incomplete: candidate snippet budget was exceeded"),
+                    omitted_snippets=omitted_budgeted_candidates,
+                    candidates_count=len(matches),
+                )
+            )
+        if not prioritized_matches and omitted_budgeted_candidates:
+            return findings
+
         bounded_high_risk_calls: set[tuple[str, str]] | None = None
         snippet_high_risk_calls: set[tuple[str, str]] = set()
         parsed_snippet_spans: list[tuple[int, int]] = []
@@ -1907,7 +1986,7 @@ class JITScriptDetector:
             # raw pattern detection active and fall back to extracted snippets.
             bounded_high_risk_calls = None
 
-        for match, span, real_ranges in _prioritized_embedded_python_snippets(matches, bounded=bounded):
+        for match, span, real_ranges in prioritized_matches:
             try:
                 if _is_span_inside_parsed_spans(span, parsed_snippet_spans):
                     continue

--- a/modelaudit/scanners/base.py
+++ b/modelaudit/scanners/base.py
@@ -21,6 +21,7 @@ from ..scanner_results import (
     Issue,
     IssueSeverity,
     ScanResult,
+    mark_inconclusive_scan_result,
 )
 from ..utils.helpers.interrupt_handler import check_interrupted
 from .rule_mapper import get_embedded_code_rule_code, get_network_rule_code, get_secret_rule_code
@@ -822,6 +823,14 @@ class BaseScanner(ABC):
                 location = getattr(finding, "context", context)
                 recommendation = getattr(finding, "recommendation", "Review JIT/Script code for security")
                 details = finding.__dict__ if hasattr(finding, "__dict__") else {"object": str(finding)}
+
+            finding_details = details.get("details") if isinstance(details, dict) else None
+            if isinstance(finding_details, dict) and finding_details.get("analysis_incomplete"):
+                reason = finding_details.get("reason")
+                mark_inconclusive_scan_result(
+                    result,
+                    reason if isinstance(reason, str) and reason else "jit_script_analysis_incomplete",
+                )
 
             jit_indicator = f"{details.get('type', '')} {message} {model_type}".strip()
             jit_rule_code = get_embedded_code_rule_code(jit_indicator)

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -263,9 +263,32 @@ class TestJITScriptDetector:
         assert incomplete[0].details["max_scan_bytes"] == jit_script_module._EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT
         assert not any(finding.type == "dangerous_import" and finding.import_ == "os" for finding in findings)
 
+    def test_scan_model_marks_import_only_omitted_middle_incomplete(self) -> None:
+        detector = JITScriptDetector()
+        padding = b"A" * (jit_script_module._EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT + 100)
+        data = b"\x00\xff" + padding + b"\nimport harmless_middle\n" + padding
+
+        findings = detector.scan_model(data, "pytorch", "middle_import.pt")
+
+        assert any(
+            finding.type == "analysis_incomplete"
+            and finding.details.get("reason") == jit_script_module._EMBEDDED_PYTHON_BYTE_LIMIT_REASON
+            for finding in findings
+        )
+
+    def test_scan_model_ignores_large_import_near_match(self) -> None:
+        detector = JITScriptDetector()
+        data = b"metadata_import harmless\n" * (
+            jit_script_module._EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT // len(b"metadata_import harmless\n") + 1
+        )
+
+        findings = detector.scan_model(data, "pytorch", "metadata.pt")
+
+        assert not any(finding.type == "analysis_incomplete" for finding in findings)
+
     def test_extract_embedded_python_marks_snippet_budget_incomplete(self) -> None:
         detector = JITScriptDetector()
-        data = b"\n".join(
+        data = b"\x00".join(
             f"import harmless_{index}".encode()
             for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
         )
@@ -281,6 +304,21 @@ class TestJITScriptDetector:
         assert len(incomplete) == 1
         assert incomplete[0].details["omitted_snippets"] > 0
         assert incomplete[0].details["candidate_snippets"] > jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS
+
+    def test_extract_embedded_python_keeps_fully_covered_over_budget_source_clean(self) -> None:
+        detector = JITScriptDetector()
+        data = b"\n".join(
+            f"import harmless_{index}".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+
+        findings = detector._extract_and_check_python_code(data, "TorchScript", "covered_snippets.pt")
+
+        assert not any(
+            finding.type == "analysis_incomplete"
+            and finding.details.get("reason") == jit_script_module._EMBEDDED_PYTHON_SNIPPET_LIMIT_REASON
+            for finding in findings
+        )
 
     def test_extract_embedded_python_keeps_benign_within_budgets_clean(self) -> None:
         detector = JITScriptDetector()
@@ -2123,6 +2161,17 @@ class TestJITScriptDetector:
         assert continued_runpy_candidate[0] in selected_candidates
         assert continued_from_runpy_candidate[0] in selected_candidates
         assert runpy_candidate[0] in selected_candidates
+
+    def test_prioritized_snippet_budget_counts_unique_spans(self) -> None:
+        duplicate = (b"import harmless\n", (0, 16), ((0, 16),))
+        unique = (b"import later\n", (20, 32), ((20, 32),))
+
+        selected, omitted_spans = jit_script_module._select_prioritized_embedded_python_snippets(
+            [*[duplicate] * jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS, unique]
+        )
+
+        assert selected == [duplicate, unique]
+        assert omitted_spans == []
 
     def test_priority_snippets_are_budgeted_and_bounded_after_default_cap(self) -> None:
         def candidate(

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -302,6 +302,45 @@ class TestJITScriptDetector:
             for finding in findings
         )
 
+    @pytest.mark.parametrize(
+        "header",
+        [
+            b"def payload():\n    values = (\n",
+            b"class Payload:\n    values = (\n",
+        ],
+    )
+    def test_extract_embedded_python_marks_long_unparseable_definition_incomplete(self, header: bytes) -> None:
+        detector = JITScriptDetector()
+        continuation = b"        1,\n"
+        data = (
+            header
+            + continuation * (jit_script_module._EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT // len(continuation) + 1)
+            + b"    )\n"
+        )
+
+        findings = detector._extract_and_check_python_code(data, "TorchScript", "long_definition.pt")
+
+        assert any(
+            finding.type == "analysis_incomplete"
+            and finding.details.get("reason") == jit_script_module._EMBEDDED_PYTHON_BYTE_LIMIT_REASON
+            for finding in findings
+        )
+
+    @pytest.mark.parametrize(
+        "prose",
+        [
+            b"def payload is described here\n",
+            b"class Payload is described here\n",
+        ],
+    )
+    def test_scan_model_ignores_large_definition_like_prose(self, prose: bytes) -> None:
+        detector = JITScriptDetector()
+        data = prose + b"A" * (jit_script_module._EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT + 100)
+
+        findings = detector.scan_model(data, "pytorch", "definition_prose.pt")
+
+        assert not any(finding.type == "analysis_incomplete" for finding in findings)
+
     def test_scan_model_does_not_duplicate_import_only_pytorch_source_findings(self) -> None:
         detector = JITScriptDetector()
 

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -276,6 +276,16 @@ class TestJITScriptDetector:
             for finding in findings
         )
 
+    def test_scan_model_ignores_large_prose_import_in_omitted_middle(self) -> None:
+        detector = JITScriptDetector()
+        padding = b"A" * (jit_script_module._EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT + 100)
+        prose = b"\ninstructions import numpy for setup\nimport numpy is required by this model\n"
+        data = b"\x00\xff" + padding + prose + padding
+
+        findings = detector.scan_model(data, "pytorch", "prose_import.pt")
+
+        assert not any(finding.type == "analysis_incomplete" for finding in findings)
+
     def test_scan_model_ignores_large_import_near_match(self) -> None:
         detector = JITScriptDetector()
         data = b"metadata_import harmless\n" * (
@@ -285,6 +295,17 @@ class TestJITScriptDetector:
         findings = detector.scan_model(data, "pytorch", "metadata.pt")
 
         assert not any(finding.type == "analysis_incomplete" for finding in findings)
+
+    def test_scan_model_fails_closed_after_source_start_probe_budget(self) -> None:
+        detector = JITScriptDetector()
+        data = b"\n".join(
+            f"import harmless_{index} is prose".encode()
+            for index in range(jit_script_module._MAX_EMBEDDED_PYTHON_SOURCE_START_PROBES + 1)
+        )
+
+        findings = detector.scan_model(data, "pytorch", "many_ambiguous_imports.pt")
+
+        assert any(finding.type == "analysis_incomplete" for finding in findings)
 
     def test_extract_embedded_python_marks_snippet_budget_incomplete(self) -> None:
         detector = JITScriptDetector()

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -263,6 +263,56 @@ class TestJITScriptDetector:
         assert incomplete[0].details["max_scan_bytes"] == jit_script_module._EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT
         assert not any(finding.type == "dangerous_import" and finding.import_ == "os" for finding in findings)
 
+    def test_scan_model_ignores_large_tensorflow_function_metadata_without_python(self) -> None:
+        detector = JITScriptDetector()
+        data = b"SavedFunction function_spec\n" + b"A" * (jit_script_module._EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT + 100)
+
+        findings = detector.scan_model(data, "tensorflow", "saved_model.pb")
+
+        assert not any(finding.type == "analysis_incomplete" for finding in findings)
+
+    def test_scan_model_marks_late_tensorflow_function_source_incomplete(self) -> None:
+        detector = JITScriptDetector()
+        data = (
+            b"SavedFunction function_spec\n"
+            + b"A" * (jit_script_module._EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT + 100)
+            + b"\nimport os\nos.system('id')\n"
+        )
+
+        findings = detector.scan_model(data, "tensorflow", "saved_model.pb")
+
+        assert any(
+            finding.type == "analysis_incomplete"
+            and finding.details.get("reason") == jit_script_module._EMBEDDED_PYTHON_BYTE_LIMIT_REASON
+            for finding in findings
+        )
+
+    def test_extract_embedded_python_marks_boundary_spanning_source_incomplete(self) -> None:
+        detector = JITScriptDetector()
+        data = (
+            b"A" * (jit_script_module._EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT - len(b"\nimport "))
+            + b"\nimport os\nos.system('id')\n"
+        )
+
+        findings = detector._extract_and_check_python_code(data, "TorchScript", "boundary_payload.pt")
+
+        assert any(
+            finding.type == "analysis_incomplete"
+            and finding.details.get("reason") == jit_script_module._EMBEDDED_PYTHON_BYTE_LIMIT_REASON
+            for finding in findings
+        )
+
+    def test_scan_model_does_not_duplicate_import_only_pytorch_source_findings(self) -> None:
+        detector = JITScriptDetector()
+
+        findings = detector.scan_model(b'import os\nos.system("id")\n', "pytorch", "payload.pt")
+
+        finding_signatures = {
+            (finding.type, finding.pattern, finding.import_, finding.operation, finding.message) for finding in findings
+        }
+        assert len(findings) == 3
+        assert len(finding_signatures) == len(findings)
+
     def test_scan_model_marks_import_only_omitted_middle_incomplete(self) -> None:
         detector = JITScriptDetector()
         padding = b"A" * (jit_script_module._EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT + 100)

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -246,6 +246,53 @@ class TestJITScriptDetector:
 
         assert any(f.type == "dangerous_import" and f.import_ == "os" for f in findings)
 
+    def test_extract_embedded_python_marks_byte_budget_incomplete(self) -> None:
+        detector = JITScriptDetector()
+        padding = b"# pad\n" * ((jit_script_module._EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT // len(b"# pad\n")) + 1)
+        data = padding + b"import os\nos.system('id')\n"
+
+        findings = detector._extract_and_check_python_code(data, "TorchScript", "late_payload.pt")
+
+        incomplete = [
+            finding
+            for finding in findings
+            if finding.type == "analysis_incomplete"
+            and finding.details.get("reason") == jit_script_module._EMBEDDED_PYTHON_BYTE_LIMIT_REASON
+        ]
+        assert len(incomplete) == 1
+        assert incomplete[0].details["max_scan_bytes"] == jit_script_module._EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT
+        assert not any(finding.type == "dangerous_import" and finding.import_ == "os" for finding in findings)
+
+    def test_extract_embedded_python_marks_snippet_budget_incomplete(self) -> None:
+        detector = JITScriptDetector()
+        data = b"\n".join(
+            f"import harmless_{index}".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS + 2)
+        )
+
+        findings = detector._extract_and_check_python_code(data, "TorchScript", "many_snippets.pt")
+
+        incomplete = [
+            finding
+            for finding in findings
+            if finding.type == "analysis_incomplete"
+            and finding.details.get("reason") == jit_script_module._EMBEDDED_PYTHON_SNIPPET_LIMIT_REASON
+        ]
+        assert len(incomplete) == 1
+        assert incomplete[0].details["omitted_snippets"] > 0
+        assert incomplete[0].details["candidate_snippets"] > jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS
+
+    def test_extract_embedded_python_keeps_benign_within_budgets_clean(self) -> None:
+        detector = JITScriptDetector()
+        data = b"\n".join(
+            f"import harmless_{index}".encode()
+            for index in range(jit_script_module._MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS)
+        )
+
+        findings = detector._extract_and_check_python_code(data, "TorchScript", "benign_snippets.pt")
+
+        assert findings == []
+
     def test_scan_model_detects_unmarked_from_import_source(self) -> None:
         detector = JITScriptDetector()
 

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -11,6 +11,7 @@ import pytest
 
 from modelaudit.cache import get_cache_manager, reset_cache_manager
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
+from modelaudit.detectors import jit_script as jit_script_module
 from modelaudit.detectors.suspicious_symbols import CVE_COMBINED_PATTERNS
 from modelaudit.scanner_results import INCONCLUSIVE_SCAN_OUTCOME, Check, ScanResult
 from modelaudit.scanners.archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY
@@ -1176,6 +1177,32 @@ def test_pytorch_zip_jit_scan_size_limit_marks_inconclusive(tmp_path: Path) -> N
     assert size_checks[0].details["skipped_count"] == len(size_checks[0].details["zip_entries"])
     assert size_checks[0].details["analysis_incomplete"] is True
     assert size_checks[0].details["max_scan_bytes"] == 4
+
+
+def test_pytorch_zip_jit_detector_byte_budget_marks_inconclusive(tmp_path: Path) -> None:
+    model_path = tmp_path / "late_jit_payload.pt"
+    padding = b"# pad\n" * ((jit_script_module._EMBEDDED_PYTHON_EXTRACT_BYTE_LIMIT // len(b"# pad\n")) + 1)
+    late_payload = padding + b"def payload():\n    return 1\n"
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}, protocol=4))
+        zip_file.writestr("archive/code/debug/source.py", late_payload)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+    aggregate = scan_model_directory_or_file(str(model_path), cache_enabled=False)
+
+    assert result.success is False
+    assert result.metadata["analysis_incomplete"] is True
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert jit_script_module._EMBEDDED_PYTHON_BYTE_LIMIT_REASON in result.metadata["scan_outcome_reasons"]
+    jit_checks = [check for check in result.checks if check.name == "JIT/Script Code Execution Detection"]
+    assert any(
+        check.details.get("details", {}).get("reason") == jit_script_module._EMBEDDED_PYTHON_BYTE_LIMIT_REASON
+        for check in jit_checks
+    )
+    assert getattr(aggregate.file_metadata[str(model_path)], "scan_outcome", None) == INCONCLUSIVE_SCAN_OUTCOME
+    assert determine_exit_code(aggregate) == 1
 
 
 def test_pytorch_zip_jit_scan_read_failure_marks_inconclusive(


### PR DESCRIPTION
Summary:\n- emit analysis_incomplete findings when embedded Python/JIT byte caps or snippet budgets are exhausted\n- mark scanner bridge outcomes inconclusive for those detector findings\n- add over-budget byte/snippet regressions plus benign within-budget guards\n\nValidation:\n- targeted new tests: 4 passed\n- focused JIT/PyTorch ZIP suites: 362 passed, 5 warnings\n- ruff format/check, mypy, git diff --check