### PR TITLE
fix: fail closed on nested protocol0 operand limits

### DIFF
--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -79,6 +79,9 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - fail closed when known-size pickle boundaries cannot be verified or contain trailing bytes, and bind file scans to one descriptor
+- fail closed before copying protocol 0 line operands larger than 8 MiB
+- fail closed before copying protocol 0 line operands larger than 8 MiB,
+  including nested payload probes
 - Invalidate cached call-graph analysis when Python sources, import hooks, loaded module origins, or parent package markers change.
 - detect dangerous call-like strings split across newline-separated statements
 - scan raw nested pickle payloads carried inside Unicode string literals

--- a/packages/modelaudit-picklescan/rust/src/nested.rs
+++ b/packages/modelaudit-picklescan/rust/src/nested.rs
@@ -1,4 +1,4 @@
-use crate::opcode::{parse_opcode, ParsedOpcode};
+use crate::opcode::{parse_opcode, ParseError, ParsedOpcode};
 
 const BASE64_LITERAL_CHARS: &[u8] =
     b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
@@ -18,10 +18,27 @@ pub(crate) struct EncodedNestedProbeWindows {
     pub(crate) limit_exceeded_encoding: Option<&'static str>,
 }
 
+pub(crate) struct DecodedNestedPayload {
+    pub(crate) encoding: &'static str,
+    pub(crate) payload: Vec<u8>,
+    pub(crate) analysis_incomplete: bool,
+}
+
+pub(crate) struct PicklePayloadExtentError {
+    error: ParseError,
+    structured_pickle_evidence: bool,
+}
+
+impl PicklePayloadExtentError {
+    pub(crate) fn is_structured_protocol0_line_operand_limit(&self) -> bool {
+        self.structured_pickle_evidence && self.error.is_protocol0_line_operand_limit()
+    }
+}
+
 pub(crate) fn decode_possible_encoded_pickle(
     value: &str,
     max_nested_pickle_bytes: usize,
-) -> Vec<(&'static str, Vec<u8>)> {
+) -> Vec<DecodedNestedPayload> {
     let stripped = value.trim();
     if stripped.len() < 16 || !encoded_literal_may_contain_pickle(stripped) {
         return Vec::new();
@@ -37,8 +54,14 @@ pub(crate) fn decode_possible_encoded_pickle(
             let bounded = take_bytes_str(&candidate, max_base64_nested_pickle_chars);
             let padded = pad_base64(&bounded);
             if let Some(decoded) = decode_base64(&padded) {
-                for payload in decoded_pickle_payloads(&decoded, max_nested_pickle_bytes) {
-                    decoded_values.push(("base64", payload));
+                for (payload, analysis_incomplete) in
+                    decoded_pickle_payloads(&decoded, max_nested_pickle_bytes)
+                {
+                    decoded_values.push(DecodedNestedPayload {
+                        encoding: "base64",
+                        payload,
+                        analysis_incomplete,
+                    });
                 }
             }
         }
@@ -57,8 +80,14 @@ pub(crate) fn decode_possible_encoded_pickle(
                 let bounded_hex_candidate =
                     take_bytes_str(&hex_candidate, max_hex_nested_pickle_chars);
                 if let Some(decoded) = decode_hex(&bounded_hex_candidate) {
-                    for payload in decoded_pickle_payloads(&decoded, max_nested_pickle_bytes) {
-                        decoded_values.push((encoding, payload));
+                    for (payload, analysis_incomplete) in
+                        decoded_pickle_payloads(&decoded, max_nested_pickle_bytes)
+                    {
+                        decoded_values.push(DecodedNestedPayload {
+                            encoding,
+                            payload,
+                            analysis_incomplete,
+                        });
                     }
                 }
             }
@@ -68,15 +97,22 @@ pub(crate) fn decode_possible_encoded_pickle(
     decoded_values
 }
 
-fn decoded_pickle_payloads(decoded: &[u8], max_nested_pickle_bytes: usize) -> Vec<Vec<u8>> {
+fn decoded_pickle_payloads(decoded: &[u8], max_nested_pickle_bytes: usize) -> Vec<(Vec<u8>, bool)> {
     let mut payloads = Vec::new();
     let mut search_start = 0usize;
-    if let Some(payload_len) = pickle_payload_extent(decoded, max_nested_pickle_bytes) {
-        payloads.push(decoded[..payload_len].to_vec());
-        search_start = payload_len;
-        if search_start >= decoded.len() {
+    match pickle_payload_extent_result(decoded, max_nested_pickle_bytes) {
+        Ok(Some(payload_len)) => {
+            payloads.push((decoded[..payload_len].to_vec(), false));
+            search_start = payload_len;
+            if search_start >= decoded.len() {
+                return payloads;
+            }
+        }
+        Err(error) if error.is_structured_protocol0_line_operand_limit() => {
+            payloads.push((decoded.to_vec(), true));
             return payloads;
         }
+        Ok(None) | Err(_) => {}
     }
 
     let mut seen_spans = Vec::new();
@@ -86,15 +122,23 @@ fn decoded_pickle_payloads(decoded: &[u8], max_nested_pickle_bytes: usize) -> Ve
             .len()
             .min(offset.saturating_add(max_nested_pickle_bytes));
         let probe = &decoded[offset..end];
-        let Some(payload_len) = pickle_payload_extent(probe, max_nested_pickle_bytes) else {
-            continue;
-        };
+        let (payload_len, analysis_incomplete) =
+            match pickle_payload_extent_result(probe, max_nested_pickle_bytes) {
+                Ok(Some(payload_len)) => (payload_len, false),
+                Err(error) if error.is_structured_protocol0_line_operand_limit() => {
+                    (probe.len(), true)
+                }
+                Ok(None) | Err(_) => continue,
+            };
         let span = (offset, offset.saturating_add(payload_len));
         if seen_spans.contains(&span) {
             continue;
         }
         seen_spans.push(span);
-        payloads.push(decoded[span.0..span.1].to_vec());
+        payloads.push((decoded[span.0..span.1].to_vec(), analysis_incomplete));
+        if analysis_incomplete {
+            break;
+        }
     }
     payloads
 }
@@ -150,26 +194,38 @@ pub(crate) fn looks_like_pickle_payload(value: &[u8], max_bytes: usize) -> bool 
 }
 
 pub(crate) fn pickle_payload_extent(value: &[u8], max_bytes: usize) -> Option<usize> {
+    pickle_payload_extent_result(value, max_bytes)
+        .ok()
+        .flatten()
+}
+
+pub(crate) fn pickle_payload_extent_result(
+    value: &[u8],
+    max_bytes: usize,
+) -> Result<Option<usize>, PicklePayloadExtentError> {
     if value.len() < 2 || value.len() > max_bytes || !has_pickle_prefix(value) {
-        return None;
+        return Ok(None);
     }
     let mut index = 0usize;
     let mut stack_depth = 0usize;
     let mut mark_depths: Vec<usize> = Vec::new();
+    let mut structured_pickle_evidence = has_binary_pickle_prefix(value);
     while index < value.len() {
-        let parsed = match parse_opcode(value, index, value.len()) {
-            Ok(parsed) => parsed,
-            Err(_) => return None,
-        };
+        let parsed =
+            parse_opcode(value, index, value.len()).map_err(|error| PicklePayloadExtentError {
+                error,
+                structured_pickle_evidence,
+            })?;
         index = parsed.next;
         if !validate_pickle_stack_effect(&parsed, &mut stack_depth, &mut mark_depths) {
-            return None;
+            return Ok(None);
         }
+        structured_pickle_evidence |= is_structured_nested_probe_anchor(parsed.name);
         if parsed.name == "STOP" {
-            return (stack_depth > 0).then_some(index);
+            return Ok((stack_depth > 0).then_some(index));
         }
     }
-    None
+    Ok(None)
 }
 
 pub(crate) fn has_execution_opcode(value: &[u8]) -> bool {
@@ -1210,8 +1266,9 @@ mod tests {
         let decoded = decode_possible_encoded_pickle(value, TEST_MAX_NESTED_PICKLE_BYTES);
 
         assert_eq!(decoded.len(), 1);
-        assert_eq!(decoded[0].0, "base64");
-        assert_eq!(decoded[0].1, b"cos\nsystem\n)R.");
+        assert_eq!(decoded[0].encoding, "base64");
+        assert_eq!(decoded[0].payload, b"cos\nsystem\n)R.");
+        assert!(!decoded[0].analysis_incomplete);
     }
 
     #[test]
@@ -1223,10 +1280,67 @@ mod tests {
 
         assert!(decoded
             .iter()
-            .any(|(encoding, payload)| *encoding == "base64" && payload == b"\x80\x04}."));
+            .any(|candidate| candidate.encoding == "base64" && candidate.payload == b"\x80\x04}."));
         assert!(decoded
             .iter()
-            .any(|(encoding, payload)| *encoding == "base64" && payload == b"cos\nsystem\n)R."));
+            .any(|candidate| candidate.encoding == "base64"
+                && candidate.payload == b"cos\nsystem\n)R."));
+    }
+
+    #[test]
+    fn decoded_payloads_preserve_protocol0_operand_limit_failures() {
+        let mut payload = b"cos\nsystem\n(S'".to_vec();
+        payload.resize(
+            payload.len() + crate::opcode::MAX_PROTOCOL0_LINE_OPERAND_BYTES,
+            b'A',
+        );
+        payload.extend_from_slice(b"'\ntR.");
+
+        let decoded = decoded_pickle_payloads(&payload, payload.len() + 16);
+
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].0, payload);
+        assert!(decoded[0].1);
+    }
+
+    #[test]
+    fn decoded_payloads_ignore_unstructured_protocol0_operand_limit_failures() {
+        let mut payload = b"S'".to_vec();
+        payload.resize(
+            payload.len() + crate::opcode::MAX_PROTOCOL0_LINE_OPERAND_BYTES + 1,
+            b'A',
+        );
+
+        assert!(decoded_pickle_payloads(&payload, payload.len() + 16).is_empty());
+        let error = pickle_payload_extent_result(&payload, payload.len() + 16)
+            .expect_err("overlong protocol 0 string should preserve its parse error");
+        assert!(!error.is_structured_protocol0_line_operand_limit());
+    }
+
+    #[test]
+    fn protocol0_operand_limit_requires_prior_structured_opcode() {
+        let mut payload = b"cos\nsystem\n(S'".to_vec();
+        payload.resize(
+            payload.len() + crate::opcode::MAX_PROTOCOL0_LINE_OPERAND_BYTES,
+            b'A',
+        );
+
+        let error = pickle_payload_extent_result(&payload, payload.len() + 16)
+            .expect_err("overlong nested operand should preserve its parse error");
+        assert!(error.is_structured_protocol0_line_operand_limit());
+    }
+
+    #[test]
+    fn protocol0_operand_limit_tracks_structured_evidence_beyond_prefix_probe() {
+        let mut payload = b"(NNNNcos\nsystem\n(S'".to_vec();
+        payload.resize(
+            payload.len() + crate::opcode::MAX_PROTOCOL0_LINE_OPERAND_BYTES,
+            b'A',
+        );
+
+        let error = pickle_payload_extent_result(&payload, payload.len() + 16)
+            .expect_err("structured evidence after setup opcodes should survive the operand cap");
+        assert!(error.is_structured_protocol0_line_operand_limit());
     }
 
     #[test]

--- a/packages/modelaudit-picklescan/rust/src/opcode.rs
+++ b/packages/modelaudit-picklescan/rust/src/opcode.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-const MAX_PROTOCOL0_LINE_OPERAND_BYTES: usize = 8 * 1024 * 1024;
+pub(crate) const MAX_PROTOCOL0_LINE_OPERAND_BYTES: usize = 8 * 1024 * 1024;
 
 #[derive(Clone)]
 pub(crate) enum ArgValue {
@@ -99,6 +99,13 @@ pub(crate) struct ParseError {
     pub(crate) message: String,
     pub(crate) exception_type: &'static str,
     pub(crate) report_index: Option<usize>,
+    kind: ParseErrorKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ParseErrorKind {
+    Generic,
+    Protocol0LineOperandLimit,
 }
 
 impl ParseError {
@@ -107,6 +114,7 @@ impl ParseError {
             message: message.into(),
             exception_type: "ValueError",
             report_index: None,
+            kind: ParseErrorKind::Generic,
         }
     }
 
@@ -120,7 +128,23 @@ impl ParseError {
             message: format!("not enough data in stream to read {read_kind}"),
             exception_type: "ValueError",
             report_index: Some(index),
+            kind: ParseErrorKind::Generic,
         }
+    }
+
+    fn protocol0_line_operand_limit(read_kind: &'static str, index: usize) -> Self {
+        Self {
+            message: format!(
+                "{read_kind} protocol 0 line operand exceeds {MAX_PROTOCOL0_LINE_OPERAND_BYTES} bytes"
+            ),
+            exception_type: "ValueError",
+            report_index: Some(index),
+            kind: ParseErrorKind::Protocol0LineOperandLimit,
+        }
+    }
+
+    pub(crate) fn is_protocol0_line_operand_limit(&self) -> bool {
+        self.kind == ParseErrorKind::Protocol0LineOperandLimit
     }
 }
 pub(crate) fn parse_opcode(
@@ -586,20 +610,16 @@ fn read_line_bytes_kind(
         .map(|offset| *cursor + offset)
         .ok_or_else(|| {
             if payload_end.saturating_sub(*cursor) > MAX_PROTOCOL0_LINE_OPERAND_BYTES {
-                ParseError::new(format!(
-                    "{read_kind} protocol 0 line operand exceeds {MAX_PROTOCOL0_LINE_OPERAND_BYTES} bytes"
-                ))
-                .at(search_end)
+                ParseError::protocol0_line_operand_limit(read_kind, search_end)
             } else {
                 ParseError::new(format!("no newline found when trying to read {read_kind}"))
                     .at(report_index)
             }
         })?;
     if line_end.saturating_sub(*cursor) > MAX_PROTOCOL0_LINE_OPERAND_BYTES {
-        return Err(ParseError::new(format!(
-            "{read_kind} protocol 0 line operand exceeds {MAX_PROTOCOL0_LINE_OPERAND_BYTES} bytes"
-        ))
-        .at(line_end));
+        return Err(ParseError::protocol0_line_operand_limit(
+            read_kind, line_end,
+        ));
     }
     let value = payload[*cursor..line_end].to_vec();
     *cursor = line_end + 1;
@@ -878,6 +898,7 @@ mod tests {
         };
 
         assert_eq!(error.exception_type, "ValueError");
+        assert!(error.is_protocol0_line_operand_limit());
         assert!(error.message.contains("protocol 0 line operand exceeds"));
         assert_eq!(
             error.report_index,

--- a/packages/modelaudit-picklescan/rust/src/state.rs
+++ b/packages/modelaudit-picklescan/rust/src/state.rs
@@ -14,9 +14,10 @@ use crate::nested::{
     encoded_literal_may_contain_pickle, encoded_nested_literal_probe_coverage_incomplete,
     encoded_nested_literal_probe_windows_with_limit, encoded_nested_window_char_limit,
     has_binary_pickle_prefix, has_execution_opcode, has_pickle_prefix, looks_like_pickle_payload,
-    nested_pickle_probe_offsets, pickle_payload_extent,
+    nested_pickle_probe_offsets, pickle_payload_extent_result,
     protocol0_global_or_inst_prefix_has_import_reference_lines,
-    truncated_pickle_prefix_requires_fail_closed, NestedProbeOffsets, MAX_NESTED_PAYLOAD_PROBES,
+    truncated_pickle_prefix_requires_fail_closed, DecodedNestedPayload, NestedProbeOffsets,
+    MAX_NESTED_PAYLOAD_PROBES,
 };
 use crate::nested_surface::{
     encoded_nested_payload_finding, is_allowlisted_nested_constructor_ref,
@@ -5801,27 +5802,32 @@ impl<'a> ScanState<'a> {
                 .len()
                 .min(offset.saturating_add(self.options.max_nested_pickle_bytes));
             let probe = &value[offset..end];
-            if let Some(payload_len) =
-                pickle_payload_extent(probe, self.options.max_nested_pickle_bytes)
-            {
-                let candidate = &probe[..payload_len];
-                let nested_has_execution_opcode = has_execution_opcode(candidate);
-                let surface_outcome =
-                    self.surface_nested_pickle_findings(candidate, "raw", position + offset);
-                self.add_nested_payload_finding(
-                    raw_nested_payload_finding(
-                        candidate.len(),
-                        position + offset,
-                        false,
-                        nested_has_execution_opcode,
-                    ),
-                    surface_outcome.promote_complete_payload(nested_has_execution_opcode),
-                );
-                if surface_outcome.should_stop_raw_probe_scan(nested_has_execution_opcode) {
+            match pickle_payload_extent_result(probe, self.options.max_nested_pickle_bytes) {
+                Ok(Some(payload_len)) => {
+                    let candidate = &probe[..payload_len];
+                    let nested_has_execution_opcode = has_execution_opcode(candidate);
+                    let surface_outcome =
+                        self.surface_nested_pickle_findings(candidate, "raw", position + offset);
+                    self.add_nested_payload_finding(
+                        raw_nested_payload_finding(
+                            candidate.len(),
+                            position + offset,
+                            false,
+                            nested_has_execution_opcode,
+                        ),
+                        surface_outcome.promote_complete_payload(nested_has_execution_opcode),
+                    );
+                    if surface_outcome.should_stop_raw_probe_scan(nested_has_execution_opcode) {
+                        return;
+                    }
+                    skip_offsets_before = offset.saturating_add(payload_len);
+                    continue;
+                }
+                Err(error) if error.is_structured_protocol0_line_operand_limit() => {
+                    self.surface_nested_pickle_findings(probe, "raw", position + offset);
                     return;
                 }
-                skip_offsets_before = offset.saturating_add(payload_len);
-                continue;
+                Ok(None) | Err(_) => {}
             }
             if has_pickle_prefix(probe)
                 && has_execution_opcode(probe)
@@ -5868,14 +5874,23 @@ impl<'a> ScanState<'a> {
                     .len()
                     .min(offset.saturating_add(self.options.max_nested_pickle_bytes));
                 let probe = &value[offset..end];
+                let payload_extent =
+                    pickle_payload_extent_result(probe, self.options.max_nested_pickle_bytes);
                 let complete_payload = last_stop_offset.is_some_and(|stop| offset < stop)
-                    && pickle_payload_extent(probe, self.options.max_nested_pickle_bytes).is_some();
+                    && matches!(&payload_extent, Ok(Some(_)));
+                let operand_limit_exceeded = payload_extent
+                    .as_ref()
+                    .is_err_and(|error| error.is_structured_protocol0_line_operand_limit());
                 let malformed_payload = has_execution_opcode(probe)
                     && (has_binary_pickle_prefix(probe)
                         || protocol0_global_or_inst_prefix_has_import_reference_lines(probe));
                 let truncated_payload = remaining_len > self.options.max_nested_pickle_bytes
                     && truncated_pickle_prefix_requires_fail_closed(probe);
-                if !complete_payload && !malformed_payload && !truncated_payload {
+                if !complete_payload
+                    && !operand_limit_exceeded
+                    && !malformed_payload
+                    && !truncated_payload
+                {
                     continue;
                 }
                 if offsets.len() >= MAX_NESTED_PAYLOAD_PROBES {
@@ -5956,7 +5971,9 @@ impl<'a> ScanState<'a> {
     fn is_data_only_encoded_nested_pickle_literal(&self, value: &str) -> bool {
         decode_possible_encoded_pickle(value, self.options.max_nested_pickle_bytes)
             .into_iter()
-            .any(|(_, decoded)| !has_execution_opcode(&decoded))
+            .any(|candidate| {
+                !candidate.analysis_incomplete && !has_execution_opcode(&candidate.payload)
+            })
     }
 
     fn is_large_uninteresting_repeated_literal(&self, value: &str) -> bool {
@@ -6042,12 +6059,18 @@ impl<'a> ScanState<'a> {
 
     fn scan_encoded_nested_pickle_candidate(&mut self, value: &str, position: usize) -> bool {
         let mut decoded_payload_found = false;
-        for (encoding, decoded) in
-            decode_possible_encoded_pickle(value, self.options.max_nested_pickle_bytes)
+        for DecodedNestedPayload {
+            encoding,
+            payload: decoded,
+            analysis_incomplete,
+        } in decode_possible_encoded_pickle(value, self.options.max_nested_pickle_bytes)
         {
             decoded_payload_found = true;
             let nested_has_execution_opcode = has_execution_opcode(&decoded);
             let surface_outcome = self.surface_nested_pickle_findings(&decoded, encoding, position);
+            if analysis_incomplete {
+                continue;
+            }
             self.add_nested_payload_finding(
                 encoded_nested_payload_finding(
                     encoding,

--- a/packages/modelaudit-picklescan/tests/test_protocol0_line_operands.py
+++ b/packages/modelaudit-picklescan/tests/test_protocol0_line_operands.py
@@ -1,11 +1,26 @@
 from __future__ import annotations
 
-from modelaudit_picklescan import SafetyVerdict, ScanStatus, scan_bytes
+import pickle
+from collections.abc import Mapping
+
+import pytest
+
+from modelaudit_picklescan import SafetyVerdict, ScanOptions, ScanStatus, scan_bytes
+
+MAX_PROTOCOL0_LINE_OPERAND_BYTES = 8 * 1024 * 1024
+
+
+def test_scan_bytes_accepts_exact_limit_protocol0_line_operand() -> None:
+    payload = b"S'" + (b"A" * (MAX_PROTOCOL0_LINE_OPERAND_BYTES - 2)) + b"'\n."
+
+    report = scan_bytes(payload, source="exact-limit-protocol0-string.pkl")
+
+    assert report.status != ScanStatus.ERROR
+    assert not report.errors
 
 
 def test_scan_bytes_fails_closed_for_overlong_protocol0_line_operand() -> None:
-    max_protocol0_line_operand_bytes = 8 * 1024 * 1024
-    payload = b"S'" + (b"A" * (max_protocol0_line_operand_bytes - 1)) + b"'\n."
+    payload = b"S'" + (b"A" * (MAX_PROTOCOL0_LINE_OPERAND_BYTES - 1)) + b"'\n."
 
     report = scan_bytes(payload, source="overlong-protocol0-string.pkl")
 
@@ -15,3 +30,67 @@ def test_scan_bytes_fails_closed_for_overlong_protocol0_line_operand() -> None:
     parse_error = report.errors[0]
     assert parse_error.category == "parse_error"
     assert "protocol 0 line operand exceeds" in parse_error.message
+
+
+@pytest.mark.parametrize("as_unicode", [False, True])
+def test_scan_bytes_fails_closed_for_nested_overlong_protocol0_line_operand(
+    as_unicode: bool,
+) -> None:
+    nested_payload = b"cos\nsystem\n(S'" + (b"A" * (MAX_PROTOCOL0_LINE_OPERAND_BYTES - 1)) + b"'\ntR."
+    nested_value = nested_payload.decode("ascii") if as_unicode else nested_payload
+    payload = pickle.dumps(nested_value, protocol=4)
+
+    report = scan_bytes(
+        payload,
+        source="nested-overlong-protocol0-string.pkl",
+        options=ScanOptions(
+            max_nested_pickle_bytes=len(nested_payload) + 16,
+            max_string_literal_scan_chars=len(nested_payload) + 16,
+        ),
+    )
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert any(
+        finding.rule_code == "DANGEROUS_GLOBAL"
+        and finding.details.get("module") == "os"
+        and finding.details.get("name") == "system"
+        for finding in report.findings
+    )
+    assert any(
+        finding.rule_code == "S213" and finding.details.get("analysis_incomplete") is True
+        for finding in report.findings
+    )
+    incomplete_notice = next(notice for notice in report.notices if notice.code == "nested_pickle_incomplete")
+    nested_notices = incomplete_notice.details.get("nested_notices")
+    assert isinstance(nested_notices, (list, tuple))
+    assert any(
+        isinstance(notice, Mapping)
+        and notice.get("code") == "parse_incomplete"
+        and isinstance(notice.get("details"), Mapping)
+        and "protocol 0 line operand exceeds" in str(notice["details"].get("exception"))
+        for notice in nested_notices
+    )
+
+
+@pytest.mark.parametrize("as_unicode", [False, True])
+def test_scan_bytes_ignores_unstructured_nested_overlong_protocol0_near_match(
+    as_unicode: bool,
+) -> None:
+    nested_value_bytes = b"S'" + (b"A" * (MAX_PROTOCOL0_LINE_OPERAND_BYTES + 1))
+    nested_value = nested_value_bytes.decode("ascii") if as_unicode else nested_value_bytes
+    payload = pickle.dumps(nested_value, protocol=4)
+
+    report = scan_bytes(
+        payload,
+        source="nested-overlong-protocol0-near-match.pkl",
+        options=ScanOptions(
+            max_nested_pickle_bytes=len(nested_value_bytes) + 16,
+            max_string_literal_scan_chars=len(nested_value) + 16,
+        ),
+    )
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert not any(finding.rule_code == "S213" for finding in report.findings)
+    assert not any(notice.code == "nested_pickle_incomplete" for notice in report.notices)


### PR DESCRIPTION
## Summary
- preserve the typed 8 MiB protocol-0 operand-limit error through raw, Unicode, base64, and hex nested-pickle probes
- fail closed only after a binary pickle header or a stack-valid structured execution/constructor opcode establishes that the candidate is a pickle
- keep unstructured oversized `STRING` near-matches clean instead of promoting ordinary data to S213
- follow up on the nested false negative introduced by #1534

## False-positive / false-negative audit
- FN closed: a nested `GLOBAL os.system` followed by an overlong protocol-0 string remains `INCONCLUSIVE` / `MALICIOUS`, surfaces the dangerous global, and records incomplete nested analysis
- FN guard: structured evidence is carried through the full extent parse, including anchors beyond the four-opcode prefix probe
- FP closed: raw and Unicode values beginning with an overlong protocol-0-like `STRING` no longer become malicious without prior pickle structure
- FP guard: decoded encoded candidates use the same structured-evidence gate
- exact-limit top-level operands remain accepted; over-limit top-level operands still fail closed

## Validation
- `cargo test --manifest-path Cargo.toml protocol0 -- --nocapture` -> 13 passed
- `cargo test --manifest-path Cargo.toml nested::tests::encoded -- --nocapture` -> 12 passed
- `cargo clippy --manifest-path Cargo.toml --all-targets -- -D warnings` -> passed
- `cargo fmt --manifest-path Cargo.toml -- --check` -> passed
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run --frozen --with pytest pytest tests/test_protocol0_line_operands.py -q` -> 6 passed
- scoped Ruff check/format and mypy -> passed
- all five published blob SHAs and the complete tree SHA exactly match the rebased local tree

The full local test suite was intentionally left to CI.