### PR TITLE
fix: contain cloud object download paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- fail closed on unsafe cloud object paths, parent-directory swaps, and download destination aliases
 - harden cloud acquisition size caps, HTTPS/R2 auto-default routing, and directory metadata failures
 - detect operator attrgetter, itemgetter, and methodcaller archive-member Python paths to command execution while preserving benign accessor names
 - redact Keras and TensorFlow scanner detail fields that echo model-controlled configs, code indicators, archive members, and external references.

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -551,7 +551,7 @@ def _cloud_url_local_basename(url: str) -> str:
         if parsed.scheme.casefold() in {"s3", "gs", "gcs", "r2"} and (not parsed.path or parsed.path.endswith("/")):
             return ""
     except Exception:
-        pass
+        logger.debug("Unable to parse cloud URL for local basename; using fallback path handling")
     return _cloud_url_basename(url).replace("\\", "/").rsplit("/", 1)[-1]
 
 
@@ -2054,7 +2054,11 @@ def _protocol_less_cloud_relative_path(base_url: str, file_url: str) -> str:
     """Preserve provider-returned bucket/prefix paths when the scheme is omitted."""
     try:
         base = urlsplit(base_url)
-        file_path = urlsplit(file_url).path.replace("\\", "/").lstrip("/")
+        parsed_file = urlsplit(file_url)
+        # Provider listings commonly return bare object keys. In that form,
+        # URL delimiters are literal key text rather than query/fragment syntax.
+        file_path = parsed_file.path if parsed_file.scheme or parsed_file.netloc else file_url
+        file_path = file_path.replace("\\", "/").lstrip("/")
     except Exception:
         return _cloud_url_local_basename(file_url)
 

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import struct
 import tempfile
+import unicodedata
 import zipfile
 from collections.abc import Callable, Collection, Coroutine, Iterator, Mapping
 from concurrent.futures import ThreadPoolExecutor
@@ -543,6 +544,17 @@ def _cloud_url_basename(url: str) -> str:
     return Path(path).name
 
 
+def _cloud_url_local_basename(url: str) -> str:
+    """Return the raw final URL path segment for local file creation."""
+    try:
+        parsed = urlsplit(url)
+        if parsed.scheme.casefold() in {"s3", "gs", "gcs", "r2"} and (not parsed.path or parsed.path.endswith("/")):
+            return ""
+    except Exception:
+        pass
+    return _cloud_url_basename(url).replace("\\", "/").rsplit("/", 1)[-1]
+
+
 def _remove_path(path: Path) -> None:
     """Remove a file, directory, symlink, or special path without following symlinks."""
     if path.is_symlink() or not path.is_dir():
@@ -727,6 +739,11 @@ def _is_within_directory(base_dir: Path, target: Path) -> bool:
     """Return True if target resolves within base_dir."""
     base_path = base_dir.resolve()
     target_path = target.resolve()
+    return _is_resolved_path_within_base(base_path, target_path)
+
+
+def _is_resolved_path_within_base(base_path: Path, target_path: Path) -> bool:
+    """Return True if two already-resolved paths have a base/child relationship."""
     if os.name == "nt":
         base_norm = os.path.normcase(os.path.normpath(str(base_path)))
         target_norm = os.path.normcase(os.path.normpath(str(target_path)))
@@ -740,11 +757,13 @@ def _is_within_directory(base_dir: Path, target: Path) -> bool:
 def _resolve_cloud_path(entry_name: str, base_dir: Path) -> tuple[Path, bool]:
     """Resolve a cloud object relative path and return whether it is safe."""
     entry = entry_name.replace("\\", "/")
-    if entry.startswith("/") or (len(entry) > 1 and entry[1] == ":"):
+    if entry.startswith("/") or (os.name == "nt" and len(entry) > 1 and entry[1] == ":"):
         return (base_dir / entry.lstrip("/")).resolve(), False
 
-    resolved = (base_dir / entry.lstrip("/")).resolve()
-    return resolved, _is_within_directory(base_dir, resolved)
+    candidate = base_dir / entry.lstrip("/")
+    parent = candidate.parent.resolve()
+    resolved = parent / candidate.name
+    return resolved, _is_resolved_path_within_base(base_dir.resolve(), parent)
 
 
 def _parse_size_value(size_value: Any) -> int:
@@ -2013,23 +2032,191 @@ def _build_safe_local_path(base_url: str, file_url: str, download_path: Path) ->
     if normalized_file_url.startswith(f"{normalized_base}/"):
         relative_path = normalized_file_url[len(normalized_base) + 1 :]
     elif normalized_file_url == normalized_base:
-        relative_path = _cloud_url_basename(file_url)
+        relative_path = _cloud_url_local_basename(file_url)
     else:
-        # Fallback to basename for unexpected path shapes.
-        relative_path = _cloud_url_basename(file_url)
+        relative_path = _protocol_less_cloud_relative_path(normalized_base, file_url)
 
-    if not relative_path:
-        raise ValueError(f"Invalid cloud object path: {file_url}")
+    relative_path = relative_path.replace("\\", "/")
+    _validate_cloud_local_path(relative_path, file_url)
 
     resolved_path, is_safe = _resolve_cloud_path(relative_path, download_path)
     if not is_safe:
         raise ValueError(f"Path traversal attempt detected in cloud object path: {file_url}")
 
     local_path = Path(resolved_path)
-    if not _is_within_directory(download_path, local_path):
+    if not _is_local_destination_within_directory(download_path, local_path):
         raise ValueError(f"Cloud object path escaped download directory: {file_url}")
 
     return local_path
+
+
+def _protocol_less_cloud_relative_path(base_url: str, file_url: str) -> str:
+    """Preserve provider-returned bucket/prefix paths when the scheme is omitted."""
+    try:
+        base = urlsplit(base_url)
+        file_path = urlsplit(file_url).path.replace("\\", "/").lstrip("/")
+    except Exception:
+        return _cloud_url_local_basename(file_url)
+
+    hostname = (base.hostname or "").casefold().rstrip(".")
+    base_path = base.path.strip("/")
+    if base.scheme.casefold() in {"http", "https"} and hostname.endswith(".s3.amazonaws.com"):
+        bucket = hostname[: -len(".s3.amazonaws.com")]
+        provider_prefix = "/".join(part for part in (bucket, base_path) if part)
+    elif base.scheme.casefold() in {"http", "https"} and (
+        hostname == "storage.googleapis.com" or hostname.endswith(".r2.cloudflarestorage.com")
+    ):
+        provider_prefix = base_path
+    else:
+        provider_prefix = "/".join(part.strip("/") for part in (base.netloc, base.path) if part.strip("/"))
+    if provider_prefix and file_path.startswith(f"{provider_prefix}/"):
+        return file_path[len(provider_prefix) + 1 :]
+    if provider_prefix and file_path == provider_prefix:
+        return _cloud_url_local_basename(file_url)
+    return _cloud_url_local_basename(file_url)
+
+
+def _is_local_destination_within_directory(base_dir: Path, target: Path) -> bool:
+    """Return True if a destination's resolved parent remains under base_dir."""
+    return _is_resolved_path_within_base(base_dir.resolve(), target.parent.resolve())
+
+
+def _validate_cloud_local_path(relative_path: str, file_url: str) -> None:
+    """Reject cloud object paths that cannot safely become local files."""
+    components = relative_path.split("/")
+    leaf = relative_path.rsplit("/", 1)[-1]
+    if (
+        not relative_path
+        or not leaf
+        or leaf in {".", ".."}
+        or "/" in leaf
+        or "\\" in leaf
+        or (
+            _uses_windows_filename_rules()
+            and any(_is_unsafe_windows_cloud_filename(component) for component in components if component)
+        )
+    ):
+        raise ValueError(f"Invalid cloud object basename: {redact_url_for_display(file_url)}")
+
+
+_WINDOWS_RESERVED_FILE_STEMS = {
+    "aux",
+    "con",
+    "nul",
+    "prn",
+    *(f"com{index}" for index in range(1, 10)),
+    *(f"lpt{index}" for index in range(1, 10)),
+    *(f"com{suffix}" for suffix in ("\u00b9", "\u00b2", "\u00b3")),
+    *(f"lpt{suffix}" for suffix in ("\u00b9", "\u00b2", "\u00b3")),
+}
+
+
+def _is_unsafe_windows_cloud_filename(leaf: str) -> bool:
+    """Return whether a cloud object leaf cannot safely name a Win32 file."""
+    if leaf != leaf.rstrip(" ."):
+        return True
+    if any(ord(char) < 32 or char in '<>:"|?*' for char in leaf):
+        return True
+    stem = leaf.split(".", 1)[0].rstrip(" ").casefold()
+    return stem in _WINDOWS_RESERVED_FILE_STEMS
+
+
+def _uses_windows_filename_rules() -> bool:
+    """Return whether local destinations must obey Win32 filename rules."""
+    return os.name == "nt"
+
+
+def _is_case_sensitive_directory(path: Path) -> bool:
+    """Probe the target filesystem's case behavior without retaining a file."""
+    probe_path: Path | None = None
+    probe_fd = -1
+    try:
+        probe_fd, probe_name = tempfile.mkstemp(prefix=".modelaudit_case_probe_Aa", dir=path)
+        probe_path = Path(probe_name)
+        os.close(probe_fd)
+        probe_fd = -1
+        alternate = probe_path.with_name(probe_path.name.swapcase())
+        if not alternate.exists():
+            return True
+        return not os.path.samefile(probe_path, alternate)
+    except OSError:
+        # Destination aliasing is security-sensitive, so uncertain filesystems
+        # are treated conservatively as case-insensitive.
+        return False
+    finally:
+        if probe_fd >= 0:
+            os.close(probe_fd)
+        if probe_path is not None:
+            probe_path.unlink(missing_ok=True)
+
+
+def _is_unicode_normalization_sensitive_directory(path: Path) -> bool:
+    """Probe whether canonically equivalent names remain distinct on the target filesystem."""
+    probe_path: Path | None = None
+    probe_fd = -1
+    try:
+        probe_fd, probe_name = tempfile.mkstemp(prefix=".modelaudit_unicode_probe_\u00e9_", dir=path)
+        probe_path = Path(probe_name)
+        os.close(probe_fd)
+        probe_fd = -1
+        alternate = probe_path.with_name(probe_path.name.replace("\u00e9", "e\u0301", 1))
+        if not alternate.exists():
+            return True
+        return not os.path.samefile(probe_path, alternate)
+    except OSError:
+        # Fail closed when the target filesystem's alias behavior cannot be probed.
+        return False
+    finally:
+        if probe_fd >= 0:
+            os.close(probe_fd)
+        if probe_path is not None:
+            probe_path.unlink(missing_ok=True)
+
+
+def _local_destination_key(
+    path: Path,
+    *,
+    case_sensitive: bool,
+    unicode_normalization_sensitive: bool,
+) -> str:
+    """Return a canonical key for local download destination comparisons."""
+    resolved = path.parent.resolve() / path.name
+    normalized = os.path.normpath(str(resolved))
+    if not unicode_normalization_sensitive:
+        normalized = unicodedata.normalize("NFC", normalized)
+    if not case_sensitive:
+        normalized = normalized.casefold()
+    return normalized
+
+
+def _build_cloud_download_plan(
+    base_url: str,
+    files: list[dict[str, Any]],
+    download_path: Path,
+) -> list[tuple[dict[str, Any], str, Path]]:
+    """Resolve all cloud objects to local paths and fail on destination aliases."""
+    planned: list[tuple[dict[str, Any], str, Path]] = []
+    destinations: dict[str, str] = {}
+    case_sensitive = _is_case_sensitive_directory(download_path)
+    unicode_normalization_sensitive = _is_unicode_normalization_sensitive_directory(download_path)
+    for file_info in files:
+        file_url = str(file_info["path"])
+        local_path = _build_safe_local_path(base_url, file_url, download_path)
+        destination_key = _local_destination_key(
+            local_path,
+            case_sensitive=case_sensitive,
+            unicode_normalization_sensitive=unicode_normalization_sensitive,
+        )
+        previous_url = destinations.get(destination_key)
+        if previous_url is not None:
+            raise ValueError(
+                "Cloud object path alias collision: "
+                f"{_redact_cloud_path_for_display(previous_url)} and "
+                f"{_redact_cloud_path_for_display(file_url)} both resolve to {local_path.name}"
+            )
+        destinations[destination_key] = file_url
+        planned.append((file_info, file_url, local_path))
+    return planned
 
 
 def _clear_directory_contents(path: Path) -> None:
@@ -2102,6 +2289,10 @@ class _CloudDownloadBudgetExceeded(ValueError):
     """Raised when a cloud transfer exceeds its bounded acquisition budget."""
 
 
+class _UnsafeCloudDownloadDestination(ValueError):
+    """Raised when a local cloud download destination is unsafe to write."""
+
+
 class _CloudDownloadBudget:
     """Track a cloud acquisition budget across objects and retry attempts."""
 
@@ -2122,26 +2313,56 @@ class _CloudDownloadBudget:
         self.remaining_bytes -= byte_count
 
 
-def _download_cloud_object(fs: Any, file_url: str, local_path: Path, budget: _CloudDownloadBudget | None) -> int:
-    """Download one cloud object while enforcing an optional transfer budget."""
-    if budget is None:
-        fs.get(file_url, str(local_path))
-        return 0
+def _ensure_cloud_download_destination_is_safe(local_path: Path, base_dir: Path) -> None:
+    """Reject escaped parents and final-component symlinks before writing an object."""
+    if not _is_local_destination_within_directory(base_dir, local_path):
+        raise _UnsafeCloudDownloadDestination(
+            f"Refusing to download cloud object through escaped parent directory: {local_path.name}"
+        )
+    if local_path.is_symlink():
+        raise _UnsafeCloudDownloadDestination(
+            f"Refusing to download cloud object through symlink destination: {local_path.name}"
+        )
 
+
+def _download_cloud_object(
+    fs: Any,
+    file_url: str,
+    local_path: Path,
+    budget: _CloudDownloadBudget | None,
+    base_dir: Path,
+) -> int:
+    """Download one cloud object while enforcing an optional transfer budget."""
+    _ensure_cloud_download_destination_is_safe(local_path, base_dir)
+    temp_fd, temp_name = tempfile.mkstemp(prefix=f".{local_path.name}.modelaudit-", dir=local_path.parent)
+    os.close(temp_fd)
+    temp_path = Path(temp_name)
+    temp_parent = temp_path.parent.resolve()
     bytes_written = 0
     try:
-        with fs.open(file_url, "rb") as remote_file, local_path.open("wb") as local_file:
-            while True:
-                chunk = remote_file.read(budget.read_size())
-                if not chunk:
-                    return bytes_written
-                if not isinstance(chunk, bytes):
-                    raise TypeError("cloud filesystem returned non-bytes content")
-                budget.consume(len(chunk))
-                bytes_written += len(chunk)
-                local_file.write(chunk)
+        if budget is None:
+            fs.get(file_url, str(temp_path))
+        else:
+            with fs.open(file_url, "rb") as remote_file, temp_path.open("wb") as local_file:
+                while True:
+                    chunk = remote_file.read(budget.read_size())
+                    if not chunk:
+                        break
+                    if not isinstance(chunk, bytes):
+                        raise TypeError("cloud filesystem returned non-bytes content")
+                    budget.consume(len(chunk))
+                    bytes_written += len(chunk)
+                    local_file.write(chunk)
+
+        _ensure_cloud_download_destination_is_safe(local_path, base_dir)
+        os.replace(temp_path, local_path)
+        return bytes_written
     except Exception:
-        local_path.unlink(missing_ok=True)
+        try:
+            if temp_path.parent.resolve() == temp_parent:
+                temp_path.unlink(missing_ok=True)
+        except OSError as cleanup_error:
+            logger.debug("Unable to remove temporary cloud download after failure: %s", cleanup_error)
         raise
 
 
@@ -2357,18 +2578,25 @@ def download_from_cloud(
 
         # Download based on type
         if metadata["type"] == "directory":
+            assert files is not None
+
             if cache:
+                with tempfile.TemporaryDirectory(
+                    prefix="modelaudit_cloud_plan_",
+                    dir=download_path.parent,
+                ) as preflight_dir:
+                    _build_cloud_download_plan(fs_url, files, Path(preflight_dir))
                 _clear_directory_contents(download_path)
 
-            assert files is not None
+            download_plan = _build_cloud_download_plan(fs_url, files, download_path)
+            for _, _, local_path in download_plan:
+                _ensure_cloud_download_destination_is_safe(local_path, download_path)
 
             # Download files
             download_budget = _CloudDownloadBudget(max_size) if max_size else None
             if download_budget is not None:
                 download_budget.consume(acquired_probe_bytes)
-            for file_info in files:
-                file_url = file_info["path"]
-                local_path = _build_safe_local_path(fs_url, file_url, download_path)
+            for file_info, file_url, local_path in download_plan:
                 local_path.parent.mkdir(parents=True, exist_ok=True)
 
                 if show_progress:
@@ -2376,30 +2604,31 @@ def download_from_cloud(
 
                 @retry_with_backoff(
                     max_retries=3,
-                    do_not_retry_on=(_CloudDownloadBudgetExceeded,),
+                    do_not_retry_on=(_CloudDownloadBudgetExceeded, _UnsafeCloudDownloadDestination),
                     verbose=show_progress,
                     sanitize_error=_cloud_error_sanitizer(file_url),
                 )
                 def download_file(url=file_url, path=local_path, budget=download_budget):
-                    return _download_cloud_object(fs, url, path, budget)
+                    return _download_cloud_object(fs, url, path, budget, download_path)
 
                 download_file()
         else:
             # Single file download
-            file_name = _cloud_url_basename(url)
-            local_file = download_path / file_name
+            local_file = _build_safe_local_path(url, url, download_path)
+            file_name = local_file.name
             download_budget = _CloudDownloadBudget(max_size) if max_size else None
             if cache:
                 _remove_path(local_file)
+            _ensure_cloud_download_destination_is_safe(local_file, download_path)
 
             @retry_with_backoff(
                 max_retries=3,
-                do_not_retry_on=(_CloudDownloadBudgetExceeded,),
+                do_not_retry_on=(_CloudDownloadBudgetExceeded, _UnsafeCloudDownloadDestination),
                 verbose=show_progress,
                 sanitize_error=_cloud_error_sanitizer(url),
             )
             def download_single_file():
-                return _download_cloud_object(fs, fs_url, local_file, download_budget)
+                return _download_cloud_object(fs, fs_url, local_file, download_budget, download_path)
 
             if show_progress and size > 100 * 1024 * 1024 * 1024:  # Show progress for files > 100GB
                 with yaspin(text=f"Downloading {file_name}") as spinner:
@@ -2532,13 +2761,13 @@ def download_from_cloud_streaming(
         download_budget = _CloudDownloadBudget(max_size) if max_size else None
         if download_budget is not None:
             download_budget.consume(acquired_probe_bytes)
-        for i, file_info in enumerate(files):
-            file_url = file_info["path"]
+        download_plan = _build_cloud_download_plan(fs_url, files, temp_dir)
+        for _, _, local_path in download_plan:
+            _ensure_cloud_download_destination_is_safe(local_path, temp_dir)
+        for i, (file_info, file_url, local_path) in enumerate(download_plan):
             file_name = file_info.get("name") or _cloud_url_basename(file_url)
             is_last = i == total_files - 1
 
-            # Build a safe local path relative to the requested cloud base path.
-            local_path = _build_safe_local_path(fs_url, file_url, temp_dir)
             local_path.parent.mkdir(parents=True, exist_ok=True)
 
             if show_progress:
@@ -2546,12 +2775,12 @@ def download_from_cloud_streaming(
 
             @retry_with_backoff(
                 max_retries=3,
-                do_not_retry_on=(_CloudDownloadBudgetExceeded,),
+                do_not_retry_on=(_CloudDownloadBudgetExceeded, _UnsafeCloudDownloadDestination),
                 verbose=show_progress,
                 sanitize_error=_cloud_error_sanitizer(file_url),
             )
             def download_file(url=file_url, path=local_path, budget=download_budget):
-                return _download_cloud_object(fs, url, path, budget)
+                return _download_cloud_object(fs, url, path, budget, temp_dir)
 
             download_file()
 

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -32,6 +32,7 @@ from modelaudit.utils.sources.cloud_storage import (
     _build_cloud_download_plan,
     _build_safe_local_path,
     _cloud_directory_cache_scope,
+    _cloud_url_local_basename,
     _download_cloud_object,
     _filter_scannable_cloud_files,
     _run_coroutine_sync,
@@ -2367,8 +2368,9 @@ def test_build_safe_local_path_preserves_signed_directory_relative_paths(tmp_pat
 def test_build_safe_local_path_preserves_literal_object_delimiters(tmp_path: Path) -> None:
     base_url = "s3://bucket/models"
 
-    question_path = _build_safe_local_path(base_url, f"{base_url}/model?one.pkl", tmp_path)
-    fragment_path = _build_safe_local_path(base_url, f"{base_url}/model#two.pkl", tmp_path)
+    with patch("modelaudit.utils.sources.cloud_storage._uses_windows_filename_rules", return_value=False):
+        question_path = _build_safe_local_path(base_url, f"{base_url}/model?one.pkl", tmp_path)
+        fragment_path = _build_safe_local_path(base_url, f"{base_url}/model#two.pkl", tmp_path)
 
     assert question_path == tmp_path / "model?one.pkl"
     assert fragment_path == tmp_path / "model#two.pkl"
@@ -2377,12 +2379,58 @@ def test_build_safe_local_path_preserves_literal_object_delimiters(tmp_path: Pat
 
 def test_build_safe_local_path_preserves_sensitive_looking_native_key_text(tmp_path: Path) -> None:
     base_url = "s3://bucket/models"
-    first = _build_safe_local_path(base_url, f"{base_url}/model.pkl?X-Amz-Signature=one", tmp_path)
-    second = _build_safe_local_path(base_url, f"{base_url}/model.pkl?X-Amz-Signature=two", tmp_path)
+    with patch("modelaudit.utils.sources.cloud_storage._uses_windows_filename_rules", return_value=False):
+        first = _build_safe_local_path(base_url, f"{base_url}/model.pkl?X-Amz-Signature=one", tmp_path)
+        second = _build_safe_local_path(base_url, f"{base_url}/model.pkl?X-Amz-Signature=two", tmp_path)
 
     assert first == tmp_path / "model.pkl?X-Amz-Signature=one"
     assert second == tmp_path / "model.pkl?X-Amz-Signature=two"
     assert first != second
+
+
+@pytest.mark.parametrize(
+    ("file_url", "expected_name"),
+    [
+        pytest.param("bucket/models/model?variant.pkl", "model?variant.pkl", id="question-mark"),
+        pytest.param("bucket/models/model#variant.pkl", "model#variant.pkl", id="fragment-marker"),
+    ],
+)
+def test_build_safe_local_path_preserves_protocol_less_literal_delimiters(
+    tmp_path: Path,
+    file_url: str,
+    expected_name: str,
+) -> None:
+    with patch("modelaudit.utils.sources.cloud_storage._uses_windows_filename_rules", return_value=False):
+        local_path = _build_safe_local_path("s3://bucket/models", file_url, tmp_path)
+
+    assert local_path == tmp_path / expected_name
+
+
+@pytest.mark.parametrize(
+    "file_url",
+    [
+        "https://bucket.s3.amazonaws.com/models/model.pkl?X-Amz-Signature=secret",
+        "https://bucket.s3.amazonaws.com/models/model.pkl#fragment-secret",
+    ],
+)
+def test_build_safe_local_path_strips_https_query_and_fragment_syntax(tmp_path: Path, file_url: str) -> None:
+    local_path = _build_safe_local_path("https://bucket.s3.amazonaws.com/models", file_url, tmp_path)
+
+    assert local_path == tmp_path / "model.pkl"
+    assert "secret" not in str(local_path)
+
+
+@patch("modelaudit.utils.sources.cloud_storage.urlsplit", side_effect=ValueError("malformed secret URL"))
+def test_cloud_url_local_basename_logs_parse_fallback_without_url(
+    _mock_urlsplit: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.DEBUG, logger="modelaudit.utils.sources.cloud_storage"):
+        basename = _cloud_url_local_basename("model.pkl?token=secret")
+
+    assert basename == "model.pkl?token=secret"
+    assert "Unable to parse cloud URL for local basename; using fallback path handling" in caplog.text
+    assert "token=secret" not in caplog.text
 
 
 @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
@@ -3197,6 +3245,17 @@ class TestCloudPathSecurity:
             Path("a/model.pkl"),
             Path("b/model.pkl"),
         ]
+
+    def test_download_plan_preserves_distinct_protocol_less_literal_delimiters(self, tmp_path: Path) -> None:
+        files = [
+            {"path": "bucket/models/model?one.pkl"},
+            {"path": "bucket/models/model#two.pkl"},
+        ]
+
+        with patch("modelaudit.utils.sources.cloud_storage._uses_windows_filename_rules", return_value=False):
+            plan = _build_cloud_download_plan("s3://bucket/models", files, tmp_path)
+
+        assert [local_path.name for _, _, local_path in plan] == ["model?one.pkl", "model#two.pkl"]
 
     @pytest.mark.parametrize(
         "base_url",

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -29,7 +29,10 @@ from modelaudit.utils.helpers.retry import RetryError
 from modelaudit.utils.sources.cloud_storage import (
     _CLOUD_CONTENT_SNIFF_BYTES,
     GCSCache,
+    _build_cloud_download_plan,
     _build_safe_local_path,
+    _cloud_directory_cache_scope,
+    _download_cloud_object,
     _filter_scannable_cloud_files,
     _run_coroutine_sync,
     analyze_cloud_target,
@@ -2017,7 +2020,12 @@ def test_download_from_cloud_uses_normalized_https_object_path(mock_fs: MagicMoc
 
     assert result == tmp_path / "model.pkl"
     metadata_fs.info.assert_called_once_with("s3://bucket/models/model.pkl")
-    download_fs.get.assert_called_once_with("s3://bucket/models/model.pkl", str(result))
+    download_fs.get.assert_called_once()
+    source, destination = download_fs.get.call_args.args
+    assert source == "s3://bucket/models/model.pkl"
+    assert Path(destination).parent == tmp_path
+    assert Path(destination).name.startswith(".model.pkl.modelaudit-")
+    assert result.read_bytes() == b"data"
 
 
 @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
@@ -2059,7 +2067,12 @@ def test_download_from_cloud_preserves_normalized_directory_hierarchy(
     )
 
     assert result == tmp_path
-    fs.get.assert_called_once_with(model_url, str(tmp_path / "nested" / "model.pkl"))
+    fs.get.assert_called_once()
+    source, destination = fs.get.call_args.args
+    assert source == model_url
+    assert Path(destination).parent == tmp_path / "nested"
+    assert Path(destination).name.startswith(".model.pkl.modelaudit-")
+    assert (tmp_path / "nested" / "model.pkl").read_bytes() == b"data"
 
 
 @patch("fsspec.filesystem")
@@ -2328,7 +2341,12 @@ def test_download_from_cloud_preserves_native_query_text_in_local_path(
 
     assert isinstance(result, Path)
     assert result.name == "model?variant.bin"
-    fs.get.assert_called_once_with(url, str(result))
+    fs.get.assert_called_once()
+    source, destination = fs.get.call_args.args
+    assert source == url
+    assert Path(destination).parent == tmp_path
+    assert Path(destination).name.startswith(".model?variant.bin.modelaudit-")
+    assert result.read_bytes() == b"data"
 
 
 def test_build_safe_local_path_preserves_signed_directory_relative_paths(tmp_path: Path) -> None:
@@ -2484,7 +2502,10 @@ async def test_download_from_cloud_async_context(tmp_path: Path) -> None:
     fs.get.assert_called_once()
     get_args = fs.get.call_args.args
     assert get_args[0] == "s3://bucket/model.pt"
-    assert Path(get_args[1]) == result
+    temporary_path = Path(get_args[1])
+    assert temporary_path.parent == result.parent
+    assert temporary_path.name.startswith(".model.pt.modelaudit-")
+    assert not temporary_path.exists()
     assert result.exists()
     assert result.read_bytes() == downloaded_content
 
@@ -3072,6 +3093,370 @@ class TestDiskSpaceCheckingForCloud:
 class TestCloudPathSecurity:
     """Test path-safety behavior for cloud downloads."""
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            pytest.param("s3://bucket/", id="empty"),
+            pytest.param("s3://bucket/.", id="dot"),
+            pytest.param("s3://bucket/..", id="dotdot"),
+        ],
+    )
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_download_rejects_unsafe_single_file_basename_before_get(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+        tmp_path: Path,
+        url: str,
+    ) -> None:
+        fs = make_fs_mock()
+        fs.info.return_value = {"type": "file", "size": 4}
+        mock_fs_class.return_value = fs
+        mock_analyze.return_value = {
+            "type": "file",
+            "size": 4,
+            "name": "model.pkl",
+            "human_size": "4 B",
+            "estimated_time": "instant",
+        }
+
+        with pytest.raises(ValueError, match="Invalid cloud object basename"):
+            download_from_cloud(url, cache_dir=tmp_path, use_cache=False, show_progress=False)
+
+        fs.get.assert_not_called()
+
+    @pytest.mark.parametrize("max_size", [None, 4])
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_download_rejects_symlink_destination_before_write(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+        tmp_path: Path,
+        max_size: int | None,
+    ) -> None:
+        url = "s3://bucket/model.pkl"
+        download_dir = tmp_path / "download"
+        download_dir.mkdir()
+        outside_file = tmp_path / "outside.pkl"
+        outside_file.write_bytes(b"keep")
+        (download_dir / "model.pkl").symlink_to(outside_file)
+
+        fs = make_fs_mock()
+        fs.info.return_value = {"type": "file", "size": 4}
+        fs.open.return_value = BytesIO(b"evil")
+        fs.get.side_effect = lambda _src, dst: Path(dst).write_bytes(b"evil")
+        mock_fs_class.return_value = fs
+        mock_analyze.return_value = {
+            "type": "file",
+            "size": 4,
+            "name": "model.pkl",
+            "human_size": "4 B",
+            "estimated_time": "instant",
+        }
+
+        with pytest.raises(ValueError, match="symlink destination"):
+            download_from_cloud(
+                url,
+                cache_dir=download_dir,
+                max_size=max_size,
+                use_cache=False,
+                show_progress=False,
+            )
+
+        assert outside_file.read_bytes() == b"keep"
+        fs.get.assert_not_called()
+        fs.open.assert_not_called()
+
+    @pytest.mark.skipif(os.name == "nt", reason="Colon-bearing object keys are not valid Win32 filenames")
+    def test_download_plan_preserves_colons_in_posix_object_keys(self, tmp_path: Path) -> None:
+        base_url = "s3://bucket/models"
+        files = [
+            {"path": f"{base_url}/a:model.pkl"},
+            {"path": f"{base_url}/b:model.pkl"},
+        ]
+
+        plan = _build_cloud_download_plan(base_url, files, tmp_path)
+
+        assert [local_path.relative_to(tmp_path) for _, _, local_path in plan] == [
+            Path("a:model.pkl"),
+            Path("b:model.pkl"),
+        ]
+
+    def test_download_plan_preserves_protocol_less_nested_object_paths(self, tmp_path: Path) -> None:
+        base_url = "s3://bucket/models"
+        files = [
+            {"path": "bucket/models/a/model.pkl"},
+            {"path": "bucket/models/b/model.pkl"},
+        ]
+
+        plan = _build_cloud_download_plan(base_url, files, tmp_path)
+
+        assert [local_path.relative_to(tmp_path) for _, _, local_path in plan] == [
+            Path("a/model.pkl"),
+            Path("b/model.pkl"),
+        ]
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://bucket.s3.amazonaws.com/models",
+            "https://storage.googleapis.com/bucket/models",
+            "https://account.r2.cloudflarestorage.com/bucket/models",
+        ],
+    )
+    def test_download_plan_preserves_https_provider_nested_object_paths(
+        self,
+        tmp_path: Path,
+        base_url: str,
+    ) -> None:
+        files = [
+            {"path": "bucket/models/a/model.pkl"},
+            {"path": "bucket/models/b/model.pkl"},
+        ]
+
+        plan = _build_cloud_download_plan(base_url, files, tmp_path)
+
+        assert [local_path.relative_to(tmp_path) for _, _, local_path in plan] == [
+            Path("a/model.pkl"),
+            Path("b/model.pkl"),
+        ]
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://bucket.s3.amazonaws.com/models",
+            "https://storage.googleapis.com/bucket/models",
+            "https://account.r2.cloudflarestorage.com/bucket/models",
+        ],
+    )
+    def test_download_plan_rejects_https_provider_path_traversal(
+        self,
+        tmp_path: Path,
+        base_url: str,
+    ) -> None:
+        with pytest.raises(ValueError, match="Path traversal attempt detected"):
+            _build_cloud_download_plan(
+                base_url,
+                [{"path": "bucket/models/../secrets/model.pkl"}],
+                tmp_path,
+            )
+
+    def test_download_plan_rejects_protocol_less_path_traversal(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="Path traversal attempt detected"):
+            _build_cloud_download_plan(
+                "s3://bucket/models",
+                [{"path": "bucket/models/../secrets/model.pkl"}],
+                tmp_path,
+            )
+
+    def test_download_plan_rejects_case_only_alias_on_case_insensitive_filesystem(self, tmp_path: Path) -> None:
+        base_url = "s3://bucket/models"
+        files = [
+            {"path": f"{base_url}/Model.pkl"},
+            {"path": f"{base_url}/model.pkl"},
+        ]
+
+        with (
+            patch("modelaudit.utils.sources.cloud_storage._is_case_sensitive_directory", return_value=False),
+            patch(
+                "modelaudit.utils.sources.cloud_storage._is_unicode_normalization_sensitive_directory",
+                return_value=True,
+            ),
+            pytest.raises(ValueError, match="alias collision"),
+        ):
+            _build_cloud_download_plan(base_url, files, tmp_path)
+
+    def test_download_plan_preserves_case_only_names_on_case_sensitive_filesystem(self, tmp_path: Path) -> None:
+        base_url = "s3://bucket/models"
+        files = [
+            {"path": f"{base_url}/Model.pkl"},
+            {"path": f"{base_url}/model.pkl"},
+        ]
+
+        with (
+            patch("modelaudit.utils.sources.cloud_storage._is_case_sensitive_directory", return_value=True),
+            patch(
+                "modelaudit.utils.sources.cloud_storage._is_unicode_normalization_sensitive_directory",
+                return_value=True,
+            ),
+        ):
+            plan = _build_cloud_download_plan(base_url, files, tmp_path)
+
+        assert [local_path.name for _, _, local_path in plan] == ["Model.pkl", "model.pkl"]
+
+    def test_download_plan_rejects_unicode_alias_on_normalization_insensitive_filesystem(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        base_url = "s3://bucket/models"
+        files = [
+            {"path": f"{base_url}/caf\u00e9.pkl"},
+            {"path": f"{base_url}/cafe\u0301.pkl"},
+        ]
+
+        with (
+            patch("modelaudit.utils.sources.cloud_storage._is_case_sensitive_directory", return_value=True),
+            patch(
+                "modelaudit.utils.sources.cloud_storage._is_unicode_normalization_sensitive_directory",
+                return_value=False,
+            ),
+            pytest.raises(ValueError, match="alias collision"),
+        ):
+            _build_cloud_download_plan(base_url, files, tmp_path)
+
+    def test_download_plan_preserves_unicode_variants_on_normalization_sensitive_filesystem(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        base_url = "s3://bucket/models"
+        files = [
+            {"path": f"{base_url}/caf\u00e9.pkl"},
+            {"path": f"{base_url}/cafe\u0301.pkl"},
+        ]
+
+        with (
+            patch("modelaudit.utils.sources.cloud_storage._is_case_sensitive_directory", return_value=True),
+            patch(
+                "modelaudit.utils.sources.cloud_storage._is_unicode_normalization_sensitive_directory",
+                return_value=True,
+            ),
+        ):
+            plan = _build_cloud_download_plan(base_url, files, tmp_path)
+
+        assert [local_path.name for _, _, local_path in plan] == ["caf\u00e9.pkl", "cafe\u0301.pkl"]
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            pytest.param("model.pkl:stream", id="alternate-data-stream"),
+            pytest.param("CON", id="reserved-device"),
+            pytest.param("NUL.txt", id="reserved-device-extension"),
+            pytest.param("model.pkl.", id="trailing-dot"),
+            pytest.param("model.pkl ", id="trailing-space"),
+            pytest.param("CON/model.pkl", id="reserved-parent-device"),
+            pytest.param("folder:stream/model.pkl", id="parent-alternate-data-stream"),
+            pytest.param("folder./model.pkl", id="parent-trailing-dot"),
+            pytest.param("folder /model.pkl", id="parent-trailing-space"),
+            pytest.param("COM\u00b9/model.pkl", id="superscript-reserved-parent-device"),
+            pytest.param("LPT\u00b2.txt", id="superscript-reserved-device-extension"),
+        ],
+    )
+    def test_build_safe_local_path_rejects_unsafe_windows_filenames(
+        self,
+        tmp_path: Path,
+        relative_path: str,
+    ) -> None:
+        base_url = "s3://bucket/models"
+
+        with (
+            patch("modelaudit.utils.sources.cloud_storage._uses_windows_filename_rules", return_value=True),
+            pytest.raises(ValueError, match="Invalid cloud object basename"),
+        ):
+            _build_safe_local_path(base_url, f"{base_url}/{relative_path}", tmp_path)
+
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_download_rejects_symlink_destination_swap_before_commit(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        url = "s3://bucket/model.pkl"
+        download_dir = tmp_path / "download"
+        download_dir.mkdir()
+        local_path = download_dir / "model.pkl"
+        outside_file = tmp_path / "outside.pkl"
+        outside_file.write_bytes(b"keep")
+
+        fs = make_fs_mock()
+        fs.info.return_value = {"type": "file", "size": 4}
+
+        def swap_destination(_src: str, destination: str) -> None:
+            Path(destination).write_bytes(b"evil")
+            local_path.symlink_to(outside_file)
+
+        fs.get.side_effect = swap_destination
+        mock_fs_class.return_value = fs
+        mock_analyze.return_value = {
+            "type": "file",
+            "size": 4,
+            "name": "model.pkl",
+            "human_size": "4 B",
+            "estimated_time": "instant",
+        }
+
+        with pytest.raises(ValueError, match="symlink destination"):
+            download_from_cloud(
+                url,
+                cache_dir=download_dir,
+                use_cache=False,
+                show_progress=False,
+            )
+
+        assert outside_file.read_bytes() == b"keep"
+        assert local_path.is_symlink()
+        assert not list(download_dir.glob(".model.pkl.modelaudit-*"))
+
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_download_rejects_nested_parent_symlink_swap_before_commit(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        url = "s3://bucket/models"
+        download_dir = tmp_path / "download"
+        download_dir.mkdir()
+        outside_dir = tmp_path / "outside"
+        outside_dir.mkdir()
+        outside_marker = outside_dir / "keep.txt"
+        outside_marker.write_text("keep", encoding="utf-8")
+        captured_dir = download_dir / "captured-subdir"
+
+        fs = make_fs_mock()
+        fs.info.return_value = {"type": "file", "size": 4}
+
+        def swap_parent(_src: str, destination: str) -> None:
+            temp_path = Path(destination)
+            temp_path.write_bytes(b"evil")
+            temp_path.parent.rename(captured_dir)
+            temp_path.parent.symlink_to(outside_dir, target_is_directory=True)
+
+        fs.get.side_effect = swap_parent
+        mock_fs_class.return_value = fs
+        mock_analyze.return_value = {
+            "type": "directory",
+            "file_count": 1,
+            "total_size": 4,
+            "human_size": "4 B",
+            "estimated_time": "instant",
+            "files": [
+                {
+                    "path": f"{url}/subdir/model.pkl",
+                    "name": "model.pkl",
+                    "size": 4,
+                    "human_size": "4 B",
+                }
+            ],
+        }
+
+        with pytest.raises(ValueError, match="escaped parent directory"):
+            download_from_cloud(
+                url,
+                cache_dir=download_dir,
+                use_cache=False,
+                selective=False,
+                show_progress=False,
+            )
+
+        assert outside_marker.read_text(encoding="utf-8") == "keep"
+        assert not (outside_dir / "model.pkl").exists()
+        assert (download_dir / "subdir").is_symlink()
+
     @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
     @patch("fsspec.filesystem")
     def test_download_rejects_path_traversal(
@@ -3110,6 +3495,290 @@ class TestCloudPathSecurity:
             )
 
         fs.get.assert_not_called()
+
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_download_rejects_directory_destination_alias_before_get(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        fs = make_fs_mock()
+        fs.info.return_value = {"type": "file", "size": 8}
+        mock_fs_class.return_value = fs
+        mock_analyze.return_value = {
+            "type": "directory",
+            "file_count": 2,
+            "total_size": 8,
+            "human_size": "8 B",
+            "estimated_time": "instant",
+            "files": [
+                {"path": "s3://bucket/models/model.pkl", "name": "model.pkl", "size": 4, "human_size": "4 B"},
+                {
+                    "path": "s3://bucket/models/subdir/../model.pkl",
+                    "name": "model.pkl",
+                    "size": 4,
+                    "human_size": "4 B",
+                },
+            ],
+        }
+
+        with pytest.raises(ValueError, match="alias collision"):
+            download_from_cloud(
+                "s3://bucket/models",
+                cache_dir=tmp_path,
+                use_cache=False,
+                selective=False,
+                show_progress=False,
+            )
+
+        fs.get.assert_not_called()
+
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_download_rejects_destination_alias_before_clearing_stale_cache(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        url = "s3://bucket/models"
+        cache_dir = tmp_path / "cache"
+        metadata = {
+            "type": "directory",
+            "etag": "etag-v2",
+            "file_count": 2,
+            "total_size": 8,
+            "human_size": "8 B",
+            "estimated_time": "instant",
+            "files": [
+                {"path": f"{url}/model.pkl", "name": "model.pkl", "size": 4, "human_size": "4 B"},
+                {
+                    "path": f"{url}/subdir/../model.pkl",
+                    "name": "model.pkl",
+                    "size": 4,
+                    "human_size": "4 B",
+                },
+            ],
+        }
+        cache_scope = _cloud_directory_cache_scope(
+            metadata,
+            selective=False,
+            scannable_extensions=None,
+            scannable_filenames=None,
+            scanner_selection=None,
+        )
+        cache = GCSCache(cache_dir=cache_dir)
+        cache_key = cache.get_cache_key(url, cache_scope=cache_scope)
+        cached_path = cache.cache_dir / cache_key[:2] / cache_key[2:4]
+        cached_path.mkdir(parents=True)
+        (cached_path / "old-model.pkl").write_bytes(b"old")
+        cache.cache_file(url, cached_path, etag="etag-v1", cache_scope=cache_scope)
+
+        fs = make_fs_mock()
+        fs.info.return_value = {"type": "file", "size": 8}
+        mock_fs_class.return_value = fs
+        mock_analyze.return_value = metadata
+
+        with pytest.raises(ValueError, match="alias collision"):
+            download_from_cloud(
+                url,
+                cache_dir=cache_dir,
+                selective=False,
+                show_progress=False,
+            )
+
+        assert (cached_path / "old-model.pkl").read_bytes() == b"old"
+        assert (
+            GCSCache(cache_dir=cache_dir).get_cached_path(url, etag="etag-v1", cache_scope=cache_scope) == cached_path
+        )
+        fs.get.assert_not_called()
+
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_download_refresh_replaces_nested_cached_symlink_without_touching_target(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        url = "s3://bucket/models"
+        cache_dir = tmp_path / "cache"
+        metadata = {
+            "type": "directory",
+            "etag": "etag-v2",
+            "file_count": 1,
+            "total_size": 4,
+            "human_size": "4 B",
+            "estimated_time": "instant",
+            "files": [
+                {
+                    "path": f"{url}/subdir/model.pkl",
+                    "name": "model.pkl",
+                    "size": 4,
+                    "human_size": "4 B",
+                }
+            ],
+        }
+        cache_scope = _cloud_directory_cache_scope(
+            metadata,
+            selective=False,
+            scannable_extensions=None,
+            scannable_filenames=None,
+            scanner_selection=None,
+        )
+        cache = GCSCache(cache_dir=cache_dir)
+        cache_key = cache.get_cache_key(url, cache_scope=cache_scope)
+        cached_path = cache.cache_dir / cache_key[:2] / cache_key[2:4]
+        cached_path.mkdir(parents=True)
+        cache.cache_file(url, cached_path, etag="etag-v1", cache_scope=cache_scope)
+
+        outside_dir = tmp_path / "outside"
+        outside_dir.mkdir()
+        outside_marker = outside_dir / "keep.txt"
+        outside_marker.write_text("keep", encoding="utf-8")
+        (cached_path / "subdir").symlink_to(outside_dir, target_is_directory=True)
+
+        fs = make_fs_mock()
+        fs.info.return_value = {"type": "file", "size": 4}
+        fs.get.side_effect = lambda _src, dst: Path(dst).write_bytes(b"new")
+        mock_fs_class.return_value = fs
+        mock_analyze.return_value = metadata
+
+        result = download_from_cloud(
+            url,
+            cache_dir=cache_dir,
+            selective=False,
+            show_progress=False,
+        )
+
+        assert result == cached_path
+        assert not (result / "subdir").is_symlink()
+        assert (result / "subdir" / "model.pkl").read_bytes() == b"new"
+        assert outside_marker.read_text(encoding="utf-8") == "keep"
+
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_streaming_rejects_directory_destination_alias_before_get(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+    ) -> None:
+        fs = make_fs_mock()
+        mock_fs_class.return_value = fs
+        mock_analyze.return_value = {
+            "type": "directory",
+            "file_count": 2,
+            "total_size": 8,
+            "human_size": "8 B",
+            "estimated_time": "instant",
+            "files": [
+                {"path": "s3://bucket/models/model.pkl", "name": "model.pkl", "size": 4, "human_size": "4 B"},
+                {
+                    "path": "s3://bucket/models/subdir/../model.pkl",
+                    "name": "model.pkl",
+                    "size": 4,
+                    "human_size": "4 B",
+                },
+            ],
+        }
+
+        with pytest.raises(ValueError, match="alias collision"):
+            list(download_from_cloud_streaming("s3://bucket/models", selective=False, show_progress=False))
+
+        fs.get.assert_not_called()
+
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_download_preserves_benign_nested_directory_files(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        fs = make_fs_mock()
+        fs.info.return_value = {"type": "file", "size": 8}
+        fs.get.side_effect = lambda _src, dst: Path(dst).write_bytes(b"data")
+        mock_fs_class.return_value = fs
+        mock_analyze.return_value = {
+            "type": "directory",
+            "file_count": 2,
+            "total_size": 8,
+            "human_size": "8 B",
+            "estimated_time": "instant",
+            "files": [
+                {"path": "s3://bucket/models/subdir/model.pkl", "name": "model.pkl", "size": 4, "human_size": "4 B"},
+                {
+                    "path": "s3://bucket/models/subdir/weights.safetensors",
+                    "name": "weights.safetensors",
+                    "size": 4,
+                    "human_size": "4 B",
+                },
+            ],
+        }
+
+        result = download_from_cloud(
+            "s3://bucket/models",
+            cache_dir=tmp_path,
+            use_cache=False,
+            selective=False,
+            show_progress=False,
+        )
+
+        assert result == tmp_path
+        assert (tmp_path / "subdir" / "model.pkl").read_bytes() == b"data"
+        assert (tmp_path / "subdir" / "weights.safetensors").read_bytes() == b"data"
+        download_destinations = [Path(call.args[1]).relative_to(tmp_path) for call in fs.get.call_args_list]
+        assert [path.parent for path in download_destinations] == [Path("subdir"), Path("subdir")]
+        assert [path.name.split(".modelaudit-", 1)[0] for path in download_destinations] == [
+            ".model.pkl",
+            ".weights.safetensors",
+        ]
+
+    @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+    @patch("fsspec.filesystem")
+    def test_streaming_preserves_benign_nested_directory_files(
+        self,
+        mock_fs_class: MagicMock,
+        mock_analyze: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        fs = make_fs_mock()
+        fs.get.side_effect = lambda _src, dst: Path(dst).write_bytes(b"data")
+        mock_fs_class.return_value = fs
+        mock_analyze.return_value = {
+            "type": "directory",
+            "file_count": 2,
+            "total_size": 8,
+            "human_size": "8 B",
+            "estimated_time": "instant",
+            "files": [
+                {"path": "s3://bucket/models/subdir/model.pkl", "name": "model.pkl", "size": 4, "human_size": "4 B"},
+                {
+                    "path": "s3://bucket/models/subdir/weights.safetensors",
+                    "name": "weights.safetensors",
+                    "size": 4,
+                    "human_size": "4 B",
+                },
+            ],
+        }
+        temp_dir = tmp_path / "streaming-tempdir"
+
+        with patch("modelaudit.utils.sources.cloud_storage.tempfile.mkdtemp", return_value=str(temp_dir)):
+            streamed = list(download_from_cloud_streaming("s3://bucket/models", selective=False, show_progress=False))
+
+        assert [(path.relative_to(temp_dir), is_last) for path, is_last in streamed] == [
+            (Path("subdir/model.pkl"), False),
+            (Path("subdir/weights.safetensors"), True),
+        ]
+        download_destinations = [Path(call.args[1]).relative_to(temp_dir) for call in fs.get.call_args_list]
+        assert [path.parent for path in download_destinations] == [Path("subdir"), Path("subdir")]
+        assert [path.name.split(".modelaudit-", 1)[0] for path in download_destinations] == [
+            ".model.pkl",
+            ".weights.safetensors",
+        ]
+        assert not temp_dir.exists()
 
     @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
     @patch("fsspec.filesystem")
@@ -3168,7 +3837,13 @@ class TestCloudPathSecurity:
         )
 
         assert result == tmp_path / "model.bin"
-        fs.get.assert_called_once_with("s3://bucket/model.bin", str(result))
+        fs.get.assert_called_once()
+        source, destination = fs.get.call_args.args
+        assert source == "s3://bucket/model.bin"
+        temporary_path = Path(destination)
+        assert temporary_path.parent == result.parent
+        assert temporary_path.name.startswith(".model.bin.modelaudit-")
+        assert not temporary_path.exists()
         fs.open.assert_not_called()
 
     @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
@@ -3753,6 +4428,24 @@ class TestCloudDownloadCleanup:
             download_from_cloud("s3://bucket/model.bin", use_cache=False, show_progress=False)
 
         assert not temp_download_dir.exists()
+
+
+def test_download_object_logs_cleanup_failure_without_masking_download_error(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    fs = MagicMock()
+    fs.get.side_effect = RuntimeError("download failed")
+    local_path = tmp_path / "model.pkl"
+
+    with (
+        patch.object(Path, "unlink", side_effect=OSError("cleanup failed")),
+        caplog.at_level(logging.DEBUG, logger="modelaudit.utils.sources.cloud_storage"),
+        pytest.raises(RuntimeError, match="download failed"),
+    ):
+        _download_cloud_object(fs, "s3://bucket/model.pkl", local_path, None, tmp_path)
+
+    assert "Unable to remove temporary cloud download after failure: cleanup failed" in caplog.text
 
 
 def test_filter_scannable_files_recognizes_pdiparams() -> None:


### PR DESCRIPTION
## Summary
- contain single-object and directory cloud downloads within their local destination
- preflight exact and file/directory-prefix aliases before downloads or destructive cache refreshes
- preserve valid provider paths and literal POSIX object-key text while rejecting traversal, symlink swaps, and unsafe Win32 names
- isolate cache entries by their full SHA-256 identity in a versioned namespace
- write cache metadata through securely randomized temporary files

## Critical review fixes
- normalize all supported HTTPS S3, GCS, and R2 URL forms to canonical provider bucket/prefix paths
- preserve protocol-less scheme-like keys, literal query/fragment text, and POSIX backslashes without weakening Windows traversal checks
- replace broad Unicode case folding with filesystem-appropriate lowercase alias detection to avoid the `straße` / `strasse` false positive
- reject ancestor/descendant download destinations in path-depth time rather than quadratic pairwise comparisons
- prevent chosen 16-bit cache-key collisions from overwriting or cross-serving model bytes
- keep new full-key cache entries outside legacy shallow directory contents so legacy cleanup cannot delete unrelated entries
- avoid following a preplanted fixed metadata temp-file symlink

## Validation
- complete associated module: `355 passed`
- Ruff lint: clean
- Ruff format check: clean
- changed-file mypy: clean
- `git diff --check`: clean
- unresolved inline review threads: `0`

## Published state
- current main: `bc9419e4d53cabc45d3e189d4eed910482a35c3f`
- head: `c3644a7372cec3de35cc292868961512f6c732cc`
- exact verified tree: `215c4510c26e04dc4894ab49f615c0d420dafb42`

Fresh CI may run on this head; continuing the randomized review queue without waiting for it.