### PR TITLE
fix: harden JFrog redirect targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- reject untrusted JFrog redirect hostnames unless explicitly allowed, block non-public IP targets, suppress ambient netrc credentials, and isolate redirect authentication and cookies
 - restrict manual Docker publishes to validated immutable version tags and their matching Git release refs before registry login or push
 - harden cloud acquisition size caps, HTTPS/R2 auto-default routing, and directory metadata failures
 - detect operator attrgetter, itemgetter, and methodcaller archive-member Python paths to command execution while preserving benign accessor names

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ modelaudit model.dvc
 - `GOOGLE_APPLICATION_CREDENTIALS` for GCS
 - `MLFLOW_TRACKING_URI` for MLflow registry access
 - `JFROG_API_TOKEN` or `JFROG_ACCESS_TOKEN` for JFrog Artifactory
+- `MODELAUDIT_JFROG_ALLOWED_HOSTS` for comma-separated custom JFrog hostnames that may receive credentials
+- `MODELAUDIT_JFROG_ALLOWED_REDIRECT_HOSTS` for comma-separated external redirect hostnames that may be downloaded without credentials
 - Store credentials in environment variables or a secrets manager, and never commit tokens/keys.
 
 ## Installation

--- a/modelaudit/utils/sources/jfrog.py
+++ b/modelaudit/utils/sources/jfrog.py
@@ -21,6 +21,7 @@ from urllib.parse import ParseResult, unquote, urljoin, urlparse, urlunparse
 
 import click
 import requests
+from requests.auth import AuthBase
 
 from ...config.constants import SCANNABLE_MODEL_EXTENSIONS
 
@@ -36,6 +37,14 @@ _MAX_JFROG_LISTING_ENTRIES = 100_000
 _MAX_JFROG_LISTED_FOLDERS = 10_000
 _MAX_JFROG_STORAGE_RESPONSE_BYTES = 64 * 1024 * 1024
 _JFROG_REDIRECT_STATUS_CODES = frozenset({301, 302, 303, 307, 308})
+_JFROG_IPV6_TRANSITION_NETWORKS = (
+    ipaddress.ip_network("::/96"),
+    ipaddress.ip_network("::ffff:0:0/96"),
+    ipaddress.ip_network("64:ff9b::/96"),
+    ipaddress.ip_network("64:ff9b:1::/48"),
+    ipaddress.ip_network("2001::/32"),
+    ipaddress.ip_network("2002::/16"),
+)
 _SENSITIVE_QUERY_PARAM_RE = re.compile(
     r"([?&][^=\s&]*(?:signature|credential|security-token|access-key|access_key|token|secret|api-key|api_key|apikey|sig)[^=\s&]*=)[^\s&#]+",
     re.IGNORECASE,
@@ -47,6 +56,16 @@ _TFLITE_MAGIC_BYTES = b"TFL3"
 _WINDOWS_RESERVED_LOCAL_NAMES = frozenset(
     {"CON", "PRN", "AUX", "NUL"} | {f"COM{index}" for index in range(1, 10)} | {f"LPT{index}" for index in range(1, 10)}
 )
+
+
+class _NoNetrcAuth(AuthBase):
+    """Prevent Requests from sourcing origin credentials from .netrc."""
+
+    def __call__(self, request: requests.PreparedRequest) -> requests.PreparedRequest:
+        return request
+
+
+_JFROG_NO_NETRC_AUTH = _NoNetrcAuth()
 
 
 def redact_jfrog_url_for_display(url: str) -> str:
@@ -248,6 +267,12 @@ def _get_trusted_jfrog_hosts() -> set[str]:
     return {host for host in _get_configured_jfrog_hosts() if not _is_local_jfrog_host(host)}
 
 
+def _get_allowed_jfrog_redirect_hosts() -> set[str]:
+    """Return redirect hostnames explicitly allowed as untrusted download targets."""
+    raw_hosts = os.getenv("MODELAUDIT_JFROG_ALLOWED_REDIRECT_HOSTS", "")
+    return {host for host in (_host_from_config_value(value) for value in raw_hosts.split(",")) if host}
+
+
 def _is_local_jfrog_host(hostname: str) -> bool:
     """Return True when a hostname is local-only development infrastructure."""
     if not hostname:
@@ -274,6 +299,33 @@ def _is_local_jfrog_host(hostname: str) -> bool:
 
 def _is_jfrog_service_host(hostname: str) -> bool:
     return hostname == "jfrog.io" or hostname.endswith(".jfrog.io")
+
+
+def _parse_jfrog_host_ip(hostname: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    try:
+        return ipaddress.ip_address(hostname)
+    except ValueError:
+        return None
+
+
+def _is_public_jfrog_ip(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    if isinstance(address, ipaddress.IPv6Address):
+        if address.scope_id is not None:
+            return False
+        if any(address in network for network in _JFROG_IPV6_TRANSITION_NETWORKS):
+            return False
+        if address.packed[8:12] in {b"\x00\x00\x5e\xfe", b"\x02\x00\x5e\xfe"}:
+            return False
+    return (
+        address.is_global
+        and not address.is_private
+        and not address.is_loopback
+        and not address.is_link_local
+        and not address.is_multicast
+        and not address.is_reserved
+        and not address.is_unspecified
+        and not (isinstance(address, ipaddress.IPv6Address) and address.is_site_local)
+    )
 
 
 def _get_requests_prepared_hostname(url: str) -> str:
@@ -410,9 +462,23 @@ def _safe_jfrog_relative_path(base_url: str, artifact_url: str) -> str:
 
 
 def _is_safe_jfrog_download_target(url: str) -> bool:
-    """Return True for unambiguous, non-local HTTPS download targets."""
+    """Return True for HTTPS targets with an explicit hostname trust decision."""
     origin = _get_jfrog_probe_origin(url)
-    return origin is not None and origin[0] == "https" and not _is_local_jfrog_host(origin[1])
+    if origin is None or origin[0] != "https":
+        return False
+
+    hostname = origin[1]
+    if (
+        _is_jfrog_service_host(hostname)
+        or hostname in _get_trusted_jfrog_hosts()
+        or hostname in _get_allowed_jfrog_redirect_hosts()
+    ):
+        return True
+    if _is_local_jfrog_host(hostname):
+        return False
+
+    parsed_ip = _parse_jfrog_host_ip(hostname)
+    return parsed_ip is not None and _is_public_jfrog_ip(parsed_ip)
 
 
 def _is_trusted_jfrog_auth_target(url: str) -> bool:
@@ -582,19 +648,21 @@ def _get_with_jfrog_redirect_policy(
     """GET a JFrog URL while isolating credentials from untrusted redirects."""
     current_url = url
     current_headers = headers
-    current_is_trusted = _is_trusted_jfrog_auth_target(url)
-    trusted_redirect_cookies = requests.cookies.RequestsCookieJar()
-    untrusted_redirect_cookies = requests.cookies.RequestsCookieJar()
+    credential_origin = _get_jfrog_probe_origin(url) if _is_trusted_jfrog_auth_target(url) else None
+    credentials_allowed = credential_origin is not None
+    redirect_cookie_jars: dict[tuple[str, str, int | None], requests.cookies.RequestsCookieJar] = {}
     for _redirect_count in range(_MAX_JFROG_REDIRECTS + 1):
-        if not _is_safe_jfrog_download_target(current_url):
+        current_origin = _get_jfrog_probe_origin(current_url)
+        if current_origin is None or not _is_safe_jfrog_download_target(current_url):
             raise requests.exceptions.RequestException(
                 f"Refusing unsafe JFrog download target {redact_jfrog_url_for_display(current_url)}"
             )
-        current_cookies = trusted_redirect_cookies if current_is_trusted else untrusted_redirect_cookies
+        current_cookies = redirect_cookie_jars.setdefault(current_origin, requests.cookies.RequestsCookieJar())
         response = requests.get(
             current_url,
             headers=current_headers,
             cookies=current_cookies,
+            auth=_JFROG_NO_NETRC_AUTH,
             timeout=timeout,
             stream=stream,
             allow_redirects=False,
@@ -613,8 +681,13 @@ def _get_with_jfrog_redirect_policy(
             )
 
         current_url = urljoin(current_url, location)
-        current_is_trusted = _is_trusted_jfrog_auth_target(current_url)
-        current_headers = headers if current_is_trusted else {}
+        next_is_trusted = _get_jfrog_probe_origin(current_url) == credential_origin and _is_trusted_jfrog_auth_target(
+            current_url
+        )
+        if credentials_allowed and not next_is_trusted:
+            redirect_cookie_jars.clear()
+        credentials_allowed = credentials_allowed and next_is_trusted
+        current_headers = headers if credentials_allowed else {}
 
     raise requests.exceptions.TooManyRedirects(
         f"Exceeded {_MAX_JFROG_REDIRECTS} redirects for JFrog URL {redact_jfrog_url_for_display(url)}"
@@ -927,6 +1000,7 @@ def _get_jfrog_response_with_redirect_policy(
             current_url,
             headers=headers,
             cookies=redirect_cookies,
+            auth=_JFROG_NO_NETRC_AUTH,
             stream=True,
             timeout=timeout,
             allow_redirects=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,6 +187,7 @@ def pytest_runtest_setup(item):
             "test_oci_layer_scanner.py",  # OCI layer path safety regression tests
             "test_jfrog.py",  # JFrog utility tests
             "test_jfrog_integration.py",  # JFrog integration tests
+            "test_jfrog_redirect_security.py",  # JFrog redirect SSRF regression tests
             "test_mlflow_integration.py",  # MLflow integration tests
             "test_streaming_analysis.py",  # signed stream routing and fallback regressions
             "test_tar_scanner.py",  # TAR archive scanner tests

--- a/tests/integrations/test_jfrog.py
+++ b/tests/integrations/test_jfrog.py
@@ -489,6 +489,7 @@ class TestJFrogDownload:
     ) -> None:
         """Full artifact downloads may follow an off-origin redirect without credentials."""
         monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_REDIRECT_HOSTS", "evil.example")
         redirect_response = _FakeStreamingResponse(
             b"",
             status_code=302,
@@ -584,6 +585,31 @@ class TestJFrogDownload:
 
         assert result.read_bytes() == b"data"
         assert mock_get.call_args_list[1].args[0] == redirected_url
+        assert mock_get.call_args_list[1].kwargs["headers"] == {"X-JFrog-Art-Api": "test-token"}
+        assert redirect_response.closed is True
+        assert final_response.closed is True
+
+    @patch("modelaudit.utils.sources.jfrog.requests.get")
+    def test_download_strips_credentials_on_alternate_port_redirect(
+        self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Credentials must not cross an effective-origin port boundary."""
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+        redirected_url = "https://company.jfrog.io:8443/artifactory/repo/model.bin"
+        redirect_response = _FakeStreamingResponse(b"", status_code=302, headers={"Location": redirected_url})
+        final_response = _FakeStreamingResponse(b"data")
+        mock_get.side_effect = [redirect_response, final_response]
+
+        result = download_artifact(
+            "https://company.jfrog.io/artifactory/repo/model.bin",
+            cache_dir=tmp_path,
+            api_token="test-token",
+        )
+
+        assert result.read_bytes() == b"data"
+        assert mock_get.call_args_list[0].kwargs["headers"] == {"X-JFrog-Art-Api": "test-token"}
+        assert mock_get.call_args_list[1].args[0] == redirected_url
+        assert mock_get.call_args_list[1].kwargs["headers"] == {}
         assert redirect_response.closed is True
         assert final_response.closed is True
 
@@ -743,6 +769,7 @@ class TestJFrogDownload:
         final_response.iter_content.return_value = [b"data"]
         mock_get.side_effect = [redirect_response, final_response]
         monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_REDIRECT_HOSTS", "evil.example")
 
         result = download_artifact(
             "https://company.jfrog.io/artifactory/repo/model.bin",
@@ -797,6 +824,7 @@ class TestJFrogDownload:
         final_response.iter_content.return_value = [b"123", b"456"]
         mock_get.side_effect = [redirect_response, final_response]
         monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_REDIRECT_HOSTS", "evil.example")
 
         with pytest.raises(Exception, match="exceeds maximum allowed size"):
             download_artifact(
@@ -914,10 +942,10 @@ class TestJFrogDownload:
         assert second_cookie_jar.get("ROUTEID") == "backend-a"
 
     @patch("modelaudit.utils.sources.jfrog.requests.get")
-    def test_download_redirect_isolates_cookies_across_trust_boundaries(
+    def test_download_redirect_does_not_restore_credentials_across_trust_boundaries(
         self, mock_get: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Trusted JFrog cookies must not cross an untrusted redirect hop."""
+        """An untrusted hop must permanently drop trusted credentials and session state."""
         trusted_redirect = MagicMock(spec=requests.Response)
         trusted_redirect.status_code = 302
         trusted_redirect.headers = {"Location": "https://evil.example/artifacts/model.bin"}
@@ -933,6 +961,7 @@ class TestJFrogDownload:
         final_response.iter_content.return_value = [b"data"]
         mock_get.side_effect = [trusted_redirect, untrusted_redirect, final_response]
         monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_REDIRECT_HOSTS", "evil.example")
 
         result = download_artifact(
             "https://company.jfrog.io/artifactory/repo/model.bin",
@@ -943,15 +972,18 @@ class TestJFrogDownload:
         assert result.read_bytes() == b"data"
         trusted_cookie_jar = mock_get.call_args_list[0].kwargs["cookies"]
         untrusted_cookie_jar = mock_get.call_args_list[1].kwargs["cookies"]
-        returning_trusted_cookie_jar = mock_get.call_args_list[2].kwargs["cookies"]
-        assert trusted_cookie_jar is returning_trusted_cookie_jar
+        returning_cookie_jar = mock_get.call_args_list[2].kwargs["cookies"]
+        assert returning_cookie_jar is not trusted_cookie_jar
+        assert returning_cookie_jar is not untrusted_cookie_jar
         assert trusted_cookie_jar is not untrusted_cookie_jar
         assert trusted_cookie_jar.get("JFROG_SESSION") == "trusted-session"
         assert trusted_cookie_jar.get("EVIL_SESSION") is None
         assert untrusted_cookie_jar.get("JFROG_SESSION") is None
         assert untrusted_cookie_jar.get("EVIL_SESSION") == "untrusted-session"
+        assert returning_cookie_jar.get("JFROG_SESSION") is None
+        assert returning_cookie_jar.get("EVIL_SESSION") is None
         assert mock_get.call_args_list[1].kwargs["headers"] == {}
-        assert mock_get.call_args_list[2].kwargs["headers"] == {"X-JFrog-Art-Api": "test-token"}
+        assert mock_get.call_args_list[2].kwargs["headers"] == {}
 
     @patch("modelaudit.utils.sources.jfrog.requests.get")
     def test_download_redirect_without_location_fails_closed(
@@ -1085,6 +1117,7 @@ class TestJFrogDownload:
         final_response = _fake_json_response({"repo": "repo", "path": "/model.bin", "size": 12})
         mock_get.side_effect = [redirect_response, final_response]
         monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+        monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_REDIRECT_HOSTS", "evil.example")
 
         result = detect_jfrog_target_type(
             "https://company.jfrog.io/artifactory/repo/model.bin",

--- a/tests/integrations/test_jfrog_redirect_security.py
+++ b/tests/integrations/test_jfrog_redirect_security.py
@@ -1,0 +1,327 @@
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from modelaudit.utils.sources.jfrog import _JFROG_NO_NETRC_AUTH, download_artifact
+
+
+class _FakeStreamingResponse:
+    def __init__(self, payload: bytes, *, status_code: int = 200, headers: dict[str, str] | None = None) -> None:
+        self.payload = payload
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.cookies = requests.cookies.RequestsCookieJar()
+        self.closed = False
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def iter_content(self, chunk_size: int = 1) -> Iterator[bytes]:
+        for offset in range(0, len(self.payload), chunk_size):
+            yield self.payload[offset : offset + chunk_size]
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.parametrize(
+    "location",
+    [
+        "https://10.0.0.8/artifacts/model.bin",
+        "https://172.16.0.8/artifacts/model.bin",
+        "https://192.168.1.8/artifacts/model.bin",
+        "https://169.254.169.254/latest/meta-data/",
+        "https://100.64.0.8/artifacts/model.bin",
+        "https://[fd00::1]/artifacts/model.bin",
+        "https://[::ffff:127.0.0.1]/artifacts/model.bin",
+        "https://[64:ff9b::7f00:1]/artifacts/model.bin",
+        "https://[64:ff9b::a9fe:a9fe]/artifacts/model.bin",
+        "https://[::127.0.0.1]/artifacts/model.bin",
+        "https://[::10.0.0.8]/artifacts/model.bin",
+        "https://[::ffff:0:127.0.0.1]/artifacts/model.bin",
+        "https://[2002:7f00:1::]/artifacts/model.bin",
+        "https://[2001::1]/artifacts/model.bin",
+        "https://[fec0::1]/artifacts/model.bin",
+        "https://[fe80::1%25eth0]/artifacts/model.bin",
+        "https://[2606:4700:4700::1111%25eth0]/artifacts/model.bin",
+        "https://[::ffff:93.184.216.34]/artifacts/model.bin",
+        "https://[2606:4700:4700:0:0:5efe:5db8:d822]/artifacts/model.bin",
+        "https://[2606:4700:4700:0:200:5efe:5db8:d822]/artifacts/model.bin",
+        "https://2130706433/artifacts/model.bin",
+        "https://127.1/artifacts/model.bin",
+        "https://0177.0.0.1/artifacts/model.bin",
+        "https://017700000001/artifacts/model.bin",
+        "https://0x7f000001/artifacts/model.bin",
+        "https://0x7f.0.0.1/artifacts/model.bin",
+        "https://010.010.010.010/artifacts/model.bin",
+        "https://8.8.8/artifacts/model.bin",
+        "https://0x08080808/artifacts/model.bin",
+        "https://224.0.0.1/artifacts/model.bin",
+        "https://[ff02::1]/artifacts/model.bin",
+    ],
+)
+@patch("modelaudit.utils.sources.jfrog.requests.get")
+def test_download_rejects_unsafe_ip_redirect_targets(
+    mock_get: MagicMock,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    location: str,
+) -> None:
+    monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+    redirect_response = _FakeStreamingResponse(b"", status_code=302, headers={"Location": location})
+    mock_get.return_value = redirect_response
+
+    with pytest.raises(Exception, match="Refusing unsafe JFrog download target"):
+        download_artifact(
+            "https://company.jfrog.io/artifactory/repo/model.bin",
+            cache_dir=tmp_path,
+            api_token="test-token",
+        )
+
+    mock_get.assert_called_once()
+    assert redirect_response.closed is True
+    assert not any(tmp_path.iterdir())
+
+
+@patch("modelaudit.utils.sources.jfrog.requests.get")
+def test_download_allows_explicit_private_redirect_host_without_credentials(
+    mock_get: MagicMock,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+    monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_REDIRECT_HOSTS", "10.0.0.8")
+    redirect_response = _FakeStreamingResponse(
+        b"",
+        status_code=302,
+        headers={"Location": "https://10.0.0.8/artifacts/model.bin"},
+    )
+    final_response = _FakeStreamingResponse(b"data")
+    mock_get.side_effect = [redirect_response, final_response]
+
+    result = download_artifact(
+        "https://company.jfrog.io/artifactory/repo/model.bin",
+        cache_dir=tmp_path,
+        api_token="test-token",
+    )
+
+    assert result.read_bytes() == b"data"
+    assert mock_get.call_args_list[0].kwargs["headers"] == {"X-JFrog-Art-Api": "test-token"}
+    assert mock_get.call_args_list[1].args[0] == "https://10.0.0.8/artifacts/model.bin"
+    assert mock_get.call_args_list[1].kwargs["headers"] == {}
+    assert redirect_response.closed is True
+    assert final_response.closed is True
+
+
+@patch("modelaudit.utils.sources.jfrog.requests.get")
+def test_download_allows_public_ip_redirect_without_credentials(
+    mock_get: MagicMock,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+    redirect_response = _FakeStreamingResponse(
+        b"",
+        status_code=302,
+        headers={"Location": "https://93.184.216.34/artifacts/model.bin"},
+    )
+    final_response = _FakeStreamingResponse(b"data")
+    mock_get.side_effect = [redirect_response, final_response]
+
+    result = download_artifact(
+        "https://company.jfrog.io/artifactory/repo/model.bin",
+        cache_dir=tmp_path,
+        api_token="test-token",
+    )
+
+    assert result.read_bytes() == b"data"
+    assert mock_get.call_args_list[1].kwargs["headers"] == {}
+
+
+@patch("modelaudit.utils.sources.jfrog.requests.get")
+def test_download_allows_public_ipv6_redirect_without_credentials(
+    mock_get: MagicMock,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+    redirect_response = _FakeStreamingResponse(
+        b"",
+        status_code=302,
+        headers={"Location": "https://[2606:4700:4700::1111]/artifacts/model.bin"},
+    )
+    final_response = _FakeStreamingResponse(b"data")
+    mock_get.side_effect = [redirect_response, final_response]
+
+    result = download_artifact(
+        "https://company.jfrog.io/artifactory/repo/model.bin",
+        cache_dir=tmp_path,
+        api_token="test-token",
+    )
+
+    assert result.read_bytes() == b"data"
+    assert mock_get.call_args_list[1].kwargs["headers"] == {}
+
+
+@patch("modelaudit.utils.sources.jfrog.requests.get")
+def test_download_rejects_untrusted_redirect_hostname_by_default(
+    mock_get: MagicMock,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+    redirect_response = _FakeStreamingResponse(
+        b"",
+        status_code=302,
+        headers={"Location": "https://storage.redirect.test/artifacts/model.bin"},
+    )
+    mock_get.return_value = redirect_response
+
+    with pytest.raises(Exception, match="Refusing unsafe JFrog download target"):
+        download_artifact(
+            "https://company.jfrog.io/artifactory/repo/model.bin",
+            cache_dir=tmp_path,
+            api_token="test-token",
+        )
+
+    mock_get.assert_called_once()
+    assert redirect_response.closed is True
+    assert not any(tmp_path.iterdir())
+
+
+@patch("modelaudit.utils.sources.jfrog.requests.get")
+def test_download_allows_explicit_redirect_hostname_without_credentials(
+    mock_get: MagicMock,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+    monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_REDIRECT_HOSTS", "public.redirect.test")
+    redirect_response = _FakeStreamingResponse(
+        b"",
+        status_code=302,
+        headers={"Location": "https://public.redirect.test/artifacts/model.bin"},
+    )
+    final_response = _FakeStreamingResponse(b"data")
+    mock_get.side_effect = [redirect_response, final_response]
+
+    result = download_artifact(
+        "https://company.jfrog.io/artifactory/repo/model.bin",
+        cache_dir=tmp_path,
+        api_token="test-token",
+    )
+
+    assert result.read_bytes() == b"data"
+    assert mock_get.call_args_list[1].kwargs["headers"] == {}
+
+
+@patch("modelaudit.utils.sources.jfrog.requests.get")
+def test_download_allows_explicit_private_redirect_hostname_without_credentials(
+    mock_get: MagicMock,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+    monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_REDIRECT_HOSTS", "storage.internal")
+    redirect_response = _FakeStreamingResponse(
+        b"",
+        status_code=302,
+        headers={"Location": "https://storage.internal/artifacts/model.bin"},
+    )
+    final_response = _FakeStreamingResponse(b"data")
+    mock_get.side_effect = [redirect_response, final_response]
+
+    result = download_artifact(
+        "https://company.jfrog.io/artifactory/repo/model.bin",
+        cache_dir=tmp_path,
+        api_token="test-token",
+    )
+
+    assert result.read_bytes() == b"data"
+    assert mock_get.call_args_list[1].kwargs["headers"] == {}
+
+
+@patch("modelaudit.utils.sources.jfrog.requests.get")
+def test_download_redirects_do_not_load_netrc_credentials(
+    mock_get: MagicMock,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+    monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_REDIRECT_HOSTS", "public.redirect.test")
+    responses = iter(
+        [
+            _FakeStreamingResponse(
+                b"",
+                status_code=302,
+                headers={"Location": "https://public.redirect.test/artifacts/model.bin"},
+            ),
+            _FakeStreamingResponse(b"data"),
+        ]
+    )
+    prepared_requests: list[requests.PreparedRequest] = []
+
+    def prepare_request(url: str, **kwargs: Any) -> _FakeStreamingResponse:
+        with patch("requests.sessions.get_netrc_auth", return_value=("ambient-user", "ambient-secret")):
+            prepared = requests.Session().prepare_request(
+                requests.Request(
+                    "GET",
+                    url,
+                    headers=kwargs["headers"],
+                    auth=kwargs["auth"],
+                )
+            )
+        prepared_requests.append(prepared)
+        return next(responses)
+
+    mock_get.side_effect = prepare_request
+
+    result = download_artifact(
+        "https://company.jfrog.io/artifactory/repo/model.bin",
+        cache_dir=tmp_path,
+        access_token="test-token",
+    )
+
+    assert result.read_bytes() == b"data"
+    assert [request.headers.get("Authorization") for request in prepared_requests] == ["Bearer test-token", None]
+    assert all(call.kwargs["auth"] is _JFROG_NO_NETRC_AUTH for call in mock_get.call_args_list)
+
+
+@patch("modelaudit.utils.sources.jfrog.requests.get")
+def test_download_isolates_cookies_between_untrusted_redirect_origins(
+    mock_get: MagicMock,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_HOSTS", "company.jfrog.io")
+    monkeypatch.setenv("MODELAUDIT_JFROG_ALLOWED_REDIRECT_HOSTS", "a.redirect.test,b.redirect.test")
+    first_redirect = _FakeStreamingResponse(
+        b"",
+        status_code=302,
+        headers={"Location": "https://a.redirect.test/artifacts/model.bin"},
+    )
+    second_redirect = _FakeStreamingResponse(
+        b"",
+        status_code=302,
+        headers={"Location": "https://b.redirect.test/artifacts/model.bin"},
+    )
+    second_redirect.cookies.set_cookie(requests.cookies.create_cookie("CDN_SESSION", "host-a", domain=".redirect.test"))
+    final_response = _FakeStreamingResponse(b"data")
+    mock_get.side_effect = [first_redirect, second_redirect, final_response]
+
+    result = download_artifact(
+        "https://company.jfrog.io/artifactory/repo/model.bin",
+        cache_dir=tmp_path,
+        api_token="test-token",
+    )
+
+    assert result.read_bytes() == b"data"
+    host_a_cookies = mock_get.call_args_list[1].kwargs["cookies"]
+    host_b_cookies = mock_get.call_args_list[2].kwargs["cookies"]
+    assert host_a_cookies is not host_b_cookies
+    assert host_a_cookies.get("CDN_SESSION") == "host-a"
+    assert host_b_cookies.get("CDN_SESSION") is None


### PR DESCRIPTION
## Summary

- integrate JFrog redirect validation directly into the source module and remove the import-time monkeypatch
- prevent DNS-rebinding and proxy split-DNS bypasses by rejecting arbitrary off-origin redirect hostnames unless they are trusted JFrog hosts or explicitly listed in `MODELAUDIT_JFROG_ALLOWED_REDIRECT_HOSTS`
- allow canonical public IP redirect targets while rejecting private, loopback, link-local, CGNAT, multicast, reserved, site-local, IPv4-mapped, NAT64, Teredo, 6to4, ISATAP, scoped IPv6, and legacy mixed-radix IPv4 destinations
- suppress ambient `.netrc` authentication so Requests cannot add credentials to allowlisted redirect targets or replace explicit Bearer auth
- keep credentials only on the original effective origin, including normalized default ports; alternate-port and untrusted redirects receive no authorization headers
- permanently drop credentials and trusted session state after an untrusted hop, and isolate redirect cookies by effective origin
- document custom JFrog and redirect-host configuration and register the regression suite for reduced CI lanes
- synchronize with current `main` at `dc0051c5bd1fa22f3779b94e9624a78f46da37d1`

## False-positive / false-negative audit

- reject IPv4-mapped IPv6 in its original form before any unwrapping
- reject short, octal, hexadecimal, and mixed-radix IPv4 spellings
- reject globally routed IPv6 literals carrying a scope identifier
- reject both RFC 5214 ISATAP interface-identifier variants
- preserve credentials and cookies across same-origin/default-port redirects
- strip credentials across alternate-port or untrusted redirects and never restore them after returning
- keep cookies isolated between distinct untrusted origins
- allow explicitly configured private redirect destinations without forwarding JFrog credentials
- found no additional high-confidence bypass after an independent current-main parser/redirect audit

## Validation

- associated JFrog modules: `211 passed, 1 skipped` (optional ONNX dependency unavailable)
- scoped Ruff check and format: passed
- scoped mypy: passed
- Prettier check for `CHANGELOG.md` and `README.md`: passed
- `git diff --check`: passed
- full local suite intentionally not run per PR-audit workflow

Published commit: `67bcc37159f10b8a9faadcacc3ba8d1d608676b2`
Verified tree: `f74e9b07ff5e40b21555d11c408431b63d58229e`