### PR TITLE
fix: enforce MLflow artifact backend allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - invalidate cached pickle call-graph results when analyzed Python sources, search paths, or loaded module origins change
 - harden CLI scan, SBOM, metadata, and scanner-catalog output writes against links, reparse points, and special files; preserve Windows ownership and ACLs, and reject EFS-encrypted destinations that cannot be replaced without changing recipients
 - distinguish valid R call/index argument tags from malformed credential assignments and fail closed on incomplete function bodies
+- require every concrete non-local MLflow artifact target to match `MODELAUDIT_MLFLOW_ALLOWED_ARTIFACT_URIS`, including artifact-path-specific entries, while safely composing local overlays and binding downloads to the validated repositories
 - validate OCI layer member and link metadata without suppressing regular-file payload scans, while preserving valid container-root symlinks
 - prevent cache identity checks from accepting temporary higher-ancestor path swaps
 - preflight MLflow artifact sizes and copy supported local repositories under hard byte limits, rejecting unsafe paths, size drift, and backends that cannot enforce the configured download budget

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ modelaudit s3://bucket/model.pt
 modelaudit gs://bucket/models/
 
 # MLflow registry
+# Non-local artifact stores: export MODELAUDIT_MLFLOW_ALLOWED_ARTIFACT_URIS=s3://trusted-bucket/models
 modelaudit models:/MyModel/Production
 
 # JFrog Artifactory (files and folders)
@@ -142,6 +143,8 @@ modelaudit model.dvc
 - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (and optional `AWS_SESSION_TOKEN`) for S3
 - `GOOGLE_APPLICATION_CREDENTIALS` for GCS
 - `MLFLOW_TRACKING_URI` for MLflow registry access
+- `MODELAUDIT_MLFLOW_ALLOWED_ARTIFACT_URIS` for non-local MLflow artifact roots (comma-separated URI prefixes)
+- Use concrete backend roots such as `s3://bucket/prefix`; logical `models:/` or `runs:/` URIs and percent-encoded remote paths are refused.
 - `JFROG_API_TOKEN` or `JFROG_ACCESS_TOKEN` for JFrog Artifactory
 - `MODELAUDIT_JFROG_ALLOWED_HOSTS` for comma-separated custom JFrog hostnames that may receive credentials
 - `MODELAUDIT_JFROG_ALLOWED_REDIRECT_HOSTS` for comma-separated external redirect hostnames that may be downloaded without credentials

--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -2969,12 +2969,18 @@ def _resolve_scan_source_for_path(
             )
 
             audit_result.aggregate_scan_result(results.model_dump())
-            download_refused = any(getattr(issue, "type", None) == "mlflow_download_budget" for issue in results.issues)
+            issue_types = {getattr(issue, "type", None) for issue in results.issues}
+            download_refused = bool(issue_types & {"mlflow_download_budget", "mlflow_artifact_trust"})
             if download_refused:
                 if download_spinner:
                     download_spinner.fail(style_text("❌ Download refused", fg="red", bold=True))
                 elif runtime.show_styled_output:
-                    click.echo("Download refused by configured size budget")
+                    refusal_reason = (
+                        "MLflow artifact trust policy"
+                        if "mlflow_artifact_trust" in issue_types
+                        else "configured size budget"
+                    )
+                    click.echo(f"Download refused by {refusal_reason}")
             else:
                 record_download_completed("mlflow", time.time() - download_start, results.bytes_scanned, path)
                 if download_spinner:

--- a/modelaudit/integrations/mlflow.py
+++ b/modelaudit/integrations/mlflow.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from itertools import islice
 from pathlib import Path, PurePosixPath
 from typing import Any
-from urllib.parse import unquote
+from urllib.parse import unquote, urlparse
 
 from ..detectors.network_comm import _redact_urls_in_text
 from ..models import Check, CheckStatus, Issue, IssueSeverity, ModelAuditResultModel, create_initial_audit_result
@@ -28,9 +28,27 @@ from ..utils.sources.cloud_storage import redact_cloud_error_for_display, redact
 logger = logging.getLogger(__name__)
 
 _MLFLOW_DOWNLOAD_BUDGET_CHECK = "MLflow Download Size Check"
+_MLFLOW_ARTIFACT_TRUST_CHECK = "MLflow Artifact Trust Check"
+_MLFLOW_ARTIFACT_TRUST_FAILURE_TYPE = "mlflow_artifact_trust"
+_MLFLOW_ALLOWED_ARTIFACT_URIS_ENV = "MODELAUDIT_MLFLOW_ALLOWED_ARTIFACT_URIS"
 _DEFAULT_MLFLOW_MAX_ARTIFACT_ENTRIES = 10000
 _MAX_MLFLOW_ERROR_DISPLAY_CHARS = 512
 _MLFLOW_COPY_CHUNK_SIZE = 1024 * 1024
+_MLFLOW_DEFAULT_URI_PORTS = {"ftp": 21, "http": 80, "https": 443, "sftp": 22}
+_MLFLOW_URI_SCHEMES_REQUIRING_AUTHORITY = {
+    "abfss",
+    "b2",
+    "ftp",
+    "gs",
+    "http",
+    "https",
+    "mlflow-artifacts",
+    "r2",
+    "s3",
+    "sftp",
+    "wasbs",
+}
+_MLFLOW_PERCENT_ESCAPE_RE = re.compile(r"%[0-9A-Fa-f]{2}")
 _OS_OPEN_SUPPORTS_DIR_FD = os.open in os.supports_dir_fd
 _IS_WINDOWS = os.name == "nt"
 _MLFLOW_SENSITIVE_KEY = rf"(?:{SENSITIVE_CONTAINER_KEY}|credentials?|jwt|session)"
@@ -92,6 +110,19 @@ class _MlflowDownloadPlan:
     artifact_path: str | None
     max_artifact_entries: int
     local_sources: tuple[_MlflowLocalSource, ...] = ()
+
+
+@dataclass(frozen=True)
+class _MlflowDelegatedDownloadTarget:
+    artifact_repository: Any
+    artifact_path: str | None
+    destination_subdirectory: str | None = None
+
+
+@dataclass(frozen=True)
+class _MlflowDelegatedDownloadPlan:
+    targets: tuple[_MlflowDelegatedDownloadTarget, ...]
+    local_plan: _MlflowDownloadPlan | None = None
 
 
 class _MlflowArtifactSizeChangedError(Exception):
@@ -194,6 +225,397 @@ def _mlflow_budget_failure_result(model_uri: str, message: str, details: dict[st
     )
     result.finalize_statistics()
     return result
+
+
+def _mlflow_artifact_trust_failure_result(
+    model_uri: str,
+    message: str,
+    details: dict[str, Any],
+) -> ModelAuditResultModel:
+    result = create_initial_audit_result()
+    result.scanner_names = ["mlflow"]
+    result.has_errors = True
+    result.success = False
+    safe_model_uri = redact_evidence_string(model_uri, max_chars=_MAX_MLFLOW_ERROR_DISPLAY_CHARS)
+    safe_details = redact_evidence_value(details, max_string_chars=_MAX_MLFLOW_ERROR_DISPLAY_CHARS)
+
+    why = (
+        "ModelAudit requires non-local MLflow artifact repositories to match a local allowlist before delegating "
+        "artifact retrieval to MLflow. Refusing the download avoids fetching from an unapproved registry-controlled "
+        "artifact store before scanners run."
+    )
+    result.checks.append(
+        Check(
+            name=_MLFLOW_ARTIFACT_TRUST_CHECK,
+            status=CheckStatus.FAILED,
+            message=message,
+            severity=IssueSeverity.INFO,
+            location=safe_model_uri,
+            details=safe_details,
+            why=why,
+        )
+    )
+    result.issues.append(
+        Issue(
+            message=message,
+            severity=IssueSeverity.INFO,
+            location=safe_model_uri,
+            details=safe_details,
+            why=why,
+            type=_MLFLOW_ARTIFACT_TRUST_FAILURE_TYPE,
+        )
+    )
+    result.finalize_statistics()
+    return result
+
+
+def _configured_mlflow_artifact_uri_prefixes() -> tuple[str, ...]:
+    raw_prefixes = os.getenv(_MLFLOW_ALLOWED_ARTIFACT_URIS_ENV, "")
+    return tuple(prefix for prefix in (value.strip() for value in raw_prefixes.split(",")) if prefix)
+
+
+def _uri_path_is_within_prefix(path: str, prefix: str) -> bool:
+    if prefix in {"", "/"}:
+        return True
+    normalized_prefix = prefix.removesuffix("/")
+    normalized_path = path.removesuffix("/")
+    return normalized_path == normalized_prefix or normalized_path.startswith(f"{normalized_prefix}/")
+
+
+def _strictly_decode_mlflow_uri_path(path: str) -> str | None:
+    index = 0
+    while index < len(path):
+        if path[index] != "%":
+            index += 1
+            continue
+        if index + 2 >= len(path) or not all(
+            character in "0123456789abcdefABCDEF" for character in path[index + 1 : index + 3]
+        ):
+            return None
+        index += 3
+
+    try:
+        decoded_path = unquote(path, errors="strict")
+    except UnicodeDecodeError:
+        return None
+    if "\x00" in decoded_path or "\\" in decoded_path:
+        return None
+    if _MLFLOW_PERCENT_ESCAPE_RE.search(decoded_path):
+        return None
+    if any(segment in {".", ".."} for segment in decoded_path.split("/")):
+        return None
+    return decoded_path
+
+
+def _strictly_validate_mlflow_remote_uri_path(path: str) -> str | None:
+    if "%" in path or "\x00" in path or "\\" in path:
+        return None
+    if any(segment in {".", ".."} for segment in path.split("/")):
+        return None
+    return path
+
+
+def _normalized_mlflow_uri_authority(
+    parsed_uri: Any, scheme: str
+) -> tuple[str | None, str | None, str | None, int | None] | None:
+    if not parsed_uri.netloc:
+        if scheme in _MLFLOW_URI_SCHEMES_REQUIRING_AUTHORITY:
+            return None
+        return (None, None, None, None)
+    try:
+        hostname = parsed_uri.hostname
+        port = parsed_uri.port
+    except ValueError:
+        return None
+    if not hostname:
+        return None
+    if port is None:
+        port = _MLFLOW_DEFAULT_URI_PORTS.get(scheme)
+    return (
+        parsed_uri.username,
+        parsed_uri.password,
+        hostname.lower().rstrip("."),
+        port,
+    )
+
+
+def _local_path_from_mlflow_artifact_uri(uri: str) -> Path | None:
+    try:
+        parsed = urlparse(uri)
+    except ValueError:
+        return None
+    if parsed.scheme and parsed.scheme != "file":
+        return None
+
+    if parsed.scheme == "file":
+        if parsed.query or parsed.fragment:
+            return None
+        netloc = parsed.netloc
+        if netloc and netloc.lower() not in {"localhost", "127.0.0.1", "::1"}:
+            return None
+        path = _strictly_decode_mlflow_uri_path(parsed.path)
+        if path is None:
+            return None
+    else:
+        path = uri
+
+    try:
+        return Path(path).expanduser().resolve(strict=False)
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def _mlflow_artifact_uri_matches_prefix(artifact_uri: str, allowed_prefix: str) -> bool:
+    artifact_path = _local_path_from_mlflow_artifact_uri(artifact_uri)
+    prefix_path = _local_path_from_mlflow_artifact_uri(allowed_prefix)
+    if artifact_path is not None and prefix_path is not None:
+        try:
+            return os.path.commonpath((prefix_path, artifact_path)) == str(prefix_path)
+        except ValueError:
+            return False
+
+    try:
+        artifact = urlparse(artifact_uri)
+        prefix = urlparse(allowed_prefix)
+    except ValueError:
+        return False
+    if not artifact.scheme or not prefix.scheme:
+        return False
+    if artifact.query or artifact.fragment or prefix.query or prefix.fragment:
+        return False
+    artifact_scheme = artifact.scheme.lower()
+    prefix_scheme = prefix.scheme.lower()
+    if artifact_scheme != prefix_scheme:
+        return False
+    if artifact_scheme in {"file", "models", "runs"}:
+        return False
+    artifact_authority = _normalized_mlflow_uri_authority(artifact, artifact_scheme)
+    prefix_authority = _normalized_mlflow_uri_authority(prefix, prefix_scheme)
+    if artifact_authority is None or prefix_authority is None or artifact_authority != prefix_authority:
+        return False
+    normalized_artifact_path = _strictly_validate_mlflow_remote_uri_path(artifact.path)
+    normalized_prefix_path = _strictly_validate_mlflow_remote_uri_path(prefix.path)
+    if normalized_artifact_path is None or normalized_prefix_path is None:
+        return False
+    return _uri_path_is_within_prefix(normalized_artifact_path, normalized_prefix_path)
+
+
+def _mlflow_artifact_uri_is_allowlisted(artifact_uri: str) -> bool:
+    return any(
+        _mlflow_artifact_uri_matches_prefix(artifact_uri, allowed_prefix)
+        for allowed_prefix in _configured_mlflow_artifact_uri_prefixes()
+    )
+
+
+def _normalize_mlflow_delegated_artifact_path(artifact_path: str | None) -> str | None:
+    if artifact_path is None:
+        return None
+    validated_path = _strictly_validate_mlflow_remote_uri_path(artifact_path)
+    if validated_path is None:
+        raise ValueError("MLflow artifact path is ambiguous")
+    if not validated_path or posixpath.isabs(validated_path) or ntpath.isabs(validated_path):
+        raise ValueError("MLflow artifact path is not relative")
+    return validated_path
+
+
+def _mlflow_delegated_download_targets(
+    artifact_repository: Any,
+    artifact_path: str | None,
+) -> tuple[_MlflowDelegatedDownloadTarget, ...] | None:
+    repository = _terminal_mlflow_artifact_repository(artifact_repository)
+    if repository is None:
+        return None
+    if not _is_runs_mlflow_artifact_repository(repository):
+        try:
+            normalized_artifact_path = _normalize_mlflow_delegated_artifact_path(artifact_path)
+        except ValueError:
+            return None
+        return (_MlflowDelegatedDownloadTarget(repository, normalized_artifact_path),)
+
+    run_repository = _terminal_mlflow_artifact_repository(getattr(repository, "repo", None))
+    if run_repository is None:
+        return None
+    wrapper_uri = getattr(repository, "artifact_uri", None)
+    parse_runs_uri = getattr(repository, "parse_runs_uri", None)
+    get_logged_model_repository = getattr(repository, "_get_logged_model_artifact_repo", None)
+    if not isinstance(wrapper_uri, str) or not callable(parse_runs_uri):
+        return None
+    try:
+        run_id, wrapper_path = parse_runs_uri(wrapper_uri)
+    except Exception:
+        return None
+    try:
+        normalized_wrapper_path = _normalize_mlflow_delegated_artifact_path(wrapper_path)
+        normalized_artifact_path = _normalize_mlflow_delegated_artifact_path(artifact_path)
+    except ValueError:
+        return None
+    if any("//" in path for path in (normalized_wrapper_path, normalized_artifact_path) if path is not None):
+        return None
+    effective_path = (
+        posixpath.join(normalized_wrapper_path, normalized_artifact_path)
+        if normalized_wrapper_path and normalized_artifact_path
+        else normalized_wrapper_path or normalized_artifact_path
+    )
+    run_artifact_path = normalized_artifact_path
+    if normalized_wrapper_path and effective_path:
+        repository_is_scoped = _runs_mlflow_repository_is_scoped(repository, run_repository, wrapper_uri)
+        if repository_is_scoped is None:
+            return None
+        if not repository_is_scoped:
+            run_artifact_path = effective_path
+    targets = [_MlflowDelegatedDownloadTarget(run_repository, run_artifact_path)]
+    if not effective_path:
+        return tuple(targets)
+    if not callable(get_logged_model_repository):
+        return None
+
+    model_name = effective_path.split("/", 1)[0]
+    try:
+        logged_model_repository = get_logged_model_repository(run_id=run_id, name=model_name)
+    except Exception:
+        return None
+    if logged_model_repository is not None:
+        terminal_logged_repository = _terminal_mlflow_artifact_repository(logged_model_repository)
+        if terminal_logged_repository is None:
+            return None
+        model_name, separator, model_artifact_path = effective_path.partition("/")
+        targets.append(
+            _MlflowDelegatedDownloadTarget(
+                terminal_logged_repository,
+                model_artifact_path if separator and model_artifact_path else None,
+                model_name,
+            )
+        )
+    return tuple(targets)
+
+
+def _mlflow_artifact_repository_uris(
+    targets: tuple[_MlflowDelegatedDownloadTarget, ...],
+) -> tuple[str, ...] | None:
+    artifact_uris: list[str] = []
+    for target in targets:
+        repository = target.artifact_repository
+        if _local_mlflow_artifact_root(repository) is not None:
+            continue
+        artifact_uri = getattr(repository, "artifact_uri", None)
+        if not isinstance(artifact_uri, str) or not artifact_uri:
+            return None
+        try:
+            parsed_artifact_uri = urlparse(artifact_uri)
+            artifact_scheme = parsed_artifact_uri.scheme.lower()
+        except ValueError:
+            return None
+        if artifact_scheme in {"", "file"}:
+            return None
+        if target.artifact_path:
+            separator = "" if parsed_artifact_uri.path.endswith("/") else "/"
+            artifact_uri = parsed_artifact_uri._replace(
+                path=f"{parsed_artifact_uri.path}{separator}{target.artifact_path}"
+            ).geturl()
+        if artifact_uri not in artifact_uris:
+            artifact_uris.append(artifact_uri)
+    return tuple(artifact_uris)
+
+
+def _partition_mlflow_delegated_targets(
+    targets: tuple[_MlflowDelegatedDownloadTarget, ...],
+) -> tuple[tuple[_MlflowDelegatedDownloadTarget, ...], tuple[_MlflowLocalSource, ...]] | None:
+    remote_targets: list[_MlflowDelegatedDownloadTarget] = []
+    local_sources: list[_MlflowLocalSource] = []
+    for target in targets:
+        local_root = _local_mlflow_artifact_root(target.artifact_repository)
+        if local_root is None:
+            remote_targets.append(target)
+            continue
+        if remote_targets:
+            return None
+        local_sources.append(
+            _MlflowLocalSource(
+                local_root,
+                target.artifact_path,
+                target.destination_subdirectory,
+            )
+        )
+    return tuple(remote_targets), tuple(local_sources)
+
+
+def _unbounded_mlflow_download_policy_result(
+    model_uri: str,
+    details: dict[str, Any],
+    targets: tuple[_MlflowDelegatedDownloadTarget, ...] | None,
+) -> ModelAuditResultModel | None:
+    artifact_uris = _mlflow_artifact_repository_uris(targets) if targets is not None else None
+    untrusted_artifact_uris = (
+        [artifact_uri for artifact_uri in artifact_uris if not _mlflow_artifact_uri_is_allowlisted(artifact_uri)]
+        if artifact_uris is not None
+        else []
+    )
+    if artifact_uris is not None and not untrusted_artifact_uris:
+        return None
+
+    artifact_uri = untrusted_artifact_uris[0] if untrusted_artifact_uris else None
+    if artifact_uri is None and targets:
+        candidate_uri = getattr(targets[0].artifact_repository, "artifact_uri", None)
+        artifact_uri = candidate_uri if isinstance(candidate_uri, str) and candidate_uri else None
+    details.update(
+        {
+            "reason": "artifact_uri_not_allowlisted",
+            "artifact_repository_uri": artifact_uri,
+            "artifact_repository_uris": list(artifact_uris) if artifact_uris is not None else None,
+            "allowlist_env_var": _MLFLOW_ALLOWED_ARTIFACT_URIS_ENV,
+        }
+    )
+    return _mlflow_artifact_trust_failure_result(
+        model_uri,
+        "MLflow artifact repository is not in the configured allowlist",
+        details,
+    )
+
+
+def _trusted_mlflow_delegated_download_plan(
+    model_uri: str,
+    root_uri: str,
+    details: dict[str, Any],
+    artifact_repository: Any,
+    *,
+    max_file_size: int,
+    max_total_size: int,
+    max_artifact_entries: int,
+) -> _MlflowDelegatedDownloadPlan | ModelAuditResultModel:
+    targets = _mlflow_delegated_download_targets(artifact_repository, details.get("artifact_path"))
+    if targets is None:
+        return _mlflow_artifact_trust_failure_result(
+            model_uri,
+            "Unable to verify the MLflow artifact repository before download",
+            details,
+        )
+    partitioned_targets = _partition_mlflow_delegated_targets(targets)
+    if partitioned_targets is None:
+        return _mlflow_artifact_trust_failure_result(
+            model_uri,
+            "Unable to safely compose remote MLflow artifacts before a local overlay",
+            details,
+        )
+    remote_targets, local_sources = partitioned_targets
+    policy_failure = _unbounded_mlflow_download_policy_result(model_uri, details, remote_targets)
+    if policy_failure is not None:
+        return policy_failure
+
+    local_plan: _MlflowDownloadPlan | None = None
+    if local_sources:
+        local_plan_result = _preflight_local_mlflow_sources(
+            model_uri,
+            root_uri,
+            local_sources,
+            details,
+            max_file_size=max_file_size,
+            max_total_size=max_total_size,
+            max_artifact_entries=max_artifact_entries,
+        )
+        if isinstance(local_plan_result, ModelAuditResultModel):
+            return local_plan_result
+        local_plan = local_plan_result
+    return _MlflowDelegatedDownloadPlan(remote_targets, local_plan)
 
 
 def _redact_mlflow_error_for_display(error: object) -> str:
@@ -380,8 +802,30 @@ def _local_mlflow_artifact_root(artifact_repository: Any) -> Path | None:
     if not isinstance(repository, LocalArtifactRepository):
         return None
 
+    artifact_uri = getattr(repository, "artifact_uri", None)
+    if isinstance(artifact_uri, str):
+        try:
+            parsed_artifact_uri = urlparse(artifact_uri)
+        except ValueError:
+            return None
+        if parsed_artifact_uri.scheme == "file" and parsed_artifact_uri.netloc.lower() not in {
+            "",
+            "localhost",
+            "127.0.0.1",
+            "::1",
+        }:
+            return None
+        if not parsed_artifact_uri.scheme and artifact_uri.startswith(("//", "\\\\")):
+            return None
+
     try:
-        artifact_root = Path(repository.artifact_dir).expanduser().resolve(strict=True)
+        raw_artifact_dir = os.fspath(repository.artifact_dir)
+    except TypeError:
+        return None
+    if raw_artifact_dir.startswith(("//", "\\\\")):
+        return None
+    try:
+        artifact_root = Path(raw_artifact_dir).expanduser().resolve(strict=True)
     except (OSError, TypeError, ValueError):
         return None
     return artifact_root if artifact_root.is_dir() else None
@@ -453,8 +897,8 @@ def _local_runs_mlflow_sources(
     try:
         logged_model_repository = get_logged_model_repository(run_id=run_id, name=model_name)
     except Exception:
-        logger.debug("MLflow logged-model lookup failed; continuing with bounded local run artifacts")
-        return tuple(sources)
+        logger.debug("MLflow logged-model lookup failed; refusing an incomplete run artifact view")
+        return None
     if logged_model_repository is None:
         return tuple(sources)
 
@@ -903,10 +1347,8 @@ def _preflight_mlflow_download_budget(
     max_file_size: int,
     max_total_size: int,
     max_artifact_entries: int,
-) -> _MlflowDownloadPlan | ModelAuditResultModel | None:
-    if not _finite_budget(max_file_size, max_total_size):
-        return None
-
+) -> _MlflowDownloadPlan | _MlflowDelegatedDownloadPlan | ModelAuditResultModel:
+    has_finite_budget = _finite_budget(max_file_size, max_total_size)
     root_uri, initial_artifact_path = _split_mlflow_artifact_uri(mlflow_module, model_uri)
     details: dict[str, Any] = {
         "model_uri": model_uri,
@@ -946,6 +1388,16 @@ def _preflight_mlflow_download_budget(
                 details,
             )
         if local_sources is None:
+            if not has_finite_budget:
+                return _trusted_mlflow_delegated_download_plan(
+                    model_uri,
+                    root_uri,
+                    details,
+                    artifact_repository,
+                    max_file_size=max_file_size,
+                    max_total_size=max_total_size,
+                    max_artifact_entries=max_artifact_entries,
+                )
             details["reason"] = "artifact_streaming_budget_unavailable"
             return _mlflow_budget_failure_result(
                 model_uri,
@@ -964,6 +1416,16 @@ def _preflight_mlflow_download_budget(
 
     local_artifact_root = _local_mlflow_artifact_root(artifact_repository)
     if local_artifact_root is None:
+        if not has_finite_budget:
+            return _trusted_mlflow_delegated_download_plan(
+                model_uri,
+                root_uri,
+                details,
+                artifact_repository,
+                max_file_size=max_file_size,
+                max_total_size=max_total_size,
+                max_artifact_entries=max_artifact_entries,
+            )
         details["reason"] = "artifact_streaming_budget_unavailable"
         return _mlflow_budget_failure_result(
             model_uri,
@@ -1376,6 +1838,26 @@ def _prepare_download_dir(model_uri: str, cache_dir: str | None) -> tuple[str, b
     return tempfile.mkdtemp(prefix=f"{cache_key}-", dir=str(download_root)), True
 
 
+def _download_trusted_mlflow_artifacts(plan: _MlflowDelegatedDownloadPlan, download_dir: str) -> str:
+    downloaded_paths: list[str] = []
+    for target in plan.targets:
+        target_download_dir = Path(download_dir)
+        if target.destination_subdirectory:
+            target_download_dir /= target.destination_subdirectory
+            target_download_dir.mkdir(parents=True, exist_ok=True)
+        downloaded_path = target.artifact_repository.download_artifacts(
+            artifact_path=target.artifact_path or "",
+            dst_path=str(target_download_dir),
+        )
+        if not isinstance(downloaded_path, str) or not downloaded_path:
+            raise RuntimeError("MLflow artifact repository did not return a download path")
+        downloaded_paths.append(downloaded_path)
+
+    if downloaded_paths:
+        return downloaded_paths[0]
+    raise RuntimeError("MLflow artifact repositories did not return a download path")
+
+
 def scan_mlflow_model(
     model_uri: str,
     *,
@@ -1448,6 +1930,7 @@ def scan_mlflow_model(
 
     try:
         logger.debug(f"Downloading MLflow model {_redact_mlflow_error_for_display(model_uri)} to {download_dir}")
+        local_path: str | None
         if isinstance(download_plan, _MlflowDownloadPlan):
             download_result = _download_preflighted_mlflow_artifacts(
                 download_plan,
@@ -1460,7 +1943,23 @@ def scan_mlflow_model(
                 return download_result
             local_path = download_result
         else:
-            local_path = mlflow.artifacts.download_artifacts(artifact_uri=model_uri, dst_path=download_dir)  # type: ignore[possibly-unbound-attribute]
+            local_path = None
+            if download_plan.local_plan is not None:
+                local_download_result = _download_preflighted_mlflow_artifacts(
+                    download_plan.local_plan,
+                    model_uri,
+                    download_dir,
+                    max_file_size=max_file_size,
+                    max_total_size=max_total_size,
+                )
+                if isinstance(local_download_result, ModelAuditResultModel):
+                    return local_download_result
+                local_path = local_download_result
+            if download_plan.targets:
+                delegated_path = _download_trusted_mlflow_artifacts(download_plan, download_dir)
+                local_path = download_dir if local_path is not None else delegated_path
+            if local_path is None:
+                raise RuntimeError("MLflow artifact download plan did not contain any targets")
         # mlflow may return a file within the download directory; ensure directory path
         download_path = os.path.dirname(local_path) if os.path.isfile(local_path) else local_path
         cache_config = {"cache_enabled": cache_enabled, "cache_dir": scan_cache_dir}

--- a/modelaudit/integrations/mlflow.py
+++ b/modelaudit/integrations/mlflow.py
@@ -35,6 +35,7 @@ _DEFAULT_MLFLOW_MAX_ARTIFACT_ENTRIES = 10000
 _MAX_MLFLOW_ERROR_DISPLAY_CHARS = 512
 _MLFLOW_COPY_CHUNK_SIZE = 1024 * 1024
 _MLFLOW_DEFAULT_URI_PORTS = {"ftp": 21, "http": 80, "https": 443, "sftp": 22}
+_MLFLOW_RESOURCE_DOES_NOT_EXIST = "RESOURCE_DOES_NOT_EXIST"
 _MLFLOW_URI_SCHEMES_REQUIRING_AUTHORITY = {
     "abfss",
     "b2",
@@ -117,6 +118,7 @@ class _MlflowDelegatedDownloadTarget:
     artifact_repository: Any
     artifact_path: str | None
     destination_subdirectory: str | None = None
+    optional_when_missing: bool = False
 
 
 @dataclass(frozen=True)
@@ -468,7 +470,8 @@ def _mlflow_delegated_download_targets(
             return None
         if not repository_is_scoped:
             run_artifact_path = effective_path
-    targets = [_MlflowDelegatedDownloadTarget(run_repository, run_artifact_path)]
+    run_target = _MlflowDelegatedDownloadTarget(run_repository, run_artifact_path)
+    targets = [run_target]
     if not effective_path:
         return tuple(targets)
     if not callable(get_logged_model_repository):
@@ -484,6 +487,11 @@ def _mlflow_delegated_download_targets(
         if terminal_logged_repository is None:
             return None
         model_name, separator, model_artifact_path = effective_path.partition("/")
+        targets[0] = _MlflowDelegatedDownloadTarget(
+            run_repository,
+            run_artifact_path,
+            optional_when_missing=True,
+        )
         targets.append(
             _MlflowDelegatedDownloadTarget(
                 terminal_logged_repository,
@@ -1843,6 +1851,14 @@ def _prepare_download_dir(model_uri: str, cache_dir: str | None) -> tuple[str, b
     return tempfile.mkdtemp(prefix=f"{cache_key}-", dir=str(download_root)), True
 
 
+def _is_missing_mlflow_artifact_error(error: Exception) -> bool:
+    try:
+        from mlflow.exceptions import MlflowException
+    except Exception:
+        return False
+    return isinstance(error, MlflowException) and error.error_code == _MLFLOW_RESOURCE_DOES_NOT_EXIST
+
+
 def _download_trusted_mlflow_artifacts(plan: _MlflowDelegatedDownloadPlan, download_dir: str) -> str:
     downloaded_paths: list[str] = []
     for target in plan.targets:
@@ -1850,10 +1866,15 @@ def _download_trusted_mlflow_artifacts(plan: _MlflowDelegatedDownloadPlan, downl
         if target.destination_subdirectory:
             target_download_dir /= target.destination_subdirectory
             target_download_dir.mkdir(parents=True, exist_ok=True)
-        downloaded_path = target.artifact_repository.download_artifacts(
-            artifact_path=target.artifact_path or "",
-            dst_path=str(target_download_dir),
-        )
+        try:
+            downloaded_path = target.artifact_repository.download_artifacts(
+                artifact_path=target.artifact_path or "",
+                dst_path=str(target_download_dir),
+            )
+        except Exception as exc:
+            if target.optional_when_missing and _is_missing_mlflow_artifact_error(exc):
+                continue
+            raise
         if not isinstance(downloaded_path, str) or not downloaded_path:
             raise RuntimeError("MLflow artifact repository did not return a download path")
         downloaded_paths.append(downloaded_path)

--- a/modelaudit/integrations/mlflow.py
+++ b/modelaudit/integrations/mlflow.py
@@ -348,7 +348,7 @@ def _local_path_from_mlflow_artifact_uri(uri: str) -> Path | None:
         return None
 
     if parsed.scheme == "file":
-        if parsed.query or parsed.fragment:
+        if parsed.params or parsed.query or parsed.fragment:
             return None
         netloc = parsed.netloc
         if netloc and netloc.lower() not in {"localhost", "127.0.0.1", "::1"}:
@@ -381,7 +381,7 @@ def _mlflow_artifact_uri_matches_prefix(artifact_uri: str, allowed_prefix: str) 
         return False
     if not artifact.scheme or not prefix.scheme:
         return False
-    if artifact.query or artifact.fragment or prefix.query or prefix.fragment:
+    if artifact.params or artifact.query or artifact.fragment or prefix.params or prefix.query or prefix.fragment:
         return False
     artifact_scheme = artifact.scheme.lower()
     prefix_scheme = prefix.scheme.lower()
@@ -413,7 +413,12 @@ def _normalize_mlflow_delegated_artifact_path(artifact_path: str | None) -> str 
     validated_path = _strictly_validate_mlflow_remote_uri_path(artifact_path)
     if validated_path is None:
         raise ValueError("MLflow artifact path is ambiguous")
-    if not validated_path or posixpath.isabs(validated_path) or ntpath.isabs(validated_path):
+    if (
+        not validated_path
+        or posixpath.isabs(validated_path)
+        or ntpath.isabs(validated_path)
+        or ntpath.splitdrive(validated_path)[0]
+    ):
         raise ValueError("MLflow artifact path is not relative")
     return validated_path
 

--- a/tests/integrations/test_mlflow_integration.py
+++ b/tests/integrations/test_mlflow_integration.py
@@ -15,13 +15,18 @@ import pytest
 from modelaudit.core import determine_exit_code
 from modelaudit.integrations.mlflow import (
     _copy_local_mlflow_artifact,
+    _download_trusted_mlflow_artifacts,
     _local_mlflow_artifact_root,
+    _mlflow_artifact_uri_matches_prefix,
     _mlflow_budget_failure_result,
     _MlflowArtifact,
     _MlflowArtifactSizeChangedError,
+    _MlflowDelegatedDownloadPlan,
+    _MlflowDelegatedDownloadTarget,
     _MlflowLocalSource,
     _normalize_mlflow_artifact_path,
     _opened_local_mlflow_path,
+    _partition_mlflow_delegated_targets,
     _redact_mlflow_error_for_display,
     _runs_mlflow_repository_is_scoped,
     _snapshot_local_mlflow_sources,
@@ -101,6 +106,47 @@ def test_snapshot_local_mlflow_sources_accepts_existing_empty_directory(tmp_path
 
     assert artifacts == {}
     assert entry_count == 0
+
+
+def test_local_mlflow_artifact_root_rejects_remote_file_authority(tmp_path: Path) -> None:
+    from mlflow.store.artifact.local_artifact_repo import LocalArtifactRepository
+
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir()
+    repository = LocalArtifactRepository(f"file://attacker.example{artifact_root.as_posix()}")
+
+    assert _local_mlflow_artifact_root(repository) is None
+
+
+def test_local_mlflow_artifact_root_rejects_remote_file_authority_before_path_lookup() -> None:
+    class LocalArtifactRepository:
+        artifact_uri = "file://attacker.example/share/model"
+
+        @property
+        def artifact_dir(self) -> str:
+            raise AssertionError("remote file authority must be rejected before path lookup")
+
+    local_module = ModuleType("mlflow.store.artifact.local_artifact_repo")
+    local_module.LocalArtifactRepository = LocalArtifactRepository  # type: ignore[attr-defined]
+
+    with patch.dict(sys.modules, {"mlflow.store.artifact.local_artifact_repo": local_module}):
+        assert _local_mlflow_artifact_root(LocalArtifactRepository()) is None
+
+
+@pytest.mark.parametrize("artifact_dir", [r"\\server\share\model", "//server/share/model"])
+def test_local_mlflow_artifact_root_rejects_unc_path_before_resolution(artifact_dir: str) -> None:
+    class LocalArtifactRepository:
+        def __init__(self, path: str) -> None:
+            self.artifact_dir = path
+
+    local_module = ModuleType("mlflow.store.artifact.local_artifact_repo")
+    local_module.LocalArtifactRepository = LocalArtifactRepository  # type: ignore[attr-defined]
+
+    with (
+        patch.dict(sys.modules, {"mlflow.store.artifact.local_artifact_repo": local_module}),
+        patch.object(Path, "resolve", side_effect=AssertionError("UNC path must not be resolved")),
+    ):
+        assert _local_mlflow_artifact_root(LocalArtifactRepository(artifact_dir)) is None
 
 
 @pytest.mark.parametrize("legacy_resolver", [False, True], ids=["current", "legacy"])
@@ -422,8 +468,8 @@ def test_scan_mlflow_model_allows_logged_model_without_run_artifact(tmp_path: Pa
     mlflow_module.artifacts.download_artifacts.assert_not_called()  # type: ignore[attr-defined]
 
 
-def test_scan_mlflow_model_allows_local_run_when_logged_model_lookup_fails(tmp_path: Path) -> None:
-    """Optional logged-model lookup failures must not hide bounded run artifacts."""
+def test_scan_mlflow_model_rejects_local_run_when_logged_model_lookup_fails(tmp_path: Path) -> None:
+    """A failed overlay lookup must not silently omit logged-model artifacts."""
 
     class LocalArtifactRepository:
         def __init__(self, artifact_dir: Path) -> None:
@@ -469,8 +515,6 @@ def test_scan_mlflow_model_allows_local_run_when_logged_model_lookup_fails(tmp_p
     mlflow_module.artifacts.get_artifact_repository.return_value = repository  # type: ignore[attr-defined]
     download_dir = tmp_path / "download"
     download_dir.mkdir()
-    scan_result: Any = {"bytes_scanned": 4, "issues": []}
-
     with (
         patch.dict(
             sys.modules,
@@ -485,7 +529,7 @@ def test_scan_mlflow_model_allows_local_run_when_logged_model_lookup_fails(tmp_p
         ),
         patch("modelaudit.integrations.mlflow.tempfile.mkdtemp", return_value=str(download_dir)),
         patch("modelaudit.integrations.mlflow.shutil.rmtree"),
-        patch("modelaudit.core.scan_model_directory_or_file", return_value=scan_result) as mock_scan,
+        patch("modelaudit.core.scan_model_directory_or_file") as mock_scan,
     ):
         result = scan_mlflow_model(
             "runs:/run-1/model",
@@ -493,9 +537,10 @@ def test_scan_mlflow_model_allows_local_run_when_logged_model_lookup_fails(tmp_p
             max_total_size=4,
         )
 
-    assert result == scan_result
-    assert (download_dir / "model" / "model.pkl").read_bytes() == b"xxxx"
-    mock_scan.assert_called_once()
+    assert determine_exit_code(result) == 2
+    assert result.checks[0].details["reason"] == "artifact_streaming_budget_unavailable"
+    assert not (download_dir / "model" / "model.pkl").exists()
+    mock_scan.assert_not_called()
     mlflow_module.artifacts.download_artifacts.assert_not_called()  # type: ignore[attr-defined]
 
 
@@ -1163,6 +1208,642 @@ def test_mlflow_budget_failure_preserves_benign_uri_context() -> None:
     }
 
 
+@pytest.mark.parametrize(
+    ("artifact_uri", "allowed_prefix"),
+    [
+        ("https://mlflow.example.com:443/artifacts/model.pkl", "https://mlflow.example.com/artifacts"),
+        ("https://mlflow.example.com/artifacts/model.pkl", "https://mlflow.example.com:443/artifacts"),
+        ("http://mlflow.example.com:80/artifacts/model.pkl", "http://mlflow.example.com/artifacts"),
+        ("ftp://mlflow.example.com:21/artifacts/model.pkl", "ftp://mlflow.example.com/artifacts"),
+        ("sftp://mlflow.example.com:22/artifacts/model.pkl", "sftp://mlflow.example.com/artifacts"),
+        ("dbfs:/trusted/models/model.pkl", "dbfs:/trusted/models"),
+        ("s3://trusted-bucket/models//model.pkl", "s3://trusted-bucket/models//"),
+        ("s3://trusted-bucket//model.pkl", "s3://trusted-bucket//"),
+    ],
+)
+def test_mlflow_artifact_uri_prefix_matching_accepts_equivalent_safe_uris(
+    artifact_uri: str,
+    allowed_prefix: str,
+) -> None:
+    assert _mlflow_artifact_uri_matches_prefix(artifact_uri, allowed_prefix) is True
+
+
+@pytest.mark.parametrize(
+    ("artifact_uri", "allowed_prefix"),
+    [
+        ("https://mlflow.example.com/artifacts/../evil/model.pkl", "https://mlflow.example.com/artifacts"),
+        ("https://mlflow.example.com/artifacts/%2e%2e/evil/model.pkl", "https://mlflow.example.com/artifacts"),
+        ("https://mlflow.example.com/artifacts/%252e%252e/evil/model.pkl", "https://mlflow.example.com/artifacts"),
+        ("https://mlflow.example.com/artifacts/%2", "https://mlflow.example.com/artifacts"),
+        ("https://mlflow.example.com/artifacts/%5c..%5cevil", "https://mlflow.example.com/artifacts"),
+        ("https://mlflow.example.com:invalid/artifacts/model.pkl", "https://mlflow.example.com/artifacts"),
+        ("s3://trusted-bucket/%6dodels/model.pkl", "s3://trusted-bucket/models"),
+        ("s3://trusted-bucket/models/model.pkl", "s3://trusted-bucket/models//"),
+        ("s3://trusted-bucket/model.pkl", "s3://trusted-bucket//"),
+        ("ftp:/artifacts/model.pkl", "ftp:/artifacts"),
+        ("file://attacker.example/share/model.pkl", "file://attacker.example/share"),
+        ("models:/TrustedModel/1", "models:/TrustedModel"),
+        ("runs:/run-1/model", "runs:/run-1"),
+    ],
+)
+def test_mlflow_artifact_uri_prefix_matching_rejects_ambiguous_uris(
+    artifact_uri: str,
+    allowed_prefix: str,
+) -> None:
+    assert _mlflow_artifact_uri_matches_prefix(artifact_uri, allowed_prefix) is False
+
+
+@pytest.mark.parametrize(
+    ("artifact_uri", "allowed_prefix"),
+    [
+        ("file:///private/tmp/modelaudit-evil/model.pkl", "file:///private/tmp/modelaudit-trusted"),
+        ("file:///private/tmp/modelaudit-trusted/model.pkl", "file:///private/tmp/modelaudit-trusted"),
+        ("https://mlflow.example.com/artifacts2/model.pkl", "https://mlflow.example.com/artifacts"),
+        ("s3://trusted-bucket/models2/model.pkl", "s3://trusted-bucket/models"),
+        ("https://mlflow.example.com/artifacts/../evil/model.pkl", "https://mlflow.example.com/artifacts"),
+        ("https://mlflow.example.com/artifacts/%2e%2e/evil/model.pkl", "https://mlflow.example.com/artifacts"),
+    ],
+)
+@patch("modelaudit.integrations.mlflow.tempfile.mkdtemp")
+@patch("modelaudit.core.scan_model_directory_or_file")
+def test_scan_mlflow_model_rejects_unallowlisted_artifact_uri_before_download(
+    mock_scan: MagicMock,
+    mock_mkdtemp: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    artifact_uri: str,
+    allowed_prefix: str,
+) -> None:
+    """Remote MLflow artifact roots must match the local allowlist before download."""
+    monkeypatch.setenv("MODELAUDIT_MLFLOW_ALLOWED_ARTIFACT_URIS", allowed_prefix)
+    mock_mlflow = MagicMock()
+    mock_mlflow.artifacts.get_artifact_repository.return_value = SimpleNamespace(artifact_uri=artifact_uri)
+
+    with patch.dict(sys.modules, {"mlflow": mock_mlflow}):
+        result = scan_mlflow_model("models:/TestModel/1")
+
+    mock_mlflow.artifacts.download_artifacts.assert_not_called()
+    mock_mkdtemp.assert_not_called()
+    mock_scan.assert_not_called()
+    assert determine_exit_code(result) == 2
+    assert result.success is False
+    assert result.checks[0].name == "MLflow Artifact Trust Check"
+    assert result.checks[0].details["reason"] == "artifact_uri_not_allowlisted"
+    assert result.checks[0].details["artifact_repository_uri"] == artifact_uri
+
+
+@patch("modelaudit.integrations.mlflow.tempfile.mkdtemp")
+@patch("modelaudit.core.scan_model_directory_or_file")
+def test_scan_mlflow_model_rejects_unallowlisted_logged_model_overlay_before_download(
+    mock_scan: MagicMock,
+    mock_mkdtemp: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A runs:/ adapter must trust both its run and logged-model artifact stores."""
+
+    class RemoteArtifactRepository:
+        def __init__(self, artifact_uri: str) -> None:
+            self.artifact_uri = artifact_uri
+
+    class RunsArtifactRepository:
+        artifact_uri = "runs:/run-1/model"
+
+        def __init__(self) -> None:
+            self.repo = RemoteArtifactRepository("s3://trusted-bucket/runs/run-1/model")
+
+        @staticmethod
+        def parse_runs_uri(uri: str) -> tuple[str, str | None]:
+            assert uri == "runs:/run-1/model"
+            return "run-1", "model"
+
+        @staticmethod
+        def get_underlying_uri(uri: str, tracking_uri: str | None = None) -> str:
+            assert uri == "runs:/run-1/model"
+            assert tracking_uri is None
+            return "s3://trusted-bucket/runs/run-1/model"
+
+        @staticmethod
+        def _get_logged_model_artifact_repo(*, run_id: str, name: str) -> RemoteArtifactRepository:
+            assert run_id == "run-1"
+            assert name == "model"
+            return RemoteArtifactRepository("s3://untrusted-bucket/logged-models/model")
+
+    class ModelsArtifactRepository:
+        def __init__(self, repo: Any) -> None:
+            self.repo = repo
+
+    monkeypatch.setenv("MODELAUDIT_MLFLOW_ALLOWED_ARTIFACT_URIS", "s3://trusted-bucket/runs")
+    mlflow_module = ModuleType("mlflow")
+    mlflow_module.artifacts = MagicMock()  # type: ignore[attr-defined]
+    mlflow_module.artifacts.get_artifact_repository.return_value = ModelsArtifactRepository(  # type: ignore[attr-defined]
+        RunsArtifactRepository()
+    )
+    store_module = ModuleType("mlflow.store")
+    artifact_module = ModuleType("mlflow.store.artifact")
+    models_module = ModuleType("mlflow.store.artifact.models_artifact_repo")
+    runs_module = ModuleType("mlflow.store.artifact.runs_artifact_repo")
+    models_module.ModelsArtifactRepository = ModelsArtifactRepository  # type: ignore[attr-defined]
+    runs_module.RunsArtifactRepository = RunsArtifactRepository  # type: ignore[attr-defined]
+
+    with patch.dict(
+        sys.modules,
+        {
+            "mlflow": mlflow_module,
+            "mlflow.store": store_module,
+            "mlflow.store.artifact": artifact_module,
+            "mlflow.store.artifact.models_artifact_repo": models_module,
+            "mlflow.store.artifact.runs_artifact_repo": runs_module,
+        },
+    ):
+        result = scan_mlflow_model("models:/TestModel/1")
+
+    mlflow_module.artifacts.download_artifacts.assert_not_called()  # type: ignore[attr-defined]
+    mock_mkdtemp.assert_not_called()
+    mock_scan.assert_not_called()
+    assert determine_exit_code(result) == 2
+    assert result.checks[0].details["artifact_repository_uri"] == "s3://untrusted-bucket/logged-models/model"
+    assert result.checks[0].details["artifact_repository_uris"] == [
+        "s3://trusted-bucket/runs/run-1/model",
+        "s3://untrusted-bucket/logged-models/model",
+    ]
+
+
+@patch("modelaudit.integrations.mlflow.shutil.rmtree")
+@patch("modelaudit.integrations.mlflow.tempfile.mkdtemp")
+@patch("modelaudit.core.scan_model_directory_or_file")
+def test_scan_mlflow_model_downloads_from_the_validated_logged_model_repository(
+    mock_scan: MagicMock,
+    mock_mkdtemp: MagicMock,
+    mock_rmtree: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A runs:/ download must not resolve its logged-model backend a second time."""
+
+    class RemoteArtifactRepository:
+        def __init__(self, artifact_uri: str, downloaded_path: Path) -> None:
+            self.artifact_uri = artifact_uri
+            self.download_artifacts = MagicMock(return_value=str(downloaded_path))
+
+    class RunsArtifactRepository:
+        artifact_uri = "runs:/run-1/model"
+
+        def __init__(self, run_repository: RemoteArtifactRepository) -> None:
+            self.repo = run_repository
+            self.download_artifacts = MagicMock(side_effect=AssertionError("wrapper download must not be used"))
+            self._get_logged_model_artifact_repo = MagicMock()
+
+        @staticmethod
+        def parse_runs_uri(uri: str) -> tuple[str, str | None]:
+            assert uri == "runs:/run-1/model"
+            return "run-1", "model"
+
+        @staticmethod
+        def get_underlying_uri(uri: str, tracking_uri: str | None = None) -> str:
+            assert uri == "runs:/run-1/model"
+            assert tracking_uri is None
+            return "s3://trusted-bucket/runs/run-1/model"
+
+    class ModelsArtifactRepository:
+        def __init__(self, repo: Any) -> None:
+            self.repo = repo
+
+    monkeypatch.setenv(
+        "MODELAUDIT_MLFLOW_ALLOWED_ARTIFACT_URIS",
+        "s3://trusted-bucket/runs,s3://trusted-bucket/logged-models",
+    )
+    download_dir = tmp_path / "download"
+    download_dir.mkdir()
+    mock_mkdtemp.return_value = str(download_dir)
+    run_repository = RemoteArtifactRepository("s3://trusted-bucket/runs/run-1/model", download_dir)
+    trusted_logged_repository = RemoteArtifactRepository(
+        "s3://trusted-bucket/logged-models/model",
+        download_dir / "model",
+    )
+    untrusted_logged_repository = RemoteArtifactRepository(
+        "s3://untrusted-bucket/logged-models/model",
+        download_dir / "model",
+    )
+    runs_repository = RunsArtifactRepository(run_repository)
+    runs_repository._get_logged_model_artifact_repo.side_effect = [
+        trusted_logged_repository,
+        untrusted_logged_repository,
+    ]
+    mlflow_module = ModuleType("mlflow")
+    mlflow_module.artifacts = MagicMock()  # type: ignore[attr-defined]
+    mlflow_module.artifacts.get_artifact_repository.return_value = ModelsArtifactRepository(  # type: ignore[attr-defined]
+        runs_repository
+    )
+    store_module = ModuleType("mlflow.store")
+    artifact_module = ModuleType("mlflow.store.artifact")
+    models_module = ModuleType("mlflow.store.artifact.models_artifact_repo")
+    runs_module = ModuleType("mlflow.store.artifact.runs_artifact_repo")
+    models_module.ModelsArtifactRepository = ModelsArtifactRepository  # type: ignore[attr-defined]
+    runs_module.RunsArtifactRepository = RunsArtifactRepository  # type: ignore[attr-defined]
+    scan_result: Any = {"bytes_scanned": 4, "issues": []}
+    mock_scan.return_value = scan_result
+
+    with patch.dict(
+        sys.modules,
+        {
+            "mlflow": mlflow_module,
+            "mlflow.store": store_module,
+            "mlflow.store.artifact": artifact_module,
+            "mlflow.store.artifact.models_artifact_repo": models_module,
+            "mlflow.store.artifact.runs_artifact_repo": runs_module,
+        },
+    ):
+        result = scan_mlflow_model("models:/TestModel/1")
+
+    assert result == scan_result
+    runs_repository._get_logged_model_artifact_repo.assert_called_once_with(run_id="run-1", name="model")
+    runs_repository.download_artifacts.assert_not_called()
+    run_repository.download_artifacts.assert_called_once_with(artifact_path="", dst_path=str(download_dir))
+    trusted_logged_repository.download_artifacts.assert_called_once_with(
+        artifact_path="",
+        dst_path=str(download_dir / "model"),
+    )
+    untrusted_logged_repository.download_artifacts.assert_not_called()
+    mock_scan.assert_called_once()
+    mock_rmtree.assert_called_once_with(str(download_dir), ignore_errors=True)
+
+
+def test_delegated_mlflow_download_fails_closed_on_target_error(tmp_path: Path) -> None:
+    """A later overlay must not hide a failed mandatory artifact target."""
+    failed_repository = SimpleNamespace(
+        download_artifacts=MagicMock(side_effect=RuntimeError("run artifact download failed"))
+    )
+    later_repository = SimpleNamespace(download_artifacts=MagicMock(return_value=str(tmp_path / "model")))
+    plan = _MlflowDelegatedDownloadPlan(
+        (
+            _MlflowDelegatedDownloadTarget(failed_repository, None),
+            _MlflowDelegatedDownloadTarget(later_repository, None, "model"),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="run artifact download failed"):
+        _download_trusted_mlflow_artifacts(plan, str(tmp_path))
+
+    later_repository.download_artifacts.assert_not_called()
+
+
+def test_delegated_mlflow_download_fails_when_later_target_errors(tmp_path: Path) -> None:
+    """A successful run target must not hide a failed logged-model overlay."""
+    run_path = tmp_path / "run"
+    run_repository = SimpleNamespace(download_artifacts=MagicMock(return_value=str(run_path)))
+    failed_logged_repository = SimpleNamespace(
+        download_artifacts=MagicMock(side_effect=RuntimeError("logged-model download failed"))
+    )
+    plan = _MlflowDelegatedDownloadPlan(
+        (
+            _MlflowDelegatedDownloadTarget(run_repository, None),
+            _MlflowDelegatedDownloadTarget(failed_logged_repository, None, "model"),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="logged-model download failed"):
+        _download_trusted_mlflow_artifacts(plan, str(tmp_path))
+
+    run_repository.download_artifacts.assert_called_once()
+    failed_logged_repository.download_artifacts.assert_called_once()
+
+
+@pytest.mark.parametrize("returned_path", [None, ""])
+def test_delegated_mlflow_download_rejects_missing_target_path(
+    tmp_path: Path,
+    returned_path: str | None,
+) -> None:
+    """An empty repository result is incomplete even if a later target could succeed."""
+    empty_repository = SimpleNamespace(download_artifacts=MagicMock(return_value=returned_path))
+    later_repository = SimpleNamespace(download_artifacts=MagicMock(return_value=str(tmp_path / "model")))
+    plan = _MlflowDelegatedDownloadPlan(
+        (
+            _MlflowDelegatedDownloadTarget(empty_repository, None),
+            _MlflowDelegatedDownloadTarget(later_repository, None, "model"),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="did not return a download path"):
+        _download_trusted_mlflow_artifacts(plan, str(tmp_path))
+
+    later_repository.download_artifacts.assert_not_called()
+
+
+@patch("modelaudit.integrations.mlflow.shutil.rmtree")
+@patch("modelaudit.integrations.mlflow.tempfile.mkdtemp")
+@patch("modelaudit.core.scan_model_directory_or_file")
+def test_scan_mlflow_model_allows_explicitly_allowlisted_remote_artifact_uri(
+    mock_scan: MagicMock,
+    mock_mkdtemp: MagicMock,
+    mock_rmtree: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Explicitly allowlisted remote artifact roots may still use MLflow's downloader."""
+    artifact_uri = "s3://trusted-bucket/models/TestModel"
+    monkeypatch.setenv("MODELAUDIT_MLFLOW_ALLOWED_ARTIFACT_URIS", "s3://trusted-bucket/models")
+    download_dir = tmp_path / "modelaudit_mlflow_allowed"
+    download_dir.mkdir()
+    mock_mkdtemp.return_value = str(download_dir)
+    scan_result: Any = {"bytes_scanned": 256, "issues": []}
+    mock_scan.return_value = scan_result
+    mock_mlflow = MagicMock()
+    artifact_repository = MagicMock()
+    artifact_repository.artifact_uri = artifact_uri
+    artifact_repository.download_artifacts.return_value = str(download_dir)
+    mock_mlflow.artifacts.get_artifact_repository.return_value = artifact_repository
+
+    with patch.dict(sys.modules, {"mlflow": mock_mlflow}):
+        result = scan_mlflow_model("models:/TestModel/1")
+
+    assert result == scan_result
+    mock_mlflow.artifacts.get_artifact_repository.assert_called_once_with("models:/TestModel/1")
+    artifact_repository.download_artifacts.assert_called_once_with(
+        artifact_path="",
+        dst_path=str(download_dir),
+    )
+    mock_mlflow.artifacts.download_artifacts.assert_not_called()
+    mock_scan.assert_called_once_with(
+        str(download_dir),
+        timeout=3600,
+        blacklist_patterns=None,
+        max_file_size=0,
+        max_total_size=0,
+        cache_enabled=True,
+        cache_dir=None,
+    )
+    mock_rmtree.assert_called_once_with(str(download_dir), ignore_errors=True)
+
+
+@patch("modelaudit.integrations.mlflow.shutil.rmtree")
+@patch("modelaudit.integrations.mlflow.tempfile.mkdtemp")
+@patch("modelaudit.core.scan_model_directory_or_file")
+def test_scan_mlflow_model_combines_hardened_local_run_with_allowlisted_remote_overlay(
+    mock_scan: MagicMock,
+    mock_mkdtemp: MagicMock,
+    mock_rmtree: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Mixed overlays must copy local targets safely and allowlist only remote targets."""
+
+    class LocalArtifactRepository:
+        def __init__(self, artifact_dir: Path) -> None:
+            self.artifact_dir = artifact_dir
+            self.artifact_uri = artifact_dir.as_uri()
+            self.download_artifacts = MagicMock(side_effect=AssertionError("local target must use hardened copy"))
+
+    class RemoteArtifactRepository:
+        def __init__(self, artifact_uri: str, downloaded_path: Path) -> None:
+            self.artifact_uri = artifact_uri
+            self.download_artifacts = MagicMock(return_value=str(downloaded_path))
+
+    class RunsArtifactRepository:
+        artifact_uri = "runs:/run-1/model"
+
+        def __init__(self, run_repository: LocalArtifactRepository) -> None:
+            self.repo = run_repository
+
+        @staticmethod
+        def parse_runs_uri(uri: str) -> tuple[str, str | None]:
+            assert uri == "runs:/run-1/model"
+            return "run-1", "model"
+
+        @staticmethod
+        def get_underlying_uri(uri: str, tracking_uri: str | None = None) -> str:
+            assert uri == "runs:/run-1/model"
+            assert tracking_uri is None
+            return run_repository.artifact_uri
+
+        @staticmethod
+        def _get_logged_model_artifact_repo(*, run_id: str, name: str) -> RemoteArtifactRepository:
+            assert run_id == "run-1"
+            assert name == "model"
+            return logged_repository
+
+    class ModelsArtifactRepository:
+        def __init__(self, repo: Any) -> None:
+            self.repo = repo
+
+    monkeypatch.setenv(
+        "MODELAUDIT_MLFLOW_ALLOWED_ARTIFACT_URIS",
+        "s3://trusted-bucket/logged-models/model",
+    )
+    local_root = tmp_path / "run-artifacts"
+    _write_local_artifacts(local_root, {"run.txt": 4})
+    download_dir = tmp_path / "mixed-download"
+    download_dir.mkdir()
+    mock_mkdtemp.return_value = str(download_dir)
+    run_repository = LocalArtifactRepository(local_root)
+    logged_repository = RemoteArtifactRepository(
+        "s3://trusted-bucket/logged-models/model",
+        download_dir / "model",
+    )
+    mlflow_module = ModuleType("mlflow")
+    mlflow_module.artifacts = MagicMock()  # type: ignore[attr-defined]
+    mlflow_module.artifacts.get_artifact_repository.return_value = ModelsArtifactRepository(  # type: ignore[attr-defined]
+        RunsArtifactRepository(run_repository)
+    )
+    store_module = ModuleType("mlflow.store")
+    artifact_module = ModuleType("mlflow.store.artifact")
+    local_module = ModuleType("mlflow.store.artifact.local_artifact_repo")
+    models_module = ModuleType("mlflow.store.artifact.models_artifact_repo")
+    runs_module = ModuleType("mlflow.store.artifact.runs_artifact_repo")
+    local_module.LocalArtifactRepository = LocalArtifactRepository  # type: ignore[attr-defined]
+    models_module.ModelsArtifactRepository = ModelsArtifactRepository  # type: ignore[attr-defined]
+    runs_module.RunsArtifactRepository = RunsArtifactRepository  # type: ignore[attr-defined]
+    scan_result: Any = {"bytes_scanned": 8, "issues": []}
+    mock_scan.return_value = scan_result
+
+    with patch.dict(
+        sys.modules,
+        {
+            "mlflow": mlflow_module,
+            "mlflow.store": store_module,
+            "mlflow.store.artifact": artifact_module,
+            "mlflow.store.artifact.local_artifact_repo": local_module,
+            "mlflow.store.artifact.models_artifact_repo": models_module,
+            "mlflow.store.artifact.runs_artifact_repo": runs_module,
+        },
+    ):
+        result = scan_mlflow_model("models:/TestModel/1")
+
+    assert result == scan_result
+    assert (download_dir / "run.txt").read_bytes() == b"xxxx"
+    run_repository.download_artifacts.assert_not_called()
+    logged_repository.download_artifacts.assert_called_once_with(
+        artifact_path="",
+        dst_path=str(download_dir / "model"),
+    )
+    mock_scan.assert_called_once_with(
+        str(download_dir),
+        timeout=3600,
+        blacklist_patterns=None,
+        max_file_size=0,
+        max_total_size=0,
+        cache_enabled=True,
+        cache_dir=None,
+    )
+    mock_rmtree.assert_called_once_with(str(download_dir), ignore_errors=True)
+
+
+@patch("modelaudit.integrations.mlflow.shutil.rmtree")
+@patch("modelaudit.integrations.mlflow.tempfile.mkdtemp")
+@patch("modelaudit.core.scan_model_directory_or_file")
+def test_scan_mlflow_model_honors_artifact_path_specific_allowlist(
+    mock_scan: MagicMock,
+    mock_mkdtemp: MagicMock,
+    mock_rmtree: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A direct artifact may be trusted without allowlisting its repository parent."""
+    artifact_uri = "s3://trusted-bucket/models/model.pkl"
+    monkeypatch.setenv("MODELAUDIT_MLFLOW_ALLOWED_ARTIFACT_URIS", artifact_uri)
+    download_dir = tmp_path / "download"
+    download_dir.mkdir()
+    mock_mkdtemp.return_value = str(download_dir)
+    scan_result: Any = {"bytes_scanned": 4, "issues": []}
+    mock_scan.return_value = scan_result
+    artifact_repository = MagicMock()
+    artifact_repository.artifact_uri = "s3://trusted-bucket/models"
+    artifact_repository.download_artifacts.return_value = str(download_dir / "model.pkl")
+    mlflow_module = ModuleType("mlflow")
+    mlflow_module.artifacts = MagicMock()  # type: ignore[attr-defined]
+    mlflow_module.artifacts._get_root_uri_and_artifact_path.return_value = (  # type: ignore[attr-defined]
+        "s3://trusted-bucket/models",
+        "model.pkl",
+    )
+    mlflow_module.artifacts.get_artifact_repository.return_value = artifact_repository  # type: ignore[attr-defined]
+
+    with patch.dict(sys.modules, {"mlflow": mlflow_module}):
+        result = scan_mlflow_model(artifact_uri)
+
+    assert result == scan_result
+    artifact_repository.download_artifacts.assert_called_once_with(
+        artifact_path="model.pkl",
+        dst_path=str(download_dir),
+    )
+    mock_scan.assert_called_once()
+    mock_rmtree.assert_called_once_with(str(download_dir), ignore_errors=True)
+
+
+def test_artifact_path_specific_allowlist_does_not_trust_sibling_object() -> None:
+    assert (
+        _mlflow_artifact_uri_matches_prefix(
+            "s3://trusted-bucket/models/other.pkl",
+            "s3://trusted-bucket/models/model.pkl",
+        )
+        is False
+    )
+
+
+def test_mixed_mlflow_overlay_fails_closed_when_local_target_follows_remote(tmp_path: Path) -> None:
+    remote_repository = object()
+    local_repository = object()
+    targets = (
+        _MlflowDelegatedDownloadTarget(remote_repository, None),
+        _MlflowDelegatedDownloadTarget(local_repository, None, "model"),
+    )
+
+    with patch(
+        "modelaudit.integrations.mlflow._local_mlflow_artifact_root",
+        side_effect=lambda repository: tmp_path if repository is local_repository else None,
+    ):
+        assert _partition_mlflow_delegated_targets(targets) is None
+
+
+@patch("modelaudit.integrations.mlflow.shutil.rmtree")
+@patch("modelaudit.integrations.mlflow.tempfile.mkdtemp")
+@patch("modelaudit.core.scan_model_directory_or_file")
+def test_scan_mlflow_model_preserves_remote_artifact_key_separators(
+    mock_scan: MagicMock,
+    mock_mkdtemp: MagicMock,
+    mock_rmtree: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Direct object-store keys must not be normalized to a different artifact."""
+    monkeypatch.setenv("MODELAUDIT_MLFLOW_ALLOWED_ARTIFACT_URIS", "s3://trusted-bucket/models")
+    download_dir = tmp_path / "download"
+    download_dir.mkdir()
+    mock_mkdtemp.return_value = str(download_dir)
+    artifact_repository = MagicMock()
+    artifact_repository.artifact_uri = "s3://trusted-bucket/models"
+    artifact_repository.download_artifacts.return_value = str(download_dir)
+    mlflow_module = ModuleType("mlflow")
+    mlflow_module.artifacts = MagicMock()  # type: ignore[attr-defined]
+    mlflow_module.artifacts._get_root_uri_and_artifact_path.return_value = (  # type: ignore[attr-defined]
+        "s3://trusted-bucket/models",
+        "weights//model.pkl",
+    )
+    mlflow_module.artifacts.get_artifact_repository.return_value = artifact_repository  # type: ignore[attr-defined]
+    scan_result: Any = {"bytes_scanned": 4, "issues": []}
+    mock_scan.return_value = scan_result
+
+    with patch.dict(sys.modules, {"mlflow": mlflow_module}):
+        result = scan_mlflow_model("s3://trusted-bucket/models/weights//model.pkl")
+
+    assert result == scan_result
+    artifact_repository.download_artifacts.assert_called_once_with(
+        artifact_path="weights//model.pkl",
+        dst_path=str(download_dir),
+    )
+    mock_scan.assert_called_once()
+    mock_rmtree.assert_called_once_with(str(download_dir), ignore_errors=True)
+
+
+def test_scan_mlflow_model_copies_local_repository_without_remote_allowlist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verified local MLflow repositories remain scannable without a remote allowlist."""
+    monkeypatch.delenv("MODELAUDIT_MLFLOW_ALLOWED_ARTIFACT_URIS", raising=False)
+
+    class LocalArtifactRepository:
+        def __init__(self, artifact_dir: Path) -> None:
+            self.artifact_dir = artifact_dir
+
+    class ModelsArtifactRepository:
+        pass
+
+    source_root = tmp_path / "mlflow_artifacts"
+    _write_local_artifacts(source_root, {"model.pkl": 4})
+    download_dir = tmp_path / "modelaudit_mlflow_local"
+    download_dir.mkdir()
+    scan_result: Any = {"bytes_scanned": 4, "issues": []}
+    mlflow_module = ModuleType("mlflow")
+    mlflow_module.artifacts = MagicMock()  # type: ignore[attr-defined]
+    mlflow_module.artifacts.get_artifact_repository.return_value = LocalArtifactRepository(source_root)  # type: ignore[attr-defined]
+    store_module = ModuleType("mlflow.store")
+    artifact_module = ModuleType("mlflow.store.artifact")
+    local_module = ModuleType("mlflow.store.artifact.local_artifact_repo")
+    models_module = ModuleType("mlflow.store.artifact.models_artifact_repo")
+    local_module.LocalArtifactRepository = LocalArtifactRepository  # type: ignore[attr-defined]
+    models_module.ModelsArtifactRepository = ModelsArtifactRepository  # type: ignore[attr-defined]
+
+    with (
+        patch.dict(
+            sys.modules,
+            {
+                "mlflow": mlflow_module,
+                "mlflow.store": store_module,
+                "mlflow.store.artifact": artifact_module,
+                "mlflow.store.artifact.local_artifact_repo": local_module,
+                "mlflow.store.artifact.models_artifact_repo": models_module,
+            },
+        ),
+        patch("modelaudit.integrations.mlflow.tempfile.mkdtemp", return_value=str(download_dir)),
+        patch("modelaudit.integrations.mlflow.shutil.rmtree"),
+        patch("modelaudit.core.scan_model_directory_or_file", return_value=scan_result) as mock_scan,
+    ):
+        result = scan_mlflow_model("models:/TestModel/1")
+
+    assert result == scan_result
+    assert (download_dir / "model.pkl").read_bytes() == b"xxxx"
+    mlflow_module.artifacts.download_artifacts.assert_not_called()  # type: ignore[attr-defined]
+    mock_scan.assert_called_once()
+
+
 def test_mlflow_budget_failure_redacts_mlflow_query_credentials_recursively() -> None:
     model_uri = "models:/PublicModel/1?auth=QUERYSECRET123&session=SESSIONSECRET123"
     boundary_error = "x" * 470 + " artifact_uri=///user:BUDGETPARTIALSECRET1234567890@host/model"
@@ -1748,25 +2429,31 @@ def test_scan_mlflow_model_uses_cache_dir_for_downloads(
     mock_mkdtemp: MagicMock,
     mock_rmtree: MagicMock,
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test MLflow model downloads use a dedicated subdirectory under cache_dir."""
     mock_mlflow = MagicMock()
+    monkeypatch.setenv("MODELAUDIT_MLFLOW_ALLOWED_ARTIFACT_URIS", "s3://trusted-bucket/models")
     cache_dir = tmp_path / "cache"
     cache_key = hashlib.sha256(b"models:/TestModel/1").hexdigest()[:16]
     expected_download_root = cache_dir / "mlflow"
     expected_download_dir = expected_download_root / f"{cache_key}-run"
     mock_mkdtemp.return_value = str(expected_download_dir)
-    mock_mlflow.artifacts.download_artifacts.return_value = str(expected_download_dir)
+    artifact_repository = MagicMock()
+    artifact_repository.artifact_uri = "s3://trusted-bucket/models/TestModel"
+    artifact_repository.download_artifacts.return_value = str(expected_download_dir)
+    mock_mlflow.artifacts.get_artifact_repository.return_value = artifact_repository
     mock_scan.return_value = {"bytes_scanned": 256, "issues": []}
 
     with patch.dict(sys.modules, {"mlflow": mock_mlflow}):
         scan_mlflow_model("models:/TestModel/1", cache_enabled=True, cache_dir=str(cache_dir))
 
     mock_mkdtemp.assert_called_once_with(prefix=f"{cache_key}-", dir=str(expected_download_root))
-    mock_mlflow.artifacts.download_artifacts.assert_called_once_with(
-        artifact_uri="models:/TestModel/1",
+    artifact_repository.download_artifacts.assert_called_once_with(
+        artifact_path="",
         dst_path=str(expected_download_dir),
     )
+    mock_mlflow.artifacts.download_artifacts.assert_not_called()
     mock_scan.assert_called_once_with(
         str(expected_download_dir),
         timeout=3600,
@@ -1782,15 +2469,24 @@ def test_scan_mlflow_model_uses_cache_dir_for_downloads(
 @patch("modelaudit.integrations.mlflow.shutil.rmtree")
 @patch("modelaudit.integrations.mlflow.tempfile.mkdtemp")
 @patch("modelaudit.core.scan_model_directory_or_file")
-def test_scan_mlflow_model_file_path(mock_scan, mock_mkdtemp, mock_rmtree):
+def test_scan_mlflow_model_file_path(
+    mock_scan: MagicMock,
+    mock_mkdtemp: MagicMock,
+    mock_rmtree: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Test MLflow model scanning when download returns a file path."""
     # Mock MLflow
     mock_mlflow = MagicMock()
+    monkeypatch.setenv("MODELAUDIT_MLFLOW_ALLOWED_ARTIFACT_URIS", "s3://trusted-bucket/models")
 
     # Create a temporary file path (simulating MLflow returning a file)
     temp_dir = "/tmp/modelaudit_mlflow_test"
     temp_file = "/tmp/modelaudit_mlflow_test/model.pkl"
-    mock_mlflow.artifacts.download_artifacts.return_value = temp_file
+    artifact_repository = MagicMock()
+    artifact_repository.artifact_uri = "s3://trusted-bucket/models/TestModel"
+    artifact_repository.download_artifacts.return_value = temp_file
+    mock_mlflow.artifacts.get_artifact_repository.return_value = artifact_repository
     mock_mkdtemp.return_value = temp_dir
 
     # Mock os.path.isfile to return True for our temp file
@@ -1811,11 +2507,19 @@ def test_scan_mlflow_model_file_path(mock_scan, mock_mkdtemp, mock_rmtree):
 
 @patch("modelaudit.integrations.mlflow.shutil.rmtree")
 @patch("modelaudit.integrations.mlflow.tempfile.mkdtemp")
-def test_scan_mlflow_model_download_error(mock_mkdtemp, mock_rmtree):
+def test_scan_mlflow_model_download_error(
+    mock_mkdtemp: MagicMock,
+    mock_rmtree: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Test error handling when MLflow download fails."""
     # Mock MLflow with download error
     mock_mlflow = MagicMock()
-    mock_mlflow.artifacts.download_artifacts.side_effect = Exception("Download failed")
+    monkeypatch.setenv("MODELAUDIT_MLFLOW_ALLOWED_ARTIFACT_URIS", "s3://trusted-bucket/models")
+    artifact_repository = MagicMock()
+    artifact_repository.artifact_uri = "s3://trusted-bucket/models/TestModel"
+    artifact_repository.download_artifacts.side_effect = Exception("Download failed")
+    mock_mlflow.artifacts.get_artifact_repository.return_value = artifact_repository
 
     temp_dir = "/tmp/modelaudit_mlflow_test"
     mock_mkdtemp.return_value = temp_dir
@@ -1836,10 +2540,15 @@ def test_scan_mlflow_model_debug_log_redacts_source_uri(
     mock_mkdtemp: MagicMock,
     mock_rmtree: MagicMock,
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     model_uri = "models:/PrivateModel/access_token=DEBUGSECRET123"
+    monkeypatch.setenv("MODELAUDIT_MLFLOW_ALLOWED_ARTIFACT_URIS", "s3://trusted-bucket/models")
     mock_mlflow = MagicMock()
-    mock_mlflow.artifacts.download_artifacts.side_effect = RuntimeError("Download failed")
+    artifact_repository = MagicMock()
+    artifact_repository.artifact_uri = "s3://trusted-bucket/models/PrivateModel"
+    artifact_repository.download_artifacts.side_effect = RuntimeError("Download failed")
+    mock_mlflow.artifacts.get_artifact_repository.return_value = artifact_repository
     mock_mkdtemp.return_value = "/tmp/modelaudit_mlflow_test"
 
     with (
@@ -1854,10 +2563,14 @@ def test_scan_mlflow_model_debug_log_redacts_source_uri(
     mock_rmtree.assert_called_once_with("/tmp/modelaudit_mlflow_test", ignore_errors=True)
 
 
-def test_scan_mlflow_model_no_registry_uri():
+def test_scan_mlflow_model_no_registry_uri(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test MLflow model scanning without registry URI."""
     mock_mlflow = MagicMock()
-    mock_mlflow.artifacts.download_artifacts.return_value = "/tmp/test_model"
+    monkeypatch.setenv("MODELAUDIT_MLFLOW_ALLOWED_ARTIFACT_URIS", "s3://trusted-bucket/models")
+    artifact_repository = MagicMock()
+    artifact_repository.artifact_uri = "s3://trusted-bucket/models/TestModel"
+    artifact_repository.download_artifacts.return_value = "/tmp/test"
+    mock_mlflow.artifacts.get_artifact_repository.return_value = artifact_repository
 
     with (
         patch.dict(sys.modules, {"mlflow": mock_mlflow}),

--- a/tests/integrations/test_mlflow_integration.py
+++ b/tests/integrations/test_mlflow_integration.py
@@ -1414,6 +1414,7 @@ def test_scan_mlflow_model_rejects_unallowlisted_logged_model_overlay_before_dow
     ]
 
 
+@pytest.mark.parametrize("run_artifact_state", ["present", "missing"])
 @patch("modelaudit.integrations.mlflow.shutil.rmtree")
 @patch("modelaudit.integrations.mlflow.tempfile.mkdtemp")
 @patch("modelaudit.core.scan_model_directory_or_file")
@@ -1423,8 +1424,9 @@ def test_scan_mlflow_model_downloads_from_the_validated_logged_model_repository(
     mock_rmtree: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    run_artifact_state: str,
 ) -> None:
-    """A runs:/ download must not resolve its logged-model backend a second time."""
+    """A runs:/ download must use the validated logged-model backend even without a run overlay."""
 
     class RemoteArtifactRepository:
         def __init__(self, artifact_uri: str, downloaded_path: Path) -> None:
@@ -1462,6 +1464,13 @@ def test_scan_mlflow_model_downloads_from_the_validated_logged_model_repository(
     download_dir.mkdir()
     mock_mkdtemp.return_value = str(download_dir)
     run_repository = RemoteArtifactRepository("s3://trusted-bucket/runs/run-1/model", download_dir)
+    if run_artifact_state == "missing":
+        mlflow_exceptions = pytest.importorskip("mlflow.exceptions")
+        mlflow_proto = pytest.importorskip("mlflow.protos.databricks_pb2")
+        run_repository.download_artifacts.side_effect = mlflow_exceptions.MlflowException(
+            "run artifact path is absent",
+            error_code=mlflow_proto.RESOURCE_DOES_NOT_EXIST,
+        )
     trusted_logged_repository = RemoteArtifactRepository(
         "s3://trusted-bucket/logged-models/model",
         download_dir / "model",
@@ -1514,20 +1523,51 @@ def test_scan_mlflow_model_downloads_from_the_validated_logged_model_repository(
     mock_rmtree.assert_called_once_with(str(download_dir), ignore_errors=True)
 
 
-def test_delegated_mlflow_download_fails_closed_on_target_error(tmp_path: Path) -> None:
-    """A later overlay must not hide a failed mandatory artifact target."""
-    failed_repository = SimpleNamespace(
-        download_artifacts=MagicMock(side_effect=RuntimeError("run artifact download failed"))
-    )
+@pytest.mark.parametrize("error_kind", ["runtime", "permission_denied"])
+def test_delegated_mlflow_download_fails_closed_on_target_error(tmp_path: Path, error_kind: str) -> None:
+    """An optional run overlay must fail closed for errors other than absence."""
+    if error_kind == "permission_denied":
+        mlflow_exceptions = pytest.importorskip("mlflow.exceptions")
+        mlflow_proto = pytest.importorskip("mlflow.protos.databricks_pb2")
+        error = mlflow_exceptions.MlflowException(
+            "run artifact access denied",
+            error_code=mlflow_proto.PERMISSION_DENIED,
+        )
+    else:
+        error = RuntimeError("run artifact download failed")
+    failed_repository = SimpleNamespace(download_artifacts=MagicMock(side_effect=error))
     later_repository = SimpleNamespace(download_artifacts=MagicMock(return_value=str(tmp_path / "model")))
     plan = _MlflowDelegatedDownloadPlan(
         (
-            _MlflowDelegatedDownloadTarget(failed_repository, None),
+            _MlflowDelegatedDownloadTarget(failed_repository, None, optional_when_missing=True),
             _MlflowDelegatedDownloadTarget(later_repository, None, "model"),
         )
     )
 
-    with pytest.raises(RuntimeError, match="run artifact download failed"):
+    with pytest.raises(type(error), match=str(error)):
+        _download_trusted_mlflow_artifacts(plan, str(tmp_path))
+
+    later_repository.download_artifacts.assert_not_called()
+
+
+def test_delegated_mlflow_download_does_not_skip_missing_mandatory_target(tmp_path: Path) -> None:
+    """A direct or sole target remains mandatory even when MLflow reports it missing."""
+    mlflow_exceptions = pytest.importorskip("mlflow.exceptions")
+    mlflow_proto = pytest.importorskip("mlflow.protos.databricks_pb2")
+    missing_error = mlflow_exceptions.MlflowException(
+        "artifact path is absent",
+        error_code=mlflow_proto.RESOURCE_DOES_NOT_EXIST,
+    )
+    missing_repository = SimpleNamespace(download_artifacts=MagicMock(side_effect=missing_error))
+    later_repository = SimpleNamespace(download_artifacts=MagicMock(return_value=str(tmp_path / "model")))
+    plan = _MlflowDelegatedDownloadPlan(
+        (
+            _MlflowDelegatedDownloadTarget(missing_repository, None),
+            _MlflowDelegatedDownloadTarget(later_repository, None, "model"),
+        )
+    )
+
+    with pytest.raises(mlflow_exceptions.MlflowException, match="artifact path is absent"):
         _download_trusted_mlflow_artifacts(plan, str(tmp_path))
 
     later_repository.download_artifacts.assert_not_called()

--- a/tests/integrations/test_mlflow_integration.py
+++ b/tests/integrations/test_mlflow_integration.py
@@ -25,6 +25,7 @@ from modelaudit.integrations.mlflow import (
     _MlflowDelegatedDownloadTarget,
     _MlflowLocalSource,
     _normalize_mlflow_artifact_path,
+    _normalize_mlflow_delegated_artifact_path,
     _opened_local_mlflow_path,
     _partition_mlflow_delegated_targets,
     _redact_mlflow_error_for_display,
@@ -56,6 +57,18 @@ def test_normalize_mlflow_artifact_path_allows_posix_colons(monkeypatch: pytest.
     monkeypatch.setattr("modelaudit.integrations.mlflow._IS_WINDOWS", False)
 
     assert _normalize_mlflow_artifact_path("checkpoint:1/model.pkl") == "checkpoint:1/model.pkl"
+
+
+@pytest.mark.parametrize("artifact_path", ["C:evil", "z:weights/model.pkl"])
+def test_normalize_mlflow_delegated_artifact_path_rejects_windows_drive_relative_paths(
+    artifact_path: str,
+) -> None:
+    with pytest.raises(ValueError, match="not relative"):
+        _normalize_mlflow_delegated_artifact_path(artifact_path)
+
+
+def test_normalize_mlflow_delegated_artifact_path_allows_non_drive_colons() -> None:
+    assert _normalize_mlflow_delegated_artifact_path("checkpoint:1/model.pkl") == "checkpoint:1/model.pkl"
 
 
 def test_opened_local_mlflow_path_preserves_windows_handle_width(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1219,6 +1232,7 @@ def test_mlflow_budget_failure_preserves_benign_uri_context() -> None:
         ("dbfs:/trusted/models/model.pkl", "dbfs:/trusted/models"),
         ("s3://trusted-bucket/models//model.pkl", "s3://trusted-bucket/models//"),
         ("s3://trusted-bucket//model.pkl", "s3://trusted-bucket//"),
+        ("https://mlflow.example.com/artifacts;v1/model.pkl", "https://mlflow.example.com/artifacts;v1/"),
     ],
 )
 def test_mlflow_artifact_uri_prefix_matching_accepts_equivalent_safe_uris(
@@ -1237,6 +1251,8 @@ def test_mlflow_artifact_uri_prefix_matching_accepts_equivalent_safe_uris(
         ("https://mlflow.example.com/artifacts/%2", "https://mlflow.example.com/artifacts"),
         ("https://mlflow.example.com/artifacts/%5c..%5cevil", "https://mlflow.example.com/artifacts"),
         ("https://mlflow.example.com:invalid/artifacts/model.pkl", "https://mlflow.example.com/artifacts"),
+        ("https://mlflow.example.com/artifacts/model.pkl;evil", "https://mlflow.example.com/artifacts/model.pkl"),
+        ("https://mlflow.example.com/artifacts/model.pkl", "https://mlflow.example.com/artifacts/model.pkl;evil"),
         ("s3://trusted-bucket/%6dodels/model.pkl", "s3://trusted-bucket/models"),
         ("s3://trusted-bucket/models/model.pkl", "s3://trusted-bucket/models//"),
         ("s3://trusted-bucket/model.pkl", "s3://trusted-bucket//"),
@@ -1262,6 +1278,7 @@ def test_mlflow_artifact_uri_prefix_matching_rejects_ambiguous_uris(
         ("s3://trusted-bucket/models2/model.pkl", "s3://trusted-bucket/models"),
         ("https://mlflow.example.com/artifacts/../evil/model.pkl", "https://mlflow.example.com/artifacts"),
         ("https://mlflow.example.com/artifacts/%2e%2e/evil/model.pkl", "https://mlflow.example.com/artifacts"),
+        ("https://mlflow.example.com/artifacts/model.pkl;evil", "https://mlflow.example.com/artifacts/model.pkl"),
     ],
 )
 @patch("modelaudit.integrations.mlflow.tempfile.mkdtemp")
@@ -1289,6 +1306,36 @@ def test_scan_mlflow_model_rejects_unallowlisted_artifact_uri_before_download(
     assert result.checks[0].name == "MLflow Artifact Trust Check"
     assert result.checks[0].details["reason"] == "artifact_uri_not_allowlisted"
     assert result.checks[0].details["artifact_repository_uri"] == artifact_uri
+
+
+@patch("modelaudit.integrations.mlflow.tempfile.mkdtemp")
+@patch("modelaudit.core.scan_model_directory_or_file")
+def test_scan_mlflow_model_rejects_drive_relative_delegated_artifact_path(
+    mock_scan: MagicMock,
+    mock_mkdtemp: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A registry-controlled Windows drive path must not escape the staging directory."""
+    artifact_root = "s3://trusted-bucket/models"
+    monkeypatch.setenv("MODELAUDIT_MLFLOW_ALLOWED_ARTIFACT_URIS", artifact_root)
+    artifact_repository = MagicMock()
+    artifact_repository.artifact_uri = artifact_root
+    artifact_repository.download_artifacts.side_effect = AssertionError("unsafe path reached the downloader")
+    mlflow_module = MagicMock()
+    mlflow_module.artifacts._get_root_uri_and_artifact_path.return_value = (artifact_root, "C:evil")
+    mlflow_module.artifacts.get_artifact_repository.return_value = artifact_repository
+
+    with patch.dict(sys.modules, {"mlflow": mlflow_module}):
+        result = scan_mlflow_model(f"{artifact_root}/C:evil")
+
+    artifact_repository.download_artifacts.assert_not_called()
+    mock_mkdtemp.assert_not_called()
+    mock_scan.assert_not_called()
+    assert determine_exit_code(result) == 2
+    assert result.success is False
+    assert result.checks[0].name == "MLflow Artifact Trust Check"
+    assert result.checks[0].message == "Unable to verify the MLflow artifact repository before download"
+    assert result.checks[0].details["artifact_path"] == "C:evil"
 
 
 @patch("modelaudit.integrations.mlflow.tempfile.mkdtemp")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4614,6 +4614,36 @@ def test_scan_mlflow_uri_budget_refusal_is_not_recorded_as_completed(
     mock_record_download_completed.assert_not_called()
 
 
+@patch("modelaudit.cli.record_download_completed")
+@patch("modelaudit.integrations.mlflow.scan_mlflow_model")
+def test_scan_mlflow_uri_trust_refusal_is_not_recorded_as_completed(
+    mock_scan_mlflow: MagicMock,
+    mock_record_download_completed: MagicMock,
+) -> None:
+    """MLflow artifact trust refusals should not emit successful-download telemetry."""
+    mock_scan_mlflow.return_value = create_mock_scan_result(
+        bytes_scanned=0,
+        issues=[
+            {
+                "message": "MLflow artifact repository is not in the configured allowlist",
+                "severity": "info",
+                "type": "mlflow_artifact_trust",
+            }
+        ],
+        files_scanned=0,
+        has_errors=True,
+        success=False,
+        scanners=["mlflow"],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["scan", "--format", "text", "models:/TestModel/1"])
+
+    assert result.exit_code == 2
+    assert "Download refused by MLflow artifact trust policy" in result.output
+    mock_record_download_completed.assert_not_called()
+
+
 @patch("modelaudit.integrations.mlflow.scan_mlflow_model")
 def test_scan_mlflow_uri_with_cache_dir(mock_scan_mlflow: MagicMock, tmp_path: Path) -> None:
     """Test scanning an MLflow URI with an explicit cache directory."""


### PR DESCRIPTION
## Summary
- require every concrete non-local MLflow artifact target to match `MODELAUDIT_MLFLOW_ALLOWED_ARTIFACT_URIS`
- preserve current-main private staging-root identity, containment, symlink, special-file, hardlink, and entry-budget validation
- bind downloads to the exact repositories validated during preflight, including run and logged-model overlays
- securely compose hardened local artifacts with allowlisted remote overlays
- validate remote artifact listings before destination creation and use guarded per-file downloads for standard MLflow repositories
- fail closed on malformed/ambiguous URIs, unsafe artifact paths, unknown custom-scheme authority changes, remote file authorities, UNC/device roots, and drive-relative paths
- skip a missing optional run overlay only when structured repository metadata shows it has no files; all other target failures remain fatal

## Security review
- closes plain, encoded, repeated-separator, and artifact-listing traversal bypasses
- prevents delegated download results and multi-target destinations from escaping ModelAudit staging
- prevents one target from planting a link that redirects a later target outside staging
- scans the composed staging root whenever multiple delegated targets contribute
- keeps scoped run and logged-model overlays in the same scanned tree
- avoids MLflow recursive-download listing swaps by downloading the validated file plan directly for standard repositories
- preserves raw authorities for unknown/custom URI schemes while normalizing known network schemes
- accepts valid bracketed IPv6 loopback file URIs and rejects malformed unbracketed forms
- preserves legitimate MLflow 3 logged-model scans with absent run-side overlays without parsing exception strings

## Validation
- Head: `f56567b4374e95cdce48773e24b00ff8daec66a2`
- Base merged: `21956abfe97ec8312bb4f6312b5da99ec0fa640e`
- Exact published tree: `4f6a61017b696f533136eec1bb197bcc3b5e9d2b`
- `tests/integrations/test_mlflow_integration.py`: `179 passed`
- MLflow CLI slice: `12 passed, 244 deselected`
- scoped mypy across the changed implementation/tests: clean
- Ruff format/check and `git diff --check`: clean
- full local suite intentionally not run; CI owns broader coverage
- all 12 existing review threads resolved