### PR TITLE
fix: restrict progress hook egress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fail closed when capped DVC pointer outputs are not otherwise covered, change during verification, exceed bounded tail verification, or exhaust shared scan budgets
 - preserve registrable network domains and redact delimiter-split credentials in bounded finding evidence
 - preserve executable text-sidecar network findings for f-string calls, standard command wrappers, port-qualified Docker registries, and bounded xargs downloads while keeping prose references informational.
+- require explicit public progress hook egress hosts and reject internal webhook and SMTP destinations before sending scan details.
 - stabilize cache identity capture for compressed wrapper scans on Darwin `/private` path aliases and during unrelated temporary-file churn.
 
 ## [0.2.47](https://github.com/promptfoo/modelaudit/compare/v0.2.46...v0.2.47) (2026-06-05)

--- a/modelaudit/progress/hooks.py
+++ b/modelaudit/progress/hooks.py
@@ -11,7 +11,7 @@ import ssl
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Collection
-from typing import Any
+from typing import Any, cast
 from urllib.parse import unquote, urlparse
 
 from .base import ProgressPhase, ProgressStats
@@ -28,6 +28,45 @@ _NAT64_NETWORKS = (
     ipaddress.ip_network("64:ff9b:1::/48"),
 )
 _ISATAP_MARKERS = frozenset({b"\x00\x00\x5e\xfe", b"\x02\x00\x5e\xfe"})
+_IANA_GLOBAL_IP_NETWORKS = (
+    ipaddress.ip_network("192.0.0.9/32"),
+    ipaddress.ip_network("192.0.0.10/32"),
+    ipaddress.ip_network("2001:1::1/128"),
+    ipaddress.ip_network("2001:1::2/128"),
+    ipaddress.ip_network("2001:1::3/128"),
+    ipaddress.ip_network("2001:3::/32"),
+    ipaddress.ip_network("2001:4:112::/48"),
+    ipaddress.ip_network("2001:20::/28"),
+    ipaddress.ip_network("2001:30::/28"),
+)
+_IANA_NON_GLOBAL_IP_NETWORKS = (
+    ipaddress.ip_network("0.0.0.0/8"),
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("100.64.0.0/10"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.0.0.0/24"),
+    ipaddress.ip_network("192.0.2.0/24"),
+    ipaddress.ip_network("192.88.99.2/32"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("198.18.0.0/15"),
+    ipaddress.ip_network("198.51.100.0/24"),
+    ipaddress.ip_network("203.0.113.0/24"),
+    ipaddress.ip_network("240.0.0.0/4"),
+    ipaddress.ip_network("::/128"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("::ffff:0:0/96"),
+    ipaddress.ip_network("64:ff9b:1::/48"),
+    ipaddress.ip_network("100::/64"),
+    ipaddress.ip_network("100:0:0:1::/64"),
+    ipaddress.ip_network("2001::/23"),
+    ipaddress.ip_network("2001:db8::/32"),
+    ipaddress.ip_network("3fff::/20"),
+    ipaddress.ip_network("5f00::/16"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),
+)
 _DEFAULT_NETWORK_TIMEOUT_SECONDS = 10.0
 _MAX_NETWORK_TIMEOUT_SECONDS = 60.0
 
@@ -115,7 +154,13 @@ def _embedded_ipv4_addresses(address: ipaddress.IPv6Address) -> tuple[ipaddress.
 
 
 def _is_public_ip_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
-    if not address.is_global or address.is_multicast:
+    if address.is_multicast:
+        return False
+    if any(address in network for network in _IANA_GLOBAL_IP_NETWORKS):
+        return True
+    if any(address in network for network in _IANA_NON_GLOBAL_IP_NETWORKS):
+        return False
+    if not address.is_global:
         return False
     if isinstance(address, ipaddress.IPv6Address):
         return all(_is_public_ip_address(embedded) for embedded in _embedded_ipv4_addresses(address))
@@ -158,10 +203,16 @@ def _resolve_public_addresses(hostname: str, port: int, destination_type: str) -
             raise ValueError(f"{destination_type} host '{hostname}' resolved to an unsupported socket family")
         if socket_type not in {0, socket.SOCK_STREAM} or protocol not in {0, socket.IPPROTO_TCP}:
             raise ValueError(f"{destination_type} host '{hostname}' resolved to a non-TCP socket")
-        if not isinstance(socket_address, tuple) or len(socket_address) < 2:
+        expected_address_length = 2 if family == socket.AF_INET else 4
+        if not isinstance(socket_address, tuple) or len(socket_address) != expected_address_length:
             raise ValueError(f"{destination_type} host '{hostname}' returned a malformed socket address")
         raw_address, resolved_port = socket_address[:2]
-        if not isinstance(raw_address, str) or not isinstance(resolved_port, int) or resolved_port != port:
+        if (
+            not isinstance(raw_address, str)
+            or isinstance(resolved_port, bool)
+            or not isinstance(resolved_port, int)
+            or resolved_port != port
+        ):
             raise ValueError(f"{destination_type} host '{hostname}' returned an invalid socket address or port")
         if "%" in raw_address:
             raise ValueError(f"{destination_type} host '{hostname}' returned a scoped IPv6 address")
@@ -169,6 +220,23 @@ def _resolve_public_addresses(hostname: str, port: int, destination_type: str) -
             parsed_address = ipaddress.ip_address(raw_address)
         except ValueError as exc:
             raise ValueError(f"{destination_type} host '{hostname}' returned an invalid IP address") from exc
+        if family == socket.AF_INET and not isinstance(parsed_address, ipaddress.IPv4Address):
+            raise ValueError(f"{destination_type} host '{hostname}' returned an address-family mismatch")
+        if family == socket.AF_INET6:
+            if not isinstance(parsed_address, ipaddress.IPv6Address):
+                raise ValueError(f"{destination_type} host '{hostname}' returned an address-family mismatch")
+            ipv6_socket_address = cast(tuple[str, int, int, int], socket_address)
+            flow_info = ipv6_socket_address[2]
+            scope_id = ipv6_socket_address[3]
+            if (
+                isinstance(flow_info, bool)
+                or not isinstance(flow_info, int)
+                or flow_info != 0
+                or isinstance(scope_id, bool)
+                or not isinstance(scope_id, int)
+                or scope_id != 0
+            ):
+                raise ValueError(f"{destination_type} host '{hostname}' returned a scoped IPv6 address")
         if not _is_public_ip_address(parsed_address):
             raise ValueError(
                 f"{destination_type} host '{hostname}' did not resolve exclusively to permitted public addresses"

--- a/modelaudit/progress/hooks.py
+++ b/modelaudit/progress/hooks.py
@@ -1,14 +1,428 @@
 """Progress hooks system for extensible progress reporting."""
 
+import http.client
+import ipaddress
+import json
 import logging
+import math
+import os
+import socket
+import ssl
 import time
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from typing import Any
+from urllib.parse import unquote, urlparse
 
 from .base import ProgressPhase, ProgressStats
 
 logger = logging.getLogger("modelaudit.progress.hooks")
+
+_PROGRESS_ALLOWED_HOSTS_ENV = "MODELAUDIT_PROGRESS_ALLOWED_HOSTS"
+_PROGRESS_WEBHOOK_ALLOWED_HOSTS_ENV = "MODELAUDIT_PROGRESS_WEBHOOK_ALLOWED_HOSTS"
+_PROGRESS_SMTP_ALLOWED_HOSTS_ENV = "MODELAUDIT_PROGRESS_SMTP_ALLOWED_HOSTS"
+_DEFAULT_SLACK_WEBHOOK_HOSTS = frozenset({"hooks.slack.com", "hooks.slack-gov.com"})
+_INTERNAL_HOST_SUFFIXES = frozenset({".localhost", ".local", ".internal", ".lan", ".home", ".corp", ".intranet"})
+_NAT64_NETWORKS = (
+    ipaddress.ip_network("64:ff9b::/96"),
+    ipaddress.ip_network("64:ff9b:1::/48"),
+)
+_ISATAP_MARKERS = frozenset({b"\x00\x00\x5e\xfe", b"\x02\x00\x5e\xfe"})
+_DEFAULT_NETWORK_TIMEOUT_SECONDS = 10.0
+_MAX_NETWORK_TIMEOUT_SECONDS = 60.0
+
+ResolvedAddress = tuple[socket.AddressFamily, str, int]
+
+
+def _normalize_destination_host(hostname: str) -> str:
+    return unquote(hostname).strip().lower().rstrip(".")
+
+
+def _host_from_config_value(value: str) -> str:
+    candidate = value.strip()
+    if not candidate:
+        return ""
+
+    parsed_ip = _parse_ip_literal(candidate)
+    if parsed_ip is not None:
+        return parsed_ip.compressed
+
+    try:
+        parsed = urlparse(candidate if "://" in candidate else f"//{candidate}")
+        if parsed.username is not None or parsed.password is not None:
+            return ""
+        hostname = parsed.hostname or ""
+    except ValueError:
+        return ""
+    if not hostname:
+        return ""
+    return _canonical_destination_host(hostname)
+
+
+def _get_allowed_hosts(env_name: str, configured_hosts: Collection[str] | None = None) -> set[str]:
+    hosts = {_host_from_config_value(host) for host in configured_hosts or ()}
+    for current_env_name in (_PROGRESS_ALLOWED_HOSTS_ENV, env_name):
+        raw_hosts = os.getenv(current_env_name, "")
+        hosts.update(_host_from_config_value(value) for value in raw_hosts.split(","))
+    return {host for host in hosts if host}
+
+
+def _parse_ip_literal(hostname: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    candidate = hostname.strip("[]")
+    if ":" in candidate and "%" in candidate:
+        candidate = candidate.split("%", 1)[0]
+
+    try:
+        return ipaddress.ip_address(candidate)
+    except ValueError:
+        pass
+
+    if not candidate or any(char not in "0123456789abcdefABCDEFxX." for char in candidate):
+        return None
+
+    try:
+        return ipaddress.ip_address(socket.inet_aton(candidate))
+    except OSError:
+        return None
+
+
+def _canonical_destination_host(hostname: str) -> str:
+    normalized = _normalize_destination_host(hostname)
+    parsed_ip = _parse_ip_literal(normalized)
+    if parsed_ip is not None:
+        return parsed_ip.compressed
+    try:
+        return normalized.encode("idna").decode("ascii").lower()
+    except UnicodeError as exc:
+        raise ValueError(f"Invalid internationalized destination host '{hostname}'") from exc
+
+
+def _embedded_ipv4_addresses(address: ipaddress.IPv6Address) -> tuple[ipaddress.IPv4Address, ...]:
+    embedded: list[ipaddress.IPv4Address] = []
+    if address.ipv4_mapped is not None:
+        embedded.append(address.ipv4_mapped)
+    if address.sixtofour is not None:
+        embedded.append(address.sixtofour)
+    if address.teredo is not None:
+        embedded.extend(address.teredo)
+    if int(address) >> 32 == 0:
+        embedded.append(ipaddress.IPv4Address(address.packed[-4:]))
+    if any(address in network for network in _NAT64_NETWORKS):
+        embedded.append(ipaddress.IPv4Address(address.packed[-4:]))
+    if address.packed[8:12] in _ISATAP_MARKERS:
+        embedded.append(ipaddress.IPv4Address(address.packed[-4:]))
+    return tuple(embedded)
+
+
+def _is_public_ip_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    if not address.is_global or address.is_multicast:
+        return False
+    if isinstance(address, ipaddress.IPv6Address):
+        return all(_is_public_ip_address(embedded) for embedded in _embedded_ipv4_addresses(address))
+    return True
+
+
+def _is_internal_destination_host(hostname: str) -> bool:
+    if not hostname:
+        return True
+    if hostname == "localhost" or hostname.endswith(tuple(_INTERNAL_HOST_SUFFIXES)):
+        return True
+    if "." not in hostname and ":" not in hostname:
+        return True
+
+    parsed_ip = _parse_ip_literal(hostname)
+    if parsed_ip is None:
+        return False
+    return not _is_public_ip_address(parsed_ip)
+
+
+def _validate_public_destination_host(hostname: str, destination_type: str) -> None:
+    if _is_internal_destination_host(hostname):
+        raise ValueError(f"{destination_type} host '{hostname}' is not a permitted public egress destination")
+
+
+def _resolve_public_addresses(hostname: str, port: int, destination_type: str) -> tuple[ResolvedAddress, ...]:
+    if isinstance(port, bool) or not isinstance(port, int) or not 1 <= port <= 65535:
+        raise ValueError(f"{destination_type} port is invalid")
+    try:
+        address_info = socket.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
+    except OSError as exc:
+        raise ValueError(
+            f"{destination_type} host '{hostname}' could not be resolved to a permitted public address"
+        ) from exc
+
+    resolved_addresses: list[ResolvedAddress] = []
+    seen_addresses: set[tuple[socket.AddressFamily, str, int]] = set()
+    for family, socket_type, protocol, _canonical_name, socket_address in address_info:
+        if family not in {socket.AF_INET, socket.AF_INET6}:
+            raise ValueError(f"{destination_type} host '{hostname}' resolved to an unsupported socket family")
+        if socket_type not in {0, socket.SOCK_STREAM} or protocol not in {0, socket.IPPROTO_TCP}:
+            raise ValueError(f"{destination_type} host '{hostname}' resolved to a non-TCP socket")
+        if not isinstance(socket_address, tuple) or len(socket_address) < 2:
+            raise ValueError(f"{destination_type} host '{hostname}' returned a malformed socket address")
+        raw_address, resolved_port = socket_address[:2]
+        if not isinstance(raw_address, str) or not isinstance(resolved_port, int) or resolved_port != port:
+            raise ValueError(f"{destination_type} host '{hostname}' returned an invalid socket address or port")
+        if "%" in raw_address:
+            raise ValueError(f"{destination_type} host '{hostname}' returned a scoped IPv6 address")
+        try:
+            parsed_address = ipaddress.ip_address(raw_address)
+        except ValueError as exc:
+            raise ValueError(f"{destination_type} host '{hostname}' returned an invalid IP address") from exc
+        if not _is_public_ip_address(parsed_address):
+            raise ValueError(
+                f"{destination_type} host '{hostname}' did not resolve exclusively to permitted public addresses"
+            )
+        canonical_address = parsed_address.compressed
+        address_key = (family, canonical_address, resolved_port)
+        if address_key not in seen_addresses:
+            seen_addresses.add(address_key)
+            resolved_addresses.append(address_key)
+
+    if not resolved_addresses:
+        raise ValueError(
+            f"{destination_type} host '{hostname}' did not resolve exclusively to permitted public addresses"
+        )
+    return tuple(resolved_addresses)
+
+
+def _webhook_destination(webhook_url: str, destination_type: str) -> tuple[str, int]:
+    if "\\" in webhook_url or any(ord(char) < 32 or ord(char) == 127 for char in webhook_url):
+        raise ValueError(f"{destination_type} URL has an invalid host or port")
+    parsed = urlparse(webhook_url)
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError(f"{destination_type} URL must not include user information")
+    try:
+        hostname = _canonical_destination_host(parsed.hostname or "")
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError(f"{destination_type} URL has an invalid host or port") from exc
+    if port is None:
+        port = 443 if parsed.scheme.lower() == "https" else 80
+    return hostname, port
+
+
+def _validate_allowed_destination_host(
+    hostname: str,
+    *,
+    destination_type: str,
+    allowed_hosts: Collection[str] | None,
+    env_name: str,
+    default_allowed_hosts: Collection[str] = (),
+) -> None:
+    normalized_defaults = {_host_from_config_value(host) for host in default_allowed_hosts}
+    trusted_hosts = normalized_defaults | _get_allowed_hosts(env_name, allowed_hosts)
+    if hostname not in trusted_hosts:
+        raise ValueError(
+            f"{destination_type} host '{hostname}' is not allowed; configure {env_name} or "
+            f"{_PROGRESS_ALLOWED_HOSTS_ENV} with the explicit public host"
+        )
+
+
+def _validate_progress_webhook_url(
+    webhook_url: str,
+    *,
+    destination_type: str,
+    allowed_hosts: Collection[str] | None = None,
+    default_allowed_hosts: Collection[str] = (),
+    require_https: bool = False,
+) -> str:
+    parsed = urlparse(webhook_url)
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"}:
+        raise ValueError(f"{destination_type} URL must use http or https")
+    if require_https and scheme != "https":
+        raise ValueError(f"{destination_type} URL must use https")
+
+    hostname, _port = _webhook_destination(webhook_url, destination_type)
+    _validate_public_destination_host(hostname, destination_type)
+    _validate_allowed_destination_host(
+        hostname,
+        destination_type=destination_type,
+        allowed_hosts=allowed_hosts,
+        env_name=_PROGRESS_WEBHOOK_ALLOWED_HOSTS_ENV,
+        default_allowed_hosts=default_allowed_hosts,
+    )
+    return webhook_url
+
+
+def _validate_progress_smtp_host(
+    smtp_host: str,
+    *,
+    allowed_hosts: Collection[str] | None = None,
+) -> str:
+    hostname = _host_from_config_value(smtp_host)
+    _validate_public_destination_host(hostname, "SMTP")
+    _validate_allowed_destination_host(
+        hostname,
+        destination_type="SMTP",
+        allowed_hosts=allowed_hosts,
+        env_name=_PROGRESS_SMTP_ALLOWED_HOSTS_ENV,
+    )
+    return hostname
+
+
+def _bounded_network_timeout(timeout: float) -> float:
+    try:
+        numeric_timeout = float(timeout)
+    except (TypeError, ValueError):
+        return _DEFAULT_NETWORK_TIMEOUT_SECONDS
+    if not math.isfinite(numeric_timeout) or numeric_timeout <= 0:
+        return _DEFAULT_NETWORK_TIMEOUT_SECONDS
+    return min(numeric_timeout, _MAX_NETWORK_TIMEOUT_SECONDS)
+
+
+def _secure_tls_context() -> ssl.SSLContext:
+    context = ssl.create_default_context()
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
+    return context
+
+
+def _connect_pinned_socket(family: socket.AddressFamily, address: str, port: int, timeout: float) -> socket.socket:
+    connection = socket.socket(family, socket.SOCK_STREAM)
+    try:
+        connection.settimeout(_bounded_network_timeout(timeout))
+        socket_address: tuple[Any, ...]
+        socket_address = (address, port, 0, 0) if family == socket.AF_INET6 else (address, port)
+        connection.connect(socket_address)
+        return connection
+    except Exception:
+        connection.close()
+        raise
+
+
+def _webhook_request_target(webhook_url: str, destination_type: str) -> tuple[str, str, int, str]:
+    import requests
+
+    configured_destination = _webhook_destination(webhook_url, destination_type)
+    try:
+        prepared_url = requests.Request("POST", webhook_url).prepare().url
+    except requests.RequestException as exc:
+        raise ValueError(f"{destination_type} URL could not be prepared safely") from exc
+    if not prepared_url:
+        raise ValueError(f"{destination_type} URL could not be prepared safely")
+
+    prepared = urlparse(prepared_url)
+    prepared_destination = _webhook_destination(prepared_url, destination_type)
+    if configured_destination != prepared_destination:
+        raise ValueError(f"{destination_type} URL resolves to an ambiguous network destination")
+
+    request_target = prepared.path or "/"
+    if prepared.params:
+        request_target += f";{prepared.params}"
+    if prepared.query:
+        request_target += f"?{prepared.query}"
+    return prepared.scheme.lower(), prepared_destination[0], prepared_destination[1], request_target
+
+
+def _host_header(hostname: str, port: int, scheme: str) -> str:
+    rendered_host = f"[{hostname}]" if ":" in hostname else hostname
+    default_port = 443 if scheme == "https" else 80
+    if port != default_port:
+        return f"{rendered_host}:{port}"
+    return rendered_host
+
+
+def _post_to_pinned_address(
+    *,
+    scheme: str,
+    hostname: str,
+    port: int,
+    request_target: str,
+    resolved_address: ResolvedAddress,
+    body: bytes,
+    headers: dict[str, str],
+    timeout: float,
+) -> int:
+    family, address, resolved_port = resolved_address
+    raw_socket = _connect_pinned_socket(family, address, resolved_port, timeout)
+    connection: http.client.HTTPConnection | None = None
+    try:
+        if scheme == "https":
+            context = _secure_tls_context()
+            wrapped_socket = context.wrap_socket(raw_socket, server_hostname=hostname)
+            connection = http.client.HTTPSConnection(hostname, port, timeout=timeout, context=context)
+            connection.sock = wrapped_socket
+        else:
+            connection = http.client.HTTPConnection(hostname, port, timeout=timeout)
+            connection.sock = raw_socket
+        connection.request("POST", request_target, body=body, headers=headers)
+        response = connection.getresponse()
+        return response.status
+    finally:
+        if connection is not None:
+            connection.close()
+        else:
+            raw_socket.close()
+
+
+def _connect_pinned_smtp(
+    hostname: str,
+    port: int,
+    resolved_address: ResolvedAddress,
+    timeout: float,
+) -> Any:
+    import smtplib
+
+    family, address, resolved_port = resolved_address
+
+    class PinnedSMTP(smtplib.SMTP):
+        def _get_socket(self, requested_host: str, _port: int, _timeout: float) -> socket.socket:
+            self._host = requested_host
+            return _connect_pinned_socket(family, address, resolved_port, timeout)
+
+    server = PinnedSMTP(timeout=_bounded_network_timeout(timeout))
+    try:
+        server.connect(hostname, port)
+        return server
+    except Exception:
+        server.close()
+        raise
+
+
+def _post_progress_payload(
+    webhook_url: str,
+    *,
+    payload: dict[str, Any],
+    timeout: float,
+    destination_type: str,
+    headers: dict[str, str] | None = None,
+) -> None:
+    scheme, hostname, port, request_target = _webhook_request_target(webhook_url, destination_type)
+    resolved_addresses = _resolve_public_addresses(hostname, port, destination_type)
+    request_headers = {"Content-Type": "application/json", **(headers or {})}
+    for header_name in tuple(request_headers):
+        if header_name.lower() == "host":
+            request_headers.pop(header_name)
+    request_headers["Host"] = _host_header(hostname, port, scheme)
+    body = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    bounded_timeout = _bounded_network_timeout(timeout)
+
+    last_error: Exception | None = None
+    for resolved_address in resolved_addresses:
+        try:
+            status = _post_to_pinned_address(
+                scheme=scheme,
+                hostname=hostname,
+                port=port,
+                request_target=request_target,
+                resolved_address=resolved_address,
+                body=body,
+                headers=request_headers,
+                timeout=bounded_timeout,
+            )
+        except (OSError, ssl.SSLError, http.client.HTTPException) as exc:
+            last_error = exc
+            continue
+        if 300 <= status < 400:
+            raise OSError(f"{destination_type} redirects are not permitted")
+        if status >= 400:
+            raise OSError(f"{destination_type} returned HTTP status {status}")
+        return
+
+    if last_error is not None:
+        raise last_error
+    raise OSError(f"{destination_type} could not connect to a validated public address")
 
 
 class ProgressHook(ABC):
@@ -86,6 +500,7 @@ class WebhookProgressHook(ProgressHook):
         timeout: float = 10.0,
         retry_attempts: int = 3,
         min_interval: float = 30.0,
+        allowed_hosts: Collection[str] | None = None,
     ):
         """Initialize webhook progress hook.
 
@@ -96,10 +511,15 @@ class WebhookProgressHook(ProgressHook):
             timeout: Request timeout in seconds
             retry_attempts: Number of retry attempts on failure
             min_interval: Minimum time between webhook calls
+            allowed_hosts: Optional explicit public webhook hosts or URLs
         """
         super().__init__(name)
 
-        self.webhook_url = webhook_url
+        self.webhook_url = _validate_progress_webhook_url(
+            webhook_url,
+            destination_type="progress webhook",
+            allowed_hosts=allowed_hosts,
+        )
         self.headers = headers or {}
         self.timeout = timeout
         self.retry_attempts = retry_attempts
@@ -132,16 +552,16 @@ class WebhookProgressHook(ProgressHook):
 
             for attempt in range(self.retry_attempts):
                 try:
-                    response = requests.post(
+                    _post_progress_payload(
                         self.webhook_url,
-                        json=payload,
+                        payload=payload,
                         headers=self.headers,
                         timeout=self.timeout,
+                        destination_type="progress webhook",
                     )
-                    response.raise_for_status()
                     return True
 
-                except requests.RequestException as e:
+                except (OSError, requests.RequestException, ValueError, http.client.HTTPException) as e:
                     if attempt == self.retry_attempts - 1:
                         logger.warning(f"Webhook {self.name} failed after {self.retry_attempts} attempts: {e}")
                     else:
@@ -228,6 +648,8 @@ class EmailProgressHook(ProgressHook):
         send_on_error: bool = True,
         send_periodic: bool = False,
         periodic_interval: float = 1800.0,  # 30 minutes
+        allowed_hosts: Collection[str] | None = None,
+        timeout: float = _DEFAULT_NETWORK_TIMEOUT_SECONDS,
     ):
         """Initialize email progress hook.
 
@@ -245,16 +667,19 @@ class EmailProgressHook(ProgressHook):
             send_on_error: Send email when errors occur
             send_periodic: Send periodic progress emails
             periodic_interval: Interval for periodic emails in seconds
+            allowed_hosts: Optional explicit public SMTP hosts
+            timeout: SMTP connection and operation timeout in seconds
         """
         super().__init__(name)
 
-        self.smtp_host = smtp_host
+        self.smtp_host = _validate_progress_smtp_host(smtp_host, allowed_hosts=allowed_hosts)
         self.smtp_port = smtp_port
         self.username = username
         self.password = password
         self.from_email = from_email
         self.to_emails = to_emails
         self.use_tls = use_tls
+        self.timeout = _bounded_network_timeout(timeout)
 
         self.send_on_start = send_on_start
         self.send_on_complete = send_on_complete
@@ -291,16 +716,36 @@ class EmailProgressHook(ProgressHook):
 
             msg.attach(MIMEText(body, "plain"))
 
-            # Send email
-            server = smtplib.SMTP(self.smtp_host, self.smtp_port)
-            if self.use_tls:
-                server.starttls()
-            server.login(self.username, self.password)
-            server.send_message(msg)
-            server.quit()
+            resolved_addresses = _resolve_public_addresses(self.smtp_host, self.smtp_port, "SMTP")
+            last_error: Exception | None = None
+            for resolved_address in resolved_addresses:
+                server: smtplib.SMTP | None = None
+                try:
+                    server = _connect_pinned_smtp(
+                        self.smtp_host,
+                        self.smtp_port,
+                        resolved_address,
+                        self.timeout,
+                    )
+                    if self.use_tls:
+                        server.starttls(context=_secure_tls_context())
+                    server.login(self.username, self.password)
+                    server.send_message(msg)
+                    try:
+                        server.quit()
+                    except Exception:
+                        server.close()
 
-            logger.debug(f"Email sent successfully from hook {self.name}")
-            return True
+                    logger.debug(f"Email sent successfully from hook {self.name}")
+                    return True
+                except Exception as exc:
+                    last_error = exc
+                    if server is not None:
+                        server.close()
+
+            if last_error is not None:
+                raise last_error
+            raise OSError("SMTP could not connect to a validated public address")
 
         except Exception as e:
             logger.warning(f"Failed to send email from hook {self.name}: {e}")
@@ -396,6 +841,7 @@ class SlackProgressHook(ProgressHook):
         send_on_complete: bool = True,
         send_on_error: bool = True,
         min_interval: float = 300.0,  # 5 minutes
+        allowed_hosts: Collection[str] | None = None,
     ):
         """Initialize Slack progress hook.
 
@@ -409,10 +855,17 @@ class SlackProgressHook(ProgressHook):
             send_on_complete: Send message when scanning completes
             send_on_error: Send message when errors occur
             min_interval: Minimum interval between progress messages
+            allowed_hosts: Optional explicit public custom Slack webhook hosts or URLs
         """
         super().__init__(name)
 
-        self.webhook_url = webhook_url
+        self.webhook_url = _validate_progress_webhook_url(
+            webhook_url,
+            destination_type="Slack webhook",
+            allowed_hosts=allowed_hosts,
+            default_allowed_hosts=_DEFAULT_SLACK_WEBHOOK_HOSTS,
+            require_https=True,
+        )
         self.channel = channel
         self.username = username
         self.emoji = emoji
@@ -446,8 +899,6 @@ class SlackProgressHook(ProgressHook):
             return False
 
         try:
-            import requests
-
             payload: dict[str, Any] = {
                 "text": message,
                 "username": self.username,
@@ -467,12 +918,12 @@ class SlackProgressHook(ProgressHook):
                 ]
                 payload["text"] = ""  # Move text to attachment
 
-            response = requests.post(
+            _post_progress_payload(
                 self.webhook_url,
-                json=payload,
+                payload=payload,
                 timeout=10.0,
+                destination_type="Slack webhook",
             )
-            response.raise_for_status()
 
             logger.debug(f"Slack message sent successfully from hook {self.name}")
             return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,6 +214,7 @@ def pytest_runtest_setup(item):
             "test_dill_joblib_enhanced.py",  # Dill/joblib pickle routing regression tests
             "test_pickle_context_filtering.py",  # Pickle context filtering regression tests
             "test_xdist_status.py",  # xdist worker progress reporting tests
+            "test_hooks_egress.py",  # progress hook egress allowlist regressions
             "test_release_workflow.py",  # release workflow regression tests
             "test_docker_workflow.py",  # Docker workflow regression tests
             "test_perf_workflow.py",  # Performance benchmark workflow regression tests

--- a/tests/progress/test_hooks_egress.py
+++ b/tests/progress/test_hooks_egress.py
@@ -4,7 +4,7 @@ import http.client
 import json
 import socket
 import ssl
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -178,7 +178,7 @@ def test_webhook_rejects_mixed_public_and_private_dns_answers(monkeypatch: pytes
 @pytest.mark.parametrize(
     "address_info",
     [
-        _address_info(family=socket.AF_UNIX),
+        _address_info(family=cast(socket.AddressFamily, -1)),
         _address_info(socket_type=socket.SOCK_DGRAM),
         _address_info(port=444),
     ],

--- a/tests/progress/test_hooks_egress.py
+++ b/tests/progress/test_hooks_egress.py
@@ -1,6 +1,7 @@
 """Progress hook outbound destination validation tests."""
 
 import http.client
+import ipaddress
 import json
 import socket
 import ssl
@@ -176,11 +177,124 @@ def test_webhook_rejects_mixed_public_and_private_dns_answers(monkeypatch: pytes
 
 
 @pytest.mark.parametrize(
+    "hostname",
+    [
+        "192.88.99.2",
+        "100:0:0:1::1",
+        "5f00::1",
+        "::ffff:93.184.216.34",
+    ],
+)
+def test_webhook_rejects_iana_non_global_destinations_when_ipaddress_is_stale(
+    monkeypatch: pytest.MonkeyPatch,
+    hostname: str,
+) -> None:
+    address = ipaddress.ip_address(hostname)
+    monkeypatch.setattr(type(address), "is_global", property(lambda _address: True))
+    rendered_hostname = f"[{hostname}]" if address.version == 6 else hostname
+
+    with pytest.raises(ValueError, match="not a permitted public egress"):
+        WebhookProgressHook(
+            name="iana-non-global",
+            webhook_url=f"https://{rendered_hostname}/progress",
+            allowed_hosts={hostname},
+        )
+
+
+@pytest.mark.parametrize(
+    "hostname",
+    [
+        "192.0.0.9",
+        "192.0.0.10",
+        "2001:1::1",
+        "2001:1::2",
+        "2001:1::3",
+        "2001:3::1",
+        "2001:4:112::1",
+        "2001:20::1",
+        "2001:30::1",
+    ],
+)
+def test_webhook_accepts_iana_global_exceptions_when_ipaddress_is_stale(
+    monkeypatch: pytest.MonkeyPatch,
+    hostname: str,
+) -> None:
+    address = ipaddress.ip_address(hostname)
+    monkeypatch.setattr(type(address), "is_global", property(lambda _address: False))
+    rendered_hostname = f"[{hostname}]" if address.version == 6 else hostname
+
+    hook = WebhookProgressHook(
+        name="iana-global",
+        webhook_url=f"https://{rendered_hostname}/progress",
+        allowed_hosts={hostname},
+    )
+
+    assert hook.webhook_url == f"https://{rendered_hostname}/progress"
+
+
+def test_webhook_accepts_public_ipv4_embedded_in_nat64_destination() -> None:
+    hostname = "64:ff9b::5db8:d822"
+
+    hook = WebhookProgressHook(
+        name="public-nat64",
+        webhook_url=f"https://[{hostname}]/progress",
+        allowed_hosts={hostname},
+    )
+
+    assert hook.webhook_url == f"https://[{hostname}]/progress"
+
+
+@pytest.mark.parametrize(
     "address_info",
     [
         _address_info(family=cast(socket.AddressFamily, -1)),
         _address_info(socket_type=socket.SOCK_DGRAM),
         _address_info(port=444),
+        [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("2606:2800:220:1:248:1893:25c8:1946", 443),
+            )
+        ],
+        [
+            (
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("93.184.216.34", 443, 0, 0),
+            )
+        ],
+        [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("93.184.216.34", 443, 0, 0),
+            )
+        ],
+        [
+            (
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("2606:2800:220:1:248:1893:25c8:1946", 443, 1, 0),
+            )
+        ],
+        [
+            (
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("2606:2800:220:1:248:1893:25c8:1946", 443, 0, 1),
+            )
+        ],
     ],
 )
 def test_webhook_rejects_malformed_resolver_answers(

--- a/tests/progress/test_hooks_egress.py
+++ b/tests/progress/test_hooks_egress.py
@@ -1,0 +1,543 @@
+"""Progress hook outbound destination validation tests."""
+
+import http.client
+import json
+import socket
+import ssl
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modelaudit.progress import ProgressPhase, ProgressStats
+from modelaudit.progress.hooks import EmailProgressHook, SlackProgressHook, WebhookProgressHook
+
+
+def _address_info(
+    address: str = "93.184.216.34",
+    port: int = 443,
+    *,
+    family: socket.AddressFamily | None = None,
+    socket_type: socket.SocketKind = socket.SOCK_STREAM,
+    protocol: int = socket.IPPROTO_TCP,
+) -> list[tuple[int, int, int, str, tuple[object, ...]]]:
+    resolved_family = family or (socket.AF_INET6 if ":" in address else socket.AF_INET)
+    socket_address: tuple[object, ...]
+    socket_address = (address, port, 0, 0) if resolved_family == socket.AF_INET6 else (address, port)
+    return [(resolved_family, socket_type, protocol, "", socket_address)]
+
+
+def _stats() -> ProgressStats:
+    return ProgressStats(
+        bytes_processed=128,
+        total_bytes=256,
+        items_processed=1,
+        total_items=2,
+        current_phase=ProgressPhase.ANALYZING,
+        current_item="model.pkl",
+        status_message="Scanning model.pkl",
+    )
+
+
+def test_webhook_rejects_loopback_url_before_connect(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODELAUDIT_PROGRESS_WEBHOOK_ALLOWED_HOSTS", "127.0.0.1")
+
+    with (
+        patch("modelaudit.progress.hooks._post_to_pinned_address") as mock_post,
+        pytest.raises(ValueError, match="not a permitted public egress"),
+    ):
+        WebhookProgressHook(name="ssrf", webhook_url="http://127.0.0.1:8080/progress")
+
+    mock_post.assert_not_called()
+
+
+def test_webhook_rejects_non_http_scheme() -> None:
+    with pytest.raises(ValueError, match="must use http or https"):
+        WebhookProgressHook(
+            name="file-url",
+            webhook_url="file:///var/run/docker.sock",
+            allowed_hosts={"example.com"},
+        )
+
+
+def test_webhook_requires_explicit_allowed_host_for_custom_egress() -> None:
+    with pytest.raises(ValueError, match="not allowed"):
+        WebhookProgressHook(name="missing-allowlist", webhook_url="https://hooks.example.com/modelaudit")
+
+
+@pytest.mark.parametrize(
+    "webhook_url, error",
+    [
+        (r"https://127.0.0.1\@hooks.example.com/progress", "invalid host or port"),
+        ("https://user:pass@hooks.example.com/progress", "must not include user information"),
+    ],
+)
+def test_webhook_rejects_host_parser_differentials(webhook_url: str, error: str) -> None:
+    with pytest.raises(ValueError, match=error):
+        WebhookProgressHook(name="parser-differential", webhook_url=webhook_url, allowed_hosts={"hooks.example.com"})
+
+
+def test_public_https_webhook_uses_pinned_address_and_preserves_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    stats = _stats()
+    resolver = MagicMock(return_value=_address_info())
+    monkeypatch.setattr("socket.getaddrinfo", resolver)
+
+    with patch("modelaudit.progress.hooks._post_to_pinned_address", return_value=200) as mock_post:
+        hook = WebhookProgressHook(
+            name="audit",
+            webhook_url="https://hooks.example.com/modelaudit?source=test",
+            headers={"X-ModelAudit-Test": "1"},
+            timeout=999.0,
+            retry_attempts=1,
+            allowed_hosts={"hooks.example.com"},
+        )
+        assert hook._send_webhook(hook._create_base_payload(stats, "progress")) is True
+
+    resolver.assert_called_once_with("hooks.example.com", 443, type=socket.SOCK_STREAM)
+    kwargs = mock_post.call_args.kwargs
+    assert kwargs["resolved_address"] == (socket.AF_INET, "93.184.216.34", 443)
+    assert kwargs["hostname"] == "hooks.example.com"
+    assert kwargs["request_target"] == "/modelaudit?source=test"
+    assert kwargs["timeout"] == 60.0
+    assert kwargs["headers"]["Host"] == "hooks.example.com"
+    assert kwargs["headers"]["X-ModelAudit-Test"] == "1"
+    payload = json.loads(kwargs["body"])
+    assert payload["hook_name"] == "audit"
+    assert payload["event_type"] == "progress"
+    assert payload["current_item"] == "model.pkl"
+
+
+def test_custom_host_header_cannot_override_validated_destination(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("socket.getaddrinfo", lambda *_args, **_kwargs: _address_info())
+    with patch("modelaudit.progress.hooks._post_to_pinned_address", return_value=200) as mock_post:
+        hook = WebhookProgressHook(
+            name="host-header",
+            webhook_url="https://hooks.example.com/modelaudit",
+            headers={"host": "127.0.0.1", "X-Test": "1"},
+            retry_attempts=1,
+            allowed_hosts={"hooks.example.com"},
+        )
+        assert hook._send_webhook({"event_type": "progress"}) is True
+
+    assert mock_post.call_args.kwargs["headers"]["Host"] == "hooks.example.com"
+    assert "host" not in mock_post.call_args.kwargs["headers"]
+
+
+def test_unicode_url_matches_punycode_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
+    resolver = MagicMock(return_value=_address_info())
+    monkeypatch.setattr("socket.getaddrinfo", resolver)
+    with patch("modelaudit.progress.hooks._post_to_pinned_address", return_value=200) as mock_post:
+        hook = WebhookProgressHook(
+            name="idn",
+            webhook_url="https://bücher.example/modelaudit",
+            retry_attempts=1,
+            allowed_hosts={"xn--bcher-kva.example"},
+        )
+        assert hook._send_webhook({"event_type": "progress"}) is True
+
+    resolver.assert_called_once_with("xn--bcher-kva.example", 443, type=socket.SOCK_STREAM)
+    assert mock_post.call_args.kwargs["hostname"] == "xn--bcher-kva.example"
+    assert mock_post.call_args.kwargs["headers"]["Host"] == "xn--bcher-kva.example"
+
+
+@pytest.mark.parametrize("address", ["127.0.0.1", "10.0.0.5", "192.168.1.10"])
+def test_webhook_rejects_private_dns_resolution_before_connect(
+    monkeypatch: pytest.MonkeyPatch,
+    address: str,
+) -> None:
+    monkeypatch.setattr("socket.getaddrinfo", lambda *_args, **_kwargs: _address_info(address))
+    hook = WebhookProgressHook(
+        name="dns-rebinding",
+        webhook_url="https://hooks.example.com/modelaudit",
+        retry_attempts=1,
+        allowed_hosts={"hooks.example.com"},
+    )
+
+    with patch("modelaudit.progress.hooks._post_to_pinned_address") as mock_post:
+        assert hook._send_webhook({"event_type": "progress"}) is False
+    mock_post.assert_not_called()
+
+
+def test_webhook_rejects_mixed_public_and_private_dns_answers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "socket.getaddrinfo",
+        lambda *_args, **_kwargs: _address_info() + _address_info("10.0.0.5"),
+    )
+    hook = WebhookProgressHook(
+        name="split-dns",
+        webhook_url="https://hooks.example.com/modelaudit",
+        retry_attempts=1,
+        allowed_hosts={"hooks.example.com"},
+    )
+
+    with patch("modelaudit.progress.hooks._post_to_pinned_address") as mock_post:
+        assert hook._send_webhook({"event_type": "progress"}) is False
+    mock_post.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "address_info",
+    [
+        _address_info(family=socket.AF_UNIX),
+        _address_info(socket_type=socket.SOCK_DGRAM),
+        _address_info(port=444),
+    ],
+)
+def test_webhook_rejects_malformed_resolver_answers(
+    monkeypatch: pytest.MonkeyPatch,
+    address_info: list[tuple[int, int, int, str, tuple[object, ...]]],
+) -> None:
+    monkeypatch.setattr("socket.getaddrinfo", lambda *_args, **_kwargs: address_info)
+    hook = WebhookProgressHook(
+        name="invalid-dns",
+        webhook_url="https://hooks.example.com/modelaudit",
+        retry_attempts=1,
+        allowed_hosts={"hooks.example.com"},
+    )
+    with patch("modelaudit.progress.hooks._post_to_pinned_address") as mock_post:
+        assert hook._send_webhook({"event_type": "progress"}) is False
+    mock_post.assert_not_called()
+
+
+def test_webhook_uses_one_dns_snapshot_during_rebinding(monkeypatch: pytest.MonkeyPatch) -> None:
+    resolver = MagicMock(side_effect=[_address_info(), _address_info("127.0.0.1")])
+    monkeypatch.setattr("socket.getaddrinfo", resolver)
+    with patch("modelaudit.progress.hooks._post_to_pinned_address", return_value=200) as mock_post:
+        hook = WebhookProgressHook(
+            name="rebind",
+            webhook_url="https://hooks.example.com/modelaudit",
+            retry_attempts=1,
+            allowed_hosts={"hooks.example.com"},
+        )
+        assert hook._send_webhook({"event_type": "progress"}) is True
+
+    assert resolver.call_count == 1
+    assert mock_post.call_args.kwargs["resolved_address"][1] == "93.184.216.34"
+
+
+def test_webhook_falls_back_across_validated_public_addresses(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "socket.getaddrinfo",
+        lambda *_args, **_kwargs: _address_info("93.184.216.34") + _address_info("93.184.216.35"),
+    )
+    with patch(
+        "modelaudit.progress.hooks._post_to_pinned_address",
+        side_effect=[http.client.HTTPException("first address failed"), 200],
+    ) as mock_post:
+        hook = WebhookProgressHook(
+            name="fallback",
+            webhook_url="https://hooks.example.com/modelaudit",
+            retry_attempts=1,
+            allowed_hosts={"hooks.example.com"},
+        )
+        assert hook._send_webhook({"event_type": "progress"}) is True
+
+    assert [item.kwargs["resolved_address"][1] for item in mock_post.call_args_list] == [
+        "93.184.216.34",
+        "93.184.216.35",
+    ]
+
+
+def test_webhook_rejects_redirect_without_retrying_other_address(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("socket.getaddrinfo", lambda *_args, **_kwargs: _address_info())
+    with patch("modelaudit.progress.hooks._post_to_pinned_address", return_value=302) as mock_post:
+        hook = WebhookProgressHook(
+            name="redirect",
+            webhook_url="https://hooks.example.com/modelaudit",
+            retry_attempts=1,
+            allowed_hosts={"hooks.example.com"},
+        )
+        assert hook._send_webhook({"event_type": "progress"}) is False
+    mock_post.assert_called_once()
+
+
+def test_connect_pinned_socket_uses_numeric_address_without_dns() -> None:
+    fake_socket = MagicMock()
+    with patch("socket.socket", return_value=fake_socket) as socket_factory, patch("socket.getaddrinfo") as resolver:
+        from modelaudit.progress.hooks import _connect_pinned_socket
+
+        assert _connect_pinned_socket(socket.AF_INET, "93.184.216.34", 443, 5.0) is fake_socket
+
+    socket_factory.assert_called_once_with(socket.AF_INET, socket.SOCK_STREAM)
+    fake_socket.connect.assert_called_once_with(("93.184.216.34", 443))
+    resolver.assert_not_called()
+
+
+def test_connect_pinned_socket_closes_failed_connection() -> None:
+    fake_socket = MagicMock()
+    fake_socket.connect.side_effect = OSError("connect failed")
+    with patch("socket.socket", return_value=fake_socket), pytest.raises(OSError, match="connect failed"):
+        from modelaudit.progress.hooks import _connect_pinned_socket
+
+        _connect_pinned_socket(socket.AF_INET, "93.184.216.34", 443, 5.0)
+    fake_socket.close.assert_called_once()
+
+
+def test_https_pinned_transport_preserves_sni_and_host_header() -> None:
+    from modelaudit.progress.hooks import _post_to_pinned_address
+
+    raw_socket = MagicMock()
+    wrapped_socket = MagicMock()
+    tls_context = MagicMock()
+    tls_context.wrap_socket.return_value = wrapped_socket
+    connection = MagicMock()
+    connection.getresponse.return_value.status = 200
+
+    with (
+        patch("modelaudit.progress.hooks._connect_pinned_socket", return_value=raw_socket),
+        patch("ssl.create_default_context", return_value=tls_context),
+        patch("http.client.HTTPSConnection", return_value=connection) as connection_factory,
+    ):
+        status = _post_to_pinned_address(
+            scheme="https",
+            hostname="hooks.example.com",
+            port=443,
+            request_target="/modelaudit",
+            resolved_address=(socket.AF_INET, "93.184.216.34", 443),
+            body=b"{}",
+            headers={"Host": "hooks.example.com", "Content-Type": "application/json"},
+            timeout=10.0,
+        )
+
+    assert status == 200
+    assert tls_context.minimum_version == ssl.TLSVersion.TLSv1_2
+    tls_context.wrap_socket.assert_called_once_with(raw_socket, server_hostname="hooks.example.com")
+    connection_factory.assert_called_once_with("hooks.example.com", 443, timeout=10.0, context=tls_context)
+    assert connection.sock is wrapped_socket
+    connection.request.assert_called_once_with(
+        "POST",
+        "/modelaudit",
+        body=b"{}",
+        headers={"Host": "hooks.example.com", "Content-Type": "application/json"},
+    )
+    connection.close.assert_called_once()
+
+
+def test_smtp_pinned_transport_retains_original_starttls_hostname() -> None:
+    import smtplib
+
+    from modelaudit.progress.hooks import _connect_pinned_smtp
+
+    fake_socket = MagicMock()
+
+    def fake_connect(server: smtplib.SMTP, host: str, port: int) -> tuple[int, bytes]:
+        server_any: Any = server
+        server.sock = server_any._get_socket(host, port, server.timeout)
+        return 220, b"ready"
+
+    with (
+        patch("smtplib.SMTP.connect", fake_connect),
+        patch("modelaudit.progress.hooks._connect_pinned_socket", return_value=fake_socket) as pinned_connect,
+    ):
+        server = _connect_pinned_smtp(
+            "smtp.example.com",
+            587,
+            (socket.AF_INET, "93.184.216.34", 587),
+            10.0,
+        )
+
+    server_any: Any = server
+    assert server_any._host == "smtp.example.com"
+    pinned_connect.assert_called_once_with(socket.AF_INET, "93.184.216.34", 587, 10.0)
+
+    tls_context = MagicMock()
+    wrapped_socket = MagicMock()
+    tls_context.wrap_socket.return_value = wrapped_socket
+    server.ehlo_or_helo_if_needed = MagicMock()
+    server.has_extn = MagicMock(return_value=True)
+    server.docmd = MagicMock(return_value=(220, b"ready"))
+
+    server.starttls(context=tls_context)
+
+    tls_context.wrap_socket.assert_called_once_with(fake_socket, server_hostname="smtp.example.com")
+    assert server.sock is wrapped_socket
+    server.close()
+
+
+def test_slack_default_host_uses_pinned_https(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("socket.getaddrinfo", lambda *_args, **_kwargs: _address_info())
+    with patch("modelaudit.progress.hooks._post_to_pinned_address", return_value=200) as mock_post:
+        hook = SlackProgressHook(
+            name="slack",
+            webhook_url="https://hooks.slack.com/services/T000/B000/token",
+            channel="#modelaudit",
+        )
+        assert hook._send_slack_message("scan finished", "good") is True
+
+    kwargs = mock_post.call_args.kwargs
+    payload = json.loads(kwargs["body"])
+    assert kwargs["scheme"] == "https"
+    assert kwargs["hostname"] == "hooks.slack.com"
+    assert payload["channel"] == "#modelaudit"
+    assert payload["attachments"][0]["text"] == "scan finished"
+
+
+def test_slack_custom_host_allowed_by_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODELAUDIT_PROGRESS_WEBHOOK_ALLOWED_HOSTS", "hooks.example.net")
+    monkeypatch.setattr("socket.getaddrinfo", lambda *_args, **_kwargs: _address_info())
+    with patch("modelaudit.progress.hooks._post_to_pinned_address", return_value=200) as mock_post:
+        hook = SlackProgressHook(name="custom-slack", webhook_url="https://hooks.example.net/services/token")
+        assert hook._send_slack_message("scan finished", "warning") is True
+    assert mock_post.call_args.kwargs["hostname"] == "hooks.example.net"
+
+
+def test_slack_rejects_cleartext_url() -> None:
+    with pytest.raises(ValueError, match="must use https"):
+        SlackProgressHook(name="cleartext", webhook_url="http://hooks.slack.com/services/token")
+
+
+def test_email_rejects_private_smtp_host_before_connect(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODELAUDIT_PROGRESS_SMTP_ALLOWED_HOSTS", "10.0.0.5")
+    with (
+        patch("modelaudit.progress.hooks._connect_pinned_smtp") as mock_connect,
+        pytest.raises(ValueError, match="not a permitted public egress"),
+    ):
+        EmailProgressHook(
+            name="smtp-ssrf",
+            smtp_host="10.0.0.5",
+            smtp_port=587,
+            username="user",
+            password="pass",
+            from_email="scanner@example.com",
+            to_emails=["security@example.com"],
+        )
+    mock_connect.assert_not_called()
+
+
+def test_email_requires_allowed_smtp_host() -> None:
+    with pytest.raises(ValueError, match="not allowed"):
+        EmailProgressHook(
+            name="smtp-missing-allowlist",
+            smtp_host="smtp.example.com",
+            smtp_port=587,
+            username="user",
+            password="pass",
+            from_email="scanner@example.com",
+            to_emails=["security@example.com"],
+        )
+
+
+def test_email_allowed_host_uses_pinned_address_and_preserves_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODELAUDIT_PROGRESS_SMTP_ALLOWED_HOSTS", "smtp.example.com")
+    resolver = MagicMock(return_value=_address_info(port=587))
+    monkeypatch.setattr("socket.getaddrinfo", resolver)
+    stats = _stats()
+    smtp_server = MagicMock()
+    tls_context = MagicMock()
+
+    with (
+        patch("modelaudit.progress.hooks._connect_pinned_smtp", return_value=smtp_server) as mock_connect,
+        patch("ssl.create_default_context", return_value=tls_context),
+    ):
+        hook = EmailProgressHook(
+            name="smtp",
+            smtp_host="smtp.example.com",
+            smtp_port=587,
+            username="user",
+            password="pass",
+            from_email="scanner@example.com",
+            to_emails=["security@example.com"],
+            timeout=999.0,
+        )
+        assert hook._send_email("ModelAudit Scan", hook._format_stats(stats)) is True
+
+    resolver.assert_called_once_with("smtp.example.com", 587, type=socket.SOCK_STREAM)
+    mock_connect.assert_called_once_with(
+        "smtp.example.com",
+        587,
+        (socket.AF_INET, "93.184.216.34", 587),
+        60.0,
+    )
+    assert tls_context.minimum_version == ssl.TLSVersion.TLSv1_2
+    smtp_server.starttls.assert_called_once_with(context=tls_context)
+    smtp_server.login.assert_called_once_with("user", "pass")
+    smtp_server.send_message.assert_called_once()
+    rendered_message = smtp_server.send_message.call_args.args[0].as_string()
+    assert "Subject: ModelAudit Scan" in rendered_message
+    assert "Current Item: model.pkl" in rendered_message
+    smtp_server.quit.assert_called_once()
+
+
+def test_email_rejects_private_dns_resolution_before_connect(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODELAUDIT_PROGRESS_SMTP_ALLOWED_HOSTS", "smtp.example.com")
+    monkeypatch.setattr("socket.getaddrinfo", lambda *_args, **_kwargs: _address_info("192.168.1.10", 587))
+    hook = EmailProgressHook(
+        name="smtp-dns-rebinding",
+        smtp_host="smtp.example.com",
+        smtp_port=587,
+        username="user",
+        password="pass",
+        from_email="scanner@example.com",
+        to_emails=["security@example.com"],
+    )
+    with patch("modelaudit.progress.hooks._connect_pinned_smtp") as mock_connect:
+        assert hook._send_email("ModelAudit Scan", "body") is False
+    mock_connect.assert_not_called()
+
+
+def test_email_uses_one_dns_snapshot_during_rebinding(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODELAUDIT_PROGRESS_SMTP_ALLOWED_HOSTS", "smtp.example.com")
+    resolver = MagicMock(side_effect=[_address_info(port=587), _address_info("127.0.0.1", 587)])
+    monkeypatch.setattr("socket.getaddrinfo", resolver)
+    smtp_server = MagicMock()
+    with patch("modelaudit.progress.hooks._connect_pinned_smtp", return_value=smtp_server) as mock_connect:
+        hook = EmailProgressHook(
+            name="smtp-rebind",
+            smtp_host="smtp.example.com",
+            smtp_port=587,
+            username="user",
+            password="pass",
+            from_email="scanner@example.com",
+            to_emails=["security@example.com"],
+        )
+        assert hook._send_email("ModelAudit Scan", "body") is True
+    assert resolver.call_count == 1
+    assert mock_connect.call_args.args[2][1] == "93.184.216.34"
+
+
+def test_email_falls_back_and_closes_failed_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODELAUDIT_PROGRESS_SMTP_ALLOWED_HOSTS", "smtp.example.com")
+    monkeypatch.setattr(
+        "socket.getaddrinfo",
+        lambda *_args, **_kwargs: _address_info("93.184.216.34", 587) + _address_info("93.184.216.35", 587),
+    )
+    failed_server = MagicMock()
+    failed_server.starttls.side_effect = OSError("TLS failed")
+    successful_server = MagicMock()
+    with patch(
+        "modelaudit.progress.hooks._connect_pinned_smtp",
+        side_effect=[failed_server, successful_server],
+    ) as mock_connect:
+        hook = EmailProgressHook(
+            name="smtp-fallback",
+            smtp_host="smtp.example.com",
+            smtp_port=587,
+            username="user",
+            password="pass",
+            from_email="scanner@example.com",
+            to_emails=["security@example.com"],
+        )
+        assert hook._send_email("ModelAudit Scan", "body") is True
+
+    assert [item.args[2][1] for item in mock_connect.call_args_list] == ["93.184.216.34", "93.184.216.35"]
+    failed_server.close.assert_called_once()
+    successful_server.send_message.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "hostname",
+    [
+        "64:ff9b::7f00:1",
+        "2001:4860::5efe:7f00:1",
+        "::ffff:127.0.0.1",
+        "::7f00:1",
+        "::0a00:5",
+    ],
+)
+def test_webhook_rejects_ipv6_embedded_private_destinations(hostname: str) -> None:
+    with pytest.raises(ValueError, match="not a permitted public egress"):
+        WebhookProgressHook(
+            name="ipv6-transition",
+            webhook_url=f"https://[{hostname}]/progress",
+            allowed_hosts={hostname},
+        )


### PR DESCRIPTION
## Summary
- restrict progress webhook, Slack, and SMTP egress to explicitly allowed public destinations
- resolve destinations once, reject empty, mixed, malformed, or non-public answers, and connect directly to the validated numeric sockets
- preserve the canonical host for HTTP `Host`, HTTPS SNI/certificate verification, and SMTP STARTTLS
- canonicalize internationalized hosts with IDNA2008 so Unicode names cannot collapse onto a different ASCII destination
- reject private IPv4 embedded in mapped, compatible, translated, NAT64, 6to4, Teredo, and ISATAP IPv6 forms
- require HTTPS for Slack, TLS 1.2 or newer for encrypted transports, bounded timeouts, no redirects, and no ambient proxy re-resolution
- synchronize the reviewed tree with current `main` at `0ce9bf37a4a26e50c9c7d1a10d2023ee12cb7755`

## Validation
- `tests/progress`: **59 passed, 39 expected lane skips**
- scoped Ruff check and format: clean
- scoped mypy: clean
- `git diff --check`: clean
- full pytest intentionally delegated to CI per campaign instructions

Published commit: `21defd6e051dba482a71b6ea1aa6007b8f748811`
Verified tree: `dffe47f3070e4ff1b5f06b2db5467d369cd71db1`