### PR TITLE
fix: bound picklescan pytorch zip members

### DIFF
--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -79,6 +79,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - Invalidate cached call-graph analysis when Python sources, import hooks, loaded module origins, or parent package markers change.
+- fail closed when PyTorch ZIP archives exceed the standalone pickle-member scan budget
 - detect dangerous call-like strings split across newline-separated statements
 - scan raw nested pickle payloads carried inside Unicode string literals
 - fail closed on protocol 5 `NEXT_BUFFER` opcodes instead of reporting clean coverage

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -77,7 +77,9 @@ _PROTO0_1_TRIVIAL_LEADING_OPCODES = frozenset(
     }
 )
 _MAX_PYTORCH_ZIP_ENTRIES = 10_000
+_MAX_PYTORCH_ZIP_PICKLE_MEMBERS = 256
 _MAX_PYTORCH_ZIP_PICKLE_MEMBER_BYTES = 512 * 1024 * 1024
+_MAX_PYTORCH_ZIP_PICKLE_TOTAL_MEMBER_BYTES = 512 * 1024 * 1024
 _RUST_EXTENSION_MODULE = "modelaudit_picklescan._rust"
 _MAX_INERT_INITIALIZATION_MODULES = 32
 _TRUSTED_REFERENCE_RECONSTRUCTION_OPCODES = frozenset({"BUILD", "NEWOBJ", "NEWOBJ_EX"})
@@ -296,6 +298,9 @@ class PickleScanner:
 
             reports: list[PickleReport] = []
             skipped_notices: list[Notice] = list(discovery_notices)
+            scanned_pickle_member_count = 0
+            scanned_pickle_member_bytes = 0
+            budget_skipped_entries: list[zipfile.ZipInfo] = []
             for entry in pickle_entries:
                 member_name = entry.filename
                 member_source = f"{source}:{member_name}"
@@ -317,6 +322,14 @@ class PickleScanner:
                         )
                     )
                     continue
+                if (
+                    scanned_pickle_member_count >= _MAX_PYTORCH_ZIP_PICKLE_MEMBERS
+                    or scanned_pickle_member_bytes + entry.file_size > _MAX_PYTORCH_ZIP_PICKLE_TOTAL_MEMBER_BYTES
+                ):
+                    budget_skipped_entries.append(entry)
+                    continue
+                scanned_pickle_member_count += 1
+                scanned_pickle_member_bytes += entry.file_size
                 try:
                     with archive.open(entry, "r") as member_stream:
                         reports.append(
@@ -338,6 +351,18 @@ class PickleScanner:
                             bytes_total=entry.file_size,
                         )
                     )
+
+            if budget_skipped_entries:
+                skipped_notices.append(
+                    _pytorch_zip_pickle_member_budget_notice(
+                        source=source,
+                        pickle_member_count=len(pickle_entries),
+                        scanned_pickle_member_count=scanned_pickle_member_count,
+                        total_pickle_member_bytes=sum(entry.file_size for entry in pickle_entries),
+                        scanned_pickle_member_bytes=scanned_pickle_member_bytes,
+                        skipped_entries=budget_skipped_entries,
+                    )
+                )
 
             return _combine_pytorch_zip_reports(
                 source=source,
@@ -684,6 +709,37 @@ def _pytorch_zip_entry_limit_report(*, source: str, size: int, entry_count: int)
     )
 
 
+def _pytorch_zip_pickle_member_budget_notice(
+    *,
+    source: str,
+    pickle_member_count: int,
+    scanned_pickle_member_count: int,
+    total_pickle_member_bytes: int,
+    scanned_pickle_member_bytes: int,
+    skipped_entries: list[zipfile.ZipInfo],
+) -> Notice:
+    return Notice(
+        message=(
+            "PyTorch ZIP analysis stopped scanning pickle members because the archive exceeds the standalone "
+            "aggregate pickle-member budget"
+        ),
+        severity=Severity.INFO,
+        location=source,
+        code="pytorch_zip_pickle_member_budget",
+        details={
+            "pickle_member_count": pickle_member_count,
+            "scanned_pickle_member_count": scanned_pickle_member_count,
+            "skipped_pickle_member_count": len(skipped_entries),
+            "max_pickle_members": _MAX_PYTORCH_ZIP_PICKLE_MEMBERS,
+            "total_pickle_member_bytes": total_pickle_member_bytes,
+            "scanned_pickle_member_bytes": scanned_pickle_member_bytes,
+            "max_total_pickle_member_bytes": _MAX_PYTORCH_ZIP_PICKLE_TOTAL_MEMBER_BYTES,
+            "skipped_pickle_members": [entry.filename for entry in skipped_entries[:10]],
+            "analysis_incomplete": True,
+        },
+    )
+
+
 def _combine_pytorch_zip_reports(
     *,
     source: str,
@@ -729,6 +785,8 @@ def _combine_pytorch_zip_reports(
     ):
         if any(report.metadata.get(metadata_key) is True for report in member_reports):
             metadata[metadata_key] = True
+    if any(notice.details.get("analysis_incomplete") is True for notice in extra_notices):
+        metadata["analysis_incomplete"] = True
     return PickleReport(
         source=source,
         status=status,

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -1872,6 +1872,105 @@ def test_scan_file_marks_oversized_pytorch_zip_member_inconclusive(
     assert any(notice.code == "pytorch_zip_member_size_limit" for notice in report.notices)
 
 
+def test_scan_file_marks_pytorch_zip_pickle_member_budget_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(package_api, "_MAX_PYTORCH_ZIP_PICKLE_MEMBERS", 2)
+    archive_path = tmp_path / "member-budget.pt"
+    safe_payload = pickle.dumps({"weights": [1, 2, 3]}, protocol=4)
+    malicious_payload = pickle.dumps(MaliciousPayload(), protocol=4)
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", safe_payload)
+        archive.writestr("archive/near-limit.pkl", safe_payload)
+        archive.writestr("archive/skipped-malicious.pkl", malicious_payload)
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+
+    report = scan_file(archive_path)
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.UNKNOWN
+    assert report.findings == ()
+    assert not report.is_clean
+    assert report.coverage.raw_scan_complete is False
+    assert report.coverage.opcode_scan_complete is False
+    assert report.metadata["analysis_incomplete"] is True
+    assert list(report.metadata["pickle_files"]) == [
+        "archive/data.pkl",
+        "archive/near-limit.pkl",
+        "archive/skipped-malicious.pkl",
+    ]
+    assert len(report.metadata["member_reports"]) == 2
+    budget_notices = [notice for notice in report.notices if notice.code == "pytorch_zip_pickle_member_budget"]
+    assert len(budget_notices) == 1
+    assert budget_notices[0].details["analysis_incomplete"] is True
+    assert budget_notices[0].details["pickle_member_count"] == 3
+    assert budget_notices[0].details["scanned_pickle_member_count"] == 2
+    assert budget_notices[0].details["skipped_pickle_member_count"] == 1
+    assert budget_notices[0].details["max_pickle_members"] == 2
+    assert list(budget_notices[0].details["skipped_pickle_members"]) == ["archive/skipped-malicious.pkl"]
+
+
+def test_scan_file_marks_pytorch_zip_pickle_member_total_bytes_budget_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive_path = tmp_path / "member-byte-budget.pt"
+    safe_payload = pickle.dumps({"weights": [1, 2, 3]}, protocol=4)
+    malicious_payload = pickle.dumps(MaliciousPayload(), protocol=4)
+    monkeypatch.setattr(package_api, "_MAX_PYTORCH_ZIP_PICKLE_MEMBERS", 10)
+    monkeypatch.setattr(package_api, "_MAX_PYTORCH_ZIP_PICKLE_TOTAL_MEMBER_BYTES", len(safe_payload) * 2)
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", safe_payload)
+        archive.writestr("archive/near-limit.pkl", safe_payload)
+        archive.writestr("archive/skipped-malicious.pkl", malicious_payload)
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+
+    report = scan_file(archive_path)
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.UNKNOWN
+    assert report.findings == ()
+    assert report.metadata["analysis_incomplete"] is True
+    assert len(report.metadata["member_reports"]) == 2
+    budget_notices = [notice for notice in report.notices if notice.code == "pytorch_zip_pickle_member_budget"]
+    assert len(budget_notices) == 1
+    assert budget_notices[0].details["pickle_member_count"] == 3
+    assert budget_notices[0].details["scanned_pickle_member_count"] == 2
+    assert budget_notices[0].details["max_pickle_members"] == 10
+    assert budget_notices[0].details["total_pickle_member_bytes"] == len(safe_payload) * 2 + len(malicious_payload)
+    assert budget_notices[0].details["scanned_pickle_member_bytes"] == len(safe_payload) * 2
+    assert budget_notices[0].details["max_total_pickle_member_bytes"] == len(safe_payload) * 2
+    assert list(budget_notices[0].details["skipped_pickle_members"]) == ["archive/skipped-malicious.pkl"]
+
+
+def test_scan_file_scans_pytorch_zip_pickle_member_budget_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive_path = tmp_path / "member-budget-boundary.pt"
+    safe_payload = pickle.dumps({"weights": [1, 2, 3]}, protocol=4)
+    monkeypatch.setattr(package_api, "_MAX_PYTORCH_ZIP_PICKLE_MEMBERS", 2)
+    monkeypatch.setattr(package_api, "_MAX_PYTORCH_ZIP_PICKLE_TOTAL_MEMBER_BYTES", len(safe_payload) * 2)
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", safe_payload)
+        archive.writestr("archive/near-limit.pkl", safe_payload)
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+
+    report = scan_file(archive_path)
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert report.is_clean
+    assert "analysis_incomplete" not in report.metadata
+    assert list(report.metadata["pickle_files"]) == ["archive/data.pkl", "archive/near-limit.pkl"]
+    assert len(report.metadata["member_reports"]) == 2
+    assert all(notice.code != "pytorch_zip_pickle_member_budget" for notice in report.notices)
+
+
 def test_scan_file_enforces_pytorch_zip_entry_cap_before_opening_archive(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Publishes local ModelAudit security remediation branch `mdangelo/codex/fix-picklescan-pytorch-zip-member-budget`.
- fix: bound picklescan pytorch zip members

## Validation
- Commit: `77b35e84e6df5148de554c1df96d586f0bfa58b3`
- Regression coverage and implementation changes are contained in this isolated branch.
- Full CI will run on this draft PR.
