### PR TITLE
fix: preserve default scanner read caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- preserve scanner read caps when core max_file_size is unlimited
 - route security-relevant protocol-less binary pickle streams through pickle analysis even when file suffixes are misleading
 - redact proxy and camel-case authorization evidence with scheme-bearing values without hiding benign counters
 - bound Keras ZIP config traversal for CVE detectors and fail closed when config.json coverage budgets are exhausted

--- a/modelaudit/scanners/base.py
+++ b/modelaudit/scanners/base.py
@@ -206,8 +206,6 @@ class BaseScanner(ABC):
             value = self.config["max_file_size"]
             if isinstance(value, bool) or not isinstance(value, int) or value < 0:
                 return self.default_max_file_read_size
-            if value == 0:
-                return 0
 
         return self.default_max_file_read_size
 

--- a/modelaudit/scanners/pmml_scanner.py
+++ b/modelaudit/scanners/pmml_scanner.py
@@ -86,8 +86,14 @@ class PmmlScanner(BaseScanner):
 
     def __init__(self, config: dict[str, Any] | None = None) -> None:
         pmml_config = dict(config or {})
-        if "max_file_read_size" not in pmml_config and "max_file_size" in pmml_config:
-            pmml_config["max_file_read_size"] = pmml_config["max_file_size"]
+        max_file_size = pmml_config.get("max_file_size")
+        if (
+            "max_file_read_size" not in pmml_config
+            and isinstance(max_file_size, int)
+            and not isinstance(max_file_size, bool)
+            and max_file_size > 0
+        ):
+            pmml_config["max_file_read_size"] = min(max_file_size, self.default_max_file_read_size)
         super().__init__(config=pmml_config)
 
     @classmethod

--- a/tests/scanners/test_base_scanner.py
+++ b/tests/scanners/test_base_scanner.py
@@ -415,11 +415,27 @@ def test_base_scanner_explicit_zero_read_limit_keeps_opt_out(tmp_path: Path) -> 
     assert result is None
 
 
-def test_base_scanner_inherits_core_max_file_size_unlimited() -> None:
-    """Core-level unlimited max_file_size should keep scanner read caps unlimited."""
+def test_base_scanner_core_max_file_size_unlimited_keeps_default_read_cap() -> None:
+    """Core-level unlimited max_file_size should not disable scanner read caps."""
     scanner = TinyReadLimitScanner(config={"max_file_size": 0})
 
-    assert scanner.max_file_read_size == 0
+    assert scanner.max_file_read_size == TinyReadLimitScanner.default_max_file_read_size
+
+
+def test_base_scanner_core_max_file_size_unlimited_still_fails_closed(tmp_path: Path) -> None:
+    """Default read caps should still apply when the core file-size limit is unlimited."""
+    scanner = TinyReadLimitScanner(config={"max_file_size": 0})
+    file_path = tmp_path / "large.test"
+    file_path.write_bytes(b"this is too long")
+
+    result = scanner._check_size_limit(str(file_path))
+
+    assert isinstance(result, ScanResult)
+    checks = {check.name: check for check in result.checks}
+    assert checks["File Size Limit"].status == CheckStatus.FAILED
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "max_file_read_size_exceeded" in result.metadata["scan_outcome_reasons"]
 
 
 def test_base_scanner_explicit_read_limit_overrides_core_file_size() -> None:

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -398,6 +398,24 @@ def test_flax_msgpack_respects_file_size_limit(tmp_path: Path) -> None:
     assert len(size_checks) == 1
 
 
+def test_flax_msgpack_max_file_size_zero_preserves_default_read_cap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Core unlimited max_file_size should not disable Flax full-read protection."""
+    monkeypatch.setattr(FlaxMsgpackScanner, "default_max_file_read_size", 10)
+    path = tmp_path / "too_large_default.msgpack"
+    create_msgpack_file(path, {"params": {"w": list(range(64))}})
+
+    result = FlaxMsgpackScanner(config={"max_file_size": 0}).scan(str(path))
+
+    assert result.success is False
+    checks = {check.name: check for check in result.checks}
+    assert checks["File Size Limit"].status == CheckStatus.FAILED
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "max_file_read_size_exceeded" in result.metadata["scan_outcome_reasons"]
+
+
 def test_flax_msgpack_scans_trailing_msgpack_objects(tmp_path: Path) -> None:
     """A malicious second msgpack object after a benign first object must still be scanned."""
     path = tmp_path / "trailing_malicious.msgpack"

--- a/tests/scanners/test_pmml_scanner.py
+++ b/tests/scanners/test_pmml_scanner.py
@@ -2,10 +2,12 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
 from modelaudit.cache import get_cache_manager, reset_cache_manager
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.scanner_results import INCONCLUSIVE_SCAN_OUTCOME
-from modelaudit.scanners.base import IssueSeverity
+from modelaudit.scanners.base import CheckStatus, IssueSeverity
 from modelaudit.scanners.pmml_scanner import PmmlScanner
 
 
@@ -730,6 +732,42 @@ def test_pmml_scanner_enforces_size_limit(tmp_path: Path) -> None:
 
     assert result.success is False
     assert any("file too large" in issue.message.lower() for issue in result.issues)
+
+
+def test_pmml_scanner_max_file_size_zero_preserves_default_read_cap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(PmmlScanner, "default_max_file_read_size", 16)
+    path = tmp_path / "oversized-default.pmml"
+    path.write_text("<PMML version='4.4'><Header/></PMML>", encoding="utf-8")
+
+    result = PmmlScanner(config={"max_file_size": 0}).scan(str(path))
+
+    assert result.success is False
+    checks = {check.name: check for check in result.checks}
+    assert checks["File Size Limit"].status == CheckStatus.FAILED
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "max_file_read_size_exceeded" in result.metadata["scan_outcome_reasons"]
+
+
+def test_pmml_scanner_explicit_zero_read_limit_keeps_opt_out() -> None:
+    scanner = PmmlScanner(config={"max_file_size": 0, "max_file_read_size": 0})
+
+    assert scanner.max_file_read_size == 0
+
+
+@pytest.mark.parametrize(("max_file_size", "expected_read_cap"), [(8, 8), (32, 16)])
+def test_pmml_scanner_core_file_limit_only_tightens_default_read_cap(
+    max_file_size: int,
+    expected_read_cap: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(PmmlScanner, "default_max_file_read_size", 16)
+
+    scanner = PmmlScanner(config={"max_file_size": max_file_size})
+
+    assert scanner.max_file_read_size == expected_read_cap
 
 
 def test_pmml_scanner_comment_doctype_is_not_xxe(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- keep bounded scanner defaults when core/CLI uses `max_file_size=0` as its unlimited routing sentinel
- preserve explicit scanner-level `max_file_read_size=0` opt-outs
- prevent PMML's compatibility alias from copying the core zero sentinel into an unlimited read
- allow positive PMML core limits to tighten its read cap without ever raising the scanner default
- synchronize with current `main`

## Security review
The false-negative audit found and closed two PMML-specific gaps:
- `max_file_size=0` was converted into explicit `max_file_read_size=0`, leaving PMML whole-file reads unbounded
- a positive core limit above the scanner default could raise PMML's bounded read cap

A registry-wide constructor probe confirmed all 45 loadable scanners preserve their class default under `max_file_size=0`. Only GGUF and SafeTensors retain intentional unlimited defaults; explicit `max_file_read_size=0` remains the separate opt-out.

## Validation
- complete associated Base/Flax/PMML modules: `231 passed`
- all 45 loadable scanner classes: zero default-cap mismatches
- scoped Ruff check/format, mypy, and `git diff --check`: clean
- all review threads are resolved
- full suite intentionally left to CI

Published head: `3990833323ede4ea6f73e094ae6f074869b58aba`
Exact tested tree: `561f2948f078ba8eebbbf16ebb34144f3303f993`
Current `main`: `ea54e39af35f7cc76ad4627c6ea1a68c6c7a0acb`