### PR TITLE
fix: audit dependencies for source changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
   dependency-audit:
     name: Dependency Audit
     needs: changes
-    if: github.event_name == 'pull_request' && (needs.changes.outputs.dependencies == 'true' || needs.changes.outputs.workflows == 'true')
+    if: github.event_name == 'pull_request' && (needs.changes.outputs.dependencies == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.python == 'true' || needs.changes.outputs.picklescan == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/tests/test_perf_workflow.py
+++ b/tests/test_perf_workflow.py
@@ -27,10 +27,14 @@ def _load_perf_workflow() -> dict[str, Any]:
     return _load_workflow("perf.yml")
 
 
-def _benchmarks_job(workflow: dict[str, Any]) -> dict[str, Any]:
+def _jobs(workflow: dict[str, Any]) -> dict[str, Any]:
     jobs = workflow["jobs"]
     assert isinstance(jobs, dict)
-    job = jobs["benchmarks"]
+    return jobs
+
+
+def _benchmarks_job(workflow: dict[str, Any]) -> dict[str, Any]:
+    job = _jobs(workflow)["benchmarks"]
     assert isinstance(job, dict)
     return job
 
@@ -122,8 +126,7 @@ def test_perf_workflow_runs_retained_memory_guard_as_blocking_step() -> None:
 
 def test_nightly_windows_lane_defers_performance_benchmarks_to_linux() -> None:
     workflow = _load_workflow("nightly.yml")
-    jobs = workflow["jobs"]
-    assert isinstance(jobs, dict)
+    jobs = _jobs(workflow)
 
     linux_steps = jobs["full-matrix"]["steps"]
     assert isinstance(linux_steps, list)
@@ -134,3 +137,16 @@ def test_nightly_windows_lane_defers_performance_benchmarks_to_linux() -> None:
     assert isinstance(windows_steps, list)
     windows_run = _step_by_name(windows_steps, "Run all Windows tests except performance benchmarks")["run"]
     assert '-m "not performance"' in windows_run
+
+
+def test_dependency_audit_runs_for_source_reachability_changes() -> None:
+    workflow = _load_workflow("test.yml")
+    job = _jobs(workflow)["dependency-audit"]
+    assert isinstance(job, dict)
+
+    condition = job["if"]
+    assert "github.event_name == 'pull_request'" in condition
+    assert "needs.changes.outputs.dependencies == 'true'" in condition
+    assert "needs.changes.outputs.workflows == 'true'" in condition
+    assert "needs.changes.outputs.python == 'true'" in condition
+    assert "needs.changes.outputs.picklescan == 'true'" in condition


### PR DESCRIPTION
## Summary

- Broaden the dependency-audit PR condition so dependency, workflow, root Python, and standalone picklescan source/package changes all trigger the audit job.
- Add a workflow regression test that asserts source-reachability changes keep dependency audit active.

## Security impact

Source-only changes can alter dependency reachability without touching lockfiles. This keeps dependency auditing active for those PRs so vulnerable reachable packages are less likely to slip through CI.

## False-positive audit

Unrelated non-source PRs still avoid dependency-audit noise from pre-existing advisories because the condition remains scoped to dependency, workflow, root Python, or picklescan changes.

## False-negative audit

Source-only reachability changes in `modelaudit/`, tests, and the standalone picklescan package now exercise dependency audit instead of being skipped.

## Validation

- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run --frozen pytest tests/test_perf_workflow.py -q --maxfail=1` (`6 passed`)
- ruff format/check, ruff format-check, full mypy, and `git diff --check` passed in `/tmp/modelaudit-fix-dependency-audit-source-only`
- Full pytest was attempted and reached `13012 passed, 1008 skipped` before two unrelated existing failures; one picklescan failure passed in isolation and the JIT detector failure reproduced on `origin/main`.

Draft until CI confirms the workflow condition in GitHub.