### PR TITLE
fix(cloud): enforce size caps on cached downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - redact compound credential names and malformed userinfo URLs in scanner evidence
 - restrict JFrog credential forwarding to explicitly trusted HTTPS hosts
 - scan duplicate and case-varied ExecuTorch pickle ZIP members without shadowable-name or metadata-routing bypasses
+- refresh cloud cache entries that cannot be proven within the configured download size limit
 - enforce automatic cloud download size limits when remote size metadata is missing or late-bound
 - avoid importing attacker-shadowed TensorFlow protobuf packages during static scanning
 - inspect every parsed GGUF chat template when duplicate or trailing malformed metadata could otherwise hide SSTI payloads

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -122,6 +122,25 @@ def _cloud_url_basename(url: str) -> str:
     return Path(path).name
 
 
+def _remove_path(path: Path) -> None:
+    """Remove a file, directory, symlink, or special path without following symlinks."""
+    if path.is_symlink() or not path.is_dir():
+        path.unlink(missing_ok=True)
+    else:
+        shutil.rmtree(path)
+
+
+def _prepare_cache_subdirectory(cache_dir: Path, cache_key: str) -> Path:
+    """Create a cache-key directory without following replaced path components."""
+    cache_subdir = cache_dir
+    for component in (cache_key[:2], cache_key[2:4]):
+        cache_subdir /= component
+        if cache_subdir.is_symlink() or (cache_subdir.exists() and not cache_subdir.is_dir()):
+            cache_subdir.unlink()
+        cache_subdir.mkdir(exist_ok=True)
+    return cache_subdir
+
+
 def _metadata_etag(metadata: Mapping[str, Any] | None) -> str | None:
     """Extract a stable object validator from fsspec-style metadata."""
     if not metadata:
@@ -558,14 +577,14 @@ class GCSCache:
         cache_key = self.get_cache_key(url)
 
         # Create cache subdirectory
-        cache_subdir = self.cache_dir / cache_key[:2] / cache_key[2:4]
-        cache_subdir.mkdir(parents=True, exist_ok=True)
+        cache_subdir = _prepare_cache_subdirectory(self.cache_dir, cache_key)
 
         # Determine cache path
         if local_path.is_file():
             cache_path = cache_subdir / local_path.name
             # Don't copy if it's already in the cache directory
             if not _is_within_directory(self.cache_dir, local_path):
+                _remove_path(cache_path)
                 shutil.copy2(local_path, cache_path)
             else:
                 cache_path = local_path
@@ -574,8 +593,7 @@ class GCSCache:
             cache_path = cache_subdir / "content"
             # Don't copy if it's already in the cache directory
             if not _is_within_directory(self.cache_dir, local_path):
-                if cache_path.exists():
-                    shutil.rmtree(cache_path)
+                _remove_path(cache_path)
                 shutil.copytree(local_path, cache_path)
             else:
                 cache_path = local_path
@@ -679,15 +697,14 @@ def _clear_directory_contents(path: Path) -> None:
     if not path.exists():
         return
     for child in path.iterdir():
-        if child.is_dir():
-            shutil.rmtree(child)
-        else:
-            child.unlink()
+        _remove_path(child)
 
 
 def _cached_path_within_size_limit(path: Path, max_size: int) -> bool:
     """Return whether a cached file or directory can be proven within a size limit."""
     try:
+        if path.is_symlink():
+            return False
         if path.is_file():
             return path.stat().st_size <= max_size
         if not path.is_dir():
@@ -867,9 +884,7 @@ def download_from_cloud(
     if cache:
         # When using cache, download directly to cache location
         cache_key = cache.get_cache_key(url)
-        cache_subdir = cache.cache_dir / cache_key[:2] / cache_key[2:4]
-        cache_subdir.mkdir(parents=True, exist_ok=True)
-        download_path = cache_subdir
+        download_path = _prepare_cache_subdirectory(cache.cache_dir, cache_key)
     elif cache_dir is None:
         download_path = Path(tempfile.mkdtemp(prefix="modelaudit_cloud_"))
     else:
@@ -981,6 +996,8 @@ def download_from_cloud(
             file_name = _cloud_url_basename(url)
             local_file = download_path / file_name
             download_budget = _CloudDownloadBudget(max_size) if max_size else None
+            if cache:
+                _remove_path(local_file)
 
             @retry_with_backoff(
                 max_retries=3,

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -685,6 +685,30 @@ def _clear_directory_contents(path: Path) -> None:
             child.unlink()
 
 
+def _cached_path_within_size_limit(path: Path, max_size: int) -> bool:
+    """Return whether a cached file or directory can be proven within a size limit."""
+    try:
+        if path.is_file():
+            return path.stat().st_size <= max_size
+        if not path.is_dir():
+            return False
+
+        total_size = 0
+        for child in path.rglob("*"):
+            if child.is_symlink():
+                return False
+            if child.is_dir():
+                continue
+            if not child.is_file():
+                return False
+            total_size += child.stat().st_size
+            if total_size > max_size:
+                return False
+        return True
+    except OSError:
+        return False
+
+
 def _selected_cloud_download_size(fs: Any, files: list[dict[str, Any]], max_size: int) -> int:
     """Return the late-bound size of selected objects, failing closed on unknown sizes."""
     total_size = 0
@@ -797,9 +821,16 @@ def download_from_cloud(
     if cache:
         cached_path = cache.get_cached_path(url, etag=etag)
         if cached_path:
-            if show_progress:
-                click.echo(f"✓ Using cached version from {cached_path}")
-            return cached_path
+            if max_size and not _cached_path_within_size_limit(cached_path, max_size):
+                logger.warning(
+                    "Ignoring cached version for %s because its local size exceeds or cannot be validated against "
+                    "the maximum download size",
+                    redact_url_for_display(url),
+                )
+            else:
+                if show_progress:
+                    click.echo(f"✓ Using cached version from {cached_path}")
+                return cached_path
 
     # Check if we can use streaming analysis
     if stream_analyze and metadata.get("type") == "file":

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -392,13 +392,45 @@ def test_download_from_cloud_reuses_cache_with_matching_etag(mock_fs: MagicMock,
     mock_fs.side_effect = [first_meta, downloader, second_meta]
 
     first = download_from_cloud(url, cache_dir=tmp_path, show_progress=False)
-    second = download_from_cloud(url, cache_dir=tmp_path, show_progress=False)
+    second = download_from_cloud(url, cache_dir=tmp_path, max_size=4, show_progress=False)
 
     assert isinstance(first, Path)
     assert second == first
     assert first.read_bytes() == b"data"
     downloader.get.assert_called_once()
     assert mock_fs.call_count == 3
+
+
+@patch("fsspec.filesystem")
+def test_download_from_cloud_does_not_reuse_cached_file_over_max_size(mock_fs: MagicMock, tmp_path: Path) -> None:
+    url = "s3://bucket/model.pt"
+
+    first_meta = make_fs_mock()
+    first_meta.info.return_value = {"type": "file", "size": 4, "ETag": "etag-v1"}
+
+    first_downloader = make_fs_mock()
+    first_downloader.info.return_value = {"type": "file", "size": 4, "ETag": "etag-v1"}
+    first_downloader.get.side_effect = lambda _src, dst: Path(dst).write_bytes(b"data")
+
+    second_meta = make_fs_mock()
+    second_meta.info.return_value = {"type": "file", "size": 4, "ETag": "etag-v1"}
+
+    second_downloader = make_fs_mock()
+    second_downloader.info.return_value = {"type": "file", "size": 4, "ETag": "etag-v1"}
+    second_downloader.open.return_value = BytesIO(b"data")
+
+    mock_fs.side_effect = [first_meta, first_downloader, second_meta, second_downloader]
+
+    first = download_from_cloud(url, cache_dir=tmp_path, show_progress=False)
+    assert isinstance(first, Path)
+    first.write_bytes(b"oversized")
+
+    second = download_from_cloud(url, cache_dir=tmp_path, max_size=4, show_progress=False)
+
+    assert second == first
+    assert second.read_bytes() == b"data"
+    second_downloader.open.assert_called_once_with(url, "rb")
+    assert mock_fs.call_count == 4
 
 
 @patch("fsspec.filesystem")

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -434,6 +434,43 @@ def test_download_from_cloud_does_not_reuse_cached_file_over_max_size(mock_fs: M
 
 
 @patch("fsspec.filesystem")
+def test_download_from_cloud_replaces_symlinked_cached_file_with_max_size(mock_fs: MagicMock, tmp_path: Path) -> None:
+    url = "s3://bucket/model.pt"
+
+    first_meta = make_fs_mock()
+    first_meta.info.return_value = {"type": "file", "size": 4, "ETag": "etag-v1"}
+
+    first_downloader = make_fs_mock()
+    first_downloader.info.return_value = {"type": "file", "size": 4, "ETag": "etag-v1"}
+    first_downloader.get.side_effect = lambda _src, dst: Path(dst).write_bytes(b"data")
+
+    second_meta = make_fs_mock()
+    second_meta.info.return_value = {"type": "file", "size": 4, "ETag": "etag-v1"}
+
+    second_downloader = make_fs_mock()
+    second_downloader.info.return_value = {"type": "file", "size": 4, "ETag": "etag-v1"}
+    second_downloader.open.return_value = BytesIO(b"safe")
+
+    mock_fs.side_effect = [first_meta, first_downloader, second_meta, second_downloader]
+
+    first = download_from_cloud(url, cache_dir=tmp_path, show_progress=False)
+    assert isinstance(first, Path)
+    decoy = first.parent / "decoy.bin"
+    decoy.write_bytes(b"keep")
+    first.unlink()
+    first.symlink_to(decoy.name)
+
+    second = download_from_cloud(url, cache_dir=tmp_path, max_size=4, show_progress=False)
+
+    assert second == first
+    assert not second.is_symlink()
+    assert second.read_bytes() == b"safe"
+    assert decoy.read_bytes() == b"keep"
+    second_downloader.open.assert_called_once_with(url, "rb")
+    assert mock_fs.call_count == 4
+
+
+@patch("fsspec.filesystem")
 def test_download_from_cloud_clears_stale_directory_cache(mock_fs: MagicMock, tmp_path: Path) -> None:
     url = "s3://bucket/models"
     cache = GCSCache(cache_dir=tmp_path / "cache")
@@ -461,6 +498,49 @@ def test_download_from_cloud_clears_stale_directory_cache(mock_fs: MagicMock, tm
     assert isinstance(result, Path)
     assert not (result / "old-model.bin").exists()
     assert (result / "new-model.bin").read_bytes() == b"new"
+
+
+@patch("fsspec.filesystem")
+def test_download_from_cloud_replaces_symlinked_directory_cache_without_touching_target(
+    mock_fs: MagicMock, tmp_path: Path
+) -> None:
+    url = "s3://bucket/models"
+    cache = GCSCache(cache_dir=tmp_path / "cache")
+    stale_dir = tmp_path / "stale"
+    stale_dir.mkdir()
+    (stale_dir / "old-model.bin").write_bytes(b"old")
+    cache.cache_file(url, stale_dir, etag="etag-v1")
+    cached_path = cache.get_cached_path(url, etag="etag-v1")
+    assert cached_path is not None
+
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    outside_marker = outside_dir / "keep.txt"
+    outside_marker.write_text("keep", encoding="utf-8")
+    (cached_path / "old-model.bin").unlink()
+    cached_path.rmdir()
+    cached_path.symlink_to(outside_dir, target_is_directory=True)
+
+    fs_meta = make_fs_mock()
+    fs_meta.info.return_value = {"type": "directory", "ETag": "etag-v2"}
+    fs_meta.glob.return_value = ["s3://bucket/models/new-model.bin"]
+    fs_meta.info.side_effect = [
+        {"type": "directory", "ETag": "etag-v2"},
+        {"type": "file", "size": 3, "ETag": "file-etag-v2"},
+    ]
+
+    fs = make_fs_mock()
+    fs.info.return_value = {"type": "file", "size": 3}
+    fs.get.side_effect = lambda _src, dst: Path(dst).write_bytes(b"new")
+
+    mock_fs.side_effect = [fs_meta, fs]
+
+    result = download_from_cloud(url, cache_dir=tmp_path / "cache", show_progress=False, selective=False)
+
+    assert isinstance(result, Path)
+    assert not result.is_symlink()
+    assert (result / "new-model.bin").read_bytes() == b"new"
+    assert outside_marker.read_text(encoding="utf-8") == "keep"
 
 
 @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)


### PR DESCRIPTION
## Summary

- validate matching cloud cache entries against the configured maximum download size before reuse
- refresh oversized, symlinked, special-file, or otherwise unverifiable cache entries through the existing bounded download path
- cover both valid capped cache reuse and the oversized-cache bypass regression

## Bug

The cloud download size cap was enforced only after cache lookup. An ETag-matching cached file could be enlarged after it was cached, then returned unchanged by a later capped call without using the bounded acquisition path.

## Validation

- regression failed before the fix by returning `b"oversized"` and passed after the fix
- `pytest tests/utils/sources/test_cloud_storage.py tests/utils/sources/test_huggingface.py tests/test_cli.py -q` -> `262 passed`
- root suite: `pytest -n auto tests/ -m "not slow and not integration" --maxfail=1` -> `6339 passed, 13 skipped`
- `ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> passed
- `ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> passed
- `mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> passed

The combined root + standalone picklescan suite was also attempted locally, but this machine's shared pytest 9/xdist environment contaminated later root workers with standalone-package import failures. The isolated root suite and focused standalone pickle checks pass; PR CI is the authoritative combined-suite validation.
