### PR TITLE
fix: detect pickle binunicode8 setitem abuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bound Joblib decompression output to the configured scanner read budget
 - bound ExecuTorch ZIP metadata and member scans while preserving eligible pickle detections across archive limits and mutations
 - close JIT replay alias, probe-budget, and compound-clause context gaps without suppressing dangerous browser or native-library calls
+- detect `BINUNICODE8` literals and bounded concatenated-stream abuse in pickle CVE-2026-24747 SETITEM analysis without treating byte literals as `STACK_GLOBAL` names
 - scan raw payload indicators inside signature-valid ExecuTorch binaries and launcher-prefixed archives before reporting them clean
 - detect Keras get_file tar extraction from effective call arguments without relying on URL suffixes
 - reject cleartext HTTP cloud storage and PyTorch Hub model sources

--- a/modelaudit/scanners/joblib_scanner.py
+++ b/modelaudit/scanners/joblib_scanner.py
@@ -17,7 +17,7 @@ from ..scanner_results import mark_inconclusive_scan_result
 from ..scanner_selection import add_scanner_selection_skip_check, embedded_pickle_scanner
 from ..utils.file.detection import read_magic_bytes
 from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, IssueSeverity, ScanResult
-from .pickle_scanner import PickleScanner, _looks_like_pickle
+from .pickle_scanner import PickleScanner
 
 _JOBLIB_NUMPY_ARRAY_WRAPPER_REF = "joblib.numpy_pickle.NumpyArrayWrapper"
 _JOBLIB_NUMPY_ARRAY_REQUIRED_REFS = {
@@ -44,6 +44,20 @@ _JOBLIB_TAIL_DANGEROUS_SEEDS = (
     b"exec",
     b"pickle.loads",
     b"marshal.loads",
+)
+_TRUNCATED_RAW_PICKLE_SIGNAL_OPCODES = frozenset(
+    {
+        "EXT1",
+        "EXT2",
+        "EXT4",
+        "GLOBAL",
+        "INST",
+        "NEWOBJ",
+        "NEWOBJ_EX",
+        "PERSID",
+        "BINPERSID",
+        "STACK_GLOBAL",
+    }
 )
 
 
@@ -112,7 +126,9 @@ def _looks_like_joblib_numpy_array_tail(tail: bytes) -> bool:
     raw_array_data = tail[1 + padding_length :]
     if not raw_array_data:
         return False
-    if _looks_like_pickle(raw_array_data):
+    # Array bytes may match protocol-less opcodes; only an explicit protocol
+    # header is strong enough evidence that this is another pickle stream.
+    if len(raw_array_data) >= 2 and raw_array_data[0] == 0x80 and raw_array_data[1] <= 5:
         return False
 
     probe = raw_array_data[:_JOBLIB_TAIL_DANGER_SCAN_BYTES].lower()
@@ -315,21 +331,20 @@ class JoblibScanner(BaseScanner):
 
     def _looks_like_raw_pickle_payload(self, data: bytes) -> bool:
         """Return True when `.joblib` bytes should be scanned directly as pickle."""
-        if _looks_like_pickle(data):
-            return True
-
         if len(data) >= 2 and data[0] == 0x80 and data[1] <= 5:
             return True
 
+        parsed_security_opcode = False
         try:
-            probe = io.BytesIO(data[:4096])
-            for _opcode_count, (opcode, _arg, _pos) in enumerate(pickletools.genops(probe), 1):
+            probe = io.BytesIO(data)
+            for opcode_count, (opcode, _arg, _pos) in enumerate(pickletools.genops(probe), 1):
+                parsed_security_opcode = parsed_security_opcode or (opcode.name in _TRUNCATED_RAW_PICKLE_SIGNAL_OPCODES)
                 if opcode.name == "STOP":
                     return True
-                if _opcode_count >= 16:
-                    break
+                if opcode_count >= 16:
+                    return True
         except Exception:
-            return False
+            return parsed_security_opcode
 
         return False
 

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -47,6 +47,8 @@ _MAX_RAW_ENCODED_BYTES = 1024 * 1024
 _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES = 4096
 _CALL_TOKEN_SEPARATOR_SCAN_LIMIT_BYTES = 4096
 _MAX_RAW_CODE_LITERAL_VALIDATION_CHARS = 8192
+_MAX_CVE_PICKLE_STREAMS = 64
+_CVE_PICKLE_STREAM_PADDING = frozenset(b"\x00\t\n\x0b\x0c\r ")
 _BASE64_CODE_EXECUTION_SEEDS: tuple[bytes, ...] = (
     b"ZXZhbCg",  # eval(
     b"ZXhlYyg",  # exec(
@@ -336,6 +338,25 @@ class _RootStreamPayloadRead:
     read_limit: int
 
 
+@dataclass(frozen=True)
+class _PickleCveStream:
+    payload: bytes
+    offset: int
+    parse_incomplete: bool
+
+
+@dataclass(frozen=True)
+class _PickleSetitemAnalysis:
+    saw_setitem: bool
+    confirmed_dangerous_target: bool
+    suspicious_entry_on_unknown_target: bool
+    parse_incomplete: bool
+
+    @property
+    def has_abuse(self) -> bool:
+        return self.confirmed_dangerous_target or (self.parse_incomplete and self.suspicious_entry_on_unknown_target)
+
+
 _BUILTIN_MODULES = frozenset({"builtins", "__builtin__", "__builtins__"})
 _SAFE_MODULE_POLICY_PREFIXES = ("os.path",)
 _DANGEROUS_FUNCTION_EXPORT_ALIASES = frozenset(
@@ -415,11 +436,95 @@ def _looks_like_pickle(data: bytes) -> bool:
 
     first = data[0]
     if first == 0x80:
-        return data[1] in {1, 2, 3, 4, 5}
+        return data[1] in {0, 1, 2, 3, 4, 5}
 
-    # Protocol 0 pickles often start directly with GLOBAL/INST/list/dict/tuple
-    # structural opcodes. This is intentionally a sniff, not validation.
-    return first in {ord("("), ord("]"), ord("}"), ord("c"), ord("i"), ord("l"), ord("d"), ord("t")}
+    # Pickles without an explicit PROTO may start with a scalar, string, global,
+    # or container constructor. This is intentionally a sniff, not validation.
+    return first in {
+        ord("("),
+        ord(")"),
+        ord("B"),
+        ord("C"),
+        ord("F"),
+        ord("G"),
+        ord("I"),
+        ord("J"),
+        ord("K"),
+        ord("L"),
+        ord("M"),
+        ord("N"),
+        ord("S"),
+        ord("T"),
+        ord("U"),
+        ord("V"),
+        ord("X"),
+        ord("]"),
+        ord("c"),
+        ord("d"),
+        ord("i"),
+        ord("l"),
+        ord("t"),
+        ord("}"),
+        0x88,  # NEWTRUE
+        0x89,  # NEWFALSE
+        0x8A,  # LONG1
+        0x8B,  # LONG4
+        0x8C,  # SHORT_BINUNICODE
+        0x8D,  # BINUNICODE8
+        0x8E,  # BINBYTES8
+        0x8F,  # EMPTY_SET
+        0x91,  # FROZENSET
+        0x96,  # BYTEARRAY8
+    }
+
+
+def _complete_pickle_stream_extent(data: bytes, offset: int = 0) -> int | None:
+    try:
+        stream = io.BytesIO(data)
+        stream.seek(offset)
+        for opcode, _arg, position in pickletools.genops(stream):
+            if opcode.name == "STOP":
+                return None if position is None else position + 1 - offset
+    except Exception:
+        return None
+    return None
+
+
+def _has_parsed_pickle_opcode_prefix(data: bytes) -> bool:
+    try:
+        next(pickletools.genops(data))
+    except Exception:
+        return False
+    return True
+
+
+def _pickle_cve_streams(data: bytes) -> tuple[tuple[_PickleCveStream, ...], bool]:
+    streams: list[_PickleCveStream] = []
+    offset = 0
+    while offset < len(data):
+        while offset < len(data) and data[offset] in _CVE_PICKLE_STREAM_PADDING:
+            offset += 1
+        if offset >= len(data):
+            break
+
+        extent = _complete_pickle_stream_extent(data, offset)
+        if len(streams) >= _MAX_CVE_PICKLE_STREAMS:
+            remainder = data[offset:]
+            return tuple(streams), (
+                extent is not None or _looks_like_pickle(remainder) or _has_parsed_pickle_opcode_prefix(remainder)
+            )
+        if extent is None:
+            if not _looks_like_pickle(data[offset:]) and not _has_parsed_pickle_opcode_prefix(data[offset:]):
+                break
+            streams.append(_PickleCveStream(data[offset:], offset, True))
+            break
+
+        streams.append(_PickleCveStream(data[offset : offset + extent], offset, False))
+        offset += extent
+
+    if not streams and data:
+        streams.append(_PickleCveStream(data, 0, True))
+    return tuple(streams), False
 
 
 def _is_primarily_documentation(data: bytes) -> bool:
@@ -808,14 +913,7 @@ def _result_has_rebuild_tensor_global(result: ScanResult) -> bool:
 def _pickle_has_parsed_rebuild_tensor_literal(data: bytes) -> bool:
     try:
         for opcode, arg, _position in pickletools.genops(data):
-            if opcode.name in {
-                "STRING",
-                "UNICODE",
-                "BINSTRING",
-                "SHORT_BINSTRING",
-                "BINUNICODE",
-                "SHORT_BINUNICODE",
-            } and (
+            if opcode.name in _PICKLE_LITERAL_OPCODE_NAMES and (
                 isinstance(arg, str)
                 and "_rebuild_tensor" in arg
                 and not _is_primarily_documentation(arg.encode("utf-8", errors="ignore"))
@@ -826,15 +924,19 @@ def _pickle_has_parsed_rebuild_tensor_literal(data: bytes) -> bool:
     return False
 
 
-def _pickle_has_setitem_abuse_for_entries(
+def _analyze_pickle_setitem_entries(
     data: bytes,
     *,
     global_needles: tuple[str, ...],
     literal_needles: tuple[str, ...] = (),
-) -> bool:
+) -> _PickleSetitemAnalysis:
     stack: list[tuple[str, str | None]] = []
     memo: dict[int, tuple[str, str | None]] = {}
     mark = ("mark", None)
+    saw_setitem = False
+    confirmed_dangerous_target = False
+    suspicious_entry_on_unknown_target = False
+    parse_incomplete = False
 
     def pop() -> tuple[str, str | None]:
         return stack.pop() if stack else ("unknown", None)
@@ -854,7 +956,11 @@ def _pickle_has_setitem_abuse_for_entries(
         if kind == "interesting_result":
             return True
         if kind == "global" and isinstance(text, str):
-            return any(needle in text for needle in global_needles)
+            global_name = text.rsplit(".", 1)[-1]
+            return any(
+                text == needle or (needle == "_rebuild_tensor" and global_name.startswith(needle))
+                for needle in global_needles
+            )
         if kind == "string" and isinstance(text, str):
             return any(needle in text for needle in literal_needles) and not _is_primarily_documentation(
                 text.encode("utf-8", errors="ignore")
@@ -884,14 +990,7 @@ def _pickle_has_setitem_abuse_for_entries(
                     stack.append(("global", f"{module[1]}.{global_name[1]}"))
                 else:
                     stack.append(("global", None))
-            elif name in {
-                "STRING",
-                "UNICODE",
-                "BINSTRING",
-                "SHORT_BINSTRING",
-                "BINUNICODE",
-                "SHORT_BINUNICODE",
-            }:
+            elif name in _PICKLE_LITERAL_OPCODE_NAMES:
                 stack.append(("string", arg if isinstance(arg, str) else None))
             elif name == "EMPTY_DICT":
                 stack.append(("dict", None))
@@ -919,36 +1018,42 @@ def _pickle_has_setitem_abuse_for_entries(
                 pop()
                 pop()
                 stack.append(collapse_callable_result(pop()))
+            elif name == "BUILD":
+                pop()
+            elif name == "INST":
+                pop_to_mark()
+                stack.append(collapse_callable_result(entry_for_global(arg)))
+            elif name == "OBJ":
+                values = pop_to_mark()
+                callable_value = values[0] if values else ("unknown", None)
+                stack.append(collapse_callable_result(callable_value))
             elif name == "SETITEM":
+                saw_setitem = True
                 value = pop()
                 key = pop()
                 target = stack[-1] if stack else ("unknown", None)
-                if is_interesting_entry(target) or is_interesting_entry(key):
-                    return True
-                if is_interesting_entry(value) and (target[0] not in {"dict", "unknown"} or value[0] == "global"):
-                    return True
+                if is_interesting_entry(target):
+                    confirmed_dangerous_target = True
+                if target[0] == "unknown" and (is_interesting_entry(key) or is_interesting_entry(value)):
+                    suspicious_entry_on_unknown_target = True
             elif name == "SETITEMS":
+                saw_setitem = True
                 values = pop_to_mark()
                 target = stack[-1] if stack else ("unknown", None)
                 if is_interesting_entry(target):
-                    return True
-                for index in range(0, len(values), 2):
-                    if is_interesting_entry(values[index]):
-                        return True
-                    if (
-                        index + 1 < len(values)
-                        and values[index + 1][0] == "global"
-                        and is_interesting_entry(values[index + 1])
-                    ):
-                        return True
+                    confirmed_dangerous_target = True
+                if target[0] == "unknown" and any(is_interesting_entry(value) for value in values):
+                    suspicious_entry_on_unknown_target = True
             elif name in {"APPEND", "APPENDS", "ADDITEMS"}:
                 if name == "APPEND":
                     pop()
                 else:
                     pop_to_mark()
-            elif name in {"POP", "DUP"}:
+            elif name in {"POP", "POP_MARK", "DUP"}:
                 if name == "POP":
                     pop()
+                elif name == "POP_MARK":
+                    pop_to_mark()
                 elif stack:
                     stack.append(stack[-1])
             elif name in {"PUT", "BINPUT", "LONG_BINPUT"}:
@@ -973,11 +1078,36 @@ def _pickle_has_setitem_abuse_for_entries(
                 "LONG",
                 "LONG1",
                 "LONG4",
+                "FLOAT",
+                "BINFLOAT",
             }:
                 stack.append(("scalar", None))
+            elif name in {"EXT1", "EXT2", "EXT4", "NEXT_BUFFER", "PERSID"}:
+                stack.append(("object", None))
+            elif name == "BINPERSID":
+                pop()
+                stack.append(("object", None))
     except Exception:
-        return False
-    return False
+        parse_incomplete = True
+    return _PickleSetitemAnalysis(
+        saw_setitem=saw_setitem,
+        confirmed_dangerous_target=confirmed_dangerous_target,
+        suspicious_entry_on_unknown_target=suspicious_entry_on_unknown_target,
+        parse_incomplete=parse_incomplete,
+    )
+
+
+def _pickle_has_setitem_abuse_for_entries(
+    data: bytes,
+    *,
+    global_needles: tuple[str, ...],
+    literal_needles: tuple[str, ...] = (),
+) -> bool:
+    return _analyze_pickle_setitem_entries(
+        data,
+        global_needles=global_needles,
+        literal_needles=literal_needles,
+    ).has_abuse
 
 
 def _pickle_has_rebuild_tensor_setitem_abuse(data: bytes) -> bool:
@@ -1117,6 +1247,7 @@ def _pickle_opcode_summary(data: bytes) -> dict[str, Any]:
     dangerous_globals: list[str] = []
     protocol: int | None = None
     total_opcodes = 0
+    parse_error: str | None = None
 
     def _memo_index(value: object) -> int | None:
         if isinstance(value, int):
@@ -1138,8 +1269,8 @@ def _pickle_opcode_summary(data: bytes) -> dict[str, Any]:
             opcode_counts[name] = opcode_counts.get(name, 0) + 1
             if name == "PROTO" and isinstance(arg, int):
                 protocol = arg
-            if name in {"STRING", "UNICODE", "BINSTRING", "SHORT_BINSTRING", "BINUNICODE", "SHORT_BINUNICODE"}:
-                stack.append(str(arg))
+            if name in _PICKLE_LITERAL_OPCODE_NAMES:
+                stack.append(arg if isinstance(arg, str) else None)
                 continue
             if name == "MEMOIZE":
                 if stack:
@@ -1196,10 +1327,10 @@ def _pickle_opcode_summary(data: bytes) -> dict[str, Any]:
             }:
                 stack.append(None)
     except Exception as error:
-        return {"parse_error": str(error)}
+        parse_error = str(error)
 
     observed_dangerous_opcodes = sorted(opcode for opcode in dangerous_opcodes if opcode_counts.get(opcode, 0) > 0)
-    return {
+    summary = {
         "dangerous_opcodes": observed_dangerous_opcodes,
         "has_dangerous_opcodes": bool(observed_dangerous_opcodes),
         "opcode_counts": opcode_counts,
@@ -1207,6 +1338,9 @@ def _pickle_opcode_summary(data: bytes) -> dict[str, Any]:
         "pickle_protocol": protocol,
         "dangerous_globals": sorted(set(dangerous_globals)),
     }
+    if parse_error is not None:
+        summary["parse_error"] = parse_error
+    return summary
 
 
 def _rebuild_tensor_indicators_are_documentation_literals(data: bytes) -> bool:
@@ -1228,14 +1362,7 @@ def _rebuild_tensor_indicators_are_documentation_literals(data: bytes) -> bool:
                     if "_rebuild_tensor" in f"{module}.{global_name}":
                         return False
                 continue
-            if opcode.name not in {
-                "STRING",
-                "UNICODE",
-                "BINSTRING",
-                "SHORT_BINSTRING",
-                "BINUNICODE",
-                "SHORT_BINUNICODE",
-            }:
+            if opcode.name not in _PICKLE_LITERAL_OPCODE_NAMES:
                 continue
             if isinstance(arg, str):
                 stack.append(arg)
@@ -2273,6 +2400,28 @@ class PickleScanner(BaseScanner):
         present_bytes: frozenset[int] | None = None,
     ) -> None:
         """Add CVE attribution checks from a bounded raw pickle scan window."""
+        streams, stream_limit_exceeded = _pickle_cve_streams(data)
+        result.metadata["pickle_cve_streams_analyzed"] = len(streams)
+        if stream_limit_exceeded:
+            reason = "pickle_cve_stream_limit_exceeded"
+            mark_inconclusive_scan_result(result, reason)
+            result.metadata[reason] = True
+            result.add_check(
+                name="Pickle CVE Stream Coverage",
+                passed=False,
+                message=f"Pickle CVE analysis stopped after {_MAX_CVE_PICKLE_STREAMS} streams",
+                severity=IssueSeverity.INFO,
+                location=source or self.current_file_path,
+                details={
+                    "streams_analyzed": len(streams),
+                    "max_streams": _MAX_CVE_PICKLE_STREAMS,
+                    "analysis_incomplete": True,
+                    "scan_outcome_reason": reason,
+                },
+                rule_code="S902",
+            )
+            result.finish(success=False)
+
         opcode_counts = _result_opcode_counts(result)
         has_setitem_opcode = opcode_counts.get("SETITEM", 0) > 0 or opcode_counts.get("SETITEMS", 0) > 0
         import_references = _result_import_references(result)
@@ -2283,44 +2432,90 @@ class PickleScanner(BaseScanner):
         lower = data.lower() if lower_data is None else lower_data
         if present_bytes is None:
             present_bytes = frozenset(lower)
-        if not _contains_any_seed_lowered(lower, _CVE_RAW_SCAN_SEEDS, present_bytes) and not (
-            has_setitem_opcode and has_dangerous_system_global
+        has_raw_cve_seed = _contains_any_seed_lowered(lower, _CVE_RAW_SCAN_SEEDS, present_bytes)
+        # Encoded STACK_GLOBAL operands are not contiguous raw-text seeds. Use
+        # a cheap candidate gate before running the Python stack model twice.
+        has_raw_setitem_opcode = ord("s") in present_bytes or ord("u") in present_bytes
+        if (
+            not has_raw_cve_seed
+            and not (has_setitem_opcode and has_dangerous_system_global)
+            and not has_raw_setitem_opcode
+        ):
+            result.metadata["pickle_cve_raw_detector_skipped"] = True
+            return
+
+        stream_setitem_analyses = [
+            (
+                _analyze_pickle_setitem_entries(
+                    stream.payload,
+                    global_needles=("_rebuild_tensor",),
+                    literal_needles=("_rebuild_tensor",),
+                ),
+                _analyze_pickle_setitem_entries(
+                    stream.payload,
+                    global_needles=("os.system", "posix.system", "nt.system"),
+                ),
+            )
+            for stream in streams
+        ]
+        has_stream_setitem_evidence = any(
+            rebuild_analysis.has_abuse or dangerous_system_analysis.has_abuse
+            for rebuild_analysis, dangerous_system_analysis in stream_setitem_analyses
+        )
+        if (
+            not has_raw_cve_seed
+            and not (has_setitem_opcode and has_dangerous_system_global)
+            and not (has_stream_setitem_evidence)
         ):
             result.metadata["pickle_cve_raw_detector_skipped"] = True
             return
 
         try:
-            from modelaudit.detectors.cve_patterns import analyze_cve_patterns
+            from modelaudit.detectors.cve_patterns import CVEAttribution, analyze_cve_patterns
         except ImportError:
             return
 
-        text = lower.decode("utf-8", errors="ignore")
         try:
-            attributions = analyze_cve_patterns(text, data)
+            attributions = analyze_cve_patterns(lower.decode("utf-8", errors="ignore"), data)
         except Exception as error:
             logger.warning("Error checking pickle CVE patterns: %s", error)
             return
 
-        has_rebuild_tensor_setitem_abuse = (
-            _pickle_has_rebuild_tensor_setitem_abuse(data) if has_setitem_opcode else False
-        )
-        has_rebuild_tensor_literal = _pickle_has_parsed_rebuild_tensor_literal(data) if has_setitem_opcode else False
-        has_cve_2026_setitem_evidence = has_rebuild_tensor_setitem_abuse or has_rebuild_tensor_literal
-        has_dangerous_system_setitem_abuse = (
-            _pickle_has_dangerous_system_setitem_abuse(data)
-            if has_setitem_opcode and has_dangerous_system_global
-            else False
-        )
+        # Other CVEs intentionally retain whole-window matching. CVE-2026-24747
+        # remains fail-closed for wholly unparseable inputs, but once a complete
+        # stream exists its target-sensitive SETITEM evidence is stream-scoped.
+        has_complete_stream = any(not stream.parse_incomplete for stream in streams)
+        all_attributions = [
+            attribution
+            for attribution in attributions
+            if attribution.cve_id != "CVE-2026-24747" or not has_complete_stream
+        ]
+        attribution_context: dict[tuple[str, str], tuple[int, int, bool]] = {}
+        dangerous_system_context: tuple[int, int, bool] | None = None
+        for stream_index, (stream, setitem_analyses) in enumerate(zip(streams, stream_setitem_analyses, strict=True)):
+            try:
+                stream_attributions = analyze_cve_patterns(
+                    stream.payload.decode("utf-8", errors="ignore"),
+                    stream.payload,
+                )
+            except Exception as error:
+                logger.warning("Error checking pickle stream CVE patterns: %s", error)
+                stream_attributions = []
+            for attribution in stream_attributions:
+                if attribution.cve_id != "CVE-2026-24747" or any(
+                    "setitem" in pattern.lower() for pattern in attribution.patterns_matched
+                ):
+                    continue
+                all_attributions.append(attribution)
+                rule_code = self._rule_code_for_cve_attribution(attribution.patterns_matched)
+                attribution_context.setdefault(
+                    (attribution.cve_id, rule_code),
+                    (stream_index, stream.offset, stream.parse_incomplete),
+                )
 
-        if (
-            has_cve_2026_setitem_evidence
-            and has_setitem_opcode
-            and not any(attribution.cve_id == "CVE-2026-24747" for attribution in attributions)
-        ):
-            from modelaudit.detectors.cve_patterns import CVEAttribution
-
-            attributions.append(
-                CVEAttribution(
+            rebuild_analysis, dangerous_system_analysis = setitem_analyses
+            if rebuild_analysis.has_abuse:
+                attribution = CVEAttribution(
                     cve_id="CVE-2026-24747",
                     description="PyTorch weights_only restricted unpickler SETITEM abuse pattern",
                     severity="CRITICAL",
@@ -2330,29 +2525,23 @@ class PickleScanner(BaseScanner):
                     remediation="Upgrade PyTorch and avoid loading untrusted pickle checkpoints",
                     patterns_matched=["_rebuild_tensor", "SETITEM opcode"],
                 )
-            )
-
-        pickle_parse_failed = _result_parse_was_incomplete(result)
-        attributions = self._dedupe_cve_attributions(
-            [
-                attribution
-                for attribution in attributions
-                if not (
-                    attribution.cve_id == "CVE-2026-24747"
-                    and (
-                        (not has_setitem_opcode and not pickle_parse_failed)
-                        or (not has_cve_2026_setitem_evidence and not pickle_parse_failed)
-                        or (
-                            not has_cve_2026_setitem_evidence
-                            and _rebuild_tensor_indicators_are_documentation_literals(data)
-                        )
-                    )
+                all_attributions.append(attribution)
+                rule_code = self._rule_code_for_cve_attribution(attribution.patterns_matched)
+                attribution_context.setdefault(
+                    (attribution.cve_id, rule_code),
+                    (stream_index, stream.offset, stream.parse_incomplete or rebuild_analysis.parse_incomplete),
                 )
-            ]
-        )
+            if dangerous_system_analysis.has_abuse and dangerous_system_context is None:
+                dangerous_system_context = (
+                    stream_index,
+                    stream.offset,
+                    stream.parse_incomplete or dangerous_system_analysis.parse_incomplete,
+                )
 
+        attributions = self._dedupe_cve_attributions(all_attributions)
         emitted_cve_rule_keys: set[tuple[str, str]] = set()
-        if has_setitem_opcode and has_dangerous_system_setitem_abuse:
+        if dangerous_system_context is not None:
+            stream_index, stream_offset, stream_parse_incomplete = dangerous_system_context
             emitted_cve_rule_keys.add(("CVE-2026-24747", "S209"))
             result.add_check(
                 name="CVE-2026-24747 SETITEM Abuse Detection",
@@ -2370,6 +2559,9 @@ class PickleScanner(BaseScanner):
                     "pattern_type": "setitem_near_dangerous_global",
                     "associated_global": "os.system",
                     "analysis": "bounded_raw_pickle_window",
+                    "pickle_stream_index": stream_index,
+                    "pickle_stream_offset": stream_offset,
+                    "pickle_stream_parse_incomplete": stream_parse_incomplete,
                 },
                 rule_code="S209",
             )
@@ -2392,13 +2584,24 @@ class PickleScanner(BaseScanner):
                 if attribution.severity.upper() in {"CRITICAL", "HIGH"}
                 else IssueSeverity.WARNING
             )
+            details = {**attribution.to_dict(), "cve_risk_score": attribution.cvss}
+            stream_context = attribution_context.get(cve_rule_key)
+            if stream_context is not None:
+                stream_index, stream_offset, stream_parse_incomplete = stream_context
+                details.update(
+                    {
+                        "pickle_stream_index": stream_index,
+                        "pickle_stream_offset": stream_offset,
+                        "pickle_stream_parse_incomplete": stream_parse_incomplete,
+                    }
+                )
             result.add_check(
                 name=f"{attribution.cve_id} Pattern Detection",
                 passed=False,
                 message=f"{attribution.cve_id}: {attribution.description}",
                 severity=severity,
                 location=source or self.current_file_path,
-                details={**attribution.to_dict(), "cve_risk_score": attribution.cvss},
+                details=details,
                 rule_code=rule_code,
             )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,7 @@ def pytest_runtest_setup(item):
         allowed_test_files = [
             "test_xgboost_scanner.py",
             "test_pickle_scanner.py",
+            "test_pickle_binunicode8_setitem.py",
             "test_picklescan_adapter.py",
             "test_basic.py",  # ScanResult private-metadata merge regressions
             "test_joblib_scanner.py",

--- a/tests/detectors/test_cve_detection.py_cases/test_pickle_binunicode8_setitem.py
+++ b/tests/detectors/test_cve_detection.py_cases/test_pickle_binunicode8_setitem.py
@@ -1,0 +1,547 @@
+import pickle
+import struct
+from pathlib import Path
+
+import pytest
+
+from modelaudit.models import ScanResult
+from modelaudit.scanner_results import INCONCLUSIVE_SCAN_OUTCOME
+from modelaudit.scanners import pickle_scanner
+from modelaudit.scanners.pickle_scanner import PickleScanner
+
+
+class _RebuildTensorProbe:
+    def __init__(self) -> None:
+        self.values: dict[object, object] = {}
+
+    def __setitem__(self, key: object, value: object) -> None:
+        self.values[key] = value
+
+
+def _rebuild_tensor_probe() -> _RebuildTensorProbe:
+    return _RebuildTensorProbe()
+
+
+def _binunicode8(value: str) -> bytes:
+    encoded = value.encode("utf-8")
+    return b"\x8d" + len(encoded).to_bytes(8, "little") + encoded
+
+
+def _binbytes(value: bytes) -> bytes:
+    return b"B" + len(value).to_bytes(4, "little") + value
+
+
+def _rebuild_tensor_probe_target() -> bytes:
+    return _binunicode8(__name__) + _binunicode8("_rebuild_tensor_probe") + b"\x93)R"
+
+
+def _system_probe_target() -> bytes:
+    return _binunicode8("os") + _binunicode8("system") + b"\x93)R"
+
+
+def _cve_2026_24747_issues(result: ScanResult) -> list[str]:
+    return [
+        issue.message
+        for issue in result.issues
+        if "CVE-2026-24747" in issue.message or "CVE-2026-24747" in str(issue.details)
+    ]
+
+
+@pytest.mark.parametrize(("mark", "setitem_opcode"), [(b"", b"s"), (b"(", b"u")])
+def test_detects_setitem_after_rebuild_tensor_binunicode8(
+    tmp_path: Path,
+    mark: bytes,
+    setitem_opcode: bytes,
+) -> None:
+    pickle_bytes = (
+        b"\x80\x04"
+        + _rebuild_tensor_probe_target()
+        + mark
+        + _binunicode8("key")
+        + _binunicode8("value")
+        + setitem_opcode
+        + b"."
+    )
+    test_file = tmp_path / "setitem_rebuild_tensor_binunicode8.pkl"
+    test_file.write_bytes(pickle_bytes)
+
+    loaded = pickle.loads(pickle_bytes)
+    result = PickleScanner().scan(str(test_file))
+
+    assert isinstance(loaded, _RebuildTensorProbe)
+    assert loaded.values == {"key": "value"}
+    assert _cve_2026_24747_issues(result), (
+        "Expected CVE-2026-24747 detection for BINUNICODE8 rebuild tensor literal. "
+        f"Issues: {[issue.message for issue in result.issues]}"
+    )
+
+
+def test_detects_setitem_after_build_on_rebuild_tensor_target(tmp_path: Path) -> None:
+    pickle_bytes = (
+        b"\x80\x04" + _rebuild_tensor_probe_target() + b"}b" + _binunicode8("key") + _binunicode8("value") + b"s."
+    )
+    test_file = tmp_path / "setitem_rebuild_tensor_after_build.pkl"
+    test_file.write_bytes(pickle_bytes)
+
+    loaded = pickle.loads(pickle_bytes)
+    result = PickleScanner().scan(str(test_file))
+
+    assert isinstance(loaded, _RebuildTensorProbe)
+    assert loaded.values == {"key": "value"}
+    assert _cve_2026_24747_issues(result)
+
+
+@pytest.mark.parametrize("key_opcode", [b"F1.25\n", b"G" + struct.pack(">d", 1.25)])
+def test_detects_setitem_with_scalar_key_on_rebuild_tensor_target(tmp_path: Path, key_opcode: bytes) -> None:
+    pickle_bytes = b"\x80\x04" + _rebuild_tensor_probe_target() + key_opcode + _binunicode8("value") + b"s."
+    test_file = tmp_path / "setitem_rebuild_tensor_scalar_key.pkl"
+    test_file.write_bytes(pickle_bytes)
+
+    loaded = pickle.loads(pickle_bytes)
+    result = PickleScanner().scan(str(test_file))
+
+    assert isinstance(loaded, _RebuildTensorProbe)
+    assert loaded.values == {1.25: "value"}
+    assert _cve_2026_24747_issues(result)
+
+
+@pytest.mark.parametrize(
+    "target_opcode",
+    [
+        b"(" + _binunicode8(__name__) + _binunicode8("_rebuild_tensor_probe") + b"\x93o",
+        b"(i" + __name__.encode() + b"\n_rebuild_tensor_probe\n",
+    ],
+)
+def test_helper_tracks_legacy_rebuild_tensor_object_targets(target_opcode: bytes) -> None:
+    pickle_bytes = b"\x80\x02" + target_opcode + _binunicode8("key") + _binunicode8("value") + b"s."
+
+    assert pickle_scanner._pickle_has_rebuild_tensor_setitem_abuse(pickle_bytes)
+
+
+@pytest.mark.parametrize("key_opcode", [b"Popaque\n", b"\x82\x01", b"\x97"])
+def test_helper_preserves_rebuild_target_for_opaque_keys(key_opcode: bytes) -> None:
+    pickle_bytes = b"\x80\x05" + _rebuild_tensor_probe_target() + key_opcode + _binunicode8("value") + b"s."
+
+    assert pickle_scanner._pickle_has_rebuild_tensor_setitem_abuse(pickle_bytes)
+
+
+def test_helper_preserves_rebuild_target_across_pop_mark() -> None:
+    pickle_bytes = (
+        b"\x80\x04" + _rebuild_tensor_probe_target() + b"(N1" + _binunicode8("key") + _binunicode8("value") + b"s."
+    )
+
+    assert pickle_scanner._pickle_has_rebuild_tensor_setitem_abuse(pickle_bytes)
+
+
+def test_detects_setitem_near_binunicode8_dangerous_global(tmp_path: Path) -> None:
+    pickle_bytes = (
+        b"\x80\x04"
+        + _binunicode8("os")
+        + _binunicode8("system")
+        + b"\x93"
+        + b")R"
+        + (b"N0" * 40)
+        + _binunicode8("key")
+        + _binunicode8("value")
+        + b"s."
+    )
+    test_file = tmp_path / "setitem_binunicode8_dangerous_global.pkl"
+    test_file.write_bytes(pickle_bytes)
+
+    result = PickleScanner().scan(str(test_file))
+
+    matching_checks = [
+        check
+        for check in result.checks
+        if check.name == "CVE-2026-24747 SETITEM Abuse Detection"
+        and (check.details or {}).get("pattern_type") == "setitem_near_dangerous_global"
+    ]
+    assert matching_checks, (
+        "Expected live setitem_near_dangerous_global detection for BINUNICODE8 STACK_GLOBAL. "
+        f"Checks: {[(check.name, check.message, check.details) for check in result.checks]}"
+    )
+    assert any("os.system" in check.message for check in matching_checks)
+
+
+def test_escaped_stack_global_operands_do_not_depend_on_raw_seed_or_result_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(pickle_scanner, "_result_opcode_counts", lambda _result: {})
+    monkeypatch.setattr(pickle_scanner, "_result_import_references", lambda _result: [])
+    pickle_bytes = b"S'\\x6f\\x73'\nS'\\x73ystem'\n\x93)RS'key'\nS'value'\ns."
+    path = tmp_path / "escaped-stack-global.pkl"
+    path.write_bytes(pickle_bytes)
+
+    result = PickleScanner().scan(str(path))
+
+    assert any(
+        check.name == "CVE-2026-24747 SETITEM Abuse Detection" and check.details.get("associated_global") == "os.system"
+        for check in result.checks
+    )
+
+
+def test_no_binunicode8_setitem_false_positive(tmp_path: Path) -> None:
+    pickle_bytes = b"\x80\x04}" + _binunicode8("key") + _binunicode8("value") + b"s."
+    test_file = tmp_path / "normal_dict_binunicode8_setitem.pkl"
+    test_file.write_bytes(pickle_bytes)
+
+    result = PickleScanner().scan(str(test_file))
+
+    assert _cve_2026_24747_issues(result) == []
+
+
+@pytest.mark.parametrize(("module", "global_name"), [("builtins", "dict"), ("collections", "OrderedDict")])
+@pytest.mark.parametrize(("mark", "setitem_opcode"), [(b"", b"s"), (b"(", b"u")])
+def test_no_binunicode8_interesting_mapping_key_false_positive(
+    tmp_path: Path,
+    mark: bytes,
+    setitem_opcode: bytes,
+    module: str,
+    global_name: str,
+) -> None:
+    pickle_bytes = (
+        b"\x80\x04"
+        + _binunicode8(module)
+        + _binunicode8(global_name)
+        + b"\x93)R"
+        + mark
+        + _binunicode8("_rebuild_tensor")
+        + _binunicode8("ordinary value")
+        + setitem_opcode
+        + b"."
+    )
+    test_file = tmp_path / "mapping_interesting_key_binunicode8.pkl"
+    test_file.write_bytes(pickle_bytes)
+
+    result = PickleScanner().scan(str(test_file))
+
+    assert _cve_2026_24747_issues(result) == []
+
+
+@pytest.mark.parametrize(("mark", "setitem_opcode"), [(b"", b"s"), (b"(", b"u")])
+def test_no_binunicode8_interesting_dict_key_false_positive(
+    tmp_path: Path,
+    mark: bytes,
+    setitem_opcode: bytes,
+) -> None:
+    pickle_bytes = (
+        b"\x80\x04}" + mark + _binunicode8("_rebuild_tensor") + _binunicode8("ordinary value") + setitem_opcode + b"."
+    )
+    test_file = tmp_path / "normal_dict_interesting_key_binunicode8.pkl"
+    test_file.write_bytes(pickle_bytes)
+
+    result = PickleScanner().scan(str(test_file))
+
+    assert _cve_2026_24747_issues(result) == []
+
+
+@pytest.mark.parametrize(("mark", "setitem_opcode"), [(b"", b"s"), (b"(", b"u")])
+@pytest.mark.parametrize(
+    ("module", "global_name"),
+    [("torch._utils", "_rebuild_tensor_v2"), ("os", "system")],
+)
+def test_no_binunicode8_interesting_dict_value_false_positive(
+    tmp_path: Path,
+    mark: bytes,
+    setitem_opcode: bytes,
+    module: str,
+    global_name: str,
+) -> None:
+    pickle_bytes = (
+        b"\x80\x04}"
+        + mark
+        + _binunicode8("ordinary key")
+        + _binunicode8(module)
+        + _binunicode8(global_name)
+        + b"\x93"
+        + setitem_opcode
+        + b"."
+    )
+    test_file = tmp_path / "normal_dict_interesting_value_binunicode8.pkl"
+    test_file.write_bytes(pickle_bytes)
+
+    result = PickleScanner().scan(str(test_file))
+
+    assert _cve_2026_24747_issues(result) == []
+
+
+def test_no_binunicode8_interesting_list_value_false_positive(tmp_path: Path) -> None:
+    pickle_bytes = b"\x80\x04]NaK\x00" + _binunicode8("_rebuild_tensor") + b"s."
+    test_file = tmp_path / "list_interesting_value_binunicode8.pkl"
+    test_file.write_bytes(pickle_bytes)
+
+    result = PickleScanner().scan(str(test_file))
+
+    assert _cve_2026_24747_issues(result) == []
+
+
+def test_byte_literals_do_not_form_stack_global_names() -> None:
+    pickle_bytes = b"\x80\x04" + _binbytes(b"os") + _binbytes(b"system") + b"\x93."
+
+    summary = pickle_scanner._pickle_opcode_summary(pickle_bytes)
+
+    assert summary["dangerous_globals"] == []
+    assert not pickle_scanner._pickle_has_setitem_abuse_for_entries(
+        pickle_bytes,
+        global_needles=("os.system",),
+    )
+
+
+@pytest.mark.parametrize(
+    "padding",
+    [b"", b"\x00", b"\t", b"\n", b"\x0b", b"\x0c", b"\r", b" ", b"\x00\n"],
+)
+def test_detects_rebuild_tensor_setitem_in_later_pickle_stream(tmp_path: Path, padding: bytes) -> None:
+    first_stream = pickle.dumps({"safe": True}, protocol=4)
+    malicious_stream = (
+        b"\x80\x04" + _rebuild_tensor_probe_target() + _binunicode8("key") + _binunicode8("value") + b"s."
+    )
+    path = tmp_path / "later-rebuild-tensor-stream.pkl"
+    path.write_bytes(first_stream + padding + malicious_stream)
+
+    result = PickleScanner().scan(str(path))
+
+    matching_checks = [check for check in result.checks if check.name == "CVE-2026-24747 Pattern Detection"]
+    assert matching_checks
+    assert any(
+        check.rule_code == "S209"
+        and check.details.get("pickle_stream_index") == 1
+        and check.details.get("pickle_stream_offset", 0) > 0
+        and check.details.get("pickle_stream_parse_incomplete") is False
+        for check in matching_checks
+    )
+
+
+def test_detects_protocol_zero_rebuild_tensor_setitem_in_later_pickle_stream(tmp_path: Path) -> None:
+    first_stream = pickle.dumps(None, protocol=4)
+    malicious_stream = b"N0ctorch._utils\n_rebuild_tensor_v2\n)R" + _binunicode8("key") + _binunicode8("value") + b"s."
+    path = tmp_path / "later-protocol-zero-rebuild-tensor-stream.pkl"
+    path.write_bytes(first_stream + malicious_stream)
+
+    result = PickleScanner().scan(str(path))
+
+    assert any(
+        check.name == "CVE-2026-24747 Pattern Detection"
+        and check.rule_code == "S209"
+        and check.details.get("pickle_stream_index") == 1
+        for check in result.checks
+    )
+
+
+@pytest.mark.parametrize("padding", [b"", b"\x00", b"\n"])
+def test_detects_system_setitem_in_later_pickle_stream(tmp_path: Path, padding: bytes) -> None:
+    first_stream = pickle.dumps({"safe": True}, protocol=4)
+    malicious_stream = b"\x80\x04" + _system_probe_target() + _binunicode8("key") + _binunicode8("value") + b"s."
+    path = tmp_path / "later-system-stream.pkl"
+    path.write_bytes(first_stream + padding + malicious_stream)
+
+    result = PickleScanner().scan(str(path))
+
+    assert any(
+        check.name == "CVE-2026-24747 SETITEM Abuse Detection"
+        and check.rule_code == "S209"
+        and check.details.get("associated_global") == "os.system"
+        and check.details.get("pickle_stream_index") == 1
+        and check.details.get("pickle_stream_parse_incomplete") is False
+        for check in result.checks
+    )
+    assert result.metadata.get("pickle_cve_raw_detector_skipped") is not True
+
+
+def test_later_pickle_stream_does_not_depend_on_python_opcode_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fail_opcode_summary(_payload: bytes) -> dict[str, object]:
+        raise AssertionError("stream-scoped SETITEM analysis should not use the Python opcode summary")
+
+    monkeypatch.setattr(pickle_scanner, "_pickle_opcode_summary", fail_opcode_summary)
+    first_stream = pickle.dumps({"safe": True}, protocol=4)
+    malicious_stream = b"\x80\x04" + _system_probe_target() + _binunicode8("key") + _binunicode8("value") + b"s."
+    path = tmp_path / "later-rust-metadata-stream.pkl"
+    path.write_bytes(first_stream + b"\x00\n" + malicious_stream)
+
+    result = PickleScanner().scan(str(path))
+
+    assert any(
+        check.name == "CVE-2026-24747 SETITEM Abuse Detection" and check.details.get("pickle_stream_index") == 1
+        for check in result.checks
+    )
+
+
+def test_raw_text_after_complete_pickle_cannot_borrow_setitem_metadata(tmp_path: Path) -> None:
+    path = tmp_path / "raw-tail-state-bleed.pkl"
+    path.write_bytes(
+        pickle.dumps({"safe": "value"}, protocol=4)
+        + b"_rebuild_tensor SETITEM storage_offset nbytes ordinary trailing text"
+    )
+
+    result = PickleScanner().scan(str(path))
+
+    assert _cve_2026_24747_issues(result) == []
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+
+
+def test_complete_stream_preserves_tensor_metadata_mismatch_attribution(tmp_path: Path) -> None:
+    path = tmp_path / "tensor-metadata-mismatch.pkl"
+    path.write_bytes(b"ctorch._utils\n_rebuild_tensor_v2\n(Vstorage_size\nVnbytes\ntR.")
+
+    result = PickleScanner().scan(str(path))
+
+    assert any(
+        check.name == "CVE-2026-24747 Pattern Detection"
+        and "PyTorch tensor metadata mismatch indicators" in check.details.get("patterns_matched", [])
+        and check.details.get("pickle_stream_index") == 0
+        and check.details.get("pickle_stream_parse_incomplete") is False
+        for check in result.checks
+    )
+
+
+def test_incomplete_ordinary_dict_with_rebuild_key_remains_clean(tmp_path: Path) -> None:
+    path = tmp_path / "incomplete-ordinary-dict.pkl"
+    path.write_bytes(b"\x80\x04}" + _binunicode8("_rebuild_tensor") + _binunicode8("value") + b"s")
+
+    result = PickleScanner().scan(str(path))
+
+    assert _cve_2026_24747_issues(result) == []
+
+
+def test_incomplete_unknown_setitem_target_fails_closed(tmp_path: Path) -> None:
+    path = tmp_path / "incomplete-unknown-target.pkl"
+    path.write_bytes(b"\x80\x04" + _binunicode8("_rebuild_tensor") + _binunicode8("value") + b"s")
+
+    result = PickleScanner().scan(str(path))
+
+    assert _cve_2026_24747_issues(result)
+    assert any(
+        check.name == "CVE-2026-24747 Pattern Detection"
+        and check.rule_code == "S209"
+        and check.details.get("pickle_stream_index") == 0
+        and check.details.get("pickle_stream_parse_incomplete") is True
+        for check in result.checks
+    )
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+
+
+@pytest.mark.parametrize("prefix", [b"]0", b"\x880", b"\x890", b"h\x000"])
+def test_incomplete_later_stream_with_discarded_root_fails_closed(tmp_path: Path, prefix: bytes) -> None:
+    first_stream = pickle.dumps(None, protocol=4)
+    incomplete_stream = prefix + _system_probe_target() + _binunicode8("key") + _binunicode8("value") + b"s"
+    path = tmp_path / "incomplete-prefixed-later-stream.pkl"
+    path.write_bytes(first_stream + incomplete_stream)
+
+    result = PickleScanner().scan(str(path))
+
+    assert any(
+        check.name == "CVE-2026-24747 SETITEM Abuse Detection"
+        and check.rule_code == "S209"
+        and check.details.get("pickle_stream_index") == 1
+        and check.details.get("pickle_stream_parse_incomplete") is True
+        for check in result.checks
+    )
+
+
+@pytest.mark.parametrize(
+    ("module", "global_name"),
+    [("notos", "systematic"), (__name__, "not_rebuild_tensor_probe")],
+)
+def test_global_name_substrings_do_not_trigger_setitem_cve(
+    tmp_path: Path,
+    module: str,
+    global_name: str,
+) -> None:
+    target = _binunicode8(module) + _binunicode8(global_name) + b"\x93)R"
+    path = tmp_path / "near-match-global.pkl"
+    path.write_bytes(b"\x80\x04" + target + _binunicode8("key") + _binunicode8("value") + b"s.")
+
+    result = PickleScanner().scan(str(path))
+
+    assert _cve_2026_24747_issues(result) == []
+
+
+def test_benign_later_stream_dictionary_remains_clean(tmp_path: Path) -> None:
+    first_stream = pickle.dumps({"safe": True}, protocol=4)
+    later_stream = b"\x80\x04}" + _binunicode8("_rebuild_tensor") + _binunicode8("ordinary value") + b"s."
+    path = tmp_path / "benign-later-dict.pkl"
+    path.write_bytes(first_stream + b"\x00\n" + later_stream)
+
+    result = PickleScanner().scan(str(path))
+
+    assert _cve_2026_24747_issues(result) == []
+    assert result.metadata["pickle_cve_streams_analyzed"] == 2
+
+
+def test_seedless_pickle_skips_python_setitem_analysis(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fail_setitem_analysis(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("seedless pickle should not run Python SETITEM analysis")
+
+    monkeypatch.setattr(pickle_scanner, "_analyze_pickle_setitem_entries", fail_setitem_analysis)
+    path = tmp_path / "seedless.pkl"
+    path.write_bytes(pickle.dumps([None] * 2048, protocol=4))
+
+    result = PickleScanner().scan(str(path))
+
+    assert result.success is True
+    assert result.metadata["pickle_cve_raw_detector_skipped"] is True
+
+
+def test_pickle_cve_stream_limit_allows_exact_limit(tmp_path: Path) -> None:
+    safe_stream = pickle.dumps(None, protocol=4)
+    path = tmp_path / "maximum-pickle-streams.pkl"
+    path.write_bytes(safe_stream * 64)
+
+    result = PickleScanner().scan(str(path))
+
+    assert result.success is True
+    assert result.metadata["pickle_cve_streams_analyzed"] == 64
+    assert not any(check.name == "Pickle CVE Stream Coverage" for check in result.checks)
+
+
+def test_pickle_cve_stream_limit_fails_closed(tmp_path: Path) -> None:
+    safe_stream = pickle.dumps(None, protocol=4)
+    path = tmp_path / "too-many-pickle-streams.pkl"
+    path.write_bytes(safe_stream * 65)
+
+    result = PickleScanner().scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "pickle_cve_stream_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert result.metadata["pickle_cve_streams_analyzed"] == 64
+    assert any(
+        check.name == "Pickle CVE Stream Coverage"
+        and check.rule_code == "S902"
+        and check.details.get("max_streams") == 64
+        and check.details.get("analysis_incomplete") is True
+        for check in result.checks
+    )
+
+
+@pytest.mark.parametrize("prefix", [b"", b"h\x000"])
+def test_pickle_cve_stream_limit_rejects_incomplete_extra_stream(tmp_path: Path, prefix: bytes) -> None:
+    safe_stream = pickle.dumps(None, protocol=4)
+    incomplete_stream = (
+        prefix + b"N0ctorch._utils\n_rebuild_tensor_v2\n)R" + _binunicode8("key") + _binunicode8("value") + b"s"
+    )
+    path = tmp_path / "incomplete-extra-pickle-stream.pkl"
+    path.write_bytes((safe_stream * 64) + incomplete_stream)
+
+    result = PickleScanner().scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "pickle_cve_stream_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert result.metadata["pickle_cve_streams_analyzed"] == 64
+    assert any(
+        check.name == "Pickle CVE Stream Coverage"
+        and check.rule_code == "S902"
+        and check.details.get("max_streams") == 64
+        and check.details.get("analysis_incomplete") is True
+        for check in result.checks
+    )

--- a/tests/scanners/test_joblib_scanner_codecs.py
+++ b/tests/scanners/test_joblib_scanner_codecs.py
@@ -56,6 +56,35 @@ def test_scan_detects_raw_protocol0_pickle_joblib(tmp_path: Path) -> None:
     assert _has_system_reduce_failure(result)
 
 
+def test_scan_detects_truncated_raw_protocol0_pickle_joblib(tmp_path: Path) -> None:
+    payload = pickle.dumps(_Payload(), protocol=0)[:-1]
+
+    result = _scan_payload(tmp_path, payload, "truncated_raw_protocol0.joblib")
+
+    assert result.success is False
+    assert _has_system_reduce_failure(result)
+    assert _compression_failures(result) == []
+
+
+@pytest.mark.parametrize("payload", [b"Pattacker-controlled-id\n", b"Vattacker-controlled-id\nQ"])
+def test_scan_detects_truncated_raw_persistent_id_joblib(tmp_path: Path, payload: bytes) -> None:
+    result = _scan_payload(tmp_path, payload, "truncated_persistent_id.joblib")
+
+    assert result.success is False
+    assert any(issue.rule_code == "S212" for issue in result.issues)
+    assert _compression_failures(result) == []
+
+
+def test_scan_detects_raw_protocol0_pickle_after_large_literal(tmp_path: Path) -> None:
+    payload = pickle.dumps(["A" * 5000, _Payload()], protocol=0)
+
+    result = _scan_payload(tmp_path, payload, "large_prefix_raw_protocol0.joblib")
+
+    assert result.success is False
+    assert _has_system_reduce_failure(result)
+    assert _compression_failures(result) == []
+
+
 def test_scan_accepts_raw_protocol4_primitive_pickle_joblib(tmp_path: Path) -> None:
     payload = pickle.dumps(7, protocol=4)
 
@@ -74,6 +103,30 @@ def test_scan_accepts_raw_protocol0_int_pickle_joblib(tmp_path: Path) -> None:
     assert result.success is True
     assert _compression_failures(result) == []
     assert not _has_system_reduce_failure(result)
+
+
+@pytest.mark.parametrize("value", [None, True, 7, 3.5, "safe", b"safe", [1, 2], {"key": "value"}])
+def test_raw_protocol0_scalar_and_container_pickles_are_recognized(value: object) -> None:
+    payload = pickle.dumps(value, protocol=0)
+
+    assert JoblibScanner()._looks_like_raw_pickle_payload(payload) is True
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"Bogus BINBYTES-like text",
+        b"Invalid INT-like text",
+        b"Not a pickle",
+        b"Routine plain text",
+        b"This is not compressed data at all!",
+        b"Xylophone BINUNICODE-like text",
+        b"]not a pickle",
+        b"}not a pickle",
+    ],
+)
+def test_opcode_looking_text_is_not_recognized_as_raw_pickle(payload: bytes) -> None:
+    assert JoblibScanner()._looks_like_raw_pickle_payload(payload) is False
 
 
 def test_scan_reports_unavailable_joblib_read_as_inconclusive_not_security_finding(
@@ -125,8 +178,12 @@ def test_scan_fails_closed_when_numpy_wrapper_prefix_has_unknown_tail(tmp_path: 
     )
 
 
-def test_scan_trusts_numpy_wrapper_zero_padding_after_pickle_boundary(tmp_path: Path) -> None:
-    payload = b"\x80\x04cjoblib.numpy_pickle\nNumpyArrayWrapper\nq\x00." + (b"\x00" * 16)
+@pytest.mark.parametrize("array_data", [b"\x00" * 15, b"B" + (b"\x00" * 14)])
+def test_scan_trusts_numpy_wrapper_zero_padding_after_pickle_boundary(
+    tmp_path: Path,
+    array_data: bytes,
+) -> None:
+    payload = b"\x80\x04cjoblib.numpy_pickle\nNumpyArrayWrapper\nq\x00." + b"\x00" + array_data
 
     result = _scan_payload(tmp_path, payload, "numpy_array_tail.joblib")
 
@@ -191,7 +248,7 @@ def test_scan_detects_zlib_trailer_after_compressed_joblib_stream(tmp_path: Path
 
 
 def test_scan_reports_plain_text_joblib_without_critical_pickle_noise(tmp_path: Path) -> None:
-    result = _scan_payload(tmp_path, b"not a pickle", "plain_text.joblib")
+    result = _scan_payload(tmp_path, b"This is not compressed data at all!", "plain_text.joblib")
 
     compression_failures = _compression_failures(result)
     assert result.success is False

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -179,6 +179,9 @@ def test_looks_like_pickle_sniffs_binary_and_protocol_zero_payloads() -> None:
     assert _looks_like_pickle(pickle.dumps({"safe": True}, protocol=4)) is True
     assert _looks_like_pickle(b"\x80\x01K\x01.") is True
     assert _looks_like_pickle(b"cos\nsystem\n.") is True
+    assert _looks_like_pickle(b"].") is True
+    assert _looks_like_pickle(b"\x88.") is True
+    assert _looks_like_pickle(b"\x89.") is True
     assert _looks_like_pickle(b"not a pickle") is False
 
 
@@ -1752,7 +1755,7 @@ def test_raw_cve_setitem_detection_ignores_unparsed_tail_strings(tmp_path: Path)
 
 def test_raw_cve_setitem_detection_is_not_suppressed_by_comment_token(tmp_path: Path) -> None:
     path = tmp_path / "comment-token-setitem.pkl"
-    path.write_bytes(b"(dS'_rebuild_tensor # comment token is not a bypass'\nS'value'\ns.")
+    path.write_bytes(b"\x80\x02S'_rebuild_tensor # comment token is not a bypass'\n)\x81S'key'\nS'value'\ns.")
 
     result = PickleScanner().scan(str(path))
 
@@ -1792,7 +1795,7 @@ def test_raw_cve_attributions_are_deduplicated_by_rule(
 
     monkeypatch.setattr(cve_patterns, "analyze_cve_patterns", duplicate_analyze_cve_patterns)
     path = tmp_path / "duplicate-setitem-attribution.pkl"
-    path.write_bytes(b"(dS'_rebuild_tensor # comment token is not a bypass'\nS'value'\ns.")
+    path.write_bytes(b"\x80\x02S'_rebuild_tensor # comment token is not a bypass'\n)\x81S'key'\nS'value'\ns.")
 
     result = PickleScanner().scan(str(path))
 
@@ -1832,7 +1835,7 @@ def test_raw_cve_comment_only_text_does_not_trigger_setitem(tmp_path: Path) -> N
 def test_raw_cve_rebuild_tensor_global_is_not_suppressed_by_documentation_literal(tmp_path: Path) -> None:
     path = tmp_path / "doc-literal-real-global.pkl"
     path.write_bytes(
-        b"(dS'doc'\nS'# _rebuild_tensor\\n# documentation only'\nsctorch\n_rebuild_tensor_v2\nS'value'\ns."
+        b"\x80\x02S'# _rebuild_tensor\\n# documentation only'\n0ctorch\n_rebuild_tensor_v2\n)RS'key'\nS'value'\ns."
     )
 
     result = PickleScanner().scan(str(path))
@@ -1844,7 +1847,7 @@ def test_raw_cve_rebuild_tensor_global_is_not_suppressed_by_documentation_litera
 def test_rebuild_tensor_documentation_literal_detector_behavior() -> None:
     doc_only_payload = pickle.dumps({"doc": "# _rebuild_tensor\n# documentation only"}, protocol=4)
     real_global_payload = (
-        b"(dS'doc'\nS'# _rebuild_tensor\\n# documentation only'\nsctorch\n_rebuild_tensor_v2\nS'value'\ns."
+        b"\x80\x02S'# _rebuild_tensor\\n# documentation only'\n0ctorch\n_rebuild_tensor_v2\n)RS'key'\nS'value'\ns."
     )
 
     assert _rebuild_tensor_indicators_are_documentation_literals(doc_only_payload) is True
@@ -1861,7 +1864,7 @@ def test_raw_cve_rebuild_tensor_doc_filter_uses_rust_import_metadata(
     )
     path = tmp_path / "rust-rebuild-tensor-global.pkl"
     path.write_bytes(
-        b"(dS'doc'\nS'# _rebuild_tensor\\n# documentation only'\nsctorch\n_rebuild_tensor_v2\nS'value'\ns."
+        b"\x80\x02S'# _rebuild_tensor\\n# documentation only'\n0ctorch\n_rebuild_tensor_v2\n)RS'key'\nS'value'\ns."
     )
 
     result = PickleScanner().scan(str(path))
@@ -1873,7 +1876,7 @@ def test_raw_cve_rebuild_tensor_doc_filter_uses_rust_import_metadata(
     )
 
 
-def test_opcode_summary_tracks_memoized_stack_global_through_structure(tmp_path: Path) -> None:
+def test_opcode_summary_tracks_memoized_stack_global_in_dict_without_setitem_cve(tmp_path: Path) -> None:
     payload = b"\x80\x04\x8c\x02os\x94}\x94\x8c\x06system\x94h\x00h\x02\x93s."
     path = tmp_path / "memoized-stack-global.pkl"
     path.write_bytes(payload)
@@ -1882,9 +1885,7 @@ def test_opcode_summary_tracks_memoized_stack_global_through_structure(tmp_path:
     result = PickleScanner().scan(str(path))
 
     assert summary["dangerous_globals"] == ["os.system"]
-    assert any(
-        issue.rule_code == "S209" and issue.details.get("associated_global") == "os.system" for issue in result.issues
-    )
+    assert not any(issue.rule_code == "S209" for issue in result.issues)
 
 
 def test_raw_cve_setitem_scan_uses_rust_metadata_not_python_opcode_summary(
@@ -1896,7 +1897,7 @@ def test_raw_cve_setitem_scan_uses_rust_metadata_not_python_opcode_summary(
 
     monkeypatch.setattr("modelaudit.scanners.pickle_scanner._pickle_opcode_summary", fail_opcode_summary)
     path = tmp_path / "rust-metadata-stack-global.pkl"
-    path.write_bytes(b"\x80\x04\x8c\x02os\x94}\x94\x8c\x06system\x94h\x00h\x02\x93s.")
+    path.write_bytes(b"\x80\x04\x8c\x02os\x8c\x06system\x93)R\x8c\x03key\x8c\x05values.")
 
     result = PickleScanner().scan(str(path))
 


### PR DESCRIPTION
## Summary
- add `BINUNICODE8` to shared pickle literal analysis without treating byte literals as `STACK_GLOBAL` names
- scope CVE-2026-24747 `SETITEM` / `SETITEMS` evidence to the actual mutation target and to bounded individual pickle streams
- analyze concatenated and incomplete streams across padding and unrecognized separators, including protocol-less scalar/container roots and memo-get prefixes
- preserve fail-closed coverage after 64 streams with a single-buffer, linear stream probe
- structurally route raw Joblib pickles, including truncated persistent-ID payloads and large leading literals, without decoding file-sized opcode arguments
- register malicious and benign regressions for reduced CI lanes

## False-positive / false-negative audit
- FN closed: a non-pickle separator can no longer hide a malicious later stream
- FN closed: later incomplete streams and escaped `STACK_GLOBAL` operands retain stream-local attribution
- FN closed: malicious extra streams beyond the 64-stream cap make the scan inconclusive
- FN closed: truncated Joblib `PERSID` / `BINPERSID` payloads reach pickle analysis and emit `S212`
- FP closed: direct globals and plain strings named `_rebuild_tensor*` are not treated as executable mutation targets
- FP closed: ordinary dict/list/mapping keys and values, raw trailing text, byte literals, and bare `STOP`-prefixed text remain clean
- DoS closed: Joblib protocol-0 classification skips large operands structurally instead of materializing them through `pickletools.genops`

## Validation
- associated tests: `270 passed`
  - `tests/detectors/test_cve_detection.py_cases/test_pickle_binunicode8_setitem.py`
  - `tests/scanners/test_joblib_scanner_codecs.py`
  - `tests/scanners/test_pickle_scanner.py`
- scoped Ruff format/check, mypy, and `git diff --check`: clean
- 100 MiB leading Unicode operand probe: `0 KiB` additional peak RSS, about `0.004s`
- 3,000 generated valid pickles across protocols 0-5: zero routing misses
- full test suite intentionally left to CI

## Published state
- current main integrated: `6f4407d7f28f7dd61a6f520a493bf85c1a68123f`
- head: `69a449ac45b93099e3a6f7cfc572012e7692128b`
- exact tested tree: `ed6eb9e62e47dfcb53de3bbb50c6c21e071f107a`

All inline review threads are resolved.