### PR TITLE
fix: escape text output controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- escape terminal and Unicode formatting controls in human-readable CLI output
 - restrict manual Docker publishes to validated immutable version tags and their matching Git release refs before registry login or push
 - harden cloud acquisition size caps, HTTPS/R2 auto-default routing, and directory metadata failures
 - detect operator attrgetter, itemgetter, and methodcaller archive-member Python paths to command execution while preserving benign accessor names

--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -12,6 +12,7 @@ import shutil
 import stat
 import sys
 import time
+import unicodedata
 from dataclasses import dataclass, field
 from pathlib import Path, PureWindowsPath
 from typing import Any, NoReturn
@@ -109,33 +110,51 @@ logger = logging.getLogger("modelaudit")
 
 def _display_path(path: str) -> str:
     """Return a path safe for user-facing CLI output."""
+    return _escape_terminal_text(_display_scan_path(path))
+
+
+def _display_scan_path(path: str) -> str:
+    """Return an exact local path or a credential-redacted remote identifier."""
     if path.startswith("models:/"):
         from .integrations.mlflow import _redact_mlflow_error_for_display
 
         return _redact_mlflow_error_for_display(path)
     if is_stream_url(path):
         return f"stream://{redact_stream_url_for_display(path[9:])}"
-    if is_cloud_url(path) or is_cleartext_cloud_url(path) or is_cleartext_pytorch_hub_url(path):
+    if (
+        is_cloud_url(path)
+        or is_cleartext_cloud_url(path)
+        or is_pytorch_hub_url(path)
+        or is_cleartext_pytorch_hub_url(path)
+    ):
         return redact_url_for_display(path)
     if is_jfrog_url_like(path):
         return redact_jfrog_url_for_display(path)
     return redact_huggingface_url_for_display(path)
 
 
-def _display_scan_path(path: str) -> str:
-    """Return a persisted scan path safe for generated reports."""
-    return _display_path(path)
-
-
 def _display_error(error: object, path: str) -> str:
     """Return an error safe for user-facing CLI output."""
     if is_stream_url(path):
-        return redact_stream_error_for_display(error, path[9:])
-    return (
-        redact_cloud_error_for_display(error, path)
-        if is_cloud_url(path) or is_cleartext_cloud_url(path) or is_cleartext_pytorch_hub_url(path)
-        else str(error)
-    )
+        display_error = redact_stream_error_for_display(error, path[9:])
+    elif is_huggingface_url(path) or is_huggingface_file_url(path):
+        display_error = redact_huggingface_urls_in_text(str(error))
+    elif is_jfrog_url_like(path):
+        display_error = redact_jfrog_error_for_display(error, path)
+    elif is_mlflow_uri(path):
+        from .integrations.mlflow import _redact_mlflow_error_for_display
+
+        display_error = _redact_mlflow_error_for_display(error)
+    else:
+        display_error = (
+            redact_cloud_error_for_display(error, path)
+            if is_cloud_url(path)
+            or is_cleartext_cloud_url(path)
+            or is_pytorch_hub_url(path)
+            or is_cleartext_pytorch_hub_url(path)
+            else str(error)
+        )
+    return _escape_terminal_text(display_error)
 
 
 class _OutputWriteError(click.ClickException):
@@ -1451,6 +1470,29 @@ def style_text(text: str, **kwargs: Any) -> str:
     return text
 
 
+def _escape_terminal_text(value: Any) -> str:
+    """Render control characters visibly before writing model-controlled text to terminals."""
+    text = "" if value is None else str(value)
+
+    def replace_control(char: str) -> str:
+        if char == "\n":
+            return "\\n"
+        if char == "\r":
+            return "\\r"
+        if char == "\t":
+            return "\\t"
+        codepoint = ord(char)
+        if codepoint <= 0xFF:
+            return f"\\x{codepoint:02x}"
+        if codepoint <= 0xFFFF:
+            return f"\\u{codepoint:04x}"
+        return f"\\U{codepoint:08x}"
+
+    return "".join(
+        replace_control(char) if unicodedata.category(char) in {"Cc", "Cf", "Cs", "Zl", "Zp"} else char for char in text
+    )
+
+
 def get_trusted_config_store() -> TrustedConfigStore:
     """Return the persistent store used for trusted local configs."""
     return TrustedConfigStore()
@@ -1597,9 +1639,9 @@ def create_progress_callback_wrapper(progress_callback: Any | None, spinner: Any
         try:
             progress_callback(message, percentage)
             if spinner and hasattr(spinner, "text"):
-                spinner.text = message
+                spinner.text = _escape_terminal_text(message)
         except Exception as e:
-            logger.warning(f"Progress callback error: {e}")
+            logger.warning(f"Progress callback error: {_escape_terminal_text(e)}")
 
     return wrapped_callback
 
@@ -2078,7 +2120,7 @@ def _emit_scan_output(
     if output:
         _write_output_text_file(output, output_text)
 
-        click.echo(f"Results written to {output}")
+        click.echo(f"Results written to {_display_path(output)}")
 
         if verbose:
             visible_issues = audit_result.issues
@@ -2145,7 +2187,9 @@ def _announce_suppressed_preferred_scanners(suppressions: list[dict[str, Any]]) 
         err=True,
     )
     for entry in suppressions[:5]:
-        click.echo(f"  - {entry['location']} (would have used: {entry['scanner_id']})", err=True)
+        location = _escape_terminal_text(entry["location"])
+        scanner_id = _escape_terminal_text(entry["scanner_id"])
+        click.echo(f"  - {location} (would have used: {scanner_id})", err=True)
     if len(suppressions) > 5:
         click.echo(f"  … and {len(suppressions) - 5} more", err=True)
 
@@ -2185,17 +2229,18 @@ def _should_skip_non_model_file(scan_path: str, runtime: _ScanRuntimeConfig, *, 
 
     _, ext = os.path.splitext(scan_path)
     ext = ext.lower()
+    display_path = _display_path(scan_path)
     if ext in (".py", ".js", ".html", ".css"):
         if verbose:
-            logger.debug(f"Skipped: {scan_path} (non-model file)")
+            logger.debug(f"Skipped: {display_path} (non-model file)")
         if runtime.show_styled_output:
-            click.echo(f"Skipping non-model file: {scan_path}")
+            click.echo(f"Skipping non-model file: {display_path}")
         return True
 
     if verbose:
-        logger.debug(f"Skipped: {scan_path} (non-model .txt file)")
+        logger.debug(f"Skipped: {display_path} (non-model .txt file)")
     if runtime.show_styled_output:
-        click.echo(f"Skipping non-model file: {scan_path}")
+        click.echo(f"Skipping non-model file: {display_path}")
     return True
 
 
@@ -2210,7 +2255,7 @@ def _create_path_progress_callback(
     if spinner and not progress_tracker:
 
         def update_progress(message: str, percentage: float, spinner_bound: Any = spinner) -> None:
-            spinner_bound.text = f"{message} ({percentage:.1f}%)"
+            spinner_bound.text = f"{_escape_terminal_text(message)} ({percentage:.1f}%)"
 
         return update_progress
 
@@ -2231,25 +2276,26 @@ def _create_path_progress_callback(
 
         progress_tracker.stats.total_bytes = total_bytes
         progress_tracker.stats.total_items = total_items
-        progress_tracker.set_phase(ProgressPhase.INITIALIZING, f"Starting scan: {_display_scan_path(actual_path)}")
+        progress_tracker.set_phase(ProgressPhase.INITIALIZING, f"Starting scan: {_display_path(actual_path)}")
     except (ImportError, RecursionError):
         return None
 
     def enhanced_progress_callback(message: str, percentage: float) -> None:
+        display_message = _escape_terminal_text(message)
         if progress_tracker:
             bytes_processed = int((percentage / 100.0) * total_bytes) if total_bytes > 0 else 0
-            progress_tracker.update_bytes(bytes_processed, message)
+            progress_tracker.update_bytes(bytes_processed, display_message)
 
             message_lower = message.lower()
             if "loading" in message_lower:
-                progress_tracker.set_phase(ProgressPhase.LOADING, message)
+                progress_tracker.set_phase(ProgressPhase.LOADING, display_message)
             elif "analyzing" in message_lower or "scanning" in message_lower:
-                progress_tracker.set_phase(ProgressPhase.ANALYZING, message)
+                progress_tracker.set_phase(ProgressPhase.ANALYZING, display_message)
             elif "checking" in message_lower:
-                progress_tracker.set_phase(ProgressPhase.CHECKING, message)
+                progress_tracker.set_phase(ProgressPhase.CHECKING, display_message)
 
         if spinner:
-            spinner.text = f"{message} ({percentage:.1f}%)"
+            spinner.text = f"{display_message} ({percentage:.1f}%)"
 
     return enhanced_progress_callback
 
@@ -2422,10 +2468,7 @@ def _scan_local_or_downloaded_path(
         elif runtime.show_styled_output:
             click.echo(f"Error scanning {display_path}")
 
-        logger.error(
-            f"Error during scan of {display_path}: {display_error}",
-            exc_info=verbose and not (is_stream_url(actual_path) or is_cloud_url(path)),
-        )
+        logger.error(f"Error during scan of {display_path}: {display_error}")
         click.echo(f"Error scanning {display_path}: {display_error}", err=True)
         audit_result.has_errors = True
         path_state.scanned_paths.append(_display_scan_path(actual_path))
@@ -2446,17 +2489,17 @@ def _resolve_scan_source_for_path(
 ) -> _SourceDispatchResult | None:
     """Resolve one source path and execute source-native scans when they should bypass local scanning."""
     if is_cleartext_cloud_url(path):
-        click.echo(f"Error: Cleartext cloud storage URL is not supported: {redact_url_for_display(path)}", err=True)
+        click.echo(f"Error: Cleartext cloud storage URL is not supported: {_display_path(path)}", err=True)
         audit_result.has_errors = True
         return None
 
     if is_cleartext_pytorch_hub_url(path):
-        click.echo(f"Error: Cleartext PyTorch Hub URL is not supported: {redact_url_for_display(path)}", err=True)
+        click.echo(f"Error: Cleartext PyTorch Hub URL is not supported: {_display_path(path)}", err=True)
         audit_result.has_errors = True
         return None
 
     if is_huggingface_file_url(path):
-        display_path = redact_huggingface_url_for_display(path)
+        display_path = _display_path(path)
         download_spinner = None
         temp_dir = None
         if runtime.show_styled_output and should_show_spinner():
@@ -2505,8 +2548,8 @@ def _resolve_scan_source_for_path(
             elif runtime.show_styled_output:
                 click.echo(style_text("❌ Download failed", fg="red", bold=True))
 
-            error_msg = redact_huggingface_urls_in_text(str(exc))
-            logger.error(f"Failed to download file from {display_path}: {error_msg}", exc_info=verbose)
+            error_msg = _display_error(exc, path)
+            logger.error(f"Failed to download file from {display_path}: {error_msg}")
             click.echo(f"Error downloading file from {display_path}: {error_msg}", err=True)
             audit_result.has_errors = True
             path_state.defer_temp_cleanup(
@@ -2517,7 +2560,7 @@ def _resolve_scan_source_for_path(
             return None
 
     if is_huggingface_url(path):
-        display_path = redact_huggingface_url_for_display(path)
+        display_path = _display_path(path)
         if runtime.show_styled_output:
             click.echo(f"\n📥 Preparing to download from {style_text(display_path, fg='cyan')}")
 
@@ -2535,13 +2578,19 @@ def _resolve_scan_source_for_path(
                 else:
                     size_str = f"{size_bytes / 1024:.2f} KB"
 
-                click.echo(f"   Model: {model_info['model_id']}")
-                click.echo(f"   Size: {size_str} ({model_info['file_count']} files)")
+                model_id = _escape_terminal_text(str(model_info["model_id"]))
+                file_count = _escape_terminal_text(str(model_info["file_count"]))
+                click.echo(f"   Model: {model_id}")
+                click.echo(f"   Size: {size_str} ({file_count} files)")
 
                 if runtime.scan_and_delete:
                     click.echo(style_text("   Mode: Streaming (scan and delete to save disk)", fg="cyan"))
             except Exception as exc:
-                logger.debug("Unable to display HuggingFace model metadata for %s: %s", path, exc)
+                logger.debug(
+                    "Unable to display HuggingFace model metadata for %s: %s",
+                    display_path,
+                    _display_error(exc, path),
+                )
 
         temp_dir = None
         try:
@@ -2664,7 +2713,7 @@ def _resolve_scan_source_for_path(
             if runtime.show_styled_output:
                 click.echo(style_text("❌ Download/scan failed", fg="red", bold=True))
 
-            error_msg = redact_huggingface_urls_in_text(str(exc))
+            error_msg = _display_error(exc, path)
             if "insufficient disk space" in error_msg.lower():
                 logger.error(f"Disk space error for {display_path}: {error_msg}")
                 click.echo(style_text(f"\n⚠️  {error_msg}", fg="yellow"), err=True)
@@ -2677,7 +2726,7 @@ def _resolve_scan_source_for_path(
                     err=True,
                 )
             else:
-                logger.error(f"Failed to process model from {display_path}: {error_msg}", exc_info=verbose)
+                logger.error(f"Failed to process model from {display_path}: {error_msg}")
                 click.echo(f"Error processing model from {display_path}: {error_msg}", err=True)
 
             audit_result.has_errors = True
@@ -2689,6 +2738,7 @@ def _resolve_scan_source_for_path(
             return None
 
     if is_pytorch_hub_url(path):
+        display_path = _display_path(path)
         download_spinner = None
         try:
             record_download_started("pytorch_hub", path)
@@ -2733,11 +2783,11 @@ def _resolve_scan_source_for_path(
                 return _SourceDispatchResult(actual_path=path, local_scan_required=False)
 
             if runtime.show_styled_output and should_show_spinner():
-                spinner_text = f"Downloading from {style_text(path, fg='cyan')}"
+                spinner_text = f"Downloading from {style_text(display_path, fg='cyan')}"
                 download_spinner = yaspin(Spinners.dots, text=spinner_text)
                 download_spinner.start()
             elif runtime.show_styled_output:
-                click.echo(f"Downloading from {path}...")
+                click.echo(f"Downloading from {display_path}...")
 
             download_path = download_pytorch_hub_model(
                 path,
@@ -2766,9 +2816,9 @@ def _resolve_scan_source_for_path(
             elif runtime.show_styled_output:
                 click.echo("Download failed")
 
-            error_msg = str(exc)
+            error_msg = _display_error(exc, path)
             if "insufficient disk space" in error_msg.lower():
-                logger.error(f"Disk space error for {path}: {error_msg}")
+                logger.error(f"Disk space error for {display_path}: {error_msg}")
                 click.echo(style_text(f"\n⚠️  {error_msg}", fg="yellow"), err=True)
                 click.echo(
                     style_text(
@@ -2778,13 +2828,14 @@ def _resolve_scan_source_for_path(
                     err=True,
                 )
             else:
-                logger.error(f"Failed to download model from {path}: {error_msg}", exc_info=verbose)
-                click.echo(f"Error downloading model from {path}: {error_msg}", err=True)
+                logger.error(f"Failed to download model from {display_path}: {error_msg}")
+                click.echo(f"Error downloading model from {display_path}: {error_msg}", err=True)
 
             audit_result.has_errors = True
             return None
 
     if is_cloud_url(path):
+        display_path = _display_path(path)
         if dry_run:
             import asyncio
 
@@ -2792,7 +2843,7 @@ def _resolve_scan_source_for_path(
 
             try:
                 metadata = asyncio.run(analyze_cloud_target(path))
-                click.echo(f"\n📊 Preview for {style_text(redact_url_for_display(path), fg='cyan')}:")
+                click.echo(f"\n📊 Preview for {style_text(display_path, fg='cyan')}:")
                 click.echo(f"   Type: {metadata['type']}")
 
                 if metadata["type"] == "file":
@@ -2816,7 +2867,7 @@ def _resolve_scan_source_for_path(
                 return _SourceDispatchResult(actual_path=path, local_scan_required=False)
             except Exception as exc:
                 error_msg = _display_error(exc, path)
-                click.echo(f"Error analyzing {redact_url_for_display(path)}: {error_msg}", err=True)
+                click.echo(f"Error analyzing {display_path}: {error_msg}", err=True)
                 audit_result.has_errors = True
                 return None
 
@@ -2872,11 +2923,11 @@ def _resolve_scan_source_for_path(
                 return _SourceDispatchResult(actual_path=path, local_scan_required=False)
 
             if runtime.show_styled_output and should_show_spinner():
-                spinner_text = f"Downloading from {style_text(redact_url_for_display(path), fg='cyan')}"
+                spinner_text = f"Downloading from {style_text(display_path, fg='cyan')}"
                 download_spinner = yaspin(Spinners.dots, text=spinner_text)
                 download_spinner.start()
             elif runtime.show_styled_output:
-                click.echo(f"Downloading from {redact_url_for_display(path)}...")
+                click.echo(f"Downloading from {display_path}...")
 
             cloud_download_kwargs: dict[str, Any] = {}
             if runtime.scannable_extensions is not None:
@@ -2921,7 +2972,7 @@ def _resolve_scan_source_for_path(
 
             error_msg = _display_error(exc, path)
             if "insufficient disk space" in error_msg.lower():
-                logger.error(f"Disk space error for {redact_url_for_display(path)}: {error_msg}")
+                logger.error(f"Disk space error for {display_path}: {error_msg}")
                 click.echo(style_text(f"\n⚠️  {error_msg}", fg="yellow"), err=True)
                 click.echo(
                     style_text(
@@ -2931,15 +2982,13 @@ def _resolve_scan_source_for_path(
                     err=True,
                 )
             else:
-                logger.error(f"Failed to download from {redact_url_for_display(path)}: {error_msg}")
-                click.echo(f"Error downloading from {redact_url_for_display(path)}: {error_msg}", err=True)
+                logger.error(f"Failed to download from {display_path}: {error_msg}")
+                click.echo(f"Error downloading from {display_path}: {error_msg}", err=True)
 
             audit_result.has_errors = True
             return None
 
     if is_mlflow_uri(path):
-        from .integrations.mlflow import _redact_mlflow_error_for_display
-
         display_path = _display_path(path)
         download_spinner = None
         if runtime.show_styled_output and should_show_spinner():
@@ -2988,14 +3037,14 @@ def _resolve_scan_source_for_path(
             elif runtime.show_styled_output:
                 click.echo("Download failed")
 
-            error_msg = _redact_mlflow_error_for_display(exc)
-            logger.error(f"Failed to download model from {display_path}: {error_msg}")
-            click.echo(f"Error downloading model from {display_path}: {error_msg}", err=True)
+            display_error = _display_error(exc, path)
+            logger.error(f"Failed to download model from {display_path}: {display_error}")
+            click.echo(f"Error downloading model from {display_path}: {display_error}", err=True)
             audit_result.has_errors = True
             return None
 
     if is_jfrog_url(path):
-        display_path = redact_jfrog_url_for_display(path)
+        display_path = _display_path(path)
         download_spinner = None
         if runtime.show_styled_output and should_show_spinner():
             download_spinner = yaspin(
@@ -3050,8 +3099,8 @@ def _resolve_scan_source_for_path(
             elif runtime.show_styled_output:
                 click.echo("Download/scan failed")
 
-            error_msg = redact_jfrog_error_for_display(exc, path)
-            logger.error(f"Failed to download/scan model from {display_path}: {error_msg}", exc_info=verbose)
+            error_msg = _display_error(exc, path)
+            logger.error(f"Failed to download/scan model from {display_path}: {error_msg}")
             click.echo(f"Error downloading/scanning model from {display_path}: {error_msg}", err=True)
             audit_result.has_errors = True
             return None
@@ -3762,10 +3811,7 @@ def scan_command(
             except Exception as exc:
                 display_path = _display_path(path)
                 display_error = _display_error(exc, path)
-                logger.error(
-                    f"Unexpected error processing {display_path}: {display_error}",
-                    exc_info=verbose and not is_stream_url(path),
-                )
+                logger.error(f"Unexpected error processing {display_path}: {display_error}")
                 click.echo(f"Unexpected error processing {display_path}: {display_error}", err=True)
                 path_state.scanned_paths.append(_display_scan_path(source_result.actual_path))
                 audit_result.has_errors = True
@@ -3886,7 +3932,7 @@ def format_text_output(results: dict[str, Any], verbose: bool = False) -> str:
     # Display metrics in a formatted grid
     for label, value, color in metrics:
         label_str = style_text(f"  {label}:", fg="bright_black")
-        value_str = style_text(value, fg=color, bold=True)
+        value_str = style_text(_escape_terminal_text(value), fg=color, bold=True)
         output_lines.append(f"{label_str} {value_str}")
 
     # Add authentication status (inspired by semgrep's approach)
@@ -3931,23 +3977,32 @@ def format_text_output(results: dict[str, Any], verbose: bool = False) -> str:
                 output_lines.append(style_text("  Model Information:", fg="bright_black"))
 
                 if "model_type" in model_info:
-                    output_lines.append(f"  • Type: {style_text(model_info['model_type'], fg='cyan')}")
+                    model_type = _escape_terminal_text(model_info["model_type"])
+                    output_lines.append(f"  • Type: {style_text(model_type, fg='cyan')}")
                 if "architectures" in model_info:
                     arch_str = (
-                        ", ".join(model_info["architectures"])
+                        ", ".join(_escape_terminal_text(architecture) for architecture in model_info["architectures"])
                         if isinstance(model_info["architectures"], list)
-                        else model_info["architectures"]
+                        else _escape_terminal_text(model_info["architectures"])
                     )
                     output_lines.append(f"  • Architecture: {style_text(arch_str, fg='cyan')}")
                 if "num_layers" in model_info:
-                    output_lines.append(f"  • Layers: {style_text(str(model_info['num_layers']), fg='cyan')}")
+                    num_layers = _escape_terminal_text(model_info["num_layers"])
+                    output_lines.append(f"  • Layers: {style_text(num_layers, fg='cyan')}")
                 if "hidden_size" in model_info:
-                    output_lines.append(f"  • Hidden Size: {style_text(str(model_info['hidden_size']), fg='cyan')}")
+                    hidden_size = _escape_terminal_text(model_info["hidden_size"])
+                    output_lines.append(f"  • Hidden Size: {style_text(hidden_size, fg='cyan')}")
                 if "vocab_size" in model_info:
-                    vocab_str = f"{model_info['vocab_size']:,}"
+                    vocab_size = model_info["vocab_size"]
+                    vocab_str = (
+                        f"{vocab_size:,}"
+                        if isinstance(vocab_size, (int, float)) and not isinstance(vocab_size, bool)
+                        else _escape_terminal_text(vocab_size)
+                    )
                     output_lines.append(f"  • Vocab Size: {style_text(vocab_str, fg='cyan')}")
                 if "framework_version" in model_info:
-                    output_lines.append(f"  • Framework: {style_text(model_info['framework_version'], fg='cyan')}")
+                    framework_version = _escape_terminal_text(model_info["framework_version"])
+                    output_lines.append(f"  • Framework: {style_text(framework_version, fg='cyan')}")
                 break  # Only show the first model info found
 
     # Add security check statistics
@@ -3991,10 +4046,10 @@ def format_text_output(results: dict[str, Any], verbose: bool = False) -> str:
         # Group failed checks by name to avoid repetition
         check_groups: dict[str, list[str]] = {}
         for check in failed_checks_list:
-            check_name = check.get("name", "Unknown check")
+            check_name = _escape_terminal_text(check.get("name", "Unknown check"))
             if check_name not in check_groups:
                 check_groups[check_name] = []
-            check_groups[check_name].append(check.get("message", ""))
+            check_groups[check_name].append(_escape_terminal_text(check.get("message", "")))
 
         # Show unique failed check types
         for check_name, messages in list(check_groups.items())[:5]:  # Show first 5 types
@@ -4211,8 +4266,8 @@ def _format_issue(
     severity: str,
 ) -> None:
     """Format a single issue with proper indentation and styling"""
-    message = _get_issue_attr(issue, "message", "Unknown issue")
-    location = _get_issue_attr(issue, "location", "")
+    message = _escape_terminal_text(_get_issue_attr(issue, "message", "Unknown issue"))
+    location = _escape_terminal_text(_get_issue_attr(issue, "location", ""))
 
     # Icon based on severity
     icons = {
@@ -4236,11 +4291,12 @@ def _format_issue(
     why = _get_issue_attr(issue, "why")
     if why:
         why_label = style_text("Why:", fg="magenta", bold=True)
+        why_text = _escape_terminal_text(why)
         # Wrap long explanations
         import textwrap
 
         wrapped_why = textwrap.fill(
-            why,
+            why_text,
             width=65,
             initial_indent="",
             subsequent_indent="           ",
@@ -4252,8 +4308,8 @@ def _format_issue(
     if details:
         for key, value in details.items():
             if value:  # Only show non-empty values
-                detail_label = style_text(f"{key}:", fg="bright_black")
-                detail_value = style_text(str(value), fg="bright_white")
+                detail_label = style_text(f"{_escape_terminal_text(key)}:", fg="bright_black")
+                detail_value = style_text(_escape_terminal_text(value), fg="bright_white")
                 output_lines.append(f"       {detail_label} {detail_value}")
 
 
@@ -4325,7 +4381,7 @@ def metadata(path: str, output_format: str, output: str | None, security_only: b
 
         if output:
             _write_output_text_file(output, output_text)
-            click.secho(f"Metadata written to {output}", fg="green")
+            click.secho(f"Metadata written to {_display_path(output)}", fg="green")
         else:
             click.echo(output_text)
 
@@ -4356,7 +4412,7 @@ def metadata(path: str, output_format: str, output: str | None, security_only: b
             format=output_format,
             error_type=type(e).__name__,
         )
-        click.secho(f"Error extracting metadata: {e}", fg="red")
+        click.secho(f"Error extracting metadata: {_display_error(e, path)}", fg="red")
         sys.exit(1)
 
 
@@ -4366,22 +4422,23 @@ def _format_metadata_table(metadata: dict[str, Any]) -> str:
 
     if "directory" in metadata:
         # Directory summary
-        output.append(f"Directory: {metadata['directory']}")
-        output.append(f"Total Files: {metadata['summary']['total_files']}")
+        output.append(f"Directory: {_escape_terminal_text(metadata['directory'])}")
+        output.append(f"Total Files: {_escape_terminal_text(metadata['summary']['total_files'])}")
         if metadata.get("analysis_incomplete"):
             output.append("\nWarning: Metadata extraction is incomplete")
             for event in metadata.get("budget_events", []):
-                output.append(f"  Budget exceeded: {event.get('limit', 'unknown')}")
+                output.append(f"  Budget exceeded: {_escape_terminal_text(event.get('limit', 'unknown'))}")
         output.append("\nFormats:")
         for fmt, count in metadata["summary"]["formats"].items():
-            output.append(f"  {fmt}: {count}")
+            output.append(f"  {_escape_terminal_text(fmt)}: {_escape_terminal_text(count)}")
         output.append("\nFiles:")
         for file_meta in metadata["files"][:10]:  # Show first 10 files
-            file_name = file_meta.get("file", "unknown")
+            file_name = _escape_terminal_text(file_meta.get("file", "unknown"))
             if error := file_meta.get("error"):
-                output.append(f"  {file_name} (error: {error})")
+                output.append(f"  {file_name} (error: {_escape_terminal_text(error)})")
             else:
-                output.append(f"  {file_name} ({file_meta.get('format', 'unknown')})")
+                file_format = _escape_terminal_text(file_meta.get("format", "unknown"))
+                output.append(f"  {file_name} ({file_format})")
                 for key in (
                     "has_custom_metadata",
                     "custom_metadata_entry_count",
@@ -4394,27 +4451,35 @@ def _format_metadata_table(metadata: dict[str, Any]) -> str:
                         continue
                     value = file_meta[key]
                     if isinstance(value, list):
-                        value = ", ".join(map(str, value)) if value else "none"
-                    output.append(f"    {key.replace('_', ' ').title()}: {value}")
+                        value = ", ".join(_escape_terminal_text(item) for item in value) if value else "none"
+                    output.append(f"    {key.replace('_', ' ').title()}: {_escape_terminal_text(value)}")
         if len(metadata["files"]) > 10:
             output.append(f"  ... and {len(metadata['files']) - 10} more")
     else:
         # Single file
-        output.append(f"File: {metadata.get('file', 'unknown')}")
-        output.append(f"Format: {metadata.get('format', 'unknown')}")
-        output.append(f"Size: {metadata.get('file_size', 0):,} bytes")
+        output.append(f"File: {_escape_terminal_text(metadata.get('file', 'unknown'))}")
+        output.append(f"Format: {_escape_terminal_text(metadata.get('format', 'unknown'))}")
+        file_size = metadata.get("file_size", 0)
+        size_text = (
+            f"{file_size:,}"
+            if isinstance(file_size, (int, float)) and not isinstance(file_size, bool)
+            else _escape_terminal_text(file_size)
+        )
+        output.append(f"Size: {size_text} bytes")
 
         # Show key metadata fields
         for key, value in metadata.items():
             if key not in ["file", "path", "format", "file_size"]:
+                label = _escape_terminal_text(str(key).replace("_", " ").title())
                 if isinstance(value, str | int | float | bool):
-                    output.append(f"{key.replace('_', ' ').title()}: {value}")
+                    output.append(f"{label}: {_escape_terminal_text(value)}")
                 elif isinstance(value, dict) and len(value) <= 5:
-                    output.append(f"{key.replace('_', ' ').title()}:")
+                    output.append(f"{label}:")
                     for k, v in value.items():
-                        output.append(f"  {k}: {v}")
+                        output.append(f"  {_escape_terminal_text(k)}: {_escape_terminal_text(v)}")
                 elif isinstance(value, list) and len(value) <= 10:
-                    output.append(f"{key.replace('_', ' ').title()}: {', '.join(map(str, value))}")
+                    values = ", ".join(_escape_terminal_text(item) for item in value)
+                    output.append(f"{label}: {values}")
 
     return "\n".join(output)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3053,7 +3053,10 @@ def test_scan_huggingface_metadata_preflight_verbose_log_is_sanitized(
         patch("shutil.rmtree"),
         caplog.at_level(logging.DEBUG, logger="modelaudit"),
     ):
-        result = CliRunner().invoke(cli, ["scan", "--verbose", "--no-cache", url])
+        result = CliRunner().invoke(
+            cli,
+            ["scan", "--verbose", "--no-cache", "--format", "text", url],
+        )
 
     assert result.exit_code == 0, result.output
     assert "https://huggingface.co/org/model" in caplog.text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,7 @@ from modelaudit.cli import (
     _create_path_progress_callback,
     _display_error,
     _display_path,
+    _display_scan_path,
     _resolve_scan_runtime_config,
     _ScanPathState,
     _summarize_progress_tree,
@@ -684,6 +685,24 @@ def test_scan_json_output_to_file(tmp_path: Path) -> None:
     assert f"Results written to {output_file}" in result.output
 
 
+def test_scan_output_confirmation_escapes_terminal_controls(tmp_path: Path) -> None:
+    test_file = tmp_path / "test_file.dat"
+    test_file.write_bytes(b"test content")
+    output_file = tmp_path / "report\nFORGED\x1b[2J.json"
+    scan_result = create_mock_scan_result(files_scanned=1, issues=[])
+
+    with patch("modelaudit.cli.scan_model_directory_or_file", return_value=scan_result):
+        result = CliRunner().invoke(
+            cli,
+            ["scan", str(test_file), "--format", "json", "--output", str(output_file)],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "report\\nFORGED\\x1b[2J.json" in result.output
+    assert "\nFORGED" not in result.output
+    assert "\x1b" not in result.output
+
+
 def test_scan_json_to_stdout_no_progress_interference(tmp_path):
     """Test that JSON to stdout remains valid (no progress output mixed in)."""
     test_file = tmp_path / "test_file.dat"
@@ -716,6 +735,31 @@ def test_scan_sbom_output(tmp_path):
         json.loads(sbom_file.read_text())
     except json.JSONDecodeError:
         pytest.fail("SBOM output is not valid JSON")
+
+
+def test_scan_sbom_preserves_control_character_filename_identity(tmp_path: Path) -> None:
+    import hashlib
+    import pickle
+
+    content = pickle.dumps({"weights": [1, 2, 3]})
+    model_path = tmp_path / "model\nname.pkl"
+    model_path.write_bytes(content)
+    sbom_file = tmp_path / "sbom.json"
+    scan_result = create_mock_scan_result(
+        assets=[{"path": str(model_path), "type": "pickle", "size": len(content)}],
+    )
+
+    with patch("modelaudit.cli.scan_model_directory_or_file", return_value=scan_result):
+        result = CliRunner().invoke(
+            cli,
+            ["scan", "--quiet", "--no-cache", "--sbom", str(sbom_file), str(model_path)],
+        )
+
+    assert result.exit_code == 0, result.output
+    sbom = json.loads(sbom_file.read_text())
+    component = next(component for component in sbom["components"] if component["name"] == model_path.name)
+    assert component["name"] == "model\nname.pkl"
+    assert component["hashes"] == [{"alg": "SHA-256", "content": hashlib.sha256(content).hexdigest()}]
 
 
 def test_cli_report_writers_reject_symlink_outputs(tmp_path: Path, requires_symlinks: None) -> None:
@@ -2533,6 +2577,220 @@ def test_format_text_output():
     # Verbose might include details, but we can't guarantee it
 
 
+def test_format_text_output_escapes_terminal_controls_in_issues(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    results = {
+        "files_scanned": 1,
+        "bytes_scanned": 10,
+        "duration": 0.1,
+        "issues": [
+            {
+                "message": "unsafe\x1b[2Jtitle\x07",
+                "severity": "warning",
+                "location": "archive.zip\nFORGED",
+                "why": "why\ttext",
+                "details": {"detail\x7fkey": "value\rnext"},
+            },
+        ],
+        "has_errors": False,
+    }
+
+    output = format_text_output(results, verbose=True)
+
+    assert "\x1b[2J" not in output
+    assert "\x07" not in output
+    assert "\x7f" not in output
+    assert "archive.zip\nFORGED" not in output
+    assert "value\rnext" not in output
+    assert "unsafe\\x1b[2Jtitle\\x07" in output
+    assert "archive.zip\\nFORGED" in output
+    assert "why\\ttext" in output
+    assert "detail\\x7fkey:" in output
+    assert "value\\rnext" in output
+
+
+def test_format_text_output_escapes_terminal_controls_in_failed_checks(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    results = {
+        "files_scanned": 1,
+        "bytes_scanned": 10,
+        "duration": 0.1,
+        "total_checks": 1,
+        "passed_checks": 0,
+        "failed_checks": 1,
+        "checks": [
+            {
+                "status": "failed",
+                "name": "Member\x1bName",
+                "message": "bad\r\nline",
+            },
+        ],
+        "issues": [],
+        "has_errors": False,
+    }
+
+    output = format_text_output(results, verbose=False)
+
+    assert "\x1bName" not in output
+    assert "bad\r\nline" not in output
+    assert "Member\\x1bName: bad\\r\\nline" in output
+
+
+def test_format_text_output_escapes_unicode_controls_and_preserves_missing_location(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    results = {
+        "files_scanned": 1,
+        "issues": [
+            {
+                "message": "hidden\u200djoiner\U000e0001tag",
+                "severity": "warning",
+                "location": None,
+            },
+        ],
+        "has_errors": False,
+    }
+
+    output = format_text_output(results)
+
+    assert "[None]" not in output
+    assert "\u200d" not in output
+    assert "\U000e0001" not in output
+    assert "hidden\\u200djoiner\\U000e0001tag" in output
+
+
+def test_format_text_output_escapes_untrusted_model_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    results = {
+        "files_scanned": 1,
+        "file_metadata": {
+            "config.json": {
+                "model_info": {
+                    "model_type": "bert\x1b[2J",
+                    "architectures": ["Safe", "Spoof\u202eName"],
+                    "num_layers": "12\nFORGED",
+                    "hidden_size": "768\u200bhidden",
+                    "vocab_size": "oops\x07",
+                    "framework_version": "4.0\rnext",
+                },
+            },
+        },
+        "issues": [],
+        "has_errors": False,
+    }
+
+    output = format_text_output(results)
+
+    assert "bert\\x1b[2J" in output
+    assert "Safe, Spoof\\u202eName" in output
+    assert "12\\nFORGED" in output
+    assert "768\\u200bhidden" in output
+    assert "oops\\x07" in output
+    assert "4.0\\rnext" in output
+
+
+def test_display_helpers_escape_terminal_controls() -> None:
+    path = "model\x1b[2J\u202efile.pkl"
+    error = RuntimeError("failed\nFORGED\u200btext")
+
+    assert _display_path(path) == "model\\x1b[2J\\u202efile.pkl"
+    assert _display_error(error, path) == "failed\\nFORGED\\u200btext"
+
+
+def test_display_scan_path_preserves_exact_local_path_for_reports() -> None:
+    path = "model\nname\u202e.pkl"
+
+    assert _display_scan_path(path) == path
+    assert _display_path(path) == "model\\nname\\u202e.pkl"
+
+
+def test_metadata_terminal_messages_escape_controls(tmp_path: Path) -> None:
+    model_path = tmp_path / "model.bin"
+    model_path.write_bytes(b"model")
+    output_path = tmp_path / "metadata\nFORGED.json"
+
+    with patch("modelaudit.metadata_extractor.ModelMetadataExtractor.extract", return_value={}):
+        result = CliRunner().invoke(
+            cli,
+            ["metadata", str(model_path), "--format", "json", "--output", str(output_path)],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "metadata\\nFORGED.json" in result.output
+    assert "\nFORGED" not in result.output
+
+    with patch(
+        "modelaudit.metadata_extractor.ModelMetadataExtractor.extract",
+        side_effect=RuntimeError("failed\nFORGED\x1b[2J"),
+    ):
+        error_result = CliRunner().invoke(cli, ["metadata", str(model_path)])
+
+    assert error_result.exit_code == 1
+    assert "failed\\nFORGED\\x1b[2J" in error_result.output
+    assert "\nFORGED" not in error_result.output
+    assert "\x1b" not in error_result.output
+
+
+def test_skipped_path_and_suppression_messages_escape_terminal_controls(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    runtime = cast(
+        Any,
+        types.SimpleNamespace(skip_non_model_files=True, show_styled_output=True),
+    )
+
+    skipped_path = tmp_path / "skip\x1b[2J.py"
+    skipped_path.write_text("print('safe')")
+
+    assert cli_module._should_skip_non_model_file(str(skipped_path), runtime, verbose=True)
+    cli_module._announce_suppressed_preferred_scanners(
+        [{"location": "archive\nFORGED.pkl", "scanner_id": "pickle\u202escanner"}]
+    )
+
+    captured = capsys.readouterr()
+    assert "Skipping non-model file:" in captured.out
+    assert "skip\\x1b[2J.py" in captured.out
+    assert "archive\\nFORGED.pkl" in captured.err
+    assert "pickle\\u202escanner" in captured.err
+
+
+def test_format_metadata_table_escapes_untrusted_values() -> None:
+    single_output = cli_module._format_metadata_table(
+        {
+            "file": "model\x1b[2J.onnx",
+            "format": "onnx\u202e",
+            "file_size": "unknown\nFORGED",
+            "producer\u200bname": "tool\x07",
+            "metadata": {"key\rnext": "value\u2066hidden"},
+            "tags": ["safe", "tag\U000e0001hidden"],
+        }
+    )
+    directory_output = cli_module._format_metadata_table(
+        {
+            "directory": "models\nFORGED",
+            "summary": {"total_files": 1, "formats": {"gguf\u202e": 1}},
+            "files": [
+                {
+                    "file": "bad\x1b[2J.gguf",
+                    "error": "decode\rfailed",
+                }
+            ],
+        }
+    )
+
+    assert "model\\x1b[2J.onnx" in single_output
+    assert "onnx\\u202e" in single_output
+    assert "unknown\\nFORGED" in single_output
+    assert "Producer\\u200bName: tool\\x07" in single_output
+    assert "key\\rnext: value\\u2066hidden" in single_output
+    assert "tag\\U000e0001hidden" in single_output
+    assert "models\\nFORGED" in directory_output
+    assert "gguf\\u202e: 1" in directory_output
+    assert "bad\\x1b[2J.gguf (error: decode\\rfailed)" in directory_output
+
+
 def test_format_text_output_only_debug_issues():
     """Ensure debug-only issues result in a success status."""
     results = {
@@ -2733,6 +2991,69 @@ def test_scan_huggingface_url_passes_max_size_to_download(
     mock_rmtree.assert_called()
 
 
+def test_scan_huggingface_metadata_preview_escapes_model_id(tmp_path: Path) -> None:
+    downloaded_dir = tmp_path / "downloaded"
+    downloaded_dir.mkdir()
+    (downloaded_dir / "model.bin").write_bytes(b"weights")
+
+    with (
+        patch("modelaudit.cli.is_huggingface_url", return_value=True),
+        patch(
+            "modelaudit.utils.sources.huggingface.get_model_info",
+            return_value={
+                "model_id": "org/model\nFORGED\u202e",
+                "total_size": 1024,
+                "file_count": "2\x1b[2J",
+            },
+        ),
+        patch("modelaudit.cli.download_model", return_value=downloaded_dir),
+        patch(
+            "modelaudit.cli.scan_model_directory_or_file",
+            return_value=create_mock_scan_result(files_scanned=1, issues=[]),
+        ),
+        patch("shutil.rmtree"),
+    ):
+        result = CliRunner().invoke(cli, ["scan", "--no-cache", "hf://org/model"])
+
+    assert result.exit_code == 0, result.output
+    assert "org/model\\nFORGED\\u202e" in result.output
+    assert "2\\x1b[2J files" in result.output
+    assert "org/model\nFORGED\u202e" not in result.output
+
+
+def test_scan_huggingface_metadata_preflight_verbose_log_is_sanitized(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    url = "https://huggingface.co/org/model?token=secret-token"
+    downloaded_dir = tmp_path / "downloaded"
+    downloaded_dir.mkdir()
+    (downloaded_dir / "model.bin").write_bytes(b"weights")
+
+    with (
+        patch("modelaudit.cli.is_huggingface_url", return_value=True),
+        patch(
+            "modelaudit.utils.sources.huggingface.get_model_info",
+            side_effect=RuntimeError(f"metadata failed for {url}\nFORGED"),
+        ),
+        patch("modelaudit.cli.download_model", return_value=downloaded_dir),
+        patch(
+            "modelaudit.cli.scan_model_directory_or_file",
+            return_value=create_mock_scan_result(files_scanned=1, issues=[]),
+        ),
+        patch("shutil.rmtree"),
+        caplog.at_level(logging.DEBUG, logger="modelaudit"),
+    ):
+        result = CliRunner().invoke(cli, ["scan", "--verbose", "--no-cache", url])
+
+    assert result.exit_code == 0, result.output
+    assert "https://huggingface.co/org/model" in caplog.text
+    assert "metadata failed" in caplog.text
+    assert "\\nFORGED" in caplog.text
+    assert "secret-token" not in caplog.text
+    assert "?token=" not in caplog.text
+
+
 @patch("modelaudit.cli.is_huggingface_url")
 @patch("modelaudit.cli.download_model")
 def test_scan_huggingface_url_download_failure(mock_download, mock_is_hf_url):
@@ -2817,23 +3138,38 @@ def test_scan_huggingface_file_passes_max_size_and_cleans_temp_dir(
 
 
 @patch("modelaudit.cli.download_file_from_hf")
-def test_scan_huggingface_file_download_failure_redacts_url(mock_download_file):
-    """Redact direct-file URL secrets from CLI download failures."""
-    mock_download_file.side_effect = Exception(
-        "Failed request https://huggingface.co/test/model/resolve/main/file.bin?token=hf_secret"
-    )
+def test_scan_huggingface_file_download_failure_redacts_url(
+    mock_download_file: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Redact secrets from chained direct-file download failures."""
+
+    def raise_chained_download_error(*_args: Any, **_kwargs: Any) -> None:
+        try:
+            raise ValueError(
+                "Failed request https://huggingface.co/test/model/resolve/main/file.bin?token=hf_secret\nFORGED\x1b[2J"
+            )
+        except ValueError as cause:
+            raise RuntimeError("Download failed") from cause
+
+    mock_download_file.side_effect = raise_chained_download_error
 
     runner = CliRunner()
-    result = runner.invoke(
-        cli,
-        ["scan", "https://huggingface.co/test/model/resolve/main/file.bin?token=hf_secret"],
-    )
+    with caplog.at_level(logging.ERROR, logger="modelaudit"):
+        result = runner.invoke(
+            cli,
+            ["scan", "--verbose", "https://huggingface.co/test/model/resolve/main/file.bin?token=hf_secret"],
+        )
 
     output = strip_ansi(result.output)
     assert result.exit_code == 2
     assert "hf_secret" not in output
     assert "token=" not in output
     assert "https://huggingface.co/test/model/resolve/main/file.bin" in output
+    assert "hf_secret" not in caplog.text
+    assert "token=" not in caplog.text
+    assert "\nFORGED" not in caplog.text
+    assert "\x1b" not in caplog.text
 
 
 @pytest.mark.parametrize(("max_size", "expected_bytes"), [("2KB", 2048), ("0", 0)])
@@ -4029,6 +4365,62 @@ def test_scan_path_state_redacts_stream_fallback_for_sbom() -> None:
     assert path_state.scanned_paths == ["stream://https://bucket.s3.amazonaws.com/model.bin"]
 
 
+def test_scan_path_state_preserves_local_asset_path_for_sbom() -> None:
+    local_path = "model\nname.pkl"
+    scan_result = create_mock_scan_result(assets=[{"path": local_path, "type": "pickle"}])
+    path_state = _ScanPathState()
+
+    path_state.track_streaming_paths_for_sbom(scan_result, None)
+
+    assert path_state.scanned_paths == [local_path]
+
+
+def test_progress_callback_escapes_model_controlled_messages(tmp_path: Path) -> None:
+    model_path = tmp_path / "model\nname.pkl"
+    model_path.write_bytes(b"data")
+
+    class _Stats:
+        total_bytes = 0
+        total_items = 0
+
+    class _Tracker:
+        stats = _Stats()
+
+        def __init__(self) -> None:
+            self.messages: list[str] = []
+
+        def set_phase(self, _phase: object, message: str) -> None:
+            self.messages.append(message)
+
+        def update_bytes(self, _bytes_processed: int, message: str) -> None:
+            self.messages.append(message)
+
+    tracker = _Tracker()
+    callback = _create_path_progress_callback(
+        spinner=None,
+        progress_tracker=tracker,
+        actual_path=str(model_path),
+    )
+
+    assert callback is not None
+    callback("Scanning member\nFORGED\x1b[2J", 50.0)
+
+    assert tracker.messages[0].endswith("model\\nname.pkl")
+    assert tracker.messages[1:] == ["Scanning member\\nFORGED\\x1b[2J", "Scanning member\\nFORGED\\x1b[2J"]
+
+
+def test_progress_callback_wrapper_escapes_spinner_message() -> None:
+    callback = MagicMock()
+    spinner = types.SimpleNamespace(text="")
+    wrapped_callback = cli_module.create_progress_callback_wrapper(callback, spinner)
+
+    assert wrapped_callback is not None
+    wrapped_callback("Scanning member\nFORGED\x1b[2J", 50.0)
+
+    callback.assert_called_once_with("Scanning member\nFORGED\x1b[2J", 50.0)
+    assert spinner.text == "Scanning member\\nFORGED\\x1b[2J"
+
+
 def test_scan_stream_unexpected_verbose_error_omits_raw_traceback(caplog: pytest.LogCaptureFixture) -> None:
     """Verbose stream failures must not reintroduce signed URLs through exception tracebacks."""
     url = "stream://https://bucket.s3.amazonaws.com/model.bin?X-Amz-Signature=deadbeef&token=secret-token"
@@ -4665,18 +5057,26 @@ def test_scan_mlflow_uri_no_cache_overrides_cache_dir(mock_scan_mlflow: MagicMoc
 
 
 @patch("modelaudit.integrations.mlflow.scan_mlflow_model")
-def test_scan_mlflow_uri_error(mock_scan_mlflow):
+def test_scan_mlflow_uri_error(
+    mock_scan_mlflow: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test error handling for MLflow URI scanning."""
-    # Setup mock to raise an error
-    mock_scan_mlflow.side_effect = Exception("MLflow connection failed")
+    mock_scan_mlflow.side_effect = Exception("MLflow connection failed token=mlflow_secret\nFORGED\x1b[2J")
 
     runner = CliRunner()
-    result = runner.invoke(cli, ["scan", "models:/TestModel/1"])
+    with caplog.at_level(logging.ERROR, logger="modelaudit"):
+        result = runner.invoke(cli, ["scan", "--verbose", "models:/TestModel/1"])
 
-    # Should fail with error code 2
     assert result.exit_code == 2
     assert "Error downloading model" in result.output
     assert "MLflow connection failed" in result.output
+    assert "mlflow_secret" not in result.output
+    assert "\nFORGED" not in result.output
+    assert "\x1b" not in result.output
+    assert "mlflow_secret" not in caplog.text
+    assert "\nFORGED" not in caplog.text
+    assert "\x1b" not in caplog.text
 
 
 @patch("modelaudit.integrations.mlflow.scan_mlflow_model")


### PR DESCRIPTION
## Summary

- escape terminal, Unicode formatting, surrogate, and line-separator controls in human-readable CLI output
- keep exact local filesystem paths for SBOM/report identity while redacting remote identifiers
- sanitize progress callbacks, output confirmations, metadata previews, and model-controlled exception sinks
- suppress raw verbose tracebacks at acquisition and scan boundaries so chained causes cannot reintroduce secrets or controls
- preserve absent issue locations and tolerate malformed model metadata without weakening output safety
- integrate current `main` at `5cf4945de43de7f977cce985410a9bb6bacce4a7`, including the shared cross-platform baseline from #1597

## False-positive / false-negative audit

- Unicode bidi, zero-width, tag, surrogate, terminal, and line-separator controls render visibly at output sinks
- exact local paths remain unmodified for scanning, report bookkeeping, SBOM component identity, and hashes
- Hugging Face metadata previews and verbose preflight failures cannot inject controls or leak query credentials
- remote cloud, JFrog, MLflow, PyTorch Hub, stream, and Hugging Face identifiers use source-aware redaction before terminal escaping
- raw chained exceptions cannot bypass the sanitized outer message under `--verbose`
- current-main shard error bookkeeping is preserved at every resolved conflict
- cross-platform sink tests avoid illegal Windows filenames while the SBOM identity regression uses a valid bidi-format filename

## Focused validation

- complete associated CLI module: `250 passed, 3 skipped` (expected Windows-only semantics)
- scoped Ruff lint and format checks: clean
- scoped mypy: clean
- `git diff --check`: clean
- exact published tree: `83ec4ec0507bdbc5a175945ac008386c46ab23aa`

Both inline review threads are resolved. No full local suite was run; CI owns broad validation. Published head: `5c0b5333e3fdd6d9b2f5faf52fda9cce8b2af2b0`.