### PR TITLE
fix: validate hf direct url paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- reject ambiguous or traversal-bearing Hugging Face direct file URL revision and filename components before SDK download
 - redact proxy and camel-case authorization evidence with scheme-bearing values without hiding benign counters
 - bound Keras ZIP config traversal for CVE detectors and fail closed when config.json coverage budgets are exhausted
 - redact MLflow registry, source, telemetry, and client exception credentials before logging, printing, or analytics export

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- reject ambiguous, lossy, SDK-invalid, or traversal-bearing Hugging Face direct file URL components before download
+- reject ambiguous, lossy, SDK-invalid, or traversal-bearing Hugging Face direct file URLs, redact rejected URL secrets, and preserve platform-valid filenames
 - harden cloud acquisition size caps, HTTPS/R2 auto-default routing, and directory metadata failures
 - detect operator attrgetter, itemgetter, and methodcaller archive-member Python paths to command execution while preserving benign accessor names
 - redact Keras and TensorFlow scanner detail fields that echo model-controlled configs, code indicators, archive members, and external references.

--- a/modelaudit/utils/sources/huggingface.py
+++ b/modelaudit/utils/sources/huggingface.py
@@ -1927,6 +1927,9 @@ def download_file_from_hf(url: str, cache_dir: Path | None = None, max_size: int
         ValueError: If max_size is set and file size is unknown or exceeds it
         Exception: If download fails
     """
+    repo_id, branch, filename = parse_huggingface_file_url(url)
+    display_url = redact_huggingface_url_for_display(url)
+
     try:
         from huggingface_hub import HfApi, hf_hub_download
     except ImportError as e:
@@ -1934,9 +1937,6 @@ def download_file_from_hf(url: str, cache_dir: Path | None = None, max_size: int
             "huggingface-hub package is required for HuggingFace URL support. "
             "Install with 'pip install modelaudit[huggingface]'"
         ) from e
-
-    repo_id, branch, filename = parse_huggingface_file_url(url)
-    display_url = redact_huggingface_url_for_display(url)
 
     try:
         if max_size is not None and max_size < 0:

--- a/modelaudit/utils/sources/huggingface_paths.py
+++ b/modelaudit/utils/sources/huggingface_paths.py
@@ -21,6 +21,7 @@ _SENSITIVE_URL_QUERY_PARAM_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _URL_USERINFO_PATTERN = re.compile(r"([a-z][a-z0-9+.-]*://)([^/@\s]+)@", re.IGNORECASE)
+_OPAQUE_URL_USERINFO_PATTERN = re.compile(r"^([a-z][a-z0-9+.-]*:)([^/@\s]+)@", re.IGNORECASE)
 _HF_REPO_COMPONENT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,95}$")
 _MALFORMED_PERCENT_ESCAPE_PATTERN = re.compile(r"%(?![0-9A-Fa-f]{2})")
 _HF_REPO_ID_MAX_LENGTH = 96
@@ -34,6 +35,8 @@ _WINDOWS_RESERVED_FILE_STEMS = {
     "PRN",
     *(f"COM{index}" for index in range(1, 10)),
     *(f"LPT{index}" for index in range(1, 10)),
+    *(f"COM{index}" for index in ("\u00b9", "\u00b2", "\u00b3")),
+    *(f"LPT{index}" for index in ("\u00b9", "\u00b2", "\u00b3")),
 }
 
 
@@ -48,6 +51,12 @@ def _decode_huggingface_url_component(raw_component: str, field_name: str) -> st
     if any(unicodedata.category(character) in {"Cc", "Cs"} for character in decoded):
         raise ValueError(f"Invalid HuggingFace {field_name} control character")
     return decoded
+
+
+def _validate_huggingface_url_input(url: str) -> None:
+    """Reject characters that URL parsing would silently discard."""
+    if url[:1].isspace() or any(unicodedata.category(character) in {"Cc", "Cs"} for character in url):
+        raise ValueError("Invalid HuggingFace URL control character")
 
 
 def _validate_huggingface_repo_component(component: str, field_name: str) -> str:
@@ -78,7 +87,7 @@ def _validate_huggingface_windows_path_component(component: str, field_name: str
         reserved_stem = component.split(".", 1)[0].rstrip(" .").upper()
         if (
             component[-1] in {" ", "."}
-            or any(character in '<>:"|?*' for character in component)
+            or any(character in '<>:"/\\|?*' for character in component)
             or reserved_stem in _WINDOWS_RESERVED_FILE_STEMS
         ):
             raise ValueError(f"Invalid HuggingFace {field_name} path component on Windows: {component!r}")
@@ -86,7 +95,7 @@ def _validate_huggingface_windows_path_component(component: str, field_name: str
 
 def _decode_huggingface_file_path_component(raw_component: str, field_name: str) -> str:
     decoded = _decode_huggingface_url_component(raw_component, field_name)
-    if not decoded or decoded in {".", ".."} or "/" in decoded or "\\" in decoded:
+    if not decoded or decoded in {".", ".."} or "/" in decoded:
         raise ValueError(f"Invalid HuggingFace {field_name} path component: {decoded!r}")
     _validate_huggingface_windows_path_component(decoded, field_name)
     return decoded
@@ -140,11 +149,17 @@ def redact_huggingface_url_for_display(url: str) -> str:
         parsed = urlparse(url)
     except ValueError:
         redacted = _URL_USERINFO_PATTERN.sub(r"\1<credentials-redacted>@", url)
+        if "://" in redacted:
+            scheme, remainder = redacted.split("://", 1)
+            _, separator, path = remainder.partition("/")
+            redacted = f"{scheme}://<invalid-authority>"
+            if separator:
+                redacted = f"{redacted}/{path}"
         return redacted.split("#", 1)[0].split("?", 1)[0]
-    if parsed.scheme == "hf":
-        return urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
-
-    if parsed.scheme not in {"http", "https"}:
+    if not parsed.netloc:
+        if parsed.scheme in {"ftp", "hf", "http", "https"}:
+            redacted = _URL_USERINFO_PATTERN.sub(r"\1<credentials-redacted>@", url)
+            return redacted.split("#", 1)[0].split("?", 1)[0]
         return url
 
     netloc = parsed.netloc
@@ -152,6 +167,14 @@ def redact_huggingface_url_for_display(url: str) -> str:
         netloc = netloc.rsplit("@", 1)[1]
 
     return urlunparse((parsed.scheme, netloc, parsed.path, "", "", ""))
+
+
+def _redact_huggingface_url_for_validation_error(url: str) -> str:
+    """Redact URL-like input before including it in a validation error."""
+    redacted = redact_huggingface_url_for_display(url)
+    redacted = _URL_USERINFO_PATTERN.sub(r"\1<credentials-redacted>@", redacted)
+    redacted = _OPAQUE_URL_USERINFO_PATTERN.sub(r"\1<credentials-redacted>@", redacted)
+    return redacted.split("#", 1)[0].split("?", 1)[0]
 
 
 def redact_huggingface_urls_in_text(text: str) -> str:
@@ -175,30 +198,36 @@ def is_huggingface_file_url(url: str) -> bool:
 
 def parse_huggingface_file_url(url: str) -> tuple[str, str, str]:
     """Parse a HuggingFace file URL to extract repo_id, branch, and filename."""
-    parsed = urlparse(url)
+    _validate_huggingface_url_input(url)
+    try:
+        parsed = urlparse(url)
+    except ValueError as exc:
+        raise ValueError(f"Invalid HuggingFace URL: {_redact_huggingface_url_for_validation_error(url)}") from exc
     if parsed.scheme not in {"http", "https"} or parsed.hostname not in ["huggingface.co", "hf.co"]:
-        raise ValueError(f"Not a HuggingFace URL: {redact_huggingface_url_for_display(url)}")
+        raise ValueError(f"Not a HuggingFace URL: {_redact_huggingface_url_for_validation_error(url)}")
     try:
         port = parsed.port
     except ValueError as exc:
-        raise ValueError(f"Invalid HuggingFace URL authority: {redact_huggingface_url_for_display(url)}") from exc
+        raise ValueError(
+            f"Invalid HuggingFace URL authority: {_redact_huggingface_url_for_validation_error(url)}"
+        ) from exc
     expected_port = 443 if parsed.scheme == "https" else 80
     if port is not None and port != expected_port:
-        raise ValueError(f"Invalid HuggingFace URL authority: {redact_huggingface_url_for_display(url)}")
+        raise ValueError(f"Invalid HuggingFace URL authority: {_redact_huggingface_url_for_validation_error(url)}")
 
     raw_path = parsed.path[1:] if parsed.path.startswith("/") else parsed.path
     if not raw_path or raw_path.startswith("/") or raw_path.endswith("/") or "//" in raw_path:
-        raise ValueError(f"Invalid HuggingFace file URL format: {redact_huggingface_url_for_display(url)}")
+        raise ValueError(f"Invalid HuggingFace file URL format: {_redact_huggingface_url_for_validation_error(url)}")
 
     path_parts = raw_path.split("/")
     if len(path_parts) >= 5 and path_parts[1:3] == ["resolve", "resolve"]:
-        raise ValueError(f"Ambiguous HuggingFace file URL format: {redact_huggingface_url_for_display(url)}")
+        raise ValueError(f"Ambiguous HuggingFace file URL format: {_redact_huggingface_url_for_validation_error(url)}")
     if len(path_parts) >= 5 and path_parts[2] == "resolve":
         resolve_index = 2
     elif len(path_parts) >= 4 and path_parts[1] == "resolve":
         resolve_index = 1
     else:
-        raise ValueError(f"Invalid HuggingFace file URL format: {redact_huggingface_url_for_display(url)}")
+        raise ValueError(f"Invalid HuggingFace file URL format: {_redact_huggingface_url_for_validation_error(url)}")
 
     if resolve_index == 2:
         namespace = _decode_huggingface_repo_component(path_parts[0], "namespace")

--- a/modelaudit/utils/sources/huggingface_paths.py
+++ b/modelaudit/utils/sources/huggingface_paths.py
@@ -45,6 +45,21 @@ def _decode_huggingface_repo_component(raw_component: str, field_name: str) -> s
     return _validate_huggingface_repo_component(decoded, field_name)
 
 
+def _decode_huggingface_file_path_component(raw_component: str, field_name: str) -> str:
+    decoded = unquote(raw_component)
+    if not decoded or decoded in {".", ".."} or "/" in decoded or "\\" in decoded:
+        raise ValueError(f"Invalid HuggingFace {field_name} path component: {decoded!r}")
+    return decoded
+
+
+def _decode_huggingface_revision(raw_component: str) -> str:
+    decoded = unquote(raw_component)
+    revision_parts = decoded.split("/")
+    if "\\" in decoded or any(not part or part in {".", ".."} for part in revision_parts):
+        raise ValueError(f"Invalid HuggingFace revision path component: {decoded!r}")
+    return decoded
+
+
 def _split_huggingface_repo_path(raw_path: str) -> tuple[str, str, list[str]]:
     stripped = raw_path.strip("/")
     if not stripped:
@@ -118,15 +133,29 @@ def parse_huggingface_file_url(url: str) -> tuple[str, str, str]:
     if parsed.hostname not in ["huggingface.co", "hf.co"]:
         raise ValueError(f"Not a HuggingFace URL: {redact_huggingface_url_for_display(url)}")
 
-    path_parts = parsed.path.strip("/").split("/")
-    if len(path_parts) < 5 or path_parts[2] != "resolve":
+    raw_path = parsed.path[1:] if parsed.path.startswith("/") else parsed.path
+    if not raw_path or raw_path.startswith("/") or raw_path.endswith("/") or "//" in raw_path:
         raise ValueError(f"Invalid HuggingFace file URL format: {redact_huggingface_url_for_display(url)}")
 
-    namespace = _decode_huggingface_repo_component(path_parts[0], "namespace")
-    repo_name = _decode_huggingface_repo_component(path_parts[1], "repository")
-    repo_id = f"{namespace}/{repo_name}"
-    branch = unquote(path_parts[3])
-    filename = "/".join(unquote(part) for part in path_parts[4:])
+    path_parts = raw_path.split("/")
+    if len(path_parts) >= 5 and path_parts[2] == "resolve":
+        resolve_index = 2
+    elif len(path_parts) >= 4 and path_parts[1] == "resolve":
+        resolve_index = 1
+    else:
+        raise ValueError(f"Invalid HuggingFace file URL format: {redact_huggingface_url_for_display(url)}")
+
+    if resolve_index == 2:
+        namespace = _decode_huggingface_repo_component(path_parts[0], "namespace")
+        repo_name = _decode_huggingface_repo_component(path_parts[1], "repository")
+        repo_id = f"{namespace}/{repo_name}"
+    else:
+        repo_id = _decode_huggingface_repo_component(path_parts[0], "repository")
+
+    branch = _decode_huggingface_revision(path_parts[resolve_index + 1])
+    filename = "/".join(
+        _decode_huggingface_file_path_component(part, "filename") for part in path_parts[resolve_index + 2 :]
+    )
 
     return repo_id, branch, filename
 
@@ -174,7 +203,13 @@ def is_huggingface_cache_path(path: str | Path) -> bool:
 
 def extract_model_id_from_path(path: str) -> tuple[str | None, str | None]:
     """Extract HuggingFace model ID and source from a local path or URL."""
-    if is_huggingface_url(path) or is_huggingface_file_url(path):
+    if is_huggingface_file_url(path):
+        try:
+            repo_id, _, _ = parse_huggingface_file_url(path)
+            return repo_id, "huggingface"
+        except ValueError:
+            pass
+    if is_huggingface_url(path):
         try:
             namespace, repo_name = parse_huggingface_url(path)
             model_id = f"{namespace}/{repo_name}" if repo_name else namespace

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -3171,6 +3171,30 @@ class TestHuggingFaceFileURLs:
         assert "token=" not in message
         assert "secret" not in message
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ftp://alice:password@huggingface.co/org/repo/resolve/main/model.bin?token=secret#frag",
+            "https:huggingface.co/org/repo/resolve/main/model.bin?token=secret#frag",
+            "https:alice:password@huggingface.co/org/repo/resolve/main/model.bin?token=secret#frag",
+            "javascript:huggingface.co/org/repo/resolve/main/model.bin?token=secret#frag",
+            "huggingface.co/org/repo/resolve/main/model.bin?token=secret#frag",
+            "https://alice:password@huggingface.co\uff0fevil/org/repo/resolve/main/model.bin?token=secret#frag",
+            "https://alice:password\uff20huggingface.co/org/repo/resolve/main/model.bin?token=secret#frag",
+        ],
+    )
+    def test_invalid_url_error_redacts_credentials_and_query(self, url: str) -> None:
+        """Rejected schemes, authorities, and netlocs must not echo embedded secrets."""
+
+        with pytest.raises(ValueError) as exc_info:
+            parse_huggingface_file_url(url)
+
+        message = str(exc_info.value)
+        assert "alice" not in message
+        assert "password" not in message
+        assert "token=" not in message
+        assert "secret" not in message
+
     def test_valid_file_urls(self) -> None:
         """Test that valid HuggingFace file URLs are detected."""
         valid_urls = [
@@ -3280,7 +3304,6 @@ class TestHuggingFaceFileURLs:
             "https://huggingface.co/test/model/resolve/refs%5Cmain/model.bin",
             "https://huggingface.co/test/model/resolve/main/%2e%2e%2Fsecrets.bin",
             "https://huggingface.co/test/model/resolve/main/subdir%2Fmodel.bin",
-            "https://huggingface.co/test/model/resolve/main/subdir%5Cmodel.bin",
             "https://huggingface.co/test/model/resolve/main/%2Fetc%2Fpasswd",
             "https://huggingface.co/test/model/resolve/main/../model.bin",
             "https://huggingface.co/test/model/resolve/main//model.bin",
@@ -3312,6 +3335,11 @@ class TestHuggingFaceFileURLs:
             "https://huggingface.co/test/model/resolve/%C2%85/model.bin",
             "https://huggingface.co/test/model/resolve/main/model%C2%85.bin",
             "https://huggingface.co/test/model/resolve/main/model\ud800.bin",
+            "\x00https://huggingface.co/test/model/resolve/main/model.bin",
+            " https://huggingface.co/test/model/resolve/main/model.bin",
+            "https://huggingface.co/te\nst/model/resolve/main/model.bin",
+            "https://huggingface.co/test/model/resolve/ma\tin/model.bin",
+            "https://huggingface.co/test/model/resolve/main/model\r.bin",
         ],
     )
     def test_parse_file_url_rejects_ambiguous_or_sdk_invalid_components(self, url: str) -> None:
@@ -3329,11 +3357,14 @@ class TestHuggingFaceFileURLs:
             "CON",
             "CONIN%24",
             "conout%24.log",
+            "COM%C2%B9",
+            "LPT%C2%B2.log",
             "nul.txt",
             "model.bin.",
             "model.bin%20",
             "model.bin%3Astream",
             "model%3F.bin",
+            "subdir%5Cmodel.bin",
         ],
     )
     def test_parse_file_url_rejects_windows_unsafe_filename_components(
@@ -3363,6 +3394,19 @@ class TestHuggingFaceFileURLs:
             "model.bin:stream",
         )
 
+    def test_parse_file_url_preserves_posix_backslash_filename(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A backslash is a literal POSIX filename character, not a path separator."""
+        monkeypatch.setattr("modelaudit.utils.sources.huggingface_paths._IS_WINDOWS", False)
+
+        assert parse_huggingface_file_url("https://huggingface.co/test/model/resolve/main/dir%5Cweights.bin") == (
+            "test/model",
+            "main",
+            "dir\\weights.bin",
+        )
+
     def test_parse_file_url_preserves_posix_colon_revision(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -3382,6 +3426,7 @@ class TestHuggingFaceFileURLs:
             "C%3A",
             "NUL",
             "refs%2FNUL%2F1",
+            "refs%2FCOM%C2%B3%2F1",
             "branch.",
             "branch%20",
             "branch%3Fname",
@@ -3452,6 +3497,7 @@ class TestHuggingFaceFileURLs:
         [
             f"https://huggingface.co/{'a' * 48}/{'b' * 48}/resolve/main/model.bin",
             "https://huggingface.co/test/model/resolve/main/model%FF.bin",
+            "https://huggingface.co/test/model/resolve/main/model\n.bin",
         ],
     )
     @patch("huggingface_hub.hf_hub_download")
@@ -3460,7 +3506,7 @@ class TestHuggingFaceFileURLs:
         mock_hf_hub_download: MagicMock,
         url: str,
     ) -> None:
-        """Repository and encoding validation must complete before the SDK call."""
+        """Repository, encoding, and raw URL validation must complete before the SDK call."""
         with pytest.raises(ValueError):
             download_file_from_hf(url)
 

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -233,6 +233,17 @@ class TestHuggingFaceURLParsing:
 class TestExtractModelIdFromPath:
     """Test HuggingFace model ID extraction from local paths."""
 
+    @pytest.mark.parametrize(
+        ("url", "model_id"),
+        [
+            ("https://huggingface.co/gpt2/resolve/main/config.json", "gpt2"),
+            ("https://huggingface.co/user/repo/resolve/refs%2Fpr%2F1/model.bin", "user/repo"),
+        ],
+    )
+    def test_extract_model_id_from_direct_file_url(self, url: str, model_id: str) -> None:
+        """Direct file URLs should retain their repository provenance."""
+        assert extract_model_id_from_path(url) == (model_id, "huggingface")
+
     def test_extract_model_id_from_local_config(self, tmp_path: Path) -> None:
         """Local config metadata should still be extracted as local provenance."""
         model_dir = tmp_path / "model"
@@ -3119,19 +3130,23 @@ class TestHuggingFaceFileURLs:
         assert "hf_secret" not in redacted
         assert "#frag" not in redacted
 
-    def test_valid_file_urls(self):
+    def test_valid_file_urls(self) -> None:
         """Test that valid HuggingFace file URLs are detected."""
         valid_urls = [
+            "https://huggingface.co/gpt2/resolve/main/config.json",
             "https://huggingface.co/bert-base/uncased/resolve/main/pytorch_model.bin",
             "https://huggingface.co/facebook/bart-large/resolve/main/config.json",
             "https://hf.co/microsoft/DialoGPT/resolve/main/model.safetensors",
-            "https://huggingface.co/user/repo/resolve/refs%2Fpr%2F1/file.bin",  # Percent-encoded revision
+            "https://hf.co/facebook/bart-large/resolve/main/subfolder/model.safetensors",
+            "https://huggingface.co/user/repo/resolve/refs%2Fpr%2F1/file.bin",
+            "https://huggingface.co/user/repo/resolve/feature%2Ffoo/file.bin",
+            "https://huggingface.co/user/repo/resolve/v1.0/model%20file.bin",
             "https://user:pass@huggingface.co/private/repo/resolve/main/model.bin?token=hf_secret",
         ]
         for url in valid_urls:
             assert is_huggingface_file_url(url), f"Failed to detect valid file URL: {url}"
 
-    def test_invalid_file_urls(self):
+    def test_invalid_file_urls(self) -> None:
         """Test that invalid URLs are not detected as HuggingFace file URLs."""
         invalid_urls = [
             "https://huggingface.co/bert-base-uncased",  # Model URL, not file URL
@@ -3142,9 +3157,13 @@ class TestHuggingFaceFileURLs:
         for url in invalid_urls:
             assert not is_huggingface_file_url(url), f"Incorrectly detected invalid file URL: {url}"
 
-    def test_parse_file_urls(self):
+    def test_parse_file_urls(self) -> None:
         """Test parsing HuggingFace file URLs."""
         test_cases = [
+            (
+                "https://huggingface.co/gpt2/resolve/main/config.json",
+                ("gpt2", "main", "config.json"),
+            ),
             (
                 "https://huggingface.co/bert-base/uncased/resolve/main/pytorch_model.bin",
                 ("bert-base/uncased", "main", "pytorch_model.bin"),
@@ -3159,7 +3178,15 @@ class TestHuggingFaceFileURLs:
             ),
             (
                 "https://huggingface.co/user/repo/resolve/refs%2Fpr%2F1/file.bin",
-                ("user/repo", "refs/pr/1", "file.bin"),  # Percent-decoded revision
+                ("user/repo", "refs/pr/1", "file.bin"),
+            ),
+            (
+                "https://huggingface.co/user/repo/resolve/feature%2Ffoo/file.bin",
+                ("user/repo", "feature/foo", "file.bin"),
+            ),
+            (
+                "https://huggingface.co/user/repo/resolve/v1.0/model%20file.bin",
+                ("user/repo", "v1.0", "model file.bin"),
             ),
             (
                 "https://user:pass@huggingface.co/private/repo/resolve/main/model.bin?token=hf_secret",
@@ -3170,7 +3197,7 @@ class TestHuggingFaceFileURLs:
             repo_id, branch, filename = parse_huggingface_file_url(url)
             assert (repo_id, branch, filename) == expected, f"Failed to parse file URL: {url}"
 
-    def test_parse_invalid_file_urls(self):
+    def test_parse_invalid_file_urls(self) -> None:
         """Test that invalid file URLs raise ValueError."""
         invalid_urls = [
             "https://github.com/user/repo/blob/main/file.bin",
@@ -3196,8 +3223,45 @@ class TestHuggingFaceFileURLs:
 
         assert is_huggingface_file_url(url) is False
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://huggingface.co/test/model/resolve/%2e%2e/model.bin",
+            "https://huggingface.co/test/model/resolve/%2e%2e%2Fmain/model.bin",
+            "https://huggingface.co/test/model/resolve/refs%2F..%2Fmain/model.bin",
+            "https://huggingface.co/test/model/resolve/%2Fmain/model.bin",
+            "https://huggingface.co/test/model/resolve/main%2F/model.bin",
+            "https://huggingface.co/test/model/resolve/refs%2F%2Fmain/model.bin",
+            "https://huggingface.co/test/model/resolve/refs%5Cmain/model.bin",
+            "https://huggingface.co/test/model/resolve/main/%2e%2e%2Fsecrets.bin",
+            "https://huggingface.co/test/model/resolve/main/subdir%2Fmodel.bin",
+            "https://huggingface.co/test/model/resolve/main/subdir%5Cmodel.bin",
+            "https://huggingface.co/test/model/resolve/main/%2Fetc%2Fpasswd",
+            "https://huggingface.co/test/model/resolve/main/../model.bin",
+            "https://huggingface.co/test/model/resolve/main//model.bin",
+            "https://huggingface.co/test/model/resolve/main/model.bin/",
+        ],
+    )
+    def test_parse_file_url_rejects_unsafe_revision_or_filename_components(self, url: str) -> None:
+        """Direct file URLs must not smuggle traversal or separators into SDK paths."""
+        with pytest.raises(ValueError):
+            parse_huggingface_file_url(url)
+
+        assert is_huggingface_file_url(url) is False
+
     @patch("huggingface_hub.hf_hub_download")
-    def test_download_file_success(self, mock_hf_hub_download):
+    def test_download_file_rejects_unsafe_direct_url_before_sdk_download(
+        self,
+        mock_hf_hub_download: MagicMock,
+    ) -> None:
+        """Unsafe decoded filename components should fail before the SDK download path."""
+        with pytest.raises(ValueError, match="Invalid HuggingFace filename path component"):
+            download_file_from_hf("https://huggingface.co/test/model/resolve/main/%2e%2e%2Fsecrets.bin")
+
+        mock_hf_hub_download.assert_not_called()
+
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_file_success(self, mock_hf_hub_download: MagicMock) -> None:
         """Test successful file download from HuggingFace."""
         mock_path = "/tmp/downloaded_file.bin"
         mock_hf_hub_download.return_value = mock_path
@@ -3215,7 +3279,24 @@ class TestHuggingFaceFileURLs:
         assert result == Path(mock_path)
 
     @patch("huggingface_hub.hf_hub_download")
-    def test_download_file_with_cache_dir(self, mock_hf_hub_download, tmp_path):
+    def test_download_file_allows_encoded_slash_revision(self, mock_hf_hub_download: MagicMock) -> None:
+        """Legitimate PR refs should reach the SDK as decoded slash-containing revisions."""
+        mock_hf_hub_download.return_value = "/tmp/downloaded_file.bin"
+
+        result = download_file_from_hf(
+            "https://huggingface.co/user/repo/resolve/refs%2Fpr%2F1/model.bin",
+        )
+
+        mock_hf_hub_download.assert_called_once_with(
+            repo_id="user/repo",
+            filename="model.bin",
+            revision="refs/pr/1",
+            cache_dir=None,
+        )
+        assert result == Path("/tmp/downloaded_file.bin")
+
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_file_with_cache_dir(self, mock_hf_hub_download: MagicMock, tmp_path: Path) -> None:
         """Test file download with custom cache directory."""
         mock_path = str(tmp_path / "downloaded_file.bin")
         mock_hf_hub_download.return_value = mock_path


### PR DESCRIPTION
## Summary
- validate Hugging Face direct file URL authority, repository, revision, and filename components before SDK download
- allow legitimate percent-encoded slash revisions such as `refs/pr/1` and `feature/foo`
- reject empty, dot, traversal, repeated-separator, leading/trailing-separator, and backslash revision segments
- reject malformed UTF-8 percent encodings and raw characters that `urlparse` would silently discard
- enforce the SDK's 96-character repository-ID limit and reject non-default or malformed URL authorities
- fail closed on Windows drive, device, wildcard, trailing-dot/space, alternate-stream, and superscript device-alias filename components
- preserve valid POSIX filenames, including literal backslashes and colons
- redact credentials and query secrets from every direct-URL validation error, including malformed and NFKC-invalid authorities
- preserve correct repository provenance for single-component and namespaced direct file URLs
- synchronize with current `main`

## False-positive / false-negative audit
- valid `refs/pr/N`, feature branches, nested filenames, spaces, exact 96-character repo IDs, and POSIX backslash filenames remain accepted
- single-component direct URLs retain model IDs such as `gpt2`
- malformed repo/revision/filename encodings and literal control characters cannot be lossy-decoded into a different SDK request
- Windows cache paths cannot be redirected through drive syntax, reserved devices (including `COM¹` / `LPT²` aliases), or NTFS alternate streams
- invalid schemes, opaque locators, and malformed authorities do not echo userinfo or query tokens
- invalid URLs fail before `huggingface_hub` download calls

## Validation
- associated Hugging Face source module: `267 passed, 1 skipped` (existing optional ONNX dependency)
- focused adversarial URL/platform regression slice: `52 passed`
- scoped Ruff check and format check
- scoped mypy for all three changed Python files
- `git diff --check origin/main...HEAD`
- exact published tree: `d6ae33ca3b93d3b3694e6da0b34da324a353305d`

All inline review threads are resolved. Full pytest remains delegated to CI. Final reviewed head: `c8bfd194a8793351b056dd9b7b97670b1c333ca0`, based on main `f85e0efc54b23c0fe296f6fe2202620b882f5ca8`.