### PR TITLE
fix: harden picklescan spec resolution

### DIFF
--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -107,6 +107,9 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - preserve reviewed safe callable references in dependency-minimal environments and
   recognize active-environment package overlays without trusting project-local shadows
 - avoid custom meta-path finder calls during pickle call-graph source probing
+- avoid hookable builtin/frozen finders, mutable import-runtime dependencies, forged
+  loaded specs, and in-place trusted-reference mutations during pickle call-graph module
+  resolution
 - prevent call-graph alias cycles from hanging scans
 - detect nested brace-format lookups that reach tracked `defaultdict` factories
 - avoid `str.format` false positives when a `ChainMap` shadows a `defaultdict`

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -8,6 +8,7 @@ import dis
 import hashlib
 import marshal
 import os
+import re
 import stat
 import sys
 import sysconfig
@@ -96,6 +97,7 @@ _MAX_TRUSTED_PTH_BYTES = 64 * 1024
 _MAX_TRUSTED_PTH_PATHS = 64
 _MAX_TRUSTED_REFERENCE_FUNCTIONS = 128
 _MAX_TRUSTED_REFERENCE_GLOBALS = 1024
+_MAX_TRUSTED_SLOT_NAMES = 1024
 _CONTROLLED_GETATTR_DISPATCH_SINK = "builtins.getattr.__call__"
 _IMPORT_EXECUTION_SINK = "builtins.__import__"
 _BUILTIN_MODULE_NAMES = frozenset(sys.builtin_module_names)
@@ -845,6 +847,7 @@ def _trusted_executable_value_snapshot(value: object) -> _TrustedExecutableValue
         ] = []
         for name in global_names:
             global_value = globals_namespace[name]
+            mutable_state_safe = _trusted_mutable_global_state_is_safe(function, name, global_value)
             dependency_snapshots: list[
                 tuple[
                     tuple[str, ...],
@@ -852,7 +855,7 @@ def _trusted_executable_value_snapshot(value: object) -> _TrustedExecutableValue
                     tuple[_RuntimeValueSnapshot, ...],
                 ]
             ] = []
-            for path in attribute_paths.get(name, ()):
+            for path in () if mutable_state_safe else attribute_paths.get(name, ()):
                 resolved, dependency, dispatch_dependencies = _runtime_attribute_path_without_hooks(global_value, path)
                 if not resolved:
                     return _runtime_value_snapshot(value), tuple(referenced_globals), False
@@ -871,7 +874,7 @@ def _trusted_executable_value_snapshot(value: object) -> _TrustedExecutableValue
                     name,
                     _runtime_value_snapshot(global_value),
                     tuple(dependency_snapshots),
-                    _trusted_mutable_global_state_is_safe(function, name, global_value),
+                    mutable_state_safe,
                 )
             )
         referenced_globals.append(
@@ -896,6 +899,11 @@ def _trusted_mutable_global_state_is_safe(function: FunctionType, name: str, val
         and function.__name__ == "_gettempdir"
         and name == "tempdir"
         and (value is None or type(value) is str)
+    ) or (
+        function.__module__ == "posixpath"
+        and function.__name__ == "expandvars"
+        and name in {"_varprog", "_varprogb"}
+        and (value is None or type(value) is re.Pattern)
     )
 
 
@@ -979,12 +987,27 @@ def _trusted_reference_executable_matches_snapshot(
         if base is not expected_base:
             return False
         raw_namespace = type.__getattribute__(base, "__dict__")
-        if raw_namespace.keys() != expected_namespace.keys() or any(
-            not _trusted_executable_value_matches_snapshot(raw_namespace[name], expected_value)
+        if any(
+            name not in raw_namespace
+            or not _trusted_executable_value_matches_snapshot(raw_namespace[name], expected_value)
             for name, expected_value in expected_namespace.items()
+        ) or any(
+            name not in expected_namespace and not _trusted_class_namespace_addition_is_safe(name, member)
+            for name, member in raw_namespace.items()
         ):
             return False
     return True
+
+
+def _trusted_class_namespace_addition_is_safe(name: str, value: object) -> bool:
+    if name != "__slotnames__":
+        return False
+    slot_names = _exact_list_items_without_hooks(value)
+    return (
+        slot_names is not None
+        and len(slot_names) <= _MAX_TRUSTED_SLOT_NAMES
+        and all(type(slot_name) is str for slot_name in slot_names)
+    )
 
 
 def _loaded_module_metadata_matches_spec_without_hooks(

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import _imp
 import ast
-import fnmatch
+import dis
 import hashlib
 import marshal
 import os
@@ -34,7 +34,7 @@ from importlib.machinery import (
 from importlib.metadata import distribution, packages_distributions
 from importlib.util import MAGIC_NUMBER, cache_from_source, source_hash
 from pathlib import Path
-from types import CodeType, FunctionType, MethodType, ModuleType
+from types import CodeType, FunctionType, GetSetDescriptorType, MappingProxyType, MethodType, ModuleType
 from typing import Any, Protocol, TypeVar, cast
 from zipimport import zipimporter
 
@@ -94,9 +94,845 @@ _MAX_DISTRIBUTIONS_PER_TOP_LEVEL = 16
 _MAX_TRUSTED_PTH_FILES = 64
 _MAX_TRUSTED_PTH_BYTES = 64 * 1024
 _MAX_TRUSTED_PTH_PATHS = 64
+_MAX_TRUSTED_REFERENCE_FUNCTIONS = 128
+_MAX_TRUSTED_REFERENCE_GLOBALS = 1024
 _CONTROLLED_GETATTR_DISPATCH_SINK = "builtins.getattr.__call__"
 _IMPORT_EXECUTION_SINK = "builtins.__import__"
-_IMPORT_EXECUTION_SAFE_MODULES = frozenset(sys.builtin_module_names)
+_BUILTIN_MODULE_NAMES = frozenset(sys.builtin_module_names)
+_IS_FROZEN_MODULE = _imp.is_frozen
+# Unloaded interpreter modules are trusted only while the import runtime keeps
+# the exact executable state captured here.
+_RuntimeValueSnapshot = tuple[
+    object,
+    FunctionType | None,
+    CodeType | None,
+    object | None,
+    object | None,
+    tuple[tuple[str, object], ...],
+    tuple[tuple[object, CodeType | None, object | None, object | None], ...],
+]
+_EMPTY_RUNTIME_CLOSURE_CELL = object()
+
+
+def _runtime_value_snapshot(value: object) -> _RuntimeValueSnapshot:
+    function: object = value
+    if isinstance(value, classmethod | staticmethod):
+        function = value.__func__
+    if isinstance(function, FunctionType):
+        keyword_defaults = function.__kwdefaults__
+        keyword_default_items = tuple(dict.items(keyword_defaults)) if type(keyword_defaults) is dict else ()
+        closure_values: list[tuple[object, CodeType | None, object | None, object | None]] = []
+        for cell in function.__closure__ or ():
+            try:
+                closure_value = cell.cell_contents
+            except ValueError:
+                closure_value = _EMPTY_RUNTIME_CLOSURE_CELL
+            if isinstance(closure_value, FunctionType):
+                closure_values.append(
+                    (
+                        closure_value,
+                        closure_value.__code__,
+                        closure_value.__defaults__,
+                        closure_value.__kwdefaults__,
+                    )
+                )
+            else:
+                closure_values.append((closure_value, None, None, None))
+        return (
+            value,
+            function,
+            function.__code__,
+            function.__defaults__,
+            keyword_defaults,
+            keyword_default_items,
+            tuple(closure_values),
+        )
+    return value, None, None, None, None, (), ()
+
+
+def _runtime_value_matches_snapshot(value: object, expected: _RuntimeValueSnapshot) -> bool:
+    current = _runtime_value_snapshot(value)
+    if not all(current[index] is expected[index] for index in range(5)):
+        return False
+    current_keyword_defaults = current[5]
+    expected_keyword_defaults = expected[5]
+    if len(current_keyword_defaults) != len(expected_keyword_defaults) or any(
+        type(current_name) is not str
+        or type(expected_name) is not str
+        or current_name != expected_name
+        or current_value is not expected_value
+        for (current_name, current_value), (expected_name, expected_value) in zip(
+            current_keyword_defaults,
+            expected_keyword_defaults,
+            strict=True,
+        )
+    ):
+        return False
+    return len(current[6]) == len(expected[6]) and all(
+        all(
+            current_part is expected_part
+            for current_part, expected_part in zip(current_value, expected_value, strict=True)
+        )
+        for current_value, expected_value in zip(current[6], expected[6], strict=True)
+    )
+
+
+def _module_namespace_snapshot(module: ModuleType) -> Mapping[str, _RuntimeValueSnapshot]:
+    namespace = ModuleType.__getattribute__(module, "__dict__")
+    if type(namespace) is not dict:
+        return MappingProxyType({})
+    return MappingProxyType({name: _runtime_value_snapshot(value) for name, value in namespace.items()})
+
+
+def _module_attribute_snapshot(
+    module: ModuleType,
+    names: tuple[str, ...],
+) -> Mapping[str, _RuntimeValueSnapshot]:
+    namespace = ModuleType.__getattribute__(module, "__dict__")
+    if type(namespace) is not dict or any(name not in namespace for name in names):
+        return MappingProxyType({})
+    return MappingProxyType({name: _runtime_value_snapshot(namespace[name]) for name in names})
+
+
+def _runtime_type_member_is_executable(value: object) -> bool:
+    value_type = type(value)
+    mro = type.__getattribute__(value_type, "__mro__")
+    is_descriptor = any("__get__" in type.__getattribute__(class_, "__dict__") for class_ in mro)
+    return is_descriptor or isinstance(value, FunctionType | classmethod | staticmethod | property) or callable(value)
+
+
+def _type_namespace_snapshot(class_: type[object]) -> Mapping[str, _RuntimeValueSnapshot]:
+    namespace = type.__getattribute__(class_, "__dict__")
+    return MappingProxyType(
+        {
+            name: _runtime_value_snapshot(value)
+            for name, value in namespace.items()
+            if _runtime_type_member_is_executable(value)
+        }
+    )
+
+
+_FROZEN_IMPORTLIB_MODULE = sys.modules.get("_frozen_importlib")
+_FROZEN_IMPORTLIB_EXTERNAL_MODULE = sys.modules.get("_frozen_importlib_external")
+_FROZEN_IMPORTLIB_NAMESPACE = (
+    ModuleType.__getattribute__(_FROZEN_IMPORTLIB_MODULE, "__dict__")
+    if type(_FROZEN_IMPORTLIB_MODULE) is ModuleType
+    else {}
+)
+_FROZEN_IMPORTLIB_EXTERNAL_NAMESPACE = (
+    ModuleType.__getattribute__(_FROZEN_IMPORTLIB_EXTERNAL_MODULE, "__dict__")
+    if type(_FROZEN_IMPORTLIB_EXTERNAL_MODULE) is ModuleType
+    else {}
+)
+_IMPORT_RUNTIME_BUILTINS = _FROZEN_IMPORTLIB_NAMESPACE.get("__builtins__")
+
+
+def _code_referenced_names(code: CodeType) -> set[str]:
+    names = set(code.co_names)
+    for value in code.co_consts:
+        if isinstance(value, CodeType):
+            names.update(_code_referenced_names(value))
+    return names
+
+
+def _code_global_attribute_paths(code: CodeType) -> Mapping[str, tuple[tuple[str, ...], ...]]:
+    paths: dict[str, set[tuple[str, ...]]] = {}
+    instructions = tuple(dis.get_instructions(code))
+    for index, instruction in enumerate(instructions):
+        if instruction.opname not in {"LOAD_GLOBAL", "LOAD_NAME"} or type(instruction.argval) is not str:
+            continue
+        attributes: list[str] = []
+        for following in instructions[index + 1 :]:
+            if following.opname not in {"LOAD_ATTR", "LOAD_METHOD"} or type(following.argval) is not str:
+                break
+            attributes.append(following.argval)
+        if attributes:
+            paths.setdefault(instruction.argval, set()).add(tuple(attributes))
+    for value in code.co_consts:
+        if not isinstance(value, CodeType):
+            continue
+        for name, nested_paths in _code_global_attribute_paths(value).items():
+            paths.setdefault(name, set()).update(nested_paths)
+    return MappingProxyType({name: tuple(sorted(name_paths)) for name, name_paths in paths.items()})
+
+
+def _import_runtime_builtin_names() -> tuple[str, ...]:
+    if type(_IMPORT_RUNTIME_BUILTINS) is not dict:
+        return ()
+    names: set[str] = set()
+    for module_namespace in (_FROZEN_IMPORTLIB_NAMESPACE, _FROZEN_IMPORTLIB_EXTERNAL_NAMESPACE):
+        for value in module_namespace.values():
+            functions: tuple[FunctionType, ...] = ()
+            if isinstance(value, FunctionType):
+                functions = (value,)
+            elif type(value) is type:
+                functions = tuple(
+                    function
+                    for member in type.__getattribute__(value, "__dict__").values()
+                    for function in (member.__func__ if isinstance(member, classmethod | staticmethod) else member,)
+                    if isinstance(function, FunctionType)
+                )
+            for function in functions:
+                names.update(
+                    name
+                    for name in _code_referenced_names(function.__code__)
+                    if name not in module_namespace and name in _IMPORT_RUNTIME_BUILTINS
+                )
+    return tuple(sorted(names))
+
+
+_IMPORT_RUNTIME_BUILTIN_NAMES = _import_runtime_builtin_names()
+_IMPORT_RUNTIME_BUILTINS_SNAPSHOT = (
+    MappingProxyType(
+        {name: _runtime_value_snapshot(_IMPORT_RUNTIME_BUILTINS[name]) for name in _IMPORT_RUNTIME_BUILTIN_NAMES}
+    )
+    if type(_IMPORT_RUNTIME_BUILTINS) is dict
+    else MappingProxyType({})
+)
+_FROZEN_IMPORTLIB_DEPENDENCY_MODULE_ATTRIBUTES = {
+    "_thread": ("RLock", "allocate_lock", "get_ident"),
+    "_warnings": ("warn",),
+    "_weakref": ("_remove_dead_weakref", "ref"),
+}
+_FROZEN_IMPORTLIB_DEPENDENCY_MODULES = tuple(
+    (name, value, attributes)
+    for name, attributes in _FROZEN_IMPORTLIB_DEPENDENCY_MODULE_ATTRIBUTES.items()
+    if type(value := _FROZEN_IMPORTLIB_NAMESPACE.get(name)) is ModuleType
+)
+_FROZEN_IMPORTLIB_EXTERNAL_DEPENDENCY_MODULE_ATTRIBUTES = {
+    "_io": ("BytesIO", "FileIO", "IncrementalNewlineDecoder", "open", "open_code"),
+    "_os": (
+        "O_CREAT",
+        "O_EXCL",
+        "O_WRONLY",
+        "fspath",
+        "getcwd",
+        "listdir",
+        "mkdir",
+        "open",
+        "replace",
+        "stat",
+        "unlink",
+    ),
+    "_warnings": ("warn",),
+    "marshal": ("dumps", "loads"),
+}
+
+
+def _import_runtime_dependency_module_name(dependency_name: str, module: ModuleType) -> str | None:
+    if sys.modules.get(dependency_name) is module:
+        return dependency_name
+    module_name = ModuleType.__getattribute__(module, "__name__")
+    if type(module_name) is str and sys.modules.get(module_name) is module:
+        return module_name
+    return None
+
+
+_FROZEN_IMPORTLIB_EXTERNAL_DEPENDENCY_MODULES = tuple(
+    (module_name, value, attributes)
+    for dependency_name, attributes in _FROZEN_IMPORTLIB_EXTERNAL_DEPENDENCY_MODULE_ATTRIBUTES.items()
+    if type(value := _FROZEN_IMPORTLIB_EXTERNAL_NAMESPACE.get(dependency_name)) is ModuleType
+    and type(module_name := _import_runtime_dependency_module_name(dependency_name, value)) is str
+)
+_IMPORT_RUNTIME_TYPES = tuple(
+    dict.fromkeys(
+        (
+            *(value for value in _FROZEN_IMPORTLIB_NAMESPACE.values() if type(value) is type),
+            *(value for value in _FROZEN_IMPORTLIB_EXTERNAL_NAMESPACE.values() if type(value) is type),
+            zipimporter,
+        )
+    )
+)
+_IMPORT_RUNTIME_MODULE_SNAPSHOTS = (
+    ("_imp", _imp, _module_namespace_snapshot(_imp)),
+    (
+        "_frozen_importlib",
+        _FROZEN_IMPORTLIB_MODULE,
+        _module_namespace_snapshot(_FROZEN_IMPORTLIB_MODULE)
+        if type(_FROZEN_IMPORTLIB_MODULE) is ModuleType
+        else MappingProxyType({}),
+    ),
+    (
+        "_frozen_importlib_external",
+        _FROZEN_IMPORTLIB_EXTERNAL_MODULE,
+        _module_namespace_snapshot(_FROZEN_IMPORTLIB_EXTERNAL_MODULE)
+        if type(_FROZEN_IMPORTLIB_EXTERNAL_MODULE) is ModuleType
+        else MappingProxyType({}),
+    ),
+    *(
+        (name, module, _module_attribute_snapshot(module, attributes))
+        for name, module, attributes in _FROZEN_IMPORTLIB_DEPENDENCY_MODULES
+    ),
+    *(
+        (name, module, _module_attribute_snapshot(module, attributes))
+        for name, module, attributes in _FROZEN_IMPORTLIB_EXTERNAL_DEPENDENCY_MODULES
+    ),
+)
+_IMPORT_RUNTIME_TYPE_SNAPSHOTS = tuple((class_, _type_namespace_snapshot(class_)) for class_ in _IMPORT_RUNTIME_TYPES)
+_IMPORT_RUNTIME_SYS_MODULES = sys.modules
+
+
+def _namespace_matches_snapshot(
+    namespace: Mapping[str, object],
+    expected: Mapping[str, _RuntimeValueSnapshot],
+) -> bool:
+    return all(
+        key in namespace
+        and namespace[key] is expected_value[0]
+        and _runtime_value_matches_snapshot(namespace[key], expected_value)
+        for key, expected_value in expected.items()
+    )
+
+
+def _type_namespace_matches_snapshot(
+    namespace: Mapping[str, object],
+    expected: Mapping[str, _RuntimeValueSnapshot],
+) -> bool:
+    return _namespace_matches_snapshot(namespace, expected) and all(
+        name in expected or not _runtime_type_member_is_executable(value) for name, value in namespace.items()
+    )
+
+
+def _interpreter_import_runtime_is_trusted() -> bool:
+    if type(sys.modules) is not dict or sys.modules is not _IMPORT_RUNTIME_SYS_MODULES:
+        return False
+    if type(_IMPORT_RUNTIME_BUILTINS) is not dict or not _namespace_matches_snapshot(
+        _IMPORT_RUNTIME_BUILTINS,
+        _IMPORT_RUNTIME_BUILTINS_SNAPSHOT,
+    ):
+        return False
+    for module_name, expected_module, expected_namespace in _IMPORT_RUNTIME_MODULE_SNAPSHOTS:
+        if type(expected_module) is not ModuleType or sys.modules.get(module_name) is not expected_module:
+            return False
+        namespace = ModuleType.__getattribute__(expected_module, "__dict__")
+        if type(namespace) is not dict or not _namespace_matches_snapshot(namespace, expected_namespace):
+            return False
+    for class_, expected_namespace in _IMPORT_RUNTIME_TYPE_SNAPSHOTS:
+        namespace = type.__getattribute__(class_, "__dict__")
+        if not _type_namespace_matches_snapshot(namespace, expected_namespace):
+            return False
+    return True
+
+
+def _interpreter_target_import_lock_state_is_safe(module_name: str) -> bool:
+    if type(_FROZEN_IMPORTLIB_MODULE) is not ModuleType:
+        return False
+    namespace = ModuleType.__getattribute__(_FROZEN_IMPORTLIB_MODULE, "__dict__")
+    if type(namespace) is not dict:
+        return False
+    module_locks = namespace.get("_module_locks")
+    if type(module_locks) is not dict:
+        return False
+    lock_names = tuple(dict.keys(module_locks))
+    return all(type(lock_name) is str for lock_name in lock_names) and all(
+        lock_name != module_name for lock_name in lock_names
+    )
+
+
+def _module_spec_fields_without_hooks(spec: ModuleSpec) -> tuple[object, object]:
+    return object.__getattribute__(spec, "origin"), object.__getattribute__(spec, "loader")
+
+
+def _loaded_module_state_without_hooks(module_name: str) -> tuple[bool, object | None, ModuleSpec | None]:
+    if module_name not in sys.modules:
+        return False, None, None
+    module = sys.modules.get(module_name)
+    if type(module) is not ModuleType:
+        return True, module, None
+    spec = ModuleType.__getattribute__(module, "__spec__")
+    if type(spec) is not ModuleSpec:
+        return True, module, None
+    return True, module, spec
+
+
+def _capture_trusted_loaded_interpreter_modules() -> Mapping[
+    str,
+    tuple[object, ModuleSpec, object, object, Mapping[str, object]],
+]:
+    trusted: dict[str, tuple[object, ModuleSpec, object, object, Mapping[str, object]]] = {}
+    for module_name in tuple(sys.modules):
+        try:
+            origin = _interpreter_module_origin_without_import_hooks(module_name)
+        except Exception:
+            continue
+        if origin is None:
+            continue
+        loaded, module, spec = _loaded_module_state_without_hooks(module_name)
+        if not loaded or module is None or spec is None:
+            continue
+        spec_origin, loader = _module_spec_fields_without_hooks(spec)
+        expected_loader = BuiltinImporter if origin == "built-in" else FrozenImporter
+        if type(spec_origin) is str and spec_origin == origin and loader is expected_loader:
+            module_namespace = ModuleType.__getattribute__(module, "__dict__")
+            if type(module_namespace) is not dict:
+                continue
+            trusted_names = {
+                name
+                for trusted_module, name in _TRUSTED_IMPORT_ONLY_REFERENCES
+                if trusted_module == module_name and "." not in name and name in module_namespace
+            }
+            trusted[module_name] = (
+                module,
+                spec,
+                spec_origin,
+                loader,
+                MappingProxyType({name: module_namespace[name] for name in trusted_names}),
+            )
+    return MappingProxyType(trusted)
+
+
+def _interpreter_module_origin_without_import_hooks(module_name: str) -> str | None:
+    if module_name in _BUILTIN_MODULE_NAMES:
+        return "built-in"
+    try:
+        if _IS_FROZEN_MODULE(module_name):
+            return "frozen"
+    except Exception:
+        return None
+    return None
+
+
+_LoadedInterpreterModuleState = tuple[
+    bool,
+    object | None,
+    object | None,
+    object | None,
+    object | None,
+]
+_LoadedInterpreterReferenceState = tuple[bool, object | None]
+_FunctionReferencedGlobalsSnapshot = tuple[
+    FunctionType,
+    object,
+    tuple[
+        tuple[
+            str,
+            _RuntimeValueSnapshot,
+            tuple[
+                tuple[
+                    tuple[str, ...],
+                    _RuntimeValueSnapshot,
+                    tuple[_RuntimeValueSnapshot, ...],
+                ],
+                ...,
+            ],
+            bool,
+        ],
+        ...,
+    ],
+    object,
+    tuple[tuple[str, _RuntimeValueSnapshot], ...],
+]
+_TrustedExecutableValueSnapshot = tuple[
+    _RuntimeValueSnapshot,
+    tuple[_FunctionReferencedGlobalsSnapshot, ...],
+    bool,
+]
+_TrustedReferenceExecutableSnapshot = tuple[
+    _TrustedExecutableValueSnapshot,
+    tuple[tuple[type[object], Mapping[str, _TrustedExecutableValueSnapshot]], ...],
+]
+_TrustedLoadedReferenceBaseline = tuple[
+    _LoadedInterpreterModuleState,
+    _LoadedInterpreterReferenceState,
+    _TrustedReferenceExecutableSnapshot,
+]
+
+
+def _loaded_reference_state_without_hooks(
+    module: object,
+    name: str,
+) -> _LoadedInterpreterReferenceState:
+    if type(module) is not ModuleType:
+        return False, None
+    value: object = module
+    for component in name.split("."):
+        if type(value) is ModuleType:
+            namespace = ModuleType.__getattribute__(value, "__dict__")
+            if type(namespace) is not dict or component not in namespace:
+                return False, None
+            value = namespace[component]
+            continue
+        if type(value) is type:
+            for base in type.__getattribute__(value, "__mro__"):
+                namespace = type.__getattribute__(base, "__dict__")
+                if component in namespace:
+                    value = namespace[component]
+                    break
+            else:
+                return False, None
+            continue
+        return False, None
+    return True, value
+
+
+def _trusted_reference_executable_snapshot(value: object) -> _TrustedReferenceExecutableSnapshot:
+    type_snapshots: tuple[tuple[type[object], Mapping[str, _TrustedExecutableValueSnapshot]], ...] = ()
+    if type(value) is type:
+        type_snapshots = tuple(
+            (
+                base,
+                MappingProxyType(
+                    {
+                        name: _trusted_class_member_snapshot(name, member)
+                        for name, member in type.__getattribute__(base, "__dict__").items()
+                    }
+                ),
+            )
+            for base in type.__getattribute__(value, "__mro__")
+        )
+    return _trusted_executable_value_snapshot(value), type_snapshots
+
+
+def _trusted_class_member_snapshot(name: str, member: object) -> _TrustedExecutableValueSnapshot:
+    if name in {"__new__", "__init__", "__getattribute__", "__getattr__", "__setattr__", "__setstate__"}:
+        return _trusted_executable_value_snapshot(member)
+    for base in type.__getattribute__(type(member), "__mro__"):
+        namespace = type.__getattribute__(base, "__dict__")
+        if "__set__" in namespace or "__delete__" in namespace:
+            return _trusted_executable_value_snapshot(member)
+    return _runtime_value_snapshot(member), (), True
+
+
+def _executable_value_functions(value: object) -> tuple[FunctionType, ...]:
+    if isinstance(value, classmethod | staticmethod):
+        value = value.__func__
+    if isinstance(value, FunctionType):
+        return (value,)
+    if isinstance(value, property):
+        return tuple(
+            function for function in (value.fget, value.fset, value.fdel) if isinstance(function, FunctionType)
+        )
+    if type(value) is type:
+        functions: list[FunctionType] = []
+        for name in ("__new__", "__init__"):
+            for base in type.__getattribute__(value, "__mro__"):
+                namespace = type.__getattribute__(base, "__dict__")
+                if name in namespace:
+                    functions.extend(_executable_value_functions(namespace[name]))
+                    break
+        return tuple(functions)
+    return ()
+
+
+def _type_member_without_hooks(class_: type[object], name: str) -> tuple[bool, object | None]:
+    for base in type.__getattribute__(class_, "__mro__"):
+        namespace = type.__getattribute__(base, "__dict__")
+        if name in namespace:
+            return True, namespace[name]
+    return False, None
+
+
+def _runtime_attribute_path_without_hooks(
+    value: object,
+    path: tuple[str, ...],
+) -> tuple[bool, object | None, tuple[object, ...]]:
+    current = value
+    dispatch_dependencies: list[object] = []
+    for component in path:
+        if type(current) is ModuleType:
+            namespace = ModuleType.__getattribute__(current, "__dict__")
+            if type(namespace) is not dict:
+                return False, None, ()
+            if component == "__dict__":
+                current = namespace
+                continue
+            if component not in namespace:
+                return False, None, ()
+            current = namespace[component]
+            continue
+        if type(current) is type:
+            if component == "__dict__":
+                current = type.__getattribute__(current, "__dict__")
+                continue
+            found, member = _type_member_without_hooks(current, component)
+            if not found:
+                return False, None, ()
+            current = member
+            continue
+        class_ = type(current)
+        dispatch_found, dispatch = _type_member_without_hooks(class_, "__getattribute__")
+        if not dispatch_found:
+            return False, None, ()
+        dispatch_dependencies.append(dispatch)
+        class_member_found, class_member = _type_member_without_hooks(class_, component)
+        if class_member_found and _value_is_data_descriptor(class_member):
+            descriptor_found, descriptor_get = _type_member_without_hooks(type(class_member), "__get__")
+            if descriptor_found:
+                dispatch_dependencies.append(descriptor_get)
+            current = class_member
+            continue
+
+        instance_dict_descriptor: object | None = None
+        for base in type.__getattribute__(class_, "__mro__"):
+            namespace = type.__getattribute__(base, "__dict__")
+            if "__dict__" in namespace:
+                instance_dict_descriptor = namespace["__dict__"]
+                break
+        if type(instance_dict_descriptor) is GetSetDescriptorType:
+            try:
+                instance_namespace = object.__getattribute__(current, "__dict__")
+            except AttributeError:
+                instance_namespace = None
+            if type(instance_namespace) is not dict:
+                return False, None, ()
+            if component in instance_namespace:
+                current = instance_namespace[component]
+                continue
+        elif instance_dict_descriptor is not None:
+            return False, None, ()
+        if not class_member_found:
+            return False, None, ()
+        descriptor_found, descriptor_get = _type_member_without_hooks(type(class_member), "__get__")
+        if descriptor_found:
+            dispatch_dependencies.append(descriptor_get)
+        current = class_member
+        continue
+    return True, current, tuple(dispatch_dependencies)
+
+
+def _value_is_data_descriptor(value: object) -> bool:
+    for base in type.__getattribute__(type(value), "__mro__"):
+        namespace = type.__getattribute__(base, "__dict__")
+        if "__set__" in namespace or "__delete__" in namespace:
+            return True
+    return False
+
+
+def _trusted_executable_value_snapshot(value: object) -> _TrustedExecutableValueSnapshot:
+    referenced_globals: list[_FunctionReferencedGlobalsSnapshot] = []
+    functions = deque(_executable_value_functions(value))
+    seen_functions: set[FunctionType] = set()
+    globals_seen = 0
+    while functions:
+        function = functions.popleft()
+        if function in seen_functions:
+            continue
+        if len(seen_functions) >= _MAX_TRUSTED_REFERENCE_FUNCTIONS:
+            return _runtime_value_snapshot(value), tuple(referenced_globals), False
+        seen_functions.add(function)
+        globals_namespace = function.__globals__
+        builtins_namespace = object.__getattribute__(function, "__builtins__")
+        if type(globals_namespace) is not dict or type(builtins_namespace) is not dict:
+            return _runtime_value_snapshot(value), tuple(referenced_globals), False
+        referenced_names = _code_referenced_names(function.__code__)
+        attribute_paths = _code_global_attribute_paths(function.__code__)
+        global_names = tuple(name for name in sorted(referenced_names) if name in globals_namespace)
+        builtin_names = tuple(
+            name for name in sorted(referenced_names) if name not in globals_namespace and name in builtins_namespace
+        )
+        globals_seen += len(global_names) + len(builtin_names)
+        if globals_seen > _MAX_TRUSTED_REFERENCE_GLOBALS:
+            return _runtime_value_snapshot(value), tuple(referenced_globals), False
+        global_snapshots: list[
+            tuple[
+                str,
+                _RuntimeValueSnapshot,
+                tuple[
+                    tuple[
+                        tuple[str, ...],
+                        _RuntimeValueSnapshot,
+                        tuple[_RuntimeValueSnapshot, ...],
+                    ],
+                    ...,
+                ],
+                bool,
+            ]
+        ] = []
+        for name in global_names:
+            global_value = globals_namespace[name]
+            dependency_snapshots: list[
+                tuple[
+                    tuple[str, ...],
+                    _RuntimeValueSnapshot,
+                    tuple[_RuntimeValueSnapshot, ...],
+                ]
+            ] = []
+            for path in attribute_paths.get(name, ()):
+                resolved, dependency, dispatch_dependencies = _runtime_attribute_path_without_hooks(global_value, path)
+                if not resolved:
+                    return _runtime_value_snapshot(value), tuple(referenced_globals), False
+                dependency_snapshots.append(
+                    (
+                        path,
+                        _runtime_value_snapshot(dependency),
+                        tuple(_runtime_value_snapshot(dispatch) for dispatch in dispatch_dependencies),
+                    )
+                )
+                functions.extend(_executable_value_functions(dependency))
+                for dispatch in dispatch_dependencies:
+                    functions.extend(_executable_value_functions(dispatch))
+            global_snapshots.append(
+                (
+                    name,
+                    _runtime_value_snapshot(global_value),
+                    tuple(dependency_snapshots),
+                    _trusted_mutable_global_state_is_safe(function, name, global_value),
+                )
+            )
+        referenced_globals.append(
+            (
+                function,
+                globals_namespace,
+                tuple(global_snapshots),
+                builtins_namespace,
+                tuple((name, _runtime_value_snapshot(builtins_namespace[name])) for name in builtin_names),
+            )
+        )
+        for name in global_names:
+            functions.extend(_executable_value_functions(globals_namespace[name]))
+        for name in builtin_names:
+            functions.extend(_executable_value_functions(builtins_namespace[name]))
+    return _runtime_value_snapshot(value), tuple(referenced_globals), True
+
+
+def _trusted_mutable_global_state_is_safe(function: FunctionType, name: str, value: object) -> bool:
+    return (
+        function.__module__ == "tempfile"
+        and function.__name__ == "_gettempdir"
+        and name == "tempdir"
+        and (value is None or type(value) is str)
+    )
+
+
+def _trusted_executable_value_matches_snapshot(
+    value: object,
+    expected: _TrustedExecutableValueSnapshot,
+) -> bool:
+    if not _runtime_value_matches_snapshot(value, expected[0]):
+        return False
+    if not expected[2]:
+        return False
+    if not expected[1]:
+        return True
+    current = _trusted_executable_value_snapshot(value)
+    if not current[2]:
+        return False
+    if len(current[1]) != len(expected[1]):
+        return False
+    for current_globals, expected_globals in zip(current[1], expected[1], strict=True):
+        if (
+            current_globals[0] is not expected_globals[0]
+            or current_globals[1] is not expected_globals[1]
+            or current_globals[3] is not expected_globals[3]
+        ):
+            return False
+        if len(current_globals[2]) != len(expected_globals[2]) or len(current_globals[4]) != len(expected_globals[4]):
+            return False
+        for current_global, expected_global in zip(current_globals[2], expected_globals[2], strict=True):
+            if current_global[0] != expected_global[0] or current_global[3] is not expected_global[3]:
+                return False
+            if not expected_global[3] and not _runtime_value_matches_snapshot(
+                current_global[1][0],
+                expected_global[1],
+            ):
+                return False
+            if len(current_global[2]) != len(expected_global[2]):
+                return False
+            for current_dependency, expected_dependency in zip(
+                current_global[2],
+                expected_global[2],
+                strict=True,
+            ):
+                if current_dependency[0] != expected_dependency[0] or not _runtime_value_matches_snapshot(
+                    current_dependency[1][0],
+                    expected_dependency[1],
+                ):
+                    return False
+                if len(current_dependency[2]) != len(expected_dependency[2]) or any(
+                    not _runtime_value_matches_snapshot(current_dispatch[0], expected_dispatch)
+                    for current_dispatch, expected_dispatch in zip(
+                        current_dependency[2],
+                        expected_dependency[2],
+                        strict=True,
+                    )
+                ):
+                    return False
+        if any(
+            current_name != expected_name or not _runtime_value_matches_snapshot(current_value[0], expected_value)
+            for (current_name, current_value), (expected_name, expected_value) in zip(
+                current_globals[4],
+                expected_globals[4],
+                strict=True,
+            )
+        ):
+            return False
+    return True
+
+
+def _trusted_reference_executable_matches_snapshot(
+    value: object,
+    expected: _TrustedReferenceExecutableSnapshot,
+) -> bool:
+    if not _trusted_executable_value_matches_snapshot(value, expected[0]):
+        return False
+    if type(value) is not type:
+        return not expected[1]
+    mro = type.__getattribute__(value, "__mro__")
+    if len(mro) != len(expected[1]):
+        return False
+    for base, (expected_base, expected_namespace) in zip(mro, expected[1], strict=True):
+        if base is not expected_base:
+            return False
+        raw_namespace = type.__getattribute__(base, "__dict__")
+        if raw_namespace.keys() != expected_namespace.keys() or any(
+            not _trusted_executable_value_matches_snapshot(raw_namespace[name], expected_value)
+            for name, expected_value in expected_namespace.items()
+        ):
+            return False
+    return True
+
+
+def _loaded_module_metadata_matches_spec_without_hooks(
+    module_name: str,
+    module: object,
+    spec: object,
+    origin: object,
+    loader: object,
+) -> bool:
+    if type(module) is not ModuleType or type(spec) is not ModuleSpec or type(origin) is not str or loader is None:
+        return False
+    namespace = ModuleType.__getattribute__(module, "__dict__")
+    if type(namespace) is not dict:
+        return False
+    locations = object.__getattribute__(spec, "submodule_search_locations")
+    expected_package = module_name if locations is not None else module_name.rpartition(".")[0]
+    loaded_name = namespace.get("__name__")
+    loaded_package = namespace.get("__package__")
+    loaded_file = namespace.get("__file__")
+    return (
+        type(loaded_name) is str
+        and loaded_name == module_name
+        and type(loaded_package) is str
+        and loaded_package == expected_package
+        and namespace.get("__spec__") is spec
+        and namespace.get("__loader__") is loader
+        and type(loaded_file) is str
+        and loaded_file == origin
+    )
+
+
+def _capture_trusted_loaded_references() -> Mapping[tuple[str, str], _TrustedLoadedReferenceBaseline]:
+    trusted: dict[tuple[str, str], _TrustedLoadedReferenceBaseline] = {}
+    for module_name, name in _TRUSTED_IMPORT_ONLY_REFERENCES:
+        if _interpreter_module_origin_without_import_hooks(module_name) is not None:
+            continue
+        loaded, module, spec = _loaded_module_state_without_hooks(module_name)
+        if not loaded or type(module) is not ModuleType or type(spec) is not ModuleSpec:
+            continue
+        origin, loader = _module_spec_fields_without_hooks(spec)
+        reference_state = _loaded_reference_state_without_hooks(module, name)
+        if (
+            _loaded_module_metadata_matches_spec_without_hooks(module_name, module, spec, origin, loader)
+            and reference_state[0]
+        ):
+            trusted[(module_name, name)] = (
+                (True, module, spec, origin, loader),
+                reference_state,
+                _trusted_reference_executable_snapshot(reference_state[1]),
+            )
+    return MappingProxyType(trusted)
+
+
 # Only modules whose import cannot resolve additional shadowable Python modules
 # are safe here. pathlib and subprocess transitively import modules such as
 # fnmatch and selectors, so a sibling shadow can still execute during unpickling.
@@ -339,6 +1175,10 @@ _TRUSTED_UNRESOLVED_IMPORT_ONLY_REFERENCES = (
     )
     | _TRUSTED_FRAMEWORK_RECONSTRUCTION_REFERENCES
 )
+# Canonical-looking specs in sys.modules are forgeable. Identity trust is
+# limited to interpreter modules already loaded when this module initializes.
+_TRUSTED_LOADED_INTERPRETER_MODULES = _capture_trusted_loaded_interpreter_modules()
+_TRUSTED_LOADED_REFERENCE_BASELINES = dict(_capture_trusted_loaded_references())
 _PICKLE_CONSTRUCTOR_ENTRYPOINT_METHODS = ("__new__", "__init__")
 _PICKLE_LIFECYCLE_ENTRYPOINT_METHODS = ("__setstate__",)
 _PICKLE_BUILD_ENTRYPOINT_METHODS = (
@@ -405,6 +1245,8 @@ class _SharedSourceSnapshot:
     module_sources: dict[str, str] = field(default_factory=dict)
     loaded_module_sources: dict[str, str] = field(default_factory=dict)
     loaded_package_paths: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    loaded_interpreter_modules: dict[str, _LoadedInterpreterModuleState] = field(default_factory=dict)
+    loaded_interpreter_references: dict[tuple[str, str], _LoadedInterpreterReferenceState] = field(default_factory=dict)
     read_fingerprints: dict[str, tuple[int, bool, bytes | None]] = field(default_factory=dict)
     generation: int = 0
     stable: bool = True
@@ -1021,16 +1863,33 @@ def import_only_reference_is_proven_trusted(module_name: str, name: str) -> bool
         return True
     origin_kind = _trusted_module_origin_kind(module_name)
     reference = (module_name, name)
-    return reference in _TRUSTED_IMPORT_ONLY_REFERENCES and (
+    if (
+        origin_kind == "stdlib"
+        and _interpreter_module_origin_without_import_hooks(module_name) is not None
+        and not _interpreter_reference_is_trusted(module_name, name)
+    ):
+        return False
+    trusted = reference in _TRUSTED_IMPORT_ONLY_REFERENCES and (
         origin_kind in {"stdlib", "site_packages"}
         or (origin_kind == "unresolved" and reference in _TRUSTED_UNRESOLVED_IMPORT_ONLY_REFERENCES)
     )
+    if not trusted:
+        return False
+    if (
+        origin_kind in {"stdlib", "site_packages"}
+        and _interpreter_module_origin_without_import_hooks(module_name) is None
+    ):
+        return _loaded_trusted_reference_matches_baseline(module_name, name)
+    return True
 
 
 def import_only_module_requires_origin_review(module_name: str, name: str) -> bool:
     """Return whether a module resolves outside trusted install paths."""
     if module_name == "__builtin__" or _legacy_pickle_compat_reference_is_trusted(module_name, name):
         return False
+    interpreter_trusted = _interpreter_module_resolution_is_trusted(module_name)
+    if interpreter_trusted is not None:
+        return not interpreter_trusted
     origin_kind = _trusted_module_origin_kind(module_name)
     return origin_kind not in {"stdlib", "site_packages"} and not (
         origin_kind == "unresolved" and (module_name, name) in _TRUSTED_UNRESOLVED_IMPORT_ONLY_REFERENCES
@@ -1049,43 +1908,193 @@ def _unresolved_trusted_import_reference_is_safe(module_name: str, name: str) ->
     ) == "unresolved"
 
 
-@_register_source_sensitive_cache
+def _current_loaded_interpreter_module_state(module_name: str) -> _LoadedInterpreterModuleState:
+    loaded, module, spec = _loaded_module_state_without_hooks(module_name)
+    if spec is None:
+        return loaded, module, None, None, None
+    origin, loader = _module_spec_fields_without_hooks(spec)
+    return loaded, module, spec, origin, loader
+
+
+def _track_loaded_interpreter_module_state(
+    module_name: str,
+    state: _LoadedInterpreterModuleState,
+) -> None:
+    snapshot = _SHARED_SOURCE_SENSITIVE_SNAPSHOT.get()
+    if snapshot is None:
+        return
+    with snapshot.lock:
+        existing = snapshot.loaded_interpreter_modules.get(module_name)
+        if existing is not None and not _loaded_interpreter_states_match(existing, state):
+            snapshot.stable = False
+        snapshot.loaded_interpreter_modules[module_name] = state
+        snapshot.reusable = False
+
+
+def _loaded_interpreter_states_match(
+    left: _LoadedInterpreterModuleState,
+    right: _LoadedInterpreterModuleState,
+) -> bool:
+    origins_match = left[3] is right[3] or (type(left[3]) is str and type(right[3]) is str and left[3] == right[3])
+    return left[0] is right[0] and left[1] is right[1] and left[2] is right[2] and origins_match and left[4] is right[4]
+
+
+def _loaded_interpreter_module_state_matches(
+    module_name: str,
+    expected: _LoadedInterpreterModuleState,
+) -> bool:
+    return _loaded_interpreter_states_match(_current_loaded_interpreter_module_state(module_name), expected)
+
+
+def _loaded_interpreter_module_matches_startup(module_name: str) -> bool:
+    state = _current_loaded_interpreter_module_state(module_name)
+    _track_loaded_interpreter_module_state(module_name, state)
+    trusted = _TRUSTED_LOADED_INTERPRETER_MODULES.get(module_name)
+    if trusted is None:
+        return False
+    return (
+        state[0]
+        and state[1] is trusted[0]
+        and state[2] is trusted[1]
+        and type(state[3]) is str
+        and state[3] == trusted[2]
+        and state[4] is trusted[3]
+    )
+
+
+def _current_loaded_interpreter_reference_state(
+    module_name: str,
+    name: str,
+) -> _LoadedInterpreterReferenceState:
+    loaded, module, _ = _loaded_module_state_without_hooks(module_name)
+    if not loaded:
+        return False, None
+    return _loaded_reference_state_without_hooks(module, name)
+
+
+def _track_loaded_interpreter_reference_state(
+    module_name: str,
+    name: str,
+    state: _LoadedInterpreterReferenceState,
+) -> None:
+    snapshot = _SHARED_SOURCE_SENSITIVE_SNAPSHOT.get()
+    if snapshot is None:
+        return
+    reference = (module_name, name)
+    with snapshot.lock:
+        existing = snapshot.loaded_interpreter_references.get(reference)
+        if existing is not None and not _loaded_interpreter_reference_states_match(existing, state):
+            snapshot.stable = False
+        snapshot.loaded_interpreter_references[reference] = state
+        snapshot.reusable = False
+
+
+def _loaded_interpreter_reference_states_match(
+    left: _LoadedInterpreterReferenceState,
+    right: _LoadedInterpreterReferenceState,
+) -> bool:
+    return left[0] is right[0] and left[1] is right[1]
+
+
+def _loaded_interpreter_reference_state_matches(
+    reference: tuple[str, str],
+    expected: _LoadedInterpreterReferenceState,
+) -> bool:
+    current = _current_loaded_interpreter_reference_state(*reference)
+    return _loaded_interpreter_reference_states_match(current, expected)
+
+
+def _interpreter_reference_is_trusted(module_name: str, name: str) -> bool:
+    loaded, _, _ = _loaded_module_state_without_hooks(module_name)
+    if not loaded:
+        return _interpreter_module_resolution_is_trusted(module_name) is True
+    if not _loaded_interpreter_module_matches_startup(module_name):
+        return False
+    trusted = _TRUSTED_LOADED_INTERPRETER_MODULES[module_name][4]
+    state = _current_loaded_interpreter_reference_state(module_name, name)
+    _track_loaded_interpreter_reference_state(module_name, name, state)
+    return state[0] and name in trusted and state[1] is trusted[name]
+
+
+def _loaded_trusted_reference_matches_baseline(module_name: str, name: str) -> bool:
+    module_state = _current_loaded_interpreter_module_state(module_name)
+    reference_state = _current_loaded_interpreter_reference_state(module_name, name)
+    _track_loaded_interpreter_module_state(module_name, module_state)
+    _track_loaded_interpreter_reference_state(module_name, name, reference_state)
+    if not module_state[0] or module_state[1] is None or module_state[2] is None or not reference_state[0]:
+        return not module_state[0]
+    if not _loaded_module_metadata_matches_spec_without_hooks(module_name, *module_state[1:]):
+        return False
+
+    expected = _TRUSTED_LOADED_REFERENCE_BASELINES.get((module_name, name))
+    if expected is None:
+        return False
+    return (
+        _loaded_interpreter_states_match(module_state, expected[0])
+        and _loaded_interpreter_reference_states_match(reference_state, expected[1])
+        and _trusted_reference_executable_matches_snapshot(reference_state[1], expected[2])
+    )
+
+
+def _interpreter_module_resolution_is_trusted(module_name: str) -> bool | None:
+    origin = _interpreter_module_origin_without_import_hooks(module_name)
+    if origin is None:
+        return None
+    loaded, _, _ = _loaded_module_state_without_hooks(module_name)
+    if loaded:
+        return _loaded_interpreter_module_matches_startup(module_name)
+    state = _current_loaded_interpreter_module_state(module_name)
+    _track_loaded_interpreter_module_state(module_name, state)
+    importer = BuiltinImporter if origin == "built-in" else FrozenImporter
+    return (
+        _interpreter_import_runtime_is_trusted()
+        and _interpreter_target_import_lock_state_is_safe(module_name)
+        and not _untrusted_meta_path_finder_precedes(
+            importer,
+            module_name,
+        )
+    )
+
+
 @lru_cache(maxsize=4096)
-def _trusted_module_origin_kind(module_name: str) -> str | None:
+def _cached_trusted_module_origin_kind(module_name: str) -> str | None:
     parts = _bounded_module_name_parts(module_name)
     if parts is None:
         return None
     _track_shared_source_candidates(parts)
+    interpreter_trusted = _interpreter_module_resolution_is_trusted(module_name)
+    if interpreter_trusted is not None:
+        return "stdlib" if interpreter_trusted else None
     try:
-        standard_spec = BuiltinImporter.find_spec(module_name)
-        if standard_spec is None:
-            standard_spec = FrozenImporter.find_spec(module_name)
-        if standard_spec is None:
-            standard_spec = _find_standard_filesystem_spec(module_name)
+        standard_spec = _find_standard_filesystem_spec(module_name)
     except Exception:
         return None
-    loaded_module = sys.modules.get(module_name)
-    loaded_spec = getattr(loaded_module, "__spec__", None)
+    loaded, _, loaded_spec = _loaded_module_state_without_hooks(module_name)
     spec: ModuleSpec | None
-    if isinstance(loaded_spec, ModuleSpec) and (standard_spec is None or loaded_spec.origin == standard_spec.origin):
+    if loaded:
+        if loaded_spec is None or _module_spec_claims_builtin_or_frozen_identity(loaded_spec):
+            return None
+        loaded_origin, _ = _module_spec_fields_without_hooks(loaded_spec)
+        if type(loaded_origin) is not str:
+            return None
+        if standard_spec is not None:
+            standard_origin, _ = _module_spec_fields_without_hooks(standard_spec)
+            if type(standard_origin) is not str or loaded_origin != standard_origin:
+                return None
         spec = loaded_spec
     else:
-        if not isinstance(loaded_spec, ModuleSpec) and (
-            _untrusted_meta_path_finder_precedes(BuiltinImporter, module_name)
-            or _untrusted_meta_path_finder_precedes(FrozenImporter, module_name)
-            or _untrusted_meta_path_finder_precedes(PathFinder, module_name)
-            or _has_untrusted_path_hook()
-        ):
+        if _untrusted_meta_path_finder_precedes(PathFinder, module_name) or _has_untrusted_path_hook():
             return None
         spec = standard_spec
     if spec is None:
         return "unresolved"
-    if _module_spec_uses_builtin_or_frozen_loader(spec):
-        return "stdlib"
-    if spec.origin is None:
+    if type(spec) is not ModuleSpec:
+        return None
+    spec_origin, _ = _module_spec_fields_without_hooks(spec)
+    if type(spec_origin) is not str:
         return None
     try:
-        origin = Path(spec.origin).resolve()
+        origin = Path(spec_origin).resolve()
     except (OSError, RuntimeError, ValueError):
         return None
     if _path_is_in_trusted_package_environment(origin):
@@ -1097,6 +2106,23 @@ def _trusted_module_origin_kind(module_name: str) -> str | None:
     if any(origin.is_relative_to(path) for path in _TRUSTED_STDLIB_PATHS):
         return "stdlib"
     return None
+
+
+class _TrustedModuleOriginKindResolver:
+    def __call__(self, module_name: str) -> str | None:
+        if _interpreter_module_origin_without_import_hooks(module_name) is not None:
+            loaded, _, _ = _loaded_module_state_without_hooks(module_name)
+            if loaded:
+                return _cached_trusted_module_origin_kind(module_name)
+        if not _interpreter_import_runtime_is_trusted():
+            return None
+        return _cached_trusted_module_origin_kind(module_name)
+
+    def cache_clear(self) -> None:
+        _cached_trusted_module_origin_kind.cache_clear()
+
+
+_trusted_module_origin_kind = _register_source_sensitive_cache(_TrustedModuleOriginKindResolver())
 
 
 def _mark_shared_source_snapshot_unreusable() -> None:
@@ -2042,6 +3068,8 @@ def _reset_shared_source_snapshot(snapshot: _SharedSourceSnapshot) -> None:
     snapshot.module_sources.clear()
     snapshot.loaded_module_sources.clear()
     snapshot.loaded_package_paths.clear()
+    snapshot.loaded_interpreter_modules.clear()
+    snapshot.loaded_interpreter_references.clear()
     snapshot.generation += 1
     snapshot.stable = True
     snapshot.reusable = _resolution_context_is_reusable(snapshot.resolution_context)
@@ -2077,6 +3105,14 @@ def _shared_source_snapshot_is_current(snapshot: _SharedSourceSnapshot) -> bool:
         if not is_loaded or current_search_path is None or tuple(current_search_path) != expected_search_path:
             return False
         if _search_path_has_untrusted_importer(current_search_path):
+            return False
+    for module_name, expected_module_state in snapshot.loaded_interpreter_modules.items():
+        if not _loaded_interpreter_module_state_matches(module_name, expected_module_state):
+            return False
+    if snapshot.loaded_interpreter_modules and not _interpreter_import_runtime_is_trusted():
+        return False
+    for reference, expected_reference_state in snapshot.loaded_interpreter_references.items():
+        if not _loaded_interpreter_reference_state_matches(reference, expected_reference_state):
             return False
     return True
 
@@ -2375,6 +3411,10 @@ def _track_shared_source_path(module_name: str, path: Path, *, loaded: bool) -> 
 
 
 def _call_graph_source_unavailable_reason(module_name: str) -> str | None:
+    interpreter_trusted = _interpreter_module_resolution_is_trusted(module_name)
+    if interpreter_trusted is not None:
+        return None if interpreter_trusted else "source_unavailable"
+
     source_path = _resolve_module_source(module_name)
     if source_path is not None:
         try:
@@ -2407,9 +3447,14 @@ def _call_graph_source_unavailable_reason(module_name: str) -> str | None:
     if spec is None:
         # Module names come from pickle metadata; do not consult executable custom meta-path finders.
         return "source_unavailable"
-    if spec.origin in {"built-in", "frozen"}:
+    if type(spec) is not ModuleSpec:
+        return "source_unavailable"
+    spec_origin, _ = _module_spec_fields_without_hooks(spec)
+    if type(spec_origin) is not str:
+        return "source_unavailable"
+    if spec_origin in {"built-in", "frozen"}:
         return None
-    if spec.origin is not None and any(spec.origin.endswith(suffix) for suffix in EXTENSION_SUFFIXES):
+    if any(spec_origin.endswith(suffix) for suffix in EXTENSION_SUFFIXES):
         return None
     return "source_unavailable"
 
@@ -2419,20 +3464,17 @@ def _find_module_spec_without_imports(module_name: str) -> ModuleSpec | None:
     if parts is None:
         return None
 
-    loaded_module = sys.modules.get(module_name)
-    loaded_spec = getattr(loaded_module, "__spec__", None)
-    if isinstance(loaded_spec, ModuleSpec):
+    interpreter_origin = _interpreter_module_origin_without_import_hooks(module_name)
+    loaded, _, loaded_spec = _loaded_module_state_without_hooks(module_name)
+    if loaded:
+        if loaded_spec is None or interpreter_origin is not None:
+            return None
+        if _module_spec_claims_builtin_or_frozen_identity(loaded_spec):
+            return None
         return loaded_spec
 
-    if not _untrusted_meta_path_finder_precedes(BuiltinImporter, module_name):
-        builtin_spec = BuiltinImporter.find_spec(module_name)
-        if builtin_spec is not None:
-            return builtin_spec
-
-    if not _untrusted_meta_path_finder_precedes(FrozenImporter, module_name):
-        frozen_spec = FrozenImporter.find_spec(module_name)
-        if frozen_spec is not None:
-            return frozen_spec
+    if interpreter_origin is not None:
+        return None
 
     if _untrusted_meta_path_finder_precedes(PathFinder, module_name) or _has_untrusted_path_hook():
         return None
@@ -2474,12 +3516,18 @@ def _loaded_package_search_path(module_name: str) -> tuple[bool, list[str] | Non
     if module_name not in sys.modules:
         return False, None
     loaded_module: Any = sys.modules[module_name]
-    if not isinstance(loaded_module, ModuleType):
+    if type(loaded_module) is not ModuleType:
         return True, None
-    raw_search_path = vars(loaded_module).get("__path__")
-    if not isinstance(raw_search_path, (list, tuple)) or not all(isinstance(entry, str) for entry in raw_search_path):
+    namespace = ModuleType.__getattribute__(loaded_module, "__dict__")
+    if type(namespace) is not dict:
         return True, None
-    return True, [str(Path(entry or os.getcwd()).absolute()) for entry in raw_search_path]
+    raw_search_path = namespace.get("__path__")
+    if type(raw_search_path) not in {list, tuple}:
+        return True, None
+    search_path = cast(list[object] | tuple[object, ...], raw_search_path)
+    if any(type(entry) is not str for entry in search_path):
+        return True, None
+    return True, [str(Path(cast(str, entry) or os.getcwd()).absolute()) for entry in search_path]
 
 
 def _source_cache_path(source_path: Path) -> Path | None:
@@ -2558,8 +3606,35 @@ def _loaded_module_source_path(module_name: str) -> str | None:
 
 def _matches_loaded_finder_type(finder: object, module_name: str, type_name: str) -> bool:
     module = sys.modules.get(module_name)
-    finder_type = getattr(module, type_name, None) if module is not None else None
+    if type(module) is not ModuleType:
+        return False
+    namespace = ModuleType.__getattribute__(module, "__dict__")
+    if type(namespace) is not dict:
+        return False
+    finder_type = namespace.get(type_name)
     return isinstance(finder_type, type) and type(finder) is finder_type
+
+
+def _star_glob_matches(value: str, pattern: str) -> bool | None:
+    if "?" in pattern or "[" in pattern or "]" in pattern:
+        return None
+    if "*" not in pattern:
+        return value == pattern
+    parts = pattern.split("*")
+    position = 0
+    if parts[0]:
+        if not value.startswith(parts[0]):
+            return False
+        position = len(parts[0])
+    for part in parts[1:-1]:
+        if not part:
+            continue
+        next_position = value.find(part, position)
+        if next_position < 0:
+            return False
+        position = next_position + len(part)
+    suffix = parts[-1]
+    return not suffix or (value.endswith(suffix) and position <= len(value) - len(suffix))
 
 
 def _known_meta_path_finder_cannot_handle(finder: object, module_name: str) -> bool:
@@ -2569,18 +3644,41 @@ def _known_meta_path_finder_cannot_handle(finder: object, module_name: str) -> b
 
     if _matches_loaded_finder_type(finder, "_virtualenv", "_Finder"):
         virtualenv_module = sys.modules.get("_virtualenv")
-        patched_modules = getattr(virtualenv_module, "_DISTUTILS_PATCH", ()) if virtualenv_module is not None else ()
+        if type(virtualenv_module) is not ModuleType:
+            return False
+        namespace = ModuleType.__getattribute__(virtualenv_module, "__dict__")
+        if type(namespace) is not dict:
+            return False
+        patched_modules = namespace.get("_DISTUTILS_PATCH", ())
+        if type(patched_modules) not in {tuple, set, frozenset} or any(
+            type(name) is not str for name in patched_modules
+        ):
+            return False
         return module_name not in patched_modules
 
     if _matches_loaded_finder_type(finder, "_pytest.assertion.rewrite", "AssertionRewritingHook"):
         if module_name == "conftest":
             return False
-        must_rewrite = getattr(finder, "_must_rewrite", ())
+        try:
+            finder_state = object.__getattribute__(finder, "__dict__")
+        except (AttributeError, TypeError):
+            return False
+        if type(finder_state) is not dict:
+            return False
+        must_rewrite = finder_state.get("_must_rewrite", ())
+        if type(must_rewrite) not in {set, frozenset} or any(type(name) is not str for name in must_rewrite):
+            return False
         if any(module_name == name or module_name.startswith(f"{name}.") for name in must_rewrite):
             return False
-        patterns = getattr(finder, "fnpats", ())
+        patterns = finder_state.get("fnpats", ())
+        if type(patterns) not in {tuple, list} or any(type(pattern) is not str for pattern in patterns):
+            return False
         module_filename = f"{module_name.rsplit('.', maxsplit=1)[-1]}.py"
-        return all(not fnmatch.fnmatchcase(module_filename, pattern) for pattern in patterns)
+        for pattern in patterns:
+            matches = _star_glob_matches(module_filename, pattern)
+            if matches is not False:
+                return False
+        return True
 
     return False
 
@@ -2608,7 +3706,7 @@ def _has_untrusted_path_hook() -> bool:
 
 
 def _find_standard_path_spec(module_name: str, search_path: list[str]) -> ModuleSpec | None:
-    if _search_path_has_untrusted_importer(search_path):
+    if not _interpreter_import_runtime_is_trusted() or _search_path_has_untrusted_importer(search_path):
         _mark_shared_source_snapshot_unreusable()
         return None
 
@@ -4910,19 +6008,10 @@ def _user_positional_argument_range(
 
 
 def _import_module_can_execute_user_code(module_name: str) -> bool:
-    if not module_name or module_name in _IMPORT_EXECUTION_SAFE_MODULES:
+    if not module_name:
         return False
-    try:
-        standard_spec = FrozenImporter.find_spec(module_name)
-    except Exception:
-        return True
-    if standard_spec is None or not _module_spec_uses_builtin_or_frozen_loader(standard_spec):
-        return True
-    loaded_module = sys.modules.get(module_name)
-    if loaded_module is not None:
-        loaded_spec = getattr(loaded_module, "__spec__", None)
-        return not (isinstance(loaded_spec, ModuleSpec) and _module_spec_uses_builtin_or_frozen_loader(loaded_spec))
-    return _untrusted_meta_path_finder_precedes(FrozenImporter, module_name)
+    interpreter_trusted = _interpreter_module_resolution_is_trusted(module_name)
+    return interpreter_trusted is not True
 
 
 def _may_use_getattr_dispatch(call_nodes: tuple[ast.Call, ...], aliases: Mapping[str, str]) -> bool:
@@ -5391,15 +6480,21 @@ def _resolve_module_source(module_name: str) -> Path | None:
         return None
     _track_shared_source_candidates(parts)
     spec = _find_standard_filesystem_spec(module_name)
-    loaded_module = sys.modules.get(module_name)
-    loaded_spec = getattr(loaded_module, "__spec__", None)
-    if isinstance(loaded_spec, ModuleSpec) and isinstance(loaded_spec.origin, str):
-        if loaded_spec.origin.endswith(tuple(SOURCE_SUFFIXES)):
-            loaded_source_path = Path(loaded_spec.origin)
-            current_origin = spec.origin if spec is not None else None
+    loaded, _, loaded_spec = _loaded_module_state_without_hooks(module_name)
+    if loaded:
+        if loaded_spec is None:
+            return None
+        loaded_origin, _ = _module_spec_fields_without_hooks(loaded_spec)
+        if type(loaded_origin) is not str:
+            return None
+        if loaded_origin.endswith(tuple(SOURCE_SUFFIXES)):
+            loaded_source_path = Path(loaded_origin)
+            current_origin = None
+            if type(spec) is ModuleSpec:
+                current_origin, _ = _module_spec_fields_without_hooks(spec)
             try:
                 origin_matches = (
-                    isinstance(current_origin, str) and loaded_source_path.resolve() == Path(current_origin).resolve()
+                    type(current_origin) is str and loaded_source_path.resolve() == Path(current_origin).resolve()
                 )
             except (OSError, RuntimeError, ValueError):
                 origin_matches = False
@@ -5407,13 +6502,16 @@ def _resolve_module_source(module_name: str) -> Path | None:
                 _track_shared_source_paths((loaded_source_path,))
                 _track_shared_source_path(module_name, loaded_source_path, loaded=True)
                 return loaded_source_path
-        elif loaded_spec.origin not in {"built-in", "frozen"}:
+        elif loaded_origin not in {"built-in", "frozen"}:
             return None
     elif _untrusted_meta_path_finder_precedes(PathFinder, module_name) or _has_untrusted_path_hook():
         return None
 
-    if spec is not None and isinstance(spec.origin, str) and spec.origin.endswith(tuple(SOURCE_SUFFIXES)):
-        source_path = Path(spec.origin)
+    spec_origin = None
+    if type(spec) is ModuleSpec:
+        spec_origin, _ = _module_spec_fields_without_hooks(spec)
+    if type(spec_origin) is str and spec_origin.endswith(tuple(SOURCE_SUFFIXES)):
+        source_path = Path(spec_origin)
         _track_shared_source_paths((source_path,))
         if source_path.is_file():
             _track_shared_source_path(module_name, source_path, loaded=False)
@@ -5421,9 +6519,13 @@ def _resolve_module_source(module_name: str) -> Path | None:
     return None
 
 
-def _module_spec_uses_builtin_or_frozen_loader(spec: ModuleSpec) -> bool:
-    loader = cast(Any, spec.loader)
-    return (loader is BuiltinImporter or loader is FrozenImporter) and spec.origin in {"built-in", "frozen"}
+def _module_spec_claims_builtin_or_frozen_identity(spec: ModuleSpec) -> bool:
+    origin, loader = _module_spec_fields_without_hooks(spec)
+    return (
+        loader is BuiltinImporter
+        or loader is FrozenImporter
+        or (type(origin) is str and origin in {"built-in", "frozen"})
+    )
 
 
 def _rce_sink(call_name: str) -> str | None:

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -56,6 +56,7 @@ from modelaudit_picklescan import (
 )
 from modelaudit_picklescan.call_graph import (
     _CALL_GRAPH_REGULAR_FILE_FINGERPRINT,
+    _TRUSTED_LOADED_REFERENCE_BASELINES,
     CallGraphFinding,
     StartupHookWriteFinding,
     UnanalyzedCallGraphReference,
@@ -4083,9 +4084,17 @@ def test_scan_bytes_flags_newobj_ex_dangerous_class() -> None:
     ],
 )
 def test_scan_bytes_does_not_treat_benign_stdlib_module_references_as_dangerous(
-    payload: bytes, expected_reference: str
+    payload: bytes,
+    expected_reference: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    report = scan_bytes(payload, source=f"{expected_reference}.pkl")
+    module_name, _, reference_name = expected_reference.partition(".")
+    with monkeypatch.context() as patch:
+        if (module_name, reference_name) not in _TRUSTED_LOADED_REFERENCE_BASELINES:
+            patch.delitem(sys.modules, module_name, raising=False)
+        _clear_source_sensitive_caches()
+        report = scan_bytes(payload, source=f"{expected_reference}.pkl")
+    _clear_source_sensitive_caches()
 
     assert report.status == ScanStatus.COMPLETE
     assert report.verdict == SafetyVerdict.CLEAN

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -2342,7 +2342,7 @@ if marker.exists():
     assert not marker.exists()
 
 
-def test_scan_bytes_analyzes_stdlib_source_modules_without_custom_meta_path_finders(
+def test_scan_bytes_fails_closed_for_late_loaded_stdlib_source_modules_without_custom_meta_path_finders(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2376,7 +2376,11 @@ def test_scan_bytes_analyzes_stdlib_source_modules_without_custom_meta_path_find
         _clear_call_graph_caches()
 
     assert report.status == ScanStatus.COMPLETE
-    assert report.verdict == SafetyVerdict.CLEAN
+    assert report.verdict == SafetyVerdict.SUSPICIOUS
+    assert any(
+        finding.rule_code == "NON_ALLOWLISTED_GLOBAL" and finding.details.get("import_reference") == "statistics.mean"
+        for finding in report.findings
+    )
     assert not _has_call_graph_source_unavailable_notice(report, module_name, "mean", "source_unavailable")
     assert not marker.exists()
     assert statistics.mean([1, 2, 3]) == 2
@@ -3482,7 +3486,7 @@ def test_call_graph_keeps_setstate_entrypoint_for_unknown_newobj_invocation(
     )
 
 
-def test_scan_bytes_ignores_torch_layout_module_dict_lookup() -> None:
+def test_scan_bytes_fails_closed_for_late_loaded_torch_layout_module_dict_lookup() -> None:
     torch = pytest.importorskip("torch")
     if not hasattr(torch, "strided"):
         pytest.skip("usable PyTorch API is unavailable")
@@ -3490,7 +3494,12 @@ def test_scan_bytes_ignores_torch_layout_module_dict_lookup() -> None:
 
     report = scan_bytes(payload, source="torch-layout-clean.pkl")
 
-    assert report.verdict == SafetyVerdict.CLEAN
+    assert report.verdict == SafetyVerdict.SUSPICIOUS
+    assert any(
+        finding.rule_code == "NON_ALLOWLISTED_GLOBAL"
+        and finding.details.get("import_reference") == "torch.serialization._get_layout"
+        for finding in report.findings
+    )
     assert not any(finding.rule_code == "DANGEROUS_CALL_GRAPH" for finding in report.findings)
 
 

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -2342,48 +2342,61 @@ if marker.exists():
     assert not marker.exists()
 
 
-def test_scan_bytes_fails_closed_for_late_loaded_stdlib_source_modules_without_custom_meta_path_finders(
+def test_scan_bytes_keeps_real_late_loaded_stdlib_source_modules_clean_without_invoking_custom_meta_path_finders(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import statistics
-
-    module_name = "statistics"
     marker = tmp_path / "meta_path_called"
+    child_code = """
+import sys
+from importlib.machinery import ModuleSpec
+from pathlib import Path
 
-    class CustomMetaPathFinder:
-        @staticmethod
-        def find_spec(
-            fullname: str,
-            path: object | None = None,
-            target: object | None = None,
-        ) -> ModuleSpec | None:
-            del path, target
-            if fullname == module_name:
-                marker.write_text(fullname, encoding="utf-8")
-                return ModuleSpec(fullname, loader=None, origin="custom://module")
-            return None
+import modelaudit_picklescan.call_graph as call_graph
+from modelaudit_picklescan import SafetyVerdict, ScanStatus, scan_bytes
 
-    monkeypatch.setattr(sys, "meta_path", [CustomMetaPathFinder(), *sys.meta_path])
-    _clear_call_graph_caches()
+module_name = "statistics"
+marker = Path(sys.argv[1])
+if module_name in sys.modules:
+    raise SystemExit("statistics was loaded before the call-graph trust snapshot")
 
-    try:
-        report = scan_bytes(
-            _global_call_payload(module_name, "mean", b"]"),
-            source="stdlib-source-call-graph-source.pkl",
-        )
-    finally:
-        _clear_call_graph_caches()
+import statistics
 
-    assert report.status == ScanStatus.COMPLETE
-    assert report.verdict == SafetyVerdict.SUSPICIOUS
-    assert any(
-        finding.rule_code == "NON_ALLOWLISTED_GLOBAL" and finding.details.get("import_reference") == "statistics.mean"
-        for finding in report.findings
+class CustomMetaPathFinder:
+    @staticmethod
+    def find_spec(fullname, path=None, target=None):
+        del path, target
+        if fullname == module_name:
+            marker.write_text(fullname, encoding="utf-8")
+            return ModuleSpec(fullname, loader=None, origin="custom://module")
+        return None
+
+sys.meta_path.insert(0, CustomMetaPathFinder())
+for function in call_graph._SOURCE_SENSITIVE_CACHED_FUNCTIONS:
+    function.cache_clear()
+payload = b"\\x80\\x04\\x8c\\x0astatistics\\x8c\\x04mean\\x93]\\x85R."
+report = scan_bytes(payload, source="stdlib-source-call-graph-source.pkl")
+if report.status != ScanStatus.COMPLETE or report.verdict != SafetyVerdict.CLEAN:
+    raise SystemExit(f"unexpected report: {report.to_dict()!r}")
+if report.findings:
+    raise SystemExit(f"unexpected findings: {report.to_dict()!r}")
+if marker.exists():
+    raise SystemExit("custom meta-path finder was invoked")
+if statistics.mean([1, 2, 3]) != 2:
+    raise SystemExit("statistics.mean changed")
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", child_code, str(marker)],
+        cwd=str(tmp_path),
+        env=dict(os.environ),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
     )
-    assert not _has_call_graph_source_unavailable_notice(report, module_name, "mean", "source_unavailable")
+
+    assert result.returncode == 0, result.stderr
     assert not marker.exists()
-    assert statistics.mean([1, 2, 3]) == 2
 
 
 def test_scan_bytes_keeps_frozen_stdlib_globals_clean_without_custom_meta_path_finders(
@@ -7474,15 +7487,33 @@ def test_scan_bytes_keeps_future_pending_callback_lazy(tmp_path: Path) -> None:
     )
     payload = _builtins_help_future_callback_payload(complete=False)
 
-    report = scan_bytes(payload, source="future-pending-callback.pkl")
+    scan_child_code = """
+import sys
 
-    assert report.verdict == SafetyVerdict.CLEAN
-    assert not any(
-        invocation.get("module") == "builtins"
-        and invocation.get("name") == "help"
-        and invocation.get("positional_arg_count") == 1
-        for invocation in report.metadata.get("callable_invocations", [])
+from modelaudit_picklescan import SafetyVerdict, scan_bytes
+
+payload = bytes.fromhex(sys.argv[1])
+report = scan_bytes(payload, source="future-pending-callback.pkl")
+if report.verdict != SafetyVerdict.CLEAN:
+    raise SystemExit(f"unexpected report: {report.to_dict()!r}")
+if any(
+    invocation.get("module") == "builtins"
+    and invocation.get("name") == "help"
+    and invocation.get("positional_arg_count") == 1
+    for invocation in report.metadata.get("callable_invocations", [])
+):
+    raise SystemExit(f"pending callback was marked invoked: {report.to_dict()!r}")
+"""
+    scan_result = subprocess.run(
+        [sys.executable, "-c", scan_child_code, payload.hex()],
+        cwd=str(tmp_path.parent),
+        env=dict(os.environ),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
     )
+    assert scan_result.returncode == 0, scan_result.stderr
 
     child_code = """
 import pickle

--- a/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
@@ -464,9 +464,11 @@ def test_loaded_trusted_function_code_mutation_is_not_allowlisted() -> None:
     if baseline is None:
         pytest.skip("tempfile.gettempdir was not loaded before the call-graph trust snapshot")
     assert baseline is not None
-    function = baseline[1][1]
-    if not isinstance(function, FunctionType):
+    function_value = baseline[1][1]
+    if not isinstance(function_value, FunctionType):
         pytest.skip("tempfile.gettempdir was not loaded before the call-graph trust snapshot")
+    assert isinstance(function_value, FunctionType)
+    function = function_value
     original_code = function.__code__
 
     def hostile_gettempdir() -> str:
@@ -666,6 +668,7 @@ def test_loaded_trusted_tempdir_posixpath_regex_cache_transition_remains_allowli
     baseline = call_graph._TRUSTED_LOADED_REFERENCE_BASELINES.get(("tempfile", "gettempdir"))
     if baseline is None:
         pytest.skip("tempfile.gettempdir was not loaded before the call-graph trust snapshot")
+    assert baseline is not None
     assert baseline[2][0][2] is True
     namespace = ModuleType.__getattribute__(posixpath, "__dict__")
     monkeypatch.setitem(namespace, "_varprog", None)

--- a/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import _imp
+import os
+import posixpath
+import re
 import subprocess
 import sys
+import tarfile
+from collections.abc import Iterator
 from importlib.machinery import BuiltinImporter, FileFinder, FrozenImporter, ModuleSpec, PathFinder
 from pathlib import Path
 from types import FunctionType, ModuleType
@@ -458,6 +463,7 @@ def test_loaded_trusted_function_code_mutation_is_not_allowlisted() -> None:
     baseline = call_graph._TRUSTED_LOADED_REFERENCE_BASELINES.get((module, name))
     if baseline is None:
         pytest.skip("tempfile.gettempdir was not loaded before the call-graph trust snapshot")
+    assert baseline is not None
     function = baseline[1][1]
     if not isinstance(function, FunctionType):
         pytest.skip("tempfile.gettempdir was not loaded before the call-graph trust snapshot")
@@ -489,6 +495,7 @@ def test_loaded_trusted_function_global_mutation_is_not_allowlisted(
     baseline = call_graph._TRUSTED_LOADED_REFERENCE_BASELINES.get((module, name))
     if baseline is None:
         pytest.skip("tempfile.gettempdir was not loaded before the call-graph trust snapshot")
+    assert baseline is not None
     loaded_reference = baseline[1][1]
     if not isinstance(loaded_reference, FunctionType):
         pytest.skip("tempfile.gettempdir was not loaded before the call-graph trust snapshot")
@@ -651,6 +658,58 @@ def test_loaded_trusted_tempdir_cache_transition_remains_allowlisted(
     assert call_graph._loaded_trusted_reference_matches_baseline("tempfile", "gettempdir") is True
 
 
+def test_loaded_trusted_tempdir_posixpath_regex_cache_transition_remains_allowlisted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if os.path is not posixpath:
+        pytest.skip("tempfile does not use posixpath on this platform")
+    baseline = call_graph._TRUSTED_LOADED_REFERENCE_BASELINES.get(("tempfile", "gettempdir"))
+    if baseline is None:
+        pytest.skip("tempfile.gettempdir was not loaded before the call-graph trust snapshot")
+    assert baseline[2][0][2] is True
+    namespace = ModuleType.__getattribute__(posixpath, "__dict__")
+    monkeypatch.setitem(namespace, "_varprog", None)
+    _clear_call_graph_caches()
+
+    initial_report = package_api.scan_bytes(b"ctempfile\ngettempdir\n.", source="tempdir-before-regex.pkl")
+    assert initial_report.verdict == SafetyVerdict.CLEAN
+
+    assert posixpath.expandvars("$MODELAUDIT_MISSING_VARIABLE") == "$MODELAUDIT_MISSING_VARIABLE"
+    assert type(namespace["_varprog"]) is re.Pattern
+    _clear_call_graph_caches()
+    populated_report = package_api.scan_bytes(b"ctempfile\ngettempdir\n.", source="tempdir-after-regex.pkl")
+
+    assert populated_report.verdict == SafetyVerdict.CLEAN
+
+
+def test_loaded_trusted_tempdir_rejects_hostile_posixpath_regex_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if os.path is not posixpath:
+        pytest.skip("tempfile does not use posixpath on this platform")
+    calls: list[str] = []
+
+    class HostileRegex:
+        def search(self, value: object) -> object:
+            del value
+            calls.append("search")
+            raise AssertionError("hostile regex cache executed")
+
+    namespace = ModuleType.__getattribute__(posixpath, "__dict__")
+    monkeypatch.setitem(namespace, "_varprog", HostileRegex())
+    _clear_call_graph_caches()
+
+    report = package_api.scan_bytes(b"ctempfile\ngettempdir\n.", source="hostile-posixpath-regex.pkl")
+
+    assert report.verdict == SafetyVerdict.SUSPICIOUS
+    assert any(
+        finding.rule_code == "NON_ALLOWLISTED_GLOBAL"
+        and finding.details.get("import_reference") == "tempfile.gettempdir"
+        for finding in report.findings
+    )
+    assert calls == []
+
+
 def test_loaded_trusted_function_builtin_mutation_is_not_allowlisted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -675,6 +734,32 @@ def test_loaded_trusted_function_builtin_mutation_is_not_allowlisted(
     report = package_api.scan_bytes(b"ctempfile\ngettempdir\n)R.", source="mutated-next.pkl")
 
     assert report.verdict == SafetyVerdict.SUSPICIOUS
+
+
+def test_loaded_trusted_class_rejects_hostile_slotnames_cache_without_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    baseline = call_graph._TRUSTED_LOADED_REFERENCE_BASELINES.get(("tarfile", "TarInfo"))
+    if baseline is None:
+        pytest.skip("tarfile.TarInfo was not loaded before the call-graph trust snapshot")
+    calls: list[str] = []
+
+    class HostileSlotNames(list[str]):
+        def __iter__(self) -> Iterator[str]:
+            calls.append("__iter__")
+            return super().__iter__()
+
+    monkeypatch.setattr(tarfile.TarInfo, "__slotnames__", HostileSlotNames(), raising=False)
+    _clear_call_graph_caches()
+
+    report = package_api.scan_bytes(b"ctarfile\nTarInfo\n)R.", source="hostile-slotnames.pkl")
+
+    assert report.verdict == SafetyVerdict.SUSPICIOUS
+    assert any(
+        finding.rule_code == "NON_ALLOWLISTED_GLOBAL" and finding.details.get("import_reference") == "tarfile.TarInfo"
+        for finding in report.findings
+    )
+    assert calls == []
 
 
 def test_loaded_trusted_class_namespace_mutation_is_not_allowlisted() -> None:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
@@ -1,0 +1,1362 @@
+"""Regressions for import-hook-free call-graph module resolution."""
+
+from __future__ import annotations
+
+import _imp
+import subprocess
+import sys
+from importlib.machinery import BuiltinImporter, FileFinder, FrozenImporter, ModuleSpec, PathFinder
+from pathlib import Path
+from types import FunctionType, ModuleType
+from typing import Any, cast
+
+import pytest
+
+import modelaudit_picklescan.api as package_api
+import modelaudit_picklescan.call_graph as call_graph
+from modelaudit_picklescan import PickleReport, SafetyVerdict, ScanStatus
+
+
+def _clear_call_graph_caches() -> None:
+    for function in call_graph._SOURCE_SENSITIVE_CACHED_FUNCTIONS:
+        function.cache_clear()
+
+
+def _has_source_unavailable_notice(report: PickleReport, module: str, name: str) -> bool:
+    return any(
+        notice.code == "call_graph_source_unavailable"
+        and notice.details.get("module") == module
+        and notice.details.get("name") == name
+        and notice.details.get("reason") == "source_unavailable"
+        for notice in report.notices
+    )
+
+
+def _fail_builtin_find_spec(calls: list[str]) -> Any:
+    def find_spec(
+        cls: type[object],
+        fullname: str,
+        path: object | None = None,
+        target: object | None = None,
+    ) -> ModuleSpec | None:
+        del cls, path, target
+        calls.append(fullname)
+        raise AssertionError(f"BuiltinImporter.find_spec called for {fullname!r}")
+
+    return classmethod(find_spec)
+
+
+def _fail_frozen_find_spec(calls: list[str]) -> Any:
+    def find_spec(
+        cls: type[object],
+        fullname: str,
+        path: object | None = None,
+        target: object | None = None,
+    ) -> ModuleSpec | None:
+        del cls, path, target
+        calls.append(fullname)
+        raise AssertionError(f"FrozenImporter.find_spec called for {fullname!r}")
+
+    return classmethod(find_spec)
+
+
+def test_call_graph_enrichment_does_not_invoke_meta_path_finders_for_pickle_names(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = "modelaudit_tp_pickle_controlled_meta_path_name"
+    name = "invoke"
+    marker = tmp_path / "meta_path_finder_called"
+    builtin_calls: list[str] = []
+    frozen_calls: list[str] = []
+    original_builtin_find_spec = type.__getattribute__(BuiltinImporter, "__dict__")["find_spec"]
+    original_frozen_find_spec = type.__getattribute__(FrozenImporter, "__dict__")["find_spec"]
+
+    class RecordingFinder:
+        @staticmethod
+        def find_spec(
+            fullname: str,
+            path: object | None = None,
+            target: object | None = None,
+        ) -> ModuleSpec | None:
+            del path, target
+            marker.write_text(fullname, encoding="utf-8")
+            return ModuleSpec(fullname, loader=None, origin="custom://module")
+
+    monkeypatch.setattr(sys, "meta_path", [RecordingFinder(), *sys.meta_path])
+    type.__setattr__(BuiltinImporter, "find_spec", _fail_builtin_find_spec(builtin_calls))
+    type.__setattr__(FrozenImporter, "find_spec", _fail_frozen_find_spec(frozen_calls))
+    _clear_call_graph_caches()
+
+    try:
+        report = PickleReport(
+            source="pickle-controlled-meta-path.pkl",
+            status=ScanStatus.COMPLETE,
+            verdict=SafetyVerdict.CLEAN,
+            metadata={
+                "import_references": (
+                    {
+                        "module": module,
+                        "name": name,
+                        "import_reference": f"{module}.{name}",
+                        "requires_origin_verification": True,
+                    },
+                ),
+                "callable_invocations": (
+                    {
+                        "module": module,
+                        "name": name,
+                        "import_reference": f"{module}.{name}",
+                        "opcode": "REDUCE",
+                    },
+                ),
+            },
+        )
+
+        updated = package_api._with_call_graph_findings(report)
+    finally:
+        type.__setattr__(BuiltinImporter, "find_spec", original_builtin_find_spec)
+        type.__setattr__(FrozenImporter, "find_spec", original_frozen_find_spec)
+        _clear_call_graph_caches()
+
+    assert updated.status == ScanStatus.INCONCLUSIVE
+    assert updated.verdict == SafetyVerdict.SUSPICIOUS
+    assert _has_source_unavailable_notice(updated, module, name)
+    assert not marker.exists()
+    assert builtin_calls == []
+    assert frozen_calls == []
+
+
+def test_loaded_builtin_and_frozen_modules_avoid_hookable_find_spec(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builtin_calls: list[str] = []
+    frozen_calls: list[str] = []
+    original_builtin_find_spec = type.__getattribute__(BuiltinImporter, "__dict__")["find_spec"]
+    original_frozen_find_spec = type.__getattribute__(FrozenImporter, "__dict__")["find_spec"]
+    type.__setattr__(BuiltinImporter, "find_spec", _fail_builtin_find_spec(builtin_calls))
+    type.__setattr__(FrozenImporter, "find_spec", _fail_frozen_find_spec(frozen_calls))
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._trusted_module_origin_kind("_io") == "stdlib"
+        assert call_graph._call_graph_source_unavailable_reason("_io") is None
+
+        if not _imp.is_frozen("ntpath"):
+            pytest.skip("ntpath is not frozen on this interpreter")
+        ntpath_was_trusted_loaded = "ntpath" in call_graph._TRUSTED_LOADED_INTERPRETER_MODULES
+        expected_reason = None if ntpath_was_trusted_loaded else "source_unavailable"
+        assert call_graph._call_graph_source_unavailable_reason("ntpath") == expected_reason
+        assert call_graph._import_module_can_execute_user_code("ntpath") is not ntpath_was_trusted_loaded
+    finally:
+        type.__setattr__(BuiltinImporter, "find_spec", original_builtin_find_spec)
+        type.__setattr__(FrozenImporter, "find_spec", original_frozen_find_spec)
+        _clear_call_graph_caches()
+
+    assert builtin_calls == []
+    assert frozen_calls == []
+
+
+def test_builtin_and_frozen_resolution_uses_import_time_snapshots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = "modelaudit_tp_forged_interpreter_module"
+    ntpath_is_frozen = call_graph._interpreter_module_origin_without_import_hooks("ntpath") == "frozen"
+    ntpath_was_trusted_loaded = "ntpath" in call_graph._TRUSTED_LOADED_INTERPRETER_MODULES
+    builtin_calls: list[str] = []
+    frozen_calls: list[str] = []
+    frozen_package_calls: list[str] = []
+    module_spec_calls: list[str] = []
+    original_builtin_find_spec = type.__getattribute__(BuiltinImporter, "__dict__")["find_spec"]
+    original_frozen_find_spec = type.__getattribute__(FrozenImporter, "__dict__")["find_spec"]
+
+    def forged_is_frozen(name: str) -> bool:
+        frozen_calls.append(name)
+        return True
+
+    def forged_is_frozen_package(name: str) -> bool:
+        frozen_package_calls.append(name)
+        return False
+
+    def forged_module_spec_init(
+        self: ModuleSpec,
+        name: str,
+        loader: object,
+        **kwargs: object,
+    ) -> None:
+        del self, loader, kwargs
+        module_spec_calls.append(name)
+        raise AssertionError(f"ModuleSpec.__init__ called for {name!r}")
+
+    monkeypatch.setattr(sys, "builtin_module_names", (*sys.builtin_module_names, module))
+    monkeypatch.setattr(_imp, "is_frozen", forged_is_frozen)
+    monkeypatch.setattr(_imp, "is_frozen_package", forged_is_frozen_package)
+    monkeypatch.setattr(ModuleSpec, "__init__", forged_module_spec_init)
+    type.__setattr__(BuiltinImporter, "find_spec", _fail_builtin_find_spec(builtin_calls))
+    type.__setattr__(FrozenImporter, "find_spec", _fail_frozen_find_spec(frozen_calls))
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._trusted_module_origin_kind(module) in {None, "unresolved"}
+        assert call_graph._call_graph_source_unavailable_reason(module) == "source_unavailable"
+        assert call_graph._import_module_can_execute_user_code(module) is True
+        assert call_graph._trusted_module_origin_kind("_io") == "stdlib"
+        if ntpath_is_frozen:
+            expected_reason = None if ntpath_was_trusted_loaded else "source_unavailable"
+            assert call_graph._call_graph_source_unavailable_reason("ntpath") == expected_reason
+            assert call_graph._import_module_can_execute_user_code("ntpath") is not ntpath_was_trusted_loaded
+    finally:
+        type.__setattr__(BuiltinImporter, "find_spec", original_builtin_find_spec)
+        type.__setattr__(FrozenImporter, "find_spec", original_frozen_find_spec)
+        _clear_call_graph_caches()
+
+    assert builtin_calls == []
+    assert frozen_calls == []
+    assert frozen_package_calls == []
+    assert module_spec_calls == []
+
+
+@pytest.mark.parametrize(
+    ("case", "origin", "loader"),
+    [
+        ("builtin-pair", "built-in", BuiltinImporter),
+        ("frozen-pair", "frozen", FrozenImporter),
+        ("builtin-origin-only", "built-in", None),
+        ("frozen-origin-only", "frozen", None),
+        ("builtin-loader-only", "custom://module", BuiltinImporter),
+        ("frozen-loader-only", "custom://module", FrozenImporter),
+    ],
+)
+def test_loaded_module_cannot_forge_builtin_or_frozen_origin(
+    case: str,
+    origin: str,
+    loader: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = f"modelaudit_tp_forged_loaded_{case.replace('-', '_')}"
+    loaded_module = ModuleType(module)
+    loaded_module.__spec__ = ModuleSpec(module, loader, origin=origin)
+    monkeypatch.setitem(sys.modules, module, loaded_module)
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._trusted_module_origin_kind(module) is None
+        assert call_graph._find_module_spec_without_imports(module) is None
+        assert call_graph._call_graph_source_unavailable_reason(module) == "source_unavailable"
+        assert call_graph._import_module_can_execute_user_code(module) is True
+    finally:
+        _clear_call_graph_caches()
+
+
+def test_loaded_trusted_interpreter_module_replacement_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = "_io"
+    assert module in call_graph._TRUSTED_LOADED_INTERPRETER_MODULES
+    replacement = ModuleType(module)
+    replacement.__spec__ = ModuleSpec(module, cast(Any, BuiltinImporter), origin="built-in")
+    monkeypatch.setitem(sys.modules, module, replacement)
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._trusted_module_origin_kind(module) is None
+        assert call_graph._call_graph_source_unavailable_reason(module) == "source_unavailable"
+        assert call_graph._import_module_can_execute_user_code(module) is True
+        report = package_api.scan_bytes(b"c_io\nBytesIO\n.", source="poisoned-builtin.pkl")
+        assert report.verdict == SafetyVerdict.SUSPICIOUS
+        assert any(
+            finding.rule_code == "NON_ALLOWLISTED_GLOBAL" and finding.details.get("import_reference") == "_io.BytesIO"
+            for finding in report.findings
+        )
+    finally:
+        _clear_call_graph_caches()
+
+
+def test_cached_interpreter_origin_cannot_hide_module_replacement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = "_io"
+    name = "BytesIO"
+    replacement = ModuleType(module)
+    replacement.__spec__ = ModuleSpec(module, cast(Any, BuiltinImporter), origin="built-in")
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._trusted_module_origin_kind(module) == "stdlib"
+        assert call_graph.import_only_module_requires_origin_review(module, name) is False
+
+        monkeypatch.setitem(sys.modules, module, replacement)
+
+        assert call_graph._trusted_module_origin_kind(module) == "stdlib"
+        assert call_graph.import_only_module_requires_origin_review(module, name) is True
+    finally:
+        _clear_call_graph_caches()
+
+
+def test_shared_source_snapshot_detects_interpreter_module_replacement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = "_io"
+    replacement = ModuleType(module)
+    replacement.__spec__ = ModuleSpec(module, cast(Any, BuiltinImporter), origin="built-in")
+
+    with call_graph.shared_source_sensitive_caches():
+        report_generation = call_graph._begin_shared_source_report()
+        assert call_graph._trusted_module_origin_kind(module) == "stdlib"
+        metadata = call_graph.shared_source_fingerprint_metadata()
+        assert metadata is not None
+        assert metadata["reusable"] is False
+
+        monkeypatch.setitem(sys.modules, module, replacement)
+        with pytest.raises(call_graph._CallGraphAnalysisLimitError, match="source changed"):
+            call_graph._ensure_shared_source_snapshot_stable(report_generation)
+
+
+def test_loaded_interpreter_reference_mutation_cannot_remain_allowlisted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = "_frozen_importlib"
+    name = "ModuleSpec"
+    loaded_module = sys.modules[module]
+    namespace = ModuleType.__getattribute__(loaded_module, "__dict__")
+    original_reference = namespace[name]
+
+    def replacement(*args: Any, **kwargs: Any) -> object:
+        return cast(Any, original_reference)(*args, **kwargs)
+
+    with call_graph.shared_source_sensitive_caches():
+        report_generation = call_graph._begin_shared_source_report()
+        assert call_graph.import_only_reference_is_proven_trusted(module, name) is True
+        monkeypatch.setitem(namespace, name, replacement)
+        with pytest.raises(call_graph._CallGraphAnalysisLimitError, match="source changed"):
+            call_graph._ensure_shared_source_snapshot_stable(report_generation)
+
+    _clear_call_graph_caches()
+    try:
+        assert call_graph._trusted_module_origin_kind(module) == "stdlib"
+        assert call_graph.import_only_reference_is_proven_trusted(module, name) is False
+        report = package_api.scan_bytes(
+            b"c_frozen_importlib\nModuleSpec\n.",
+            source="mutated-module-spec.pkl",
+        )
+        assert report.verdict == SafetyVerdict.SUSPICIOUS
+        assert any(
+            finding.rule_code == "NON_ALLOWLISTED_GLOBAL"
+            and finding.details.get("import_reference") == "_frozen_importlib.ModuleSpec"
+            for finding in report.findings
+        )
+    finally:
+        _clear_call_graph_caches()
+
+
+def test_loaded_parent_package_namespace_hook_is_not_executed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    class HostilePackage(ModuleType):
+        def __getattribute__(self, name: str) -> Any:
+            if name == "__dict__":
+                calls.append(name)
+                raise AttributeError("loaded package hook executed")
+            return super().__getattribute__(name)
+
+    package = HostilePackage("modelaudit_tp_hostile_parent")
+    ModuleType.__getattribute__(package, "__dict__")["__path__"] = []
+    monkeypatch.setitem(sys.modules, package.__name__, package)
+    _clear_call_graph_caches()
+
+    try:
+        report = package_api.scan_bytes(
+            b"cmodelaudit_tp_hostile_parent.child\nThing\n.",
+            source="hostile-parent.pkl",
+        )
+        assert calls == []
+        assert report.verdict == SafetyVerdict.SUSPICIOUS
+        assert any(finding.rule_code == "NON_ALLOWLISTED_GLOBAL" for finding in report.findings)
+    finally:
+        _clear_call_graph_caches()
+
+
+def test_loaded_filesystem_reference_replacement_cannot_reuse_cached_origin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = "argparse"
+    name = "Namespace"
+    baseline = call_graph._TRUSTED_LOADED_REFERENCE_BASELINES.get((module, name))
+    if baseline is None:
+        pytest.skip("argparse.Namespace was not loaded before the call-graph trust snapshot")
+    assert baseline is not None
+    original_module = baseline[0][1]
+    assert sys.modules[module] is original_module
+    original_spec = ModuleType.__getattribute__(original_module, "__spec__")
+    assert type(original_spec) is ModuleSpec
+    original_origin, original_loader = call_graph._module_spec_fields_without_hooks(original_spec)
+    assert type(original_origin) is str
+
+    _clear_call_graph_caches()
+    clean_report = package_api.scan_bytes(b"cargparse\nNamespace\n)R.", source="original-argparse.pkl")
+    assert clean_report.verdict == SafetyVerdict.CLEAN
+
+    replacement = ModuleType(module)
+    replacement.__spec__ = ModuleSpec(module, cast(Any, original_loader), origin=original_origin)
+    ModuleType.__getattribute__(replacement, "__dict__")[name] = lambda: None
+    monkeypatch.setitem(sys.modules, module, replacement)
+
+    assert call_graph._trusted_module_origin_kind(module) == "stdlib"
+    replaced_report = package_api.scan_bytes(b"cargparse\nNamespace\n)R.", source="replaced-argparse.pkl")
+
+    assert replaced_report.verdict == SafetyVerdict.SUSPICIOUS
+    assert any(
+        finding.rule_code == "NON_ALLOWLISTED_GLOBAL"
+        and finding.details.get("import_reference") == "argparse.Namespace"
+        for finding in replaced_report.findings
+    )
+
+
+def test_forged_loaded_filesystem_reference_is_not_trusted_on_first_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = "statistics"
+    name = "mean"
+    if (module, name) in call_graph._TRUSTED_LOADED_REFERENCE_BASELINES:
+        pytest.skip("statistics.mean was loaded before the call-graph trust snapshot")
+
+    spec = call_graph._find_standard_filesystem_spec(module)
+    assert type(spec) is ModuleSpec
+    origin, loader = call_graph._module_spec_fields_without_hooks(spec)
+    assert type(origin) is str
+
+    replacement = ModuleType(module)
+    replacement_spec = ModuleSpec(module, cast(Any, loader), origin=origin)
+    replacement_namespace = ModuleType.__getattribute__(replacement, "__dict__")
+    replacement_namespace.update(
+        {
+            "__package__": "",
+            "__spec__": replacement_spec,
+            "__loader__": loader,
+            "__file__": origin,
+            name: lambda values: values,
+        }
+    )
+    monkeypatch.setitem(sys.modules, module, replacement)
+    _clear_call_graph_caches()
+
+    assert call_graph._trusted_module_origin_kind(module) == "stdlib"
+    report = package_api.scan_bytes(b"cstatistics\nmean\n.", source="forged-statistics.pkl")
+
+    assert report.verdict == SafetyVerdict.SUSPICIOUS
+    assert any(
+        finding.rule_code == "NON_ALLOWLISTED_GLOBAL" and finding.details.get("import_reference") == "statistics.mean"
+        for finding in report.findings
+    )
+
+
+def test_loaded_trusted_function_code_mutation_is_not_allowlisted() -> None:
+    module = "tempfile"
+    name = "gettempdir"
+    baseline = call_graph._TRUSTED_LOADED_REFERENCE_BASELINES.get((module, name))
+    if baseline is None:
+        pytest.skip("tempfile.gettempdir was not loaded before the call-graph trust snapshot")
+    function = baseline[1][1]
+    if not isinstance(function, FunctionType):
+        pytest.skip("tempfile.gettempdir was not loaded before the call-graph trust snapshot")
+    original_code = function.__code__
+
+    def hostile_gettempdir() -> str:
+        raise AssertionError("mutated trusted function executed")
+
+    function.__code__ = hostile_gettempdir.__code__
+    _clear_call_graph_caches()
+    try:
+        report = package_api.scan_bytes(b"ctempfile\ngettempdir\n)R.", source="mutated-gettempdir.pkl")
+        assert report.verdict == SafetyVerdict.SUSPICIOUS
+        assert any(
+            finding.rule_code == "NON_ALLOWLISTED_GLOBAL"
+            and finding.details.get("import_reference") == "tempfile.gettempdir"
+            for finding in report.findings
+        )
+    finally:
+        function.__code__ = original_code
+        _clear_call_graph_caches()
+
+
+def test_loaded_trusted_function_global_mutation_is_not_allowlisted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = "tempfile"
+    name = "gettempdir"
+    baseline = call_graph._TRUSTED_LOADED_REFERENCE_BASELINES.get((module, name))
+    if baseline is None:
+        pytest.skip("tempfile.gettempdir was not loaded before the call-graph trust snapshot")
+    loaded_reference = baseline[1][1]
+    if not isinstance(loaded_reference, FunctionType):
+        pytest.skip("tempfile.gettempdir was not loaded before the call-graph trust snapshot")
+    loaded_module = baseline[0][1]
+    assert isinstance(loaded_module, ModuleType)
+    namespace = ModuleType.__getattribute__(loaded_module, "__dict__")
+    calls: list[str] = []
+
+    def hostile_gettempdir() -> str:
+        calls.append("_gettempdir")
+        raise AssertionError("mutated trusted function global executed")
+
+    monkeypatch.setitem(namespace, "_gettempdir", hostile_gettempdir)
+    _clear_call_graph_caches()
+    try:
+        report = package_api.scan_bytes(b"ctempfile\ngettempdir\n)R.", source="mutated-gettempdir-global.pkl")
+        assert report.verdict == SafetyVerdict.SUSPICIOUS
+        assert any(
+            finding.rule_code == "NON_ALLOWLISTED_GLOBAL"
+            and finding.details.get("import_reference") == "tempfile.gettempdir"
+            for finding in report.findings
+        )
+    finally:
+        _clear_call_graph_caches()
+
+    assert calls == []
+
+
+def test_loaded_trusted_function_transitive_global_mutation_is_not_allowlisted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    baseline = call_graph._TRUSTED_LOADED_REFERENCE_BASELINES.get(("tempfile", "gettempdir"))
+    if baseline is None:
+        pytest.skip("tempfile.gettempdir was not loaded before the call-graph trust snapshot")
+    assert baseline is not None
+    loaded_module = baseline[0][1]
+    assert type(loaded_module) is ModuleType
+    namespace = ModuleType.__getattribute__(loaded_module, "__dict__")
+    calls: list[str] = []
+
+    def hostile_default_tempdir() -> str:
+        calls.append("_get_default_tempdir")
+        raise AssertionError("mutated transitive trusted function global executed")
+
+    monkeypatch.setitem(namespace, "_get_default_tempdir", hostile_default_tempdir)
+    _clear_call_graph_caches()
+    report = package_api.scan_bytes(b"ctempfile\ngettempdir\n)R.", source="mutated-default-tempdir.pkl")
+
+    assert report.verdict == SafetyVerdict.SUSPICIOUS
+    assert calls == []
+
+
+def test_loaded_trusted_function_module_attribute_mutation_is_not_allowlisted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    baseline = call_graph._TRUSTED_LOADED_REFERENCE_BASELINES.get(("tempfile", "gettempdir"))
+    if baseline is None:
+        pytest.skip("tempfile.gettempdir was not loaded before the call-graph trust snapshot")
+    assert baseline is not None
+    loaded_module = baseline[0][1]
+    assert type(loaded_module) is ModuleType
+    namespace = ModuleType.__getattribute__(loaded_module, "__dict__")
+    os_module = namespace["_os"]
+    assert type(os_module) is ModuleType
+    os_namespace = ModuleType.__getattribute__(os_module, "__dict__")
+    calls: list[str] = []
+
+    def hostile_fsdecode(value: object) -> str:
+        del value
+        calls.append("fsdecode")
+        raise AssertionError("mutated trusted module attribute executed")
+
+    monkeypatch.setitem(os_namespace, "fsdecode", hostile_fsdecode)
+    _clear_call_graph_caches()
+    report = package_api.scan_bytes(b"ctempfile\ngettempdir\n)R.", source="mutated-fsdecode.pkl")
+
+    assert report.verdict == SafetyVerdict.SUSPICIOUS
+    assert calls == []
+
+
+def test_loaded_trusted_function_instance_attribute_shadow_is_not_allowlisted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    baseline = call_graph._TRUSTED_LOADED_REFERENCE_BASELINES.get(("tempfile", "gettempdir"))
+    if baseline is None:
+        pytest.skip("tempfile.gettempdir was not loaded before the call-graph trust snapshot")
+    assert baseline is not None
+    loaded_module = baseline[0][1]
+    assert type(loaded_module) is ModuleType
+    namespace = ModuleType.__getattribute__(loaded_module, "__dict__")
+    os_module = namespace["_os"]
+    assert type(os_module) is ModuleType
+    os_namespace = ModuleType.__getattribute__(os_module, "__dict__")
+    environ = os_namespace["environ"]
+    environ_namespace = object.__getattribute__(environ, "__dict__")
+    assert type(environ_namespace) is dict
+    calls: list[str] = []
+
+    def hostile_get(key: str, default: object = None) -> object:
+        del key, default
+        calls.append("get")
+        raise AssertionError("shadowed trusted instance method executed")
+
+    monkeypatch.setitem(environ_namespace, "get", hostile_get)
+    _clear_call_graph_caches()
+
+    assert call_graph._loaded_trusted_reference_matches_baseline("tempfile", "gettempdir") is False
+    assert calls == []
+
+
+def test_loaded_trusted_function_attribute_dispatch_mutation_is_not_allowlisted() -> None:
+    script = """
+import tempfile
+
+import modelaudit_picklescan.call_graph as call_graph
+
+environ_class = type(tempfile._os.environ)
+original_getattribute = type.__getattribute__(environ_class, "__getattribute__")
+calls = []
+
+def hostile_getattribute(self, name):
+    if name == "get":
+        calls.append(name)
+        return lambda key, default=None: default
+    return original_getattribute(self, name)
+
+type.__setattr__(environ_class, "__getattribute__", hostile_getattribute)
+for function in call_graph._SOURCE_SENSITIVE_CACHED_FUNCTIONS:
+    function.cache_clear()
+assert call_graph._loaded_trusted_reference_matches_baseline("tempfile", "gettempdir") is False
+assert calls == []
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_loaded_trusted_tempdir_cache_transition_remains_allowlisted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    baseline = call_graph._TRUSTED_LOADED_REFERENCE_BASELINES.get(("tempfile", "gettempdir"))
+    if baseline is None:
+        pytest.skip("tempfile.gettempdir was not loaded before the call-graph trust snapshot")
+    assert baseline is not None
+    loaded_module = baseline[0][1]
+    assert type(loaded_module) is ModuleType
+    namespace = ModuleType.__getattribute__(loaded_module, "__dict__")
+    gettempdir = namespace["gettempdir"]
+    assert isinstance(gettempdir, FunctionType)
+    monkeypatch.setitem(namespace, "tempdir", None)
+    _clear_call_graph_caches()
+
+    assert call_graph._loaded_trusted_reference_matches_baseline("tempfile", "gettempdir") is True
+    assert type(gettempdir()) is str
+    _clear_call_graph_caches()
+    assert call_graph._loaded_trusted_reference_matches_baseline("tempfile", "gettempdir") is True
+
+
+def test_loaded_trusted_function_builtin_mutation_is_not_allowlisted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    baseline = call_graph._TRUSTED_LOADED_REFERENCE_BASELINES.get(("tempfile", "gettempdir"))
+    if baseline is None:
+        pytest.skip("tempfile.gettempdir was not loaded before the call-graph trust snapshot")
+    assert baseline is not None
+    loaded_module = baseline[0][1]
+    assert type(loaded_module) is ModuleType
+    namespace = ModuleType.__getattribute__(loaded_module, "__dict__")
+    helper = namespace["_get_default_tempdir"]
+    assert isinstance(helper, FunctionType)
+    builtins_namespace = object.__getattribute__(helper, "__builtins__")
+    assert type(builtins_namespace) is dict
+    original_next = builtins_namespace["next"]
+
+    def hostile_next(iterator: object) -> object:
+        return cast(Any, original_next)(iterator)
+
+    monkeypatch.setitem(builtins_namespace, "next", hostile_next)
+    _clear_call_graph_caches()
+    report = package_api.scan_bytes(b"ctempfile\ngettempdir\n)R.", source="mutated-next.pkl")
+
+    assert report.verdict == SafetyVerdict.SUSPICIOUS
+
+
+def test_loaded_trusted_class_namespace_mutation_is_not_allowlisted() -> None:
+    script = """
+import argparse
+
+import modelaudit_picklescan.api as package_api
+import modelaudit_picklescan.call_graph as call_graph
+from modelaudit_picklescan import SafetyVerdict
+
+baseline = call_graph._TRUSTED_LOADED_REFERENCE_BASELINES[("argparse", "Namespace")]
+class_ = baseline[1][1]
+calls = []
+
+class HostileDescriptor:
+    def __get__(self, instance, owner):
+        calls.append("__new__")
+        raise AssertionError("mutated trusted class descriptor executed")
+
+type.__setattr__(class_, "__new__", HostileDescriptor())
+for function in call_graph._SOURCE_SENSITIVE_CACHED_FUNCTIONS:
+    function.cache_clear()
+report = package_api.scan_bytes(b"cargparse\\nNamespace\\n)R.", source="mutated-namespace.pkl")
+assert report.verdict == SafetyVerdict.SUSPICIOUS
+assert any(
+    finding.rule_code == "NON_ALLOWLISTED_GLOBAL"
+    and finding.details.get("import_reference") == "argparse.Namespace"
+    for finding in report.findings
+)
+assert calls == []
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_loaded_module_metadata_comparison_does_not_execute_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = "statistics"
+    name = "mean"
+    spec = call_graph._find_standard_filesystem_spec(module)
+    assert type(spec) is ModuleSpec
+    origin, loader = call_graph._module_spec_fields_without_hooks(spec)
+    assert type(origin) is str
+    calls: list[str] = []
+
+    class HostileName:
+        def __eq__(self, other: object) -> bool:
+            del other
+            calls.append("__eq__")
+            raise AssertionError("loaded module metadata comparison executed attacker code")
+
+    replacement = ModuleType(module)
+    replacement_namespace = ModuleType.__getattribute__(replacement, "__dict__")
+    replacement_namespace.update(
+        {
+            "__name__": HostileName(),
+            "__package__": "",
+            "__spec__": spec,
+            "__loader__": loader,
+            "__file__": origin,
+            name: lambda values: values,
+        }
+    )
+    monkeypatch.setitem(sys.modules, module, replacement)
+    _clear_call_graph_caches()
+
+    try:
+        report = package_api.scan_bytes(b"cstatistics\nmean\n)R.", source="hostile-module-name.pkl")
+        assert report.verdict == SafetyVerdict.SUSPICIOUS
+    finally:
+        _clear_call_graph_caches()
+
+    assert calls == []
+
+
+def test_loaded_module_origin_value_cannot_execute_during_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = "modelaudit_tp_hostile_loaded_origin"
+    calls: list[str] = []
+
+    class HostileOrigin:
+        __hash__: Any = None
+
+        def __fspath__(self) -> str:
+            calls.append("fspath")
+            raise AssertionError("hostile origin was treated as a path")
+
+        def __eq__(self, other: object) -> bool:
+            del other
+            calls.append("eq")
+            raise AssertionError("hostile origin was compared")
+
+    loaded_module = ModuleType(module)
+    loaded_module.__spec__ = ModuleSpec(module, loader=None, origin=cast(Any, HostileOrigin()))
+    monkeypatch.setitem(sys.modules, module, loaded_module)
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._trusted_module_origin_kind(module) is None
+        assert call_graph._call_graph_source_unavailable_reason(module) == "source_unavailable"
+        assert call_graph._import_module_can_execute_user_code(module) is True
+    finally:
+        _clear_call_graph_caches()
+
+    assert calls == []
+
+
+def test_unloaded_builtin_with_pristine_import_runtime_remains_safe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = next((name for name in sys.builtin_module_names if name not in sys.modules), None)
+    if module is None:
+        pytest.skip("all builtin modules are already loaded")
+    assert module is not None
+    monkeypatch.setattr(sys, "meta_path", [BuiltinImporter, FrozenImporter, PathFinder])
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._trusted_module_origin_kind(module) == "stdlib"
+        assert call_graph._call_graph_source_unavailable_reason(module) is None
+        assert call_graph._import_module_can_execute_user_code(module) is False
+    finally:
+        _clear_call_graph_caches()
+
+
+def test_unrelated_import_runtime_attribute_does_not_block_unloaded_builtin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = next((name for name in sys.builtin_module_names if name not in sys.modules), None)
+    if module is None:
+        pytest.skip("all builtin modules are already loaded")
+    assert module is not None
+    monkeypatch.setattr(sys, "meta_path", [BuiltinImporter, FrozenImporter, PathFinder])
+    marker = object()
+    type.__setattr__(ModuleSpec, "_modelaudit_test_marker", marker)
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._trusted_module_origin_kind(module) == "stdlib"
+        assert call_graph._call_graph_source_unavailable_reason(module) is None
+        assert call_graph._import_module_can_execute_user_code(module) is False
+    finally:
+        type.__delattr__(ModuleSpec, "_modelaudit_test_marker")
+        _clear_call_graph_caches()
+
+
+def test_added_import_runtime_type_hook_blocks_resolution_without_execution() -> None:
+    calls: list[str] = []
+
+    def hostile_getattribute(self: object, name: str) -> object:
+        del self, name
+        calls.append("FileFinder.__getattribute__")
+        raise AssertionError("added import runtime type hook was executed")
+
+    type.__setattr__(FileFinder, "__getattribute__", hostile_getattribute)
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._interpreter_import_runtime_is_trusted() is False
+        assert call_graph._trusted_module_origin_kind("statistics") is None
+    finally:
+        type.__delattr__(FileFinder, "__getattribute__")
+        _clear_call_graph_caches()
+
+    assert calls == []
+
+
+def test_added_import_runtime_data_descriptor_blocks_resolution_without_execution() -> None:
+    calls: list[str] = []
+
+    class HostilePath:
+        def __get__(self, instance: object, owner: type[object] | None = None) -> object:
+            del self, instance, owner
+            calls.append("FileFinder.path.__get__")
+            raise AssertionError("added import runtime descriptor was executed")
+
+        def __set__(self, instance: object, value: object) -> None:
+            del self, instance, value
+            calls.append("FileFinder.path.__set__")
+            raise AssertionError("added import runtime descriptor was executed")
+
+    type.__setattr__(FileFinder, "path", HostilePath())
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._interpreter_import_runtime_is_trusted() is False
+        assert call_graph._trusted_module_origin_kind("statistics") is None
+    finally:
+        type.__delattr__(FileFinder, "path")
+        _clear_call_graph_caches()
+
+    assert calls == []
+
+
+def test_in_place_io_open_mutation_blocks_resolution_without_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frozen_importlib_external = sys.modules["_frozen_importlib_external"]
+    frozen_namespace = ModuleType.__getattribute__(frozen_importlib_external, "__dict__")
+    io_module = frozen_namespace["_io"]
+    io_namespace = ModuleType.__getattribute__(io_module, "__dict__")
+    calls: list[tuple[object, ...]] = []
+
+    def hostile_open(*args: object, **kwargs: object) -> object:
+        del kwargs
+        calls.append(args)
+        raise AssertionError("mutated _io.open was executed")
+
+    monkeypatch.setitem(io_namespace, "open", hostile_open)
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._interpreter_import_runtime_is_trusted() is False
+        assert call_graph._trusted_module_origin_kind("statistics") is None
+    finally:
+        _clear_call_graph_caches()
+
+    assert calls == []
+
+
+def test_import_runtime_dependency_prefers_frozen_namespace_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = ModuleType("canonical_dependency_name")
+    monkeypatch.setitem(sys.modules, "frozen_dependency_name", module)
+
+    assert (
+        call_graph._import_runtime_dependency_module_name("frozen_dependency_name", module) == "frozen_dependency_name"
+    )
+    assert any(
+        module_name == "_io" and dependency_module is sys.modules["_io"]
+        for module_name, dependency_module, _ in call_graph._FROZEN_IMPORTLIB_EXTERNAL_DEPENDENCY_MODULES
+    )
+
+
+def test_replaced_sys_modules_mapping_blocks_resolution_without_execution() -> None:
+    script = """
+import sys
+
+import modelaudit_picklescan.call_graph as call_graph
+
+original_modules = sys.modules
+calls = []
+
+class HostileModules(dict):
+    def get(self, key, default=None):
+        calls.append(key)
+        raise AssertionError("replacement sys.modules mapping was accessed")
+
+sys.modules = HostileModules(original_modules)
+try:
+    runtime_is_trusted = call_graph._interpreter_import_runtime_is_trusted()
+    origin_kind = call_graph._trusted_module_origin_kind("statistics")
+finally:
+    sys.modules = original_modules
+
+assert runtime_is_trusted is False
+assert origin_kind is None
+assert calls == []
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_cached_origin_is_rejected_after_import_runtime_mutation() -> None:
+    module = "statistics"
+    finder_function = type.__getattribute__(FileFinder, "__dict__")["find_spec"]
+    original_code = finder_function.__code__
+
+    def forged_find_spec(
+        self: object,
+        fullname: str,
+        target: object | None = None,
+    ) -> ModuleSpec | None:
+        del self, fullname, target
+        raise AssertionError("mutated filesystem import runtime was executed")
+
+    _clear_call_graph_caches()
+    assert call_graph._trusted_module_origin_kind(module) == "stdlib"
+    finder_function.__code__ = forged_find_spec.__code__
+
+    try:
+        assert call_graph._interpreter_import_runtime_is_trusted() is False
+        assert call_graph._trusted_module_origin_kind(module) is None
+        assert call_graph.import_only_module_requires_origin_review(module, "mean") is True
+    finally:
+        finder_function.__code__ = original_code
+        _clear_call_graph_caches()
+
+
+def test_in_place_importer_code_mutation_blocks_unloaded_builtin() -> None:
+    module = next((name for name in sys.builtin_module_names if name not in sys.modules), None)
+    if module is None:
+        pytest.skip("all builtin modules are already loaded")
+    assert module is not None
+    descriptor = type.__getattribute__(BuiltinImporter, "__dict__")["find_spec"]
+    function = descriptor.__func__
+    original_code = function.__code__
+
+    def forged_find_spec(
+        cls: type[object],
+        fullname: str,
+        path: object | None = None,
+        target: object | None = None,
+    ) -> ModuleSpec | None:
+        del cls, fullname, path, target
+        return None
+
+    function.__code__ = forged_find_spec.__code__
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._trusted_module_origin_kind(module) is None
+        assert call_graph._call_graph_source_unavailable_reason(module) == "source_unavailable"
+        assert call_graph._import_module_can_execute_user_code(module) is True
+    finally:
+        function.__code__ = original_code
+        _clear_call_graph_caches()
+
+
+def test_in_place_import_runtime_dependency_mutation_blocks_unloaded_builtin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = next((name for name in sys.builtin_module_names if name not in sys.modules), None)
+    if module is None:
+        pytest.skip("all builtin modules are already loaded")
+    assert module is not None
+    frozen_importlib = sys.modules["_frozen_importlib"]
+    frozen_namespace = ModuleType.__getattribute__(frozen_importlib, "__dict__")
+    thread_module = frozen_namespace["_thread"]
+    thread_namespace = ModuleType.__getattribute__(thread_module, "__dict__")
+    calls: list[str] = []
+
+    def hostile_rlock() -> object:
+        calls.append("RLock")
+        raise AssertionError("mutated import runtime dependency was executed")
+
+    monkeypatch.setitem(thread_namespace, "RLock", hostile_rlock)
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._interpreter_import_runtime_is_trusted() is False
+        assert call_graph._trusted_module_origin_kind(module) is None
+        assert call_graph._call_graph_source_unavailable_reason(module) == "source_unavailable"
+        assert call_graph._import_module_can_execute_user_code(module) is True
+    finally:
+        _clear_call_graph_caches()
+
+    assert calls == []
+
+
+def test_in_place_import_runtime_builtins_mutation_blocks_unloaded_builtin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = next((name for name in sys.builtin_module_names if name not in sys.modules), None)
+    if module is None:
+        pytest.skip("all builtin modules are already loaded")
+    assert module is not None
+    builtins_namespace = call_graph._IMPORT_RUNTIME_BUILTINS
+    assert type(builtins_namespace) is dict
+    calls: list[object] = []
+    original_hasattr = builtins_namespace["hasattr"]
+
+    def hostile_hasattr(value: object, name: str) -> bool:
+        calls.append(value)
+        return bool(cast(Any, original_hasattr)(value, name))
+
+    monkeypatch.setitem(builtins_namespace, "hasattr", hostile_hasattr)
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._interpreter_import_runtime_is_trusted() is False
+        assert call_graph._trusted_module_origin_kind(module) is None
+        assert call_graph._call_graph_source_unavailable_reason(module) == "source_unavailable"
+        assert call_graph._import_module_can_execute_user_code(module) is True
+    finally:
+        _clear_call_graph_caches()
+
+    assert calls == []
+
+
+def test_in_place_import_runtime_class_mutation_blocks_unloaded_builtin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = next((name for name in sys.builtin_module_names if name not in sys.modules), None)
+    if module is None:
+        pytest.skip("all builtin modules are already loaded")
+    assert module is not None
+    frozen_importlib = sys.modules["_frozen_importlib"]
+    frozen_namespace = ModuleType.__getattribute__(frozen_importlib, "__dict__")
+    module_lock = frozen_namespace["_ModuleLock"]
+    original_init = type.__getattribute__(module_lock, "__dict__")["__init__"]
+    calls: list[str] = []
+
+    def hostile_init(self: object, name: str) -> None:
+        del self, name
+        calls.append("_ModuleLock.__init__")
+        raise AssertionError("mutated import runtime class was executed")
+
+    monkeypatch.setattr(module_lock, "__init__", hostile_init)
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._interpreter_import_runtime_is_trusted() is False
+        assert call_graph._trusted_module_origin_kind(module) is None
+        assert call_graph._call_graph_source_unavailable_reason(module) == "source_unavailable"
+        assert call_graph._import_module_can_execute_user_code(module) is True
+    finally:
+        monkeypatch.setattr(module_lock, "__init__", original_init)
+        _clear_call_graph_caches()
+
+    assert calls == []
+
+
+def test_in_place_file_finder_code_mutation_blocks_filesystem_resolution() -> None:
+    finder_function = type.__getattribute__(FileFinder, "__dict__")["find_spec"]
+    original_code = finder_function.__code__
+
+    def forged_find_spec(
+        cls: type[object],
+        fullname: str,
+        path: object | None = None,
+        target: object | None = None,
+    ) -> ModuleSpec | None:
+        del cls, fullname, path, target
+        raise AssertionError("mutated filesystem import runtime was executed")
+
+    finder_function.__code__ = forged_find_spec.__code__
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._interpreter_import_runtime_is_trusted() is False
+        assert call_graph._find_standard_filesystem_spec("modelaudit_tp_mutated_path_finder") is None
+    finally:
+        finder_function.__code__ = original_code
+        _clear_call_graph_caches()
+
+
+def test_hostile_importer_keyword_defaults_fail_closed_without_execution() -> None:
+    module = next((name for name in sys.builtin_module_names if name not in sys.modules), None)
+    if module is None:
+        pytest.skip("all builtin modules are already loaded")
+    assert module is not None
+    descriptor = type.__getattribute__(BuiltinImporter, "__dict__")["find_spec"]
+    function = descriptor.__func__
+    original_keyword_defaults = function.__kwdefaults__
+    calls: list[str] = []
+
+    class HostileKeywordDefaults(dict[str, object]):
+        def __bool__(self) -> bool:
+            calls.append("bool")
+            raise TypeError("keyword defaults truthiness was evaluated")
+
+        def items(self) -> Any:
+            calls.append("items")
+            raise AssertionError("keyword defaults items hook was called")
+
+    function.__kwdefaults__ = HostileKeywordDefaults()
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._trusted_module_origin_kind(module) is None
+        assert call_graph._call_graph_source_unavailable_reason(module) == "source_unavailable"
+        assert call_graph._import_module_can_execute_user_code(module) is True
+    finally:
+        function.__kwdefaults__ = original_keyword_defaults
+        _clear_call_graph_caches()
+
+    assert calls == []
+
+
+def test_poisoned_import_lock_blocks_unloaded_builtin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = next((name for name in sys.builtin_module_names if name not in sys.modules), None)
+    if module is None:
+        pytest.skip("all builtin modules are already loaded")
+    assert module is not None
+    module_name = module
+    bootstrap = call_graph._FROZEN_IMPORTLIB_MODULE
+    assert type(bootstrap) is ModuleType
+    namespace = ModuleType.__getattribute__(bootstrap, "__dict__")
+    module_locks = namespace["_module_locks"]
+    assert type(module_locks) is dict
+    calls: list[str] = []
+
+    class PoisonedKey:
+        def __hash__(self) -> int:
+            calls.append("hash")
+            return hash(module_name)
+
+        def __eq__(self, other: object) -> bool:
+            del other
+            calls.append("eq")
+            raise AssertionError("poisoned import-lock key was compared")
+
+    class PoisonedLock:
+        def __call__(self) -> object:
+            calls.append(module_name)
+            return self
+
+    monkeypatch.setattr(sys, "meta_path", [BuiltinImporter, FrozenImporter, PathFinder])
+    monkeypatch.setitem(module_locks, PoisonedKey(), PoisonedLock())
+    calls.clear()
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._trusted_module_origin_kind(module) is None
+        assert call_graph._call_graph_source_unavailable_reason(module) == "source_unavailable"
+        assert call_graph._import_module_can_execute_user_code(module) is True
+    finally:
+        _clear_call_graph_caches()
+
+    assert calls == []
+
+
+def test_unloaded_builtin_with_mutated_importer_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = next((name for name in sys.builtin_module_names if name not in sys.modules), None)
+    if module is None:
+        pytest.skip("all builtin modules are already loaded")
+    assert module is not None
+    builtin_calls: list[str] = []
+    is_builtin_calls: list[str] = []
+    original_builtin_find_spec = type.__getattribute__(BuiltinImporter, "__dict__")["find_spec"]
+
+    def forged_is_builtin(name: str) -> int:
+        is_builtin_calls.append(name)
+        return 1
+
+    type.__setattr__(BuiltinImporter, "find_spec", _fail_builtin_find_spec(builtin_calls))
+    monkeypatch.setattr(_imp, "is_builtin", forged_is_builtin)
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._trusted_module_origin_kind(module) is None
+        assert call_graph._call_graph_source_unavailable_reason(module) == "source_unavailable"
+        assert call_graph._import_module_can_execute_user_code(module) is True
+    finally:
+        type.__setattr__(BuiltinImporter, "find_spec", original_builtin_find_spec)
+        _clear_call_graph_caches()
+
+    assert builtin_calls == []
+    assert is_builtin_calls == []
+
+
+def test_unloaded_frozen_module_with_pristine_import_runtime_remains_safe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frozen_names = getattr(_imp, "_frozen_module_names", lambda: ())()
+    module = next(
+        (
+            name
+            for name in frozen_names
+            if name not in call_graph._TRUSTED_LOADED_INTERPRETER_MODULES
+            and call_graph._interpreter_module_origin_without_import_hooks(name) == "frozen"
+        ),
+        None,
+    )
+    if module is None:
+        pytest.skip("all frozen modules were loaded when call_graph initialized")
+    assert module is not None
+    monkeypatch.setattr(sys, "meta_path", [BuiltinImporter, FrozenImporter, PathFinder])
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._trusted_module_origin_kind(module) == "stdlib"
+        assert call_graph._call_graph_source_unavailable_reason(module) is None
+        assert call_graph._import_module_can_execute_user_code(module) is False
+    finally:
+        _clear_call_graph_caches()
+
+
+def test_unloaded_frozen_module_with_mutated_importer_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frozen_names = getattr(_imp, "_frozen_module_names", lambda: ())()
+    module = next(
+        (
+            name
+            for name in frozen_names
+            if name not in call_graph._TRUSTED_LOADED_INTERPRETER_MODULES
+            and call_graph._interpreter_module_origin_without_import_hooks(name) == "frozen"
+        ),
+        None,
+    )
+    if module is None:
+        pytest.skip("all frozen modules were loaded when call_graph initialized")
+    assert module is not None
+    frozen_calls: list[str] = []
+    find_frozen_calls: list[str] = []
+    original_frozen_find_spec = type.__getattribute__(FrozenImporter, "__dict__")["find_spec"]
+
+    def forged_find_frozen(name: str, *args: object, **kwargs: object) -> object:
+        del args, kwargs
+        find_frozen_calls.append(name)
+        return None
+
+    type.__setattr__(FrozenImporter, "find_spec", _fail_frozen_find_spec(frozen_calls))
+    monkeypatch.setattr(_imp, "find_frozen", forged_find_frozen)
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._trusted_module_origin_kind(module) is None
+        assert call_graph._call_graph_source_unavailable_reason(module) == "source_unavailable"
+        assert call_graph._import_module_can_execute_user_code(module) is True
+    finally:
+        type.__setattr__(FrozenImporter, "find_spec", original_frozen_find_spec)
+        _clear_call_graph_caches()
+
+    assert frozen_calls == []
+    assert find_frozen_calls == []
+
+
+def test_in_place_importer_closure_code_mutation_blocks_unloaded_frozen() -> None:
+    frozen_names = getattr(_imp, "_frozen_module_names", lambda: ())()
+    module = next(
+        (
+            name
+            for name in frozen_names
+            if name not in call_graph._TRUSTED_LOADED_INTERPRETER_MODULES
+            and call_graph._interpreter_module_origin_without_import_hooks(name) == "frozen"
+        ),
+        None,
+    )
+    if module is None:
+        pytest.skip("all frozen modules were loaded when call_graph initialized")
+    assert module is not None
+    descriptor = type.__getattribute__(FrozenImporter, "__dict__")["get_code"]
+    wrapper = descriptor.__func__
+    inner = next(
+        (cell.cell_contents for cell in wrapper.__closure__ or () if isinstance(cell.cell_contents, FunctionType)),
+        None,
+    )
+    if inner is None:
+        pytest.skip("FrozenImporter.get_code has no function closure")
+    assert inner is not None
+    original_code = inner.__code__
+
+    def forged_get_code(cls: type[object], fullname: str) -> None:
+        del cls, fullname
+
+    inner.__code__ = forged_get_code.__code__
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._trusted_module_origin_kind(module) is None
+        assert call_graph._call_graph_source_unavailable_reason(module) == "source_unavailable"
+        assert call_graph._import_module_can_execute_user_code(module) is True
+    finally:
+        inner.__code__ = original_code
+        _clear_call_graph_caches()
+
+
+def test_late_loaded_builtin_with_canonical_spec_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = next((name for name in sys.builtin_module_names if name not in sys.modules), None)
+    if module is None:
+        pytest.skip("all builtin modules are already loaded")
+    assert module is not None
+    loaded_module = ModuleType(module)
+    loaded_module.__spec__ = ModuleSpec(module, cast(Any, BuiltinImporter), origin="built-in")
+    monkeypatch.setitem(sys.modules, module, loaded_module)
+    _clear_call_graph_caches()
+
+    try:
+        assert call_graph._trusted_module_origin_kind(module) is None
+        assert call_graph._call_graph_source_unavailable_reason(module) == "source_unavailable"
+        assert call_graph._import_module_can_execute_user_code(module) is True
+    finally:
+        _clear_call_graph_caches()

--- a/tests/benchmarks/test_scan_benchmarks.py
+++ b/tests/benchmarks/test_scan_benchmarks.py
@@ -230,7 +230,6 @@ def test_scan_suspicious_pickle_intake(benchmark: Any, benchmark_inputs: dict[st
         workload="suspicious-pickle-intake",
     )
 
-    assert result.success is True
     assert result.files_scanned >= 4
     assert result.issues
     assert determine_exit_code(result) == 1


### PR DESCRIPTION
## Summary
- harden picklescan module/spec resolution without invoking mutable import hooks
- fail closed on forged or replaced interpreter modules, trusted references, import-runtime dependencies, attribute dispatch, stale origin caches, and replaced import-state containers
- preserve reviewed startup-loaded references only while their bounded executable dependency graph remains trustworthy
- fail closed for source modules first loaded after the trust snapshot because their provenance cannot be distinguished safely from a forged first-use replacement
- support both legacy `posixpath._varprog` caches and current `posixpath._varsub` bound-regex caches without executing hostile cache values
- add malicious and benign regressions for direct/transitive mutation, descriptor/dispatch changes, cache transitions, and Python portability

## Review and QA fixes
- snapshot importlib code, classes, selected dependency modules, effective builtins, and `_io.open`
- reject executable or descriptor members added to import-runtime types
- guard `sys.modules`, `sys.meta_path`, `sys.path`, `sys.path_hooks`, and `sys.path_importer_cache` before traversal
- revalidate the import runtime before reusing cached filesystem-origin classifications
- preserve only bounded, inert standard-library cache transitions: `tempfile.tempdir`, exact regex-backed expandvars caches, and exact-string `__slotnames__` lists
- reject hostile cache objects and list subclasses without invoking their hooks
- isolate import-state-sensitive regressions in fresh interpreters so test ordering cannot mask or manufacture results

## Validation
- both changed call-graph modules: `382 passed, 5 skipped`
- focused late-load, forgery, benign-cache, and hostile-cache regressions: `4 passed`
- scoped Ruff format/check, mypy, and `git diff --check`: clean
- the benchmark test cannot be collected locally because `pytest-benchmark` is unavailable; CI remains authoritative for that benchmark

## Published state
- current main integrated: `838f25046fb94fe018b18a5a2a84e4aef3ed969e`
- head: `516dd9fa51e96d46df81a96d6b7a019df7dd3d01`
- exact tested tree: `993656c047555fca220dedc7148a5aab9b61f4fa`

All inline review threads are resolved. The former shared baseline gate in #1597 has merged.