### PR TITLE
fix: bound protocol0 line operands

### DIFF
--- a/packages/modelaudit-picklescan/rust/src/opcode.rs
+++ b/packages/modelaudit-picklescan/rust/src/opcode.rs
@@ -1,5 +1,7 @@
 use std::borrow::Cow;
 
+const MAX_PROTOCOL0_LINE_OPERAND_BYTES: usize = 8 * 1024 * 1024;
+
 #[derive(Clone)]
 pub(crate) enum ArgValue {
     None,
@@ -575,15 +577,30 @@ fn read_line_bytes_kind(
                 .at(report_index),
         );
     }
-    let search_end = limit.min(payload.len());
+    let payload_end = limit.min(payload.len());
+    let search_end =
+        payload_end.min((*cursor).saturating_add(MAX_PROTOCOL0_LINE_OPERAND_BYTES + 1));
     let line_end = payload[*cursor..search_end]
         .iter()
         .position(|byte| *byte == b'\n')
         .map(|offset| *cursor + offset)
         .ok_or_else(|| {
-            ParseError::new(format!("no newline found when trying to read {read_kind}"))
-                .at(report_index)
+            if payload_end.saturating_sub(*cursor) > MAX_PROTOCOL0_LINE_OPERAND_BYTES {
+                ParseError::new(format!(
+                    "{read_kind} protocol 0 line operand exceeds {MAX_PROTOCOL0_LINE_OPERAND_BYTES} bytes"
+                ))
+                .at(search_end)
+            } else {
+                ParseError::new(format!("no newline found when trying to read {read_kind}"))
+                    .at(report_index)
+            }
         })?;
+    if line_end.saturating_sub(*cursor) > MAX_PROTOCOL0_LINE_OPERAND_BYTES {
+        return Err(ParseError::new(format!(
+            "{read_kind} protocol 0 line operand exceeds {MAX_PROTOCOL0_LINE_OPERAND_BYTES} bytes"
+        ))
+        .at(line_end));
+    }
     let value = payload[*cursor..line_end].to_vec();
     *cursor = line_end + 1;
     Ok(value)
@@ -833,6 +850,39 @@ mod tests {
 
         assert_eq!(opcode.name, "STRING");
         assert_eq!(opcode.arg.text(payload).as_ref(), "os\n");
+    }
+
+    #[test]
+    fn parse_protocol0_line_operand_accepts_exact_limit() {
+        let mut payload = Vec::with_capacity(MAX_PROTOCOL0_LINE_OPERAND_BYTES + 3);
+        payload.extend_from_slice(b"S'");
+        payload.resize(payload.len() + MAX_PROTOCOL0_LINE_OPERAND_BYTES - 2, b'a');
+        payload.extend_from_slice(b"'\n.");
+
+        let opcode = parse_opcode(&payload, 0, payload.len()).expect("STRING at line limit");
+
+        assert_eq!(opcode.name, "STRING");
+        assert_eq!(opcode.next, MAX_PROTOCOL0_LINE_OPERAND_BYTES + 2);
+    }
+
+    #[test]
+    fn parse_protocol0_line_operand_rejects_over_limit_before_copy() {
+        let mut payload = Vec::with_capacity(MAX_PROTOCOL0_LINE_OPERAND_BYTES + 4);
+        payload.extend_from_slice(b"S'");
+        payload.resize(payload.len() + MAX_PROTOCOL0_LINE_OPERAND_BYTES - 1, b'a');
+        payload.extend_from_slice(b"'\n.");
+
+        let error = match parse_opcode(&payload, 0, payload.len()) {
+            Ok(_) => panic!("overlong protocol 0 line operand should fail"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.exception_type, "ValueError");
+        assert!(error.message.contains("protocol 0 line operand exceeds"));
+        assert_eq!(
+            error.report_index,
+            Some(MAX_PROTOCOL0_LINE_OPERAND_BYTES + 2)
+        );
     }
 
     #[test]

--- a/packages/modelaudit-picklescan/tests/test_protocol0_line_operands.py
+++ b/packages/modelaudit-picklescan/tests/test_protocol0_line_operands.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from modelaudit_picklescan import SafetyVerdict, ScanStatus, scan_bytes
+
+
+def test_scan_bytes_fails_closed_for_overlong_protocol0_line_operand() -> None:
+    max_protocol0_line_operand_bytes = 8 * 1024 * 1024
+    payload = b"S'" + (b"A" * (max_protocol0_line_operand_bytes - 1)) + b"'\n."
+
+    report = scan_bytes(payload, source="overlong-protocol0-string.pkl")
+
+    assert report.status == ScanStatus.ERROR
+    assert report.verdict != SafetyVerdict.CLEAN
+    assert report.errors
+    parse_error = report.errors[0]
+    assert parse_error.category == "parse_error"
+    assert "protocol 0 line operand exceeds" in parse_error.message


### PR DESCRIPTION
## Summary
- Add an 8 MiB cap for protocol-0 newline-delimited operands before copying or decoding them.
- Limit the newline search window so overlong operands fail before scanning the rest of an attacker-controlled line.
- Add Rust parser boundary tests plus a public API regression that confirms overlong operands fail closed.

## Security Notes
- Finding: M-20 protocol-0 line operands allocate before budgets apply.
- False positives: exact-limit protocol-0 operands still parse successfully; binary opcode span handling is unchanged.
- False negatives: over-limit operands now produce a parse error and non-clean report before operand materialization.

## Validation
- `cargo test --manifest-path Cargo.toml parse_protocol0_line_operand -- --nocapture` (2 passed)
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run --frozen pytest packages/modelaudit-picklescan/tests/test_protocol0_line_operands.py -q --maxfail=1` (1 passed)
- `cargo test --manifest-path Cargo.toml` (133 passed)
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run --frozen pytest packages/modelaudit-picklescan/tests/test_rust_engine.py packages/modelaudit-picklescan/tests/test_api.py::test_scan_bytes_reports_parse_errors_without_security_findings packages/modelaudit-picklescan/tests/test_api.py::test_scan_bytes_fails_closed_for_overlong_protocol0_line_operand -q --maxfail=1` before moving the API test to the small file (100 passed)
- `cargo check --manifest-path Cargo.toml --locked`
- `cargo fmt --manifest-path Cargo.toml -- --check`
- `uv run --frozen ruff format --check packages/modelaudit-picklescan/tests/test_protocol0_line_operands.py`
- `uv run --frozen ruff check --fix packages/modelaudit-picklescan/tests/test_protocol0_line_operands.py`
- `uv run --frozen mypy packages/modelaudit-picklescan/tests/test_protocol0_line_operands.py`
- `git diff --check`

Draft until review confirms the 8 MiB protocol-0 operand cap is the desired compatibility boundary.