### PR TITLE
test(picklescan): stabilize Windows cache regressions

### DIFF
--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -4262,7 +4262,14 @@ def test_scan_bytes_warns_when_inert_source_imports_transitively_shadowable_stdl
         and finding.details.get("import_reference") == f"{module_name}.Gadget"
         for finding in report.findings
     )
-    load_payload = f"import pickle, sys; sys.path.insert(0, {str(tmp_path)!r}); pickle.loads({payload!r})"
+    load_payload = (
+        "import importlib, pickle, sys; "
+        f"sys.path.insert(0, {str(tmp_path)!r}); "
+        f"sys.modules.pop({stdlib_module!r}, None); "
+        f"sys.modules.pop({shadow_module!r}, None); "
+        "importlib.invalidate_caches(); "
+        f"pickle.loads({payload!r})"
+    )
     subprocess.run([sys.executable, "-c", load_payload], check=True)
     assert marker.read_text(encoding="utf-8") == "owned"
 
@@ -4378,14 +4385,14 @@ def test_scan_bytes_warns_when_timestamp_cache_overrides_inert_source(
     benign_source = "class Gadget:\n    pass\n"
     benign_source += "#" * (len(malicious_source.encode()) - len(benign_source.encode()))
     fixed_mtime = 1_700_000_000
-    source_path.write_text(malicious_source, encoding="utf-8")
+    source_path.write_bytes(malicious_source.encode())
     os.utime(source_path, (fixed_mtime, fixed_mtime))
     py_compile.compile(
         str(source_path),
         doraise=True,
         invalidation_mode=py_compile.PycInvalidationMode.TIMESTAMP,
     )
-    source_path.write_text(benign_source, encoding="utf-8")
+    source_path.write_bytes(benign_source.encode())
     os.utime(source_path, (fixed_mtime, fixed_mtime))
     monkeypatch.syspath_prepend(str(tmp_path))
     payload = f"c{module_name}\nGadget\n.".encode()
@@ -4418,7 +4425,7 @@ def test_scan_bytes_warns_when_optimized_cache_overrides_inert_source(
     benign_source = "class Gadget:\n    pass\n"
     benign_source += "#" * (len(malicious_source.encode()) - len(benign_source.encode()))
     fixed_mtime = 1_700_000_000
-    source_path.write_text(malicious_source, encoding="utf-8")
+    source_path.write_bytes(malicious_source.encode())
     os.utime(source_path, (fixed_mtime, fixed_mtime))
     py_compile.compile(
         str(source_path),
@@ -4426,7 +4433,7 @@ def test_scan_bytes_warns_when_optimized_cache_overrides_inert_source(
         optimize=1,
         invalidation_mode=py_compile.PycInvalidationMode.TIMESTAMP,
     )
-    source_path.write_text(benign_source, encoding="utf-8")
+    source_path.write_bytes(benign_source.encode())
     os.utime(source_path, (fixed_mtime, fixed_mtime))
     monkeypatch.syspath_prepend(str(tmp_path))
     payload = f"c{module_name}\nGadget\n.".encode()
@@ -4457,12 +4464,12 @@ def test_scan_bytes_warns_when_higher_optimized_cache_overrides_inert_source(
     benign_source = "class Gadget:\n    pass\n"
     benign_source += "#" * (len(malicious_source.encode()) - len(benign_source.encode()))
     fixed_mtime = 1_700_000_000
-    source_path.write_text(malicious_source, encoding="utf-8")
+    source_path.write_bytes(malicious_source.encode())
     os.utime(source_path, (fixed_mtime, fixed_mtime))
     compile_module = f"import sys; sys.path.insert(0, {str(tmp_path)!r}); import {module_name}"
     subprocess.run([sys.executable, "-OOO", "-c", compile_module], check=True)
     marker.unlink()
-    source_path.write_text(benign_source, encoding="utf-8")
+    source_path.write_bytes(benign_source.encode())
     os.utime(source_path, (fixed_mtime, fixed_mtime))
     monkeypatch.syspath_prepend(str(tmp_path))
     payload = f"c{module_name}\nGadget\n.".encode()


### PR DESCRIPTION
## Summary

- make timestamp-based bytecode cache fixtures preserve exact source sizes on Windows
- clear preloaded stdlib modules before proving transitive shadow-module execution
- restore the standalone picklescan Windows release lane

## Root cause

The new import-origin regressions wrote malicious and benign Python source in text mode. Windows newline translation changed their on-disk sizes by different amounts, so CPython correctly treated the timestamp cache as stale and the tests no longer exercised the intended cache override. The transitive shadow proof also depended on the target stdlib modules not already being present in the child process import cache.

## Validation

- focused import-cache regressions: 5 passed
- standalone picklescan Python 3.12 suite: 1496 passed, 76 skipped
- standalone ruff check/format and mypy: passed
- root ruff format/check and mypy: passed
- root fast suite: 11676 passed, 14 skipped; two unrelated wall-clock checks failed under 16-worker contention and passed in isolation
- isolated debug timing: 1 passed in 4.94s
- isolated directory performance: 1 passed in 42.28s
