### PR TITLE
fix: bound executorch zip scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fail closed on JFrog folder downloads whose selected artifacts use unsafe, colliding, or overlapping local paths
 - detect dangerous textual byte keys in Flax MessagePack checkpoints
 - bound Joblib decompression output to the configured scanner read budget
+- fail closed on over-entry, over-aggregate, oversized-member, or suspiciously compressed ExecuTorch ZIP archives before member scanning
 - close JIT replay alias, probe-budget, and compound-clause context gaps without suppressing dangerous browser or native-library calls
 - scan raw payload indicators inside signature-valid ExecuTorch binaries and launcher-prefixed archives before reporting them clean
 - detect Keras get_file tar extraction from effective call arguments without relying on URL suffixes

--- a/modelaudit/scanners/executorch_scanner.py
+++ b/modelaudit/scanners/executorch_scanner.py
@@ -641,21 +641,21 @@ class ExecuTorchScanner(BaseScanner):
         *,
         all_entries: list[zipfile.ZipInfo],
         safe_entries: list[zipfile.ZipInfo],
-    ) -> ScanResult | None:
+    ) -> bool:
         declared_uncompressed_size = sum(entry.file_size for entry in all_entries if not entry.is_dir())
         safe_uncompressed_size = sum(entry.file_size for entry in safe_entries if not entry.is_dir())
         result.metadata["executorch_zip_declared_uncompressed_size"] = declared_uncompressed_size
         result.metadata["executorch_zip_uncompressed_size"] = safe_uncompressed_size
         result.metadata["max_executorch_zip_total_uncompressed_size"] = self.max_total_uncompressed_size
         if safe_uncompressed_size > self.max_total_uncompressed_size:
-            return self._finish_zip_budget_failure(
+            self._add_zip_budget_failure(
                 result,
                 path,
                 check_name="ExecuTorch ZIP Aggregate Size Limit",
                 message=(
                     f"ExecuTorch ZIP total uncompressed size exceeds limit "
                     f"({safe_uncompressed_size} > {self.max_total_uncompressed_size} bytes); "
-                    "skipping member content scan"
+                    "limiting pickle member content scans to the configured budget"
                 ),
                 details={
                     "archive_uncompressed_size": safe_uncompressed_size,
@@ -664,6 +664,7 @@ class ExecuTorchScanner(BaseScanner):
                 },
                 reason=self.ZIP_AGGREGATE_LIMIT_INCONCLUSIVE_REASON,
             )
+            return True
 
         result.add_check(
             name="ExecuTorch ZIP Aggregate Size Limit",
@@ -679,7 +680,27 @@ class ExecuTorchScanner(BaseScanner):
                 "max_total_uncompressed_size": self.max_total_uncompressed_size,
             },
         )
-        return None
+        return False
+
+    def _limit_pickle_entries_to_aggregate_budget(
+        self,
+        result: ScanResult,
+        pickle_entries: list[zipfile.ZipInfo],
+    ) -> tuple[list[zipfile.ZipInfo], bool]:
+        bytes_selected = 0
+        scannable_entries: list[zipfile.ZipInfo] = []
+        skipped_entries: list[zipfile.ZipInfo] = []
+        for entry in pickle_entries:
+            if bytes_selected + entry.file_size > self.max_total_uncompressed_size:
+                skipped_entries.append(entry)
+                continue
+            scannable_entries.append(entry)
+            bytes_selected += entry.file_size
+
+        result.metadata["executorch_zip_pickle_scan_uncompressed_size"] = bytes_selected
+        if skipped_entries:
+            result.metadata["executorch_zip_skipped_pickle_files"] = [entry.filename for entry in skipped_entries[:20]]
+        return scannable_entries, bool(skipped_entries)
 
     @staticmethod
     def _add_python_entry_checks(result: ScanResult, path: str, safe_entries: list[zipfile.ZipInfo]) -> None:
@@ -831,22 +852,26 @@ class ExecuTorchScanner(BaseScanner):
                     safe_entries.append(entry)
 
                 self._add_python_entry_checks(result, path, safe_entries)
-                aggregate_limit_result = self._check_zip_aggregate_size(
+                aggregate_coverage_incomplete = self._check_zip_aggregate_size(
                     result,
                     path,
                     all_entries=archive_entries,
                     safe_entries=safe_entries,
                 )
-                if aggregate_limit_result:
-                    return aggregate_limit_result
 
                 pickle_entries = [entry for entry in safe_entries if entry.filename.casefold().endswith(".pkl")]
                 pickle_files = [entry.filename for entry in pickle_entries]
                 result.metadata["pickle_files"] = pickle_files
-                pickle_entries, pickle_coverage_incomplete = self._check_pickle_member_budgets(
+                pickle_entries, member_coverage_incomplete = self._check_pickle_member_budgets(
                     result,
                     path,
                     pickle_entries,
+                )
+                pickle_entries, aggregate_pickle_coverage_incomplete = self._limit_pickle_entries_to_aggregate_budget(
+                    result, pickle_entries
+                )
+                pickle_coverage_incomplete = (
+                    aggregate_coverage_incomplete or member_coverage_incomplete or aggregate_pickle_coverage_incomplete
                 )
                 bytes_scanned = 0
 

--- a/modelaudit/scanners/executorch_scanner.py
+++ b/modelaudit/scanners/executorch_scanner.py
@@ -3,7 +3,8 @@
 import os
 import tempfile
 import zipfile
-from typing import Any, BinaryIO, ClassVar, cast
+from pathlib import Path
+from typing import Any, BinaryIO, ClassVar, Final, cast
 
 from ..scanner_results import mark_inconclusive_scan_result
 from ..scanner_selection import add_scanner_selection_skip_check, embedded_pickle_scanner
@@ -21,6 +22,18 @@ from .picklescan_adapter import (
 from .pytorch_binary_scanner import PyTorchBinaryScanner
 
 CONTENT_ROUTE_BLOCKED_EXTENSIONS = frozenset({".bin", ".meta", ".pb"})
+_ZIP_EOCD_SIGNATURE: Final[bytes] = b"PK\x05\x06"
+_ZIP_EOCD_MIN_SIZE: Final[int] = 22
+_ZIP_MAX_COMMENT_SIZE: Final[int] = 0xFFFF
+_ZIP64_EOCD_LOCATOR_SIGNATURE: Final[bytes] = b"PK\x06\x07"
+_ZIP64_EOCD_LOCATOR_SIZE: Final[int] = 20
+_ZIP64_EOCD_SIGNATURE: Final[bytes] = b"PK\x06\x06"
+_ZIP64_EOCD_MIN_SIZE: Final[int] = 56
+_ZIP64_SENTINEL_ENTRY_COUNT: Final[int] = 0xFFFF
+_ZIP_CENTRAL_DIRECTORY_SIGNATURE: Final[bytes] = b"PK\x01\x02"
+_ZIP_CENTRAL_DIRECTORY_HEADER_SIZE: Final[int] = 46
+_ZIP_CENTRAL_DIRECTORY_DIGITAL_SIGNATURE: Final[bytes] = b"PK\x05\x05"
+_ZIP_CENTRAL_DIRECTORY_DIGITAL_SIGNATURE_HEADER_SIZE: Final[int] = 6
 PYTORCH_BINARY_PRIMARY_SCANNED_CONFIG_KEY = "_pytorch_binary_primary_scanned"
 
 
@@ -30,10 +43,38 @@ class ExecuTorchScanner(BaseScanner):
     name = "executorch"
     description = "Scans ExecuTorch mobile model files for suspicious content"
     supported_extensions: ClassVar[list[str]] = [".ptl", ".pte"]
+    DEFAULT_MAX_ARCHIVE_ENTRIES: ClassVar[int] = 10000
+    DEFAULT_MAX_CENTRAL_DIRECTORY_SIZE: ClassVar[int] = 64 * 1024 * 1024
+    DEFAULT_MAX_TOTAL_UNCOMPRESSED_SIZE: ClassVar[int] = 10 * 1024 * 1024 * 1024
+    MAX_COMPRESSION_RATIO: ClassVar[int] = 100
+    MIN_COMPRESSION_BOMB_UNCOMPRESSED_SIZE: ClassVar[int] = 1024 * 1024
+    UNLIMITED_ARCHIVE_SIZE: ClassVar[int] = 1024 * 1024 * 1024 * 1024
+    ZIP_ENTRY_LIMIT_INCONCLUSIVE_REASON: ClassVar[str] = "executorch_zip_entry_limit"
+    ZIP_CENTRAL_DIRECTORY_INVALID_REASON: ClassVar[str] = "executorch_zip_central_directory_invalid"
+    ZIP_CENTRAL_DIRECTORY_SIZE_LIMIT_INCONCLUSIVE_REASON: ClassVar[str] = "executorch_zip_central_directory_size_limit"
+    ZIP_AGGREGATE_LIMIT_INCONCLUSIVE_REASON: ClassVar[str] = "executorch_zip_total_uncompressed_size_limit"
+    ZIP_PICKLE_MEMBER_LIMIT_INCONCLUSIVE_REASON: ClassVar[str] = "executorch_zip_pickle_member_size_limit"
+    ZIP_COMPRESSION_RATIO_INCONCLUSIVE_REASON: ClassVar[str] = "executorch_zip_compression_ratio_limit"
 
     def __init__(self, config: dict[str, Any] | None = None) -> None:
         super().__init__(config)
         self.pickle_scanner, self.scanner_selection = embedded_pickle_scanner(self.config, PickleScanner)
+        self.max_archive_entries = self._normalize_positive_int_config(
+            self.config.get(
+                "max_executorch_zip_entries",
+                self.config.get("max_archive_entries", self.config.get("max_zip_entries")),
+            ),
+            self.DEFAULT_MAX_ARCHIVE_ENTRIES,
+        )
+        self.max_central_directory_size = self._normalize_positive_int_config(
+            self.config.get("max_executorch_zip_central_directory_size"),
+            self.DEFAULT_MAX_CENTRAL_DIRECTORY_SIZE,
+        )
+        self.max_total_uncompressed_size = self._get_max_total_uncompressed_size()
+        self.min_compression_bomb_uncompressed_size = self._normalize_positive_int_config(
+            self.config.get("zip_min_compression_bomb_uncompressed_size"),
+            self.MIN_COMPRESSION_BOMB_UNCOMPRESSED_SIZE,
+        )
 
     @classmethod
     def can_handle(cls, path: str) -> bool:
@@ -57,6 +98,256 @@ class ExecuTorchScanner(BaseScanner):
         with open(path, "rb") as f:
             return f.read(length)
 
+    @classmethod
+    def _get_max_total_uncompressed_size_from_config(cls, config: dict[str, Any]) -> int:
+        """Return the configured aggregate ExecuTorch ZIP budget."""
+        positive_limits: list[int] = []
+        configured_limit = config.get("max_executorch_zip_total_uncompressed_size")
+        if configured_limit is None:
+            configured_limit = config.get("max_zip_total_uncompressed_size")
+
+        if configured_limit is not None:
+            is_unlimited = (
+                isinstance(configured_limit, int) and not isinstance(configured_limit, bool) and configured_limit == 0
+            )
+            if not is_unlimited:
+                positive_limits.append(
+                    cls._normalize_positive_int_config(configured_limit, cls.DEFAULT_MAX_TOTAL_UNCOMPRESSED_SIZE)
+                )
+        else:
+            positive_limits.append(cls.DEFAULT_MAX_TOTAL_UNCOMPRESSED_SIZE)
+
+        for config_key in ("max_total_size", "max_file_size"):
+            configured_public_limit = config.get(config_key)
+            if configured_public_limit is None or (
+                isinstance(configured_public_limit, int)
+                and not isinstance(configured_public_limit, bool)
+                and configured_public_limit == 0
+            ):
+                continue
+            positive_limits.append(
+                cls._normalize_positive_int_config(configured_public_limit, cls.DEFAULT_MAX_TOTAL_UNCOMPRESSED_SIZE)
+            )
+
+        return min(positive_limits) if positive_limits else cls.UNLIMITED_ARCHIVE_SIZE
+
+    def _get_max_total_uncompressed_size(self) -> int:
+        return self._get_max_total_uncompressed_size_from_config(self.config)
+
+    @staticmethod
+    def _find_zip_eocd_index(tail: bytes) -> tuple[int, bool, tuple[int, ...]] | None:
+        candidate_indexes: list[int] = []
+        search_start = 0
+        while True:
+            candidate_index = tail.find(_ZIP_EOCD_SIGNATURE, search_start)
+            if candidate_index < 0:
+                break
+            if candidate_index + _ZIP_EOCD_MIN_SIZE <= len(tail):
+                candidate_indexes.append(candidate_index)
+            search_start = candidate_index + 1
+
+        if not candidate_indexes:
+            return None
+
+        exact_candidates = []
+        for candidate_index in candidate_indexes:
+            comment_length = int.from_bytes(tail[candidate_index + 20 : candidate_index + 22], "little")
+            if candidate_index + _ZIP_EOCD_MIN_SIZE + comment_length == len(tail):
+                exact_candidates.append(candidate_index)
+
+        selected_index = candidate_indexes[-1]
+        ambiguous = len(exact_candidates) > 1 or (len(exact_candidates) == 1 and exact_candidates[0] != selected_index)
+        return selected_index, ambiguous, tuple(candidate_indexes)
+
+    @staticmethod
+    def _count_central_directory_entries(
+        handle: BinaryIO,
+        *,
+        directory_start: int,
+        directory_size: int,
+        entry_limit: int,
+    ) -> tuple[int, bool]:
+        """Count bounded central-directory records without constructing ZipInfo objects."""
+        if directory_start < 0 or directory_size < 0:
+            return 0, False
+
+        handle.seek(directory_start)
+        remaining = directory_size
+        entry_count = 0
+        while remaining > 0:
+            signature = handle.read(4)
+            if len(signature) != 4:
+                return entry_count, False
+
+            if signature == _ZIP_CENTRAL_DIRECTORY_DIGITAL_SIGNATURE:
+                signature_size_bytes = handle.read(2)
+                if len(signature_size_bytes) != 2:
+                    return entry_count, False
+                signature_size = int.from_bytes(signature_size_bytes, "little")
+                record_size = _ZIP_CENTRAL_DIRECTORY_DIGITAL_SIGNATURE_HEADER_SIZE + signature_size
+                if record_size != remaining:
+                    return entry_count, False
+                handle.seek(signature_size, os.SEEK_CUR)
+                remaining -= record_size
+                continue
+
+            if signature != _ZIP_CENTRAL_DIRECTORY_SIGNATURE or remaining < _ZIP_CENTRAL_DIRECTORY_HEADER_SIZE:
+                return entry_count, False
+
+            header_tail = handle.read(_ZIP_CENTRAL_DIRECTORY_HEADER_SIZE - 4)
+            if len(header_tail) != _ZIP_CENTRAL_DIRECTORY_HEADER_SIZE - 4:
+                return entry_count, False
+            header = signature + header_tail
+
+            filename_length = int.from_bytes(header[28:30], "little")
+            extra_length = int.from_bytes(header[30:32], "little")
+            comment_length = int.from_bytes(header[32:34], "little")
+            record_size = _ZIP_CENTRAL_DIRECTORY_HEADER_SIZE + filename_length + extra_length + comment_length
+            if record_size > remaining:
+                return entry_count, False
+
+            entry_count += 1
+            if entry_count > entry_limit:
+                return entry_count, True
+            handle.seek(record_size - _ZIP_CENTRAL_DIRECTORY_HEADER_SIZE, os.SEEK_CUR)
+            remaining -= record_size
+
+        return entry_count, True
+
+    @classmethod
+    def _has_prior_valid_eocd_overlay(
+        cls,
+        handle: BinaryIO,
+        *,
+        tail: bytes,
+        tail_start: int,
+        selected_index: int,
+        candidate_indexes: tuple[int, ...],
+        entry_limit: int,
+        central_directory_size_limit: int,
+    ) -> bool:
+        """Detect a complete ZIP archive hidden before a trailing EOCD overlay."""
+        for candidate_index in candidate_indexes:
+            if candidate_index >= selected_index:
+                continue
+            comment_length = int.from_bytes(tail[candidate_index + 20 : candidate_index + 22], "little")
+            if candidate_index + _ZIP_EOCD_MIN_SIZE + comment_length > selected_index:
+                continue
+
+            entry_count = int.from_bytes(tail[candidate_index + 10 : candidate_index + 12], "little")
+            directory_size = int.from_bytes(tail[candidate_index + 12 : candidate_index + 16], "little")
+            if entry_count == 0 and directory_size == 0:
+                continue
+
+            candidate_absolute_index = tail_start + candidate_index
+            if entry_count == _ZIP64_SENTINEL_ENTRY_COUNT:
+                locator_offset = candidate_absolute_index - _ZIP64_EOCD_LOCATOR_SIZE
+                if locator_offset >= 0:
+                    handle.seek(locator_offset)
+                    if handle.read(4) == _ZIP64_EOCD_LOCATOR_SIGNATURE:
+                        return True
+                continue
+
+            directory_start = candidate_absolute_index - directory_size
+            if directory_size == 0 or directory_start < 0:
+                continue
+            if directory_size > central_directory_size_limit:
+                handle.seek(directory_start)
+                if handle.read(4) == _ZIP_CENTRAL_DIRECTORY_SIGNATURE:
+                    return True
+                continue
+
+            parsed_count, parsed_completely = cls._count_central_directory_entries(
+                handle,
+                directory_start=directory_start,
+                directory_size=directory_size,
+                entry_limit=entry_limit,
+            )
+            if parsed_count > entry_limit or (parsed_completely and parsed_count > 0):
+                return True
+        return False
+
+    @classmethod
+    def _read_zip_entry_count(
+        cls,
+        handle: BinaryIO,
+        file_size: int,
+        entry_limit: int,
+        central_directory_size_limit: int,
+    ) -> tuple[int, int, bool] | None:
+        """Read and validate bounded central-directory metadata without ZipInfo allocation."""
+        if file_size < _ZIP_EOCD_MIN_SIZE:
+            return None
+
+        tail_size = min(file_size, _ZIP_EOCD_MIN_SIZE + _ZIP_MAX_COMMENT_SIZE)
+        handle.seek(file_size - tail_size)
+        tail = handle.read(tail_size)
+        eocd_match = cls._find_zip_eocd_index(tail)
+        if eocd_match is None:
+            return None
+        eocd_index, eocd_ambiguous, candidate_indexes = eocd_match
+
+        entry_count = int.from_bytes(tail[eocd_index + 10 : eocd_index + 12], "little")
+        central_directory_size = int.from_bytes(tail[eocd_index + 12 : eocd_index + 16], "little")
+        tail_start = file_size - tail_size
+        if eocd_ambiguous or cls._has_prior_valid_eocd_overlay(
+            handle,
+            tail=tail,
+            tail_start=tail_start,
+            selected_index=eocd_index,
+            candidate_indexes=candidate_indexes,
+            entry_limit=entry_limit,
+            central_directory_size_limit=central_directory_size_limit,
+        ):
+            return entry_count, central_directory_size, False
+
+        central_directory_end = tail_start + eocd_index
+        locator_offset = central_directory_end - _ZIP64_EOCD_LOCATOR_SIZE
+        zip64_locator_found = False
+        if locator_offset >= 0:
+            handle.seek(locator_offset)
+            locator = handle.read(_ZIP64_EOCD_LOCATOR_SIZE)
+            if locator.startswith(_ZIP64_EOCD_LOCATOR_SIGNATURE):
+                zip64_locator_found = True
+                stored_zip64_eocd_offset = int.from_bytes(locator[8:16], "little")
+                candidate_offsets = [stored_zip64_eocd_offset]
+                physical_zip64_eocd_offset = locator_offset - _ZIP64_EOCD_MIN_SIZE
+                if physical_zip64_eocd_offset != stored_zip64_eocd_offset:
+                    candidate_offsets.append(physical_zip64_eocd_offset)
+
+                zip64_eocd = b""
+                for candidate_offset in candidate_offsets:
+                    if candidate_offset < 0:
+                        continue
+                    handle.seek(candidate_offset)
+                    candidate = handle.read(_ZIP64_EOCD_MIN_SIZE)
+                    if len(candidate) >= _ZIP64_EOCD_MIN_SIZE and candidate.startswith(_ZIP64_EOCD_SIGNATURE):
+                        zip64_eocd = candidate
+                        central_directory_end = candidate_offset
+                        break
+                if not zip64_eocd:
+                    return entry_count, central_directory_size, False
+
+                entry_count = int.from_bytes(zip64_eocd[32:40], "little")
+                central_directory_size = int.from_bytes(zip64_eocd[40:48], "little")
+
+        if entry_count == _ZIP64_SENTINEL_ENTRY_COUNT and not zip64_locator_found:
+            return entry_count, central_directory_size, False
+        if entry_count > entry_limit or central_directory_size > central_directory_size_limit:
+            return entry_count, central_directory_size, True
+
+        parsed_entry_count, parsed_completely = cls._count_central_directory_entries(
+            handle,
+            directory_start=central_directory_end - central_directory_size,
+            directory_size=central_directory_size,
+            entry_limit=entry_limit,
+        )
+        return (
+            max(entry_count, parsed_entry_count),
+            central_directory_size,
+            parsed_completely and parsed_entry_count == entry_count,
+        )
+
     @staticmethod
     def _finish_read_failure(result: ScanResult, path: str, exc: OSError) -> ScanResult:
         mark_inconclusive_scan_result(result, "executorch_read_failed")
@@ -76,6 +367,343 @@ class ExecuTorchScanner(BaseScanner):
         )
         result.finish(success=False)
         return result
+
+    @classmethod
+    def _add_zip_budget_failure(
+        cls,
+        result: ScanResult,
+        path: str,
+        *,
+        check_name: str,
+        message: str,
+        details: dict[str, Any],
+        reason: str,
+        rule_code: str = "S410",
+    ) -> None:
+        mark_inconclusive_scan_result(result, reason)
+        result.add_check(
+            name=check_name,
+            passed=False,
+            message=message,
+            severity=IssueSeverity.WARNING,
+            location=path,
+            details={
+                **details,
+                "analysis_incomplete": True,
+                "scan_outcome_reason": reason,
+            },
+            rule_code=rule_code,
+        )
+
+    @classmethod
+    def _finish_zip_budget_failure(
+        cls,
+        result: ScanResult,
+        path: str,
+        *,
+        check_name: str,
+        message: str,
+        details: dict[str, Any],
+        reason: str,
+        rule_code: str = "S410",
+    ) -> ScanResult:
+        cls._add_zip_budget_failure(
+            result,
+            path,
+            check_name=check_name,
+            message=message,
+            details=details,
+            reason=reason,
+            rule_code=rule_code,
+        )
+        result.finish(success=False)
+        return result
+
+    def _check_zip_entry_count_preflight(
+        self,
+        result: ScanResult,
+        path: str,
+        archive_handle: BinaryIO,
+        file_size: int,
+    ) -> ScanResult | None:
+        preflight = self._read_zip_entry_count(
+            archive_handle,
+            file_size,
+            self.max_archive_entries,
+            self.max_central_directory_size,
+        )
+        if preflight is None:
+            return None
+        entry_count, central_directory_size, central_directory_valid = preflight
+
+        result.metadata["executorch_zip_entry_count"] = entry_count
+        result.metadata["max_executorch_zip_entries"] = self.max_archive_entries
+        result.metadata["executorch_zip_central_directory_size"] = central_directory_size
+        result.metadata["max_executorch_zip_central_directory_size"] = self.max_central_directory_size
+
+        if entry_count > self.max_archive_entries:
+            return self._finish_zip_budget_failure(
+                result,
+                path,
+                check_name="ExecuTorch ZIP Entry Count Preflight",
+                message=(
+                    f"ExecuTorch ZIP contains too many entries before archive open "
+                    f"({entry_count} > {self.max_archive_entries})"
+                ),
+                details={
+                    "entry_count": entry_count,
+                    "max_entries": self.max_archive_entries,
+                    "phase": "pre_open",
+                },
+                reason=self.ZIP_ENTRY_LIMIT_INCONCLUSIVE_REASON,
+            )
+
+        if central_directory_size > self.max_central_directory_size:
+            return self._finish_zip_budget_failure(
+                result,
+                path,
+                check_name="ExecuTorch ZIP Central Directory Size Preflight",
+                message=(
+                    f"ExecuTorch ZIP central directory exceeds the pre-open allocation limit "
+                    f"({central_directory_size} > {self.max_central_directory_size} bytes)"
+                ),
+                details={
+                    "central_directory_size": central_directory_size,
+                    "max_central_directory_size": self.max_central_directory_size,
+                    "phase": "pre_open",
+                },
+                reason=self.ZIP_CENTRAL_DIRECTORY_SIZE_LIMIT_INCONCLUSIVE_REASON,
+            )
+
+        if central_directory_valid:
+            return None
+        return self._finish_zip_budget_failure(
+            result,
+            path,
+            check_name="ExecuTorch ZIP Central Directory Preflight",
+            message="ExecuTorch ZIP central-directory metadata is inconsistent; refusing incomplete analysis",
+            details={
+                "entry_count": entry_count,
+                "central_directory_size": central_directory_size,
+                "phase": "pre_open",
+            },
+            reason=self.ZIP_CENTRAL_DIRECTORY_INVALID_REASON,
+            rule_code="S902",
+        )
+
+    def _check_zip_entry_count(
+        self, result: ScanResult, path: str, entries: list[zipfile.ZipInfo]
+    ) -> ScanResult | None:
+        entry_count = len(entries)
+        result.metadata["executorch_zip_entry_count"] = entry_count
+        result.metadata["max_executorch_zip_entries"] = self.max_archive_entries
+        if entry_count > self.max_archive_entries:
+            return self._finish_zip_budget_failure(
+                result,
+                path,
+                check_name="ExecuTorch ZIP Entry Count Limit",
+                message=f"ExecuTorch ZIP contains too many entries ({entry_count} > {self.max_archive_entries})",
+                details={
+                    "entry_count": entry_count,
+                    "max_entries": self.max_archive_entries,
+                    "phase": "post_open",
+                },
+                reason=self.ZIP_ENTRY_LIMIT_INCONCLUSIVE_REASON,
+            )
+
+        result.add_check(
+            name="ExecuTorch ZIP Entry Count Limit",
+            passed=True,
+            message=f"ExecuTorch ZIP entry count ({entry_count}) is within limits",
+            location=path,
+            details={
+                "entry_count": entry_count,
+                "max_entries": self.max_archive_entries,
+            },
+        )
+        return None
+
+    def _check_pickle_member_budgets(
+        self,
+        result: ScanResult,
+        path: str,
+        pickle_entries: list[zipfile.ZipInfo],
+    ) -> tuple[list[zipfile.ZipInfo], bool]:
+        small_high_ratio_uncompressed_size = 0
+        small_high_ratio_compressed_size = 0
+        small_high_ratio_entries: list[zipfile.ZipInfo] = []
+        oversized_entries: list[zipfile.ZipInfo] = []
+        large_high_ratio_entries: list[tuple[zipfile.ZipInfo, float | None]] = []
+        blocked_entry_ids: set[int] = set()
+        analysis_incomplete = False
+        pickle_member_limit = self.pickle_scanner.max_file_read_size if self.pickle_scanner is not None else 0
+        for entry in pickle_entries:
+            if pickle_member_limit > 0 and entry.file_size > pickle_member_limit:
+                oversized_entries.append(entry)
+                blocked_entry_ids.add(id(entry))
+                analysis_incomplete = True
+                continue
+
+            compression_ratio = entry.file_size / entry.compress_size if entry.compress_size > 0 else None
+            exceeds_ratio = compression_ratio is None or compression_ratio > self.MAX_COMPRESSION_RATIO
+            if not exceeds_ratio:
+                continue
+
+            if entry.file_size < self.min_compression_bomb_uncompressed_size:
+                small_high_ratio_uncompressed_size += entry.file_size
+                small_high_ratio_compressed_size += entry.compress_size
+                small_high_ratio_entries.append(entry)
+                continue
+
+            large_high_ratio_entries.append((entry, compression_ratio))
+            blocked_entry_ids.add(id(entry))
+            analysis_incomplete = True
+
+        if oversized_entries:
+            first_entry = oversized_entries[0]
+            self._add_zip_budget_failure(
+                result,
+                path,
+                check_name="ExecuTorch ZIP Pickle Member Size Limit",
+                message=(
+                    f"ExecuTorch pickle member {first_entry.filename} exceeds the pickle scan limit "
+                    f"({first_entry.file_size} > {pickle_member_limit} bytes); skipping "
+                    f"{len(oversized_entries)} oversized member content scan(s)"
+                ),
+                details={
+                    "member": first_entry.filename,
+                    "member_count": len(oversized_entries),
+                    "uncompressed_size": first_entry.file_size,
+                    "max_pickle_member_size": pickle_member_limit,
+                },
+                reason=self.ZIP_PICKLE_MEMBER_LIMIT_INCONCLUSIVE_REASON,
+            )
+
+        if large_high_ratio_entries:
+            first_entry, first_ratio = large_high_ratio_entries[0]
+            ratio_text = "infinite" if first_ratio is None else f"{first_ratio:.1f}x"
+            self._add_zip_budget_failure(
+                result,
+                path,
+                check_name="ExecuTorch ZIP Pickle Compression Ratio Limit",
+                message=(
+                    f"ExecuTorch pickle member {first_entry.filename} has a suspicious compression ratio "
+                    f"({ratio_text}); skipping {len(large_high_ratio_entries)} suspicious member content scan(s)"
+                ),
+                details={
+                    "member": first_entry.filename,
+                    "member_count": len(large_high_ratio_entries),
+                    "compressed_size": first_entry.compress_size,
+                    "uncompressed_size": first_entry.file_size,
+                    "compression_ratio": first_ratio,
+                    "max_compression_ratio": self.MAX_COMPRESSION_RATIO,
+                    "min_uncompressed_size": self.min_compression_bomb_uncompressed_size,
+                },
+                reason=self.ZIP_COMPRESSION_RATIO_INCONCLUSIVE_REASON,
+            )
+
+        if small_high_ratio_uncompressed_size >= self.min_compression_bomb_uncompressed_size:
+            aggregate_ratio = (
+                small_high_ratio_uncompressed_size / small_high_ratio_compressed_size
+                if small_high_ratio_compressed_size > 0
+                else None
+            )
+            ratio_text = "infinite" if aggregate_ratio is None else f"{aggregate_ratio:.1f}x"
+            self._add_zip_budget_failure(
+                result,
+                path,
+                check_name="ExecuTorch ZIP Pickle Compression Ratio Limit",
+                message=(
+                    "ExecuTorch ZIP contains multiple small pickle members with a suspicious aggregate "
+                    f"compression ratio ({ratio_text}); skipping those member content scans"
+                ),
+                details={
+                    "aggregate_small_member_check": True,
+                    "member_count": len(small_high_ratio_entries),
+                    "compressed_size": small_high_ratio_compressed_size,
+                    "uncompressed_size": small_high_ratio_uncompressed_size,
+                    "compression_ratio": aggregate_ratio,
+                    "max_compression_ratio": self.MAX_COMPRESSION_RATIO,
+                    "min_uncompressed_size": self.min_compression_bomb_uncompressed_size,
+                },
+                reason=self.ZIP_COMPRESSION_RATIO_INCONCLUSIVE_REASON,
+            )
+            blocked_entry_ids.update(id(entry) for entry in small_high_ratio_entries)
+            analysis_incomplete = True
+
+        scannable_entries = [entry for entry in pickle_entries if id(entry) not in blocked_entry_ids]
+        return scannable_entries, analysis_incomplete
+
+    def _check_zip_aggregate_size(
+        self,
+        result: ScanResult,
+        path: str,
+        *,
+        all_entries: list[zipfile.ZipInfo],
+        safe_entries: list[zipfile.ZipInfo],
+    ) -> ScanResult | None:
+        declared_uncompressed_size = sum(entry.file_size for entry in all_entries if not entry.is_dir())
+        safe_uncompressed_size = sum(entry.file_size for entry in safe_entries if not entry.is_dir())
+        result.metadata["executorch_zip_declared_uncompressed_size"] = declared_uncompressed_size
+        result.metadata["executorch_zip_uncompressed_size"] = safe_uncompressed_size
+        result.metadata["max_executorch_zip_total_uncompressed_size"] = self.max_total_uncompressed_size
+        if safe_uncompressed_size > self.max_total_uncompressed_size:
+            return self._finish_zip_budget_failure(
+                result,
+                path,
+                check_name="ExecuTorch ZIP Aggregate Size Limit",
+                message=(
+                    f"ExecuTorch ZIP total uncompressed size exceeds limit "
+                    f"({safe_uncompressed_size} > {self.max_total_uncompressed_size} bytes); "
+                    "skipping member content scan"
+                ),
+                details={
+                    "archive_uncompressed_size": safe_uncompressed_size,
+                    "archive_declared_uncompressed_size": declared_uncompressed_size,
+                    "max_total_uncompressed_size": self.max_total_uncompressed_size,
+                },
+                reason=self.ZIP_AGGREGATE_LIMIT_INCONCLUSIVE_REASON,
+            )
+
+        result.add_check(
+            name="ExecuTorch ZIP Aggregate Size Limit",
+            passed=True,
+            message=(
+                f"ExecuTorch ZIP total uncompressed size ({safe_uncompressed_size}) is within "
+                f"limit ({self.max_total_uncompressed_size})"
+            ),
+            location=path,
+            details={
+                "archive_uncompressed_size": safe_uncompressed_size,
+                "archive_declared_uncompressed_size": declared_uncompressed_size,
+                "max_total_uncompressed_size": self.max_total_uncompressed_size,
+            },
+        )
+        return None
+
+    @staticmethod
+    def _add_python_entry_checks(result: ScanResult, path: str, safe_entries: list[zipfile.ZipInfo]) -> None:
+        for entry in safe_entries:
+            name = entry.filename
+            if name.casefold().endswith(".py"):
+                result.add_check(
+                    name="Python File Detection",
+                    passed=False,
+                    message=f"Python code file found in ExecuTorch model: {name}",
+                    severity=IssueSeverity.INFO,
+                    location=f"{path}:{name}",
+                    details={"file": name},
+                    rule_code="S507",  # Python embedded code
+                )
+                result.add_check(
+                    name="Executable File Detection",
+                    passed=False,
+                    message=f"Executable file found in ExecuTorch model: {name}",
+                    severity=IssueSeverity.CRITICAL,
+                    location=f"{path}:{name}",
+                    details={"file": name},
+                    rule_code="S104",
+                )
 
     @staticmethod
     def _supplemental_raw_binary_config(config: dict[str, Any]) -> dict[str, Any]:
@@ -123,6 +751,7 @@ class ExecuTorchScanner(BaseScanner):
         result = self._create_result()
         file_size = self.get_file_size(path)
         result.metadata["file_size"] = file_size
+        pickle_coverage_incomplete = False
 
         try:
             header = self._read_header(path, length=8)
@@ -167,11 +796,24 @@ class ExecuTorchScanner(BaseScanner):
             result.finish(success=False)
             return result
 
+        archive_handle: BinaryIO | None = None
         try:
+            # Kept open across preflight and ZipFile to prevent path-reopen races.
+            archive_handle = Path(path).open("rb")  # noqa: SIM115
+            preflight_result = self._check_zip_entry_count_preflight(result, path, archive_handle, file_size)
+            if preflight_result:
+                return preflight_result
+
+            archive_handle.seek(0)
             self.current_file_path = path
-            with zipfile.ZipFile(path, "r") as z:
+            with zipfile.ZipFile(archive_handle, "r") as z:
+                archive_entries = z.infolist()
+                entry_limit_result = self._check_zip_entry_count(result, path, archive_entries)
+                if entry_limit_result:
+                    return entry_limit_result
+
                 safe_entries: list[zipfile.ZipInfo] = []
-                for entry in z.infolist():
+                for entry in archive_entries:
                     name = entry.filename
                     temp_base = os.path.join(tempfile.gettempdir(), "extract")
                     _, is_safe = sanitize_archive_path(name, temp_base)
@@ -188,9 +830,24 @@ class ExecuTorchScanner(BaseScanner):
                         continue
                     safe_entries.append(entry)
 
+                self._add_python_entry_checks(result, path, safe_entries)
+                aggregate_limit_result = self._check_zip_aggregate_size(
+                    result,
+                    path,
+                    all_entries=archive_entries,
+                    safe_entries=safe_entries,
+                )
+                if aggregate_limit_result:
+                    return aggregate_limit_result
+
                 pickle_entries = [entry for entry in safe_entries if entry.filename.casefold().endswith(".pkl")]
                 pickle_files = [entry.filename for entry in pickle_entries]
                 result.metadata["pickle_files"] = pickle_files
+                pickle_entries, pickle_coverage_incomplete = self._check_pickle_member_budgets(
+                    result,
+                    path,
+                    pickle_entries,
+                )
                 bytes_scanned = 0
 
                 for member_info in pickle_entries:
@@ -214,28 +871,6 @@ class ExecuTorchScanner(BaseScanner):
                         )
                     apply_pickle_member_context(sub_result, archive_path=path, member_name=name)
                     result.merge(sub_result)
-
-                for entry in safe_entries:
-                    name = entry.filename
-                    if name.casefold().endswith(".py"):
-                        result.add_check(
-                            name="Python File Detection",
-                            passed=False,
-                            message=f"Python code file found in ExecuTorch model: {name}",
-                            severity=IssueSeverity.INFO,
-                            location=f"{path}:{name}",
-                            details={"file": name},
-                            rule_code="S507",  # Python embedded code
-                        )
-                        result.add_check(
-                            name="Executable File Detection",
-                            passed=False,
-                            message=f"Executable file found in ExecuTorch model: {name}",
-                            severity=IssueSeverity.CRITICAL,
-                            location=f"{path}:{name}",
-                            details={"file": name},
-                            rule_code="S104",
-                        )
 
                 result.bytes_scanned = bytes_scanned
         except zipfile.BadZipFile:
@@ -267,8 +902,11 @@ class ExecuTorchScanner(BaseScanner):
             )
             result.finish(success=False)
             return result
+        finally:
+            if archive_handle is not None:
+                archive_handle.close()
 
         if valid_binary_program or not header.startswith(b"PK"):
             self._merge_raw_binary_analysis(path, result, file_size)
-        result.finish(success=True)
+        result.finish(success=not pickle_coverage_incomplete)
         return result

--- a/tests/scanners/test_executorch_scanner.py
+++ b/tests/scanners/test_executorch_scanner.py
@@ -1023,6 +1023,38 @@ def test_executorch_zip_aggregate_limit_fails_before_member_content_scan(
     )
 
 
+@pytest.mark.parametrize("malicious_first", [True, False])
+def test_executorch_zip_aggregate_limit_preserves_scannable_member_detection(
+    tmp_path: Path,
+    malicious_first: bool,
+) -> None:
+    model_path = tmp_path / "mixed-aggregate.ptl"
+    malicious_payload = _pickle_payload_with_eval("print('evil')")
+    benign_payload = pickle.dumps({"weights": b"A" * 4096})
+    members = [
+        ("malicious.pkl", malicious_payload),
+        ("benign.pkl", benign_payload),
+    ]
+    if not malicious_first:
+        members.reverse()
+
+    with zipfile.ZipFile(model_path, "w", compression=zipfile.ZIP_STORED) as zipf:
+        zipf.writestr("version", "1")
+        for name, payload in members:
+            zipf.writestr(name, payload)
+
+    result = ExecuTorchScanner(config={"max_executorch_zip_total_uncompressed_size": len(malicious_payload)}).scan(
+        str(model_path)
+    )
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "executorch_zip_total_uncompressed_size_limit" in result.metadata["scan_outcome_reasons"]
+    assert result.bytes_scanned == len(malicious_payload)
+    assert result.metadata["executorch_zip_skipped_pickle_files"] == ["benign.pkl"]
+    assert any(issue.severity == IssueSeverity.CRITICAL and "eval" in issue.message.lower() for issue in result.issues)
+
+
 def test_executorch_zip_aggregate_limit_allows_benign_near_match(tmp_path: Path) -> None:
     model_path = tmp_path / "aggregate-near-match.ptl"
     with zipfile.ZipFile(model_path, "w") as zipf:

--- a/tests/scanners/test_executorch_scanner.py
+++ b/tests/scanners/test_executorch_scanner.py
@@ -1,7 +1,9 @@
 import pickle
 import struct
 import zipfile
+from io import BytesIO
 from pathlib import Path
+from typing import Any, BinaryIO
 
 import pytest
 
@@ -88,6 +90,52 @@ def _corrupt_zip_member_crc(zip_path: Path, member_index: int) -> None:
         cursor += 46 + filename_len + extra_len + comment_len
 
     raise AssertionError(f"Unable to locate central directory entry at offset {member_info.header_offset}")
+
+
+def _patch_zip_eocd_metadata(zip_path: Path, *, entry_count: int, directory_size: int | None = None) -> None:
+    archive_bytes = bytearray(zip_path.read_bytes())
+    eocd_offset = archive_bytes.rfind(b"PK\x05\x06")
+    if eocd_offset < 0:
+        raise AssertionError("Unable to locate ZIP end-of-central-directory record")
+    struct.pack_into("<HH", archive_bytes, eocd_offset + 8, entry_count, entry_count)
+    if directory_size is not None:
+        struct.pack_into("<I", archive_bytes, eocd_offset + 12, directory_size)
+    zip_path.write_bytes(archive_bytes)
+
+
+def _zip_central_directory_size(zip_path: Path) -> int:
+    archive_bytes = zip_path.read_bytes()
+    eocd_offset = archive_bytes.rfind(b"PK\x05\x06")
+    if eocd_offset < 0:
+        raise AssertionError("Unable to locate ZIP end-of-central-directory record")
+    return int(struct.unpack_from("<I", archive_bytes, eocd_offset + 12)[0])
+
+
+def _insert_zip64_directory_metadata(zip_path: Path, *, entry_count: int, legacy_entry_count: int) -> None:
+    archive_bytes = bytearray(zip_path.read_bytes())
+    eocd_offset = archive_bytes.rfind(b"PK\x05\x06")
+    if eocd_offset < 0:
+        raise AssertionError("Unable to locate ZIP end-of-central-directory record")
+
+    directory_size = struct.unpack_from("<I", archive_bytes, eocd_offset + 12)[0]
+    directory_offset = struct.unpack_from("<I", archive_bytes, eocd_offset + 16)[0]
+    zip64_eocd = struct.pack(
+        "<4sQ2H2L4Q",
+        b"PK\x06\x06",
+        44,
+        45,
+        45,
+        0,
+        0,
+        entry_count,
+        entry_count,
+        directory_size,
+        directory_offset,
+    )
+    zip64_locator = struct.pack("<4sLQL", b"PK\x06\x07", 0, eocd_offset, 1)
+    legacy_eocd = bytearray(archive_bytes[eocd_offset:])
+    struct.pack_into("<HH", legacy_eocd, 8, legacy_entry_count, legacy_entry_count)
+    zip_path.write_bytes(archive_bytes[:eocd_offset] + zip64_eocd + zip64_locator + legacy_eocd)
 
 
 def test_executorch_scanner_can_handle(tmp_path: Path) -> None:
@@ -549,6 +597,701 @@ def test_executorch_scanner_streams_pickle_members_without_zip_read(
     result = ExecuTorchScanner().scan(str(model_path))
 
     assert any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+
+
+def test_executorch_zip_entry_preflight_fails_before_archive_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = tmp_path / "entry-bomb.ptl"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("first.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("second.pkl", _pickle_payload_with_eval("print('evil')"))
+
+    def reject_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("entry-count preflight should reject before ZipFile opens")
+
+    monkeypatch.setattr(zipfile, "ZipFile", reject_zipfile_open)
+
+    result = ExecuTorchScanner(config={"max_executorch_zip_entries": 2}).scan(str(model_path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "executorch_zip_entry_limit" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "ExecuTorch ZIP Entry Count Preflight"
+        and check.status == CheckStatus.FAILED
+        and check.rule_code == "S410"
+        and check.details["entry_count"] == 3
+        and check.details["phase"] == "pre_open"
+        for check in result.checks
+    )
+
+
+def test_executorch_zip_entry_limit_allows_exact_limit(tmp_path: Path) -> None:
+    model_path = create_executorch_archive(tmp_path)
+
+    result = ExecuTorchScanner(config={"max_executorch_zip_entries": 2}).scan(str(model_path))
+
+    assert result.success is True
+    assert result.metadata["executorch_zip_entry_count"] == 2
+    assert result.metadata["max_executorch_zip_entries"] == 2
+
+
+def test_executorch_zip_entry_preflight_counts_central_directory_records(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = tmp_path / "forged-entry-count.ptl"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("first.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("second.pkl", _pickle_payload_with_eval("print('evil')"))
+    _patch_zip_eocd_metadata(model_path, entry_count=1)
+
+    def reject_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("central-directory preflight should reject before ZipFile opens")
+
+    monkeypatch.setattr(zipfile, "ZipFile", reject_zipfile_open)
+
+    result = ExecuTorchScanner(config={"max_executorch_zip_entries": 2}).scan(str(model_path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "executorch_zip_entry_limit" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "ExecuTorch ZIP Entry Count Preflight"
+        and check.details["entry_count"] == 3
+        and check.details["phase"] == "pre_open"
+        for check in result.checks
+    )
+
+
+def test_executorch_zip_entry_preflight_rejects_truncated_central_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = tmp_path / "forged-directory-size.ptl"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("benign.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("hidden.pkl", _pickle_payload_with_eval("print('evil')"))
+    _patch_zip_eocd_metadata(model_path, entry_count=1, directory_size=0)
+
+    def reject_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("invalid central-directory metadata should fail before ZipFile opens")
+
+    monkeypatch.setattr(zipfile, "ZipFile", reject_zipfile_open)
+
+    result = ExecuTorchScanner(config={"max_executorch_zip_entries": 2}).scan(str(model_path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "executorch_zip_central_directory_invalid" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "ExecuTorch ZIP Central Directory Preflight"
+        and check.status == CheckStatus.FAILED
+        and check.rule_code == "S902"
+        and check.details["entry_count"] == 1
+        and check.details["phase"] == "pre_open"
+        for check in result.checks
+    )
+
+
+def test_executorch_zip_entry_preflight_allows_trailing_bytes_without_opening_large_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = tmp_path / "trailing-bytes.ptl"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("first.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("second.pkl", _pickle_payload_with_eval("print('evil')"))
+    model_path.write_bytes(model_path.read_bytes() + b"\x00")
+    assert zipfile.is_zipfile(model_path)
+
+    def reject_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("trailing bytes must not bypass the entry-count preflight")
+
+    monkeypatch.setattr(zipfile, "ZipFile", reject_zipfile_open)
+
+    result = ExecuTorchScanner(config={"max_executorch_zip_entries": 2}).scan(str(model_path))
+
+    assert result.success is False
+    assert "executorch_zip_entry_limit" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "ExecuTorch ZIP Entry Count Preflight" and check.details["entry_count"] == 3
+        for check in result.checks
+    )
+
+
+def test_executorch_zip_entry_preflight_uses_zip64_count_with_legacy_near_match(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = tmp_path / "zip64-count.ptl"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("first.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("second.pkl", _pickle_payload_with_eval("print('evil')"))
+    _insert_zip64_directory_metadata(model_path, entry_count=3, legacy_entry_count=1)
+    with zipfile.ZipFile(model_path, "r") as zipf:
+        assert len(zipf.infolist()) == 3
+
+    def reject_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("ZIP64 entry count must be checked before ZipFile opens")
+
+    monkeypatch.setattr(zipfile, "ZipFile", reject_zipfile_open)
+
+    result = ExecuTorchScanner(config={"max_executorch_zip_entries": 2}).scan(str(model_path))
+
+    assert result.success is False
+    assert "executorch_zip_entry_limit" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "ExecuTorch ZIP Entry Count Preflight" and check.details["entry_count"] == 3
+        for check in result.checks
+    )
+
+
+def test_executorch_zip_entry_preflight_rejects_eocd_shaped_comment_suffix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = tmp_path / "ambiguous-eocd.ptl"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("hidden.pkl", _pickle_payload_with_eval("print('evil')"))
+        zipf.comment = b"prefixPK\x05\x06" + b"\x00" * 18
+    with zipfile.ZipFile(model_path, "r") as zipf:
+        assert zipf.namelist() == []
+
+    def reject_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("ambiguous EOCD metadata should fail before ZipFile opens")
+
+    monkeypatch.setattr(zipfile, "ZipFile", reject_zipfile_open)
+
+    result = ExecuTorchScanner().scan(str(model_path))
+
+    assert result.success is False
+    assert "executorch_zip_central_directory_invalid" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "ExecuTorch ZIP Central Directory Preflight"
+        and check.status == CheckStatus.FAILED
+        and check.rule_code == "S902"
+        for check in result.checks
+    )
+
+
+def test_executorch_zip_entry_preflight_rejects_trailing_eocd_overlay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = tmp_path / "trailing-eocd-overlay.ptl"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("hidden.pkl", _pickle_payload_with_eval("print('evil')"))
+    model_path.write_bytes(model_path.read_bytes() + b"PK\x05\x06" + b"\x00" * 18)
+    with zipfile.ZipFile(model_path, "r") as zipf:
+        assert zipf.namelist() == []
+
+    def reject_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("ambiguous trailing EOCD overlay should fail before ZipFile opens")
+
+    monkeypatch.setattr(zipfile, "ZipFile", reject_zipfile_open)
+
+    result = ExecuTorchScanner().scan(str(model_path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "executorch_zip_central_directory_invalid" in result.metadata["scan_outcome_reasons"]
+
+
+def test_executorch_zip_entry_preflight_ignores_unstructured_member_eocd_near_match(tmp_path: Path) -> None:
+    model_path = tmp_path / "member-eocd-near-match.ptl"
+    eocd_near_match = struct.pack(
+        "<4s4H2LH",
+        b"PK\x05\x06",
+        0,
+        0,
+        0xFFFE,
+        0xFFFE,
+        0xFFFFFF00,
+        0,
+        0,
+    )
+    with zipfile.ZipFile(model_path, "w", compression=zipfile.ZIP_STORED) as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("bytecode.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("metadata.bin", eocd_near_match)
+
+    result = ExecuTorchScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert "executorch_zip_central_directory_invalid" not in result.metadata.get("scan_outcome_reasons", [])
+
+
+def test_executorch_zip_entry_preflight_rejects_repeated_digital_signatures() -> None:
+    repeated_signatures = BytesIO((b"PK\x05\x05\x00\x00") * 2)
+
+    entry_count, parsed_completely = ExecuTorchScanner._count_central_directory_entries(
+        repeated_signatures,
+        directory_start=0,
+        directory_size=12,
+        entry_limit=10,
+    )
+
+    assert entry_count == 0
+    assert parsed_completely is False
+    assert repeated_signatures.tell() == 6
+
+
+def test_executorch_zip_central_directory_size_fails_before_archive_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = tmp_path / "large-central-directory.ptl"
+    member = zipfile.ZipInfo("version")
+    member.comment = b"A" * 256
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr(member, "1")
+
+    def reject_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("central-directory size preflight should reject before ZipFile opens")
+
+    def reject_directory_parse(*_args: Any, **_kwargs: Any) -> tuple[int, bool]:
+        raise AssertionError("central-directory size preflight should reject before parsing directory entries")
+
+    monkeypatch.setattr(zipfile, "ZipFile", reject_zipfile_open)
+    monkeypatch.setattr(ExecuTorchScanner, "_count_central_directory_entries", staticmethod(reject_directory_parse))
+
+    result = ExecuTorchScanner(config={"max_executorch_zip_central_directory_size": 128}).scan(str(model_path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "executorch_zip_central_directory_size_limit" in result.metadata["scan_outcome_reasons"]
+    assert result.metadata["executorch_zip_central_directory_size"] > 128
+    assert any(
+        check.name == "ExecuTorch ZIP Central Directory Size Preflight"
+        and check.status == CheckStatus.FAILED
+        and check.rule_code == "S410"
+        and check.details["central_directory_size"] > 128
+        and check.details["max_central_directory_size"] == 128
+        and check.details["phase"] == "pre_open"
+        for check in result.checks
+    )
+
+
+def test_executorch_zip_central_directory_size_allows_exact_limit(tmp_path: Path) -> None:
+    model_path = create_executorch_archive(tmp_path)
+    central_directory_size = _zip_central_directory_size(model_path)
+
+    result = ExecuTorchScanner(config={"max_executorch_zip_central_directory_size": central_directory_size}).scan(
+        str(model_path)
+    )
+
+    assert result.success is True
+    assert result.metadata["executorch_zip_central_directory_size"] == central_directory_size
+    assert result.metadata["max_executorch_zip_central_directory_size"] == central_directory_size
+    assert result.bytes_scanned > 0
+
+
+def test_executorch_zip_preflight_and_zipfile_share_one_handle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = create_executorch_archive(tmp_path)
+    original_read_entry_count = ExecuTorchScanner._read_zip_entry_count
+    original_zipfile = zipfile.ZipFile
+    preflight_handle: BinaryIO | None = None
+
+    def record_preflight_handle(
+        _cls: type[ExecuTorchScanner],
+        handle: BinaryIO,
+        file_size: int,
+        entry_limit: int,
+        directory_limit: int,
+    ) -> tuple[int, int, bool] | None:
+        nonlocal preflight_handle
+        preflight_handle = handle
+        return original_read_entry_count(handle, file_size, entry_limit, directory_limit)
+
+    def verify_zipfile_handle(file: Any, *args: Any, **kwargs: Any) -> zipfile.ZipFile:
+        assert preflight_handle is not None
+        assert file is preflight_handle
+        return original_zipfile(preflight_handle, *args, **kwargs)
+
+    monkeypatch.setattr(ExecuTorchScanner, "_read_zip_entry_count", classmethod(record_preflight_handle))
+    monkeypatch.setattr(zipfile, "ZipFile", verify_zipfile_handle)
+
+    result = ExecuTorchScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert preflight_handle is not None
+    assert preflight_handle.closed is True
+
+
+def test_executorch_zip_preflight_read_failure_stops_before_zipfile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = create_executorch_archive(tmp_path)
+
+    def fail_preflight_read(*_args: Any, **_kwargs: Any) -> tuple[int, int, bool] | None:
+        raise OSError("simulated central-directory read failure")
+
+    def reject_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("ZipFile must not open after a preflight read failure")
+
+    monkeypatch.setattr(ExecuTorchScanner, "_read_zip_entry_count", classmethod(fail_preflight_read))
+    monkeypatch.setattr(zipfile, "ZipFile", reject_zipfile_open)
+
+    result = ExecuTorchScanner().scan(str(model_path))
+
+    assert result.success is False
+    assert "executorch_read_failed" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "ExecuTorch File Read"
+        and check.details["exception_type"] == "OSError"
+        and check.details["scan_outcome_reason"] == "executorch_read_failed"
+        for check in result.checks
+    )
+
+
+def test_executorch_zip_entry_limit_fails_after_open_when_preflight_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = tmp_path / "entry-bomb-post-open.ptl"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("first.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("second.pkl", _pickle_payload_with_eval("print('evil')"))
+
+    monkeypatch.setattr(
+        ExecuTorchScanner,
+        "_read_zip_entry_count",
+        classmethod(lambda _cls, _path, _size, _entry_limit, _directory_limit: None),
+    )
+
+    result = ExecuTorchScanner(config={"max_executorch_zip_entries": 2}).scan(str(model_path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "executorch_zip_entry_limit" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "ExecuTorch ZIP Entry Count Limit"
+        and check.status == CheckStatus.FAILED
+        and check.rule_code == "S410"
+        and check.details["entry_count"] == 3
+        and check.details["phase"] == "post_open"
+        for check in result.checks
+    )
+
+
+def test_executorch_zip_aggregate_limit_fails_before_member_content_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = tmp_path / "split-size-bomb.ptl"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("bytecode.pkl", _pickle_payload_with_eval("print('evil')"))
+        zipf.writestr("weights.bin", b"A" * 32)
+
+    scanner = ExecuTorchScanner(config={"max_executorch_zip_total_uncompressed_size": 16})
+    assert scanner.pickle_scanner is not None
+
+    def reject_pickle_scan(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("aggregate-size preflight should stop before scanning pickle members")
+
+    monkeypatch.setattr(scanner.pickle_scanner, "scan_stream", reject_pickle_scan)
+
+    result = scanner.scan(str(model_path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "executorch_zip_total_uncompressed_size_limit" in result.metadata["scan_outcome_reasons"]
+    assert result.metadata["executorch_zip_uncompressed_size"] > 16
+    assert any(
+        check.name == "ExecuTorch ZIP Aggregate Size Limit"
+        and check.status == CheckStatus.FAILED
+        and check.rule_code == "S410"
+        and check.details["archive_uncompressed_size"] > 16
+        and check.details["max_total_uncompressed_size"] == 16
+        for check in result.checks
+    )
+
+
+def test_executorch_zip_aggregate_limit_allows_benign_near_match(tmp_path: Path) -> None:
+    model_path = tmp_path / "aggregate-near-match.ptl"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("bytecode.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("weights.bin", b"A" * 8)
+
+    with zipfile.ZipFile(model_path, "r") as zipf:
+        aggregate_limit = sum(entry.file_size for entry in zipf.infolist() if not entry.is_dir())
+
+    result = ExecuTorchScanner(config={"max_executorch_zip_total_uncompressed_size": aggregate_limit}).scan(
+        str(model_path)
+    )
+
+    assert result.success is True
+    assert result.metadata["executorch_zip_uncompressed_size"] == aggregate_limit
+    assert result.bytes_scanned > 0
+    assert not any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+    assert any(
+        check.name == "ExecuTorch ZIP Aggregate Size Limit"
+        and check.status == CheckStatus.PASSED
+        and check.details["archive_uncompressed_size"] == aggregate_limit
+        for check in result.checks
+    )
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"max_executorch_zip_total_uncompressed_size": False},
+        {"max_executorch_zip_total_uncompressed_size": 0.0},
+        {"max_zip_total_uncompressed_size": False},
+        {"max_executorch_zip_total_uncompressed_size": 0, "max_total_size": False},
+    ],
+)
+def test_executorch_zip_invalid_zero_like_aggregate_limits_use_safe_default(config: dict[str, Any]) -> None:
+    assert (
+        ExecuTorchScanner._get_max_total_uncompressed_size_from_config(config)
+        == ExecuTorchScanner.DEFAULT_MAX_TOTAL_UNCOMPRESSED_SIZE
+    )
+
+
+def test_executorch_zip_integer_zero_aggregate_limit_remains_unlimited() -> None:
+    assert (
+        ExecuTorchScanner._get_max_total_uncompressed_size_from_config(
+            {"max_executorch_zip_total_uncompressed_size": 0}
+        )
+        == ExecuTorchScanner.UNLIMITED_ARCHIVE_SIZE
+    )
+
+
+def test_executorch_zip_pickle_compression_ratio_fails_before_member_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = tmp_path / "compression-bomb.ptl"
+    payload = pickle.dumps({"weights": b"A" * (2 * 1024 * 1024)})
+    with zipfile.ZipFile(model_path, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("bytecode.pkl", payload)
+
+    scanner = ExecuTorchScanner()
+    assert scanner.pickle_scanner is not None
+
+    def reject_pickle_scan(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("compression-ratio preflight should stop before scanning pickle members")
+
+    monkeypatch.setattr(scanner.pickle_scanner, "scan_stream", reject_pickle_scan)
+
+    result = scanner.scan(str(model_path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "executorch_zip_compression_ratio_limit" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "ExecuTorch ZIP Pickle Compression Ratio Limit"
+        and check.status == CheckStatus.FAILED
+        and check.rule_code == "S410"
+        and check.details["compression_ratio"] > check.details["max_compression_ratio"]
+        for check in result.checks
+    )
+
+
+def test_executorch_zip_pickle_compression_ratio_allows_small_benign_member(tmp_path: Path) -> None:
+    model_path = tmp_path / "small-compressible.ptl"
+    payload = pickle.dumps({"weights": b"A" * (512 * 1024)})
+    with zipfile.ZipFile(model_path, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("bytecode.pkl", payload)
+
+    result = ExecuTorchScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert result.bytes_scanned == len(payload)
+    assert "executorch_zip_compression_ratio_limit" not in result.metadata.get("scan_outcome_reasons", [])
+
+
+def test_executorch_zip_pickle_compression_ratio_rejects_split_small_members() -> None:
+    scanner = ExecuTorchScanner()
+    result = scanner._create_result()
+    pickle_entries = []
+    for index in range(2):
+        entry = zipfile.ZipInfo(f"split-{index}.pkl")
+        entry.file_size = 600 * 1024
+        entry.compress_size = 1024
+        pickle_entries.append(entry)
+
+    scannable_entries, analysis_incomplete = scanner._check_pickle_member_budgets(
+        result,
+        "split-bomb.ptl",
+        pickle_entries,
+    )
+
+    assert scannable_entries == []
+    assert analysis_incomplete is True
+    assert "executorch_zip_compression_ratio_limit" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "ExecuTorch ZIP Pickle Compression Ratio Limit"
+        and check.details["aggregate_small_member_check"] is True
+        and check.details["member_count"] == 2
+        for check in result.checks
+    )
+
+
+def test_executorch_zip_pickle_compression_ratio_allows_exact_ratio_limit() -> None:
+    scanner = ExecuTorchScanner()
+    result = scanner._create_result()
+    entry = zipfile.ZipInfo("exact-ratio.pkl")
+    entry.file_size = 1_048_600
+    entry.compress_size = 10_486
+
+    scannable_entries, analysis_incomplete = scanner._check_pickle_member_budgets(
+        result,
+        "exact-ratio.ptl",
+        [entry],
+    )
+
+    assert scannable_entries == [entry]
+    assert analysis_incomplete is False
+
+
+def test_executorch_zip_pickle_member_size_fails_before_member_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = create_executorch_archive(tmp_path)
+    scanner = ExecuTorchScanner()
+    assert scanner.pickle_scanner is not None
+    monkeypatch.setattr(scanner.pickle_scanner, "max_file_read_size", 16)
+
+    def reject_pickle_scan(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("pickle member size preflight should stop before scanning")
+
+    monkeypatch.setattr(scanner.pickle_scanner, "scan_stream", reject_pickle_scan)
+
+    result = scanner.scan(str(model_path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "executorch_zip_pickle_member_size_limit" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "ExecuTorch ZIP Pickle Member Size Limit"
+        and check.status == CheckStatus.FAILED
+        and check.rule_code == "S410"
+        and check.details["uncompressed_size"] > check.details["max_pickle_member_size"]
+        for check in result.checks
+    )
+
+
+def test_executorch_zip_pickle_member_size_preserves_safe_member_detection(tmp_path: Path) -> None:
+    model_path = tmp_path / "mixed-size.ptl"
+    malicious_payload = _pickle_payload_with_eval("print('evil')")
+    oversized_payload = pickle.dumps({"weights": b"A" * 4096})
+    with zipfile.ZipFile(model_path, "w", compression=zipfile.ZIP_STORED) as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("malicious.pkl", malicious_payload)
+        zipf.writestr("oversized.pkl", oversized_payload)
+
+    scanner = ExecuTorchScanner()
+    assert scanner.pickle_scanner is not None
+    scanner.pickle_scanner.max_file_read_size = len(malicious_payload)
+
+    result = scanner.scan(str(model_path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "executorch_zip_pickle_member_size_limit" in result.metadata["scan_outcome_reasons"]
+    assert result.bytes_scanned == len(malicious_payload)
+    assert any(issue.severity == IssueSeverity.CRITICAL and "eval" in issue.message.lower() for issue in result.issues)
+
+
+def test_executorch_zip_pickle_compression_ratio_preserves_safe_member_detection(tmp_path: Path) -> None:
+    model_path = tmp_path / "mixed-ratio.ptl"
+    malicious_payload = _pickle_payload_with_eval("print('evil')")
+    compressed_payload = pickle.dumps({"weights": b"A" * (2 * 1024 * 1024)})
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("malicious.pkl", malicious_payload, compress_type=zipfile.ZIP_STORED)
+        zipf.writestr("compressed.pkl", compressed_payload, compress_type=zipfile.ZIP_DEFLATED)
+
+    result = ExecuTorchScanner().scan(str(model_path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "executorch_zip_compression_ratio_limit" in result.metadata["scan_outcome_reasons"]
+    assert result.bytes_scanned == len(malicious_payload)
+    assert any(issue.severity == IssueSeverity.CRITICAL and "eval" in issue.message.lower() for issue in result.issues)
+
+
+def test_executorch_zip_pickle_member_size_allows_exact_limit() -> None:
+    scanner = ExecuTorchScanner()
+    assert scanner.pickle_scanner is not None
+    scanner.pickle_scanner.max_file_read_size = 16
+    result = scanner._create_result()
+    entry = zipfile.ZipInfo("exact-size.pkl")
+    entry.file_size = 16
+    entry.compress_size = 16
+
+    scannable_entries, analysis_incomplete = scanner._check_pickle_member_budgets(
+        result,
+        "exact-size.ptl",
+        [entry],
+    )
+
+    assert scannable_entries == [entry]
+    assert analysis_incomplete is False
+
+
+@pytest.mark.parametrize(
+    ("config", "reason"),
+    [
+        ({"max_executorch_zip_entries": 2}, "executorch_zip_entry_limit"),
+        (
+            {"max_executorch_zip_total_uncompressed_size": 16},
+            "executorch_zip_total_uncompressed_size_limit",
+        ),
+    ],
+)
+def test_executorch_zip_budget_failure_propagates_exit_code_and_is_not_cached(
+    tmp_path: Path,
+    config: dict[str, int],
+    reason: str,
+) -> None:
+    model_path = tmp_path / f"{reason}.ptl"
+    with zipfile.ZipFile(model_path, "w") as zipf:
+        zipf.writestr("version", "1")
+        zipf.writestr("bytecode.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zipf.writestr("weights.bin", b"A" * 32)
+    cache_dir = tmp_path / "cache"
+
+    reset_cache_manager()
+    try:
+        for _ in range(2):
+            scan_kwargs: dict[str, Any] = {
+                "cache_enabled": True,
+                "cache_dir": str(cache_dir),
+                "min_cache_file_size": 0,
+                **config,
+            }
+            aggregate = core.scan_model_directory_or_file(str(model_path), **scan_kwargs)
+            metadata = aggregate.file_metadata[str(model_path)]
+            assert aggregate.success is True
+            assert metadata["analysis_incomplete"] is True
+            assert metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+            assert reason in metadata["scan_outcome_reasons"]
+            assert core.determine_exit_code(aggregate) == 1
+        assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+    finally:
+        reset_cache_manager()
 
 
 def test_executorch_duplicate_pickle_members_scan_malicious_first_entry(tmp_path: Path) -> None:

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -2108,6 +2108,16 @@ class TestModelDownloadStreaming:
         _mock_monotonic: MagicMock,
     ) -> None:
         """The scan deadline should stop acquisition before a late remote probe begins."""
+
+        def finish_listing_after_deadline(
+            *_args: object,
+            **_kwargs: object,
+        ) -> tuple[list[str], str, None]:
+            _mock_monotonic.return_value = 102.0
+            return ["pytorch_model.bin", "hidden.payload"], _HF_TEST_REVISION, None
+
+        _mock_list_repo_files.side_effect = finish_listing_after_deadline
+
         with pytest.raises(Exception, match=r"hidden\.payload \(TimeoutError\)"):
             list(download_model_streaming("https://huggingface.co/test/model", timeout_seconds=1))
 


### PR DESCRIPTION
## Summary
- Bound ExecuTorch ZIP central-directory processing before `ZipFile` allocation.
- Parse a bounded private snapshot and reject archives that mutate during the scan.
- Fail closed on entry-count, central-directory-size, aggregate-size, pickle-member-size, compression-ratio, and ambiguous legacy/ZIP64 overlay limits.
- Preserve eligible malicious pickle detections across aggregate limits, unreadable members, oversized siblings, and suspiciously compressed siblings.
- Keep exact-limit benign archives clean and make the two touched Hugging Face deadline regressions state-driven.

## False-positive / false-negative audit
- Reject forged-low or zero counts, truncated directories, malformed ZIP64 metadata, repeated digital-signature records, and hidden prior archives outside the EOCD tail.
- Structurally validate legacy and ZIP64 preambles while preserving incidental EOCD/locator near-matches.
- Re-read descriptor size, snapshot the selected inode, and report in-place mutation instead of accepting a stale success.
- Continue past unsupported or unreadable pickle members so later malicious payloads remain visible.
- Preserve malicious findings in either archive order while enforcing the cumulative pickle scan budget.
- Preserve exact entry-count, central-directory, aggregate, member-size, and compression-ratio boundaries.

## Validation
- Reviewed head: `462bd2e52a2a0a3dbaf376f6f7aa55264755fa7f`
- Exact published tree: `361fc08b923e417a5d699a94099d4afe5e218934`
- Complete ExecuTorch scanner module plus both touched Hugging Face deadline tests: `81 passed`
- Scoped Ruff check/format, mypy, and `git diff --check`: clean
- All inline review threads are addressed and resolved.
- Full-suite validation is intentionally deferred to CI.