### PR TITLE
fix: reject cleartext remote model sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - close JIT replay alias, probe-budget, and compound-clause context gaps without suppressing dangerous browser or native-library calls
+- reject cleartext HTTP cloud storage and PyTorch Hub model sources
 - preserve dangerous JIT embedded-Python findings after benign member overwrites while bounding replay and suppression analysis
 - fail closed when capped DVC pointer outputs are not otherwise covered, change during verification, exceed bounded tail verification, or exhaust shared scan budgets
 - preserve registrable network domains and redact delimiter-split credentials in bounded finding evidence

--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -75,6 +75,7 @@ from .utils.helpers.auto_defaults import (
 from .utils.helpers.interrupt_handler import interruptible_scan
 from .utils.sources.cloud_storage import (
     download_from_cloud,
+    is_cleartext_cloud_url,
     is_cloud_url,
     is_stream_url,
     redact_cloud_error_for_display,
@@ -97,7 +98,11 @@ from .utils.sources.jfrog import (
     redact_jfrog_error_for_display,
     redact_jfrog_url_for_display,
 )
-from .utils.sources.pytorch_hub import download_pytorch_hub_model, is_pytorch_hub_url
+from .utils.sources.pytorch_hub import (
+    download_pytorch_hub_model,
+    is_cleartext_pytorch_hub_url,
+    is_pytorch_hub_url,
+)
 
 logger = logging.getLogger("modelaudit")
 
@@ -106,7 +111,7 @@ def _display_path(path: str) -> str:
     """Return a path safe for user-facing CLI output."""
     if is_stream_url(path):
         return f"stream://{redact_stream_url_for_display(path[9:])}"
-    if is_cloud_url(path):
+    if is_cloud_url(path) or is_cleartext_cloud_url(path) or is_cleartext_pytorch_hub_url(path):
         return redact_url_for_display(path)
     if is_jfrog_url_like(path):
         return redact_jfrog_url_for_display(path)
@@ -122,7 +127,11 @@ def _display_error(error: object, path: str) -> str:
     """Return an error safe for user-facing CLI output."""
     if is_stream_url(path):
         return redact_stream_error_for_display(error, path[9:])
-    return redact_cloud_error_for_display(error, path) if is_cloud_url(path) else str(error)
+    return (
+        redact_cloud_error_for_display(error, path)
+        if is_cloud_url(path) or is_cleartext_cloud_url(path) or is_cleartext_pytorch_hub_url(path)
+        else str(error)
+    )
 
 
 class _OutputWriteError(click.ClickException):
@@ -2432,6 +2441,16 @@ def _resolve_scan_source_for_path(
     dry_run: bool,
 ) -> _SourceDispatchResult | None:
     """Resolve one source path and execute source-native scans when they should bypass local scanning."""
+    if is_cleartext_cloud_url(path):
+        click.echo(f"Error: Cleartext cloud storage URL is not supported: {redact_url_for_display(path)}", err=True)
+        audit_result.has_errors = True
+        return None
+
+    if is_cleartext_pytorch_hub_url(path):
+        click.echo(f"Error: Cleartext PyTorch Hub URL is not supported: {redact_url_for_display(path)}", err=True)
+        audit_result.has_errors = True
+        return None
+
     if is_huggingface_file_url(path):
         display_path = redact_huggingface_url_for_display(path)
         download_spinner = None

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -34,6 +34,7 @@ from ..helpers.disk_space import check_disk_space
 logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
 _CLOUD_DOWNLOAD_CHUNK_BYTES = 1024 * 1024
+_CLEARTEXT_CLOUD_ERROR = "Cleartext cloud storage URL is not supported"
 
 _QUERY_PARAM_RE = re.compile(r"(?P<prefix>[?&#;])(?P<key>[^=\s&#;]+)=(?P<value>[^\s&#;]*)")
 _BARE_ASSIGNMENT_RE = re.compile(
@@ -131,18 +132,55 @@ def _run_coroutine_sync(coro_factory: Callable[[], Coroutine[Any, Any, _T]]) -> 
         return executor.submit(lambda: asyncio.run(coro_factory())).result()
 
 
+def _http_cloud_protocol(url: str) -> str | None:
+    """Return the provider protocol for a recognized HTTP(S) cloud URL."""
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme.casefold() not in {"http", "https"}:
+            return None
+        hostname = (parsed.hostname or "").casefold().rstrip(".")
+    except ValueError:
+        return None
+
+    if hostname.endswith(".s3.amazonaws.com"):
+        return "s3"
+    if hostname == "storage.googleapis.com":
+        return "gcs"
+    if hostname.endswith(".r2.cloudflarestorage.com"):
+        return "s3"
+    return None
+
+
+def is_cleartext_cloud_url(url: str) -> bool:
+    """Return True for HTTP URLs targeting a supported cloud provider."""
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme.casefold() != "http":
+            return False
+        hostname = (parsed.hostname or "").casefold().rstrip(".")
+    except ValueError:
+        return False
+
+    return (
+        hostname.endswith(".s3.amazonaws.com")
+        or hostname == "storage.googleapis.com"
+        or hostname.endswith(".r2.cloudflarestorage.com")
+    )
+
+
 def is_cloud_url(url: str) -> bool:
     """Return True if the URL points to a supported cloud storage provider."""
-    patterns = [
-        r"^s3://.+",
-        r"^gs://.+",
-        r"^gcs://.+",
-        r"^r2://.+",
-        r"^https?://[^/]+\.s3\.amazonaws\.com/.+",
-        r"^https?://storage.googleapis.com/.+",
-        r"^https?://[^/]+\.r2\.cloudflarestorage\.com/.+",
-    ]
-    return any(re.match(p, url, re.IGNORECASE) for p in patterns)
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+
+    scheme = parsed.scheme.casefold()
+    if scheme in {"s3", "gs", "gcs", "r2"}:
+        return bool(parsed.netloc or parsed.path)
+    if scheme != "https" or _http_cloud_protocol(url) is None:
+        return False
+    return bool(parsed.path.lstrip("/"))
 
 
 def is_stream_url(url: str) -> bool:
@@ -482,19 +520,18 @@ def _cloud_url_without_query(url: str) -> str:
 
 def get_fs_protocol(url: str) -> str:
     """Get the fsspec protocol for a given URL."""
-    parsed = urlparse(url)
-    scheme = parsed.scheme
-    hostname = (parsed.hostname or "").casefold()
-
+    try:
+        parsed = urlparse(url)
+    except ValueError as exc:
+        raise ValueError(f"Unsupported cloud storage URL: {redact_url_for_display(url)}") from exc
+    scheme = parsed.scheme.casefold()
     if scheme in {"http", "https"}:
-        if hostname.endswith(".s3.amazonaws.com"):
-            return "s3"
-        elif hostname == "storage.googleapis.com":
-            return "gcs"
-        elif hostname.endswith(".r2.cloudflarestorage.com"):
-            return "s3"
-        else:
+        protocol = _http_cloud_protocol(url)
+        if protocol is None:
             raise ValueError(f"Unsupported cloud storage URL: {redact_url_for_display(url)}")
+        if scheme == "http":
+            raise ValueError(f"{_CLEARTEXT_CLOUD_ERROR}: {redact_url_for_display(url)}")
+        return protocol
     elif scheme == "gcs" or scheme == "gs":
         return "gcs"
     elif scheme in {"s3", "r2"}:

--- a/modelaudit/utils/sources/pytorch_hub.py
+++ b/modelaudit/utils/sources/pytorch_hub.py
@@ -18,7 +18,7 @@ import requests
 
 from ..helpers.disk_space import check_disk_space
 
-_PYTORCH_HUB_PATTERN = r"^https?://pytorch\.org/hub/[\w\-_.]+/?$"
+_PYTORCH_HUB_PATTERN = r"^https://pytorch\.org/hub/[\w\-_.]+/?$"
 _PYTORCH_MODEL_URL_PATTERN = re.compile(
     r"https://download\.pytorch\.org/models/[^\s\"'<>]+",
     re.IGNORECASE,
@@ -374,6 +374,21 @@ class _GithubSourceLinkParser(HTMLParser):
 def is_pytorch_hub_url(url: str) -> bool:
     """Return True if the URL points to a PyTorch Hub model page."""
     return bool(re.match(_PYTORCH_HUB_PATTERN, url, re.IGNORECASE))
+
+
+def is_cleartext_pytorch_hub_url(url: str) -> bool:
+    """Return True for HTTP PyTorch Hub model-page URLs."""
+    try:
+        parsed = urlsplit(url)
+        hostname = (parsed.hostname or "").casefold().rstrip(".")
+    except ValueError:
+        return False
+
+    return (
+        parsed.scheme.casefold() == "http"
+        and hostname == "pytorch.org"
+        and re.fullmatch(r"/hub/[\w\-_.]+/?", parsed.path) is not None
+    )
 
 
 def _extract_weight_urls(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3966,6 +3966,32 @@ def test_display_path_redacts_mixed_case_signed_urls() -> None:
     assert _display_path(cloud_url) == "https://bucket.s3.amazonaws.com/model.bin"
 
 
+@patch("modelaudit.cli.download_from_cloud")
+def test_scan_rejects_cleartext_cloud_url_without_leaking_credentials(mock_download: MagicMock) -> None:
+    url = "HTTP://BUCKET.S3.AMAZONAWS.COM:80/model.bin?X-Amz-Signature=cloud-secret"
+
+    result = CliRunner().invoke(cli, ["scan", url])
+
+    assert result.exit_code == 2
+    assert "Cleartext cloud storage URL is not supported" in result.output
+    assert "http://bucket.s3.amazonaws.com:80/model.bin" in result.output.lower()
+    assert "cloud-secret" not in result.output
+    mock_download.assert_not_called()
+
+
+@patch("modelaudit.cli.download_pytorch_hub_model")
+def test_scan_rejects_cleartext_pytorch_hub_url_without_downloading(mock_download: MagicMock) -> None:
+    url = "HTTP://PYTORCH.ORG:80/hub/pytorch_vision_resnet/?token=hub-secret"
+
+    result = CliRunner().invoke(cli, ["scan", url])
+
+    assert result.exit_code == 2
+    assert "Cleartext PyTorch Hub URL is not supported" in result.output
+    assert "http://pytorch.org:80/hub/pytorch_vision_resnet/" in result.output.lower()
+    assert "hub-secret" not in result.output
+    mock_download.assert_not_called()
+
+
 def test_progress_initial_status_redacts_signed_stream_url() -> None:
     """Initial progress status should not expose signed stream URLs."""
     url = "stream://https://bucket.s3.amazonaws.com/model.bin?X-Amz-Signature=deadbeef&token=secret-token"

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -32,6 +32,7 @@ from modelaudit.utils.sources.cloud_storage import (
     filter_scannable_files,
     get_cloud_object_size,
     get_fs_protocol,
+    is_cleartext_cloud_url,
     is_cloud_url,
     is_sensitive_credential_key,
     redact_cloud_error_for_display,
@@ -182,6 +183,78 @@ class TestCloudURLDetection:
     )
     def test_resolves_mixed_case_https_provider_hosts(self, url: str, expected_protocol: str) -> None:
         assert get_fs_protocol(url) == expected_protocol
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://bucket.s3.amazonaws.com/model.bin",
+        "HTTP://bucket.s3.amazonaws.com:80/model.bin?X-Amz-Signature=secret",
+        "http://storage.googleapis.com/bucket/model.bin",
+        "http://account.r2.cloudflarestorage.com/bucket/model.bin",
+    ],
+)
+def test_rejects_cleartext_cloud_provider_urls(url: str) -> None:
+    assert not is_cloud_url(url)
+    assert is_cleartext_cloud_url(url)
+
+    with pytest.raises(ValueError, match="Cleartext cloud storage URL is not supported") as exc_info:
+        get_fs_protocol(url)
+
+    assert "secret" not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://bucket.s3.amazonaws.com./model.bin",
+        "http://storage.googleapis.com.:80/bucket/model.bin",
+        "http://account.r2.cloudflarestorage.com./bucket/model.bin",
+    ],
+)
+def test_rejects_cleartext_cloud_provider_urls_with_absolute_hostnames(url: str) -> None:
+    assert is_cleartext_cloud_url(url)
+    with pytest.raises(ValueError, match="Cleartext cloud storage URL is not supported"):
+        get_fs_protocol(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://storage.googleapis.com.evil.example/bucket/model.bin",
+        "http://storage.googleapis.com@evil.example/bucket/model.bin",
+        "http://pytorch.org/hub/pytorch_vision_resnet/",
+    ],
+)
+def test_cleartext_cloud_provider_detection_rejects_hostname_near_matches(url: str) -> None:
+    assert not is_cleartext_cloud_url(url)
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_protocol"),
+    [
+        ("https://bucket.s3.amazonaws.com:443/model.bin", "s3"),
+        ("https://storage.googleapis.com:443/bucket/model.bin", "gcs"),
+        ("https://account.r2.cloudflarestorage.com:443/bucket/model.bin", "s3"),
+    ],
+)
+def test_routes_secure_cloud_provider_urls_with_ports(url: str, expected_protocol: str) -> None:
+    assert is_cloud_url(url)
+    assert get_fs_protocol(url) == expected_protocol
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://bucket.s3.amazonaws.com.evil.example/model.bin",
+        "https://storage.googleapis.com.evil.example/bucket/model.bin",
+        "https://account.r2.cloudflarestorage.com.evil.example/model.bin",
+    ],
+)
+def test_rejects_cloud_provider_hostname_near_matches(url: str) -> None:
+    assert not is_cloud_url(url)
+    with pytest.raises(ValueError, match="Unsupported cloud storage URL"):
+        get_fs_protocol(url)
 
 
 class TestCloudURLRedaction:

--- a/tests/utils/sources/test_pytorch_hub.py
+++ b/tests/utils/sources/test_pytorch_hub.py
@@ -19,6 +19,7 @@ from modelaudit.utils.sources.pytorch_hub import (
     _supports_secure_cache_commit,
     download_pytorch_hub_model,
     download_pytorch_hub_model_streaming,
+    is_cleartext_pytorch_hub_url,
     is_pytorch_hub_url,
 )
 
@@ -41,6 +42,30 @@ class TestPytorchHubURLDetection:
         ]
         for url in invalid:
             assert not is_pytorch_hub_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://pytorch.org/hub/pytorch_vision_resnet/",
+        "HTTP://PYTORCH.ORG/hub/pytorch_vision_resnet/",
+    ],
+)
+def test_rejects_cleartext_pytorch_hub_urls(url: str) -> None:
+    assert not is_pytorch_hub_url(url)
+    assert is_cleartext_pytorch_hub_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://pytorch.org.evil.example/hub/pytorch_vision_resnet/",
+        "http://pytorch.org@evil.example/hub/pytorch_vision_resnet/",
+        "http://example.com/hub/pytorch_vision_resnet/",
+    ],
+)
+def test_cleartext_pytorch_hub_detection_rejects_hostname_near_matches(url: str) -> None:
+    assert not is_cleartext_pytorch_hub_url(url)
 
 
 @patch("modelaudit.utils.sources.pytorch_hub.check_disk_space")


### PR DESCRIPTION
## Summary
- Enforce HTTPS directly in cloud storage and PyTorch Hub source detection instead of mutating imported modules at package load.
- Reject recognized cleartext S3, GCS, R2, and PyTorch Hub URLs explicitly in the CLI with exit code 2 before any downloader runs.
- Redact query credentials and userinfo from both the scan banner and rejection errors.
- Preserve HTTPS/native provider routing, including mixed-case schemes, explicit ports, and absolute DNS hostnames.
- Add the required `[Unreleased]` changelog entry and remove unrelated/corrupt fixture edits from the original remote head.

## False-positive / false-negative audit
- Rejected: mixed-case HTTP provider URLs, signed cleartext URLs, explicit ports, absolute DNS hostnames, and cleartext PyTorch Hub pages.
- Preserved: HTTPS S3/GCS/R2 URLs, native `s3://`/`gs://`/`gcs://`/`r2://` sources, and uppercase HTTPS PyTorch Hub pages.
- Near-match guards: malicious hostname suffixes and userinfo-based lookalikes do not classify as provider URLs.
- Runtime proof: cleartext CLI inputs return exit code 2, do not call either downloader, and do not expose signed query values.

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run --frozen pytest tests/utils/sources/test_cloud_storage.py tests/utils/sources/test_pytorch_hub.py tests/test_cli.py::test_scan_rejects_cleartext_cloud_url_without_leaking_credentials tests/test_cli.py::test_scan_rejects_cleartext_pytorch_hub_url_without_downloading -q --maxfail=1` -> `274 passed`
- `uv run --frozen ruff check modelaudit/cli.py modelaudit/utils/sources/cloud_storage.py modelaudit/utils/sources/pytorch_hub.py tests/test_cli.py tests/utils/sources/test_cloud_storage.py tests/utils/sources/test_pytorch_hub.py` -> passed
- `uv run --frozen mypy modelaudit/cli.py modelaudit/utils/sources/cloud_storage.py modelaudit/utils/sources/pytorch_hub.py tests/test_cli.py tests/utils/sources/test_cloud_storage.py tests/utils/sources/test_pytorch_hub.py` -> passed
- `git diff --check` -> passed
- Published tree SHA `3308eba35be425efab0a2ddd215000508472cba0` exactly matches the reviewed local tree.