### PR TITLE
fix: require defusedxml for pmml parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- fail closed on PMML XML parsing when defusedxml is unavailable instead of using the stdlib parser
 - detect operator attrgetter, itemgetter, and methodcaller archive-member Python paths to command execution while preserving benign accessor names
 - redact Keras and TensorFlow scanner detail fields that echo model-controlled configs, code indicators, archive members, and external references.
 - route security-relevant protocol-less binary pickle streams through pickle analysis even when file suffixes are misleading

--- a/modelaudit/scanners/pmml_scanner.py
+++ b/modelaudit/scanners/pmml_scanner.py
@@ -10,17 +10,15 @@ from .base import BaseScanner, IssueSeverity, ScanResult
 try:
     from defusedxml import ElementTree as DefusedET
 
+    if not callable(getattr(DefusedET, "fromstring", None)):
+        raise ImportError("defusedxml.ElementTree.fromstring is unavailable")
     HAS_DEFUSEDXML = True
-except ImportError:  # pragma: no cover - defusedxml may not be installed
+except Exception:  # pragma: no cover - defusedxml may be unavailable or broken
     HAS_DEFUSEDXML = False
     if TYPE_CHECKING:
         from defusedxml import ElementTree as DefusedET  # type: ignore[no-redef]
     else:
         DefusedET = None  # type: ignore[assignment]
-
-# Only import unsafe XML as fallback
-if not HAS_DEFUSEDXML:
-    import xml.etree.ElementTree as UnsafeET
 
 
 SUSPICIOUS_PATTERNS = [
@@ -69,7 +67,7 @@ class PmmlScanner(BaseScanner):
     external references.
 
     Security features:
-    - Uses defusedxml for safe XML parsing when available
+    - Requires defusedxml for safe XML parsing and fails closed when it is unavailable
     - Detects DOCTYPE and ENTITY declarations that could enable XXE attacks
     - Scans for suspicious patterns in Extension elements
     - Identifies external resource references
@@ -83,6 +81,7 @@ class PmmlScanner(BaseScanner):
     FILE_READ_INCOMPLETE_REASON: ClassVar[str] = "pmml_file_read_failed"
     EXTENSION_TRAVERSAL_INCOMPLETE_REASON: ClassVar[str] = "pmml_extension_traversal_limit_exceeded"
     XML_PARSE_INCOMPLETE_REASON: ClassVar[str] = "pmml_xml_parse_failed"
+    XML_PARSER_UNAVAILABLE_INCOMPLETE_REASON: ClassVar[str] = "pmml_safe_xml_parser_unavailable"
 
     def __init__(self, config: dict[str, Any] | None = None) -> None:
         pmml_config = dict(config or {})
@@ -173,23 +172,30 @@ class PmmlScanner(BaseScanner):
         # Check for dangerous XML constructs before parsing
         self._check_dangerous_xml_constructs(text, result, path)
 
-        # Parse XML using safe parser when available
+        if not HAS_DEFUSEDXML or DefusedET is None:
+            mark_inconclusive_scan_result(result, self.XML_PARSER_UNAVAILABLE_INCOMPLETE_REASON)
+            result.add_check(
+                name="XML Parser Security Check",
+                passed=False,
+                message="PMML XML parsing skipped because defusedxml is unavailable",
+                severity=IssueSeverity.INFO,
+                location=path,
+                details={
+                    "required_package": "defusedxml",
+                    "analysis_incomplete": True,
+                    "scan_outcome_reason": self.XML_PARSER_UNAVAILABLE_INCOMPLETE_REASON,
+                },
+                why=(
+                    "PMML parsing requires defusedxml. Falling back to the standard XML parser would parse "
+                    "attacker-controlled XML without the hardened entity-expansion protections."
+                ),
+            )
+            result.finish(success=False)
+            return result
+
+        # Parse XML using the safe parser
         try:
-            if HAS_DEFUSEDXML:
-                root = DefusedET.fromstring(text)
-            else:
-                # Warn about using unsafe parser
-                result.add_check(
-                    name="XML Parser Security Check",
-                    passed=False,
-                    message="Using unsafe XML parser - defusedxml not available",
-                    severity=IssueSeverity.WARNING,
-                    location=path,
-                    why="defusedxml is not installed. The standard XML parser may be vulnerable to XXE attacks. "
-                    "Install defusedxml for better security.",
-                    rule_code="S902",
-                )
-                root = UnsafeET.fromstring(text)
+            root = DefusedET.fromstring(text)
         except Exception as e:
             mark_inconclusive_scan_result(result, self.XML_PARSE_INCOMPLETE_REASON)
             result.add_check(

--- a/modelaudit/utils/helpers/cache_decorator.py
+++ b/modelaudit/utils/helpers/cache_decorator.py
@@ -102,11 +102,24 @@ def _h5py_availability() -> bool:
     return HAS_H5PY
 
 
+def _defusedxml_availability() -> bool:
+    """Return whether hardened PMML XML analysis is available in this process."""
+    try:
+        from ...scanners.pmml_scanner import HAS_DEFUSEDXML
+    except Exception:
+        return False
+
+    return HAS_DEFUSEDXML
+
+
 def add_optional_dependency_availability_to_version_context(version_context: dict[str, Any]) -> dict[str, Any]:
     """Key caches on optional dependencies that change scan coverage."""
     return {
         **version_context,
-        "optional_dependency_availability": {"h5py": _h5py_availability()},
+        "optional_dependency_availability": {
+            "defusedxml": _defusedxml_availability(),
+            "h5py": _h5py_availability(),
+        },
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,6 +137,7 @@ def pytest_runtest_setup(item):
             "test_numpy_scanner.py",  # NumPy scanner CVE-2019-6446 tests
             "test_onnx_scanner.py",  # ONNX scanner CVE-2025-51480 tests
             "test_pmml_scanner.py",  # PMML suspicious-content false-positive regressions
+            "test_pmml_dependency_handling.py",  # PMML safe-parser fail-closed regressions
             "test_safetensors_scanner.py",  # SafeTensors scanner dtype and metadata tests
             "test_weight_distribution_scanner.py",  # Weight-distribution false-positive and coverage tests
             "test_rule_mapper.py",  # Rule mapper validity and network mapping tests

--- a/tests/scanners/test_pmml_dependency_handling.py
+++ b/tests/scanners/test_pmml_dependency_handling.py
@@ -13,8 +13,9 @@ import pytest
     [
         'raise RuntimeError("broken defusedxml installation")\n',
         "ElementTree = None\n",
+        "class ElementTree:\n    fromstring = None\n",
     ],
-    ids=["import-error", "missing-element-tree"],
+    ids=["import-error", "missing-element-tree", "non-callable-parser"],
 )
 def test_pmml_scanner_broken_defusedxml_fails_closed(
     tmp_path: Path,

--- a/tests/scanners/test_pmml_dependency_handling.py
+++ b/tests/scanners/test_pmml_dependency_handling.py
@@ -1,0 +1,69 @@
+"""Regression tests for PMML scanner dependency handling."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "fake_package_source",
+    [
+        'raise RuntimeError("broken defusedxml installation")\n',
+        "ElementTree = None\n",
+    ],
+    ids=["import-error", "missing-element-tree"],
+)
+def test_pmml_scanner_broken_defusedxml_fails_closed(
+    tmp_path: Path,
+    fake_package_source: str,
+) -> None:
+    fake_dependencies = tmp_path / "fake-dependencies"
+    fake_package = fake_dependencies / "defusedxml"
+    fake_package.mkdir(parents=True)
+    (fake_package / "__init__.py").write_text(
+        fake_package_source,
+        encoding="utf-8",
+    )
+    pmml_path = tmp_path / "model.pmml"
+    pmml_path.write_text(
+        "<?xml version='1.0'?><PMML version='4.4'><Header/></PMML>",
+        encoding="utf-8",
+    )
+
+    repository_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    python_path = [str(fake_dependencies), str(repository_root)]
+    if existing_python_path := env.get("PYTHONPATH"):
+        python_path.append(existing_python_path)
+    env["PYTHONPATH"] = os.pathsep.join(python_path)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "from modelaudit.scanner_results import INCONCLUSIVE_SCAN_OUTCOME; "
+                "from modelaudit.scanners import pmml_scanner; "
+                "result = pmml_scanner.PmmlScanner().scan(sys.argv[1]); "
+                "assert pmml_scanner.HAS_DEFUSEDXML is False; "
+                "assert pmml_scanner.DefusedET is None; "
+                "assert result.success is False; "
+                "assert result.metadata['scan_outcome'] == INCONCLUSIVE_SCAN_OUTCOME; "
+                "assert result.metadata['scan_outcome_reasons'] == "
+                "[pmml_scanner.PmmlScanner.XML_PARSER_UNAVAILABLE_INCOMPLETE_REASON]; "
+                "assert any(check.name == 'XML Parser Security Check' for check in result.checks)"
+            ),
+            str(pmml_path),
+        ],
+        capture_output=True,
+        check=False,
+        env=env,
+        text=True,
+        timeout=30,
+    )
+
+    assert completed.returncode == 0, completed.stderr

--- a/tests/scanners/test_pmml_scanner.py
+++ b/tests/scanners/test_pmml_scanner.py
@@ -118,6 +118,44 @@ def test_pmml_scanner_missing_defusedxml_fails_closed_without_unsafe_parse(
     )
 
 
+def test_pmml_cache_invalidates_when_safe_parser_becomes_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "model.pmml"
+    path.write_text(
+        "<?xml version='1.0'?><PMML version='4.4'><Header/></PMML>",
+        encoding="utf-8",
+    )
+    cache_dir = tmp_path / "cache"
+    reset_cache_manager()
+    try:
+        first = scan_model_directory_or_file(
+            str(path),
+            cache_enabled=True,
+            cache_dir=str(cache_dir),
+            min_cache_file_size=0,
+        )
+        assert determine_exit_code(first) == 0
+
+        monkeypatch.setattr(pmml_scanner_module, "HAS_DEFUSEDXML", False)
+        monkeypatch.setattr(pmml_scanner_module, "DefusedET", None)
+
+        second = scan_model_directory_or_file(
+            str(path),
+            cache_enabled=True,
+            cache_dir=str(cache_dir),
+            min_cache_file_size=0,
+        )
+
+        metadata = second.file_metadata[str(path)]
+        assert metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert metadata["scan_outcome_reasons"] == [PmmlScanner.XML_PARSER_UNAVAILABLE_INCOMPLETE_REASON]
+        assert determine_exit_code(second) == 2
+    finally:
+        reset_cache_manager()
+
+
 def test_pmml_scanner_missing_defusedxml_preserves_xxe_preparse_detection(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/scanners/test_pmml_scanner.py
+++ b/tests/scanners/test_pmml_scanner.py
@@ -2,9 +2,12 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
 from modelaudit.cache import get_cache_manager, reset_cache_manager
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.scanner_results import INCONCLUSIVE_SCAN_OUTCOME
+from modelaudit.scanners import pmml_scanner as pmml_scanner_module
 from modelaudit.scanners.base import IssueSeverity
 from modelaudit.scanners.pmml_scanner import PmmlScanner
 
@@ -80,6 +83,68 @@ def test_pmml_scanner_xxe(tmp_path: Path) -> None:
     assert result.success is False
     assert any("doctype" in m or "entity" in m for m in messages)
     assert any(i.severity == IssueSeverity.CRITICAL for i in result.issues)
+
+
+def test_pmml_scanner_missing_defusedxml_fails_closed_without_unsafe_parse(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pmml = """<?xml version='1.0'?>
+<PMML version='4.4'>
+  <Header/>
+  <DataDictionary numberOfFields='0'/>
+</PMML>"""
+    path = tmp_path / "model.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    monkeypatch.setattr(pmml_scanner_module, "HAS_DEFUSEDXML", False)
+    monkeypatch.setattr(pmml_scanner_module, "DefusedET", None)
+
+    result = PmmlScanner().scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert result.metadata["scan_outcome_reasons"] == [PmmlScanner.XML_PARSER_UNAVAILABLE_INCOMPLETE_REASON]
+    parser_checks = [check for check in result.checks if check.name == "XML Parser Security Check"]
+    assert len(parser_checks) == 1
+    assert parser_checks[0].severity == IssueSeverity.INFO
+    assert parser_checks[0].details["scan_outcome_reason"] == PmmlScanner.XML_PARSER_UNAVAILABLE_INCOMPLETE_REASON
+    assert "pmml_version" not in result.metadata
+
+    _assert_inconclusive_aggregate_not_cached(
+        path,
+        PmmlScanner.XML_PARSER_UNAVAILABLE_INCOMPLETE_REASON,
+        tmp_path / "cache",
+    )
+
+
+def test_pmml_scanner_missing_defusedxml_preserves_xxe_preparse_detection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    xxe_target = tmp_path / "xxe-target"
+    pmml = f"""<?xml version='1.0'?>
+<!DOCTYPE pmml [ <!ENTITY xxe SYSTEM '{xxe_target.as_uri()}'> ]>
+<PMML version='4.4'>
+  <Header>
+    <Extension>&xxe;</Extension>
+  </Header>
+</PMML>"""
+    path = tmp_path / "evil.pmml"
+    path.write_text(pmml, encoding="utf-8")
+
+    monkeypatch.setattr(pmml_scanner_module, "HAS_DEFUSEDXML", False)
+    monkeypatch.setattr(pmml_scanner_module, "DefusedET", None)
+
+    result = PmmlScanner().scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert PmmlScanner.XML_PARSER_UNAVAILABLE_INCOMPLETE_REASON in result.metadata["scan_outcome_reasons"]
+    assert any(issue.severity == IssueSeverity.CRITICAL and "DOCTYPE" in issue.message for issue in result.issues)
+
+    aggregate = scan_model_directory_or_file(str(path), cache_enabled=False)
+    assert determine_exit_code(aggregate) == 1
 
 
 def test_pmml_scanner_suspicious_extension_content(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- remove the unsafe stdlib XML fallback from PMML parsing and fail closed when the required hardened parser is unavailable
- treat import failures and incomplete `defusedxml` installations as parser unavailability, including missing or non-callable `ElementTree.fromstring`
- preserve dangerous XML prechecks before dependency failure so XXE/DOCTYPE findings still determine the security exit code
- key scan caches on hardened PMML parser availability so a previously cached clean result cannot bypass fail-closed behavior
- register the dependency regression in reduced Python CI lanes and keep fixtures deterministic under `tmp_path`
- synchronize with current `main`

## Security and QA
- missing or broken `defusedxml` returns an explicit inconclusive result instead of crashing or parsing attacker-controlled XML unsafely
- subprocess regressions scan a real PMML file for exception-raising, missing-parser, and non-callable-parser packages
- clean PMML remains fail-closed when the parser is unavailable; malicious DOCTYPE input still reports the critical preparse finding
- a healthy-to-unavailable dependency transition invalidates the prior cache context and returns exit code 2 instead of stale exit code 0
- all inline review threads and substantive top-level feedback are addressed

## Validation
- `tests/scanners/test_pmml_scanner.py`
- `tests/scanners/test_pmml_dependency_handling.py`
- result after current-main sync: `52 passed`
- two adjacent h5py cache-transition tests were selected but skipped because h5py is not installed in this environment
- scoped Ruff check and format
- scoped mypy
- `git diff --check origin/main...HEAD`
- exact published tree: `cb80854a7b13ae64f2f225b7ac4bbb6acb22e01f`

Full pytest remains delegated to CI. Final reviewed head: `eb2df8ac7c10aeff9c638e7b175baf4cce0f9aa6`, based on main `def9169bd2f7ab06d6e094023a52ab6c575bfbc7`.