### PR TITLE
fix: preserve unusual docs filenames in formatter

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -2,21 +2,9 @@ name: Documentation Check
 
 on:
   pull_request:
-    paths:
-      - "**.md"
-      - "**.txt"
-      - "**.rst"
-      - "LICENSE*"
-      - ".github/workflows/docs-check.yml"
   push:
     branches:
       - main
-    paths:
-      - "**.md"
-      - "**.txt"
-      - "**.rst"
-      - "LICENSE*"
-      - ".github/workflows/docs-check.yml"
 
 permissions:
   contents: read
@@ -29,22 +17,91 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
-          files: |
-            **.md
-            **.yaml
-            **.yml
-            **.json
+          fetch-depth: 0
 
       - name: Setup Node.js
-        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
+
+      - name: Collect changed documentation files
+        id: changed-files
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+          CHANGED_FILES_JSON_PATH: ${{ runner.temp }}/modelaudit-doc-files.json
+        run: |
+          node <<'NODE'
+          const { appendFileSync, writeFileSync } = require("node:fs");
+          const { extname } = require("node:path");
+          const { spawnSync } = require("node:child_process");
+
+          const baseSha = process.env.BASE_SHA || "";
+          const headSha = process.env.HEAD_SHA || "";
+          const shaPattern = /^[0-9a-f]{40,64}$/i;
+          if (!shaPattern.test(baseSha) || !shaPattern.test(headSha)) {
+            throw new Error("Invalid workflow diff boundary");
+          }
+
+          let effectiveBaseSha = baseSha;
+          if (/^0+$/.test(baseSha)) {
+            const emptyTree = spawnSync("git", ["hash-object", "-t", "tree", "--stdin"], {
+              input: Buffer.alloc(0),
+              encoding: "utf8",
+            });
+            if (emptyTree.error) {
+              throw emptyTree.error;
+            }
+            if (emptyTree.status !== 0) {
+              process.stderr.write(emptyTree.stderr);
+              process.exit(emptyTree.status ?? 1);
+            }
+            effectiveBaseSha = emptyTree.stdout.trim();
+            if (!shaPattern.test(effectiveBaseSha)) {
+              throw new Error("Git returned an invalid empty-tree hash");
+            }
+          }
+          const result = spawnSync(
+            "git",
+            ["diff", "--name-only", "-z", "--diff-filter=ACMRTUX", effectiveBaseSha, headSha],
+            { encoding: "buffer", maxBuffer: 16 * 1024 * 1024 },
+          );
+          if (result.error) {
+            throw result.error;
+          }
+          if (result.status !== 0) {
+            process.stderr.write(result.stderr);
+            process.exit(result.status ?? 1);
+          }
+
+          const extensions = new Set([".md", ".yaml", ".yml", ".json"]);
+          const changedFiles = [];
+          let start = 0;
+          for (let index = 0; index < result.stdout.length; index += 1) {
+            if (result.stdout[index] !== 0) {
+              continue;
+            }
+            const rawFile = result.stdout.subarray(start, index);
+            const file = rawFile.toString("utf8");
+            if (!Buffer.from(file, "utf8").equals(rawFile)) {
+              throw new Error("Changed filename is not valid UTF-8");
+            }
+            if (extensions.has(extname(file).toLowerCase())) {
+              changedFiles.push(file);
+            }
+            start = index + 1;
+          }
+          if (start !== result.stdout.length) {
+            throw new Error("Git returned a non-terminated filename list");
+          }
+
+          writeFileSync(process.env.CHANGED_FILES_JSON_PATH, JSON.stringify(changedFiles), {
+            encoding: "utf8",
+            mode: 0o600,
+          });
+          appendFileSync(process.env.GITHUB_OUTPUT, `any_changed=${changedFiles.length > 0}\n`);
+          NODE
 
       - name: Install Node dependencies
         if: steps.changed-files.outputs.any_changed == 'true'
@@ -52,14 +109,35 @@ jobs:
 
       - name: Check markdown formatting with prettier
         if: steps.changed-files.outputs.any_changed == 'true'
+        env:
+          CHANGED_FILES_JSON_PATH: ${{ runner.temp }}/modelaudit-doc-files.json
         run: |
-          echo "Checking formatting for changed files:"
-          echo "${{ steps.changed-files.outputs.all_changed_files }}"
-          npx prettier --check ${{ steps.changed-files.outputs.all_changed_files }} || (
-            echo "Documentation is not properly formatted. Run:"
-            echo "npm ci --ignore-scripts && npx prettier --write '**/*.{md,yaml,yml,json}'"
-            exit 1
-          )
+          node <<'NODE'
+          const { spawnSync } = require("node:child_process");
+          const { readFileSync } = require("node:fs");
+
+          const changedFiles = JSON.parse(readFileSync(process.env.CHANGED_FILES_JSON_PATH, "utf8"));
+          if (!Array.isArray(changedFiles) || changedFiles.some((file) => typeof file !== "string")) {
+            throw new Error("changed-files returned an invalid filename list");
+          }
+
+          console.log("Checking formatting for changed files:");
+          for (const file of changedFiles) {
+            console.log(JSON.stringify(file));
+          }
+
+          const result = spawnSync("npx", ["prettier", "--check", "--", ...changedFiles], {
+            stdio: "inherit",
+          });
+          if (result.error) {
+            throw result.error;
+          }
+          if (result.status !== 0) {
+            console.error("Documentation is not properly formatted. Run:");
+            console.error("npm ci --ignore-scripts && npx prettier --write '**/*.{md,yaml,yml,json}'");
+            process.exit(result.status ?? 1);
+          }
+          NODE
 
       - name: Skip if no relevant files changed
         if: steps.changed-files.outputs.any_changed == 'false'

--- a/tests/test_perf_workflow.py
+++ b/tests/test_perf_workflow.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import json
+import os
+import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
+import pytest
 import yaml
 
 
@@ -50,6 +54,50 @@ def _step_by_name(steps: list[dict[str, Any]], name: str) -> dict[str, Any]:
         if step.get("name") == name:
             return step
     raise AssertionError(f"Step {name!r} not found")
+
+
+def _node_script(step: dict[str, Any]) -> str:
+    run = step["run"]
+    assert isinstance(run, str)
+    prefix = "node <<'NODE'\n"
+    suffix = "\nNODE\n"
+    assert run.startswith(prefix)
+    assert run.endswith(suffix)
+    return run[len(prefix) : -len(suffix)]
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_test_repository(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "--quiet")
+    _git(repo, "config", "user.name", "ModelAudit Tests")
+    _git(repo, "config", "user.email", "tests@example.com")
+    (repo / "README.md").write_text("# Base\n", encoding="utf-8")
+    (repo / "deleted.md").write_text("# Deleted\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "--quiet", "-m", "base")
+    return repo, _git(repo, "rev-parse", "HEAD")
+
+
+def _run_node_script(script: str, repo: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["node", "-e", script],
+        cwd=repo,
+        env={**os.environ, **env},
+        capture_output=True,
+        text=True,
+    )
 
 
 def test_perf_workflow_compares_against_detached_base_worktree() -> None:
@@ -137,6 +185,193 @@ def test_nightly_windows_lane_defers_performance_benchmarks_to_linux() -> None:
     assert isinstance(windows_steps, list)
     windows_run = _step_by_name(windows_steps, "Run all Windows tests except performance benchmarks")["run"]
     assert '-m "not performance"' in windows_run
+
+
+def test_docs_workflow_passes_changed_files_to_prettier_as_json() -> None:
+    workflow = _load_workflow("docs-check.yml")
+    raw_workflow = cast(dict[Any, Any], workflow)
+    triggers = raw_workflow.get("on", raw_workflow.get(True))
+    assert isinstance(triggers, dict)
+    assert triggers["pull_request"] is None
+    push_trigger = triggers["push"]
+    assert isinstance(push_trigger, dict)
+    assert push_trigger["branches"] == ["main"]
+    assert "paths" not in push_trigger
+
+    job = _jobs(workflow)["format-check"]
+    assert isinstance(job, dict)
+    steps = job["steps"]
+    assert isinstance(steps, list)
+
+    checkout_step = _step_by_name(steps, "Checkout repo")
+    assert checkout_step["with"]["fetch-depth"] == 0
+
+    changed_files_step = _step_by_name(steps, "Collect changed documentation files")
+    assert changed_files_step["env"]["BASE_SHA"].startswith("${{ github.event_name == 'pull_request'")
+    assert changed_files_step["env"]["HEAD_SHA"] == "${{ github.sha }}"
+    assert changed_files_step["env"]["CHANGED_FILES_JSON_PATH"].startswith("${{ runner.temp }}")
+    changed_files_run = changed_files_step["run"]
+    assert '["diff", "--name-only", "-z", "--diff-filter=ACMRTUX"' in changed_files_run
+    assert "writeFileSync(process.env.CHANGED_FILES_JSON_PATH" in changed_files_run
+    assert "Changed filename is not valid UTF-8" in changed_files_run
+    assert '["hash-object", "-t", "tree", "--stdin"]' in changed_files_run
+    assert "any_changed=" in changed_files_run
+
+    prettier_step = _step_by_name(steps, "Check markdown formatting with prettier")
+    assert prettier_step["env"]["CHANGED_FILES_JSON_PATH"].startswith("${{ runner.temp }}")
+    run = prettier_step["run"]
+    assert 'JSON.parse(readFileSync(process.env.CHANGED_FILES_JSON_PATH, "utf8"))' in run
+    assert '["prettier", "--check", "--", ...changedFiles]' in run
+    assert "console.log(JSON.stringify(file))" in run
+    assert "spawnSync" in run
+    assert "${{" not in run
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Git filename edge cases require POSIX filesystem semantics")
+def test_docs_workflow_preserves_unusual_filenames_end_to_end(tmp_path: Path) -> None:
+    workflow = _load_workflow("docs-check.yml")
+    steps = _jobs(workflow)["format-check"]["steps"]
+    assert isinstance(steps, list)
+    collect_script = _node_script(_step_by_name(steps, "Collect changed documentation files"))
+    prettier_script = _node_script(_step_by_name(steps, "Check markdown formatting with prettier"))
+
+    repo, base_sha = _init_test_repository(tmp_path)
+    changed_files = [
+        "space name.md",
+        "-leading.md",
+        "docs/line\n::add-mask::masked-value\nname.md",
+        "docs/unicode-\u00e9.md",
+        "docs/$(touch injected).md",
+        "config.JSON",
+        "workflow.YML",
+    ]
+    for filename in changed_files:
+        path = repo / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("# Changed\n", encoding="utf-8")
+    (repo / "ignored.txt").write_text("ignored\n", encoding="utf-8")
+    (repo / "deleted.md").unlink()
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "--quiet", "-m", "head")
+    head_sha = _git(repo, "rev-parse", "HEAD")
+
+    changed_json = tmp_path / "changed.json"
+    github_output = tmp_path / "github-output"
+    collect_result = _run_node_script(
+        collect_script,
+        repo,
+        {
+            "BASE_SHA": base_sha,
+            "HEAD_SHA": head_sha,
+            "CHANGED_FILES_JSON_PATH": str(changed_json),
+            "GITHUB_OUTPUT": str(github_output),
+        },
+    )
+    assert collect_result.returncode == 0, collect_result.stderr
+    collected_files = json.loads(changed_json.read_text(encoding="utf-8"))
+    assert set(collected_files) == set(changed_files)
+    assert "deleted.md" not in collected_files
+    assert "ignored.txt" not in collected_files
+    assert github_output.read_text(encoding="utf-8") == "any_changed=true\n"
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_npx = fake_bin / "npx"
+    fake_npx.write_text(
+        "#!/usr/bin/env node\n"
+        'require("node:fs").writeFileSync(process.env.ARGS_PATH, JSON.stringify(process.argv.slice(2)));\n',
+        encoding="utf-8",
+    )
+    fake_npx.chmod(0o755)
+    args_path = tmp_path / "npx-args.json"
+    prettier_result = _run_node_script(
+        prettier_script,
+        repo,
+        {
+            "ARGS_PATH": str(args_path),
+            "CHANGED_FILES_JSON_PATH": str(changed_json),
+            "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        },
+    )
+    assert prettier_result.returncode == 0, prettier_result.stderr
+    assert json.loads(args_path.read_text(encoding="utf-8")) == [
+        "prettier",
+        "--check",
+        "--",
+        *collected_files,
+    ]
+    assert "\n::add-mask::" not in prettier_result.stdout
+    assert "\\n::add-mask::masked-value\\n" in prettier_result.stdout
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Invalid UTF-8 filenames require POSIX filesystem semantics")
+def test_docs_workflow_rejects_invalid_utf8_and_invalid_revisions(tmp_path: Path) -> None:
+    workflow = _load_workflow("docs-check.yml")
+    steps = _jobs(workflow)["format-check"]["steps"]
+    assert isinstance(steps, list)
+    collect_script = _node_script(_step_by_name(steps, "Collect changed documentation files"))
+
+    repo, base_sha = _init_test_repository(tmp_path)
+    bad_path = os.fsencode(repo) + b"/invalid-\xff.md"
+    descriptor = os.open(bad_path, os.O_WRONLY | os.O_CREAT, 0o600)
+    os.write(descriptor, b"# Invalid\n")
+    os.close(descriptor)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "--quiet", "-m", "invalid filename")
+    head_sha = _git(repo, "rev-parse", "HEAD")
+
+    changed_json = tmp_path / "invalid.json"
+    github_output = tmp_path / "invalid-output"
+    invalid_utf8_result = _run_node_script(
+        collect_script,
+        repo,
+        {
+            "BASE_SHA": base_sha,
+            "HEAD_SHA": head_sha,
+            "CHANGED_FILES_JSON_PATH": str(changed_json),
+            "GITHUB_OUTPUT": str(github_output),
+        },
+    )
+    assert invalid_utf8_result.returncode != 0
+    assert "Changed filename is not valid UTF-8" in invalid_utf8_result.stderr
+
+    invalid_revision_result = _run_node_script(
+        collect_script,
+        repo,
+        {
+            "BASE_SHA": "not-a-revision",
+            "HEAD_SHA": head_sha,
+            "CHANGED_FILES_JSON_PATH": str(changed_json),
+            "GITHUB_OUTPUT": str(github_output),
+        },
+    )
+    assert invalid_revision_result.returncode != 0
+    assert "Invalid workflow diff boundary" in invalid_revision_result.stderr
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Git empty-tree behavior is covered on POSIX CI")
+def test_docs_workflow_zero_base_scans_the_full_tree(tmp_path: Path) -> None:
+    workflow = _load_workflow("docs-check.yml")
+    steps = _jobs(workflow)["format-check"]["steps"]
+    assert isinstance(steps, list)
+    collect_script = _node_script(_step_by_name(steps, "Collect changed documentation files"))
+
+    repo, _ = _init_test_repository(tmp_path)
+    head_sha = _git(repo, "rev-parse", "HEAD")
+    changed_json = tmp_path / "zero-base.json"
+    github_output = tmp_path / "zero-base-output"
+    result = _run_node_script(
+        collect_script,
+        repo,
+        {
+            "BASE_SHA": "0" * 40,
+            "HEAD_SHA": head_sha,
+            "CHANGED_FILES_JSON_PATH": str(changed_json),
+            "GITHUB_OUTPUT": str(github_output),
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    assert set(json.loads(changed_json.read_text(encoding="utf-8"))) == {"README.md", "deleted.md"}
 
 
 def test_dependency_audit_runs_for_source_reachability_changes() -> None:


### PR DESCRIPTION
## Summary
- Collect changed documentation/config filenames directly from Git with a NUL-delimited diff and strict UTF-8 validation.
- Persist the exact list as JSON and invoke Prettier with an argument array plus an explicit `--` separator.
- Run the workflow on every pull request and main push, then skip internally when no relevant files changed. This avoids GitHub path-filter false negatives, including the documented 300-file limit.
- Escape filenames before logging so names beginning with `::` or containing newlines cannot become Actions workflow commands.
- Compare all files against Git's empty tree when the push event has an all-zero base SHA.

## False-positive / false-negative audit
- Preserved exactly: spaces, leading dashes, shell-looking text, embedded newlines, Unicode, and uppercase Markdown/YAML/JSON suffixes.
- Excluded: deleted files and unsupported extensions.
- Rejected: invalid UTF-8 filenames, malformed revision boundaries, failed Git diffs, and non-NUL-terminated output.
- Injection guard: filenames are never interpolated into shell source, are passed after `--`, and are JSON-escaped before logging.
- Trigger guard: internal filtering replaces event `paths`, which GitHub limits to the first 300 changed files ([documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#git-diff-comparisons)).

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run --frozen pytest tests/test_perf_workflow.py -q --maxfail=1` -> `10 passed`
- `uv run --frozen ruff check tests/test_perf_workflow.py` -> passed
- `uv run --frozen mypy tests/test_perf_workflow.py` -> passed
- `npm_config_cache=/tmp/modelaudit-npm-cache npx prettier --check -- .github/workflows/docs-check.yml` -> passed
- `git diff --check` -> passed
- Published tree SHA `6a43f1eacbdfdca26fdedb942dd77f042a1d7e09` exactly matches the reviewed local tree.

The full local test suite was intentionally left to CI.