### PR TITLE
fix: verify rustup installer in docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
 ARG PYTHON_IMAGE=python:3.13-slim@sha256:b04b5d7233d2ad9c379e22ea8927cd1378cd15c60d4ef876c065b25ea8fb3bf3
 # Keep the major/minor version in sync with packages/modelaudit-picklescan/Cargo.toml rust-version.
 ARG PICKLESCAN_RUST_TOOLCHAIN=1.83.0
+ARG RUSTUP_VERSION=1.29.0
+ARG RUSTUP_INIT_X86_64_UNKNOWN_LINUX_GNU_SHA256=4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10
+ARG RUSTUP_INIT_AARCH64_UNKNOWN_LINUX_GNU_SHA256=9732d6c5e2a098d3521fca8145d826ae0aaa067ef2385ead08e6feac88fa5792
 
 FROM ${PYTHON_IMAGE} AS builder
 ARG PICKLESCAN_RUST_TOOLCHAIN
+ARG RUSTUP_VERSION
+ARG RUSTUP_INIT_X86_64_UNKNOWN_LINUX_GNU_SHA256
+ARG RUSTUP_INIT_AARCH64_UNKNOWN_LINUX_GNU_SHA256
+ARG TARGETARCH=amd64
 
 WORKDIR /build
 
@@ -14,8 +21,19 @@ COPY modelaudit ./modelaudit
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends --only-upgrade libc-bin libc6 libcap2 libsystemd0 libudev1 \
     && apt-get install --yes --no-install-recommends build-essential ca-certificates curl \
-    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-        | sh -s -- -y --profile minimal --default-toolchain "${PICKLESCAN_RUST_TOOLCHAIN}" \
+    && case "${TARGETARCH}" in \
+        amd64) rustup_target="x86_64-unknown-linux-gnu"; rustup_sha256="${RUSTUP_INIT_X86_64_UNKNOWN_LINUX_GNU_SHA256}" ;; \
+        arm64) rustup_target="aarch64-unknown-linux-gnu"; rustup_sha256="${RUSTUP_INIT_AARCH64_UNKNOWN_LINUX_GNU_SHA256}" ;; \
+        *) echo "Unsupported Docker build architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl --proto '=https' --tlsv1.2 -fsSL \
+        "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${rustup_target}/rustup-init" \
+        -o /tmp/rustup-init \
+    && printf '%s  %s\n' "${rustup_sha256}" /tmp/rustup-init > /tmp/rustup-init.sha256 \
+    && sha256sum -c /tmp/rustup-init.sha256 \
+    && chmod +x /tmp/rustup-init \
+    && /tmp/rustup-init -y --profile minimal --default-toolchain "${PICKLESCAN_RUST_TOOLCHAIN}" \
+    && rm -f /tmp/rustup-init /tmp/rustup-init.sha256 \
     && PATH="/root/.cargo/bin:${PATH}" pip wheel --no-cache-dir --wheel-dir /wheels \
         ./packages/modelaudit-picklescan \
         .

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -1,9 +1,16 @@
 ARG PYTHON_IMAGE=python:3.13-slim@sha256:b04b5d7233d2ad9c379e22ea8927cd1378cd15c60d4ef876c065b25ea8fb3bf3
 # Keep the major/minor version in sync with packages/modelaudit-picklescan/Cargo.toml rust-version.
 ARG PICKLESCAN_RUST_TOOLCHAIN=1.83.0
+ARG RUSTUP_VERSION=1.29.0
+ARG RUSTUP_INIT_X86_64_UNKNOWN_LINUX_GNU_SHA256=4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10
+ARG RUSTUP_INIT_AARCH64_UNKNOWN_LINUX_GNU_SHA256=9732d6c5e2a098d3521fca8145d826ae0aaa067ef2385ead08e6feac88fa5792
 
 FROM ${PYTHON_IMAGE} AS builder
 ARG PICKLESCAN_RUST_TOOLCHAIN
+ARG RUSTUP_VERSION
+ARG RUSTUP_INIT_X86_64_UNKNOWN_LINUX_GNU_SHA256
+ARG RUSTUP_INIT_AARCH64_UNKNOWN_LINUX_GNU_SHA256
+ARG TARGETARCH=amd64
 
 WORKDIR /build
 
@@ -12,8 +19,19 @@ COPY . .
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends --only-upgrade libc-bin libc6 libcap2 libsystemd0 libudev1 \
     && apt-get install --yes --no-install-recommends build-essential ca-certificates curl \
-    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-        | sh -s -- -y --profile minimal --default-toolchain "${PICKLESCAN_RUST_TOOLCHAIN}" \
+    && case "${TARGETARCH}" in \
+        amd64) rustup_target="x86_64-unknown-linux-gnu"; rustup_sha256="${RUSTUP_INIT_X86_64_UNKNOWN_LINUX_GNU_SHA256}" ;; \
+        arm64) rustup_target="aarch64-unknown-linux-gnu"; rustup_sha256="${RUSTUP_INIT_AARCH64_UNKNOWN_LINUX_GNU_SHA256}" ;; \
+        *) echo "Unsupported Docker build architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl --proto '=https' --tlsv1.2 -fsSL \
+        "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${rustup_target}/rustup-init" \
+        -o /tmp/rustup-init \
+    && printf '%s  %s\n' "${rustup_sha256}" /tmp/rustup-init > /tmp/rustup-init.sha256 \
+    && sha256sum -c /tmp/rustup-init.sha256 \
+    && chmod +x /tmp/rustup-init \
+    && /tmp/rustup-init -y --profile minimal --default-toolchain "${PICKLESCAN_RUST_TOOLCHAIN}" \
+    && rm -f /tmp/rustup-init /tmp/rustup-init.sha256 \
     && PATH="/root/.cargo/bin:${PATH}" pip wheel --no-cache-dir --wheel-dir /wheels \
         ./packages/modelaudit-picklescan \
         .

--- a/tests/test_docker_workflow.py
+++ b/tests/test_docker_workflow.py
@@ -8,6 +8,7 @@ import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _PINNED_PYTHON_IMAGE_RE = re.compile(r"^python:(?P<version>\d+\.\d+-slim)@sha256:(?P<digest>[0-9a-f]{64})$")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
 def _load_docker_workflow() -> dict[str, Any]:
@@ -22,12 +23,16 @@ def _dockerfile_lines(path: str) -> list[str]:
 
 
 def _python_image_from_arg(path: str) -> str:
+    return _dockerfile_arg(path, "PYTHON_IMAGE")
+
+
+def _dockerfile_arg(path: str, name: str) -> str:
     lines = _dockerfile_lines(path)
-    prefix = "ARG PYTHON_IMAGE="
+    prefix = f"ARG {name}="
     for line in lines:
         if line.startswith(prefix):
             return line.removeprefix(prefix)
-    raise AssertionError(f"{path} does not define PYTHON_IMAGE")
+    raise AssertionError(f"{path} does not define {name}")
 
 
 def _assert_pinned_python_image(image: str, expected_version: str) -> None:
@@ -71,6 +76,31 @@ def test_dockerfiles_pin_python_base_images_by_digest() -> None:
 
     tensorflow_from = _dockerfile_lines("Dockerfile.tensorflow")[0].removeprefix("FROM ")
     _assert_pinned_python_image(tensorflow_from, "3.12-slim")
+
+
+def test_dockerfiles_verify_pinned_rustup_init_instead_of_streaming_shell() -> None:
+    expected_rustup_version = _dockerfile_arg("Dockerfile", "RUSTUP_VERSION")
+    expected_amd64_sha256 = _dockerfile_arg("Dockerfile", "RUSTUP_INIT_X86_64_UNKNOWN_LINUX_GNU_SHA256")
+    expected_arm64_sha256 = _dockerfile_arg("Dockerfile", "RUSTUP_INIT_AARCH64_UNKNOWN_LINUX_GNU_SHA256")
+
+    assert re.fullmatch(r"\d+\.\d+\.\d+", expected_rustup_version)
+    assert _SHA256_RE.fullmatch(expected_amd64_sha256)
+    assert _SHA256_RE.fullmatch(expected_arm64_sha256)
+
+    for path in ("Dockerfile", "Dockerfile.full"):
+        content = (_REPO_ROOT / path).read_text(encoding="utf-8")
+        assert "https://sh.rustup.rs" not in content
+        assert "| sh" not in content
+        assert "sh -s --" not in content
+        assert _dockerfile_arg(path, "RUSTUP_VERSION") == expected_rustup_version
+        assert _dockerfile_arg(path, "RUSTUP_INIT_X86_64_UNKNOWN_LINUX_GNU_SHA256") == expected_amd64_sha256
+        assert _dockerfile_arg(path, "RUSTUP_INIT_AARCH64_UNKNOWN_LINUX_GNU_SHA256") == expected_arm64_sha256
+        assert "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${rustup_target}/rustup-init" in content
+        assert "printf '%s  %s\\n' \"${rustup_sha256}\" /tmp/rustup-init > /tmp/rustup-init.sha256" in content
+        assert "sha256sum -c /tmp/rustup-init.sha256" in content
+        assert content.index("sha256sum -c /tmp/rustup-init.sha256") < content.index(
+            "/tmp/rustup-init -y --profile minimal --default-toolchain"
+        )
 
 
 def test_docker_success_job_waits_for_all_image_results() -> None:


### PR DESCRIPTION
Summary:
- Replace remote `sh.rustup.rs | sh` Docker install path with pinned `rustup-init` downloads from `static.rust-lang.org`.
- Verify x86_64 and arm64 rustup-init SHA256 before execution.
- Add Dockerfile regression coverage that rejects streamed shell installs and requires checksum verification before execution.

False-positive / false-negative audit:
- FN closed: both Dockerfiles no longer execute mutable remote installer scripts directly.
- FP guard: Rust toolchain remains `PICKLESCAN_RUST_TOOLCHAIN=1.83.0`; amd64/arm64 are supported; unsupported Docker architectures fail closed.

Validation:
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run --frozen pytest tests/test_docker_workflow.py -q --maxfail=1` -> 5 passed.
- `uv run --frozen ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> unchanged.
- `uv run --frozen ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> passed.
- `uv run --frozen ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> passed.
- `uv run --frozen mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> passed.

Residual risk:
- I did not run an actual Docker image build locally in this workspace.