### PR TITLE
fix: restrict manual docker publish tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,6 +8,7 @@ on:
       tag:
         description: "Image tag (e.g., 0.2.26)"
         required: true
+        type: string
 
 permissions:
   contents: read
@@ -18,13 +19,99 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  validate-manual-publish:
+    name: Validate Manual Publish
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      image_tag: ${{ steps.validate.outputs.image_tag }}
+      source_ref: ${{ steps.validate.outputs.source_ref }}
+      source_sha: ${{ steps.validate.outputs.source_sha }}
+    environment:
+      name: ghcr-manual-publish
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Validate manual image tag
+        id: validate
+        env:
+          IMAGE_TAG: ${{ inputs.tag }}
+        run: |
+          SOURCE_TAG="$(python scripts/validate_docker_publish_tag.py "$IMAGE_TAG")"
+          SOURCE_REF="refs/tags/v${SOURCE_TAG}"
+          git fetch --no-tags --depth=1 origin "$SOURCE_REF"
+          SOURCE_SHA="$(git rev-parse 'FETCH_HEAD^{commit}')"
+          echo "image_tag=$SOURCE_TAG" >> "$GITHUB_OUTPUT"
+          echo "source_ref=$SOURCE_REF" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+
+  validate-release-publish:
+    name: Validate Release Publish
+    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      image_tag: ${{ steps.validate.outputs.image_tag }}
+      source_ref: ${{ steps.validate.outputs.source_ref }}
+      source_sha: ${{ steps.validate.outputs.source_sha }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Validate release image tag
+        id: validate
+        env:
+          IMAGE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          SOURCE_TAG="$(python scripts/validate_docker_publish_tag.py "$IMAGE_TAG")"
+          if [[ "$IMAGE_TAG" != "v${SOURCE_TAG}" ]]; then
+            echo "Docker images are published only for root vX.Y.Z releases" >&2
+            exit 1
+          fi
+          SOURCE_REF="refs/tags/v${SOURCE_TAG}"
+          git fetch --no-tags --depth=1 origin "$SOURCE_REF"
+          SOURCE_SHA="$(git rev-parse 'FETCH_HEAD^{commit}')"
+          echo "image_tag=$SOURCE_TAG" >> "$GITHUB_OUTPUT"
+          echo "source_ref=$SOURCE_REF" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+
   publish:
     name: Build and Push Docker Image
+    needs: [validate-manual-publish, validate-release-publish]
+    if: >-
+      ${{ always() && (
+        (github.event_name == 'workflow_dispatch' && needs.validate-manual-publish.result == 'success') ||
+        (github.event_name == 'release' && needs.validate-release-publish.result == 'success')
+      ) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && needs.validate-manual-publish.outputs.source_ref || needs.validate-release-publish.outputs.source_ref }}
+
+      - name: Resolve source commit
+        id: source
+        env:
+          EXPECTED_SOURCE_SHA: ${{ github.event_name == 'workflow_dispatch' && needs.validate-manual-publish.outputs.source_sha || needs.validate-release-publish.outputs.source_sha }}
+        run: |
+          SOURCE_SHA="$(git rev-parse HEAD)"
+          if [[ -n "$EXPECTED_SOURCE_SHA" && "$SOURCE_SHA" != "$EXPECTED_SOURCE_SHA" ]]; then
+            echo "Validated source commit changed before publish" >&2
+            exit 1
+          fi
+          echo "short_sha=${SOURCE_SHA:0:7}" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
@@ -43,13 +130,15 @@ jobs:
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
+          context: git
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: latest=false
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
             type=sha
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
-            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=raw,value=${{ needs.validate-manual-publish.outputs.image_tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push lightweight image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
@@ -66,5 +155,5 @@ jobs:
       - name: Verify published image
         run: |
           # Pull and verify the image works
-          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${GITHUB_SHA::7}
-          docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${GITHUB_SHA::7} --version
+          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ steps.source.outputs.short_sha }}
+          docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ steps.source.outputs.short_sha }} --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- restrict manual Docker publishes to validated immutable version tags and their matching Git release refs before registry login or push
 - harden cloud acquisition size caps, HTTPS/R2 auto-default routing, and directory metadata failures
 - detect operator attrgetter, itemgetter, and methodcaller archive-member Python paths to command execution while preserving benign accessor names
 - redact Keras and TensorFlow scanner detail fields that echo model-controlled configs, code indicators, archive members, and external references.

--- a/scripts/validate_docker_publish_tag.py
+++ b/scripts/validate_docker_publish_tag.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import re
+import sys
+
+_MAX_DOCKER_TAG_LENGTH = 128
+_PRERELEASE_IDENTIFIER = r"(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)"
+_VERSION_TAG_RE = re.compile(
+    r"^v?"
+    r"(0|[1-9][0-9]*)"
+    r"\.(0|[1-9][0-9]*)"
+    r"\.(0|[1-9][0-9]*)"
+    rf"(?:-{_PRERELEASE_IDENTIFIER}(?:\.{_PRERELEASE_IDENTIFIER})*)?"
+    r"$"
+)
+
+
+def normalize_publish_tag(tag: str) -> str | None:
+    if tag != tag.strip():
+        return None
+    normalized_tag = tag.removeprefix("v")
+    if not tag or len(normalized_tag) > _MAX_DOCKER_TAG_LENGTH:
+        return None
+    if _VERSION_TAG_RE.fullmatch(tag) is None:
+        return None
+    return normalized_tag
+
+
+def is_allowed_publish_tag(tag: str) -> bool:
+    return normalize_publish_tag(tag) is not None
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: validate_docker_publish_tag.py <tag>", file=sys.stderr)
+        return 2
+
+    tag = argv[1]
+    normalized_tag = normalize_publish_tag(tag)
+    if normalized_tag is not None:
+        print(normalized_tag)
+        return 0
+
+    print(
+        "Manual Docker publishes only accept immutable version tags like 0.2.26, v0.2.26, or 0.2.26-rc.1.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_docker_workflow.py
+++ b/tests/test_docker_workflow.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import re
+import subprocess
+import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
+import pytest
 import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -16,6 +19,29 @@ def _load_docker_workflow() -> dict[str, Any]:
     workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
     assert isinstance(workflow, dict)
     return workflow
+
+
+def _load_docker_publish_workflow() -> dict[str, Any]:
+    workflow_path = _REPO_ROOT / ".github" / "workflows" / "docker-publish.yml"
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    return workflow
+
+
+def _workflow_triggers(workflow: dict[str, Any]) -> dict[str, Any]:
+    raw_workflow = cast(dict[Any, Any], workflow)
+    triggers = raw_workflow.get("on", raw_workflow.get(True))
+    assert isinstance(triggers, dict)
+    return triggers
+
+
+def _run_tag_validator(tag: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_REPO_ROOT / "scripts" / "validate_docker_publish_tag.py"), tag],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
 
 
 def _dockerfile_lines(path: str) -> list[str]:
@@ -76,6 +102,157 @@ def test_dockerfiles_pin_python_base_images_by_digest() -> None:
 
     tensorflow_from = _dockerfile_lines("Dockerfile.tensorflow")[0].removeprefix("FROM ")
     _assert_pinned_python_image(tensorflow_from, "3.12-slim")
+
+
+def test_docker_publish_manual_dispatch_is_guarded_before_push() -> None:
+    workflow = _load_docker_publish_workflow()
+
+    dispatch_inputs = _workflow_triggers(workflow)["workflow_dispatch"]["inputs"]
+    assert dispatch_inputs["tag"] == {
+        "description": "Image tag (e.g., 0.2.26)",
+        "required": True,
+        "type": "string",
+    }
+
+    validation_job = _jobs(workflow)["validate-manual-publish"]
+    assert validation_job["if"] == "github.event_name == 'workflow_dispatch'"
+    assert validation_job["outputs"] == {
+        "image_tag": "${{ steps.validate.outputs.image_tag }}",
+        "source_ref": "${{ steps.validate.outputs.source_ref }}",
+        "source_sha": "${{ steps.validate.outputs.source_sha }}",
+    }
+    assert validation_job["environment"] == {"name": "ghcr-manual-publish"}
+
+    validation_steps = _job_steps(workflow, "validate-manual-publish")
+    validation_checkout = _step_by_name(validation_steps, "Checkout repo")
+    assert validation_checkout["with"] == {"ref": "${{ github.event.repository.default_branch }}"}
+    validation_step = _step_by_name(validation_steps, "Validate manual image tag")
+    assert validation_step["id"] == "validate"
+    assert validation_step["env"] == {"IMAGE_TAG": "${{ inputs.tag }}"}
+    validation_run = validation_step["run"]
+    assert 'SOURCE_TAG="$(python scripts/validate_docker_publish_tag.py "$IMAGE_TAG")"' in validation_run
+    assert 'SOURCE_REF="refs/tags/v${SOURCE_TAG}"' in validation_run
+    assert 'git fetch --no-tags --depth=1 origin "$SOURCE_REF"' in validation_run
+    assert "SOURCE_SHA=\"$(git rev-parse 'FETCH_HEAD^{commit}')\"" in validation_run
+    assert 'echo "image_tag=$SOURCE_TAG" >> "$GITHUB_OUTPUT"' in validation_run
+    assert 'echo "source_ref=$SOURCE_REF" >> "$GITHUB_OUTPUT"' in validation_run
+    assert 'echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"' in validation_run
+
+    release_validation_job = _jobs(workflow)["validate-release-publish"]
+    assert release_validation_job["if"] == (
+        "github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')"
+    )
+    assert release_validation_job["outputs"] == validation_job["outputs"]
+    assert "environment" not in release_validation_job
+    release_validation_steps = _job_steps(workflow, "validate-release-publish")
+    release_checkout = _step_by_name(release_validation_steps, "Checkout repo")
+    assert release_checkout["with"] == {"ref": "${{ github.event.repository.default_branch }}"}
+    release_validation_step = _step_by_name(release_validation_steps, "Validate release image tag")
+    assert release_validation_step["env"] == {"IMAGE_TAG": "${{ github.event.release.tag_name }}"}
+    release_validation_run = release_validation_step["run"]
+    assert 'SOURCE_TAG="$(python scripts/validate_docker_publish_tag.py "$IMAGE_TAG")"' in release_validation_run
+    assert '[[ "$IMAGE_TAG" != "v${SOURCE_TAG}" ]]' in release_validation_run
+    assert "Docker images are published only for root vX.Y.Z releases" in release_validation_run
+    assert 'SOURCE_REF="refs/tags/v${SOURCE_TAG}"' in release_validation_run
+    assert 'echo "image_tag=$SOURCE_TAG" >> "$GITHUB_OUTPUT"' in release_validation_run
+
+    publish_job = _jobs(workflow)["publish"]
+    assert publish_job["needs"] == ["validate-manual-publish", "validate-release-publish"]
+    assert " ".join(publish_job["if"].split()) == (
+        "${{ always() && ( "
+        "(github.event_name == 'workflow_dispatch' && needs.validate-manual-publish.result == 'success') || "
+        "(github.event_name == 'release' && needs.validate-release-publish.result == 'success') "
+        ") }}"
+    )
+    publish_checkout = _step_by_name(_job_steps(workflow, "publish"), "Checkout repo")
+    assert publish_checkout["with"] == {
+        "ref": (
+            "${{ github.event_name == 'workflow_dispatch' && "
+            "needs.validate-manual-publish.outputs.source_ref || "
+            "needs.validate-release-publish.outputs.source_ref }}"
+        )
+    }
+
+    publish_steps = _job_steps(workflow, "publish")
+    source_step = _step_by_name(publish_steps, "Resolve source commit")
+    assert source_step["id"] == "source"
+    assert source_step["env"] == {
+        "EXPECTED_SOURCE_SHA": (
+            "${{ github.event_name == 'workflow_dispatch' && needs.validate-manual-publish.outputs.source_sha || "
+            "needs.validate-release-publish.outputs.source_sha }}"
+        )
+    }
+    assert 'SOURCE_SHA="$(git rev-parse HEAD)"' in source_step["run"]
+    assert '[[ -n "$EXPECTED_SOURCE_SHA" && "$SOURCE_SHA" != "$EXPECTED_SOURCE_SHA" ]]' in source_step["run"]
+    assert 'echo "Validated source commit changed before publish" >&2' in source_step["run"]
+    assert "exit 1" in source_step["run"]
+    assert 'echo "short_sha=${SOURCE_SHA:0:7}" >> "$GITHUB_OUTPUT"' in source_step["run"]
+    assert "git rev-parse --short" not in source_step["run"]
+
+    metadata_step = _step_by_name(publish_steps, "Extract metadata")
+    assert metadata_step["with"]["context"] == "git"
+    assert metadata_step["with"]["flavor"] == "latest=false"
+    metadata_tags = metadata_step["with"]["tags"]
+    assert "type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}" in metadata_tags
+    assert "type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}" in metadata_tags
+    assert (
+        "type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}"
+    ) in metadata_tags
+    assert (
+        "type=raw,value=${{ needs.validate-manual-publish.outputs.image_tag }},"
+        "enable=${{ github.event_name == 'workflow_dispatch' }}"
+    ) in metadata_tags
+
+    verify_step = _step_by_name(publish_steps, "Verify published image")
+    verify_run = verify_step["run"]
+    assert "GITHUB_SHA" not in verify_run
+    assert verify_run.count("sha-${{ steps.source.outputs.short_sha }}") == 2
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected_tag"),
+    [
+        ("0.2.26", "0.2.26"),
+        ("v0.2.26", "0.2.26"),
+        ("1.0.0-rc.1", "1.0.0-rc.1"),
+        ("2.10.0-alpha.1", "2.10.0-alpha.1"),
+        ("1.2.3--", "1.2.3--"),
+        (f"1.2.3-{'a' * 122}", f"1.2.3-{'a' * 122}"),
+    ],
+)
+def test_docker_publish_tag_validator_allows_immutable_version_tags(tag: str, expected_tag: str) -> None:
+    result = _run_tag_validator(tag)
+
+    assert result.returncode == 0
+    assert result.stdout == f"{expected_tag}\n"
+
+
+@pytest.mark.parametrize(
+    "tag",
+    [
+        "",
+        "latest",
+        "main",
+        "sha-abcdef0",
+        "0.2",
+        "01.2.3",
+        "0.02.3",
+        "0.2.03",
+        "0.2.3+build.1",
+        "0.2.3/evil",
+        "0.2.3-",
+        "0.2.3-01",
+        "0.2.3-rc..1",
+        "0.2.3-\nlatest",
+        " 0.2.3",
+        f"1.2.3-{'a' * 123}",
+    ],
+)
+def test_docker_publish_tag_validator_rejects_mutable_or_non_version_tags(tag: str) -> None:
+    result = _run_tag_validator(tag)
+
+    assert result.returncode != 0
+    assert "only accept immutable version tags" in result.stderr
 
 
 def test_dockerfiles_verify_pinned_rustup_init_instead_of_streaming_shell() -> None:

--- a/tests/workflows/test_docker_workflow.py
+++ b/tests/workflows/test_docker_workflow.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import yaml
 
+from scripts.validate_docker_publish_tag import normalize_publish_tag
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _WORKFLOW_DIR = _REPO_ROOT / ".github" / "workflows"
 _ACTION_DIR = _REPO_ROOT / ".github" / "actions"
@@ -143,3 +145,14 @@ def test_action_pin_validation_rejects_mutable_refs() -> None:
         ".github/workflows/example.yml: owner/action@v1",
         ".github/workflows/example.yml: docker://ghcr.io/owner/action:latest",
     ]
+
+
+def test_optional_v_prefix_preserves_maximum_docker_tag_length() -> None:
+    normalized_tag = f"1.2.3-{'a' * 122}"
+    overlong_tag = f"{normalized_tag}a"
+
+    assert len(normalized_tag) == 128
+    assert normalize_publish_tag(normalized_tag) == normalized_tag
+    assert normalize_publish_tag(f"v{normalized_tag}") == normalized_tag
+    assert normalize_publish_tag(overlong_tag) is None
+    assert normalize_publish_tag(f"v{overlong_tag}") is None


### PR DESCRIPTION
## Summary
- validate manual Docker publish tags before GHCR login, build, or push
- normalize accepted `0.2.26` and `v0.2.26` inputs to the canonical Docker tag `0.2.26`
- require the corresponding existing root `vX.Y.Z` Git tag and bind checkout, metadata, and verification to its peeled commit SHA
- gate workflow-dispatch publishes behind the `ghcr-manual-publish` environment
- publish release-event images only for root `v...` releases; sibling picklescan releases skip cleanly
- prevent prereleases from moving `latest` by disabling metadata-action auto-latest and emitting only the guarded explicit tag
- document the release-pipeline hardening under `[Unreleased]`

## False-positive / false-negative audit
- rejects mutable or misleading tags such as `latest`, `main`, and `sha-abcdef0`
- rejects malformed versions, paths, whitespace, build metadata, empty prerelease identifiers, and numeric prereleases with leading zeros
- accepts immutable normal and prerelease versions, including an optional leading `v`, while always publishing the canonical non-`v` Docker tag
- rejects otherwise valid inputs when the matching root Git release tag does not exist
- detects a tag movement race by comparing checked-out `HEAD` with the peeled SHA captured during validation
- skips legitimate `modelaudit-picklescan-v...` releases without producing a false workflow failure
- keeps root prerelease version tags publishable without updating the stable `latest` alias
- preserves the stable-release `latest` tag through the explicit non-prerelease rule

## Validation
- `32 passed`: `tests/test_docker_workflow.py` and `tests/workflows/test_docker_workflow.py`
- exact pinned `docker/metadata-action` prerelease/latest behavior reviewed at source
- scoped Ruff check and format check
- scoped mypy
- workflow YAML parse
- Prettier check for the workflow and changelog
- `git diff --check`
- full suite intentionally left to CI per review workflow

## Published state
- current main: `d95880729eba446a4e35be2ba05e2f1e7e89cad8`
- head: `1c64c82cc391a7c22cc76696e68c2205a29881dd`
- exact verified tree: `7cb39e4ccebc3de302ae7e6d4172ed4b52441eb8`

Fresh CI is running on the published head.