### PR TITLE
fix: disable unsafe metadata deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- disable unsafe Joblib and NumPy object metadata deserialization
 - harden cloud acquisition size caps, HTTPS/R2 auto-default routing, and directory metadata failures
 - detect operator attrgetter, itemgetter, and methodcaller archive-member Python paths to command execution while preserving benign accessor names
 - redact Keras and TensorFlow scanner detail fields that echo model-controlled configs, code indicators, archive members, and external references.

--- a/modelaudit/metadata_extractor.py
+++ b/modelaudit/metadata_extractor.py
@@ -282,6 +282,7 @@ class ModelMetadataExtractor:
             "has_external_data",
             # Deserialization status
             "deserialization_skipped",
+            "allow_metadata_deserialization_ignored",
             "reason",
             "dangerous_opcodes",
             "has_dangerous_opcodes",

--- a/modelaudit/scanners/joblib_scanner.py
+++ b/modelaudit/scanners/joblib_scanner.py
@@ -10,6 +10,7 @@ import pickletools
 import zlib
 from collections.abc import Callable
 from contextlib import suppress
+from importlib.metadata import version as distribution_version
 from typing import Any, ClassVar
 
 from ..detectors.cve_patterns import analyze_cve_patterns, enhance_scan_result_with_cve
@@ -576,85 +577,12 @@ class JoblibScanner(BaseScanner):
         """Extract joblib metadata."""
         metadata = super().extract_metadata(file_path)
 
-        allow_deserialization = bool(self.config.get("allow_metadata_deserialization"))
+        with suppress(Exception):
+            metadata["joblib_version"] = distribution_version("joblib")
 
-        if not allow_deserialization:
-            metadata["deserialization_skipped"] = True
-            metadata["reason"] = "Deserialization disabled for metadata extraction"
-            return metadata
-
-        try:
-            import joblib
-
-            # Try to load the joblib file
-            obj = joblib.load(file_path)
-
-            metadata.update(
-                {
-                    "joblib_version": joblib.__version__,
-                    "object_type": type(obj).__name__,
-                    "object_module": getattr(type(obj), "__module__", "unknown"),
-                }
-            )
-
-            # Analyze sklearn models specifically
-            if hasattr(obj, "_sklearn_version"):
-                metadata["sklearn_version"] = str(obj._sklearn_version)
-
-            if hasattr(obj, "get_params"):
-                try:
-                    try:
-                        params = obj.get_params(deep=False)
-                    except TypeError:
-                        params = obj.get_params()
-                    metadata.update(
-                        {
-                            "model_parameters": len(params),
-                            "key_parameters": list(params.keys())[:10],  # First 10 parameters
-                        }
-                    )
-                except Exception:
-                    metadata["model_parameters_unavailable"] = True
-
-            # Check for common sklearn model attributes
-            if hasattr(obj, "n_features_in_"):
-                metadata["n_features_in"] = obj.n_features_in_
-
-            if hasattr(obj, "classes_"):
-                metadata.update(
-                    {
-                        "n_classes": len(obj.classes_),
-                        "classes": list(obj.classes_)[:10]
-                        if len(obj.classes_) <= 10
-                        else f"{len(obj.classes_)} classes",
-                    }
-                )
-
-            if hasattr(obj, "feature_importances_"):
-                metadata["has_feature_importances"] = True
-                with suppress(Exception):
-                    importances = obj.feature_importances_
-                    metadata["feature_importance_stats"] = {
-                        "min": float(min(importances)),
-                        "max": float(max(importances)),
-                        "mean": float(sum(importances) / len(importances)),
-                    }
-            else:
-                metadata["has_feature_importances"] = False
-
-            # Check for ensemble models
-            if hasattr(obj, "estimators_"):
-                metadata.update(
-                    {
-                        "is_ensemble": True,
-                        "n_estimators": len(obj.estimators_),
-                    }
-                )
-            else:
-                metadata["is_ensemble"] = False
-
-        except Exception as e:
-            metadata["extraction_error"] = str(e)
-            metadata["extraction_error_type"] = type(e).__name__
+        metadata["deserialization_skipped"] = True
+        metadata["reason"] = "Unsafe in-process joblib deserialization is disabled for metadata extraction"
+        if self.config.get("allow_metadata_deserialization"):
+            metadata["allow_metadata_deserialization_ignored"] = True
 
         return metadata

--- a/modelaudit/scanners/numpy_scanner.py
+++ b/modelaudit/scanners/numpy_scanner.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import ast
+import io
+import struct
 import sys
 import warnings
 from typing import TYPE_CHECKING, Any, BinaryIO, ClassVar
@@ -57,6 +60,62 @@ def _finish_with_inconclusive_contract(result: ScanResult, *, default_success: b
 
 
 NUMPY_OBJECT_EMBEDDED_PICKLE_SELECTION_SKIP_REASON = "numpy_object_embedded_pickle_scanner_selection_skip"
+NUMPY_HEADER_MAX_SIZE = 10_000
+NUMPY_V3_HEADER_MAX_BYTES = NUMPY_HEADER_MAX_SIZE * 4
+
+
+def _read_numpy_array_header(handle: BinaryIO, version: tuple[int, int]) -> tuple[tuple[int, ...], bool, Any]:
+    """Read a bounded NumPy header while preserving v3 UTF-8 field names."""
+    if version == (1, 0):
+        header_length_format = "<H"
+    elif version in {(2, 0), (3, 0)}:
+        header_length_format = "<I"
+    else:
+        raise ValueError(f"Unsupported NumPy file format version: {version}")
+
+    header_length_size = struct.calcsize(header_length_format)
+    header_length_bytes = handle.read(header_length_size)
+    if len(header_length_bytes) != header_length_size:
+        raise ValueError("EOF while reading NumPy header length")
+    header_length = struct.unpack(header_length_format, header_length_bytes)[0]
+    max_header_bytes = NUMPY_V3_HEADER_MAX_BYTES if version == (3, 0) else NUMPY_HEADER_MAX_SIZE
+    if header_length > max_header_bytes:
+        raise ValueError(
+            f"NumPy header is too large: {header_length} bytes (max: {max_header_bytes})",
+        )
+
+    header_bytes = handle.read(header_length)
+    if len(header_bytes) != header_length:
+        raise ValueError("EOF while reading NumPy header")
+
+    if version == (1, 0):
+        shape, fortran_order, dtype = fmt.read_array_header_1_0(io.BytesIO(header_length_bytes + header_bytes))
+    elif version == (2, 0):
+        shape, fortran_order, dtype = fmt.read_array_header_2_0(io.BytesIO(header_length_bytes + header_bytes))
+    else:
+        header_text = header_bytes.decode("utf-8")
+        if len(header_text) > NUMPY_HEADER_MAX_SIZE:
+            raise ValueError(
+                f"NumPy header is too large: {len(header_text)} characters (max: {NUMPY_HEADER_MAX_SIZE})",
+            )
+        header = ast.literal_eval(header_text)
+        if not isinstance(header, dict) or set(header) != {"descr", "fortran_order", "shape"}:
+            raise ValueError("Invalid NumPy v3 header dictionary")
+
+        shape = header["shape"]
+        fortran_order = header["fortran_order"]
+        if not isinstance(shape, tuple) or not all(isinstance(dim, int) for dim in shape):
+            raise ValueError("Invalid NumPy v3 array shape")
+        if not isinstance(fortran_order, bool):
+            raise ValueError("Invalid NumPy v3 fortran_order value")
+        dtype = fmt.descr_to_dtype(header["descr"])
+
+    if any(isinstance(dim, bool) for dim in shape):
+        raise ValueError("Boolean NumPy shape dimensions are invalid")
+    if any(dim < 0 for dim in shape):
+        raise ValueError("Negative NumPy shape dimensions are invalid")
+
+    return shape, fortran_order, dtype
 
 
 class NumPyScanner(BaseScanner):
@@ -325,17 +384,7 @@ class NumPyScanner(BaseScanner):
                     # Use format module with version compatibility
                     try:
                         major, minor = fmt.read_magic(f)
-                        if (major, minor) == (1, 0):
-                            shape, fortran, dtype = fmt.read_array_header_1_0(f)
-                        elif (major, minor) == (2, 0):
-                            shape, fortran, dtype = fmt.read_array_header_2_0(f)
-                        else:
-                            # For newer versions, try the private method with fallback
-                            if hasattr(fmt, "_read_array_header"):
-                                shape, fortran, dtype = fmt._read_array_header(f, version=(major, minor))
-                            else:
-                                # Fallback for newer NumPy versions
-                                shape, fortran, dtype = fmt.read_array_header_2_0(f)
+                        shape, fortran, dtype = _read_numpy_array_header(f, (major, minor))
                     except OSError:
                         raise
                     except Exception as header_error:
@@ -645,41 +694,68 @@ class NumPyScanner(BaseScanner):
     def extract_metadata(self, file_path: str) -> dict[str, Any]:
         """Extract NumPy array metadata without deserializing object arrays."""
         metadata = super().extract_metadata(file_path)
-        allow_deserialization = self.config.get("allow_metadata_deserialization", False)
 
         try:
             import numpy as np
 
-            # SECURITY: always pass allow_pickle=False to prevent code execution
-            # via crafted object-dtype .npy files or .npz containing pickled data.
-            try:
-                array = np.load(file_path, mmap_mode="r", allow_pickle=False)
-            except ValueError:
-                # File contains object arrays that require pickle deserialization
-                if not allow_deserialization:
+            with open(file_path, "rb") as handle:
+                major, minor = fmt.read_magic(handle)
+                shape, fortran_order, dtype = _read_numpy_array_header(handle, (major, minor))
+
+                array_size = 1
+                for dim in shape:
+                    array_size *= int(dim)
+                array_nbytes = array_size * int(dtype.itemsize)
+
+                metadata.update(
+                    {
+                        "numpy_version": np.__version__,
+                        "array_shape": list(shape),
+                        "array_dtype": str(dtype),
+                        "array_size": array_size,
+                        "array_nbytes": array_nbytes,
+                        "array_ndim": len(shape),
+                        "memory_usage_mb": array_nbytes / (1024 * 1024),
+                    }
+                )
+
+                has_object_dtype = dtype.kind == "O" or bool(getattr(dtype, "hasobject", False))
+                if has_object_dtype:
+                    metadata["contains_objects"] = True
+                    metadata["security_note"] = "Object arrays may contain arbitrary Python objects"
                     metadata["deserialization_skipped"] = True
-                    metadata["reason"] = "File contains object arrays requiring pickle deserialization"
+                    metadata["reason"] = "File contains object arrays requiring unsafe pickle deserialization"
+                    if self.config.get("allow_metadata_deserialization"):
+                        metadata["allow_metadata_deserialization_ignored"] = True
                     return metadata
-                array = np.load(file_path, allow_pickle=True)
 
-            metadata.update(
-                {
-                    "numpy_version": np.__version__,
-                    "array_shape": list(array.shape),
-                    "array_dtype": str(array.dtype),
-                    "array_size": array.size,
-                    "array_nbytes": array.nbytes,
-                    "array_ndim": array.ndim,
-                    "memory_usage_mb": array.nbytes / (1024 * 1024),
-                }
-            )
+                metadata["contains_objects"] = False
+                if dtype.kind in ["U", "S"]:
+                    metadata["contains_strings"] = True
 
-            # Analyze array properties
-            if array.size > 0:
-                try:
-                    # For small arrays, get some statistics
-                    if array.nbytes < 10 * 1024 * 1024:  # Less than 10MB
-                        if np.issubdtype(array.dtype, np.number):
+                data_offset = handle.tell()
+                handle.seek(0, io.SEEK_END)
+                actual_file_size = handle.tell()
+                expected_file_size = data_offset + array_nbytes
+                if actual_file_size < expected_file_size:
+                    available_bytes = max(0, actual_file_size - data_offset)
+                    raise ValueError(
+                        f"NumPy array data is truncated: expected {array_nbytes} bytes, found {available_bytes}",
+                    )
+                handle.seek(data_offset)
+
+                if array_size > 0:
+                    if array_nbytes < 10 * 1024 * 1024 and np.issubdtype(dtype, np.number):
+                        payload = handle.read(array_nbytes)
+                        if len(payload) != array_nbytes:
+                            raise ValueError(
+                                f"NumPy array data is truncated: expected {array_nbytes} bytes, found {len(payload)}",
+                            )
+                        try:
+                            array = np.frombuffer(payload, dtype=dtype, count=array_size).reshape(
+                                shape,
+                                order="F" if fortran_order else "C",
+                            )
                             metadata.update(
                                 {
                                     "min_value": float(np.min(array)),
@@ -688,18 +764,10 @@ class NumPyScanner(BaseScanner):
                                     "std_value": float(np.std(array)),
                                 }
                             )
-                    else:
+                        except Exception:
+                            pass  # Skip optional statistics if the numeric operation is unsupported
+                    elif array_nbytes >= 10 * 1024 * 1024:
                         metadata["large_array_stats"] = "Skipped statistics for large array"
-
-                except Exception:
-                    pass  # Skip stats if not numeric
-
-            # Check for unusual patterns
-            if array.dtype.kind in ["U", "S", "O"]:  # String or object arrays
-                metadata["contains_objects"] = True
-                metadata["security_note"] = "Object arrays may contain arbitrary Python objects"
-            else:
-                metadata["contains_objects"] = False
 
         except Exception as e:
             metadata["extraction_error"] = str(e)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,6 +223,7 @@ def pytest_runtest_setup(item):
             "tests/scanners/test_weight_distribution_scanner.py::TestWeightDistributionScanner::test_allows_torch_load_for_stable_patched_pytorch",
             "tests/scanners/test_weight_distribution_scanner.py::TestWeightDistributionScanner::test_blocks_torch_load_for_unknown_pytorch_version",
             "tests/scanners/test_weight_distribution_scanner.py::TestWeightDistributionScanner::test_blocks_torch_load_for_unknown_patched_version_suffixes",
+            "tests/test_security_enhancements.py::TestNumPyScannerSecurity::test_negative_dimension_rejection",
         ]
 
         # Check if this is an allowed test file

--- a/tests/scanners/test_joblib_scanner.py
+++ b/tests/scanners/test_joblib_scanner.py
@@ -29,6 +29,26 @@ def test_joblib_scanner_basic(tmp_path: Path) -> None:
     assert result.bytes_scanned > 0
 
 
+def test_joblib_metadata_extraction_ignores_deserialization_opt_in(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "model.joblib"
+    joblib.dump({"a": np.arange(5)}, path, compress=3)
+
+    def fail_load(_path: str) -> object:
+        raise AssertionError("joblib.load must not run during metadata extraction")
+
+    monkeypatch.setattr(joblib, "load", fail_load)
+
+    metadata = JoblibScanner({"allow_metadata_deserialization": True}).extract_metadata(str(path))
+
+    assert metadata["deserialization_skipped"] is True
+    assert metadata["allow_metadata_deserialization_ignored"] is True
+    assert "Unsafe in-process joblib deserialization is disabled" in metadata["reason"]
+    assert "object_type" not in metadata
+
+
 def test_joblib_default_decompressed_cap_tracks_file_read_budget() -> None:
     scanner = JoblibScanner()
 

--- a/tests/scanners/test_joblib_scanner_codecs.py
+++ b/tests/scanners/test_joblib_scanner_codecs.py
@@ -6,6 +6,7 @@ import bz2
 import gzip
 import pickle
 import zlib
+from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 
 import pytest
@@ -104,6 +105,27 @@ def test_scan_reports_unavailable_joblib_read_as_inconclusive_not_security_findi
     assert aggregate.success is False
     assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in aggregate.issues)
     assert determine_exit_code(aggregate) == 2
+
+
+@pytest.mark.parametrize("version_error", [PackageNotFoundError("joblib"), RuntimeError("broken metadata")])
+def test_metadata_extraction_with_unavailable_joblib_version_remains_a_safe_skip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    version_error: Exception,
+) -> None:
+    path = tmp_path / "safe.joblib"
+    path.write_bytes(pickle.dumps(7, protocol=4))
+
+    def missing_distribution(_name: str) -> str:
+        raise version_error
+
+    monkeypatch.setattr("modelaudit.scanners.joblib_scanner.distribution_version", missing_distribution)
+
+    metadata = JoblibScanner().extract_metadata(str(path))
+
+    assert metadata["deserialization_skipped"] is True
+    assert "joblib_version" not in metadata
+    assert "extraction_error" not in metadata
 
 
 def test_scan_fails_closed_when_numpy_wrapper_prefix_has_unknown_tail(tmp_path: Path) -> None:

--- a/tests/scanners/test_numpy_scanner.py
+++ b/tests/scanners/test_numpy_scanner.py
@@ -1,3 +1,4 @@
+import io
 import zipfile
 from collections.abc import Callable
 from pathlib import Path
@@ -11,7 +12,7 @@ from modelaudit.config import ModelAuditConfig, reset_config, set_config
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.rules import Severity
 from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, Check, CheckStatus, IssueSeverity, ScanResult
-from modelaudit.scanners.numpy_scanner import NumPyScanner
+from modelaudit.scanners.numpy_scanner import NUMPY_HEADER_MAX_SIZE, NumPyScanner, _read_numpy_array_header
 
 
 def test_numpy_scanner_valid(tmp_path):
@@ -268,6 +269,18 @@ class _ExecPayload:
         return (exec, ("print('owned')",))
 
 
+def _write_metadata_marker(path: str) -> None:
+    Path(path).write_text("executed", encoding="utf-8")
+
+
+class _MetadataExecPayload:
+    def __init__(self, marker_path: Path) -> None:
+        self.marker_path = str(marker_path)
+
+    def __reduce__(self) -> tuple[Callable[..., Any], tuple[Any, ...]]:
+        return (_write_metadata_marker, (self.marker_path,))
+
+
 class _SSLPayload:
     def __reduce__(self) -> tuple[Callable[..., Any], tuple[Any, ...]]:
         import ssl
@@ -294,6 +307,239 @@ def _assert_no_trailing_pickle_parse_noise(result: ScanResult) -> None:
     assert not any(term in issue_text for term in parse_noise_terms)
     assert isinstance(reasons, list)
     assert "parse_incomplete" not in reasons
+
+
+def test_numpy_metadata_extraction_preserves_numeric_header_and_stats(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "numeric.npy"
+    np.save(path, np.array([1.0, 2.0, 3.0], dtype=np.float32), allow_pickle=False)
+
+    def fail_load(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("metadata extraction must not reopen the path with numpy.load")
+
+    monkeypatch.setattr(np, "load", fail_load)
+
+    metadata = NumPyScanner().extract_metadata(str(path))
+
+    assert metadata["array_shape"] == [3]
+    assert metadata["array_dtype"] == "float32"
+    assert metadata["array_size"] == 3
+    assert metadata["contains_objects"] is False
+    assert metadata["min_value"] == 1.0
+    assert metadata["max_value"] == 3.0
+
+
+def test_numpy_metadata_extraction_preserves_v3_unicode_field_names(tmp_path: Path) -> None:
+    path = tmp_path / "unicode-fields.npy"
+    array = np.zeros(1, dtype=[("\u03bc", np.int64)])
+    with path.open("wb") as handle:
+        np.lib.format.write_array(handle, array, version=(3, 0), allow_pickle=False)
+
+    metadata = NumPyScanner().extract_metadata(str(path))
+
+    assert metadata["array_dtype"] == "[('\u03bc', '<i8')]"
+    assert metadata["contains_objects"] is False
+    assert "extraction_error" not in metadata
+
+
+@pytest.mark.parametrize(
+    (("version", "length_size", "header_length")),
+    [
+        ((1, 0), 2, NUMPY_HEADER_MAX_SIZE + 1),
+        ((2, 0), 4, NUMPY_HEADER_MAX_SIZE + 1),
+        ((3, 0), 4, (NUMPY_HEADER_MAX_SIZE * 4) + 1),
+    ],
+)
+def test_numpy_metadata_extraction_bounds_header_reads(
+    tmp_path: Path,
+    version: tuple[int, int],
+    length_size: int,
+    header_length: int,
+) -> None:
+    path = tmp_path / f"oversized-v{version[0]}-header.npy"
+    path.write_bytes(
+        b"\x93NUMPY" + bytes(version) + header_length.to_bytes(length_size, "little"),
+    )
+
+    metadata = NumPyScanner().extract_metadata(str(path))
+
+    assert "NumPy header is too large" in metadata["extraction_error"]
+
+
+def test_numpy_metadata_extraction_bounds_v3_decoded_header_characters(tmp_path: Path) -> None:
+    path = tmp_path / "oversized-v3-decoded-header.npy"
+    header = b" " * (NUMPY_HEADER_MAX_SIZE + 1)
+    path.write_bytes(b"\x93NUMPY\x03\x00" + len(header).to_bytes(4, "little") + header)
+
+    metadata = NumPyScanner().extract_metadata(str(path))
+
+    assert "NumPy header is too large" in metadata["extraction_error"]
+    assert "characters" in metadata["extraction_error"]
+
+
+def test_numpy_v3_unicode_header_uses_decoded_character_limit(tmp_path: Path) -> None:
+    path = tmp_path / "long-unicode-header.npy"
+    field_name = "\u03bc" * 5_000
+    array = np.zeros(1, dtype=[(field_name, np.int8)])
+    with path.open("wb") as handle:
+        np.lib.format.write_array(handle, array, version=(3, 0), allow_pickle=False)
+
+    with path.open("rb") as handle:
+        assert np.lib.format.read_magic(handle) == (3, 0)
+        header_length = int.from_bytes(handle.read(4), "little")
+        header_bytes = handle.read(header_length)
+    assert len(header_bytes) > NUMPY_HEADER_MAX_SIZE
+    assert len(header_bytes.decode("utf-8")) <= NUMPY_HEADER_MAX_SIZE
+
+    result = NumPyScanner().scan(str(path))
+    metadata = NumPyScanner().extract_metadata(str(path))
+
+    assert result.success is True
+    assert metadata["array_dtype"] == f"[('{field_name}', 'i1')]"
+    assert "extraction_error" not in metadata
+
+
+@pytest.mark.parametrize((("version", "length_size")), [((1, 0), 2), ((2, 0), 4), ((3, 0), 4)])
+def test_numpy_scan_rejects_boolean_shape_dimensions(
+    tmp_path: Path,
+    version: tuple[int, int],
+    length_size: int,
+) -> None:
+    path = tmp_path / f"boolean-shape-v{version[0]}.npy"
+    header = repr({"descr": "<i8", "fortran_order": False, "shape": (False,)}).encode("ascii")
+    path.write_bytes(b"\x93NUMPY" + bytes(version) + len(header).to_bytes(length_size, "little") + header)
+
+    result = NumPyScanner().scan(str(path))
+
+    assert result.success is False
+    assert any(
+        check.name == "NumPy Header Read" and "Boolean NumPy shape dimensions are invalid" in check.message
+        for check in result.checks
+    )
+
+
+@pytest.mark.parametrize((("version", "length_size")), [((1, 0), 2), ((2, 0), 4), ((3, 0), 4)])
+def test_numpy_metadata_extraction_rejects_negative_shape_dimensions(
+    tmp_path: Path,
+    version: tuple[int, int],
+    length_size: int,
+) -> None:
+    path = tmp_path / f"negative-shape-v{version[0]}.npy"
+    header = repr({"descr": "<i8", "fortran_order": False, "shape": (-1,)}).encode("ascii")
+    path.write_bytes(
+        b"\x93NUMPY" + bytes(version) + len(header).to_bytes(length_size, "little") + header + (b"A" * 1024),
+    )
+
+    metadata = NumPyScanner().extract_metadata(str(path))
+
+    assert metadata["extraction_error"] == "Negative NumPy shape dimensions are invalid"
+
+
+def test_numpy_scan_accepts_empty_integer_dimension(tmp_path: Path) -> None:
+    path = tmp_path / "empty.npy"
+    np.save(path, np.empty((0,), dtype=np.int64), allow_pickle=False)
+
+    result = NumPyScanner().scan(str(path))
+
+    assert result.success is True
+    assert result.metadata["shape"] == (0,)
+
+
+def test_numpy_header_parser_does_not_rewind_the_untrusted_stream() -> None:
+    class NoRewindBytesIO(io.BytesIO):
+        def seek(self, offset: int, whence: int = 0) -> int:
+            raise AssertionError(f"unexpected rewind: {offset}, {whence}")
+
+    encoded_header = io.BytesIO()
+    np.lib.format.write_array_header_2_0(
+        encoded_header,
+        {"descr": "<i8", "fortran_order": False, "shape": (1,)},
+    )
+    stream = NoRewindBytesIO(encoded_header.getvalue())
+    assert np.lib.format.read_magic(stream) == (2, 0)
+
+    shape, fortran_order, dtype = _read_numpy_array_header(stream, (2, 0))
+
+    assert shape == (1,)
+    assert fortran_order is False
+    assert dtype == np.dtype("<i8")
+
+
+def test_numpy_metadata_extraction_does_not_flag_fixed_width_strings_as_objects(tmp_path: Path) -> None:
+    path = tmp_path / "strings.npy"
+    np.save(path, np.array(["abc"], dtype="U3"), allow_pickle=False)
+
+    metadata = NumPyScanner().extract_metadata(str(path))
+
+    assert metadata["contains_objects"] is False
+    assert metadata["contains_strings"] is True
+    assert "security_note" not in metadata
+
+
+def test_numpy_metadata_extraction_never_deserializes_object_arrays(tmp_path: Path) -> None:
+    marker_path = tmp_path / "metadata-executed"
+    path = tmp_path / "object.npy"
+    np.save(path, np.array([_MetadataExecPayload(marker_path)], dtype=object), allow_pickle=True)
+
+    metadata = NumPyScanner({"allow_metadata_deserialization": True}).extract_metadata(str(path))
+
+    assert marker_path.exists() is False
+    assert metadata["array_shape"] == [1]
+    assert metadata["array_dtype"] == "object"
+    assert metadata["contains_objects"] is True
+    assert metadata["deserialization_skipped"] is True
+    assert metadata["allow_metadata_deserialization_ignored"] is True
+    assert "unsafe pickle deserialization" in metadata["reason"]
+    assert "extraction_error" not in metadata
+
+
+def test_numpy_metadata_extraction_never_deserializes_structured_object_fields(tmp_path: Path) -> None:
+    marker_path = tmp_path / "structured-metadata-executed"
+    path = tmp_path / "structured-object.npy"
+    array = np.empty(1, dtype=[("value", np.int64), ("payload", object)])
+    array["value"] = 1
+    array["payload"][0] = _MetadataExecPayload(marker_path)
+    np.save(path, array, allow_pickle=True)
+
+    metadata = NumPyScanner({"allow_metadata_deserialization": True}).extract_metadata(str(path))
+
+    assert marker_path.exists() is False
+    assert metadata["array_shape"] == [1]
+    assert metadata["contains_objects"] is True
+    assert metadata["deserialization_skipped"] is True
+    assert metadata["allow_metadata_deserialization_ignored"] is True
+    assert "unsafe pickle deserialization" in metadata["reason"]
+    assert "extraction_error" not in metadata
+
+
+@pytest.mark.parametrize(
+    (("dtype", "shape")),
+    [
+        (np.dtype("<i8"), (1,)),
+        (np.dtype("S8"), (1,)),
+        (np.dtype("<i8"), ((10 * 1024 * 1024 // 8) + 1,)),
+    ],
+)
+def test_numpy_metadata_extraction_reports_truncated_fixed_width_payloads(
+    tmp_path: Path,
+    dtype: np.dtype[Any],
+    shape: tuple[int, ...],
+) -> None:
+    path = tmp_path / "truncated.npy"
+    with path.open("wb") as handle:
+        np.lib.format.write_array_header_2_0(
+            handle,
+            {"descr": np.lib.format.dtype_to_descr(dtype), "fortran_order": False, "shape": shape},
+        )
+
+    metadata = NumPyScanner().extract_metadata(str(path))
+
+    assert metadata["array_shape"] == list(shape)
+    assert metadata["array_dtype"] == str(dtype)
+    assert metadata["extraction_error"].startswith("NumPy array data is truncated:")
+    assert "found 0" in metadata["extraction_error"]
 
 
 def _inject_comment_token_into_npy_payload(path: Path) -> None:

--- a/tests/test_metadata_extractor.py
+++ b/tests/test_metadata_extractor.py
@@ -866,7 +866,7 @@ class TestModelMetadataExtractor:
         metadata = extractor.extract(str(joblib_file))
 
         assert metadata.get("deserialization_skipped") is True
-        assert metadata.get("reason") == "Deserialization disabled for metadata extraction"
+        assert metadata.get("reason") == "Unsafe in-process joblib deserialization is disabled for metadata extraction"
 
     def test_tf_savedmodel_metadata_no_deserialization(self, tmp_path: Path) -> None:
         """Ensure TensorFlow SavedModel metadata extraction does not deserialize by default."""
@@ -966,8 +966,8 @@ class TestModelMetadataExtractor:
         assert metadata.get("deserialization_skipped") is True
         assert "pickle" in metadata.get("reason", "").lower()
 
-    def test_numpy_object_array_allowed_with_deserialization(self, tmp_path: Path) -> None:
-        """Ensure NumPy object arrays load when deserialization is explicitly allowed."""
+    def test_numpy_object_array_deserialization_opt_in_is_ignored(self, tmp_path: Path) -> None:
+        """Ensure NumPy object-array metadata never performs unsafe deserialization."""
         np = pytest.importorskip("numpy")
         extractor = metadata_extractor_module.ModelMetadataExtractor()
 
@@ -976,11 +976,18 @@ class TestModelMetadataExtractor:
         np.save(str(npy_file), obj_arr, allow_pickle=True)
 
         metadata = extractor.extract(str(npy_file), allow_deserialization=True)
+        security_metadata = extractor.extract(
+            str(npy_file),
+            security_only=True,
+            allow_deserialization=True,
+        )
 
-        # With deserialization allowed, should extract metadata
-        assert metadata.get("deserialization_skipped") is not True
+        assert metadata.get("deserialization_skipped") is True
+        assert metadata.get("allow_metadata_deserialization_ignored") is True
         assert metadata.get("array_dtype") == "object"
         assert metadata.get("contains_objects") is True
+        assert security_metadata.get("deserialization_skipped") is True
+        assert security_metadata.get("allow_metadata_deserialization_ignored") is True
 
     def test_xgboost_metadata_no_deserialization(self, tmp_path: Path) -> None:
         """Ensure XGBoost metadata extraction is blocked without deserialization flag."""
@@ -1030,6 +1037,7 @@ class TestModelMetadataExtractor:
             "format": "pickle",
             "file_size": 100,
             "deserialization_skipped": True,
+            "allow_metadata_deserialization_ignored": True,
             "reason": "Deserialization disabled for metadata extraction",
             "dangerous_opcodes": ["REDUCE"],
             "has_dangerous_opcodes": True,
@@ -1040,6 +1048,7 @@ class TestModelMetadataExtractor:
         filtered = extractor._filter_security_metadata(metadata)
 
         assert filtered["deserialization_skipped"] is True
+        assert filtered["allow_metadata_deserialization_ignored"] is True
         assert filtered["reason"] == "Deserialization disabled for metadata extraction"
         assert filtered["dangerous_opcodes"] == ["REDUCE"]
         assert filtered["has_dangerous_opcodes"] is True

--- a/tests/test_security_enhancements.py
+++ b/tests/test_security_enhancements.py
@@ -229,8 +229,10 @@ class TestNumPyScannerSecurity:
         result = scanner.scan(str(npy_file))
 
         assert result.success is False
-        validation_issues = [issue for issue in result.issues if "negative dimension" in issue.message.lower()]
-        assert len(validation_issues) > 0
+        header_check = next(check for check in result.checks if check.name == "NumPy Header Read")
+        assert header_check.status == CheckStatus.FAILED
+        assert header_check.rule_code == "S902"
+        assert "Negative NumPy shape dimensions are invalid" in header_check.message
 
     def test_too_many_dimensions_rejection(self, tmp_path):
         """Test rejection of arrays with too many dimensions."""


### PR DESCRIPTION
## Summary
- remove in-process `joblib.load()` metadata extraction and make the ignored unsafe opt-in explicit
- parse NumPy headers without deserializing object arrays
- bound v1/v2 headers to 10,000 bytes and v3 headers to worst-case UTF-8 bytes plus 10,000 decoded characters
- preserve valid long UTF-8 field names in v3 headers without weakening the parser budget
- validate fixed-width NumPy payload lengths from the same open descriptor before optional statistics
- avoid labeling fixed-width string arrays as arbitrary Python objects
- reject malformed boolean and negative NumPy shape dimensions while preserving valid empty integer dimensions
- preserve `allow_metadata_deserialization_ignored` in `security_only=True` output
- integrate current `main` at `29af2dedd63f5901a206417dd758fba6ed95d9af`, preserving the newer Joblib static parser

## False-positive / false-negative audit
- valid v3 Unicode headers larger than 10,000 encoded bytes but within NumPy's decoded-character limit remain accepted
- truncated small numeric, fixed-width string, and large fixed-width payloads report extraction errors
- numeric and fixed-width string arrays retain safe metadata without object warnings
- plain and nested structured object dtypes are identified through `dtype.hasobject` and never deserialized
- Joblib metadata reports safe base metadata and distribution version without importing optional Joblib code
- boolean and negative dimensions cannot trigger malformed or unbounded reads; valid `(0,)` remains accepted
- unsafe deserialization opt-ins are ignored and remain visible to both full and security-only metadata callers

## Focused validation
- five PR-associated test modules: `165 passed, 24 skipped`
- scoped Ruff lint and format checks passed for all nine modified Python files
- scoped mypy passed
- `git diff --check` passed
- optional Joblib-installed tests were unavailable locally; the safe raw-protocol skip path was checked separately and CI owns the optional-dependency lane
- exact published tree: `5994a62471157d6b0de43ef497181fe6a343ca82`

All inline review threads are resolved. No full local suite was run; CI owns broad validation. Published head: `e49a03e695929a78cf46f3323f4cd976a234b80f`.