### PR TITLE
fix(routing): avoid false Flax overlap on complete pickles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- avoid false inconclusive Flax overlap results for complete pickle payloads with no trailing data
 - scan ONNX external data references in sparse initializers, tensor-valued attributes, and function defaults
 - avoid false-positive process-launch findings for parsed framed Python string literals
 - detect dangerous Python calls retrieved through module namespace dictionaries in ZIP and TAR members

--- a/modelaudit/scanners/archive_dispatch.py
+++ b/modelaudit/scanners/archive_dispatch.py
@@ -92,6 +92,36 @@ def _is_pickle_parse_only_overlap_issue(issue: Issue) -> bool:
     )
 
 
+def _pickle_result_consumes_entire_payload(path: str, result: ScanResult) -> bool:
+    """Return whether complete Pickle analysis proves no trailing Flax stream exists."""
+    if (
+        result.scanner_name != "pickle"
+        or result.metadata.get("pickle_report_status") != "complete"
+        or result.metadata.get("analysis_incomplete") is True
+    ):
+        return False
+
+    coverage = result.metadata.get("pickle_coverage")
+    if not isinstance(coverage, dict):
+        return False
+    if coverage.get("raw_scan_complete") is not True or coverage.get("opcode_scan_complete") is not True:
+        return False
+
+    positions = (
+        result.metadata.get("first_pickle_end_pos"),
+        coverage.get("bytes_scanned"),
+        coverage.get("bytes_total"),
+    )
+    if any(not isinstance(position, int) or isinstance(position, bool) for position in positions):
+        return False
+
+    try:
+        file_size = os.path.getsize(path)
+    except OSError:
+        return False
+    return positions[0] == positions[1] == positions[2] == file_size
+
+
 def _select_nested_scanner_id(path: str, header_format_override: str | None = None) -> str | None:
     """Select a scanner for extracted archive members using trusted file structure first."""
     header_format = header_format_override or detect_file_format(path)
@@ -431,6 +461,8 @@ def merge_inconclusive_flax_msgpack_outcome(
     """Preserve ambiguous Flax coverage when a strict overlapping owner is primary."""
     from . import _registry
 
+    if _pickle_result_consumes_entire_payload(path, result):
+        return
     if result.scanner_name not in detect_flax_msgpack_overlap_routes(
         path
     ) or not has_inconclusive_renamed_flax_msgpack_routing(path):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1476,6 +1476,49 @@ def test_scan_file_routes_renamed_flax_stream_after_pickle_shaped_prefix(tmp_pat
     assert any(issue.message == "Suspicious object attribute detected: __reduce__" for issue in result.issues)
 
 
+@pytest.mark.parametrize("nested", [False, True], ids=["direct", "nested"])
+def test_scan_file_complete_pickle_does_not_merge_inconclusive_flax(tmp_path: Path, nested: bool) -> None:
+    payload = pickle.dumps((complex(1, 2), {f"field{i}": i for i in range(2500)}), protocol=4)
+    complete_pickle = tmp_path / "complete.pkl"
+    complete_pickle.write_bytes(payload)
+
+    assert file_detection.has_inconclusive_renamed_flax_msgpack_routing(complete_pickle)
+
+    target = complete_pickle
+    expected_scanner = "pickle"
+    if nested:
+        target = tmp_path / "complete.zip"
+        _create_misnamed_zip(target, {"complete.pkl": payload})
+        expected_scanner = "zip"
+
+    result = scan_file(str(target), config={"cache_scan_results": False})
+
+    assert result.scanner_name == expected_scanner
+    assert result.success is True
+    assert "flax_msgpack_routing_incomplete" not in result.metadata.get("scan_outcome_reasons", [])
+    assert not any(check.name == "MessagePack Routing Analysis Incomplete" for check in result.checks)
+
+
+def test_scan_file_still_detects_flax_after_complete_pickle_prefix(tmp_path: Path) -> None:
+    if not flax_msgpack_scanner.HAS_MSGPACK:
+        pytest.skip("msgpack unavailable")
+
+    checkpoint = tmp_path / "complete-pickle-prefix.jpg"
+    checkpoint.write_bytes(
+        pickle.dumps(None, protocol=4)
+        + flax_msgpack_scanner.msgpack.packb(
+            {"params": {"w": [1, 2, 3]}, "__reduce__": "os.system"},
+            use_bin_type=True,
+        )
+    )
+
+    result = scan_file(str(checkpoint), config={"cache_scan_results": False})
+
+    assert result.scanner_name == "flax_msgpack"
+    assert result.success is False
+    assert any(issue.message == "Suspicious object attribute detected: __reduce__" for issue in result.issues)
+
+
 def test_scan_file_preserves_pickle_findings_in_protocol0_flax_overlap(tmp_path: Path) -> None:
     if not flax_msgpack_scanner.HAS_MSGPACK:
         pytest.skip("msgpack unavailable")


### PR DESCRIPTION
## Summary

- stop ambiguous Flax overlap probing from converting a fully consumed, completely analyzed pickle into an operational scan error
- require trusted pickle coverage metadata and exact full-payload consumption before skipping the fail-closed Flax composition
- preserve detection when a valid pickle prefix is followed by a malicious Flax MessagePack stream

## Root cause

The scheduled [Nightly CI run](https://github.com/promptfoo/modelaudit/actions/runs/26865852689) repeatedly failed its Python 3.11 Linux and Windows asset-inventory tests. A clean nested `model_state.pkl` was completely analyzed by the pickle scanner, but a separate bounded Flax routing probe was inconclusive and overwrote the successful result with `flax_msgpack_routing_incomplete` / exit code 2.

## Validation

- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` (`7714 passed, 16 skipped`)
- Nightly asset-inventory regression tests (`3 passed`)
- focused direct, nested, trailing-Flax, and related routing regressions (`7 passed`)
