### PR TITLE
fix: stream Flax msgpack analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - bound Joblib decompression output to the configured scanner read budget
+- stream Flax MessagePack containers without materializing decoded object graphs and remove the default whole-file size cutoff
 - close JIT replay alias, probe-budget, and compound-clause context gaps without suppressing dangerous browser or native-library calls
 - reject cleartext HTTP cloud storage and PyTorch Hub model sources
 - preserve dangerous JIT embedded-Python findings after benign member overwrites while bounding replay and suppression analysis

--- a/modelaudit/scanners/flax_msgpack_scanner.py
+++ b/modelaudit/scanners/flax_msgpack_scanner.py
@@ -2039,16 +2039,17 @@ class FlaxMsgpackScanner(BaseScanner):
                 key = key_value.value
                 if key_value.is_container or key_value.type_name == "skipped":
                     key = f"<{key_value.type_name}_key>"
+                key_text = _text_for_security_matching(key)
                 key_str, safe_key_str = self._analyze_stream_key(key, location, result, summary)
                 key_location = f"{location}/{safe_key_str}" if location else safe_key_str
-                if isinstance(key, str) and key in transformer_keys:
-                    direct_string_keys.add(key)
+                if key_text is not None and key_text in transformer_keys:
+                    direct_string_keys.add(key_text)
                 if top_level:
                     if len(summary.top_level_keys) < 50:
                         summary.top_level_keys.append(_redact_evidence_key(key))
-                    if isinstance(key, str) and len(key) <= 128:
-                        summary.top_level_string_keys.add(key)
-                        if key.startswith("__orbax"):
+                    if key_text is not None and len(key_text) <= 128:
+                        summary.top_level_string_keys.add(key_text)
+                        if key_text.startswith("__orbax"):
                             summary.orbax_format = True
 
                 value = self._read_stream_value(
@@ -2060,18 +2061,18 @@ class FlaxMsgpackScanner(BaseScanner):
                     location=key_location,
                     depth=depth + 1,
                     count_node=True,
-                    capture_sequence=key == "shape",
+                    capture_sequence=key_text == "shape",
                 )
                 self._check_suspicious_keys(key_str, value.value, key_location, result)
 
-                if key == "__jax_array__":
+                if key_text == "__jax_array__":
                     has_jax_array = True
 
                 if (
                     top_level
                     and value.type_name == "dict"
-                    and isinstance(key, str)
-                    and (value.direct_string_keys & transformer_keys or key.lower() in model_name_keys)
+                    and key_text is not None
+                    and (value.direct_string_keys & transformer_keys or key_text.lower() in model_name_keys)
                 ):
                     summary.has_nested_transformer_keys = True
 

--- a/modelaudit/scanners/flax_msgpack_scanner.py
+++ b/modelaudit/scanners/flax_msgpack_scanner.py
@@ -8,7 +8,7 @@ import re
 from collections.abc import Iterable
 from contextlib import suppress
 from dataclasses import dataclass, field
-from typing import Any, ClassVar
+from typing import Any, BinaryIO, ClassVar
 
 from ..scanner_results import INCONCLUSIVE_SCAN_OUTCOME, mark_inconclusive_scan_result
 from ..utils.file.detection import has_inconclusive_renamed_flax_msgpack_routing, is_flax_msgpack_checkpoint_file
@@ -30,6 +30,7 @@ _EVIDENCE_REDACTION_INPUT_CHARS = 4096
 _MIN_SHORT_BINARY_TEXT_PERCENT = 85
 _MAX_STREAM_TENSOR_SAMPLES = 64
 _MAX_STREAM_SEQUENCE_EVIDENCE = 64
+_STREAM_MARKER_CHUNK_BYTES = 64 * 1024
 _STREAM_TEXT_CHUNK_BYTES = 64 * 1024
 _STREAM_TEXT_OVERLAP_CHARS = 4096
 _UNBOUNDED_GETATTR_PATTERN = r"getattr\s*\(\s*.*\s*,\s*['\"]__.*__['\"]"
@@ -60,6 +61,27 @@ class _StreamTraversalState:
     node_budget_reported: bool = False
     decode_limit_reported: bool = False
     recursion_limit_reported: bool = False
+
+
+@dataclass
+class _StreamMarkerReader:
+    source: BinaryIO
+    chunk_start: int = -1
+    chunk: bytes = b""
+
+    def peek(self, offset: int) -> int | None:
+        chunk_offset = offset - self.chunk_start
+        if 0 <= chunk_offset < len(self.chunk):
+            return self.chunk[chunk_offset]
+
+        source_offset = self.source.tell()
+        try:
+            self.source.seek(offset)
+            self.chunk_start = offset
+            self.chunk = self.source.read(_STREAM_MARKER_CHUNK_BYTES)
+        finally:
+            self.source.seek(source_offset)
+        return self.chunk[0] if self.chunk else None
 
 
 @dataclass
@@ -2160,6 +2182,7 @@ class FlaxMsgpackScanner(BaseScanner):
     def _read_stream_value(
         self,
         unpacker: Any,
+        marker_reader: _StreamMarkerReader,
         result: ScanResult,
         summary: _FlaxStreamSummary,
         state: _StreamTraversalState,
@@ -2215,11 +2238,9 @@ class FlaxMsgpackScanner(BaseScanner):
             unpacker.skip()
             return _StreamValue("skipped")
 
-        try:
+        marker = marker_reader.peek(unpacker.tell())
+        if marker is not None and (0x80 <= marker <= 0x8F or marker in {0xDE, 0xDF}):
             map_length = unpacker.read_map_header()
-        except ValueError:
-            pass
-        else:
             if top_level:
                 summary.top_level_key_count = map_length
             direct_string_keys: set[str] = set()
@@ -2267,6 +2288,7 @@ class FlaxMsgpackScanner(BaseScanner):
             for index in range(visible_items):
                 key_value = self._read_stream_value(
                     unpacker,
+                    marker_reader,
                     result,
                     summary,
                     state,
@@ -2294,6 +2316,7 @@ class FlaxMsgpackScanner(BaseScanner):
 
                 value = self._read_stream_value(
                     unpacker,
+                    marker_reader,
                     result,
                     summary,
                     state,
@@ -2323,11 +2346,8 @@ class FlaxMsgpackScanner(BaseScanner):
                 self._check_jax_array_metadata({"__jax_array__": True}, location, result)
             return _StreamValue("dict", direct_string_keys=direct_string_keys)
 
-        try:
+        if marker is not None and (0x90 <= marker <= 0x9F or marker in {0xDC, 0xDD}):
             array_length = unpacker.read_array_header()
-        except ValueError:
-            pass
-        else:
             visible_items = min(array_length, self.max_items_per_container)
             if array_length > self.max_items_per_container:
                 summary.analysis_complete = False
@@ -2341,6 +2361,7 @@ class FlaxMsgpackScanner(BaseScanner):
             for index in range(visible_items):
                 value = self._read_stream_value(
                     unpacker,
+                    marker_reader,
                     result,
                     summary,
                     state,
@@ -2425,6 +2446,7 @@ class FlaxMsgpackScanner(BaseScanner):
         try:
             with open(path, "rb") as source:
                 stream_size = os.fstat(source.fileno()).st_size
+                marker_reader = _StreamMarkerReader(source)
                 unpacker = msgpack.Unpacker(
                     source,
                     read_size=self._msgpack_stream_read_size(),
@@ -2458,6 +2480,7 @@ class FlaxMsgpackScanner(BaseScanner):
                     try:
                         value = self._read_stream_value(
                             unpacker,
+                            marker_reader,
                             result,
                             summary,
                             state,

--- a/modelaudit/scanners/flax_msgpack_scanner.py
+++ b/modelaudit/scanners/flax_msgpack_scanner.py
@@ -377,6 +377,7 @@ class FlaxMsgpackScanner(BaseScanner):
     STRUCTURE_BUDGET_INCONCLUSIVE_REASON: ClassVar[str] = "flax_msgpack_structure_budget_exceeded"
     DECODE_LIMIT_INCONCLUSIVE_REASON: ClassVar[str] = "flax_msgpack_decode_limit_exceeded"
     BINARY_PATTERN_INCONCLUSIVE_REASON: ClassVar[str] = "flax_msgpack_binary_pattern_coverage_incomplete"
+    TRUNCATED_STREAM_INCONCLUSIVE_REASON: ClassVar[str] = "flax_msgpack_truncated_stream"
     DEFAULT_MAX_STRUCTURE_NODES: ClassVar[int] = 200_000
     DEFAULT_MAX_BOUNDED_TEXT_CHARS: ClassVar[int] = 1_000_000
     DEFAULT_MAX_MSGPACK_DECODE_BYTES: ClassVar[int] = 512 * 1024 * 1024
@@ -2100,6 +2101,29 @@ class FlaxMsgpackScanner(BaseScanner):
         )
         result.finish(success=False)
 
+    def _add_msgpack_truncated_stream_check(
+        self,
+        result: ScanResult,
+        path: str,
+        *,
+        stream_offset: int,
+        stream_size: int,
+    ) -> None:
+        parse_error = "incomplete trailing msgpack object"
+        self._add_incomplete_check(
+            result,
+            reason=self.TRUNCATED_STREAM_INCONCLUSIVE_REASON,
+            name="Msgpack Parse Check",
+            message=f"Failed to parse msgpack data: {parse_error}",
+            location=path,
+            details={
+                "parse_error": parse_error,
+                "stream_offset": stream_offset,
+                "stream_size": stream_size,
+            },
+        )
+        result.finish(success=False)
+
     def _add_msgpack_stream_object_limit_check(self, result: ScanResult, path: str, parsed_object_count: int) -> None:
         result.add_check(
             name="Msgpack Stream Object Limit",
@@ -2400,6 +2424,7 @@ class FlaxMsgpackScanner(BaseScanner):
         trailing_state = _StreamTraversalState(max_nodes=self.max_structure_nodes)
         try:
             with open(path, "rb") as source:
+                stream_size = os.fstat(source.fileno()).st_size
                 unpacker = msgpack.Unpacker(
                     source,
                     read_size=self._msgpack_stream_read_size(),
@@ -2411,8 +2436,17 @@ class FlaxMsgpackScanner(BaseScanner):
                         try:
                             unpacker.skip()
                         except Exception as error:
-                            if self._is_msgpack_out_of_data(error) and unpacker.tell() == previous_offset:
-                                break
+                            if self._is_msgpack_out_of_data(error):
+                                current_offset = unpacker.tell()
+                                if current_offset == previous_offset and previous_offset == stream_size:
+                                    break
+                                self._add_msgpack_truncated_stream_check(
+                                    result,
+                                    path,
+                                    stream_offset=current_offset,
+                                    stream_size=stream_size,
+                                )
+                                return None
                             raise
                         self._add_msgpack_stream_object_limit_check(result, path, len(object_types))
                         return None
@@ -2434,12 +2468,14 @@ class FlaxMsgpackScanner(BaseScanner):
                         )
                     except Exception as error:
                         if self._is_msgpack_out_of_data(error):
-                            if unpacker.tell() == previous_offset:
+                            current_offset = unpacker.tell()
+                            if current_offset == previous_offset and previous_offset == stream_size:
                                 break
-                            self._add_msgpack_parse_failure_check(
+                            self._add_msgpack_truncated_stream_check(
                                 result,
                                 path,
-                                ValueError("incomplete trailing msgpack object"),
+                                stream_offset=current_offset,
+                                stream_size=stream_size,
                             )
                             return None
                         raise

--- a/modelaudit/scanners/flax_msgpack_scanner.py
+++ b/modelaudit/scanners/flax_msgpack_scanner.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import codecs
 import os
 import re
 from contextlib import suppress
+from dataclasses import dataclass, field
 from typing import Any, ClassVar
 
 from ..scanner_results import INCONCLUSIVE_SCAN_OUTCOME, mark_inconclusive_scan_result
@@ -25,11 +27,117 @@ _EVIDENCE_SAMPLE_CHARS = 200
 _EVIDENCE_LOCATION_CHARS = 300
 _EVIDENCE_REDACTION_INPUT_CHARS = 4096
 _MIN_SHORT_BINARY_TEXT_PERCENT = 85
+_MAX_STREAM_TENSOR_SAMPLES = 64
+_MAX_STREAM_SEQUENCE_EVIDENCE = 64
+_STREAM_TEXT_CHUNK_BYTES = 64 * 1024
+_STREAM_TEXT_OVERLAP_CHARS = 4096
+_UNBOUNDED_GETATTR_PATTERN = r"getattr\s*\(\s*.*\s*,\s*['\"]__.*__['\"]"
+_WHITESPACE_RUN_PATTERN = re.compile(r"\s+")
+_STREAM_SAFE_WHITESPACE_REPEAT_PATTERN = re.compile(r"\\s(?:[+*]|\{\d+,\})")
+
+
+class _StreamCoverageStopped(Exception):
+    """Internal signal that a fail-closed container budget ended the walk."""
+
+
+@dataclass
+class _StreamValue:
+    type_name: str
+    value: Any = None
+    direct_string_keys: set[str] = field(default_factory=set)
+    sequence_summary: _StreamSequenceSummary | None = None
+
+    @property
+    def is_container(self) -> bool:
+        return self.type_name in {"dict", "list"}
+
+
+@dataclass
+class _StreamTraversalState:
+    max_nodes: int
+    nodes: int = 0
+    node_budget_reported: bool = False
+    decode_limit_reported: bool = False
+    recursion_limit_reported: bool = False
+
+
+@dataclass
+class _StreamSequenceSummary:
+    item_count: int
+    evidence_values: list[Any] = field(default_factory=list)
+    evidence_complete: bool = True
+    negative_dimension: tuple[int, int] | None = None
+    oversized_dimension: tuple[int, int] | None = None
+
+
+@dataclass
+class _FlaxStreamSummary:
+    analysis_complete: bool = True
+    top_level_type: str = "unknown"
+    top_level_keys: list[Any] = field(default_factory=list)
+    top_level_string_keys: set[str] = field(default_factory=set)
+    top_level_key_count: int = 0
+    has_nested_transformer_keys: bool = False
+    orbax_format: bool = False
+    architecture_hints: set[str] = field(default_factory=set)
+    layer_keywords: set[str] = field(default_factory=set)
+    parameter_count: int = 0
+    layer_count: int = 0
+    has_optimizer_state: bool = False
+    tensor_count: int = 0
+    large_tensor_count: int = 0
+    compatible_tensor_count: int = 0
+    compatible_tensor_samples: list[dict[str, Any]] = field(default_factory=list)
+    embedding_tensor_count: int = 0
+    embedding_evidence: list[str] = field(default_factory=list)
+    suspicious_tensor_count: int = 0
+    bounded_text_chars: int = 0
 
 
 def _matching_jax_transforms(key_str: str, value_str: str) -> list[str]:
     value_lower = value_str.lower()
     return [transform for transform in _DANGEROUS_JAX_TRANSFORMS if transform in key_str or transform in value_lower]
+
+
+def _pattern_has_stream_unsafe_repeat(pattern: str) -> bool:
+    """Return whether bounded overlap cannot guarantee coverage for this regex."""
+    remaining = _STREAM_SAFE_WHITESPACE_REPEAT_PATTERN.sub("", pattern)
+    escaped = False
+    in_character_class = False
+    for index, char in enumerate(remaining):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == "[":
+            in_character_class = True
+            continue
+        if char == "]" and in_character_class:
+            in_character_class = False
+            continue
+        if in_character_class:
+            continue
+        if char in {"*", "+"}:
+            return True
+        if char != "{":
+            continue
+        closing_index = remaining.find("}", index + 1)
+        if closing_index == -1:
+            continue
+        repeat_range = remaining[index + 1 : closing_index]
+        if re.fullmatch(r"\d*,", repeat_range):
+            return True
+    return False
+
+
+def _pattern_literal_anchor(pattern: str) -> str | None:
+    """Return a useful literal token for conservative incomplete-coverage checks."""
+    literal_runs = re.findall(r"[A-Za-z0-9_]{3,}", pattern)
+    if not literal_runs:
+        return None
+    return max(literal_runs, key=len).lower()
 
 
 def _is_text_like_short_binary(value: bytes | bytearray) -> bool:
@@ -100,8 +208,12 @@ class FlaxMsgpackScanner(BaseScanner):
     RECURSION_LIMIT_INCONCLUSIVE_REASON: ClassVar[str] = "flax_msgpack_recursion_limit_exceeded"
     STRUCTURE_BUDGET_INCONCLUSIVE_REASON: ClassVar[str] = "flax_msgpack_structure_budget_exceeded"
     DECODE_LIMIT_INCONCLUSIVE_REASON: ClassVar[str] = "flax_msgpack_decode_limit_exceeded"
+    BINARY_PATTERN_INCONCLUSIVE_REASON: ClassVar[str] = "flax_msgpack_binary_pattern_coverage_incomplete"
     DEFAULT_MAX_STRUCTURE_NODES: ClassVar[int] = 200_000
     DEFAULT_MAX_BOUNDED_TEXT_CHARS: ClassVar[int] = 1_000_000
+    DEFAULT_MAX_MSGPACK_DECODE_BYTES: ClassVar[int] = 512 * 1024 * 1024
+    # Container traversal is streaming, so total file size is no longer a memory proxy.
+    default_max_file_read_size: ClassVar[int] = 0
     # Enhanced file extension support for JAX/Flax ecosystem
     supported_extensions: ClassVar[list[str]] = [
         ".msgpack",
@@ -120,7 +232,7 @@ class FlaxMsgpackScanner(BaseScanner):
         self.max_items_per_container = self.config.get("max_items_per_container", 50000)  # Increased for large models
         self.max_msgpack_stream_objects = self.config.get("max_msgpack_stream_objects", 4096)
         default_decode_limit = (
-            self.max_file_read_size if self.max_file_read_size > 0 else self.default_max_file_read_size
+            self.max_file_read_size if self.max_file_read_size > 0 else self.DEFAULT_MAX_MSGPACK_DECODE_BYTES
         )
         self.max_msgpack_decode_bytes = self._positive_int_config("max_msgpack_decode_bytes", default_decode_limit)
         self.max_structure_nodes = self._positive_int_config(
@@ -161,7 +273,7 @@ class FlaxMsgpackScanner(BaseScanner):
                 r"jax\.vmap\s*\(\s*exec",
                 r"jax\.pmap\s*\(\s*eval",
                 # Dynamic code execution
-                r"getattr\s*\(\s*.*\s*,\s*['\"]__.*__['\"]",
+                _UNBOUNDED_GETATTR_PATTERN,
                 # Dangerous imports in serialized functions
                 r"import\s+subprocess",
                 r"from\s+subprocess\s+import",
@@ -172,6 +284,11 @@ class FlaxMsgpackScanner(BaseScanner):
         self._compiled_suspicious_patterns = tuple(
             (pattern, re.compile(pattern, re.IGNORECASE), pattern.lower()) for pattern in self.suspicious_patterns
         )
+        self._stream_unsafe_pattern_anchors = {
+            pattern: _pattern_literal_anchor(pattern)
+            for pattern in self.suspicious_patterns
+            if _pattern_has_stream_unsafe_repeat(pattern)
+        }
 
         self.suspicious_keys = self.config.get(
             "suspicious_keys",
@@ -336,6 +453,50 @@ class FlaxMsgpackScanner(BaseScanner):
         ml_analysis: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Extract JAX/Flax specific metadata from the checkpoint."""
+        if isinstance(obj, _FlaxStreamSummary):
+            architecture_hints = sorted(obj.architecture_hints)
+            model_type = "unknown"
+            if any(pattern in architecture_hints for pattern in self.jax_patterns["transformer_patterns"]):
+                model_type = "transformer"
+            elif any(pattern in architecture_hints for pattern in self.jax_patterns["cnn_patterns"]):
+                model_type = "cnn"
+            elif any(pattern in architecture_hints for pattern in self.jax_patterns["embedding_patterns"]):
+                model_type = "embedding"
+
+            if ml_analysis is None:
+                ml_analysis = self._analyze_ml_structure(obj, result)
+            stream_metadata: dict[str, Any] = {
+                "model_type": model_type,
+                "architecture_hints": architecture_hints,
+                "parameter_count": obj.parameter_count,
+                "layer_count": obj.layer_count,
+                "has_optimizer_state": obj.has_optimizer_state,
+                "jax_version_hints": [],
+                "orbax_format": obj.orbax_format,
+                "confidence": ml_analysis["confidence"],
+                "is_ml_model": ml_analysis["is_ml_model"],
+                "ml_evidence": ml_analysis["evidence"],
+                "tensor_count": ml_analysis["tensor_count"],
+            }
+            if obj.orbax_format:
+                result.add_check(
+                    name="Checkpoint Format Detection",
+                    passed=True,
+                    message="Orbax checkpoint format detected",
+                    location="root",
+                    details={"checkpoint_format": "orbax"},
+                    rule_code=None,
+                )
+            result.metadata.update(
+                {
+                    "jax_metadata": stream_metadata,
+                    "estimated_parameters": obj.parameter_count,
+                    "model_architecture": model_type,
+                    "layer_count": obj.layer_count,
+                }
+            )
+            return stream_metadata
+
         metadata: dict[str, Any] = {
             "model_type": "unknown",
             "architecture_hints": [],
@@ -437,18 +598,22 @@ class FlaxMsgpackScanner(BaseScanner):
     ) -> None:
         """Check one visible key/value pair for dangerous JAX transforms."""
         for transform in _matching_jax_transforms(key.lower(), value):
-            result.add_check(
-                name="JAX Transform Security Check",
-                passed=False,
-                message=f"Suspicious JAX transform detected: {transform}",
-                severity=IssueSeverity.CRITICAL,
-                location=_redact_evidence_location(location),
-                details={
-                    "transform": transform,
-                    "context": _redact_evidence_sample(value),
-                },
-                rule_code="S1105",
-            )
+            self._add_jax_transform_check(transform, value, location, result)
+
+    @staticmethod
+    def _add_jax_transform_check(transform: str, context: str, location: str, result: ScanResult) -> None:
+        result.add_check(
+            name="JAX Transform Security Check",
+            passed=False,
+            message=f"Suspicious JAX transform detected: {transform}",
+            severity=IssueSeverity.CRITICAL,
+            location=_redact_evidence_location(location),
+            details={
+                "transform": transform,
+                "context": _redact_evidence_sample(context),
+            },
+            rule_code="S1105",
+        )
 
     @staticmethod
     def _check_jax_array_metadata(value: dict[Any, Any], location: str, result: ScanResult) -> None:
@@ -489,6 +654,56 @@ class FlaxMsgpackScanner(BaseScanner):
                 rule_code="S804",
             )
 
+    @classmethod
+    def _check_stream_shape_metadata(
+        cls,
+        shape: _StreamSequenceSummary,
+        location: str,
+        result: ScanResult,
+    ) -> None:
+        """Preserve shape validation without retaining arbitrarily large arrays."""
+        if shape.evidence_complete and len(shape.evidence_values) == shape.item_count:
+            cls._check_jax_array_metadata({"shape": shape.evidence_values}, location, result)
+            return
+
+        shape_evidence = [_redact_evidence_key(dim) for dim in shape.evidence_values]
+        common_details = {
+            "shape": shape_evidence,
+            "shape_item_count": shape.item_count,
+            "shape_evidence_truncated": True,
+        }
+        if shape.negative_dimension is not None:
+            dimension_index, dimension = shape.negative_dimension
+            result.add_check(
+                name="Tensor Shape Validation",
+                passed=False,
+                message="Invalid tensor shape with negative dimensions",
+                severity=IssueSeverity.INFO,
+                location=_redact_evidence_location(location),
+                details={
+                    **common_details,
+                    "dimension_index": dimension_index,
+                    "dimension": dimension,
+                },
+                rule_code="S902",
+            )
+        elif shape.oversized_dimension is not None:
+            dimension_index, dimension = shape.oversized_dimension
+            result.add_check(
+                name="Tensor Dimension Check",
+                passed=False,
+                message="Suspiciously large tensor dimensions",
+                severity=IssueSeverity.WARNING,
+                location=_redact_evidence_location(location),
+                details={
+                    **common_details,
+                    "dimension_index": dimension_index,
+                    "dimension": dimension,
+                    "max_safe_dimension": 10**9,
+                },
+                rule_code="S804",
+            )
+
     def _check_suspicious_strings(
         self,
         value: str,
@@ -501,29 +716,47 @@ class FlaxMsgpackScanner(BaseScanner):
         sample_value = value if evidence_value is None else evidence_value
         for pattern, compiled_pattern, lowered_pattern in self._compiled_suspicious_patterns:
             if compiled_pattern.search(value):
-                # Determine appropriate rule code based on pattern
-                if "eval" in lowered_pattern:
-                    rule_code = "S104"  # eval/exec usage
-                elif "compile" in lowered_pattern:
-                    rule_code = "S105"  # compile usage
-                elif "import\\s+os" in lowered_pattern or "os\\.system" in lowered_pattern:
-                    rule_code = "S101"  # os module usage
-                else:
-                    rule_code = "S999"  # Unknown/generic suspicious pattern
-
-                result.add_check(
-                    name="Code Pattern Security Check",
-                    passed=False,
-                    message=f"Suspicious code pattern detected: {pattern}",
-                    severity=IssueSeverity.CRITICAL,
-                    location=_redact_evidence_location(location),
-                    details={
-                        "pattern": pattern,
-                        "sample": _redact_evidence_sample(sample_value),
-                        "full_length": len(value),
-                    },
-                    rule_code=rule_code,
+                self._add_suspicious_string_check(
+                    pattern,
+                    lowered_pattern,
+                    sample_value,
+                    len(value),
+                    location,
+                    result,
                 )
+
+    @staticmethod
+    def _suspicious_pattern_rule_code(lowered_pattern: str) -> str:
+        if "eval" in lowered_pattern:
+            return "S104"
+        if "compile" in lowered_pattern:
+            return "S105"
+        if "import\\s+os" in lowered_pattern or "os\\.system" in lowered_pattern:
+            return "S101"
+        return "S999"
+
+    def _add_suspicious_string_check(
+        self,
+        pattern: str,
+        lowered_pattern: str,
+        sample_value: Any,
+        full_length: int,
+        location: str,
+        result: ScanResult,
+    ) -> None:
+        result.add_check(
+            name="Code Pattern Security Check",
+            passed=False,
+            message=f"Suspicious code pattern detected: {pattern}",
+            severity=IssueSeverity.CRITICAL,
+            location=_redact_evidence_location(location),
+            details={
+                "pattern": pattern,
+                "sample": _redact_evidence_sample(sample_value),
+                "full_length": full_length,
+            },
+            rule_code=self._suspicious_pattern_rule_code(lowered_pattern),
+        )
 
     def _check_suspicious_keys(
         self,
@@ -924,6 +1157,45 @@ class FlaxMsgpackScanner(BaseScanner):
             "suspicious_patterns": [],
         }
 
+        if isinstance(obj, _FlaxStreamSummary):
+            analysis["tensor_count"] = obj.tensor_count
+            if obj.tensor_count == 0:
+                analysis["suspicious_patterns"].append("No numerical data found - not a typical ML model")
+                return analysis
+            if obj.large_tensor_count == 0:
+                analysis["suspicious_patterns"].append("No substantial weight matrices found")
+                return analysis
+
+            if obj.compatible_tensor_count:
+                analysis["evidence"].append(
+                    f"Found {obj.compatible_tensor_count} tensors with ML-compatible dimensions"
+                )
+                analysis["weight_matrices"] = obj.compatible_tensor_samples
+                analysis["confidence"] += 0.4
+
+            layer_evidence = len(obj.layer_keywords)
+            if layer_evidence >= 2:
+                analysis["evidence"].append(f"Found hierarchical layer structure ({layer_evidence} layer indicators)")
+                analysis["confidence"] += 0.5
+
+            analysis["evidence"].extend(obj.embedding_evidence)
+            if obj.embedding_tensor_count:
+                analysis["confidence"] += 0.3
+
+            if obj.suspicious_tensor_count > obj.tensor_count * 0.5:
+                analysis["confidence"] *= 0.5
+
+            if analysis["confidence"] >= 0.7:
+                analysis["is_ml_model"] = True
+                analysis["evidence"].append(
+                    "High confidence this is a legitimate ML model based on structural analysis"
+                )
+            elif analysis["confidence"] > 0.4:
+                analysis["evidence"].append("Moderate confidence this could be an ML model")
+            else:
+                analysis["suspicious_patterns"].append("Low confidence in ML model structure - may be malicious data")
+            return analysis
+
         if not isinstance(obj, dict):
             return analysis
 
@@ -1057,21 +1329,28 @@ class FlaxMsgpackScanner(BaseScanner):
         ml_analysis: dict[str, Any] | None = None,
     ) -> None:
         """Validate that the msgpack structure looks like a legitimate Flax checkpoint using structural analysis."""
-        if not isinstance(obj, dict):
+        is_stream_summary = isinstance(obj, _FlaxStreamSummary)
+        top_level_type = obj.top_level_type if is_stream_summary else type(obj).__name__
+        if (is_stream_summary and obj.top_level_type != "dict") or (
+            not is_stream_summary and not isinstance(obj, dict)
+        ):
             result.add_check(
                 name="Flax Structure Validation",
                 passed=False,
-                message=f"Unexpected top-level type: {type(obj).__name__} (expected dict)",
+                message=f"Unexpected top-level type: {top_level_type} (expected dict)",
                 rule_code="S903",
                 severity=IssueSeverity.WARNING,
                 location="root",
-                details={"actual_type": type(obj).__name__, "expected_type": "dict"},
+                details={"actual_type": top_level_type, "expected_type": "dict"},
             )
             return
 
         # Check for standard Flax checkpoint patterns first
         expected_keys = {"params", "state", "opt_state", "model_state", "step", "epoch"}
-        found_keys = set(obj.keys()) if isinstance(obj, dict) else set()
+        found_keys = obj.top_level_string_keys if is_stream_summary else set(obj.keys())
+        displayed_found_keys = (
+            obj.top_level_keys if is_stream_summary else [_redact_evidence_key(key) for key in list(found_keys)[:20]]
+        )
 
         # Also check for common transformer model patterns (BERT, GPT, T5, etc.)
         transformer_keys = {"embeddings", "encoder", "decoder", "pooler", "lm_head", "transformer", "model"}
@@ -1105,9 +1384,11 @@ class FlaxMsgpackScanner(BaseScanner):
             "score",
         }
         has_transformer_keys = any(key in found_keys for key in transformer_keys)
+        if is_stream_summary:
+            has_transformer_keys = has_transformer_keys or obj.has_nested_transformer_keys
 
         # Check if any top-level key contains transformer sub-keys (nested model structure)
-        if not has_transformer_keys:
+        if not has_transformer_keys and not is_stream_summary:
             for key in found_keys:
                 value = obj.get(key)
                 if isinstance(value, dict):
@@ -1155,7 +1436,7 @@ class FlaxMsgpackScanner(BaseScanner):
                 details={
                     "found_transformer_keys": [k for k in transformer_keys if k in found_keys],
                     "model_type": "transformer_model",
-                    "all_keys": [_redact_evidence_key(key) for key in list(found_keys)[:20]],
+                    "all_keys": displayed_found_keys,
                 },
                 rule_code=None,  # Passing check
             )
@@ -1203,7 +1484,7 @@ class FlaxMsgpackScanner(BaseScanner):
                 location="root",
                 details={
                     "analysis": ml_analysis,
-                    "found_keys": [_redact_evidence_key(key) for key in list(found_keys)[:20]],
+                    "found_keys": displayed_found_keys,
                     "expected_any_of": list(expected_keys),
                     "model_type": "suspicious",
                     "suspicious_patterns": ml_analysis["suspicious_patterns"],
@@ -1251,6 +1532,305 @@ class FlaxMsgpackScanner(BaseScanner):
     def _msgpack_stream_read_size(self) -> int:
         """Leave decoder-buffer headroom for an object split across filesystem reads."""
         return min(self.chunk_size, max(self.max_msgpack_decode_bytes // 2, 1))
+
+    def _msgpack_event_unpacker_kwargs(self) -> dict[str, Any]:
+        """Allow container headers through; the event walker enforces their budgets."""
+        kwargs = self._msgpack_unpacker_kwargs()
+        kwargs["max_array_len"] = 2**32 - 1
+        kwargs["max_map_len"] = 2**32 - 1
+        return kwargs
+
+    def _record_stream_text(self, value: str, summary: _FlaxStreamSummary) -> None:
+        remaining = self.max_bounded_text_chars - summary.bounded_text_chars
+        if remaining <= 0:
+            return
+        visible = value[:remaining].lower()
+        summary.bounded_text_chars += len(visible)
+
+        for patterns in self.jax_patterns.values():
+            summary.architecture_hints.update(pattern for pattern in patterns if pattern in visible)
+        summary.layer_keywords.update(
+            keyword for keyword in ("layer", "block", "attention", "ffn", "mlp", "linear", "conv") if keyword in visible
+        )
+        if any(indicator in visible for indicator in ("opt_state", "optimizer", "adam", "sgd", "learning_rate")):
+            summary.has_optimizer_state = True
+
+    def _record_stream_tensor(self, value: bytes | bytearray, location: str, summary: _FlaxStreamSummary) -> None:
+        size = len(value)
+        if size >= 16 and size % 4 == 0:
+            summary.parameter_count += size // 4
+        if size < 16 or (size % 4 != 0 and size % 8 != 0):
+            return
+
+        summary.tensor_count += 1
+        if size < 100 or size > 500 * 1024 * 1024:
+            summary.suspicious_tensor_count += 1
+        if size <= 1024:
+            return
+
+        summary.large_tensor_count += 1
+        elements = size // 4
+        potential_shapes: list[tuple[int, int]] = []
+        for dim1 in (64, 128, 256, 512, 768, 1024, 1536, 2048, 4096, 8192):
+            if elements % dim1 == 0:
+                dim2 = elements // dim1
+                if 1 <= dim2 <= 100000:
+                    potential_shapes.append((dim1, dim2))
+        if potential_shapes:
+            summary.compatible_tensor_count += 1
+            if len(summary.compatible_tensor_samples) < _MAX_STREAM_TENSOR_SAMPLES:
+                summary.compatible_tensor_samples.append(
+                    {
+                        "tensor": {
+                            "path": _redact_evidence_location(location),
+                            "size": size,
+                            "type": "binary_blob",
+                            "potential_elements": elements,
+                        },
+                        "potential_shapes": potential_shapes[:5],
+                    }
+                )
+
+        for vocab_size in (30522, 50257, 32000, 28996, 51200):
+            matched = False
+            for embed_dim in (128, 256, 384, 512, 768, 1024, 1536, 2048):
+                expected_elements = vocab_size * embed_dim
+                if abs(elements - expected_elements) < expected_elements * 0.1:
+                    summary.embedding_tensor_count += 1
+                    if len(summary.embedding_evidence) < _MAX_STREAM_TENSOR_SAMPLES:
+                        summary.embedding_evidence.append(f"Found embedding-like matrix: ~{vocab_size}x{embed_dim}")
+                    matched = True
+                    break
+            if matched:
+                break
+
+    def _analyze_large_text(
+        self,
+        value: str,
+        location: str,
+        result: ScanResult,
+        *,
+        check_jax_transform: bool,
+        jax_location: str | None = None,
+    ) -> None:
+        tail = ""
+        matched_transforms: dict[str, str] = {}
+        for offset in range(0, len(value), _STREAM_TEXT_CHUNK_BYTES):
+            window = tail + value[offset : offset + _STREAM_TEXT_CHUNK_BYTES]
+            window_lower = window.lower()
+            if check_jax_transform:
+                for transform in _DANGEROUS_JAX_TRANSFORMS:
+                    if transform not in matched_transforms and transform in window_lower:
+                        matched_transforms[transform] = window
+            tail = window[-_STREAM_TEXT_OVERLAP_CHARS:]
+
+        for transform, context in matched_transforms.items():
+            self._add_jax_transform_check(transform, context, jax_location or location, result)
+        self._check_suspicious_strings(value, location, result)
+
+    def _analyze_large_binary_text(self, value: bytes | bytearray, location: str, result: ScanResult) -> None:
+        decoder = codecs.getincrementaldecoder("utf-8")(errors="ignore")
+        raw_tail = ""
+        normalized_tail = ""
+        previous_chunk_ended_with_whitespace = False
+        decoded_chars = 0
+        matched_patterns: dict[str, tuple[str, str]] = {}
+        matched_transforms: dict[str, str] = {}
+        unresolved_pattern_candidates: set[str] = set()
+        raw_value = memoryview(value)
+
+        def inspect_windows(raw_window: str, normalized_window: str) -> None:
+            raw_window_lower = raw_window.lower()
+            normalized_window_lower = normalized_window.lower()
+            for transform in _DANGEROUS_JAX_TRANSFORMS:
+                if transform not in matched_transforms and transform in raw_window_lower:
+                    matched_transforms[transform] = raw_window
+            for pattern, compiled_pattern, lowered_pattern in self._compiled_suspicious_patterns:
+                if pattern not in matched_patterns:
+                    match_sample: str | None = None
+                    if compiled_pattern.search(raw_window):
+                        match_sample = raw_window
+                    elif "\\s" in pattern and compiled_pattern.search(normalized_window):
+                        match_sample = normalized_window
+                    if match_sample is not None:
+                        matched_patterns[pattern] = (lowered_pattern, match_sample)
+
+                if pattern in self._stream_unsafe_pattern_anchors:
+                    anchor = self._stream_unsafe_pattern_anchors[pattern]
+                    if anchor is None or anchor in normalized_window_lower:
+                        unresolved_pattern_candidates.add(pattern)
+
+        for offset in range(0, len(raw_value), _STREAM_TEXT_CHUNK_BYTES):
+            chunk = decoder.decode(raw_value[offset : offset + _STREAM_TEXT_CHUNK_BYTES], final=False)
+            decoded_chars += len(chunk)
+            normalized_chunk = _WHITESPACE_RUN_PATTERN.sub(" ", chunk)
+            if previous_chunk_ended_with_whitespace and normalized_chunk.startswith(" "):
+                normalized_chunk = normalized_chunk[1:]
+            if chunk:
+                previous_chunk_ended_with_whitespace = chunk[-1].isspace()
+
+            raw_window = raw_tail + chunk
+            normalized_window = normalized_tail + normalized_chunk
+            inspect_windows(raw_window, normalized_window)
+            raw_tail = raw_window[-_STREAM_TEXT_OVERLAP_CHARS:]
+            normalized_tail = normalized_window[-_STREAM_TEXT_OVERLAP_CHARS:]
+
+        final_chunk = decoder.decode(b"", final=True)
+        if final_chunk:
+            decoded_chars += len(final_chunk)
+            normalized_chunk = _WHITESPACE_RUN_PATTERN.sub(" ", final_chunk)
+            if previous_chunk_ended_with_whitespace and normalized_chunk.startswith(" "):
+                normalized_chunk = normalized_chunk[1:]
+            inspect_windows(raw_tail + final_chunk, normalized_tail + normalized_chunk)
+
+        for transform, context in matched_transforms.items():
+            self._add_jax_transform_check(transform, context, location, result)
+        for pattern, (lowered_pattern, sample) in matched_patterns.items():
+            self._add_suspicious_string_check(
+                pattern,
+                lowered_pattern,
+                sample,
+                decoded_chars,
+                f"{location}[decoded_binary]",
+                result,
+            )
+
+        unresolved_patterns = sorted(unresolved_pattern_candidates - set(matched_patterns))
+        existing_reasons = result.metadata.get("scan_outcome_reasons", [])
+        if unresolved_patterns and self.BINARY_PATTERN_INCONCLUSIVE_REASON not in existing_reasons:
+            self._add_incomplete_check(
+                result,
+                reason=self.BINARY_PATTERN_INCONCLUSIVE_REASON,
+                name="Flax MessagePack Binary Pattern Coverage",
+                message="Large binary text contained an unresolved pattern beyond the streaming overlap",
+                location=location,
+                details={
+                    "pattern": unresolved_patterns[0],
+                    "patterns": unresolved_patterns,
+                    "binary_size": len(value),
+                    "stream_overlap_chars": _STREAM_TEXT_OVERLAP_CHARS,
+                },
+            )
+
+    def _analyze_stream_scalar(
+        self,
+        value: Any,
+        location: str,
+        result: ScanResult,
+        summary: _FlaxStreamSummary,
+        *,
+        check_string_jax_transform: bool = True,
+    ) -> None:
+        if HAS_MSGPACK and isinstance(value, msgpack.ExtType):
+            self._analyze_stream_scalar(
+                value.data,
+                f"{location}[1]",
+                result,
+                summary,
+                check_string_jax_transform=check_string_jax_transform,
+            )
+            return
+
+        if isinstance(value, bytes | bytearray):
+            size = len(value)
+            if size > self.max_blob_bytes:
+                result.add_check(
+                    name="Binary Blob Size Check",
+                    passed=False,
+                    message=f"Suspiciously large binary blob: {size:,} bytes",
+                    severity=IssueSeverity.INFO,
+                    location=_redact_evidence_location(location),
+                    details={"size": size, "max_allowed": self.max_blob_bytes},
+                    rule_code="S902",
+                )
+            if size > _STREAM_TEXT_CHUNK_BYTES:
+                self._analyze_large_binary_text(value, location, result)
+            else:
+                decoded = bytes(value).decode("utf-8", errors="ignore")
+                if check_string_jax_transform:
+                    self._check_jax_transform("", decoded, location, result)
+                if len(decoded) > 50 or _is_text_like_short_binary(value):
+                    self._check_suspicious_strings(decoded, f"{location}[decoded_binary]", result)
+            self._record_stream_tensor(value, location, summary)
+            return
+
+        if isinstance(value, str):
+            if len(value) > _STREAM_TEXT_CHUNK_BYTES:
+                self._analyze_large_text(
+                    value,
+                    location,
+                    result,
+                    check_jax_transform=check_string_jax_transform,
+                )
+            else:
+                if check_string_jax_transform:
+                    self._check_jax_transform("", value, location, result)
+                self._check_suspicious_strings(value, location, result)
+            if len(value) > 100000:
+                result.add_check(
+                    name="String Length Check",
+                    passed=False,
+                    message=f"Extremely long string found: {len(value):,} characters",
+                    rule_code="S902",
+                    severity=IssueSeverity.INFO,
+                    location=_redact_evidence_location(location),
+                    details={"length": len(value), "threshold": 100000},
+                )
+            self._record_stream_text(value, summary)
+            return
+
+        if isinstance(value, int) and not isinstance(value, bool) and abs(value) > 2**63:
+            result.add_check(
+                name="Integer Value Range Check",
+                passed=False,
+                message=f"Extremely large integer value: {value}",
+                severity=IssueSeverity.INFO,
+                location=_redact_evidence_location(location),
+                details={"value": value},
+                rule_code="S902",
+            )
+
+    def _analyze_stream_key(
+        self,
+        key: Any,
+        location: str,
+        result: ScanResult,
+        summary: _FlaxStreamSummary,
+    ) -> tuple[str, str]:
+        key_str = _stringify_evidence_fragment(key)
+        safe_key_str = _stringify_safe_evidence_fragment(key)
+        location_key = _redact_evidence_location(key)
+        key_value_location = f"{location}/{location_key}" if location else location_key
+        key_evidence_location = f"{location}[key:{location_key}]"
+        if len(key_str) > _STREAM_TEXT_CHUNK_BYTES:
+            self._analyze_large_text(
+                key_str,
+                key_evidence_location,
+                result,
+                check_jax_transform=True,
+                jax_location=key_value_location,
+            )
+        else:
+            self._check_jax_transform(key_str, "", key_value_location, result)
+            self._check_suspicious_strings(
+                key_str,
+                key_evidence_location,
+                result,
+                evidence_value=safe_key_str,
+            )
+        self._record_stream_text(key_str, summary)
+        layer_words = ("layer", "block", "level")
+        if len(key_str) <= _STREAM_TEXT_CHUNK_BYTES:
+            has_layer_word = any(layer_word in key_str.lower() for layer_word in layer_words)
+        else:
+            has_layer_word = any(
+                layer_word in key_str[offset : offset + _STREAM_TEXT_CHUNK_BYTES].lower()
+                for offset in range(0, len(key_str), _STREAM_TEXT_CHUNK_BYTES)
+                for layer_word in layer_words
+            )
+        if has_layer_word:
+            summary.layer_count += 1
+        return key_str, location_key
 
     @staticmethod
     def _is_msgpack_limit_error(error: Exception) -> bool:
@@ -1310,28 +1890,261 @@ class FlaxMsgpackScanner(BaseScanner):
     def _is_msgpack_out_of_data(error: Exception) -> bool:
         return type(error).__name__ == "OutOfData"
 
-    def _drain_msgpack_unpacker(self, unpacker: Any, objects: list[Any], result: ScanResult, path: str) -> bool | None:
-        """Append complete objects and report whether the unpacker consumed a partial tail."""
-        while True:
-            previous_offset = unpacker.tell()
-            try:
-                stream_obj = unpacker.unpack()
-            except Exception as error:
-                if self._is_msgpack_out_of_data(error):
-                    return unpacker.tell() > previous_offset
-                raise
-
-            if len(objects) >= self.max_msgpack_stream_objects:
-                self._add_msgpack_stream_object_limit_check(result, path, len(objects))
-                return None
-            objects.append(stream_obj)
-
-    def _add_msgpack_stream_integrity_check(self, objects: list[Any], result: ScanResult, path: str) -> None:
-        if len(objects) <= 1:
+    def _report_stream_decode_limit(
+        self,
+        state: _StreamTraversalState,
+        result: ScanResult,
+        path: str,
+        message: str,
+    ) -> None:
+        if state.decode_limit_reported:
             return
-        trailing_objects_are_container_like = all(
-            isinstance(stream_obj, (dict, list, tuple)) for stream_obj in objects[1:]
-        )
+        state.decode_limit_reported = True
+        self._add_msgpack_decode_limit_check(result, path, ValueError(message))
+
+    def _read_stream_value(
+        self,
+        unpacker: Any,
+        result: ScanResult,
+        summary: _FlaxStreamSummary,
+        state: _StreamTraversalState,
+        *,
+        path: str,
+        location: str,
+        depth: int,
+        analyze_scalar: bool = True,
+        top_level: bool = False,
+        count_node: bool = True,
+        capture_sequence: bool = False,
+    ) -> _StreamValue:
+        if state.node_budget_reported:
+            summary.analysis_complete = False
+            unpacker.skip()
+            return _StreamValue("skipped")
+        if count_node:
+            state.nodes += 1
+        if count_node and state.nodes > state.max_nodes:
+            summary.analysis_complete = False
+            if not state.node_budget_reported:
+                self._add_structure_budget_check(
+                    result,
+                    location=location,
+                    budget="node_count",
+                    observed=state.nodes,
+                    maximum=state.max_nodes,
+                )
+                state.node_budget_reported = True
+            unpacker.skip()
+            return _StreamValue("skipped")
+
+        if depth > self.max_recursion_depth:
+            summary.analysis_complete = False
+            if not state.recursion_limit_reported:
+                self._add_incomplete_check(
+                    result,
+                    reason=self.RECURSION_LIMIT_INCONCLUSIVE_REASON,
+                    name="Flax MessagePack Preanalysis Depth Limit",
+                    message=f"Maximum preanalysis recursion depth exceeded: {depth}",
+                    location=location,
+                    details={"depth": depth, "max_allowed": self.max_recursion_depth},
+                )
+                self._add_incomplete_check(
+                    result,
+                    reason=self.RECURSION_LIMIT_INCONCLUSIVE_REASON,
+                    name="Recursion Depth Check",
+                    message=f"Maximum recursion depth exceeded: {depth}",
+                    location=location,
+                    details={"depth": depth, "max_allowed": self.max_recursion_depth},
+                )
+                state.recursion_limit_reported = True
+            unpacker.skip()
+            return _StreamValue("skipped")
+
+        try:
+            map_length = unpacker.read_map_header()
+        except ValueError:
+            pass
+        else:
+            if top_level:
+                summary.top_level_key_count = map_length
+            direct_string_keys: set[str] = set()
+            has_jax_array = False
+            visible_items = min(map_length, self.max_items_per_container)
+            if map_length > self.max_items_per_container:
+                summary.analysis_complete = False
+                self._report_stream_decode_limit(
+                    state,
+                    result,
+                    path,
+                    f"map length {map_length} exceeds max_map_len({self.max_items_per_container})",
+                )
+
+            transformer_keys = {"embeddings", "encoder", "decoder", "pooler", "lm_head", "transformer", "model"}
+            model_name_keys = {
+                "bert",
+                "roberta",
+                "distilbert",
+                "albert",
+                "electra",
+                "xlm",
+                "gpt2",
+                "gpt_neo",
+                "gpt_neox",
+                "gptj",
+                "opt",
+                "llama",
+                "t5",
+                "bart",
+                "pegasus",
+                "mbart",
+                "blenderbot",
+                "vit",
+                "clip",
+                "whisper",
+                "wav2vec2",
+                "flax_model",
+                "classifier",
+                "qa_outputs",
+                "lm_head",
+                "score",
+            }
+
+            for index in range(visible_items):
+                key_value = self._read_stream_value(
+                    unpacker,
+                    result,
+                    summary,
+                    state,
+                    path=path,
+                    location=f"{location}[key:{index}]",
+                    depth=depth + 1,
+                    analyze_scalar=False,
+                    count_node=False,
+                )
+                key = key_value.value
+                if key_value.is_container or key_value.type_name == "skipped":
+                    key = f"<{key_value.type_name}_key>"
+                key_str, safe_key_str = self._analyze_stream_key(key, location, result, summary)
+                key_location = f"{location}/{safe_key_str}" if location else safe_key_str
+                if isinstance(key, str) and key in transformer_keys:
+                    direct_string_keys.add(key)
+                if top_level:
+                    if len(summary.top_level_keys) < 50:
+                        summary.top_level_keys.append(_redact_evidence_key(key))
+                    if isinstance(key, str) and len(key) <= 128:
+                        summary.top_level_string_keys.add(key)
+                        if key.startswith("__orbax"):
+                            summary.orbax_format = True
+
+                value = self._read_stream_value(
+                    unpacker,
+                    result,
+                    summary,
+                    state,
+                    path=path,
+                    location=key_location,
+                    depth=depth + 1,
+                    count_node=True,
+                    capture_sequence=key == "shape",
+                )
+                self._check_suspicious_keys(key_str, value.value, key_location, result)
+
+                if key == "__jax_array__":
+                    has_jax_array = True
+
+                if (
+                    top_level
+                    and value.type_name == "dict"
+                    and isinstance(key, str)
+                    and (value.direct_string_keys & transformer_keys or key.lower() in model_name_keys)
+                ):
+                    summary.has_nested_transformer_keys = True
+
+            if map_length > visible_items:
+                raise _StreamCoverageStopped
+
+            if has_jax_array:
+                self._check_jax_array_metadata({"__jax_array__": True}, location, result)
+            return _StreamValue("dict", direct_string_keys=direct_string_keys)
+
+        try:
+            array_length = unpacker.read_array_header()
+        except ValueError:
+            pass
+        else:
+            visible_items = min(array_length, self.max_items_per_container)
+            if array_length > self.max_items_per_container:
+                summary.analysis_complete = False
+                self._report_stream_decode_limit(
+                    state,
+                    result,
+                    path,
+                    f"array length {array_length} exceeds max_array_len({self.max_items_per_container})",
+                )
+            sequence_summary = _StreamSequenceSummary(item_count=array_length) if capture_sequence else None
+            for index in range(visible_items):
+                value = self._read_stream_value(
+                    unpacker,
+                    result,
+                    summary,
+                    state,
+                    path=path,
+                    location=f"{location}[{index}]",
+                    depth=depth + 1,
+                    count_node=True,
+                )
+                if sequence_summary is None:
+                    continue
+
+                if isinstance(value.value, int) and not isinstance(value.value, bool):
+                    if value.value < 0 and sequence_summary.negative_dimension is None:
+                        sequence_summary.negative_dimension = (index, value.value)
+                    elif value.value > 10**9 and sequence_summary.oversized_dimension is None:
+                        sequence_summary.oversized_dimension = (index, value.value)
+
+                if len(sequence_summary.evidence_values) >= _MAX_STREAM_SEQUENCE_EVIDENCE or (
+                    value.is_container
+                    or value.type_name == "skipped"
+                    or (isinstance(value.value, str | bytes | bytearray) and len(value.value) > 4096)
+                    or (HAS_MSGPACK and isinstance(value.value, msgpack.ExtType))
+                ):
+                    sequence_summary.evidence_complete = False
+                else:
+                    sequence_summary.evidence_values.append(value.value)
+            if sequence_summary is not None:
+                shape_location = location.rsplit("/", 1)[0] if "/" in location else location
+                self._check_stream_shape_metadata(sequence_summary, shape_location, result)
+            if array_length > visible_items:
+                raise _StreamCoverageStopped
+            captured_values = None
+            if (
+                sequence_summary is not None
+                and sequence_summary.evidence_complete
+                and len(sequence_summary.evidence_values) == sequence_summary.item_count
+            ):
+                captured_values = sequence_summary.evidence_values
+            return _StreamValue("list", value=captured_values, sequence_summary=sequence_summary)
+
+        value = unpacker.unpack()
+        if analyze_scalar:
+            self._analyze_stream_scalar(value, location, result, summary)
+        if value is None:
+            type_name = "NoneType"
+        elif HAS_MSGPACK and isinstance(value, msgpack.ExtType):
+            type_name = "ExtType"
+        else:
+            type_name = type(value).__name__
+        return _StreamValue(type_name, value=value)
+
+    def _add_msgpack_stream_integrity_check_from_types(
+        self,
+        object_types: list[str],
+        result: ScanResult,
+        path: str,
+    ) -> None:
+        if len(object_types) <= 1:
+            return
+        trailing_objects_are_container_like = all(object_type in {"dict", "list"} for object_type in object_types[1:])
         result.add_check(
             name="Msgpack Stream Integrity Check",
             passed=False,
@@ -1340,134 +2153,88 @@ class FlaxMsgpackScanner(BaseScanner):
             location=path,
             details={
                 "has_trailing_data": True,
-                "trailing_object_count": len(objects) - 1,
-                "trailing_object_types": [type(stream_obj).__name__ for stream_obj in objects[1:9]],
+                "trailing_object_count": len(object_types) - 1,
+                "trailing_object_types": object_types[1:9],
                 "trailing_objects_are_container_like": trailing_objects_are_container_like,
             },
             rule_code="S902",
         )
 
-    def _unpack_bounded_msgpack_preview_value(
-        self,
-        unpacker: Any,
-        *,
-        depth: int,
-        state: dict[str, int],
-    ) -> tuple[Any, bool]:
-        """Decode a bounded visible prefix without materializing oversized containers."""
-        if depth > self.max_recursion_depth or state["nodes"] >= self.max_structure_nodes:
-            return None, False
-        state["nodes"] += 1
-
-        try:
-            map_length = unpacker.read_map_header()
-        except ValueError:
-            pass
-        else:
-            pairs: list[dict[Any, Any]] = []
-            for _ in range(min(map_length, self.max_items_per_container)):
-                key, key_complete = self._unpack_bounded_msgpack_preview_value(
-                    unpacker,
-                    depth=depth + 1,
-                    state=state,
-                )
-                if not key_complete:
-                    pairs.append({"<partial_key>": key})
-                    return pairs, False
-                value, value_complete = self._unpack_bounded_msgpack_preview_value(
-                    unpacker,
-                    depth=depth + 1,
-                    state=state,
-                )
-                normalized_key = str(key) if isinstance(key, list | dict) else key
-                pair = {normalized_key: value}
-                pairs.append(pair)
-                if not value_complete:
-                    return pairs, False
-            return pairs, map_length <= self.max_items_per_container
-
-        try:
-            array_length = unpacker.read_array_header()
-        except ValueError:
-            pass
-        else:
-            items: list[Any] = []
-            for _ in range(min(array_length, self.max_items_per_container)):
-                value, value_complete = self._unpack_bounded_msgpack_preview_value(
-                    unpacker,
-                    depth=depth + 1,
-                    state=state,
-                )
-                items.append(value)
-                if not value_complete:
-                    return items, False
-            return items, array_length <= self.max_items_per_container
-
-        return unpacker.unpack(), True
-
-    def _scan_bounded_msgpack_decode_prefix(self, path: str, result: ScanResult) -> None:
-        """Preserve visible security findings when normal decoding hits a budget."""
-        state = {"nodes": 0}
+    def _scan_msgpack_stream_from_path(self, path: str, result: ScanResult) -> _FlaxStreamSummary | None:
+        """Walk MessagePack tokens without materializing container objects."""
+        primary_summary = _FlaxStreamSummary()
+        object_types: list[str] = []
+        primary_state = _StreamTraversalState(max_nodes=self.max_structure_nodes)
+        trailing_state = _StreamTraversalState(max_nodes=self.max_structure_nodes)
         try:
             with open(path, "rb") as source:
                 unpacker = msgpack.Unpacker(
                     source,
                     read_size=self._msgpack_stream_read_size(),
-                    **self._msgpack_unpacker_kwargs(),
+                    **self._msgpack_event_unpacker_kwargs(),
                 )
-                for object_index in range(self.max_msgpack_stream_objects):
-                    preview, complete = self._unpack_bounded_msgpack_preview_value(
-                        unpacker,
-                        depth=0,
-                        state=state,
-                    )
-                    if preview is not None:
-                        self._analyze_content(preview, f"root[bounded_decode_prefix_{object_index}]", result)
-                    if not complete:
-                        break
-        except Exception:
-            # The original decode failure is already surfaced as inconclusive.
-            return
-
-    def _unpack_msgpack_objects_from_path(self, path: str, result: ScanResult) -> list[Any] | None:
-        """Stream MessagePack from disk so scans do not allocate the whole file before decoding."""
-        unpacker = msgpack.Unpacker(**self._msgpack_unpacker_kwargs())
-        objects: list[Any] = []
-        has_incomplete_tail = False
-        try:
-            with open(path, "rb") as source:
-                while chunk := source.read(self._msgpack_stream_read_size()):
-                    unpacker.feed(chunk)
-                    drain_result = self._drain_msgpack_unpacker(unpacker, objects, result, path)
-                    if drain_result is None:
+                while True:
+                    previous_offset = unpacker.tell()
+                    if len(object_types) >= self.max_msgpack_stream_objects:
+                        try:
+                            unpacker.skip()
+                        except Exception as error:
+                            if self._is_msgpack_out_of_data(error) and unpacker.tell() == previous_offset:
+                                break
+                            raise
+                        self._add_msgpack_stream_object_limit_check(result, path, len(object_types))
                         return None
-                    has_incomplete_tail = drain_result
-        except Exception as e:
-            if self._is_msgpack_limit_error(e):
-                self._scan_bounded_msgpack_decode_prefix(path, result)
-                self._add_msgpack_decode_limit_check(result, path, e)
+
+                    object_index = len(object_types)
+                    summary = primary_summary if object_index == 0 else _FlaxStreamSummary()
+                    state = primary_state if object_index == 0 else trailing_state
+                    location = "root" if object_index == 0 else f"root[msgpack_object_{object_index}]"
+                    try:
+                        value = self._read_stream_value(
+                            unpacker,
+                            result,
+                            summary,
+                            state,
+                            path=path,
+                            location=location,
+                            depth=0,
+                            top_level=True,
+                        )
+                    except Exception as error:
+                        if self._is_msgpack_out_of_data(error):
+                            if unpacker.tell() == previous_offset:
+                                break
+                            self._add_msgpack_parse_failure_check(
+                                result,
+                                path,
+                                ValueError("incomplete trailing msgpack object"),
+                            )
+                            return None
+                        raise
+                    object_types.append(value.type_name)
+                    if object_index == 0:
+                        primary_summary.top_level_type = value.type_name
+        except _StreamCoverageStopped:
+            return None
+        except Exception as error:
+            if self._is_msgpack_limit_error(error):
+                self._add_msgpack_decode_limit_check(result, path, error)
             else:
-                self._add_msgpack_parse_failure_check(result, path, e)
+                self._add_msgpack_parse_failure_check(result, path, error)
             return None
 
-        if has_incomplete_tail:
-            self._add_msgpack_parse_failure_check(result, path, ValueError("incomplete trailing msgpack object"))
-            return None
-        if not objects:
-            result.add_check(
-                name="Msgpack Parse Check",
-                passed=False,
-                message="Failed to parse msgpack data: no decodable objects",
-                severity=IssueSeverity.WARNING,
-                location=path,
-                details={"parse_error": "no decodable objects"},
-                rule_code="S902",
-            )
-            result.finish(success=False)
+        if not object_types:
+            self._add_msgpack_parse_failure_check(result, path, ValueError("no decodable objects"))
             return None
 
-        self._add_msgpack_stream_integrity_check(objects, result, path)
-        return objects
+        if len(object_types) > 1:
+            result.metadata["msgpack_object_count"] = len(object_types)
+        result.metadata["msgpack_stream_analyzed_nodes"] = min(primary_state.nodes, primary_state.max_nodes) + min(
+            trailing_state.nodes, trailing_state.max_nodes
+        )
+        result.metadata["msgpack_stream_node_budget"] = primary_state.max_nodes + trailing_state.max_nodes
+        self._add_msgpack_stream_integrity_check_from_types(object_types, result, path)
+        return primary_summary
 
     def scan(self, path: str) -> ScanResult:
         path_check_result = self._check_path(path)
@@ -1521,48 +2288,20 @@ class FlaxMsgpackScanner(BaseScanner):
         try:
             self.current_file_path = path
 
-            objects = self._unpack_msgpack_objects_from_path(path, result)
-            if objects is None:
+            summary = self._scan_msgpack_stream_from_path(path, result)
+            if summary is None:
                 return result
 
-            obj = objects[0]
-
             # Record metadata
-            result.metadata["top_level_type"] = type(obj).__name__
-            if isinstance(obj, dict):
-                result.metadata["top_level_keys"] = [_redact_evidence_key(key) for key in list(obj.keys())[:50]]
-                result.metadata["key_count"] = len(obj.keys())
-            if len(objects) > 1:
-                result.metadata["msgpack_object_count"] = len(objects)
+            result.metadata["top_level_type"] = summary.top_level_type
+            if summary.top_level_type == "dict":
+                result.metadata["top_level_keys"] = summary.top_level_keys
+                result.metadata["key_count"] = summary.top_level_key_count
 
-            preanalysis_complete = self._check_preanalysis_structure_budget(
-                obj,
-                result,
-                location="root",
-                max_nodes=self.max_structure_nodes,
-            )
-            ml_analysis: dict[str, Any] | None = None
-            if preanalysis_complete:
-                # Extract JAX/Flax specific metadata and architecture information
-                ml_analysis = self._analyze_ml_structure(obj, result)
-                self._extract_jax_metadata(obj, result, ml_analysis=ml_analysis)
-
-                # Validate Flax structure with enhanced analysis
-                self._validate_flax_structure(obj, result, ml_analysis=ml_analysis)
-
-            # Perform deep security analysis
-            traversal_state = self._new_content_traversal_state(max_nodes=self.max_structure_nodes)
-            self._analyze_content(obj, "root", result, traversal_state=traversal_state)
-
-            trailing_max_nodes_per_object = max(1, self.max_structure_nodes // max(1, len(objects) - 1))
-            for object_index, stream_obj in enumerate(objects[1:], start=1):
-                stream_location = f"root[msgpack_object_{object_index}]"
-                self._analyze_content(
-                    stream_obj,
-                    stream_location,
-                    result,
-                    traversal_state=self._new_content_traversal_state(max_nodes=trailing_max_nodes_per_object),
-                )
+            if summary.analysis_complete:
+                ml_analysis = self._analyze_ml_structure(summary, result)
+                self._extract_jax_metadata(summary, result, ml_analysis=ml_analysis)
+                self._validate_flax_structure(summary, result, ml_analysis=ml_analysis)
 
             result.bytes_scanned = file_size
         except MemoryError:

--- a/modelaudit/scanners/flax_msgpack_scanner.py
+++ b/modelaudit/scanners/flax_msgpack_scanner.py
@@ -34,7 +34,6 @@ _STREAM_TEXT_CHUNK_BYTES = 64 * 1024
 _STREAM_TEXT_OVERLAP_CHARS = 4096
 _UNBOUNDED_GETATTR_PATTERN = r"getattr\s*\(\s*.*\s*,\s*['\"]__.*__['\"]"
 _WHITESPACE_RUN_PATTERN = re.compile(r"\s+")
-_STREAM_SAFE_WHITESPACE_REPEAT_PATTERN = re.compile(r"\\s(?:[+*]|\{[01],\})")
 _JAX_TRANSFORM_DEDUP_METADATA_KEY = "flax_msgpack_jax_transform_findings"
 
 
@@ -137,17 +136,87 @@ def _contains_suspicious_getattr(value: str) -> bool:
     return False
 
 
+def _get_regex_parser() -> Any:
+    return vars(re).get("_parser")
+
+
+def _strip_stream_safe_whitespace_repeats(pattern: str) -> str:
+    remaining: list[str] = []
+    in_character_class = False
+    index = 0
+    while index < len(pattern):
+        char = pattern[index]
+        if char == "[":
+            in_character_class = True
+            remaining.append(char)
+            index += 1
+            continue
+        if char == "]" and in_character_class:
+            in_character_class = False
+            remaining.append(char)
+            index += 1
+            continue
+        if char != "\\" or index + 1 >= len(pattern):
+            remaining.append(char)
+            index += 1
+            continue
+
+        escaped_char = pattern[index + 1]
+        if not in_character_class and escaped_char == "s":
+            suffix = pattern[index + 2 :]
+            if suffix.startswith(("*", "+")):
+                index += 3
+                continue
+            if suffix.startswith(("{0,}", "{1,}")):
+                index += 6
+                continue
+
+        remaining.extend((char, escaped_char))
+        index += 2
+
+    return "".join(remaining)
+
+
 def _pattern_has_stream_unsafe_repeat(pattern: str) -> bool:
     """Return whether bounded overlap cannot guarantee coverage for this regex."""
-    remaining = _STREAM_SAFE_WHITESPACE_REPEAT_PATTERN.sub("", pattern)
-    try:
-        parser = vars(re).get("_parser")
-        if parser is None:
+    remaining = _strip_stream_safe_whitespace_repeats(pattern)
+    parser = _get_regex_parser()
+    if parser is not None:
+        try:
+            _, max_width = parser.parse(remaining, re.IGNORECASE).getwidth()
+        except Exception:
             return True
-        _, max_width = parser.parse(remaining, re.IGNORECASE).getwidth()
-    except Exception:
-        return True
-    return max_width > _STREAM_TEXT_OVERLAP_CHARS
+        return max_width > _STREAM_TEXT_OVERLAP_CHARS
+
+    escaped = False
+    in_character_class = False
+    for index, char in enumerate(remaining):
+        if escaped:
+            if char.isdigit() and char != "0":
+                return True
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == "[":
+            in_character_class = True
+            continue
+        if char == "]" and in_character_class:
+            in_character_class = False
+            continue
+        if in_character_class:
+            continue
+        if char in {"*", "+"}:
+            return True
+        if char == "?" and (index == 0 or remaining[index - 1] != "("):
+            return True
+        if char == "{" and re.match(r"(?:\d+(?:,\d*)?|,\d+)\}", remaining[index + 1 :]):
+            return True
+        if remaining.startswith("(?P=", index):
+            return True
+
+    return len(remaining) > _STREAM_TEXT_OVERLAP_CHARS
 
 
 def _pattern_literal_anchors(pattern: str) -> tuple[str, ...] | None:

--- a/modelaudit/scanners/flax_msgpack_scanner.py
+++ b/modelaudit/scanners/flax_msgpack_scanner.py
@@ -35,6 +35,7 @@ _STREAM_TEXT_OVERLAP_CHARS = 4096
 _UNBOUNDED_GETATTR_PATTERN = r"getattr\s*\(\s*.*\s*,\s*['\"]__.*__['\"]"
 _WHITESPACE_RUN_PATTERN = re.compile(r"\s+")
 _STREAM_SAFE_WHITESPACE_REPEAT_PATTERN = re.compile(r"\\s(?:[+*]|\{[01],\})")
+_JAX_TRANSFORM_DEDUP_METADATA_KEY = "flax_msgpack_jax_transform_findings"
 
 
 class _StreamCoverageStopped(Exception):
@@ -192,11 +193,28 @@ def _pattern_literal_anchors(pattern: str) -> tuple[str, ...] | None:
             continue
         if char == "|":
             return None
-        if char == "{":
+        if char in {"?", "*"}:
+            if current_run:
+                current_run.pop()
+            elif index > 0 and pattern[index - 1] == ")":
+                return None
             flush_run()
+            index += 1
+            continue
+        if char == "{":
             closing_index = pattern.find("}", index + 1)
             if closing_index == -1:
                 return None
+            repeat_range = pattern[index + 1 : closing_index]
+            repeat_match = re.fullmatch(r"(\d+)(?:,\d*)?", repeat_range)
+            if repeat_match is None:
+                return None
+            if int(repeat_match.group(1)) == 0:
+                if current_run:
+                    current_run.pop()
+                elif index > 0 and pattern[index - 1] == ")":
+                    return None
+            flush_run()
             index = closing_index + 1
             continue
         if char.isascii() and (char.isalnum() or char == "_"):
@@ -684,13 +702,14 @@ class FlaxMsgpackScanner(BaseScanner):
     @staticmethod
     def _add_jax_transform_check(transform: str, context: str, location: str, result: ScanResult) -> None:
         safe_location = _redact_evidence_location(location)
-        if any(
-            check.name == "JAX Transform Security Check"
-            and check.location == safe_location
-            and check.details.get("transform") == transform
-            for check in result.checks
-        ):
+        seen_findings = result._private_metadata.get(_JAX_TRANSFORM_DEDUP_METADATA_KEY)
+        if not isinstance(seen_findings, set):
+            seen_findings = set()
+            result._private_metadata[_JAX_TRANSFORM_DEDUP_METADATA_KEY] = seen_findings
+        finding_key = (safe_location, transform)
+        if finding_key in seen_findings:
             return
+        seen_findings.add(finding_key)
         result.add_check(
             name="JAX Transform Security Check",
             passed=False,

--- a/modelaudit/scanners/flax_msgpack_scanner.py
+++ b/modelaudit/scanners/flax_msgpack_scanner.py
@@ -33,6 +33,7 @@ _MAX_STREAM_SEQUENCE_EVIDENCE = 64
 _STREAM_MARKER_CHUNK_BYTES = 64 * 1024
 _STREAM_TEXT_CHUNK_BYTES = 64 * 1024
 _STREAM_TEXT_OVERLAP_CHARS = 4096
+_DEFAULT_MAX_STREAM_KEY_LENGTH = 1024 * 1024
 _UNBOUNDED_GETATTR_PATTERN = r"getattr\s*\(\s*.*\s*,\s*['\"]__.*__['\"]"
 _WHITESPACE_RUN_PATTERN = re.compile(r"\s+")
 _JAX_TRANSFORM_DEDUP_METADATA_KEY = "flax_msgpack_jax_transform_findings"
@@ -69,10 +70,10 @@ class _StreamMarkerReader:
     chunk_start: int = -1
     chunk: bytes = b""
 
-    def peek(self, offset: int) -> int | None:
+    def read(self, offset: int, max_bytes: int) -> bytes:
         chunk_offset = offset - self.chunk_start
-        if 0 <= chunk_offset < len(self.chunk):
-            return self.chunk[chunk_offset]
+        if chunk_offset >= 0 and chunk_offset + max_bytes <= len(self.chunk):
+            return self.chunk[chunk_offset : chunk_offset + max_bytes]
 
         source_offset = self.source.tell()
         try:
@@ -81,7 +82,11 @@ class _StreamMarkerReader:
             self.chunk = self.source.read(_STREAM_MARKER_CHUNK_BYTES)
         finally:
             self.source.seek(source_offset)
-        return self.chunk[0] if self.chunk else None
+        return self.chunk[:max_bytes]
+
+    def peek(self, offset: int) -> int | None:
+        prefix = self.read(offset, 1)
+        return prefix[0] if prefix else None
 
 
 @dataclass
@@ -115,6 +120,54 @@ class _FlaxStreamSummary:
     embedding_evidence: list[str] = field(default_factory=list)
     suspicious_tensor_count: int = 0
     bounded_text_chars: int = 0
+
+
+_MSGPACK_MARKER_HEADER_BYTES = {
+    0xC4: 2,
+    0xC5: 3,
+    0xC6: 5,
+    0xC7: 3,
+    0xC8: 4,
+    0xC9: 6,
+    0xCA: 5,
+    0xCB: 9,
+    0xCC: 2,
+    0xCD: 3,
+    0xCE: 5,
+    0xCF: 9,
+    0xD0: 2,
+    0xD1: 3,
+    0xD2: 5,
+    0xD3: 9,
+    0xD4: 2,
+    0xD5: 2,
+    0xD6: 2,
+    0xD7: 2,
+    0xD8: 2,
+    0xD9: 2,
+    0xDA: 3,
+    0xDB: 5,
+    0xDC: 3,
+    0xDD: 5,
+    0xDE: 3,
+    0xDF: 5,
+}
+
+
+def _msgpack_marker_header_bytes(marker: int) -> int:
+    return _MSGPACK_MARKER_HEADER_BYTES.get(marker, 1)
+
+
+def _msgpack_declared_data_bytes(marker: int, prefix: bytes) -> int | None:
+    if 0xA0 <= marker <= 0xBF:
+        return marker & 0x1F
+    if marker in {0xC4, 0xC7, 0xD9} and len(prefix) >= 2:
+        return prefix[1]
+    if marker in {0xC5, 0xC8, 0xDA} and len(prefix) >= 3:
+        return int.from_bytes(prefix[1:3], "big")
+    if marker in {0xC6, 0xC9, 0xDB} and len(prefix) >= 5:
+        return int.from_bytes(prefix[1:5], "big")
+    return {0xD4: 1, 0xD5: 2, 0xD6: 4, 0xD7: 8, 0xD8: 16}.get(marker)
 
 
 def _matching_jax_transforms(key_str: str, value_str: str) -> list[str]:
@@ -429,6 +482,10 @@ class FlaxMsgpackScanner(BaseScanner):
         self.max_structure_nodes = self._positive_int_config(
             "max_msgpack_structure_nodes",
             self.DEFAULT_MAX_STRUCTURE_NODES,
+        )
+        self.max_stream_key_length = self._positive_int_config(
+            "max_msgpack_key_length",
+            _DEFAULT_MAX_STREAM_KEY_LENGTH,
         )
         self.max_bounded_text_chars = self._positive_int_config(
             "max_msgpack_bounded_text_chars",
@@ -2106,6 +2163,7 @@ class FlaxMsgpackScanner(BaseScanner):
                 "error_type": type(error).__name__,
                 "max_msgpack_decode_bytes": self.max_msgpack_decode_bytes,
                 "max_items_per_container": self.max_items_per_container,
+                "max_msgpack_key_length": self.max_stream_key_length,
             },
         )
         result.finish(success=False)
@@ -2150,7 +2208,10 @@ class FlaxMsgpackScanner(BaseScanner):
         result.add_check(
             name="Msgpack Stream Object Limit",
             passed=False,
-            message=f"Msgpack stream object count exceeds configured limit ({self.max_msgpack_stream_objects})",
+            message=(
+                "Msgpack stream has unvalidated trailing data after the configured object limit "
+                f"({self.max_msgpack_stream_objects})"
+            ),
             severity=IssueSeverity.WARNING,
             location=path,
             details={
@@ -2197,8 +2258,7 @@ class FlaxMsgpackScanner(BaseScanner):
     ) -> _StreamValue:
         if state.node_budget_reported:
             summary.analysis_complete = False
-            unpacker.skip()
-            return _StreamValue("skipped")
+            raise _StreamCoverageStopped
         if count_node:
             state.nodes += 1
         if count_node and state.nodes > state.max_nodes:
@@ -2212,8 +2272,7 @@ class FlaxMsgpackScanner(BaseScanner):
                     maximum=state.max_nodes,
                 )
                 state.node_budget_reported = True
-            unpacker.skip()
-            return _StreamValue("skipped")
+            raise _StreamCoverageStopped
 
         if depth > self.max_recursion_depth:
             summary.analysis_complete = False
@@ -2235,8 +2294,7 @@ class FlaxMsgpackScanner(BaseScanner):
                     details={"depth": depth, "max_allowed": self.max_recursion_depth},
                 )
                 state.recursion_limit_reported = True
-            unpacker.skip()
-            return _StreamValue("skipped")
+            raise _StreamCoverageStopped
 
         marker = marker_reader.peek(unpacker.tell())
         if marker is not None and (0x80 <= marker <= 0x8F or marker in {0xDE, 0xDF}):
@@ -2286,6 +2344,20 @@ class FlaxMsgpackScanner(BaseScanner):
             }
 
             for index in range(visible_items):
+                key_offset = unpacker.tell()
+                key_prefix = marker_reader.read(key_offset, 6)
+                if key_prefix:
+                    declared_key_length = _msgpack_declared_data_bytes(key_prefix[0], key_prefix)
+                    if declared_key_length is not None and declared_key_length > self.max_stream_key_length:
+                        summary.analysis_complete = False
+                        self._report_stream_decode_limit(
+                            state,
+                            result,
+                            path,
+                            "map key length "
+                            f"{declared_key_length} exceeds max_msgpack_key_length({self.max_stream_key_length})",
+                        )
+                        raise _StreamCoverageStopped
                 key_value = self._read_stream_value(
                     unpacker,
                     marker_reader,
@@ -2301,6 +2373,20 @@ class FlaxMsgpackScanner(BaseScanner):
                 key = key_value.value
                 if key_value.is_container or key_value.type_name == "skipped":
                     key = f"<{key_value.type_name}_key>"
+                key_length: int | None = None
+                if HAS_MSGPACK and isinstance(key, msgpack.ExtType):
+                    key_length = len(key.data)
+                elif isinstance(key, str | bytes | bytearray):
+                    key_length = len(key)
+                if key_length is not None and key_length > self.max_stream_key_length:
+                    summary.analysis_complete = False
+                    self._report_stream_decode_limit(
+                        state,
+                        result,
+                        path,
+                        f"map key length {key_length} exceeds max_msgpack_key_length({self.max_stream_key_length})",
+                    )
+                    raise _StreamCoverageStopped
                 key_str, safe_key_str = self._analyze_stream_key(key, location, result, summary)
                 key_text = _text_for_security_matching(key)
                 key_location = f"{location}/{safe_key_str}" if location else safe_key_str
@@ -2455,21 +2541,32 @@ class FlaxMsgpackScanner(BaseScanner):
                 while True:
                     previous_offset = unpacker.tell()
                     if len(object_types) >= self.max_msgpack_stream_objects:
-                        try:
-                            unpacker.skip()
-                        except Exception as error:
-                            if self._is_msgpack_out_of_data(error):
-                                current_offset = unpacker.tell()
-                                if current_offset == previous_offset and previous_offset == stream_size:
-                                    break
-                                self._add_msgpack_truncated_stream_check(
-                                    result,
-                                    path,
-                                    stream_offset=current_offset,
-                                    stream_size=stream_size,
-                                )
-                                return None
-                            raise
+                        if previous_offset == stream_size:
+                            break
+                        marker = marker_reader.peek(previous_offset)
+                        required_header_bytes = 1 if marker is None else _msgpack_marker_header_bytes(marker)
+                        remaining_bytes = stream_size - previous_offset
+                        marker_prefix = marker_reader.read(previous_offset, required_header_bytes)
+                        declared_data_bytes = (
+                            None if marker is None else _msgpack_declared_data_bytes(marker, marker_prefix)
+                        )
+                        scalar_is_truncated = (
+                            declared_data_bytes is not None
+                            and remaining_bytes < required_header_bytes + declared_data_bytes
+                        )
+                        if (
+                            marker is None
+                            or marker == 0xC1
+                            or remaining_bytes < required_header_bytes
+                            or scalar_is_truncated
+                        ):
+                            self._add_msgpack_truncated_stream_check(
+                                result,
+                                path,
+                                stream_offset=previous_offset,
+                                stream_size=stream_size,
+                            )
+                            return None
                         self._add_msgpack_stream_object_limit_check(result, path, len(object_types))
                         return None
 
@@ -2506,6 +2603,7 @@ class FlaxMsgpackScanner(BaseScanner):
                     if object_index == 0:
                         primary_summary.top_level_type = value.type_name
         except _StreamCoverageStopped:
+            result.finish(success=False)
             return None
         except Exception as error:
             if self._is_msgpack_limit_error(error):

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -4,6 +4,7 @@ import struct
 import subprocess
 import sys
 import textwrap
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, cast
 
@@ -18,7 +19,7 @@ from modelaudit.cache import get_cache_manager, reset_cache_manager
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.integrations.sarif_formatter import _create_results
 from modelaudit.scanner_results import INCONCLUSIVE_SCAN_OUTCOME
-from modelaudit.scanners.base import CheckStatus, IssueSeverity, ScanResult
+from modelaudit.scanners.base import Check, CheckStatus, IssueSeverity, ScanResult
 from modelaudit.scanners.flax_msgpack_scanner import (
     _UNBOUNDED_GETATTR_PATTERN,
     FlaxMsgpackScanner,
@@ -391,6 +392,20 @@ def test_flax_msgpack_deduplicates_transform_in_key_and_value(tmp_path: Path) ->
         if check.name == "JAX Transform Security Check" and check.details.get("transform") == "runtime_eval"
     ]
     assert len(transform_checks) == 1
+
+
+def test_flax_msgpack_jax_transform_dedup_does_not_scan_existing_checks() -> None:
+    class NonIterableChecks(list[Check]):
+        def __iter__(self) -> Iterator[Check]:
+            raise AssertionError("transform deduplication must not scan prior checks")
+
+    result = ScanResult("flax_msgpack")
+    result.checks = NonIterableChecks()
+
+    FlaxMsgpackScanner._add_jax_transform_check("runtime_eval", "runtime_eval", "root/key", result)
+    FlaxMsgpackScanner._add_jax_transform_check("runtime_eval", "runtime_eval", "root/key", result)
+
+    assert len(result.checks) == 1
 
 
 @pytest.mark.parametrize(
@@ -861,6 +876,27 @@ def test_flax_msgpack_large_binary_fails_closed_for_stream_unsafe_custom_pattern
 ) -> None:
     path = tmp_path / "large_binary_custom_pattern.msgpack"
     create_msgpack_file(path, {"params": {"blob": (b"x" * (64 * 1024)) + payload}})
+
+    result = FlaxMsgpackScanner(config={"suspicious_patterns": [pattern]}).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    coverage_check = next(check for check in result.checks if check.name == "Flax MessagePack Binary Pattern Coverage")
+    assert coverage_check.details["pattern"] == pattern
+
+
+@pytest.mark.parametrize(
+    ("pattern", "suffix"),
+    [(r"foo.*bar?END", b"baEND"), (r"foo.*(bar)?END", b"END")],
+)
+def test_flax_msgpack_large_binary_fails_closed_when_optional_regex_anchor_is_absent(
+    tmp_path: Path,
+    pattern: str,
+    suffix: bytes,
+) -> None:
+    path = tmp_path / "large_binary_optional_anchor.msgpack"
+    payload = b"foo" + (b"x" * 70000) + suffix
+    create_msgpack_file(path, {"params": {"blob": payload}})
 
     result = FlaxMsgpackScanner(config={"suspicious_patterns": [pattern]}).scan(str(path))
 

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -15,7 +15,6 @@ pytest.importorskip("msgpack")
 
 import msgpack
 
-import modelaudit.scanners.flax_msgpack_scanner as flax_msgpack_scanner
 from modelaudit.cache import get_cache_manager, reset_cache_manager
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.integrations.sarif_formatter import _create_results
@@ -25,6 +24,7 @@ from modelaudit.scanners.flax_msgpack_scanner import (
     _UNBOUNDED_GETATTR_PATTERN,
     FlaxMsgpackScanner,
     _matching_jax_transforms,
+    _pattern_has_stream_unsafe_repeat,
 )
 from modelaudit.utils.file.detection import FLAX_MSGPACK_STRUCTURE_READ_BYTES
 
@@ -798,7 +798,7 @@ def test_flax_msgpack_large_binary_preserves_cross_chunk_findings_without_re_par
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(flax_msgpack_scanner, "_get_regex_parser", lambda: None)
+    monkeypatch.setattr("modelaudit.scanners.flax_msgpack_scanner._get_regex_parser", lambda: None)
     path = tmp_path / "large_binary_pattern_without_re_parser.msgpack"
     stream_chunk_bytes = 64 * 1024
     prefix = b"x" * (stream_chunk_bytes - 3)
@@ -814,7 +814,7 @@ def test_flax_msgpack_large_binary_preserves_cross_chunk_findings_without_re_par
 
 
 def test_stream_repeat_fallback_without_re_parser(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(flax_msgpack_scanner, "_get_regex_parser", lambda: None)
+    monkeypatch.setattr("modelaudit.scanners.flax_msgpack_scanner._get_regex_parser", lambda: None)
 
     for pattern in (
         r"os\.system",
@@ -824,7 +824,7 @@ def test_stream_repeat_fallback_without_re_parser(monkeypatch: pytest.MonkeyPatc
         r"eval\s{1,}\(",
         r"[\s+]",
     ):
-        assert flax_msgpack_scanner._pattern_has_stream_unsafe_repeat(pattern) is False
+        assert _pattern_has_stream_unsafe_repeat(pattern) is False
 
     for pattern in (
         r"eval.*\(",
@@ -835,7 +835,7 @@ def test_stream_repeat_fallback_without_re_parser(monkeypatch: pytest.MonkeyPatc
         r"BEGIN.{5000}END",
         r"\\s+",
     ):
-        assert flax_msgpack_scanner._pattern_has_stream_unsafe_repeat(pattern) is True
+        assert _pattern_has_stream_unsafe_repeat(pattern) is True
 
 
 def test_flax_msgpack_large_binary_does_not_join_tokens_across_invalid_utf8(tmp_path: Path) -> None:
@@ -1714,6 +1714,19 @@ def test_flax_msgpack_redacts_openai_project_key_across_persisted_outputs(tmp_pa
         assert cache_stats["cache_hits"] == 1
     finally:
         reset_cache_manager()
+
+
+def test_flax_msgpack_unresolved_binary_pattern_aggregate_exits_with_error_and_is_not_cached(tmp_path: Path) -> None:
+    path = tmp_path / "large_binary_unbounded_pattern.msgpack"
+    gap = b"x" * (64 * 1024 + 4096 + 100)
+    payload = b"getattr(object" + gap + b", '__custom_hook__')"
+    create_msgpack_file(path, {"params": {"blob": payload}})
+
+    _assert_inconclusive_aggregate_not_cached(
+        path,
+        FlaxMsgpackScanner.BINARY_PATTERN_INCONCLUSIVE_REASON,
+        tmp_path / "binary-pattern-cache",
+    )
 
 
 def test_flax_msgpack_stringifies_extension_metadata_keys(tmp_path: Path) -> None:

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -15,6 +15,7 @@ pytest.importorskip("msgpack")
 
 import msgpack
 
+import modelaudit.scanners.flax_msgpack_scanner as flax_msgpack_scanner
 from modelaudit.cache import get_cache_manager, reset_cache_manager
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.integrations.sarif_formatter import _create_results
@@ -793,6 +794,50 @@ def test_flax_msgpack_large_binary_preserves_cross_chunk_findings(tmp_path: Path
     )
 
 
+def test_flax_msgpack_large_binary_preserves_cross_chunk_findings_without_re_parser(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(flax_msgpack_scanner, "_get_regex_parser", lambda: None)
+    path = tmp_path / "large_binary_pattern_without_re_parser.msgpack"
+    stream_chunk_bytes = 64 * 1024
+    prefix = b"x" * (stream_chunk_bytes - 3)
+    create_msgpack_file(path, {"params": {"blob": prefix + b"os.system('id')"}})
+
+    result = FlaxMsgpackScanner().scan(str(path))
+
+    assert result.success is False
+    assert any(
+        issue.severity == IssueSeverity.CRITICAL and issue.message == r"Suspicious code pattern detected: os\.system"
+        for issue in result.issues
+    )
+
+
+def test_stream_repeat_fallback_without_re_parser(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(flax_msgpack_scanner, "_get_regex_parser", lambda: None)
+
+    for pattern in (
+        r"os\.system",
+        r"eval\s*\(",
+        r"import\s+os",
+        r"eval\s{0,}\(",
+        r"eval\s{1,}\(",
+        r"[\s+]",
+    ):
+        assert flax_msgpack_scanner._pattern_has_stream_unsafe_repeat(pattern) is False
+
+    for pattern in (
+        r"eval.*\(",
+        r"eval\s{2,}\(",
+        r"(foo)?bar",
+        r"(foo)\1",
+        r"(?P<name>foo)(?P=name)",
+        r"BEGIN.{5000}END",
+        r"\\s+",
+    ):
+        assert flax_msgpack_scanner._pattern_has_stream_unsafe_repeat(pattern) is True
+
+
 def test_flax_msgpack_large_binary_does_not_join_tokens_across_invalid_utf8(tmp_path: Path) -> None:
     path = tmp_path / "large_binary_invalid_utf8.msgpack"
     payload = (b"x" * (64 * 1024 + 100)) + b"ev\xffal("
@@ -864,9 +909,13 @@ def test_flax_msgpack_large_binary_benign_getattr_prose_is_not_inconclusive(tmp_
 @pytest.mark.parametrize(
     ("pattern", "payload"),
     [
-        (r"(?:eval|harmless_long_anchor).*\(", b"eval" + (b"x" * 70000) + b"("),
-        (r"eval\s{2,}\(", b"eval" + (b" " * 70000) + b"("),
-        (r"BEGIN.{5000}END", b"BEGIN" + (b"x" * 5000) + b"END"),
+        pytest.param(
+            r"(?:eval|harmless_long_anchor).*\(",
+            b"eval" + (b"x" * 70000) + b"(",
+            id="unbounded-alternation",
+        ),
+        pytest.param(r"eval\s{2,}\(", b"eval" + (b" " * 70000) + b"(", id="unbounded-whitespace"),
+        pytest.param(r"BEGIN.{5000}END", b"BEGIN" + (b"x" * 5000) + b"END", id="wide-bounded-repeat"),
     ],
 )
 def test_flax_msgpack_large_binary_fails_closed_for_stream_unsafe_custom_patterns(

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -619,21 +619,81 @@ def test_flax_msgpack_scalar_trailing_junk_stays_warning(tmp_path: Path) -> None
     assert stream_checks[0].details["trailing_objects_are_container_like"] is False
 
 
-def test_flax_msgpack_incomplete_trailing_object_fails_closed(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("trailer_name", "trailer"),
+    [
+        ("partial_fixmap", b"\x81\xa1"),
+        ("partial_array16", b"\xdc"),
+        ("partial_array32", b"\xdd"),
+        ("partial_map16", b"\xde"),
+        ("partial_map32", b"\xdf"),
+    ],
+)
+def test_flax_msgpack_incomplete_trailing_object_fails_closed(
+    tmp_path: Path,
+    trailer_name: str,
+    trailer: bytes,
+) -> None:
     """A partial trailing object must not disappear into the streaming unpacker buffer."""
-    path = tmp_path / "incomplete_trailing_object.msgpack"
-    payload = msgpack.packb({"params": {"w": [1, 2, 3]}}, use_bin_type=True) + b"\x81\xa1"
+    path = tmp_path / f"incomplete_trailing_{trailer_name}.msgpack"
+    payload = msgpack.packb({"params": {"w": [1, 2, 3]}}, use_bin_type=True) + trailer
     path.write_bytes(payload)
 
     result = FlaxMsgpackScanner().scan(str(path))
 
     assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert result.metadata["scan_outcome_reasons"] == [FlaxMsgpackScanner.TRUNCATED_STREAM_INCONCLUSIVE_REASON]
     assert any(
         check.name == "Msgpack Parse Check"
         and check.status == CheckStatus.FAILED
         and check.details["parse_error"] == "incomplete trailing msgpack object"
+        and check.details["analysis_incomplete"] is True
+        and check.details["stream_size"] == len(payload)
         for check in result.checks
     )
+
+
+def test_flax_msgpack_clean_eof_and_valid_width_prefixed_trailer_remain_complete(tmp_path: Path) -> None:
+    """Clean EOF and valid concatenated containers must remain distinguishable from truncation."""
+    primary = msgpack.packb({"params": {"w": [1, 2, 3]}}, use_bin_type=True)
+    clean_path = tmp_path / "clean_eof.msgpack"
+    clean_path.write_bytes(primary)
+    concatenated_path = tmp_path / "valid_array16_trailer.msgpack"
+    concatenated_path.write_bytes(primary + msgpack.packb(list(range(16)), use_bin_type=True))
+
+    clean_result = FlaxMsgpackScanner().scan(str(clean_path))
+    concatenated_result = FlaxMsgpackScanner().scan(str(concatenated_path))
+
+    assert clean_result.success is True
+    assert "scan_outcome" not in clean_result.metadata
+    assert concatenated_result.success is True
+    assert concatenated_result.metadata["msgpack_object_count"] == 2
+    assert FlaxMsgpackScanner.TRUNCATED_STREAM_INCONCLUSIVE_REASON not in concatenated_result.metadata.get(
+        "scan_outcome_reasons", []
+    )
+
+
+def test_flax_msgpack_truncated_width_prefixed_trailer_exits_with_error_and_is_not_cached(tmp_path: Path) -> None:
+    path = tmp_path / "truncated_map16_trailer.msgpack"
+    path.write_bytes(msgpack.packb({"params": {"w": [1]}}, use_bin_type=True) + b"\xde")
+
+    _assert_inconclusive_aggregate_not_cached(
+        path,
+        FlaxMsgpackScanner.TRUNCATED_STREAM_INCONCLUSIVE_REASON,
+        tmp_path / "truncated-stream-cache",
+    )
+
+
+def test_flax_msgpack_truncated_trailer_at_stream_object_limit_fails_closed(tmp_path: Path) -> None:
+    path = tmp_path / "truncated_trailer_at_object_limit.msgpack"
+    path.write_bytes(msgpack.packb({"params": {"w": [1]}}, use_bin_type=True) + b"\xdc")
+
+    result = FlaxMsgpackScanner(config={"max_msgpack_stream_objects": 1}).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome_reasons"] == [FlaxMsgpackScanner.TRUNCATED_STREAM_INCONCLUSIVE_REASON]
+    assert not [check for check in result.checks if check.name == "Msgpack Stream Object Limit"]
 
 
 def test_flax_msgpack_caps_trailing_stream_object_count(tmp_path: Path) -> None:

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -233,6 +233,36 @@ def test_flax_msgpack_byte_encoded_dangerous_top_level_key_is_critical(tmp_path:
     )
 
 
+def test_flax_msgpack_byte_encoded_standard_key_is_recognized(tmp_path: Path) -> None:
+    path = tmp_path / "byte_params_key.msgpack"
+    create_msgpack_file(path, {b"params": {b"weights": b"\x00" * 4096}})
+
+    result = FlaxMsgpackScanner().scan(str(path))
+
+    assert result.success is True
+    assert any(
+        check.name == "Flax Checkpoint Format Detection"
+        and check.status == CheckStatus.PASSED
+        and check.details["found_standard_keys"] == ["params"]
+        for check in result.checks
+    )
+
+
+def test_flax_msgpack_byte_encoded_shape_key_is_validated(tmp_path: Path) -> None:
+    path = tmp_path / "byte_shape_key.msgpack"
+    create_msgpack_file(path, {b"params": {b"shape": [-1, 2]}})
+
+    result = FlaxMsgpackScanner().scan(str(path))
+
+    assert result.success is True
+    assert any(
+        check.name == "Tensor Shape Validation"
+        and check.details["shape"] == [-1, 2]
+        and check.location == "root/params"
+        for check in result.checks
+    )
+
+
 def test_flax_msgpack_byte_encoded_function_metadata_key_is_value_aware(tmp_path: Path) -> None:
     path = tmp_path / "byte_restore_fn_key.msgpack"
     create_msgpack_file(path, {"params": {"w": [1, 2, 3]}, b"restore_fn": "eval"})

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -518,8 +518,8 @@ def test_flax_msgpack_scans_trailing_msgpack_objects(tmp_path: Path) -> None:
     )
 
 
-def test_flax_msgpack_preserves_trailing_scan_after_first_object_exhausts_node_budget(tmp_path: Path) -> None:
-    """A large first object must not starve a small malicious trailing object."""
+def test_flax_msgpack_stops_when_first_object_exhausts_node_budget(tmp_path: Path) -> None:
+    """Coverage exhaustion must stop before unbounded work on the object remainder."""
     path = tmp_path / "trailing_after_budget.msgpack"
     payload = msgpack.packb({"params": list(range(8))}, use_bin_type=True)
     payload += msgpack.packb("eval('x')", use_bin_type=True)
@@ -529,12 +529,8 @@ def test_flax_msgpack_preserves_trailing_scan_after_first_object_exhausts_node_b
 
     assert result.success is False
     assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
-    assert any(
-        issue.severity == IssueSeverity.CRITICAL
-        and issue.message == r"Suspicious code pattern detected: eval\s*\("
-        and issue.location == "root[msgpack_object_1]"
-        for issue in result.issues
-    )
+    assert FlaxMsgpackScanner.STRUCTURE_BUDGET_INCONCLUSIVE_REASON in result.metadata["scan_outcome_reasons"]
+    assert not any(issue.location == "root[msgpack_object_1]" for issue in result.issues)
 
 
 def test_flax_msgpack_trailing_objects_do_not_dilute_primary_scan_budget(tmp_path: Path) -> None:
@@ -571,12 +567,35 @@ def test_flax_msgpack_trailing_objects_share_an_aggregate_node_budget(tmp_path: 
     assert result.success is False
     assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
     assert FlaxMsgpackScanner.STRUCTURE_BUDGET_INCONCLUSIVE_REASON in result.metadata["scan_outcome_reasons"]
-    assert result.metadata["msgpack_object_count"] == 13
-    assert result.metadata["msgpack_stream_analyzed_nodes"] <= 10
-    assert result.metadata["msgpack_stream_node_budget"] == 10
     budget_checks = [check for check in result.checks if check.name == "Flax MessagePack Structure Budget"]
     assert len(budget_checks) == 1
     assert budget_checks[0].details["max_allowed"] == 5
+
+
+def test_flax_msgpack_node_budget_does_not_call_unbounded_skip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fallback = pytest.importorskip("msgpack.fallback")
+
+    def fail_skip(_self: Any) -> None:
+        raise AssertionError("coverage exhaustion must not skip an unbounded nested object")
+
+    monkeypatch.setattr(fallback.Unpacker, "skip", fail_skip)
+    monkeypatch.setattr(msgpack, "Unpacker", fallback.Unpacker)
+    path = tmp_path / "nested_after_node_budget.msgpack"
+    create_msgpack_file(path, [[0] * 100])
+
+    result = FlaxMsgpackScanner(
+        config={
+            "max_items_per_container": 10,
+            "max_msgpack_structure_nodes": 1,
+        }
+    ).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome_reasons"] == [FlaxMsgpackScanner.STRUCTURE_BUDGET_INCONCLUSIVE_REASON]
+    assert not [check for check in result.checks if check.name == "Msgpack Parse Check"]
 
 
 def test_flax_msgpack_benign_trailing_dict_object_is_info_only(tmp_path: Path) -> None:
@@ -696,6 +715,29 @@ def test_flax_msgpack_truncated_trailer_at_stream_object_limit_fails_closed(tmp_
     assert not [check for check in result.checks if check.name == "Msgpack Stream Object Limit"]
 
 
+@pytest.mark.parametrize(
+    "trailer",
+    [
+        pytest.param(b"\xa5ab", id="fixstr-body"),
+        pytest.param(b"\xd9\x05ab", id="str8-body"),
+        pytest.param(b"\xc6\x00\x00\x00\x05ab", id="bin32-body"),
+        pytest.param(b"\xc1", id="reserved-marker"),
+    ],
+)
+def test_flax_msgpack_truncated_scalar_at_stream_object_limit_fails_closed(
+    tmp_path: Path,
+    trailer: bytes,
+) -> None:
+    path = tmp_path / "truncated_scalar_at_object_limit.msgpack"
+    path.write_bytes(msgpack.packb({"params": {"w": [1]}}, use_bin_type=True) + trailer)
+
+    result = FlaxMsgpackScanner(config={"max_msgpack_stream_objects": 1}).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome_reasons"] == [FlaxMsgpackScanner.TRUNCATED_STREAM_INCONCLUSIVE_REASON]
+    assert not [check for check in result.checks if check.name == "Msgpack Stream Object Limit"]
+
+
 def test_flax_msgpack_caps_trailing_stream_object_count(tmp_path: Path) -> None:
     """Too many trailing msgpack objects should fail closed without materializing the full stream."""
     path = tmp_path / "many_objects.msgpack"
@@ -715,6 +757,99 @@ def test_flax_msgpack_caps_trailing_stream_object_count(tmp_path: Path) -> None:
     ]
     assert len(object_limit_checks) == 1
     assert object_limit_checks[0].details["max_msgpack_stream_objects"] == 4
+
+
+def test_flax_msgpack_stream_object_limit_does_not_decode_extra_object(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fallback = pytest.importorskip("msgpack.fallback")
+
+    def fail_skip(_self: Any) -> None:
+        raise AssertionError("object limit must not decode the extra object")
+
+    monkeypatch.setattr(fallback.Unpacker, "skip", fail_skip)
+    monkeypatch.setattr(msgpack, "Unpacker", fallback.Unpacker)
+    path = tmp_path / "large_extra_object.msgpack"
+    path.write_bytes(msgpack.packb({}, use_bin_type=True) + msgpack.packb([0] * 100, use_bin_type=True))
+
+    result = FlaxMsgpackScanner(config={"max_msgpack_stream_objects": 1}).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["operational_error_reason"] == "msgpack_stream_object_limit_exceeded"
+    assert not [check for check in result.checks if check.name == "Msgpack Parse Check"]
+
+
+@pytest.mark.parametrize(
+    "trailer",
+    [
+        pytest.param(b"\x92\x01", id="partial-array-body"),
+        pytest.param(b"\x81\xa1k", id="partial-map-body"),
+    ],
+)
+def test_flax_msgpack_stream_object_limit_reports_unvalidated_container_trailer(
+    tmp_path: Path,
+    trailer: bytes,
+) -> None:
+    path = tmp_path / "unvalidated_container_at_object_limit.msgpack"
+    path.write_bytes(msgpack.packb({}, use_bin_type=True) + trailer)
+
+    result = FlaxMsgpackScanner(config={"max_msgpack_stream_objects": 1}).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["operational_error_reason"] == "msgpack_stream_object_limit_exceeded"
+    limit_check = next(check for check in result.checks if check.name == "Msgpack Stream Object Limit")
+    assert "unvalidated trailing data" in limit_check.message
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        pytest.param("x" * 17, id="string"),
+        pytest.param(b"x" * 17, id="binary"),
+        pytest.param(msgpack.ExtType(1, b"x" * 17), id="extension"),
+    ],
+)
+def test_flax_msgpack_fails_closed_before_stringifying_oversized_map_key(tmp_path: Path, key: object) -> None:
+    path = tmp_path / "oversized_key.msgpack"
+    create_msgpack_file(path, {key: 0})
+
+    result = FlaxMsgpackScanner(config={"max_msgpack_key_length": 16}).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome_reasons"] == [FlaxMsgpackScanner.DECODE_LIMIT_INCONCLUSIVE_REASON]
+    decode_check = next(check for check in result.checks if check.name == "Msgpack Decode Budget")
+    assert "map key length 17 exceeds max_msgpack_key_length(16)" in decode_check.details["error"]
+
+
+def test_flax_msgpack_oversized_map_key_is_rejected_before_unpack(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fallback = pytest.importorskip("msgpack.fallback")
+
+    def fail_unpack(_self: Any) -> object:
+        raise AssertionError("oversized map key must be rejected before scalar materialization")
+
+    monkeypatch.setattr(fallback.Unpacker, "unpack", fail_unpack)
+    monkeypatch.setattr(msgpack, "Unpacker", fallback.Unpacker)
+    path = tmp_path / "oversized_key_preflight.msgpack"
+    create_msgpack_file(path, {b"x" * 17: 0})
+
+    result = FlaxMsgpackScanner(config={"max_msgpack_key_length": 16}).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome_reasons"] == [FlaxMsgpackScanner.DECODE_LIMIT_INCONCLUSIVE_REASON]
+    assert not [check for check in result.checks if check.name == "Msgpack Parse Check"]
+
+
+def test_flax_msgpack_accepts_map_key_at_length_limit(tmp_path: Path) -> None:
+    path = tmp_path / "bounded_key.msgpack"
+    create_msgpack_file(path, {"params": {b"x" * 16: 0}})
+
+    result = FlaxMsgpackScanner(config={"max_msgpack_key_length": 16}).scan(str(path))
+
+    assert result.success is True
 
 
 def test_flax_msgpack_streaming_decode_does_not_call_unpackb(

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -736,6 +736,44 @@ def test_flax_msgpack_streaming_decode_does_not_call_unpackb(
     assert result.metadata.get("top_level_type") == "dict"
 
 
+def test_flax_msgpack_pure_python_unpacker_preserves_malicious_scalar_boundaries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fallback = pytest.importorskip("msgpack.fallback")
+    monkeypatch.setattr(msgpack, "Unpacker", fallback.Unpacker)
+    path = tmp_path / "pure_python_malicious.msgpack"
+    create_msgpack_file(path, {"params": {"w": [1, 2, 3]}, "__reduce__": "os.system"})
+
+    result = FlaxMsgpackScanner().scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["top_level_type"] == "dict"
+    assert any(
+        issue.severity == IssueSeverity.CRITICAL
+        and issue.message == "Suspicious object attribute detected: __reduce__"
+        and issue.location == "root/__reduce__"
+        for issue in result.issues
+    )
+    assert not any("Failed to parse msgpack data" in issue.message for issue in result.issues)
+
+
+def test_flax_msgpack_pure_python_unpacker_preserves_benign_scalar_boundaries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fallback = pytest.importorskip("msgpack.fallback")
+    monkeypatch.setattr(msgpack, "Unpacker", fallback.Unpacker)
+    path = tmp_path / "pure_python_benign.msgpack"
+    create_msgpack_file(path, {"params": {"w": [1, 2, 3]}, "metadata": "safe"})
+
+    result = FlaxMsgpackScanner().scan(str(path))
+
+    assert result.success is True
+    assert result.metadata["top_level_type"] == "dict"
+    assert not result.issues
+
+
 def test_flax_msgpack_event_walker_scans_nested_and_trailing_content(tmp_path: Path) -> None:
     """Nested and trailing content should be inspected one scalar at a time."""
     path = tmp_path / "event_walk.msgpack"

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -1,5 +1,9 @@
 import json
 import os
+import struct
+import subprocess
+import sys
+import textwrap
 from pathlib import Path
 from typing import Any
 
@@ -374,6 +378,30 @@ def test_flax_msgpack_trailing_objects_do_not_dilute_primary_scan_budget(tmp_pat
     )
 
 
+def test_flax_msgpack_trailing_objects_share_an_aggregate_node_budget(tmp_path: Path) -> None:
+    path = tmp_path / "bounded_trailing_stream.msgpack"
+    payload = msgpack.packb({"params": [1]}, use_bin_type=True)
+    payload += b"".join(msgpack.packb(["a", "b", "c", "d"], use_bin_type=True) for _ in range(12))
+    path.write_bytes(payload)
+
+    result = FlaxMsgpackScanner(
+        config={
+            "max_msgpack_stream_objects": 32,
+            "max_msgpack_structure_nodes": 5,
+        }
+    ).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert FlaxMsgpackScanner.STRUCTURE_BUDGET_INCONCLUSIVE_REASON in result.metadata["scan_outcome_reasons"]
+    assert result.metadata["msgpack_object_count"] == 13
+    assert result.metadata["msgpack_stream_analyzed_nodes"] <= 10
+    assert result.metadata["msgpack_stream_node_budget"] == 10
+    budget_checks = [check for check in result.checks if check.name == "Flax MessagePack Structure Budget"]
+    assert len(budget_checks) == 1
+    assert budget_checks[0].details["max_allowed"] == 5
+
+
 def test_flax_msgpack_benign_trailing_dict_object_is_info_only(tmp_path: Path) -> None:
     """Valid trailing dict objects should be scanned without warning-level stream noise."""
     path = tmp_path / "benign_two_objects.msgpack"
@@ -469,6 +497,193 @@ def test_flax_msgpack_streaming_decode_does_not_call_unpackb(
 
     assert result.success is True
     assert result.metadata.get("top_level_type") == "dict"
+
+
+def test_flax_msgpack_event_walker_scans_nested_and_trailing_content(tmp_path: Path) -> None:
+    """Nested and trailing content should be inspected one scalar at a time."""
+    path = tmp_path / "event_walk.msgpack"
+    payload = msgpack.packb(
+        {"params": {"notes": "evaluate(safely)", "weights": [1, 2, 3]}},
+        use_bin_type=True,
+    )
+    payload += msgpack.packb({"__reduce__": "os.system"}, use_bin_type=True)
+    path.write_bytes(payload)
+
+    result = FlaxMsgpackScanner().scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["msgpack_object_count"] == 2
+    assert any(
+        issue.message == "Suspicious object attribute detected: __reduce__"
+        and issue.location == "root[msgpack_object_1]/__reduce__"
+        for issue in result.issues
+    )
+    assert not any(issue.message == r"Suspicious code pattern detected: eval\s*\(" for issue in result.issues)
+
+
+def test_flax_msgpack_complex_map_keys_consume_node_budget(tmp_path: Path) -> None:
+    path = tmp_path / "complex_key.msgpack"
+    key_item_count = 1000
+    payload = b"\x81\xdc" + struct.pack(">H", key_item_count) + (b"\x01" * key_item_count) + b"\x00"
+    path.write_bytes(payload)
+
+    result = FlaxMsgpackScanner(
+        config={
+            "max_items_per_container": 2000,
+            "max_msgpack_structure_nodes": 2,
+        }
+    ).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    budget_checks = [check for check in result.checks if check.name == "Flax MessagePack Structure Budget"]
+    assert len(budget_checks) == 1
+    assert budget_checks[0].details["max_allowed"] == 2
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="resource peak RSS is unavailable on Windows")
+def test_flax_msgpack_large_container_peak_memory_is_bounded(tmp_path: Path) -> None:
+    """A large scalar array must not expand into a retained Python object graph."""
+    path = tmp_path / "large_array.msgpack"
+    item_count = 750_000
+    with path.open("wb") as output:
+        output.write(b"\xdd" + struct.pack(">I", item_count))
+        for start in range(0, item_count, 50_000):
+            payload = bytearray()
+            for value in range(start, min(start + 50_000, item_count)):
+                payload.append(0xCE)
+                payload.extend(struct.pack(">I", value))
+            output.write(payload)
+
+    repo_root = Path(__file__).resolve().parents[2]
+    script = textwrap.dedent(
+        """
+        import json
+        import resource
+        import sys
+
+        from modelaudit.scanners.flax_msgpack_scanner import FlaxMsgpackScanner
+
+        before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        result = FlaxMsgpackScanner(
+            config={
+                "max_file_read_size": 0,
+                "max_items_per_container": 800_000,
+                "max_msgpack_structure_nodes": 800_010,
+            }
+        ).scan(sys.argv[1])
+        after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        scale = 1 if sys.platform == "darwin" else 1024
+        print(
+            json.dumps(
+                {
+                    "peak_delta_mb": (after - before) * scale / (1024 * 1024),
+                    "top_level_type": result.metadata.get("top_level_type"),
+                    "scan_outcome": result.metadata.get("scan_outcome"),
+                }
+            )
+        )
+        """
+    )
+    env = {**os.environ, "PYTHONPATH": str(repo_root)}
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(path)],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=60,
+    )
+    metrics = json.loads(completed.stdout.strip().splitlines()[-1])
+
+    assert metrics["top_level_type"] == "list"
+    assert metrics["scan_outcome"] is None
+    assert metrics["peak_delta_mb"] < 20
+
+
+def test_flax_msgpack_large_binary_preserves_cross_chunk_findings(tmp_path: Path) -> None:
+    path = tmp_path / "large_binary_pattern.msgpack"
+    stream_chunk_bytes = 64 * 1024
+    prefix = b"x" * (stream_chunk_bytes - 3)
+    create_msgpack_file(path, {"params": {"blob": prefix + b"os.system('id')"}})
+
+    result = FlaxMsgpackScanner().scan(str(path))
+
+    assert result.success is False
+    assert any(
+        issue.severity == IssueSeverity.CRITICAL and issue.message == r"Suspicious code pattern detected: os\.system"
+        for issue in result.issues
+    )
+
+
+def test_flax_msgpack_large_binary_preserves_long_whitespace_pattern(tmp_path: Path) -> None:
+    path = tmp_path / "large_binary_whitespace_pattern.msgpack"
+    stream_chunk_bytes = 64 * 1024
+    prefix = b"x" * (stream_chunk_bytes - 5004)
+    payload = prefix + b"eval" + (b" " * 6000) + b"("
+    create_msgpack_file(path, {"params": {"blob": payload}})
+
+    result = FlaxMsgpackScanner().scan(str(path))
+
+    assert result.success is False
+    assert any(
+        issue.severity == IssueSeverity.CRITICAL and issue.message == r"Suspicious code pattern detected: eval\s*\("
+        for issue in result.issues
+    )
+    assert all(check.name != "Flax MessagePack Binary Pattern Coverage" for check in result.checks)
+
+
+def test_flax_msgpack_large_binary_preserves_long_whitespace_near_match(tmp_path: Path) -> None:
+    path = tmp_path / "large_binary_whitespace_near_match.msgpack"
+    stream_chunk_bytes = 64 * 1024
+    prefix = b"x" * (stream_chunk_bytes - 5010)
+    payload = prefix + b"evaluation" + (b" " * 6000) + b"("
+    create_msgpack_file(path, {"params": {"blob": payload}})
+
+    result = FlaxMsgpackScanner().scan(str(path))
+
+    assert result.success is True
+    assert all(check.name != "Code Pattern Security Check" for check in result.checks)
+    assert all(check.name != "Flax MessagePack Binary Pattern Coverage" for check in result.checks)
+
+
+def test_flax_msgpack_large_binary_fails_closed_for_unresolved_unbounded_pattern(tmp_path: Path) -> None:
+    path = tmp_path / "large_binary_unbounded_pattern.msgpack"
+    gap = b"x" * (64 * 1024 + 4096 + 100)
+    payload = b"getattr(object" + gap + b", '__custom_hook__')"
+    create_msgpack_file(path, {"params": {"blob": payload}})
+
+    result = FlaxMsgpackScanner().scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert FlaxMsgpackScanner.BINARY_PATTERN_INCONCLUSIVE_REASON in result.metadata["scan_outcome_reasons"]
+    coverage_check = next(check for check in result.checks if check.name == "Flax MessagePack Binary Pattern Coverage")
+    assert coverage_check.details["analysis_incomplete"] is True
+    assert coverage_check.details["stream_overlap_chars"] == 4096
+
+
+def test_flax_msgpack_streams_shape_validation_beyond_evidence_limit(tmp_path: Path) -> None:
+    malicious_path = tmp_path / "long_malicious_shape.msgpack"
+    benign_path = tmp_path / "long_benign_shape.msgpack"
+    create_msgpack_file(malicious_path, {"params": {"shape": [1] * 64 + [-1]}})
+    create_msgpack_file(benign_path, {"params": {"shape": [1] * 65}})
+
+    malicious_result = FlaxMsgpackScanner().scan(str(malicious_path))
+    benign_result = FlaxMsgpackScanner().scan(str(benign_path))
+
+    shape_check = next(check for check in malicious_result.checks if check.name == "Tensor Shape Validation")
+    assert shape_check.details["dimension_index"] == 64
+    assert shape_check.details["dimension"] == -1
+    assert shape_check.details["shape_item_count"] == 65
+    assert shape_check.details["shape_evidence_truncated"] is True
+    assert all(check.name != "Tensor Shape Validation" for check in benign_result.checks)
+
+
+def test_flax_msgpack_file_size_cap_is_opt_in() -> None:
+    assert FlaxMsgpackScanner().max_file_read_size == 0
+    assert FlaxMsgpackScanner(config={"max_file_read_size": 1024}).max_file_read_size == 1024
 
 
 def test_flax_msgpack_small_decode_buffer_accepts_stream_of_small_objects(tmp_path: Path) -> None:
@@ -665,6 +880,24 @@ def test_flax_msgpack_deep_nesting_is_inconclusive(tmp_path: Path) -> None:
         FlaxMsgpackScanner.RECURSION_LIMIT_INCONCLUSIVE_REASON,
         tmp_path / "benign-recursion-cache",
     )
+
+
+def test_flax_msgpack_depth_limit_reporting_is_bounded(tmp_path: Path) -> None:
+    path = tmp_path / "wide_beyond_depth.msgpack"
+    create_msgpack_file(path, [0] * 1000)
+
+    result = FlaxMsgpackScanner(
+        config={
+            "max_items_per_container": 2000,
+            "max_msgpack_structure_nodes": 5000,
+            "max_recursion_depth": 0,
+        }
+    ).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert sum(check.name == "Flax MessagePack Preanalysis Depth Limit" for check in result.checks) == 1
+    assert sum(check.name == "Recursion Depth Check" for check in result.checks) == 1
 
 
 def test_flax_msgpack_renamed_hidden_pattern_beyond_recursion_limit_is_inconclusive(tmp_path: Path) -> None:
@@ -1359,10 +1592,10 @@ def test_flax_msgpack_redacts_parse_error_evidence(
     secret = "PARSEERRORSECRET123456789"
     create_msgpack_file(path, {"params": {"w": [1, 2, 3]}})
 
-    def raise_parse_error(*_args: Any, **_kwargs: Any) -> bool:
+    def raise_parse_error(*_args: Any, **_kwargs: Any) -> object:
         raise ValueError(f"token={secret}")
 
-    monkeypatch.setattr(FlaxMsgpackScanner, "_drain_msgpack_unpacker", raise_parse_error)
+    monkeypatch.setattr(FlaxMsgpackScanner, "_read_stream_value", raise_parse_error)
 
     result = FlaxMsgpackScanner().scan(str(path))
     parse_check = next(check for check in result.checks if check.name == "Msgpack Parse Check")
@@ -1639,3 +1872,17 @@ def test_flax_msgpack_custom_suspicious_patterns_still_match(tmp_path: Path) -> 
     result = FlaxMsgpackScanner(config={"suspicious_patterns": [r"custom_threat"]}).scan(str(path))
 
     assert any(issue.details.get("pattern") == r"custom_threat" for issue in result.issues)
+
+
+def test_flax_msgpack_custom_long_suspicious_key_still_matches(tmp_path: Path) -> None:
+    path = tmp_path / "custom_long_key.msgpack"
+    suspicious_key = "dangerous_" + ("x" * 80)
+    create_msgpack_file(path, {suspicious_key: "safe"})
+
+    result = FlaxMsgpackScanner(config={"suspicious_keys": {suspicious_key}}).scan(str(path))
+
+    assert any(
+        check.name == "Object Attribute Security Check"
+        and check.message == f"Suspicious object attribute detected: {suspicious_key}"
+        for check in result.checks
+    )

--- a/tests/scanners/test_weight_distribution_scanner.py
+++ b/tests/scanners/test_weight_distribution_scanner.py
@@ -547,14 +547,14 @@ class TestWeightDistributionScanner:
         assert 3 in extreme_anomaly["details"]["affected_neurons"]
 
     @pytest.mark.skipif(False, reason="Dynamic skip - see test method")
-    def test_pytorch_model_scan(self):
+    def test_pytorch_model_scan(self, tmp_path: Path) -> None:
         """Test scanning a PyTorch model with anomalous weights"""
         if not has_torch():
             pytest.skip("PyTorch not installed")
 
         import torch
 
-        scanner = WeightDistributionScanner()
+        scanner = WeightDistributionScanner({"enable_unsafe_torch_load": True})
 
         # Create a simple model with anomalous weights
         class SimpleModel(torch.nn.Module):
@@ -570,29 +570,23 @@ class TestWeightDistributionScanner:
 
         model = SimpleModel()
 
-        # Save model
-        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
-            torch.save(model.state_dict(), f.name)
-            temp_path = f.name
+        model_path = tmp_path / "model.pt"
+        torch.save(model.state_dict(), model_path)
 
-        try:
-            result = scanner.scan(temp_path)
-            assert result.success
+        result = scanner.scan(str(model_path))
+        assert result.success
 
-            # If no issues found, it might be because the scanner couldn't extract weights
-            # This test is more about integration than specific anomaly detection
-            # So we'll make it more lenient
-            if len(result.issues) == 0:
-                # Check if any layers were analyzed
-                assert result.metadata.get("layers_analyzed", 0) >= 0
-            else:
-                # Check that anomaly was detected - could be either type
-                has_magnitude = any("abnormal weight magnitudes" in issue.message for issue in result.issues)
-                has_extreme = any("extremely large weight values" in issue.message for issue in result.issues)
-                assert has_magnitude or has_extreme
-
-        finally:
-            os.unlink(temp_path)
+        # If no issues found, it might be because the scanner couldn't extract weights
+        # This test is more about integration than specific anomaly detection
+        # So we'll make it more lenient
+        if len(result.issues) == 0:
+            # Check if any layers were analyzed
+            assert result.metadata.get("layers_analyzed", 0) >= 0
+        else:
+            # Check that anomaly was detected - could be either type
+            has_magnitude = any("abnormal weight magnitudes" in issue.message for issue in result.issues)
+            has_extreme = any("extremely large weight values" in issue.message for issue in result.issues)
+            assert has_magnitude or has_extreme
 
     @pytest.mark.skipif(False, reason="Dynamic skip - see test method")
     def test_keras_model_scan(self):


### PR DESCRIPTION
## Summary

- replace whole-file `msgpack.unpackb()` materialization with a token-by-token event walker
- remove the inherited total file-size cap while retaining bounded per-scalar decoding
- preserve security analysis for string and byte keys/values, JAX transforms, arrays, ExtType payloads, and trailing objects
- fail closed on depth, node, container, object-count, decode, key-length, and streaming-regex coverage limits
- retain bounded ML metadata and tensor-shape analysis without retaining the decoded object graph

## Security review

Adversarial review found and fixed additional false-negative, false-positive, denial-of-service, and memory-amplification paths:

- binary callable metadata bypassing exact dangerous-callable matching
- invalid UTF-8 collapsing into synthetic suspicious tokens
- alternations and wide/unbounded regexes missing cross-window matches
- quadratic default `getattr.*` matching on large scalar values
- benign large binary prose producing noisy inconclusive findings
- duplicate reports when a JAX transform appeared as both key and value
- byte-encoded Flax keys losing standard-key, shape, transform, and Orbax semantics
- long-gap binary matches, malicious dimensions beyond retained shape evidence, complex-key accounting, and recursion output amplification
- node/depth exhaustion and stream-object caps parsing unbounded subtrees through `Unpacker.skip()`
- large binary and ExtType map keys being repeatedly materialized into whole-key strings

Coverage exhaustion now stops immediately and fails closed. Oversized str/bin/ext map keys are rejected from their MessagePack length prefix before scalar materialization. Post-cap scalar truncation remains explicit, while container bytes beyond the object cap are reported as unvalidated trailing coverage.

## Validation

- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run --frozen pytest -q tests/scanners/test_flax_msgpack_scanner.py`: **151 passed**
- `tests/test_jax_flax_integration.py`: **8 skipped** by the repository's Python 3.13 lane gate
- randomized C and fallback unpacker probes found no additional parser mismatches
- 2,000,000-element fallback bound probe: about **1.1 s -> 0.02 s**
- 64 MiB declared binary-key probe exits before materialization with explicit decode-limit outcome
- scoped Ruff check and format: clean
- scoped mypy: clean
- `git diff --check`: clean

All inline review threads are resolved. Exact published head: `fffdf4b6a46b97fa948107cc38cd7dacc660eac1`. Exact tree: `e168f64aab720fecf015a4cf0dda74f9f26b4f82`.

Fixes #1505