### PR TITLE
test(dvc): isolate non-DVC symlink resolution

### DIFF
--- a/tests/utils/sources/test_dvc_integration.py
+++ b/tests/utils/sources/test_dvc_integration.py
@@ -397,9 +397,7 @@ class TestDvcIntegration:
         requires_symlinks: None,
     ) -> None:
         """Unrelated cache symlinks must stay on the generic symlink-handling path."""
-        hf_home = tmp_path / ".cache" / "huggingface"
-        monkeypatch.setenv("HF_HOME", str(hf_home))
-        snapshots = hf_home / "hub" / "models--test" / "snapshots" / "abc"
+        snapshots = tmp_path / "cache" / "snapshots" / "abc"
         snapshots.mkdir(parents=True)
         broken_link = snapshots / "model.bin"
         broken_link.symlink_to(Path("../../blobs/missing"))


### PR DESCRIPTION
## Summary

- keep the non-DVC symlink regression on the generic directory-scan path
- remove the accidental Hugging Face cache-layout dependency from the fixture
- preserve the assertion that unrelated symlinks never enter DVC-only strict resolution

## Root cause

The Nightly CI DVC regression placed its broken-symlink fixture inside a Hugging Face cache. The Hugging Face trust helper now intentionally calls `Path.resolve(strict=True)` to validate the blobs directory, so the test's global `Path.resolve` assertion failed before it reached the DVC isolation behavior it was meant to verify.

## Validation

- `tests/utils/sources/test_dvc_integration.py`: 126 passed
- focused regression: passed
- Ruff format/check: clean
- targeted mypy: clean
- full fast suite: 3,514 passed before four unrelated contention-sensitive failures; all four passed immediately in isolation
- full mypy remains blocked by the existing macOS `os.listxattr` / `os.getxattr` / `os.setxattr` stub errors in `modelaudit/cli.py` and `tests/test_cli.py`