### PR TITLE
fix: scan model links in oci layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- scan safe OCI layer links with model-looking member names instead of treating link metadata as complete coverage
 - restrict manual Docker publishes to validated immutable version tags and their matching Git release refs before registry login or push
 - harden cloud acquisition size caps, HTTPS/R2 auto-default routing, and directory metadata failures
 - detect operator attrgetter, itemgetter, and methodcaller archive-member Python paths to command execution while preserving benign accessor names

--- a/modelaudit/scanners/oci_layer_scanner.py
+++ b/modelaudit/scanners/oci_layer_scanner.py
@@ -287,6 +287,22 @@ class _LayerPayloadScanOutcome:
     total_budget_exhausted: bool = False
 
 
+@dataclass
+class _LayerLinkResolutionState:
+    """Bound aggregate path-resolution work across all links in one layer."""
+
+    max_steps: int
+    steps: int = 0
+    exhausted: bool = False
+
+    def consume_step(self) -> bool:
+        if self.steps >= self.max_steps:
+            self.exhausted = True
+            return False
+        self.steps += 1
+        return True
+
+
 class OciLayerScanner(BaseScanner):
     """Scanner for OCI/Artifactory manifest files with .tar.gz layers."""
 
@@ -323,6 +339,7 @@ class OciLayerScanner(BaseScanner):
     _DEFAULT_MAX_DECOMPRESSED_BYTES: ClassVar[int] = 512 * 1024 * 1024
     _DEFAULT_MAX_EXTRACTED_BYTES: ClassVar[int] = 512 * 1024 * 1024
     _DEFAULT_MAX_DECOMPRESSION_RATIO: ClassVar[float] = 250.0
+    _LINK_RESOLUTION_STEPS_PER_ENTRY: ClassVar[int] = 4
     _REMOTE_LAYER_REF_SCHEMES: ClassVar[frozenset[str]] = frozenset({"http", "https", "s3", "gs", "oci"})
     _PARENT_IDENTITY_METADATA_KEYS: ClassVar[frozenset[str]] = frozenset({"file_size", "file_hashes"})
 
@@ -886,33 +903,48 @@ class OciLayerScanner(BaseScanner):
         member: tarfile.TarInfo,
         members_by_name: dict[str, tarfile.TarInfo],
         resolved_payload_cache: dict[tarfile.TarInfo, tarfile.TarInfo | None],
+        resolved_member_path_cache: dict[str, tarfile.TarInfo | None],
+        resolution_state: _LayerLinkResolutionState | None = None,
     ) -> tarfile.TarInfo | None:
         """Resolve a link chain using only members admitted by the layer preflight."""
         extraction_root = os.path.join(tempfile.gettempdir(), "extract_oci_layer")
+        if resolution_state is None:
+            resolution_state = _LayerLinkResolutionState(max_steps=max(1, len(members_by_name) * 4))
         current = member
         visited: set[str] = set()
         traversed: list[tarfile.TarInfo] = []
 
         def resolve_member_path(target_name: str) -> tarfile.TarInfo | None:
+            original_target_name = target_name
+            if original_target_name in resolved_member_path_cache:
+                return resolved_member_path_cache[original_target_name]
+
             while True:
                 target_member = members_by_name.get(target_name)
                 if target_member is not None:
+                    resolved_member_path_cache[original_target_name] = target_member
                     return target_member
+                if not resolution_state.consume_step():
+                    return None
 
                 parts = target_name.split("/")
                 component_link: tarfile.TarInfo | None = None
                 component_count = 0
                 for index in range(1, len(parts)):
-                    candidate = members_by_name.get("/".join(parts[:index]))
+                    candidate_name = "/".join(parts[:index])
+                    candidate = members_by_name.get(candidate_name)
                     if candidate is not None and candidate.issym():
                         component_link = candidate
                         component_count = index
                         break
                 if component_link is None:
+                    resolved_member_path_cache[original_target_name] = None
                     return None
 
+                suffix_parts = tuple(parts[component_count:])
                 component_name = posixpath.normpath(component_link.name.replace("\\", "/"))
                 if component_name in visited:
+                    resolved_member_path_cache[original_target_name] = None
                     return None
                 visited.add(component_name)
                 resolved_component, component_safe = cls._resolve_link_target(
@@ -925,20 +957,23 @@ class OciLayerScanner(BaseScanner):
                     is_symlink=True,
                 )
                 if not component_safe:
+                    resolved_member_path_cache[original_target_name] = None
                     return None
 
                 try:
                     combined_from_root = os.path.relpath(
-                        os.path.join(resolved_component, *parts[component_count:]),
+                        os.path.join(resolved_component, *suffix_parts),
                         extraction_root,
                     )
                     resolved_target, target_safe = sanitize_archive_path(combined_from_root, extraction_root)
                     if not target_safe:
+                        resolved_member_path_cache[original_target_name] = None
                         return None
                     target_name = posixpath.normpath(
                         os.path.relpath(resolved_target, extraction_root).replace("\\", "/")
                     )
                 except ValueError:
+                    resolved_member_path_cache[original_target_name] = None
                     return None
 
         resolved_payload: tarfile.TarInfo | None
@@ -948,6 +983,9 @@ class OciLayerScanner(BaseScanner):
                 resolved_payload = resolved_payload_cache[current]
                 break
             if current_name in visited:
+                resolved_payload = None
+                break
+            if not resolution_state.consume_step():
                 resolved_payload = None
                 break
             visited.add(current_name)
@@ -1643,6 +1681,10 @@ class OciLayerScanner(BaseScanner):
                     deferred_links: list[tarfile.TarInfo] = []
                     scanned_payloads: set[tuple[int, str | None]] = set()
                     resolved_payload_cache: dict[tarfile.TarInfo, tarfile.TarInfo | None] = {}
+                    resolved_member_path_cache: dict[str, tarfile.TarInfo | None] = {}
+                    link_resolution_state = _LayerLinkResolutionState(
+                        max_steps=max(1, self.max_layer_entries * self._LINK_RESOLUTION_STEPS_PER_ENTRY)
+                    )
                     layer_extraction_budget_exhausted = False
                     while preflight_member_limit is None or layer_entry_count < preflight_member_limit:
                         member = tar.next()
@@ -1719,7 +1761,33 @@ class OciLayerScanner(BaseScanner):
                                 link_member,
                                 members_by_name,
                                 resolved_payload_cache,
+                                resolved_member_path_cache,
+                                link_resolution_state,
                             )
+                            if link_resolution_state.exhausted:
+                                scan_complete = False
+                                reason = "oci_link_resolution_limit_exceeded"
+                                self._mark_incomplete_coverage(result, reason)
+                                result.add_check(
+                                    name="Layer Link Resolution Budget Check",
+                                    passed=False,
+                                    message=(
+                                        f"Layer {self._normalize_layer_ref(layer_ref)} link resolution exceeded "
+                                        f"the bounded work limit ({link_resolution_state.max_steps} steps)"
+                                    ),
+                                    severity=IssueSeverity.INFO,
+                                    location=f"{path}:{layer_ref}:{link_member.name}",
+                                    details={
+                                        "layer": layer_ref,
+                                        "member": link_member.name,
+                                        "resolution_steps": link_resolution_state.steps,
+                                        "max_resolution_steps": link_resolution_state.max_steps,
+                                        "analysis_incomplete": True,
+                                        "scan_outcome_reason": reason,
+                                    },
+                                    rule_code="S902",
+                                )
+                                break
                             payload_key = (
                                 (payload_member.offset_data, matched_ext) if payload_member is not None else None
                             )

--- a/modelaudit/scanners/oci_layer_scanner.py
+++ b/modelaudit/scanners/oci_layer_scanner.py
@@ -277,6 +277,16 @@ class _LayerMetadataState:
     invalid_whiteout_reported: bool = False
 
 
+@dataclass(frozen=True)
+class _LayerPayloadScanOutcome:
+    """Result of extracting and scanning one layer payload."""
+
+    success: bool
+    extracted_bytes: int = 0
+    layer_budget_exhausted: bool = False
+    total_budget_exhausted: bool = False
+
+
 class OciLayerScanner(BaseScanner):
     """Scanner for OCI/Artifactory manifest files with .tar.gz layers."""
 
@@ -838,7 +848,7 @@ class OciLayerScanner(BaseScanner):
                     rule_code="S406",
                 )
                 return False, False
-            return metadata_valid, False
+            return metadata_valid, self._get_scannable_extension(name) is not None
 
         return metadata_valid, member.isfile()
 
@@ -869,6 +879,294 @@ class OciLayerScanner(BaseScanner):
         except ValueError:
             return target_resolved, False
         return sanitize_archive_path(target_from_root, extraction_root)
+
+    @classmethod
+    def _resolve_link_payload_member(
+        cls,
+        member: tarfile.TarInfo,
+        members_by_name: dict[str, tarfile.TarInfo],
+        resolved_payload_cache: dict[tarfile.TarInfo, tarfile.TarInfo | None],
+    ) -> tarfile.TarInfo | None:
+        """Resolve a link chain using only members admitted by the layer preflight."""
+        extraction_root = os.path.join(tempfile.gettempdir(), "extract_oci_layer")
+        current = member
+        visited: set[str] = set()
+        traversed: list[tarfile.TarInfo] = []
+
+        def resolve_member_path(target_name: str) -> tarfile.TarInfo | None:
+            while True:
+                target_member = members_by_name.get(target_name)
+                if target_member is not None:
+                    return target_member
+
+                parts = target_name.split("/")
+                component_link: tarfile.TarInfo | None = None
+                component_count = 0
+                for index in range(1, len(parts)):
+                    candidate = members_by_name.get("/".join(parts[:index]))
+                    if candidate is not None and candidate.issym():
+                        component_link = candidate
+                        component_count = index
+                        break
+                if component_link is None:
+                    return None
+
+                component_name = posixpath.normpath(component_link.name.replace("\\", "/"))
+                if component_name in visited:
+                    return None
+                visited.add(component_name)
+                resolved_component, component_safe = cls._resolve_link_target(
+                    component_link.linkname,
+                    resolved_member_name=os.path.join(
+                        extraction_root,
+                        component_name.replace("/", os.sep),
+                    ),
+                    extraction_root=extraction_root,
+                    is_symlink=True,
+                )
+                if not component_safe:
+                    return None
+
+                try:
+                    combined_from_root = os.path.relpath(
+                        os.path.join(resolved_component, *parts[component_count:]),
+                        extraction_root,
+                    )
+                    resolved_target, target_safe = sanitize_archive_path(combined_from_root, extraction_root)
+                    if not target_safe:
+                        return None
+                    target_name = posixpath.normpath(
+                        os.path.relpath(resolved_target, extraction_root).replace("\\", "/")
+                    )
+                except ValueError:
+                    return None
+
+        resolved_payload: tarfile.TarInfo | None
+        while current.issym() or current.islnk():
+            current_name = posixpath.normpath(current.name.replace("\\", "/"))
+            if current in resolved_payload_cache:
+                resolved_payload = resolved_payload_cache[current]
+                break
+            if current_name in visited:
+                resolved_payload = None
+                break
+            visited.add(current_name)
+            traversed.append(current)
+
+            resolved_target, target_safe = cls._resolve_link_target(
+                current.linkname,
+                resolved_member_name=os.path.join(extraction_root, current_name.replace("/", os.sep)),
+                extraction_root=extraction_root,
+                is_symlink=current.issym(),
+            )
+            if not target_safe:
+                resolved_payload = None
+                break
+            try:
+                target_from_root = os.path.relpath(resolved_target, extraction_root)
+            except ValueError:
+                resolved_payload = None
+                break
+            target_name = posixpath.normpath(target_from_root.replace("\\", "/"))
+            target_member = resolve_member_path(target_name)
+            if target_member is None:
+                resolved_payload = None
+                break
+            current = target_member
+        else:
+            resolved_payload = current if current.isfile() else None
+
+        for traversed_member in traversed:
+            resolved_payload_cache[traversed_member] = resolved_payload
+        return resolved_payload
+
+    def _scan_layer_payload_member(
+        self,
+        tar: tarfile.TarFile,
+        result: ScanResult,
+        *,
+        manifest_path: str,
+        layer_ref: str,
+        display_member: tarfile.TarInfo,
+        payload_member: tarfile.TarInfo | None,
+        matched_ext: str | None,
+        extracted_member_bytes: int,
+        total_extracted_member_bytes: int,
+    ) -> _LayerPayloadScanOutcome:
+        """Extract and scan one validated member payload under the display member's identity."""
+        name = display_member.name
+        if payload_member is None:
+            self._mark_incomplete_coverage(result, "oci_member_extraction_failed")
+            result.add_check(
+                name="Layer Member Extraction",
+                passed=False,
+                message=f"Layer member {name} was not extracted from {layer_ref}",
+                severity=IssueSeverity.INFO,
+                location=f"{manifest_path}:{layer_ref}:{name}",
+                details={
+                    "layer": layer_ref,
+                    "member": name,
+                    "analysis_incomplete": True,
+                    "scan_outcome_reason": "oci_member_extraction_failed",
+                },
+                rule_code="S902",
+            )
+            return _LayerPayloadScanOutcome(success=False)
+
+        payload_size = max(0, payload_member.size)
+        if self.max_layer_file_size > 0 and payload_size > self.max_layer_file_size:
+            self._mark_incomplete_coverage(result, "oci_member_size_limit_exceeded")
+            details: dict[str, Any] = {
+                "layer": layer_ref,
+                "member": name,
+                "size": payload_size,
+                "max_file_size": self.max_layer_file_size,
+                "analysis_incomplete": True,
+                "scan_outcome_reason": "oci_member_size_limit_exceeded",
+            }
+            if payload_member is not display_member:
+                details["target_member"] = payload_member.name
+            result.add_check(
+                name="Layer Member Size Check",
+                passed=False,
+                message=(
+                    f"Layer member {name} resolves to a payload that is too large to scan: "
+                    f"{payload_size} bytes (max: {self.max_layer_file_size})"
+                ),
+                severity=IssueSeverity.INFO,
+                location=f"{manifest_path}:{layer_ref}:{name}",
+                details=details,
+                rule_code="S902",
+            )
+            return _LayerPayloadScanOutcome(success=False)
+
+        projected_extracted_bytes = extracted_member_bytes + payload_size
+        if self.max_layer_extracted_bytes > 0 and projected_extracted_bytes > self.max_layer_extracted_bytes:
+            details = {
+                "member": name,
+                "member_size": payload_size,
+                "extracted_bytes": projected_extracted_bytes,
+                "previous_extracted_bytes": extracted_member_bytes,
+                "max_extracted_bytes": self.max_layer_extracted_bytes,
+            }
+            if payload_member is not display_member:
+                details["target_member"] = payload_member.name
+            self._add_layer_extraction_budget_check(
+                result,
+                manifest_path=manifest_path,
+                layer_ref=layer_ref,
+                reason="oci_layer_extracted_size_exceeded",
+                message=(
+                    f"Layer {self._normalize_layer_ref(layer_ref)} extracted member bytes exceed limit "
+                    f"({projected_extracted_bytes} > {self.max_layer_extracted_bytes})"
+                ),
+                details=details,
+            )
+            return _LayerPayloadScanOutcome(success=False, layer_budget_exhausted=True)
+
+        projected_total_extracted_bytes = total_extracted_member_bytes + payload_size
+        if self.max_total_extracted_bytes > 0 and projected_total_extracted_bytes > self.max_total_extracted_bytes:
+            details = {
+                "member": name,
+                "member_size": payload_size,
+                "total_extracted_bytes": projected_total_extracted_bytes,
+                "previous_total_extracted_bytes": total_extracted_member_bytes,
+                "max_total_extracted_bytes": self.max_total_extracted_bytes,
+            }
+            if payload_member is not display_member:
+                details["target_member"] = payload_member.name
+            self._add_layer_extraction_budget_check(
+                result,
+                manifest_path=manifest_path,
+                layer_ref=layer_ref,
+                reason="oci_total_extracted_size_exceeded",
+                message=(
+                    "OCI manifest extracted member bytes exceed total limit "
+                    f"({projected_total_extracted_bytes} > {self.max_total_extracted_bytes})"
+                ),
+                details=details,
+            )
+            return _LayerPayloadScanOutcome(success=False, total_budget_exhausted=True)
+
+        try:
+            fileobj = tar.extractfile(payload_member)
+        except (KeyError, OSError, tarfile.TarError):
+            fileobj = None
+        if fileobj is None:
+            self._mark_incomplete_coverage(result, "oci_member_extraction_failed")
+            result.add_check(
+                name="Layer Member Extraction",
+                passed=False,
+                message=f"Layer member {name} was not extracted from {layer_ref}",
+                severity=IssueSeverity.INFO,
+                location=f"{manifest_path}:{layer_ref}:{name}",
+                details={
+                    "layer": layer_ref,
+                    "member": name,
+                    "analysis_incomplete": True,
+                    "scan_outcome_reason": "oci_member_extraction_failed",
+                },
+                rule_code="S902",
+            )
+            return _LayerPayloadScanOutcome(success=False)
+
+        header_prefix = b""
+        tmp_path: str | None = None
+        try:
+            if matched_ext is None:
+                header_prefix = fileobj.read(self._MEMBER_HEADER_PROBE_BYTES)
+
+            with tempfile.NamedTemporaryFile(suffix=matched_ext or "", delete=False) as tmp:
+                tmp_path = tmp.name
+                if header_prefix:
+                    tmp.write(header_prefix)
+                shutil.copyfileobj(fileobj, tmp)
+
+            from .. import core
+
+            nested_config = dict(self.config)
+            nested_config["cache_enabled"] = False
+            try:
+                archive_depth = int(nested_config.get("_archive_depth", 0))
+            except (TypeError, ValueError):
+                archive_depth = 0
+            nested_config["_archive_depth"] = max(archive_depth, 0) + 1
+
+            file_result = core.scan_file(tmp_path, nested_config)
+            detected_suffix = self._get_detected_format_suffix(tmp_path)
+            if file_result.scanner_name == "unknown" and detected_suffix and not tmp_path.endswith(detected_suffix):
+                retargeted_path = f"{tmp_path}{detected_suffix}"
+                os.replace(tmp_path, retargeted_path)
+                tmp_path = retargeted_path
+                file_result = core.scan_file(tmp_path, nested_config)
+            for check in file_result.checks:
+                check.location = self._rewrite_embedded_location(
+                    check.location,
+                    manifest_path=manifest_path,
+                    layer_ref=layer_ref,
+                    member_name=name,
+                    extracted_path=tmp_path,
+                )
+            for issue in file_result.issues:
+                issue.location = self._rewrite_embedded_location(
+                    issue.location,
+                    manifest_path=manifest_path,
+                    layer_ref=layer_ref,
+                    member_name=name,
+                    extracted_path=tmp_path,
+                )
+                if issue.details is None:
+                    issue.details = {}
+                issue.details["layer"] = layer_ref
+            self._merge_nested_result(result, file_result)
+            return _LayerPayloadScanOutcome(
+                success=file_result.success and not file_result.has_errors,
+                extracted_bytes=payload_size,
+            )
+        finally:
+            fileobj.close()
+            if tmp_path and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
 
     @classmethod
     def can_handle(cls, path: str) -> bool:
@@ -1340,6 +1638,12 @@ class OciLayerScanner(BaseScanner):
                 extracted_member_bytes = 0
                 metadata_state = _LayerMetadataState()
                 with tarfile.open(layer_path, "r:gz") as tar:
+                    members_by_name: dict[str, tarfile.TarInfo] = {}
+                    ambiguous_member_names: set[str] = set()
+                    deferred_links: list[tarfile.TarInfo] = []
+                    scanned_payloads: set[tuple[int, str | None]] = set()
+                    resolved_payload_cache: dict[tarfile.TarInfo, tarfile.TarInfo | None] = {}
+                    layer_extraction_budget_exhausted = False
                     while preflight_member_limit is None or layer_entry_count < preflight_member_limit:
                         member = tar.next()
                         if member is None:
@@ -1369,170 +1673,80 @@ class OciLayerScanner(BaseScanner):
                         )
                         if not metadata_valid:
                             scan_complete = False
+                        normalized_member_name = posixpath.normpath(member.name.replace("\\", "/"))
+                        if normalized_member_name in ambiguous_member_names:
+                            pass
+                        elif normalized_member_name in members_by_name:
+                            # Duplicate archive paths are ambiguous: do not let a link
+                            # silently select one payload after metadata validation failed.
+                            members_by_name.pop(normalized_member_name)
+                            ambiguous_member_names.add(normalized_member_name)
+                        elif metadata_valid:
+                            members_by_name[normalized_member_name] = member
                         if not should_scan_member:
                             continue
-                        name = member.name
-                        matched_ext = self._get_scannable_extension(name)
-                        if self.max_layer_file_size > 0 and member.size > self.max_layer_file_size:
-                            scan_complete = False
-                            self._mark_incomplete_coverage(result, "oci_member_size_limit_exceeded")
-                            result.add_check(
-                                name="Layer Member Size Check",
-                                passed=False,
-                                message=(
-                                    f"Layer member {name} is too large to scan: "
-                                    f"{member.size} bytes (max: {self.max_layer_file_size})"
-                                ),
-                                severity=IssueSeverity.INFO,
-                                location=f"{path}:{layer_ref}:{name}",
-                                details={
-                                    "layer": layer_ref,
-                                    "member": name,
-                                    "size": member.size,
-                                    "max_file_size": self.max_layer_file_size,
-                                    "analysis_incomplete": True,
-                                    "scan_outcome_reason": "oci_member_size_limit_exceeded",
-                                },
-                                rule_code="S902",
-                            )
+                        if member.issym() or member.islnk():
+                            deferred_links.append(member)
                             continue
-
-                        member_size = max(0, member.size)
-                        projected_extracted_bytes = extracted_member_bytes + member_size
-                        if (
-                            self.max_layer_extracted_bytes > 0
-                            and projected_extracted_bytes > self.max_layer_extracted_bytes
-                        ):
+                        matched_ext = self._get_scannable_extension(member.name)
+                        outcome = self._scan_layer_payload_member(
+                            tar,
+                            result,
+                            manifest_path=path,
+                            layer_ref=layer_ref,
+                            display_member=member,
+                            payload_member=member,
+                            matched_ext=matched_ext,
+                            extracted_member_bytes=extracted_member_bytes,
+                            total_extracted_member_bytes=total_extracted_member_bytes,
+                        )
+                        if not outcome.success:
                             scan_complete = False
-                            self._add_layer_extraction_budget_check(
-                                result,
-                                manifest_path=path,
-                                layer_ref=layer_ref,
-                                reason="oci_layer_extracted_size_exceeded",
-                                message=(
-                                    f"Layer {self._normalize_layer_ref(layer_ref)} extracted member bytes exceed "
-                                    f"limit ({projected_extracted_bytes} > {self.max_layer_extracted_bytes})"
-                                ),
-                                details={
-                                    "member": name,
-                                    "member_size": member_size,
-                                    "extracted_bytes": projected_extracted_bytes,
-                                    "previous_extracted_bytes": extracted_member_bytes,
-                                    "max_extracted_bytes": self.max_layer_extracted_bytes,
-                                },
+                        extracted_member_bytes += outcome.extracted_bytes
+                        total_extracted_member_bytes += outcome.extracted_bytes
+                        scanned_payloads.add((member.offset_data, matched_ext))
+                        if outcome.layer_budget_exhausted or outcome.total_budget_exhausted:
+                            layer_extraction_budget_exhausted = True
+                            total_extraction_budget_exhausted = (
+                                total_extraction_budget_exhausted or outcome.total_budget_exhausted
                             )
                             break
 
-                        projected_total_extracted_bytes = total_extracted_member_bytes + member_size
-                        if (
-                            self.max_total_extracted_bytes > 0
-                            and projected_total_extracted_bytes > self.max_total_extracted_bytes
-                        ):
-                            scan_complete = False
-                            total_extraction_budget_exhausted = True
-                            self._add_layer_extraction_budget_check(
+                    if not layer_extraction_budget_exhausted:
+                        for link_member in deferred_links:
+                            matched_ext = self._get_scannable_extension(link_member.name)
+                            payload_member = self._resolve_link_payload_member(
+                                link_member,
+                                members_by_name,
+                                resolved_payload_cache,
+                            )
+                            payload_key = (
+                                (payload_member.offset_data, matched_ext) if payload_member is not None else None
+                            )
+                            if payload_key is not None and payload_key in scanned_payloads:
+                                continue
+                            outcome = self._scan_layer_payload_member(
+                                tar,
                                 result,
                                 manifest_path=path,
                                 layer_ref=layer_ref,
-                                reason="oci_total_extracted_size_exceeded",
-                                message=(
-                                    "OCI manifest extracted member bytes exceed total limit "
-                                    f"({projected_total_extracted_bytes} > {self.max_total_extracted_bytes})"
-                                ),
-                                details={
-                                    "member": name,
-                                    "member_size": member_size,
-                                    "total_extracted_bytes": projected_total_extracted_bytes,
-                                    "previous_total_extracted_bytes": total_extracted_member_bytes,
-                                    "max_total_extracted_bytes": self.max_total_extracted_bytes,
-                                },
+                                display_member=link_member,
+                                payload_member=payload_member,
+                                matched_ext=matched_ext,
+                                extracted_member_bytes=extracted_member_bytes,
+                                total_extracted_member_bytes=total_extracted_member_bytes,
                             )
-                            break
-
-                        fileobj = tar.extractfile(member)
-                        if fileobj is None:
-                            scan_complete = False
-                            self._mark_incomplete_coverage(result, "oci_member_extraction_failed")
-                            result.add_check(
-                                name="Layer Member Extraction",
-                                passed=False,
-                                message=f"Layer member {name} was not extracted from {layer_ref}",
-                                severity=IssueSeverity.INFO,
-                                location=f"{path}:{layer_ref}:{name}",
-                                details={
-                                    "layer": layer_ref,
-                                    "member": name,
-                                    "analysis_incomplete": True,
-                                    "scan_outcome_reason": "oci_member_extraction_failed",
-                                },
-                                rule_code="S902",
-                            )
-                            continue
-                        header_prefix = b""
-                        tmp_path: str | None = None
-                        try:
-                            if matched_ext is None:
-                                header_prefix = fileobj.read(self._MEMBER_HEADER_PROBE_BYTES)
-
-                            with tempfile.NamedTemporaryFile(
-                                suffix=matched_ext or "",
-                                delete=False,
-                            ) as tmp:
-                                tmp_path = tmp.name
-                                if header_prefix:
-                                    tmp.write(header_prefix)
-                                shutil.copyfileobj(fileobj, tmp)
-                            extracted_member_bytes = projected_extracted_bytes
-                            total_extracted_member_bytes = projected_total_extracted_bytes
-
-                            from .. import core
-
-                            nested_config = dict(self.config)
-                            # Extracted members are deleted below, so their temporary paths are not reusable cache keys.
-                            nested_config["cache_enabled"] = False
-                            try:
-                                _oci_depth = int(nested_config.get("_archive_depth", 0))
-                            except (TypeError, ValueError):
-                                _oci_depth = 0
-                            nested_config["_archive_depth"] = max(_oci_depth, 0) + 1
-
-                            file_result = core.scan_file(tmp_path, nested_config)
-                            detected_suffix = self._get_detected_format_suffix(tmp_path)
-                            if (
-                                file_result.scanner_name == "unknown"
-                                and detected_suffix
-                                and not tmp_path.endswith(detected_suffix)
-                            ):
-                                retargeted_path = f"{tmp_path}{detected_suffix}"
-                                os.replace(tmp_path, retargeted_path)
-                                tmp_path = retargeted_path
-                                file_result = core.scan_file(tmp_path, nested_config)
-                            for check in file_result.checks:
-                                check.location = self._rewrite_embedded_location(
-                                    check.location,
-                                    manifest_path=path,
-                                    layer_ref=layer_ref,
-                                    member_name=name,
-                                    extracted_path=tmp_path,
-                                )
-                            for issue in file_result.issues:
-                                issue.location = self._rewrite_embedded_location(
-                                    issue.location,
-                                    manifest_path=path,
-                                    layer_ref=layer_ref,
-                                    member_name=name,
-                                    extracted_path=tmp_path,
-                                )
-                                if issue.details is None:
-                                    issue.details = {}
-                                issue.details["layer"] = layer_ref
-                            self._merge_nested_result(result, file_result)
-                            if not file_result.success or file_result.has_errors:
+                            if not outcome.success:
                                 scan_complete = False
-                        finally:
-                            fileobj.close()
-                            if tmp_path and os.path.exists(tmp_path):
-                                os.unlink(tmp_path)
+                            extracted_member_bytes += outcome.extracted_bytes
+                            total_extracted_member_bytes += outcome.extracted_bytes
+                            if payload_key is not None:
+                                scanned_payloads.add(payload_key)
+                            if outcome.layer_budget_exhausted or outcome.total_budget_exhausted:
+                                total_extraction_budget_exhausted = (
+                                    total_extraction_budget_exhausted or outcome.total_budget_exhausted
+                                )
+                                break
             except Exception as e:
                 scan_complete = False
                 self._mark_incomplete_coverage(result, "oci_layer_processing_failed")

--- a/tests/scanners/test_oci_layer_scanner.py
+++ b/tests/scanners/test_oci_layer_scanner.py
@@ -2338,6 +2338,397 @@ class TestOciLayerScanner:
         checks = [check for check in result.checks if check.name == "Symlink Safety Validation"]
         assert checks == []
 
+    @pytest.mark.parametrize(
+        ("link_type", "link_target"),
+        [(tarfile.SYMTYPE, "../payload.bin"), (tarfile.LNKTYPE, "payload.bin")],
+        ids=["symlink", "hardlink"],
+    )
+    def test_scan_layer_scans_safe_model_link_targets(
+        self,
+        tmp_path: Path,
+        link_type: bytes,
+        link_target: str,
+    ) -> None:
+        """Safe in-layer links with model-looking names must not bypass nested scanning."""
+        evil_pickle = Path(__file__).parent.parent / "assets/samples/pickles/evil.pickle"
+        layer_path = tmp_path / "linked-model.tar.gz"
+        with tarfile.open(layer_path, "w:gz") as tar:
+            tar.add(evil_pickle, arcname="payload.bin")
+            link_info = tarfile.TarInfo("models/weights.pkl")
+            link_info.type = link_type
+            link_info.linkname = link_target
+            tar.addfile(link_info)
+
+        manifest_path = tmp_path / "linked-model.manifest"
+        manifest_path.write_text(json.dumps({"layers": [layer_path.name]}))
+
+        result = OciLayerScanner({"compressed_max_decompression_ratio": 10000.0}).scan(str(manifest_path))
+
+        assert result.success is False
+        critical_issues = [issue for issue in result.issues if issue.severity == IssueSeverity.CRITICAL]
+        assert any(
+            f"{manifest_path}:linked-model.tar.gz:models/weights.pkl" in (issue.location or "")
+            for issue in critical_issues
+        )
+
+    @pytest.mark.parametrize("link_target", ["../payload.bin", "/payload.bin"])
+    def test_scan_layer_scans_forward_model_symlink_targets(
+        self,
+        tmp_path: Path,
+        link_target: str,
+    ) -> None:
+        """Forward and container-absolute symlinks must resolve within the admitted layer."""
+        evil_pickle = Path(__file__).parent.parent / "assets/samples/pickles/evil.pickle"
+        layer_path = tmp_path / "forward-linked-model.tar.gz"
+        with tarfile.open(layer_path, "w:gz") as tar:
+            link_info = tarfile.TarInfo("models/weights.pkl")
+            link_info.type = tarfile.SYMTYPE
+            link_info.linkname = link_target
+            tar.addfile(link_info)
+            tar.add(evil_pickle, arcname="payload.bin")
+
+        manifest_path = tmp_path / "forward-linked-model.manifest"
+        manifest_path.write_text(json.dumps({"layers": [layer_path.name]}))
+
+        result = OciLayerScanner({"compressed_max_decompression_ratio": 10000.0}).scan(str(manifest_path))
+
+        assert result.success is False
+        assert any(
+            issue.severity == IssueSeverity.CRITICAL
+            and f"{manifest_path}:{layer_path.name}:models/weights.pkl" in (issue.location or "")
+            for issue in result.issues
+        )
+
+    def test_scan_layer_applies_member_size_limit_to_link_payload(self, tmp_path: Path) -> None:
+        """A zero-size link header must not bypass the target payload size budget."""
+        payload = tmp_path / "payload.bin"
+        payload.write_bytes(b"A" * 8192)
+        layer_path = tmp_path / "oversized-linked-model.tar.gz"
+        with tarfile.open(layer_path, "w:gz") as tar:
+            tar.add(payload, arcname="payload.bin")
+            link_info = tarfile.TarInfo("models/weights.pkl")
+            link_info.type = tarfile.SYMTYPE
+            link_info.linkname = "../payload.bin"
+            tar.addfile(link_info)
+
+        manifest_path = tmp_path / "oversized-linked-model.manifest"
+        manifest_path.write_text(json.dumps({"layers": [layer_path.name]}))
+
+        with patch("modelaudit.core.scan_file") as mock_scan:
+            result = OciLayerScanner({"max_file_size": 4096}).scan(str(manifest_path))
+
+        link_size_checks = [
+            check
+            for check in result.checks
+            if check.name == "Layer Member Size Check" and check.details.get("member") == "models/weights.pkl"
+        ]
+        assert result.success is False
+        assert mock_scan.call_count == 0
+        assert len(link_size_checks) == 1
+        assert link_size_checks[0].details["size"] == 8192
+        assert link_size_checks[0].details["target_member"] == "payload.bin"
+        assert "oci_member_size_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+
+    @pytest.mark.parametrize(
+        ("budget_key", "reason", "previous_bytes_key"),
+        [
+            (
+                "max_oci_layer_extracted_bytes",
+                "oci_layer_extracted_size_exceeded",
+                "previous_extracted_bytes",
+            ),
+            ("max_total_size", "oci_total_extracted_size_exceeded", "previous_total_extracted_bytes"),
+        ],
+    )
+    def test_scan_layer_counts_link_payload_against_extraction_budgets(
+        self,
+        tmp_path: Path,
+        budget_key: str,
+        reason: str,
+        previous_bytes_key: str,
+    ) -> None:
+        """A model-looking alias must not recopy its target beyond aggregate budgets."""
+        payload = tmp_path / "payload.bin"
+        payload.write_bytes(pickle.dumps({"weights": [1, 2, 3]}))
+        layer_path = tmp_path / "budgeted-linked-model.tar.gz"
+        with tarfile.open(layer_path, "w:gz") as tar:
+            tar.add(payload, arcname="payload.bin")
+            link_info = tarfile.TarInfo("models/weights.pkl")
+            link_info.type = tarfile.SYMTYPE
+            link_info.linkname = "../payload.bin"
+            tar.addfile(link_info)
+
+        manifest_path = tmp_path / "budgeted-linked-model.manifest"
+        manifest_path.write_text(json.dumps({"layers": [layer_path.name]}))
+
+        def clean_scan(_path: str, _config: dict[str, Any]) -> ScanResult:
+            nested_result = ScanResult(scanner_name="pickle")
+            nested_result.finish()
+            return nested_result
+
+        with (
+            patch("modelaudit.core.scan_file", side_effect=clean_scan) as mock_scan,
+            patch("modelaudit.scanners.oci_layer_scanner.shutil.copyfileobj", wraps=shutil.copyfileobj) as mock_copy,
+        ):
+            result = OciLayerScanner({budget_key: payload.stat().st_size}).scan(str(manifest_path))
+
+        checks = [check for check in result.checks if check.name == "Layer Extraction Budget Check"]
+        assert result.success is False
+        assert mock_scan.call_count == 1
+        assert mock_copy.call_count == 1
+        assert reason in result.metadata["scan_outcome_reasons"]
+        assert len(checks) == 1
+        assert checks[0].details["member"] == "models/weights.pkl"
+        assert checks[0].details["target_member"] == "payload.bin"
+        assert checks[0].details[previous_bytes_key] == payload.stat().st_size
+
+    def test_resolve_link_payload_member_memoizes_long_chains(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Resolving every alias in a long chain should take linear total work."""
+        chain_length = 256
+        payload = tarfile.TarInfo("payload.bin")
+        payload.type = tarfile.REGTYPE
+        members_by_name = {payload.name: payload}
+        links: list[tarfile.TarInfo] = []
+        for index in range(chain_length):
+            link = tarfile.TarInfo(f"link-{index}.pkl")
+            link.type = tarfile.SYMTYPE
+            link.linkname = f"link-{index + 1}.pkl" if index + 1 < chain_length else payload.name
+            members_by_name[link.name] = link
+            links.append(link)
+
+        resolve_calls = 0
+        original_resolver = OciLayerScanner._resolve_link_target
+
+        def counted_resolver(
+            target: str,
+            *,
+            resolved_member_name: str,
+            extraction_root: str,
+            is_symlink: bool,
+        ) -> tuple[str, bool]:
+            nonlocal resolve_calls
+            resolve_calls += 1
+            return original_resolver(
+                target,
+                resolved_member_name=resolved_member_name,
+                extraction_root=extraction_root,
+                is_symlink=is_symlink,
+            )
+
+        monkeypatch.setattr(OciLayerScanner, "_resolve_link_target", staticmethod(counted_resolver))
+        resolved_payload_cache: dict[tarfile.TarInfo, tarfile.TarInfo | None] = {}
+
+        for link in links:
+            assert (
+                OciLayerScanner._resolve_link_payload_member(link, members_by_name, resolved_payload_cache) is payload
+            )
+
+        assert resolve_calls == chain_length
+
+    def test_scan_layer_does_not_resolve_link_beyond_entry_limit(self, tmp_path: Path) -> None:
+        """Link resolution must not make tarfile inspect a target outside the admitted entry window."""
+        payload = tmp_path / "payload.bin"
+        payload.write_bytes(pickle.dumps({"weights": [1, 2, 3]}))
+        layer_path = tmp_path / "limited-linked-model.tar.gz"
+        with tarfile.open(layer_path, "w:gz") as tar:
+            link_info = tarfile.TarInfo("model.pkl")
+            link_info.type = tarfile.SYMTYPE
+            link_info.linkname = "payload.bin"
+            tar.addfile(link_info)
+            tar.add(payload, arcname="payload.bin")
+
+        manifest_path = tmp_path / "limited-linked-model.manifest"
+        manifest_path.write_text(json.dumps({"layers": [layer_path.name]}))
+
+        with patch("modelaudit.core.scan_file") as mock_scan:
+            result = OciLayerScanner({"max_oci_layer_entries": 1}).scan(str(manifest_path))
+
+        extraction_checks = [check for check in result.checks if check.name == "Layer Member Extraction"]
+        assert result.success is False
+        mock_scan.assert_not_called()
+        assert len(extraction_checks) == 1
+        assert extraction_checks[0].details["member"] == "model.pkl"
+        assert "oci_layer_entry_count_exceeded" in result.metadata["scan_outcome_reasons"]
+        assert "oci_member_extraction_failed" in result.metadata["scan_outcome_reasons"]
+
+    def test_scan_layer_reports_model_link_cycle_as_incomplete(self, tmp_path: Path) -> None:
+        """Cyclic model links must terminate and fail closed without nested scans."""
+        layer_path = tmp_path / "cyclic-linked-model.tar.gz"
+        with tarfile.open(layer_path, "w:gz") as tar:
+            first_link = tarfile.TarInfo("models/first.pkl")
+            first_link.type = tarfile.SYMTYPE
+            first_link.linkname = "second.pkl"
+            tar.addfile(first_link)
+            second_link = tarfile.TarInfo("models/second.pkl")
+            second_link.type = tarfile.SYMTYPE
+            second_link.linkname = "first.pkl"
+            tar.addfile(second_link)
+
+        manifest_path = tmp_path / "cyclic-linked-model.manifest"
+        manifest_path.write_text(json.dumps({"layers": [layer_path.name]}))
+
+        with patch("modelaudit.core.scan_file") as mock_scan:
+            result = OciLayerScanner().scan(str(manifest_path))
+
+        extraction_checks = [check for check in result.checks if check.name == "Layer Member Extraction"]
+        assert result.success is False
+        mock_scan.assert_not_called()
+        assert {check.details["member"] for check in extraction_checks} == {
+            "models/first.pkl",
+            "models/second.pkl",
+        }
+        assert "oci_member_extraction_failed" in result.metadata["scan_outcome_reasons"]
+
+    def test_scan_layer_does_not_resolve_ambiguous_duplicate_link_target(self, tmp_path: Path) -> None:
+        """A model link must fail closed when its target path appears more than once."""
+        layer_path = tmp_path / "duplicate-target-linked-model.tar.gz"
+        with tarfile.open(layer_path, "w:gz") as tar:
+            for payload in (b"first", b"second", b"third"):
+                payload_info = tarfile.TarInfo("payload.bin")
+                payload_info.size = len(payload)
+                tar.addfile(payload_info, io.BytesIO(payload))
+            link_info = tarfile.TarInfo("model.pkl")
+            link_info.type = tarfile.SYMTYPE
+            link_info.linkname = "payload.bin"
+            tar.addfile(link_info)
+
+        manifest_path = tmp_path / "duplicate-target-linked-model.manifest"
+        manifest_path.write_text(json.dumps({"layers": [layer_path.name]}))
+
+        with patch("modelaudit.core.scan_file") as mock_scan:
+            result = OciLayerScanner().scan(str(manifest_path))
+
+        extraction_checks = [check for check in result.checks if check.name == "Layer Member Extraction"]
+        assert result.success is False
+        assert len(extraction_checks) == 1
+        assert extraction_checks[0].details["member"] == "model.pkl"
+        assert mock_scan.call_count == 3
+        assert "oci_member_extraction_failed" in result.metadata["scan_outcome_reasons"]
+
+    def test_scan_layer_does_not_reuse_cached_target_for_duplicate_link_names(self, tmp_path: Path) -> None:
+        """Duplicate link headers must resolve their own targets instead of sharing a name-keyed cache entry."""
+        layer_path = tmp_path / "duplicate-link-name.tar.gz"
+        with tarfile.open(layer_path, "w:gz") as tar:
+            for name, payload in (("benign.bin", b"benign"), ("malicious.bin", b"malicious")):
+                payload_info = tarfile.TarInfo(name)
+                payload_info.size = len(payload)
+                tar.addfile(payload_info, io.BytesIO(payload))
+            for target in ("benign.bin", "malicious.bin"):
+                link_info = tarfile.TarInfo("model.onnx")
+                link_info.type = tarfile.SYMTYPE
+                link_info.linkname = target
+                tar.addfile(link_info)
+
+        manifest_path = tmp_path / "duplicate-link-name.manifest"
+        manifest_path.write_text(json.dumps({"layers": [layer_path.name]}))
+        routed_payloads: list[bytes] = []
+
+        def record_scan(scan_path: str, _config: dict[str, Any]) -> ScanResult:
+            if scan_path.endswith(".onnx"):
+                routed_payloads.append(Path(scan_path).read_bytes())
+            nested_result = ScanResult(scanner_name="unknown")
+            nested_result.finish()
+            return nested_result
+
+        with patch("modelaudit.core.scan_file", side_effect=record_scan):
+            result = OciLayerScanner().scan(str(manifest_path))
+
+        assert result.success is False
+        assert routed_payloads == [b"benign", b"malicious"]
+
+    def test_scan_layer_resolves_model_link_through_directory_symlink(self, tmp_path: Path) -> None:
+        """A safe model link may traverse an admitted same-layer directory symlink."""
+        payload = b"model-payload"
+        layer_path = tmp_path / "component-symlink.tar.gz"
+        with tarfile.open(layer_path, "w:gz") as tar:
+            payload_info = tarfile.TarInfo("payloads/data.bin")
+            payload_info.size = len(payload)
+            tar.addfile(payload_info, io.BytesIO(payload))
+
+            directory_link = tarfile.TarInfo("models")
+            directory_link.type = tarfile.SYMTYPE
+            directory_link.linkname = "payloads"
+            tar.addfile(directory_link)
+
+            model_link = tarfile.TarInfo("weights.onnx")
+            model_link.type = tarfile.SYMTYPE
+            model_link.linkname = "models/data.bin"
+            tar.addfile(model_link)
+
+        manifest_path = tmp_path / "component-symlink.manifest"
+        manifest_path.write_text(json.dumps({"layers": [layer_path.name]}))
+        routed_payloads: list[bytes] = []
+
+        def record_scan(scan_path: str, _config: dict[str, Any]) -> ScanResult:
+            if scan_path.endswith(".onnx"):
+                routed_payloads.append(Path(scan_path).read_bytes())
+            nested_result = ScanResult(scanner_name="unknown")
+            nested_result.finish()
+            return nested_result
+
+        with patch("modelaudit.core.scan_file", side_effect=record_scan):
+            result = OciLayerScanner().scan(str(manifest_path))
+
+        assert result.success is True, [
+            (check.name, check.message) for check in result.checks if check.status.value == "failed"
+        ]
+        assert routed_payloads == [payload]
+
+    def test_scan_layer_deduplicates_equivalent_model_link_payloads(self, tmp_path: Path) -> None:
+        """Equivalent model aliases should not multiply nested scans of the same payload."""
+        payload = tmp_path / "payload.bin"
+        payload.write_bytes(pickle.dumps({"weights": [1, 2, 3]}))
+        layer_path = tmp_path / "duplicate-linked-model.tar.gz"
+        with tarfile.open(layer_path, "w:gz") as tar:
+            tar.add(payload, arcname="payload.bin")
+            for name in ("models/first.pkl", "models/second.pkl"):
+                link_info = tarfile.TarInfo(name)
+                link_info.type = tarfile.SYMTYPE
+                link_info.linkname = "../payload.bin"
+                tar.addfile(link_info)
+
+        manifest_path = tmp_path / "duplicate-linked-model.manifest"
+        manifest_path.write_text(json.dumps({"layers": [layer_path.name]}))
+
+        def clean_scan(_path: str, _config: dict[str, Any]) -> ScanResult:
+            nested_result = ScanResult(scanner_name="unknown")
+            nested_result.finish()
+            return nested_result
+
+        with (
+            patch("modelaudit.core.scan_file", side_effect=clean_scan),
+            patch("modelaudit.scanners.oci_layer_scanner.shutil.copyfileobj", wraps=shutil.copyfileobj) as mock_copy,
+        ):
+            result = OciLayerScanner().scan(str(manifest_path))
+
+        assert result.success is True
+        assert mock_copy.call_count == 2
+
+    def test_scan_layer_allows_benign_safe_model_link_target(self, tmp_path: Path) -> None:
+        """Safe links to benign in-layer model payloads should scan without false positives."""
+        benign_pickle = tmp_path / "benign.pickle"
+        benign_pickle.write_bytes(pickle.dumps({"weights": [1, 2, 3]}))
+        layer_path = tmp_path / "benign-linked-model.tar.gz"
+        with tarfile.open(layer_path, "w:gz") as tar:
+            tar.add(benign_pickle, arcname="payload.bin")
+            link_info = tarfile.TarInfo("models/weights.pkl")
+            link_info.type = tarfile.SYMTYPE
+            link_info.linkname = "../payload.bin"
+            tar.addfile(link_info)
+
+        manifest_path = tmp_path / "benign-linked-model.manifest"
+        manifest_path.write_text(json.dumps({"layers": [layer_path.name]}))
+
+        result = OciLayerScanner({"compressed_max_decompression_ratio": 10000.0}).scan(str(manifest_path))
+
+        assert result.success is True
+        assert not [
+            issue for issue in result.issues if issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL}
+        ]
+
     def test_scan_layer_allows_symlink_target_under_layer_root(self, tmp_path: Path) -> None:
         """Symlink targets are resolved from the link directory but contained by the layer root."""
         layer_path = tmp_path / "safe-sibling-link.tar.gz"

--- a/tests/scanners/test_oci_layer_scanner.py
+++ b/tests/scanners/test_oci_layer_scanner.py
@@ -2520,13 +2520,218 @@ class TestOciLayerScanner:
 
         monkeypatch.setattr(OciLayerScanner, "_resolve_link_target", staticmethod(counted_resolver))
         resolved_payload_cache: dict[tarfile.TarInfo, tarfile.TarInfo | None] = {}
+        resolved_member_path_cache: dict[str, tarfile.TarInfo | None] = {}
 
         for link in links:
             assert (
-                OciLayerScanner._resolve_link_payload_member(link, members_by_name, resolved_payload_cache) is payload
+                OciLayerScanner._resolve_link_payload_member(
+                    link,
+                    members_by_name,
+                    resolved_payload_cache,
+                    resolved_member_path_cache,
+                )
+                is payload
             )
 
         assert resolve_calls == chain_length
+
+    def test_resolve_link_payload_member_memoizes_component_symlink_chains(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Equivalent component-link paths should be resolved only once across aliases."""
+        chain_length = 128
+        alias_count = 128
+        members_by_name: dict[str, tarfile.TarInfo] = {}
+        for index in range(chain_length):
+            link = tarfile.TarInfo(f"d{index}")
+            link.type = tarfile.SYMTYPE
+            link.linkname = f"d{index + 1}"
+            members_by_name[link.name] = link
+
+        payload = tarfile.TarInfo(f"d{chain_length}/payload.bin")
+        payload.type = tarfile.REGTYPE
+        members_by_name[payload.name] = payload
+        aliases: list[tarfile.TarInfo] = []
+        for index in range(alias_count):
+            alias = tarfile.TarInfo(f"model-{index}.pkl")
+            alias.type = tarfile.SYMTYPE
+            alias.linkname = "d0/payload.bin"
+            aliases.append(alias)
+
+        resolve_calls = 0
+        original_resolver = OciLayerScanner._resolve_link_target
+
+        def counted_resolver(
+            target: str,
+            *,
+            resolved_member_name: str,
+            extraction_root: str,
+            is_symlink: bool,
+        ) -> tuple[str, bool]:
+            nonlocal resolve_calls
+            resolve_calls += 1
+            return original_resolver(
+                target,
+                resolved_member_name=resolved_member_name,
+                extraction_root=extraction_root,
+                is_symlink=is_symlink,
+            )
+
+        monkeypatch.setattr(OciLayerScanner, "_resolve_link_target", staticmethod(counted_resolver))
+        resolved_payload_cache: dict[tarfile.TarInfo, tarfile.TarInfo | None] = {}
+        resolved_member_path_cache: dict[str, tarfile.TarInfo | None] = {}
+
+        for alias in aliases:
+            assert (
+                OciLayerScanner._resolve_link_payload_member(
+                    alias,
+                    members_by_name,
+                    resolved_payload_cache,
+                    resolved_member_path_cache,
+                )
+                is payload
+            )
+
+        assert resolve_calls == chain_length + alias_count
+        assert resolved_member_path_cache["d0/payload.bin"] is payload
+
+    def test_resolve_link_payload_member_does_not_cache_suffix_specific_cycle(self) -> None:
+        """A cyclic child path must not poison benign siblings through the same directory link."""
+        directory_link = tarfile.TarInfo("a")
+        directory_link.type = tarfile.SYMTYPE
+        directory_link.linkname = "base"
+
+        cyclic_child = tarfile.TarInfo("base/x")
+        cyclic_child.type = tarfile.SYMTYPE
+        cyclic_child.linkname = "../a/x"
+
+        payload = tarfile.TarInfo("base/z/file.bin")
+        payload.type = tarfile.REGTYPE
+        members_by_name = {
+            directory_link.name: directory_link,
+            cyclic_child.name: cyclic_child,
+            payload.name: payload,
+        }
+
+        cyclic_alias = tarfile.TarInfo("cyclic.pkl")
+        cyclic_alias.type = tarfile.SYMTYPE
+        cyclic_alias.linkname = "a/x/file.bin"
+        benign_alias = tarfile.TarInfo("benign.pkl")
+        benign_alias.type = tarfile.SYMTYPE
+        benign_alias.linkname = "a/z/file.bin"
+
+        resolved_payload_cache: dict[tarfile.TarInfo, tarfile.TarInfo | None] = {}
+        resolved_member_path_cache: dict[str, tarfile.TarInfo | None] = {}
+
+        assert (
+            OciLayerScanner._resolve_link_payload_member(
+                cyclic_alias,
+                members_by_name,
+                resolved_payload_cache,
+                resolved_member_path_cache,
+            )
+            is None
+        )
+        assert (
+            OciLayerScanner._resolve_link_payload_member(
+                benign_alias,
+                members_by_name,
+                resolved_payload_cache,
+                resolved_member_path_cache,
+            )
+            is payload
+        )
+        assert resolved_member_path_cache["a/x/file.bin"] is None
+        assert resolved_member_path_cache["a/z/file.bin"] is payload
+
+    def test_resolve_link_payload_member_does_not_cache_suffix_rewrite_as_parent_target(self) -> None:
+        """A child symlink rewrite must not change the cached target of its parent directory link."""
+        directory_link = tarfile.TarInfo("a")
+        directory_link.type = tarfile.SYMTYPE
+        directory_link.linkname = "base"
+
+        child_link = tarfile.TarInfo("base/x")
+        child_link.type = tarfile.SYMTYPE
+        child_link.linkname = "../other/x"
+
+        rewritten_payload = tarfile.TarInfo("other/x/file.bin")
+        rewritten_payload.type = tarfile.REGTYPE
+        sibling_payload = tarfile.TarInfo("base/z/file.bin")
+        sibling_payload.type = tarfile.REGTYPE
+        members_by_name = {
+            directory_link.name: directory_link,
+            child_link.name: child_link,
+            rewritten_payload.name: rewritten_payload,
+            sibling_payload.name: sibling_payload,
+        }
+
+        rewritten_alias = tarfile.TarInfo("rewritten.pkl")
+        rewritten_alias.type = tarfile.SYMTYPE
+        rewritten_alias.linkname = "a/x/file.bin"
+        sibling_alias = tarfile.TarInfo("sibling.pkl")
+        sibling_alias.type = tarfile.SYMTYPE
+        sibling_alias.linkname = "a/z/file.bin"
+
+        resolved_payload_cache: dict[tarfile.TarInfo, tarfile.TarInfo | None] = {}
+        resolved_member_path_cache: dict[str, tarfile.TarInfo | None] = {}
+
+        assert (
+            OciLayerScanner._resolve_link_payload_member(
+                rewritten_alias,
+                members_by_name,
+                resolved_payload_cache,
+                resolved_member_path_cache,
+            )
+            is rewritten_payload
+        )
+        assert (
+            OciLayerScanner._resolve_link_payload_member(
+                sibling_alias,
+                members_by_name,
+                resolved_payload_cache,
+                resolved_member_path_cache,
+            )
+            is sibling_payload
+        )
+        assert resolved_member_path_cache["a/x/file.bin"] is rewritten_payload
+        assert resolved_member_path_cache["a/z/file.bin"] is sibling_payload
+
+    def test_scan_layer_fails_closed_when_link_resolution_work_limit_is_exhausted(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Adversarial link graphs should stop at an explicit aggregate work budget."""
+        layer_path = tmp_path / "link-resolution-budget.tar.gz"
+        with tarfile.open(layer_path, "w:gz") as tar:
+            payload = b"benign"
+            payload_info = tarfile.TarInfo("d1/payload.bin")
+            payload_info.size = len(payload)
+            tar.addfile(payload_info, io.BytesIO(payload))
+
+            directory_link = tarfile.TarInfo("d0")
+            directory_link.type = tarfile.SYMTYPE
+            directory_link.linkname = "d1"
+            tar.addfile(directory_link)
+
+            model_link = tarfile.TarInfo("model.pkl")
+            model_link.type = tarfile.SYMTYPE
+            model_link.linkname = "d0/payload.bin"
+            tar.addfile(model_link)
+
+        manifest_path = tmp_path / "link-resolution-budget.manifest"
+        manifest_path.write_text(json.dumps({"layers": [layer_path.name]}))
+        monkeypatch.setattr(OciLayerScanner, "_LINK_RESOLUTION_STEPS_PER_ENTRY", 0)
+
+        result = OciLayerScanner().scan(str(manifest_path))
+
+        checks = [check for check in result.checks if check.name == "Layer Link Resolution Budget Check"]
+        assert result.success is False
+        assert len(checks) == 1
+        assert checks[0].details["member"] == "model.pkl"
+        assert checks[0].details["max_resolution_steps"] == 1
+        assert "oci_link_resolution_limit_exceeded" in result.metadata["scan_outcome_reasons"]
 
     def test_scan_layer_does_not_resolve_link_beyond_entry_limit(self, tmp_path: Path) -> None:
         """Link resolution must not make tarfile inspect a target outside the admitted entry window."""


### PR DESCRIPTION
## Summary
- scan safe OCI symlink and hardlink members with model-looking names using container-root path semantics
- resolve link chains only through metadata-valid members admitted by active preflight and entry budgets
- resolve same-layer paths through admitted intermediate directory symlinks while preserving root containment and cycle bounds
- apply per-file, per-layer, and whole-manifest extraction limits to the resolved payload before copying
- keep duplicate target paths ambiguous and key resolution caching by the actual TAR header so duplicate link names cannot reuse the wrong target
- deduplicate equivalent aliases and path-compress direct link-chain resolution
- bound aggregate component-link traversal work linearly and memoize only complete resolved paths

## False-positive / false-negative audit
- enforce `max_file_size` against target payloads rather than zero-size link headers
- prevent resolution beyond `preflight_member_limit` / `max_oci_layer_entries`
- translate POSIX-absolute OCI symlinks to archive-root members
- scan each distinct duplicate link header's own target instead of colliding in a normalized-name cache
- accept valid same-layer paths such as `models -> payloads` plus `weights.onnx -> models/data.bin`
- preserve cumulative extraction budgets for regular members and aliases
- fail closed with an operationally explicit check when aggregate link resolution exceeds its linear budget
- cache exact paths only, so a cyclic or rewritten child suffix cannot poison a benign sibling
- cover relative, absolute, forward, oversized, cyclic, duplicate, repeated-alias, aggregate-budget, component-symlink, long-chain, cache-poisoning, and resolution-exhaustion cases

## Validation
- complete associated OCI scanner module: `149 passed`
- adversarial scaling probe: 200 component links plus 200 distinct aliases stopped at the 1,600-step linear cap
- scoped Ruff check and format check
- scoped mypy for the scanner and its tests
- `git diff --check origin/main...HEAD`
- exact published tree: `69079ef35c8a66d8fa38af71bfd447db1bb24466`

## Known limitation
Cross-layer symlink targets require an overlay-aware index with OCI whiteout semantics. Until that broader support exists, unresolved cross-layer links fail closed as incomplete coverage.

All inline review threads are resolved. Full pytest remains delegated to CI. Final reviewed head: `5eb923c3ac440dd35b8e6a3673aefe76317298c9`, based on main `c55de216637b0ca341cd6659d915d1cc2c4f5e2c`.