### PR TITLE
fix: strictly pin picklescan maturin backend

### DIFF
--- a/packages/modelaudit-picklescan/pyproject.toml
+++ b/packages/modelaudit-picklescan/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.9,<2"]
+requires = ["maturin===1.13.3"]
 build-backend = "maturin"
 
 [project]

--- a/tests/test_dependency_lock.py
+++ b/tests/test_dependency_lock.py
@@ -3,9 +3,16 @@
 import re
 from pathlib import Path
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib  # type: ignore[no-redef]
+
 ROOT_DIR = Path(__file__).resolve().parents[1]
 LOCKFILE = ROOT_DIR / "uv.lock"
+PICKLESCAN_PYPROJECT = ROOT_DIR / "packages" / "modelaudit-picklescan" / "pyproject.toml"
 PATCHED_GITPYTHON_FLOOR = (3, 1, 50)
+PINNED_MATURIN_BACKEND = "maturin===1.13.3"
 
 
 def _lock_package_block(name: str) -> str:
@@ -52,3 +59,12 @@ def test_mlflow_skinny_transitive_gitpython_dependency_is_guarded() -> None:
     mlflow_skinny_block = _lock_package_block("mlflow-skinny")
 
     assert "gitpython" in _dependency_names(mlflow_skinny_block)
+
+
+def test_picklescan_build_backend_is_exactly_pinned() -> None:
+    package_config = tomllib.loads(PICKLESCAN_PYPROJECT.read_text(encoding="utf-8"))
+    build_system = package_config["build-system"]
+
+    assert build_system["build-backend"] == "maturin"
+    # PEP 440 `==1.13.3` also accepts local versions such as `1.13.3+local`.
+    assert build_system["requires"] == [PINNED_MATURIN_BACKEND]


### PR DESCRIPTION
## Summary
- pin the standalone `modelaudit-picklescan` PEP 517 backend from `maturin>=1.9,<2` to `maturin===1.13.3`
- use PEP 440 arbitrary equality so private-index local variants such as `1.13.3+local` cannot satisfy the pin
- add a dependency-lock regression that rejects future range, wildcard, alternate-backend, or ordinary-equality requirements
- rebase the branch onto current `main`

## Security notes
- fixes M-13 from the repository security audit: future Maturin 1.x or local-version backend code cannot enter source builds without an explicit reviewed `pyproject.toml` change
- false-negative closed during review: `maturin==1.13.3` accepts `1.13.3+local`; `===1.13.3` does not
- false-positive guard: the pinned release is the version already resolved by current builds, and runtime dependencies, Rust features, wheel tags, and scanner behavior are unchanged

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run --frozen pytest tests/test_dependency_lock.py -q --maxfail=1` -> 3 passed
- `uv lock --check` in `packages/modelaudit-picklescan` -> passed
- real standalone source distribution and wheel build under `maturin===1.13.3` -> passed
- scoped Ruff check/format and mypy -> passed
- all published blob SHAs and the complete tree SHA exactly match the rebased local tree

The full local test suite was intentionally left to CI.