### PR TITLE
fix: classify pytorch zip symlink targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- classify unsafe PyTorch ZIP symlink targets as critical archive-link findings while preserving safe relative links
 - harden cloud acquisition size caps, HTTPS/R2 auto-default routing, and directory metadata failures
 - detect operator attrgetter, itemgetter, and methodcaller archive-member Python paths to command execution while preserving benign accessor names
 - redact Keras and TensorFlow scanner detail fields that echo model-controlled configs, code indicators, archive members, and external references.

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -5,6 +5,7 @@ import io
 import logging
 import os
 import pickletools
+import posixpath
 import re
 import stat
 import tempfile
@@ -22,7 +23,7 @@ from ..scanner_results import (
     mark_inconclusive_scan_result,
 )
 from ..scanner_selection import add_scanner_selection_skip_check, embedded_pickle_scanner
-from ..utils import sanitize_archive_path
+from ..utils import is_absolute_archive_path, is_critical_system_path, sanitize_archive_path
 from ..utils.file.detection import PROTO0_1_MAX_PROBE_BYTES, PROTO0_1_START_BYTES, _looks_like_proto0_or_1_pickle
 from ._archive_config import get_archive_depth
 from ._archive_locations import rewrite_extracted_member_location
@@ -133,6 +134,19 @@ _JIT_SCAN_MEMBER_MAX_BYTES = 32 * 1024 * 1024
 _PICKLE_DISCOVERY_LONG_PROBE_BYTES = PROTO0_1_MAX_PROBE_BYTES
 _NESTED_ZIP_HEADER_PROBE_BYTES = 4
 _ZIP_LOCAL_FILE_SIGNATURES: tuple[bytes, ...] = (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")
+CRITICAL_SYSTEM_PATHS: tuple[str, ...] = (
+    "/etc",
+    "/bin",
+    "/usr",
+    "/var",
+    "/lib",
+    "/boot",
+    "/sys",
+    "/proc",
+    "/dev",
+    "/sbin",
+    "C:\\Windows",
+)
 
 
 @dataclass(frozen=True)
@@ -254,6 +268,7 @@ class PyTorchZipScanner(BaseScanner):
     MAX_COMPRESSION_RATIO: ClassVar[int] = 100  # 100:1 compression ratio threshold
     MIN_COMPRESSION_BOMB_UNCOMPRESSED_SIZE: ClassVar[int] = 1024 * 1024
     MAX_ARCHIVE_ENTRIES: ClassVar[int] = 10000  # Maximum number of entries in archive
+    MAX_SYMLINK_TARGET_BYTES: ClassVar[int] = 64 * 1024
     MAX_VERSION_METADATA_BYTES: ClassVar[int] = 4096
     MAX_VERSION_JSON_BYTES: ClassVar[int] = 10 * 1024 * 1024
     DEFAULT_VERSION_PICKLE_PROBE_BYTES: ClassVar[int] = 1024 * 1024
@@ -654,6 +669,41 @@ class PyTorchZipScanner(BaseScanner):
             max_bytes=max_bytes,
         )
 
+    def _read_symlink_target(
+        self, zip_file: zipfile.ZipFile, info: zipfile.ZipInfo, result: ScanResult
+    ) -> tuple[str, bool]:
+        """Read a bounded ZIP symlink target and report whether it was complete."""
+        target = self._read_member_prefix(
+            zip_file,
+            info,
+            self.MAX_SYMLINK_TARGET_BYTES + 1,
+            phase="symlink_target_validation",
+            result=result,
+        )
+        target_complete = len(target) <= self.MAX_SYMLINK_TARGET_BYTES
+        bounded_target = target[: self.MAX_SYMLINK_TARGET_BYTES]
+        return bounded_target.decode("utf-8", errors="surrogateescape"), target_complete
+
+    @staticmethod
+    def _resolve_symlink_target(
+        target: str,
+        *,
+        resolved_name: str,
+        extraction_root: str,
+    ) -> tuple[str, bool]:
+        """Resolve a relative symlink target while enforcing the archive extraction root."""
+        if is_absolute_archive_path(target):
+            return target, False
+
+        normalized_target = target.replace("\\", os.sep).replace("/", os.sep)
+        target_base = os.path.dirname(resolved_name)
+        target_resolved = os.path.normpath(os.path.join(target_base, normalized_target))
+        try:
+            target_from_root = os.path.relpath(target_resolved, extraction_root)
+        except ValueError:
+            return target_resolved, False
+        return sanitize_archive_path(target_from_root, extraction_root)
+
     def _read_member_to_spooled_file(
         self,
         zip_file: zipfile.ZipFile,
@@ -838,7 +888,7 @@ class PyTorchZipScanner(BaseScanner):
                     duplicate_entry_collisions_found = True
 
             # Check for path traversal
-            _, is_safe = sanitize_archive_path(name, temp_base)
+            resolved_name, is_safe = sanitize_archive_path(name, temp_base)
             if not is_safe:
                 result.add_check(
                     name="Path Traversal Protection",
@@ -855,31 +905,101 @@ class PyTorchZipScanner(BaseScanner):
             is_symlink = (info.external_attr >> 16) & 0o170000 == stat.S_IFLNK
             if is_symlink:
                 try:
-                    # Read only a bounded prefix (4KB) to avoid DoS from a
-                    # symlink entry that hides a large compressed payload.
-                    # Real symlink targets are short filesystem paths.
-                    target = self._read_member_prefix(
-                        zip_file,
-                        info,
-                        4096,
-                        phase="symlink_target_validation",
-                        result=result,
-                    ).decode("utf-8", "replace")
-                except Exception:
-                    target = "<unreadable>"
-                result.add_check(
-                    name="Symlink Safety Validation",
-                    passed=False,
-                    message=f"Symlink entry detected: {name} -> {target}",
-                    severity=IssueSeverity.WARNING,
-                    location=f"{path}:{name}",
-                    details={
-                        "entry": name,
-                        "target": target,
-                        "risk": "Symlinks in PyTorch models can be used for path traversal attacks",
-                    },
-                    why="Symlinks in model archives are unusual and may indicate an attack attempt",
+                    target, target_complete = self._read_symlink_target(zip_file, info, result)
+                except Exception as exc:
+                    reason = "pytorch_zip_symlink_target_read_incomplete"
+                    mark_inconclusive_scan_result(result, reason)
+                    result.add_check(
+                        name="Symlink Safety Validation",
+                        passed=False,
+                        message=f"Unable to read symlink target for {name}: {exc!s}",
+                        severity=IssueSeverity.INFO,
+                        rule_code="S902",
+                        location=f"{path}:{name}",
+                        details={
+                            "entry": name,
+                            "exception": str(exc),
+                            "exception_type": type(exc).__name__,
+                            "analysis_incomplete": True,
+                            "scan_outcome_reason": reason,
+                        },
+                    )
+                    symlink_issues_found = True
+                    continue
+
+                safe_target = redact_evidence_string(target, max_chars=1024)
+                if not target_complete:
+                    result.add_check(
+                        name="Symlink Safety Validation",
+                        passed=False,
+                        message=f"Symlink {name} has an invalid target that exceeds the maximum length",
+                        severity=IssueSeverity.CRITICAL,
+                        rule_code="S406",
+                        location=f"{path}:{name}",
+                        details={"entry": name, "target": safe_target, "target_class": "invalid"},
+                    )
+                    symlink_issues_found = True
+                    continue
+
+                if not target or "\x00" in target:
+                    invalid_reason = "empty" if not target else "contains a NUL byte"
+                    result.add_check(
+                        name="Symlink Safety Validation",
+                        passed=False,
+                        message=f"Symlink {name} has an invalid target that {invalid_reason}",
+                        severity=IssueSeverity.CRITICAL,
+                        rule_code="S406",
+                        location=f"{path}:{name}",
+                        details={"entry": name, "target": safe_target, "target_class": "invalid"},
+                    )
+                    symlink_issues_found = True
+                    continue
+
+                _target_resolved, target_safe = self._resolve_symlink_target(
+                    target,
+                    resolved_name=resolved_name,
+                    extraction_root=temp_base,
                 )
+                normalized_absolute_target = posixpath.normpath(target.replace("\\", "/"))
+                targets_critical_system_path = is_absolute_archive_path(target) and is_critical_system_path(
+                    normalized_absolute_target,
+                    CRITICAL_SYSTEM_PATHS,
+                )
+                if not target_safe:
+                    if targets_critical_system_path:
+                        message = f"Symlink {name} points to critical system path: {safe_target}"
+                        target_class = "critical_system_path"
+                    else:
+                        message = f"Symlink {name} resolves outside extraction directory"
+                        target_class = "external"
+                    result.add_check(
+                        name="Symlink Safety Validation",
+                        passed=False,
+                        message=message,
+                        severity=IssueSeverity.CRITICAL,
+                        rule_code="S406",
+                        location=f"{path}:{name}",
+                        details={"entry": name, "target": safe_target, "target_class": target_class},
+                    )
+                elif targets_critical_system_path:
+                    result.add_check(
+                        name="Symlink Safety Validation",
+                        passed=False,
+                        message=f"Symlink {name} points to critical system path: {safe_target}",
+                        severity=IssueSeverity.CRITICAL,
+                        rule_code="S408",
+                        location=f"{path}:{name}",
+                        details={"entry": name, "target": safe_target, "target_class": "critical_system_path"},
+                    )
+                else:
+                    result.add_check(
+                        name="Symlink Safety Validation",
+                        passed=True,
+                        message=f"Symlink {name} is safe",
+                        location=f"{path}:{name}",
+                        rule_code=None,
+                        details={"entry": name, "target": safe_target, "target_class": "safe"},
+                    )
                 symlink_issues_found = True
                 continue
 

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1,5 +1,6 @@
 import json
 import pickle
+import stat
 import struct
 import time
 import warnings
@@ -111,6 +112,17 @@ def _write_zip_with_duplicate_data_pkl(zip_path: Path, first_payload: bytes, sec
             zipf.writestr("version", "3")
             zipf.writestr("data.pkl", first_payload)
             zipf.writestr("data.pkl", second_payload)
+
+
+def _write_pytorch_zip_with_symlink(zip_path: Path, link_name: str, target: str | bytes) -> None:
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        zipf.writestr("version", "3")
+        zipf.writestr("data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        symlink_info = zipfile.ZipInfo(link_name)
+        symlink_info.create_system = 3
+        symlink_info.external_attr = (stat.S_IFLNK | 0o777) << 16
+        symlink_info.compress_type = zipfile.ZIP_STORED
+        zipf.writestr(symlink_info, target)
 
 
 def _assert_standard_cve_details(details: dict[str, object], cve_id: str, detected_version: str) -> None:
@@ -6732,18 +6744,15 @@ def test_pytorch_zip_entry_validation_checks_timeout_between_members(
     scanner = PyTorchZipScanner(config={"max_archive_entries": 3})
     checked_members: list[str] = []
     timeout_checks = 0
-    original_read_member_prefix = scanner._read_member_prefix
+    original_read_symlink_target = scanner._read_symlink_target
 
-    def track_member_read(
+    def track_symlink_read(
         zip_file: zipfile.ZipFile,
-        name: str | zipfile.ZipInfo,
-        limit: int,
-        *,
-        phase: str,
+        info: zipfile.ZipInfo,
         result: ScanResult,
-    ) -> bytes:
-        checked_members.append(name.filename if isinstance(name, zipfile.ZipInfo) else name)
-        return original_read_member_prefix(zip_file, name, limit, phase=phase, result=result)
+    ) -> tuple[str, bool]:
+        checked_members.append(info.filename)
+        return original_read_symlink_target(zip_file, info, result)
 
     def check_timeout() -> None:
         nonlocal timeout_checks
@@ -6751,7 +6760,7 @@ def test_pytorch_zip_entry_validation_checks_timeout_between_members(
         if timeout_checks == 2:
             raise TimeoutError("entry validation deadline exceeded")
 
-    monkeypatch.setattr(scanner, "_read_member_prefix", track_member_read)
+    monkeypatch.setattr(scanner, "_read_symlink_target", track_symlink_read)
     monkeypatch.setattr(scanner, "_check_timeout", check_timeout)
 
     result = scanner.scan(str(zip_path))
@@ -7235,7 +7244,193 @@ def test_pytorch_zip_scanner_compression_ratio_passes(tmp_path):
     assert all(c.status == CheckStatus.PASSED for c in ratio_checks)
 
 
-def test_pytorch_zip_scanner_symlink_detection(tmp_path):
+@pytest.mark.parametrize(
+    ("link_name", "target", "message_fragment", "target_class"),
+    [
+        ("models/link", "../../outside.bin", "resolves outside extraction directory", "external"),
+        ("models/link", "..\\..\\outside.bin", "resolves outside extraction directory", "external"),
+        ("models/link", "/tmp/outside-model.bin", "resolves outside extraction directory", "external"),
+        ("models/link", "\\\\server\\share\\model.bin", "resolves outside extraction directory", "external"),
+        ("models/link", "/etc/passwd", "points to critical system path", "critical_system_path"),
+        ("models/link", "/tmp/../etc/passwd", "points to critical system path", "critical_system_path"),
+        ("models/link", "/etc/../tmp/benign", "resolves outside extraction directory", "external"),
+        ("models/link", "C:\\Windows\\System32\\config\\SAM", "points to critical system path", "critical_system_path"),
+    ],
+)
+def test_pytorch_zip_symlink_unsafe_targets_are_critical(
+    tmp_path: Path,
+    link_name: str,
+    target: str,
+    message_fragment: str,
+    target_class: str,
+) -> None:
+    zip_path = tmp_path / "unsafe-link-target.pt"
+    _write_pytorch_zip_with_symlink(zip_path, link_name, target)
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    assert result.success is False
+    symlink_checks = [
+        check
+        for check in result.checks
+        if check.name == "Symlink Safety Validation" and check.details.get("entry") == link_name
+    ]
+    assert len(symlink_checks) == 1
+    assert symlink_checks[0].status == CheckStatus.FAILED
+    assert symlink_checks[0].severity == IssueSeverity.CRITICAL
+    assert symlink_checks[0].rule_code == "S406"
+    assert message_fragment in symlink_checks[0].message
+    assert symlink_checks[0].details == {
+        "entry": link_name,
+        "target": target,
+        "target_class": target_class,
+    }
+
+
+def test_pytorch_zip_symlink_parent_near_match_inside_archive_is_safe(tmp_path: Path) -> None:
+    zip_path = tmp_path / "safe-parent-target.pt"
+    _write_pytorch_zip_with_symlink(zip_path, "models/link", "safe/../target.bin")
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    symlink_checks = [
+        check
+        for check in result.checks
+        if check.name == "Symlink Safety Validation" and check.details.get("entry") == "models/link"
+    ]
+    assert len(symlink_checks) == 1
+    assert symlink_checks[0].status == CheckStatus.PASSED
+    assert symlink_checks[0].details == {
+        "entry": "models/link",
+        "target": "safe/../target.bin",
+        "target_class": "safe",
+    }
+    assert not any(check.rule_code in {"S406", "S408"} for check in result.checks)
+    assert not any(issue.rule_code in {"S406", "S408"} for issue in result.issues)
+
+
+def test_pytorch_zip_symlink_parent_target_inside_archive_root_is_safe(tmp_path: Path) -> None:
+    zip_path = tmp_path / "safe-parent-directory-target.pt"
+    _write_pytorch_zip_with_symlink(zip_path, "models/link", "../target.bin")
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    symlink_check = next(
+        check
+        for check in result.checks
+        if check.name == "Symlink Safety Validation" and check.details.get("entry") == "models/link"
+    )
+    assert symlink_check.status == CheckStatus.PASSED
+    assert symlink_check.details["target_class"] == "safe"
+    assert not any(issue.rule_code in {"S406", "S408"} for issue in result.issues)
+
+
+@pytest.mark.parametrize(("target", "reason"), [(b"", "empty"), (b"safe\x00outside", "NUL byte")])
+def test_pytorch_zip_symlink_invalid_targets_are_critical(tmp_path: Path, target: bytes, reason: str) -> None:
+    zip_path = tmp_path / "invalid-link-target.pt"
+    _write_pytorch_zip_with_symlink(zip_path, "models/link", target)
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    symlink_check = next(
+        check
+        for check in result.checks
+        if check.name == "Symlink Safety Validation" and check.details.get("entry") == "models/link"
+    )
+    assert symlink_check.status == CheckStatus.FAILED
+    assert symlink_check.severity == IssueSeverity.CRITICAL
+    assert symlink_check.rule_code == "S406"
+    assert reason in symlink_check.message
+    assert symlink_check.details["target_class"] == "invalid"
+
+
+def test_pytorch_zip_symlink_non_utf8_safe_target_is_classified(tmp_path: Path) -> None:
+    zip_path = tmp_path / "non-utf8-safe-link-target.pt"
+    _write_pytorch_zip_with_symlink(zip_path, "models/link", b"safe-\xff-target")
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    symlink_check = next(
+        check
+        for check in result.checks
+        if check.name == "Symlink Safety Validation" and check.details.get("entry") == "models/link"
+    )
+    assert symlink_check.status == CheckStatus.PASSED
+    assert symlink_check.rule_code is None
+    assert symlink_check.details["target_class"] == "safe"
+    assert not any(check.rule_code in {"S406", "S408", "S902"} for check in result.checks)
+    assert "pytorch_zip_symlink_target_read_incomplete" not in result.metadata.get("scan_outcome_reasons", [])
+
+
+def test_pytorch_zip_symlink_non_utf8_external_target_is_critical(tmp_path: Path) -> None:
+    zip_path = tmp_path / "non-utf8-external-link-target.pt"
+    _write_pytorch_zip_with_symlink(zip_path, "models/link", b"../../outside-\xff")
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    symlink_check = next(
+        check
+        for check in result.checks
+        if check.name == "Symlink Safety Validation" and check.details.get("entry") == "models/link"
+    )
+    assert symlink_check.status == CheckStatus.FAILED
+    assert symlink_check.severity == IssueSeverity.CRITICAL
+    assert symlink_check.rule_code == "S406"
+    assert symlink_check.details["target_class"] == "external"
+    assert not any(check.rule_code == "S902" for check in result.checks)
+    assert "pytorch_zip_symlink_target_read_incomplete" not in result.metadata.get("scan_outcome_reasons", [])
+
+
+def test_pytorch_zip_symlink_target_evidence_is_bounded(tmp_path: Path) -> None:
+    zip_path = tmp_path / "long-link-target.pt"
+    target = "../../" + ("secret/" * 300)
+    _write_pytorch_zip_with_symlink(zip_path, "models/link", target)
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    symlink_check = next(
+        check
+        for check in result.checks
+        if check.name == "Symlink Safety Validation" and check.details.get("entry") == "models/link"
+    )
+    assert symlink_check.status == CheckStatus.FAILED
+    assert symlink_check.rule_code == "S406"
+    assert len(str(symlink_check.details["target"])) <= 1024
+
+
+def test_pytorch_zip_symlink_target_at_size_limit_is_safe(tmp_path: Path) -> None:
+    zip_path = tmp_path / "maximum-size-link-target.pt"
+    target = b"a" * PyTorchZipScanner.MAX_SYMLINK_TARGET_BYTES
+    _write_pytorch_zip_with_symlink(zip_path, "models/link", target)
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    symlink_check = next(check for check in result.checks if check.name == "Symlink Safety Validation")
+    assert symlink_check.status == CheckStatus.PASSED
+    assert symlink_check.rule_code is None
+    assert symlink_check.details["target_class"] == "safe"
+    assert not any(check.rule_code in {"S406", "S408", "S902"} for check in result.checks)
+
+
+def test_pytorch_zip_oversized_symlink_target_is_critical(tmp_path: Path) -> None:
+    zip_path = tmp_path / "oversized-link-target.pt"
+    target = b"../../outside/" + b"a" * PyTorchZipScanner.MAX_SYMLINK_TARGET_BYTES
+    _write_pytorch_zip_with_symlink(zip_path, "models/link", target)
+
+    result = PyTorchZipScanner().scan(str(zip_path))
+
+    assert result.success is False
+    symlink_check = next(check for check in result.checks if check.name == "Symlink Safety Validation")
+    assert symlink_check.status == CheckStatus.FAILED
+    assert symlink_check.severity == IssueSeverity.CRITICAL
+    assert symlink_check.rule_code == "S406"
+    assert symlink_check.details["target_class"] == "invalid"
+    assert len(str(symlink_check.details["target"])) <= 1024
+    assert not any(check.rule_code == "S902" for check in result.checks)
+    assert "pytorch_zip_symlink_target_read_incomplete" not in result.metadata.get("scan_outcome_reasons", [])
+
+
+def test_pytorch_zip_scanner_symlink_detection(tmp_path: Path) -> None:
     """Test that scanner detects symlinks in archives."""
 
     zip_path = tmp_path / "model.pt"
@@ -7257,13 +7452,15 @@ def test_pytorch_zip_scanner_symlink_detection(tmp_path):
     scanner = PyTorchZipScanner()
     result = scanner.scan(str(zip_path))
 
-    # Should have warning about symlink
-    symlink_issues = [i for i in result.issues if "symlink" in i.message.lower()]
-    assert len(symlink_issues) > 0
-    assert symlink_issues[0].severity == IssueSeverity.WARNING
+    symlink_checks = [check for check in result.checks if check.name == "Symlink Safety Validation"]
+    assert len(symlink_checks) == 1
+    assert symlink_checks[0].status == CheckStatus.FAILED
+    assert symlink_checks[0].severity == IssueSeverity.CRITICAL
+    assert symlink_checks[0].rule_code == "S406"
+    assert symlink_checks[0].details["target_class"] == "critical_system_path"
 
 
-def test_pytorch_zip_scanner_no_symlinks_passes(tmp_path):
+def test_pytorch_zip_scanner_no_symlinks_passes(tmp_path: Path) -> None:
     """Test that scanner passes when no symlinks are present."""
     zip_path = tmp_path / "model.pt"
 
@@ -7311,7 +7508,7 @@ def test_pytorch_zip_scanner_combined_security_controls(tmp_path: Path) -> None:
     # Symlink should also trigger independently
     symlink_issues = [i for i in result.issues if "symlink" in i.message.lower()]
     assert len(symlink_issues) > 0
-    assert symlink_issues[0].severity == IssueSeverity.WARNING
+    assert symlink_issues[0].severity == IssueSeverity.CRITICAL
 
 
 def test_pytorch_zip_version_extraction_returns_metadata_when_present(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- classify PyTorch ZIP symlink targets as safe, external, critical-system, invalid, or unreadable
- resolve relative targets against the link entry while enforcing the archive extraction root
- preserve raw Unix path bytes with `surrogateescape` so non-UTF-8 targets still receive traversal classification
- bound both decompressed target bytes and compressed input
- normalize dot segments before critical-system attribution
- integrate current `main` at `21956abfe97ec8312bb4f6312b5da99ec0fa640e`

## False-positive and false-negative fixes
- accept in-root parent targets and the exact configured byte limit
- reject POSIX, Windows, UNC, reserved DOS-device, empty, NUL-containing, oversized, and compression-abusive targets
- preserve benign device-name near matches and non-UTF-8 relative targets
- keep pickle/JIT/content analysis active when symlink mode bits are attached to a PyTorch member
- trust Unix mode bits only for Unix/Darwin ZIP creator systems, avoiding DOS/FAT metadata false positives
- verify local-header or data-descriptor payload bounds against central-directory metadata
- prevent forged central CRC, compressed size, and uncompressed size from hiding an escaping suffix behind a safe prefix
- redact attacker-controlled ZIP read errors and bound stored evidence

## Focused validation
- integrated associated-module baseline: `806 passed, 5 warnings`
- final symlink/security slice: `35 passed, 773 deselected`
- valid data-descriptor and forced-ZIP64 symlink probes passed
- touched-file Ruff format/check clean
- touched-file mypy clean
- `git diff --check` clean
- full repository suite intentionally left to CI per review workflow

Published commit: `2b2fb4f548d79d9a6f5380dd284f76dea0c79592`
Published tree: `7df9a6a009130673453fe0dfb8e1fce99af3cc84`