### PR TITLE
fix: classify tar link escapes as symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- report TAR external link escapes with the dedicated symlink rule code, resolve link targets from their correct archive bases, and avoid retaining passing checks for benign link floods
 - harden cloud acquisition size caps, HTTPS/R2 auto-default routing, and directory metadata failures
 - detect operator attrgetter, itemgetter, and methodcaller archive-member Python paths to command execution while preserving benign accessor names
 - redact Keras and TensorFlow scanner detail fields that echo model-controlled configs, code indicators, archive members, and external references.

--- a/RULES.md
+++ b/RULES.md
@@ -87,18 +87,18 @@ The catalog currently contains 113 rules.
 
 ### File System And Archive Security
 
-| Code   | Default severity | Name                         | Description                          |
-| ------ | ---------------- | ---------------------------- | ------------------------------------ |
-| `S401` | MEDIUM           | open() for write/append      | File write operations detected       |
-| `S402` | MEDIUM           | pathlib write operations     | Path-based file writes               |
-| `S403` | MEDIUM           | shutil operations            | File/directory operations via shutil |
-| `S404` | LOW              | tempfile operations          | Temporary file creation              |
-| `S405` | CRITICAL         | Path traversal attempts      | Directory escape attempts detected   |
-| `S406` | HIGH             | Symlink to external location | Symbolic link pointing outside scope |
-| `S407` | LOW              | Hidden file access           | Dotfile operations detected          |
-| `S408` | HIGH             | /etc or system file access   | System configuration file access     |
-| `S409` | MEDIUM           | Home directory access        | User directory operations            |
-| `S410` | HIGH             | Archive bomb detected        | Excessive compression ratio          |
+| Code   | Default severity | Name                              | Description                                          |
+| ------ | ---------------- | --------------------------------- | ---------------------------------------------------- |
+| `S401` | MEDIUM           | open() for write/append           | File write operations detected                       |
+| `S402` | MEDIUM           | pathlib write operations          | Path-based file writes                               |
+| `S403` | MEDIUM           | shutil operations                 | File/directory operations via shutil                 |
+| `S404` | LOW              | tempfile operations               | Temporary file creation                              |
+| `S405` | CRITICAL         | Path traversal attempts           | Directory escape attempts detected                   |
+| `S406` | HIGH             | Archive link to external location | Symbolic or hard archive link pointing outside scope |
+| `S407` | LOW              | Hidden file access                | Dotfile operations detected                          |
+| `S408` | HIGH             | /etc or system file access        | System configuration file access                     |
+| `S409` | MEDIUM           | Home directory access             | User directory operations                            |
+| `S410` | HIGH             | Archive bomb detected             | Excessive compression ratio                          |
 
 ### Embedded Executables And Scripts
 

--- a/modelaudit/rule_catalog.py
+++ b/modelaudit/rule_catalog.py
@@ -297,9 +297,9 @@ RULE_CATALOG: tuple[RuleCatalogEntry, ...] = (
     ),
     RuleCatalogEntry(
         code="S406",
-        name="Symlink to external location",
+        name="Archive link to external location",
         severity="HIGH",
-        description="Symbolic link pointing outside scope",
+        description="Symbolic or hard archive link pointing outside scope",
         patterns=(r"symlink.*external", r"link.*outside", r"symlink"),
     ),
     RuleCatalogEntry(

--- a/modelaudit/scanners/tar_scanner.py
+++ b/modelaudit/scanners/tar_scanner.py
@@ -214,6 +214,29 @@ class TarScanner(BaseScanner):
             preserve_non_delimited_suffix=False,
         )
 
+    @staticmethod
+    def _resolve_link_target(
+        target: str,
+        *,
+        resolved_member_name: str,
+        extraction_root: str,
+        is_symlink: bool,
+    ) -> tuple[str, bool]:
+        """Resolve TAR symlinks from their parent and hardlinks from the archive root."""
+        if not is_symlink:
+            return sanitize_archive_path(target, extraction_root)
+        if is_absolute_archive_path(target):
+            return sanitize_archive_path(target, extraction_root)
+
+        normalized_target = target.replace("\\", os.sep).replace("/", os.sep)
+        target_base = os.path.dirname(resolved_member_name)
+        target_resolved = os.path.normpath(os.path.join(target_base, normalized_target))
+        try:
+            target_from_root = os.path.relpath(target_resolved, extraction_root)
+        except ValueError:
+            return target_resolved, False
+        return sanitize_archive_path(target_from_root, extraction_root)
+
     def _extract_member_to_tempfile(
         self,
         tar: tarfile.TarFile,
@@ -553,41 +576,42 @@ class TarScanner(BaseScanner):
 
                 if member.issym() or member.islnk():
                     target = member.linkname
-                    target_base = os.path.dirname(resolved_name)
-                    _target_resolved, target_safe = sanitize_archive_path(target, target_base)
+                    link_kind = "Symlink" if member.issym() else "Hard link"
+                    if target:
+                        _target_resolved, target_safe = self._resolve_link_target(
+                            target,
+                            resolved_member_name=resolved_name,
+                            extraction_root=temp_base,
+                            is_symlink=member.issym(),
+                        )
+                    else:
+                        target_safe = False
                     if not target_safe:
                         # Check if it's specifically a critical system path
                         if is_absolute_archive_path(target) and is_critical_system_path(target, CRITICAL_SYSTEM_PATHS):
-                            message = f"Symlink {name} points to critical system path: {target}"
+                            message = f"{link_kind} {name} points to critical system path: {target}"
+                        elif not target:
+                            message = f"{link_kind} {name} has an empty target"
                         else:
-                            message = f"Symlink {name} resolves outside extraction directory"
+                            message = f"{link_kind} {name} resolves outside extraction directory"
                         result.add_check(
                             name="Symlink Safety Validation",
                             passed=False,
                             message=message,
                             severity=IssueSeverity.CRITICAL,
                             location=f"{path}:{name}",
-                            details={"target": target},
-                            rule_code="S902",
+                            details={"target": target, "entry": name},
+                            rule_code="S406",
                         )
                     elif is_absolute_archive_path(target) and is_critical_system_path(target, CRITICAL_SYSTEM_PATHS):
                         result.add_check(
                             name="Symlink Safety Validation",
                             passed=False,
-                            message=f"Symlink {name} points to critical system path: {target}",
+                            message=f"{link_kind} {name} points to critical system path: {target}",
                             severity=IssueSeverity.CRITICAL,
                             location=f"{path}:{name}",
-                            details={"target": target},
-                            rule_code="S406",
-                        )
-                    else:
-                        result.add_check(
-                            name="Symlink Safety Validation",
-                            passed=True,
-                            message=f"Symlink {name} is safe",
-                            location=f"{path}:{name}",
                             details={"target": target, "entry": name},
-                            rule_code=None,  # Passing check
+                            rule_code="S406",
                         )
                     continue
 

--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -973,6 +973,146 @@ class TestTarScanner:
         finally:
             os.unlink(tmp_path)
 
+    def test_symlink_outside_extraction_root_uses_dedicated_rule(self, tmp_path: Path) -> None:
+        """External TAR links must use the dedicated symlink escape rule."""
+        archive_path = tmp_path / "external_link.tar"
+        with tarfile.open(archive_path, "w") as archive:
+            info = tarfile.TarInfo("link.txt")
+            info.type = tarfile.SYMTYPE
+            info.linkname = "../../../etc/passwd"
+            archive.addfile(info)
+
+        result = self.scanner.scan(str(archive_path))
+
+        symlink_checks = [check for check in result.checks if check.name == "Symlink Safety Validation"]
+        assert result.success is False
+        assert len(symlink_checks) == 1
+        assert symlink_checks[0].rule_code == "S406"
+        assert symlink_checks[0].severity == IssueSeverity.CRITICAL
+        assert symlink_checks[0].details == {"target": "../../../etc/passwd", "entry": "link.txt"}
+
+    def test_parent_relative_symlink_within_archive_is_safe(self, tmp_path: Path) -> None:
+        """A symlink may traverse its parent while remaining inside the archive root."""
+        archive_path = tmp_path / "parent_relative_link.tar"
+        with tarfile.open(archive_path, "w") as archive:
+            target = tarfile.TarInfo("weights.bin")
+            target.size = 0
+            archive.addfile(target, tarfile.io.BytesIO(b""))  # type: ignore[attr-defined]
+
+            link = tarfile.TarInfo("nested/link.bin")
+            link.type = tarfile.SYMTYPE
+            link.linkname = "../weights.bin"
+            archive.addfile(link)
+
+        result = self.scanner.scan(str(archive_path))
+
+        symlink_checks = [check for check in result.checks if check.name == "Symlink Safety Validation"]
+        assert result.success is True
+        assert symlink_checks == []
+
+    def test_archive_root_relative_hardlink_within_archive_is_safe(self, tmp_path: Path) -> None:
+        """TAR hardlink targets are resolved from the archive root, not the member parent."""
+        archive_path = tmp_path / "root_relative_hardlink.tar"
+        with tarfile.open(archive_path, "w") as archive:
+            target = tarfile.TarInfo("weights.bin")
+            target.size = 0
+            archive.addfile(target, tarfile.io.BytesIO(b""))  # type: ignore[attr-defined]
+
+            link = tarfile.TarInfo("nested/link.bin")
+            link.type = tarfile.LNKTYPE
+            link.linkname = "weights.bin"
+            archive.addfile(link)
+
+        result = self.scanner.scan(str(archive_path))
+
+        symlink_checks = [check for check in result.checks if check.name == "Symlink Safety Validation"]
+        assert result.success is True
+        assert symlink_checks == []
+
+    def test_many_safe_links_do_not_amplify_scan_results(self, tmp_path: Path) -> None:
+        """Benign link floods must not create one passing check per TAR member."""
+        archive_path = tmp_path / "many_safe_links.tar"
+        with tarfile.open(archive_path, "w") as archive:
+            for index in range(250):
+                link = tarfile.TarInfo(f"links/link-{index}")
+                link.type = tarfile.SYMTYPE
+                link.linkname = "../targets/model.bin"
+                archive.addfile(link)
+
+        result = self.scanner.scan(str(archive_path))
+
+        assert result.success is True
+        assert not [check for check in result.checks if check.name == "Symlink Safety Validation"]
+
+    def test_hardlink_outside_extraction_root_survives_s902_suppression(self, tmp_path: Path) -> None:
+        """Suppressing generic structure noise must not suppress TAR hardlink escapes."""
+        archive_path = tmp_path / "external_link_suppressed.tar"
+        with tarfile.open(archive_path, "w") as archive:
+            info = tarfile.TarInfo("nested/link.txt")
+            info.type = tarfile.LNKTYPE
+            info.linkname = "../outside"
+            archive.addfile(info)
+
+        reset_config()
+        set_config(ModelAuditConfig(suppress={"S902"}))
+        try:
+            result = self.scanner.scan(str(archive_path))
+        finally:
+            reset_config()
+
+        symlink_checks = [check for check in result.checks if check.name == "Symlink Safety Validation"]
+        assert result.success is False
+        assert len(symlink_checks) == 1
+        assert symlink_checks[0].rule_code == "S406"
+        assert symlink_checks[0].message == "Hard link nested/link.txt resolves outside extraction directory"
+        assert symlink_checks[0].details["entry"] == "nested/link.txt"
+
+    @pytest.mark.parametrize(
+        ("link_type", "expected_kind"),
+        [(tarfile.SYMTYPE, "Symlink"), (tarfile.LNKTYPE, "Hard link")],
+    )
+    def test_empty_link_target_fails_closed(
+        self,
+        tmp_path: Path,
+        link_type: bytes,
+        expected_kind: str,
+    ) -> None:
+        """Malformed archive links with empty targets must not be reported as safe."""
+        archive_path = tmp_path / f"empty_{expected_kind.lower().replace(' ', '_')}.tar"
+        with tarfile.open(archive_path, "w") as archive:
+            info = tarfile.TarInfo("nested/link.txt")
+            info.type = link_type
+            info.linkname = ""
+            archive.addfile(info)
+
+        result = self.scanner.scan(str(archive_path))
+
+        link_checks = [check for check in result.checks if check.name == "Symlink Safety Validation"]
+        assert result.success is False
+        assert len(link_checks) == 1
+        assert link_checks[0].rule_code == "S406"
+        assert link_checks[0].message == f"{expected_kind} nested/link.txt has an empty target"
+        assert link_checks[0].details == {"target": "", "entry": "nested/link.txt"}
+
+    def test_symlink_outside_extraction_root_respects_s406_suppression(self, tmp_path: Path) -> None:
+        """The dedicated link escape rule remains directly suppressible."""
+        archive_path = tmp_path / "external_link_s406_suppressed.tar"
+        with tarfile.open(archive_path, "w") as archive:
+            info = tarfile.TarInfo("link.txt")
+            info.type = tarfile.SYMTYPE
+            info.linkname = "../../../etc/passwd"
+            archive.addfile(info)
+
+        reset_config()
+        set_config(ModelAuditConfig(suppress={"S406"}))
+        try:
+            result = self.scanner.scan(str(archive_path))
+        finally:
+            reset_config()
+
+        assert result.success is True
+        assert not any(check.rule_code == "S406" for check in result.checks)
+
     def test_symlink_to_critical_path(self):
         """Symlinks targeting critical system paths should be flagged"""
         with tempfile.NamedTemporaryFile(suffix=".tar", delete=False) as tmp:


### PR DESCRIPTION
## Summary

- report TAR external symbolic-link and hardlink escapes with the dedicated S406 rule instead of generic structural S902
- resolve symbolic-link targets from the member directory while enforcing extraction-root containment
- resolve TAR hardlinks from the archive root, matching TAR semantics
- fail closed on empty link targets and include the archive entry in failure evidence
- distinguish symbolic links from hardlinks in user-facing diagnostics
- avoid retaining one passing check per benign link, preventing result amplification from link-heavy archives
- broaden the public S406 description to cover both archive link types
- synchronize with current `main` at `0c69e696807a2654455c245c739e9843faa6e49a`

## False-positive / false-negative audit

- preserved benign parent-relative symlinks that remain inside the extraction root
- preserved benign root-relative hardlinks to existing archive members
- detected nested hardlink targets that escape the archive root
- detected empty symbolic-link and hardlink targets instead of reporting them safe
- confirmed S902 suppression no longer hides link escapes
- confirmed direct S406 suppression remains supported
- retained critical absolute-system-path detection
- confirmed 250 benign links do not create 250 passing result objects

## Validation

- associated TAR scanner and rule modules: `131 passed, 43 expected Python 3.13 lane skips`
- independent focused rule/suppression audit: `10 passed, 121 deselected`
- scoped Ruff format/check and mypy: passed
- `git diff --check`: passed
- full local suite intentionally not run per PR-audit workflow

Published commit: `8c4c131c12280adb9c985b3d80504b1caa11c95d`
Verified tree: `cc6a4f58927acfdb3bb84aef259b052fafe19e0f`