### PR TITLE
fix: redact Keras and TensorFlow scanner evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- redact Keras and TensorFlow scanner detail fields that echo model-controlled configs, code indicators, archive members, and external references.
 - bound Joblib decompression output to the configured scanner read budget
 - close JIT replay alias, probe-budget, and compound-clause context gaps without suppressing dangerous browser or native-library calls
 - reject cleartext HTTP cloud storage and PyTorch Hub model sources

--- a/modelaudit/scanners/_evidence_redaction.py
+++ b/modelaudit/scanners/_evidence_redaction.py
@@ -11,7 +11,7 @@ import textwrap
 import tokenize
 import unicodedata
 from bisect import bisect_right
-from collections.abc import Iterator, Sequence
+from collections.abc import Collection, Iterator, Sequence
 from typing import Any, Final
 from urllib.parse import parse_qsl, unquote, unquote_plus, urlencode, urlsplit, urlunsplit
 
@@ -3428,6 +3428,30 @@ def is_sensitive_evidence_key(key: str) -> bool:
     )
 
 
+def _unique_redacted_mapping_key(existing_keys: Collection[object], redacted_key: str) -> str:
+    if redacted_key not in existing_keys:
+        return redacted_key
+
+    occurrence = 2
+    while f"{redacted_key}[{occurrence}]" in existing_keys:
+        occurrence += 1
+    return f"{redacted_key}[{occurrence}]"
+
+
+def redact_evidence_mapping_key(
+    key: object,
+    existing_keys: Collection[object],
+    max_string_chars: int = 180,
+) -> str:
+    """Return a redacted mapping key without overwriting existing evidence."""
+    redacted_key = (
+        redact_evidence_string(key, max_chars=max_string_chars)
+        if isinstance(key, str)
+        else f"<{type(key).__name__}-key>"
+    )
+    return _unique_redacted_mapping_key(existing_keys, redacted_key)
+
+
 def redact_evidence_value(value: Any, max_string_chars: int = 180, *, _depth: int = 0) -> Any:
     """Recursively redact credentials from scanner detail values."""
     if _depth >= MAX_REDACTION_VALUE_DEPTH:
@@ -3438,23 +3462,24 @@ def redact_evidence_value(value: Any, max_string_chars: int = 180, *, _depth: in
         return redact_evidence_string(repr(value), max_chars=max_string_chars)
     if isinstance(value, dict):
         redacted_items: dict[Any, Any] = {}
-        string_keys_by_lower = {key.lower(): key for key in value if isinstance(key, str)}
-        sensitive_name_value_pair = "value" in string_keys_by_lower and any(
-            isinstance(value.get(string_keys_by_lower[key]), str)
-            and _is_sensitive_detail_key(value[string_keys_by_lower[key]])
-            for key in ("name", "key")
-            if key in string_keys_by_lower
+        sensitive_name_value_pair = any(
+            isinstance(key, str)
+            and key.lower() in {"name", "key"}
+            and isinstance(child, str)
+            and _is_sensitive_detail_key(child)
+            for key, child in value.items()
         )
         for key, child in value.items():
             if not isinstance(key, str):
-                redacted_items[f"<{type(key).__name__}-key>"] = redact_evidence_value(
+                redacted_key = redact_evidence_mapping_key(key, redacted_items)
+                redacted_items[redacted_key] = redact_evidence_value(
                     child,
                     max_string_chars=max_string_chars,
                     _depth=_depth + 1,
                 )
                 continue
 
-            redacted_key = redact_evidence_string(key, max_chars=max_string_chars)
+            redacted_key = redact_evidence_mapping_key(key, redacted_items, max_string_chars)
             if _is_sensitive_detail_key(key) or (sensitive_name_value_pair and key.lower() == "value"):
                 redacted_items[redacted_key] = REDACTED_EVIDENCE_VALUE
             else:

--- a/modelaudit/scanners/keras_h5_scanner.py
+++ b/modelaudit/scanners/keras_h5_scanner.py
@@ -26,6 +26,7 @@ from ..config.explanations import (
     get_pattern_explanation,
 )
 from ..utils.file.hdf5 import find_hdf5_signature_offset
+from ._evidence_redaction import redact_evidence_mapping_key, redact_evidence_string, redact_evidence_value
 from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, IssueSeverity, ScanResult
 from .keras_utils import (
     check_custom_loss_config,
@@ -231,6 +232,7 @@ class KerasH5Scanner(BaseScanner):
     _MAX_HDF5_LINK_VISITS: ClassVar[int] = 4096
     _MAX_HDF5_EXTERNAL_REFERENCE_REPORTS: ClassVar[int] = 20
     _MAX_HDF5_EXTERNAL_STORAGE_SEGMENT_REPORTS: ClassVar[int] = 20
+    _MAX_HDF5_REFERENCE_TEXT_CHARS: ClassVar[int] = 4096
     _MODEL_CONTAINER_CLASSES: ClassVar[frozenset[str]] = frozenset({"Model", "Functional", "Sequential"})
     _WRAPPED_LAYER_SCAN_MODEL: ClassVar[dict[str, Any]] = {"class_name": "Sequential", "config": {"layers": []}}
 
@@ -244,6 +246,7 @@ class KerasH5Scanner(BaseScanner):
         self.suspicious_config_props = list(SUSPICIOUS_CONFIG_PROPERTIES)
         if config and "suspicious_config_properties" in config:
             self.suspicious_config_props.extend(config["suspicious_config_properties"])
+        self._current_h5_keras_version: str | None = None
 
     @classmethod
     def can_handle(cls, path: str) -> bool:
@@ -265,6 +268,7 @@ class KerasH5Scanner(BaseScanner):
         """Scan a Keras model file for suspicious configurations"""
         # Initialize context for this file
         self._initialize_context(path)
+        self._current_h5_keras_version = None
 
         # Check if path is valid
         path_check_result = self._check_path(path)
@@ -311,11 +315,14 @@ class KerasH5Scanner(BaseScanner):
 
             with h5py.File(path, "r") as f:
                 result.bytes_scanned = file_size
+                raw_keras_version: str | None = None
                 keras_version_attr = f.attrs.get("keras_version")
                 if isinstance(keras_version_attr, bytes):
                     keras_version_attr = keras_version_attr.decode("utf-8", errors="ignore")
                 if isinstance(keras_version_attr, str) and keras_version_attr.strip():
-                    result.metadata["keras_version"] = keras_version_attr.strip()
+                    raw_keras_version = keras_version_attr.strip()
+                    result.metadata["keras_version"] = redact_evidence_string(raw_keras_version)
+                self._current_h5_keras_version = raw_keras_version
 
                 # CVE-2026-1669 applies to weight loading too. Inspect full
                 # Keras files and weights-like HDF5 layouts while leaving
@@ -385,7 +392,7 @@ class KerasH5Scanner(BaseScanner):
                         severity=IssueSeverity.INFO,
                         location=f"{self.current_file_path} (model_config)",
                         rule_code="S302",
-                        details={"custom_objects": custom_objects_list},
+                        details={"custom_objects": redact_evidence_value(custom_objects_list, max_string_chars=200)},
                     )
 
                 # Check for custom metrics and custom loss
@@ -583,8 +590,18 @@ class KerasH5Scanner(BaseScanner):
                 names.append(item)
         return [name for name in names if name]
 
-    def _check_hdf5_external_references(self, h5_file: Any, result: ScanResult, source_path: str) -> None:
+    def _check_hdf5_external_references(
+        self,
+        h5_file: Any,
+        result: ScanResult,
+        source_path: str,
+        *,
+        keras_version: str | None = None,
+    ) -> None:
         """Detect HDF5 external links/storage before any Keras-specific parsing short-circuits."""
+        if keras_version is None:
+            keras_version = self._current_h5_keras_version
+
         findings: list[dict[str, Any]] = []
         external_reference_count = 0
         external_storage_segments_truncated = False
@@ -594,14 +611,22 @@ class KerasH5Scanner(BaseScanner):
             if isinstance(link, h5py.ExternalLink):
                 external_reference_count += 1
                 if len(findings) < self._MAX_HDF5_EXTERNAL_REFERENCE_REPORTS:
-                    findings.append(
-                        {
-                            "kind": "ExternalLink",
-                            "hdf5_path": f"/{name}".replace("//", "/"),
-                            "filename": link.filename,
-                            "path": link.path,
-                        },
-                    )
+                    hdf5_path, hdf5_path_truncated = self._bounded_hdf5_reference_text(f"/{name}".replace("//", "/"))
+                    filename, filename_truncated = self._bounded_hdf5_reference_text(link.filename)
+                    target_path, target_path_truncated = self._bounded_hdf5_reference_text(link.path)
+                    external_link_finding: dict[str, Any] = {
+                        "kind": "ExternalLink",
+                        "hdf5_path": hdf5_path,
+                        "filename": filename,
+                        "path": target_path,
+                    }
+                    if hdf5_path_truncated:
+                        external_link_finding["hdf5_path_truncated"] = True
+                    if filename_truncated:
+                        external_link_finding["filename_truncated"] = True
+                    if target_path_truncated:
+                        external_link_finding["path_truncated"] = True
+                    findings.append(external_link_finding)
                 return
 
             if not isinstance(link, h5py.HardLink):
@@ -615,21 +640,28 @@ class KerasH5Scanner(BaseScanner):
                     if len(findings) >= self._MAX_HDF5_EXTERNAL_REFERENCE_REPORTS:
                         return
                     segments = [
-                        {"filename": filename, "offset": int(offset), "size": int(size)}
+                        {
+                            **self._hdf5_external_storage_filename_details(filename),
+                            "offset": int(offset),
+                            "size": int(size),
+                        }
                         for filename, offset, size in external_storage[
                             : self._MAX_HDF5_EXTERNAL_STORAGE_SEGMENT_REPORTS
                         ]
                     ]
-                    finding: dict[str, Any] = {
+                    hdf5_path, hdf5_path_truncated = self._bounded_hdf5_reference_text(f"/{name}".replace("//", "/"))
+                    external_storage_finding: dict[str, Any] = {
                         "kind": "external_storage",
-                        "hdf5_path": f"/{name}".replace("//", "/"),
+                        "hdf5_path": hdf5_path,
                         "segments": segments,
                     }
+                    if hdf5_path_truncated:
+                        external_storage_finding["hdf5_path_truncated"] = True
                     if len(external_storage) > len(segments):
                         external_storage_segments_truncated = True
-                        finding["segment_count"] = len(external_storage)
-                        finding["segments_truncated"] = True
-                    findings.append(finding)
+                        external_storage_finding["segment_count"] = len(external_storage)
+                        external_storage_finding["segments_truncated"] = True
+                    findings.append(external_storage_finding)
 
         visited_link_count, link_visits_truncated = self._visit_hdf5_links(
             h5_file,
@@ -663,7 +695,6 @@ class KerasH5Scanner(BaseScanner):
         if not findings:
             return
 
-        keras_version = result.metadata.get("keras_version")
         location = f"{source_path} (weights)"
         details = {
             "cve_id": "CVE-2026-1669",
@@ -682,14 +713,15 @@ class KerasH5Scanner(BaseScanner):
             details["external_references_truncated"] = external_references_truncated
             details["external_storage_segments_truncated"] = external_storage_segments_truncated
 
+        display_keras_version = redact_evidence_string(keras_version) if isinstance(keras_version, str) else None
         vuln_status = self._is_vulnerable_to_cve_2026_1669(keras_version) if isinstance(keras_version, str) else None
         if vuln_status is True:
-            details["keras_version"] = keras_version
+            details["keras_version"] = display_keras_version
             result.add_check(
                 name="CVE-2026-1669: HDF5 External Weight Reference",
                 passed=False,
                 message=(
-                    f"CVE-2026-1669: Keras {keras_version} weight file uses HDF5 external references that can "
+                    f"CVE-2026-1669: Keras {display_keras_version} weight file uses HDF5 external references that can "
                     "disclose arbitrary local file contents during model loading"
                 ),
                 severity=IssueSeverity.WARNING,
@@ -700,7 +732,7 @@ class KerasH5Scanner(BaseScanner):
             return
 
         if isinstance(keras_version, str):
-            details["keras_version"] = keras_version
+            details["keras_version"] = display_keras_version
             if vuln_status is False:
                 details["parse_status"] = "untrusted_artifact_version"
                 details["version_source"] = "hdf5_file_attribute"
@@ -709,7 +741,7 @@ class KerasH5Scanner(BaseScanner):
                     passed=False,
                     message=(
                         "HDF5 external references detected in standalone Keras H5 weights; "
-                        f"the file claims Keras {keras_version}, but artifact-controlled version metadata "
+                        f"the file claims Keras {display_keras_version}, but artifact-controlled version metadata "
                         "cannot prove the loader runtime is outside the CVE-2026-1669 vulnerable ranges"
                     ),
                     severity=IssueSeverity.WARNING,
@@ -727,7 +759,7 @@ class KerasH5Scanner(BaseScanner):
             passed=False,
             message=(
                 "HDF5 external references detected in weights, but "
-                f"{self._format_keras_version_context(keras_version)}; cannot confidently attribute "
+                f"{self._format_keras_version_context(display_keras_version)}; cannot confidently attribute "
                 "CVE-2026-1669 without reliable version context"
             ),
             severity=IssueSeverity.WARNING,
@@ -738,6 +770,30 @@ class KerasH5Scanner(BaseScanner):
             },
             why=get_cve_2026_1669_explanation("hdf5_external_reference"),
         )
+
+    @staticmethod
+    def _fsdecode_evidence(value: Any) -> str:
+        try:
+            return os.fsdecode(value)
+        except TypeError:
+            return str(value)
+
+    @classmethod
+    def _bounded_hdf5_reference_text(cls, value: Any) -> tuple[str, bool]:
+        """Return redacted, bounded HDF5 reference evidence and whether it was truncated."""
+        text = cls._fsdecode_evidence(value)
+        redacted_text = redact_evidence_string(text, max_chars=cls._MAX_HDF5_REFERENCE_TEXT_CHARS)
+        was_truncated = max(len(text), len(redacted_text)) > cls._MAX_HDF5_REFERENCE_TEXT_CHARS
+        return redacted_text[: cls._MAX_HDF5_REFERENCE_TEXT_CHARS], was_truncated
+
+    @classmethod
+    def _hdf5_external_storage_filename_details(cls, filename: Any) -> dict[str, Any]:
+        """Return bounded external-storage filename evidence."""
+        bounded_filename, filename_truncated = cls._bounded_hdf5_reference_text(filename)
+        details: dict[str, Any] = {"filename": bounded_filename}
+        if filename_truncated:
+            details["filename_truncated"] = True
+        return details
 
     @staticmethod
     def _visit_hdf5_links(
@@ -822,7 +878,8 @@ class KerasH5Scanner(BaseScanner):
 
         # Check model class name
         model_class = model_config.get("class_name", "")
-        result.metadata["model_class"] = model_class
+        redacted_model_class = redact_evidence_string(str(model_class))
+        result.metadata["model_class"] = redacted_model_class
 
         # Check for subclassed models (custom class names)
         check_subclassed_model(model_class, result, self.current_file_path)
@@ -836,11 +893,11 @@ class KerasH5Scanner(BaseScanner):
                 result.add_check(
                     name="Layers Presence Validation",
                     passed=False,
-                    message=f"Model config for {model_class} is missing required layers list",
+                    message=f"Model config for {redacted_model_class} is missing required layers list",
                     rule_code="S902",
                     severity=IssueSeverity.INFO,
                     location=self.current_file_path,
-                    details={"model_class": model_class, "expected_key": "config.layers"},
+                    details={"model_class": redacted_model_class, "expected_key": "config.layers"},
                 )
             else:
                 result.add_check(
@@ -848,7 +905,7 @@ class KerasH5Scanner(BaseScanner):
                     passed=True,
                     message="Keras model config has no layer configuration",
                     location=self.current_file_path,
-                    details={"model_class": model_class},
+                    details={"model_class": redacted_model_class},
                 )
         elif not isinstance(config_value, dict):
             self._mark_inconclusive_scan_result(result, "keras_h5_model_config_structure_invalid")
@@ -881,15 +938,16 @@ class KerasH5Scanner(BaseScanner):
             result.add_check(
                 name="Layers Presence Validation",
                 passed=False,
-                message=f"Model config for {model_class} is missing required layers list",
+                message=f"Model config for {redacted_model_class} is missing required layers list",
                 rule_code="S902",
                 severity=IssueSeverity.INFO,
                 location=self.current_file_path,
-                details={"model_class": model_class, "expected_key": "config.layers"},
+                details={"model_class": redacted_model_class, "expected_key": "config.layers"},
             )
 
         # Count of each layer type
         layer_counts: dict[str, int] = {}
+        layer_count_display_keys: dict[str, str] = {}
         lambda_layer_count = 0
 
         # Check each layer
@@ -907,8 +965,25 @@ class KerasH5Scanner(BaseScanner):
                 )
                 continue
             layer_class = layer.get("class_name", "")
+            layer_class_is_string = isinstance(layer_class, str)
+            redacted_layer_class = (
+                redact_evidence_string(layer_class)
+                if layer_class_is_string
+                else f"<invalid:{type(layer_class).__name__}>"
+            )
+            if not layer_class_is_string:
+                self._mark_inconclusive_scan_result(result, "keras_h5_layer_class_invalid_type")
+                result.add_check(
+                    name="Layer Class Type Validation",
+                    passed=False,
+                    message=f"Invalid layer class type: expected str, got {type(layer_class).__name__}",
+                    rule_code="S902",
+                    severity=IssueSeverity.WARNING,
+                    location=self.current_file_path,
+                    details={"actual_type": type(layer_class).__name__, "expected_type": "str"},
+                )
             layer_config = layer.get("config", {})
-            is_lambda_layer = self._is_lambda_layer_class(layer_class)
+            is_lambda_layer = layer_class_is_string and self._is_lambda_layer_class(layer_class)
             layer_count_key = "Lambda" if is_lambda_layer else layer_class
             if not isinstance(layer_config, dict):
                 self._mark_inconclusive_scan_result(result, "keras_h5_layer_config_invalid_type")
@@ -924,23 +999,37 @@ class KerasH5Scanner(BaseScanner):
                 layer_config = {}
 
             # Update layer count
-            if layer_count_key in layer_counts:
-                layer_counts[layer_count_key] += 1
-            else:
-                layer_counts[layer_count_key] = 1
+            layer_count_identity = (
+                f"str:{layer_count_key}"
+                if isinstance(layer_count_key, str)
+                else f"invalid:{type(layer_count_key).__name__}"
+            )
+            redacted_layer_count_key = layer_count_display_keys.get(layer_count_identity)
+            if redacted_layer_count_key is None:
+                display_key = (
+                    layer_count_key
+                    if isinstance(layer_count_key, str)
+                    else f"<invalid:{type(layer_count_key).__name__}>"
+                )
+                redacted_layer_count_key = redact_evidence_mapping_key(display_key, layer_counts)
+                layer_count_display_keys[layer_count_identity] = redacted_layer_count_key
+            layer_counts[redacted_layer_count_key] = layer_counts.get(redacted_layer_count_key, 0) + 1
 
             # Check for suspicious layer types
-            if layer_class in self.suspicious_layer_types or is_lambda_layer:
+            if (layer_class_is_string and layer_class in self.suspicious_layer_types) or is_lambda_layer:
                 # Special handling for Lambda layers - validate Python code
                 if is_lambda_layer:
                     lambda_layer_count += 1
                     layer_name = f"lambda_{lambda_layer_count}"
                     self._check_lambda_layer(layer_config, result, layer_name)
                     keras_version = result.metadata.get("keras_version")
+                    classification_keras_version = self._current_h5_keras_version
 
                     # CVE-2024-3660: Lambda layers enable arbitrary code injection
                     cve_2024_3660_status = (
-                        self._is_vulnerable_to_cve_2024_3660(keras_version) if isinstance(keras_version, str) else None
+                        self._is_vulnerable_to_cve_2024_3660(classification_keras_version)
+                        if isinstance(classification_keras_version, str)
+                        else None
                     )
                     if cve_2024_3660_status is True:
                         result.add_check(
@@ -991,7 +1080,9 @@ class KerasH5Scanner(BaseScanner):
 
                     # CVE-2025-9905: safe_mode=True is silently ignored for H5 format
                     vuln_status = (
-                        self._is_vulnerable_to_cve_2025_9905(keras_version) if isinstance(keras_version, str) else None
+                        self._is_vulnerable_to_cve_2025_9905(classification_keras_version)
+                        if isinstance(classification_keras_version, str)
+                        else None
                     )
                     if vuln_status is True:
                         result.add_check(
@@ -1066,29 +1157,29 @@ class KerasH5Scanner(BaseScanner):
                     result.add_check(
                         name="Suspicious Layer Type Detection",
                         passed=False,
-                        message=f"Suspicious layer type found: {layer_class}",
+                        message=f"Suspicious layer type found: {redacted_layer_class}",
                         severity=IssueSeverity.CRITICAL,
                         location=self.current_file_path,
                         details={
-                            "layer_class": layer_class,
+                            "layer_class": redacted_layer_class,
                             "description": self.suspicious_layer_types[layer_class],
-                            "layer_config": layer_config,
+                            "layer_config": redact_evidence_value(layer_config, max_string_chars=200),
                         },
                         why=get_pattern_explanation("lambda_layer") if is_lambda_layer else None,
                         rule_code="S902",
                     )
 
             # Detect unknown/custom layer classes not in the standard Keras set
-            elif layer_class and not is_known_safe_keras_layer_class(layer_class):
+            elif layer_class_is_string and layer_class and not is_known_safe_keras_layer_class(layer_class):
                 result.add_check(
                     name="Custom Layer Class Detection",
                     passed=False,
-                    message=f"Unknown/custom layer class detected: {layer_class}",
+                    message=f"Unknown/custom layer class detected: {redacted_layer_class}",
                     severity=IssueSeverity.WARNING,
                     location=self.current_file_path,
                     details={
-                        "layer_class": layer_class,
-                        "layer_config": layer.get("config", {}),
+                        "layer_class": redacted_layer_class,
+                        "layer_config": redact_evidence_value(layer.get("config", {}), max_string_chars=200),
                         "risk": "Custom layer classes require external code to load and may execute arbitrary logic",
                     },
                     rule_code="S810",
@@ -1098,13 +1189,13 @@ class KerasH5Scanner(BaseScanner):
             self._check_config_for_suspicious_strings(
                 layer_config,
                 result,
-                "Lambda" if is_lambda_layer else layer_class,
+                "Lambda" if is_lambda_layer else redacted_layer_class,
                 redact_nested_context=is_lambda_layer,
                 case_sensitive=is_lambda_layer,
             )
 
             # If there are nested models, scan them recursively
-            if layer_class in self._MODEL_CONTAINER_CLASSES and "config" in layer:
+            if layer_class_is_string and layer_class in self._MODEL_CONTAINER_CLASSES and "config" in layer:
                 nested_config = layer.get("config")
                 if isinstance(nested_config, dict) and "layers" in nested_config:
                     self._scan_model_config(layer, result)
@@ -1113,11 +1204,11 @@ class KerasH5Scanner(BaseScanner):
                     result.add_check(
                         name="Nested Model Layers Presence Validation",
                         passed=False,
-                        message=f"Nested model config for {layer_class} is missing required layers list",
+                        message=f"Nested model config for {redacted_layer_class} is missing required layers list",
                         rule_code="S902",
                         severity=IssueSeverity.INFO,
                         location=self.current_file_path,
-                        details={"layer_class": layer_class, "expected_key": "config.layers"},
+                        details={"layer_class": redacted_layer_class, "expected_key": "config.layers"},
                     )
 
             if not is_lambda_layer:
@@ -1670,16 +1761,19 @@ class KerasH5Scanner(BaseScanner):
                         suspicious_term,
                         case_sensitive=case_sensitive and key == "function",
                     ):
+                        redacted_context = redact_evidence_string(str(context))
                         result.add_check(
                             name="Suspicious Configuration String Check",
                             passed=False,
-                            message=f"Suspicious configuration string found in {context}: '{suspicious_term}'",
+                            message=(
+                                f"Suspicious configuration string found in {redacted_context}: '{suspicious_term}'"
+                            ),
                             severity=IssueSeverity.INFO,
-                            location=f"{self.current_file_path} ({context})",
+                            location=f"{self.current_file_path} ({redacted_context})",
                             rule_code="S902",
                             details={
                                 "suspicious_term": suspicious_term,
-                                "context": context,
+                                "context": redacted_context,
                             },
                         )
             elif isinstance(value, dict):

--- a/modelaudit/scanners/keras_h5_scanner.py
+++ b/modelaudit/scanners/keras_h5_scanner.py
@@ -878,17 +878,32 @@ class KerasH5Scanner(BaseScanner):
 
         # Check model class name
         model_class = model_config.get("class_name", "")
-        redacted_model_class = redact_evidence_string(str(model_class))
+        model_class_is_string = isinstance(model_class, str)
+        redacted_model_class = (
+            redact_evidence_string(model_class) if model_class_is_string else f"<invalid:{type(model_class).__name__}>"
+        )
         result.metadata["model_class"] = redacted_model_class
 
         # Check for subclassed models (custom class names)
-        check_subclassed_model(model_class, result, self.current_file_path)
+        if model_class_is_string:
+            check_subclassed_model(model_class, result, self.current_file_path)
+        else:
+            self._mark_inconclusive_scan_result(result, "keras_h5_model_class_invalid_type")
+            result.add_check(
+                name="Model Class Type Validation",
+                passed=False,
+                message=f"Invalid model class type: expected str, got {type(model_class).__name__}",
+                rule_code="S902",
+                severity=IssueSeverity.WARNING,
+                location=self.current_file_path,
+                details={"actual_type": type(model_class).__name__, "expected_type": "str"},
+            )
 
         # Collect all layers
         layers = []
         config_value = model_config.get("config")
         if config_value is None:
-            if model_class in self._MODEL_CONTAINER_CLASSES:
+            if model_class_is_string and model_class in self._MODEL_CONTAINER_CLASSES:
                 self._mark_inconclusive_scan_result(result, "keras_h5_model_layers_missing")
                 result.add_check(
                     name="Layers Presence Validation",
@@ -933,7 +948,7 @@ class KerasH5Scanner(BaseScanner):
                     location=self.current_file_path,
                     details={"actual_type": type(layers_value).__name__, "expected_type": "list"},
                 )
-        elif model_class in self._MODEL_CONTAINER_CLASSES:
+        elif model_class_is_string and model_class in self._MODEL_CONTAINER_CLASSES:
             self._mark_inconclusive_scan_result(result, "keras_h5_model_layers_missing")
             result.add_check(
                 name="Layers Presence Validation",

--- a/modelaudit/scanners/keras_zip_scanner.py
+++ b/modelaudit/scanners/keras_zip_scanner.py
@@ -7,7 +7,7 @@ import re
 import tempfile
 import zipfile
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 from modelaudit.detectors.network_comm import redact_url_for_finding
 from modelaudit.detectors.suspicious_symbols import (
@@ -35,13 +35,13 @@ from ..utils.file.hdf5 import (
     is_hdf5_signature_probe_complete,
 )
 from ._archive_config import get_archive_depth
-from ._evidence_redaction import redact_evidence_string, redact_evidence_value
+from ._evidence_redaction import redact_evidence_mapping_key, redact_evidence_string, redact_evidence_value
 from .archive_dispatch import (
     KNOWN_UNREADABLE_ARCHIVE_ENTRY_OFFSETS_CONFIG_KEY,
     SKIP_COMPOSED_ARCHIVE_MEMBER_SCAN_CONFIG_KEY,
 )
 from .archive_member_security import is_executable_archive_member_name
-from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, IssueSeverity, ScanResult
+from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, Check, Issue, IssueSeverity, ScanResult
 from .keras_utils import (
     check_custom_loss_config,
     check_custom_metric_config,
@@ -371,6 +371,7 @@ class KerasZipScanner(BaseScanner):
     MAX_HDF5_EXTERNAL_REFERENCE_REPORTS: ClassVar[int] = 20
     MAX_HDF5_EXTERNAL_STORAGE_SEGMENT_REPORTS: ClassVar[int] = 20
     MAX_HDF5_REFERENCE_TEXT_CHARS: ClassVar[int] = 4096
+    MAX_ARCHIVE_MEMBER_TEXT_CHARS: ClassVar[int] = 4096
     MAX_NESTED_LAYER_DEPTH: ClassVar[int] = 64
     MAX_NESTED_LAYER_ITEMS: ClassVar[int] = 1_000
     _MODEL_CONTAINER_CLASSES: ClassVar[frozenset[str]] = frozenset({"Model", "Functional", "Sequential"})
@@ -412,7 +413,41 @@ class KerasZipScanner(BaseScanner):
         self._nested_layer_items_scanned = 0
         self._content_route_embedded_weights = False
         self._checked_config_module_references: set[tuple[int, str, str]] = set()
+        self._current_keras_version: str | None = None
         self._torchmodule_version_status: bool | None = None
+
+    @classmethod
+    def _redact_archive_member_name(cls, member_name: str) -> str:
+        """Return bounded, redacted archive-member evidence for serialized findings."""
+        return redact_evidence_string(member_name, max_chars=cls.MAX_ARCHIVE_MEMBER_TEXT_CHARS)
+
+    @classmethod
+    def _redact_recursive_archive_scan_result(cls, nested_result: ScanResult) -> None:
+        """Redact model-controlled ZIP member evidence before merging generic archive findings."""
+        findings: list[Check | Issue] = [*nested_result.checks, *nested_result.issues]
+        for finding in findings:
+            finding.message = redact_evidence_string(
+                finding.message,
+                max_chars=cls.MAX_ARCHIVE_MEMBER_TEXT_CHARS,
+            )
+            if finding.location is not None:
+                finding.location = redact_evidence_string(
+                    finding.location,
+                    max_chars=cls.MAX_ARCHIVE_MEMBER_TEXT_CHARS,
+                )
+            finding.details = cast(
+                dict[str, Any],
+                redact_evidence_value(
+                    finding.details,
+                    max_string_chars=cls.MAX_ARCHIVE_MEMBER_TEXT_CHARS,
+                ),
+            )
+
+        if "contents" in nested_result.metadata:
+            nested_result.metadata["contents"] = redact_evidence_value(
+                nested_result.metadata["contents"],
+                max_string_chars=cls.MAX_ARCHIVE_MEMBER_TEXT_CHARS,
+            )
 
     @staticmethod
     def _is_allowlisted_keras_module(module_value: Any) -> bool:
@@ -635,6 +670,7 @@ class KerasZipScanner(BaseScanner):
         )
         if has_embedded_weights_limit:
             self._suppress_expected_embedded_weights_limit_noise(nested_result)
+        self._redact_recursive_archive_scan_result(nested_result)
         preserved_metadata = dict(result.metadata)
         nested_contents = nested_result.metadata.get("contents")
         result.merge(nested_result)
@@ -659,6 +695,7 @@ class KerasZipScanner(BaseScanner):
         self._nested_layer_items_scanned = 0
         self._content_route_embedded_weights = False
         self._checked_config_module_references.clear()
+        self._current_keras_version = None
         self._torchmodule_version_status = None
 
         # Check if path is valid
@@ -694,7 +731,7 @@ class KerasZipScanner(BaseScanner):
                         message="No config.json found in Keras ZIP file",
                         severity=IssueSeverity.INFO,
                         location=path,
-                        details={"files": zf.namelist()},
+                        details={"files": [self._redact_archive_member_name(name) for name in zf.namelist()]},
                     )
                     self._load_keras_metadata(zf, result)
                     self._check_archive_security_members(zf, path, result)
@@ -723,7 +760,7 @@ class KerasZipScanner(BaseScanner):
                         passed=False,
                         message=f"Failed to parse config.json: {e}",
                         severity=IssueSeverity.INFO,
-                        location=f"{path}/{config_info.filename}",
+                        location=f"{path}/{self._redact_archive_member_name(config_info.filename)}",
                         details={
                             "error": str(e),
                             "max_config_bytes": _KERAS_CONFIG_MAX_BYTES,
@@ -749,7 +786,7 @@ class KerasZipScanner(BaseScanner):
                         passed=False,
                         message=f"Invalid config.json type: expected dict, got {type(model_config).__name__}",
                         severity=IssueSeverity.INFO,
-                        location=f"{path}/{config_info.filename}",
+                        location=f"{path}/{self._redact_archive_member_name(config_info.filename)}",
                         details={"actual_type": type(model_config).__name__, "expected_type": "dict"},
                     )
                     self._check_archive_security_members(zf, path, result)
@@ -765,15 +802,22 @@ class KerasZipScanner(BaseScanner):
                 self._merge_recursive_archive_scan(path, result)
 
         except _AmbiguousKerasArchiveMemberError as e:
+            redacted_member_name = self._redact_archive_member_name(e.member_name)
+            redacted_candidate_filenames = [
+                self._redact_archive_member_name(filename) for filename in e.candidate_filenames
+            ]
             result.add_check(
                 name="Keras ZIP Member Path Validation",
                 passed=False,
-                message=str(e),
+                message=(
+                    f"Ambiguous Keras ZIP member '{redacted_member_name}' matches multiple archive entries: "
+                    f"{', '.join(redacted_candidate_filenames)}"
+                ),
                 severity=IssueSeverity.CRITICAL,
                 location=path,
                 details={
-                    "member_name": e.member_name,
-                    "candidate_filenames": e.candidate_filenames,
+                    "member_name": redacted_member_name,
+                    "candidate_filenames": redacted_candidate_filenames,
                 },
             )
             self._merge_recursive_archive_scan(path, result)
@@ -841,6 +885,7 @@ class KerasZipScanner(BaseScanner):
         keras_version = metadata.get("keras_version")
         if isinstance(keras_version, str) and keras_version.strip():
             raw_keras_version = keras_version.strip()
+            self._current_keras_version = raw_keras_version
             # Classify before evidence truncation can alter a valid long local-version label.
             self._torchmodule_version_status = self._is_vulnerable_keras_3_11_x(raw_keras_version)
             result.metadata["keras_version"] = redact_evidence_string(raw_keras_version)
@@ -856,22 +901,24 @@ class KerasZipScanner(BaseScanner):
         for filename in archive.namelist():
             normalized_name = filename.lower()
             if normalized_name.endswith((".py", ".pyc", ".pyo")):
+                redacted_filename = self._redact_archive_member_name(filename)
                 result.add_check(
                     name="Python File Detection",
                     passed=False,
-                    message=f"Python file found in Keras ZIP: {filename}",
+                    message=f"Python file found in Keras ZIP: {redacted_filename}",
                     severity=IssueSeverity.WARNING,
-                    location=f"{archive_path}/{filename}",
-                    details={"filename": filename},
+                    location=f"{archive_path}/{redacted_filename}",
+                    details={"filename": redacted_filename},
                 )
             elif is_executable_archive_member_name(normalized_name):
+                redacted_filename = self._redact_archive_member_name(filename)
                 result.add_check(
                     name="Executable File Detection",
                     passed=False,
-                    message=f"Executable file found in Keras ZIP: {filename}",
+                    message=f"Executable file found in Keras ZIP: {redacted_filename}",
                     severity=IssueSeverity.CRITICAL,
-                    location=f"{archive_path}/{filename}",
-                    details={"filename": filename},
+                    location=f"{archive_path}/{redacted_filename}",
+                    details={"filename": redacted_filename},
                 )
 
     @staticmethod
@@ -1051,6 +1098,7 @@ class KerasZipScanner(BaseScanner):
 
         # Count of each layer type
         layer_counts: dict[str, int] = {}
+        layer_count_display_keys: dict[str, str] = {}
 
         # Check each layer
         for i, layer in enumerate(layers):
@@ -1089,11 +1137,14 @@ class KerasZipScanner(BaseScanner):
                 )
 
             # Update layer count
-            layer_count_key = (
-                redact_evidence_string(layer_class)
-                if isinstance(layer_class, str)
-                else f"<invalid:{type(layer_class).__name__}>"
+            layer_count_identity = (
+                f"str:{layer_class}" if isinstance(layer_class, str) else f"invalid:{type(layer_class).__name__}"
             )
+            layer_count_key = layer_count_display_keys.get(layer_count_identity)
+            if layer_count_key is None:
+                display_key = layer_class if isinstance(layer_class, str) else f"<invalid:{type(layer_class).__name__}>"
+                layer_count_key = redact_evidence_mapping_key(display_key, layer_counts)
+                layer_count_display_keys[layer_count_identity] = layer_count_key
             layer_counts[layer_count_key] = layer_counts.get(layer_count_key, 0) + 1
 
             # CVE-2025-49655: TorchModuleWrapper uses torch.load(weights_only=False)
@@ -1111,8 +1162,11 @@ class KerasZipScanner(BaseScanner):
             if is_lambda_layer:
                 self._check_lambda_layer(layer, result, layer_name)
                 keras_version = result.metadata.get("keras_version")
+                classification_keras_version = self._current_keras_version
                 cve_2024_3660_status = (
-                    self._is_vulnerable_to_cve_2024_3660(keras_version) if isinstance(keras_version, str) else None
+                    self._is_vulnerable_to_cve_2024_3660(classification_keras_version)
+                    if isinstance(classification_keras_version, str)
+                    else None
                 )
                 if cve_2024_3660_status is True:
                     # CVE-2024-3660: Lambda layers enable arbitrary code injection
@@ -1900,7 +1954,7 @@ class KerasZipScanner(BaseScanner):
                 location=f"{self.current_file_path}/config.json",
                 details={
                     "cve_id": "CVE-2025-8747",
-                    "context": context,
+                    "context": redact_evidence_string(context),
                     "cvss": 8.8,
                     "cwe": "CWE-502",
                     "description": (
@@ -1951,7 +2005,7 @@ class KerasZipScanner(BaseScanner):
                 location=f"{self.current_file_path}/config.json",
                 details={
                     "cve_id": "CVE-2025-12060",
-                    "context": context,
+                    "context": redact_evidence_string(context),
                     "urls": [_redact_url_for_display(url) for url in archive_urls[:5]],
                     "cvss": 8.8,
                     "cwe": "CWE-22",
@@ -2141,6 +2195,7 @@ class KerasZipScanner(BaseScanner):
             return
 
         keras_version = result.metadata.get("keras_version")
+        classification_keras_version = self._current_keras_version
         redacted_vocabulary = (
             redact_url_for_finding(vocabulary)
             if _URL_SCHEME_PATTERN.match(vocabulary.strip())
@@ -2162,7 +2217,9 @@ class KerasZipScanner(BaseScanner):
             "affected_versions": "Keras < 3.12.0",
         }
         vulnerability_status = (
-            self._is_vulnerable_to_cve_2025_12058(keras_version) if isinstance(keras_version, str) else None
+            self._is_vulnerable_to_cve_2025_12058(classification_keras_version)
+            if isinstance(classification_keras_version, str)
+            else None
         )
 
         if vulnerability_status is True:
@@ -2239,6 +2296,7 @@ class KerasZipScanner(BaseScanner):
 
         if weights_info.file_size > self.max_embedded_weights_bytes:
             weights_entry = weights_info.filename
+            display_weights_entry = self._redact_archive_member_name(weights_entry)
             self._mark_inconclusive_scan_result(result, "keras_zip_embedded_weights_too_large")
             result.add_check(
                 name="Embedded Weights Size Limit",
@@ -2248,9 +2306,9 @@ class KerasZipScanner(BaseScanner):
                     f"exceeds the configured size limit ({weights_info.file_size} > {self.max_embedded_weights_bytes})"
                 ),
                 severity=IssueSeverity.INFO,
-                location=f"{self.current_file_path}:{weights_entry}",
+                location=f"{self.current_file_path}:{display_weights_entry}",
                 details={
-                    "entry": weights_entry,
+                    "entry": display_weights_entry,
                     "uncompressed_size": weights_info.file_size,
                     "compressed_size": weights_info.compress_size,
                     "max_embedded_weights_bytes": self.max_embedded_weights_bytes,
@@ -2271,6 +2329,7 @@ class KerasZipScanner(BaseScanner):
                 return
 
             weights_entry = weights_info.filename
+            display_weights_entry = self._redact_archive_member_name(weights_entry)
             reason = "keras_zip_embedded_weights_h5py_unavailable"
             result.metadata["embedded_weights_hdf5_signature_offset"] = hdf5_signature_offset
             self._mark_inconclusive_scan_result(result, reason)
@@ -2289,9 +2348,9 @@ class KerasZipScanner(BaseScanner):
                     "analysis. Install with 'pip install modelaudit[h5]'."
                 ),
                 severity=IssueSeverity.INFO,
-                location=f"{self.current_file_path}:{weights_entry}",
+                location=f"{self.current_file_path}:{display_weights_entry}",
                 details={
-                    "entry": weights_entry,
+                    "entry": display_weights_entry,
                     "required_package": "h5py",
                     "hdf5_signature_offset": hdf5_signature_offset,
                     "analysis_incomplete": True,
@@ -2329,15 +2388,16 @@ class KerasZipScanner(BaseScanner):
                 )
         except _EmbeddedWeightsLimitExceeded as exc:
             weights_entry = weights_info.filename
+            display_weights_entry = self._redact_archive_member_name(weights_entry)
             self._mark_inconclusive_scan_result(result, "keras_zip_embedded_weights_too_large")
             result.add_check(
                 name="Embedded Weights Size Limit",
                 passed=False,
                 message=str(exc),
                 severity=IssueSeverity.INFO,
-                location=f"{self.current_file_path}:{weights_entry}",
+                location=f"{self.current_file_path}:{display_weights_entry}",
                 details={
-                    "entry": weights_entry,
+                    "entry": display_weights_entry,
                     "extracted_bytes": exc.extracted_bytes,
                     "uncompressed_size": weights_info.file_size,
                     "compressed_size": weights_info.compress_size,
@@ -2363,7 +2423,7 @@ class KerasZipScanner(BaseScanner):
                 passed=False,
                 message="Embedded Keras HDF5 external-reference analysis reached a configured safety limit",
                 severity=IssueSeverity.INFO,
-                location=f"{self.current_file_path}:{weights_info.filename}",
+                location=f"{self.current_file_path}:{self._redact_archive_member_name(weights_info.filename)}",
                 details={
                     "analysis_incomplete": True,
                     "scan_outcome_reason": reason,
@@ -2376,7 +2436,8 @@ class KerasZipScanner(BaseScanner):
             return
 
         keras_version = result.metadata.get("keras_version")
-        location = f"{self.current_file_path}:{weights_info.filename}"
+        classification_keras_version = self._current_keras_version
+        location = f"{self.current_file_path}:{self._redact_archive_member_name(weights_info.filename)}"
         details = {
             "cve_id": "CVE-2026-1669",
             "cvss": 8.1,
@@ -2406,7 +2467,9 @@ class KerasZipScanner(BaseScanner):
             )
 
         cve_2026_1669_status = (
-            self._is_vulnerable_to_cve_2026_1669(keras_version) if isinstance(keras_version, str) else None
+            self._is_vulnerable_to_cve_2026_1669(classification_keras_version)
+            if isinstance(classification_keras_version, str)
+            else None
         )
         if cve_2026_1669_status is True:
             details["keras_version"] = keras_version
@@ -2479,6 +2542,7 @@ class KerasZipScanner(BaseScanner):
         result: ScanResult,
     ) -> None:
         weights_entry = weights_info.filename
+        display_weights_entry = self._redact_archive_member_name(weights_entry)
         reason = "keras_zip_embedded_weights_hdf5_signature_probe_incomplete"
         self._mark_inconclusive_scan_result(result, reason)
         result.add_check(
@@ -2490,9 +2554,9 @@ class KerasZipScanner(BaseScanner):
                 "Install with 'pip install modelaudit[h5]'."
             ),
             severity=IssueSeverity.INFO,
-            location=f"{self.current_file_path}:{weights_entry}",
+            location=f"{self.current_file_path}:{display_weights_entry}",
             details={
-                "entry": weights_entry,
+                "entry": display_weights_entry,
                 "required_package": "h5py",
                 "file_size": weights_info.file_size,
                 "hdf5_signature_probe_max_bytes": HDF5_SIGNATURE_SCAN_MAX_BYTES,
@@ -2516,6 +2580,7 @@ class KerasZipScanner(BaseScanner):
             return
 
         weights_entry = weights_info.filename
+        display_weights_entry = self._redact_archive_member_name(weights_entry)
         from .pickle_scanner import PickleScanner
         from .picklescan_adapter import apply_pickle_member_context
 
@@ -2557,11 +2622,11 @@ class KerasZipScanner(BaseScanner):
                         prefix_result,
                         temp_path,
                         self.current_file_path,
-                        weights_entry,
+                        display_weights_entry,
                     )
                     self._annotate_embedded_weights_security_prefix_result(
                         prefix_result,
-                        weights_entry=weights_entry,
+                        weights_entry=display_weights_entry,
                         hdf5_signature_offset=hdf5_signature_offset,
                     )
                     result.merge(prefix_result)
@@ -2576,7 +2641,9 @@ class KerasZipScanner(BaseScanner):
                 if temp_path is not None:
                     Path(temp_path).unlink(missing_ok=True)
 
-            pickle_source = f"{self.current_file_path}:{weights_entry}:embedded-weights-prefix-{segment_index}.pkl"
+            pickle_source = (
+                f"{self.current_file_path}:{display_weights_entry}:embedded-weights-prefix-{segment_index}.pkl"
+            )
             pickle_result = PickleScanner(config=self.config).scan_stream(
                 io.BytesIO(prefix),
                 len(prefix),
@@ -2586,11 +2653,11 @@ class KerasZipScanner(BaseScanner):
                 apply_pickle_member_context(
                     pickle_result,
                     archive_path=self.current_file_path,
-                    member_name=weights_entry,
+                    member_name=display_weights_entry,
                 )
                 self._annotate_embedded_weights_security_prefix_result(
                     pickle_result,
-                    weights_entry=weights_entry,
+                    weights_entry=display_weights_entry,
                     hdf5_signature_offset=hdf5_signature_offset,
                 )
                 result.merge(pickle_result)
@@ -2629,11 +2696,11 @@ class KerasZipScanner(BaseScanner):
                 full_result,
                 temp_path,
                 self.current_file_path,
-                weights_info.filename,
+                self._redact_archive_member_name(weights_info.filename),
             )
             self._annotate_embedded_weights_security_prefix_result(
                 full_result,
-                weights_entry=weights_info.filename,
+                weights_entry=self._redact_archive_member_name(weights_info.filename),
                 hdf5_signature_offset=hdf5_signature_offset,
             )
             result.merge(full_result)
@@ -2649,15 +2716,19 @@ class KerasZipScanner(BaseScanner):
         weights_entry: str,
         hdf5_signature_offset: int | None,
     ) -> None:
+        display_weights_entry = redact_evidence_string(
+            weights_entry,
+            max_chars=KerasZipScanner.MAX_ARCHIVE_MEMBER_TEXT_CHARS,
+        )
         for check in prefix_result.checks:
-            check.details.setdefault("zip_entry", weights_entry)
+            check.details.setdefault("zip_entry", display_weights_entry)
             check.details["embedded_weights_hdf5_userblock"] = True
             if hdf5_signature_offset is None:
                 check.details["hdf5_signature_probe_max_bytes"] = HDF5_SIGNATURE_SCAN_MAX_BYTES
             else:
                 check.details["hdf5_signature_offset"] = hdf5_signature_offset
         for issue in prefix_result.issues:
-            issue.details.setdefault("zip_entry", weights_entry)
+            issue.details.setdefault("zip_entry", display_weights_entry)
             issue.details["embedded_weights_hdf5_userblock"] = True
             if hdf5_signature_offset is None:
                 issue.details["hdf5_signature_probe_max_bytes"] = HDF5_SIGNATURE_SCAN_MAX_BYTES

--- a/modelaudit/scanners/keras_zip_scanner.py
+++ b/modelaudit/scanners/keras_zip_scanner.py
@@ -1017,11 +1017,26 @@ class KerasZipScanner(BaseScanner):
 
         # Check model class name
         model_class = model_config.get("class_name", "")
-        redacted_model_class = redact_evidence_string(str(model_class))
+        model_class_is_string = isinstance(model_class, str)
+        redacted_model_class = (
+            redact_evidence_string(model_class) if model_class_is_string else f"<invalid:{type(model_class).__name__}>"
+        )
         result.metadata["model_class"] = redacted_model_class
 
         # Check for subclassed models (custom class names)
-        check_subclassed_model(model_class, result, self.current_file_path)
+        if model_class_is_string:
+            check_subclassed_model(model_class, result, self.current_file_path)
+        else:
+            self._mark_inconclusive_scan_result(result, "keras_zip_model_class_invalid_type")
+            result.add_check(
+                name="Model Class Type Validation",
+                passed=False,
+                message=f"Invalid model class type: expected str, got {type(model_class).__name__}",
+                rule_code="S902",
+                severity=IssueSeverity.WARNING,
+                location=f"{self.current_file_path}/config.json",
+                details={"actual_type": type(model_class).__name__, "expected_type": "str"},
+            )
 
         # Root configs can themselves be serialized callables rather than model containers.
         self._check_layer_module_references(
@@ -1033,7 +1048,7 @@ class KerasZipScanner(BaseScanner):
         )
 
         # Check for suspicious model types (Lambda, etc.)
-        if model_class in self.suspicious_layer_types:
+        if model_class_is_string and model_class in self.suspicious_layer_types:
             result.add_check(
                 name="Model Type Security Check",
                 passed=False,
@@ -1317,7 +1332,13 @@ class KerasZipScanner(BaseScanner):
                         details={"actual_type": type(nested_config).__name__, "expected_type": "dict"},
                     )
 
-            self._scan_wrapped_layer_config(layer_class, layer_config, result, layer_name, nested_layer_depth)
+            self._scan_wrapped_layer_config(
+                layer_class,
+                layer_config,
+                result,
+                redacted_layer_name,
+                nested_layer_depth,
+            )
 
         # Add layer counts to metadata
         result.metadata["layer_counts"] = layer_counts

--- a/modelaudit/scanners/tf_savedmodel_scanner.py
+++ b/modelaudit/scanners/tf_savedmodel_scanner.py
@@ -26,7 +26,12 @@ from modelaudit.utils.tensorflow_compat import has_tensorflow_protobuf_stubs
 
 from ..core_results import mark_operational_scan_error
 from ..scanner_results import INCONCLUSIVE_SCAN_OUTCOME, mark_inconclusive_scan_result
-from ._evidence_redaction import REDACTED_URL_CREDENTIALS, redact_evidence_string
+from ._evidence_redaction import (
+    REDACTED_URL_CREDENTIALS,
+    redact_evidence_mapping_key,
+    redact_evidence_string,
+    redact_evidence_value,
+)
 from .base import BaseScanner, CheckStatus, IssueSeverity, ScanResult
 from .keras_utils import find_case_insensitive_substrings, find_lambda_dangerous_patterns
 
@@ -300,6 +305,26 @@ def _safe_decoded_preview(text: str, limit: int) -> str:
     if len(text) <= limit and len(redacted) <= limit:
         return redacted
     return f"{redacted[:limit]}..."
+
+
+def _redact_savedmodel_detail_string(value: Any, max_chars: int = 200) -> str:
+    return redact_evidence_string(str(value), max_chars=max_chars)
+
+
+def _redact_savedmodel_detail_value(value: Any, max_string_chars: int = 200) -> Any:
+    return redact_evidence_value(value, max_string_chars=max_string_chars)
+
+
+def _redact_savedmodel_relative_path(file_path: Path, model_root: Path) -> str:
+    try:
+        relative_path = file_path.relative_to(model_root)
+    except ValueError:
+        relative_path = Path(file_path.name)
+    return str(Path(*(_redact_savedmodel_detail_string(part) for part in relative_path.parts)))
+
+
+def _redact_savedmodel_file_location(file_path: Path, model_root: Path) -> str:
+    return str(model_root / _redact_savedmodel_relative_path(file_path, model_root))
 
 
 def _looks_like_pe_executable(content_head: bytes) -> bool:
@@ -777,13 +802,14 @@ class TensorFlowSavedModelScanner(BaseScanner):
         except OSError as e:
             return self._finish_read_failure(result, path, e)
         except Exception as e:
+            redacted_error = _redact_savedmodel_detail_string(e, max_chars=500)
             result.add_check(
                 name="SavedModel Parsing",
                 passed=False,
-                message=f"Error scanning TF SavedModel file: {e!s}",
+                message=f"Error scanning TF SavedModel file: {redacted_error}",
                 severity=IssueSeverity.CRITICAL,
                 location=path,
-                details={"exception": str(e), "exception_type": type(e).__name__},
+                details={"exception": redacted_error, "exception_type": type(e).__name__},
             )
             result.finish(success=False)
             return result
@@ -831,6 +857,9 @@ class TensorFlowSavedModelScanner(BaseScanner):
         for root, _dirs, files in os.walk(dir_path):
             for file in files:
                 file_path = Path(root) / file
+                redacted_file = _redact_savedmodel_detail_string(file)
+                redacted_location = _redact_savedmodel_file_location(file_path, model_root)
+                redacted_directory = str(Path(redacted_location).parent)
                 if (
                     any(
                         file_path.is_relative_to(model_root / asset_dir_name)
@@ -844,11 +873,11 @@ class TensorFlowSavedModelScanner(BaseScanner):
                     result.add_check(
                         name="Python File Detection",
                         passed=False,
-                        message=f"Python file found in SavedModel: {file}",
+                        message=f"Python file found in SavedModel: {redacted_file}",
                         severity=IssueSeverity.INFO,
-                        location=str(file_path),
+                        location=redacted_location,
                         rule_code="S902",
-                        details={"file": file, "directory": root},
+                        details={"file": redacted_file, "directory": redacted_directory},
                     )
 
                 # Check for blacklist patterns in text files
@@ -877,23 +906,24 @@ class TensorFlowSavedModelScanner(BaseScanner):
                                         result.add_check(
                                             name="Blacklist Pattern Check",
                                             passed=False,
-                                            message=f"Blacklisted pattern '{pattern}' found in file {file}",
+                                            message=f"Blacklisted pattern '{pattern}' found in file {redacted_file}",
                                             severity=IssueSeverity.CRITICAL,
-                                            location=str(file_path),
+                                            location=redacted_location,
                                             rule_code="S902",
-                                            details={"pattern": pattern, "file": file},
+                                            details={"pattern": pattern, "file": redacted_file},
                                         )
                     except Exception as e:
+                        redacted_error = _redact_savedmodel_detail_string(e, max_chars=500)
                         result.add_check(
                             name="File Read Check",
                             passed=False,
-                            message=f"Error reading file {file}: {e!s}",
+                            message=f"Error reading file {redacted_file}: {redacted_error}",
                             severity=IssueSeverity.DEBUG,
-                            location=str(file_path),
+                            location=redacted_location,
                             rule_code="S902",
                             details={
-                                "file": file,
-                                "exception": str(e),
+                                "file": redacted_file,
+                                "exception": redacted_error,
                                 "exception_type": type(e).__name__,
                             },
                         )
@@ -953,23 +983,27 @@ class TensorFlowSavedModelScanner(BaseScanner):
                 retained_dirs: list[str] = []
                 for dir_name in dir_names:
                     child_dir = Path(root) / dir_name
+                    redacted_dir_name = _redact_savedmodel_detail_string(dir_name)
+                    redacted_relative_dir = _redact_savedmodel_relative_path(child_dir, model_root)
+                    redacted_dir_location = _redact_savedmodel_file_location(child_dir, model_root)
                     try:
                         child_stat = child_dir.lstat()
                     except OSError as exc:
+                        redacted_error = _redact_savedmodel_detail_string(exc, max_chars=500)
                         result.add_check(
                             name="SavedModel Assets Security Check",
                             passed=False,
                             message=(
                                 "Cannot inspect nested asset directory for security analysis: "
-                                f"{child_dir.relative_to(model_root)}: {exc}"
+                                f"{redacted_relative_dir}: {redacted_error}"
                             ),
                             severity=IssueSeverity.WARNING,
-                            location=str(child_dir),
+                            location=redacted_dir_location,
                             details={
-                                "file_name": dir_name,
+                                "file_name": redacted_dir_name,
                                 "detected_content_type": "unscannable_asset_dir",
                                 "asset_kind": "stat_error",
-                                "exception": str(exc),
+                                "exception": redacted_error,
                                 "exception_type": type(exc).__name__,
                             },
                             rule_code="S902",
@@ -982,12 +1016,12 @@ class TensorFlowSavedModelScanner(BaseScanner):
                             passed=False,
                             message=(
                                 "Symlinked nested asset directory is not traversed during security analysis: "
-                                f"{child_dir.relative_to(model_root)}"
+                                f"{redacted_relative_dir}"
                             ),
                             severity=IssueSeverity.WARNING,
-                            location=str(child_dir),
+                            location=redacted_dir_location,
                             details={
-                                "file_name": dir_name,
+                                "file_name": redacted_dir_name,
                                 "detected_content_type": "unscannable_asset_dir",
                                 "asset_kind": "symlink_directory",
                             },
@@ -1002,22 +1036,24 @@ class TensorFlowSavedModelScanner(BaseScanner):
 
                 for file_name in files:
                     file_path = Path(root) / file_name
-                    detected_types = self._detect_suspicious_asset_content(file_path, result)
+                    detected_types = self._detect_suspicious_asset_content(file_path, result, model_root=model_root)
                     if not detected_types:
                         continue
 
                     file_size = self.get_file_size(str(file_path))
+                    redacted_file_name = _redact_savedmodel_detail_string(file_name)
+                    redacted_relative_path = _redact_savedmodel_relative_path(file_path, model_root)
                     result.add_check(
                         name="SavedModel Assets Security Check",
                         passed=False,
                         message=(
                             "Suspicious executable-like content detected in SavedModel assets: "
-                            f"{file_path.relative_to(model_root)}"
+                            f"{redacted_relative_path}"
                         ),
                         severity=IssueSeverity.WARNING,
-                        location=str(file_path),
+                        location=_redact_savedmodel_file_location(file_path, model_root),
                         details={
-                            "file_name": file_name,
+                            "file_name": redacted_file_name,
                             "detected_content_type": ", ".join(detected_types),
                             "size": file_size,
                         },
@@ -1027,20 +1063,23 @@ class TensorFlowSavedModelScanner(BaseScanner):
     def _scan_saved_model_root_siblings(self, model_root: Path, result: ScanResult) -> None:
         """Scan non-canonical root entries that can accompany a SavedModel."""
         for child_path in model_root.iterdir():
+            redacted_child_name = _redact_savedmodel_detail_string(child_path.name)
+            redacted_child_location = _redact_savedmodel_file_location(child_path, model_root)
             try:
                 child_stat = child_path.lstat()
             except OSError as exc:
+                redacted_error = _redact_savedmodel_detail_string(exc, max_chars=500)
                 result.add_check(
                     name="SavedModel Supplemental Directory Security Check",
                     passed=False,
-                    message=f"Cannot inspect SavedModel supplemental entry: {child_path.name}: {exc}",
+                    message=f"Cannot inspect SavedModel supplemental entry: {redacted_child_name}: {redacted_error}",
                     severity=IssueSeverity.WARNING,
-                    location=str(child_path),
+                    location=redacted_child_location,
                     details={
-                        "file_name": child_path.name,
+                        "file_name": redacted_child_name,
                         "detected_content_type": "unscannable_supplemental_entry",
                         "entry_kind": "stat_error",
-                        "exception": str(exc),
+                        "exception": redacted_error,
                         "exception_type": type(exc).__name__,
                     },
                     rule_code="S902",
@@ -1059,7 +1098,7 @@ class TensorFlowSavedModelScanner(BaseScanner):
                 self._scan_saved_model_supplemental_directory(model_root, child_path, result)
                 continue
 
-            self._scan_saved_model_supplemental_file(child_path, result)
+            self._scan_saved_model_supplemental_file(model_root, child_path, result)
 
     def _scan_saved_model_supplemental_directory(
         self,
@@ -1072,23 +1111,27 @@ class TensorFlowSavedModelScanner(BaseScanner):
             retained_dirs: list[str] = []
             for dir_name in dir_names:
                 child_dir = Path(root) / dir_name
+                redacted_dir_name = _redact_savedmodel_detail_string(dir_name)
+                redacted_relative_dir = _redact_savedmodel_relative_path(child_dir, model_root)
+                redacted_dir_location = _redact_savedmodel_file_location(child_dir, model_root)
                 try:
                     child_stat = child_dir.lstat()
                 except OSError as exc:
+                    redacted_error = _redact_savedmodel_detail_string(exc, max_chars=500)
                     result.add_check(
                         name="SavedModel Supplemental Directory Security Check",
                         passed=False,
                         message=(
                             "Cannot inspect nested SavedModel supplemental directory: "
-                            f"{child_dir.relative_to(model_root)}: {exc}"
+                            f"{redacted_relative_dir}: {redacted_error}"
                         ),
                         severity=IssueSeverity.WARNING,
-                        location=str(child_dir),
+                        location=redacted_dir_location,
                         details={
-                            "file_name": dir_name,
+                            "file_name": redacted_dir_name,
                             "detected_content_type": "unscannable_supplemental_dir",
                             "entry_kind": "stat_error",
-                            "exception": str(exc),
+                            "exception": redacted_error,
                             "exception_type": type(exc).__name__,
                         },
                         rule_code="S902",
@@ -1101,12 +1144,12 @@ class TensorFlowSavedModelScanner(BaseScanner):
                         passed=False,
                         message=(
                             "Symlinked SavedModel supplemental directory is not traversed during security analysis: "
-                            f"{child_dir.relative_to(model_root)}"
+                            f"{redacted_relative_dir}"
                         ),
                         severity=IssueSeverity.WARNING,
-                        location=str(child_dir),
+                        location=redacted_dir_location,
                         details={
-                            "file_name": dir_name,
+                            "file_name": redacted_dir_name,
                             "detected_content_type": "unscannable_supplemental_dir",
                             "entry_kind": "symlink_directory",
                         },
@@ -1120,13 +1163,19 @@ class TensorFlowSavedModelScanner(BaseScanner):
             dir_names[:] = retained_dirs
 
             for file_name in files:
-                self._scan_saved_model_supplemental_file(Path(root) / file_name, result)
+                self._scan_saved_model_supplemental_file(model_root, Path(root) / file_name, result)
 
-    def _scan_saved_model_supplemental_file(self, file_path: Path, result: ScanResult) -> None:
+    def _scan_saved_model_supplemental_file(
+        self,
+        model_root: Path,
+        file_path: Path,
+        result: ScanResult,
+    ) -> None:
         """Scan one supplemental SavedModel file-like entry."""
         detected_types = self._detect_suspicious_asset_content(
             file_path,
             result,
+            model_root=model_root,
             check_name="SavedModel Supplemental File Security Check",
             file_label="supplemental file",
         )
@@ -1134,14 +1183,17 @@ class TensorFlowSavedModelScanner(BaseScanner):
             return
 
         file_size = self.get_file_size(str(file_path))
+        redacted_file_name = _redact_savedmodel_detail_string(file_path.name)
         result.add_check(
             name="SavedModel Supplemental File Security Check",
             passed=False,
-            message=f"Suspicious executable-like content detected in SavedModel supplemental file: {file_path.name}",
+            message=(
+                f"Suspicious executable-like content detected in SavedModel supplemental file: {redacted_file_name}"
+            ),
             severity=IssueSeverity.WARNING,
-            location=str(file_path),
+            location=_redact_savedmodel_file_location(file_path, model_root),
             details={
-                "file_name": file_path.name,
+                "file_name": redacted_file_name,
                 "detected_content_type": ", ".join(detected_types),
                 "size": file_size,
             },
@@ -1153,24 +1205,28 @@ class TensorFlowSavedModelScanner(BaseScanner):
         file_path: Path,
         result: ScanResult,
         *,
+        model_root: Path,
         check_name: str = "SavedModel Assets Security Check",
         file_label: str = "asset file",
     ) -> list[str]:
         """Return suspicious content types found in a SavedModel asset file."""
+        redacted_file_name = _redact_savedmodel_detail_string(file_path.name)
+        redacted_location = _redact_savedmodel_file_location(file_path, model_root)
         try:
             file_stat = file_path.lstat()
         except OSError as exc:
+            redacted_error = _redact_savedmodel_detail_string(exc, max_chars=500)
             result.add_check(
                 name=check_name,
                 passed=False,
-                message=f"Cannot inspect {file_label} for security analysis: {file_path.name}: {exc}",
+                message=f"Cannot inspect {file_label} for security analysis: {redacted_file_name}: {redacted_error}",
                 severity=IssueSeverity.WARNING,
-                location=str(file_path),
+                location=redacted_location,
                 details={
-                    "file_name": file_path.name,
+                    "file_name": redacted_file_name,
                     "detected_content_type": "unscannable_asset",
                     "asset_kind": "stat_error",
-                    "exception": str(exc),
+                    "exception": redacted_error,
                     "exception_type": type(exc).__name__,
                 },
                 rule_code="S902",
@@ -1180,11 +1236,11 @@ class TensorFlowSavedModelScanner(BaseScanner):
             result.add_check(
                 name=check_name,
                 passed=False,
-                message=f"Symlink {file_label} is not followed during security analysis: {file_path.name}",
+                message=f"Symlink {file_label} is not followed during security analysis: {redacted_file_name}",
                 severity=IssueSeverity.WARNING,
-                location=str(file_path),
+                location=redacted_location,
                 details={
-                    "file_name": file_path.name,
+                    "file_name": redacted_file_name,
                     "detected_content_type": "unscannable_asset",
                     "asset_kind": "symlink",
                     "size": file_stat.st_size,
@@ -1196,11 +1252,11 @@ class TensorFlowSavedModelScanner(BaseScanner):
             result.add_check(
                 name=check_name,
                 passed=False,
-                message=f"Non-regular {file_label} is not scanned during security analysis: {file_path.name}",
+                message=f"Non-regular {file_label} is not scanned during security analysis: {redacted_file_name}",
                 severity=IssueSeverity.WARNING,
-                location=str(file_path),
+                location=redacted_location,
                 details={
-                    "file_name": file_path.name,
+                    "file_name": redacted_file_name,
                     "detected_content_type": "unscannable_asset",
                     "asset_kind": "non_regular",
                     "size": file_stat.st_size,
@@ -1213,18 +1269,19 @@ class TensorFlowSavedModelScanner(BaseScanner):
             with file_path.open("rb") as file_obj:
                 content_head = file_obj.read(_ASSET_PROBE_BYTES)
         except OSError as exc:
+            redacted_error = _redact_savedmodel_detail_string(exc, max_chars=500)
             result.add_check(
                 name=check_name,
                 passed=False,
-                message=f"Cannot read {file_label} for security analysis: {file_path.name}: {exc}",
+                message=f"Cannot read {file_label} for security analysis: {redacted_file_name}: {redacted_error}",
                 severity=IssueSeverity.WARNING,
-                location=str(file_path),
+                location=redacted_location,
                 details={
-                    "file_name": file_path.name,
+                    "file_name": redacted_file_name,
                     "detected_content_type": "unscannable_asset",
                     "asset_kind": "unreadable",
                     "size": file_stat.st_size,
-                    "exception": str(exc),
+                    "exception": redacted_error,
                     "exception_type": type(exc).__name__,
                 },
                 rule_code="S902",
@@ -1270,11 +1327,11 @@ class TensorFlowSavedModelScanner(BaseScanner):
             result.add_check(
                 name="SavedModel Asset Probe Limit",
                 passed=False,
-                message=f"Asset exceeds bounded security probe window: {file_path.name}",
+                message=f"Asset exceeds bounded security probe window: {redacted_file_name}",
                 severity=IssueSeverity.INFO,
-                location=str(file_path),
+                location=redacted_location,
                 details={
-                    "file_name": file_path.name,
+                    "file_name": redacted_file_name,
                     "asset_size": file_stat.st_size,
                     "probe_bytes": _ASSET_PROBE_BYTES,
                     "analysis_incomplete": True,
@@ -1322,8 +1379,10 @@ class TensorFlowSavedModelScanner(BaseScanner):
         """Scan MetaGraph collection payloads embedded in SavedModel files."""
         for meta_graph in saved_model.meta_graphs:
             meta_graph_tag = self._get_meta_graph_tag(meta_graph)
+            redacted_meta_graph_tag = _redact_savedmodel_detail_string(meta_graph_tag)
             for key, collection in meta_graph.collection_def.items():
                 key_lower = key.lower()
+                redacted_key = _redact_savedmodel_detail_string(key)
                 if not hasattr(collection, "bytes_list"):
                     continue
 
@@ -1336,11 +1395,11 @@ class TensorFlowSavedModelScanner(BaseScanner):
                             severity=IssueSeverity.WARNING,
                             location=self.current_file_path,
                             details={
-                                "collection_key": key,
+                                "collection_key": redacted_key,
                                 "index": index,
                                 "entry_size": len(value),
                                 "max_expected": _MAX_COLLECTION_VALUE_BYTES,
-                                "meta_graph": meta_graph_tag,
+                                "meta_graph": redacted_meta_graph_tag,
                             },
                         )
 
@@ -1356,10 +1415,10 @@ class TensorFlowSavedModelScanner(BaseScanner):
                             severity=IssueSeverity.WARNING,
                             location=self.current_file_path,
                             details={
-                                "collection_key": key,
+                                "collection_key": redacted_key,
                                 "index": index,
                                 "value_preview": _safe_decoded_preview(decoded, 200),
-                                "meta_graph": meta_graph_tag,
+                                "meta_graph": redacted_meta_graph_tag,
                             },
                         )
 
@@ -1372,10 +1431,10 @@ class TensorFlowSavedModelScanner(BaseScanner):
         """Format a finding location for a graph node."""
         location_parts = []
         if node_context.function_name:
-            location_parts.append(f"function: {node_context.function_name}")
-        location_parts.append(f"node: {node_context.node.name}")
+            location_parts.append(f"function: {_redact_savedmodel_detail_string(node_context.function_name)}")
+        location_parts.append(f"node: {_redact_savedmodel_detail_string(node_context.node.name)}")
         if attr_name:
-            location_parts.append(f"attr: {attr_name}")
+            location_parts.append(f"attr: {_redact_savedmodel_detail_string(attr_name)}")
         return f"{self.current_file_path} ({', '.join(location_parts)})"
 
     def _build_node_details(
@@ -1385,14 +1444,16 @@ class TensorFlowSavedModelScanner(BaseScanner):
     ) -> dict[str, Any]:
         """Build consistent finding details for a graph node."""
         details: dict[str, Any] = {
-            "node_name": node_context.node.name,
-            "meta_graph": node_context.meta_graph_tag,
+            "node_name": _redact_savedmodel_detail_string(node_context.node.name),
+            "meta_graph": _redact_savedmodel_detail_string(node_context.meta_graph_tag),
             "node_scope": node_context.node_scope,
         }
         if node_context.function_name:
-            details["function_name"] = node_context.function_name
+            details["function_name"] = _redact_savedmodel_detail_string(node_context.function_name)
         if extra_details:
-            details.update(extra_details)
+            redacted_extra_details = _redact_savedmodel_detail_value(extra_details)
+            if isinstance(redacted_extra_details, dict):
+                details.update(redacted_extra_details)
         return details
 
     def _scan_tf_operations(self, saved_model: Any) -> list[dict[str, Any]]:
@@ -1424,6 +1485,7 @@ class TensorFlowSavedModelScanner(BaseScanner):
         """Analyze the saved model for suspicious operations"""
         suspicious_op_found = False
         op_counts: dict[str, int] = {}
+        op_count_display_keys: dict[str, str] = {}
 
         # Regex to detect Lambda-layer node names in the graph.
         # Matches node names that start with "lambda" (case-insensitive)
@@ -1441,7 +1503,11 @@ class TensorFlowSavedModelScanner(BaseScanner):
             node = node_context.node
 
             # Count all operation types
-            op_counts[node.op] = op_counts.get(node.op, 0) + 1
+            redacted_op = op_count_display_keys.get(node.op)
+            if redacted_op is None:
+                redacted_op = redact_evidence_mapping_key(node.op, op_counts)
+                op_count_display_keys[node.op] = redacted_op
+            op_counts[redacted_op] = op_counts.get(redacted_op, 0) + 1
 
             if node.op in self.suspicious_ops:
                 suspicious_op_found = True
@@ -1453,7 +1519,7 @@ class TensorFlowSavedModelScanner(BaseScanner):
                     result.add_check(
                         name="TensorFlow Operation Security Check",
                         passed=False,
-                        message=f"Suspicious TensorFlow operation: {node.op}",
+                        message=f"Suspicious TensorFlow operation: {redacted_op}",
                         severity=IssueSeverity.CRITICAL,
                         location=self._build_node_location(node_context),
                         rule_code="S703",
@@ -1483,10 +1549,11 @@ class TensorFlowSavedModelScanner(BaseScanner):
                     # _scan_keras_metadata.
                     matched_pattern = self._match_suspicious_function_name(func_name)
                     if matched_pattern is not None:
+                        redacted_func_name = _redact_savedmodel_detail_string(func_name)
                         result.add_check(
                             name="StatefulPartitionedCall Security Check",
                             passed=False,
-                            message=f"StatefulPartitionedCall with suspicious function: {func_name}",
+                            message=f"StatefulPartitionedCall with suspicious function: {redacted_func_name}",
                             severity=IssueSeverity.WARNING,
                             location=self._build_node_location(node_context),
                             details=self._build_node_details(
@@ -1602,10 +1669,11 @@ class TensorFlowSavedModelScanner(BaseScanner):
                             func_name = attr.s.decode("utf-8", errors="ignore")
                             matched_reference = self._match_pyfunc_reference_token(func_name)
                             if matched_reference is not None:
+                                redacted_func_name = _redact_savedmodel_detail_string(func_name)
                                 result.add_check(
                                     name="PyFunc Function Reference Check",
                                     passed=False,
-                                    message=f"{node.op} operation references dangerous function: {func_name}",
+                                    message=f"{node.op} operation references dangerous function: {redacted_func_name}",
                                     severity=IssueSeverity.CRITICAL,
                                     location=self._build_node_location(node_context),
                                     rule_code="S902",
@@ -2052,7 +2120,7 @@ class TensorFlowSavedModelScanner(BaseScanner):
                             "node_name_length": len(node.name),
                             "name_threshold": 2048,
                             "attack_type": "protobuf_buffer_overflow",
-                            "node_name_preview": node.name[:200],  # First 200 chars
+                            "node_name_preview": _redact_savedmodel_detail_string(node.name[:200]),
                         },
                     ),
                 )
@@ -2063,7 +2131,10 @@ class TensorFlowSavedModelScanner(BaseScanner):
                     result.add_check(
                         name="Protobuf Input Name Length Check",
                         passed=False,
-                        message=f"Abnormally long input name (length: {len(input_name)}) in node {node.name}",
+                        message=(
+                            f"Abnormally long input name (length: {len(input_name)}) in node "
+                            f"{_redact_savedmodel_detail_string(node.name)}"
+                        ),
                         severity=IssueSeverity.WARNING,
                         location=self._build_node_location(node_context),
                         details=self._build_node_details(
@@ -2203,19 +2274,24 @@ class TensorFlowSavedModelScanner(BaseScanner):
             with contextlib.suppress(PackageNotFoundError, Exception):
                 metadata["tensorflow_version"] = version("tensorflow")
 
+            redacted_signature_details = _redact_savedmodel_detail_value(signature_details)
             metadata.update(
                 {
                     "meta_graph_count": len(saved_model.meta_graphs),
                     "saved_model_pb_size": len(content),
-                    "signatures": sorted(signature_details.keys()),
-                    "signature_details": signature_details,
+                    "signatures": (
+                        sorted(redacted_signature_details.keys())
+                        if isinstance(redacted_signature_details, dict)
+                        else []
+                    ),
+                    "signature_details": redacted_signature_details,
                     "trackable_objects": trackable_objects,
                 }
             )
             if tag_sets:
-                metadata["tag_sets"] = tag_sets
+                metadata["tag_sets"] = _redact_savedmodel_detail_value(tag_sets)
 
         except Exception as e:
-            metadata["extraction_error"] = str(e)
+            metadata["extraction_error"] = _redact_savedmodel_detail_string(e, max_chars=500)
 
         return metadata

--- a/tests/scanners/test_evidence_redaction.py
+++ b/tests/scanners/test_evidence_redaction.py
@@ -1380,6 +1380,45 @@ def test_redacts_secret_bearing_structured_keys() -> None:
     )
 
 
+def test_preserves_values_when_redacted_mapping_keys_collide() -> None:
+    """Redaction must not silently overwrite distinct mapping entries."""
+    secret = "sk-proj-REDACTEDKEYCOLLISION1234567890"
+
+    redacted_value = redact_evidence_value(
+        {
+            f"node_{secret}": "secret-derived-key",
+            f"node_{REDACTED_EVIDENCE_VALUE}": "literal-redacted-key",
+            1: "first-non-string-key",
+            2: "second-non-string-key",
+        },
+        max_string_chars=500,
+    )
+
+    assert redacted_value == {
+        f"node_{REDACTED_EVIDENCE_VALUE}": "secret-derived-key",
+        f"node_{REDACTED_EVIDENCE_VALUE}[2]": "literal-redacted-key",
+        "<int-key>": "first-non-string-key",
+        "<int-key>[2]": "second-non-string-key",
+    }
+    assert secret not in json.dumps(redacted_value)
+
+
+def test_case_variant_name_keys_cannot_bypass_value_redaction() -> None:
+    """Every name/key alias must contribute to name-value sensitivity."""
+    secret = "context-only-sensitive-value"
+
+    redacted_value = redact_evidence_value(
+        {
+            "name": "API_KEY",
+            "Name": "public_label",
+            "value": secret,
+        }
+    )
+
+    assert redacted_value["value"] == REDACTED_EVIDENCE_VALUE
+    assert secret not in json.dumps(redacted_value)
+
+
 def test_redacts_camel_case_structured_credential_keys() -> None:
     """SDK-style camelCase credential keys should redact values by key context."""
     aws_secret = "AWS_SECRET_ACCESS_KEY_VALUE"

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -192,6 +192,40 @@ def create_h5_with_external_storage(
     return model_path
 
 
+def create_h5_with_sensitive_external_references(tmp_path: Path, raw_secret: str) -> Path:
+    """Create a Keras H5 file whose external-reference metadata contains sensitive evidence."""
+    raw_storage = tmp_path / f"{raw_secret}.raw"
+    raw_storage.write_bytes(b"\x00" * 8)
+
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "name": "sequential",
+                "layers": [{"class_name": "Dense", "config": {"units": 1}}],
+            },
+        },
+        keras_version=f"3.13.1+{raw_secret}",
+        file_name="sensitive_external_refs.h5",
+    )
+
+    with h5py.File(model_path, "a") as f:
+        weights_group = f.require_group("model_weights")
+        weights_group[f"linked_{raw_secret}"] = h5py.ExternalLink(
+            f"https://user:very-secret-password@example.com/private/model.h5?token={raw_secret}",
+            f"/payload/{raw_secret}",
+        )
+        weights_group.create_dataset(
+            f"external_{raw_secret}_kernel",
+            shape=(2,),
+            dtype="float32",
+            external=[(raw_storage.name, 0, 8)],
+        )
+
+    return model_path
+
+
 def test_keras_h5_scanner_safe_model(tmp_path):
     """Test scanning a safe Keras H5 model."""
     model_path = create_mock_h5_file(tmp_path)
@@ -245,6 +279,108 @@ def test_keras_h5_scanner_detects_cve_2026_1669_external_storage(tmp_path: Path)
             "segments": [{"filename": "weights.raw", "offset": 0, "size": 8}],
         },
     ]
+
+
+def test_keras_h5_external_reference_details_redact_model_controlled_values(tmp_path: Path) -> None:
+    """HDF5 external-reference details should not serialize secrets, URL creds, or private path tokens."""
+    raw_secret = "sk-proj-CAND061H5DETAILSECRET000000000000"
+    model_path = create_h5_with_sensitive_external_references(tmp_path, raw_secret)
+
+    result = KerasH5Scanner().scan(str(model_path))
+    cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2026-1669"]
+
+    assert len(cve_issues) == 1
+    serialized_result = result.to_json()
+    assert raw_secret not in serialized_result
+    assert "very-secret-password" not in serialized_result
+    details_json = json.dumps(cve_issues[0].details, sort_keys=True)
+    assert "model_weights" in details_json
+    assert "https://" in details_json
+    assert "<redacted>" in details_json
+
+
+def test_keras_h5_custom_layer_config_details_redact_model_controlled_values(tmp_path: Path) -> None:
+    """Custom layer details should keep benign config keys while redacting sensitive model-controlled values."""
+    raw_secret = "sk-proj-CAND061H5CONFIGSECRET000000000000"
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "CustomAuditLayer",
+                        "config": {
+                            "api_key": raw_secret,
+                            "callback": f"https://callback.example/hook?token={raw_secret}",
+                            "safe_label": "public_label",
+                        },
+                    }
+                ]
+            },
+        },
+    )
+
+    result = KerasH5Scanner().scan(str(model_path))
+    custom_issues = [check for check in result.checks if check.name == "Custom Layer Class Detection"]
+
+    assert custom_issues
+    layer_config = custom_issues[0].details["layer_config"]
+    assert layer_config["api_key"] == "<redacted>"
+    assert layer_config["safe_label"] == "public_label"
+    assert raw_secret not in result.to_json()
+
+
+def test_keras_h5_layer_counts_preserve_colliding_redacted_classes(tmp_path: Path) -> None:
+    """Distinct model-controlled class names must not collapse into one count."""
+    first_secret = "sk-proj-" + "A" * 24
+    second_secret = "sk-proj-" + "B" * 24
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {"class_name": f"token={first_secret}", "config": {}},
+                    {"class_name": f"token={second_secret}", "config": {}},
+                    {"class_name": f"token={first_secret}", "config": {}},
+                ]
+            },
+        },
+    )
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    assert result.metadata["layer_counts"] == {"token=<redacted>": 2, "token=<redacted>[2]": 1}
+    assert first_secret not in result.to_json()
+    assert second_secret not in result.to_json()
+
+
+def test_keras_h5_non_string_layer_class_fails_closed_without_abort(tmp_path: Path) -> None:
+    """Malformed structured class names should remain explicit and serializable."""
+    raw_secret = "sk-proj-CAND061H5CLASSSECRET000000000000"
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {"class_name": {"api_key": raw_secret}, "config": {}},
+                    {"class_name": "Dense", "config": {"units": 2}},
+                ]
+            },
+        },
+    )
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    type_checks = [check for check in result.checks if check.name == "Layer Class Type Validation"]
+    assert len(type_checks) == 1
+    assert type_checks[0].severity == IssueSeverity.WARNING
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "keras_h5_layer_class_invalid_type" in result.metadata["scan_outcome_reasons"]
+    assert result.metadata["layer_counts"]["<invalid:dict>"] == 1
+    assert raw_secret not in result.to_json()
 
 
 @pytest.mark.parametrize(
@@ -4600,6 +4736,34 @@ class TestCVE20259905H5SafeMode:
         cve_issues = [i for i in result.issues if "CVE-2025-9905" in i.message]
         assert len(cve_issues) >= 1, "Lambda in H5 should trigger CVE-2025-9905"
         assert cve_issues[0].severity == IssueSeverity.CRITICAL
+
+    def test_redacted_local_version_still_triggers_cve_2025_9905(self, tmp_path: Path) -> None:
+        """Display redaction must not downgrade a valid vulnerable local version."""
+        raw_secret = "sk-proj-CAND061H5VERSIONSECRET000000000000"
+        model_path = create_custom_h5_file(
+            tmp_path,
+            {
+                "class_name": "Sequential",
+                "config": {
+                    "layers": [
+                        {
+                            "class_name": "Lambda",
+                            "config": {"function": "lambda x: x"},
+                        }
+                    ]
+                },
+            },
+            keras_version=f"3.10.0+{raw_secret}",
+            file_name="redacted_local_version.h5",
+        )
+
+        result = KerasH5Scanner().scan(str(model_path))
+        cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-9905"]
+
+        assert len(cve_issues) == 1
+        assert cve_issues[0].severity == IssueSeverity.CRITICAL
+        assert cve_issues[0].details["keras_version"] == "3.10.0+<redacted>"
+        assert raw_secret not in result.to_json()
 
     @pytest.mark.parametrize(
         "layer_class",

--- a/tests/scanners/test_keras_h5_scanner.py
+++ b/tests/scanners/test_keras_h5_scanner.py
@@ -383,6 +383,34 @@ def test_keras_h5_non_string_layer_class_fails_closed_without_abort(tmp_path: Pa
     assert raw_secret not in result.to_json()
 
 
+def test_keras_h5_non_string_model_class_preserves_nested_cve_detection(tmp_path: Path) -> None:
+    """Malformed root metadata must not suppress scanning of nested layers."""
+    raw_secret = "sk-proj-CAND061H5MODELCLASSSECRET000000000000"
+    model_path = create_custom_h5_file(
+        tmp_path,
+        {
+            "class_name": {"api_key": raw_secret},
+            "config": {
+                "layers": [
+                    {"class_name": "Lambda", "config": {"function": "lambda x: x"}},
+                ]
+            },
+        },
+        keras_version="3.10.0",
+    )
+
+    result = KerasH5Scanner().scan(str(model_path))
+
+    type_checks = [check for check in result.checks if check.name == "Model Class Type Validation"]
+    cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2025-9905"]
+    assert len(type_checks) == 1
+    assert len(cve_issues) == 1
+    assert cve_issues[0].severity == IssueSeverity.CRITICAL
+    assert result.metadata["model_class"] == "<invalid:dict>"
+    assert "keras_h5_model_class_invalid_type" in result.metadata["scan_outcome_reasons"]
+    assert raw_secret not in result.to_json()
+
+
 @pytest.mark.parametrize(
     "fixture_factory",
     [create_h5_with_external_link, create_h5_with_external_storage],

--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -140,6 +140,39 @@ def test_keras_zip_layer_counts_preserve_colliding_redacted_classes(tmp_path: Pa
     assert second_secret not in result.to_json()
 
 
+def test_keras_zip_non_string_model_class_preserves_nested_cve_detection(tmp_path: Path) -> None:
+    """Malformed root metadata must not suppress scanning of nested layers."""
+    raw_secret = "sk-proj-CAND061ZIPMODELCLASSSECRET000000000000"
+    encoded = base64.b64encode(b"lambda x: x * 2").decode()
+    model_path = create_configured_keras_zip(
+        tmp_path,
+        {
+            "class_name": {"api_key": raw_secret},
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Lambda",
+                        "name": "nested_lambda",
+                        "config": {"function": [encoded, None, None]},
+                    }
+                ]
+            },
+        },
+        keras_version="2.12.0",
+    )
+
+    result = KerasZipScanner().scan(str(model_path))
+
+    type_checks = [check for check in result.checks if check.name == "Model Class Type Validation"]
+    cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2024-3660"]
+    assert len(type_checks) == 1
+    assert len(cve_issues) == 1
+    assert cve_issues[0].severity == IssueSeverity.CRITICAL
+    assert result.metadata["model_class"] == "<invalid:dict>"
+    assert "keras_zip_model_class_invalid_type" in result.metadata["scan_outcome_reasons"]
+    assert raw_secret not in result.to_json()
+
+
 def create_external_link_weights_h5(tmp_path: Path) -> Path:
     """Create a weights H5 file containing an ExternalLink to a local fixture."""
     if h5py is None:
@@ -4640,6 +4673,31 @@ __import__('pickle').loads(data)
             for check in result.checks
         )
         assert determine_exit_code(audit_result) == 2
+
+    def test_wrapped_layer_validation_redacts_sensitive_layer_name(self, tmp_path: Path) -> None:
+        raw_secret = "sk-proj-CAND061ZIPWRAPPERSECRET000000000000"
+        keras_path = create_configured_keras_zip(
+            tmp_path,
+            {
+                "class_name": "Sequential",
+                "config": {
+                    "layers": [
+                        {
+                            "class_name": "TimeDistributed",
+                            "name": f"wrapper_{raw_secret}",
+                            "config": {},
+                        }
+                    ]
+                },
+            },
+        )
+
+        result = KerasZipScanner().scan(str(keras_path))
+        wrapped_checks = [check for check in result.checks if check.name == "Wrapped Layer Config Validation"]
+
+        assert len(wrapped_checks) == 1
+        assert wrapped_checks[0].location and "wrapper_<redacted>" in wrapped_checks[0].location
+        assert raw_secret not in result.to_json()
 
     @pytest.mark.parametrize("layer_class", ["Dense", "myproject.TimeDistributed"])
     def test_nonwrapper_layer_config_scalar_nested_names_remain_quiet(self, tmp_path: Path, layer_class: str) -> None:

--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -115,6 +115,31 @@ def _assert_inconclusive_keras_zip_scan_not_cached(model_path: Path, reason: str
         reset_cache_manager()
 
 
+def test_keras_zip_layer_counts_preserve_colliding_redacted_classes(tmp_path: Path) -> None:
+    """Distinct model-controlled class names must not collapse into one count."""
+    first_secret = "sk-proj-" + "A" * 24
+    second_secret = "sk-proj-" + "B" * 24
+    model_path = create_configured_keras_zip(
+        tmp_path,
+        {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {"class_name": f"token={first_secret}", "config": {}},
+                    {"class_name": f"token={second_secret}", "config": {}},
+                    {"class_name": f"token={first_secret}", "config": {}},
+                ]
+            },
+        },
+    )
+
+    result = KerasZipScanner().scan(str(model_path))
+
+    assert result.metadata["layer_counts"] == {"token=<redacted>": 2, "token=<redacted>[2]": 1}
+    assert first_secret not in result.to_json()
+    assert second_secret not in result.to_json()
+
+
 def create_external_link_weights_h5(tmp_path: Path) -> Path:
     """Create a weights H5 file containing an ExternalLink to a local fixture."""
     if h5py is None:
@@ -242,6 +267,26 @@ class TestKerasZipScanner:
         assert scanner is not None
         assert scanner.name == "keras_zip"
 
+    def test_archive_member_details_redact_model_controlled_values(self, tmp_path: Path) -> None:
+        """Archive member names should remain useful without serializing embedded secrets."""
+        raw_secret = "sk-proj-CAND061ZIPDETAILSECRET000000000000"
+        keras_path = tmp_path / "missing_config.keras"
+        with zipfile.ZipFile(keras_path, "w") as zf:
+            zf.writestr("assets/public/readme.txt", "benign")
+            zf.writestr(f"assets/{raw_secret}/payload.py", "print('review')")
+
+        result = KerasZipScanner().scan(str(keras_path))
+        format_checks = [check for check in result.checks if check.name == "Keras ZIP Format Check"]
+        python_checks = [check for check in result.checks if check.name == "Python File Detection"]
+
+        assert format_checks
+        assert python_checks
+        serialized_result = result.to_json()
+        assert raw_secret not in serialized_result
+        assert "assets/public/readme.txt" in format_checks[0].details["files"]
+        assert any("<redacted>" in filename for filename in format_checks[0].details["files"])
+        assert "<redacted>" in python_checks[0].details["filename"]
+
     def test_detects_cve_2026_1669_in_embedded_weights(self, tmp_path: Path) -> None:
         """Vulnerable .keras archives should warn on embedded HDF5 ExternalLink weights."""
         scanner = KerasZipScanner()
@@ -266,6 +311,24 @@ class TestKerasZipScanner:
                 "path": "/payload",
             },
         ]
+
+    def test_redacted_local_version_still_triggers_cve_2026_1669(self, tmp_path: Path) -> None:
+        """Embedded HDF5 attribution must classify the unredacted local version."""
+        raw_secret = "sk-proj-CAND061ZIPH5VERSIONSECRET000000000000"
+        keras_path = create_configured_keras_zip(
+            tmp_path,
+            {"class_name": "Sequential", "config": {"layers": []}},
+            keras_version=f"3.12.0+{raw_secret}",
+            weights_h5_path=create_external_link_weights_h5(tmp_path),
+        )
+
+        result = KerasZipScanner().scan(str(keras_path))
+
+        cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2026-1669"]
+        assert len(cve_issues) == 1
+        assert cve_issues[0].severity == IssueSeverity.WARNING
+        assert cve_issues[0].details["keras_version"] == "3.12.0+<redacted>"
+        assert raw_secret not in result.to_json()
 
     @pytest.mark.parametrize(
         "weights_factory",
@@ -3557,6 +3620,35 @@ __import__('pickle').loads(data)
         assert cve_checks[0].severity == IssueSeverity.WARNING
         assert cve_checks[0].details["layer_name"] == "string_lookup"
         assert cve_checks[0].details["cwe"] == "CWE-502, CWE-918"
+
+    def test_redacted_local_version_still_triggers_cve_2025_12058(self, tmp_path: Path) -> None:
+        """StringLookup attribution must classify the unredacted local version."""
+        raw_secret = "sk-proj-CAND061ZIPLOOKUPVERSIONSECRET000000000000"
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "StringLookup",
+                        "name": "string_lookup",
+                        "config": {"vocabulary": str(tmp_path / "vocab.txt")},
+                    },
+                ],
+            },
+        }
+        model_path = create_configured_keras_zip(
+            tmp_path,
+            config,
+            keras_version=f"3.11.3+{raw_secret}",
+        )
+
+        result = KerasZipScanner().scan(str(model_path))
+
+        cve_checks = [check for check in result.checks if check.details.get("cve_id") == "CVE-2025-12058"]
+        assert len(cve_checks) == 1
+        assert cve_checks[0].status == CheckStatus.FAILED
+        assert cve_checks[0].details["keras_version"] == "3.11.3+<redacted>"
+        assert raw_secret not in result.to_json()
 
     def test_stringlookup_remote_vocabulary_url_triggers_cve_2025_12058(self, tmp_path: Path) -> None:
         """Remote StringLookup vocabulary URLs should also be attributed to CVE-2025-12058."""
@@ -7475,6 +7567,31 @@ class TestCVE20243660LambdaAttribution:
         assert cve_issues[0].details["description"]
         assert cve_issues[0].details["remediation"]
         assert cve_issues[0].details["layer_name"] == "my_lambda"
+
+    def test_redacted_local_version_still_triggers_cve_2024_3660(self, tmp_path: Path) -> None:
+        """Display redaction must not downgrade a valid vulnerable local version."""
+        raw_secret = "sk-proj-CAND061ZIPVERSIONSECRET000000000000"
+        encoded = base64.b64encode(b"lambda x: x * 2").decode()
+        config = {
+            "class_name": "Sequential",
+            "config": {
+                "layers": [
+                    {
+                        "class_name": "Lambda",
+                        "name": "redacted_version_lambda",
+                        "config": {"function": [encoded, None, None]},
+                    }
+                ]
+            },
+        }
+
+        result = KerasZipScanner().scan(self._make_keras_zip(config, tmp_path, keras_version=f"2.12.0+{raw_secret}"))
+        cve_issues = [issue for issue in result.issues if issue.details.get("cve_id") == "CVE-2024-3660"]
+
+        assert len(cve_issues) == 1
+        assert cve_issues[0].severity == IssueSeverity.CRITICAL
+        assert cve_issues[0].details["keras_version"] == "2.12.0+<redacted>"
+        assert raw_secret not in result.to_json()
 
     @pytest.mark.parametrize(
         "layer_class",

--- a/tests/scanners/test_tf_savedmodel_scanner.py
+++ b/tests/scanners/test_tf_savedmodel_scanner.py
@@ -28,6 +28,7 @@ class _RequiredNodeSpec(TypedDict):
 
 class _NodeSpec(_RequiredNodeSpec, total=False):
     name: str
+    inputs: list[str]
     string_attrs: dict[str, str]
     string_list_attrs: dict[str, list[str]]
     function_ref: str
@@ -1185,6 +1186,61 @@ def test_safe_function_definition_ops_do_not_trigger_findings(tmp_path: Path) ->
 
 
 @pytest.mark.skipif(not has_tf_protos(), reason="TensorFlow protobuf stubs unavailable")
+def test_savedmodel_op_counts_preserve_redacted_key_collisions(tmp_path: Path) -> None:
+    first_secret = "sk-proj-CAND061TFOPSECRETAAAAAAAAAAAAAAAA"
+    second_secret = "sk-proj-CAND061TFOPSECRETBBBBBBBBBBBBBBBB"
+    model_path = _create_test_savedmodel_with_scoped_nodes(
+        tmp_path,
+        graph_nodes=[
+            {"op": f"Custom_{first_secret}"},
+            {"op": f"Custom_{second_secret}"},
+            {"op": f"Custom_{first_secret}"},
+        ],
+        model_name="redacted_op_counts",
+    )
+
+    result = tf_savedmodel_module.TensorFlowSavedModelScanner().scan(model_path)
+
+    assert result.metadata["op_counts"] == {"Custom_<redacted>": 2, "Custom_<redacted>[2]": 1}
+    _assert_secret_absent_from_exported_result(result, first_secret)
+    _assert_secret_absent_from_exported_result(result, second_secret)
+
+
+@pytest.mark.skipif(not has_tf_protos(), reason="TensorFlow protobuf stubs unavailable")
+def test_savedmodel_long_input_message_redacts_node_name(tmp_path: Path) -> None:
+    from tensorflow.core.protobuf.saved_model_pb2 import SavedModel
+
+    raw_secret = "sk-proj-CAND061TFNODENAMESECRET000000000000"
+    model_dir = Path(
+        _create_test_savedmodel_with_scoped_nodes(
+            tmp_path,
+            graph_nodes=[
+                {
+                    "op": "Identity",
+                    "name": f"node_{raw_secret}",
+                    "inputs": ["x" * 2049],
+                }
+            ],
+            model_name="redacted_long_input_node",
+        )
+    )
+    model_path = model_dir / "saved_model.pb"
+    saved_model = SavedModel()
+    saved_model.ParseFromString(model_path.read_bytes())
+    scanner = tf_savedmodel_module.TensorFlowSavedModelScanner()
+    scanner._initialize_context(str(model_path))
+    result = scanner._create_result()
+
+    scanner._check_protobuf_buffer_overflow(saved_model, result)
+
+    input_checks = [check for check in result.checks if check.name == "Protobuf Input Name Length Check"]
+
+    assert len(input_checks) == 1
+    assert "node_<redacted>" in input_checks[0].message
+    _assert_secret_absent_from_exported_result(result, raw_secret)
+
+
+@pytest.mark.skipif(not has_tf_protos(), reason="TensorFlow protobuf stubs unavailable")
 def test_savedmodel_graph_node_budget_marks_scan_inconclusive(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1506,6 +1562,117 @@ def test_protobuf_string_injection_detected_in_list_attribute(tmp_path: Path) ->
     assert injection_checks
     assert any(check.details.get("attribute_name") == "labels" for check in injection_checks)
     assert any(check.details.get("attack_type") == "system_command" for check in injection_checks)
+
+
+@pytest.mark.skipif(not has_tf_protos(), reason="TensorFlow protobuf stubs unavailable")
+def test_savedmodel_protobuf_string_details_redact_model_controlled_values(tmp_path: Path) -> None:
+    raw_secret = "sk-proj-CAND061SAVEDDETAILSECRET000000000"
+    model_path = _create_test_savedmodel_with_scoped_nodes(
+        tmp_path,
+        graph_nodes=[
+            {
+                "op": "Const",
+                "name": f"node_{raw_secret}",
+                "string_attrs": {
+                    f"payload_{raw_secret}": (f'<script src="https://cdn.example/{raw_secret}/payload.js"></script>')
+                },
+            }
+        ],
+        model_name="protobuf_detail_secret",
+    )
+
+    result = tf_savedmodel_module.TensorFlowSavedModelScanner().scan(model_path)
+    injection_checks = [check for check in result.checks if check.name == "Protobuf String Injection Check"]
+
+    assert injection_checks
+    details = injection_checks[0].details
+    matches_text = repr(details["matches"])
+    assert "<redacted>" in details["node_name"]
+    assert "<redacted>" in details["attribute_name"]
+    assert "<script" in matches_text
+    assert "<redacted>" in matches_text
+    _assert_secret_absent_from_exported_result(result, raw_secret)
+
+
+@pytest.mark.skipif(not has_tf_protos(), reason="TensorFlow protobuf stubs unavailable")
+def test_savedmodel_oversized_node_preview_redacts_model_controlled_values(tmp_path: Path) -> None:
+    import importlib
+
+    importlib.import_module("modelaudit.protos")
+    from tensorflow.core.protobuf.saved_model_pb2 import SavedModel
+
+    raw_secret = "sk-proj-CAND061SAVEDNODEPREVIEWSECRET000000000"
+    saved_model = SavedModel()
+    node = saved_model.meta_graphs.add().graph_def.node.add()
+    node.op = "Const"
+    node.name = f"node_{raw_secret}_{'A' * 2048}"
+    model_path = tmp_path / "saved_model.pb"
+    model_path.write_bytes(saved_model.SerializeToString())
+
+    scanner = tf_savedmodel_module.TensorFlowSavedModelScanner()
+    scanner._initialize_context(str(model_path))
+    result = scanner._create_result()
+    scanner._check_protobuf_buffer_overflow(saved_model, result)
+    length_checks = [check for check in result.checks if check.name == "Protobuf Node Name Length Check"]
+
+    assert len(length_checks) == 1
+    assert "<redacted>" in length_checks[0].details["node_name_preview"]
+    _assert_secret_absent_from_exported_result(result, raw_secret)
+
+
+@pytest.mark.skipif(not has_tf_protos(), reason="TensorFlow protobuf stubs unavailable")
+def test_savedmodel_metadata_redacts_signature_and_tensor_identifiers(tmp_path: Path) -> None:
+    import importlib
+
+    importlib.import_module("modelaudit.protos")
+    from tensorflow.core.protobuf.saved_model_pb2 import SavedModel
+
+    raw_secret = "sk-proj-CAND061SAVEDMETADATASECRET0000000000"
+    model_dir = tmp_path / "metadata_redaction"
+    model_dir.mkdir()
+    saved_model = SavedModel()
+    meta_graph = saved_model.meta_graphs.add()
+    meta_graph.meta_info_def.tags.append(f"tag_{raw_secret}")
+    signature = meta_graph.signature_def[f"serve_{raw_secret}"]
+    signature.method_name = f"method_{raw_secret}"
+    signature.inputs[f"input_{raw_secret}"].name = f"tensor_{raw_secret}:0"
+    signature.outputs[f"output_{raw_secret}"].name = f"result_{raw_secret}:0"
+    (model_dir / "saved_model.pb").write_bytes(saved_model.SerializeToString())
+
+    metadata = tf_savedmodel_module.TensorFlowSavedModelScanner(
+        config={"allow_metadata_deserialization": True}
+    ).extract_metadata(str(model_dir))
+    serialized_metadata = repr(metadata)
+
+    assert raw_secret not in serialized_metadata
+    assert "<redacted>" in serialized_metadata
+
+
+@pytest.mark.skipif(not has_tf_protos(), reason="TensorFlow protobuf stubs unavailable")
+def test_savedmodel_protobuf_string_details_preserve_public_context(tmp_path: Path) -> None:
+    model_path = _create_test_savedmodel_with_scoped_nodes(
+        tmp_path,
+        graph_nodes=[
+            {
+                "op": "Const",
+                "name": "public_script_node",
+                "string_attrs": {
+                    "html_snippet": '<script src="https://cdn.example/public/payload.js"></script>',
+                },
+            }
+        ],
+        model_name="protobuf_detail_public",
+    )
+
+    result = tf_savedmodel_module.TensorFlowSavedModelScanner().scan(model_path)
+    injection_checks = [check for check in result.checks if check.name == "Protobuf String Injection Check"]
+
+    assert injection_checks
+    details = injection_checks[0].details
+    assert details["node_name"] == "public_script_node"
+    assert details["attribute_name"] == "html_snippet"
+    assert "https://cdn.example/public/payload.js" in repr(details["matches"])
+    assert "<redacted>" not in repr(details)
 
 
 @pytest.mark.skipif(not has_tf_protos(), reason="TensorFlow protobuf stubs unavailable")
@@ -1936,6 +2103,26 @@ def test_savedmodel_collection_preview_redacts_sensitive_values(tmp_path: Path) 
 
 
 @pytest.mark.skipif(not has_tf_protos(), reason="TensorFlow protobuf stubs unavailable")
+def test_savedmodel_collection_key_details_redact_sensitive_values(tmp_path: Path) -> None:
+    raw_secret = "sk-proj-CAND061SAVEDCOLLECTIONSECRET000000"
+    model_path = _create_test_savedmodel_with_collection(
+        tmp_path,
+        key=f"runtime_hook_{raw_secret}",
+        value=b'os.system("curl https://callback.example/public")',
+        model_name="collection_key_secret",
+    )
+
+    result = tf_savedmodel_module.TensorFlowSavedModelScanner().scan(model_path)
+    collection_checks = [check for check in result.checks if check.name == "SavedModel Collection Executable Pattern"]
+
+    assert collection_checks
+    assert "runtime_hook" in collection_checks[0].details["collection_key"]
+    assert "<redacted>" in collection_checks[0].details["collection_key"]
+    assert "https://callback.example/public" in collection_checks[0].details["value_preview"]
+    _assert_secret_absent_from_exported_result(result, raw_secret)
+
+
+@pytest.mark.skipif(not has_tf_protos(), reason="TensorFlow protobuf stubs unavailable")
 def test_pyfunc_code_preview_redacts_sensitive_values(tmp_path: Path) -> None:
     raw_secret = "c081-pyfunc-secret-value-00000000"
     python_code = (
@@ -2155,6 +2342,23 @@ def test_savedmodel_root_sibling_directory_pickle_is_flagged(tmp_path: Path) -> 
 
     assert matching_checks
     assert any("pickle_payload" in check.details.get("detected_content_type", "") for check in matching_checks)
+
+
+@pytest.mark.skipif(not has_tf_protos(), reason="TensorFlow protobuf stubs unavailable")
+def test_savedmodel_supplemental_filename_details_redact_sensitive_values(tmp_path: Path) -> None:
+    raw_secret = "sk-proj-CAND061TFFILENAMESECRET000000000000"
+    model_dir = Path(create_tf_savedmodel(tmp_path))
+    sibling_path = model_dir / "supplemental" / f"payload_{raw_secret}.bin"
+    sibling_path.parent.mkdir()
+    sibling_path.write_text("#!/bin/sh\necho review\n", encoding="utf-8")
+
+    result = tf_savedmodel_module.TensorFlowSavedModelScanner().scan(str(model_dir))
+    matching_checks = [check for check in result.checks if check.name == "SavedModel Supplemental File Security Check"]
+
+    assert matching_checks
+    assert any(check.location and "payload_<redacted>.bin" in check.location for check in matching_checks)
+    assert any(check.details.get("file_name") == "payload_<redacted>.bin" for check in matching_checks)
+    _assert_secret_absent_from_exported_result(result, raw_secret)
 
 
 @pytest.mark.skipif(not has_tf_protos(), reason="TensorFlow protobuf stubs unavailable")
@@ -2669,6 +2873,7 @@ def _create_test_savedmodel_with_scoped_nodes(
         node = node_collection.add()
         node.name = spec.get("name", default_name)
         node.op = spec["op"]
+        node.input.extend(spec.get("inputs", []))
 
         for attr_name, attr_value in spec.get("string_attrs", {}).items():
             node.attr[attr_name].s = attr_value.encode("utf-8")


### PR DESCRIPTION
## Summary
- redact model-controlled Keras H5, Keras ZIP, and TensorFlow SavedModel evidence before serialization
- preserve distinct evidence entries with amortized-linear redacted-key collision allocation
- normalize Unicode-equivalent sensitive evidence keys and contextual name/key labels
- fail closed for structured credential containers, byte labels/keys, plural value aliases, and opaque metadata exceptions
- retain raw Keras versions internally for CVE classification while exporting only redacted display values
- sync current `main` while preserving trusted Keras weight routing and artifact-version safeguards

## Validation
- evidence redaction helper: `303 passed`
- Keras H5 scanner: `292 passed`
- Keras ZIP scanner: `583 passed, 3 skipped` (optional ONNX dependency unavailable)
- TensorFlow SavedModel scanner: `129 passed`
- PyTorch weight-distribution CI regression: `1 passed`
- scoped `ruff format --check`, `ruff check`, `mypy`, and `git diff --check`: clean
- no full repository test suite run locally, per review workflow

## Review
- fixed quadratic mapping-key suffix allocation and collision overwrites
- fixed fullwidth, invisible-character, byte-label, byte-key, and opaque container-key bypasses
- redacted H5 metadata identifiers, dataset names, archive members, external references, and scanner exceptions
- made SavedModel metadata extraction errors fail closed instead of preserving opaque attacker-controlled text
- preserved current-main CVE-2025-12060 origin-only semantics, trusted bounded reads, and untrusted artifact-version behavior
- no unresolved inline review threads

Verified head: `deb1eeb07d0bbebb0ca913a5d2fa60ad6a22e738`
Verified tree: `6e4554f37e7727397085abbfcce8ce0f0585b8fb`
