### PR TITLE
fix: bound manifest jinja collection traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- bound manifest embedded-Jinja template collection so deeply nested configs fail closed without hiding recovered template findings
 - bound Joblib decompression output to the configured scanner read budget
 - close JIT replay alias, probe-budget, and compound-clause context gaps without suppressing dangerous browser or native-library calls
 - reject cleartext HTTP cloud storage and PyTorch Hub model sources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- bound manifest embedded-Jinja template collection so deeply nested configs fail closed without hiding recovered template findings
+- bound manifest embedded-Jinja template collection while preserving findings across deep branches, cycles, and shared YAML aliases
 - restrict manual Docker publishes to validated immutable version tags and their matching Git release refs before registry login or push
 - harden cloud acquisition size caps, HTTPS/R2 auto-default routing, and directory metadata failures
 - detect operator attrgetter, itemgetter, and methodcaller archive-member Python paths to command execution while preserving benign accessor names

--- a/modelaudit/scanners/manifest_scanner.py
+++ b/modelaudit/scanners/manifest_scanner.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 from dataclasses import dataclass
+from itertools import chain
 from types import ModuleType
 from typing import Any, Final
 from urllib.parse import urlparse, urlsplit, urlunsplit
@@ -1046,7 +1047,7 @@ class ManifestScanner(BaseScanner):
                 allow_plain_field_scalar=mode == _JINJA_COLLECTION_MODE_CONTAINER,
             )
         ]
-        expanded_container_ids: set[tuple[str, int]] = set()
+        expanded_container_depths: dict[tuple[str, bool, int], int] = {}
 
         while stack:
             self._check_timeout()
@@ -1058,6 +1059,18 @@ class ManifestScanner(BaseScanner):
                 if collection.items_visited > max_items:
                     self._mark_jinja_collection_budget_exceeded(collection, "items", frame.path)
                     break
+
+                if isinstance(frame.value, (dict, list)):
+                    container_key = (
+                        frame.mode,
+                        "chat_template" in frame.path.lower(),
+                        id(frame.value),
+                    )
+                    expanded_depth = expanded_container_depths.get(container_key)
+                    if expanded_depth is not None and expanded_depth <= frame.depth:
+                        stack.pop()
+                        continue
+
                 if frame.depth > max_depth:
                     self._mark_jinja_collection_budget_exceeded(collection, "depth", frame.path)
                     stack.pop()
@@ -1075,20 +1088,27 @@ class ManifestScanner(BaseScanner):
                     continue
 
                 if isinstance(frame.value, dict):
-                    container_key = (frame.mode, id(frame.value))
-                    if container_key in expanded_container_ids:
-                        stack.pop()
-                        continue
-                    expanded_container_ids.add(container_key)
-                    frame.iterator = iter(frame.value.items())
+                    expanded_container_depths[(frame.mode, "chat_template" in frame.path.lower(), id(frame.value))] = (
+                        frame.depth
+                    )
+                    if frame.mode == _JINJA_COLLECTION_MODE_FIELDS:
+                        priority_items = (
+                            (field_name, frame.value[field_name])
+                            for field_name in sorted(JINJA_TEMPLATE_FIELD_NAMES)
+                            if field_name in frame.value
+                        )
+                        remaining_items = (
+                            (key, item) for key, item in frame.value.items() if key not in JINJA_TEMPLATE_FIELD_NAMES
+                        )
+                        frame.iterator = chain(priority_items, remaining_items)
+                    else:
+                        frame.iterator = iter(frame.value.items())
                     continue
 
                 if isinstance(frame.value, list):
-                    container_key = (frame.mode, id(frame.value))
-                    if container_key in expanded_container_ids:
-                        stack.pop()
-                        continue
-                    expanded_container_ids.add(container_key)
+                    expanded_container_depths[(frame.mode, "chat_template" in frame.path.lower(), id(frame.value))] = (
+                        frame.depth
+                    )
                     frame.iterator = enumerate(frame.value)
                     continue
 
@@ -1128,7 +1148,7 @@ class ManifestScanner(BaseScanner):
     def _get_positive_int_config(self, key: str, default: int) -> int:
         try:
             value = int(self.config.get(key, default))
-        except (TypeError, ValueError):
+        except (OverflowError, TypeError, ValueError):
             return default
         return value if value > 0 else default
 
@@ -1138,6 +1158,8 @@ class ManifestScanner(BaseScanner):
         limit_type: str,
         path: str,
     ) -> None:
+        if collection.budget_exceeded and limit_type != "items":
+            return
         collection.budget_exceeded = True
         collection.limit_type = limit_type
         collection.path = path

--- a/modelaudit/scanners/manifest_scanner.py
+++ b/modelaudit/scanners/manifest_scanner.py
@@ -5,6 +5,7 @@ import importlib
 import json
 import os
 import re
+from dataclasses import dataclass
 from types import ModuleType
 from typing import Any, Final
 from urllib.parse import urlparse, urlsplit, urlunsplit
@@ -13,6 +14,7 @@ from modelaudit.core_results import mark_operational_scan_error, scan_result_has
 from modelaudit.scanner_results import mark_inconclusive_scan_result
 
 from ..scanner_selection import add_scanner_selection_skip_check, policy_from_config
+from ._evidence_redaction import redact_evidence_string
 from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, CheckStatus, IssueSeverity, ScanResult, logger
 
 try:
@@ -178,6 +180,36 @@ HASH_INTEGRITY_KEYS = [
 HEX_PATTERN = re.compile(r"^[a-fA-F0-9]+$")
 JINJA_TEMPLATE_FIELD_NAMES = frozenset({"chat_template", "template", "jinja_template", "custom_chat_template"})
 JINJA_TEMPLATE_INDICATORS = ("{{", "{%", "{#")
+JINJA_TEMPLATE_COLLECTION_BUDGET_REASON: Final[str] = "manifest_jinja_template_collection_budget_exceeded"
+JINJA_TEMPLATE_COLLECTION_MAX_DEPTH_CONFIG_KEY: Final[str] = "jinja_template_collection_max_depth"
+JINJA_TEMPLATE_COLLECTION_MAX_ITEMS_CONFIG_KEY: Final[str] = "jinja_template_collection_max_items"
+DEFAULT_JINJA_TEMPLATE_COLLECTION_MAX_DEPTH: Final[int] = 64
+DEFAULT_JINJA_TEMPLATE_COLLECTION_MAX_ITEMS: Final[int] = 50_000
+_JINJA_COLLECTION_MODE_FIELDS: Final[str] = "fields"
+_JINJA_COLLECTION_MODE_CONTAINER: Final[str] = "container"
+
+
+@dataclass
+class _JinjaTemplateCollection:
+    templates: dict[str, str]
+    budget_exceeded: bool = False
+    limit_type: str = ""
+    path: str = ""
+    items_visited: int = 0
+    max_depth: int = DEFAULT_JINJA_TEMPLATE_COLLECTION_MAX_DEPTH
+    max_items: int = DEFAULT_JINJA_TEMPLATE_COLLECTION_MAX_ITEMS
+
+
+@dataclass
+class _JinjaTraversalFrame:
+    mode: str
+    value: Any
+    path: str
+    depth: int
+    allow_plain_field_scalar: bool = False
+    iterator: Any | None = None
+    visited: bool = False
+
 
 # Comprehensive allowlist of trusted domains for ML model configs
 # URLs from domains NOT in this list will be flagged as untrusted
@@ -952,10 +984,6 @@ class ManifestScanner(BaseScanner):
         return _PARSE_FAILED
 
     def _scan_embedded_jinja_templates(self, path: str, content: Any, result: ScanResult) -> None:
-        templates = self._collect_jinja_template_fields(content)
-        if not templates:
-            return
-
         scanner_selection = policy_from_config(self.config)
         if not scanner_selection.allows("jinja2_template"):
             if scanner_selection.active:
@@ -968,68 +996,193 @@ class ManifestScanner(BaseScanner):
                 )
             return
 
+        collection = self._collect_jinja_template_fields_with_budget(content)
+        templates = collection.templates
+        if collection.budget_exceeded:
+            self._record_jinja_collection_budget_exceeded(result, path, collection)
+            self._check_timeout()
+
+        if not templates:
+            return
+
         from .jinja2_template_scanner import Jinja2TemplateScanner
 
         result.merge(Jinja2TemplateScanner(config=self.config).scan_extracted_templates(path, templates))
 
     def _collect_jinja_template_fields(self, value: Any, path: str = "") -> dict[str, str]:
-        self._check_timeout()
-        if isinstance(value, dict):
-            templates: dict[str, str] = {}
-            for key, item in value.items():
-                self._check_timeout()
-                child_path = f"{path}.{key}" if path else str(key)
-                if key in JINJA_TEMPLATE_FIELD_NAMES:
-                    self._merge_jinja_templates(templates, self._collect_jinja_template_container(item, child_path))
-                    continue
-                self._merge_jinja_templates(templates, self._collect_jinja_template_fields(item, child_path))
-            return templates
-        if isinstance(value, list):
-            list_templates: dict[str, str] = {}
-            for index, item in enumerate(value):
-                self._check_timeout()
-                child_path = f"{path}[{index}]" if path else f"[{index}]"
-                self._merge_jinja_templates(list_templates, self._collect_jinja_template_fields(item, child_path))
-            return list_templates
-        return {}
+        return self._collect_jinja_template_fields_with_budget(value, path).templates
+
+    def _collect_jinja_template_fields_with_budget(self, value: Any, path: str = "") -> _JinjaTemplateCollection:
+        return self._collect_jinja_templates_with_budget(value, path, _JINJA_COLLECTION_MODE_FIELDS)
 
     def _collect_jinja_template_container(self, value: Any, path: str) -> dict[str, str]:
-        self._check_timeout()
-        if isinstance(value, str):
-            if value.strip() and (
-                path.rsplit(".", 1)[-1] in JINJA_TEMPLATE_FIELD_NAMES or self._looks_like_jinja(value)
-            ):
-                return {path: value}
-            return {}
+        return self._collect_jinja_templates_with_budget(value, path, _JINJA_COLLECTION_MODE_CONTAINER).templates
 
-        if isinstance(value, dict):
-            templates: dict[str, str] = {}
-            for key, item in value.items():
-                self._check_timeout()
-                child_path = f"{path}.{key}"
-                if isinstance(item, str):
-                    if item.strip() and self._looks_like_jinja(item):
-                        self._record_jinja_template(templates, child_path, item)
-                    continue
-                self._merge_jinja_templates(templates, self._collect_jinja_template_container(item, child_path))
-            return templates
+    def _collect_jinja_templates_with_budget(
+        self,
+        value: Any,
+        path: str,
+        mode: str,
+    ) -> _JinjaTemplateCollection:
+        max_depth = self._get_positive_int_config(
+            JINJA_TEMPLATE_COLLECTION_MAX_DEPTH_CONFIG_KEY,
+            DEFAULT_JINJA_TEMPLATE_COLLECTION_MAX_DEPTH,
+        )
+        max_items = self._get_positive_int_config(
+            JINJA_TEMPLATE_COLLECTION_MAX_ITEMS_CONFIG_KEY,
+            DEFAULT_JINJA_TEMPLATE_COLLECTION_MAX_ITEMS,
+        )
+        collection = _JinjaTemplateCollection(
+            templates={},
+            max_depth=max_depth,
+            max_items=max_items,
+        )
+        stack = [
+            _JinjaTraversalFrame(
+                mode=mode,
+                value=value,
+                path=path,
+                depth=0,
+                allow_plain_field_scalar=mode == _JINJA_COLLECTION_MODE_CONTAINER,
+            )
+        ]
 
-        if isinstance(value, list):
-            list_templates: dict[str, str] = {}
-            for index, item in enumerate(value):
-                self._check_timeout()
-                child_path = f"{path}[{index}]"
-                if isinstance(item, str):
-                    if item.strip() and self._looks_like_jinja(item):
-                        self._record_jinja_template(list_templates, child_path, item)
+        while stack:
+            self._check_timeout()
+            frame = stack[-1]
+
+            if not frame.visited:
+                frame.visited = True
+                collection.items_visited += 1
+                if collection.items_visited > max_items:
+                    self._mark_jinja_collection_budget_exceeded(collection, "items", frame.path)
+                    break
+                if frame.depth > max_depth:
+                    self._mark_jinja_collection_budget_exceeded(collection, "depth", frame.path)
+                    break
+
+                if isinstance(frame.value, str):
+                    self._record_jinja_scalar_if_template(
+                        collection.templates,
+                        frame.mode,
+                        frame.path,
+                        frame.value,
+                        allow_plain_field_scalar=frame.allow_plain_field_scalar,
+                    )
+                    stack.pop()
                     continue
-                self._merge_jinja_templates(
-                    list_templates,
-                    self._collect_jinja_template_container(item, child_path),
+
+                if isinstance(frame.value, dict):
+                    frame.iterator = iter(frame.value.items())
+                    continue
+
+                if isinstance(frame.value, list):
+                    frame.iterator = enumerate(frame.value)
+                    continue
+
+                stack.pop()
+                continue
+
+            if frame.iterator is None:
+                stack.pop()
+                continue
+
+            try:
+                key, item = next(frame.iterator)
+            except StopIteration:
+                stack.pop()
+                continue
+
+            self._check_timeout()
+            child_path = self._jinja_collection_child_path(frame.path, key, isinstance(frame.value, list))
+            child_mode = frame.mode
+            allow_plain_field_scalar = False
+            if frame.mode == _JINJA_COLLECTION_MODE_FIELDS:
+                is_template_field = isinstance(key, str) and key in JINJA_TEMPLATE_FIELD_NAMES
+                child_mode = _JINJA_COLLECTION_MODE_CONTAINER if is_template_field else _JINJA_COLLECTION_MODE_FIELDS
+                allow_plain_field_scalar = is_template_field
+            stack.append(
+                _JinjaTraversalFrame(
+                    mode=child_mode,
+                    value=item,
+                    path=child_path,
+                    depth=frame.depth + 1,
+                    allow_plain_field_scalar=allow_plain_field_scalar,
                 )
-            return list_templates
+            )
 
-        return {}
+        return collection
+
+    def _get_positive_int_config(self, key: str, default: int) -> int:
+        try:
+            value = int(self.config.get(key, default))
+        except (TypeError, ValueError):
+            return default
+        return value if value > 0 else default
+
+    @staticmethod
+    def _mark_jinja_collection_budget_exceeded(
+        collection: _JinjaTemplateCollection,
+        limit_type: str,
+        path: str,
+    ) -> None:
+        collection.budget_exceeded = True
+        collection.limit_type = limit_type
+        collection.path = path
+
+    def _record_jinja_scalar_if_template(
+        self,
+        templates: dict[str, str],
+        mode: str,
+        path: str,
+        value: str,
+        *,
+        allow_plain_field_scalar: bool,
+    ) -> None:
+        if mode != _JINJA_COLLECTION_MODE_CONTAINER or not value.strip():
+            return
+        if allow_plain_field_scalar or self._looks_like_jinja(value):
+            self._record_jinja_template(templates, path, value)
+
+    @staticmethod
+    def _jinja_collection_child_path(path: str, key: Any, parent_is_list: bool) -> str:
+        if parent_is_list:
+            return f"{path}[{key}]" if path else f"[{key}]"
+        return f"{path}.{key}" if path else str(key)
+
+    def _record_jinja_collection_budget_exceeded(
+        self,
+        result: ScanResult,
+        path: str,
+        collection: _JinjaTemplateCollection,
+    ) -> None:
+        self._mark_inconclusive_scan_result(result, JINJA_TEMPLATE_COLLECTION_BUDGET_REASON)
+        result.add_check(
+            name="Embedded Jinja Collection Budget",
+            passed=False,
+            message=(
+                "Embedded Jinja template analysis incomplete because parsed manifest traversal exceeded "
+                "the configured collection budget"
+            ),
+            severity=IssueSeverity.INFO,
+            location=path,
+            details={
+                "reason": JINJA_TEMPLATE_COLLECTION_BUDGET_REASON,
+                "scan_outcome_reason": JINJA_TEMPLATE_COLLECTION_BUDGET_REASON,
+                "analysis_incomplete": True,
+                "limit_type": collection.limit_type,
+                "path": redact_evidence_string(collection.path, max_chars=240),
+                "items_visited": collection.items_visited,
+                "max_depth": collection.max_depth,
+                "max_items": collection.max_items,
+                "templates_collected": len(collection.templates),
+            },
+            why=(
+                "Manifest configs can contain attacker-controlled nested JSON, YAML, TOML, or INI structures. "
+                "The embedded Jinja collector stops at a bounded traversal budget and marks analysis incomplete "
+                "rather than recursively walking untrusted structures without limit."
+            ),
+        )
 
     @staticmethod
     def _record_jinja_template(templates: dict[str, str], path: str, value: str) -> None:

--- a/modelaudit/scanners/manifest_scanner.py
+++ b/modelaudit/scanners/manifest_scanner.py
@@ -1046,6 +1046,7 @@ class ManifestScanner(BaseScanner):
                 allow_plain_field_scalar=mode == _JINJA_COLLECTION_MODE_CONTAINER,
             )
         ]
+        expanded_container_ids: set[tuple[str, int]] = set()
 
         while stack:
             self._check_timeout()
@@ -1059,7 +1060,8 @@ class ManifestScanner(BaseScanner):
                     break
                 if frame.depth > max_depth:
                     self._mark_jinja_collection_budget_exceeded(collection, "depth", frame.path)
-                    break
+                    stack.pop()
+                    continue
 
                 if isinstance(frame.value, str):
                     self._record_jinja_scalar_if_template(
@@ -1073,10 +1075,20 @@ class ManifestScanner(BaseScanner):
                     continue
 
                 if isinstance(frame.value, dict):
+                    container_key = (frame.mode, id(frame.value))
+                    if container_key in expanded_container_ids:
+                        stack.pop()
+                        continue
+                    expanded_container_ids.add(container_key)
                     frame.iterator = iter(frame.value.items())
                     continue
 
                 if isinstance(frame.value, list):
+                    container_key = (frame.mode, id(frame.value))
+                    if container_key in expanded_container_ids:
+                        stack.pop()
+                        continue
+                    expanded_container_ids.add(container_key)
                     frame.iterator = enumerate(frame.value)
                     continue
 

--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -764,42 +764,6 @@ def test_manifest_scanner_nested_chat_template_collection_enforces_timeout(monke
         scanner._collect_jinja_template_fields({"chat_template": {"default": "{{ harmless }}"}})
 
 
-def test_manifest_scanner_shared_jinja_aliases_are_expanded_once_per_mode() -> None:
-    scanner = ManifestScanner(config={"jinja_template_collection_max_items": 1_100})
-    shared = {"chat_template": "{{ harmless }}"}
-
-    collection = scanner._collect_jinja_template_fields_with_budget(
-        {"model_type": "llama", "aliases": [shared] * 1_000}
-    )
-
-    assert collection.budget_exceeded is False
-    assert collection.items_visited == 1_004
-    assert collection.templates == {"aliases[0].chat_template": "{{ harmless }}"}
-
-
-def test_manifest_scanner_recursive_jinja_alias_preserves_sibling_template() -> None:
-    scanner = ManifestScanner(config={"jinja_template_collection_max_depth": 4})
-    recursive: dict[str, Any] = {}
-    recursive["self"] = recursive
-    recursive["chat_template"] = "{{ harmless }}"
-
-    collection = scanner._collect_jinja_template_fields_with_budget(recursive)
-
-    assert collection.budget_exceeded is False
-    assert collection.items_visited == 3
-    assert collection.templates == {"chat_template": "{{ harmless }}"}
-
-
-def test_manifest_scanner_shared_jinja_alias_is_revisited_when_mode_changes() -> None:
-    scanner = ManifestScanner()
-    shared = {"default": "{{ harmless }}"}
-
-    collection = scanner._collect_jinja_template_fields_with_budget({"metadata": shared, "chat_template": shared})
-
-    assert collection.budget_exceeded is False
-    assert collection.templates == {"chat_template.default": "{{ harmless }}"}
-
-
 def test_manifest_scanner_deep_jinja_collection_budget_fails_closed(tmp_path: Path) -> None:
     config_path = tmp_path / "config.json"
     nested_config: dict[str, Any] = {"leaf": "plain metadata"}
@@ -841,8 +805,8 @@ def test_manifest_scanner_jinja_collection_budget_preserves_malicious_template_d
         json.dumps(
             {
                 "model_type": "llama",
-                "metadata": nested_config,
                 "chat_template": "{{ ''.__class__.__mro__[1].__subclasses__() }}",
+                "metadata": nested_config,
             }
         ),
         encoding="utf-8",
@@ -862,6 +826,184 @@ def test_manifest_scanner_jinja_collection_budget_preserves_malicious_template_d
         check.name == "Jinja2 Template Injection Detection" and check.status == CheckStatus.FAILED
         for check in result.checks
     )
+
+
+def test_manifest_scanner_shared_jinja_aliases_expand_once_per_mode() -> None:
+    scanner = ManifestScanner(
+        config={
+            "jinja_template_collection_max_depth": 16,
+            "jinja_template_collection_max_items": 1100,
+        }
+    )
+    shared = {"chat_template": {"default": "{{ message['content'] }}"}}
+
+    collection = scanner._collect_jinja_template_fields_with_budget({"metadata": [shared] * 1000})
+
+    assert collection.budget_exceeded is False
+    assert collection.items_visited == 1004
+    assert collection.templates == {"metadata[0].chat_template.default": "{{ message['content'] }}"}
+
+
+def test_manifest_scanner_recursive_jinja_alias_preserves_sibling_template() -> None:
+    scanner = ManifestScanner(
+        config={
+            "jinja_template_collection_max_depth": 3,
+            "jinja_template_collection_max_items": 100,
+        }
+    )
+    malicious = "{{ ''.__class__.__mro__[1].__subclasses__() }}"
+    recursive: dict[str, Any] = {}
+    recursive["loop"] = recursive
+    recursive["chat_template"] = malicious
+
+    collection = scanner._collect_jinja_template_fields_with_budget(recursive)
+
+    assert collection.budget_exceeded is False
+    assert collection.items_visited == 3
+    assert collection.templates == {"chat_template": malicious}
+
+
+def test_manifest_scanner_alias_identity_is_scoped_to_collection_mode() -> None:
+    scanner = ManifestScanner()
+    malicious = "{{ ''.__class__.__mro__[1].__subclasses__() }}"
+    shared = {"chat_template": malicious}
+
+    collection = scanner._collect_jinja_template_fields_with_budget(
+        {
+            "chat_template": shared,
+            "metadata": shared,
+        }
+    )
+
+    assert collection.templates == {
+        "chat_template.chat_template": malicious,
+        "metadata.chat_template": malicious,
+    }
+
+
+def test_manifest_scanner_alias_identity_preserves_chat_template_context(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    benign_macro = "{% macro render() %}hello{% endmacro %}"
+    config_path.write_text(
+        f"""
+a:
+  template: &shared
+    default: "{benign_macro}"
+z:
+  chat_template: *shared
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    result = ManifestScanner().scan(str(config_path))
+
+    assert not any(
+        check.name == "Jinja2 Template Injection Detection" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+
+
+def test_manifest_scanner_reexpands_alias_at_shallower_depth(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    malicious = "{{ ''.__class__.__mro__[1].__subclasses__() }}"
+    config_path.write_text(
+        f"""
+metadata:
+  deep: &shared
+    chat_template: "{malicious}"
+later: *shared
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    result = ManifestScanner(config={"jinja_template_collection_max_depth": 2}).scan(str(config_path))
+
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert any(
+        check.name == "Embedded Jinja Collection Budget"
+        and check.status == CheckStatus.FAILED
+        and check.details["limit_type"] == "depth"
+        for check in result.checks
+    )
+    assert any(
+        check.name == "Jinja2 Template Injection Detection" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+
+
+def test_manifest_scanner_depth_budget_skips_only_overdeep_branch(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    malicious = "{{ ''.__class__.__mro__[1].__subclasses__() }}"
+    nested_config: dict[str, Any] = {"leaf": "plain metadata"}
+    for _ in range(5):
+        nested_config = {"nested": nested_config}
+    config_path.write_text(
+        json.dumps(
+            {
+                "metadata": nested_config,
+                "later": {"chat_template": malicious},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = ManifestScanner(config={"jinja_template_collection_max_depth": 3}).scan(str(config_path))
+
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert any(
+        check.name == "Embedded Jinja Collection Budget"
+        and check.status == CheckStatus.FAILED
+        and check.details["limit_type"] == "depth"
+        and check.details["templates_collected"] == 1
+        for check in result.checks
+    )
+    assert any(
+        check.name == "Jinja2 Template Injection Detection" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+
+
+def test_manifest_scanner_prioritizes_template_fields_before_item_budget(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    malicious = "{{ ''.__class__.__mro__[1].__subclasses__() }}"
+    config_path.write_text(
+        json.dumps(
+            {
+                "metadata": [{"name": f"layer-{index}"} for index in range(8)],
+                "chat_template": malicious,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = ManifestScanner(config={"jinja_template_collection_max_items": 3}).scan(str(config_path))
+
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert any(
+        check.name == "Embedded Jinja Collection Budget"
+        and check.status == CheckStatus.FAILED
+        and check.details["limit_type"] == "items"
+        and check.details["templates_collected"] == 1
+        for check in result.checks
+    )
+    assert any(
+        check.name == "Jinja2 Template Injection Detection" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+
+
+def test_manifest_scanner_invalid_jinja_budget_values_use_defaults() -> None:
+    scanner = ManifestScanner(
+        config={
+            "jinja_template_collection_max_depth": float("inf"),
+            "jinja_template_collection_max_items": float("inf"),
+        }
+    )
+
+    collection = scanner._collect_jinja_template_fields_with_budget({"chat_template": "{{ message }}"})
+
+    assert collection.budget_exceeded is False
+    assert collection.templates == {"chat_template": "{{ message }}"}
 
 
 def test_manifest_scanner_wide_jinja_collection_item_budget_fails_closed(tmp_path: Path) -> None:

--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -764,6 +764,168 @@ def test_manifest_scanner_nested_chat_template_collection_enforces_timeout(monke
         scanner._collect_jinja_template_fields({"chat_template": {"default": "{{ harmless }}"}})
 
 
+def test_manifest_scanner_deep_jinja_collection_budget_fails_closed(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    nested_config: dict[str, Any] = {"leaf": "plain metadata"}
+    for index in range(5):
+        nested_config = {"nested": nested_config, "level": index}
+
+    config_path.write_text(
+        json.dumps(
+            {
+                "model_type": "llama",
+                "metadata": nested_config,
+            }
+        ),
+        encoding="utf-8",
+    )
+    config = {"jinja_template_collection_max_depth": 3}
+
+    result = ManifestScanner(config=config).scan(str(config_path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "manifest_jinja_template_collection_budget_exceeded" in result.metadata["scan_outcome_reasons"]
+    budget_checks = [check for check in result.checks if check.name == "Embedded Jinja Collection Budget"]
+    assert len(budget_checks) == 1
+    assert budget_checks[0].status == CheckStatus.FAILED
+    assert "parsed manifest traversal exceeded" in budget_checks[0].message
+    assert budget_checks[0].details["limit_type"] == "depth"
+    assert budget_checks[0].details["max_depth"] == 3
+    assert budget_checks[0].details["scan_outcome_reason"] == "manifest_jinja_template_collection_budget_exceeded"
+
+
+def test_manifest_scanner_jinja_collection_budget_preserves_malicious_template_detection(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    nested_config: dict[str, Any] = {"leaf": "plain metadata"}
+    for index in range(5):
+        nested_config = {"nested": nested_config, "level": index}
+
+    config_path.write_text(
+        json.dumps(
+            {
+                "model_type": "llama",
+                "chat_template": "{{ ''.__class__.__mro__[1].__subclasses__() }}",
+                "metadata": nested_config,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = ManifestScanner(config={"jinja_template_collection_max_depth": 3}).scan(str(config_path))
+
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "manifest_jinja_template_collection_budget_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Embedded Jinja Collection Budget"
+        and check.status == CheckStatus.FAILED
+        and check.details["templates_collected"] == 1
+        for check in result.checks
+    )
+    assert any(
+        check.name == "Jinja2 Template Injection Detection" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+
+
+def test_manifest_scanner_wide_jinja_collection_item_budget_fails_closed(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "model_type": "llama",
+                "metadata": [{"name": f"layer-{index}"} for index in range(8)],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = ManifestScanner(config={"jinja_template_collection_max_items": 4}).scan(str(config_path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "manifest_jinja_template_collection_budget_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Embedded Jinja Collection Budget"
+        and check.status == CheckStatus.FAILED
+        and check.details["limit_type"] == "items"
+        and check.details["max_items"] == 4
+        for check in result.checks
+    )
+
+
+def test_manifest_scanner_jinja_collection_budget_redacts_path_evidence(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    secret = "MANIFEST_COLLECTION_SECRET"
+    config_path.write_text(
+        json.dumps({f"api_key={secret}": {"nested": {"value": "plain metadata"}}}),
+        encoding="utf-8",
+    )
+
+    result = ManifestScanner(config={"jinja_template_collection_max_depth": 1}).scan(str(config_path))
+
+    budget_checks = [check for check in result.checks if check.name == "Embedded Jinja Collection Budget"]
+    assert len(budget_checks) == 1
+    assert budget_checks[0].details["path"] == "api_key=<redacted>"
+    assert secret not in json.dumps(budget_checks[0].details)
+
+
+def test_manifest_scanner_nested_near_match_jinja_template_still_scanned(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "model_type": "llama",
+                "chat_template_metadata": {"description": "near-match container name"},
+                "generation": {
+                    "variants": [
+                        {"chat_template": ("{% for message in messages %}{{ message['content'] }}{% endfor %}")}
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = ManifestScanner(
+        config={
+            "jinja_template_collection_max_depth": 8,
+            "jinja_template_collection_max_items": 64,
+        }
+    ).scan(str(config_path))
+
+    assert "manifest_jinja_template_collection_budget_exceeded" not in result.metadata.get(
+        "scan_outcome_reasons",
+        [],
+    )
+    assert not any(check.name == "Embedded Jinja Collection Budget" for check in result.checks)
+    assert any(check.name == "Jinja2 SSTI Analysis" and check.status == CheckStatus.PASSED for check in result.checks)
+    assert not any(
+        check.name == "Jinja2 Template Injection Detection" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+
+
+def test_manifest_scanner_ignores_plain_nested_template_metadata() -> None:
+    scanner = ManifestScanner()
+    payload = "{{ message['content'] }}"
+
+    assert scanner._collect_jinja_template_fields({"chat_template": "plain template text"}) == {
+        "chat_template": "plain template text"
+    }
+
+    templates = scanner._collect_jinja_template_fields(
+        {
+            "chat_template": {
+                "default": payload,
+                "metadata": {"template": "Documentation example: requests.get(url)"},
+            }
+        }
+    )
+
+    assert templates == {"chat_template.default": payload}
+
+
 def test_manifest_scanner_nested_oversized_chat_template_fails_closed(tmp_path: Path) -> None:
     config_path = tmp_path / "config.json"
     payload = "{{ message['content'] }}" + (" safe" * 32)
@@ -925,6 +1087,28 @@ def test_manifest_scanner_honors_excluded_embedded_jinja_selection(tmp_path: Pat
 
     assert "jinja2_template" in result.metadata["skipped_scanner_ids"]
     assert not any(check.name == "Jinja2 Template Injection Detection" for check in result.checks)
+
+
+def test_manifest_scanner_skips_jinja_collection_budget_when_excluded(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"model_type": "llama", "metadata": {"nested": {"value": "benign"}}}),
+        encoding="utf-8",
+    )
+
+    result = ManifestScanner(
+        config={
+            "scanners": ["manifest"],
+            "jinja_template_collection_max_depth": 1,
+        }
+    ).scan(str(config_path))
+
+    assert "jinja2_template" in result.metadata["skipped_scanner_ids"]
+    assert "manifest_jinja_template_collection_budget_exceeded" not in result.metadata.get(
+        "scan_outcome_reasons",
+        [],
+    )
+    assert not any(check.name == "Embedded Jinja Collection Budget" for check in result.checks)
 
 
 def test_manifest_scanner_redacts_untrusted_url_credentials(tmp_path: Path) -> None:

--- a/tests/scanners/test_manifest_scanner.py
+++ b/tests/scanners/test_manifest_scanner.py
@@ -764,6 +764,42 @@ def test_manifest_scanner_nested_chat_template_collection_enforces_timeout(monke
         scanner._collect_jinja_template_fields({"chat_template": {"default": "{{ harmless }}"}})
 
 
+def test_manifest_scanner_shared_jinja_aliases_are_expanded_once_per_mode() -> None:
+    scanner = ManifestScanner(config={"jinja_template_collection_max_items": 1_100})
+    shared = {"chat_template": "{{ harmless }}"}
+
+    collection = scanner._collect_jinja_template_fields_with_budget(
+        {"model_type": "llama", "aliases": [shared] * 1_000}
+    )
+
+    assert collection.budget_exceeded is False
+    assert collection.items_visited == 1_004
+    assert collection.templates == {"aliases[0].chat_template": "{{ harmless }}"}
+
+
+def test_manifest_scanner_recursive_jinja_alias_preserves_sibling_template() -> None:
+    scanner = ManifestScanner(config={"jinja_template_collection_max_depth": 4})
+    recursive: dict[str, Any] = {}
+    recursive["self"] = recursive
+    recursive["chat_template"] = "{{ harmless }}"
+
+    collection = scanner._collect_jinja_template_fields_with_budget(recursive)
+
+    assert collection.budget_exceeded is False
+    assert collection.items_visited == 3
+    assert collection.templates == {"chat_template": "{{ harmless }}"}
+
+
+def test_manifest_scanner_shared_jinja_alias_is_revisited_when_mode_changes() -> None:
+    scanner = ManifestScanner()
+    shared = {"default": "{{ harmless }}"}
+
+    collection = scanner._collect_jinja_template_fields_with_budget({"metadata": shared, "chat_template": shared})
+
+    assert collection.budget_exceeded is False
+    assert collection.templates == {"chat_template.default": "{{ harmless }}"}
+
+
 def test_manifest_scanner_deep_jinja_collection_budget_fails_closed(tmp_path: Path) -> None:
     config_path = tmp_path / "config.json"
     nested_config: dict[str, Any] = {"leaf": "plain metadata"}
@@ -805,8 +841,8 @@ def test_manifest_scanner_jinja_collection_budget_preserves_malicious_template_d
         json.dumps(
             {
                 "model_type": "llama",
-                "chat_template": "{{ ''.__class__.__mro__[1].__subclasses__() }}",
                 "metadata": nested_config,
+                "chat_template": "{{ ''.__class__.__mro__[1].__subclasses__() }}",
             }
         ),
         encoding="utf-8",


### PR DESCRIPTION
## Summary

- replace recursive embedded-Jinja collection with explicit depth and item budgets
- fail closed on incomplete collection while preserving templates recovered before and after over-depth branches
- expand shared containers once per semantic mode and chat-template context, while revisiting them at a shallower depth when needed
- terminate recursive aliases without duplicate-template amplification
- prioritize direct template fields before untrusted metadata under the global item budget
- skip collection when the embedded Jinja scanner is excluded
- redact and bound attacker-controlled traversal and delegated template-location evidence
- preserve every template when redacted locations collide
- fall back to safe defaults for invalid and infinite traversal-budget values
- make the earlier model-name, URL, and weak-hash manifest walks cycle-safe so recursive YAML aliases cannot prevent Jinja analysis
- normalize non-string YAML keys in those walks and bound path construction before concatenation

## False-positive / false-negative audit

- 100,000 randomized acyclic manifests matched the prior collector's normalized template semantics
- 1,000 references to one shared mapping remain bounded and do not become falsely inconclusive
- recursive aliases terminate through the public YAML scan path and preserve sibling malicious templates
- numeric YAML keys no longer abort structured analysis before embedded-Jinja detection
- over-depth branches are pruned locally, so later malicious siblings are still analyzed
- aliases first encountered deeply are revisited at shallower paths
- direct malicious template fields are analyzed before wide metadata can exhaust the item budget
- JSON, YAML, TOML, and INI delegation probes detect nested malicious templates
- credential-bearing manifest keys do not leak through Jinja findings or oversized-template reports
- benign template locations and collision-distinct templates are preserved
- a 64 KiB repeated path segment at depth 64 dropped from about 140 MB traced peak allocation to about 1.3 MB; evidence paths remain capped at 240 characters

## Validation

- `PROMPTFOO_DISABLE_TELEMETRY=1 UV_CACHE_DIR=/tmp/modelaudit-uv-cache uv run --frozen pytest -q tests/scanners/test_manifest_scanner.py` -> 97 passed, 1 skipped (optional `jinja2.sandbox` unavailable)
- scoped Ruff check and format checks passed
- scoped mypy passed
- `git diff --check origin/main` passed
- current `main` integrated at `43d2fb80731878757b307e3fc018f7097b072fae`
- exact remote tree verified: `7565c505d23bc0e794e30a51098a2f4975637282`
- published head: `6758ae22782d5c73449260648c95b00fa3a431f6`

The full local suite was intentionally left to CI per the PR-audit workflow.