### PR TITLE
fix: bound PyTorch ZIP version probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - mark compressed-wrapper partial-analysis outcomes explicitly inconclusive
 - scan decompressed Python and content-disguised executable payloads through bounded security checks without caching ephemeral inner files
 - detect executable PyTorch ZIP sidecars hidden behind ordinary filenames while excluding raw tensor-storage bytes
-- fail closed and cap downstream scanning and metadata listings when PyTorch ZIP archives exceed the configured entry limit, preserve parent structure attribution across nested limits, and retain deadline and prefixed-layout metadata handling
+- fail closed and cap downstream scanning, metadata listings, and version metadata probes for PyTorch ZIP archives, preserve parent structure attribution across nested entry limits, and retain deadline and prefixed-layout metadata handling
 - scan 7-Zip Python members and content-disguised executable sidecars through shared archive security checks
 - enforce `--max-size` while downloading PyTorch Hub models in normal acquisition mode
 - detect structurally valid executable payloads throughout PyTorch binary files while bounding context analysis and findings

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -251,12 +251,15 @@ class PyTorchZipScanner(BaseScanner):
     MIN_COMPRESSION_BOMB_UNCOMPRESSED_SIZE: ClassVar[int] = 1024 * 1024
     MAX_ARCHIVE_ENTRIES: ClassVar[int] = 10000  # Maximum number of entries in archive
     MAX_VERSION_METADATA_BYTES: ClassVar[int] = 4096
+    MAX_VERSION_JSON_BYTES: ClassVar[int] = 1024 * 1024
+    DEFAULT_VERSION_PICKLE_PROBE_BYTES: ClassVar[int] = 1024 * 1024
     DEFAULT_MAX_NESTED_ZIP_DEPTH: ClassVar[int] = 5
     DEFAULT_MAX_BLACKLIST_SCAN_BYTES: ClassVar[int] = 100 * 1024 * 1024
     BLACKLIST_SIZE_LIMIT_INCONCLUSIVE_REASON: ClassVar[str] = "pytorch_zip_blacklist_member_size_limit"
     BLACKLIST_READ_INCONCLUSIVE_REASON: ClassVar[str] = "pytorch_zip_blacklist_member_read_failed"
     ENTRY_LIMIT_INCONCLUSIVE_REASON: ClassVar[str] = "pytorch_zip_entry_limit"
     LOCAL_ENTRY_LIMIT_METADATA_KEY: ClassVar[str] = "pytorch_zip_local_entry_limit_exceeded"
+    VERSION_METADATA_LIMIT_INCONCLUSIVE_REASON: ClassVar[str] = "pytorch_zip_version_metadata_size_limit"
     SCAN_INCONCLUSIVE_REASON: ClassVar[str] = "pytorch_zip_scan_incomplete"
 
     def __init__(self, config: dict[str, Any] | None = None):
@@ -274,6 +277,10 @@ class PyTorchZipScanner(BaseScanner):
         self.max_archive_entries = self._normalize_positive_int_config(
             self.config.get("max_archive_entries"),
             self.MAX_ARCHIVE_ENTRIES,
+        )
+        self.max_version_probe_bytes = self._normalize_positive_int_config(
+            self.config.get("version_probe_bytes"),
+            self.DEFAULT_VERSION_PICKLE_PROBE_BYTES,
         )
         # ``max_jit_scan_member_bytes`` caps per-member reads during the JIT /
         # network pattern pass to avoid unbounded memory blowup. Non-positive
@@ -2384,6 +2391,51 @@ class PyTorchZipScanner(BaseScanner):
         result.finish(success=False)
         return result
 
+    def _read_bounded_version_metadata(
+        self,
+        zipfile_obj: zipfile.ZipFile,
+        entry: zipfile.ZipInfo,
+        result: ScanResult,
+        *,
+        max_bytes: int,
+    ) -> bytes | None:
+        """Read version metadata without allowing optional probes to allocate unbounded memory."""
+        name = self._get_zip_member_name(entry)
+        try:
+            return self._read_member_bytes(
+                zipfile_obj,
+                entry,
+                phase="version_probe",
+                result=result,
+                max_bytes=max_bytes,
+            )
+        except ValueError as exc:
+            mark_inconclusive_scan_result(result, self.VERSION_METADATA_LIMIT_INCONCLUSIVE_REASON)
+            result.add_check(
+                name="PyTorch Version Metadata Limit",
+                passed=False,
+                message=(
+                    f"Skipped version metadata in {name} because it exceeds the bounded read limit "
+                    f"({entry.file_size} > {max_bytes} bytes)"
+                ),
+                severity=IssueSeverity.INFO,
+                location=f"{self.current_file_path}:{name}",
+                details={
+                    "zip_entry": name,
+                    "file_size": entry.file_size,
+                    "max_read_bytes": max_bytes,
+                    "exception": str(exc),
+                    "analysis_incomplete": True,
+                    "scan_outcome_reason": self.VERSION_METADATA_LIMIT_INCONCLUSIVE_REASON,
+                },
+            )
+            return None
+
+    @classmethod
+    def _version_metadata_analysis_incomplete(cls, result: ScanResult) -> bool:
+        reasons = result.metadata.get("scan_outcome_reasons")
+        return isinstance(reasons, list) and cls.VERSION_METADATA_LIMIT_INCONCLUSIVE_REASON in reasons
+
     def _extract_pytorch_version_info(
         self,
         zipfile_obj: zipfile.ZipFile,
@@ -2402,31 +2454,25 @@ class PyTorchZipScanner(BaseScanner):
             version_entry = self._find_zip_entry(safe_entries, "version")
             archive_version_entry = self._find_zip_entry(safe_entries, "archive/version")
             if version_entry is not None:
-                version_data = (
-                    self._read_member_bytes(
-                        zipfile_obj,
-                        version_entry,
-                        phase="version_probe",
-                        result=result,
-                    )
-                    .decode("utf-8", errors="ignore")
-                    .strip()
+                version_bytes = self._read_bounded_version_metadata(
+                    zipfile_obj,
+                    version_entry,
+                    result,
+                    max_bytes=self.MAX_VERSION_METADATA_BYTES,
                 )
-                version_info["pytorch_archive_version"] = version_data
-                version_info["pytorch_version_source"] = "version"
+                if version_bytes is not None:
+                    version_info["pytorch_archive_version"] = version_bytes.decode("utf-8", errors="ignore").strip()
+                    version_info["pytorch_version_source"] = "version"
             elif archive_version_entry is not None:
-                version_data = (
-                    self._read_member_bytes(
-                        zipfile_obj,
-                        archive_version_entry,
-                        phase="version_probe",
-                        result=result,
-                    )
-                    .decode("utf-8", errors="ignore")
-                    .strip()
+                version_bytes = self._read_bounded_version_metadata(
+                    zipfile_obj,
+                    archive_version_entry,
+                    result,
+                    max_bytes=self.MAX_VERSION_METADATA_BYTES,
                 )
-                version_info["pytorch_archive_version"] = version_data
-                version_info["pytorch_version_source"] = "archive/version"
+                if version_bytes is not None:
+                    version_info["pytorch_archive_version"] = version_bytes.decode("utf-8", errors="ignore").strip()
+                    version_info["pytorch_version_source"] = "archive/version"
 
             # Try to extract PyTorch framework version from pickle files
             # Look for torch.__version__ references in pickle GLOBAL opcodes
@@ -2435,12 +2481,10 @@ class PyTorchZipScanner(BaseScanner):
                 if name.endswith(".pkl"):
                     try:
                         # Cap read for version probing to 1MB; adjust via config if needed
-                        cfg = self.config or {}
-                        probe_bytes = cfg.get("version_probe_bytes", 1024 * 1024)  # 1MB default
                         pickle_data = self._read_member_prefix(
                             zipfile_obj,
                             entry,
-                            probe_bytes,
+                            self.max_version_probe_bytes,
                             phase="version_probe",
                             result=result,
                         )
@@ -2461,14 +2505,15 @@ class PyTorchZipScanner(BaseScanner):
                     try:
                         import json
 
-                        meta_data = json.loads(
-                            self._read_member_bytes(
-                                zipfile_obj,
-                                meta_entry,
-                                phase="version_probe",
-                                result=result,
-                            ).decode("utf-8")
+                        metadata_bytes = self._read_bounded_version_metadata(
+                            zipfile_obj,
+                            meta_entry,
+                            result,
+                            max_bytes=self.MAX_VERSION_JSON_BYTES,
                         )
+                        if metadata_bytes is None:
+                            continue
+                        meta_data = json.loads(metadata_bytes.decode("utf-8"))
                         # Look for framework-specific version fields in metadata.
                         # Avoid generic "version" keys, which often describe model/config
                         # schema versions and can cause false CVE attributions.
@@ -2691,7 +2736,7 @@ class PyTorchZipScanner(BaseScanner):
                     "size mismatches, enabling heap layout manipulation and arbitrary code execution."
                 ),
             )
-        else:
+        elif not self._version_metadata_analysis_incomplete(result):
             result.add_check(
                 name="CVE-2026-24747 PyTorch Version Check",
                 passed=True,

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -251,7 +251,7 @@ class PyTorchZipScanner(BaseScanner):
     MIN_COMPRESSION_BOMB_UNCOMPRESSED_SIZE: ClassVar[int] = 1024 * 1024
     MAX_ARCHIVE_ENTRIES: ClassVar[int] = 10000  # Maximum number of entries in archive
     MAX_VERSION_METADATA_BYTES: ClassVar[int] = 4096
-    MAX_VERSION_JSON_BYTES: ClassVar[int] = 1024 * 1024
+    MAX_VERSION_JSON_BYTES: ClassVar[int] = 10 * 1024 * 1024
     DEFAULT_VERSION_PICKLE_PROBE_BYTES: ClassVar[int] = 1024 * 1024
     DEFAULT_MAX_NESTED_ZIP_DEPTH: ClassVar[int] = 5
     DEFAULT_MAX_BLACKLIST_SCAN_BYTES: ClassVar[int] = 100 * 1024 * 1024
@@ -260,6 +260,7 @@ class PyTorchZipScanner(BaseScanner):
     ENTRY_LIMIT_INCONCLUSIVE_REASON: ClassVar[str] = "pytorch_zip_entry_limit"
     LOCAL_ENTRY_LIMIT_METADATA_KEY: ClassVar[str] = "pytorch_zip_local_entry_limit_exceeded"
     VERSION_METADATA_LIMIT_INCONCLUSIVE_REASON: ClassVar[str] = "pytorch_zip_version_metadata_size_limit"
+    VERSION_METADATA_READ_INCONCLUSIVE_REASON: ClassVar[str] = "pytorch_zip_version_metadata_read_failed"
     SCAN_INCONCLUSIVE_REASON: ClassVar[str] = "pytorch_zip_scan_incomplete"
 
     def __init__(self, config: dict[str, Any] | None = None):
@@ -2430,11 +2431,34 @@ class PyTorchZipScanner(BaseScanner):
                 },
             )
             return None
+        except Exception as exc:
+            mark_inconclusive_scan_result(result, self.VERSION_METADATA_READ_INCONCLUSIVE_REASON)
+            result.add_check(
+                name="PyTorch Version Metadata Read",
+                passed=False,
+                message=f"Could not read version metadata in {name}: {exc!s}",
+                severity=IssueSeverity.INFO,
+                location=f"{self.current_file_path}:{name}",
+                details={
+                    "zip_entry": name,
+                    "exception": str(exc),
+                    "exception_type": type(exc).__name__,
+                    "analysis_incomplete": True,
+                    "scan_outcome_reason": self.VERSION_METADATA_READ_INCONCLUSIVE_REASON,
+                },
+            )
+            return None
 
     @classmethod
     def _version_metadata_analysis_incomplete(cls, result: ScanResult) -> bool:
         reasons = result.metadata.get("scan_outcome_reasons")
-        return isinstance(reasons, list) and cls.VERSION_METADATA_LIMIT_INCONCLUSIVE_REASON in reasons
+        return isinstance(reasons, list) and any(
+            reason in reasons
+            for reason in (
+                cls.VERSION_METADATA_LIMIT_INCONCLUSIVE_REASON,
+                cls.VERSION_METADATA_READ_INCONCLUSIVE_REASON,
+            )
+        )
 
     def _extract_pytorch_version_info(
         self,

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -7040,6 +7040,40 @@ def test_pytorch_zip_scan_accepts_archive_version_at_metadata_limit(
     assert not [check for check in result.checks if check.name == "PyTorch Version Metadata Limit"]
 
 
+def test_pytorch_zip_version_metadata_read_failure_suppresses_fixed_version_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = tmp_path / "unreadable-version.pt"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("archive/version", "3")
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+
+    scanner = PyTorchZipScanner()
+    original_read_member_bytes = scanner._read_member_bytes
+
+    def fail_version_probe(*args: Any, **kwargs: Any) -> bytes:
+        if kwargs.get("phase") == "version_probe":
+            raise OSError("simulated version metadata read failure")
+        return original_read_member_bytes(*args, **kwargs)
+
+    monkeypatch.setattr(scanner, "_read_member_bytes", fail_version_probe)
+    monkeypatch.setattr(scanner, "_get_installed_pytorch_version", lambda: "2.10.0")
+
+    result = scanner.scan(str(model_path))
+
+    read_check = next(check for check in result.checks if check.name == "PyTorch Version Metadata Read")
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert PyTorchZipScanner.VERSION_METADATA_READ_INCONCLUSIVE_REASON in result.metadata["scan_outcome_reasons"]
+    assert read_check.details["zip_entry"] == "archive/version"
+    assert read_check.details["exception_type"] == "OSError"
+    assert not [
+        check
+        for check in result.checks
+        if check.name == "CVE-2026-24747 PyTorch Version Check" and check.status == CheckStatus.PASSED
+    ]
+
+
 def test_pytorch_zip_oversized_json_suppresses_fixed_version_claim(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -7000,6 +7000,105 @@ def test_pytorch_zip_version_extraction_returns_metadata_when_present(monkeypatc
     assert source == "metadata:config.json:pytorch_version"
 
 
+def test_pytorch_zip_scan_bounds_archive_version_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = tmp_path / "oversized-version.pt"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("archive/version", b"3" + (b" " * 8))
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+
+    monkeypatch.setattr(PyTorchZipScanner, "MAX_VERSION_METADATA_BYTES", 8)
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    limit_check = next(check for check in result.checks if check.name == "PyTorch Version Metadata Limit")
+    assert result.metadata["pytorch_archive_version"] is None
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert PyTorchZipScanner.VERSION_METADATA_LIMIT_INCONCLUSIVE_REASON in result.metadata["scan_outcome_reasons"]
+    assert limit_check.details["zip_entry"] == "archive/version"
+    assert limit_check.details["file_size"] == 9
+    assert limit_check.details["max_read_bytes"] == 8
+
+
+def test_pytorch_zip_scan_accepts_archive_version_at_metadata_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = tmp_path / "bounded-version.pt"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("archive/version", b"3" + (b" " * 7))
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+
+    monkeypatch.setattr(PyTorchZipScanner, "MAX_VERSION_METADATA_BYTES", 8)
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.metadata["pytorch_archive_version"] == "3"
+    assert PyTorchZipScanner.VERSION_METADATA_LIMIT_INCONCLUSIVE_REASON not in result.metadata.get(
+        "scan_outcome_reasons", []
+    )
+    assert not [check for check in result.checks if check.name == "PyTorch Version Metadata Limit"]
+
+
+def test_pytorch_zip_oversized_json_suppresses_fixed_version_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = tmp_path / "oversized-version-json.pt"
+    metadata = json.dumps({"padding": "x" * 32, "pytorch_version": "2.9.0"}).encode()
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("archive/version", "3")
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("config.json", metadata)
+
+    monkeypatch.setattr(PyTorchZipScanner, "MAX_VERSION_JSON_BYTES", len(metadata) - 1)
+    scanner = PyTorchZipScanner()
+    monkeypatch.setattr(scanner, "_get_installed_pytorch_version", lambda: "2.10.0")
+
+    result = scanner.scan(str(model_path))
+
+    assert PyTorchZipScanner.VERSION_METADATA_LIMIT_INCONCLUSIVE_REASON in result.metadata["scan_outcome_reasons"]
+    assert not [
+        check
+        for check in result.checks
+        if check.name == "CVE-2026-24747 PyTorch Version Check" and check.status == CheckStatus.PASSED
+    ]
+
+
+def test_pytorch_zip_oversized_json_preserves_vulnerable_local_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = tmp_path / "oversized-version-json-vulnerable-local.pt"
+    metadata = json.dumps({"padding": "x" * 32, "pytorch_version": "2.10.0"}).encode()
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("archive/version", "3")
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("config.json", metadata)
+
+    monkeypatch.setattr(PyTorchZipScanner, "MAX_VERSION_JSON_BYTES", len(metadata) - 1)
+    scanner = PyTorchZipScanner()
+    monkeypatch.setattr(scanner, "_get_installed_pytorch_version", lambda: "2.9.0")
+
+    result = scanner.scan(str(model_path))
+
+    failed_checks = [
+        check
+        for check in result.checks
+        if check.name == "CVE-2026-24747 PyTorch Version Check" and check.status == CheckStatus.FAILED
+    ]
+    assert len(failed_checks) == 1
+    assert failed_checks[0].details["detected_pytorch_version"] == "2.9.0"
+    assert failed_checks[0].details["pytorch_version_source"] == "local_environment"
+
+
+@pytest.mark.parametrize("invalid_probe_limit", [0, -1, False, "1024"])
+def test_pytorch_zip_version_probe_rejects_invalid_overrides(invalid_probe_limit: object) -> None:
+    scanner = PyTorchZipScanner(config={"version_probe_bytes": invalid_probe_limit})
+
+    assert scanner.max_version_probe_bytes == scanner.DEFAULT_VERSION_PICKLE_PROBE_BYTES
+
+
 def test_pytorch_zip_version_selection_prefers_local_vulnerable_version(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -7530,6 +7629,25 @@ def test_pytorch_zip_entry_limit_is_exit1_and_not_cached(tmp_path: Path) -> None
         expected_success=True,
         expected_exit_code=1,
         max_archive_entries=max_archive_entries,
+    )
+
+
+def test_pytorch_zip_version_metadata_limit_is_exit2_and_not_cached(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    zip_path = tmp_path / "oversized-version-metadata.pt"
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        zipf.writestr("archive/version", b"3" + (b" " * 8))
+        zipf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+
+    monkeypatch.setattr(PyTorchZipScanner, "MAX_VERSION_METADATA_BYTES", 8)
+    _assert_pytorch_zip_inconclusive_not_cached(
+        zip_path,
+        tmp_path / "version-metadata-limit-cache",
+        PyTorchZipScanner.VERSION_METADATA_LIMIT_INCONCLUSIVE_REASON,
+        expected_success=False,
+        expected_exit_code=2,
     )
 
 


### PR DESCRIPTION
## Summary

Follow-up to #1455. The entry cap bounded metadata listings, but the actual PyTorch version-detection path could still read `version`, `archive/version`, and JSON metadata members without a limit. It also accepted invalid `version_probe_bytes` values, including negative values that can request an unbounded read.

This change:
- bounds version files at 4 KiB and version JSON at 10 MiB
- normalizes pickle version-probe limits to a positive integer
- fails closed on oversized or unreadable version metadata
- suppresses fixed-version clean claims when version evidence is incomplete
- preserves vulnerable local-version findings
- adds malicious, boundary, invalid-config, cache, and exit-code regressions

## Validation

- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1`
  - 10,365 passed, 815 skipped
- `uv --no-config lock --check`