### PR TITLE
fix: bound jinja scalar range render probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- fail closed on CPU-heavy scalar Jinja range filters when sandbox render workers are unavailable
 - report TAR external link escapes with the dedicated symlink rule code, resolve link targets from their correct archive bases, and avoid retaining passing checks for benign link floods
 - bind direct sharded-model cache entries to sibling shard and selected model configuration content fingerprints, and strengthen cache configuration hashes
 - fail closed on PMML XML parsing when defusedxml is unavailable instead of using the stdlib parser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- fail closed on CPU-heavy scalar Jinja range filters when sandbox render workers are unavailable
+- bound Jinja static render analysis and fail closed on CPU-heavy aliased, recursive, container-wrapped, and arithmetic range probes when sandbox workers are unavailable
 - report TAR external link escapes with the dedicated symlink rule code, resolve link targets from their correct archive bases, and avoid retaining passing checks for benign link floods
 - bind direct sharded-model cache entries to sibling shard and selected model configuration content fingerprints, and strengthen cache configuration hashes
 - fail closed on PMML XML parsing when defusedxml is unavailable instead of using the stdlib parser

--- a/modelaudit/scanners/jinja2_template_scanner.py
+++ b/modelaudit/scanners/jinja2_template_scanner.py
@@ -1770,7 +1770,12 @@ class Jinja2TemplateScanner(BaseScanner):
                 int_bindings,
                 namespace_range_attrs,
             )
-            self._collect_static_macro_assignment(node.target, node.node, macro_bindings)
+            self._collect_static_macro_assignment(
+                node.target,
+                node.node,
+                macro_bindings,
+                namespace_range_attrs,
+            )
             return False
 
         if isinstance(node, jinja2.nodes.AssignBlock):
@@ -2013,7 +2018,12 @@ class Jinja2TemplateScanner(BaseScanner):
                         item_int_bindings,
                         item_namespace_attrs,
                     )
-                    self._collect_static_macro_assignment(node.target, item, item_macro_bindings)
+                    self._collect_static_macro_assignment(
+                        node.target,
+                        item,
+                        item_macro_bindings,
+                        item_namespace_attrs,
+                    )
 
                     test_condition: bool | None = True
                     if node.test is not None:
@@ -2151,7 +2161,12 @@ class Jinja2TemplateScanner(BaseScanner):
                     with_int_bindings,
                     with_namespace_attrs,
                 )
-                self._collect_static_macro_assignment(target, value, with_macro_bindings)
+                self._collect_static_macro_assignment(
+                    target,
+                    value,
+                    with_macro_bindings,
+                    with_namespace_attrs,
+                )
             has_risk = any(
                 self._static_node_has_oversized_sandbox_range_call(
                     child,
@@ -2317,7 +2332,7 @@ class Jinja2TemplateScanner(BaseScanner):
             argument.name: value for argument, value in zip(macro.args, positional_arguments, strict=False)
         }
         supplied_arguments.update(dict(keyword_arguments))
-        namespace_argument_sources: dict[str, str] = {}
+        namespace_argument_sources: dict[str, tuple[tuple[str, ...], set[str]]] = {}
         default_offset = len(macro.args) - len(macro.defaults)
         for index, argument in enumerate(macro.args):
             value = supplied_arguments.get(argument.name)
@@ -2327,8 +2342,12 @@ class Jinja2TemplateScanner(BaseScanner):
                 uses_default = True
             if value is None:
                 continue
+            namespace_source_names: tuple[str, ...] = ()
             if isinstance(value, jinja2.nodes.Name) and value.name in namespace_range_attrs:
-                namespace_argument_sources[argument.name] = value.name
+                call_source_attrs = namespace_range_attrs[value.name]
+                namespace_source_names = tuple(
+                    name for name, attrs in namespace_range_attrs.items() if attrs is call_source_attrs
+                )
             if uses_default and self._static_node_has_oversized_sandbox_range_call(
                 value,
                 range_aliases,
@@ -2350,6 +2369,11 @@ class Jinja2TemplateScanner(BaseScanner):
                 macro_namespace_attrs,
                 nested_macro_bindings,
             )
+            if namespace_source_names and argument.name in macro_namespace_attrs:
+                namespace_argument_sources[argument.name] = (
+                    namespace_source_names,
+                    macro_namespace_attrs[argument.name],
+                )
 
         if accepts_kwargs:
             kwargs_range_attrs = {
@@ -2399,15 +2423,27 @@ class Jinja2TemplateScanner(BaseScanner):
         )
         if has_risk:
             return True
-        for argument_name, source_name in namespace_argument_sources.items():
-            argument_attrs = macro_namespace_attrs.get(argument_name)
-            source_attrs = namespace_range_attrs.get(source_name)
-            if argument_attrs is None or source_attrs is None:
+        for argument_name, (source_names, bound_argument_attrs) in namespace_argument_sources.items():
+            if macro_namespace_attrs.get(argument_name) is not bound_argument_attrs:
                 continue
-            if argument_attrs is source_attrs:
-                continue
-            source_attrs.clear()
-            source_attrs.update(argument_attrs)
+            argument_prefix = f"{argument_name}."
+            argument_macro_attrs = {
+                name.removeprefix(argument_prefix): macros
+                for name, macros in nested_macro_bindings.items()
+                if name.startswith(argument_prefix)
+            }
+            for source_name in source_names:
+                outer_source_attrs = namespace_range_attrs.get(source_name)
+                if outer_source_attrs is None:
+                    continue
+                if outer_source_attrs is not bound_argument_attrs:
+                    outer_source_attrs.clear()
+                    outer_source_attrs.update(bound_argument_attrs)
+                source_prefix = f"{source_name}."
+                for name in [name for name in macro_bindings if name.startswith(source_prefix)]:
+                    macro_bindings.pop(name, None)
+                for attribute, macros in argument_macro_attrs.items():
+                    macro_bindings[f"{source_prefix}{attribute}"] = macros
         return False
 
     @staticmethod
@@ -2515,6 +2551,9 @@ class Jinja2TemplateScanner(BaseScanner):
                     candidate_ids.add(id(macro))
                     candidates.append(macro)
             return tuple(candidates)
+        literal_item = cls._static_literal_container_item(node)
+        if literal_item is not None:
+            return cls._static_macro_binding_for_node(literal_item, macro_bindings)
         key = cls._static_macro_binding_key(node)
         return macro_bindings.get(key, ()) if key is not None else ()
 
@@ -2532,8 +2571,9 @@ class Jinja2TemplateScanner(BaseScanner):
         target: Any,
         value: Any,
         macro_bindings: dict[str, tuple[Any, ...]],
+        namespace_range_attrs: dict[str, set[str]],
     ) -> None:
-        if isinstance(target, jinja2.nodes.Tuple) and isinstance(value, jinja2.nodes.Tuple):
+        if isinstance(target, jinja2.nodes.Tuple) and isinstance(value, jinja2.nodes.List | jinja2.nodes.Tuple):
             if len(target.items) != len(value.items):
                 cls._clear_static_macro_binding(target, macro_bindings)
                 return
@@ -2550,7 +2590,7 @@ class Jinja2TemplateScanner(BaseScanner):
         source_macros = cls._static_macro_binding_for_node(value, original_bindings)
         cls._clear_static_macro_binding(target, macro_bindings)
         if isinstance(target, jinja2.nodes.NSRef):
-            if source_macros:
+            if target.name in namespace_range_attrs and source_macros:
                 macro_bindings[f"{target.name}.{target.attr}"] = source_macros
             return
         if isinstance(target, jinja2.nodes.Name) and source_macros:
@@ -2566,7 +2606,7 @@ class Jinja2TemplateScanner(BaseScanner):
                 keyword_macros = cls._static_macro_binding_for_node(keyword.value, original_bindings)
                 if keyword_macros:
                     macro_bindings[f"{target.name}.{keyword.key}"] = keyword_macros
-        elif isinstance(value, jinja2.nodes.Name):
+        elif isinstance(value, jinja2.nodes.Name) and value.name in namespace_range_attrs:
             source_prefix = f"{value.name}."
             target_prefix = f"{target.name}."
             for name, namespace_macro in original_bindings.items():
@@ -2756,7 +2796,7 @@ class Jinja2TemplateScanner(BaseScanner):
         int_bindings: dict[str, _StaticIntBinding],
         namespace_range_attrs: dict[str, set[str]],
     ) -> bool:
-        if isinstance(target, jinja2.nodes.Tuple) and isinstance(value, jinja2.nodes.Tuple):
+        if isinstance(target, jinja2.nodes.Tuple) and isinstance(value, jinja2.nodes.List | jinja2.nodes.Tuple):
             if len(target.items) != len(value.items):
                 self._clear_static_range_binding(target, range_aliases, int_bindings, namespace_range_attrs)
                 return False
@@ -2838,8 +2878,9 @@ class Jinja2TemplateScanner(BaseScanner):
                 for keyword in value.kwargs
                 if self._is_static_range_callable(keyword.value, range_aliases, namespace_range_attrs)
             }
-            if namespace_range_attrs.get(target.name) != attrs:
-                namespace_range_attrs[target.name] = attrs
+            previous_attrs = namespace_range_attrs.get(target.name)
+            namespace_range_attrs[target.name] = attrs
+            if previous_attrs is not attrs:
                 changed = True
         elif isinstance(value, jinja2.nodes.Name) and value.name in namespace_range_attrs:
             attrs = namespace_range_attrs[value.name]
@@ -2902,6 +2943,9 @@ class Jinja2TemplateScanner(BaseScanner):
                 branch is not None and cls._is_static_range_callable(branch, range_aliases, namespace_range_attrs)
                 for branch in branches
             )
+        literal_item = cls._static_literal_container_item(node)
+        if literal_item is not None:
+            return cls._is_static_range_callable(literal_item, range_aliases, namespace_range_attrs)
         if (
             isinstance(node, jinja2.nodes.Getitem)
             and isinstance(node.node, jinja2.nodes.Name)
@@ -2914,6 +2958,22 @@ class Jinja2TemplateScanner(BaseScanner):
             and isinstance(node.node, jinja2.nodes.Name)
             and node.attr in namespace_range_attrs.get(node.node.name, set())
         )
+
+    @staticmethod
+    def _static_literal_container_item(node: Any) -> Any | None:
+        if not isinstance(node, jinja2.nodes.Getitem) or not isinstance(node.arg, jinja2.nodes.Const):
+            return None
+        key = node.arg.value
+        if isinstance(node.node, jinja2.nodes.List | jinja2.nodes.Tuple) and isinstance(key, int):
+            try:
+                return node.node.items[key]
+            except IndexError:
+                return None
+        if isinstance(node.node, jinja2.nodes.Dict):
+            for pair in reversed(node.node.items):
+                if isinstance(pair.key, jinja2.nodes.Const) and pair.key.value == key:
+                    return pair.value
+        return None
 
     def _constant_int_expression_results_with_bindings(
         self,
@@ -3413,8 +3473,13 @@ class Jinja2TemplateScanner(BaseScanner):
                 if right_saturated:
                     return None
                 return self._constant_int_result(-1 if right % 2 else 1, cap)
-            if left_saturated or right_saturated:
+            if right_saturated:
+                if left < 0:
+                    return None
                 return self._saturated_constant_int_result(cap)
+            if left_saturated:
+                sign = -1 if left < 0 and right % 2 else 1
+                return self._saturated_constant_int_result(cap, sign)
             magnitude_cap = self._constant_int_magnitude_cap(cap)
             if abs(left) > 1 and (abs(left).bit_length() - 1) * right >= magnitude_cap.bit_length():
                 sign = -1 if left < 0 and right % 2 else 1

--- a/modelaudit/scanners/jinja2_template_scanner.py
+++ b/modelaudit/scanners/jinja2_template_scanner.py
@@ -96,6 +96,8 @@ _DEFAULT_SANDBOX_RENDER_MAX_MEMORY_BYTES = 512 * 1024 * 1024
 _SANDBOX_RENDER_SPAWN_STARTUP_GRACE_SECONDS = 2.0
 _SANDBOX_RENDER_BUDGET_REASON = "jinja2_sandbox_render_budget_exceeded"
 _STATIC_INT_EVAL_MAX_ABS = 10**100
+_MAX_STATIC_RENDER_ANALYSIS_STEPS = 20_000
+_MAX_STATIC_RANGE_PROJECTION_ITEMS = 200_000
 _SANDBOX_MAX_RANGE_ITERATIONS = int(jinja2.sandbox.MAX_RANGE) if HAS_JINJA2_SANDBOX else 100_000
 _EAGER_RANGE_ITERATION_FILTERS = frozenset({"groupby", "join", "list", "sort"})
 _LAZY_RANGE_ITERATION_FILTERS = frozenset(
@@ -111,6 +113,41 @@ class _StaticIntCandidates:
 
 
 _StaticIntBinding = _StaticIntResult | _StaticIntCandidates
+
+
+class _StaticMacroAnalysisState(set[int]):
+    def __init__(
+        self,
+        values: set[int] | None = None,
+        remaining_steps: list[int] | None = None,
+        remaining_range_items: list[int] | None = None,
+        preflight_only: bool = False,
+    ):
+        super().__init__(values or ())
+        self.remaining_steps = remaining_steps or [_MAX_STATIC_RENDER_ANALYSIS_STEPS]
+        self.remaining_range_items = remaining_range_items or [_MAX_STATIC_RANGE_PROJECTION_ITEMS]
+        self.preflight_only = preflight_only
+
+    def consume(self) -> bool:
+        if self.remaining_steps[0] <= 0:
+            return False
+        self.remaining_steps[0] -= 1
+        return True
+
+    def nested(self, macro_id: int) -> "_StaticMacroAnalysisState":
+        return _StaticMacroAnalysisState(
+            {*self, macro_id},
+            self.remaining_steps,
+            self.remaining_range_items,
+            self.preflight_only,
+        )
+
+    def consume_range_items(self, count: int) -> bool:
+        if count > self.remaining_range_items[0]:
+            self.remaining_range_items[0] = 0
+            return False
+        self.remaining_range_items[0] -= count
+        return True
 
 
 class _SandboxRenderBudgetExceeded(Exception):
@@ -1587,11 +1624,10 @@ class Jinja2TemplateScanner(BaseScanner):
         parsed = self._parse_template_ast(template_content)
         if parsed is None:
             return False
-        return (
-            self._template_ast_has_static_range_list_budget_risk(parsed)
-            or self._template_ast_has_static_range_join_budget_risk(parsed)
-            or self._template_ast_has_static_repeated_sequence_budget_risk(parsed)
-        )
+        return self._template_ast_has_oversized_sandbox_range_call(
+            parsed,
+            preflight_only=True,
+        ) or self._template_ast_has_static_repeated_sequence_budget_risk(parsed)
 
     def _template_has_static_sandbox_risk(self, template_content: str) -> bool:
         return bool(
@@ -1639,13 +1675,6 @@ class Jinja2TemplateScanner(BaseScanner):
 
         if self._template_ast_has_oversized_sandbox_range_call(parsed):
             return True
-
-        if self._template_ast_has_static_range_list_budget_risk(parsed):
-            return True
-
-        if self._template_ast_has_static_iterated_range_budget_risk(parsed):
-            return True
-
         return self._template_ast_has_static_repeated_sequence_budget_risk(parsed)
 
     def _template_ast_has_static_repeated_sequence_budget_risk(self, parsed: Any) -> bool:
@@ -1671,7 +1700,7 @@ class Jinja2TemplateScanner(BaseScanner):
 
         return False
 
-    def _template_ast_has_oversized_sandbox_range_call(self, parsed: Any) -> bool:
+    def _template_ast_has_oversized_sandbox_range_call(self, parsed: Any, *, preflight_only: bool = False) -> bool:
         range_aliases = {"range"}
         int_bindings: dict[str, _StaticIntBinding] = {}
         namespace_range_attrs: dict[str, set[str]] = {}
@@ -1682,7 +1711,7 @@ class Jinja2TemplateScanner(BaseScanner):
             int_bindings,
             namespace_range_attrs,
             macro_bindings,
-            set(),
+            _StaticMacroAnalysisState(preflight_only=preflight_only),
         )
 
     def _static_node_has_oversized_sandbox_range_call(
@@ -1694,6 +1723,8 @@ class Jinja2TemplateScanner(BaseScanner):
         macro_bindings: dict[str, tuple[Any, ...]],
         active_macros: set[int],
     ) -> bool:
+        if isinstance(active_macros, _StaticMacroAnalysisState) and not active_macros.consume():
+            return True
         if isinstance(node, jinja2.nodes.Block):
             block_aliases = set(range_aliases)
             block_int_bindings = dict(int_bindings)
@@ -1942,7 +1973,9 @@ class Jinja2TemplateScanner(BaseScanner):
             )
 
         if isinstance(node, jinja2.nodes.For):
-            if self._static_range_iterable_exceeds_budget(
+            if not (
+                isinstance(active_macros, _StaticMacroAnalysisState) and active_macros.preflight_only
+            ) and self._static_range_iterable_exceeds_budget(
                 node.iter,
                 max(1, self.sandbox_render_max_output_chars),
                 range_aliases,
@@ -1975,7 +2008,12 @@ class Jinja2TemplateScanner(BaseScanner):
 
             literal_items = node.iter.items if isinstance(node.iter, jinja2.nodes.List | jinja2.nodes.Tuple) else None
             iteration_count: int | None = len(literal_items) if literal_items is not None else None
-            range_call = self._static_iterable_range_call(node.iter, range_aliases, namespace_range_attrs)
+            range_call = self._static_iterable_range_call(
+                node.iter,
+                range_aliases,
+                int_bindings,
+                namespace_range_attrs,
+            )
             if range_call is not None:
                 iteration_count = self._constant_range_iteration_count_with_bindings(
                     range_call.args,
@@ -2189,12 +2227,18 @@ class Jinja2TemplateScanner(BaseScanner):
         if (
             isinstance(node, jinja2.nodes.Filter)
             and node.name in _EAGER_RANGE_ITERATION_FILTERS
+            and (
+                not isinstance(active_macros, _StaticMacroAnalysisState)
+                or not active_macros.preflight_only
+                or node.name in {"list", "join"}
+            )
             and self._static_range_filter_exceeds_budget(
                 node,
                 max(1, self.sandbox_render_max_output_chars),
                 range_aliases,
                 int_bindings,
                 namespace_range_attrs,
+                active_macros if isinstance(active_macros, _StaticMacroAnalysisState) else None,
             )
         ):
             return True
@@ -2237,11 +2281,15 @@ class Jinja2TemplateScanner(BaseScanner):
         ):
             return True
 
-        normalized_range_call = self._range_call_with_literal_unpacking(node)
-        if normalized_range_call is not None and self._is_static_range_callable(
-            normalized_range_call.node,
-            range_aliases,
-            namespace_range_attrs,
+        normalized_range_call = self._range_call_with_static_unpacking(node, int_bindings)
+        if (
+            not (isinstance(active_macros, _StaticMacroAnalysisState) and active_macros.preflight_only)
+            and normalized_range_call is not None
+            and self._is_static_range_callable(
+                normalized_range_call.node,
+                range_aliases,
+                namespace_range_attrs,
+            )
         ):
             count = self._constant_range_iteration_count_with_bindings(
                 normalized_range_call.args,
@@ -2273,9 +2321,24 @@ class Jinja2TemplateScanner(BaseScanner):
         active_macros: set[int],
     ) -> bool:
         macros = self._static_macro_binding_for_node(node.node, macro_bindings)
-        return any(
-            id(macro) not in active_macros
-            and self._static_single_macro_call_has_oversized_sandbox_range_call(
+        for macro in macros:
+            if id(macro) in active_macros:
+                normalized_arguments = self._static_macro_call_arguments(
+                    node,
+                    int_bindings,
+                    namespace_range_attrs,
+                    macro_bindings,
+                )
+                if normalized_arguments is None:
+                    continue
+                positional_arguments, keyword_arguments = normalized_arguments
+                if any(
+                    self._is_static_range_callable(value, range_aliases, namespace_range_attrs)
+                    for value in [*positional_arguments, *(value for _, value in keyword_arguments)]
+                ):
+                    return True
+                continue
+            if self._static_single_macro_call_has_oversized_sandbox_range_call(
                 node,
                 macro,
                 range_aliases,
@@ -2283,9 +2346,9 @@ class Jinja2TemplateScanner(BaseScanner):
                 namespace_range_attrs,
                 macro_bindings,
                 active_macros,
-            )
-            for macro in macros
-        )
+            ):
+                return True
+        return False
 
     def _static_single_macro_call_has_oversized_sandbox_range_call(
         self,
@@ -2297,7 +2360,12 @@ class Jinja2TemplateScanner(BaseScanner):
         macro_bindings: dict[str, tuple[Any, ...]],
         active_macros: set[int],
     ) -> bool:
-        normalized_arguments = self._static_macro_call_arguments(node)
+        normalized_arguments = self._static_macro_call_arguments(
+            node,
+            int_bindings,
+            namespace_range_attrs,
+            macro_bindings,
+        )
         if normalized_arguments is None:
             return False
         positional_arguments, keyword_arguments = normalized_arguments
@@ -2409,7 +2477,11 @@ class Jinja2TemplateScanner(BaseScanner):
                 if vararg_macros:
                     nested_macro_bindings[f"varargs.{index}"] = vararg_macros
 
-        nested_active_macros = {*active_macros, id(macro)}
+        nested_active_macros = (
+            active_macros.nested(id(macro))
+            if isinstance(active_macros, _StaticMacroAnalysisState)
+            else {*active_macros, id(macro)}
+        )
         has_risk = any(
             self._static_node_has_oversized_sandbox_range_call(
                 child,
@@ -2446,23 +2518,114 @@ class Jinja2TemplateScanner(BaseScanner):
                     macro_bindings[f"{source_prefix}{attribute}"] = macros
         return False
 
-    @staticmethod
-    def _static_macro_call_arguments(node: Any) -> tuple[list[Any], list[tuple[str, Any]]] | None:
+    def _static_macro_call_arguments(
+        self,
+        node: Any,
+        int_bindings: dict[str, _StaticIntBinding],
+        namespace_range_attrs: dict[str, set[str]],
+        macro_bindings: dict[str, tuple[Any, ...]],
+    ) -> tuple[list[Any], list[tuple[str, Any]]] | None:
         positional_arguments = list(node.args)
         if node.dyn_args is not None:
-            if not isinstance(node.dyn_args, jinja2.nodes.List | jinja2.nodes.Tuple):
+            if isinstance(node.dyn_args, jinja2.nodes.List | jinja2.nodes.Tuple):
+                positional_arguments.extend(node.dyn_args.items)
+            elif isinstance(node.dyn_args, jinja2.nodes.Name):
+                bound_arguments = self._static_bound_sequence_arguments(
+                    node.dyn_args.name,
+                    int_bindings,
+                    namespace_range_attrs,
+                    macro_bindings,
+                )
+                if bound_arguments is None:
+                    return None
+                positional_arguments.extend(bound_arguments)
+            else:
                 return None
-            positional_arguments.extend(node.dyn_args.items)
 
         keyword_arguments = [(keyword.key, keyword.value) for keyword in node.kwargs]
         if node.dyn_kwargs is not None:
-            if not isinstance(node.dyn_kwargs, jinja2.nodes.Dict):
-                return None
-            for pair in node.dyn_kwargs.items:
-                if not isinstance(pair.key, jinja2.nodes.Const) or not isinstance(pair.key.value, str):
+            if isinstance(node.dyn_kwargs, jinja2.nodes.Dict):
+                for pair in node.dyn_kwargs.items:
+                    if not isinstance(pair.key, jinja2.nodes.Const) or not isinstance(pair.key.value, str):
+                        return None
+                    keyword_arguments.append((pair.key.value, pair.value))
+            elif isinstance(node.dyn_kwargs, jinja2.nodes.Name):
+                bound_keywords = self._static_bound_mapping_arguments(
+                    node.dyn_kwargs.name,
+                    int_bindings,
+                    namespace_range_attrs,
+                    macro_bindings,
+                )
+                if bound_keywords is None:
                     return None
-                keyword_arguments.append((pair.key.value, pair.value))
+                keyword_arguments.extend(bound_keywords)
+            else:
+                return None
         return positional_arguments, keyword_arguments
+
+    def _static_bound_sequence_arguments(
+        self,
+        name: str,
+        int_bindings: dict[str, _StaticIntBinding],
+        namespace_range_attrs: dict[str, set[str]],
+        macro_bindings: dict[str, tuple[Any, ...]],
+    ) -> list[Any] | None:
+        length_binding = int_bindings.get(self._static_container_length_key(name))
+        if length_binding is None or isinstance(length_binding, _StaticIntCandidates) or length_binding[1]:
+            return None
+        return [
+            self._static_bound_container_value_node(
+                name,
+                str(index),
+                namespace_range_attrs,
+                macro_bindings,
+            )
+            for index in range(length_binding[0])
+        ]
+
+    def _static_bound_mapping_arguments(
+        self,
+        name: str,
+        int_bindings: dict[str, _StaticIntBinding],
+        namespace_range_attrs: dict[str, set[str]],
+        macro_bindings: dict[str, tuple[Any, ...]],
+    ) -> list[tuple[str, Any]] | None:
+        prefix = f"{name}."
+        keys = set(namespace_range_attrs.get(name, set()))
+        keys.update(key.removeprefix(prefix) for key in int_bindings if key.startswith(prefix))
+        keys.update(key.removeprefix(prefix) for key in macro_bindings if key.startswith(prefix))
+        if not keys:
+            return None
+        return [
+            (
+                key,
+                self._static_bound_container_value_node(
+                    name,
+                    key,
+                    namespace_range_attrs,
+                    macro_bindings,
+                ),
+            )
+            for key in sorted(keys)
+        ]
+
+    @staticmethod
+    def _static_bound_container_value_node(
+        name: str,
+        key: str,
+        namespace_range_attrs: dict[str, set[str]],
+        macro_bindings: dict[str, tuple[Any, ...]],
+    ) -> Any:
+        if key in namespace_range_attrs.get(name, set()):
+            return jinja2.nodes.Name("range", "load")
+        binding_name = f"{name}.{key}"
+        if binding_name in macro_bindings:
+            return jinja2.nodes.Name(binding_name, "load")
+        return jinja2.nodes.Name(binding_name, "load")
+
+    @staticmethod
+    def _static_container_length_key(name: str) -> str:
+        return f"{name}\0length"
 
     def _bind_static_macro_argument(
         self,
@@ -2597,6 +2760,14 @@ class Jinja2TemplateScanner(BaseScanner):
             macro_bindings[target.name] = source_macros
         if not isinstance(target, jinja2.nodes.Name):
             return
+        container_entries = cls._static_literal_container_entries(value)
+        if container_entries is not None:
+            entries, _ = container_entries
+            for key, item in entries:
+                item_macros = cls._static_macro_binding_for_node(item, original_bindings)
+                if item_macros:
+                    macro_bindings[f"{target.name}.{key}"] = item_macros
+            return
         if (
             isinstance(value, jinja2.nodes.Call)
             and isinstance(value.node, jinja2.nodes.Name)
@@ -2672,7 +2843,12 @@ class Jinja2TemplateScanner(BaseScanner):
         int_bindings: dict[str, _StaticIntBinding],
         namespace_range_attrs: dict[str, set[str]],
     ) -> bool:
-        range_call = self._static_iterable_range_call(node, range_aliases, namespace_range_attrs)
+        range_call = self._static_iterable_range_call(
+            node,
+            range_aliases,
+            int_bindings,
+            namespace_range_attrs,
+        )
         if range_call is None:
             return False
         count = self._constant_range_iteration_count_with_bindings(range_call.args, threshold, int_bindings)
@@ -2685,10 +2861,24 @@ class Jinja2TemplateScanner(BaseScanner):
         range_aliases: set[str],
         int_bindings: dict[str, _StaticIntBinding],
         namespace_range_attrs: dict[str, set[str]],
+        analysis_state: _StaticMacroAnalysisState | None = None,
     ) -> bool:
-        range_call = self._static_iterable_range_call(node.node, range_aliases, namespace_range_attrs)
+        range_call = self._static_iterable_range_call(
+            node.node,
+            range_aliases,
+            int_bindings,
+            namespace_range_attrs,
+        )
         if range_call is None:
             return False
+        if node.name in {"list", "join"} and analysis_state is not None:
+            count = self._constant_range_iteration_count_with_bindings(
+                range_call.args,
+                _SANDBOX_MAX_RANGE_ITERATIONS,
+                int_bindings,
+            )
+            if count is not None and not analysis_state.consume_range_items(min(count, _SANDBOX_MAX_RANGE_ITERATIONS)):
+                return True
         if node.name == "list":
             projected_size = self._constant_range_rendered_list_size_with_bindings(
                 range_call.args,
@@ -2711,11 +2901,12 @@ class Jinja2TemplateScanner(BaseScanner):
         self,
         node: Any,
         range_aliases: set[str],
+        int_bindings: dict[str, _StaticIntBinding],
         namespace_range_attrs: dict[str, set[str]],
     ) -> Any | None:
         while isinstance(node, jinja2.nodes.Filter) and node.name in _LAZY_RANGE_ITERATION_FILTERS:
             node = node.node
-        normalized_range_call = self._range_call_with_literal_unpacking(node)
+        normalized_range_call = self._range_call_with_static_unpacking(node, int_bindings)
         if normalized_range_call is not None and self._is_static_range_callable(
             normalized_range_call.node,
             range_aliases,
@@ -2723,6 +2914,27 @@ class Jinja2TemplateScanner(BaseScanner):
         ):
             return normalized_range_call
         return None
+
+    def _range_call_with_static_unpacking(
+        self,
+        node: Any,
+        int_bindings: dict[str, _StaticIntBinding],
+    ) -> Any | None:
+        normalized = self._range_call_with_literal_unpacking(node)
+        if normalized is not None or not isinstance(node, jinja2.nodes.Call) or node.dyn_args is None:
+            return normalized
+        if not isinstance(node.dyn_args, jinja2.nodes.Name) or node.kwargs or node.dyn_kwargs is not None:
+            return None
+        length_binding = int_bindings.get(self._static_container_length_key(node.dyn_args.name))
+        if length_binding is None or isinstance(length_binding, _StaticIntCandidates) or length_binding[1]:
+            return None
+        arguments = [*node.args]
+        arguments.extend(
+            jinja2.nodes.Name(f"{node.dyn_args.name}.{index}", "load") for index in range(length_binding[0])
+        )
+        if not 1 <= len(arguments) <= 3:
+            return None
+        return jinja2.nodes.Call(node.node, arguments, [], None, None)
 
     @staticmethod
     def _range_call_with_literal_unpacking(node: Any) -> Any | None:
@@ -2759,6 +2971,10 @@ class Jinja2TemplateScanner(BaseScanner):
             return
         range_aliases.discard(target.name)
         int_bindings.pop(target.name, None)
+        int_bindings.pop(self._static_container_length_key(target.name), None)
+        prefix = f"{target.name}."
+        for name in [name for name in int_bindings if name.startswith(prefix)]:
+            int_bindings.pop(name, None)
         namespace_range_attrs.pop(target.name, None)
 
     @staticmethod
@@ -2848,6 +3064,7 @@ class Jinja2TemplateScanner(BaseScanner):
         if not isinstance(target, jinja2.nodes.Name):
             return False
 
+        original_int_bindings = dict(int_bindings)
         changed = False
         if self._is_static_range_callable(value, range_aliases, namespace_range_attrs):
             previous_size = len(range_aliases)
@@ -2868,6 +3085,36 @@ class Jinja2TemplateScanner(BaseScanner):
         elif int_binding is None:
             int_bindings.pop(target.name, None)
 
+        int_bindings.pop(self._static_container_length_key(target.name), None)
+        target_prefix = f"{target.name}."
+        for name in [name for name in int_bindings if name.startswith(target_prefix)]:
+            int_bindings.pop(name, None)
+
+        container_entries = self._static_literal_container_entries(value)
+        if container_entries is not None:
+            entries, is_sequence = container_entries
+            attrs = {
+                key
+                for key, item in entries
+                if self._is_static_range_callable(item, range_aliases, namespace_range_attrs)
+            }
+            namespace_range_attrs[target.name] = attrs
+            if is_sequence:
+                int_bindings[self._static_container_length_key(target.name)] = self._constant_int_result(
+                    len(entries),
+                    _SANDBOX_MAX_RANGE_ITERATIONS,
+                )
+            for key, item in entries:
+                nested_results = self._constant_int_expression_results_with_bindings(
+                    item,
+                    _SANDBOX_MAX_RANGE_ITERATIONS,
+                    original_int_bindings,
+                )
+                nested_binding = self._make_static_int_binding(nested_results)
+                if nested_binding is not None:
+                    int_bindings[f"{target.name}.{key}"] = nested_binding
+            return True
+
         if (
             isinstance(value, jinja2.nodes.Call)
             and isinstance(value.node, jinja2.nodes.Name)
@@ -2887,6 +3134,13 @@ class Jinja2TemplateScanner(BaseScanner):
             if namespace_range_attrs.get(target.name) is not attrs:
                 namespace_range_attrs[target.name] = attrs
                 changed = True
+            source_length_key = self._static_container_length_key(value.name)
+            if source_length_key in original_int_bindings:
+                int_bindings[self._static_container_length_key(target.name)] = original_int_bindings[source_length_key]
+            source_prefix = f"{value.name}."
+            for name, binding in original_int_bindings.items():
+                if name.startswith(source_prefix):
+                    int_bindings[f"{target.name}.{name.removeprefix(source_prefix)}"] = binding
         else:
             namespace_range_attrs.pop(target.name, None)
 
@@ -2959,20 +3213,83 @@ class Jinja2TemplateScanner(BaseScanner):
             and node.attr in namespace_range_attrs.get(node.node.name, set())
         )
 
-    @staticmethod
-    def _static_literal_container_item(node: Any) -> Any | None:
-        if not isinstance(node, jinja2.nodes.Getitem) or not isinstance(node.arg, jinja2.nodes.Const):
+    @classmethod
+    def _static_literal_container_item(cls, node: Any) -> Any | None:
+        if (
+            isinstance(node, jinja2.nodes.Call)
+            and isinstance(node.node, jinja2.nodes.Getattr)
+            and node.node.attr == "get"
+            and isinstance(node.node.node, jinja2.nodes.Dict)
+            and not node.kwargs
+            and node.dyn_args is None
+            and node.dyn_kwargs is None
+            and 1 <= len(node.args) <= 2
+        ):
+            key = cls._static_literal_container_key(node.args[0])
+            if key is None:
+                return None
+            for pair in reversed(node.node.node.items):
+                if isinstance(pair.key, jinja2.nodes.Const) and pair.key.value == key:
+                    return pair.value
+            return node.args[1] if len(node.args) == 2 else None
+        if not isinstance(node, jinja2.nodes.Getitem):
             return None
-        key = node.arg.value
-        if isinstance(node.node, jinja2.nodes.List | jinja2.nodes.Tuple) and isinstance(key, int):
+        key = cls._static_literal_container_key(node.arg)
+        if key is None:
+            return None
+        sequence_items = cls._static_literal_sequence_items(node.node)
+        if sequence_items is not None and isinstance(key, int):
             try:
-                return node.node.items[key]
+                return sequence_items[key]
             except IndexError:
                 return None
         if isinstance(node.node, jinja2.nodes.Dict):
             for pair in reversed(node.node.items):
                 if isinstance(pair.key, jinja2.nodes.Const) and pair.key.value == key:
                     return pair.value
+        return None
+
+    @classmethod
+    def _static_literal_sequence_items(cls, node: Any) -> list[Any] | None:
+        if isinstance(node, jinja2.nodes.List | jinja2.nodes.Tuple):
+            return list(node.items)
+        if isinstance(node, jinja2.nodes.Add):
+            left_items = cls._static_literal_sequence_items(node.left)
+            right_items = cls._static_literal_sequence_items(node.right)
+            if left_items is not None and right_items is not None:
+                return [*left_items, *right_items]
+        return None
+
+    @classmethod
+    def _static_literal_container_entries(cls, node: Any) -> tuple[list[tuple[str, Any]], bool] | None:
+        sequence_items = cls._static_literal_sequence_items(node)
+        if sequence_items is not None:
+            return [(str(index), item) for index, item in enumerate(sequence_items)], True
+        if isinstance(node, jinja2.nodes.Dict):
+            entries: list[tuple[str, Any]] = []
+            for pair in node.items:
+                key = cls._static_literal_container_key(pair.key)
+                if not isinstance(key, str | int):
+                    return None
+                entries.append((str(key), pair.value))
+            return entries, False
+        return None
+
+    @staticmethod
+    def _static_literal_container_key(node: Any) -> str | int | None:
+        if (
+            isinstance(node, jinja2.nodes.Const)
+            and isinstance(node.value, str | int)
+            and not isinstance(node.value, bool)
+        ):
+            return node.value
+        if (
+            isinstance(node, jinja2.nodes.Neg)
+            and isinstance(node.node, jinja2.nodes.Const)
+            and isinstance(node.node.value, int)
+            and not isinstance(node.node.value, bool)
+        ):
+            return -node.node.value
         return None
 
     def _constant_int_expression_results_with_bindings(
@@ -3396,6 +3713,12 @@ class Jinja2TemplateScanner(BaseScanner):
                 if node.left == node.right or same_result:
                     return self._constant_int_result(0, cap)
                 if left_saturated or right_saturated:
+                    quotient_signature = self._static_power_quotient_signature(node.left, int_bindings)
+                    if quotient_signature is not None and quotient_signature == self._static_power_signature(
+                        node.right,
+                        int_bindings,
+                    ):
+                        return self._constant_int_result(0, cap)
                     wrapped_difference = self._constant_wrapped_difference_result(
                         node.left,
                         node.right,
@@ -3404,6 +3727,14 @@ class Jinja2TemplateScanner(BaseScanner):
                     )
                     if wrapped_difference is not None:
                         return wrapped_difference
+                    wrapped_right_difference = self._constant_wrapped_right_difference_result(
+                        node.left,
+                        node.right,
+                        cap,
+                        int_bindings,
+                    )
+                    if wrapped_right_difference is not None:
+                        return wrapped_right_difference
                     if left_saturated and right_saturated:
                         if (left < 0) == (right < 0):
                             magnitude_comparison = self._compare_static_power_magnitudes(
@@ -3434,6 +3765,9 @@ class Jinja2TemplateScanner(BaseScanner):
                 if not left_saturated and left == 0:
                     return self._constant_int_result(0, cap)
                 if left_saturated or right_saturated:
+                    quotient_signature = self._static_power_quotient_signature(node, int_bindings)
+                    if quotient_signature is not None:
+                        return self._constant_power_signature_result(quotient_signature, cap)
                     if not left_saturated:
                         quotient = -1 if left * right < 0 else 0
                         return self._constant_int_result(quotient, cap)
@@ -3444,9 +3778,25 @@ class Jinja2TemplateScanner(BaseScanner):
             if node.left == node.right or same_result or (not left_saturated and left == 0):
                 return self._constant_int_result(0, cap)
             if left_saturated or right_saturated:
+                wrapped_modulo = self._constant_wrapped_modulo_result(
+                    node.left,
+                    node.right,
+                    cap,
+                    int_bindings,
+                )
+                if wrapped_modulo is not None:
+                    return wrapped_modulo
                 if left_saturated:
                     if right_saturated:
                         return None
+                    power_modulo = self._constant_power_modulo_result(
+                        node.left,
+                        right,
+                        cap,
+                        int_bindings,
+                    )
+                    if power_modulo is not None:
+                        return power_modulo
                     if abs(right) == 1:
                         return self._constant_int_result(0, cap)
                     return None
@@ -3475,7 +3825,10 @@ class Jinja2TemplateScanner(BaseScanner):
                 return self._constant_int_result(-1 if right % 2 else 1, cap)
             if right_saturated:
                 if left < 0:
-                    return None
+                    exponent_parity = self._constant_int_expression_parity(node.right, int_bindings)
+                    if exponent_parity is None:
+                        return None
+                    return self._saturated_constant_int_result(cap, -1 if exponent_parity else 1)
                 return self._saturated_constant_int_result(cap)
             if left_saturated:
                 sign = -1 if left < 0 and right % 2 else 1
@@ -3493,6 +3846,92 @@ class Jinja2TemplateScanner(BaseScanner):
             return self._constant_int_expression_result(branch, cap, int_bindings) if branch is not None else None
         if isinstance(node, jinja2.nodes.Filter):
             return self._constant_int_filter_result(node, cap, int_bindings)
+        return None
+
+    def _static_power_signature(
+        self,
+        node: Any,
+        int_bindings: dict[str, _StaticIntBinding] | None,
+    ) -> tuple[int, int] | None:
+        if not isinstance(node, jinja2.nodes.Pow):
+            return None
+        base_result = self._constant_int_expression_result(node.left, _STATIC_INT_EVAL_MAX_ABS, int_bindings)
+        exponent_result = self._constant_int_expression_result(node.right, _STATIC_INT_EVAL_MAX_ABS, int_bindings)
+        if (
+            base_result is None
+            or exponent_result is None
+            or base_result[1]
+            or exponent_result[1]
+            or abs(base_result[0]) <= 1
+            or exponent_result[0] < 0
+        ):
+            return None
+        return base_result[0], exponent_result[0]
+
+    def _static_power_quotient_signature(
+        self,
+        node: Any,
+        int_bindings: dict[str, _StaticIntBinding] | None,
+    ) -> tuple[int, int] | None:
+        if not isinstance(node, jinja2.nodes.FloorDiv):
+            return None
+        numerator = self._static_power_signature(node.left, int_bindings)
+        if numerator is None:
+            return None
+        denominator = self._static_power_signature(node.right, int_bindings)
+        if denominator is None:
+            denominator_result = self._constant_int_expression_result(
+                node.right,
+                _STATIC_INT_EVAL_MAX_ABS,
+                int_bindings,
+            )
+            if denominator_result is None or denominator_result[1] or denominator_result[0] != numerator[0]:
+                return None
+            denominator = (numerator[0], 1)
+        if numerator[0] != denominator[0] or numerator[1] < denominator[1]:
+            return None
+        return numerator[0], numerator[1] - denominator[1]
+
+    def _constant_power_signature_result(self, signature: tuple[int, int], cap: int) -> tuple[int, bool]:
+        base, exponent = signature
+        if exponent == 0:
+            return self._constant_int_result(1, cap)
+        magnitude_cap = self._constant_int_magnitude_cap(cap)
+        if (abs(base).bit_length() - 1) * exponent >= magnitude_cap.bit_length():
+            return self._saturated_constant_int_result(cap, -1 if base < 0 and exponent % 2 else 1)
+        return self._constant_int_result(base**exponent, cap)
+
+    def _constant_int_expression_parity(
+        self,
+        node: Any,
+        int_bindings: dict[str, _StaticIntBinding] | None,
+    ) -> int | None:
+        if isinstance(node, jinja2.nodes.Name):
+            binding = int_bindings.get(node.name) if int_bindings is not None else None
+            if binding is None or isinstance(binding, _StaticIntCandidates) or binding[1]:
+                return None
+            return binding[0] % 2
+        if isinstance(node, jinja2.nodes.Const):
+            if isinstance(node.value, bool) or not isinstance(node.value, int):
+                return None
+            return node.value % 2
+        if isinstance(node, jinja2.nodes.Neg | jinja2.nodes.Pos):
+            return self._constant_int_expression_parity(node.node, int_bindings)
+        if isinstance(node, jinja2.nodes.Add | jinja2.nodes.Sub):
+            left = self._constant_int_expression_parity(node.left, int_bindings)
+            right = self._constant_int_expression_parity(node.right, int_bindings)
+            return None if left is None or right is None else (left + right) % 2
+        if isinstance(node, jinja2.nodes.Mul):
+            left = self._constant_int_expression_parity(node.left, int_bindings)
+            right = self._constant_int_expression_parity(node.right, int_bindings)
+            return None if left is None or right is None else left * right
+        if isinstance(node, jinja2.nodes.Pow):
+            exponent = self._constant_int_expression_result(node.right, _STATIC_INT_EVAL_MAX_ABS, int_bindings)
+            if exponent is None or exponent[0] < 0:
+                return None
+            if not exponent[1] and exponent[0] == 0:
+                return 1
+            return self._constant_int_expression_parity(node.left, int_bindings)
         return None
 
     def _compare_static_power_magnitudes(
@@ -3591,6 +4030,80 @@ class Jinja2TemplateScanner(BaseScanner):
             return offset_result
         return None
 
+    def _constant_wrapped_modulo_result(
+        self,
+        left: Any,
+        right: Any,
+        cap: int,
+        int_bindings: dict[str, _StaticIntBinding] | None,
+    ) -> tuple[int, bool] | None:
+        if not isinstance(right, jinja2.nodes.Neg) or not isinstance(right.node, jinja2.nodes.Add):
+            return None
+        left_result = self._constant_int_expression_result(left, cap, int_bindings)
+        if left_result is None or left_result[0] < 0:
+            return None
+        for dominant, offset in ((right.node.left, right.node.right), (right.node.right, right.node.left)):
+            dominant_result = self._constant_int_expression_result(dominant, cap, int_bindings)
+            offset_result = self._constant_int_expression_result(offset, cap, int_bindings)
+            if (
+                dominant_result is None
+                or dominant_result[0] < 0
+                or offset_result is None
+                or offset_result[1]
+                or offset_result[0] <= 0
+            ):
+                continue
+            if dominant != left and self._compare_static_power_magnitudes(dominant, left, int_bindings) != 0:
+                continue
+            return self._constant_int_result(-offset_result[0], cap)
+        return None
+
+    def _constant_wrapped_right_difference_result(
+        self,
+        left: Any,
+        right: Any,
+        cap: int,
+        int_bindings: dict[str, _StaticIntBinding] | None,
+    ) -> tuple[int, bool] | None:
+        if not isinstance(right, jinja2.nodes.Add):
+            return None
+        left_result = self._constant_int_expression_result(left, cap, int_bindings)
+        if left_result is None or not left_result[1]:
+            return None
+        for dominant, offset in ((right.left, right.right), (right.right, right.left)):
+            dominant_result = self._constant_int_expression_result(dominant, cap, int_bindings)
+            offset_result = self._constant_int_expression_result(offset, cap, int_bindings)
+            if dominant_result is None or not dominant_result[1] or offset_result is None or offset_result[1]:
+                continue
+            comparison = self._compare_static_power_magnitudes(left, dominant, int_bindings)
+            if comparison is None:
+                continue
+            left_sign = -1 if left_result[0] < 0 else 1
+            dominant_sign = -1 if dominant_result[0] < 0 else 1
+            if left_sign != dominant_sign or comparison > 0:
+                return self._saturated_constant_int_result(cap, left_sign)
+            if comparison < 0:
+                return self._saturated_constant_int_result(cap, -dominant_sign)
+            return self._constant_int_result(-offset_result[0], cap)
+        return None
+
+    def _constant_power_modulo_result(
+        self,
+        left: Any,
+        divisor: int,
+        cap: int,
+        int_bindings: dict[str, _StaticIntBinding] | None,
+    ) -> tuple[int, bool] | None:
+        signature = self._static_power_signature(left, int_bindings)
+        if signature is None or divisor == 0:
+            return None
+        base, exponent = signature
+        modulus = abs(divisor)
+        remainder = pow(base, exponent, modulus)
+        if divisor < 0 and remainder:
+            remainder -= modulus
+        return self._constant_int_result(remainder, cap)
+
     def _constant_int_filter_result(
         self,
         node: Any,
@@ -3638,6 +4151,17 @@ class Jinja2TemplateScanner(BaseScanner):
             elif isinstance(value, str):
                 text = value.strip()
                 if len(text) > 4096:
+                    if base == 10:
+                        sign = -1 if text.startswith("-") else 1
+                        digits = text[1:] if text.startswith(("-", "+")) else text
+                        if not digits or not digits.isdecimal():
+                            return default_result
+                        significant_digits = digits.lstrip("0")
+                        if not significant_digits:
+                            return self._constant_int_result(0, cap)
+                        if len(significant_digits) <= 4096:
+                            return self._constant_int_result(sign * int(significant_digits), cap)
+                        return self._saturated_constant_int_result(cap, sign)
                     return self._saturated_constant_int_result(cap, -1 if text.startswith("-") else 1)
                 try:
                     parsed = int(text, base)

--- a/modelaudit/scanners/jinja2_template_scanner.py
+++ b/modelaudit/scanners/jinja2_template_scanner.py
@@ -28,6 +28,7 @@ import queue
 import re
 import warnings
 from contextlib import suppress
+from dataclasses import dataclass
 from typing import Any, ClassVar, cast
 
 try:
@@ -95,10 +96,21 @@ _DEFAULT_SANDBOX_RENDER_MAX_MEMORY_BYTES = 512 * 1024 * 1024
 _SANDBOX_RENDER_SPAWN_STARTUP_GRACE_SECONDS = 2.0
 _SANDBOX_RENDER_BUDGET_REASON = "jinja2_sandbox_render_budget_exceeded"
 _STATIC_INT_EVAL_MAX_ABS = 10**100
+_SANDBOX_MAX_RANGE_ITERATIONS = int(jinja2.sandbox.MAX_RANGE) if HAS_JINJA2_SANDBOX else 100_000
 _EAGER_RANGE_ITERATION_FILTERS = frozenset({"groupby", "join", "list", "sort"})
 _LAZY_RANGE_ITERATION_FILTERS = frozenset(
-    {"batch", "map", "reject", "rejectattr", "reverse", "select", "selectattr", "slice", "unique"}
+    {"batch", "d", "default", "map", "reject", "rejectattr", "reverse", "select", "selectattr", "slice", "unique"}
 )
+
+_StaticIntResult = tuple[int, bool]
+
+
+@dataclass(frozen=True)
+class _StaticIntCandidates:
+    values: tuple[_StaticIntResult, ...]
+
+
+_StaticIntBinding = _StaticIntResult | _StaticIntCandidates
 
 
 class _SandboxRenderBudgetExceeded(Exception):
@@ -1625,6 +1637,9 @@ class Jinja2TemplateScanner(BaseScanner):
         if parsed is None:
             return False
 
+        if self._template_ast_has_oversized_sandbox_range_call(parsed):
+            return True
+
         if self._template_ast_has_static_range_list_budget_risk(parsed):
             return True
 
@@ -1655,6 +1670,1359 @@ class Jinja2TemplateScanner(BaseScanner):
                 return True
 
         return False
+
+    def _template_ast_has_oversized_sandbox_range_call(self, parsed: Any) -> bool:
+        range_aliases = {"range"}
+        int_bindings: dict[str, _StaticIntBinding] = {}
+        namespace_range_attrs: dict[str, set[str]] = {}
+        macro_bindings: dict[str, tuple[Any, ...]] = {}
+        return self._static_node_has_oversized_sandbox_range_call(
+            parsed,
+            range_aliases,
+            int_bindings,
+            namespace_range_attrs,
+            macro_bindings,
+            set(),
+        )
+
+    def _static_node_has_oversized_sandbox_range_call(
+        self,
+        node: Any,
+        range_aliases: set[str],
+        int_bindings: dict[str, _StaticIntBinding],
+        namespace_range_attrs: dict[str, set[str]],
+        macro_bindings: dict[str, tuple[Any, ...]],
+        active_macros: set[int],
+    ) -> bool:
+        if isinstance(node, jinja2.nodes.Block):
+            block_aliases = set(range_aliases)
+            block_int_bindings = dict(int_bindings)
+            block_namespace_attrs = self._clone_static_namespace_bindings(namespace_range_attrs)
+            inherited_namespace_attrs = dict(block_namespace_attrs)
+            block_macro_bindings = dict(macro_bindings)
+            has_risk = any(
+                self._static_node_has_oversized_sandbox_range_call(
+                    child,
+                    block_aliases,
+                    block_int_bindings,
+                    block_namespace_attrs,
+                    block_macro_bindings,
+                    active_macros,
+                )
+                for child in node.body
+            )
+            if not has_risk:
+                self._propagate_static_namespace_mutations(
+                    namespace_range_attrs,
+                    block_namespace_attrs,
+                    inherited_namespace_attrs,
+                )
+            return has_risk
+
+        if isinstance(node, jinja2.nodes.FilterBlock):
+            if self._static_node_has_oversized_sandbox_range_call(
+                node.filter,
+                range_aliases,
+                int_bindings,
+                namespace_range_attrs,
+                macro_bindings,
+                active_macros,
+            ):
+                return True
+            block_aliases = set(range_aliases)
+            block_int_bindings = dict(int_bindings)
+            block_namespace_attrs = self._clone_static_namespace_bindings(namespace_range_attrs)
+            inherited_namespace_attrs = dict(block_namespace_attrs)
+            block_macro_bindings = dict(macro_bindings)
+            has_risk = any(
+                self._static_node_has_oversized_sandbox_range_call(
+                    child,
+                    block_aliases,
+                    block_int_bindings,
+                    block_namespace_attrs,
+                    block_macro_bindings,
+                    active_macros,
+                )
+                for child in node.body
+            )
+            if not has_risk:
+                self._propagate_static_namespace_mutations(
+                    namespace_range_attrs,
+                    block_namespace_attrs,
+                    inherited_namespace_attrs,
+                )
+            return has_risk
+
+        if isinstance(node, jinja2.nodes.Assign):
+            if self._static_node_has_oversized_sandbox_range_call(
+                node.node,
+                range_aliases,
+                int_bindings,
+                namespace_range_attrs,
+                macro_bindings,
+                active_macros,
+            ):
+                return True
+            self._collect_static_range_assignment(
+                node.target,
+                node.node,
+                range_aliases,
+                int_bindings,
+                namespace_range_attrs,
+            )
+            self._collect_static_macro_assignment(node.target, node.node, macro_bindings)
+            return False
+
+        if isinstance(node, jinja2.nodes.AssignBlock):
+            block_aliases = set(range_aliases)
+            block_int_bindings = dict(int_bindings)
+            block_namespace_attrs = self._clone_static_namespace_bindings(namespace_range_attrs)
+            inherited_namespace_attrs = dict(block_namespace_attrs)
+            block_macro_bindings = dict(macro_bindings)
+            if any(
+                self._static_node_has_oversized_sandbox_range_call(
+                    child,
+                    block_aliases,
+                    block_int_bindings,
+                    block_namespace_attrs,
+                    block_macro_bindings,
+                    active_macros,
+                )
+                for child in node.body
+            ):
+                return True
+            self._propagate_static_namespace_mutations(
+                namespace_range_attrs,
+                block_namespace_attrs,
+                inherited_namespace_attrs,
+            )
+            self._clear_static_range_binding(
+                node.target,
+                range_aliases,
+                int_bindings,
+                namespace_range_attrs,
+            )
+            self._clear_static_macro_binding(node.target, macro_bindings)
+            return False
+
+        if isinstance(node, jinja2.nodes.Macro):
+            macro_target = jinja2.nodes.Name(node.name, "store")
+            self._clear_static_range_binding(
+                macro_target,
+                range_aliases,
+                int_bindings,
+                namespace_range_attrs,
+            )
+            self._clear_static_macro_binding(macro_target, macro_bindings)
+            macro_bindings[node.name] = (node,)
+            return False
+
+        if isinstance(node, jinja2.nodes.If):
+            if self._static_node_has_oversized_sandbox_range_call(
+                node.test,
+                range_aliases,
+                int_bindings,
+                namespace_range_attrs,
+                macro_bindings,
+                active_macros,
+            ):
+                return True
+            condition = self._constant_condition_value(node.test)
+            if condition is True:
+                return any(
+                    self._static_node_has_oversized_sandbox_range_call(
+                        child,
+                        range_aliases,
+                        int_bindings,
+                        namespace_range_attrs,
+                        macro_bindings,
+                        active_macros,
+                    )
+                    for child in node.body
+                )
+
+            possible_branches = [node.body] if condition is None else []
+            can_reach_later_branch = True
+            for elif_node in node.elif_:
+                if self._static_node_has_oversized_sandbox_range_call(
+                    elif_node.test,
+                    range_aliases,
+                    int_bindings,
+                    namespace_range_attrs,
+                    macro_bindings,
+                    active_macros,
+                ):
+                    return True
+                elif_condition = self._constant_condition_value(elif_node.test)
+                if can_reach_later_branch and elif_condition is not False:
+                    possible_branches.append(elif_node.body)
+                if elif_condition is True:
+                    can_reach_later_branch = False
+                    break
+            if can_reach_later_branch:
+                possible_branches.append(node.else_)
+
+            branch_states: list[
+                tuple[
+                    set[str],
+                    dict[str, _StaticIntBinding],
+                    dict[str, set[str]],
+                    dict[str, tuple[Any, ...]],
+                ]
+            ] = []
+            for branch in possible_branches:
+                branch_aliases = set(range_aliases)
+                branch_int_bindings = dict(int_bindings)
+                branch_namespace_attrs = self._clone_static_namespace_bindings(namespace_range_attrs)
+                branch_macro_bindings = dict(macro_bindings)
+                for child in branch:
+                    if self._static_node_has_oversized_sandbox_range_call(
+                        child,
+                        branch_aliases,
+                        branch_int_bindings,
+                        branch_namespace_attrs,
+                        branch_macro_bindings,
+                        active_macros,
+                    ):
+                        return True
+                branch_states.append(
+                    (
+                        branch_aliases,
+                        branch_int_bindings,
+                        branch_namespace_attrs,
+                        branch_macro_bindings,
+                    )
+                )
+            self._merge_static_branch_bindings(
+                branch_states,
+                range_aliases,
+                int_bindings,
+                namespace_range_attrs,
+                macro_bindings,
+            )
+            return False
+
+        if isinstance(node, jinja2.nodes.CondExpr):
+            if self._static_node_has_oversized_sandbox_range_call(
+                node.test,
+                range_aliases,
+                int_bindings,
+                namespace_range_attrs,
+                macro_bindings,
+                active_macros,
+            ):
+                return True
+            condition = self._constant_condition_value(node.test)
+            if condition is not None:
+                selected_expression = node.expr1 if condition else node.expr2
+                return selected_expression is not None and self._static_node_has_oversized_sandbox_range_call(
+                    selected_expression,
+                    range_aliases,
+                    int_bindings,
+                    namespace_range_attrs,
+                    macro_bindings,
+                    active_macros,
+                )
+            return any(
+                branch is not None
+                and self._static_node_has_oversized_sandbox_range_call(
+                    branch,
+                    range_aliases,
+                    int_bindings,
+                    namespace_range_attrs,
+                    macro_bindings,
+                    active_macros,
+                )
+                for branch in (node.expr1, node.expr2)
+            )
+
+        if isinstance(node, jinja2.nodes.For):
+            if self._static_range_iterable_exceeds_budget(
+                node.iter,
+                max(1, self.sandbox_render_max_output_chars),
+                range_aliases,
+                int_bindings,
+                namespace_range_attrs,
+            ):
+                return True
+            if self._static_node_has_oversized_sandbox_range_call(
+                node.iter,
+                range_aliases,
+                int_bindings,
+                namespace_range_attrs,
+                macro_bindings,
+                active_macros,
+            ):
+                return True
+
+            if node.test is not None and self._constant_condition_value(node.test) is False:
+                return any(
+                    self._static_node_has_oversized_sandbox_range_call(
+                        child,
+                        range_aliases,
+                        int_bindings,
+                        namespace_range_attrs,
+                        macro_bindings,
+                        active_macros,
+                    )
+                    for child in node.else_
+                )
+
+            literal_items = node.iter.items if isinstance(node.iter, jinja2.nodes.List | jinja2.nodes.Tuple) else None
+            iteration_count: int | None = len(literal_items) if literal_items is not None else None
+            range_call = self._static_iterable_range_call(node.iter, range_aliases, namespace_range_attrs)
+            if range_call is not None:
+                iteration_count = self._constant_range_iteration_count_with_bindings(
+                    range_call.args,
+                    _SANDBOX_MAX_RANGE_ITERATIONS,
+                    int_bindings,
+                )
+            if iteration_count == 0:
+                return any(
+                    self._static_node_has_oversized_sandbox_range_call(
+                        child,
+                        range_aliases,
+                        int_bindings,
+                        namespace_range_attrs,
+                        macro_bindings,
+                        active_macros,
+                    )
+                    for child in node.else_
+                )
+
+            outer_namespace_names = set(namespace_range_attrs)
+            if literal_items is not None:
+                loop_namespace_attrs = self._clone_static_namespace_bindings(namespace_range_attrs)
+                definitely_iterates = False
+                for item in literal_items:
+                    item_aliases = set(range_aliases)
+                    item_int_bindings = dict(int_bindings)
+                    item_namespace_attrs = self._clone_static_namespace_bindings(loop_namespace_attrs)
+                    item_macro_bindings = dict(macro_bindings)
+                    self._clear_static_range_binding(
+                        node.target,
+                        item_aliases,
+                        item_int_bindings,
+                        item_namespace_attrs,
+                    )
+                    self._clear_static_macro_binding(node.target, item_macro_bindings)
+                    self._collect_static_range_assignment(
+                        node.target,
+                        item,
+                        item_aliases,
+                        item_int_bindings,
+                        item_namespace_attrs,
+                    )
+                    self._collect_static_macro_assignment(node.target, item, item_macro_bindings)
+
+                    test_condition: bool | None = True
+                    if node.test is not None:
+                        if self._static_node_has_oversized_sandbox_range_call(
+                            node.test,
+                            item_aliases,
+                            item_int_bindings,
+                            item_namespace_attrs,
+                            item_macro_bindings,
+                            active_macros,
+                        ):
+                            return True
+                        test_condition = self._constant_condition_value(node.test)
+                    if test_condition is False:
+                        continue
+
+                    executed_namespace_attrs = self._clone_static_namespace_bindings(item_namespace_attrs)
+                    if any(
+                        self._static_node_has_oversized_sandbox_range_call(
+                            child,
+                            item_aliases,
+                            item_int_bindings,
+                            executed_namespace_attrs,
+                            item_macro_bindings,
+                            active_macros,
+                        )
+                        for child in node.body
+                    ):
+                        return True
+
+                    if test_condition is True:
+                        definitely_iterates = True
+                        loop_namespace_attrs = executed_namespace_attrs
+                    else:
+                        for name, attrs in executed_namespace_attrs.items():
+                            loop_namespace_attrs.setdefault(name, set()).update(attrs)
+
+                for name in outer_namespace_names:
+                    namespace_range_attrs[name] = set(loop_namespace_attrs.get(name, set()))
+
+                if definitely_iterates:
+                    return False
+                return any(
+                    self._static_node_has_oversized_sandbox_range_call(
+                        child,
+                        range_aliases,
+                        int_bindings,
+                        namespace_range_attrs,
+                        macro_bindings,
+                        active_macros,
+                    )
+                    for child in node.else_
+                )
+
+            loop_aliases = set(range_aliases)
+            loop_int_bindings = dict(int_bindings)
+            loop_namespace_attrs = self._clone_static_namespace_bindings(namespace_range_attrs)
+            loop_macro_bindings = dict(macro_bindings)
+            self._clear_static_range_binding(
+                node.target,
+                loop_aliases,
+                loop_int_bindings,
+                loop_namespace_attrs,
+            )
+            self._clear_static_macro_binding(node.target, loop_macro_bindings)
+            if node.test is not None and self._static_node_has_oversized_sandbox_range_call(
+                node.test,
+                loop_aliases,
+                loop_int_bindings,
+                loop_namespace_attrs,
+                loop_macro_bindings,
+                active_macros,
+            ):
+                return True
+            if any(
+                self._static_node_has_oversized_sandbox_range_call(
+                    child,
+                    loop_aliases,
+                    loop_int_bindings,
+                    loop_namespace_attrs,
+                    loop_macro_bindings,
+                    active_macros,
+                )
+                for child in node.body
+            ):
+                return True
+
+            loop_definitely_executes = (
+                iteration_count is not None
+                and iteration_count > 0
+                and (node.test is None or self._constant_condition_value(node.test) is True)
+            )
+            for name in outer_namespace_names:
+                loop_attrs = loop_namespace_attrs.get(name, set())
+                if loop_definitely_executes:
+                    namespace_range_attrs[name] = set(loop_attrs)
+                else:
+                    namespace_range_attrs[name].update(loop_attrs)
+
+            if loop_definitely_executes:
+                return False
+            return any(
+                self._static_node_has_oversized_sandbox_range_call(
+                    child,
+                    range_aliases,
+                    int_bindings,
+                    namespace_range_attrs,
+                    macro_bindings,
+                    active_macros,
+                )
+                for child in node.else_
+            )
+
+        if isinstance(node, jinja2.nodes.With):
+            for value in node.values:
+                if self._static_node_has_oversized_sandbox_range_call(
+                    value,
+                    range_aliases,
+                    int_bindings,
+                    namespace_range_attrs,
+                    macro_bindings,
+                    active_macros,
+                ):
+                    return True
+            with_aliases = set(range_aliases)
+            with_int_bindings = dict(int_bindings)
+            with_namespace_attrs = self._clone_static_namespace_bindings(namespace_range_attrs)
+            inherited_namespace_attrs = dict(with_namespace_attrs)
+            with_macro_bindings = dict(macro_bindings)
+            for target, value in zip(node.targets, node.values, strict=False):
+                self._collect_static_range_assignment(
+                    target,
+                    value,
+                    with_aliases,
+                    with_int_bindings,
+                    with_namespace_attrs,
+                )
+                self._collect_static_macro_assignment(target, value, with_macro_bindings)
+            has_risk = any(
+                self._static_node_has_oversized_sandbox_range_call(
+                    child,
+                    with_aliases,
+                    with_int_bindings,
+                    with_namespace_attrs,
+                    with_macro_bindings,
+                    active_macros,
+                )
+                for child in node.body
+            )
+            if not has_risk:
+                self._propagate_static_namespace_mutations(
+                    namespace_range_attrs,
+                    with_namespace_attrs,
+                    inherited_namespace_attrs,
+                )
+            return has_risk
+
+        if (
+            isinstance(node, jinja2.nodes.Filter)
+            and node.name in _EAGER_RANGE_ITERATION_FILTERS
+            and self._static_range_filter_exceeds_budget(
+                node,
+                max(1, self.sandbox_render_max_output_chars),
+                range_aliases,
+                int_bindings,
+                namespace_range_attrs,
+            )
+        ):
+            return True
+
+        if isinstance(node, jinja2.nodes.CallBlock):
+            caller_macro = jinja2.nodes.Macro("caller", node.args, node.defaults, node.body)
+            call_macro_bindings = dict(macro_bindings)
+            call_macro_bindings["caller"] = (caller_macro,)
+            macros = self._static_macro_binding_for_node(node.call.node, call_macro_bindings)
+            if self._static_node_has_oversized_sandbox_range_call(
+                node.call,
+                range_aliases,
+                int_bindings,
+                namespace_range_attrs,
+                call_macro_bindings,
+                active_macros,
+            ):
+                return True
+            if macros:
+                return False
+            return any(
+                self._static_node_has_oversized_sandbox_range_call(
+                    child,
+                    range_aliases,
+                    int_bindings,
+                    namespace_range_attrs,
+                    macro_bindings,
+                    active_macros,
+                )
+                for child in node.body
+            )
+
+        if isinstance(node, jinja2.nodes.Call) and self._static_macro_call_has_oversized_sandbox_range_call(
+            node,
+            range_aliases,
+            int_bindings,
+            namespace_range_attrs,
+            macro_bindings,
+            active_macros,
+        ):
+            return True
+
+        normalized_range_call = self._range_call_with_literal_unpacking(node)
+        if normalized_range_call is not None and self._is_static_range_callable(
+            normalized_range_call.node,
+            range_aliases,
+            namespace_range_attrs,
+        ):
+            count = self._constant_range_iteration_count_with_bindings(
+                normalized_range_call.args,
+                _SANDBOX_MAX_RANGE_ITERATIONS,
+                int_bindings,
+            )
+            if count is not None and count > _SANDBOX_MAX_RANGE_ITERATIONS:
+                return True
+
+        return any(
+            self._static_node_has_oversized_sandbox_range_call(
+                child,
+                range_aliases,
+                int_bindings,
+                namespace_range_attrs,
+                macro_bindings,
+                active_macros,
+            )
+            for child in node.iter_child_nodes()
+        )
+
+    def _static_macro_call_has_oversized_sandbox_range_call(
+        self,
+        node: Any,
+        range_aliases: set[str],
+        int_bindings: dict[str, _StaticIntBinding],
+        namespace_range_attrs: dict[str, set[str]],
+        macro_bindings: dict[str, tuple[Any, ...]],
+        active_macros: set[int],
+    ) -> bool:
+        macros = self._static_macro_binding_for_node(node.node, macro_bindings)
+        return any(
+            id(macro) not in active_macros
+            and self._static_single_macro_call_has_oversized_sandbox_range_call(
+                node,
+                macro,
+                range_aliases,
+                int_bindings,
+                namespace_range_attrs,
+                macro_bindings,
+                active_macros,
+            )
+            for macro in macros
+        )
+
+    def _static_single_macro_call_has_oversized_sandbox_range_call(
+        self,
+        node: Any,
+        macro: Any,
+        range_aliases: set[str],
+        int_bindings: dict[str, _StaticIntBinding],
+        namespace_range_attrs: dict[str, set[str]],
+        macro_bindings: dict[str, tuple[Any, ...]],
+        active_macros: set[int],
+    ) -> bool:
+        normalized_arguments = self._static_macro_call_arguments(node)
+        if normalized_arguments is None:
+            return False
+        positional_arguments, keyword_arguments = normalized_arguments
+        accepts_varargs = self._static_macro_uses_special_argument(macro, "varargs")
+        accepts_kwargs = self._static_macro_uses_special_argument(macro, "kwargs")
+        if len(positional_arguments) > len(macro.args) and not accepts_varargs:
+            return False
+        argument_names = {argument.name for argument in macro.args}
+        positional_names = {argument.name for argument in macro.args[: len(positional_arguments)]}
+        keyword_names: set[str] = set()
+        for keyword_name, _ in keyword_arguments:
+            if keyword_name in positional_names or keyword_name in keyword_names:
+                return False
+            if keyword_name not in argument_names and not accepts_kwargs:
+                return False
+            keyword_names.add(keyword_name)
+
+        macro_aliases = set(range_aliases)
+        macro_int_bindings = dict(int_bindings)
+        macro_namespace_attrs = self._clone_static_namespace_bindings(namespace_range_attrs)
+        nested_macro_bindings = dict(macro_bindings)
+        for argument in macro.args:
+            self._clear_static_range_binding(
+                argument,
+                macro_aliases,
+                macro_int_bindings,
+                macro_namespace_attrs,
+            )
+            self._clear_static_macro_binding(argument, nested_macro_bindings)
+
+        supplied_arguments = {
+            argument.name: value for argument, value in zip(macro.args, positional_arguments, strict=False)
+        }
+        supplied_arguments.update(dict(keyword_arguments))
+        namespace_argument_sources: dict[str, str] = {}
+        default_offset = len(macro.args) - len(macro.defaults)
+        for index, argument in enumerate(macro.args):
+            value = supplied_arguments.get(argument.name)
+            uses_default = False
+            if value is None and index >= default_offset:
+                value = macro.defaults[index - default_offset]
+                uses_default = True
+            if value is None:
+                continue
+            if isinstance(value, jinja2.nodes.Name) and value.name in namespace_range_attrs:
+                namespace_argument_sources[argument.name] = value.name
+            if uses_default and self._static_node_has_oversized_sandbox_range_call(
+                value,
+                range_aliases,
+                int_bindings,
+                namespace_range_attrs,
+                macro_bindings,
+                active_macros,
+            ):
+                return True
+            self._bind_static_macro_argument(
+                argument,
+                value,
+                range_aliases,
+                int_bindings,
+                namespace_range_attrs,
+                macro_bindings,
+                macro_aliases,
+                macro_int_bindings,
+                macro_namespace_attrs,
+                nested_macro_bindings,
+            )
+
+        if accepts_kwargs:
+            kwargs_range_attrs = {
+                keyword_name
+                for keyword_name, keyword_value in keyword_arguments
+                if keyword_name not in argument_names
+                and self._is_static_range_callable(keyword_value, range_aliases, namespace_range_attrs)
+            }
+            if kwargs_range_attrs:
+                macro_namespace_attrs["kwargs"] = kwargs_range_attrs
+            else:
+                macro_namespace_attrs.pop("kwargs", None)
+            for keyword_name, keyword_value in keyword_arguments:
+                if keyword_name in argument_names:
+                    continue
+                keyword_macros = self._static_macro_binding_for_node(keyword_value, macro_bindings)
+                if keyword_macros:
+                    nested_macro_bindings[f"kwargs.{keyword_name}"] = keyword_macros
+
+        if accepts_varargs:
+            extra_arguments = positional_arguments[len(macro.args) :]
+            varargs_range_attrs = {
+                str(index)
+                for index, value in enumerate(extra_arguments)
+                if self._is_static_range_callable(value, range_aliases, namespace_range_attrs)
+            }
+            if varargs_range_attrs:
+                macro_namespace_attrs["varargs"] = varargs_range_attrs
+            else:
+                macro_namespace_attrs.pop("varargs", None)
+            for index, value in enumerate(extra_arguments):
+                vararg_macros = self._static_macro_binding_for_node(value, macro_bindings)
+                if vararg_macros:
+                    nested_macro_bindings[f"varargs.{index}"] = vararg_macros
+
+        nested_active_macros = {*active_macros, id(macro)}
+        has_risk = any(
+            self._static_node_has_oversized_sandbox_range_call(
+                child,
+                macro_aliases,
+                macro_int_bindings,
+                macro_namespace_attrs,
+                nested_macro_bindings,
+                nested_active_macros,
+            )
+            for child in macro.body
+        )
+        if has_risk:
+            return True
+        for argument_name, source_name in namespace_argument_sources.items():
+            argument_attrs = macro_namespace_attrs.get(argument_name)
+            source_attrs = namespace_range_attrs.get(source_name)
+            if argument_attrs is None or source_attrs is None:
+                continue
+            if argument_attrs is source_attrs:
+                continue
+            source_attrs.clear()
+            source_attrs.update(argument_attrs)
+        return False
+
+    @staticmethod
+    def _static_macro_call_arguments(node: Any) -> tuple[list[Any], list[tuple[str, Any]]] | None:
+        positional_arguments = list(node.args)
+        if node.dyn_args is not None:
+            if not isinstance(node.dyn_args, jinja2.nodes.List | jinja2.nodes.Tuple):
+                return None
+            positional_arguments.extend(node.dyn_args.items)
+
+        keyword_arguments = [(keyword.key, keyword.value) for keyword in node.kwargs]
+        if node.dyn_kwargs is not None:
+            if not isinstance(node.dyn_kwargs, jinja2.nodes.Dict):
+                return None
+            for pair in node.dyn_kwargs.items:
+                if not isinstance(pair.key, jinja2.nodes.Const) or not isinstance(pair.key.value, str):
+                    return None
+                keyword_arguments.append((pair.key.value, pair.value))
+        return positional_arguments, keyword_arguments
+
+    def _bind_static_macro_argument(
+        self,
+        target: Any,
+        value: Any,
+        source_aliases: set[str],
+        source_int_bindings: dict[str, _StaticIntBinding],
+        source_namespace_attrs: dict[str, set[str]],
+        source_macro_bindings: dict[str, tuple[Any, ...]],
+        range_aliases: set[str],
+        int_bindings: dict[str, _StaticIntBinding],
+        namespace_range_attrs: dict[str, set[str]],
+        macro_bindings: dict[str, tuple[Any, ...]],
+    ) -> None:
+        if not isinstance(target, jinja2.nodes.Name):
+            return
+        if self._is_static_range_callable(value, source_aliases, source_namespace_attrs):
+            range_aliases.add(target.name)
+        int_results = self._constant_int_expression_results_with_bindings(
+            value,
+            _SANDBOX_MAX_RANGE_ITERATIONS,
+            source_int_bindings,
+        )
+        int_binding = self._make_static_int_binding(int_results)
+        if int_binding is not None:
+            int_bindings[target.name] = int_binding
+        if isinstance(value, jinja2.nodes.Name):
+            if value.name in source_namespace_attrs:
+                namespace_range_attrs[target.name] = source_namespace_attrs[value.name]
+            source_prefix = f"{value.name}."
+            target_prefix = f"{target.name}."
+            for name, namespace_macro in source_macro_bindings.items():
+                if name.startswith(source_prefix):
+                    macro_bindings[f"{target_prefix}{name.removeprefix(source_prefix)}"] = namespace_macro
+        source_macros = self._static_macro_binding_for_node(value, source_macro_bindings)
+        if source_macros:
+            macro_bindings[target.name] = source_macros
+
+    @classmethod
+    def _clear_static_macro_binding(cls, target: Any, macro_bindings: dict[str, tuple[Any, ...]]) -> None:
+        if isinstance(target, jinja2.nodes.Tuple):
+            for item in target.items:
+                cls._clear_static_macro_binding(item, macro_bindings)
+        elif isinstance(target, jinja2.nodes.NSRef):
+            macro_bindings.pop(f"{target.name}.{target.attr}", None)
+        elif isinstance(target, jinja2.nodes.Name):
+            macro_bindings.pop(target.name, None)
+            prefix = f"{target.name}."
+            for name in [name for name in macro_bindings if name.startswith(prefix)]:
+                macro_bindings.pop(name, None)
+
+    @classmethod
+    def _static_macro_binding_key(cls, node: Any) -> str | None:
+        if isinstance(node, jinja2.nodes.Name):
+            return node.name
+        if isinstance(node, jinja2.nodes.Getattr) and isinstance(node.node, jinja2.nodes.Name):
+            return f"{node.node.name}.{node.attr}"
+        if (
+            isinstance(node, jinja2.nodes.Getitem)
+            and isinstance(node.node, jinja2.nodes.Name)
+            and isinstance(node.arg, jinja2.nodes.Const)
+            and isinstance(node.arg.value, str | int)
+        ):
+            return f"{node.node.name}.{node.arg.value}"
+        return None
+
+    @classmethod
+    def _static_macro_binding_for_node(
+        cls,
+        node: Any,
+        macro_bindings: dict[str, tuple[Any, ...]],
+    ) -> tuple[Any, ...]:
+        if isinstance(node, jinja2.nodes.CondExpr):
+            condition = cls._constant_condition_value(node.test)
+            if condition is not None:
+                branch = node.expr1 if condition else node.expr2
+                return cls._static_macro_binding_for_node(branch, macro_bindings) if branch is not None else ()
+            candidates: list[Any] = []
+            candidate_ids: set[int] = set()
+            for branch in (node.expr1, node.expr2):
+                if branch is None:
+                    continue
+                for macro in cls._static_macro_binding_for_node(branch, macro_bindings):
+                    if id(macro) in candidate_ids:
+                        continue
+                    candidate_ids.add(id(macro))
+                    candidates.append(macro)
+            return tuple(candidates)
+        key = cls._static_macro_binding_key(node)
+        return macro_bindings.get(key, ()) if key is not None else ()
+
+    @staticmethod
+    def _static_macro_uses_special_argument(macro: Any, name: str) -> bool:
+        return any(
+            candidate.name == name and candidate.ctx == "load"
+            for child in macro.body
+            for candidate in child.find_all(jinja2.nodes.Name)
+        )
+
+    @classmethod
+    def _collect_static_macro_assignment(
+        cls,
+        target: Any,
+        value: Any,
+        macro_bindings: dict[str, tuple[Any, ...]],
+    ) -> None:
+        if isinstance(target, jinja2.nodes.Tuple) and isinstance(value, jinja2.nodes.Tuple):
+            if len(target.items) != len(value.items):
+                cls._clear_static_macro_binding(target, macro_bindings)
+                return
+            original_bindings = dict(macro_bindings)
+            cls._clear_static_macro_binding(target, macro_bindings)
+            for item_target, item_value in zip(target.items, value.items, strict=False):
+                if not isinstance(item_target, jinja2.nodes.Name):
+                    continue
+                source_macros = cls._static_macro_binding_for_node(item_value, original_bindings)
+                if source_macros:
+                    macro_bindings[item_target.name] = source_macros
+            return
+        original_bindings = dict(macro_bindings)
+        source_macros = cls._static_macro_binding_for_node(value, original_bindings)
+        cls._clear_static_macro_binding(target, macro_bindings)
+        if isinstance(target, jinja2.nodes.NSRef):
+            if source_macros:
+                macro_bindings[f"{target.name}.{target.attr}"] = source_macros
+            return
+        if isinstance(target, jinja2.nodes.Name) and source_macros:
+            macro_bindings[target.name] = source_macros
+        if not isinstance(target, jinja2.nodes.Name):
+            return
+        if (
+            isinstance(value, jinja2.nodes.Call)
+            and isinstance(value.node, jinja2.nodes.Name)
+            and value.node.name == "namespace"
+        ):
+            for keyword in value.kwargs:
+                keyword_macros = cls._static_macro_binding_for_node(keyword.value, original_bindings)
+                if keyword_macros:
+                    macro_bindings[f"{target.name}.{keyword.key}"] = keyword_macros
+        elif isinstance(value, jinja2.nodes.Name):
+            source_prefix = f"{value.name}."
+            target_prefix = f"{target.name}."
+            for name, namespace_macro in original_bindings.items():
+                if name.startswith(source_prefix):
+                    macro_bindings[f"{target_prefix}{name.removeprefix(source_prefix)}"] = namespace_macro
+
+    @staticmethod
+    def _merge_static_branch_bindings(
+        branch_states: list[
+            tuple[
+                set[str],
+                dict[str, _StaticIntBinding],
+                dict[str, set[str]],
+                dict[str, tuple[Any, ...]],
+            ]
+        ],
+        range_aliases: set[str],
+        int_bindings: dict[str, _StaticIntBinding],
+        namespace_range_attrs: dict[str, set[str]],
+        macro_bindings: dict[str, tuple[Any, ...]],
+    ) -> None:
+        range_aliases.clear()
+        range_aliases.update(*(aliases for aliases, _, _, _ in branch_states))
+
+        int_bindings.clear()
+        int_names = {name for _, int_state_bindings, _, _ in branch_states for name in int_state_bindings}
+        for name in int_names:
+            candidates: list[_StaticIntResult] = []
+            for _, int_state_bindings, _, _ in branch_states:
+                binding = int_state_bindings.get(name)
+                if isinstance(binding, _StaticIntCandidates):
+                    candidates.extend(binding.values)
+                elif binding is not None:
+                    candidates.append(binding)
+            merged_binding = Jinja2TemplateScanner._make_static_int_binding(candidates)
+            if merged_binding is not None:
+                int_bindings[name] = merged_binding
+
+        namespace_range_attrs.clear()
+        for _, _, attrs_by_name, _ in branch_states:
+            for name, attrs in attrs_by_name.items():
+                namespace_range_attrs.setdefault(name, set()).update(attrs)
+
+        macro_bindings.clear()
+        macro_names = {name for _, _, _, macro_state_bindings in branch_states for name in macro_state_bindings}
+        for name in macro_names:
+            macro_candidates: list[Any] = []
+            candidate_ids: set[int] = set()
+            for _, _, _, macro_state_bindings in branch_states:
+                for macro in macro_state_bindings.get(name, ()):
+                    if id(macro) in candidate_ids:
+                        continue
+                    candidate_ids.add(id(macro))
+                    macro_candidates.append(macro)
+            if macro_candidates:
+                macro_bindings[name] = tuple(macro_candidates)
+
+    def _static_range_iterable_exceeds_budget(
+        self,
+        node: Any,
+        threshold: int,
+        range_aliases: set[str],
+        int_bindings: dict[str, _StaticIntBinding],
+        namespace_range_attrs: dict[str, set[str]],
+    ) -> bool:
+        range_call = self._static_iterable_range_call(node, range_aliases, namespace_range_attrs)
+        if range_call is None:
+            return False
+        count = self._constant_range_iteration_count_with_bindings(range_call.args, threshold, int_bindings)
+        return count is not None and count >= threshold
+
+    def _static_range_filter_exceeds_budget(
+        self,
+        node: Any,
+        threshold: int,
+        range_aliases: set[str],
+        int_bindings: dict[str, _StaticIntBinding],
+        namespace_range_attrs: dict[str, set[str]],
+    ) -> bool:
+        range_call = self._static_iterable_range_call(node.node, range_aliases, namespace_range_attrs)
+        if range_call is None:
+            return False
+        if node.name == "list":
+            projected_size = self._constant_range_rendered_list_size_with_bindings(
+                range_call.args,
+                threshold,
+                int_bindings,
+            )
+            return projected_size is not None and projected_size > threshold
+        if node.name == "join":
+            projected_size = self._constant_range_joined_size_with_bindings(
+                range_call.args,
+                node.args,
+                threshold,
+                int_bindings,
+            )
+            return projected_size is not None and projected_size > threshold
+        count = self._constant_range_iteration_count_with_bindings(range_call.args, threshold, int_bindings)
+        return count is not None and count >= threshold
+
+    def _static_iterable_range_call(
+        self,
+        node: Any,
+        range_aliases: set[str],
+        namespace_range_attrs: dict[str, set[str]],
+    ) -> Any | None:
+        while isinstance(node, jinja2.nodes.Filter) and node.name in _LAZY_RANGE_ITERATION_FILTERS:
+            node = node.node
+        normalized_range_call = self._range_call_with_literal_unpacking(node)
+        if normalized_range_call is not None and self._is_static_range_callable(
+            normalized_range_call.node,
+            range_aliases,
+            namespace_range_attrs,
+        ):
+            return normalized_range_call
+        return None
+
+    @staticmethod
+    def _range_call_with_literal_unpacking(node: Any) -> Any | None:
+        if not isinstance(node, jinja2.nodes.Call) or node.kwargs or node.dyn_kwargs is not None:
+            return None
+        arguments = list(node.args)
+        if node.dyn_args is not None:
+            if not isinstance(node.dyn_args, jinja2.nodes.List | jinja2.nodes.Tuple):
+                return None
+            arguments.extend(node.dyn_args.items)
+        if not 1 <= len(arguments) <= 3:
+            return None
+        if node.dyn_args is None:
+            return node
+        return jinja2.nodes.Call(node.node, arguments, [], None, None)
+
+    def _clear_static_range_binding(
+        self,
+        target: Any,
+        range_aliases: set[str],
+        int_bindings: dict[str, _StaticIntBinding],
+        namespace_range_attrs: dict[str, set[str]],
+    ) -> None:
+        if isinstance(target, jinja2.nodes.Tuple):
+            for item in target.items:
+                self._clear_static_range_binding(item, range_aliases, int_bindings, namespace_range_attrs)
+            return
+        if isinstance(target, jinja2.nodes.NSRef):
+            attrs = namespace_range_attrs.get(target.name)
+            if attrs is not None:
+                attrs.discard(target.attr)
+            return
+        if not isinstance(target, jinja2.nodes.Name):
+            return
+        range_aliases.discard(target.name)
+        int_bindings.pop(target.name, None)
+        namespace_range_attrs.pop(target.name, None)
+
+    @staticmethod
+    def _clone_static_namespace_bindings(
+        namespace_range_attrs: dict[str, set[str]],
+    ) -> dict[str, set[str]]:
+        cloned_sets: dict[int, set[str]] = {}
+        cloned_bindings: dict[str, set[str]] = {}
+        for name, attrs in namespace_range_attrs.items():
+            cloned_bindings[name] = cloned_sets.setdefault(id(attrs), set(attrs))
+        return cloned_bindings
+
+    @staticmethod
+    def _propagate_static_namespace_mutations(
+        namespace_range_attrs: dict[str, set[str]],
+        scoped_namespace_attrs: dict[str, set[str]],
+        inherited_namespace_attrs: dict[str, set[str]],
+    ) -> None:
+        propagated_ids: set[int] = set()
+        for name, outer_attrs in namespace_range_attrs.items():
+            inherited_attrs = inherited_namespace_attrs.get(name)
+            if inherited_attrs is None or scoped_namespace_attrs.get(name) is not inherited_attrs:
+                continue
+            if id(outer_attrs) in propagated_ids:
+                continue
+            propagated_ids.add(id(outer_attrs))
+            outer_attrs.clear()
+            outer_attrs.update(inherited_attrs)
+
+    def _collect_static_range_assignment(
+        self,
+        target: Any,
+        value: Any,
+        range_aliases: set[str],
+        int_bindings: dict[str, _StaticIntBinding],
+        namespace_range_attrs: dict[str, set[str]],
+    ) -> bool:
+        if isinstance(target, jinja2.nodes.Tuple) and isinstance(value, jinja2.nodes.Tuple):
+            if len(target.items) != len(value.items):
+                self._clear_static_range_binding(target, range_aliases, int_bindings, namespace_range_attrs)
+                return False
+            original_aliases = set(range_aliases)
+            original_int_bindings = dict(int_bindings)
+            original_namespace_attrs = self._clone_static_namespace_bindings(namespace_range_attrs)
+            evaluated_bindings: list[
+                tuple[
+                    Any,
+                    set[str],
+                    dict[str, _StaticIntBinding],
+                    dict[str, set[str]],
+                ]
+            ] = []
+            for item_target, item_value in zip(target.items, value.items, strict=False):
+                item_aliases = set(original_aliases)
+                item_int_bindings = dict(original_int_bindings)
+                item_namespace_attrs = self._clone_static_namespace_bindings(original_namespace_attrs)
+                self._collect_static_range_assignment(
+                    item_target,
+                    item_value,
+                    item_aliases,
+                    item_int_bindings,
+                    item_namespace_attrs,
+                )
+                evaluated_bindings.append((item_target, item_aliases, item_int_bindings, item_namespace_attrs))
+            self._clear_static_range_binding(target, range_aliases, int_bindings, namespace_range_attrs)
+            for item_target, item_aliases, item_int_bindings, item_namespace_attrs in evaluated_bindings:
+                self._copy_static_target_binding(
+                    item_target,
+                    item_aliases,
+                    item_int_bindings,
+                    item_namespace_attrs,
+                    range_aliases,
+                    int_bindings,
+                    namespace_range_attrs,
+                )
+            return True
+        if isinstance(target, jinja2.nodes.NSRef):
+            attrs = namespace_range_attrs.get(target.name)
+            if attrs is None:
+                return False
+            if self._is_static_range_callable(value, range_aliases, namespace_range_attrs):
+                previous_size = len(attrs)
+                attrs.add(target.attr)
+                return len(attrs) != previous_size
+            attrs.discard(target.attr)
+            return True
+        if not isinstance(target, jinja2.nodes.Name):
+            return False
+
+        changed = False
+        if self._is_static_range_callable(value, range_aliases, namespace_range_attrs):
+            previous_size = len(range_aliases)
+            range_aliases.add(target.name)
+            changed |= len(range_aliases) != previous_size
+        else:
+            range_aliases.discard(target.name)
+
+        int_results = self._constant_int_expression_results_with_bindings(
+            value,
+            _SANDBOX_MAX_RANGE_ITERATIONS,
+            int_bindings,
+        )
+        int_binding = self._make_static_int_binding(int_results)
+        if int_binding is not None and int_bindings.get(target.name) != int_binding:
+            int_bindings[target.name] = int_binding
+            changed = True
+        elif int_binding is None:
+            int_bindings.pop(target.name, None)
+
+        if (
+            isinstance(value, jinja2.nodes.Call)
+            and isinstance(value.node, jinja2.nodes.Name)
+            and value.node.name == "namespace"
+        ):
+            attrs = {
+                keyword.key
+                for keyword in value.kwargs
+                if self._is_static_range_callable(keyword.value, range_aliases, namespace_range_attrs)
+            }
+            if namespace_range_attrs.get(target.name) != attrs:
+                namespace_range_attrs[target.name] = attrs
+                changed = True
+        elif isinstance(value, jinja2.nodes.Name) and value.name in namespace_range_attrs:
+            attrs = namespace_range_attrs[value.name]
+            if namespace_range_attrs.get(target.name) is not attrs:
+                namespace_range_attrs[target.name] = attrs
+                changed = True
+        else:
+            namespace_range_attrs.pop(target.name, None)
+
+        return changed
+
+    def _copy_static_target_binding(
+        self,
+        target: Any,
+        source_aliases: set[str],
+        source_int_bindings: dict[str, _StaticIntBinding],
+        source_namespace_attrs: dict[str, set[str]],
+        range_aliases: set[str],
+        int_bindings: dict[str, _StaticIntBinding],
+        namespace_range_attrs: dict[str, set[str]],
+    ) -> None:
+        if isinstance(target, jinja2.nodes.Tuple):
+            for item in target.items:
+                self._copy_static_target_binding(
+                    item,
+                    source_aliases,
+                    source_int_bindings,
+                    source_namespace_attrs,
+                    range_aliases,
+                    int_bindings,
+                    namespace_range_attrs,
+                )
+            return
+        if isinstance(target, jinja2.nodes.NSRef):
+            if target.attr in source_namespace_attrs.get(target.name, set()):
+                namespace_range_attrs.setdefault(target.name, set()).add(target.attr)
+            return
+        if not isinstance(target, jinja2.nodes.Name):
+            return
+        if target.name in source_aliases:
+            range_aliases.add(target.name)
+        if target.name in source_int_bindings:
+            int_bindings[target.name] = source_int_bindings[target.name]
+        if target.name in source_namespace_attrs:
+            namespace_range_attrs[target.name] = set(source_namespace_attrs[target.name])
+
+    @classmethod
+    def _is_static_range_callable(
+        cls,
+        node: Any,
+        range_aliases: set[str],
+        namespace_range_attrs: dict[str, set[str]],
+    ) -> bool:
+        if isinstance(node, jinja2.nodes.Name):
+            return node.name in range_aliases
+        if isinstance(node, jinja2.nodes.CondExpr):
+            condition = cls._constant_condition_value(node.test)
+            branches = (node.expr1, node.expr2) if condition is None else (node.expr1 if condition else node.expr2,)
+            return any(
+                branch is not None and cls._is_static_range_callable(branch, range_aliases, namespace_range_attrs)
+                for branch in branches
+            )
+        if (
+            isinstance(node, jinja2.nodes.Getitem)
+            and isinstance(node.node, jinja2.nodes.Name)
+            and isinstance(node.arg, jinja2.nodes.Const)
+            and isinstance(node.arg.value, str | int)
+        ):
+            return str(node.arg.value) in namespace_range_attrs.get(node.node.name, set())
+        return bool(
+            isinstance(node, jinja2.nodes.Getattr)
+            and isinstance(node.node, jinja2.nodes.Name)
+            and node.attr in namespace_range_attrs.get(node.node.name, set())
+        )
+
+    def _constant_int_expression_results_with_bindings(
+        self,
+        node: Any,
+        cap: int,
+        int_bindings: dict[str, _StaticIntBinding],
+    ) -> list[_StaticIntResult]:
+        variants, truncated = self._static_int_binding_variants(int_bindings, [node])
+        if truncated:
+            return [
+                self._saturated_constant_int_result(cap),
+                self._saturated_constant_int_result(cap, -1),
+                self._constant_int_result(0, cap),
+                self._constant_int_result(1, cap),
+                self._constant_int_result(-1, cap),
+            ]
+        results: list[_StaticIntResult] = []
+        for variant in variants:
+            result = self._constant_int_expression_result(node, cap, variant)
+            if result is not None and result not in results:
+                results.append(result)
+        return results
+
+    @staticmethod
+    def _make_static_int_binding(results: list[_StaticIntResult]) -> _StaticIntBinding | None:
+        unique_results = list(dict.fromkeys(results))
+        if not unique_results:
+            return None
+        if len(unique_results) == 1:
+            return unique_results[0]
+        if len(unique_results) > 8:
+            selected: list[_StaticIntResult] = []
+            for candidate in (
+                min(unique_results, key=lambda result: result[0]),
+                max(unique_results, key=lambda result: result[0]),
+                min(unique_results, key=lambda result: abs(result[0])),
+                max(unique_results, key=lambda result: abs(result[0])),
+            ):
+                if candidate not in selected:
+                    selected.append(candidate)
+            for sign in (-1, 1):
+                signed = [result for result in unique_results if (result[0] < 0) == (sign < 0) and result[0] != 0]
+                if signed:
+                    candidate = min(signed, key=lambda result: abs(result[0]))
+                    if candidate not in selected:
+                        selected.append(candidate)
+            unique_results = selected
+        return _StaticIntCandidates(tuple(unique_results))
+
+    @staticmethod
+    def _static_int_binding_variants(
+        int_bindings: dict[str, _StaticIntBinding],
+        nodes: list[Any],
+    ) -> tuple[list[dict[str, _StaticIntBinding]], bool]:
+        referenced_names: set[str] = set()
+        for node in nodes:
+            if isinstance(node, jinja2.nodes.Name):
+                referenced_names.add(node.name)
+            referenced_names.update(candidate.name for candidate in node.find_all(jinja2.nodes.Name))
+
+        variants: list[dict[str, _StaticIntBinding]] = [
+            {name: binding for name, binding in int_bindings.items() if not isinstance(binding, _StaticIntCandidates)}
+        ]
+        for name, binding in int_bindings.items():
+            if name not in referenced_names or not isinstance(binding, _StaticIntCandidates):
+                continue
+            if len(variants) * len(binding.values) > 4096:
+                return variants, True
+            variants = [{**variant, name: value} for variant in variants for value in binding.values]
+        return variants, False
+
+    def _constant_range_iteration_count_with_bindings(
+        self,
+        args: list[Any],
+        cap: int,
+        int_bindings: dict[str, _StaticIntBinding],
+    ) -> int | None:
+        range_values_candidates, truncated = self._constant_range_values_for_binding_variants(
+            args,
+            cap,
+            int_bindings,
+        )
+        if truncated:
+            return cap + 1
+        counts = [self._range_iteration_count(*range_values, cap) for range_values in range_values_candidates]
+        return max(counts) if counts else None
+
+    def _constant_range_values_for_binding_variants(
+        self,
+        args: list[Any],
+        cap: int,
+        int_bindings: dict[str, _StaticIntBinding],
+    ) -> tuple[list[tuple[int, int, int]], bool]:
+        variants, truncated = self._static_int_binding_variants(int_bindings, args[:3])
+        if truncated:
+            return [], True
+        range_values_candidates: list[tuple[int, int, int]] = []
+        for variant in variants:
+            results: list[_StaticIntResult] = []
+            for arg in args[:3]:
+                result = self._constant_int_expression_result(arg, cap, variant)
+                if result is None:
+                    break
+                results.append(result)
+            else:
+                range_values = self._constant_range_values_from_results(args, results, cap, variant)
+                if range_values is not None and range_values not in range_values_candidates:
+                    range_values_candidates.append(range_values)
+        return range_values_candidates, False
 
     def _template_ast_has_static_range_list_budget_risk(self, parsed: Any) -> bool:
         range_threshold = max(1, self.sandbox_render_max_output_chars)
@@ -1700,7 +3068,8 @@ class Jinja2TemplateScanner(BaseScanner):
     def _iterable_range_call(self, node: Any) -> Any | None:
         while isinstance(node, jinja2.nodes.Filter) and node.name in _LAZY_RANGE_ITERATION_FILTERS:
             node = node.node
-        return node if self._is_range_call(node) else None
+        normalized_range_call = self._range_call_with_literal_unpacking(node)
+        return normalized_range_call if self._is_range_call(normalized_range_call) else None
 
     def _is_range_call(self, node: Any) -> bool:
         return (
@@ -1778,6 +3147,28 @@ class Jinja2TemplateScanner(BaseScanner):
         range_values = self._constant_range_values(args, cap)
         if range_values is None:
             return None
+        return self._constant_range_rendered_list_size_from_values(range_values, cap)
+
+    def _constant_range_rendered_list_size_with_bindings(
+        self,
+        args: list[Any],
+        cap: int,
+        int_bindings: dict[str, _StaticIntBinding],
+    ) -> int | None:
+        range_values_candidates, truncated = self._constant_range_values_for_binding_variants(args, cap, int_bindings)
+        if truncated:
+            return cap + 1
+        sizes = [
+            self._constant_range_rendered_list_size_from_values(range_values, cap)
+            for range_values in range_values_candidates
+        ]
+        return max(sizes) if sizes else None
+
+    def _constant_range_rendered_list_size_from_values(
+        self,
+        range_values: tuple[int, int, int],
+        cap: int,
+    ) -> int:
         start, stop, step = range_values
         count = self._range_iteration_count(start, stop, step, cap)
         if count == 0:
@@ -1811,6 +3202,31 @@ class Jinja2TemplateScanner(BaseScanner):
         range_values = self._constant_range_values(args, cap)
         if range_values is None:
             return None
+        return self._constant_range_joined_size_from_values(range_values, join_args, cap)
+
+    def _constant_range_joined_size_with_bindings(
+        self,
+        args: list[Any],
+        join_args: list[Any],
+        cap: int,
+        int_bindings: dict[str, _StaticIntBinding],
+    ) -> int | None:
+        range_values_candidates, truncated = self._constant_range_values_for_binding_variants(args, cap, int_bindings)
+        if truncated:
+            return cap + 1
+        sizes = [
+            self._constant_range_joined_size_from_values(range_values, join_args, cap)
+            for range_values in range_values_candidates
+        ]
+        known_sizes = [size for size in sizes if size is not None]
+        return max(known_sizes) if known_sizes else None
+
+    def _constant_range_joined_size_from_values(
+        self,
+        range_values: tuple[int, int, int],
+        join_args: list[Any],
+        cap: int,
+    ) -> int | None:
 
         separator_size = 0
         if join_args:
@@ -1865,13 +3281,21 @@ class Jinja2TemplateScanner(BaseScanner):
         result = self._constant_int_expression_result(node, cap)
         return result[0] if result is not None else None
 
-    def _constant_int_expression_result(self, node: Any, cap: int) -> tuple[int, bool] | None:
+    def _constant_int_expression_result(
+        self,
+        node: Any,
+        cap: int,
+        int_bindings: dict[str, _StaticIntBinding] | None = None,
+    ) -> tuple[int, bool] | None:
+        if isinstance(node, jinja2.nodes.Name):
+            binding = int_bindings.get(node.name) if int_bindings is not None else None
+            return None if isinstance(binding, _StaticIntCandidates) else binding
         if isinstance(node, jinja2.nodes.Const):
             if isinstance(node.value, bool) or not isinstance(node.value, int):
                 return None
             return self._constant_int_result(node.value, cap)
         if isinstance(node, jinja2.nodes.Neg | jinja2.nodes.Pos):
-            result = self._constant_int_expression_result(node.node, cap)
+            result = self._constant_int_expression_result(node.node, cap, int_bindings)
             if result is None or isinstance(node, jinja2.nodes.Pos):
                 return result
             value, saturated = result
@@ -1880,31 +3304,63 @@ class Jinja2TemplateScanner(BaseScanner):
             node,
             jinja2.nodes.Add | jinja2.nodes.Sub | jinja2.nodes.Mul | jinja2.nodes.FloorDiv | jinja2.nodes.Mod,
         ):
-            left_result = self._constant_int_expression_result(node.left, cap)
-            right_result = self._constant_int_expression_result(node.right, cap)
+            left_result = self._constant_int_expression_result(node.left, cap, int_bindings)
+            right_result = self._constant_int_expression_result(node.right, cap, int_bindings)
             if left_result is None or right_result is None:
                 return None
             left, left_saturated = left_result
             right, right_saturated = right_result
+            same_result = left_result is right_result
             if isinstance(node, jinja2.nodes.FloorDiv | jinja2.nodes.Mod) and right == 0 and not right_saturated:
                 return None
             if isinstance(node, jinja2.nodes.Add):
                 if left_saturated or right_saturated:
-                    if left_saturated and not right_saturated and right == 0:
-                        return left_result
-                    if right_saturated and not left_saturated and left == 0:
-                        return right_result
-                    return self._saturated_constant_int_result(cap)
+                    if left_saturated and right_saturated:
+                        if (left < 0) != (right < 0):
+                            magnitude_comparison = self._compare_static_power_magnitudes(
+                                node.left,
+                                node.right,
+                                int_bindings,
+                            )
+                            if magnitude_comparison is None:
+                                return None
+                            if magnitude_comparison == 0:
+                                return self._constant_int_result(0, cap)
+                            dominant_value = left if magnitude_comparison > 0 else right
+                            return self._saturated_constant_int_result(cap, -1 if dominant_value < 0 else 1)
+                        return self._saturated_constant_int_result(cap, -1 if left < 0 else 1)
+                    saturated_result = left_result if left_saturated else right_result
+                    return self._saturated_constant_int_result(cap, -1 if saturated_result[0] < 0 else 1)
                 return self._constant_int_result(left + right, cap)
             if isinstance(node, jinja2.nodes.Sub):
-                if node.left == node.right:
+                if node.left == node.right or same_result:
                     return self._constant_int_result(0, cap)
                 if left_saturated or right_saturated:
-                    if left_saturated and not right_saturated and right == 0:
-                        return left_result
-                    if right_saturated and not left_saturated and left == 0:
-                        return self._saturated_constant_int_result(cap, -1 if right > 0 else 1)
-                    return self._saturated_constant_int_result(cap)
+                    wrapped_difference = self._constant_wrapped_difference_result(
+                        node.left,
+                        node.right,
+                        cap,
+                        int_bindings,
+                    )
+                    if wrapped_difference is not None:
+                        return wrapped_difference
+                    if left_saturated and right_saturated:
+                        if (left < 0) == (right < 0):
+                            magnitude_comparison = self._compare_static_power_magnitudes(
+                                node.left,
+                                node.right,
+                                int_bindings,
+                            )
+                            if magnitude_comparison is None:
+                                return None
+                            if magnitude_comparison == 0:
+                                return self._constant_int_result(0, cap)
+                            result_sign = (-1 if left < 0 else 1) * magnitude_comparison
+                            return self._saturated_constant_int_result(cap, result_sign)
+                        return self._saturated_constant_int_result(cap, -1 if left < 0 else 1)
+                    if left_saturated:
+                        return self._saturated_constant_int_result(cap, -1 if left < 0 else 1)
+                    return self._saturated_constant_int_result(cap, -1 if right > 0 else 1)
                 return self._constant_int_result(left - right, cap)
             if isinstance(node, jinja2.nodes.Mul):
                 if (not left_saturated and left == 0) or (not right_saturated and right == 0):
@@ -1913,27 +3369,34 @@ class Jinja2TemplateScanner(BaseScanner):
                     return self._saturated_constant_int_result(cap, -1 if left * right < 0 else 1)
                 return self._constant_int_result(left * right, cap)
             if isinstance(node, jinja2.nodes.FloorDiv):
-                if node.left == node.right:
+                if node.left == node.right or same_result:
                     return self._constant_int_result(1, cap)
                 if not left_saturated and left == 0:
                     return self._constant_int_result(0, cap)
                 if left_saturated or right_saturated:
                     if not left_saturated:
-                        return self._constant_int_result(0, cap)
-                    if not right_saturated and abs(right) == 1:
-                        return self._saturated_constant_int_result(cap, -1 if left * right < 0 else 1)
-                    return self._saturated_constant_int_result(cap)
+                        quotient = -1 if left * right < 0 else 0
+                        return self._constant_int_result(quotient, cap)
+                    if right_saturated:
+                        return None
+                    return self._saturated_constant_int_result(cap, -1 if left * right < 0 else 1)
                 return self._constant_int_result(left // right, cap)
-            if node.left == node.right or (not left_saturated and left == 0):
+            if node.left == node.right or same_result or (not left_saturated and left == 0):
                 return self._constant_int_result(0, cap)
             if left_saturated or right_saturated:
-                if left_saturated and not right_saturated and abs(right) == 1:
-                    return self._constant_int_result(0, cap)
-                return self._saturated_constant_int_result(cap)
+                if left_saturated:
+                    if right_saturated:
+                        return None
+                    if abs(right) == 1:
+                        return self._constant_int_result(0, cap)
+                    return None
+                if (left < 0) == (right < 0):
+                    return self._constant_int_result(left, cap)
+                return self._saturated_constant_int_result(cap, -1 if right < 0 else 1)
             return self._constant_int_result(left % right, cap)
         if isinstance(node, jinja2.nodes.Pow):
-            left_result = self._constant_int_expression_result(node.left, cap)
-            right_result = self._constant_int_expression_result(node.right, cap)
+            left_result = self._constant_int_expression_result(node.left, cap, int_bindings)
+            right_result = self._constant_int_expression_result(node.right, cap, int_bindings)
             if left_result is None or right_result is None:
                 return None
             left, left_saturated = left_result
@@ -1943,11 +3406,17 @@ class Jinja2TemplateScanner(BaseScanner):
             if not right_saturated and right == 0:
                 return self._constant_int_result(1, cap)
             if not left_saturated and left in {-1, 0, 1}:
-                return self._constant_int_result(0 if left == 0 else 1, cap)
+                if left == 0:
+                    return self._constant_int_result(0, cap)
+                if left == 1:
+                    return self._constant_int_result(1, cap)
+                if right_saturated:
+                    return None
+                return self._constant_int_result(-1 if right % 2 else 1, cap)
             if left_saturated or right_saturated:
                 return self._saturated_constant_int_result(cap)
             magnitude_cap = self._constant_int_magnitude_cap(cap)
-            if abs(left) > 1 and right > magnitude_cap.bit_length():
+            if abs(left) > 1 and (abs(left).bit_length() - 1) * right >= magnitude_cap.bit_length():
                 sign = -1 if left < 0 and right % 2 else 1
                 return self._saturated_constant_int_result(cap, sign)
             return self._constant_int_result(left**right, cap)
@@ -1956,16 +3425,117 @@ class Jinja2TemplateScanner(BaseScanner):
             if condition is None:
                 return None
             branch = node.expr1 if condition else node.expr2
-            return self._constant_int_expression_result(branch, cap) if branch is not None else None
+            return self._constant_int_expression_result(branch, cap, int_bindings) if branch is not None else None
         if isinstance(node, jinja2.nodes.Filter):
-            return self._constant_int_filter_result(node, cap)
+            return self._constant_int_filter_result(node, cap, int_bindings)
         return None
 
-    def _constant_int_filter_result(self, node: Any, cap: int) -> tuple[int, bool] | None:
+    def _compare_static_power_magnitudes(
+        self,
+        left: Any,
+        right: Any,
+        int_bindings: dict[str, _StaticIntBinding] | None,
+    ) -> int | None:
+        while isinstance(left, jinja2.nodes.Neg | jinja2.nodes.Pos):
+            left = left.node
+        while isinstance(right, jinja2.nodes.Neg | jinja2.nodes.Pos):
+            right = right.node
+        left, left_factor = self._static_power_factor(left, int_bindings)
+        right, right_factor = self._static_power_factor(right, int_bindings)
+        if not isinstance(left, jinja2.nodes.Pow) or not isinstance(right, jinja2.nodes.Pow):
+            return None
+        left_base = self._constant_int_expression_result(left.left, _STATIC_INT_EVAL_MAX_ABS, int_bindings)
+        right_base = self._constant_int_expression_result(right.left, _STATIC_INT_EVAL_MAX_ABS, int_bindings)
+        left_exponent = self._constant_int_expression_result(left.right, _STATIC_INT_EVAL_MAX_ABS, int_bindings)
+        right_exponent = self._constant_int_expression_result(right.right, _STATIC_INT_EVAL_MAX_ABS, int_bindings)
+        if (
+            left_base is None
+            or right_base is None
+            or left_exponent is None
+            or right_exponent is None
+            or left_base[1]
+            or right_base[1]
+            or left_exponent[1]
+            or right_exponent[1]
+            or left_exponent[0] < 0
+            or right_exponent[0] < 0
+            or abs(left_base[0]) <= 1
+            or abs(right_base[0]) <= 1
+        ):
+            return None
+        if left.left == right.left:
+            exponent_comparison = (left_exponent[0] > right_exponent[0]) - (left_exponent[0] < right_exponent[0])
+            if exponent_comparison != 0 and left_factor == right_factor == 1:
+                return exponent_comparison
+            if exponent_comparison == 0:
+                return (left_factor > right_factor) - (left_factor < right_factor)
+
+        left_log = left_exponent[0] * math.log(abs(left_base[0])) + math.log(left_factor)
+        right_log = right_exponent[0] * math.log(abs(right_base[0])) + math.log(right_factor)
+        difference = left_log - right_log
+        tolerance = 1e-12 * max(1.0, abs(left_log), abs(right_log))
+        if not math.isfinite(difference) or abs(difference) <= tolerance:
+            return None
+        return 1 if difference > 0 else -1
+
+    def _static_power_factor(
+        self,
+        node: Any,
+        int_bindings: dict[str, _StaticIntBinding] | None,
+    ) -> tuple[Any, int]:
+        if not isinstance(node, jinja2.nodes.Mul):
+            return node, 1
+        for factor_node, value_node in ((node.left, node.right), (node.right, node.left)):
+            factor_result = self._constant_int_expression_result(
+                factor_node,
+                _STATIC_INT_EVAL_MAX_ABS,
+                int_bindings,
+            )
+            if factor_result is not None and not factor_result[1] and factor_result[0] != 0:
+                return value_node, abs(factor_result[0])
+        return node, 1
+
+    def _constant_wrapped_difference_result(
+        self,
+        left: Any,
+        right: Any,
+        cap: int,
+        int_bindings: dict[str, _StaticIntBinding] | None,
+    ) -> tuple[int, bool] | None:
+        if not isinstance(left, jinja2.nodes.Add):
+            return None
+        right_result = self._constant_int_expression_result(right, cap, int_bindings)
+        if right_result is None or not right_result[1]:
+            return None
+        for dominant, offset in ((left.left, left.right), (left.right, left.left)):
+            dominant_result = self._constant_int_expression_result(dominant, cap, int_bindings)
+            offset_result = self._constant_int_expression_result(offset, cap, int_bindings)
+            if dominant_result is None or not dominant_result[1] or offset_result is None or offset_result[1]:
+                continue
+            if dominant == right:
+                return offset_result
+            magnitude_comparison = self._compare_static_power_magnitudes(dominant, right, int_bindings)
+            if magnitude_comparison is None:
+                continue
+            dominant_sign = -1 if dominant_result[0] < 0 else 1
+            right_sign = -1 if right_result[0] < 0 else 1
+            if dominant_sign != right_sign or magnitude_comparison > 0:
+                return self._saturated_constant_int_result(cap, dominant_sign)
+            if magnitude_comparison < 0:
+                return self._saturated_constant_int_result(cap, -right_sign)
+            return offset_result
+        return None
+
+    def _constant_int_filter_result(
+        self,
+        node: Any,
+        cap: int,
+        int_bindings: dict[str, _StaticIntBinding] | None = None,
+    ) -> tuple[int, bool] | None:
         if node.kwargs or node.dyn_args is not None or node.dyn_kwargs is not None:
             return None
         if node.name == "abs" and not node.args:
-            result = self._constant_int_expression_result(node.node, cap)
+            result = self._constant_int_expression_result(node.node, cap, int_bindings)
             if result is None:
                 return None
             value, saturated = result
@@ -1974,7 +3544,7 @@ class Jinja2TemplateScanner(BaseScanner):
             return None
 
         if node.args:
-            parsed_default_result = self._constant_int_expression_result(node.args[0], cap)
+            parsed_default_result = self._constant_int_expression_result(node.args[0], cap, int_bindings)
             if parsed_default_result is None:
                 return None
             default_result = parsed_default_result
@@ -1983,12 +3553,12 @@ class Jinja2TemplateScanner(BaseScanner):
 
         base = 10
         if len(node.args) == 2:
-            base_result = self._constant_int_expression_result(node.args[1], cap)
+            base_result = self._constant_int_expression_result(node.args[1], cap, int_bindings)
             if base_result is None or base_result[1]:
                 return None
             base = base_result[0]
 
-        source_result = self._constant_int_expression_result(node.node, cap)
+        source_result = self._constant_int_expression_result(node.node, cap, int_bindings)
         if source_result is not None:
             return source_result
         if not isinstance(node.node, jinja2.nodes.Const):
@@ -2002,7 +3572,7 @@ class Jinja2TemplateScanner(BaseScanner):
                 parsed = int(value)
             elif isinstance(value, str):
                 text = value.strip()
-                if len(text) > 1024:
+                if len(text) > 4096:
                     return self._saturated_constant_int_result(cap, -1 if text.startswith("-") else 1)
                 try:
                     parsed = int(text, base)
@@ -2019,12 +3589,60 @@ class Jinja2TemplateScanner(BaseScanner):
 
     @staticmethod
     def _constant_condition_value(node: Any) -> bool | None:
-        if not isinstance(node, jinja2.nodes.Const):
+        known, value = Jinja2TemplateScanner._constant_condition_scalar(node)
+        if not known:
             return None
-        value = node.value
         if value is None or isinstance(value, bool | int | float | str | bytes):
             return bool(value)
         return None
+
+    @staticmethod
+    def _constant_condition_scalar(node: Any, depth: int = 0) -> tuple[bool, Any]:
+        if depth > 32:
+            return False, None
+        if isinstance(node, jinja2.nodes.Const):
+            return True, node.value
+        if isinstance(node, jinja2.nodes.Neg | jinja2.nodes.Pos):
+            known, value = Jinja2TemplateScanner._constant_condition_scalar(node.node, depth + 1)
+            if not known or not isinstance(value, int | float):
+                return False, None
+            return True, -value if isinstance(node, jinja2.nodes.Neg) else +value
+        if not isinstance(
+            node,
+            jinja2.nodes.Add
+            | jinja2.nodes.Sub
+            | jinja2.nodes.Mul
+            | jinja2.nodes.FloorDiv
+            | jinja2.nodes.Mod
+            | jinja2.nodes.Pow,
+        ):
+            return False, None
+        left_known, left = Jinja2TemplateScanner._constant_condition_scalar(node.left, depth + 1)
+        right_known, right = Jinja2TemplateScanner._constant_condition_scalar(node.right, depth + 1)
+        if not left_known or not right_known or not isinstance(left, int | float) or not isinstance(right, int | float):
+            return False, None
+        try:
+            if isinstance(node, jinja2.nodes.Add):
+                result = left + right
+            elif isinstance(node, jinja2.nodes.Sub):
+                result = left - right
+            elif isinstance(node, jinja2.nodes.Mul):
+                result = left * right
+            elif isinstance(node, jinja2.nodes.FloorDiv):
+                result = left // right
+            elif isinstance(node, jinja2.nodes.Mod):
+                result = left % right
+            else:
+                if not isinstance(right, int) or right < 0 or right > 4096:
+                    return False, None
+                result = left**right
+        except (OverflowError, TypeError, ValueError, ZeroDivisionError):
+            return False, None
+        if isinstance(result, int) and result.bit_length() > 4096:
+            return False, None
+        if isinstance(result, float) and not math.isfinite(result):
+            return False, None
+        return True, result
 
     def _constant_int_result(self, value: int, cap: int, *, saturated: bool = False) -> tuple[int, bool]:
         capped_value = self._cap_constant_int(value, cap)
@@ -2048,6 +3666,18 @@ class Jinja2TemplateScanner(BaseScanner):
                 return None
             results.append(result)
 
+        return self._constant_range_values_from_results(args, results, cap)
+
+    def _constant_range_values_from_results(
+        self,
+        args: list[Any],
+        results: list[tuple[int, bool]],
+        cap: int,
+        int_bindings: dict[str, _StaticIntBinding] | None = None,
+    ) -> tuple[int, int, int] | None:
+        if not results:
+            return None
+
         if len(results) == 1:
             start_result = (0, False)
             stop_result = results[0]
@@ -2059,20 +3689,117 @@ class Jinja2TemplateScanner(BaseScanner):
 
         start, start_saturated = start_result
         stop, stop_saturated = stop_result
-        step, _step_saturated = step_result
+        step, step_saturated = step_result
 
         if step == 0:
             return 0, 0, 1
         if len(args) >= 2 and args[0] == args[1]:
             return 0, 0, 1
 
+        if len(args) >= 2 and (start_saturated or stop_saturated):
+            delta_result = self._constant_range_bound_delta(args[0], args[1], cap, int_bindings)
+            if delta_result is not None:
+                delta, delta_saturated = delta_result
+                if not delta_saturated:
+                    return 0, delta, step
+
         comparison = self._compare_constant_int_results(start_result, stop_result)
         if comparison is not None and ((step > 0 and comparison >= 0) or (step < 0 and comparison <= 0)):
             return 0, 0, 1
+        if step_saturated and self._static_zero_start_range_span_within_step(
+            args,
+            start_result,
+            stop_result,
+            step_result,
+            int_bindings,
+        ):
+            return (0, 1, 1) if step > 0 else (1, 0, -1)
         if start_saturated or stop_saturated:
             synthetic_stop = max(1, abs(cap)) + 1
             return (0, synthetic_stop, 1) if step > 0 else (synthetic_stop, 0, -1)
         return start, stop, step
+
+    def _static_zero_start_range_span_within_step(
+        self,
+        args: list[Any],
+        start_result: tuple[int, bool],
+        stop_result: tuple[int, bool],
+        step_result: tuple[int, bool],
+        int_bindings: dict[str, _StaticIntBinding] | None,
+    ) -> bool:
+        if len(args) < 3 or start_result != (0, False):
+            return False
+        stop, stop_saturated = stop_result
+        step, step_saturated = step_result
+        if not stop_saturated or not step_saturated or stop == 0 or step == 0 or (stop < 0) != (step < 0):
+            return False
+        if args[1] == args[2]:
+            return True
+        magnitude_comparison = self._compare_static_power_magnitudes(args[1], args[2], int_bindings)
+        return magnitude_comparison is not None and magnitude_comparison <= 0
+
+    def _constant_range_bound_delta(
+        self,
+        start: Any,
+        stop: Any,
+        cap: int,
+        int_bindings: dict[str, _StaticIntBinding] | None = None,
+    ) -> tuple[int, bool] | None:
+        stop_offset = self._constant_offset_from_base(stop, start, cap, int_bindings)
+        if stop_offset is not None:
+            return stop_offset
+        start_offset = self._constant_offset_from_base(start, stop, cap, int_bindings)
+        if start_offset is not None:
+            value, saturated = start_offset
+            return self._constant_int_result(-value, cap, saturated=saturated)
+        if isinstance(stop, jinja2.nodes.Add):
+            if stop.left == start:
+                return self._constant_int_expression_result(stop.right, cap, int_bindings)
+            if stop.right == start:
+                return self._constant_int_expression_result(stop.left, cap, int_bindings)
+        if isinstance(stop, jinja2.nodes.Sub) and stop.left == start:
+            result = self._constant_int_expression_result(stop.right, cap, int_bindings)
+            if result is not None:
+                value, saturated = result
+                return self._constant_int_result(-value, cap, saturated=saturated)
+        if isinstance(start, jinja2.nodes.Add):
+            if start.left == stop:
+                result = self._constant_int_expression_result(start.right, cap, int_bindings)
+            elif start.right == stop:
+                result = self._constant_int_expression_result(start.left, cap, int_bindings)
+            else:
+                result = None
+            if result is not None:
+                value, saturated = result
+                return self._constant_int_result(-value, cap, saturated=saturated)
+        if isinstance(start, jinja2.nodes.Sub) and start.left == stop:
+            return self._constant_int_expression_result(start.right, cap, int_bindings)
+        return None
+
+    def _constant_offset_from_base(
+        self,
+        expression: Any,
+        base: Any,
+        cap: int,
+        int_bindings: dict[str, _StaticIntBinding] | None,
+    ) -> tuple[int, bool] | None:
+        if expression == base:
+            return self._constant_int_result(0, cap)
+        if isinstance(expression, jinja2.nodes.Add):
+            for nested, constant in ((expression.left, expression.right), (expression.right, expression.left)):
+                nested_offset = self._constant_offset_from_base(nested, base, cap, int_bindings)
+                constant_result = self._constant_int_expression_result(constant, cap, int_bindings)
+                if nested_offset is None or constant_result is None:
+                    continue
+                value = nested_offset[0] + constant_result[0]
+                return self._constant_int_result(value, cap, saturated=nested_offset[1] or constant_result[1])
+        if isinstance(expression, jinja2.nodes.Sub):
+            nested_offset = self._constant_offset_from_base(expression.left, base, cap, int_bindings)
+            constant_result = self._constant_int_expression_result(expression.right, cap, int_bindings)
+            if nested_offset is not None and constant_result is not None:
+                value = nested_offset[0] - constant_result[0]
+                return self._constant_int_result(value, cap, saturated=nested_offset[1] or constant_result[1])
+        return None
 
     @staticmethod
     def _compare_constant_int_results(left: tuple[int, bool], right: tuple[int, bool]) -> int | None:

--- a/tests/scanners/test_jinja2_template_scanner.py
+++ b/tests/scanners/test_jinja2_template_scanner.py
@@ -1545,8 +1545,19 @@ class TestJinja2TemplateScannerEdgeCases:
             + "{% macro bind(x) %}{% set x.m=bad %}{% endmacro %}{{ bind(other) }}{{ ns.m() }}",
             "{{ [range][0](100001)|min }}",
             "{{ (range,)[0](100001)|min }}",
+            "{{ (range, range)[-1](100001)|min }}",
+            "{{ ([range] + [range])[0](100001)|min }}",
             "{{ {'r': range}['r'](100001)|min }}",
+            "{{ {'r': range}.get('r')(100001)|min }}",
+            "{% set xs=[range] %}{{ xs[0](100001)|min }}",
+            "{% set funcs={'r': range} %}{{ funcs['r'](100001)|min }}",
             "{% macro bad() %}{{ range(100001)|min }}{% endmacro %}{{ [bad][0]() }}",
+            "{% set args=[range] %}{% macro m(r) %}{{ r(100001)|min }}{% endmacro %}{{ m(*args) }}",
+            "{% set kw={'r': range} %}{% macro m(r) %}{{ r(100001)|min }}{% endmacro %}{{ m(**kw) }}",
+            "{% set args=[100001] %}{{ range(*args)|min }}",
+            "{% macro small(_count) %}0{% endmacro %}"
+            + "{% macro recurse(n, f) %}{% if n %}{{ recurse(0, range) }}"
+            + "{% else %}{{ f(100001)|min }}{% endif %}{% endmacro %}{{ recurse(1, small) }}",
             "{% if condition %}{% set n=100001 %}{% else %}{% set n=1 %}{% endif %}{{ range(n)|min }}",
             "{% if condition %}{% set n=1 %}{% else %}{% set n=200001 %}{% endif %}" + "{{ range(0, 200001, n)|min }}",
             "{% if condition %}{% set n=-1 %}{% else %}{% set n=-200001 %}{% endif %}"
@@ -1567,6 +1578,9 @@ class TestJinja2TemplateScannerEdgeCases:
             "{{ range((10 ** 1000 + 1) - 10 ** 999)|min }}",
             "{{ range(3 ** 1000 - 2 ** 1000)|min }}",
             "{{ range((-(10 ** 1000)) ** 3, 0)|min }}",
+            "{{ range((-2) ** (10 ** 101))|list }}",
+            "{{ range((2 ** 400) % 999983)|list }}",
+            "{{ range(3 ** 300 - (2 ** 400 + 1))|min }}",
         ],
     )
     def test_unavailable_sandbox_worker_fails_closed_for_wrapped_scalar_range_filters(
@@ -1777,6 +1791,72 @@ class TestJinja2TemplateScannerEdgeCases:
         assert "scan_outcome" not in result.metadata
         assert not [c for c in result.checks if c.name == "Template Sandbox Safety Probe"]
 
+    @pytest.mark.parametrize(
+        "template_content",
+        [
+            "{% macro range(_count) %}12{% endmacro %}{{ range(100001)|list }}",
+            "{% macro range(_count) %}12{% endmacro %}{{ range(100001)|join }}",
+            "{% macro range(_count) %}12{% endmacro %}{% for item in range(100001) %}{{ item }}{% endfor %}",
+        ],
+    )
+    def test_unavailable_sandbox_worker_respects_shadowed_range_in_eager_contexts(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        template_content: str,
+    ) -> None:
+        pytest.importorskip("jinja2.sandbox")
+        template_file = tmp_path / "shadowed-range-eager.jinja"
+        template_file.write_text(template_content, encoding="utf-8")
+
+        scanner = Jinja2TemplateScanner({"sandbox_render_max_output_chars": 16})
+        monkeypatch.setattr(
+            scanner,
+            "_test_template_safety_with_budget",
+            lambda _template_content: ("worker_unavailable", "AssertionError"),
+        )
+        result = scanner.scan(str(template_file))
+
+        assert result.success is True
+        assert "scan_outcome" not in result.metadata
+        assert not [c for c in result.checks if c.name == "Template Sandbox Safety Probe"]
+
+    def test_static_range_analysis_fails_closed_when_macro_expansion_budget_is_exhausted(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        pytest.importorskip("jinja2.sandbox")
+        monkeypatch.setattr(jinja2_template_scanner, "_MAX_STATIC_RENDER_ANALYSIS_STEPS", 32)
+        definitions: list[str] = []
+        assignments: list[str] = []
+        for index in range(6):
+            next_call = f"f{index + 1}()" if index + 1 < 6 else "0"
+            definitions.extend(
+                [
+                    f"{{% macro a{index}() %}}{{{{ {next_call} }}}}{{% endmacro %}}",
+                    f"{{% macro b{index}() %}}{{{{ {next_call} }}}}{{% endmacro %}}",
+                ]
+            )
+            assignments.append(
+                f"{{% if condition{index} %}}{{% set f{index}=a{index} %}}"
+                f"{{% else %}}{{% set f{index}=b{index} %}}{{% endif %}}"
+            )
+        template_content = "".join([*definitions, *assignments, "{{ f0() }}"])
+
+        scanner = Jinja2TemplateScanner({"sandbox_render_max_output_chars": 16})
+
+        assert scanner._template_has_static_render_budget_risk(template_content) is True
+
+    def test_static_range_analysis_fails_closed_when_projection_budget_is_exhausted(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        pytest.importorskip("jinja2.sandbox")
+        monkeypatch.setattr(jinja2_template_scanner, "_MAX_STATIC_RANGE_PROJECTION_ITEMS", 15_000)
+        scanner = Jinja2TemplateScanner({"sandbox_render_max_output_chars": 1_000_000})
+
+        assert scanner._template_has_static_render_budget_risk("{{ range(10000)|list }}" * 2) is True
+
     def test_unavailable_sandbox_worker_respects_overwritten_range_function_alias(
         self,
         tmp_path: Path,
@@ -1960,6 +2040,8 @@ class TestJinja2TemplateScannerEdgeCases:
             "{{ range(10 ** 1000 - 10 ** 1000)|list }}",
             "{{ range((10 ** 1000) // (10 ** 1000))|list }}",
             "{{ range((10 ** 1000) % (10 ** 1000))|list }}",
+            "{{ range((10 ** 101) // 10 - 10 ** 100)|list }}",
+            "{{ range(0, (10 ** 100) % (-(10 ** 100 + 1)), -1)|list }}",
             "{{ range(-(10 ** 1000))|list }}",
             "{{ range(10 ** 1000, 0)|list }}",
         ],
@@ -1973,6 +2055,50 @@ class TestJinja2TemplateScannerEdgeCases:
         pytest.importorskip("jinja2.sandbox")
         template_file = tmp_path / "invalid-range.jinja"
         template_file.write_text(template_content, encoding="utf-8")
+
+        scanner = Jinja2TemplateScanner({"sandbox_render_max_output_chars": 16})
+        monkeypatch.setattr(
+            scanner,
+            "_test_template_safety_with_budget",
+            lambda _template_content: ("worker_unavailable", "AssertionError"),
+        )
+        result = scanner.scan(str(template_file))
+
+        assert result.success is True
+        assert "scan_outcome" not in result.metadata
+        assert not [c for c in result.checks if c.name == "Template Sandbox Safety Probe"]
+
+    def test_unavailable_sandbox_worker_keeps_exact_saturated_power_quotient_clean(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        pytest.importorskip("jinja2.sandbox")
+        template_file = tmp_path / "exact-power-quotient.jinja"
+        template_file.write_text("{{ range((10 ** 101) // (10 ** 100))|list }}", encoding="utf-8")
+
+        scanner = Jinja2TemplateScanner({"sandbox_render_max_output_chars": 1000})
+        monkeypatch.setattr(
+            scanner,
+            "_test_template_safety_with_budget",
+            lambda _template_content: ("worker_unavailable", "AssertionError"),
+        )
+        result = scanner.scan(str(template_file))
+
+        assert result.success is True
+        assert "scan_outcome" not in result.metadata
+        assert not [c for c in result.checks if c.name == "Template Sandbox Safety Probe"]
+
+    @pytest.mark.parametrize("numeric_text", ["x" * 4097, "0" * 4097])
+    def test_unavailable_sandbox_worker_keeps_long_non_amplifying_int_filters_clean(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        numeric_text: str,
+    ) -> None:
+        pytest.importorskip("jinja2.sandbox")
+        template_file = tmp_path / "long-int-filter.jinja"
+        template_file.write_text(f'{{{{ range("{numeric_text}"|int)|list }}}}', encoding="utf-8")
 
         scanner = Jinja2TemplateScanner({"sandbox_render_max_output_chars": 16})
         monkeypatch.setattr(

--- a/tests/scanners/test_jinja2_template_scanner.py
+++ b/tests/scanners/test_jinja2_template_scanner.py
@@ -1480,6 +1480,7 @@ class TestJinja2TemplateScannerEdgeCases:
             "{% set r = range %}{% set s = r %}{{ s(100001)|min }}",
             "{% set r = range %}{{ r(100001)|min }}{% set r = small %}",
             "{% set r, n = range, 100001 %}{{ r(n)|max }}",
+            "{% set (r,) = [range] %}{{ r(100001)|min }}",
             "{% macro small(_count) %}12{% endmacro %}{% set range, r = small, range %}{{ r(100001)|min }}",
             "{% set n = 100000 %}{{ range(n + 1)|min }}",
             "{% set n = 100001 %}{{ range(n)|min }}{% set n = 1 %}",
@@ -1493,6 +1494,7 @@ class TestJinja2TemplateScannerEdgeCases:
             "{% macro m(r, n) %}{{ r(n)|min }}{% endmacro %}{{ m(range, 100001) }}",
             "{% macro m(r) %}{{ r(100001)|min }}{% endmacro %}{% set alias = m %}{{ alias(range) }}",
             "{% macro m(r) %}{{ r(100001)|min }}{% endmacro %}{% set alias, _ = m, 0 %}{{ alias(range) }}",
+            "{% macro m(r) %}{{ r(100001)|min }}{% endmacro %}{% set (alias,) = [m] %}{{ alias(range) }}",
             "{% macro m(r) %}{{ r(100001)|min }}{% endmacro %}" + "{% set ns = namespace(m=m) %}{{ ns.m(range) }}",
             "{% macro m(r) %}{{ r(100001)|min }}{% endmacro %}"
             + "{% set ns = namespace() %}{% set ns.m = m %}{{ ns.m(range) }}",
@@ -1537,6 +1539,14 @@ class TestJinja2TemplateScannerEdgeCases:
             "{% set ns=namespace() %}{% set other=ns %}{% set other.r=range %}{{ ns.r(100001)|min }}",
             "{% set ns=namespace() %}{% macro bind(x) %}{% set x.r=range %}{% endmacro %}"
             + "{{ bind(ns) }}{{ ns.r(100001)|min }}",
+            "{% macro bad() %}{{ range(100001)|min }}{% endmacro %}{% set ns=namespace() %}"
+            + "{% macro bind(x) %}{% set x.m=bad %}{% endmacro %}{{ bind(ns) }}{{ ns.m() }}",
+            "{% macro bad() %}{{ range(100001)|min }}{% endmacro %}{% set ns=namespace() %}{% set other=ns %}"
+            + "{% macro bind(x) %}{% set x.m=bad %}{% endmacro %}{{ bind(other) }}{{ ns.m() }}",
+            "{{ [range][0](100001)|min }}",
+            "{{ (range,)[0](100001)|min }}",
+            "{{ {'r': range}['r'](100001)|min }}",
+            "{% macro bad() %}{{ range(100001)|min }}{% endmacro %}{{ [bad][0]() }}",
             "{% if condition %}{% set n=100001 %}{% else %}{% set n=1 %}{% endif %}{{ range(n)|min }}",
             "{% if condition %}{% set n=1 %}{% else %}{% set n=200001 %}{% endif %}" + "{{ range(0, 200001, n)|min }}",
             "{% if condition %}{% set n=-1 %}{% else %}{% set n=-200001 %}{% endif %}"
@@ -1556,6 +1566,7 @@ class TestJinja2TemplateScannerEdgeCases:
             "{% set ns=namespace() %}{% with %}{% set ns.r=range %}{% endwith %}" + "{{ ns.r(100001)|min }}",
             "{{ range((10 ** 1000 + 1) - 10 ** 999)|min }}",
             "{{ range(3 ** 1000 - 2 ** 1000)|min }}",
+            "{{ range((-(10 ** 1000)) ** 3, 0)|min }}",
         ],
     )
     def test_unavailable_sandbox_worker_fails_closed_for_wrapped_scalar_range_filters(
@@ -1635,6 +1646,12 @@ class TestJinja2TemplateScannerEdgeCases:
             "{% macro m() %}{{ range(100001)|min }}{% endmacro %}{{ m(foo=1) }}",
             "{% macro m() %}{{ range(100001)|min }}{% endmacro %}" + "{% set ns = namespace(m=m) %}{{ ns.m(foo=1) }}",
             "{% set ns = 1 %}{% set ns.r = range %}{{ ns.r(100001)|min }}",
+            "{% macro bad() %}{{ range(100001)|min }}{% endmacro %}"
+            + "{% set ns = 1 %}{% set ns.m = bad %}{{ ns.m() }}",
+            "{% macro bad() %}{{ range(100001)|min }}{% endmacro %}{% set ns=namespace() %}"
+            + "{% macro bind(x) %}{% set x=namespace(m=bad) %}{% endmacro %}{{ bind(ns) }}{{ ns.m() }}",
+            "{{ [range][0](100000)|min }}",
+            "{{ range((-(10 ** 1000)) ** 2, 0)|min }}",
             "{% set r = range %}{{ r(4)|list }}",
             "{% set r = range %}{{ r(10)|join }}",
             "{% for n in [100001] if false %}{{ range(n)|min }}{% else %}ok{% endfor %}",

--- a/tests/scanners/test_jinja2_template_scanner.py
+++ b/tests/scanners/test_jinja2_template_scanner.py
@@ -1057,6 +1057,30 @@ class TestJinja2TemplateScannerEdgeCases:
         assert budget_checks[0].details["budget_type"] == "budget_exceeded"
         assert budget_checks[0].details["detail"] == "output"
 
+    def test_json_chat_template_output_budget_is_inconclusive_without_security_finding(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        pytest.importorskip("jinja2.sandbox")
+        tokenizer_file = tmp_path / "tokenizer_config.json"
+        tokenizer_file.write_text(json.dumps({"chat_template": "{{ 'A' * 1000000 }}"}), encoding="utf-8")
+
+        result = Jinja2TemplateScanner(
+            {
+                "sandbox_render_max_output_chars": 16,
+                "sandbox_render_timeout_seconds": 2,
+            }
+        ).scan(str(tokenizer_file))
+
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == "inconclusive"
+        assert "jinja2_sandbox_render_budget_exceeded" in result.metadata["scan_outcome_reasons"]
+        budget_checks = [c for c in result.checks if c.name == "Template Sandbox Safety Probe"]
+        assert len(budget_checks) == 1
+        assert budget_checks[0].details["budget_type"] == "budget_exceeded"
+        assert budget_checks[0].details["detail"] == "output"
+        assert not [c for c in result.checks if c.name == "Jinja2 Template Injection Detection"]
+
     def test_sandbox_probe_preflights_static_range_list_before_starting_worker(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1380,6 +1404,184 @@ class TestJinja2TemplateScannerEdgeCases:
         assert len(budget_checks) == 1
         assert budget_checks[0].details["budget_type"] == "worker_unavailable"
 
+    @pytest.mark.parametrize(
+        "template_content",
+        [
+            "{% set r = range %}{{ r(1000)|list }}",
+            "{% set ns = namespace(r=range) %}{{ ns.r(1000)|join }}",
+            "{% set r = range %}{% for item in r(1000) %}{{ item }}{% endfor %}",
+        ],
+    )
+    def test_unavailable_sandbox_worker_uses_configured_budget_for_range_aliases(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        template_content: str,
+    ) -> None:
+        pytest.importorskip("jinja2.sandbox")
+        template_file = tmp_path / "configured-range-alias.jinja"
+        template_file.write_text(template_content, encoding="utf-8")
+
+        scanner = Jinja2TemplateScanner({"sandbox_render_max_output_chars": 16})
+        monkeypatch.setattr(
+            scanner,
+            "_test_template_safety_with_budget",
+            lambda _template_content: ("worker_unavailable", "AssertionError"),
+        )
+        result = scanner.scan(str(template_file))
+
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == "inconclusive"
+        budget_checks = [c for c in result.checks if c.name == "Template Sandbox Safety Probe"]
+        assert len(budget_checks) == 1
+        assert budget_checks[0].details["budget_type"] == "worker_unavailable"
+
+    @pytest.mark.parametrize(
+        "template_content",
+        [
+            "{{ range(100001)|min }}",
+            "{{ range(100001)|max }}",
+            "{{ range(100001)|sum }}",
+            "{{ range(100001)|select('odd')|sum }}",
+        ],
+    )
+    def test_unavailable_sandbox_worker_fails_closed_for_cpu_heavy_scalar_range_filters(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        template_content: str,
+    ) -> None:
+        pytest.importorskip("jinja2.sandbox")
+        template_file = tmp_path / "range-scalar-filter.jinja"
+        template_file.write_text(template_content, encoding="utf-8")
+
+        scanner = Jinja2TemplateScanner({"sandbox_render_max_output_chars": 16})
+        monkeypatch.setattr(
+            scanner,
+            "_test_template_safety_with_budget",
+            lambda _template_content: ("worker_unavailable", "AssertionError"),
+        )
+        result = scanner.scan(str(template_file))
+
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == "inconclusive"
+        assert "jinja2_sandbox_render_budget_exceeded" in result.metadata["scan_outcome_reasons"]
+        budget_checks = [c for c in result.checks if c.name == "Template Sandbox Safety Probe"]
+        assert len(budget_checks) == 1
+        assert budget_checks[0].details["budget_type"] == "worker_unavailable"
+
+    @pytest.mark.parametrize(
+        "template_content",
+        [
+            "{{ range(100001)|default([])|min }}",
+            "{{ range(100001)|d([])|max }}",
+            "{% set values = range(100001) %}{{ values|sum }}",
+            "{% set r = range %}{{ r(100001)|sum }}",
+            "{% set r = range %}{% set s = r %}{{ s(100001)|min }}",
+            "{% set r = range %}{{ r(100001)|min }}{% set r = small %}",
+            "{% set r, n = range, 100001 %}{{ r(n)|max }}",
+            "{% macro small(_count) %}12{% endmacro %}{% set range, r = small, range %}{{ r(100001)|min }}",
+            "{% set n = 100000 %}{{ range(n + 1)|min }}",
+            "{% set n = 100001 %}{{ range(n)|min }}{% set n = 1 %}",
+            "{% if true %}{% set r = range %}{{ r(100001)|sum }}{% endif %}",
+            "{% if 1 + 1 %}{% set r = range %}{% endif %}{{ r(100001)|min }}",
+            "{% if false %}{% set r = small %}{% elif true %}{% set r = range %}"
+            + "{% else %}{% set r = small %}{% endif %}{{ r(100001)|min }}",
+            "{% macro m(r) %}{{ r(100001)|min }}{% endmacro %}{{ m(range) }}",
+            "{% set r = range %}{% macro m(fn) %}{{ fn(100001)|min }}{% endmacro %}{{ m(r) }}",
+            "{% macro m(r=range) %}{{ r(100001)|min }}{% endmacro %}{{ m() }}",
+            "{% macro m(r, n) %}{{ r(n)|min }}{% endmacro %}{{ m(range, 100001) }}",
+            "{% macro m(r) %}{{ r(100001)|min }}{% endmacro %}{% set alias = m %}{{ alias(range) }}",
+            "{% macro m(r) %}{{ r(100001)|min }}{% endmacro %}{% set alias, _ = m, 0 %}{{ alias(range) }}",
+            "{% macro m(r) %}{{ r(100001)|min }}{% endmacro %}" + "{% set ns = namespace(m=m) %}{{ ns.m(range) }}",
+            "{% macro m(r) %}{{ r(100001)|min }}{% endmacro %}"
+            + "{% set ns = namespace() %}{% set ns.m = m %}{{ ns.m(range) }}",
+            "{% macro m(r) %}{{ r(100001)|min }}{% endmacro %}"
+            + "{% set ns = namespace(m=m) %}{% set other = ns %}{{ other.m(range) }}",
+            "{% macro m() %}{{ kwargs.r(100001)|min }}{% endmacro %}{{ m(r=range) }}",
+            "{% for r in [range] %}{{ r(100001)|min }}{% endfor %}",
+            "{% set ns = namespace() %}{% for _ in [0] %}{% set ns.r = range %}{% endfor %}{{ ns.r(100001)|min }}",
+            "{% set ns = namespace(r=range) %}{{ ns.r(100001)|min }}",
+            "{% set ns = namespace() %}{% set ns.r = range %}{{ ns.r(100001)|min }}",
+            "{% set ns = namespace(r=range) %}{% set other = ns %}{{ other.r(100001)|min }}",
+            "{% set ns = namespace(xs=range(100001)) %}{{ ns.xs|max }}",
+            "{{ range(100001)|min }}{% set range = 1 %}",
+            "{{ range(100001)|min }}{% macro range(n) %}1{% endmacro %}",
+            "{{ range(10 ** 101, 10 ** 101 + 100001)|min }}",
+            "{% set n = 10 ** 101 %}{% set m = 100001 %}{{ range(n, n + m)|min }}",
+            "{{ range(((-1) ** 100001) * -100001)|min }}",
+            "{% set exponent = 100001 %}{{ range(((-1) ** exponent) * -100001)|sum }}",
+            "{{ range((1 // -(10 ** 1000)) * -100001)|min }}",
+            "{% set denominator = -(10 ** 1000) %}{{ range((1 // denominator) * -100001)|sum }}",
+            "{% set denominator = -(10 ** 1000) %}{{ range((1 % denominator) * -1)|sum }}",
+            "{% set huge = 10 ** 1000 %}{{ range((-huge + -huge) * -1)|sum }}",
+            "{% set huge = 10 ** 1000 %}{{ range((-huge - huge) * -1)|sum }}",
+            "{{ range(10 ** 1000 + -(10 ** 999))|min }}",
+            "{% macro m(xs=range(100001)) %}{{ xs|min }}{% endmacro %}{{ m() }}",
+            "{% set r = range %}{{ r(10)|list }}",
+            "{% set r = range %}{{ r(15)|join }}",
+            "{{ [range(100001)]|map('min')|first }}",
+            "{{ range(100001)|batch(100001)|first|min }}",
+            "{{ range(*[100001])|min }}",
+            "{% for n in [1, 100001] %}{{ range(n)|min }}{% endfor %}",
+            "{% if condition %}{% macro m() %}{{ range(100001)|min }}{% endmacro %}{% endif %}{{ m() }}",
+            "{% macro bad() %}{{ range(100001)|min }}{% endmacro %}"
+            + "{% macro good() %}ok{% endmacro %}"
+            + "{% if condition %}{% set f=bad %}{% else %}{% set f=good %}{% endif %}{{ f() }}",
+            "{% macro m(r) %}{{ r(100001)|min }}{% endmacro %}{{ m(*[range]) }}",
+            "{% macro m() %}{{ kwargs['r'](100001)|min }}{% endmacro %}{{ m(**{'r': range}) }}",
+            "{% macro m() %}{{ varargs[0](100001)|min }}{% endmacro %}{{ m(range) }}",
+            "{% set r = range if condition else range %}{{ r(100001)|min }}",
+            "{% macro m(r) %}{{ r(100001)|min }}{% endmacro %}{{ (m if condition else m)(range) }}",
+            "{% macro w() %}{{ caller(range) }}{% endmacro %}" + "{% call(r) w() %}{{ r(100001)|min }}{% endcall %}",
+            "{% set ns=namespace() %}{% set other=ns %}{% set other.r=range %}{{ ns.r(100001)|min }}",
+            "{% set ns=namespace() %}{% macro bind(x) %}{% set x.r=range %}{% endmacro %}"
+            + "{{ bind(ns) }}{{ ns.r(100001)|min }}",
+            "{% if condition %}{% set n=100001 %}{% else %}{% set n=1 %}{% endif %}{{ range(n)|min }}",
+            "{% if condition %}{% set n=1 %}{% else %}{% set n=200001 %}{% endif %}" + "{{ range(0, 200001, n)|min }}",
+            "{% if condition %}{% set n=-1 %}{% else %}{% set n=-200001 %}{% endif %}"
+            + "{{ range(200001, 0, n)|min }}",
+            "{% if condition %}{% set n=-200001 %}{% else %}{% set n=100001 %}{% endif %}{{ range(n)|min }}",
+            "{% if condition %}{% set n=0 %}{% else %}{% set n=200000 %}{% endif %}"
+            + "{% set step=n + 1 %}{{ range(0, 200001, step)|min }}",
+            "{% macro small(_count) %}12{% endmacro %}{% set r=range %}"
+            + "{% block b %}{% set r=small %}{% endblock %}{{ r(100001)|min }}",
+            "{% macro small(_count) %}12{% endmacro %}{% set r=range %}"
+            + "{% filter string %}{% set r=small %}{% endfilter %}{{ r(100001)|min }}",
+            "{% macro small(_count) %}12{% endmacro %}{% set r=range %}"
+            + "{% set x %}{% set r=small %}{% endset %}{{ r(100001)|min }}",
+            "{% set ns=namespace() %}{% block b %}{% set ns.r=range %}{% endblock %}" + "{{ ns.r(100001)|min }}",
+            "{% set ns=namespace() %}{% filter upper %}{% set ns.r=range %}{% endfilter %}" + "{{ ns.r(100001)|min }}",
+            "{% set ns=namespace() %}{% set x %}{% set ns.r=range %}{% endset %}" + "{{ ns.r(100001)|min }}",
+            "{% set ns=namespace() %}{% with %}{% set ns.r=range %}{% endwith %}" + "{{ ns.r(100001)|min }}",
+            "{{ range((10 ** 1000 + 1) - 10 ** 999)|min }}",
+            "{{ range(3 ** 1000 - 2 ** 1000)|min }}",
+        ],
+    )
+    def test_unavailable_sandbox_worker_fails_closed_for_wrapped_scalar_range_filters(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        template_content: str,
+    ) -> None:
+        pytest.importorskip("jinja2.sandbox")
+        template_file = tmp_path / "wrapped-range-scalar-filter.jinja"
+        template_file.write_text(template_content, encoding="utf-8")
+
+        scanner = Jinja2TemplateScanner({"sandbox_render_max_output_chars": 16})
+        monkeypatch.setattr(
+            scanner,
+            "_test_template_safety_with_budget",
+            lambda _template_content: ("worker_unavailable", "AssertionError"),
+        )
+        result = scanner.scan(str(template_file))
+
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == "inconclusive"
+        budget_checks = [c for c in result.checks if c.name == "Template Sandbox Safety Probe"]
+        assert len(budget_checks) == 1
+        assert budget_checks[0].details["budget_type"] == "worker_unavailable"
+
     def test_unavailable_sandbox_worker_keeps_direct_range_repr_clean(
         self,
         tmp_path: Path,
@@ -1387,7 +1589,7 @@ class TestJinja2TemplateScannerEdgeCases:
     ) -> None:
         pytest.importorskip("jinja2.sandbox")
         template_file = tmp_path / "direct-range-expression.jinja"
-        template_file.write_text("{{ range(1000) }}", encoding="utf-8")
+        template_file.write_text("{{ range(100000) }}", encoding="utf-8")
 
         scanner = Jinja2TemplateScanner({"sandbox_render_max_output_chars": 16})
         monkeypatch.setattr(
@@ -1404,9 +1606,111 @@ class TestJinja2TemplateScannerEdgeCases:
     @pytest.mark.parametrize(
         "template_content",
         [
-            "{{ range(1000)|min }}",
-            "{{ range(1000)|max }}",
-            "{{ range(1000)|sum }}",
+            "{% set range = 1 %}{{ range(100001)|min }}",
+            "{% set n = 1 %}{{ range(n)|min }}{% set n = 100001 %}",
+            "{% macro small(_count) %}12{% endmacro %}",
+            "{% set ns = namespace(r=range) %}{% set ns.r = small %}{{ ns.r(100001)|min }}",
+            "{% set range %}not callable{% endset %}{{ range(100001)|min }}",
+            "{% macro small(_count) %}12{% endmacro %}{% with range = small %}{{ range(100001)|min }}{% endwith %}",
+            "{% macro small(_count) %}12{% endmacro %}{% for range in [small] %}{{ range(100001)|min }}{% endfor %}",
+            "{{ range(10 ** 101, 10 ** 101 + 100000)|min }}",
+            "{% set n = 10 ** 101 %}{% set m = 100000 %}{{ range(n, n + m)|min }}",
+            "{% macro small(_count) %}12{% endmacro %}{% macro m(r) %}{{ r(100001)|min }}{% endmacro %}{{ m(small) }}",
+            "{% macro small(_count) %}12{% endmacro %}{% macro m(r=small) %}{{ r(100001)|min }}{% endmacro %}{{ m() }}",
+            "{% set r = range %}{% if condition %}{% set r = small %}"
+            + "{% else %}{% set r = small %}{% endif %}{{ r(100001)|min }}",
+            "{{ range((10 ** 1000) // (10 ** 999))|sum }}",
+            "{{ range((10 ** 1000) % (10 ** 999))|sum }}",
+            "{{ range(10 ** 1000 + -(10 ** 1000))|sum }}",
+            "{% set a = 10 ** 1000 %}{% set b = a %}{{ range(a - b)|min }}",
+            "{% set a = 10 ** 1000 %}{% set b = a %}{{ range(a // b)|min }}",
+            "{% set a = 10 ** 1000 %}{% set b = a %}{{ range(a % b)|min }}",
+            "{{ range(0, 10 ** 1000, 10 ** 1000)|min }}",
+            "{% macro m() %}{{ range(100001)|min }}{% endmacro %}",
+            "{% for _ in range(0) %}{{ range(100001)|min }}{% endfor %}",
+            "{{ range(100001)|min if false else 0 }}",
+            "{% set r, x = (range,) %}{{ r(100001)|min }}",
+            "{% macro small(_count) %}12{% endmacro %}{% macro m(r) %}{{ r(100001)|min }}{% endmacro %}"
+            + "{{ m(small, r=range) }}",
+            "{% macro m() %}{{ range(100001)|min }}{% endmacro %}{{ m(foo=1) }}",
+            "{% macro m() %}{{ range(100001)|min }}{% endmacro %}" + "{% set ns = namespace(m=m) %}{{ ns.m(foo=1) }}",
+            "{% set ns = 1 %}{% set ns.r = range %}{{ ns.r(100001)|min }}",
+            "{% set r = range %}{{ r(4)|list }}",
+            "{% set r = range %}{{ r(10)|join }}",
+            "{% for n in [100001] if false %}{{ range(n)|min }}{% else %}ok{% endfor %}",
+            "{% macro noop(caller=None) %}ok{% endmacro %}" + "{% call noop() %}{{ range(100001)|min }}{% endcall %}",
+            "{% macro small(_count) %}12{% endmacro %}{% set ns=namespace(r=range) %}"
+            + "{% set other=ns %}{% set other.r=small %}{{ ns.r(100001)|min }}",
+            "{% macro small(_count) %}12{% endmacro %}{% set r=small %}"
+            + "{% block b %}{% set r=range %}{% endblock %}{{ r(100001)|min }}",
+            "{% macro small(_count) %}12{% endmacro %}{% set r=small %}"
+            + "{% filter string %}{% set r=range %}{% endfilter %}{{ r(100001)|min }}",
+            "{% macro small(_count) %}12{% endmacro %}{% set ns=namespace(r=range) %}"
+            + "{% block b %}{% set ns.r=small %}{% endblock %}{{ ns.r(100001)|min }}",
+            "{% macro small(_count) %}12{% endmacro %}{% set ns=namespace(r=range) %}"
+            + "{% filter upper %}{% set ns.r=small %}{% endfilter %}{{ ns.r(100001)|min }}",
+            "{% macro small(_count) %}12{% endmacro %}{% set ns=namespace(r=range) %}"
+            + "{% set x %}{% set ns.r=small %}{% endset %}{{ ns.r(100001)|min }}",
+            "{% macro small(_count) %}12{% endmacro %}{% set ns=namespace(r=range) %}"
+            + "{% with %}{% set ns.r=small %}{% endwith %}{{ ns.r(100001)|min }}",
+            "{% if 1 - 1 %}{{ range(100001)|min }}{% endif %}",
+            "{{ range(0, 10 ** 1000, 2 * 10 ** 1000)|min }}",
+            "{% if condition %}{% set n=100001 %}{% else %}{% set n=200001 %}{% endif %}"
+            + "{{ range(0, 200001, n)|min }}",
+        ],
+    )
+    def test_unavailable_sandbox_worker_keeps_ordered_range_boundaries_clean(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        template_content: str,
+    ) -> None:
+        pytest.importorskip("jinja2.sandbox")
+        template_file = tmp_path / "ordered-range-boundary.jinja"
+        template_file.write_text(template_content, encoding="utf-8")
+
+        scanner = Jinja2TemplateScanner({"sandbox_render_max_output_chars": 16})
+        monkeypatch.setattr(
+            scanner,
+            "_test_template_safety_with_budget",
+            lambda _template_content: ("worker_unavailable", "AssertionError"),
+        )
+        result = scanner.scan(str(template_file))
+
+        assert result.success is True
+        assert "scan_outcome" not in result.metadata
+        assert not [c for c in result.checks if c.name == "Template Sandbox Safety Probe"]
+
+    def test_unavailable_sandbox_worker_keeps_small_symbolic_range_delta_clean(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        pytest.importorskip("jinja2.sandbox")
+        template_file = tmp_path / "small-symbolic-range-delta.jinja"
+        template_file.write_text(
+            "{{ range(10 ** 1000, (10 ** 1000 + 2) - 1) }}",
+            encoding="utf-8",
+        )
+
+        scanner = Jinja2TemplateScanner({"sandbox_render_max_output_chars": 65536})
+        monkeypatch.setattr(
+            scanner,
+            "_test_template_safety_with_budget",
+            lambda _template_content: ("worker_unavailable", "AssertionError"),
+        )
+        result = scanner.scan(str(template_file))
+
+        assert result.success is True
+        assert "scan_outcome" not in result.metadata
+        assert not [c for c in result.checks if c.name == "Template Sandbox Safety Probe"]
+
+    @pytest.mark.parametrize(
+        "template_content",
+        [
+            "{{ range(100000)|min }}",
+            "{{ range(100000)|max }}",
+            "{{ range(100000)|sum }}",
             "{{ range(1000)|slice(10) }}",
         ],
     )
@@ -1420,7 +1724,56 @@ class TestJinja2TemplateScannerEdgeCases:
         template_file = tmp_path / "bounded-range-filter.jinja"
         template_file.write_text(template_content, encoding="utf-8")
 
-        scanner = Jinja2TemplateScanner({"sandbox_render_max_output_chars": 64})
+        scanner = Jinja2TemplateScanner({"sandbox_render_max_output_chars": 16})
+        monkeypatch.setattr(
+            scanner,
+            "_test_template_safety_with_budget",
+            lambda _template_content: ("worker_unavailable", "AssertionError"),
+        )
+        result = scanner.scan(str(template_file))
+
+        assert result.success is True
+        assert "scan_outcome" not in result.metadata
+        assert not [c for c in result.checks if c.name == "Template Sandbox Safety Probe"]
+
+    def test_unavailable_sandbox_worker_respects_shadowed_range_macro(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        pytest.importorskip("jinja2.sandbox")
+        template_file = tmp_path / "shadowed-range-macro.jinja"
+        template_file.write_text(
+            "{% macro range(_count) %}12{% endmacro %}{{ range(100001)|min }}",
+            encoding="utf-8",
+        )
+
+        scanner = Jinja2TemplateScanner({"sandbox_render_max_output_chars": 16})
+        monkeypatch.setattr(
+            scanner,
+            "_test_template_safety_with_budget",
+            lambda _template_content: ("worker_unavailable", "AssertionError"),
+        )
+        result = scanner.scan(str(template_file))
+
+        assert result.success is True
+        assert "scan_outcome" not in result.metadata
+        assert not [c for c in result.checks if c.name == "Template Sandbox Safety Probe"]
+
+    def test_unavailable_sandbox_worker_respects_overwritten_range_function_alias(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        pytest.importorskip("jinja2.sandbox")
+        template_file = tmp_path / "overwritten-range-function.jinja"
+        template_file.write_text(
+            "{% macro small(_count) %}12{% endmacro %}"
+            "{% set reducer = range %}{% set reducer = small %}{{ reducer(100001)|min }}",
+            encoding="utf-8",
+        )
+
+        scanner = Jinja2TemplateScanner({"sandbox_render_max_output_chars": 16})
         monkeypatch.setattr(
             scanner,
             "_test_template_safety_with_budget",


### PR DESCRIPTION
## Summary

- fail closed when statically reachable sandbox `range` work exceeds Jinja's `MAX_RANGE` and the render worker is unavailable
- preserve execution order and binding state across branches, loops, macros, caller blocks, namespaces, assignment blocks, aliases, `varargs`, `kwargs`, and bounded literal unpacking
- resolve range, integer, scalar, and macro values through nested literal containers while respecting dict method-vs-item lookup semantics
- carry possibly-undefined branch bindings into `default` / `d` and `.get()` fallback analysis
- bound static traversal, range projection, container paths, destructuring, macro candidates, formal argument cleanup, and unpacked argument projection

## Critical review fixes

- closed false negatives in branch-only bindings, macro fallbacks, nested containers, typed keys, scalar conversions, and special macro arguments
- closed false positives in filtered loops, definitely-defined defaults, namespace/assignment-block values, and dict method collisions
- added fail-closed limits for exponential container aliases and wide or repeated macro argument binding

## Validation

- exact published head: `73bf639e0da7fb6d0933df0ad01da62e1c9fb918`
- exact published tree: `54637b4b959f61346dea50acbaf48a1fcac611a2`
- merged current `main`: `838f25046fb94fe018b18a5a2a84e4aef3ed969e`
- associated Jinja scanner suite: `410 passed, 1 skipped` (expected optional `gguf` dependency unavailable)
- adversarial differential matrix: `25/25` expected outcomes
- scoped Ruff check and format check: clean
- scoped mypy: clean
- `git diff --check`: clean

All reviewed inline threads were resolved before publication.