### PR TITLE
fix: bound joblib decompression output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- bound Joblib decompression output to the configured scanner read budget
 - preserve dangerous JIT embedded-Python findings after benign member overwrites while bounding replay and suppression analysis
 - fail closed when capped DVC pointer outputs are not otherwise covered, change during verification, exceed bounded tail verification, or exhaust shared scan budgets
 - preserve registrable network domains and redact delimiter-split credentials in bounded finding evidence

--- a/modelaudit/scanners/joblib_scanner.py
+++ b/modelaudit/scanners/joblib_scanner.py
@@ -132,15 +132,30 @@ class JoblibScanner(BaseScanner):
         self.pickle_scanner, self.scanner_selection = embedded_pickle_scanner(self.config, PickleScanner)
         # Security limits
         self.max_decompression_ratio = self.config.get("max_decompression_ratio", 100.0)
+        has_explicit_read_budget = "max_file_read_size" in self.config
+        configured_file_size = self.config.get("max_file_size")
+        public_file_size_budget = (
+            configured_file_size
+            if not isinstance(configured_file_size, bool)
+            and isinstance(configured_file_size, int)
+            and configured_file_size > 0
+            else None
+        )
         decompressed_read_budget = (
             self.max_file_read_size if self.max_file_read_size > 0 else self.default_max_file_read_size
         )
+        if not has_explicit_read_budget and public_file_size_budget is not None:
+            decompressed_read_budget = public_file_size_budget
         configured_decompressed_size = self._normalize_positive_int_config(
             self.config.get("max_decompressed_size", decompressed_read_budget),
             decompressed_read_budget,
         )
         self.max_decompressed_size = configured_decompressed_size
-        if self.max_file_read_size > 0:
+        if has_explicit_read_budget and self.max_file_read_size > 0:
+            self.max_decompressed_size = min(self.max_decompressed_size, self.max_file_read_size)
+        elif not has_explicit_read_budget and public_file_size_budget is not None:
+            self.max_decompressed_size = min(self.max_decompressed_size, public_file_size_budget)
+        elif configured_file_size != 0 and self.max_file_read_size > 0:
             self.max_decompressed_size = min(self.max_decompressed_size, self.max_file_read_size)
         self.chunk_size = self.config.get("chunk_size", 8192)  # 8KB chunks
 

--- a/modelaudit/scanners/joblib_scanner.py
+++ b/modelaudit/scanners/joblib_scanner.py
@@ -132,10 +132,14 @@ class JoblibScanner(BaseScanner):
         self.pickle_scanner, self.scanner_selection = embedded_pickle_scanner(self.config, PickleScanner)
         # Security limits
         self.max_decompression_ratio = self.config.get("max_decompression_ratio", 100.0)
-        self.max_decompressed_size = self.config.get(
-            "max_decompressed_size",
-            10 * 1024 * 1024 * 1024,
-        )  # 10GB for large ML models
+        decompressed_read_budget = (
+            self.max_file_read_size if self.max_file_read_size > 0 else self.default_max_file_read_size
+        )
+        configured_decompressed_size = self._normalize_positive_int_config(
+            self.config.get("max_decompressed_size", decompressed_read_budget),
+            decompressed_read_budget,
+        )
+        self.max_decompressed_size = min(configured_decompressed_size, decompressed_read_budget)
         self.chunk_size = self.config.get("chunk_size", 8192)  # 8KB chunks
 
     @classmethod

--- a/modelaudit/scanners/joblib_scanner.py
+++ b/modelaudit/scanners/joblib_scanner.py
@@ -139,7 +139,9 @@ class JoblibScanner(BaseScanner):
             self.config.get("max_decompressed_size", decompressed_read_budget),
             decompressed_read_budget,
         )
-        self.max_decompressed_size = min(configured_decompressed_size, decompressed_read_budget)
+        self.max_decompressed_size = configured_decompressed_size
+        if self.max_file_read_size > 0:
+            self.max_decompressed_size = min(self.max_decompressed_size, self.max_file_read_size)
         self.chunk_size = self.config.get("chunk_size", 8192)  # 8KB chunks
 
     @classmethod

--- a/tests/scanners/test_joblib_scanner.py
+++ b/tests/scanners/test_joblib_scanner.py
@@ -34,6 +34,10 @@ def test_joblib_default_decompressed_cap_tracks_file_read_budget() -> None:
 
     assert scanner.max_decompressed_size == 2 * 1024 * 1024
 
+    scanner = JoblibScanner({"max_file_read_size": 0, "max_decompressed_size": 1024 * 1024 * 1024})
+
+    assert scanner.max_decompressed_size == 1024 * 1024 * 1024
+
     scanner = JoblibScanner({"max_file_read_size": 2 * 1024 * 1024, "max_decompressed_size": 4 * 1024 * 1024})
 
     assert scanner.max_decompressed_size == 2 * 1024 * 1024

--- a/tests/scanners/test_joblib_scanner.py
+++ b/tests/scanners/test_joblib_scanner.py
@@ -1,4 +1,8 @@
+import bz2
+import gzip
+import lzma
 import zlib
+from collections.abc import Callable
 from pathlib import Path
 
 import numpy as np
@@ -41,6 +45,28 @@ def test_joblib_default_decompressed_cap_tracks_file_read_budget() -> None:
     scanner = JoblibScanner({"max_file_read_size": 2 * 1024 * 1024, "max_decompressed_size": 4 * 1024 * 1024})
 
     assert scanner.max_decompressed_size == 2 * 1024 * 1024
+
+
+@pytest.mark.parametrize("invalid_value", [None, 0, -1, True, False, 1.5, "1024"])
+def test_joblib_invalid_decompressed_cap_uses_read_budget(invalid_value: object) -> None:
+    scanner = JoblibScanner({"max_file_read_size": 4096, "max_decompressed_size": invalid_value})
+
+    assert scanner.max_decompressed_size == 4096
+
+
+@pytest.mark.parametrize(
+    "compress",
+    [zlib.compress, gzip.compress, bz2.compress, lzma.compress],
+    ids=["zlib", "gzip", "bz2", "lzma"],
+)
+def test_joblib_decompression_cap_is_exact_for_all_supported_codecs(
+    compress: Callable[[bytes], bytes],
+) -> None:
+    scanner = JoblibScanner({"max_decompressed_size": 128, "max_decompression_ratio": 1000.0})
+
+    assert scanner._safe_decompress(compress(b"A" * 128)) == b"A" * 128
+    with pytest.raises(ValueError, match=r"Decompressed size too large: 129 bytes \(max: 128\)"):
+        scanner._safe_decompress(compress(b"A" * 129))
 
 
 def test_joblib_scanner_respects_explicit_decompressed_cap(tmp_path: Path) -> None:

--- a/tests/scanners/test_joblib_scanner.py
+++ b/tests/scanners/test_joblib_scanner.py
@@ -1,3 +1,4 @@
+import zlib
 from pathlib import Path
 
 import numpy as np
@@ -22,6 +23,46 @@ def test_joblib_scanner_basic(tmp_path: Path) -> None:
 
     assert result.success is True
     assert result.bytes_scanned > 0
+
+
+def test_joblib_default_decompressed_cap_tracks_file_read_budget() -> None:
+    scanner = JoblibScanner()
+
+    assert scanner.max_decompressed_size == scanner.max_file_read_size
+
+    scanner = JoblibScanner({"max_file_read_size": 2 * 1024 * 1024})
+
+    assert scanner.max_decompressed_size == 2 * 1024 * 1024
+
+    scanner = JoblibScanner({"max_file_read_size": 2 * 1024 * 1024, "max_decompressed_size": 4 * 1024 * 1024})
+
+    assert scanner.max_decompressed_size == 2 * 1024 * 1024
+
+
+def test_joblib_scanner_respects_explicit_decompressed_cap(tmp_path: Path) -> None:
+    path = tmp_path / "model.joblib"
+    joblib.dump({"a": np.arange(5)}, path, compress=3)
+
+    result = JoblibScanner({"max_decompressed_size": 64 * 1024}).scan(str(path))
+
+    assert result.success is True
+    assert not any(
+        check.name == "Compression Bomb Detection" and check.status.value == "failed" for check in result.checks
+    )
+
+
+def test_joblib_scanner_fails_before_large_decompression_allocation(tmp_path: Path) -> None:
+    path = tmp_path / "oversized.joblib"
+    path.write_bytes(zlib.compress(b"A" * 4096))
+
+    result = JoblibScanner({"max_decompressed_size": 128, "max_decompression_ratio": 1000.0}).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["operational_error_reason"] == "joblib_wrapper_decode_failed"
+    failed_check = next(check for check in result.checks if check.name == "Compression Bomb Detection")
+    assert failed_check.status.value == "failed"
+    assert "Decompressed size too large" in failed_check.message
+    assert "max: 128" in failed_check.message
 
 
 def test_joblib_scanner_closes_bytesio(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/scanners/test_joblib_scanner.py
+++ b/tests/scanners/test_joblib_scanner.py
@@ -46,6 +46,24 @@ def test_joblib_default_decompressed_cap_tracks_file_read_budget() -> None:
 
     assert scanner.max_decompressed_size == 2 * 1024 * 1024
 
+    scanner = JoblibScanner({"max_file_size": 1024 * 1024 * 1024})
+
+    assert scanner.max_decompressed_size == 1024 * 1024 * 1024
+
+    scanner = JoblibScanner({"max_file_size": 1024 * 1024 * 1024, "max_decompressed_size": 2 * 1024 * 1024 * 1024})
+
+    assert scanner.max_decompressed_size == 1024 * 1024 * 1024
+
+    scanner = JoblibScanner(
+        {
+            "max_file_size": 1024 * 1024 * 1024,
+            "max_file_read_size": 256 * 1024 * 1024,
+            "max_decompressed_size": 2 * 1024 * 1024 * 1024,
+        }
+    )
+
+    assert scanner.max_decompressed_size == 256 * 1024 * 1024
+
 
 @pytest.mark.parametrize("invalid_value", [None, 0, -1, True, False, 1.5, "1024"])
 def test_joblib_invalid_decompressed_cap_uses_read_budget(invalid_value: object) -> None:


### PR DESCRIPTION
## Summary
- bound Joblib decompressed-output defaults to the scanner read budget instead of a 10 GB in-memory cap
- cap explicit `max_decompressed_size` by the active read budget unless callers also raise that budget
- preserve explicit decompression caps when `max_file_read_size=0` opts out of the scanner read cap
- validate exact-limit and over-limit behavior for zlib, gzip, bz2, and lzma wrappers
- normalize invalid decompression caps to the bounded read budget
- document the user-visible security hardening under `[Unreleased]`

## False-positive / false-negative audit
- benign compressed joblib fixtures still scan successfully with a small explicit decompressed cap
- exact-cap payloads remain accepted across all supported codecs
- every supported wrapper stops at 129 bytes for a 128-byte cap and fails closed before large allocation
- oversized payloads produce an operational failed scan, not a warning/critical security finding
- invalid, zero, negative, boolean, float, and string decompression caps fall back to the bounded read budget
- explicit larger scans remain possible by raising the scanner read budget and decompression cap together; `max_file_read_size=0` preserves an explicit cap

## Validation
- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run --frozen --extra joblib pytest -q tests/scanners/test_joblib_scanner.py tests/scanners/test_joblib_scanner_codecs.py --maxfail=1` -> 31 passed
- scoped Ruff check and format check -> clean
- scoped mypy -> success
- `git diff --check` -> clean

The previous Python CI failure was the known unrelated JIT detector regression. The full local test suite was intentionally left to CI.