### PR TITLE
fix: reconcile cross-directory model shards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - bound Joblib decompression output to the configured scanner read budget
-- reconcile complete sharded models scanned across separate directories without hiding malicious findings or changed targets
+- reconcile validated streamed shard families across staging directories and add an explicit opt-in for local cross-directory shards
 - close JIT replay alias, probe-budget, and compound-clause context gaps without suppressing dangerous browser or native-library calls
 - reject cleartext HTTP cloud storage and PyTorch Hub model sources
 - preserve dangerous JIT embedded-Python findings after benign member overwrites while bounding replay and suppression analysis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - bound Joblib decompression output to the configured scanner read budget
+- reconcile complete sharded models scanned across separate directories without hiding malicious findings or changed targets
 - close JIT replay alias, probe-budget, and compound-clause context gaps without suppressing dangerous browser or native-library calls
 - reject cleartext HTTP cloud storage and PyTorch Hub model sources
 - preserve dangerous JIT embedded-Python findings after benign member overwrites while bounding replay and suppression analysis

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Common scan options:
 --strict                     Fail on warnings, scan all file types, strict license validation
 --sbom FILE                  Generate CycloneDX SBOM
 --stream                     Process files one-by-one; remote downloads are deleted after scanning
+--assume-shard-family        Treat explicitly listed cross-directory shards as one model family
 --max-size SIZE              Size limit (e.g., 10GB)
 --timeout SECONDS            Override scan timeout
 --dry-run                    Preview what would be scanned

--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -37,6 +37,8 @@ from .config.local_config import find_local_config_for_paths
 from .core import (
     DVC_EXTERNAL_COVERED_DIRECTORIES_CONFIG_KEY,
     DVC_EXTERNAL_COVERED_PATHS_CONFIG_KEY,
+    _reconcile_cross_directory_shard_coverage,
+    _snapshot_validated_shard_target,
     determine_exit_code,
     scan_model_directory_or_file,
 )
@@ -66,6 +68,7 @@ from .telemetry import (
     record_scan_started,
 )
 from .utils import resolve_dvc_file_with_metadata, should_skip_file
+from .utils.file.handlers import ValidatedShardTargets
 from .utils.helpers.auto_defaults import (
     apply_auto_overrides,
     detect_ci_environment,
@@ -1329,6 +1332,31 @@ class _ScanPathState:
     sbom_paths_resolved: bool = False
     dvc_covered_paths: set[str] = field(default_factory=set)
     dvc_covered_directories: set[str] = field(default_factory=set)
+    validated_shard_targets: ValidatedShardTargets = field(default_factory=dict)
+
+    def record_validated_shard_targets(
+        self,
+        scan_result: ModelAuditResultModel,
+        *,
+        pre_scan_target: ValidatedShardTargets | None = None,
+    ) -> None:
+        """Record stable regular-file identities for shard assets that were scanned."""
+        for asset in scan_result.assets:
+            if not asset.path or asset.type == "error":
+                continue
+            metadata = scan_result.file_metadata.get(asset.path)
+            if metadata is not None and metadata.get("operational_error") is True:
+                continue
+            post_scan_target = _snapshot_validated_shard_target(asset.path)
+            if not post_scan_target:
+                continue
+            if pre_scan_target:
+                common_sources = pre_scan_target.keys() & post_scan_target.keys()
+                if common_sources and any(
+                    pre_scan_target[source_path] != post_scan_target[source_path] for source_path in common_sources
+                ):
+                    continue
+            self.validated_shard_targets.update(post_scan_target)
 
     def track_streaming_paths_for_sbom(
         self,
@@ -2275,6 +2303,7 @@ def _scan_local_or_downloaded_path(
     """Scan a local artifact or a downloaded path resolved by source dispatch."""
     actual_path = source_result.actual_path
     display_path = _display_path(path)
+    pre_scan_shard_target = _snapshot_validated_shard_target(actual_path) if os.path.isfile(actual_path) else {}
     if _should_skip_non_model_file(actual_path, runtime, verbose=verbose):
         return
 
@@ -2365,6 +2394,10 @@ def _scan_local_or_downloaded_path(
             skip_file_types=runtime.skip_non_model_files,
             use_hf_whitelist=runtime.use_hf_whitelist,
             **config_overrides,
+        )
+        path_state.record_validated_shard_targets(
+            scan_results,
+            pre_scan_target=pre_scan_shard_target,
         )
         audit_result.aggregate_scan_result(scan_results.model_dump())
         if is_dvc_pointer and has_prior_dvc_coverage:
@@ -2594,6 +2627,7 @@ def _resolve_scan_source_for_path(
 
                 streaming_result = scan_model_streaming(
                     file_generator=file_generator,
+                    shard_family_group=f"stream-invocation:{id(file_generator):x}",
                     timeout=runtime.timeout,
                     delete_after_scan=True,
                     blacklist_patterns=list(blacklist) if blacklist else None,
@@ -2707,6 +2741,7 @@ def _resolve_scan_source_for_path(
                 )
                 streaming_result = scan_model_streaming(
                     file_generator=file_generator,
+                    shard_family_group=f"stream-invocation:{id(file_generator):x}",
                     timeout=runtime.timeout,
                     delete_after_scan=True,
                     blacklist_patterns=list(blacklist) if blacklist else None,
@@ -2846,6 +2881,7 @@ def _resolve_scan_source_for_path(
                 )
                 streaming_result = scan_model_streaming(
                     file_generator=file_generator,
+                    shard_family_group=f"stream-invocation:{id(file_generator):x}",
                     timeout=runtime.timeout,
                     delete_after_scan=True,
                     blacklist_patterns=list(blacklist) if blacklist else None,
@@ -3794,6 +3830,7 @@ def scan_command(
 
     _complete_progress_tracking(progress_tracker, verbose=verbose)
     _cleanup_progress_reporters(progress_reporters)
+    _reconcile_cross_directory_shard_coverage(audit_result, path_state.validated_shard_targets)
     audit_result.finalize_statistics()
     audit_result.deduplicate_issues()
 

--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -1334,6 +1334,17 @@ class _ScanPathState:
     dvc_covered_directories: set[str] = field(default_factory=set)
     validated_shard_targets: ValidatedShardTargets = field(default_factory=dict)
     explicit_shard_family_groups: dict[str, str] = field(default_factory=dict)
+    has_errors_outside_reconciled_shards: bool = False
+
+    def mark_non_shard_error(self, audit_result: ModelAuditResultModel) -> None:
+        """Record an aggregate error that shard reconciliation does not own."""
+        self.has_errors_outside_reconciled_shards = True
+        audit_result.has_errors = True
+
+    def record_non_shard_result_errors(self, scan_result: ModelAuditResultModel) -> None:
+        """Preserve errors from results that cannot join final CLI shard reconciliation."""
+        if scan_result.has_errors:
+            self.has_errors_outside_reconciled_shards = True
 
     def explicit_shard_family_group_for(self, path: str) -> str | None:
         """Return the opt-in family group only for an exact explicit file argument."""
@@ -2427,6 +2438,7 @@ def _scan_local_or_downloaded_path(
                 cache_dir=runtime.cache_dir,
                 **_scanner_selection_overrides(runtime),
             )
+            path_state.record_non_shard_result_errors(streaming_result)
             audit_result.aggregate_scan_result(streaming_result.model_dump())
             path_state.record_dvc_coverage(actual_path, streaming_result, scanner_config=runtime.config)
             path_state.track_streaming_paths_for_sbom(streaming_result, actual_path)
@@ -2535,7 +2547,7 @@ def _scan_local_or_downloaded_path(
             exc_info=verbose and not (is_stream_url(actual_path) or is_cloud_url(path)),
         )
         click.echo(f"Error scanning {display_path}: {display_error}", err=True)
-        audit_result.has_errors = True
+        path_state.mark_non_shard_error(audit_result)
         path_state.scanned_paths.append(_display_scan_path(actual_path))
 
         if progress_tracker:
@@ -2555,12 +2567,12 @@ def _resolve_scan_source_for_path(
     """Resolve one source path and execute source-native scans when they should bypass local scanning."""
     if is_cleartext_cloud_url(path):
         click.echo(f"Error: Cleartext cloud storage URL is not supported: {redact_url_for_display(path)}", err=True)
-        audit_result.has_errors = True
+        path_state.mark_non_shard_error(audit_result)
         return None
 
     if is_cleartext_pytorch_hub_url(path):
         click.echo(f"Error: Cleartext PyTorch Hub URL is not supported: {redact_url_for_display(path)}", err=True)
-        audit_result.has_errors = True
+        path_state.mark_non_shard_error(audit_result)
         return None
 
     if is_huggingface_file_url(path):
@@ -2616,7 +2628,7 @@ def _resolve_scan_source_for_path(
             error_msg = redact_huggingface_urls_in_text(str(exc))
             logger.error(f"Failed to download file from {display_path}: {error_msg}", exc_info=verbose)
             click.echo(f"Error downloading file from {display_path}: {error_msg}", err=True)
-            audit_result.has_errors = True
+            path_state.mark_non_shard_error(audit_result)
             path_state.defer_temp_cleanup(
                 temp_dir,
                 cache_enabled=runtime.cache_enabled,
@@ -2719,6 +2731,7 @@ def _resolve_scan_source_for_path(
                     cache_dir=runtime.cache_dir,
                     **streaming_kwargs,
                 )
+                path_state.record_non_shard_result_errors(streaming_result)
                 audit_result.aggregate_scan_result(streaming_result.model_dump())
                 path_state.track_streaming_paths_for_sbom(streaming_result, path)
 
@@ -2789,7 +2802,7 @@ def _resolve_scan_source_for_path(
                 logger.error(f"Failed to process model from {display_path}: {error_msg}", exc_info=verbose)
                 click.echo(f"Error processing model from {display_path}: {error_msg}", err=True)
 
-            audit_result.has_errors = True
+            path_state.mark_non_shard_error(audit_result)
             path_state.defer_temp_cleanup(
                 temp_dir,
                 cache_enabled=runtime.cache_enabled,
@@ -2834,6 +2847,7 @@ def _resolve_scan_source_for_path(
                     **_scanner_selection_overrides(runtime),
                 )
                 path_state.track_streaming_paths_for_sbom(streaming_result, path)
+                path_state.record_non_shard_result_errors(streaming_result)
                 audit_result.aggregate_scan_result(streaming_result.model_dump())
                 record_download_completed("pytorch_hub", time.time() - download_start, 0, path)
 
@@ -2891,7 +2905,7 @@ def _resolve_scan_source_for_path(
                 logger.error(f"Failed to download model from {path}: {error_msg}", exc_info=verbose)
                 click.echo(f"Error downloading model from {path}: {error_msg}", err=True)
 
-            audit_result.has_errors = True
+            path_state.mark_non_shard_error(audit_result)
             return None
 
     if is_cloud_url(path):
@@ -2927,7 +2941,7 @@ def _resolve_scan_source_for_path(
             except Exception as exc:
                 error_msg = _display_error(exc, path)
                 click.echo(f"Error analyzing {redact_url_for_display(path)}: {error_msg}", err=True)
-                audit_result.has_errors = True
+                path_state.mark_non_shard_error(audit_result)
                 return None
 
         download_spinner = None
@@ -2974,6 +2988,7 @@ def _resolve_scan_source_for_path(
                     **_scanner_selection_overrides(runtime),
                 )
                 path_state.track_streaming_paths_for_sbom(streaming_result, path)
+                path_state.record_non_shard_result_errors(streaming_result)
                 audit_result.aggregate_scan_result(streaming_result.model_dump())
                 record_download_completed("cloud_storage", time.time() - download_start, 0, path)
 
@@ -3045,7 +3060,7 @@ def _resolve_scan_source_for_path(
                 logger.error(f"Failed to download from {redact_url_for_display(path)}: {error_msg}")
                 click.echo(f"Error downloading from {redact_url_for_display(path)}: {error_msg}", err=True)
 
-            audit_result.has_errors = True
+            path_state.mark_non_shard_error(audit_result)
             return None
 
     if is_mlflow_uri(path):
@@ -3076,6 +3091,7 @@ def _resolve_scan_source_for_path(
                 **_scanner_selection_overrides(runtime),
             )
 
+            path_state.record_non_shard_result_errors(results)
             audit_result.aggregate_scan_result(results.model_dump())
             download_refused = any(getattr(issue, "type", None) == "mlflow_download_budget" for issue in results.issues)
             if download_refused:
@@ -3098,7 +3114,7 @@ def _resolve_scan_source_for_path(
 
             logger.error(f"Failed to download model from {path}: {exc!s}", exc_info=verbose)
             click.echo(f"Error downloading model from {path}: {exc!s}", err=True)
-            audit_result.has_errors = True
+            path_state.mark_non_shard_error(audit_result)
             return None
 
     if is_jfrog_url(path):
@@ -3148,6 +3164,7 @@ def _resolve_scan_source_for_path(
             elif runtime.show_styled_output:
                 click.echo("Downloaded and scanned successfully")
 
+            path_state.record_non_shard_result_errors(jfrog_results)
             audit_result.aggregate_scan_result(jfrog_results.model_dump())
             record_download_completed("jfrog", time.time() - download_start, jfrog_results.bytes_scanned, path)
             return _SourceDispatchResult(actual_path=path, local_scan_required=False)
@@ -3160,12 +3177,12 @@ def _resolve_scan_source_for_path(
             error_msg = redact_jfrog_error_for_display(exc, path)
             logger.error(f"Failed to download/scan model from {display_path}: {error_msg}", exc_info=verbose)
             click.echo(f"Error downloading/scanning model from {display_path}: {error_msg}", err=True)
-            audit_result.has_errors = True
+            path_state.mark_non_shard_error(audit_result)
             return None
 
     if not os.path.exists(path):
         click.echo(f"Error: Path does not exist: {_display_path(path)}", err=True)
-        audit_result.has_errors = True
+        path_state.mark_non_shard_error(audit_result)
         return None
 
     return _SourceDispatchResult(actual_path=path)
@@ -3883,7 +3900,7 @@ def scan_command(
                 )
                 click.echo(f"Unexpected error processing {display_path}: {display_error}", err=True)
                 path_state.scanned_paths.append(_display_scan_path(source_result.actual_path))
-                audit_result.has_errors = True
+                path_state.mark_non_shard_error(audit_result)
 
                 if progress_tracker:
                     progress_tracker.report_error(Exception(display_error))
@@ -3917,7 +3934,11 @@ def scan_command(
 
     _complete_progress_tracking(progress_tracker, verbose=verbose)
     _cleanup_progress_reporters(progress_reporters)
-    _reconcile_cross_directory_shard_coverage(audit_result, path_state.validated_shard_targets)
+    _reconcile_cross_directory_shard_coverage(
+        audit_result,
+        path_state.validated_shard_targets,
+        missing_shard_errors_only=not path_state.has_errors_outside_reconciled_shards,
+    )
     audit_result.finalize_statistics()
     audit_result.deduplicate_issues()
 

--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -68,7 +68,7 @@ from .telemetry import (
     record_scan_started,
 )
 from .utils import resolve_dvc_file_with_metadata, should_skip_file
-from .utils.file.handlers import ValidatedShardTargets
+from .utils.file.handlers import ShardedModelDetector, ValidatedShardTargets
 from .utils.helpers.auto_defaults import (
     apply_auto_overrides,
     detect_ci_environment,
@@ -1333,7 +1333,12 @@ class _ScanPathState:
     dvc_covered_paths: set[str] = field(default_factory=set)
     dvc_covered_directories: set[str] = field(default_factory=set)
     validated_shard_targets: ValidatedShardTargets = field(default_factory=dict)
-    explicit_shard_family_group: str | None = None
+    explicit_shard_family_groups: dict[str, str] = field(default_factory=dict)
+
+    def explicit_shard_family_group_for(self, path: str) -> str | None:
+        """Return the opt-in family group only for an exact explicit file argument."""
+        normalized_path = os.path.normcase(os.path.normpath(os.path.abspath(path)))
+        return self.explicit_shard_family_groups.get(normalized_path)
 
     def record_validated_shard_targets(
         self,
@@ -1348,10 +1353,11 @@ class _ScanPathState:
             metadata = scan_result.file_metadata.get(asset.path)
             if metadata is not None and metadata.get("operational_error") is True:
                 continue
+            explicit_family_group = self.explicit_shard_family_group_for(asset.path)
             post_scan_target = _snapshot_validated_shard_target(
                 asset.path,
-                family_group=self.explicit_shard_family_group,
-                family_group_policy="explicit" if self.explicit_shard_family_group else None,
+                family_group=explicit_family_group,
+                family_group_policy="explicit" if explicit_family_group else None,
             )
             if not post_scan_target:
                 continue
@@ -1581,6 +1587,65 @@ def expand_paths(paths: tuple[str, ...]) -> tuple[list[str], list[str]]:
         else:
             expanded.append(str(path.resolve()) if path.exists() else path_str)
     return expanded, missing_globs
+
+
+def _explicit_local_shard_family_groups(paths: tuple[str, ...]) -> dict[str, str]:
+    """Map exact local file arguments to conservative explicit-family groups."""
+    grouped_paths: dict[tuple[str, int], list[tuple[str, Path, int]]] = {}
+    for path_str in paths:
+        if "://" in path_str or "*" in path_str or "?" in path_str:
+            continue
+        path = Path(path_str)
+        if not path.is_file():
+            continue
+        try:
+            resolved_path = str(path.resolve(strict=True))
+        except (OSError, RuntimeError):
+            continue
+        shard_match = ShardedModelDetector.match_shard_filename(Path(resolved_path).name)
+        if shard_match is None:
+            continue
+        pattern = shard_match.get("pattern")
+        shard_index = shard_match.get("current_shard_index")
+        expected_total = shard_match.get("expected_total_shards")
+        if (
+            not isinstance(pattern, str)
+            or not isinstance(shard_index, int)
+            or not isinstance(expected_total, int)
+            or expected_total <= 1
+            or not 1 <= shard_index <= expected_total
+        ):
+            continue
+        normalized_path = os.path.normcase(os.path.normpath(os.path.abspath(resolved_path)))
+        grouped_paths.setdefault((pattern, expected_total), []).append(
+            (normalized_path, Path(resolved_path), shard_index)
+        )
+
+    groups: dict[str, str] = {}
+    for (_pattern, expected_total), records in grouped_paths.items():
+        targets_by_scope: dict[str, dict[int, list[str]]] = {}
+        scopes_by_source: dict[str, set[str]] = {}
+        for normalized_path, resolved_path_obj, shard_index in records:
+            source_scopes = scopes_by_source.setdefault(normalized_path, set())
+            for ancestor in (resolved_path_obj.parent, *resolved_path_obj.parent.parents):
+                normalized_scope = os.path.normcase(os.path.normpath(str(ancestor)))
+                source_scopes.add(normalized_scope)
+                targets_by_scope.setdefault(normalized_scope, {}).setdefault(shard_index, []).append(normalized_path)
+
+        complete_scopes = {
+            scope
+            for scope, targets_by_index in targets_by_scope.items()
+            if len(targets_by_index) == expected_total
+            and all(len(targets) == 1 for targets in targets_by_index.values())
+        }
+        for normalized_path, _resolved_path, _shard_index in records:
+            matching_scopes = scopes_by_source[normalized_path] & complete_scopes
+            if matching_scopes:
+                family_scope = max(matching_scopes, key=lambda scope: len(Path(scope).parts))
+                groups[normalized_path] = f"explicit-cli:{family_scope}"
+            else:
+                groups[normalized_path] = "explicit-cli:undiscriminated"
+    return groups
 
 
 def parse_severity_overrides(values: tuple[str, ...]) -> dict[str, str]:
@@ -2308,11 +2373,12 @@ def _scan_local_or_downloaded_path(
     """Scan a local artifact or a downloaded path resolved by source dispatch."""
     actual_path = source_result.actual_path
     display_path = _display_path(path)
+    explicit_family_group = path_state.explicit_shard_family_group_for(actual_path)
     pre_scan_shard_target = (
         _snapshot_validated_shard_target(
             actual_path,
-            family_group=path_state.explicit_shard_family_group,
-            family_group_policy="explicit" if path_state.explicit_shard_family_group else None,
+            family_group=explicit_family_group,
+            family_group_policy="explicit" if explicit_family_group else None,
         )
         if os.path.isfile(actual_path)
         else {}
@@ -3773,7 +3839,7 @@ def scan_command(
         audit_result.scanner_selection = dict(runtime.scanner_selection_metadata)
     path_state = _ScanPathState(
         collect_dvc_coverage=any(os.path.isfile(path) and path.lower().endswith(".dvc") for path in expanded_paths),
-        explicit_shard_family_group="explicit-cli-shard-family" if assume_shard_family else None,
+        explicit_shard_family_groups=_explicit_local_shard_family_groups(paths) if assume_shard_family else {},
     )
 
     # Scan each path with interrupt handling

--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -1333,6 +1333,7 @@ class _ScanPathState:
     dvc_covered_paths: set[str] = field(default_factory=set)
     dvc_covered_directories: set[str] = field(default_factory=set)
     validated_shard_targets: ValidatedShardTargets = field(default_factory=dict)
+    explicit_shard_family_group: str | None = None
 
     def record_validated_shard_targets(
         self,
@@ -1347,7 +1348,11 @@ class _ScanPathState:
             metadata = scan_result.file_metadata.get(asset.path)
             if metadata is not None and metadata.get("operational_error") is True:
                 continue
-            post_scan_target = _snapshot_validated_shard_target(asset.path)
+            post_scan_target = _snapshot_validated_shard_target(
+                asset.path,
+                family_group=self.explicit_shard_family_group,
+                family_group_policy="explicit" if self.explicit_shard_family_group else None,
+            )
             if not post_scan_target:
                 continue
             if pre_scan_target:
@@ -2303,7 +2308,15 @@ def _scan_local_or_downloaded_path(
     """Scan a local artifact or a downloaded path resolved by source dispatch."""
     actual_path = source_result.actual_path
     display_path = _display_path(path)
-    pre_scan_shard_target = _snapshot_validated_shard_target(actual_path) if os.path.isfile(actual_path) else {}
+    pre_scan_shard_target = (
+        _snapshot_validated_shard_target(
+            actual_path,
+            family_group=path_state.explicit_shard_family_group,
+            family_group_policy="explicit" if path_state.explicit_shard_family_group else None,
+        )
+        if os.path.isfile(actual_path)
+        else {}
+    )
     if _should_skip_non_model_file(actual_path, runtime, verbose=verbose):
         return
 
@@ -3605,6 +3618,11 @@ def delegate_info() -> None:
     is_flag=True,
     help="Stream scan: download files one-by-one, scan immediately, then delete to save disk space",
 )
+@click.option(
+    "--assume-shard-family",
+    is_flag=True,
+    help="Treat explicitly provided cross-directory shard paths as one model family",
+)
 def scan_command(
     paths: tuple[str, ...],
     format: str | None,
@@ -3627,6 +3645,7 @@ def scan_command(
     no_cache: bool,
     cache_dir: str | None,
     stream: bool,
+    assume_shard_family: bool,
 ) -> None:
     """Scan files, directories, HuggingFace models, MLflow models, cloud storage,
     or JFrog artifacts for security issues.
@@ -3694,6 +3713,7 @@ def scan_command(
         "strict": strict,
         "no_whitelist": no_whitelist,
         "dry_run": dry_run,
+        "assume_shard_family": assume_shard_family,
         "has_scanner_selection": bool(scanners or exclude_scanners),
         "num_paths": len(paths),
     }
@@ -3752,7 +3772,8 @@ def scan_command(
     if runtime.scanner_selection_metadata is not None:
         audit_result.scanner_selection = dict(runtime.scanner_selection_metadata)
     path_state = _ScanPathState(
-        collect_dvc_coverage=any(os.path.isfile(path) and path.lower().endswith(".dvc") for path in expanded_paths)
+        collect_dvc_coverage=any(os.path.isfile(path) and path.lower().endswith(".dvc") for path in expanded_paths),
+        explicit_shard_family_group="explicit-cli-shard-family" if assume_shard_family else None,
     )
 
     # Scan each path with interrupt handling

--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -37,6 +37,7 @@ from .config.local_config import find_local_config_for_paths
 from .core import (
     DVC_EXTERNAL_COVERED_DIRECTORIES_CONFIG_KEY,
     DVC_EXTERNAL_COVERED_PATHS_CONFIG_KEY,
+    _make_trusted_stream_shard_root,
     _reconcile_cross_directory_shard_coverage,
     _snapshot_validated_shard_target,
     determine_exit_code,
@@ -2719,6 +2720,11 @@ def _resolve_scan_source_for_path(
                 streaming_result = scan_model_streaming(
                     file_generator=file_generator,
                     shard_family_group=f"stream-invocation:{id(file_generator):x}",
+                    _trusted_shard_family_root=(
+                        _make_trusted_stream_shard_root(str(hf_cache_dir / "huggingface"))
+                        if runtime.cache_enabled and trusted_source_provenance is not None
+                        else None
+                    ),
                     timeout=runtime.timeout,
                     delete_after_scan=True,
                     blacklist_patterns=list(blacklist) if blacklist else None,

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -690,6 +690,21 @@ def _results_have_explicit_operational_error(results: ModelAuditResultModel) -> 
     return any(isinstance(record.details, dict) and bool(record.details.get("operational_error")) for record in records)
 
 
+def _results_have_retained_incomplete_outcome(results: ModelAuditResultModel) -> bool:
+    """Return whether retained evidence still identifies incomplete analysis."""
+    if any(
+        bool(metadata.get("analysis_incomplete")) or metadata.get("scan_outcome") == "inconclusive"
+        for metadata in results.file_metadata.values()
+    ):
+        return True
+    records: list[Check | Issue] = [*results.checks, *results.issues]
+    return any(
+        isinstance(record.details, dict)
+        and (bool(record.details.get("analysis_incomplete")) or record.details.get("scan_outcome") == "inconclusive")
+        for record in records
+    )
+
+
 def _reconcile_cross_directory_shard_coverage(
     results: ModelAuditResultModel,
     validated_targets: ValidatedShardTargets,
@@ -796,7 +811,10 @@ def _reconcile_cross_directory_shard_coverage(
         reconciled = True
 
     if reconciled:
-        results.has_errors = _results_have_explicit_operational_error(results)
+        had_errors = results.has_errors
+        results.has_errors = _results_have_explicit_operational_error(results) or (
+            had_errors and _results_have_retained_incomplete_outcome(results)
+        )
         results.success = not _results_should_be_unsuccessful(results)
     return reconciled
 

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -473,6 +473,31 @@ def _shard_family_key_for_path(path: str) -> _ShardFamilyKey | None:
     return (str(path_obj.parent), pattern, expected_total)
 
 
+def _trusted_stream_shard_family_group(resolved_source: Path, family_group: str) -> str | None:
+    """Scope a trusted stream group to the artifact's logical staging parent."""
+    try:
+        temp_root = Path(tempfile.gettempdir()).resolve(strict=True)
+        resolved_parent = resolved_source.parent
+        staging_root: Path | None = None
+        candidate = resolved_parent
+        while candidate != temp_root and candidate != candidate.parent:
+            if candidate.parent == temp_root and candidate.name.startswith(_TRUSTED_STREAM_SHARD_PARENT_PREFIXES):
+                staging_root = candidate
+                break
+            candidate = candidate.parent
+        if staging_root is None:
+            return None
+        relative_parent = resolved_parent.relative_to(staging_root)
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+    scope = hashlib.sha256()
+    scope.update(family_group.encode("utf-8", errors="surrogatepass"))
+    scope.update(b"\0")
+    scope.update(os.path.normcase(relative_parent.as_posix()).encode("utf-8", errors="surrogatepass"))
+    return f"stream-staging:{scope.hexdigest()}"
+
+
 def _snapshot_validated_shard_target(
     source_path: str,
     *,
@@ -510,15 +535,11 @@ def _snapshot_validated_shard_target(
     if family_group_policy == "explicit" and family_group:
         target["family_group"] = family_group
     elif family_group_policy == "stream_staging":
-        try:
-            resolved_parent = source.absolute().parent.resolve(strict=True)
-            is_owned_stream_parent = resolved_parent.parent == Path(tempfile.gettempdir()).resolve(
-                strict=True
-            ) and resolved_parent.name.startswith(_TRUSTED_STREAM_SHARD_PARENT_PREFIXES)
-        except (OSError, RuntimeError):
-            is_owned_stream_parent = False
-        if family_group and is_owned_stream_parent:
-            target["family_group"] = family_group
+        trusted_family_group = (
+            _trusted_stream_shard_family_group(resolved_source, family_group) if family_group else None
+        )
+        if trusted_family_group:
+            target["family_group"] = trusted_family_group
     return {str(source.absolute()): target}
 
 
@@ -659,6 +680,16 @@ def _update_missing_shard_coverage_record(record: Check | Issue, reason: str, me
     record.message = message
 
 
+def _results_have_explicit_operational_error(results: ModelAuditResultModel) -> bool:
+    """Return whether retained result evidence identifies an operational failure."""
+    if any(bool(metadata.get("operational_error")) for metadata in results.file_metadata.values()):
+        return True
+    if any(asset.type == "error" for asset in results.assets):
+        return True
+    records: list[Check | Issue] = [*results.checks, *results.issues]
+    return any(isinstance(record.details, dict) and bool(record.details.get("operational_error")) for record in records)
+
+
 def _reconcile_cross_directory_shard_coverage(
     results: ModelAuditResultModel,
     validated_targets: ValidatedShardTargets,
@@ -765,6 +796,7 @@ def _reconcile_cross_directory_shard_coverage(
         reconciled = True
 
     if reconciled:
+        results.has_errors = _results_have_explicit_operational_error(results)
         results.success = not _results_should_be_unsuccessful(results)
     return reconciled
 

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -708,6 +708,8 @@ def _results_have_retained_incomplete_outcome(results: ModelAuditResultModel) ->
 def _reconcile_cross_directory_shard_coverage(
     results: ModelAuditResultModel,
     validated_targets: ValidatedShardTargets,
+    *,
+    preserve_has_errors: bool = False,
 ) -> bool:
     """Remove only missing-shard outcomes disproven by this scan's validated targets."""
     complete_sources = _complete_validated_shard_family_sources(validated_targets)
@@ -813,7 +815,7 @@ def _reconcile_cross_directory_shard_coverage(
     if reconciled:
         had_errors = results.has_errors
         results.has_errors = _results_have_explicit_operational_error(results) or (
-            had_errors and _results_have_retained_incomplete_outcome(results)
+            had_errors and (preserve_has_errors or _results_have_retained_incomplete_outcome(results))
         )
         results.success = not _results_should_be_unsuccessful(results)
     return reconciled
@@ -3964,6 +3966,7 @@ def scan_model_streaming(
     nearby_license_cache: dict[str, list[str]] = {}
     pending_delete_failures: dict[Path, Exception] = {}
     validated_shard_targets: ValidatedShardTargets = {}
+    preserve_shard_reconciliation_errors = False
 
     def delete_streamed_source(source_path: Path, context: str) -> None:
         if not delete_after_scan or not (source_path.exists() or source_path.is_symlink()):
@@ -3995,6 +3998,7 @@ def scan_model_streaming(
             # Check timeout
             if time.time() - start_time > timeout:
                 results.has_errors = True
+                preserve_shard_reconciliation_errors = True
                 aggregate_hash_complete = False
                 logger.error(f"Streaming scan timeout after {timeout}s")
                 delete_streamed_source(source_path, "after streaming timeout")
@@ -4015,6 +4019,7 @@ def scan_model_streaming(
                     )
                     if entry_unavailable:
                         results.has_errors = True
+                        preserve_shard_reconciliation_errors = True
                     if resolved_path is None:
                         continue
                     scan_path = resolved_path
@@ -4095,6 +4100,8 @@ def scan_model_streaming(
                         metadata_dict.setdefault("source_path", report_path)
                         metadata_dict.setdefault("resolved_path", resolved_report_path)
                     operational_scan_failure = _scan_result_has_operational_error(scan_result)
+                    if operational_scan_failure:
+                        preserve_shard_reconciliation_errors = True
                     post_scan_shard_target = _snapshot_validated_shard_target(
                         str(source_path),
                         resolved_path=str(scan_path),
@@ -4155,18 +4162,24 @@ def scan_model_streaming(
                         details={"max_total_size": max_total_size, "analysis_incomplete": True},
                     )
                     results.has_errors = True
+                    preserve_shard_reconciliation_errors = True
                     break
 
             except Exception as e:
                 logger.error(f"Error processing {source_path}: {e}", exc_info=True)
                 results.has_errors = True
+                preserve_shard_reconciliation_errors = True
                 aggregate_hash_complete = False
 
             finally:
                 # Delete file after scanning if requested
                 delete_streamed_source(source_path, "after scanning")
 
-        _reconcile_cross_directory_shard_coverage(results, validated_shard_targets)
+        _reconcile_cross_directory_shard_coverage(
+            results,
+            validated_shard_targets,
+            preserve_has_errors=preserve_shard_reconciliation_errors,
+        )
 
         # Compute aggregate hash from all file hashes
         if file_hashes and aggregate_hash_complete:

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -4,7 +4,6 @@ import hashlib
 import itertools
 import logging
 import os
-import re
 import stat
 import tempfile
 import time
@@ -479,6 +478,7 @@ def _snapshot_validated_shard_target(
     *,
     resolved_path: str | None = None,
     family_group: str | None = None,
+    family_group_policy: str | None = None,
 ) -> ValidatedShardTargets:
     """Snapshot one selected shard path after resolving it to a regular file."""
     source = Path(source_path)
@@ -507,49 +507,32 @@ def _snapshot_validated_shard_target(
         "mtime_ns": target_stat.st_mtime_ns,
         "ctime_ns": target_stat.st_ctime_ns,
     }
-    if family_group is not None:
-        target["family_scope_policy"] = "stream_logical_parent"
+    if family_group_policy == "explicit" and family_group:
+        target["family_group"] = family_group
+    elif family_group_policy == "stream_staging":
         try:
             resolved_parent = source.absolute().parent.resolve(strict=True)
-            temp_root = Path(tempfile.gettempdir()).resolve(strict=True)
+            is_owned_stream_parent = resolved_parent.parent == Path(tempfile.gettempdir()).resolve(
+                strict=True
+            ) and resolved_parent.name.startswith(_TRUSTED_STREAM_SHARD_PARENT_PREFIXES)
         except (OSError, RuntimeError):
-            resolved_parent = None
-            temp_root = None
-        if (
-            family_group
-            and resolved_parent is not None
-            and temp_root is not None
-            and resolved_parent.parent == temp_root
-            and resolved_parent.name.startswith(_TRUSTED_STREAM_SHARD_PARENT_PREFIXES)
-        ):
+            is_owned_stream_parent = False
+        if family_group and is_owned_stream_parent:
             target["family_group"] = family_group
     return {str(source.absolute()): target}
 
 
 def _validated_shard_family_scopes(
     source_path: str,
-    shard_index: int,
     target: dict[str, int | str],
 ) -> set[str]:
-    """Return conservative lexical scopes that may identify one shard family."""
+    """Return validated scopes that may identify one shard family."""
     parent = Path(source_path).absolute().parent
     normalized_parent = os.path.normcase(os.path.normpath(str(parent)))
     scopes = {f"directory:{normalized_parent}"}
     family_group = target.get("family_group")
     if isinstance(family_group, str) and family_group:
         scopes.add(f"trusted-group:{family_group}")
-    if target.get("family_scope_policy") == "stream_logical_parent":
-        return scopes
-
-    matching_index_runs = [match for match in re.finditer(r"\d+", parent.name) if int(match.group(0)) == shard_index]
-    if len(matching_index_runs) != 1:
-        return scopes
-
-    index_run = matching_index_runs[0]
-    templated_name = f"{parent.name[: index_run.start()]}{{shard-index}}{parent.name[index_run.end() :]}"
-    templated_parent = parent.with_name(templated_name)
-    normalized_template = os.path.normcase(os.path.normpath(str(templated_parent)))
-    scopes.add(f"indexed-directory:{normalized_template}")
     return scopes
 
 
@@ -574,7 +557,7 @@ def _complete_validated_shard_family_sources(validated_targets: ValidatedShardTa
             or not 1 <= shard_index <= expected_total
         ):
             continue
-        for family_scope in _validated_shard_family_scopes(source_path, shard_index, target):
+        for family_scope in _validated_shard_family_scopes(source_path, target):
             grouped_targets.setdefault((pattern, expected_total, family_scope), {}).setdefault(shard_index, []).append(
                 (source_path, target)
             )
@@ -3917,6 +3900,7 @@ def scan_model_streaming(
                     str(source_path),
                     resolved_path=str(scan_path),
                     family_group=shard_family_group,
+                    family_group_policy="stream_staging",
                 )
 
                 file_hash: str | None = None
@@ -3965,6 +3949,7 @@ def scan_model_streaming(
                         str(source_path),
                         resolved_path=str(scan_path),
                         family_group=shard_family_group,
+                        family_group_policy="stream_staging",
                     )
                     if (
                         not operational_scan_failure

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -4,7 +4,9 @@ import hashlib
 import itertools
 import logging
 import os
+import re
 import stat
+import tempfile
 import time
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager, suppress
@@ -344,6 +346,11 @@ _TENSORFLOW_PROTOBUF_ROUTING_INCOMPLETE_REASON = "tensorflow_protobuf_routing_in
 _ShardFamilyKey = tuple[str, str, int | None]
 _ScanEntry = tuple[str, list[str], _ShardFamilyKey | None]
 _SHARD_FAMILY_CACHE_FINGERPRINT_CONFIG_KEY = "shard_family_cache_fingerprint"
+_TRUSTED_STREAM_SHARD_PARENT_PREFIXES = (
+    "modelaudit_hf_",
+    "modelaudit_pth_stream_",
+    "modelaudit_stream_",
+)
 
 
 def _redacted_stream_url_for_reporting(stream_url: str) -> str:
@@ -465,6 +472,218 @@ def _shard_family_key_for_path(path: str) -> _ShardFamilyKey | None:
         expected_total = None
 
     return (str(path_obj.parent), pattern, expected_total)
+
+
+def _snapshot_validated_shard_target(
+    source_path: str,
+    *,
+    resolved_path: str | None = None,
+    family_group: str | None = None,
+) -> ValidatedShardTargets:
+    """Snapshot one selected shard path after resolving it to a regular file."""
+    source = Path(source_path)
+    shard_match = ShardedModelDetector.match_shard_filename(source.name)
+    if shard_match is None or not isinstance(shard_match.get("expected_total_shards"), int):
+        return {}
+
+    try:
+        resolved_source = source.resolve(strict=True)
+        resolved_target = Path(resolved_path).resolve(strict=True) if resolved_path is not None else resolved_source
+        if os.path.normcase(os.path.normpath(str(resolved_source))) != os.path.normcase(
+            os.path.normpath(str(resolved_target))
+        ):
+            return {}
+        target_stat = os.stat(resolved_target, follow_symlinks=False)
+    except (OSError, RuntimeError):
+        return {}
+    if not stat.S_ISREG(target_stat.st_mode):
+        return {}
+
+    target: dict[str, int | str] = {
+        "resolved_path": str(resolved_target),
+        "device": target_stat.st_dev,
+        "inode": target_stat.st_ino,
+        "size": target_stat.st_size,
+        "mtime_ns": target_stat.st_mtime_ns,
+        "ctime_ns": target_stat.st_ctime_ns,
+    }
+    if family_group is not None:
+        target["family_scope_policy"] = "stream_logical_parent"
+        try:
+            resolved_parent = source.absolute().parent.resolve(strict=True)
+            temp_root = Path(tempfile.gettempdir()).resolve(strict=True)
+        except (OSError, RuntimeError):
+            resolved_parent = None
+            temp_root = None
+        if (
+            family_group
+            and resolved_parent is not None
+            and temp_root is not None
+            and resolved_parent.parent == temp_root
+            and resolved_parent.name.startswith(_TRUSTED_STREAM_SHARD_PARENT_PREFIXES)
+        ):
+            target["family_group"] = family_group
+    return {str(source.absolute()): target}
+
+
+def _validated_shard_family_scopes(
+    source_path: str,
+    shard_index: int,
+    target: dict[str, int | str],
+) -> set[str]:
+    """Return conservative lexical scopes that may identify one shard family."""
+    parent = Path(source_path).absolute().parent
+    normalized_parent = os.path.normcase(os.path.normpath(str(parent)))
+    scopes = {f"directory:{normalized_parent}"}
+    family_group = target.get("family_group")
+    if isinstance(family_group, str) and family_group:
+        scopes.add(f"trusted-group:{family_group}")
+    if target.get("family_scope_policy") == "stream_logical_parent":
+        return scopes
+
+    matching_index_runs = [match for match in re.finditer(r"\d+", parent.name) if int(match.group(0)) == shard_index]
+    if len(matching_index_runs) != 1:
+        return scopes
+
+    index_run = matching_index_runs[0]
+    templated_name = f"{parent.name[: index_run.start()]}{{shard-index}}{parent.name[index_run.end() :]}"
+    templated_parent = parent.with_name(templated_name)
+    normalized_template = os.path.normcase(os.path.normpath(str(templated_parent)))
+    scopes.add(f"indexed-directory:{normalized_template}")
+    return scopes
+
+
+def _complete_validated_shard_family_sources(validated_targets: ValidatedShardTargets) -> set[str]:
+    """Return source paths belonging to complete, uniquely targeted shard families."""
+    grouped_targets: dict[
+        tuple[str, int, str],
+        dict[int, list[tuple[str, dict[str, int | str]]]],
+    ] = {}
+    for source_path, target in validated_targets.items():
+        shard_match = ShardedModelDetector.match_shard_filename(Path(source_path).name)
+        if shard_match is None:
+            continue
+        pattern = shard_match.get("pattern")
+        shard_index = shard_match.get("current_shard_index")
+        expected_total = shard_match.get("expected_total_shards")
+        if (
+            not isinstance(pattern, str)
+            or not isinstance(shard_index, int)
+            or not isinstance(expected_total, int)
+            or expected_total <= 1
+            or not 1 <= shard_index <= expected_total
+        ):
+            continue
+        for family_scope in _validated_shard_family_scopes(source_path, shard_index, target):
+            grouped_targets.setdefault((pattern, expected_total, family_scope), {}).setdefault(shard_index, []).append(
+                (source_path, target)
+            )
+
+    complete_sources: set[str] = set()
+    for (_pattern, expected_total, _family_scope), targets_by_index in grouped_targets.items():
+        # Indices are already bounded to [1, expected_total], so matching the
+        # expected cardinality proves the complete range without materializing
+        # an attacker-controlled range.
+        if len(targets_by_index) != expected_total:
+            continue
+        if any(len(records) != 1 for records in targets_by_index.values()):
+            continue
+        records = [records[0] for records in targets_by_index.values()]
+
+        target_identities: set[tuple[int | str, ...]] = set()
+        duplicate_target = False
+        for _source_path, target in records:
+            inode = target.get("inode")
+            device = target.get("device")
+            resolved_target = target.get("resolved_path")
+            if isinstance(inode, int) and inode and isinstance(device, int):
+                target_identity: tuple[int | str, ...] = ("inode", device, inode)
+            elif isinstance(resolved_target, str):
+                target_identity = (
+                    "path",
+                    os.path.normcase(os.path.normpath(resolved_target)),
+                )
+            else:
+                duplicate_target = True
+                break
+            if target_identity in target_identities:
+                duplicate_target = True
+                break
+            target_identities.add(target_identity)
+        if duplicate_target:
+            continue
+
+        complete_sources.update(
+            os.path.normcase(os.path.normpath(os.path.abspath(source_path))) for source_path, _target in records
+        )
+    return complete_sources
+
+
+def _reconcile_cross_directory_shard_coverage(
+    results: ModelAuditResultModel,
+    validated_targets: ValidatedShardTargets,
+) -> bool:
+    """Remove only missing-shard outcomes disproven by this scan's validated targets."""
+    complete_sources = _complete_validated_shard_family_sources(validated_targets)
+    if not complete_sources:
+        return False
+
+    def source_is_complete(path: str | None) -> bool:
+        if not isinstance(path, str):
+            return False
+        normalized_path = os.path.normcase(os.path.normpath(os.path.abspath(path)))
+        return normalized_path in complete_sources
+
+    reconciled = False
+    retained_checks: list[Check] = []
+    for check in results.checks:
+        details = check.details if isinstance(check.details, dict) else {}
+        if (
+            check.name == "Sharded Model Coverage Check"
+            and details.get("scan_outcome_reason") == "missing_model_shards"
+            and source_is_complete(check.location)
+        ):
+            reconciled = True
+            continue
+        retained_checks.append(check)
+    results.checks = retained_checks
+
+    retained_issues: list[Issue] = []
+    for issue in results.issues:
+        details = issue.details if isinstance(issue.details, dict) else {}
+        if details.get("scan_outcome_reason") == "missing_model_shards" and source_is_complete(issue.location):
+            reconciled = True
+            continue
+        retained_issues.append(issue)
+    results.issues = retained_issues
+
+    from .models import FileMetadataModel
+
+    for source_path, metadata_model in list(results.file_metadata.items()):
+        if not source_is_complete(source_path):
+            continue
+        metadata = metadata_model.model_dump(mode="python")
+        reasons = metadata.get("scan_outcome_reasons")
+        if not isinstance(reasons, list) or "missing_model_shards" not in reasons:
+            continue
+        remaining_reasons = [reason for reason in reasons if reason != "missing_model_shards"]
+        if remaining_reasons:
+            metadata["scan_outcome_reasons"] = remaining_reasons
+            if metadata.get("scan_outcome_reason") == "missing_model_shards":
+                metadata["scan_outcome_reason"] = remaining_reasons[0]
+        else:
+            metadata.pop("scan_outcome_reasons", None)
+            if metadata.get("scan_outcome_reason") == "missing_model_shards":
+                metadata.pop("scan_outcome_reason", None)
+            if metadata.get("scan_outcome") == "inconclusive":
+                metadata.pop("scan_outcome", None)
+            metadata.pop("analysis_incomplete", None)
+        results.file_metadata[source_path] = FileMetadataModel(**metadata)
+        reconciled = True
+
+    if reconciled:
+        results.success = not _results_should_be_unsuccessful(results)
+    return reconciled
 
 
 def _build_shard_family_cache_fingerprint(
@@ -3564,6 +3783,7 @@ def scan_model_streaming(
     progress_callback: ProgressCallback | None = None,
     delete_after_scan: bool = True,
     scan_root: FilePath | None = None,
+    shard_family_group: str | None = None,
     **kwargs: Any,
 ) -> ModelAuditResultModel:
     """
@@ -3578,6 +3798,7 @@ def scan_model_streaming(
         progress_callback: Optional callback for progress reporting
         delete_after_scan: Whether to delete files after scanning (default: True)
         scan_root: Optional root directory for local streaming traversal validation
+        shard_family_group: Trusted source group, admitted only for recognized ephemeral staging parents
         **kwargs: Additional arguments passed to scanners
 
     Returns:
@@ -3609,6 +3830,7 @@ def scan_model_streaming(
     )
     nearby_license_cache: dict[str, list[str]] = {}
     pending_delete_failures: dict[Path, Exception] = {}
+    validated_shard_targets: ValidatedShardTargets = {}
 
     def delete_streamed_source(source_path: Path, context: str) -> None:
         if not delete_after_scan or not (source_path.exists() or source_path.is_symlink()):
@@ -3691,6 +3913,11 @@ def scan_model_streaming(
                     "timeout": timeout - int(time.time() - start_time),
                     **scan_kwargs,
                 }
+                pre_scan_shard_target = _snapshot_validated_shard_target(
+                    str(source_path),
+                    resolved_path=str(scan_path),
+                    family_group=shard_family_group,
+                )
 
                 file_hash: str | None = None
                 defer_hash_for_max_total_size = _should_defer_hash_for_max_total_size(
@@ -3734,6 +3961,17 @@ def scan_model_streaming(
                         metadata_dict.setdefault("source_path", report_path)
                         metadata_dict.setdefault("resolved_path", resolved_report_path)
                     operational_scan_failure = _scan_result_has_operational_error(scan_result)
+                    post_scan_shard_target = _snapshot_validated_shard_target(
+                        str(source_path),
+                        resolved_path=str(scan_path),
+                        family_group=shard_family_group,
+                    )
+                    if (
+                        not operational_scan_failure
+                        and pre_scan_shard_target
+                        and pre_scan_shard_target == post_scan_shard_target
+                    ):
+                        validated_shard_targets.update(post_scan_shard_target)
 
                     if file_hash is not None:
                         existing_hashes = metadata_dict.get("file_hashes")
@@ -3792,6 +4030,8 @@ def scan_model_streaming(
             finally:
                 # Delete file after scanning if requested
                 delete_streamed_source(source_path, "after scanning")
+
+        _reconcile_cross_directory_shard_coverage(results, validated_shard_targets)
 
         # Compute aggregate hash from all file hashes
         if file_hashes and aggregate_hash_complete:

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -709,9 +709,9 @@ def _reconcile_cross_directory_shard_coverage(
     results: ModelAuditResultModel,
     validated_targets: ValidatedShardTargets,
     *,
-    preserve_has_errors: bool = False,
+    missing_shard_errors_only: bool = False,
 ) -> bool:
-    """Remove only missing-shard outcomes disproven by this scan's validated targets."""
+    """Remove missing-shard outcomes, clearing errors only with explicit ownership proof."""
     complete_sources = _complete_validated_shard_family_sources(validated_targets)
     if not complete_sources:
         return False
@@ -815,7 +815,7 @@ def _reconcile_cross_directory_shard_coverage(
     if reconciled:
         had_errors = results.has_errors
         results.has_errors = _results_have_explicit_operational_error(results) or (
-            had_errors and (preserve_has_errors or _results_have_retained_incomplete_outcome(results))
+            had_errors and (not missing_shard_errors_only or _results_have_retained_incomplete_outcome(results))
         )
         results.success = not _results_should_be_unsuccessful(results)
     return reconciled
@@ -4178,7 +4178,7 @@ def scan_model_streaming(
         _reconcile_cross_directory_shard_coverage(
             results,
             validated_shard_targets,
-            preserve_has_errors=preserve_shard_reconciliation_errors,
+            missing_shard_errors_only=not preserve_shard_reconciliation_errors,
         )
 
         # Compute aggregate hash from all file hashes

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -9,6 +9,7 @@ import tempfile
 import time
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager, suppress
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -350,6 +351,23 @@ _TRUSTED_STREAM_SHARD_PARENT_PREFIXES = (
     "modelaudit_pth_stream_",
     "modelaudit_stream_",
 )
+_TRUSTED_STREAM_SHARD_ROOT_TOKEN = object()
+
+
+@dataclass(frozen=True)
+class _TrustedStreamShardRoot:
+    """Internal marker for a source-owned persistent streaming root."""
+
+    path: Path
+    token: object
+
+
+def _make_trusted_stream_shard_root(path: FilePath) -> object:
+    """Mark a persistent root selected by a trusted remote-source dispatcher."""
+    return _TrustedStreamShardRoot(
+        path=Path(path).expanduser().absolute(),
+        token=_TRUSTED_STREAM_SHARD_ROOT_TOKEN,
+    )
 
 
 def _redacted_stream_url_for_reporting(stream_url: str) -> str:
@@ -473,21 +491,39 @@ def _shard_family_key_for_path(path: str) -> _ShardFamilyKey | None:
     return (str(path_obj.parent), pattern, expected_total)
 
 
-def _trusted_stream_shard_family_group(resolved_source: Path, family_group: str) -> str | None:
+def _trusted_stream_shard_family_group(
+    source: Path,
+    resolved_source: Path,
+    family_group: str,
+    trusted_root_marker: object | None = None,
+) -> str | None:
     """Scope a trusted stream group to the artifact's logical staging parent."""
     try:
-        temp_root = Path(tempfile.gettempdir()).resolve(strict=True)
-        resolved_parent = resolved_source.parent
-        staging_root: Path | None = None
-        candidate = resolved_parent
-        while candidate != temp_root and candidate != candidate.parent:
-            if candidate.parent == temp_root and candidate.name.startswith(_TRUSTED_STREAM_SHARD_PARENT_PREFIXES):
-                staging_root = candidate
-                break
-            candidate = candidate.parent
-        if staging_root is None:
+        logical_parent = source.absolute().parent.resolve(strict=True)
+        trusted_root: Path | None = None
+        if (
+            isinstance(trusted_root_marker, _TrustedStreamShardRoot)
+            and trusted_root_marker.token is _TRUSTED_STREAM_SHARD_ROOT_TOKEN
+        ):
+            candidate_root = trusted_root_marker.path.resolve(strict=True)
+            if candidate_root.is_dir():
+                trusted_root = candidate_root
+
+        if trusted_root is None:
+            temp_root = Path(tempfile.gettempdir()).resolve(strict=True)
+            candidate = logical_parent
+            while candidate != temp_root and candidate != candidate.parent:
+                if candidate.parent == temp_root and candidate.name.startswith(_TRUSTED_STREAM_SHARD_PARENT_PREFIXES):
+                    trusted_root = candidate
+                    break
+                candidate = candidate.parent
+        if trusted_root is None:
             return None
-        relative_parent = resolved_parent.relative_to(staging_root)
+        if not is_within_directory(str(trusted_root), str(logical_parent)) or not is_within_directory(
+            str(trusted_root), str(resolved_source)
+        ):
+            return None
+        relative_parent = logical_parent.relative_to(trusted_root)
     except (OSError, RuntimeError, ValueError):
         return None
 
@@ -504,6 +540,7 @@ def _snapshot_validated_shard_target(
     resolved_path: str | None = None,
     family_group: str | None = None,
     family_group_policy: str | None = None,
+    trusted_root_marker: object | None = None,
 ) -> ValidatedShardTargets:
     """Snapshot one selected shard path after resolving it to a regular file."""
     source = Path(source_path)
@@ -536,7 +573,14 @@ def _snapshot_validated_shard_target(
         target["family_group"] = family_group
     elif family_group_policy == "stream_staging":
         trusted_family_group = (
-            _trusted_stream_shard_family_group(resolved_source, family_group) if family_group else None
+            _trusted_stream_shard_family_group(
+                source,
+                resolved_source,
+                family_group,
+                trusted_root_marker,
+            )
+            if family_group
+            else None
         )
         if trusted_family_group:
             target["family_group"] = trusted_family_group
@@ -3919,6 +3963,7 @@ def scan_model_streaming(
     delete_after_scan: bool = True,
     scan_root: FilePath | None = None,
     shard_family_group: str | None = None,
+    _trusted_shard_family_root: object | None = None,
     **kwargs: Any,
 ) -> ModelAuditResultModel:
     """
@@ -3934,6 +3979,7 @@ def scan_model_streaming(
         delete_after_scan: Whether to delete files after scanning (default: True)
         scan_root: Optional root directory for local streaming traversal validation
         shard_family_group: Trusted source group, admitted only for recognized ephemeral staging parents
+        _trusted_shard_family_root: Internal marker for a source-owned persistent staging root
         **kwargs: Additional arguments passed to scanners
 
     Returns:
@@ -4056,6 +4102,7 @@ def scan_model_streaming(
                     resolved_path=str(scan_path),
                     family_group=shard_family_group,
                     family_group_policy="stream_staging",
+                    trusted_root_marker=_trusted_shard_family_root,
                 )
 
                 file_hash: str | None = None
@@ -4107,6 +4154,7 @@ def scan_model_streaming(
                         resolved_path=str(scan_path),
                         family_group=shard_family_group,
                         family_group_policy="stream_staging",
+                        trusted_root_marker=_trusted_shard_family_root,
                     )
                     if (
                         not operational_scan_failure

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -602,6 +602,63 @@ def _complete_validated_shard_family_sources(validated_targets: ValidatedShardTa
     return complete_sources
 
 
+def _remaining_shard_coverage_outcome(details: dict[str, Any]) -> tuple[str, str] | None:
+    """Return the next visible incomplete-coverage reason after missing peers are disproven."""
+    out_of_scope_count = details.get("out_of_scope_shard_count")
+    if isinstance(out_of_scope_count, int) and out_of_scope_count > 0:
+        return (
+            "out_of_scope_model_shards",
+            f"Skipped {out_of_scope_count} model shard(s) resolving outside the direct scan directory; "
+            "scan coverage is incomplete.",
+        )
+
+    unreadable_count = details.get("unreadable_shard_count")
+    if isinstance(unreadable_count, int) and unreadable_count > 0:
+        return (
+            "unreadable_model_shards",
+            f"Unable to read {unreadable_count} model shard(s); scan coverage is incomplete.",
+        )
+
+    unvalidated_count = details.get("unvalidated_shard_count")
+    if isinstance(unvalidated_count, int) and unvalidated_count > 0:
+        return (
+            "unvalidated_model_shards",
+            f"Skipped {unvalidated_count} model shard(s) outside the validated family; scan coverage is incomplete.",
+        )
+
+    duplicate_count = details.get("duplicate_shard_count")
+    if isinstance(duplicate_count, int) and duplicate_count > 0:
+        return (
+            "duplicate_model_shard_targets",
+            f"Skipped {duplicate_count} model shard name(s) resolving to duplicate targets; "
+            "scan coverage is incomplete.",
+        )
+    return None
+
+
+def _update_missing_shard_coverage_record(record: Check | Issue, reason: str, message: str) -> None:
+    """Replace a disproven missing-shard outcome with a remaining coverage failure."""
+    details = dict(record.details) if isinstance(record.details, dict) else {}
+    for field_name in (
+        "missing_shard_count",
+        "missing_shard_indices",
+        "missing_shard_indices_truncated",
+    ):
+        details.pop(field_name, None)
+    existing_reasons = details.get("scan_outcome_reasons")
+    if isinstance(existing_reasons, list):
+        remaining_reasons = [
+            existing_reason for existing_reason in existing_reasons if existing_reason != "missing_model_shards"
+        ]
+        if reason not in remaining_reasons:
+            remaining_reasons.append(reason)
+        details["scan_outcome_reasons"] = remaining_reasons
+    details.pop("scan_outcome_message", None)
+    details["scan_outcome_reason"] = reason
+    record.details = details
+    record.message = message
+
+
 def _reconcile_cross_directory_shard_coverage(
     results: ModelAuditResultModel,
     validated_targets: ValidatedShardTargets,
@@ -617,7 +674,23 @@ def _reconcile_cross_directory_shard_coverage(
         normalized_path = os.path.normcase(os.path.normpath(os.path.abspath(path)))
         return normalized_path in complete_sources
 
+    def record_key(record: Check | Issue, reason: str) -> tuple[str, str] | None:
+        if not source_is_complete(record.location):
+            return None
+        assert isinstance(record.location, str)
+        normalized_location = os.path.normcase(os.path.normpath(os.path.abspath(record.location)))
+        return (normalized_location, reason)
+
     reconciled = False
+    existing_check_reasons = {
+        key
+        for check in results.checks
+        if check.name == "Sharded Model Coverage Check"
+        and isinstance(check.details, dict)
+        and isinstance((reason := check.details.get("scan_outcome_reason")), str)
+        and reason != "missing_model_shards"
+        and (key := record_key(check, reason)) is not None
+    }
     retained_checks: list[Check] = []
     for check in results.checks:
         details = check.details if isinstance(check.details, dict) else {}
@@ -627,16 +700,42 @@ def _reconcile_cross_directory_shard_coverage(
             and source_is_complete(check.location)
         ):
             reconciled = True
-            continue
+            replacement = _remaining_shard_coverage_outcome(details)
+            if replacement is None:
+                continue
+            reason, message = replacement
+            key = record_key(check, reason)
+            if key in existing_check_reasons:
+                continue
+            _update_missing_shard_coverage_record(check, reason, message)
+            if key is not None:
+                existing_check_reasons.add(key)
         retained_checks.append(check)
     results.checks = retained_checks
 
+    existing_issue_reasons = {
+        key
+        for issue in results.issues
+        if isinstance(issue.details, dict)
+        and isinstance((reason := issue.details.get("scan_outcome_reason")), str)
+        and reason != "missing_model_shards"
+        and (key := record_key(issue, reason)) is not None
+    }
     retained_issues: list[Issue] = []
     for issue in results.issues:
         details = issue.details if isinstance(issue.details, dict) else {}
         if details.get("scan_outcome_reason") == "missing_model_shards" and source_is_complete(issue.location):
             reconciled = True
-            continue
+            replacement = _remaining_shard_coverage_outcome(details)
+            if replacement is None:
+                continue
+            reason, message = replacement
+            key = record_key(issue, reason)
+            if key in existing_issue_reasons:
+                continue
+            _update_missing_shard_coverage_record(issue, reason, message)
+            if key is not None:
+                existing_issue_reasons.add(key)
         retained_issues.append(issue)
     results.issues = retained_issues
 
@@ -661,6 +760,7 @@ def _reconcile_cross_directory_shard_coverage(
             if metadata.get("scan_outcome") == "inconclusive":
                 metadata.pop("scan_outcome", None)
             metadata.pop("analysis_incomplete", None)
+            metadata.pop("scan_outcome_message", None)
         results.file_metadata[source_path] = FileMetadataModel(**metadata)
         reconciled = True
 

--- a/modelaudit/utils/file/handlers.py
+++ b/modelaudit/utils/file/handlers.py
@@ -215,7 +215,7 @@ class ShardedModelDetector:
                     normalized_candidate = os.path.normcase(os.path.normpath(os.path.abspath(candidate)))
                     candidate_paths.setdefault(normalized_candidate, candidate)
 
-                for file in sorted(candidate_paths.values(), key=lambda candidate: str(candidate)):
+                for file in sorted(candidate_paths.values(), key=str):
                     file_match = re.fullmatch(pattern, file.name)
                     if file_match:
                         candidate_expected_total: int | None = None

--- a/modelaudit/utils/file/handlers.py
+++ b/modelaudit/utils/file/handlers.py
@@ -177,6 +177,11 @@ class ShardedModelDetector:
             if allowed_targets is not None
             else None
         )
+        validated_peer_paths = (
+            [Path(source_path) for source_path in allowed_targets if isinstance(source_path, str)]
+            if allowed_targets is not None
+            else []
+        )
         allowed_path_set: set[str] | None = None
         if allowed_paths is not None:
             allowed_path_set = {os.path.normcase(os.path.normpath(os.path.abspath(path))) for path in allowed_paths}
@@ -203,8 +208,14 @@ class ShardedModelDetector:
                         requested_expected_total = int(match.group(2))
                         expected_totals.add(requested_expected_total)
 
-                # Find all related shards
-                for file in sorted(dir_path.glob("*")):
+                # Find local siblings plus any cross-directory peers that the
+                # caller already resolved and snapshotted for this scan.
+                candidate_paths: dict[str, Path] = {}
+                for candidate in (*dir_path.glob("*"), *validated_peer_paths):
+                    normalized_candidate = os.path.normcase(os.path.normpath(os.path.abspath(candidate)))
+                    candidate_paths.setdefault(normalized_candidate, candidate)
+
+                for file in sorted(candidate_paths.values(), key=lambda candidate: str(candidate)):
                     file_match = re.fullmatch(pattern, file.name)
                     if file_match:
                         candidate_expected_total: int | None = None
@@ -242,6 +253,7 @@ class ShardedModelDetector:
                             continue
                         if (
                             allowed_path_set is None
+                            and normalized_allowed_targets is None
                             and not _is_resolved_path_within_directory(
                                 dir_path,
                                 resolved_file,
@@ -951,17 +963,24 @@ class ParallelShardHandler:
         pattern = self.shard_info["pattern"]
         expected_total = self.shard_info.get("expected_total_shards")
         members: set[str] = set()
-        for candidate in current_file.parent.glob("*"):
-            match = re.fullmatch(pattern, candidate.name)
-            if match is None:
-                continue
-            if isinstance(expected_total, int) and (match.lastindex or 0) >= 2:
-                try:
-                    if int(match.group(2)) != expected_total:
-                        continue
-                except (IndexError, ValueError):
+        family_directories = {current_file.parent}
+        shard_targets = self.shard_info.get("shard_targets")
+        if isinstance(shard_targets, dict):
+            family_directories.update(
+                Path(source_path).parent for source_path in shard_targets if isinstance(source_path, str)
+            )
+        for family_directory in family_directories:
+            for candidate in family_directory.glob("*"):
+                match = re.fullmatch(pattern, candidate.name)
+                if match is None:
                     continue
-            members.add(str(candidate.absolute()))
+                if isinstance(expected_total, int) and (match.lastindex or 0) >= 2:
+                    try:
+                        if int(match.group(2)) != expected_total:
+                            continue
+                    except (IndexError, ValueError):
+                        continue
+                members.add(str(candidate.absolute()))
         return members
 
     def _scan_single_shard(self, shard_path: str) -> "ScanResult":
@@ -1242,6 +1261,7 @@ class AdvancedFileHandler:
                     passed=False,
                     message=(f"Missing {missing_count} expected model shard(s); scan coverage is incomplete."),
                     severity=IssueSeverity.INFO,
+                    location=self.file_path,
                     details={
                         "expected_total_shards": self.shard_info.get("expected_total_shards"),
                         "present_total_shards": self.shard_info.get("total_shards"),
@@ -1272,6 +1292,7 @@ class AdvancedFileHandler:
                         "scan coverage is incomplete."
                     ),
                     severity=IssueSeverity.INFO,
+                    location=self.file_path,
                     details={
                         "present_total_shards": self.shard_info.get("total_shards"),
                         "out_of_scope_shard_count": out_of_scope_count,
@@ -1293,6 +1314,7 @@ class AdvancedFileHandler:
                     passed=False,
                     message=f"Unable to read {unreadable_count} model shard(s); scan coverage is incomplete.",
                     severity=IssueSeverity.INFO,
+                    location=self.file_path,
                     details={
                         "present_total_shards": self.shard_info.get("total_shards"),
                         "unreadable_shard_count": unreadable_count,
@@ -1315,6 +1337,7 @@ class AdvancedFileHandler:
                         "scan coverage is incomplete."
                     ),
                     severity=IssueSeverity.INFO,
+                    location=self.file_path,
                     details={
                         "present_total_shards": self.shard_info.get("total_shards"),
                         "unvalidated_shard_count": unvalidated_count,
@@ -1333,6 +1356,7 @@ class AdvancedFileHandler:
                         "scan coverage is incomplete."
                     ),
                     severity=IssueSeverity.INFO,
+                    location=self.file_path,
                     details={
                         "present_total_shards": self.shard_info.get("total_shards"),
                         "duplicate_shard_count": duplicate_count,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -624,6 +624,8 @@ def mock_cli_scan_command():
         mock_model.files_scanned = mock_result_dict["files_scanned"]
         mock_model.bytes_scanned = mock_result_dict["bytes_scanned"]
         mock_model.has_errors = mock_result_dict["has_errors"]
+        mock_model.assets = mock_result_dict["assets"]
+        mock_model.file_metadata = mock_result_dict["file_metadata"]
 
         mock_scan.return_value = mock_model
         yield mock_scan

--- a/tests/scanners/test_weight_distribution_scanner.py
+++ b/tests/scanners/test_weight_distribution_scanner.py
@@ -547,14 +547,14 @@ class TestWeightDistributionScanner:
         assert 3 in extreme_anomaly["details"]["affected_neurons"]
 
     @pytest.mark.skipif(False, reason="Dynamic skip - see test method")
-    def test_pytorch_model_scan(self):
+    def test_pytorch_model_scan(self, tmp_path: Path) -> None:
         """Test scanning a PyTorch model with anomalous weights"""
         if not has_torch():
             pytest.skip("PyTorch not installed")
 
         import torch
 
-        scanner = WeightDistributionScanner()
+        scanner = WeightDistributionScanner({"enable_unsafe_torch_load": True})
 
         # Create a simple model with anomalous weights
         class SimpleModel(torch.nn.Module):
@@ -570,29 +570,23 @@ class TestWeightDistributionScanner:
 
         model = SimpleModel()
 
-        # Save model
-        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
-            torch.save(model.state_dict(), f.name)
-            temp_path = f.name
+        model_path = tmp_path / "model.pt"
+        torch.save(model.state_dict(), model_path)
 
-        try:
-            result = scanner.scan(temp_path)
-            assert result.success
+        result = scanner.scan(str(model_path))
+        assert result.success
 
-            # If no issues found, it might be because the scanner couldn't extract weights
-            # This test is more about integration than specific anomaly detection
-            # So we'll make it more lenient
-            if len(result.issues) == 0:
-                # Check if any layers were analyzed
-                assert result.metadata.get("layers_analyzed", 0) >= 0
-            else:
-                # Check that anomaly was detected - could be either type
-                has_magnitude = any("abnormal weight magnitudes" in issue.message for issue in result.issues)
-                has_extreme = any("extremely large weight values" in issue.message for issue in result.issues)
-                assert has_magnitude or has_extreme
-
-        finally:
-            os.unlink(temp_path)
+        # If no issues found, it might be because the scanner couldn't extract weights
+        # This test is more about integration than specific anomaly detection
+        # So we'll make it more lenient
+        if len(result.issues) == 0:
+            # Check if any layers were analyzed
+            assert result.metadata.get("layers_analyzed", 0) >= 0
+        else:
+            # Check that anomaly was detected - could be either type
+            has_magnitude = any("abnormal weight magnitudes" in issue.message for issue in result.issues)
+            has_extreme = any("extremely large weight values" in issue.message for issue in result.issues)
+            assert has_magnitude or has_extreme
 
     @pytest.mark.skipif(False, reason="Dynamic skip - see test method")
     def test_keras_model_scan(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -636,6 +636,47 @@ def test_scan_multiple_cross_directory_shards_reconciles_complete_family(tmp_pat
     )
 
 
+def test_scan_cross_directory_shards_preserves_nonexistent_path_error(tmp_path: Path) -> None:
+    """Shard reconciliation must not clear a separate caller-level path error."""
+    header = b'{"__metadata__":{"format":"pt"}}'
+    shard_paths: list[str] = []
+    for shard_index in range(1, 3):
+        shard_dir = tmp_path / f"part-{shard_index}"
+        shard_dir.mkdir()
+        shard_path = shard_dir / f"model-{shard_index:05d}-of-00002.safetensors"
+        shard_path.write_bytes(struct.pack("<Q", len(header)) + header)
+        shard_paths.append(str(shard_path))
+    nonexistent_path = tmp_path / "missing.safetensors"
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "scan",
+            *shard_paths,
+            str(nonexistent_path),
+            "--assume-shard-family",
+            "--format",
+            "json",
+            "--no-cache",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 2, result.output
+    assert f"Path does not exist: {nonexistent_path}" in result.output
+    output_payload = parse_click_json_output(result.output)
+    assert output_payload["has_errors"] is True
+    assert output_payload["success"] is False
+    assert not any(
+        check.get("details", {}).get("scan_outcome_reason") == "missing_model_shards"
+        for check in output_payload["checks"]
+    )
+    assert not any(
+        issue.get("details", {}).get("scan_outcome_reason") == "missing_model_shards"
+        for issue in output_payload["issues"]
+    )
+
+
 def test_scan_multiple_cross_directory_shards_reconciles_independent_families(tmp_path: Path) -> None:
     """Explicit opt-in should keep independently templated shard families separate."""
     header = b'{"__metadata__":{"format":"pt"}}'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,7 @@ from modelaudit.cli import (
     _create_path_progress_callback,
     _display_error,
     _display_path,
+    _explicit_local_shard_family_groups,
     _resolve_scan_runtime_config,
     _ScanPathState,
     _summarize_progress_tree,
@@ -633,6 +634,79 @@ def test_scan_multiple_cross_directory_shards_reconciles_complete_family(tmp_pat
         issue.get("details", {}).get("scan_outcome_reason") == "missing_model_shards"
         for issue in output_payload["issues"]
     )
+
+
+def test_scan_multiple_cross_directory_shards_reconciles_independent_families(tmp_path: Path) -> None:
+    """Explicit opt-in should keep independently templated shard families separate."""
+    header = b'{"__metadata__":{"format":"pt"}}'
+    shard_paths: list[str] = []
+    for family_name in ("model-a", "model-b"):
+        for shard_index, shard_directory_name in ((1, "left"), (2, "right")):
+            shard_dir = tmp_path / family_name / shard_directory_name
+            shard_dir.mkdir(parents=True)
+            shard_path = shard_dir / f"model-{shard_index:05d}-of-00002.safetensors"
+            shard_path.write_bytes(struct.pack("<Q", len(header)) + header)
+            shard_paths.append(str(shard_path))
+
+    result = CliRunner().invoke(
+        cli,
+        ["scan", *shard_paths, "--assume-shard-family", "--format", "json", "--no-cache"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    output_payload = parse_click_json_output(result.output)
+    assert output_payload["files_scanned"] == 4
+    assert output_payload["success"] is True
+    assert not any(
+        check.get("details", {}).get("scan_outcome_reason") == "missing_model_shards"
+        for check in output_payload["checks"]
+    )
+    assert not any(
+        issue.get("details", {}).get("scan_outcome_reason") == "missing_model_shards"
+        for issue in output_payload["issues"]
+    )
+
+
+def test_scan_directory_does_not_assume_cross_directory_shard_family(tmp_path: Path) -> None:
+    """The explicit-family opt-in must not combine shards discovered through a directory input."""
+    header = b'{"__metadata__":{"format":"pt"}}'
+    for shard_index, family_name in ((1, "model-a"), (2, "model-b")):
+        shard_dir = tmp_path / family_name
+        shard_dir.mkdir()
+        shard_path = shard_dir / f"model-{shard_index:05d}-of-00002.safetensors"
+        shard_path.write_bytes(struct.pack("<Q", len(header)) + header)
+
+    result = CliRunner().invoke(
+        cli,
+        ["scan", str(tmp_path), "--assume-shard-family", "--format", "json", "--no-cache"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 2, result.output
+    output_payload = parse_click_json_output(result.output)
+    assert output_payload["success"] is False
+    assert any(
+        check.get("details", {}).get("scan_outcome_reason") == "missing_model_shards"
+        for check in output_payload["checks"]
+    )
+    assert any(
+        issue.get("details", {}).get("scan_outcome_reason") == "missing_model_shards"
+        for issue in output_payload["issues"]
+    )
+
+
+def test_explicit_shard_family_groups_reject_resolved_non_shard_target(
+    tmp_path: Path,
+    requires_symlinks: None,
+) -> None:
+    """A shard-looking symlink must not opt its non-shard target into reconciliation."""
+    target = tmp_path / "payload.bin"
+    target.write_bytes(b"not a shard")
+    shard_link = tmp_path / "model-00001-of-00002.safetensors"
+    shard_link.symlink_to(target)
+
+    assert _explicit_local_shard_family_groups((str(shard_link),)) == {}
 
 
 def test_scan_multiple_cross_directory_shards_requires_explicit_family_opt_in(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -617,7 +617,7 @@ def test_scan_multiple_cross_directory_shards_reconciles_complete_family(tmp_pat
 
     result = CliRunner().invoke(
         cli,
-        ["scan", *shard_paths, "--format", "json", "--no-cache"],
+        ["scan", *shard_paths, "--assume-shard-family", "--format", "json", "--no-cache"],
         catch_exceptions=False,
     )
 
@@ -630,6 +630,36 @@ def test_scan_multiple_cross_directory_shards_reconciles_complete_family(tmp_pat
         for check in output_payload["checks"]
     )
     assert not any(
+        issue.get("details", {}).get("scan_outcome_reason") == "missing_model_shards"
+        for issue in output_payload["issues"]
+    )
+
+
+def test_scan_multiple_cross_directory_shards_requires_explicit_family_opt_in(tmp_path: Path) -> None:
+    """Numeric directory names must not silently merge unrelated local checkpoints."""
+    header = b'{"__metadata__":{"format":"pt"}}'
+    shard_paths: list[str] = []
+    for shard_index in range(1, 3):
+        shard_dir = tmp_path / f"checkpoint-{shard_index}"
+        shard_dir.mkdir()
+        shard_path = shard_dir / f"model-{shard_index:05d}-of-00002.safetensors"
+        shard_path.write_bytes(struct.pack("<Q", len(header)) + header)
+        shard_paths.append(str(shard_path))
+
+    result = CliRunner().invoke(
+        cli,
+        ["scan", *shard_paths, "--format", "json", "--no-cache"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 2, result.output
+    output_payload = parse_click_json_output(result.output)
+    assert output_payload["success"] is False
+    assert any(
+        check.get("details", {}).get("scan_outcome_reason") == "missing_model_shards"
+        for check in output_payload["checks"]
+    )
+    assert any(
         issue.get("details", {}).get("scan_outcome_reason") == "missing_model_shards"
         for issue in output_payload["issues"]
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ import struct
 import subprocess
 import sys
 import types
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -3509,6 +3510,61 @@ def test_scan_huggingface_streaming_success(mock_scan_streaming, mock_download_s
         assert output_json["files_scanned"] == 3
     except json.JSONDecodeError:
         pytest.fail("Output is not valid JSON")
+
+
+@patch("modelaudit.cli.is_huggingface_url")
+@patch("modelaudit.utils.sources.huggingface.download_model_streaming")
+def test_scan_huggingface_cached_stream_reconciles_snapshot_alias_shards(
+    mock_download_streaming: MagicMock,
+    mock_is_hf_url: MagicMock,
+    tmp_path: Path,
+    requires_symlinks: None,
+) -> None:
+    """A cache-enabled HF stream should trust aliases of one logical snapshot parent."""
+    mock_is_hf_url.return_value = True
+    header = b'{"__metadata__":{"format":"pt"}}'
+    cache_root = tmp_path / "persistent-cache"
+    snapshot_dir = cache_root / "huggingface" / "models--test--model" / "snapshots" / _HF_TEST_REVISION
+    snapshot_dir.mkdir(parents=True)
+    alias_root = cache_root / "huggingface" / "test" / "model"
+    alias_root.mkdir(parents=True)
+    first_alias = alias_root / "cache-a"
+    second_alias = alias_root / "cache-b"
+    first_alias.symlink_to(snapshot_dir, target_is_directory=True)
+    second_alias.symlink_to(snapshot_dir, target_is_directory=True)
+
+    def file_generator() -> Iterator[tuple[Path, bool]]:
+        for shard_index, alias_path in ((1, first_alias), (2, second_alias)):
+            shard_name = f"model-{shard_index:05d}-of-00002.safetensors"
+            snapshot_path = snapshot_dir / shard_name
+            snapshot_path.write_bytes(struct.pack("<Q", len(header)) + header)
+            yield (alias_path / shard_name, shard_index == 2)
+
+    mock_download_streaming.return_value = file_generator()
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "scan",
+            "--stream",
+            "--quiet",
+            "--format",
+            "json",
+            "--cache-dir",
+            str(cache_root),
+            "hf://test/model",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    output_payload = parse_click_json_output(result.output)
+    assert output_payload["success"] is True
+    assert output_payload["files_scanned"] == 2
+    assert not any(
+        record.get("details", {}).get("scan_outcome_reason") == "missing_model_shards"
+        for record in [*output_payload["checks"], *output_payload["issues"]]
+    )
 
 
 @patch("modelaudit.cli.is_huggingface_url")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import stat
+import struct
 import subprocess
 import sys
 import types
@@ -600,6 +601,37 @@ def test_scan_multiple_paths(tmp_path):
         or "Size:" in result.output
         or "bytes_scanned" in result.output
         or "files_scanned" in result.output
+    )
+
+
+def test_scan_multiple_cross_directory_shards_reconciles_complete_family(tmp_path: Path) -> None:
+    """Explicit shard paths should be reconciled across their separate parent directories."""
+    header = b'{"__metadata__":{"format":"pt"}}'
+    shard_paths: list[str] = []
+    for shard_index in range(1, 4):
+        shard_dir = tmp_path / f"part-{shard_index}"
+        shard_dir.mkdir()
+        shard_path = shard_dir / f"model-{shard_index:05d}-of-00003.safetensors"
+        shard_path.write_bytes(struct.pack("<Q", len(header)) + header)
+        shard_paths.append(str(shard_path))
+
+    result = CliRunner().invoke(
+        cli,
+        ["scan", *shard_paths, "--format", "json", "--no-cache"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    output_payload = parse_click_json_output(result.output)
+    assert output_payload["files_scanned"] == 3
+    assert output_payload["success"] is True
+    assert not any(
+        check.get("details", {}).get("scan_outcome_reason") == "missing_model_shards"
+        for check in output_payload["checks"]
+    )
+    assert not any(
+        issue.get("details", {}).get("scan_outcome_reason") == "missing_model_shards"
+        for issue in output_payload["issues"]
     )
 
 
@@ -3229,6 +3261,7 @@ def test_scan_pytorchhub_stream_passes_max_download_bytes(
     assert result.exit_code == 0
     assert mock_download_streaming.call_args.kwargs["max_size"] == 5 * 1024
     assert mock_download_streaming.call_args.kwargs["timeout"] > 0
+    assert mock_scan_streaming.call_args.kwargs["shard_family_group"].startswith("stream-invocation:")
 
 
 @pytest.mark.parametrize(
@@ -3321,6 +3354,7 @@ def test_scan_huggingface_streaming_success(mock_scan_streaming, mock_download_s
     streaming_provenance = mock_scan_streaming.call_args.kwargs["_trusted_source_provenance"]
     assert streaming_provenance.model_id == "test/streaming-model"
     assert streaming_provenance.model_source == "huggingface"
+    assert mock_scan_streaming.call_args.kwargs["shard_family_group"].startswith("stream-invocation:")
 
     # Verify content_hash is in JSON output
     try:
@@ -3820,6 +3854,7 @@ def test_scan_cloud_url_streaming_passes_scanner_selection_to_content_filter(
     assert mock_download_streaming.call_args.kwargs["scannable_extensions"] == frozenset({".safetensors"})
     assert mock_download_streaming.call_args.kwargs["scannable_filenames"] == frozenset()
     assert mock_download_streaming.call_args.kwargs["scanner_selection"]["enabled_scanner_ids"] == ["safetensors"]
+    assert mock_scan_streaming.call_args.kwargs["shard_family_group"].startswith("stream-invocation:")
 
 
 @patch("os.remove")

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -573,7 +573,9 @@ def test_scan_model_streaming_reconciles_cross_directory_shard_coverage(
     with ExitStack() as stack:
         shards: list[Path] = []
         for shard_index in range(1, 4):
-            shard_dir = Path(stack.enter_context(tempfile.TemporaryDirectory(prefix="modelaudit_stream_")))
+            staging_root = Path(stack.enter_context(tempfile.TemporaryDirectory(prefix="modelaudit_stream_")))
+            shard_dir = staging_root / "huggingface" / "models--org--repo" / "snapshots" / "revision"
+            shard_dir.mkdir(parents=True)
             shard_path = shard_dir / f"model-{shard_index:05d}-of-00003.safetensors"
             shard_path.write_bytes(struct.pack("<Q", len(header)) + header)
             shards.append(shard_path)
@@ -657,6 +659,46 @@ def test_scan_model_streaming_does_not_reconcile_distinct_remote_model_directori
         assert determine_exit_code(result) == 2
         assert any(check.details.get("scan_outcome_reason") == "missing_model_shards" for check in result.checks)
         assert any(issue.details.get("scan_outcome_reason") == "missing_model_shards" for issue in result.issues)
+
+
+def test_stream_staging_family_groups_are_scoped_to_nested_logical_parent() -> None:
+    """Nested trusted staging paths must not combine unrelated remote model directories."""
+    with tempfile.TemporaryDirectory(prefix="modelaudit_stream_") as staging_directory:
+        staging_root = Path(staging_directory)
+        snapshots = []
+        for shard_index, model_id in ((1, "model-a"), (2, "model-b")):
+            shard_dir = staging_root / "remote" / model_id
+            shard_dir.mkdir(parents=True)
+            shard_path = shard_dir / f"model-{shard_index:05d}-of-00002.safetensors"
+            shard_path.write_bytes(b"shard")
+            snapshots.append(
+                _snapshot_validated_shard_target(
+                    str(shard_path),
+                    family_group="trusted-stream:remote-repo",
+                    family_group_policy="stream_staging",
+                )
+            )
+
+    family_groups = [next(iter(snapshot.values())).get("family_group") for snapshot in snapshots]
+    assert all(isinstance(family_group, str) for family_group in family_groups)
+    assert family_groups[0] != family_groups[1]
+
+
+def test_stream_staging_family_group_rejects_nested_prefix_lookalike(tmp_path: Path) -> None:
+    """A prefixed directory outside the direct temp root must not gain trusted grouping."""
+    shard_dir = tmp_path / "modelaudit_stream_untrusted" / "remote" / "model-a"
+    shard_dir.mkdir(parents=True)
+    shard_path = shard_dir / "model-00001-of-00002.safetensors"
+    shard_path.write_bytes(b"shard")
+
+    snapshot = _snapshot_validated_shard_target(
+        str(shard_path),
+        family_group="attacker-controlled",
+        family_group_policy="stream_staging",
+    )
+
+    assert snapshot
+    assert "family_group" not in next(iter(snapshot.values()))
 
 
 def test_cross_directory_shard_reconciliation_bounds_untrusted_expected_total() -> None:
@@ -820,6 +862,74 @@ def test_cross_directory_shard_reconciliation_clears_stale_outcome_message() -> 
             assert "scan_outcome_reason" not in metadata
             assert "scan_outcome_reasons" not in metadata
             assert "scan_outcome_message" not in metadata
+
+
+def test_cross_directory_shard_reconciliation_clears_stale_operational_error_state() -> None:
+    """A disproven missing-shard failure must not leave the aggregate at exit code 2."""
+    with ExitStack() as stack:
+        validated_targets = {}
+        result = create_initial_audit_result()
+        result.files_scanned = 2
+        result.has_errors = True
+        result.success = False
+        for shard_index in range(1, 3):
+            shard_dir = Path(stack.enter_context(tempfile.TemporaryDirectory(prefix="modelaudit_stream_")))
+            shard_path = shard_dir / f"model-{shard_index:05d}-of-00002.safetensors"
+            shard_path.write_bytes(b"shard")
+            validated_targets.update(
+                _snapshot_validated_shard_target(
+                    str(shard_path),
+                    family_group="trusted-stream:model-a",
+                    family_group_policy="stream_staging",
+                )
+            )
+            result.file_metadata[str(shard_path)] = FileMetadataModel(
+                analysis_incomplete=True,
+                scan_outcome="inconclusive",
+                scan_outcome_reason="missing_model_shards",
+                scan_outcome_reasons=["missing_model_shards"],
+            )
+
+        assert _reconcile_cross_directory_shard_coverage(result, validated_targets) is True
+        assert result.has_errors is False
+        assert result.success is True
+        assert determine_exit_code(result) == 0
+
+
+def test_cross_directory_shard_reconciliation_preserves_independent_operational_error() -> None:
+    """Clearing a shard gap must retain an unrelated explicit operational failure."""
+    with ExitStack() as stack:
+        validated_targets = {}
+        result = create_initial_audit_result()
+        result.files_scanned = 3
+        result.has_errors = True
+        result.success = False
+        for shard_index in range(1, 3):
+            shard_dir = Path(stack.enter_context(tempfile.TemporaryDirectory(prefix="modelaudit_stream_")))
+            shard_path = shard_dir / f"model-{shard_index:05d}-of-00002.safetensors"
+            shard_path.write_bytes(b"shard")
+            validated_targets.update(
+                _snapshot_validated_shard_target(
+                    str(shard_path),
+                    family_group="trusted-stream:model-a",
+                    family_group_policy="stream_staging",
+                )
+            )
+            result.file_metadata[str(shard_path)] = FileMetadataModel(
+                analysis_incomplete=True,
+                scan_outcome="inconclusive",
+                scan_outcome_reason="missing_model_shards",
+                scan_outcome_reasons=["missing_model_shards"],
+            )
+        result.file_metadata["failed-download"] = FileMetadataModel(
+            operational_error=True,
+            operational_error_reason="download_failed",
+        )
+
+        assert _reconcile_cross_directory_shard_coverage(result, validated_targets) is True
+        assert result.has_errors is True
+        assert result.success is False
+        assert determine_exit_code(result) == 2
 
 
 def test_scan_model_streaming_does_not_reconcile_duplicate_shard_targets(

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -919,7 +919,14 @@ def test_cross_directory_shard_reconciliation_clears_stale_operational_error_sta
                 scan_outcome_reasons=["missing_model_shards"],
             )
 
-        assert _reconcile_cross_directory_shard_coverage(result, validated_targets) is True
+        assert (
+            _reconcile_cross_directory_shard_coverage(
+                result,
+                validated_targets,
+                missing_shard_errors_only=True,
+            )
+            is True
+        )
         assert result.has_errors is False
         assert result.success is True
         assert determine_exit_code(result) == 0
@@ -958,7 +965,14 @@ def test_cross_directory_shard_reconciliation_preserves_retained_aggregate_failu
             )
         )
 
-        assert _reconcile_cross_directory_shard_coverage(result, validated_targets) is True
+        assert (
+            _reconcile_cross_directory_shard_coverage(
+                result,
+                validated_targets,
+                missing_shard_errors_only=True,
+            )
+            is True
+        )
         assert result.has_errors is True
         assert result.success is False
         assert determine_exit_code(result) == 2
@@ -994,7 +1008,6 @@ def test_cross_directory_shard_reconciliation_preserves_unattributed_runtime_fai
             _reconcile_cross_directory_shard_coverage(
                 result,
                 validated_targets,
-                preserve_has_errors=True,
             )
             is True
         )
@@ -1033,7 +1046,14 @@ def test_cross_directory_shard_reconciliation_preserves_independent_operational_
             operational_error_reason="download_failed",
         )
 
-        assert _reconcile_cross_directory_shard_coverage(result, validated_targets) is True
+        assert (
+            _reconcile_cross_directory_shard_coverage(
+                result,
+                validated_targets,
+                missing_shard_errors_only=True,
+            )
+            is True
+        )
         assert result.has_errors is True
         assert result.success is False
         assert determine_exit_code(result) == 2

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -595,6 +595,10 @@ def test_scan_model_streaming_reconciles_cross_directory_shard_coverage(
             "missing_model_shards" not in metadata.model_dump().get("scan_outcome_reasons", [])
             for metadata in result.file_metadata.values()
         )
+        assert all(
+            "scan_outcome_message" not in metadata.model_dump(exclude_none=True)
+            for metadata in result.file_metadata.values()
+        )
 
 
 def test_scan_model_streaming_preserves_malicious_cross_directory_shard_findings() -> None:
@@ -714,6 +718,108 @@ def test_cross_directory_shard_reconciliation_updates_stale_scalar_reason() -> N
             assert metadata["scan_outcome_reason"] == "shard_scan_error"
             assert metadata["analysis_incomplete"] is True
             assert metadata["scan_outcome"] == "inconclusive"
+
+
+def test_cross_directory_shard_reconciliation_preserves_secondary_coverage_failure() -> None:
+    """Disproving missing peers must retain another incomplete-coverage explanation."""
+    with ExitStack() as stack:
+        shards: list[Path] = []
+        validated_targets = {}
+        for shard_index in range(1, 3):
+            shard_dir = Path(stack.enter_context(tempfile.TemporaryDirectory(prefix="modelaudit_stream_")))
+            shard_path = shard_dir / f"model-{shard_index:05d}-of-00002.safetensors"
+            shard_path.write_bytes(b"shard")
+            shards.append(shard_path)
+            validated_targets.update(
+                _snapshot_validated_shard_target(
+                    str(shard_path),
+                    family_group="trusted-stream:model-a",
+                    family_group_policy="stream_staging",
+                )
+            )
+
+        source_result = ScanResult(scanner_name="safetensors")
+        source_result.add_check(
+            name="Sharded Model Coverage Check",
+            passed=False,
+            message="Missing 1 expected model shard(s); scan coverage is incomplete.",
+            severity=IssueSeverity.INFO,
+            location=str(shards[0]),
+            details={
+                "missing_shard_count": 1,
+                "unreadable_shard_count": 1,
+                "unreadable_shards": [str(shards[0].with_name("unreadable.safetensors"))],
+                "analysis_incomplete": True,
+                "scan_outcome": "inconclusive",
+                "scan_outcome_reason": "missing_model_shards",
+                "scan_outcome_reasons": ["missing_model_shards", "unreadable_model_shards"],
+                "scan_outcome_message": "Missing model shards prevented complete analysis.",
+            },
+        )
+        result = create_initial_audit_result()
+        result.success = False
+        result.checks = list(source_result.checks)
+        result.issues = list(source_result.issues)
+        for shard in shards:
+            result.file_metadata[str(shard)] = FileMetadataModel(
+                analysis_incomplete=True,
+                scan_outcome="inconclusive",
+                scan_outcome_reason="missing_model_shards",
+                scan_outcome_reasons=["missing_model_shards", "unreadable_model_shards"],
+            )
+
+        assert _reconcile_cross_directory_shard_coverage(result, validated_targets) is True
+        assert result.success is False
+        assert len(result.checks) == 1
+        assert result.checks[0].details["scan_outcome_reason"] == "unreadable_model_shards"
+        assert result.checks[0].details["scan_outcome_reasons"] == ["unreadable_model_shards"]
+        assert "scan_outcome_message" not in result.checks[0].details
+        assert "Unable to read 1 model shard(s)" in result.checks[0].message
+        assert len(result.issues) == 1
+        assert result.issues[0].details["scan_outcome_reason"] == "unreadable_model_shards"
+        assert result.issues[0].details["scan_outcome_reasons"] == ["unreadable_model_shards"]
+        assert "scan_outcome_message" not in result.issues[0].details
+        assert "Unable to read 1 model shard(s)" in result.issues[0].message
+
+
+def test_cross_directory_shard_reconciliation_clears_stale_outcome_message() -> None:
+    """Removing the final inconclusive reason must remove its stale explanation."""
+    with ExitStack() as stack:
+        shards: list[Path] = []
+        validated_targets = {}
+        for shard_index in range(1, 3):
+            shard_dir = Path(stack.enter_context(tempfile.TemporaryDirectory(prefix="modelaudit_stream_")))
+            shard_path = shard_dir / f"model-{shard_index:05d}-of-00002.safetensors"
+            shard_path.write_bytes(b"shard")
+            shards.append(shard_path)
+            validated_targets.update(
+                _snapshot_validated_shard_target(
+                    str(shard_path),
+                    family_group="trusted-stream:model-a",
+                    family_group_policy="stream_staging",
+                )
+            )
+
+        result = create_initial_audit_result()
+        result.success = False
+        for shard in shards:
+            result.file_metadata[str(shard)] = FileMetadataModel(
+                analysis_incomplete=True,
+                scan_outcome="inconclusive",
+                scan_outcome_reason="missing_model_shards",
+                scan_outcome_reasons=["missing_model_shards"],
+                scan_outcome_message="Scan analysis incomplete; failed closed because full coverage was not available.",
+            )
+
+        assert _reconcile_cross_directory_shard_coverage(result, validated_targets) is True
+        assert result.success is True
+        for metadata_model in result.file_metadata.values():
+            metadata = metadata_model.model_dump(exclude_none=True)
+            assert "analysis_incomplete" not in metadata
+            assert "scan_outcome" not in metadata
+            assert "scan_outcome_reason" not in metadata
+            assert "scan_outcome_reasons" not in metadata
+            assert "scan_outcome_message" not in metadata
 
 
 def test_scan_model_streaming_does_not_reconcile_duplicate_shard_targets(

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -690,6 +690,39 @@ def test_scan_model_streaming_does_not_reconcile_distinct_remote_model_directori
         assert any(issue.details.get("scan_outcome_reason") == "missing_model_shards" for issue in result.issues)
 
 
+def test_scan_model_streaming_keeps_hf_snapshot_symlink_families_separate(
+    requires_symlinks: None,
+) -> None:
+    """Logical model directories must not merge through one shared HF blobs parent."""
+    header = b'{"__metadata__":{"format":"pt"}}'
+    with tempfile.TemporaryDirectory(prefix="modelaudit_stream_") as staging_directory:
+        staging_root = Path(staging_directory)
+        blobs_dir = staging_root / "huggingface" / "models--org--repo" / "blobs"
+        blobs_dir.mkdir(parents=True)
+        shards: list[Path] = []
+        for shard_index, model_id in ((1, "model-a"), (2, "model-b")):
+            blob_path = blobs_dir / f"blob-{shard_index}"
+            blob_path.write_bytes(struct.pack("<Q", len(header)) + header)
+            logical_dir = staging_root / "snapshots" / model_id
+            logical_dir.mkdir(parents=True)
+            shard_path = logical_dir / f"model-{shard_index:05d}-of-00002.safetensors"
+            shard_path.symlink_to(blob_path)
+            shards.append(shard_path)
+
+        result = scan_model_streaming(
+            file_generator=iter((shard, index == len(shards) - 1) for index, shard in enumerate(shards)),
+            timeout=30,
+            delete_after_scan=False,
+            shard_family_group="trusted-stream:remote-repo",
+            cache_enabled=False,
+        )
+
+        assert result.success is False
+        assert determine_exit_code(result) == 2
+        assert any(check.details.get("scan_outcome_reason") == "missing_model_shards" for check in result.checks)
+        assert any(issue.details.get("scan_outcome_reason") == "missing_model_shards" for issue in result.issues)
+
+
 def test_stream_staging_family_groups_are_scoped_to_nested_logical_parent() -> None:
     """Nested trusted staging paths must not combine unrelated remote model directories."""
     with tempfile.TemporaryDirectory(prefix="modelaudit_stream_") as staging_directory:
@@ -724,6 +757,22 @@ def test_stream_staging_family_group_rejects_nested_prefix_lookalike(tmp_path: P
         str(shard_path),
         family_group="attacker-controlled",
         family_group_policy="stream_staging",
+    )
+
+    assert snapshot
+    assert "family_group" not in next(iter(snapshot.values()))
+
+
+def test_stream_staging_family_group_rejects_plain_persistent_root(tmp_path: Path) -> None:
+    """A caller-provided path must not act as a trusted persistent stream root."""
+    shard_path = tmp_path / "model-00001-of-00002.safetensors"
+    shard_path.write_bytes(b"shard")
+
+    snapshot = _snapshot_validated_shard_target(
+        str(shard_path),
+        family_group="attacker-controlled",
+        family_group_policy="stream_staging",
+        trusted_root_marker=tmp_path,
     )
 
     assert snapshot

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -603,6 +603,35 @@ def test_scan_model_streaming_reconciles_cross_directory_shard_coverage(
         )
 
 
+def test_scan_model_streaming_preserves_max_total_size_failure_after_shard_reconciliation() -> None:
+    """Completing a shard family must not erase an independent aggregate size failure."""
+    header = b'{"__metadata__":{"format":"pt"}}'
+    with ExitStack() as stack:
+        shards: list[Path] = []
+        for shard_index in range(1, 3):
+            shard_dir = Path(stack.enter_context(tempfile.TemporaryDirectory(prefix="modelaudit_stream_")))
+            shard_path = shard_dir / f"model-{shard_index:05d}-of-00002.safetensors"
+            shard_path.write_bytes(struct.pack("<Q", len(header)) + header)
+            shards.append(shard_path)
+
+        max_total_size = sum(shard.stat().st_size for shard in shards) - 1
+        result = scan_model_streaming(
+            file_generator=iter((shard, index == len(shards) - 1) for index, shard in enumerate(shards)),
+            timeout=30,
+            delete_after_scan=False,
+            max_total_size=max_total_size,
+            shard_family_group="trusted-stream:model-a",
+            cache_enabled=False,
+        )
+
+        assert not any(check.details.get("scan_outcome_reason") == "missing_model_shards" for check in result.checks)
+        assert not any(issue.details.get("scan_outcome_reason") == "missing_model_shards" for issue in result.issues)
+        assert any(issue.details.get("max_total_size") == max_total_size for issue in result.issues)
+        assert result.has_errors is True
+        assert result.success is False
+        assert determine_exit_code(result) == 2
+
+
 def test_scan_model_streaming_preserves_malicious_cross_directory_shard_findings() -> None:
     """Coverage reconciliation must not suppress a malicious finding from a complete family."""
     safe_header = b'{"__metadata__":{"format":"pt"}}'

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -4,18 +4,27 @@ import logging
 import os
 import pickle
 import struct
+import subprocess
+import sys
 import tempfile
 import time
 from collections.abc import Iterator
+from contextlib import ExitStack
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
 
-from modelaudit.core import determine_exit_code, scan_model_directory_or_file, scan_model_streaming
+from modelaudit.core import (
+    _reconcile_cross_directory_shard_coverage,
+    _snapshot_validated_shard_target,
+    determine_exit_code,
+    scan_model_directory_or_file,
+    scan_model_streaming,
+)
 from modelaudit.integrations.sarif_formatter import format_sarif_output
-from modelaudit.models import LicenseInfoModel
+from modelaudit.models import FileMetadataModel, LicenseInfoModel, create_initial_audit_result
 from modelaudit.scanners import safetensors_scanner
 from modelaudit.scanners.base import Issue, IssueSeverity, ScanResult
 from modelaudit.utils.file.detection import SAFETENSORS_ROUTING_HEADER_PARSE_BYTES
@@ -553,6 +562,186 @@ def test_scan_model_streaming_basic(temp_test_files: list[Path]) -> None:
         assert result.has_errors is False
         assert result.content_hash is not None
         assert len(result.content_hash) == 64  # SHA256 hex string
+
+
+@pytest.mark.parametrize("delete_after_scan", [False, True])
+def test_scan_model_streaming_reconciles_cross_directory_shard_coverage(
+    delete_after_scan: bool,
+) -> None:
+    """A complete streamed family should not fail merely because each shard has its own directory."""
+    header = b'{"__metadata__":{"format":"pt"}}'
+    with ExitStack() as stack:
+        shards: list[Path] = []
+        for shard_index in range(1, 4):
+            shard_dir = Path(stack.enter_context(tempfile.TemporaryDirectory(prefix="modelaudit_stream_")))
+            shard_path = shard_dir / f"model-{shard_index:05d}-of-00003.safetensors"
+            shard_path.write_bytes(struct.pack("<Q", len(header)) + header)
+            shards.append(shard_path)
+
+        result = scan_model_streaming(
+            file_generator=iter((shard, index == len(shards) - 1) for index, shard in enumerate(shards)),
+            timeout=30,
+            delete_after_scan=delete_after_scan,
+            shard_family_group="trusted-stream:model-a",
+            cache_enabled=False,
+        )
+
+        assert result.files_scanned == 3
+        assert result.success is True
+        assert determine_exit_code(result) == 0
+        assert not any(check.details.get("scan_outcome_reason") == "missing_model_shards" for check in result.checks)
+        assert not any(issue.details.get("scan_outcome_reason") == "missing_model_shards" for issue in result.issues)
+        assert all(
+            "missing_model_shards" not in metadata.model_dump().get("scan_outcome_reasons", [])
+            for metadata in result.file_metadata.values()
+        )
+
+
+def test_scan_model_streaming_preserves_malicious_cross_directory_shard_findings() -> None:
+    """Coverage reconciliation must not suppress a malicious finding from a complete family."""
+    safe_header = b'{"__metadata__":{"format":"pt"}}'
+    malicious_header = (
+        b'{"tensor":{"dtype":"U8","shape":[1],"data_offsets":[0,1]},"__metadata__":{"api_key":"SECRET_METADATA_TOKEN"}}'
+    )
+    with ExitStack() as stack:
+        shards: list[Path] = []
+        for shard_index in range(1, 4):
+            shard_dir = Path(stack.enter_context(tempfile.TemporaryDirectory(prefix="modelaudit_stream_")))
+            shard_path = shard_dir / f"model-{shard_index:05d}-of-00003.safetensors"
+            header = malicious_header if shard_index == 2 else safe_header
+            tensor_data = b"\x00" if shard_index == 2 else b""
+            shard_path.write_bytes(struct.pack("<Q", len(header)) + header + tensor_data)
+            shards.append(shard_path)
+
+        result = scan_model_streaming(
+            file_generator=iter((shard, index == len(shards) - 1) for index, shard in enumerate(shards)),
+            timeout=30,
+            delete_after_scan=False,
+            shard_family_group="trusted-stream:model-a",
+            cache_enabled=False,
+        )
+
+        assert result.files_scanned == 3
+        assert any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+        assert determine_exit_code(result) == 1
+        assert not any(check.details.get("scan_outcome_reason") == "missing_model_shards" for check in result.checks)
+        assert not any(issue.details.get("scan_outcome_reason") == "missing_model_shards" for issue in result.issues)
+
+
+def test_scan_model_streaming_does_not_reconcile_distinct_remote_model_directories() -> None:
+    """One remote stream must not combine complementary shards from distinct logical parents."""
+    with tempfile.TemporaryDirectory(prefix="modelaudit_stream_") as staging_directory:
+        staging_root = Path(staging_directory)
+        shards: list[Path] = []
+        for shard_index, model_id in ((1, "model-a"), (2, "model-b")):
+            shard_dir = staging_root / model_id
+            shard_dir.mkdir()
+            shard_path = shard_dir / f"model-{shard_index:05d}-of-00002.safetensors"
+            header = f'{{"__metadata__":{{"format":"pt","model_id":"{model_id}"}}}}'.encode()
+            shard_path.write_bytes(struct.pack("<Q", len(header)) + header)
+            shards.append(shard_path)
+
+        result = scan_model_streaming(
+            file_generator=iter((shard, index == len(shards) - 1) for index, shard in enumerate(shards)),
+            timeout=30,
+            delete_after_scan=False,
+            shard_family_group="trusted-stream:remote-repo",
+            cache_enabled=False,
+        )
+
+        assert result.success is False
+        assert determine_exit_code(result) == 2
+        assert any(check.details.get("scan_outcome_reason") == "missing_model_shards" for check in result.checks)
+        assert any(issue.details.get("scan_outcome_reason") == "missing_model_shards" for issue in result.issues)
+
+
+def test_cross_directory_shard_reconciliation_bounds_untrusted_expected_total() -> None:
+    """An attacker-controlled shard count must not allocate the declared range."""
+    script = "\n".join(
+        (
+            "from modelaudit.core import _complete_validated_shard_family_sources",
+            "total = '9' * 100",
+            "source = f'/tmp/part-1/model-00001-of-{total}.safetensors'",
+            "targets = {source: {'resolved_path': '/tmp/one', 'device': 1, 'inode': 1}}",
+            "assert _complete_validated_shard_family_sources(targets) == set()",
+        )
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=5,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_cross_directory_shard_reconciliation_updates_stale_scalar_reason() -> None:
+    """Removing one reason must leave scalar outcome metadata aligned with the remaining reason."""
+    with ExitStack() as stack:
+        shards: list[Path] = []
+        validated_targets = {}
+        for shard_index in range(1, 3):
+            shard_dir = Path(stack.enter_context(tempfile.TemporaryDirectory(prefix="modelaudit_stream_")))
+            shard_path = shard_dir / f"model-{shard_index:05d}-of-00002.safetensors"
+            shard_path.write_bytes(b"shard")
+            shards.append(shard_path)
+            validated_targets.update(
+                _snapshot_validated_shard_target(
+                    str(shard_path),
+                    family_group="trusted-stream:model-a",
+                )
+            )
+
+        result = create_initial_audit_result()
+        result.success = False
+        for shard in shards:
+            result.file_metadata[str(shard)] = FileMetadataModel(
+                analysis_incomplete=True,
+                scan_outcome="inconclusive",
+                scan_outcome_reason="missing_model_shards",
+                scan_outcome_reasons=["missing_model_shards", "shard_scan_error"],
+            )
+
+        assert _reconcile_cross_directory_shard_coverage(result, validated_targets) is True
+        assert result.success is False
+        for metadata_model in result.file_metadata.values():
+            metadata = metadata_model.model_dump()
+            assert metadata["scan_outcome_reasons"] == ["shard_scan_error"]
+            assert metadata["scan_outcome_reason"] == "shard_scan_error"
+            assert metadata["analysis_incomplete"] is True
+            assert metadata["scan_outcome"] == "inconclusive"
+
+
+def test_scan_model_streaming_does_not_reconcile_duplicate_shard_targets(
+    tmp_path: Path,
+    requires_symlinks: None,
+) -> None:
+    """Two shard indices resolving to one target must remain incomplete."""
+    header = b'{"__metadata__":{"format":"pt"}}'
+    shared_target = tmp_path / "shared-target"
+    shared_target.write_bytes(struct.pack("<Q", len(header)) + header)
+    shards: list[Path] = []
+    for shard_index in range(1, 3):
+        shard_dir = tmp_path / f"part-{shard_index}"
+        shard_dir.mkdir()
+        shard_path = shard_dir / f"model-{shard_index:05d}-of-00002.safetensors"
+        shard_path.symlink_to(shared_target)
+        shards.append(shard_path)
+
+    result = scan_model_streaming(
+        file_generator=iter((shard, index == len(shards) - 1) for index, shard in enumerate(shards)),
+        timeout=30,
+        delete_after_scan=False,
+        shard_family_group="trusted-stream:model-a",
+        cache_enabled=False,
+    )
+
+    assert result.success is False
+    assert determine_exit_code(result) == 2
+    assert any(check.details.get("scan_outcome_reason") == "missing_model_shards" for check in result.checks)
 
 
 def test_scan_model_streaming_skips_non_model_files(tmp_path: Path) -> None:

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -692,6 +692,7 @@ def test_cross_directory_shard_reconciliation_updates_stale_scalar_reason() -> N
                 _snapshot_validated_shard_target(
                     str(shard_path),
                     family_group="trusted-stream:model-a",
+                    family_group_policy="stream_staging",
                 )
             )
 

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -904,7 +904,11 @@ def test_cross_directory_shard_reconciliation_distinguishes_reused_inode_generat
         },
     }
 
-    assert _complete_validated_shard_family_sources(targets) == {shard_one, shard_two}
+    expected_sources = {
+        os.path.normcase(os.path.normpath(os.path.abspath(shard_one))),
+        os.path.normcase(os.path.normpath(os.path.abspath(shard_two))),
+    }
+    assert _complete_validated_shard_family_sources(targets) == expected_sources
 
 
 def test_cross_directory_shard_reconciliation_rejects_sequential_hardlinks() -> None:

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -925,6 +925,84 @@ def test_cross_directory_shard_reconciliation_clears_stale_operational_error_sta
         assert determine_exit_code(result) == 0
 
 
+def test_cross_directory_shard_reconciliation_preserves_retained_aggregate_failure() -> None:
+    """A retained incomplete-analysis issue must keep the aggregate at exit code 2."""
+    with ExitStack() as stack:
+        validated_targets = {}
+        result = create_initial_audit_result()
+        result.files_scanned = 2
+        result.has_errors = True
+        result.success = False
+        for shard_index in range(1, 3):
+            shard_dir = Path(stack.enter_context(tempfile.TemporaryDirectory(prefix="modelaudit_stream_")))
+            shard_path = shard_dir / f"model-{shard_index:05d}-of-00002.safetensors"
+            shard_path.write_bytes(b"shard")
+            validated_targets.update(
+                _snapshot_validated_shard_target(
+                    str(shard_path),
+                    family_group="trusted-stream:model-a",
+                    family_group_policy="stream_staging",
+                )
+            )
+            result.file_metadata[str(shard_path)] = FileMetadataModel(
+                analysis_incomplete=True,
+                scan_outcome="inconclusive",
+                scan_outcome_reason="missing_model_shards",
+                scan_outcome_reasons=["missing_model_shards"],
+            )
+        result.issues.append(
+            Issue(
+                message="Total scan size limit exceeded",
+                severity=IssueSeverity.INFO,
+                details={"max_total_size": 1, "analysis_incomplete": True},
+            )
+        )
+
+        assert _reconcile_cross_directory_shard_coverage(result, validated_targets) is True
+        assert result.has_errors is True
+        assert result.success is False
+        assert determine_exit_code(result) == 2
+
+
+def test_cross_directory_shard_reconciliation_preserves_unattributed_runtime_failure() -> None:
+    """Caller provenance must preserve a runtime failure without durable result evidence."""
+    with ExitStack() as stack:
+        validated_targets = {}
+        result = create_initial_audit_result()
+        result.files_scanned = 2
+        result.has_errors = True
+        result.success = False
+        for shard_index in range(1, 3):
+            shard_dir = Path(stack.enter_context(tempfile.TemporaryDirectory(prefix="modelaudit_stream_")))
+            shard_path = shard_dir / f"model-{shard_index:05d}-of-00002.safetensors"
+            shard_path.write_bytes(b"shard")
+            validated_targets.update(
+                _snapshot_validated_shard_target(
+                    str(shard_path),
+                    family_group="trusted-stream:model-a",
+                    family_group_policy="stream_staging",
+                )
+            )
+            result.file_metadata[str(shard_path)] = FileMetadataModel(
+                analysis_incomplete=True,
+                scan_outcome="inconclusive",
+                scan_outcome_reason="missing_model_shards",
+                scan_outcome_reasons=["missing_model_shards"],
+            )
+
+        assert (
+            _reconcile_cross_directory_shard_coverage(
+                result,
+                validated_targets,
+                preserve_has_errors=True,
+            )
+            is True
+        )
+        assert result.has_errors is True
+        assert result.success is False
+        assert determine_exit_code(result) == 2
+
+
 def test_cross_directory_shard_reconciliation_preserves_independent_operational_error() -> None:
     """Clearing a shard gap must retain an unrelated explicit operational failure."""
     with ExitStack() as stack:

--- a/tests/utils/file/test_advanced_file_handler.py
+++ b/tests/utils/file/test_advanced_file_handler.py
@@ -120,6 +120,20 @@ class PatternMemoryMappedScanner:
 _SHARD_SCAN_CONTEXT: ContextVar[str] = ContextVar("_SHARD_SCAN_CONTEXT", default="missing")
 
 
+def _validated_target(path: Path) -> dict[str, int | str]:
+    """Return the target identity fields used by grouped shard scans."""
+    resolved_path = path.resolve(strict=True)
+    path_stat = os.stat(resolved_path, follow_symlinks=False)
+    return {
+        "resolved_path": str(resolved_path),
+        "device": path_stat.st_dev,
+        "inode": path_stat.st_ino,
+        "size": path_stat.st_size,
+        "mtime_ns": path_stat.st_mtime_ns,
+        "ctime_ns": path_stat.st_ctime_ns,
+    }
+
+
 class ContextRecordingShardScanner:
     """Scanner that records worker context for propagation tests."""
 
@@ -237,6 +251,74 @@ class TestShardedModelDetector:
         assert shard_info is not None
         assert shard_info["shards"] == [str(shard_one)]
         assert shard_info["total_shards"] == 1
+
+    def test_detect_shards_includes_validated_cross_directory_peers(self, tmp_path: Path) -> None:
+        """Validated peers selected in separate directories should form one complete family."""
+        shards: list[Path] = []
+        for shard_index in range(1, 4):
+            shard_dir = tmp_path / f"part-{shard_index}"
+            shard_dir.mkdir()
+            shard_path = shard_dir / f"model-{shard_index:05d}-of-00003.safetensors"
+            shard_path.write_bytes(f"shard-{shard_index}".encode())
+            shards.append(shard_path)
+        near_match = shards[1].parent / "model-00002-of-00003.safetensors.bak"
+        near_match.write_bytes(b"not-a-shard")
+        allowed_targets = {str(shard): _validated_target(shard) for shard in shards}
+
+        shard_info = ShardedModelDetector.detect_shards(
+            str(shards[0]),
+            allowed_targets=allowed_targets,
+        )
+        result = AdvancedFileHandler(
+            str(shards[0]),
+            CompletingShardScanner(),
+            allowed_shard_paths=[str(shard.resolve()) for shard in shards],
+            allowed_shard_targets=allowed_targets,
+        ).scan()
+
+        assert shard_info is not None
+        assert shard_info["shards"] == [str(shard) for shard in shards]
+        assert shard_info["total_shards"] == 3
+        assert "missing_shard_count" not in shard_info
+        assert result.success is True
+        assert result.bytes_scanned == sum(shard.stat().st_size for shard in shards)
+
+    def test_detect_shards_rejects_changed_cross_directory_peer(
+        self,
+        tmp_path: Path,
+        requires_symlinks: None,
+    ) -> None:
+        """A cross-directory peer cannot retarget after its identity is validated."""
+        first_dir = tmp_path / "first"
+        second_dir = tmp_path / "second"
+        targets_dir = tmp_path / "targets"
+        first_dir.mkdir()
+        second_dir.mkdir()
+        targets_dir.mkdir()
+        shard_one = first_dir / "model-00001-of-00002.safetensors"
+        shard_two = second_dir / "model-00002-of-00002.safetensors"
+        original_target = targets_dir / "original"
+        replacement_target = targets_dir / "replacement"
+        shard_one.write_bytes(b"one")
+        original_target.write_bytes(b"two")
+        replacement_target.write_bytes(b"replacement")
+        shard_two.symlink_to(original_target)
+        allowed_targets = {
+            str(shard_one): _validated_target(shard_one),
+            str(shard_two): _validated_target(shard_two),
+        }
+        shard_two.unlink()
+        shard_two.symlink_to(replacement_target)
+
+        shard_info = ShardedModelDetector.detect_shards(
+            str(shard_one),
+            allowed_targets=allowed_targets,
+        )
+
+        assert shard_info is not None
+        assert shard_info["shards"] == [str(shard_one)]
+        assert shard_info["missing_shard_count"] == 1
+        assert shard_info["unvalidated_shards"] == [str(shard_two)]
 
     def test_detect_shards_rejects_direct_sibling_symlink_outside_scan_directory(
         self,


### PR DESCRIPTION
## Summary

- reconcile complete shard families streamed through separate ModelAudit staging directories
- add `--assume-shard-family` as an explicit opt-in for local cross-directory shard paths
- partition independent and nested explicit complete families without combining directory-discovered or ambiguous leftover shard sets
- deduplicate repeated explicit shard arguments before family grouping
- bind streamed shard hashing and scanning to a private pinned hardlink of the selected regular-file target
- distinguish legitimate sequential inode reuse from duplicate paths, symlink aliases, and hardlink targets
- preserve malicious findings, aggregate/runtime failures, secondary coverage failures, and all other incomplete reasons
- prevent operationally failed local shard scans from proving complete coverage
- prevent unrelated model directories, duplicate targets, changed targets, writable staging descendants, publicly writable roots, and attacker-controlled shard counts from being treated as complete

## Security notes

Remote invocation grouping is admitted only for private ModelAudit staging roots whose descendant family directories are also owner-controlled; preserved logical subdirectories remain isolated. Streamed shard scanning uses the original logical shard filename while pinning the selected inode, so a symlink/path swap cannot redirect the scanner to clean content during reconciliation.

Local CLI grouping applies only to exact file arguments supplied with `--assume-shard-family`; directory inputs, quoted globs, remote sources, publicly writable parents, resolved non-shard symlink targets, and ambiguous unmatched families do not participate. Operational scan errors remain fail-closed and cannot be erased by later family reconciliation.

## Validation

- `tests/test_streaming_scan.py`: 78 passed
- shard/source-focused `tests/test_cli.py` selection: 15 passed
- cross-directory `tests/utils/file/test_advanced_file_handler.py` selection: 2 passed
- scoped Ruff check and format check passed for all changed Python files
- scoped mypy passed for all changed Python files
- `git diff --check`
- all 13 review threads resolved; zero unresolved threads at publish time

Published exact tested tree `502f786bfab5a66f8624fa082455ac39cdfcf644` at commit `9e12d1d8b0eacd89c5ad0ff1704f0e0e42f9c5ab`, parented on current `main` `423913409542aa6e4c3fc5eccffb2d6b1cb1f218`.

Fixes #1504