### PR TITLE
fix(picklescan): preserve nested INST limit findings

### DIFF
--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -78,6 +78,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- preserve fail-closed nested protocol 0 analysis after `INST` opcodes
 - fail closed when known-size pickle boundaries cannot be verified or contain trailing bytes, and bind file scans to one descriptor
 - fail closed before copying protocol 0 line operands larger than 8 MiB
 - fail closed before copying protocol 0 line operands larger than 8 MiB,

--- a/packages/modelaudit-picklescan/rust/src/nested.rs
+++ b/packages/modelaudit-picklescan/rust/src/nested.rs
@@ -512,6 +512,7 @@ fn is_structured_nested_probe_anchor(name: &str) -> bool {
     matches!(
         name,
         "GLOBAL"
+            | "INST"
             | "STACK_GLOBAL"
             | "EXT1"
             | "EXT2"
@@ -1290,6 +1291,22 @@ mod tests {
     #[test]
     fn decoded_payloads_preserve_protocol0_operand_limit_failures() {
         let mut payload = b"cos\nsystem\n(S'".to_vec();
+        payload.resize(
+            payload.len() + crate::opcode::MAX_PROTOCOL0_LINE_OPERAND_BYTES,
+            b'A',
+        );
+        payload.extend_from_slice(b"'\ntR.");
+
+        let decoded = decoded_pickle_payloads(&payload, payload.len() + 16);
+
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].0, payload);
+        assert!(decoded[0].1);
+    }
+
+    #[test]
+    fn decoded_payloads_preserve_protocol0_operand_limit_after_inst() {
+        let mut payload = b"(ios\nsystem\n(S'".to_vec();
         payload.resize(
             payload.len() + crate::opcode::MAX_PROTOCOL0_LINE_OPERAND_BYTES,
             b'A',

--- a/packages/modelaudit-picklescan/tests/test_protocol0_line_operands.py
+++ b/packages/modelaudit-picklescan/tests/test_protocol0_line_operands.py
@@ -74,6 +74,47 @@ def test_scan_bytes_fails_closed_for_nested_overlong_protocol0_line_operand(
 
 
 @pytest.mark.parametrize("as_unicode", [False, True])
+def test_scan_bytes_fails_closed_for_nested_overlong_protocol0_line_operand_after_inst(
+    as_unicode: bool,
+) -> None:
+    nested_payload = b"(ios\nsystem\n(S'" + (b"A" * (MAX_PROTOCOL0_LINE_OPERAND_BYTES - 1)) + b"'\ntR."
+    nested_value = nested_payload.decode("ascii") if as_unicode else nested_payload
+    payload = pickle.dumps(nested_value, protocol=4)
+
+    report = scan_bytes(
+        payload,
+        source="nested-inst-overlong-protocol0-string.pkl",
+        options=ScanOptions(
+            max_nested_pickle_bytes=len(nested_payload) + 16,
+            max_string_literal_scan_chars=len(nested_payload) + 16,
+        ),
+    )
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert any(
+        finding.rule_code == "DANGEROUS_CALL"
+        and finding.details.get("opcode") == "INST"
+        and finding.details.get("import_reference") == "os.system"
+        for finding in report.findings
+    )
+    assert any(
+        finding.rule_code == "S213" and finding.details.get("analysis_incomplete") is True
+        for finding in report.findings
+    )
+    incomplete_notice = next(notice for notice in report.notices if notice.code == "nested_pickle_incomplete")
+    nested_notices = incomplete_notice.details.get("nested_notices")
+    assert isinstance(nested_notices, (list, tuple))
+    assert any(
+        isinstance(notice, Mapping)
+        and notice.get("code") == "parse_incomplete"
+        and isinstance(notice.get("details"), Mapping)
+        and "protocol 0 line operand exceeds" in str(notice["details"].get("exception"))
+        for notice in nested_notices
+    )
+
+
+@pytest.mark.parametrize("as_unicode", [False, True])
 def test_scan_bytes_ignores_unstructured_nested_overlong_protocol0_near_match(
     as_unicode: bool,
 ) -> None:


### PR DESCRIPTION
## Summary

- treat protocol 0 `INST` as structured nested-pickle evidence
- preserve fail-closed analysis when a later line operand exceeds the 8 MiB cap
- add decoder-level and public `scan_bytes` regressions covering byte and Unicode nested payloads
- update the picklescan changelog

## False-positive / false-negative audit

- nested `INST os.system` payloads followed by overlong protocol 0 operands now remain visible to the scanner instead of being dropped
- the public result is `INCONCLUSIVE` and `MALICIOUS`, with a nested `DANGEROUS_CALL`, an incomplete `S213` finding, and the underlying parse-limit notice
- unstructured overlong protocol 0 string near-matches remain clean
- the pre-existing fail-closed handling for truncated plausible `INST` import-line windows is intentionally preserved because an offset window may omit the earlier `MARK`

## Validation

- `UV_CACHE_DIR=/tmp/modelaudit-uv-cache PROMPTFOO_DISABLE_TELEMETRY=1 uv run --frozen pytest -q tests/test_protocol0_line_operands.py` (`8 passed`)
- `cargo test --manifest-path Cargo.toml decoded_payloads_preserve_protocol0_operand_limit_after_inst` (`1 passed`)
- `cargo fmt --manifest-path Cargo.toml -- --check`
- scoped Ruff check and format check for `tests/test_protocol0_line_operands.py`
- scoped mypy for `tests/test_protocol0_line_operands.py`
- `git diff --check`

The original head also completed all GitHub Actions workflows successfully. Fresh CI is running on the added public regression; the full local suite was intentionally left to CI.