### PR TITLE
fix: preflight generic zip entry limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - preserve registrable network domains and redact delimiter-split credentials in bounded finding evidence
 - preserve executable text-sidecar network findings for f-string calls, standard command wrappers, port-qualified Docker registries, and bounded xargs downloads while keeping prose references informational.
 - stabilize cache identity capture for compressed wrapper scans on Darwin `/private` path aliases and during unrelated temporary-file churn.
+- fail closed on over-entry, oversized, or inconsistent generic ZIP directories before `zipfile` materializes their entries, including ZIP-backed models selected for weight analysis.
 - bound per-tensor and cumulative weight-distribution extraction before materializing PyTorch, HDF5, TensorFlow, and ONNX payloads
 
 ## [0.2.47](https://github.com/promptfoo/modelaudit/compare/v0.2.46...v0.2.47) (2026-06-05)

--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -1621,6 +1621,10 @@ def _local_path_will_be_scanned(path: str, *, skip_non_model_files: bool) -> boo
         return True
 
     from modelaudit.scanners import SCANNER_REGISTRY
+    from modelaudit.scanners.zip_scanner import ZipScanner
+
+    if ZipScanner.can_handle(path):
+        return True
 
     return any(scanner_class().can_handle(path) for scanner_class in SCANNER_REGISTRY)
 

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -36,6 +36,7 @@ from modelaudit.scanner_selection import (
     ScannerSelectionPolicy,
     add_scanner_selection_skip_check,
     allows_protobuf_model_candidate_analysis,
+    allows_zip_structure_analysis,
     make_scanner_selection_skip_result,
     normalize_scanner_selection_config,
     policy_from_config,
@@ -689,21 +690,28 @@ def _resolve_discovered_shard_path(shard_path: str, results: ModelAuditResultMod
         return None
 
 
-def _select_non_hdf5_preferred_scanner_id(path: str, header_format: str, ext: str) -> str | None:
+def _select_non_hdf5_preferred_scanner_id(
+    path: str,
+    header_format: str,
+    ext: str,
+    config: dict[str, Any] | None = None,
+) -> str | None:
     """Select the trusted route that owns content before an HDF5 user block."""
     if header_format == EXECUTABLE_ZIP_POLYGLOT_FORMAT:
         return "zip"
 
     if header_format == "zip":
-        if is_torchserve_mar_archive(path):
+        if config is not None and not allows_zip_structure_analysis(policy_from_config(config)):
+            return "joblib" if ext == ".joblib" else "zip"
+        if is_torchserve_mar_archive(path, config):
             return "torchserve_mar"
-        if is_keras_zip_archive(path, allow_config_only=ext == ".keras"):
+        if is_keras_zip_archive(path, allow_config_only=ext == ".keras", config=config):
             return "keras_zip"
-        if is_pytorch_zip_archive(path):
+        if is_pytorch_zip_archive(path, config):
             return "pytorch_zip"
-        if is_executorch_archive(path):
+        if is_executorch_archive(path, config):
             return "executorch"
-        if is_skops_archive(path):
+        if is_skops_archive(path, config):
             return "skops"
         if ext == ".skops":
             return "skops"
@@ -723,9 +731,14 @@ def _select_non_hdf5_preferred_scanner_id(path: str, header_format: str, ext: st
     return _registry.get_scanner_id_for_header_format(header_format)
 
 
-def _select_hdf5_userblock_supplemental_scanner_id(path: str, header_format: str, ext: str) -> str | None:
+def _select_hdf5_userblock_supplemental_scanner_id(
+    path: str,
+    header_format: str,
+    ext: str,
+    config: dict[str, Any] | None = None,
+) -> str | None:
     """Preserve the non-HDF5 scanner that owns a user-block prefix or path."""
-    scanner_id = _select_non_hdf5_preferred_scanner_id(path, header_format, ext)
+    scanner_id = _select_non_hdf5_preferred_scanner_id(path, header_format, ext, config)
     if scanner_id is not None:
         return scanner_id
 
@@ -733,11 +746,16 @@ def _select_hdf5_userblock_supplemental_scanner_id(path: str, header_format: str
     return path_scanner_id if path_scanner_id != "keras_h5" else None
 
 
-def _select_preferred_scanner_id(path: str, header_format: str, ext: str) -> str | None:
+def _select_preferred_scanner_id(
+    path: str,
+    header_format: str,
+    ext: str,
+    config: dict[str, Any] | None = None,
+) -> str | None:
     """Select a scanner by trusted file structure, not just suffix."""
     if find_hdf5_signature_offset(path) is not None:
         return "keras_h5"
-    return _select_non_hdf5_preferred_scanner_id(path, header_format, ext)
+    return _select_non_hdf5_preferred_scanner_id(path, header_format, ext, config)
 
 
 def _merge_supplemental_scanner_analysis(
@@ -821,8 +839,20 @@ def _preferred_scanner_can_handle(
         )
         return True
 
+    if header_format == "zip" and scanner_id in {
+        "executorch",
+        "keras_zip",
+        "pytorch_zip",
+        "skops",
+        "torchserve_mar",
+    }:
+        return True
+
     if scanner_class.can_handle(path):
         return True
+
+    if scanner_id == "zip":
+        return False
 
     if os.path.exists(path) and _is_direct_header_route(scanner_id, header_format):
         logger.debug(
@@ -2921,6 +2951,7 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
     config = normalize_scanner_selection_config(config)
     scanner_selection = policy_from_config(config)
     validate_scan_config(config)
+    from modelaudit.scanners.zip_scanner import ZipPreflightRejected, ZipScanner
 
     allowed_shard_paths = _allowed_shard_paths_from_config(config)
     allowed_shard_targets = _validated_shard_targets_from_config(config)
@@ -3039,6 +3070,18 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
         sr.finish(success=False)
         return sr
 
+    try:
+        max_zip_entries = int(config.get("max_zip_entries", ZipScanner.DEFAULT_MAX_ENTRIES))
+    except (TypeError, ValueError):
+        max_zip_entries = ZipScanner.DEFAULT_MAX_ENTRIES
+    max_zip_directory_size = ZipScanner.central_directory_size_limit(config)
+    if allows_zip_structure_analysis(scanner_selection) and ZipScanner.requires_preflight_result(
+        path,
+        max_zip_entries,
+        max_zip_directory_size,
+    ):
+        return ZipScanner(config=config).scan(path)
+
     logger.debug(f"Processing: {path}")
 
     format_probe_error: OSError | None = None
@@ -3057,8 +3100,21 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
         format_probe_error = e
     ext_format = detect_format_from_extension(path)
     ext = os.path.splitext(path)[1].lower()
+    pytorch_binary_supplemental_scanner_id = (
+        detect_pytorch_binary_supplemental_format(path) if ext == ".bin" and header_format == "pytorch_binary" else None
+    )
+    if (
+        format_probe_error is None
+        and header_format in {"unknown", "pytorch_binary"}
+        and pytorch_binary_supplemental_scanner_id is None
+        and scanner_selection.allows("zip")
+        and ZipScanner.can_handle(path)
+    ):
+        header_format = "zip"
     if format_probe_error is not None:
         magic_format = "unknown"
+    elif header_format == "zip":
+        magic_format = "zip"
     elif header_format in {"mxnet", MXNET_SYMBOL_ROUTING_INCONCLUSIVE_FORMAT}:
         magic_format = header_format
     else:
@@ -3230,17 +3286,19 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
 
     # Prefer scanners based on trusted structure rather than the filename alone.
     preferred_scanner: type[BaseScanner] | None = None
-    scanner_id = (
-        "keras_h5" if hdf5_signature_offset is not None else _select_preferred_scanner_id(path, header_format, ext)
-    )
-    hdf5_userblock_supplemental_scanner_id = (
-        _select_hdf5_userblock_supplemental_scanner_id(path, magic_format, ext)
-        if scanner_id == "keras_h5" and hdf5_signature_offset not in (None, 0)
-        else None
-    )
-    pytorch_binary_supplemental_scanner_id = (
-        detect_pytorch_binary_supplemental_format(path) if ext == ".bin" and header_format == "pytorch_binary" else None
-    )
+    try:
+        scanner_id = (
+            "keras_h5"
+            if hdf5_signature_offset is not None
+            else _select_preferred_scanner_id(path, header_format, ext, config)
+        )
+        hdf5_userblock_supplemental_scanner_id = (
+            _select_hdf5_userblock_supplemental_scanner_id(path, magic_format, ext, config)
+            if scanner_id == "keras_h5" and hdf5_signature_offset not in (None, 0)
+            else None
+        )
+    except ZipPreflightRejected as exc:
+        return exc.result
     skipped_preferred_scanner_id: str | None = None
     unavailable_preferred_scanner_id: str | None = None
     trusted_flax_overlap_scanner_id: str | None = None
@@ -3434,6 +3492,20 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
                     result = make_scanner_selection_skip_result(path, candidate_scanner_id, scanner_selection)
                     if result.bytes_scanned == 0 and file_size > 0:
                         result.bytes_scanned = file_size
+                    userblock_zip_allowed = hdf5_signature_offset not in (None, 0) and (
+                        scanner_selection.allows("zip")
+                        or scanner_selection.allows(hdf5_userblock_supplemental_scanner_id)
+                    )
+                    if userblock_zip_allowed:
+                        assert hdf5_signature_offset is not None
+                        result.scanner_name = "zip"
+                        merge_hdf5_userblock_zip_findings(
+                            path,
+                            result,
+                            config,
+                            hdf5_signature_offset,
+                            context="HDF5 user-block ZIP",
+                        )
                     return result
 
             if unavailable_preferred_scanner_id is not None:

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -701,7 +701,7 @@ def _select_non_hdf5_preferred_scanner_id(
         return "zip"
 
     if header_format == "zip":
-        if config is not None and not allows_zip_structure_analysis(policy_from_config(config)):
+        if config is not None and not allows_zip_structure_analysis(policy_from_config(config), path):
             return "joblib" if ext == ".joblib" else "zip"
         if is_torchserve_mar_archive(path, config):
             return "torchserve_mar"
@@ -3075,7 +3075,7 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
     except (TypeError, ValueError):
         max_zip_entries = ZipScanner.DEFAULT_MAX_ENTRIES
     max_zip_directory_size = ZipScanner.central_directory_size_limit(config)
-    if allows_zip_structure_analysis(scanner_selection) and ZipScanner.requires_preflight_result(
+    if allows_zip_structure_analysis(scanner_selection, path) and ZipScanner.requires_preflight_result(
         path,
         max_zip_entries,
         max_zip_directory_size,

--- a/modelaudit/scanner_selection.py
+++ b/modelaudit/scanner_selection.py
@@ -36,6 +36,19 @@ _ZIP_STRUCTURE_ROUTED_SCANNER_IDS = frozenset(
         "zip",
     }
 )
+_ZIP_CONTENT_ROUTED_SCANNER_IDS = frozenset(
+    {
+        "executorch",
+        "keras_zip",
+        "pytorch_zip",
+        "skops",
+        "torchserve_mar",
+        "zip",
+    }
+)
+_ZIP_EXTENSION_ROUTE_OVERRIDES = {
+    "numpy": frozenset({".npz"}),
+}
 
 
 def scanner_catalog() -> list[dict[str, Any]]:
@@ -191,9 +204,29 @@ def allows_protobuf_model_candidate_analysis(policy: ScannerSelectionPolicy) -> 
     )
 
 
-def allows_zip_structure_analysis(policy: ScannerSelectionPolicy) -> bool:
-    """Return whether any selected scanner relies on ZIP container structure."""
-    return any(policy.allows(scanner_id) for scanner_id in _ZIP_STRUCTURE_ROUTED_SCANNER_IDS)
+def allows_zip_structure_analysis(policy: ScannerSelectionPolicy, path: str | None = None) -> bool:
+    """Return whether a selected route may analyze ZIP structure for this path."""
+    selected_zip_scanner_ids = {
+        scanner_id for scanner_id in _ZIP_STRUCTURE_ROUTED_SCANNER_IDS if policy.allows(scanner_id)
+    }
+    if not selected_zip_scanner_ids or path is None or not policy.active:
+        return bool(selected_zip_scanner_ids)
+    if selected_zip_scanner_ids & _ZIP_CONTENT_ROUTED_SCANNER_IDS:
+        return True
+
+    extension = os.path.splitext(path)[1].lower()
+    metadata = _scanner_metadata()
+    for scanner_id in selected_zip_scanner_ids:
+        scanner_info = metadata.get(scanner_id, {})
+        routed_extensions = {
+            str(value).lower()
+            for key in ("extensions", "content_routed_extensions", "scanner_only_extensions")
+            for value in scanner_info.get(key, ())
+        }
+        routed_extensions.update(_ZIP_EXTENSION_ROUTE_OVERRIDES.get(scanner_id, ()))
+        if extension in routed_extensions:
+            return True
+    return False
 
 
 def allows_protobuf_model_candidate_analyzer(policy: ScannerSelectionPolicy, scanner_id: str) -> bool:

--- a/modelaudit/scanner_selection.py
+++ b/modelaudit/scanner_selection.py
@@ -25,7 +25,16 @@ _GENERIC_CONTAINER_SCANNER_IDS = frozenset({"compressed", "rar", "sevenzip", "ta
 _PROTOBUF_MODEL_CANDIDATE_SCANNER_ID = "protobuf_model_candidate"
 _PROTOBUF_MODEL_CANDIDATE_ANALYZER_IDS = frozenset({"onnx", "coreml"})
 _ZIP_STRUCTURE_ROUTED_SCANNER_IDS = frozenset(
-    {"executorch", "keras_zip", "pytorch_zip", "skops", "torchserve_mar", "zip"}
+    {
+        "executorch",
+        "keras_zip",
+        "numpy",
+        "pytorch_zip",
+        "skops",
+        "torchserve_mar",
+        "weight_distribution",
+        "zip",
+    }
 )
 
 
@@ -180,6 +189,11 @@ def allows_protobuf_model_candidate_analysis(policy: ScannerSelectionPolicy) -> 
     return policy.allows(_PROTOBUF_MODEL_CANDIDATE_SCANNER_ID) or any(
         policy.allows(scanner_id) for scanner_id in _PROTOBUF_MODEL_CANDIDATE_ANALYZER_IDS
     )
+
+
+def allows_zip_structure_analysis(policy: ScannerSelectionPolicy) -> bool:
+    """Return whether any selected scanner relies on ZIP container structure."""
+    return any(policy.allows(scanner_id) for scanner_id in _ZIP_STRUCTURE_ROUTED_SCANNER_IDS)
 
 
 def allows_protobuf_model_candidate_analyzer(policy: ScannerSelectionPolicy, scanner_id: str) -> bool:

--- a/modelaudit/scanners/__init__.py
+++ b/modelaudit/scanners/__init__.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from ..scanner_registry_metadata import get_scanner_registry_metadata
-from ..scanner_selection import ScannerSelectionPolicy, policy_from_config
+from ..scanner_selection import ScannerSelectionPolicy, allows_zip_structure_analysis, policy_from_config
 from .base import BaseScanner, Check, CheckStatus, Issue, IssueSeverity, ScanResult
 
 logger = logging.getLogger(__name__)
@@ -395,7 +395,9 @@ class ScannerRegistry:
             and (scanner_selection is None or scanner_selection.allows(header_scanner_id))
         ):
             scanner_class = self._load_scanner(header_scanner_id)
-            if scanner_class and (scanner_class.can_handle(path) or os.path.exists(path)):
+            if scanner_class and (
+                scanner_class.can_handle(path) or (header_scanner_id != "zip" and os.path.exists(path))
+            ):
                 return scanner_class
 
         # Manifest-like config files sometimes intentionally use generic or
@@ -570,6 +572,20 @@ def __getattr__(name: str) -> Any:
 def get_scanner_for_file(path: str, config: dict[str, Any] | None = None) -> BaseScanner | None:
     """Get an instantiated scanner for a given file path"""
     scanner_selection = policy_from_config(config)
+    from .zip_scanner import ZipScanner
+
+    raw_config = config or {}
+    try:
+        max_entries = int(raw_config.get("max_zip_entries", ZipScanner.DEFAULT_MAX_ENTRIES))
+    except (TypeError, ValueError):
+        max_entries = ZipScanner.DEFAULT_MAX_ENTRIES
+    max_directory_size = ZipScanner.central_directory_size_limit(raw_config)
+    if allows_zip_structure_analysis(scanner_selection) and ZipScanner.requires_preflight_result(
+        path,
+        max_entries,
+        max_directory_size,
+    ):
+        return ZipScanner(config=config)
     scanner_class = _registry.get_scanner_for_path(
         path,
         scanner_selection=scanner_selection if scanner_selection.active else None,

--- a/modelaudit/scanners/archive_dispatch.py
+++ b/modelaudit/scanners/archive_dispatch.py
@@ -22,6 +22,7 @@ from ..scanner_selection import (
     SCANNER_SELECTION_PREFERRED_KIND,
     add_scanner_selection_skip_check,
     allows_protobuf_model_candidate_analysis,
+    allows_zip_structure_analysis,
     make_scanner_selection_skip_result,
     policy_from_config,
 )
@@ -145,21 +146,27 @@ def _pickle_result_consumes_entire_payload(path: str, result: ScanResult) -> boo
     return positions[0] == positions[1] == positions[2] == file_size
 
 
-def _select_nested_scanner_id(path: str, header_format_override: str | None = None) -> str | None:
+def _select_nested_scanner_id(
+    path: str,
+    header_format_override: str | None = None,
+    config: dict[str, Any] | None = None,
+) -> str | None:
     """Select a scanner for extracted archive members using trusted file structure first."""
     header_format = header_format_override or detect_file_format(path)
     ext = os.path.splitext(path)[1].lower()
 
     if header_format == "zip":
-        if is_torchserve_mar_archive(path):
+        if config is not None and not allows_zip_structure_analysis(policy_from_config(config)):
+            return "joblib" if ext == ".joblib" else "zip"
+        if is_torchserve_mar_archive(path, config):
             return "torchserve_mar"
-        if is_keras_zip_archive(path, allow_config_only=ext == ".keras"):
+        if is_keras_zip_archive(path, allow_config_only=ext == ".keras", config=config):
             return "keras_zip"
-        if is_pytorch_zip_archive(path):
+        if is_pytorch_zip_archive(path, config):
             return "pytorch_zip"
-        if is_executorch_archive(path):
+        if is_executorch_archive(path, config):
             return "executorch"
-        if is_skops_archive(path):
+        if is_skops_archive(path, config):
             return "skops"
         if ext == ".skops":
             return "skops"
@@ -237,6 +244,9 @@ def _nested_scanner_can_handle(
     """Honor trusted header routing even when temporary archive paths are suffix-gated."""
     if scanner_class.can_handle(path):
         return True
+
+    if scanner_id == "zip":
+        return False
 
     if not os.path.exists(path):
         return False
@@ -371,7 +381,7 @@ def merge_executable_zip_container_findings(
 ) -> None:
     """Merge all enabled subtype checks and one generic ZIP member traversal."""
     from . import _registry
-    from .zip_scanner import ZipScanner
+    from .zip_scanner import ZipPreflightRejected, ZipScanner
 
     try:
         if not zipfile.is_zipfile(path):
@@ -382,16 +392,20 @@ def merge_executable_zip_container_findings(
     scanner_selection = policy_from_config(config)
     ext = os.path.splitext(path)[1].lower()
     subtype_ids: list[str] = []
-    if is_torchserve_mar_archive(path):
-        subtype_ids.append("torchserve_mar")
-    if is_keras_zip_archive(path, allow_config_only=ext == ".keras"):
-        subtype_ids.append("keras_zip")
-    if is_pytorch_zip_archive(path):
-        subtype_ids.append("pytorch_zip")
-    if is_executorch_archive(path):
-        subtype_ids.append("executorch")
-    if is_skops_archive(path):
-        subtype_ids.append("skops")
+    try:
+        if is_torchserve_mar_archive(path, config):
+            subtype_ids.append("torchserve_mar")
+        if is_keras_zip_archive(path, allow_config_only=ext == ".keras", config=config):
+            subtype_ids.append("keras_zip")
+        if is_pytorch_zip_archive(path, config):
+            subtype_ids.append("pytorch_zip")
+        if is_executorch_archive(path, config):
+            subtype_ids.append("executorch")
+        if is_skops_archive(path, config):
+            subtype_ids.append("skops")
+    except ZipPreflightRejected as exc:
+        result.merge(exc.result)
+        return
 
     subtype_config = dict(config or {})
     subtype_config[SKIP_COMPOSED_ARCHIVE_MEMBER_SCAN_CONFIG_KEY] = True
@@ -952,8 +966,21 @@ def _make_incomplete_pickle_routing_result(path: str) -> ScanResult:
 def scan_nested_file(path: str, config: dict[str, Any] | None = None) -> ScanResult:
     """Scan an extracted archive member without importing `modelaudit.core`."""
     from . import _registry
+    from .zip_scanner import ZipPreflightRejected, ZipScanner
 
     scanner_selection = policy_from_config(config)
+    raw_config = config or {}
+    try:
+        max_zip_entries = int(raw_config.get("max_zip_entries", ZipScanner.DEFAULT_MAX_ENTRIES))
+    except (TypeError, ValueError):
+        max_zip_entries = ZipScanner.DEFAULT_MAX_ENTRIES
+    max_zip_directory_size = ZipScanner.central_directory_size_limit(raw_config)
+    if allows_zip_structure_analysis(scanner_selection) and ZipScanner.requires_preflight_result(
+        path,
+        max_zip_entries,
+        max_zip_directory_size,
+    ):
+        return ZipScanner(config=config).scan(path)
     scanner_class = None
     routed_content_format = detect_file_format(path)
     trusted_content_format = detect_file_format_from_magic(path)
@@ -1052,7 +1079,10 @@ def scan_nested_file(path: str, config: dict[str, Any] | None = None) -> ScanRes
         return result
 
     header_format_override = trusted_content_format if trusted_content_format in {"mxnet", "xgboost"} else None
-    scanner_id = _select_nested_scanner_id(path, header_format_override)
+    try:
+        scanner_id = _select_nested_scanner_id(path, header_format_override, config)
+    except ZipPreflightRejected as exc:
+        return exc.result
     pytorch_binary_supplemental_scanner_id = (
         detect_pytorch_binary_supplemental_format(path)
         if os.path.splitext(path)[1].lower() == ".bin" and scanner_id == "pytorch_binary"

--- a/modelaudit/scanners/keras_zip_scanner.py
+++ b/modelaudit/scanners/keras_zip_scanner.py
@@ -1,5 +1,6 @@
 """Scanner for ZIP-based Keras model files (.keras format)."""
 
+import contextlib
 import io
 import json
 import os
@@ -758,7 +759,12 @@ class KerasZipScanner(BaseScanner):
         recursive_config[ZIP_CONTENT_ONLY_MEMBER_ENTRIES_CONFIG_KEY] = content_only_entries
         return recursive_config
 
-    def _merge_recursive_archive_scan(self, path: str, result: ScanResult) -> None:
+    def _merge_recursive_archive_scan(
+        self,
+        path: str,
+        result: ScanResult,
+        archive: zipfile.ZipFile | None = None,
+    ) -> None:
         """Recursively scan every ZIP member through the generic archive scanner."""
         if self.config.get(SKIP_COMPOSED_ARCHIVE_MEMBER_SCAN_CONFIG_KEY):
             return
@@ -773,10 +779,7 @@ class KerasZipScanner(BaseScanner):
                 content_only_weights_entry=content_only_weights_entry,
             )
         )
-        nested_result = zip_scanner._scan_zip_file(
-            path,
-            depth=max(zip_scanner._get_archive_depth(), zip_scanner._get_zip_depth()),
-        )
+        nested_result = zip_scanner.scan_archive_members(path, archive=archive)
         if has_embedded_weights_limit:
             self._suppress_expected_embedded_weights_limit_noise(nested_result)
         self._redact_recursive_archive_scan_result(nested_result)
@@ -788,10 +791,15 @@ class KerasZipScanner(BaseScanner):
             result.metadata["contents"] = nested_contents
         result.success = result.success and nested_result.success
 
-    def _merge_recursive_archive_scan_after_primary_failure(self, path: str, result: ScanResult) -> None:
+    def _merge_recursive_archive_scan_after_primary_failure(
+        self,
+        path: str,
+        result: ScanResult,
+        archive: zipfile.ZipFile | None = None,
+    ) -> None:
         """Preserve independently detectable archive findings when Keras analysis is unavailable."""
         try:
-            self._merge_recursive_archive_scan(path, result)
+            self._merge_recursive_archive_scan(path, result, archive=archive)
         except Exception:
             # The primary failure already makes this scan inconclusive; a
             # failing fallback must not replace that explicit outcome.
@@ -826,8 +834,13 @@ class KerasZipScanner(BaseScanner):
         # Store the file path for use in issue locations
         self.current_file_path = path
 
+        from .zip_scanner import ZipPreflightRejected, open_preflighted_zip
+
+        archive_stack = contextlib.ExitStack()
+        zf: zipfile.ZipFile | None = None
         try:
-            with zipfile.ZipFile(path, "r") as zf:
+            zf = archive_stack.enter_context(open_preflighted_zip(path, self.config))
+            with contextlib.nullcontext():
                 result.bytes_scanned = file_size
 
                 config_info = self._get_archive_member_info(zf, _KERAS_CONFIG_ENTRY)
@@ -844,7 +857,7 @@ class KerasZipScanner(BaseScanner):
                     )
                     self._load_keras_metadata(zf, result)
                     self._check_archive_security_members(zf, path, result)
-                    self._merge_recursive_archive_scan(path, result)
+                    self._merge_recursive_archive_scan(path, result, archive=zf)
                     self._finish_scan_result(result)
                     return result
 
@@ -882,7 +895,7 @@ class KerasZipScanner(BaseScanner):
                     )
                     self._load_keras_metadata(zf, result)
                     self._check_archive_security_members(zf, path, result)
-                    self._merge_recursive_archive_scan(path, result)
+                    self._merge_recursive_archive_scan(path, result, archive=zf)
                     self._finish_scan_result(result)
                     return result
 
@@ -905,7 +918,7 @@ class KerasZipScanner(BaseScanner):
                         details={"actual_type": type(model_config).__name__, "expected_type": "dict"},
                     )
                     self._check_archive_security_members(zf, path, result)
-                    self._merge_recursive_archive_scan(path, result)
+                    self._merge_recursive_archive_scan(path, result, archive=zf)
                     self._finish_scan_result(result)
                     return result
 
@@ -914,8 +927,10 @@ class KerasZipScanner(BaseScanner):
 
                 self._check_archive_security_members(zf, path, result)
 
-                self._merge_recursive_archive_scan(path, result)
+                self._merge_recursive_archive_scan(path, result, archive=zf)
 
+        except ZipPreflightRejected as exc:
+            return exc.result
         except _AmbiguousKerasArchiveMemberError as e:
             redacted_member_name = self._redact_archive_member_name(e.member_name)
             redacted_candidate_filenames = [
@@ -935,7 +950,7 @@ class KerasZipScanner(BaseScanner):
                     "candidate_filenames": redacted_candidate_filenames,
                 },
             )
-            self._merge_recursive_archive_scan(path, result)
+            self._merge_recursive_archive_scan(path, result, archive=zf)
             result.finish(success=False)
             return result
         except OSError as e:
@@ -954,7 +969,7 @@ class KerasZipScanner(BaseScanner):
                     "scan_outcome_reason": "keras_zip_read_failed",
                 },
             )
-            self._merge_recursive_archive_scan_after_primary_failure(path, result)
+            self._merge_recursive_archive_scan_after_primary_failure(path, result, archive=zf)
             self._finish_scan_result(result)
             return result
         except Exception as e:
@@ -973,9 +988,11 @@ class KerasZipScanner(BaseScanner):
                     "scan_outcome_reason": "keras_zip_scan_failed",
                 },
             )
-            self._merge_recursive_archive_scan_after_primary_failure(path, result)
+            self._merge_recursive_archive_scan_after_primary_failure(path, result, archive=zf)
             self._finish_scan_result(result)
             return result
+        finally:
+            archive_stack.close()
 
         self._finish_scan_result(result)
         return result

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -46,6 +46,7 @@ from .pytorch_zip_support import (
     read_member_to_spooled_file,
     read_zip_header,
 )
+from .zip_scanner import ZipPreflightRejected
 
 logger = logging.getLogger(__name__)
 _INSTALLED_PYTORCH_VERSION_UNSET = object()
@@ -348,7 +349,9 @@ class PyTorchZipScanner(BaseScanner):
             # Store the file path for use in issue locations
             self.current_file_path = path
 
-            with zipfile.ZipFile(path, "r") as zip_file:
+            from .zip_scanner import open_preflighted_zip
+
+            with open_preflighted_zip(path, self.config) as zip_file:
                 # Validate ZIP entries and check for path traversal
                 safe_entries = self._validate_zip_entries(zip_file, result, path)
                 self._check_timeout()  # Check timeout after entry validation
@@ -403,6 +406,8 @@ class PyTorchZipScanner(BaseScanner):
             )
             result.finish(success=False)
             return result
+        except ZipPreflightRejected as exc:
+            return exc.result
         except zipfile.BadZipFile:
             return self._handle_bad_zip_error(path)
         except Exception as e:
@@ -3414,7 +3419,9 @@ class PyTorchZipScanner(BaseScanner):
         metadata = super().extract_metadata(file_path)
 
         try:
-            with zipfile.ZipFile(file_path, "r") as zip_file:
+            from .zip_scanner import open_preflighted_zip
+
+            with open_preflighted_zip(file_path, self.config) as zip_file:
                 archive_entries = zip_file.infolist()
                 total_files = len(archive_entries)
                 entries_to_process = archive_entries[: self.max_archive_entries]

--- a/modelaudit/scanners/skops_scanner.py
+++ b/modelaudit/scanners/skops_scanner.py
@@ -474,7 +474,12 @@ class SkopsScanner(BaseScanner):
                 ),
             )
 
-    def _scan_archive_members(self, path: str, result: ScanResult) -> None:
+    def _scan_archive_members(
+        self,
+        path: str,
+        result: ScanResult,
+        archive: zipfile.ZipFile | None = None,
+    ) -> None:
         """Recursively scan embedded archive members through the generic ZIP pipeline."""
         if self.config.get(SKIP_COMPOSED_ARCHIVE_MEMBER_SCAN_CONFIG_KEY):
             return
@@ -499,7 +504,7 @@ class SkopsScanner(BaseScanner):
             else []
         )
         zip_scanner = ZipScanner(config=nested_config)
-        result.merge(zip_scanner.scan_archive_members(path))
+        result.merge(zip_scanner.scan_archive_members(path, archive=archive))
         for reason in preserved_reasons:
             mark_archive_scan_incomplete(result, reason)
 
@@ -517,6 +522,8 @@ class SkopsScanner(BaseScanner):
         result = self._create_result()
         file_size = self.get_file_size(path)
         result.metadata["file_size"] = file_size
+
+        from .zip_scanner import ZipPreflightRejected, open_preflighted_zip
 
         try:
             self.current_file_path = path
@@ -537,7 +544,7 @@ class SkopsScanner(BaseScanner):
                 return result
 
             # Open as ZIP archive
-            with zipfile.ZipFile(path, "r") as zip_file:
+            with open_preflighted_zip(path, self.config) as zip_file:
                 # Get file list
                 file_list = zip_file.namelist()
 
@@ -602,13 +609,15 @@ class SkopsScanner(BaseScanner):
                 self._check_unsafe_joblib_fallback(zip_file, result, path)
 
                 # Recursively scan embedded members with the broader scanner suite.
-                self._scan_archive_members(path, result)
+                self._scan_archive_members(path, result, archive=zip_file)
 
                 # Add file integrity check
                 self.add_file_integrity_check(path, result)
 
                 result.bytes_scanned += file_size
 
+        except ZipPreflightRejected as exc:
+            return exc.result
         except zipfile.BadZipFile:
             result.add_check(
                 name="Skops File Format Check",

--- a/modelaudit/scanners/torchserve_mar_scanner.py
+++ b/modelaudit/scanners/torchserve_mar_scanner.py
@@ -330,8 +330,10 @@ class TorchServeMarScanner(BaseScanner):
             details={"depth": current_depth, "max_depth": self.max_depth},
         )
 
+        from .zip_scanner import ZipPreflightRejected, open_preflighted_zip
+
         try:
-            with zipfile.ZipFile(path, "r") as archive:
+            with open_preflighted_zip(path, self.config) as archive:
                 member_infos = archive.infolist()
                 member_set = self._member_name_set(archive)
 
@@ -344,6 +346,8 @@ class TorchServeMarScanner(BaseScanner):
                     result=result,
                     current_depth=current_depth,
                 )
+        except ZipPreflightRejected as exc:
+            return exc.result
         except zipfile.BadZipFile:
             result.add_check(
                 name="TorchServe MAR Archive Validation",

--- a/modelaudit/scanners/weight_distribution_scanner.py
+++ b/modelaudit/scanners/weight_distribution_scanner.py
@@ -10,6 +10,7 @@ from typing import Any, ClassVar
 
 from ..scanner_results import mark_inconclusive_scan_result
 from .base import BaseScanner, IssueSeverity, ScanResult, logger
+from .zip_scanner import ZipPreflightRejected
 
 _ANALYSIS_INCONCLUSIVE_REASON = "weight_distribution_analysis_incomplete"
 _FINAL_LAYER_NAME_PATTERNS = ("fc", "classifier", "head", "output", "final", "dense")
@@ -283,6 +284,8 @@ class WeightDistributionScanner(BaseScanner):
                 result.finish(success=False)
                 return result
 
+        except ZipPreflightRejected as exc:
+            return exc.result
         except Exception as e:
             self._mark_analysis_incomplete(
                 result,
@@ -503,59 +506,67 @@ class WeightDistributionScanner(BaseScanner):
         max_tensor_bytes = self._max_tensor_bytes()
 
         try:
-            if zipfile.is_zipfile(path):
-                with zipfile.ZipFile(path, "r") as archive:
-                    selected = self._select_pytorch_data_pickle(archive)
-                    if selected is None:
-                        return not self.extraction_incomplete
-                    root, data_pkl_info = selected
-                    prefix_parts = root.split("/") if root else []
-                    selected_members = [data_pkl_info]
-                    selected_names = {data_pkl_info.filename}
-                    for member_info in archive.infolist():
-                        parts = member_info.filename.strip("/").split("/")
-                        is_storage = (
-                            len(parts) == len(prefix_parts) + 2
-                            and parts[: len(prefix_parts)] == prefix_parts
-                            and parts[-2] == "data"
-                            and parts[-1].isdigit()
-                        )
-                        if member_info.is_dir() or not is_storage:
-                            continue
-                        if member_info.filename in selected_names:
+            from .zip_scanner import open_preflighted_zip_handle
+
+            with open_preflighted_zip_handle(path, self.config, require_zip=False) as archive_handle:
+                has_zip_signature = archive_handle.read(4).startswith(b"PK")
+                archive_handle.seek(0)
+                if has_zip_signature:
+                    with zipfile.ZipFile(archive_handle) as archive:
+                        selected = self._select_pytorch_data_pickle(archive)
+                        if selected is None:
+                            return not self.extraction_incomplete
+                        root, data_pkl_info = selected
+                        prefix_parts = root.split("/") if root else []
+                        selected_members = [data_pkl_info]
+                        selected_names = {data_pkl_info.filename}
+                        for member_info in archive.infolist():
+                            parts = member_info.filename.strip("/").split("/")
+                            is_storage = (
+                                len(parts) == len(prefix_parts) + 2
+                                and parts[: len(prefix_parts)] == prefix_parts
+                                and parts[-2] == "data"
+                                and parts[-1].isdigit()
+                            )
+                            if member_info.is_dir() or not is_storage:
+                                continue
+                            if member_info.filename in selected_names:
+                                self._record_extraction_incomplete(
+                                    "pytorch_archive_member_ambiguous",
+                                    failed_tensors=[member_info.filename],
+                                )
+                                return False
+                            selected_names.add(member_info.filename)
+                            selected_members.append(member_info)
+                            if max_tensor_bytes is not None and member_info.file_size > max_tensor_bytes:
+                                self._record_oversized_tensor(
+                                    "pytorch_tensor_storage_size_limit",
+                                    member_info.filename,
+                                    tensor_nbytes=member_info.file_size,
+                                )
+                                return False
+
+                        load_bytes = sum(member.file_size for member in selected_members)
+
+                        if max_total_bytes is not None and load_bytes > max_total_bytes:
                             self._record_extraction_incomplete(
-                                "pytorch_archive_member_ambiguous",
-                                failed_tensors=[member_info.filename],
-                            )
-                            return False
-                        selected_names.add(member_info.filename)
-                        selected_members.append(member_info)
-                        if max_tensor_bytes is not None and member_info.file_size > max_tensor_bytes:
-                            self._record_oversized_tensor(
-                                "pytorch_tensor_storage_size_limit",
-                                member_info.filename,
-                                tensor_nbytes=member_info.file_size,
+                                "pytorch_load_size_limit",
+                                failed_tensors=[path],
+                                oversized_tensors=1,
+                                tensor_nbytes=load_bytes,
+                                max_total_tensor_bytes=max_total_bytes,
                             )
                             return False
 
-                    load_bytes = sum(member.file_size for member in selected_members)
+                        data = self._read_zip_member_bounded(archive, data_pkl_info)
+                        if data is None or not self._pickle_object_budget_allows(data, data_pkl_info.filename):
+                            return False
+                    return True
 
-                    if max_total_bytes is not None and load_bytes > max_total_bytes:
-                        self._record_extraction_incomplete(
-                            "pytorch_load_size_limit",
-                            failed_tensors=[path],
-                            oversized_tensors=1,
-                            tensor_nbytes=load_bytes,
-                            max_total_tensor_bytes=max_total_bytes,
-                        )
-                        return False
-
-                    data = self._read_zip_member_bounded(archive, data_pkl_info)
-                    if data is None or not self._pickle_object_budget_allows(data, data_pkl_info.filename):
-                        return False
-                return True
-            else:
-                load_bytes = os.path.getsize(path)
+                try:
+                    load_bytes = os.fstat(archive_handle.fileno()).st_size
+                except (AttributeError, OSError):
+                    load_bytes = os.path.getsize(path)
         except (OSError, zipfile.BadZipFile):
             return True
 
@@ -914,7 +925,10 @@ class WeightDistributionScanner(BaseScanner):
                 return {}
 
             # Load model with map_location to CPU to avoid GPU requirements
-            model_data = torch.load(path, **load_kwargs)
+            from .zip_scanner import open_preflighted_zip_handle
+
+            with open_preflighted_zip_handle(path, self.config, require_zip=False) as model_handle:
+                model_data = torch.load(model_handle, **load_kwargs)
 
             # Handle different PyTorch save formats
             if isinstance(model_data, dict):
@@ -958,11 +972,15 @@ class WeightDistributionScanner(BaseScanner):
                         if array is not None:
                             weights_info[key_text] = array
 
+        except ZipPreflightRejected:
+            raise
         except Exception as e:
             logger.debug(f"Failed to extract weights from {path}: {e}")
             safe_fallback_processed = False
             try:
-                with zipfile.ZipFile(path, "r") as z:
+                from .zip_scanner import open_preflighted_zip
+
+                with open_preflighted_zip(path, self.config) as z:
                     selected = self._select_pytorch_data_pickle(z)
                     if selected is not None:
                         import io
@@ -1113,6 +1131,8 @@ class WeightDistributionScanner(BaseScanner):
                                 safe_fallback_processed = True
                     elif self.extraction_incomplete:
                         safe_fallback_processed = True
+            except ZipPreflightRejected:
+                raise
             except Exception as e2:  # pragma: no cover - defensive
                 logger.debug(f"Failed to extract weights from {path}: {e2}")
 

--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -1,10 +1,15 @@
+import bz2
 import contextlib
 import os
 import re
 import stat
 import tempfile
 import zipfile
-from typing import Any, ClassVar
+import zlib
+from collections.abc import Iterator
+from dataclasses import dataclass
+from itertools import pairwise
+from typing import Any, BinaryIO, ClassVar, cast
 
 from ..core_results import mark_operational_scan_error
 from ..utils import is_absolute_archive_path, is_critical_system_path, sanitize_archive_path
@@ -36,6 +41,78 @@ CRITICAL_SYSTEM_PATHS = [
 ARCHIVE_MEMBER_COPY_CHUNK_BYTES = 64 * 1024
 ZIP_SECURITY_ONLY_MEMBER_ENTRIES_CONFIG_KEY = "_zip_security_only_member_entries"
 ZIP_CONTENT_ONLY_MEMBER_ENTRIES_CONFIG_KEY = "_zip_content_only_member_entries"
+_ZIP_EOCD_SIGNATURE = b"PK\x05\x06"
+_ZIP_EOCD_MIN_SIZE = 22
+_ZIP_MAX_COMMENT_SIZE = 0xFFFF
+_ZIP_MAX_EOCD_CANDIDATES = 16
+_ZIP_CENTRAL_DIRECTORY_SIGNATURE = b"PK\x01\x02"
+_ZIP_CENTRAL_DIRECTORY_HEADER_SIZE = 46
+_ZIP_MAX_CENTRAL_DIRECTORY_RECORD_SIZE = _ZIP_CENTRAL_DIRECTORY_HEADER_SIZE + (3 * 0xFFFF)
+_ZIP_LOCAL_FILE_HEADER_SIGNATURE = b"PK\x03\x04"
+_ZIP_LOCAL_FILE_HEADER_SIZE = 30
+_ZIP_DATA_DESCRIPTOR_SIGNATURE = b"PK\x07\x08"
+_ZIP_ARCHIVE_EXTRA_DATA_SIGNATURE = b"PK\x06\x08"
+_ZIP_MAX_ARCHIVE_EXTRA_DATA_RECORDS = 1024
+_ZIP_MAX_LOCAL_PREFIX_SCAN_SIZE = 64 * 1024 * 1024
+_ZIP_MAX_LOCAL_PAYLOAD_VALIDATION_SIZE = 64 * 1024 * 1024
+_ZIP_MAX_LOCAL_ENTRY_PADDING = 64 * 1024
+_ZIP_MAX_LOCAL_HEADER_CANDIDATES = 10000
+_ZIP64_EOCD_LOCATOR_SIGNATURE = b"PK\x06\x07"
+_ZIP64_EOCD_LOCATOR_SIZE = 20
+_ZIP64_EOCD_SIGNATURE = b"PK\x06\x06"
+_ZIP64_EOCD_MIN_SIZE = 56
+_ZIP64_SENTINEL_ENTRY_COUNT = 0xFFFF
+_ZIP64_SENTINEL_OFFSET = 0xFFFFFFFF
+
+
+@dataclass(frozen=True)
+class _ZipDirectoryMetadata:
+    entry_count: int
+    directory_start: int
+    directory_size: int
+    archive_prefix_size: int
+
+
+@dataclass(frozen=True)
+class _ZipCentralDirectoryEntry:
+    filename: bytes
+    flags: int
+    compression_method: int
+    crc32: int
+    compressed_size: int
+    uncompressed_size: int
+    relative_local_offset: int
+    uses_zip64_sizes: bool
+
+
+@dataclass(frozen=True)
+class _ZipLocalEntryLayout:
+    offset: int
+    end_candidates: frozenset[int]
+
+
+class _InvalidZipDirectory(ValueError):
+    def __init__(self, message: str, *, routing_evidence: bool = False):
+        super().__init__(message)
+        self.routing_evidence = routing_evidence
+
+
+class _ZipCentralDirectorySizeExceeded(_InvalidZipDirectory):
+    def __init__(self, directory_size: int, max_directory_size: int):
+        super().__init__(
+            f"ZIP central directory is too large ({directory_size} > {max_directory_size} bytes)",
+            routing_evidence=True,
+        )
+        self.directory_size = directory_size
+        self.max_directory_size = max_directory_size
+
+
+class ZipPreflightRejected(Exception):
+    """Raised when a same-handle ZIP preflight produces a terminal scan result."""
+
+    def __init__(self, result: ScanResult):
+        super().__init__("ZIP central-directory preflight rejected the archive")
+        self.result = result
 
 
 class ZipScanner(BaseScanner):
@@ -49,6 +126,8 @@ class ZipScanner(BaseScanner):
     MAX_SYMLINK_TARGET_BYTES: ClassVar[int] = 64 * 1024
     MAX_COMPRESSION_RATIO: ClassVar[int] = 100
     MIN_COMPRESSION_BOMB_UNCOMPRESSED_SIZE: ClassVar[int] = 1024 * 1024
+    DEFAULT_MAX_ENTRIES: ClassVar[int] = 10000
+    DEFAULT_MAX_CENTRAL_DIRECTORY_SIZE: ClassVar[int] = 64 * 1024 * 1024
     DEFAULT_MAX_ENTRY_SIZE: ClassVar[int] = 10 * 1024 * 1024 * 1024
     DEFAULT_MAX_TOTAL_UNCOMPRESSED_SIZE: ClassVar[int] = 10 * 1024 * 1024 * 1024
     UNLIMITED_ARCHIVE_SIZE: ClassVar[int] = 1024 * 1024 * 1024 * 1024
@@ -58,8 +137,9 @@ class ZipScanner(BaseScanner):
         self.max_depth = self.config.get("max_zip_depth", 5)  # Prevent zip bomb attacks
         self.max_entries = self.config.get(
             "max_zip_entries",
-            10000,
+            self.DEFAULT_MAX_ENTRIES,
         )  # Limit number of entries
+        self.max_central_directory_size = self.central_directory_size_limit(self.config)
         self.max_compression_ratio = self.MAX_COMPRESSION_RATIO
         self.min_compression_bomb_uncompressed_size = self._normalize_positive_int_config(
             self.config.get("zip_min_compression_bomb_uncompressed_size"),
@@ -93,6 +173,13 @@ class ZipScanner(BaseScanner):
     def _get_archive_depth(self) -> int:
         """Return the current shared archive depth from config."""
         return get_archive_depth(self.config)
+
+    @classmethod
+    def central_directory_size_limit(cls, config: dict[str, Any] | None = None) -> int:
+        """Return the byte cap applied before ``zipfile`` materializes directory metadata."""
+        raw_limit = (config or {}).get("max_zip_central_directory_size")
+        configured_limit = cls._normalize_positive_int_config(raw_limit, cls.DEFAULT_MAX_CENTRAL_DIRECTORY_SIZE)
+        return min(configured_limit, cls.DEFAULT_MAX_CENTRAL_DIRECTORY_SIZE)
 
     def _get_max_entry_size(self) -> int:
         """Return the configured per-entry extraction limit with a safe unlimited fallback."""
@@ -167,6 +254,1004 @@ class ZipScanner(BaseScanner):
     def _is_known_unreadable_archive_entry(self, info: zipfile.ZipInfo) -> bool:
         return info.header_offset in self.known_unreadable_archive_entry_offsets
 
+    @staticmethod
+    def _find_zip_eocd_indices(tail: bytes) -> tuple[int, ...]:
+        primary_index = tail.rfind(_ZIP_EOCD_SIGNATURE)
+        if primary_index < 0 or primary_index + _ZIP_EOCD_MIN_SIZE > len(tail):
+            return ()
+
+        earlier_indices: list[int] = []
+        primary_record_end = primary_index + _ZIP_EOCD_MIN_SIZE
+        primary_is_empty = not any(tail[primary_index + 8 : primary_index + 16])
+        search_start = 0
+        while True:
+            eocd_index = tail.find(_ZIP_EOCD_SIGNATURE, search_start, primary_index)
+            if eocd_index < 0 or eocd_index + _ZIP_EOCD_MIN_SIZE > len(tail):
+                return (primary_index, *reversed(earlier_indices))
+            comment_length = int.from_bytes(tail[eocd_index + 20 : eocd_index + 22], "little")
+            record_fields = tail[eocd_index + 8 : eocd_index + 20]
+            if eocd_index + _ZIP_EOCD_MIN_SIZE + comment_length >= primary_record_end or (
+                primary_is_empty and any(record_fields)
+            ):
+                earlier_indices.append(eocd_index)
+                if len(earlier_indices) + 1 >= _ZIP_MAX_EOCD_CANDIDATES:
+                    return (primary_index, *reversed(earlier_indices))
+            search_start = eocd_index + 1
+
+    @staticmethod
+    def _zip_directory_metadata(
+        *,
+        entry_count: int,
+        directory_size: int,
+        directory_offset: int,
+        directory_end: int,
+    ) -> _ZipDirectoryMetadata:
+        directory_start = directory_end - directory_size
+        if directory_start < 0 or directory_offset > directory_start:
+            raise _InvalidZipDirectory("ZIP central-directory offsets are inconsistent")
+        return _ZipDirectoryMetadata(
+            entry_count=entry_count,
+            directory_start=directory_start,
+            directory_size=directory_size,
+            archive_prefix_size=directory_start - directory_offset,
+        )
+
+    @classmethod
+    def _read_zip64_directory_metadata(
+        cls,
+        handle: BinaryIO,
+        *,
+        locator_offset: int,
+    ) -> _ZipDirectoryMetadata:
+        if locator_offset < 0:
+            raise _InvalidZipDirectory("ZIP64 locator is missing")
+
+        handle.seek(locator_offset)
+        locator = handle.read(_ZIP64_EOCD_LOCATOR_SIZE)
+        if len(locator) != _ZIP64_EOCD_LOCATOR_SIZE or not locator.startswith(_ZIP64_EOCD_LOCATOR_SIGNATURE):
+            raise _InvalidZipDirectory("ZIP64 locator is missing")
+        if int.from_bytes(locator[4:8], "little") != 0 or int.from_bytes(locator[16:20], "little") != 1:
+            raise _InvalidZipDirectory("multi-disk ZIP64 archives are unsupported")
+
+        relative_record_offset = int.from_bytes(locator[8:16], "little")
+        candidate_offsets = (relative_record_offset, locator_offset - _ZIP64_EOCD_MIN_SIZE)
+        record_offset: int | None = None
+        record = b""
+        for candidate_offset in candidate_offsets:
+            if candidate_offset < 0 or candidate_offset > locator_offset - _ZIP64_EOCD_MIN_SIZE:
+                continue
+            try:
+                handle.seek(candidate_offset)
+                candidate = handle.read(_ZIP64_EOCD_MIN_SIZE)
+            except (OSError, OverflowError, ValueError):
+                continue
+            if len(candidate) == _ZIP64_EOCD_MIN_SIZE and candidate.startswith(_ZIP64_EOCD_SIGNATURE):
+                record_offset = candidate_offset
+                record = candidate
+                break
+        if record_offset is None:
+            raise _InvalidZipDirectory("ZIP64 end-of-directory record is missing")
+
+        record_size = int.from_bytes(record[4:12], "little")
+        if record_size < _ZIP64_EOCD_MIN_SIZE - 12 or record_offset + 12 + record_size != locator_offset:
+            raise _InvalidZipDirectory("ZIP64 end-of-directory size is inconsistent")
+        if int.from_bytes(record[16:20], "little") != 0 or int.from_bytes(record[20:24], "little") != 0:
+            raise _InvalidZipDirectory("multi-disk ZIP64 archives are unsupported")
+
+        entries_on_disk = int.from_bytes(record[24:32], "little")
+        entry_count = int.from_bytes(record[32:40], "little")
+        directory_size = int.from_bytes(record[40:48], "little")
+        directory_offset = int.from_bytes(record[48:56], "little")
+        if entries_on_disk != entry_count or directory_offset + directory_size != relative_record_offset:
+            raise _InvalidZipDirectory("ZIP64 central-directory metadata is inconsistent", routing_evidence=True)
+        return cls._zip_directory_metadata(
+            entry_count=entry_count,
+            directory_size=directory_size,
+            directory_offset=directory_offset,
+            directory_end=record_offset,
+        )
+
+    @classmethod
+    def _read_zip_directory_metadata_at(
+        cls,
+        handle: BinaryIO,
+        *,
+        file_size: int,
+        tail_size: int,
+        tail: bytes,
+        eocd_index: int,
+    ) -> _ZipDirectoryMetadata:
+        eocd = tail[eocd_index : eocd_index + _ZIP_EOCD_MIN_SIZE]
+        disk_number = int.from_bytes(eocd[4:6], "little")
+        directory_disk = int.from_bytes(eocd[6:8], "little")
+        entries_on_disk = int.from_bytes(eocd[8:10], "little")
+        entry_count = int.from_bytes(eocd[10:12], "little")
+        eocd_offset = file_size - tail_size + eocd_index
+        directory_size = int.from_bytes(eocd[12:16], "little")
+        directory_offset = int.from_bytes(eocd[16:20], "little")
+        locator_offset = eocd_offset - _ZIP64_EOCD_LOCATOR_SIZE
+        if locator_offset >= 0:
+            handle.seek(locator_offset)
+            if handle.read(len(_ZIP64_EOCD_LOCATOR_SIGNATURE)) == _ZIP64_EOCD_LOCATOR_SIGNATURE:
+                return cls._read_zip64_directory_metadata(handle, locator_offset=locator_offset)
+        if (
+            entry_count == _ZIP64_SENTINEL_ENTRY_COUNT
+            or entries_on_disk == _ZIP64_SENTINEL_ENTRY_COUNT
+            or directory_size == _ZIP64_SENTINEL_OFFSET
+            or directory_offset == _ZIP64_SENTINEL_OFFSET
+        ):
+            return cls._read_zip64_directory_metadata(
+                handle,
+                locator_offset=eocd_offset - _ZIP64_EOCD_LOCATOR_SIZE,
+            )
+        if disk_number != 0 or directory_disk != 0:
+            raise _InvalidZipDirectory("multi-disk ZIP archives are unsupported")
+        if entries_on_disk != entry_count:
+            raise _InvalidZipDirectory("ZIP entry counts are inconsistent")
+        return cls._zip_directory_metadata(
+            entry_count=entry_count,
+            directory_size=directory_size,
+            directory_offset=directory_offset,
+            directory_end=eocd_offset,
+        )
+
+    @classmethod
+    def _read_zip_tail(cls, handle: BinaryIO) -> tuple[int, int, bytes, tuple[int, ...]] | None:
+        handle.seek(0, os.SEEK_END)
+        file_size = handle.tell()
+        if file_size < _ZIP_EOCD_MIN_SIZE:
+            return None
+        tail_size = min(file_size, _ZIP_EOCD_MIN_SIZE + _ZIP_MAX_COMMENT_SIZE)
+        handle.seek(file_size - tail_size)
+        tail = handle.read(tail_size)
+        return file_size, tail_size, tail, cls._find_zip_eocd_indices(tail)
+
+    @classmethod
+    def _has_zip_routing_evidence(cls, path: str) -> bool:
+        return os.path.splitext(path)[1].lower() in cls.supported_extensions
+
+    @classmethod
+    def _count_bounded_central_directory_entries(
+        cls,
+        handle: BinaryIO,
+        metadata: _ZipDirectoryMetadata,
+        max_entries: int,
+    ) -> tuple[int, bool]:
+        """Count fixed central-directory records, stopping once the configured cap is exceeded."""
+        consumed = 0
+        entry_count = 0
+        entries: list[_ZipCentralDirectoryEntry] = []
+        try:
+            handle.seek(metadata.directory_start)
+            while consumed < metadata.directory_size:
+                remaining = metadata.directory_size - consumed
+                if remaining < _ZIP_CENTRAL_DIRECTORY_HEADER_SIZE:
+                    raise _InvalidZipDirectory(
+                        "ZIP central directory is truncated",
+                        routing_evidence=entry_count > 0,
+                    )
+                header = handle.read(_ZIP_CENTRAL_DIRECTORY_HEADER_SIZE)
+                if len(header) != _ZIP_CENTRAL_DIRECTORY_HEADER_SIZE:
+                    raise _InvalidZipDirectory(
+                        "ZIP central directory is truncated",
+                        routing_evidence=entry_count > 0,
+                    )
+                if not header.startswith(_ZIP_CENTRAL_DIRECTORY_SIGNATURE):
+                    raise _InvalidZipDirectory("ZIP central-directory signature is invalid")
+
+                variable_size = (
+                    int.from_bytes(header[28:30], "little")
+                    + int.from_bytes(header[30:32], "little")
+                    + int.from_bytes(header[32:34], "little")
+                )
+                record_size = _ZIP_CENTRAL_DIRECTORY_HEADER_SIZE + variable_size
+                if record_size > remaining:
+                    raise _InvalidZipDirectory(
+                        "ZIP central-directory record exceeds its declared size",
+                        routing_evidence=True,
+                    )
+
+                entry_count += 1
+                if entry_count > max_entries:
+                    return entry_count, True
+                variable_data = handle.read(variable_size)
+                if len(variable_data) != variable_size:
+                    raise _InvalidZipDirectory(
+                        "ZIP central directory is truncated",
+                        routing_evidence=True,
+                    )
+                filename_size = int.from_bytes(header[28:30], "little")
+                extra_size = int.from_bytes(header[30:32], "little")
+                filename = variable_data[:filename_size]
+                extra = variable_data[filename_size : filename_size + extra_size]
+                entries.append(cls._central_directory_entry(header, filename, extra))
+                consumed += record_size
+        except OSError as exc:
+            raise _InvalidZipDirectory(f"ZIP central directory could not be read: {exc}") from exc
+
+        if entry_count != metadata.entry_count:
+            raise _InvalidZipDirectory(
+                f"ZIP entry count mismatch ({metadata.entry_count} declared, {entry_count} observed)",
+                routing_evidence=True,
+            )
+        cls._validate_declared_local_entry_layout(handle, metadata, entries)
+        return entry_count, False
+
+    @staticmethod
+    def _zip64_extra_field(extra: bytes) -> bytes | None:
+        field_offset = 0
+        while field_offset + 4 <= len(extra):
+            field_id = int.from_bytes(extra[field_offset : field_offset + 2], "little")
+            field_size = int.from_bytes(extra[field_offset + 2 : field_offset + 4], "little")
+            field_data = extra[field_offset + 4 : field_offset + 4 + field_size]
+            if len(field_data) != field_size:
+                return None
+            field_offset += 4 + field_size
+            if field_id == 0x0001:
+                return field_data
+        return None
+
+    @classmethod
+    def _central_directory_entry(
+        cls,
+        header: bytes,
+        filename: bytes,
+        extra: bytes,
+    ) -> _ZipCentralDirectoryEntry:
+        if not filename or b"\x00" in filename:
+            raise _InvalidZipDirectory("ZIP central-directory filename is invalid", routing_evidence=True)
+
+        raw_uncompressed_size = int.from_bytes(header[24:28], "little")
+        raw_compressed_size = int.from_bytes(header[20:24], "little")
+        raw_local_offset = int.from_bytes(header[42:46], "little")
+        raw_disk_start = int.from_bytes(header[34:36], "little")
+        requires_zip64 = (
+            raw_uncompressed_size == _ZIP64_SENTINEL_OFFSET
+            or raw_compressed_size == _ZIP64_SENTINEL_OFFSET
+            or raw_local_offset == _ZIP64_SENTINEL_OFFSET
+            or raw_disk_start == _ZIP64_SENTINEL_ENTRY_COUNT
+        )
+        zip64_data = cls._zip64_extra_field(extra) if requires_zip64 else b""
+        if zip64_data is None:
+            raise _InvalidZipDirectory("ZIP64 central-directory metadata is incomplete", routing_evidence=True)
+
+        value_offset = 0
+
+        def zip64_value(raw_value: int, sentinel: int, width: int) -> int:
+            nonlocal value_offset
+            if raw_value != sentinel:
+                return raw_value
+            if value_offset + width > len(zip64_data):
+                raise _InvalidZipDirectory("ZIP64 central-directory metadata is incomplete", routing_evidence=True)
+            value = int.from_bytes(zip64_data[value_offset : value_offset + width], "little")
+            value_offset += width
+            return value
+
+        uncompressed_size = zip64_value(raw_uncompressed_size, _ZIP64_SENTINEL_OFFSET, 8)
+        compressed_size = zip64_value(raw_compressed_size, _ZIP64_SENTINEL_OFFSET, 8)
+        relative_local_offset = zip64_value(raw_local_offset, _ZIP64_SENTINEL_OFFSET, 8)
+        disk_start = zip64_value(raw_disk_start, _ZIP64_SENTINEL_ENTRY_COUNT, 4)
+        if disk_start != 0:
+            raise _InvalidZipDirectory("multi-disk ZIP archives are unsupported", routing_evidence=True)
+
+        return _ZipCentralDirectoryEntry(
+            filename=filename,
+            flags=int.from_bytes(header[8:10], "little"),
+            compression_method=int.from_bytes(header[10:12], "little"),
+            crc32=int.from_bytes(header[16:20], "little"),
+            compressed_size=compressed_size,
+            uncompressed_size=uncompressed_size,
+            relative_local_offset=relative_local_offset,
+            uses_zip64_sizes=(
+                raw_uncompressed_size == _ZIP64_SENTINEL_OFFSET or raw_compressed_size == _ZIP64_SENTINEL_OFFSET
+            ),
+        )
+
+    @classmethod
+    def _local_sizes(cls, header: bytes, extra: bytes) -> tuple[int, int] | None:
+        raw_uncompressed_size = int.from_bytes(header[22:26], "little")
+        raw_compressed_size = int.from_bytes(header[18:22], "little")
+        if raw_uncompressed_size != _ZIP64_SENTINEL_OFFSET and raw_compressed_size != _ZIP64_SENTINEL_OFFSET:
+            return raw_compressed_size, raw_uncompressed_size
+        zip64_data = cls._zip64_extra_field(extra)
+        if zip64_data is None:
+            return None
+        value_offset = 0
+
+        def zip64_value(raw_value: int) -> int | None:
+            nonlocal value_offset
+            if raw_value != _ZIP64_SENTINEL_OFFSET:
+                return raw_value
+            if value_offset + 8 > len(zip64_data):
+                return None
+            value = int.from_bytes(zip64_data[value_offset : value_offset + 8], "little")
+            value_offset += 8
+            return value
+
+        uncompressed_size = zip64_value(raw_uncompressed_size)
+        compressed_size = zip64_value(raw_compressed_size)
+        if uncompressed_size is None or compressed_size is None:
+            return None
+        return compressed_size, uncompressed_size
+
+    @staticmethod
+    def _data_descriptor_end_candidates(
+        descriptor: bytes,
+        descriptor_offset: int,
+        entry: _ZipCentralDirectoryEntry,
+        *,
+        uses_zip64_sizes: bool,
+    ) -> frozenset[int]:
+        size_width = 8 if uses_zip64_sizes else 4
+        payload_size = 4 + (2 * size_width)
+        end_candidates: set[int] = set()
+        for signature_size in (0, len(_ZIP_DATA_DESCRIPTOR_SIGNATURE)):
+            if signature_size and not descriptor.startswith(_ZIP_DATA_DESCRIPTOR_SIGNATURE):
+                continue
+            end = signature_size + payload_size
+            if len(descriptor) < end:
+                continue
+            payload = descriptor[signature_size:end]
+            crc32 = int.from_bytes(payload[:4], "little")
+            compressed_size = int.from_bytes(payload[4 : 4 + size_width], "little")
+            uncompressed_size = int.from_bytes(payload[4 + size_width :], "little")
+            if (
+                crc32 == entry.crc32
+                and compressed_size == entry.compressed_size
+                and uncompressed_size == entry.uncompressed_size
+            ):
+                end_candidates.add(descriptor_offset + end)
+        return frozenset(end_candidates)
+
+    @classmethod
+    def _local_entry_layout(
+        cls,
+        handle: BinaryIO,
+        metadata: _ZipDirectoryMetadata,
+        entry: _ZipCentralDirectoryEntry,
+        local_header_offset: int,
+    ) -> _ZipLocalEntryLayout | None:
+        if local_header_offset < 0 or local_header_offset + _ZIP_LOCAL_FILE_HEADER_SIZE > metadata.directory_start:
+            return None
+        try:
+            handle.seek(local_header_offset)
+            header = handle.read(_ZIP_LOCAL_FILE_HEADER_SIZE)
+            if len(header) != _ZIP_LOCAL_FILE_HEADER_SIZE or not header.startswith(_ZIP_LOCAL_FILE_HEADER_SIGNATURE):
+                return None
+            filename_size = int.from_bytes(header[26:28], "little")
+            extra_size = int.from_bytes(header[28:30], "little")
+            variable_data = handle.read(filename_size + extra_size)
+            if len(variable_data) != filename_size + extra_size:
+                return None
+            filename = variable_data[:filename_size]
+            extra = variable_data[filename_size:]
+        except OSError as exc:
+            raise _InvalidZipDirectory(f"ZIP local header could not be read: {exc}") from exc
+
+        local_flags = int.from_bytes(header[6:8], "little")
+        if (
+            filename != entry.filename
+            or local_flags != entry.flags
+            or int.from_bytes(header[8:10], "little") != entry.compression_method
+        ):
+            return None
+
+        uses_data_descriptor = bool(local_flags & 0x0008)
+        local_crc32 = int.from_bytes(header[14:18], "little")
+        local_uses_zip64_sizes = (
+            int.from_bytes(header[18:22], "little") == _ZIP64_SENTINEL_OFFSET
+            or int.from_bytes(header[22:26], "little") == _ZIP64_SENTINEL_OFFSET
+        )
+        local_sizes = cls._local_sizes(header, extra)
+        if local_sizes is None:
+            return None
+        local_compressed_size, local_uncompressed_size = local_sizes
+        if uses_data_descriptor:
+            if local_crc32 not in {0, entry.crc32}:
+                return None
+            if local_compressed_size not in {0, entry.compressed_size}:
+                return None
+            if local_uncompressed_size not in {0, entry.uncompressed_size}:
+                return None
+        elif (
+            local_crc32 != entry.crc32
+            or local_compressed_size != entry.compressed_size
+            or local_uncompressed_size != entry.uncompressed_size
+        ):
+            return None
+
+        data_offset = local_header_offset + _ZIP_LOCAL_FILE_HEADER_SIZE + filename_size + extra_size
+        data_end = data_offset + entry.compressed_size
+        if data_end > metadata.directory_start:
+            return None
+        if not uses_data_descriptor:
+            return _ZipLocalEntryLayout(offset=local_header_offset, end_candidates=frozenset({data_end}))
+
+        uses_zip64_descriptor = entry.uses_zip64_sizes or local_uses_zip64_sizes
+        descriptor_size = 24 if uses_zip64_descriptor else 16
+        try:
+            handle.seek(data_end)
+            descriptor = handle.read(descriptor_size)
+        except OSError as exc:
+            raise _InvalidZipDirectory(f"ZIP data descriptor could not be read: {exc}") from exc
+        end_candidates = cls._data_descriptor_end_candidates(
+            descriptor,
+            data_end,
+            entry,
+            uses_zip64_sizes=uses_zip64_descriptor,
+        )
+        if not end_candidates:
+            return None
+        return _ZipLocalEntryLayout(offset=local_header_offset, end_candidates=end_candidates)
+
+    @classmethod
+    def _validate_declared_local_entry_layout(
+        cls,
+        handle: BinaryIO,
+        metadata: _ZipDirectoryMetadata,
+        entries: list[_ZipCentralDirectoryEntry],
+    ) -> None:
+        if not entries:
+            if cls._has_preceding_central_directory_entry(
+                handle, metadata
+            ) or cls._has_unreferenced_local_entry_ending_at(handle, metadata.directory_start):
+                raise _InvalidZipDirectory(
+                    "ZIP central directory omits a preceding record",
+                    routing_evidence=True,
+                )
+            return
+        layouts: list[_ZipLocalEntryLayout] = []
+        for entry in entries:
+            candidates = {
+                entry.relative_local_offset,
+                metadata.archive_prefix_size + entry.relative_local_offset,
+            }
+            matching_layouts = [
+                layout
+                for candidate in candidates
+                if (layout := cls._local_entry_layout(handle, metadata, entry, candidate)) is not None
+            ]
+            if len(matching_layouts) != 1:
+                raise _InvalidZipDirectory(
+                    "ZIP central directory does not uniquely identify its local entry",
+                    routing_evidence=True,
+                )
+            layouts.append(matching_layouts[0])
+
+        layouts.sort(key=lambda layout: layout.offset)
+        if cls._has_unreferenced_local_entry_ending_at(handle, layouts[0].offset):
+            raise _InvalidZipDirectory(
+                "ZIP central directory omits a preceding record",
+                routing_evidence=True,
+            )
+        for layout, next_layout in pairwise(layouts):
+            if next_layout.offset not in layout.end_candidates:
+                raise _InvalidZipDirectory(
+                    "ZIP central directory omits a preceding record",
+                    routing_evidence=True,
+                )
+        if metadata.directory_start not in layouts[-1].end_candidates and not any(
+            cls._archive_extra_data_records_cover(handle, end, metadata.directory_start)
+            for end in layouts[-1].end_candidates
+        ):
+            raise _InvalidZipDirectory("ZIP central directory omits a preceding record", routing_evidence=True)
+
+    @staticmethod
+    def _archive_extra_data_records_cover(handle: BinaryIO, start: int, end: int) -> bool:
+        if start >= end:
+            return False
+        offset = start
+        record_count = 0
+        try:
+            while offset < end:
+                record_count += 1
+                if record_count > _ZIP_MAX_ARCHIVE_EXTRA_DATA_RECORDS:
+                    raise _InvalidZipDirectory(
+                        "too many ZIP archive extra data records",
+                        routing_evidence=True,
+                    )
+                if end - offset < 8:
+                    return False
+                handle.seek(offset)
+                header = handle.read(8)
+                if len(header) != 8 or not header.startswith(_ZIP_ARCHIVE_EXTRA_DATA_SIGNATURE):
+                    return False
+                record_size = int.from_bytes(header[4:8], "little")
+                offset += 8 + record_size
+                if offset > end:
+                    return False
+        except OSError as exc:
+            raise _InvalidZipDirectory(f"ZIP archive extra data could not be read: {exc}") from exc
+        return offset == end
+
+    @classmethod
+    def _has_preceding_central_directory_entry(
+        cls,
+        handle: BinaryIO,
+        metadata: _ZipDirectoryMetadata,
+    ) -> bool:
+        window_size = min(metadata.directory_start, _ZIP_MAX_CENTRAL_DIRECTORY_RECORD_SIZE)
+        if window_size < _ZIP_CENTRAL_DIRECTORY_HEADER_SIZE:
+            return False
+        window_start = metadata.directory_start - window_size
+        try:
+            handle.seek(window_start)
+            prefix = handle.read(window_size)
+        except OSError as exc:
+            raise _InvalidZipDirectory(f"ZIP central-directory prefix could not be read: {exc}") from exc
+
+        candidate_index = prefix.find(_ZIP_CENTRAL_DIRECTORY_SIGNATURE)
+        while candidate_index >= 0:
+            header_end = candidate_index + _ZIP_CENTRAL_DIRECTORY_HEADER_SIZE
+            if header_end <= len(prefix):
+                header = prefix[candidate_index:header_end]
+                filename_size = int.from_bytes(header[28:30], "little")
+                extra_size = int.from_bytes(header[30:32], "little")
+                comment_size = int.from_bytes(header[32:34], "little")
+                record_end = header_end + filename_size + extra_size + comment_size
+                if record_end <= len(prefix):
+                    filename = prefix[header_end : header_end + filename_size]
+                    extra = prefix[header_end + filename_size : header_end + filename_size + extra_size]
+                    try:
+                        entry = cls._central_directory_entry(header, filename, extra)
+                    except _InvalidZipDirectory:
+                        pass
+                    else:
+                        for local_offset in {
+                            entry.relative_local_offset,
+                            metadata.archive_prefix_size + entry.relative_local_offset,
+                        }:
+                            if cls._local_entry_layout(handle, metadata, entry, local_offset) is not None:
+                                return True
+            candidate_index = prefix.find(_ZIP_CENTRAL_DIRECTORY_SIGNATURE, candidate_index + 1)
+        return False
+
+    @classmethod
+    def _has_unreferenced_local_entry_ending_at(cls, handle: BinaryIO, boundary: int) -> bool:
+        if boundary < _ZIP_LOCAL_FILE_HEADER_SIZE:
+            return False
+        if boundary > _ZIP_MAX_LOCAL_PREFIX_SCAN_SIZE:
+            raise _InvalidZipDirectory(
+                "ZIP local-entry prefix is too large to validate safely",
+                routing_evidence=True,
+            )
+
+        overlap = len(_ZIP_LOCAL_FILE_HEADER_SIGNATURE) - 1
+        search_offset = 0
+        trailing = b""
+        candidate_count = 0
+        while search_offset < boundary:
+            read_size = min(64 * 1024, boundary - search_offset)
+            try:
+                handle.seek(search_offset)
+                chunk = handle.read(read_size)
+            except OSError as exc:
+                raise _InvalidZipDirectory(f"ZIP local-entry prefix could not be read: {exc}") from exc
+            if not chunk:
+                break
+            search_data = trailing + chunk
+            data_offset = search_offset - len(trailing)
+            candidate_index = search_data.find(_ZIP_LOCAL_FILE_HEADER_SIGNATURE)
+            while candidate_index >= 0:
+                candidate_count += 1
+                if candidate_count > _ZIP_MAX_LOCAL_HEADER_CANDIDATES:
+                    raise _InvalidZipDirectory(
+                        "too many plausible ZIP local headers before the declared entries",
+                        routing_evidence=True,
+                    )
+                candidate_offset = data_offset + candidate_index
+                if cls._unreferenced_local_entry_ends_at(handle, candidate_offset, boundary):
+                    return True
+                candidate_index = search_data.find(_ZIP_LOCAL_FILE_HEADER_SIGNATURE, candidate_index + 1)
+            trailing = search_data[-overlap:]
+            search_offset += len(chunk)
+        return False
+
+    @staticmethod
+    def _local_entry_payload_matches_header(
+        handle: BinaryIO,
+        *,
+        data_offset: int,
+        compressed_size: int,
+        uncompressed_size: int,
+        compression_method: int,
+        expected_crc32: int,
+        flags: int,
+    ) -> bool:
+        """Validate a bounded local-entry payload when its central record is absent."""
+        if flags & 0x0001:
+            return True
+        if (
+            compressed_size > _ZIP_MAX_LOCAL_PAYLOAD_VALIDATION_SIZE
+            or uncompressed_size > _ZIP_MAX_LOCAL_PAYLOAD_VALIDATION_SIZE
+        ):
+            return True
+        if compression_method == zipfile.ZIP_LZMA:
+            # ZIP's LZMA wrapper cannot bound output per call. A structurally
+            # valid hidden entry must fail closed rather than risk decompression.
+            return True
+        if compression_method not in {zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED, zipfile.ZIP_BZIP2}:
+            return True
+
+        try:
+            handle.seek(data_offset)
+            compressed_data = handle.read(compressed_size)
+        except OSError as exc:
+            raise _InvalidZipDirectory(f"ZIP local-entry data could not be read: {exc}") from exc
+        if len(compressed_data) != compressed_size:
+            return False
+
+        crc32 = 0
+        output_size = 0
+
+        def consume_output(output: bytes) -> bool:
+            nonlocal crc32, output_size
+            output_size += len(output)
+            if output_size > uncompressed_size:
+                return False
+            crc32 = zlib.crc32(output, crc32)
+            return True
+
+        if compression_method == zipfile.ZIP_STORED:
+            return compressed_size == uncompressed_size and consume_output(compressed_data) and crc32 == expected_crc32
+
+        if compression_method == zipfile.ZIP_DEFLATED:
+            decompressor: Any = zlib.decompressobj(-15)
+            pending = compressed_data
+            try:
+                while pending:
+                    output = decompressor.decompress(
+                        pending,
+                        min(64 * 1024, uncompressed_size - output_size + 1),
+                    )
+                    pending = decompressor.unconsumed_tail
+                    if not consume_output(output):
+                        return False
+                    if pending and not output:
+                        return False
+            except zlib.error:
+                return False
+            if not decompressor.eof or decompressor.unused_data:
+                return False
+        else:
+            decompressor = bz2.BZ2Decompressor()
+            pending = compressed_data
+            try:
+                while pending or not decompressor.needs_input:
+                    output = decompressor.decompress(
+                        pending,
+                        max_length=min(64 * 1024, uncompressed_size - output_size + 1),
+                    )
+                    pending = b""
+                    if not consume_output(output):
+                        return False
+                    if decompressor.eof:
+                        break
+                    if decompressor.needs_input and not pending:
+                        break
+            except (OSError, EOFError):
+                return False
+            if not decompressor.eof or decompressor.unused_data:
+                return False
+
+        return output_size == uncompressed_size and crc32 == expected_crc32
+
+    @classmethod
+    def _unreferenced_local_entry_ends_at(cls, handle: BinaryIO, offset: int, boundary: int) -> bool:
+        try:
+            handle.seek(offset)
+            header = handle.read(_ZIP_LOCAL_FILE_HEADER_SIZE)
+            if len(header) != _ZIP_LOCAL_FILE_HEADER_SIZE or not header.startswith(_ZIP_LOCAL_FILE_HEADER_SIGNATURE):
+                return False
+            version_needed = int.from_bytes(header[4:6], "little")
+            flags = int.from_bytes(header[6:8], "little")
+            filename_size = int.from_bytes(header[26:28], "little")
+            extra_size = int.from_bytes(header[28:30], "little")
+            if not (10 <= version_needed <= 100) or filename_size == 0:
+                return False
+            variable_data = handle.read(filename_size + extra_size)
+            if len(variable_data) != filename_size + extra_size:
+                return False
+            filename = variable_data[:filename_size]
+            if b"\x00" in filename:
+                return False
+            extra = variable_data[filename_size:]
+        except OSError as exc:
+            raise _InvalidZipDirectory(f"ZIP local-entry prefix could not be read: {exc}") from exc
+
+        data_offset = offset + _ZIP_LOCAL_FILE_HEADER_SIZE + filename_size + extra_size
+        local_sizes = cls._local_sizes(header, extra)
+        if local_sizes is None:
+            return False
+        compressed_size, uncompressed_size = local_sizes
+        if not flags & 0x0008:
+            entry_end = data_offset + compressed_size
+            if entry_end == boundary:
+                return True
+            if entry_end < boundary:
+                return cls._local_entry_payload_matches_header(
+                    handle,
+                    data_offset=data_offset,
+                    compressed_size=compressed_size,
+                    uncompressed_size=uncompressed_size,
+                    compression_method=int.from_bytes(header[8:10], "little"),
+                    expected_crc32=int.from_bytes(header[14:18], "little"),
+                    flags=flags,
+                )
+            return False
+
+        raw_compressed_size = int.from_bytes(header[18:22], "little")
+        raw_uncompressed_size = int.from_bytes(header[22:26], "little")
+        descriptor_window_start = max(
+            data_offset,
+            boundary - (_ZIP_MAX_LOCAL_ENTRY_PADDING + 24),
+        )
+        try:
+            handle.seek(descriptor_window_start)
+            descriptor_window = handle.read(boundary - descriptor_window_start)
+        except OSError as exc:
+            raise _InvalidZipDirectory(f"ZIP data descriptor could not be read: {exc}") from exc
+        for size_width in (4, 8):
+            for signature_size in (0, len(_ZIP_DATA_DESCRIPTOR_SIGNATURE)):
+                descriptor_size = signature_size + 4 + (2 * size_width)
+                for descriptor_end in range(boundary, descriptor_window_start + descriptor_size - 1, -1):
+                    descriptor_offset = descriptor_end - descriptor_size
+                    relative_offset = descriptor_offset - descriptor_window_start
+                    descriptor = descriptor_window[relative_offset : relative_offset + descriptor_size]
+                    if len(descriptor) != descriptor_size:
+                        continue
+                    if signature_size and not descriptor.startswith(_ZIP_DATA_DESCRIPTOR_SIGNATURE):
+                        continue
+                    payload = descriptor[signature_size:]
+                    descriptor_crc32 = int.from_bytes(payload[:4], "little")
+                    descriptor_compressed_size = int.from_bytes(payload[4 : 4 + size_width], "little")
+                    descriptor_uncompressed_size = int.from_bytes(payload[4 + size_width :], "little")
+                    if data_offset + descriptor_compressed_size != descriptor_offset:
+                        continue
+                    if raw_compressed_size not in {0, _ZIP64_SENTINEL_OFFSET, descriptor_compressed_size}:
+                        continue
+                    if raw_uncompressed_size not in {0, _ZIP64_SENTINEL_OFFSET, descriptor_uncompressed_size}:
+                        continue
+                    if compressed_size not in {0, descriptor_compressed_size}:
+                        continue
+                    if uncompressed_size not in {0, descriptor_uncompressed_size}:
+                        continue
+                    if cls._local_entry_payload_matches_header(
+                        handle,
+                        data_offset=data_offset,
+                        compressed_size=descriptor_compressed_size,
+                        uncompressed_size=descriptor_uncompressed_size,
+                        compression_method=int.from_bytes(header[8:10], "little"),
+                        expected_crc32=descriptor_crc32,
+                        flags=flags,
+                    ):
+                        return True
+        return False
+
+    @staticmethod
+    def _candidate_has_directory_signature(
+        handle: BinaryIO,
+        *,
+        file_size: int,
+        tail_size: int,
+        tail: bytes,
+        eocd_index: int,
+    ) -> bool:
+        directory_size = int.from_bytes(tail[eocd_index + 12 : eocd_index + 16], "little")
+        if directory_size in {0, _ZIP64_SENTINEL_OFFSET}:
+            return False
+        eocd_offset = file_size - tail_size + eocd_index
+        directory_start = eocd_offset - directory_size
+        if directory_start < 0:
+            return False
+        try:
+            handle.seek(directory_start)
+            return handle.read(len(_ZIP_CENTRAL_DIRECTORY_SIGNATURE)) == _ZIP_CENTRAL_DIRECTORY_SIGNATURE
+        except OSError:
+            return False
+
+    @classmethod
+    def _preflight_zip_directory(
+        cls,
+        handle: BinaryIO,
+        max_entries: int,
+        max_directory_size: int,
+    ) -> tuple[int, bool] | None:
+        tail_data = cls._read_zip_tail(handle)
+        if tail_data is None:
+            return None
+        file_size, tail_size, tail, eocd_indices = tail_data
+        if not eocd_indices:
+            return None
+        if len(eocd_indices) >= _ZIP_MAX_EOCD_CANDIDATES:
+            raise _InvalidZipDirectory(
+                "too many plausible ZIP end-of-directory records",
+                routing_evidence=True,
+            )
+
+        last_error: _InvalidZipDirectory | None = None
+        size_limit_error: _ZipCentralDirectorySizeExceeded | None = None
+        candidate_errors: list[tuple[int, bool]] = []
+        valid_preflight: tuple[int, bool] | None = None
+        valid_eocd_index: int | None = None
+        for eocd_index in eocd_indices:
+            try:
+                metadata = cls._read_zip_directory_metadata_at(
+                    handle,
+                    file_size=file_size,
+                    tail_size=tail_size,
+                    tail=tail,
+                    eocd_index=eocd_index,
+                )
+                if metadata.directory_size > max_directory_size:
+                    raise _ZipCentralDirectorySizeExceeded(metadata.directory_size, max_directory_size)
+                candidate_preflight = cls._count_bounded_central_directory_entries(handle, metadata, max_entries)
+            except _ZipCentralDirectorySizeExceeded as exc:
+                size_limit_error = exc
+                candidate_errors.append((eocd_index, True))
+                continue
+            except _InvalidZipDirectory as exc:
+                candidate_errors.append(
+                    (
+                        eocd_index,
+                        exc.routing_evidence
+                        or cls._candidate_has_directory_signature(
+                            handle,
+                            file_size=file_size,
+                            tail_size=tail_size,
+                            tail=tail,
+                            eocd_index=eocd_index,
+                        ),
+                    )
+                )
+                if last_error is None or (exc.routing_evidence and not last_error.routing_evidence):
+                    last_error = exc
+                continue
+            if valid_preflight is not None:
+                raise _InvalidZipDirectory(
+                    "multiple valid ZIP end-of-directory records are ambiguous",
+                    routing_evidence=True,
+                )
+            valid_preflight = candidate_preflight
+            valid_eocd_index = eocd_index
+        if valid_preflight is not None:
+            assert valid_eocd_index is not None
+            valid_comment_length = int.from_bytes(tail[valid_eocd_index + 20 : valid_eocd_index + 22], "little")
+            valid_record_end = valid_eocd_index + _ZIP_EOCD_MIN_SIZE + valid_comment_length
+            if any(
+                strong_evidence
+                and not (
+                    valid_eocd_index < error_index
+                    and error_index
+                    + _ZIP_EOCD_MIN_SIZE
+                    + int.from_bytes(tail[error_index + 20 : error_index + 22], "little")
+                    <= valid_record_end
+                )
+                for error_index, strong_evidence in candidate_errors
+            ):
+                raise _InvalidZipDirectory(
+                    "multiple plausible ZIP end-of-directory records are ambiguous",
+                    routing_evidence=True,
+                )
+            return valid_preflight
+        if size_limit_error is not None:
+            raise size_limit_error
+        if last_error is not None:
+            raise last_error
+        return None
+
+    @classmethod
+    def requires_preflight_result(cls, path: str, max_entries: int, max_directory_size: int | None = None) -> bool:
+        """Return whether ZIP routing must defer to this scanner before materializing entries."""
+        directory_size_limit = max_directory_size or cls.DEFAULT_MAX_CENTRAL_DIRECTORY_SIZE
+        try:
+            with open(path, "rb") as handle:
+                preflight = cls._preflight_zip_directory(handle, max_entries, directory_size_limit)
+        except _InvalidZipDirectory as exc:
+            if exc.routing_evidence:
+                return True
+            try:
+                return cls._has_zip_routing_evidence(path)
+            except OSError:
+                return False
+        except OSError:
+            return False
+        return preflight is not None and preflight[1]
+
+    def _add_entry_count_limit_check(
+        self,
+        result: ScanResult,
+        path: str,
+        entry_count: int,
+        *,
+        passed: bool,
+        source: str,
+    ) -> None:
+        details: dict[str, Any] = {
+            "entries": entry_count,
+            "max_entries": self.max_entries,
+            "entry_count_source": source,
+        }
+        if not passed:
+            details["analysis_incomplete"] = True
+            details["scan_outcome_reason"] = "zip_analysis_incomplete"
+
+        result.add_check(
+            name="Entry Count Limit Check",
+            passed=passed,
+            message=(
+                f"Entry count ({entry_count}) is within limits"
+                if passed
+                else f"ZIP file contains too many entries ({entry_count} > {self.max_entries})"
+            ),
+            severity=None if passed else IssueSeverity.WARNING,
+            rule_code=None if passed else "S410",
+            location=path,
+            details=details,
+        )
+
+    def _preflight_rejection_result(
+        self,
+        path: str,
+        *,
+        entry_count: int | None = None,
+        error: _InvalidZipDirectory | None = None,
+    ) -> ScanResult:
+        result = self._create_result()
+        with contextlib.suppress(OSError):
+            result.metadata["file_size"] = os.path.getsize(path)
+        if entry_count is not None:
+            result.metadata["zip_entry_count_preflight"] = entry_count
+            self._add_entry_count_limit_check(
+                result,
+                path,
+                entry_count,
+                passed=False,
+                source="central_directory_preflight",
+            )
+        elif isinstance(error, _ZipCentralDirectorySizeExceeded):
+            self._add_central_directory_size_limit_check(result, path, error)
+        else:
+            assert error is not None
+            result.add_check(
+                name="ZIP Central Directory Preflight",
+                passed=False,
+                message=f"ZIP central-directory validation failed: {error}",
+                severity=IssueSeverity.INFO,
+                rule_code="S902",
+                location=path,
+                details={
+                    "exception": str(error),
+                    "exception_type": type(error).__name__,
+                    "analysis_incomplete": True,
+                    "scan_outcome_reason": "zip_analysis_incomplete",
+                },
+            )
+        mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
+        result.finish(success=False)
+        return result
+
+    @staticmethod
+    def _add_central_directory_size_limit_check(
+        result: ScanResult,
+        path: str,
+        exc: _ZipCentralDirectorySizeExceeded,
+    ) -> None:
+        result.add_check(
+            name="Central Directory Size Limit Check",
+            passed=False,
+            message=str(exc),
+            severity=IssueSeverity.WARNING,
+            rule_code="S410",
+            location=path,
+            details={
+                "central_directory_size": exc.directory_size,
+                "max_central_directory_size": exc.max_directory_size,
+                "analysis_incomplete": True,
+                "scan_outcome_reason": "zip_analysis_incomplete",
+            },
+        )
+
     def _read_symlink_target(self, archive: zipfile.ZipFile, info: zipfile.ZipInfo) -> str:
         """Read a symlink target with a hard cap to avoid materializing large archive members."""
         target_bytes = bytearray()
@@ -188,14 +1273,18 @@ class ZipScanner(BaseScanner):
         if not os.path.isfile(path):
             return False
 
-        # Verify it's actually a zip file. Header-routed scans may reach this
-        # scanner even when the outer filename uses a misleading suffix.
         try:
-            with zipfile.ZipFile(path, "r") as _:
-                pass
-            return True
-        except zipfile.BadZipFile:
-            return False
+            with open(path, "rb") as handle:
+                preflight = cls._preflight_zip_directory(
+                    handle,
+                    cls.DEFAULT_MAX_ENTRIES,
+                    cls.DEFAULT_MAX_CENTRAL_DIRECTORY_SIZE,
+                )
+            return preflight is not None or cls._has_zip_routing_evidence(path)
+        except _InvalidZipDirectory as exc:
+            if exc.routing_evidence:
+                return True
+            return cls._has_zip_routing_evidence(path)
         except OSError:
             return os.path.splitext(path)[1].lower() in cls.supported_extensions
         except Exception:
@@ -263,7 +1352,7 @@ class ZipScanner(BaseScanner):
         result.metadata["file_size"] = os.path.getsize(path)
         return result
 
-    def scan_archive_members(self, path: str) -> ScanResult:
+    def scan_archive_members(self, path: str, archive: zipfile.ZipFile | None = None) -> ScanResult:
         """Recursively scan entries of an already validated ZIP container."""
         # Shared archive depth must survive scanner handoffs, while nested ZIP
         # recursion still needs its own counter for extensionless ZIP members
@@ -271,6 +1360,7 @@ class ZipScanner(BaseScanner):
         return self._scan_zip_file(
             path,
             depth=max(self._get_archive_depth(), self._get_zip_depth()),
+            archive=archive,
         )
 
     def _rewrite_nested_result_context(
@@ -423,7 +1513,12 @@ class ZipScanner(BaseScanner):
 
         return True, True
 
-    def _scan_zip_file(self, path: str, depth: int = 0) -> ScanResult:
+    def _scan_zip_file(
+        self,
+        path: str,
+        depth: int = 0,
+        archive: zipfile.ZipFile | None = None,
+    ) -> ScanResult:
         """Recursively scan a ZIP file and its contents"""
         result = ScanResult(scanner_name=self.name)
         contents: list[dict[str, Any]] = []
@@ -459,39 +1554,116 @@ class ZipScanner(BaseScanner):
                 details={"depth": depth, "max_depth": self.max_depth},
             )
 
-        with zipfile.ZipFile(path, "r") as z:
-            max_total_uncompressed_size = self._get_max_total_uncompressed_size()
-            entries = z.infolist()
-
-            # Check number of entries
-            entry_count = len(entries)
-            if entry_count > self.max_entries:
+        with contextlib.ExitStack() as archive_stack:
+            opened_archive_handle: BinaryIO
+            if archive is None:
+                opened_archive_handle = archive_stack.enter_context(open(path, "rb"))
+            else:
+                archive_fp = archive.fp
+                if archive_fp is None:
+                    raise zipfile.BadZipFile("ZIP archive is already closed")
+                opened_archive_handle = cast(BinaryIO, archive_fp)
+            try:
+                archive_file_size = os.fstat(opened_archive_handle.fileno()).st_size
+            except (AttributeError, OSError):
+                archive_file_size = os.path.getsize(path)
+            try:
+                preflight = self._preflight_zip_directory(
+                    opened_archive_handle,
+                    self.max_entries,
+                    self.max_central_directory_size,
+                )
+                if preflight is not None:
+                    preflight_entry_count, exceeds_limit = preflight
+                    result.metadata["zip_entry_count_preflight"] = preflight_entry_count
+                else:
+                    preflight_entry_count = None
+            except _ZipCentralDirectorySizeExceeded as exc:
+                self._add_central_directory_size_limit_check(result, path, exc)
+                mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
+                result.finish(success=False)
+                return result
+            except _InvalidZipDirectory as exc:
                 result.add_check(
-                    name="Entry Count Limit Check",
+                    name="ZIP Central Directory Preflight",
                     passed=False,
-                    message=f"ZIP file contains too many entries ({entry_count} > {self.max_entries})",
-                    severity=IssueSeverity.WARNING,
-                    rule_code="S410",  # Archive bomb
+                    message=f"ZIP central-directory validation failed: {exc}",
+                    severity=IssueSeverity.INFO,
+                    rule_code="S902",
                     location=path,
                     details={
-                        "entries": entry_count,
-                        "max_entries": self.max_entries,
+                        "exception": str(exc),
+                        "exception_type": type(exc).__name__,
+                        "analysis_incomplete": True,
+                        "scan_outcome_reason": "zip_analysis_incomplete",
                     },
                 )
                 mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
                 result.finish(success=False)
                 return result
-            else:
+
+            if preflight_entry_count is not None and exceeds_limit:
+                self._add_entry_count_limit_check(
+                    result,
+                    path,
+                    preflight_entry_count,
+                    passed=False,
+                    source="central_directory_preflight",
+                )
+                mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
+                result.finish(success=False)
+                return result
+
+            opened_archive_handle.seek(0)
+            z = (
+                archive
+                if archive is not None
+                else archive_stack.enter_context(zipfile.ZipFile(opened_archive_handle, "r"))
+            )
+            max_total_uncompressed_size = self._get_max_total_uncompressed_size()
+            entries = z.infolist()
+
+            # Check number of entries
+            entry_count = len(entries)
+            if preflight_entry_count is not None and entry_count != preflight_entry_count:
                 result.add_check(
-                    name="Entry Count Limit Check",
-                    passed=True,
-                    message=f"Entry count ({entry_count}) is within limits",
+                    name="ZIP Central Directory Preflight",
+                    passed=False,
+                    message=(
+                        "ZIP central directory changed between preflight and parsing "
+                        f"({preflight_entry_count} != {entry_count})"
+                    ),
+                    severity=IssueSeverity.INFO,
+                    rule_code="S902",
                     location=path,
                     details={
-                        "entries": entry_count,
-                        "max_entries": self.max_entries,
+                        "preflight_entries": preflight_entry_count,
+                        "parsed_entries": entry_count,
+                        "analysis_incomplete": True,
+                        "scan_outcome_reason": "zip_analysis_incomplete",
                     },
-                    rule_code=None,  # Passing check
+                )
+                mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
+                result.finish(success=False)
+                return result
+            if entry_count > self.max_entries:
+                self._add_entry_count_limit_check(
+                    result,
+                    path,
+                    entry_count,
+                    passed=False,
+                    source="post_open_fallback",
+                )
+                mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
+                result.finish(success=False)
+                return result
+            else:
+                self._add_entry_count_limit_check(
+                    result,
+                    path,
+                    entry_count,
+                    passed=True,
+                    source=("post_open_fallback" if preflight_entry_count is None else "central_directory_preflight"),
                 )
 
             temp_base = os.path.join(tempfile.gettempdir(), "extract")
@@ -766,7 +1938,7 @@ class ZipScanner(BaseScanner):
                     )
 
         result.metadata["contents"] = contents
-        result.metadata["file_size"] = os.path.getsize(path)
+        result.metadata["file_size"] = archive_file_size
         if not scan_complete:
             mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
         result.finish(success=scan_complete and not member_scan_incomplete(result) and not result.has_errors)
@@ -875,7 +2047,7 @@ class ZipScanner(BaseScanner):
         metadata = super().extract_metadata(file_path)
 
         try:
-            with zipfile.ZipFile(file_path, "r") as zip_file:
+            with open_preflighted_zip(file_path, self.config) as zip_file:
                 file_list = zip_file.namelist()
 
                 # Basic ZIP info
@@ -957,3 +2129,59 @@ class ZipScanner(BaseScanner):
             metadata["extraction_error"] = str(e)
 
         return metadata
+
+
+@contextlib.contextmanager
+def open_preflighted_zip_handle(
+    path: str | os.PathLike[str],
+    config: dict[str, Any] | None = None,
+    *,
+    require_zip: bool = True,
+) -> Iterator[BinaryIO]:
+    """Open once, preflight that descriptor, and yield it without a pathname race."""
+    scanner = ZipScanner(config=config)
+    path_text = os.fspath(path)
+    with open(path, "rb") as handle:
+        if not require_zip:
+            try:
+                leading_signature = handle.read(4)
+                if leading_signature not in {
+                    _ZIP_LOCAL_FILE_HEADER_SIGNATURE,
+                    _ZIP_EOCD_SIGNATURE,
+                    _ZIP64_EOCD_SIGNATURE,
+                }:
+                    handle.seek(0)
+                    yield handle
+                    return
+            except OSError:
+                handle.seek(0)
+                yield handle
+                return
+            handle.seek(0)
+        try:
+            preflight = scanner._preflight_zip_directory(
+                handle,
+                scanner.max_entries,
+                scanner.max_central_directory_size,
+            )
+        except _InvalidZipDirectory as exc:
+            raise ZipPreflightRejected(scanner._preflight_rejection_result(path_text, error=exc)) from exc
+        if preflight is None:
+            if require_zip:
+                raise zipfile.BadZipFile("File is not a valid ZIP archive")
+        else:
+            entry_count, exceeds_limit = preflight
+            if exceeds_limit:
+                raise ZipPreflightRejected(scanner._preflight_rejection_result(path_text, entry_count=entry_count))
+        handle.seek(0)
+        yield handle
+
+
+@contextlib.contextmanager
+def open_preflighted_zip(
+    path: str | os.PathLike[str],
+    config: dict[str, Any] | None = None,
+) -> Iterator[zipfile.ZipFile]:
+    """Construct ``ZipFile`` only after preflighting the same open descriptor."""
+    with open_preflighted_zip_handle(path, config) as handle, zipfile.ZipFile(handle, "r") as archive:
+        yield archive

--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -1399,6 +1399,20 @@ class ZipScanner(BaseScanner):
                 else entry_name
             )
 
+    @staticmethod
+    @contextlib.contextmanager
+    def _open_archive_handle(path: str, archive: zipfile.ZipFile | None) -> Iterator[BinaryIO]:
+        """Yield an owned path handle or borrow the handle from an existing archive."""
+        if archive is None:
+            with open(path, "rb") as handle:
+                yield handle
+            return
+
+        archive_fp = archive.fp
+        if archive_fp is None:
+            raise zipfile.BadZipFile("ZIP archive is already closed")
+        yield cast(BinaryIO, archive_fp)
+
     def _scan_nested_archive_entry(self, path: str, nested_config: dict[str, Any]) -> ScanResult:
         """Dispatch a nested archive member through an injected callback or registry fallback."""
         nested_scan_callback = self.config.get(NESTED_SCAN_CALLBACK_CONFIG_KEY)
@@ -1554,15 +1568,7 @@ class ZipScanner(BaseScanner):
                 details={"depth": depth, "max_depth": self.max_depth},
             )
 
-        with contextlib.ExitStack() as archive_stack:
-            opened_archive_handle: BinaryIO
-            if archive is None:
-                opened_archive_handle = archive_stack.enter_context(open(path, "rb"))
-            else:
-                archive_fp = archive.fp
-                if archive_fp is None:
-                    raise zipfile.BadZipFile("ZIP archive is already closed")
-                opened_archive_handle = cast(BinaryIO, archive_fp)
+        with self._open_archive_handle(path, archive) as opened_archive_handle, contextlib.ExitStack() as archive_stack:
             try:
                 archive_file_size = os.fstat(opened_archive_handle.fileno()).st_size
             except (AttributeError, OSError):

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -2172,14 +2172,16 @@ def _looks_like_pytorch_zip_storage_members(member_names: set[str], prefix: str)
     return False
 
 
-def is_torchserve_mar_archive(path: str) -> bool:
+def is_torchserve_mar_archive(path: str, config: dict[str, Any] | None = None) -> bool:
     """Return whether a ZIP-backed `.mar` looks like a real TorchServe archive."""
     file_path = Path(path)
     if not file_path.is_file():
         return False
 
+    from ...scanners.zip_scanner import ZipPreflightRejected, open_preflighted_zip
+
     try:
-        with zipfile.ZipFile(file_path, "r") as archive:
+        with open_preflighted_zip(file_path, config) as archive:
             manifest_info = None
             manifest_name = _normalize_archive_member_name(_TORCHSERVE_MANIFEST_PATH)
             for info in archive.infolist():
@@ -2202,6 +2204,10 @@ def is_torchserve_mar_archive(path: str) -> bool:
         zipfile.BadZipFile,
         zipfile.LargeZipFile,
     ):
+        return False
+    except ZipPreflightRejected:
+        if config is not None:
+            raise
         return False
 
 
@@ -2248,27 +2254,40 @@ def _is_keras_zip_archive_content(archive: zipfile.ZipFile, *, allow_config_only
     return _looks_like_keras_config(config_data)
 
 
-def is_keras_zip_archive(path: str, *, allow_config_only: bool = False) -> bool:
+def is_keras_zip_archive(
+    path: str,
+    *,
+    allow_config_only: bool = False,
+    config: dict[str, Any] | None = None,
+) -> bool:
     """Return whether a ZIP-backed file has the minimal Keras archive structure."""
     file_path = Path(path)
     if not file_path.is_file():
         return False
 
+    from ...scanners.zip_scanner import ZipPreflightRejected, open_preflighted_zip
+
     try:
-        with zipfile.ZipFile(file_path, "r") as archive:
+        with open_preflighted_zip(file_path, config) as archive:
             return _is_keras_zip_archive_content(archive, allow_config_only=allow_config_only)
     except (OSError, RuntimeError, zipfile.BadZipFile, zipfile.LargeZipFile):
         return False
+    except ZipPreflightRejected:
+        if config is not None:
+            raise
+        return False
 
 
-def is_pytorch_zip_archive(path: str) -> bool:
+def is_pytorch_zip_archive(path: str, config: dict[str, Any] | None = None) -> bool:
     """Return whether a ZIP-backed file has a conservative PyTorch archive signature."""
     file_path = Path(path)
     if not file_path.is_file():
         return False
 
+    from ...scanners.zip_scanner import ZipPreflightRejected, open_preflighted_zip
+
     try:
-        with zipfile.ZipFile(file_path, "r") as archive:
+        with open_preflighted_zip(file_path, config) as archive:
             member_names = {
                 _normalize_archive_member_name(info.filename)
                 for info in archive.infolist()
@@ -2289,18 +2308,24 @@ def is_pytorch_zip_archive(path: str) -> bool:
                     return True
     except (OSError, RuntimeError, zipfile.BadZipFile, zipfile.LargeZipFile):
         return False
+    except ZipPreflightRejected:
+        if config is not None:
+            raise
+        return False
 
     return False
 
 
-def is_executorch_archive(path: str) -> bool:
+def is_executorch_archive(path: str, config: dict[str, Any] | None = None) -> bool:
     """Return whether a ZIP-backed file matches the mobile/ExecuTorch archive layout."""
     file_path = Path(path)
     if not file_path.is_file():
         return False
 
+    from ...scanners.zip_scanner import ZipPreflightRejected, open_preflighted_zip
+
     try:
-        with zipfile.ZipFile(file_path, "r") as archive:
+        with open_preflighted_zip(file_path, config) as archive:
             members_by_name: dict[str, list[zipfile.ZipInfo]] = {}
             for info in archive.infolist():
                 if not info.filename or info.is_dir():
@@ -2323,11 +2348,15 @@ def is_executorch_archive(path: str) -> bool:
                         return True
     except (OSError, RuntimeError, zipfile.BadZipFile, zipfile.LargeZipFile):
         return False
+    except ZipPreflightRejected:
+        if config is not None:
+            raise
+        return False
 
     return False
 
 
-def is_skops_archive(path: str) -> bool:
+def is_skops_archive(path: str, config: dict[str, Any] | None = None) -> bool:
     """Return whether a ZIP-backed file has a Skops schema payload.
 
     Oversized schema members are treated as Skops to avoid failing open on
@@ -2338,8 +2367,10 @@ def is_skops_archive(path: str) -> bool:
     if not file_path.is_file():
         return False
 
+    from ...scanners.zip_scanner import ZipPreflightRejected, open_preflighted_zip
+
     try:
-        with zipfile.ZipFile(file_path, "r") as archive:
+        with open_preflighted_zip(file_path, config) as archive:
             for info in archive.infolist():
                 if not info.filename or info.is_dir():
                     continue
@@ -2358,6 +2389,10 @@ def is_skops_archive(path: str) -> bool:
                 if _looks_like_skops_schema(schema_data):
                     return True
     except (OSError, RuntimeError, zipfile.BadZipFile, zipfile.LargeZipFile):
+        return False
+    except ZipPreflightRejected:
+        if config is not None:
+            raise
         return False
 
     return False

--- a/modelaudit/utils/file/handlers.py
+++ b/modelaudit/utils/file/handlers.py
@@ -21,6 +21,7 @@ from ..helpers.cache_decorator import (
     add_optional_dependency_availability_to_version_context,
     should_bypass_cache_for_safetensors_header_limit,
     should_bypass_cache_for_unavailable_hdf5_analysis,
+    should_bypass_cache_for_zip_entry_preflight,
 )
 from ..sources._huggingface_cache import _find_hf_cache_root, _path_has_part, _trusted_hf_blobs_root
 
@@ -1609,6 +1610,16 @@ def scan_advanced_large_file(
 
     # If caching is disabled, proceed with direct scan
     if not cache_enabled:
+        return _scan_advanced_large_file_internal(
+            file_path,
+            scanner,
+            progress_callback,
+            timeout,
+            allowed_shard_paths=allowed_shard_paths,
+            allowed_shard_targets=allowed_shard_targets,
+        )
+    if should_bypass_cache_for_zip_entry_preflight(file_path, config):
+        logger.debug(f"Bypassing advanced-file cache for bounded ZIP entry preflight: {file_path}")
         return _scan_advanced_large_file_internal(
             file_path,
             scanner,

--- a/modelaudit/utils/file/large_file_handler.py
+++ b/modelaudit/utils/file/large_file_handler.py
@@ -16,6 +16,7 @@ from ..helpers.cache_decorator import (
     add_optional_dependency_availability_to_version_context,
     should_bypass_cache_for_safetensors_header_limit,
     should_bypass_cache_for_unavailable_hdf5_analysis,
+    should_bypass_cache_for_zip_entry_preflight,
 )
 
 # Lazy import to avoid circular dependency
@@ -252,6 +253,9 @@ def scan_large_file(
 
     # If caching is disabled, proceed with direct scan
     if not cache_enabled:
+        return _scan_large_file_internal(file_path, scanner, progress_callback, timeout)
+    if should_bypass_cache_for_zip_entry_preflight(file_path, config):
+        logger.debug(f"Bypassing large-file cache for bounded ZIP entry preflight: {file_path}")
         return _scan_large_file_internal(file_path, scanner, progress_callback, timeout)
     if should_bypass_cache_for_unavailable_hdf5_analysis(file_path):
         logger.debug(f"Bypassing large-file cache because HDF5 analysis is unavailable: {file_path}")

--- a/modelaudit/utils/helpers/cache_decorator.py
+++ b/modelaudit/utils/helpers/cache_decorator.py
@@ -154,6 +154,21 @@ def should_bypass_cache_for_unavailable_hdf5_analysis(file_path: str) -> bool:
         return True
 
 
+def should_bypass_cache_for_zip_entry_preflight(file_path: str, config: dict[str, Any]) -> bool:
+    """Avoid cache probes that materialize an over-limit or inconsistent ZIP directory."""
+    try:
+        from ...scanner_selection import allows_zip_structure_analysis, policy_from_config
+        from ...scanners.zip_scanner import ZipScanner
+
+        if not allows_zip_structure_analysis(policy_from_config(config)):
+            return False
+        max_entries = int(config.get("max_zip_entries", ZipScanner.DEFAULT_MAX_ENTRIES))
+        max_directory_size = ZipScanner.central_directory_size_limit(config)
+        return ZipScanner.requires_preflight_result(file_path, max_entries, max_directory_size)
+    except (OSError, TypeError, ValueError):
+        return False
+
+
 def _h5py_runtime_available() -> bool:
     """Return whether h5py can create and close an in-memory HDF5 file."""
     if not _h5py_availability():
@@ -171,15 +186,16 @@ def _h5py_runtime_available() -> bool:
 def _has_embedded_keras_hdf5_weights(file_path: str) -> bool:
     """Return whether a Keras ZIP contains its standard HDF5 weights member."""
     try:
+        from ...scanners.zip_scanner import ZipPreflightRejected, open_preflighted_zip
         from ..file.detection import _normalize_archive_member_name
 
-        with zipfile.ZipFile(file_path) as archive:
+        with open_preflighted_zip(file_path) as archive:
             member_names = {
                 _normalize_archive_member_name(info.filename)
                 for info in archive.infolist()
                 if info.filename and not info.is_dir()
             }
-    except (OSError, zipfile.BadZipFile):
+    except (OSError, zipfile.BadZipFile, ZipPreflightRejected):
         return False
     return "config.json" in member_names and "model.weights.h5" in member_names
 
@@ -293,6 +309,11 @@ def cached_scan(cache_enabled_key: str = "cache_enabled", cache_dir_key: str = "
                     logger.debug(f"Bypassing cache for sharded model family: {file_path}")
                     return func(*args, **kwargs)
 
+                raw_config, _ = _extract_config_and_path(args, kwargs)
+                if should_bypass_cache_for_zip_entry_preflight(file_path, raw_config or {}):
+                    logger.debug(f"Bypassing cache for bounded ZIP entry preflight: {file_path}")
+                    return func(*args, **kwargs)
+
                 if should_bypass_cache_for_unavailable_hdf5_analysis(file_path):
                     logger.debug(f"Bypassing cache because HDF5 analysis is unavailable: {file_path}")
                     return func(*args, **kwargs)
@@ -301,7 +322,6 @@ def cached_scan(cache_enabled_key: str = "cache_enabled", cache_dir_key: str = "
                     logger.debug(f"File {file_path} not suitable for caching, calling function directly")
                     return func(*args, **kwargs)
 
-                raw_config, _ = _extract_config_and_path(args, kwargs)
                 if should_bypass_cache_for_safetensors_header_limit(file_path, raw_config or {}):
                     logger.debug(f"Bypassing cache for bounded SafeTensors header failure: {file_path}")
                     return func(*args, **kwargs)

--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -2082,6 +2082,43 @@ class TestKerasZipScanner:
             check.name == "Keras ZIP Format Check" and check.status == CheckStatus.FAILED for check in result.checks
         )
 
+    def test_recursive_member_scan_reuses_preflighted_archive_after_path_replacement(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        keras_path = create_configured_keras_zip(
+            tmp_path,
+            {"class_name": "Sequential", "config": {"layers": []}},
+            file_name="same_descriptor.keras",
+        )
+        with zipfile.ZipFile(keras_path, "a") as archive:
+            archive.writestr("safe.txt", "safe")
+
+        replacement_path = tmp_path / "replacement.keras"
+        with zipfile.ZipFile(replacement_path, "w") as archive:
+            archive.writestr("config.json", json.dumps({"class_name": "Sequential", "config": {"layers": []}}))
+            archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo replacement"\ntR.')
+
+        original_scan_archive_members = keras_zip_scanner_module.ZipScanner.scan_archive_members
+
+        def replace_then_scan(
+            scanner: keras_zip_scanner_module.ZipScanner,
+            path: str,
+            archive: zipfile.ZipFile | None = None,
+        ) -> ScanResult:
+            assert archive is not None
+            replacement_path.replace(path)
+            return original_scan_archive_members(scanner, path, archive=archive)
+
+        monkeypatch.setattr(keras_zip_scanner_module.ZipScanner, "scan_archive_members", replace_then_scan)
+
+        result = KerasZipScanner().scan(str(keras_path))
+
+        assert not any(issue.details.get("zip_entry") == "payload.pkl" for issue in result.issues)
+        assert any(entry.get("path", "").endswith(":safe.txt") for entry in result.metadata["contents"])
+        assert not any(entry.get("path", "").endswith(":payload.pkl") for entry in result.metadata["contents"])
+
     def test_read_failure_returns_inconclusive_exit2(
         self,
         tmp_path: Path,

--- a/tests/scanners/test_scanner_registry.py
+++ b/tests/scanners/test_scanner_registry.py
@@ -9,7 +9,7 @@ import tarfile
 import zipfile
 from collections.abc import Callable
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 import pytest
 
@@ -520,6 +520,40 @@ def test_get_scanner_for_path_routes_generic_zip_without_skops_markers_to_zip(tm
     )
 
     _assert_scanner_for_path(model_path, "zip")
+
+
+def test_get_scanner_for_file_routes_over_entry_zip_before_specialized_zip_probes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = _write_zip_archive(
+        tmp_path / "over-entry.zip",
+        {"one.txt": b"one", "two.txt": b"two"},
+    )
+
+    def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("specialized routing must not materialize an over-limit ZIP directory")
+
+    monkeypatch.setattr(zipfile, "ZipFile", fail_zipfile_open)
+
+    scanner = get_scanner_for_file(str(model_path), config={"max_zip_entries": 1})
+
+    assert scanner is not None
+    assert scanner.name == "zip"
+
+
+def test_get_scanner_for_file_honors_selection_before_zip_preflight(tmp_path: Path) -> None:
+    model_path = _write_zip_archive(
+        tmp_path / "selected-pickle.zip",
+        {"one.txt": b"one", "two.txt": b"two"},
+    )
+
+    scanner = get_scanner_for_file(
+        str(model_path),
+        config={"scanners": ["pickle"], "max_zip_entries": 1},
+    )
+
+    assert scanner is None
 
 
 def test_get_scanner_for_file_routes_disguised_rar_by_header(tmp_path: Path) -> None:

--- a/tests/scanners/test_skops_scanner.py
+++ b/tests/scanners/test_skops_scanner.py
@@ -12,6 +12,7 @@ import pytest
 from modelaudit.cache import get_cache_manager, reset_cache_manager
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.models import ModelAuditResultModel
+from modelaudit.scanners import zip_scanner as zip_scanner_module
 from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity, ScanResult
 from modelaudit.scanners.skops_scanner import SkopsScanner
 
@@ -1118,7 +1119,13 @@ class TestSkopsScannerEdgeCases:
         with zipfile.ZipFile(skops_file, "w", compression=zipfile.ZIP_DEFLATED) as zf:
             zf.writestr("schema.json", '{"version": "1.0"}')
 
-        def fail_member_scan(_self: SkopsScanner, _path: str, _result: ScanResult) -> None:
+        def fail_member_scan(
+            _self: SkopsScanner,
+            _path: str,
+            _result: ScanResult,
+            archive: zipfile.ZipFile | None = None,
+        ) -> None:
+            del archive
             raise RuntimeError("unexpected nested scan failure")
 
         monkeypatch.setattr(SkopsScanner, "_scan_archive_members", fail_member_scan)
@@ -1138,6 +1145,40 @@ class TestSkopsScannerEdgeCases:
             assert stats["total_entries"] == 0
         finally:
             reset_cache_manager()
+
+    def test_recursive_member_scan_reuses_preflighted_archive_after_path_replacement(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        skops_path = tmp_path / "same_descriptor.skops"
+        with zipfile.ZipFile(skops_path, "w") as archive:
+            archive.writestr("schema.json", '{"version": "1.0"}')
+            archive.writestr("safe.txt", "safe")
+
+        replacement_path = tmp_path / "replacement.skops"
+        with zipfile.ZipFile(replacement_path, "w") as archive:
+            archive.writestr("schema.json", '{"version": "1.0"}')
+            archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo replacement"\ntR.')
+
+        original_scan_archive_members = zip_scanner_module.ZipScanner.scan_archive_members
+
+        def replace_then_scan(
+            scanner: zip_scanner_module.ZipScanner,
+            path: str,
+            archive: zipfile.ZipFile | None = None,
+        ) -> ScanResult:
+            assert archive is not None
+            replacement_path.replace(path)
+            return original_scan_archive_members(scanner, path, archive=archive)
+
+        monkeypatch.setattr(zip_scanner_module.ZipScanner, "scan_archive_members", replace_then_scan)
+
+        result = SkopsScanner().scan(str(skops_path))
+
+        assert not any(issue.details.get("zip_entry") == "payload.pkl" for issue in result.issues)
+        assert any(entry.get("path", "").endswith(":safe.txt") for entry in result.metadata["contents"])
+        assert not any(entry.get("path", "").endswith(":payload.pkl") for entry in result.metadata["contents"])
 
     def test_oversized_numpy_payload_core_exits_zero_and_still_caches(self, tmp_path: Path) -> None:
         """Oversized numeric arrays should not become Skops CVE false positives in aggregate scans."""

--- a/tests/scanners/test_weight_distribution_scanner.py
+++ b/tests/scanners/test_weight_distribution_scanner.py
@@ -1018,6 +1018,23 @@ def test_pytorch_zip_alias_expansion_is_rejected_before_numpy(
     assert scanner.extraction_incomplete_reasons == ["pytorch_tensor_materialization_failed"]
 
 
+def test_pytorch_load_budget_ignores_incidental_eocd_in_legacy_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "legacy.pt"
+    path.write_bytes(b"legacy tensor payload" + b"PK\x05\x06" + (b"\x00" * 18))
+
+    def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("legacy non-ZIP files must not enter ZIP parsing")
+
+    monkeypatch.setattr(zipfile, "ZipFile", fail_zipfile_open)
+    scanner = WeightDistributionScanner()
+
+    assert scanner._pytorch_load_within_budget(str(path)) is True
+    assert scanner.extraction_incomplete is False
+
+
 def test_pytorch_zip_small_shared_sequence_is_not_treated_as_cycle(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -9706,6 +9706,22 @@ class TestZipScanner:
         assert result.success is True
         assert opened_with_handle is True
 
+    def test_owned_archive_handle_closes_when_consumer_raises(self, tmp_path: Path) -> None:
+        archive_path = tmp_path / "owned_handle.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("safe.txt", "safe")
+
+        opened_handle: Any = None
+        with (
+            pytest.raises(RuntimeError, match="stop scan"),
+            ZipScanner._open_archive_handle(str(archive_path), None) as handle,
+        ):
+            opened_handle = handle
+            raise RuntimeError("stop scan")
+
+        assert opened_handle is not None
+        assert opened_handle.closed is True
+
     def test_max_entries_limit_zip64_preflight_rejects_before_zipfile_open(
         self,
         tmp_path: Path,

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -6,6 +6,7 @@ import json
 import lzma
 import os
 import stat
+import struct
 import tarfile
 import tempfile
 import zipfile
@@ -39,6 +40,7 @@ from modelaudit.scanners.zip_scanner import (
     ZIP_CONTENT_ONLY_MEMBER_ENTRIES_CONFIG_KEY,
     ZIP_SECURITY_ONLY_MEMBER_ENTRIES_CONFIG_KEY,
     ZipScanner,
+    open_preflighted_zip_handle,
 )
 from modelaudit.utils.file import detection as file_detection
 from modelaudit.utils.tensorflow_compat import has_tensorflow_protobuf_stubs as _has_tf_protos
@@ -7652,6 +7654,29 @@ class TestZipScanner:
         finally:
             os.unlink(tmp_path)
 
+    def test_can_handle_does_not_materialize_central_directory(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        archive_path = tmp_path / "routed.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("one.txt", "one")
+            archive.writestr("two.txt", "two")
+
+        def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("can_handle must not parse the central directory")
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+        assert ZipScanner.can_handle(str(archive_path)) is True
+
+    def test_can_handle_does_not_claim_stray_local_header_bytes(self, tmp_path: Path) -> None:
+        model_path = tmp_path / "weights.bin"
+        model_path.write_bytes(b"model metadata PK\x03\x04 embedded tensor bytes")
+
+        assert ZipScanner.can_handle(str(model_path)) is False
+
     def test_symlink_outside_extraction_root(self):
         """Symlinks resolving outside the extraction root should be flagged."""
         with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
@@ -8551,6 +8576,1283 @@ class TestZipScanner:
         assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
         assert result.metadata["analysis_incomplete"] is True
         assert "zip_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+
+    def test_max_entries_limit_preflight_rejects_before_zipfile_open(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """EOCD entry counts should fail closed before ZipFile parses the central directory."""
+        archive_path = tmp_path / "preflight_many_entries.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("safe.txt", "safe")
+            archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo hidden"\ntR.')
+
+        def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("entry-count preflight should stop before ZipFile construction")
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+        result = ZipScanner(config={"max_zip_entries": 1}).scan(str(archive_path))
+
+        assert result.success is False
+        assert result.has_errors is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert result.metadata["zip_entry_count_preflight"] == 2
+        assert "zip_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+        assert any(
+            check.name == "Entry Count Limit Check"
+            and check.status == CheckStatus.FAILED
+            and check.rule_code == "S410"
+            and check.details["entries"] == 2
+            and check.details["max_entries"] == 1
+            and check.details["entry_count_source"] == "central_directory_preflight"
+            for check in result.checks
+        )
+
+    def test_central_directory_size_limit_rejects_before_zipfile_open(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        archive_path = tmp_path / "oversized_directory.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("safe.txt", "safe")
+
+        archive_bytes = archive_path.read_bytes()
+        eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+        assert eocd_index >= 0
+        directory_size = int.from_bytes(archive_bytes[eocd_index + 12 : eocd_index + 16], "little")
+
+        def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("directory-size preflight should stop before ZipFile construction")
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+        result = ZipScanner(config={"max_zip_central_directory_size": directory_size - 1}).scan(str(archive_path))
+
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert any(
+            check.name == "Central Directory Size Limit Check"
+            and check.status == CheckStatus.FAILED
+            and check.rule_code == "S410"
+            and check.details["central_directory_size"] == directory_size
+            and check.details["max_central_directory_size"] == directory_size - 1
+            for check in result.checks
+        )
+
+    def test_central_directory_size_exact_limit_still_scans(self, tmp_path: Path) -> None:
+        archive_path = tmp_path / "directory_at_limit.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("safe.txt", "safe")
+
+        archive_bytes = archive_path.read_bytes()
+        eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+        assert eocd_index >= 0
+        directory_size = int.from_bytes(archive_bytes[eocd_index + 12 : eocd_index + 16], "little")
+
+        result = ZipScanner(config={"max_zip_central_directory_size": directory_size}).scan(str(archive_path))
+
+        assert result.success is True
+        assert not any(check.name == "Central Directory Size Limit Check" for check in result.checks)
+
+    def test_central_directory_size_limit_cannot_be_raised(self) -> None:
+        assert (
+            ZipScanner.central_directory_size_limit(
+                {"max_zip_central_directory_size": ZipScanner.DEFAULT_MAX_CENTRAL_DIRECTORY_SIZE * 2}
+            )
+            == ZipScanner.DEFAULT_MAX_CENTRAL_DIRECTORY_SIZE
+        )
+
+    def test_oversized_directory_with_valid_empty_eocd_fails_ambiguous_before_zipfile_open(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        archive_path = tmp_path / "oversized_with_empty_eocd.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo hidden"\ntR.')
+
+        archive_bytes = bytearray(archive_path.read_bytes())
+        real_eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+        assert real_eocd_index >= 0
+        fake_empty_eocd = b"PK\x05\x06" + (b"\x00" * 18)
+        archive_bytes[real_eocd_index + 20 : real_eocd_index + 22] = len(fake_empty_eocd).to_bytes(2, "little")
+        archive_bytes.extend(fake_empty_eocd)
+        archive_path.write_bytes(archive_bytes)
+
+        def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("ambiguous oversized directories must fail before ZipFile construction")
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+        result = ZipScanner(config={"max_zip_central_directory_size": 1}).scan(str(archive_path))
+
+        assert result.success is False
+        assert any(
+            check.name == "Central Directory Size Limit Check" and check.status == CheckStatus.FAILED
+            for check in result.checks
+        )
+
+    def test_max_entries_limit_forged_low_eocd_rejects_before_zipfile_open(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A low forged EOCD count must not hide additional central-directory records."""
+        archive_path = tmp_path / "forged_low_count.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("one.txt", "one")
+            archive.writestr("two.txt", "two")
+
+        archive_bytes = bytearray(archive_path.read_bytes())
+        eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+        assert eocd_index >= 0
+        archive_bytes[eocd_index + 8 : eocd_index + 10] = (1).to_bytes(2, "little")
+        archive_bytes[eocd_index + 10 : eocd_index + 12] = (1).to_bytes(2, "little")
+        archive_path.write_bytes(archive_bytes)
+
+        def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("forged EOCD count must fail before ZipFile construction")
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+        result = ZipScanner(config={"max_zip_entries": 1}).scan(str(archive_path))
+
+        assert result.success is False
+        assert result.metadata["zip_entry_count_preflight"] == 2
+        assert any(
+            check.name == "Entry Count Limit Check"
+            and check.status == CheckStatus.FAILED
+            and check.details["entry_count_source"] == "central_directory_preflight"
+            for check in result.checks
+        )
+
+    @pytest.mark.parametrize("forged_prefix_shift", [0, 1])
+    def test_suffix_only_central_directory_rejects_before_zipfile_open(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        forged_prefix_shift: int,
+    ) -> None:
+        archive_path = tmp_path / "suffix_only_directory.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo hidden"\ntR.')
+            archive.writestr("safe.txt", "safe")
+
+        archive_bytes = bytearray(archive_path.read_bytes())
+        eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+        assert eocd_index >= 0
+        directory_size = int.from_bytes(archive_bytes[eocd_index + 12 : eocd_index + 16], "little")
+        directory_start = eocd_index - directory_size
+        last_record_start = archive_bytes.rfind(b"PK\x01\x02", directory_start, eocd_index)
+        assert last_record_start > directory_start
+        archive_bytes[eocd_index + 8 : eocd_index + 10] = (1).to_bytes(2, "little")
+        archive_bytes[eocd_index + 10 : eocd_index + 12] = (1).to_bytes(2, "little")
+        archive_bytes[eocd_index + 12 : eocd_index + 16] = (eocd_index - last_record_start).to_bytes(4, "little")
+        archive_bytes[eocd_index + 16 : eocd_index + 20] = (last_record_start - forged_prefix_shift).to_bytes(
+            4,
+            "little",
+        )
+        if forged_prefix_shift:
+            safe_local_offset = int.from_bytes(archive_bytes[last_record_start + 42 : last_record_start + 46], "little")
+            archive_bytes[last_record_start + 42 : last_record_start + 46] = (
+                safe_local_offset - forged_prefix_shift
+            ).to_bytes(4, "little")
+        archive_path.write_bytes(archive_bytes)
+
+        def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("suffix-only directories must fail before ZipFile construction")
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is False
+        assert any(
+            check.name == "ZIP Central Directory Preflight"
+            and check.status == CheckStatus.FAILED
+            and "omits a preceding record" in check.message
+            for check in result.checks
+        )
+
+    def test_suffix_only_directory_with_corrupted_omitted_record_rejects_before_zipfile_open(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        archive_path = tmp_path / "suffix_only_corrupted_directory.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo hidden"\ntR.')
+            archive.writestr("safe.txt", "safe")
+
+        archive_bytes = bytearray(archive_path.read_bytes())
+        eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+        assert eocd_index >= 0
+        directory_size = int.from_bytes(archive_bytes[eocd_index + 12 : eocd_index + 16], "little")
+        directory_start = eocd_index - directory_size
+        last_record_start = archive_bytes.rfind(b"PK\x01\x02", directory_start, eocd_index)
+        assert last_record_start > directory_start
+        archive_bytes[directory_start : directory_start + 2] = b"XX"
+        archive_bytes[eocd_index + 8 : eocd_index + 10] = (1).to_bytes(2, "little")
+        archive_bytes[eocd_index + 10 : eocd_index + 12] = (1).to_bytes(2, "little")
+        archive_bytes[eocd_index + 12 : eocd_index + 16] = (eocd_index - last_record_start).to_bytes(4, "little")
+        archive_bytes[eocd_index + 16 : eocd_index + 20] = last_record_start.to_bytes(4, "little")
+        archive_path.write_bytes(archive_bytes)
+
+        def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("unreferenced local entries must fail before ZipFile construction")
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is False
+        assert any(
+            check.name == "ZIP Central Directory Preflight"
+            and check.status == CheckStatus.FAILED
+            and "omits a preceding record" in check.message
+            for check in result.checks
+        )
+
+    def test_suffix_only_directory_with_corrupted_omitted_record_metadata_rejects_before_zipfile_open(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        archive_path = tmp_path / "suffix_only_corrupted_directory_metadata.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo hidden"\ntR.')
+            archive.writestr("safe.txt", "safe")
+
+        archive_bytes = bytearray(archive_path.read_bytes())
+        eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+        assert eocd_index >= 0
+        directory_size = int.from_bytes(archive_bytes[eocd_index + 12 : eocd_index + 16], "little")
+        directory_start = eocd_index - directory_size
+        last_record_start = archive_bytes.rfind(b"PK\x01\x02", directory_start, eocd_index)
+        assert last_record_start > directory_start
+        archive_bytes[directory_start : directory_start + 4] = b"XXXX"
+        archive_bytes[directory_start + 6 : directory_start + 8] = (101).to_bytes(2, "little")
+        archive_bytes[eocd_index + 8 : eocd_index + 10] = (1).to_bytes(2, "little")
+        archive_bytes[eocd_index + 10 : eocd_index + 12] = (1).to_bytes(2, "little")
+        archive_bytes[eocd_index + 12 : eocd_index + 16] = (eocd_index - last_record_start).to_bytes(4, "little")
+        archive_bytes[eocd_index + 16 : eocd_index + 20] = last_record_start.to_bytes(4, "little")
+        archive_path.write_bytes(archive_bytes)
+
+        def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("unreferenced local entries must fail before ZipFile construction")
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is False
+        assert any(
+            check.name == "ZIP Central Directory Preflight"
+            and check.status == CheckStatus.FAILED
+            and "omits a preceding record" in check.message
+            for check in result.checks
+        )
+
+    def test_suffix_only_directory_with_deleted_omitted_record_rejects_before_zipfile_open(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        archive_path = tmp_path / "suffix_only_deleted_directory_record.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo hidden"\ntR.')
+            archive.writestr("safe.txt", "safe")
+
+        archive_bytes = bytearray(archive_path.read_bytes())
+        original_eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+        assert original_eocd_index >= 0
+        original_directory_size = int.from_bytes(
+            archive_bytes[original_eocd_index + 12 : original_eocd_index + 16],
+            "little",
+        )
+        directory_start = original_eocd_index - original_directory_size
+        last_record_start = archive_bytes.rfind(b"PK\x01\x02", directory_start, original_eocd_index)
+        assert last_record_start > directory_start
+        del archive_bytes[directory_start:last_record_start]
+        eocd_index = original_eocd_index - (last_record_start - directory_start)
+        archive_bytes[eocd_index + 8 : eocd_index + 10] = (1).to_bytes(2, "little")
+        archive_bytes[eocd_index + 10 : eocd_index + 12] = (1).to_bytes(2, "little")
+        archive_bytes[eocd_index + 12 : eocd_index + 16] = (eocd_index - directory_start).to_bytes(4, "little")
+        archive_bytes[eocd_index + 16 : eocd_index + 20] = directory_start.to_bytes(4, "little")
+        archive_path.write_bytes(archive_bytes)
+
+        def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("unreferenced local entries must fail before ZipFile construction")
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is False
+        assert any(
+            check.name == "ZIP Central Directory Preflight"
+            and check.status == CheckStatus.FAILED
+            and "omits a preceding record" in check.message
+            for check in result.checks
+        )
+
+    def test_empty_directory_cannot_hide_unreferenced_local_entry(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        archive_path = tmp_path / "empty_directory_hides_local_entry.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo hidden"\ntR.')
+
+        archive_bytes = bytearray(archive_path.read_bytes())
+        original_eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+        assert original_eocd_index >= 0
+        directory_size = int.from_bytes(archive_bytes[original_eocd_index + 12 : original_eocd_index + 16], "little")
+        directory_start = original_eocd_index - directory_size
+        del archive_bytes[directory_start:original_eocd_index]
+        eocd_index = directory_start
+        archive_bytes[eocd_index + 8 : eocd_index + 12] = b"\x00" * 4
+        archive_bytes[eocd_index + 12 : eocd_index + 16] = b"\x00" * 4
+        archive_bytes[eocd_index + 16 : eocd_index + 20] = eocd_index.to_bytes(4, "little")
+        archive_path.write_bytes(archive_bytes)
+
+        def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("empty forged directories must fail before ZipFile construction")
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is False
+        assert any(
+            check.name == "ZIP Central Directory Preflight"
+            and check.status == CheckStatus.FAILED
+            and "omits a preceding record" in check.message
+            for check in result.checks
+        )
+
+    def test_deleted_omitted_record_with_local_padding_rejects_before_zipfile_open(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        archive_path = tmp_path / "deleted_record_with_local_padding.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo hidden"\ntR.')
+            archive.writestr("safe.txt", "safe")
+
+        archive_bytes = bytearray(archive_path.read_bytes())
+        original_eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+        assert original_eocd_index >= 0
+        directory_size = int.from_bytes(archive_bytes[original_eocd_index + 12 : original_eocd_index + 16], "little")
+        directory_start = original_eocd_index - directory_size
+        last_record_start = archive_bytes.rfind(b"PK\x01\x02", directory_start, original_eocd_index)
+        assert last_record_start > directory_start
+        safe_local_offset = int.from_bytes(archive_bytes[last_record_start + 42 : last_record_start + 46], "little")
+        removed_size = last_record_start - directory_start
+        del archive_bytes[directory_start:last_record_start]
+        archive_bytes[safe_local_offset:safe_local_offset] = b"X"
+        last_record_start = directory_start + 1
+        eocd_index = original_eocd_index - removed_size + 1
+        archive_bytes[last_record_start + 42 : last_record_start + 46] = (safe_local_offset + 1).to_bytes(4, "little")
+        archive_bytes[eocd_index + 8 : eocd_index + 10] = (1).to_bytes(2, "little")
+        archive_bytes[eocd_index + 10 : eocd_index + 12] = (1).to_bytes(2, "little")
+        archive_bytes[eocd_index + 12 : eocd_index + 16] = (eocd_index - last_record_start).to_bytes(4, "little")
+        archive_bytes[eocd_index + 16 : eocd_index + 20] = last_record_start.to_bytes(4, "little")
+        archive_path.write_bytes(archive_bytes)
+
+        def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("padded hidden local entries must fail before ZipFile construction")
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is False
+        assert any(
+            check.name == "ZIP Central Directory Preflight"
+            and check.status == CheckStatus.FAILED
+            and "omits a preceding record" in check.message
+            for check in result.checks
+        )
+
+    def test_force_zip64_streamed_entry_uses_local_descriptor_width(self, tmp_path: Path) -> None:
+        class NonSeekableBuffer(io.BytesIO):
+            def seek(self, *_args: Any, **_kwargs: Any) -> int:
+                raise io.UnsupportedOperation("not seekable")
+
+            def seekable(self) -> bool:
+                return False
+
+        archive_buffer = NonSeekableBuffer()
+        with (
+            zipfile.ZipFile(archive_buffer, "w") as archive,
+            archive.open("safe.txt", "w", force_zip64=True) as member,
+        ):
+            member.write(b"safe")
+
+        archive_path = tmp_path / "force_zip64_streamed.zip"
+        archive_path.write_bytes(archive_buffer.getvalue())
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is True
+        assert not any(
+            check.name == "ZIP Central Directory Preflight" and check.status == CheckStatus.FAILED
+            for check in result.checks
+        )
+
+    def test_streamed_descriptor_entry_with_padding_rejects_before_zipfile_open(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class NonSeekableBuffer(io.BytesIO):
+            def seek(self, *_args: Any, **_kwargs: Any) -> int:
+                raise io.UnsupportedOperation("not seekable")
+
+            def seekable(self) -> bool:
+                return False
+
+        archive_buffer = NonSeekableBuffer()
+        with zipfile.ZipFile(archive_buffer, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo hidden"\ntR.')
+            archive.writestr("safe.txt", "safe")
+
+        archive_bytes = bytearray(archive_buffer.getvalue())
+        original_eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+        assert original_eocd_index >= 0
+        original_directory_size = int.from_bytes(
+            archive_bytes[original_eocd_index + 12 : original_eocd_index + 16],
+            "little",
+        )
+        original_directory_start = original_eocd_index - original_directory_size
+        original_last_record_start = archive_bytes.rfind(
+            b"PK\x01\x02",
+            original_directory_start,
+            original_eocd_index,
+        )
+        assert original_last_record_start > original_directory_start
+        safe_local_offset = int.from_bytes(
+            archive_bytes[original_last_record_start + 42 : original_last_record_start + 46],
+            "little",
+        )
+
+        archive_bytes[safe_local_offset:safe_local_offset] = b"X"
+        eocd_index = original_eocd_index + 1
+        directory_start = original_directory_start + 1
+        last_record_start = original_last_record_start + 1
+        archive_bytes[last_record_start + 42 : last_record_start + 46] = (safe_local_offset + 1).to_bytes(4, "little")
+        archive_bytes[directory_start : directory_start + 2] = b"XX"
+        archive_bytes[eocd_index + 8 : eocd_index + 10] = (1).to_bytes(2, "little")
+        archive_bytes[eocd_index + 10 : eocd_index + 12] = (1).to_bytes(2, "little")
+        archive_bytes[eocd_index + 12 : eocd_index + 16] = (eocd_index - last_record_start).to_bytes(4, "little")
+        archive_bytes[eocd_index + 16 : eocd_index + 20] = last_record_start.to_bytes(4, "little")
+        archive_path = tmp_path / "streamed_descriptor_padding.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("padded hidden streamed entries must fail before ZipFile construction")
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is False
+        assert any(
+            check.name == "ZIP Central Directory Preflight"
+            and check.status == CheckStatus.FAILED
+            and "omits a preceding record" in check.message
+            for check in result.checks
+        )
+
+    @pytest.mark.parametrize(
+        "compression",
+        [zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED, zipfile.ZIP_BZIP2, zipfile.ZIP_LZMA],
+    )
+    def test_suffix_only_directory_with_local_entry_padding_rejects_before_zipfile_open(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        compression: int,
+    ) -> None:
+        archive_path = tmp_path / f"suffix_only_padded_entry_{compression}.zip"
+        with zipfile.ZipFile(archive_path, "w", compression=compression) as archive:
+            archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo hidden"\ntR.')
+            archive.writestr("safe.txt", "safe")
+
+        archive_bytes = bytearray(archive_path.read_bytes())
+        original_eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+        assert original_eocd_index >= 0
+        original_directory_size = int.from_bytes(
+            archive_bytes[original_eocd_index + 12 : original_eocd_index + 16],
+            "little",
+        )
+        original_directory_start = original_eocd_index - original_directory_size
+        original_last_record_start = archive_bytes.rfind(
+            b"PK\x01\x02",
+            original_directory_start,
+            original_eocd_index,
+        )
+        assert original_last_record_start > original_directory_start
+        safe_local_offset = int.from_bytes(
+            archive_bytes[original_last_record_start + 42 : original_last_record_start + 46],
+            "little",
+        )
+
+        archive_bytes[safe_local_offset:safe_local_offset] = b"X"
+        eocd_index = original_eocd_index + 1
+        directory_start = original_directory_start + 1
+        last_record_start = original_last_record_start + 1
+        archive_bytes[last_record_start + 42 : last_record_start + 46] = (safe_local_offset + 1).to_bytes(4, "little")
+        archive_bytes[directory_start : directory_start + 2] = b"XX"
+        archive_bytes[eocd_index + 8 : eocd_index + 10] = (1).to_bytes(2, "little")
+        archive_bytes[eocd_index + 10 : eocd_index + 12] = (1).to_bytes(2, "little")
+        archive_bytes[eocd_index + 12 : eocd_index + 16] = (eocd_index - last_record_start).to_bytes(4, "little")
+        archive_bytes[eocd_index + 16 : eocd_index + 20] = last_record_start.to_bytes(4, "little")
+        archive_path.write_bytes(archive_bytes)
+
+        def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("padded hidden entries must fail before ZipFile construction")
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is False
+        assert any(
+            check.name == "ZIP Central Directory Preflight"
+            and check.status == CheckStatus.FAILED
+            and "omits a preceding record" in check.message
+            for check in result.checks
+        )
+
+    def test_suffix_only_directory_with_central_record_gap_rejects_before_zipfile_open(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Padding before the declared suffix must not hide an omitted central record."""
+        archive_path = tmp_path / "suffix_only_central_gap.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo hidden"\ntR.')
+            archive.writestr("safe.txt", "safe")
+
+        archive_bytes = bytearray(archive_path.read_bytes())
+        original_eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+        assert original_eocd_index >= 0
+        original_directory_size = int.from_bytes(
+            archive_bytes[original_eocd_index + 12 : original_eocd_index + 16],
+            "little",
+        )
+        original_directory_start = original_eocd_index - original_directory_size
+        original_last_record_start = archive_bytes.rfind(
+            b"PK\x01\x02",
+            original_directory_start,
+            original_eocd_index,
+        )
+        assert original_last_record_start > original_directory_start
+
+        archive_bytes[original_last_record_start:original_last_record_start] = b"X"
+        eocd_index = original_eocd_index + 1
+        last_record_start = original_last_record_start + 1
+        archive_bytes[eocd_index + 8 : eocd_index + 10] = (1).to_bytes(2, "little")
+        archive_bytes[eocd_index + 10 : eocd_index + 12] = (1).to_bytes(2, "little")
+        archive_bytes[eocd_index + 12 : eocd_index + 16] = (eocd_index - last_record_start).to_bytes(4, "little")
+        archive_bytes[eocd_index + 16 : eocd_index + 20] = last_record_start.to_bytes(4, "little")
+        archive_path.write_bytes(archive_bytes)
+
+        def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("gapped suffix-only directories must fail before ZipFile construction")
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is False
+        assert any(
+            check.name == "ZIP Central Directory Preflight"
+            and check.status == CheckStatus.FAILED
+            and "omits a preceding record" in check.message
+            for check in result.checks
+        )
+
+    def test_prefixed_zip_does_not_trigger_preceding_directory_false_positive(self, tmp_path: Path) -> None:
+        archive_path = tmp_path / "prefixed.zip"
+        archive_bytes = io.BytesIO()
+        with zipfile.ZipFile(archive_bytes, "w") as archive:
+            archive.writestr("safe.txt", "safe")
+        archive_path.write_bytes(b"SFX-STUB" + archive_bytes.getvalue())
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is True
+        assert not any(
+            check.name == "ZIP Central Directory Preflight" and check.status == CheckStatus.FAILED
+            for check in result.checks
+        )
+
+    def test_large_archive_extra_data_record_before_directory_still_scans(self, tmp_path: Path) -> None:
+        archive_path = tmp_path / "archive_extra_data.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("safe.txt", "safe")
+
+        archive_bytes = bytearray(archive_path.read_bytes())
+        original_eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+        assert original_eocd_index >= 0
+        directory_size = int.from_bytes(archive_bytes[original_eocd_index + 12 : original_eocd_index + 16], "little")
+        directory_start = original_eocd_index - directory_size
+        extra_payload = b"A" * (2 * 1024 * 1024)
+        extra_record = b"PK\x06\x08" + len(extra_payload).to_bytes(4, "little") + extra_payload
+        archive_bytes[directory_start:directory_start] = extra_record
+        eocd_index = original_eocd_index + len(extra_record)
+        archive_bytes[eocd_index + 16 : eocd_index + 20] = (directory_start + len(extra_record)).to_bytes(4, "little")
+        archive_path.write_bytes(archive_bytes)
+
+        with zipfile.ZipFile(archive_path) as archive:
+            assert archive.namelist() == ["safe.txt"]
+
+        class ReadTrackingBuffer(io.BytesIO):
+            bytes_read = 0
+
+            def read(self, size: int | None = -1) -> bytes:
+                data = super().read(size)
+                self.bytes_read += len(data)
+                return data
+
+        tracked_archive = ReadTrackingBuffer(archive_path.read_bytes())
+        assert ZipScanner._preflight_zip_directory(
+            tracked_archive,
+            ZipScanner.DEFAULT_MAX_ENTRIES,
+            ZipScanner.DEFAULT_MAX_CENTRAL_DIRECTORY_SIZE,
+        ) == (1, False)
+        assert tracked_archive.bytes_read < 256 * 1024
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is True
+        assert not any(
+            check.name == "ZIP Central Directory Preflight" and check.status == CheckStatus.FAILED
+            for check in result.checks
+        )
+
+    def test_archive_extra_data_record_count_is_bounded_before_zipfile_open(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        archive_path = tmp_path / "many_archive_extra_records.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("safe.txt", "safe")
+
+        archive_bytes = bytearray(archive_path.read_bytes())
+        original_eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+        assert original_eocd_index >= 0
+        directory_size = int.from_bytes(
+            archive_bytes[original_eocd_index + 12 : original_eocd_index + 16],
+            "little",
+        )
+        directory_start = original_eocd_index - directory_size
+        extra_records = b"PK\x06\x08\x00\x00\x00\x00" * (zip_scanner_module._ZIP_MAX_ARCHIVE_EXTRA_DATA_RECORDS + 1)
+        archive_bytes[directory_start:directory_start] = extra_records
+        eocd_index = original_eocd_index + len(extra_records)
+        archive_bytes[eocd_index + 16 : eocd_index + 20] = (directory_start + len(extra_records)).to_bytes(4, "little")
+        archive_path.write_bytes(archive_bytes)
+
+        def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("archive-extra record floods must fail before ZipFile construction")
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is False
+        assert any(
+            check.name == "ZIP Central Directory Preflight"
+            and check.status == CheckStatus.FAILED
+            and "too many ZIP archive extra data records" in check.message
+            for check in result.checks
+        )
+
+    def test_optional_zip_guard_ignores_incidental_eocd_in_non_zip_file(self, tmp_path: Path) -> None:
+        legacy_path = tmp_path / "legacy.pt"
+        fake_eocd = struct.pack("<4s4H2LH", b"PK\x05\x06", 0, 0, 1, 1, 46, 0, 0)
+        payload = b"legacy tensor payload" + fake_eocd
+        legacy_path.write_bytes(payload)
+
+        with open_preflighted_zip_handle(legacy_path, require_zip=False) as handle:
+            assert handle.read() == payload
+
+    def test_archive_member_scan_reuses_open_archive_after_path_replacement(self, tmp_path: Path) -> None:
+        archive_path = tmp_path / "original.zip"
+        replacement_path = tmp_path / "replacement.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("safe.txt", "safe")
+        with zipfile.ZipFile(replacement_path, "w") as archive:
+            archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo replacement"\ntR.')
+
+        with zipfile.ZipFile(archive_path) as archive:
+            os.replace(replacement_path, archive_path)
+            result = ZipScanner().scan_archive_members(str(archive_path), archive=archive)
+
+        assert result.success is True
+        assert not result.issues
+        assert any(entry.get("path", "").endswith(":safe.txt") for entry in result.metadata["contents"])
+        assert not any(entry.get("path", "").endswith(":payload.pkl") for entry in result.metadata["contents"])
+
+    def test_empty_sfx_with_eocd_shaped_prefix_still_scans(self, tmp_path: Path) -> None:
+        fake_eocd = struct.pack(
+            "<4s4H2LH",
+            b"PK\x05\x06",
+            0,
+            0,
+            1,
+            1,
+            46,
+            0,
+            0,
+        )
+        archive_path = tmp_path / "empty-sfx.zip"
+        archive_path.write_bytes(b"SFX-RUNTIME" + fake_eocd + b"MORE-RUNTIME" + b"PK\x05\x06" + (b"\x00" * 18))
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is True
+        assert not any(
+            check.name == "ZIP Central Directory Preflight" and check.status == CheckStatus.FAILED
+            for check in result.checks
+        )
+
+    def test_sfx_with_local_header_shaped_runtime_prefix_still_scans(self, tmp_path: Path) -> None:
+        fake_local_header = struct.pack(
+            "<4s5H3L2H",
+            b"PK\x03\x04",
+            20,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            3,
+            3,
+            0,
+        )
+        archive_bytes = io.BytesIO()
+        with zipfile.ZipFile(archive_bytes, "w") as archive:
+            archive.writestr("safe.txt", "safe")
+
+        archive_path = tmp_path / "local-header-sfx.zip"
+        archive_path.write_bytes(
+            b"SFX-RUNTIME" + fake_local_header + b"fooabc" + b"MORE-RUNTIME" + archive_bytes.getvalue()
+        )
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is True
+        assert not any(
+            check.name == "ZIP Central Directory Preflight" and check.status == CheckStatus.FAILED
+            for check in result.checks
+        )
+
+    def test_sfx_with_deflated_local_header_wrong_crc_still_scans(self, tmp_path: Path) -> None:
+        compressor = zlib.compressobj(wbits=-15)
+        compressed_payload = compressor.compress(b"abc") + compressor.flush()
+        fake_local_header = struct.pack(
+            "<4s5H3L2H",
+            b"PK\x03\x04",
+            20,
+            0,
+            zipfile.ZIP_DEFLATED,
+            0,
+            0,
+            0,
+            len(compressed_payload),
+            3,
+            3,
+            0,
+        )
+        archive_bytes = io.BytesIO()
+        with zipfile.ZipFile(archive_bytes, "w") as archive:
+            archive.writestr("safe.txt", "safe")
+
+        archive_path = tmp_path / "deflated-local-header-sfx.zip"
+        archive_path.write_bytes(
+            b"SFX-RUNTIME"
+            + fake_local_header
+            + b"foo"
+            + compressed_payload
+            + b"MORE-RUNTIME"
+            + archive_bytes.getvalue()
+        )
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is True
+        assert not any(
+            check.name == "ZIP Central Directory Preflight" and check.status == CheckStatus.FAILED
+            for check in result.checks
+        )
+
+    def test_stored_member_ending_with_central_header_near_match_still_scans(self, tmp_path: Path) -> None:
+        archive_path = tmp_path / "central_header_near_match.zip"
+        with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_STORED) as archive:
+            archive.writestr("payload.bin", b"ordinary payload" + b"PK\x01\x02" + (b"\x00" * 42))
+
+        result = ZipScanner(config={ZIP_SECURITY_ONLY_MEMBER_ENTRIES_CONFIG_KEY: ["payload.bin"]}).scan(
+            str(archive_path)
+        )
+
+        assert result.success is True
+        assert not any(
+            check.name == "ZIP Central Directory Preflight" and check.status == CheckStatus.FAILED
+            for check in result.checks
+        )
+
+    def test_stored_member_ending_with_foreign_central_directory_fragment_still_scans(self, tmp_path: Path) -> None:
+        inner_archive = io.BytesIO()
+        with zipfile.ZipFile(inner_archive, "w") as archive:
+            archive.writestr("note.txt", "safe")
+        inner_bytes = inner_archive.getvalue()
+        inner_eocd_index = inner_bytes.rfind(b"PK\x05\x06")
+        assert inner_eocd_index >= 0
+        inner_directory_size = int.from_bytes(inner_bytes[inner_eocd_index + 12 : inner_eocd_index + 16], "little")
+        inner_directory = inner_bytes[inner_eocd_index - inner_directory_size : inner_eocd_index]
+
+        archive_path = tmp_path / "foreign_directory_fragment.zip"
+        with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_STORED) as archive:
+            archive.writestr("blob.bin", b"harmless prefix" + inner_directory)
+
+        result = ZipScanner(config={ZIP_SECURITY_ONLY_MEMBER_ENTRIES_CONFIG_KEY: ["blob.bin"]}).scan(str(archive_path))
+
+        assert result.success is True
+        assert not any(
+            check.name == "ZIP Central Directory Preflight" and check.status == CheckStatus.FAILED
+            for check in result.checks
+        )
+
+    def test_stored_nested_zip_with_same_inner_and_outer_name_still_scans(self, tmp_path: Path) -> None:
+        inner_archive = io.BytesIO()
+        with zipfile.ZipFile(inner_archive, "w") as archive:
+            archive.writestr("nested.zip", "safe")
+
+        archive_path = tmp_path / "same_name_nested.zip"
+        with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_STORED) as archive:
+            archive.writestr("nested.zip", inner_archive.getvalue())
+
+        result = ZipScanner(config={ZIP_SECURITY_ONLY_MEMBER_ENTRIES_CONFIG_KEY: ["nested.zip"]}).scan(
+            str(archive_path)
+        )
+
+        assert result.success is True
+        assert not any(
+            check.name == "ZIP Central Directory Preflight" and check.status == CheckStatus.FAILED
+            for check in result.checks
+        )
+
+    def test_nested_routing_rejects_over_entry_zip_before_specialized_probes(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        archive_path = tmp_path / "nested_over_entry.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("one.txt", "one")
+            archive.writestr("two.txt", "two")
+
+        def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("nested routing must reject before ZipFile construction")
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+        result = scan_nested_file(
+            str(archive_path),
+            {"max_zip_entries": 1, "cache_enabled": False},
+        )
+
+        assert result.scanner_name == "zip"
+        assert result.success is False
+        assert any(check.name == "Entry Count Limit Check" for check in result.checks)
+
+    def test_nested_routing_honors_selection_before_zip_preflight(self, tmp_path: Path) -> None:
+        archive_path = tmp_path / "nested_selected_pickle.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("one.txt", "one")
+            archive.writestr("two.txt", "two")
+
+        result = scan_nested_file(
+            str(archive_path),
+            {
+                "scanners": ["pickle"],
+                "max_zip_entries": 1,
+                "cache_enabled": False,
+            },
+        )
+
+        assert result.scanner_name == "scanner_selection"
+        assert not any(check.name == "Entry Count Limit Check" for check in result.checks)
+        assert any(
+            check.name == "Scanner Selection" and check.details.get("skipped_scanner_id") == "zip"
+            for check in result.checks
+        )
+
+    def test_eocd_signature_in_comment_does_not_create_forged_high_count_false_positive(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A fake EOCD inside the legal archive comment must not override the real directory."""
+        archive_path = tmp_path / "fake_eocd_comment.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("safe.txt", b"ok")
+
+        archive_bytes = bytearray(archive_path.read_bytes())
+        real_eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+        assert real_eocd_index >= 0
+        eocd_fields = struct.unpack(
+            "<4s4H2LH",
+            archive_bytes[real_eocd_index : real_eocd_index + 22],
+        )
+        central_directory = bytes(archive_bytes[eocd_fields[6] : eocd_fields[6] + eocd_fields[5]])
+        archive_bytes[real_eocd_index + 20 : real_eocd_index + 22] = (len(central_directory) + 22).to_bytes(
+            2,
+            "little",
+        )
+        duplicate_directory_offset = len(archive_bytes)
+        forged_eocd = struct.pack(
+            "<4s4H2LH",
+            b"PK\x05\x06",
+            0,
+            0,
+            10001,
+            10001,
+            len(central_directory),
+            duplicate_directory_offset,
+            0,
+        )
+        archive_bytes.extend(central_directory + forged_eocd)
+        archive_path.write_bytes(archive_bytes)
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is True
+        assert result.metadata["zip_entry_count_preflight"] == 1
+        assert any(
+            check.name == "Entry Count Limit Check"
+            and check.status == CheckStatus.PASSED
+            and check.details["entries"] == 1
+            for check in result.checks
+        )
+
+    def test_valid_empty_eocd_in_comment_fails_closed_when_parser_hides_entries(self, tmp_path: Path) -> None:
+        """A valid EOCD in a comment must not hide entries from the stdlib parser."""
+        archive_path = tmp_path / "ambiguous_empty_eocd.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo hidden"\ntR.')
+
+        archive_bytes = bytearray(archive_path.read_bytes())
+        real_eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+        assert real_eocd_index >= 0
+        fake_empty_eocd = b"PK\x05\x06" + (b"\x00" * 18)
+        archive_bytes[real_eocd_index + 20 : real_eocd_index + 22] = len(fake_empty_eocd).to_bytes(2, "little")
+        archive_bytes.extend(fake_empty_eocd)
+        archive_path.write_bytes(archive_bytes)
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert any(
+            check.name == "ZIP Central Directory Preflight"
+            and check.status == CheckStatus.FAILED
+            and "changed between preflight and parsing (1 != 0)" in check.message
+            for check in result.checks
+        )
+
+    def test_appended_empty_eocd_fails_closed_before_content_is_hidden(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        archive_path = tmp_path / "appended_empty_eocd.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo hidden"\ntR.')
+
+        fake_empty_eocd = bytearray(b"PK\x05\x06" + (b"\x00" * 18))
+        fake_empty_eocd[16:20] = (1).to_bytes(4, "little")
+        archive_path.write_bytes(archive_path.read_bytes() + fake_empty_eocd)
+
+        def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("appended EOCD records must fail before ZipFile construction")
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert any(
+            check.name == "ZIP Central Directory Preflight"
+            and check.status == CheckStatus.FAILED
+            and "ambiguous" in check.message
+            for check in result.checks
+        )
+
+    def test_appended_empty_eocd_cannot_hide_invalid_real_directory(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        archive_path = tmp_path / "appended_empty_hides_invalid.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo hidden"\ntR.')
+
+        archive_bytes = bytearray(archive_path.read_bytes())
+        real_eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+        assert real_eocd_index >= 0
+        archive_bytes[real_eocd_index + 8 : real_eocd_index + 10] = (2).to_bytes(2, "little")
+        archive_bytes[real_eocd_index + 10 : real_eocd_index + 12] = (2).to_bytes(2, "little")
+        archive_bytes.extend(b"PK\x05\x06" + (b"\x00" * 18))
+        archive_path.write_bytes(archive_bytes)
+
+        def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("invalid real directories must fail before ZipFile construction")
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is False
+        assert any(
+            check.name == "ZIP Central Directory Preflight"
+            and check.status == CheckStatus.FAILED
+            and "omits a preceding record" in check.message
+            for check in result.checks
+        )
+
+    def test_eocd_shaped_stored_member_content_is_not_treated_as_ambiguous(self, tmp_path: Path) -> None:
+        archive_path = tmp_path / "benign_member_signature.zip"
+        with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_STORED) as archive:
+            archive.writestr("signature.bin", b"PK\x05\x06" + (b"\x00" * 18))
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is True
+        assert not any(check.name == "ZIP Central Directory Preflight" for check in result.checks)
+        assert any(
+            check.name == "Entry Count Limit Check"
+            and check.status == CheckStatus.PASSED
+            and check.details["entries"] == 1
+            for check in result.checks
+        )
+
+    def test_stored_nested_zip_eocd_is_not_treated_as_top_level_ambiguity(self, tmp_path: Path) -> None:
+        inner_archive = io.BytesIO()
+        with zipfile.ZipFile(inner_archive, "w") as archive:
+            archive.writestr("note.txt", "safe")
+
+        archive_path = tmp_path / "stored_nested.zip"
+        with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_STORED) as archive:
+            archive.writestr("nested.bin", inner_archive.getvalue())
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is True
+        assert not any(
+            check.name == "ZIP Central Directory Preflight" and check.status == CheckStatus.FAILED
+            for check in result.checks
+        )
+
+    def test_many_eocd_signatures_in_stored_member_are_not_treated_as_candidates(self, tmp_path: Path) -> None:
+        archive_path = tmp_path / "many_eocd_signatures.zip"
+        payload = (b"PK\x05\x06" + (b"A" * 16) + b"\x00\x00") * 16
+        with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_STORED) as archive:
+            archive.writestr("payload.bin", payload)
+
+        result = ZipScanner(config={ZIP_SECURITY_ONLY_MEMBER_ENTRIES_CONFIG_KEY: ["payload.bin"]}).scan(
+            str(archive_path)
+        )
+
+        assert result.success is True
+        assert not any(
+            check.name == "ZIP Central Directory Preflight" and check.status == CheckStatus.FAILED
+            for check in result.checks
+        )
+
+    def test_scan_reuses_preflight_file_handle_for_zipfile(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        archive_path = tmp_path / "same_handle.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("safe.txt", "safe")
+
+        original_zipfile = zipfile.ZipFile
+        opened_with_handle = False
+
+        def capture_zipfile(file: Any, *args: Any, **kwargs: Any) -> zipfile.ZipFile:
+            nonlocal opened_with_handle
+            opened_with_handle = not isinstance(file, (str, bytes, os.PathLike))
+            return original_zipfile(file, *args, **kwargs)
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", capture_zipfile)
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is True
+        assert opened_with_handle is True
+
+    def test_max_entries_limit_zip64_preflight_rejects_before_zipfile_open(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """ZIP64 EOCD counts should also enforce the cap before central-directory parsing."""
+        archive_path = tmp_path / "zip64_many_entries.zip"
+        central_directory_parts: list[bytes] = []
+        for name in (b"one", b"two", b"three"):
+            header = bytearray(46)
+            header[0:4] = b"PK\x01\x02"
+            header[28:30] = len(name).to_bytes(2, "little")
+            central_directory_parts.append(bytes(header) + name)
+        central_directory = b"".join(central_directory_parts)
+        zip64_eocd_offset = len(central_directory)
+        zip64_eocd = bytearray(56)
+        zip64_eocd[0:4] = b"PK\x06\x06"
+        zip64_eocd[4:12] = (44).to_bytes(8, "little")
+        zip64_eocd[24:32] = (3).to_bytes(8, "little")
+        zip64_eocd[32:40] = (3).to_bytes(8, "little")
+        zip64_eocd[40:48] = len(central_directory).to_bytes(8, "little")
+        zip64_eocd[48:56] = (0).to_bytes(8, "little")
+        locator = bytearray(20)
+        locator[0:4] = b"PK\x06\x07"
+        locator[8:16] = zip64_eocd_offset.to_bytes(8, "little")
+        locator[16:20] = (1).to_bytes(4, "little")
+        eocd = bytearray(22)
+        eocd[0:4] = b"PK\x05\x06"
+        eocd[8:10] = (0xFFFF).to_bytes(2, "little")
+        eocd[10:12] = (0xFFFF).to_bytes(2, "little")
+        eocd[12:16] = (0xFFFFFFFF).to_bytes(4, "little")
+        eocd[16:20] = (0xFFFFFFFF).to_bytes(4, "little")
+        archive_path.write_bytes(central_directory + zip64_eocd + locator + eocd)
+
+        def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("ZIP64 entry-count preflight should stop before ZipFile construction")
+
+        monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+        result = ZipScanner(config={"max_zip_entries": 2}).scan(str(archive_path))
+
+        assert result.success is False
+        assert result.metadata["zip_entry_count_preflight"] == 3
+        assert "zip_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+        assert any(
+            check.name == "Entry Count Limit Check"
+            and check.status == CheckStatus.FAILED
+            and check.details["entries"] == 3
+            and check.details["entry_count_source"] == "central_directory_preflight"
+            for check in result.checks
+        )
+
+    def test_valid_small_zip64_at_exact_limit_still_scans(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        archive_path = tmp_path / "small_zip64.zip"
+        monkeypatch.setattr(zipfile, "ZIP64_LIMIT", 0)
+        with zipfile.ZipFile(archive_path, "w", allowZip64=True) as archive:
+            archive.writestr("one.txt", "one")
+            archive.writestr("two.txt", "two")
+
+        result = ZipScanner(config={"max_zip_entries": 2}).scan(str(archive_path))
+
+        assert result.success is True
+        assert result.metadata["zip_entry_count_preflight"] == 2
+        assert any(
+            check.name == "Entry Count Limit Check"
+            and check.status == CheckStatus.PASSED
+            and check.details["entry_count_source"] == "central_directory_preflight"
+            for check in result.checks
+        )
+
+    def test_max_entries_limit_post_open_fallback_rejects_when_preflight_unavailable(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If EOCD preflight cannot determine a count, the post-open cap still fails closed."""
+        archive_path = tmp_path / "fallback_many_entries.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("one.txt", "one")
+            archive.writestr("two.txt", "two")
+
+        scanner = ZipScanner(config={"max_zip_entries": 1})
+        monkeypatch.setattr(
+            scanner,
+            "_preflight_zip_directory",
+            lambda _handle, _max_entries, _max_directory_size: None,
+        )
+
+        result = scanner.scan(str(archive_path))
+
+        assert result.success is False
+        assert "zip_entry_count_preflight" not in result.metadata
+        assert "zip_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+        assert any(
+            check.name == "Entry Count Limit Check"
+            and check.status == CheckStatus.FAILED
+            and check.details["entries"] == 2
+            and check.details["entry_count_source"] == "post_open_fallback"
+            for check in result.checks
+        )
+
+    def test_max_entries_exact_limit_still_scans_malicious_member(self, tmp_path: Path) -> None:
+        """An archive at the entry cap should still inspect and report dangerous members."""
+        archive_path = tmp_path / "exact_limit_malicious.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo exact limit"\ntR.')
+            archive.writestr("notes.txt", "benign")
+
+        result = ZipScanner(config={"max_zip_entries": 2}).scan(str(archive_path))
+
+        assert result.success is False
+        assert any(
+            check.name == "Entry Count Limit Check"
+            and check.status == CheckStatus.PASSED
+            and check.details["entries"] == 2
+            and check.details["entry_count_source"] == "central_directory_preflight"
+            for check in result.checks
+        )
+        assert any(
+            issue.severity == IssueSeverity.CRITICAL
+            and issue.details.get("zip_entry") == "payload.pkl"
+            and ("os.system" in issue.message.lower() or "posix.system" in issue.message.lower())
+            for issue in result.issues
+        )
+
+    def test_max_entries_exact_limit_benign_archive_succeeds(self, tmp_path: Path) -> None:
+        """A benign archive exactly at the cap should not be treated as an entry-count bomb."""
+        archive_path = tmp_path / "exact_limit_benign.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            archive.writestr("one.txt", "one")
+            archive.writestr("two.txt", "two")
+
+        result = ZipScanner(config={"max_zip_entries": 2}).scan(str(archive_path))
+
+        assert result.success is True
+        assert not result.has_errors
+        assert any(
+            check.name == "Entry Count Limit Check"
+            and check.status == CheckStatus.PASSED
+            and check.details["entries"] == 2
+            and check.details["max_entries"] == 2
+            for check in result.checks
+        )
 
     def test_aggregate_size_limit_uses_public_scan_limits(self) -> None:
         """Public size limits should constrain ZIP aggregate extraction by default."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ import stat
 import subprocess
 import sys
 import types
+import zipfile
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -23,6 +24,7 @@ from modelaudit.cli import (
     _create_path_progress_callback,
     _display_error,
     _display_path,
+    _local_path_will_be_scanned,
     _resolve_scan_runtime_config,
     _ScanPathState,
     _summarize_progress_tree,
@@ -35,6 +37,24 @@ from modelaudit.models import ModelAuditResultModel, create_initial_audit_result
 from modelaudit.utils.tensorflow_compat import has_tensorflow_protobuf_stubs as _has_tf_protos
 from tests.cli_output import parse_click_json_output
 from tests.helpers import create_mock_pytorch_zip
+
+
+def test_local_txt_zip_prefilter_uses_bounded_zip_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive_path = tmp_path / "many.txt"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("one.txt", "one")
+        archive.writestr("two.txt", "two")
+
+    def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("CLI prefilter must not materialize ZIP entries")
+
+    monkeypatch.setattr("modelaudit.scanners.zip_scanner.zipfile.ZipFile", fail_zipfile_open)
+
+    assert _local_path_will_be_scanned(str(archive_path), skip_non_model_files=True) is True
+
 
 _HF_TEST_REVISION = "a" * 40
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2264,6 +2264,31 @@ def test_scan_file_selected_numpy_preserves_within_limit_npz_selection(tmp_path:
     assert not any(check.name == "Entry Count Limit Check" for check in result.checks)
 
 
+def test_scan_file_selected_numpy_honors_selection_before_plain_zip_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive_path = tmp_path / "not-numpy.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("one.txt", "one")
+        archive.writestr("two.txt", "two")
+
+    def fail_zip_preflight(*_args: Any, **_kwargs: Any) -> bool:
+        raise AssertionError("unselected plain ZIP routes must not be preflighted")
+
+    monkeypatch.setattr("modelaudit.scanners.zip_scanner.ZipScanner.requires_preflight_result", fail_zip_preflight)
+
+    result = scan_file(
+        str(archive_path),
+        config={"scanners": ["numpy"], "max_zip_entries": 1, "cache_enabled": False},
+    )
+
+    assert result.scanner_name == "scanner_selection"
+    assert result.success is True
+    assert result.metadata["skipped_scanner_id"] == "zip"
+    assert not any(check.name == "Entry Count Limit Check" for check in result.checks)
+
+
 def test_scan_file_hf_bookkeeping_skip_precedes_zip_preflight(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1302,7 +1302,13 @@ def test_scan_file_passes_shard_allowlist_to_advanced_handler(
         def __init__(self, config: dict[str, Any] | None = None) -> None:
             self.config = config or {}
 
-    def fake_select_preferred_scanner_id(path: str, header_format: str, ext: str) -> str | None:
+    def fake_select_preferred_scanner_id(
+        path: str,
+        header_format: str,
+        ext: str,
+        config: dict[str, Any] | None = None,
+    ) -> str | None:
+        del config
         assert path == str(shard)
         assert isinstance(header_format, str)
         assert ext == ".safetensors"
@@ -1761,7 +1767,13 @@ def test_scan_file_passes_shard_allowlist_to_preferred_advanced_handler(
         def can_handle(path: str) -> bool:
             return path == str(shard)
 
-    def fake_select_preferred_scanner_id(path: str, header_format: str, ext: str) -> str | None:
+    def fake_select_preferred_scanner_id(
+        path: str,
+        header_format: str,
+        ext: str,
+        config: dict[str, Any] | None = None,
+    ) -> str | None:
+        del config
         assert path == str(shard)
         assert isinstance(header_format, str)
         assert ext == ".safetensors"
@@ -2040,6 +2052,354 @@ def test_scan_file_detects_malicious_zip_with_misleading_extension(tmp_path: Pat
 
     assert result.scanner_name == "zip"
     _assert_system_pickle_detected(result, "payload.pkl")
+
+
+def test_scan_file_rejects_over_entry_zip_before_routing_opens_zipfile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive_path = tmp_path / "over_entry.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("one.txt", "one")
+        archive.writestr("two.txt", "two")
+
+    def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("routing and preflight must reject before ZipFile construction")
+
+    monkeypatch.setattr("modelaudit.scanners.zip_scanner.zipfile.ZipFile", fail_zipfile_open)
+
+    result = scan_file(str(archive_path), config={"max_zip_entries": 1})
+
+    assert result.scanner_name == "zip"
+    assert result.success is False
+    assert any(
+        check.name == "Entry Count Limit Check"
+        and check.status == CheckStatus.FAILED
+        and check.details["entry_count_source"] == "central_directory_preflight"
+        for check in result.checks
+    )
+
+
+def test_scan_file_selected_keras_still_enforces_zip_entry_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive_path = tmp_path / "over-entry.keras"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("config.json", "{}")
+        archive.writestr("metadata.json", "{}")
+
+    def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("selected ZIP-backed scanners must not bypass the container cap")
+
+    monkeypatch.setattr("modelaudit.scanners.zip_scanner.zipfile.ZipFile", fail_zipfile_open)
+
+    result = scan_file(
+        str(archive_path),
+        config={"scanners": ["keras_zip"], "max_zip_entries": 1, "cache_enabled": False},
+    )
+
+    assert result.scanner_name == "zip"
+    assert result.success is False
+    assert any(check.name == "Entry Count Limit Check" for check in result.checks)
+
+
+def test_scan_file_selected_keras_rechecks_replaced_archive_on_open_handle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive_path = tmp_path / "replaced.keras"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("config.json", "{}")
+
+    replacement_path = tmp_path / "replacement.keras"
+    with zipfile.ZipFile(replacement_path, "w") as archive:
+        archive.writestr("config.json", "{}")
+        archive.writestr("metadata.json", "{}")
+
+    from modelaudit.scanners.zip_scanner import ZipScanner
+
+    original_requires_preflight_result = ZipScanner.requires_preflight_result
+    replacement_installed = False
+
+    def replace_after_initial_preflight(
+        path: str,
+        max_entries: int,
+        max_directory_size: int | None = None,
+    ) -> bool:
+        nonlocal replacement_installed
+        result = original_requires_preflight_result(path, max_entries, max_directory_size)
+        if not replacement_installed:
+            os.replace(replacement_path, archive_path)
+            replacement_installed = True
+        return result
+
+    def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("the over-limit replacement must be rejected before ZipFile construction")
+
+    monkeypatch.setattr(ZipScanner, "requires_preflight_result", replace_after_initial_preflight)
+    monkeypatch.setattr("modelaudit.scanners.zip_scanner.zipfile.ZipFile", fail_zipfile_open)
+
+    result = scan_file(
+        str(archive_path),
+        config={"scanners": ["keras_zip"], "max_zip_entries": 1, "cache_enabled": False},
+    )
+
+    assert replacement_installed is True
+    assert result.scanner_name == "zip"
+    assert result.success is False
+    assert any(
+        check.name == "Entry Count Limit Check" and check.status == CheckStatus.FAILED and check.details["entries"] == 2
+        for check in result.checks
+    )
+
+
+def test_scan_file_selected_weight_distribution_enforces_zip_entry_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive_path = tmp_path / "over-entry.pt"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", b"data")
+        archive.writestr("archive/version", b"1")
+
+    def fail_weight_scan(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("ZIP entry preflight must reject before weight extraction")
+
+    monkeypatch.setattr(
+        "modelaudit.scanners.weight_distribution_scanner.WeightDistributionScanner.scan",
+        fail_weight_scan,
+    )
+
+    result = scan_file(
+        str(archive_path),
+        config={"scanners": ["weight_distribution"], "max_zip_entries": 1, "cache_enabled": False},
+    )
+
+    assert result.scanner_name == "zip"
+    assert result.success is False
+    assert any(
+        check.name == "Entry Count Limit Check"
+        and check.status == CheckStatus.FAILED
+        and check.details["entry_count_source"] == "central_directory_preflight"
+        for check in result.checks
+    )
+
+
+def test_scan_file_selected_weight_distribution_routes_within_entry_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive_path = tmp_path / "within-entry-limit.pt"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", b"data")
+
+    def fake_weight_scan(_self: Any, path: str) -> ScanResult:
+        assert path == str(archive_path)
+        result = ScanResult(scanner_name="weight_distribution")
+        result.finish(success=True)
+        return result
+
+    monkeypatch.setattr(
+        "modelaudit.scanners.weight_distribution_scanner.WeightDistributionScanner.scan",
+        fake_weight_scan,
+    )
+
+    result = scan_file(
+        str(archive_path),
+        config={"scanners": ["weight_distribution"], "max_zip_entries": 1, "cache_enabled": False},
+    )
+
+    assert result.scanner_name == "weight_distribution"
+    assert result.success is True
+    assert not any(check.name == "Entry Count Limit Check" for check in result.checks)
+
+
+def test_scan_file_selected_numpy_enforces_npz_entry_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive_path = tmp_path / "over-entry.npz"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("one.npy", b"first")
+        archive.writestr("two.npy", b"second")
+
+    def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("NPZ entry preflight must reject before ZipFile construction")
+
+    def fail_numpy_scan(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("NPZ entry preflight must reject before NumPy loading")
+
+    monkeypatch.setattr("modelaudit.scanners.zip_scanner.zipfile.ZipFile", fail_zipfile_open)
+    monkeypatch.setattr("modelaudit.scanners.numpy_scanner.NumPyScanner.scan", fail_numpy_scan)
+
+    result = scan_file(
+        str(archive_path),
+        config={"scanners": ["numpy"], "max_zip_entries": 1, "cache_enabled": False},
+    )
+
+    assert result.scanner_name == "zip"
+    assert result.success is False
+    assert any(
+        check.name == "Entry Count Limit Check"
+        and check.status == CheckStatus.FAILED
+        and check.details["entry_count_source"] == "central_directory_preflight"
+        for check in result.checks
+    )
+
+
+def test_scan_file_selected_numpy_preserves_within_limit_npz_selection(tmp_path: Path) -> None:
+    archive_path = tmp_path / "within-entry-limit.npz"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("weights.npy", b"safe")
+
+    result = scan_file(
+        str(archive_path),
+        config={"scanners": ["numpy"], "max_zip_entries": 1, "cache_enabled": False},
+    )
+
+    assert result.scanner_name == "scanner_selection"
+    assert result.success is True
+    assert result.metadata["skipped_scanner_id"] == "zip"
+    assert not any(check.name == "Entry Count Limit Check" for check in result.checks)
+
+
+def test_scan_file_hf_bookkeeping_skip_precedes_zip_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hf_home = tmp_path / "hf-home"
+    monkeypatch.setenv("HF_HOME", str(hf_home))
+    metadata_path = hf_home / "download" / "model.metadata"
+    metadata_path.parent.mkdir(parents=True)
+    metadata_path.write_text("{}")
+
+    def fail_zip_preflight(*_args: Any, **_kwargs: Any) -> bool:
+        raise AssertionError("Hugging Face bookkeeping must be skipped before ZIP preflight")
+
+    monkeypatch.setattr("modelaudit.scanners.zip_scanner.ZipScanner.requires_preflight_result", fail_zip_preflight)
+
+    result = scan_file(str(metadata_path), config={"cache_enabled": False})
+
+    assert result.scanner_name == "skipped"
+    assert result.success is True
+    assert any(check.name == "HuggingFace Cache File Skip" for check in result.checks)
+
+
+def test_scan_file_size_limit_precedes_zip_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive_path = tmp_path / "oversized.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("safe.txt", "safe")
+
+    def fail_zip_preflight(*_args: Any, **_kwargs: Any) -> bool:
+        raise AssertionError("file-size rejection must precede ZIP preflight")
+
+    monkeypatch.setattr("modelaudit.scanners.zip_scanner.ZipScanner.requires_preflight_result", fail_zip_preflight)
+
+    result = scan_file(
+        str(archive_path),
+        config={"max_file_size": 1, "cache_enabled": False},
+    )
+
+    assert result.scanner_name == "size_check"
+    assert result.success is False
+    assert any(check.name == "File Size Limit Check" and check.status == CheckStatus.FAILED for check in result.checks)
+
+
+def test_scan_file_selected_pickle_honors_selection_before_zip_preflight(tmp_path: Path) -> None:
+    archive_path = tmp_path / "selected-pickle.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("one.txt", "one")
+        archive.writestr("two.txt", "two")
+
+    result = scan_file(
+        str(archive_path),
+        config={"scanners": ["pickle"], "max_zip_entries": 1, "cache_enabled": False},
+    )
+
+    assert result.scanner_name == "scanner_selection"
+    assert not any(check.name == "Entry Count Limit Check" for check in result.checks)
+    assert any(
+        check.name == "Scanner Selection" and check.details.get("skipped_scanner_id") == "zip"
+        for check in result.checks
+    )
+
+
+def test_scan_file_long_prefix_ambiguous_zip_fails_closed(tmp_path: Path) -> None:
+    archive_path = tmp_path / "ambiguous-sfx.bin"
+    archive_bytes = io.BytesIO()
+    with zipfile.ZipFile(archive_bytes, "w") as archive:
+        archive.writestr("payload.pkl", _build_malicious_pickle())
+    real_archive = bytearray(archive_bytes.getvalue())
+    real_eocd_index = real_archive.rfind(b"PK\x05\x06")
+    assert real_eocd_index >= 0
+    fake_empty_eocd = b"PK\x05\x06" + (b"\x00" * 18)
+    real_archive[real_eocd_index + 20 : real_eocd_index + 22] = len(fake_empty_eocd).to_bytes(2, "little")
+    archive_path.write_bytes((b"A" * (1024 * 1024 + 1)) + real_archive + fake_empty_eocd)
+
+    result = scan_file(str(archive_path), config={"cache_enabled": False})
+
+    assert result.scanner_name == "zip"
+    assert result.success is False
+    assert any(check.name == "ZIP Central Directory Preflight" for check in result.checks)
+
+
+def test_scan_file_routes_prefixed_zip_with_trailing_bytes_and_misleading_extension(tmp_path: Path) -> None:
+    archive_path = tmp_path / "payload.bin"
+    archive_bytes = io.BytesIO()
+    with zipfile.ZipFile(archive_bytes, "w") as archive:
+        archive.writestr("payload.pkl", _build_malicious_pickle())
+    archive_path.write_bytes(b"SFX-STUB" + archive_bytes.getvalue() + b"TRAILING-JUNK")
+
+    result = scan_file(str(archive_path))
+
+    assert result.scanner_name == "zip"
+    _assert_system_pickle_detected(result, "payload.pkl")
+
+
+def test_scan_file_does_not_route_bogus_terminal_eocd_as_zip(tmp_path: Path) -> None:
+    path = tmp_path / "not-a-zip.bin"
+    fake_directory = b"not a central directory".ljust(46, b"x")
+    fake_eocd = struct.pack(
+        "<4s4H2LH",
+        b"PK\x05\x06",
+        0,
+        0,
+        1,
+        1,
+        len(fake_directory),
+        0,
+        0,
+    )
+    path.write_bytes(fake_directory + fake_eocd)
+
+    result = scan_file(str(path))
+
+    assert result.scanner_name != "zip"
+
+
+def test_scan_file_malformed_zip64_locator_offset_fails_closed_without_raising(tmp_path: Path) -> None:
+    path = tmp_path / "malformed-zip64.zip"
+    locator = bytearray(20)
+    locator[0:4] = b"PK\x06\x07"
+    locator[8:16] = ((1 << 64) - 1).to_bytes(8, "little")
+    locator[16:20] = (1).to_bytes(4, "little")
+    eocd = bytearray(22)
+    eocd[0:4] = b"PK\x05\x06"
+    eocd[8:10] = (0xFFFF).to_bytes(2, "little")
+    eocd[10:12] = (0xFFFF).to_bytes(2, "little")
+    eocd[12:16] = (0xFFFFFFFF).to_bytes(4, "little")
+    eocd[16:20] = (0xFFFFFFFF).to_bytes(4, "little")
+    path.write_bytes(b"PK\x03\x04" + (b"\x00" * 60) + locator + eocd)
+
+    result = scan_file(str(path), config={"cache_enabled": False})
+
+    assert result.scanner_name == "zip"
+    assert result.success is False
+    assert any(check.name == "ZIP Central Directory Preflight" for check in result.checks)
 
 
 def test_scan_file_routes_protocolless_binary_pickle_with_misleading_extension(tmp_path: Path) -> None:
@@ -6135,6 +6495,36 @@ def test_scan_file_merges_executorch_archive_analysis_for_signature_valid_bin(tm
     assert result.scanner_name == "pytorch_binary"
     assert result.metadata["supplemental_scanners"] == ["executorch"]
     assert any(issue.rule_code == "S104" and "evil.py" in (issue.location or "") for issue in result.issues)
+
+
+def test_scan_file_preflights_over_entry_executorch_archive_before_specialized_routing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_path = tmp_path / "program.bin"
+    model_path.write_bytes(b"\x0c\x00\x00\x00ET13\x04\x00\x04\x00\x04\x00\x00\x00")
+    with zipfile.ZipFile(model_path, "a") as archive:
+        archive.writestr("one.py", "print('one')")
+        archive.writestr("two.py", "print('two')")
+
+    def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("entry-count preflight must reject before specialized routing opens the ZIP")
+
+    monkeypatch.setattr("modelaudit.scanners.zip_scanner.zipfile.ZipFile", fail_zipfile_open)
+
+    result = scan_file(
+        str(model_path),
+        config={"cache_scan_results": False, "max_zip_entries": 1},
+    )
+
+    assert result.scanner_name == "zip"
+    assert result.success is False
+    assert any(
+        check.name == "Entry Count Limit Check"
+        and check.status == CheckStatus.FAILED
+        and check.details["entry_count_source"] == "central_directory_preflight"
+        for check in result.checks
+    )
 
 
 def test_preferred_scanner_does_not_route_generic_zip_bin_to_pickle(tmp_path: Path) -> None:

--- a/tests/utils/file/test_large_file_handler.py
+++ b/tests/utils/file/test_large_file_handler.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import os
 import struct
 import sys
+import zipfile
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -19,6 +20,7 @@ from modelaudit.scanners.keras_h5_scanner import KerasH5Scanner
 from modelaudit.scanners.safetensors_scanner import MAX_HEADER_BYTES, SafeTensorsScanner
 from modelaudit.utils.file import handlers as advanced_handlers
 from modelaudit.utils.file import large_file_handler
+from modelaudit.utils.helpers.cache_decorator import should_bypass_cache_for_zip_entry_preflight
 from modelaudit.utils.helpers.secure_hasher import SecureFileHasher
 
 
@@ -195,6 +197,62 @@ def test_disabled_large_handler_cache_skips_hdf5_probe(
     result = scan_func(str(payload), scanner)
 
     assert result.success is True
+
+
+@pytest.mark.parametrize(
+    ("scan_func", "handler_module", "internal_name"),
+    [
+        (large_file_handler.scan_large_file, large_file_handler, "_scan_large_file_internal"),
+        (advanced_handlers.scan_advanced_large_file, advanced_handlers, "_scan_advanced_large_file_internal"),
+    ],
+)
+def test_large_handler_cache_bypasses_zip_entry_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    scan_func: Callable[..., ScanResult],
+    handler_module: Any,
+    internal_name: str,
+) -> None:
+    payload = tmp_path / "over-entry.zip"
+    payload.write_bytes(b"bounded preflight fixture")
+    scanner = DummyNonChunkScanner()
+    scanner.config = {"cache_enabled": True, "cache_dir": str(tmp_path / "cache")}  # type: ignore[attr-defined]
+    internal_calls = 0
+    original_internal = getattr(handler_module, internal_name)
+
+    def record_internal(*args: Any, **kwargs: Any) -> ScanResult:
+        nonlocal internal_calls
+        internal_calls += 1
+        return cast(ScanResult, original_internal(*args, **kwargs))
+
+    monkeypatch.setattr(handler_module, "should_bypass_cache_for_zip_entry_preflight", lambda _path, _config: True)
+    monkeypatch.setattr(handler_module, internal_name, record_internal)
+
+    reset_cache_manager()
+    try:
+        result = scan_func(str(payload), scanner)
+
+        assert result.success is True
+        assert internal_calls == 1
+        assert get_cache_manager(str(tmp_path / "cache"), enabled=True).get_stats()["total_entries"] == 0
+    finally:
+        reset_cache_manager()
+
+
+def test_zip_entry_preflight_cache_bypass_honors_scanner_selection(tmp_path: Path) -> None:
+    payload = tmp_path / "selected-scanner.zip"
+    with zipfile.ZipFile(payload, "w") as archive:
+        archive.writestr("one.txt", "one")
+        archive.writestr("two.txt", "two")
+
+    assert not should_bypass_cache_for_zip_entry_preflight(
+        str(payload),
+        {"scanners": ["pickle"], "max_zip_entries": 1},
+    )
+    assert should_bypass_cache_for_zip_entry_preflight(
+        str(payload),
+        {"scanners": ["keras_zip"], "max_zip_entries": 1},
+    )
 
 
 def test_large_handler_missing_h5py_does_not_return_stale_clean_cache(


### PR DESCRIPTION
## Summary
- validate EOCD and ZIP64 metadata against a bounded central-directory walk before Python materializes ZIP entries
- enforce ZIP preflight only for the selected path route across core, nested, registry, cache, large-file, CLI, NumPy NPZ, and weight-distribution paths
- fail closed on forged counts, hidden top-level local entries, trailing local records, ambiguous directories, and incomplete streamed-entry coverage
- preserve scanner selection and explicit ZIP exclusions, SFX, HDF5 user blocks, legacy PyTorch, benign archive-extra records, and local-header near matches
- bound aggregate hidden-entry payload validation and data-descriptor search work

## Review hardening
- cross-check EOCD/ZIP64 counts against observed central records and local-entry layouts
- reject omitted stored, deflated, BZIP2, LZMA, and streamed data-descriptor entries, including padded and out-of-window variants
- detect structured local records appended after EOCD or hidden in EOCD comments before `ZipFile` construction
- validate exact-boundary SFX-like and trailing local-header candidates by structure, payload, and CRC to avoid false positives
- preflight prefixed ZIPs in optional PyTorch paths and reuse the same descriptor from budget validation through `torch.load`
- treat Unix mode bits as symlinks only for Unix creator systems and resolve nested relative targets against the archive extraction root
- keep max-file-size precedence, bookkeeping skips, scanner exclusions, and explicit scanner selection semantics intact

## Validation
- Published head: `26f2366d157bf4f4ff37e1c0d41cf2ddc6de0fd2`
- Current base: `c7e1699d4b874f02e0e8eb99c881a36cbda1c927`
- Exact tested/published tree: `de2e2d43318c64c3109c2baf2d95e027561b43c6`
- `tests/scanners/test_zip_scanner.py`: 891 passed, 4 optional-ONNX skips
- `tests/scanners/test_weight_distribution_scanner.py`: 73 passed, 17 optional-dependency skips
- `tests/test_scanner_selection.py`: 40 passed, 2 optional-ONNX skips
- focused core/registry selection and ZIP-preflight regressions: 8 passed
- Ruff format/check: clean for all touched Python files
- mypy: clean for all touched Python files
- full pytest suite intentionally left to CI per review workflow