### PR TITLE
fix: avoid exact-budget cloud pickle false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - detect operator attrgetter, itemgetter, and methodcaller archive-member Python paths to command execution while preserving benign accessor names
 - redact Keras and TensorFlow scanner detail fields that echo model-controlled configs, code indicators, archive members, and external references.
 - route security-relevant protocol-less binary pickle streams through pickle analysis even when file suffixes are misleading
+- avoid routing complete benign cloud objects as protocol-less pickle prefixes when they exactly consume the content-sniff budget
+- redact proxy and camel-case authorization evidence with scheme-bearing values without hiding benign counters
 - redact folded, placeholder-adjacent, proxy, and camel-case authorization evidence with scheme-bearing values without hiding benign counters
 - bound Keras ZIP config traversal for CVE detectors and fail closed when config.json coverage budgets are exhausted
 - redact MLflow registry, source, telemetry, and client exception credentials before logging, printing, or analytics export

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -1810,6 +1810,7 @@ def _detect_cloud_content_route_format(
     size_is_known = sniff_budget.prefix_is_complete(file_url) if sniff_budget is not None else size < prefix_limit
 
     from modelaudit.utils.file.detection import (
+        PICKLE_ROUTING_INCONCLUSIVE_FORMAT,
         PROTO0_1_MAX_PROBE_BYTES,
         _could_start_proto0_or_1_pickle,
         _is_cntk_signature,
@@ -1870,21 +1871,45 @@ def _detect_cloud_content_route_format(
         pickle_probe_is_prefix=not size_is_known,
     )
     if (
-        detected_format == "pickle"
-        and sniff_budget is not None
-        and sniff_budget.remaining_bytes == 0
+        sniff_budget is not None
         and not size_is_known
-        and _get_cloud_content_size_for_routing(fs, file_url) == len(prefix)
+        and detected_format in {"pickle", PICKLE_ROUTING_INCONCLUSIVE_FORMAT}
     ):
-        detected_format = detect_format_from_magic_bytes(
-            prefix[:4],
-            prefix[:8],
-            prefix[:16],
-            len(prefix),
-            None,
-            pickle_probe_sample=prefix,
-            pickle_probe_is_prefix=False,
-        )
+        cached_prefix = sniff_budget.cached_prefix(file_url)
+        try:
+            proven_size = _get_cloud_content_size_for_routing(fs, file_url)
+        except ValueError:
+            complete_prefix_format = detect_format_from_magic_bytes(
+                cached_prefix[:4],
+                cached_prefix[:8],
+                cached_prefix[:16],
+                len(cached_prefix),
+                None,
+                pickle_probe_sample=cached_prefix,
+                pickle_probe_is_prefix=False,
+            )
+            if complete_prefix_format != "pickle":
+                raise
+            proven_size = None
+        if (
+            proven_size is not None
+            and proven_size >= len(cached_prefix)
+            and proven_size - len(cached_prefix) <= sniff_budget.remaining_bytes
+        ):
+            complete_probe = _read_cloud_content_prefix(fs, file_url, proven_size, sniff_budget)
+            if len(complete_probe) == proven_size:
+                prefix = complete_probe
+                size = proven_size
+                size_is_known = True
+                detected_format = detect_format_from_magic_bytes(
+                    prefix[:4],
+                    prefix[:8],
+                    prefix[:16],
+                    size,
+                    None,
+                    pickle_probe_sample=prefix,
+                    pickle_probe_is_prefix=False,
+                )
     if (
         detected_format == "unknown"
         and prefix[_TFLITE_MAGIC_OFFSET : _TFLITE_MAGIC_OFFSET + len(_TFLITE_MAGIC_BYTES)] == _TFLITE_MAGIC_BYTES
@@ -1937,9 +1962,8 @@ def _detect_cloud_content_route_format(
         sniff_budget=sniff_budget,
     )
     if shared_detected_format is None and sniff_budget is not None:
-        if (
+        if size_is_known or (
             sniff_budget.remaining_bytes == 0
-            and not sniff_budget.prefix_is_complete(file_url)
             and _get_cloud_content_size_for_routing(fs, file_url) == len(sniff_budget.cached_prefix(file_url))
         ):
             return None

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -1384,6 +1384,19 @@ class _CloudContentSniffBudget:
         self._complete_prefixes: set[str] = set()
         self.incomplete_stream_reads = 0
 
+    def _read_bounded(self, remote_file: Any, max_bytes: int) -> bytes:
+        """Charge each transferred chunk before a later transport read can fail."""
+        payload = bytearray()
+        while len(payload) < max_bytes:
+            chunk = remote_file.read(max_bytes - len(payload))
+            if not isinstance(chunk, bytes):
+                raise TypeError("cloud filesystem returned non-bytes content")
+            if not chunk:
+                break
+            payload.extend(chunk)
+            self.remaining_bytes -= len(chunk)
+        return bytes(payload)
+
     def read_prefix(self, fs: Any, file_url: str, max_bytes: int) -> bytes:
         """Return a cached prefix, extending it without rereading transferred bytes."""
         prefix = self._prefixes.get(file_url, b"")
@@ -1397,9 +1410,8 @@ class _CloudContentSniffBudget:
         with fs.open(file_url, "rb") as remote_file:
             if prefix:
                 remote_file.seek(len(prefix))
-            chunk = _read_bounded_cloud_content(remote_file, read_size)
+            chunk = self._read_bounded(remote_file, read_size)
 
-        self.remaining_bytes -= len(chunk)
         prefix += chunk
         self._prefixes[file_url] = prefix
         if len(chunk) < read_size:
@@ -1420,9 +1432,8 @@ class _CloudContentSniffBudget:
 
         with fs.open(file_url, "rb") as remote_file:
             remote_file.seek(range_offset)
-            chunk = _read_bounded_cloud_content(remote_file, read_size)
+            chunk = self._read_bounded(remote_file, read_size)
 
-        self.remaining_bytes -= len(chunk)
         return cached + chunk
 
     def read_stream(self, remote_file: Any, requested_bytes: int | None = -1) -> bytes:
@@ -1888,12 +1899,21 @@ def _detect_cloud_content_route_format(
             and proven_size - len(cached_prefix) <= sniff_budget.remaining_bytes
         ):
             try:
-                complete_probe = _read_cloud_content_prefix(fs, file_url, proven_size, sniff_budget)
-            except ValueError:
-                if detected_format != "pickle":
-                    raise
-            else:
-                if len(complete_probe) == proven_size:
+                reported_size = _parse_size_value(file_info.get("size"))
+            except (TypeError, ValueError):
+                reported_size = None
+            size_proof_is_contradicted = reported_size is not None and reported_size > proven_size
+            if not size_proof_is_contradicted:
+                remaining_probe_bytes = proven_size - len(cached_prefix)
+                complete_probe_limit = proven_size + int(remaining_probe_bytes < sniff_budget.remaining_bytes)
+                try:
+                    complete_probe = _read_cloud_content_prefix(fs, file_url, complete_probe_limit, sniff_budget)
+                except ValueError:
+                    if detected_format != "pickle":
+                        raise
+                else:
+                    if len(complete_probe) != proven_size:
+                        return detected_format
                     prefix = complete_probe
                     size = proven_size
                     size_is_known = True

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -1879,16 +1879,7 @@ def _detect_cloud_content_route_format(
         try:
             proven_size = _get_cloud_content_size_for_routing(fs, file_url)
         except ValueError:
-            complete_prefix_format = detect_format_from_magic_bytes(
-                cached_prefix[:4],
-                cached_prefix[:8],
-                cached_prefix[:16],
-                len(cached_prefix),
-                None,
-                pickle_probe_sample=cached_prefix,
-                pickle_probe_is_prefix=False,
-            )
-            if complete_prefix_format != "pickle":
+            if detected_format != "pickle":
                 raise
             proven_size = None
         if (
@@ -1896,20 +1887,25 @@ def _detect_cloud_content_route_format(
             and proven_size >= len(cached_prefix)
             and proven_size - len(cached_prefix) <= sniff_budget.remaining_bytes
         ):
-            complete_probe = _read_cloud_content_prefix(fs, file_url, proven_size, sniff_budget)
-            if len(complete_probe) == proven_size:
-                prefix = complete_probe
-                size = proven_size
-                size_is_known = True
-                detected_format = detect_format_from_magic_bytes(
-                    prefix[:4],
-                    prefix[:8],
-                    prefix[:16],
-                    size,
-                    None,
-                    pickle_probe_sample=prefix,
-                    pickle_probe_is_prefix=False,
-                )
+            try:
+                complete_probe = _read_cloud_content_prefix(fs, file_url, proven_size, sniff_budget)
+            except ValueError:
+                if detected_format != "pickle":
+                    raise
+            else:
+                if len(complete_probe) == proven_size:
+                    prefix = complete_probe
+                    size = proven_size
+                    size_is_known = True
+                    detected_format = detect_format_from_magic_bytes(
+                        prefix[:4],
+                        prefix[:8],
+                        prefix[:16],
+                        size,
+                        None,
+                        pickle_probe_sample=prefix,
+                        pickle_probe_is_prefix=False,
+                    )
     if (
         detected_format == "unknown"
         and prefix[_TFLITE_MAGIC_OFFSET : _TFLITE_MAGIC_OFFSET + len(_TFLITE_MAGIC_BYTES)] == _TFLITE_MAGIC_BYTES

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -112,6 +112,12 @@ def make_safetensors_payload() -> bytes:
     return struct.pack("<Q", len(header)) + header + b"\x00" * 4
 
 
+def make_incomplete_pickle_probe_payload(*, malicious: bool) -> bytes:
+    operand = b"a" * _CLOUD_CONTENT_SNIFF_BYTES
+    prefix = b"\x8c\x02os\x94\x8c\x06system\x94\x93\x94" if malicious else b"\x88\x89"
+    return prefix + b"\x8d" + struct.pack("<Q", len(operand)) + operand + (b"0." if malicious else b".")
+
+
 def make_coreml_payload(tmp_path: Path) -> bytes:
     return create_mock_coreml(tmp_path / "model.jpg").read_bytes()
 
@@ -1486,9 +1492,9 @@ def test_filter_scannable_cloud_files_routes_large_protocolless_pickle_at_exact_
     assert transferred == [len(payload)]
 
 
-def test_filter_scannable_cloud_files_keeps_pickle_route_without_tail_seek() -> None:
+def test_filter_scannable_cloud_files_preserves_prefix_only_pickle_route_without_tail_seek() -> None:
     url = "s3://bucket/models/evil.payload"
-    payload = b"\x8c\x02os\x94\x8c\x06system\x94\x93\x94\x8c\x02id\x94\x85\x94R\x94."
+    payload = make_incomplete_pickle_probe_payload(malicious=True)
     transferred = [0]
     fs = make_fs_mock()
     fs.open.side_effect = lambda _path, _mode="rb": _NoTailSeekCountingBytesIO(payload, transferred)
@@ -1497,21 +1503,67 @@ def test_filter_scannable_cloud_files_keeps_pickle_route_without_tail_seek() -> 
     assert _filter_scannable_cloud_files(files, fs=fs, max_sniff_bytes=len(payload)) == [
         {**files[0], "content_detected_format": "pickle"}
     ]
-    assert transferred == [len(payload)]
+    assert transferred == [_CLOUD_CONTENT_SNIFF_BYTES]
 
 
-def test_filter_scannable_cloud_files_fails_closed_for_ambiguous_prefix_without_tail_seek() -> None:
+def test_filter_scannable_cloud_files_fails_closed_for_benign_near_match_without_tail_seek() -> None:
     url = "s3://bucket/models/preview.payload"
-    payload = b"\x89PNG\r\n\x1a\n"
+    payload = make_incomplete_pickle_probe_payload(malicious=False)
     transferred = [0]
     fs = make_fs_mock()
     fs.open.side_effect = lambda _path, _mode="rb": _NoTailSeekCountingBytesIO(payload, transferred)
-    files = [{"path": url, "name": "preview.payload", "size": len(payload), "human_size": "8 B"}]
+    files = [{"path": url, "name": "preview.payload", "size": len(payload), "human_size": f"{len(payload)} B"}]
 
     with pytest.raises(ValueError, match="unable to inspect skipped object"):
         _filter_scannable_cloud_files(files, fs=fs, max_sniff_bytes=len(payload))
 
-    assert transferred == [len(payload)]
+    assert transferred == [_CLOUD_CONTENT_SNIFF_BYTES]
+
+
+def test_filter_scannable_cloud_files_preserves_pickle_route_when_prefix_extension_fails() -> None:
+    url = "s3://bucket/models/evil.payload"
+    payload = make_incomplete_pickle_probe_payload(malicious=True)
+    transferred = [0]
+    open_count = [0]
+    fs = make_fs_mock()
+
+    def open_side_effect(_path: str, _mode: str = "rb") -> _CountingBytesIO:
+        open_count[0] += 1
+        if open_count[0] == 3:
+            raise OSError("second ranged read is unavailable")
+        return _CountingBytesIO(payload, transferred)
+
+    fs.open.side_effect = open_side_effect
+    files = [{"path": url, "name": "evil.payload", "size": len(payload), "human_size": f"{len(payload)} B"}]
+
+    assert _filter_scannable_cloud_files(files, fs=fs, max_sniff_bytes=len(payload)) == [
+        {**files[0], "content_detected_format": "pickle"}
+    ]
+    assert open_count == [3]
+    assert transferred == [_CLOUD_CONTENT_SNIFF_BYTES]
+
+
+def test_filter_scannable_cloud_files_fails_closed_for_benign_near_match_when_prefix_extension_fails() -> None:
+    url = "s3://bucket/models/preview.payload"
+    payload = make_incomplete_pickle_probe_payload(malicious=False)
+    transferred = [0]
+    open_count = [0]
+    fs = make_fs_mock()
+
+    def open_side_effect(_path: str, _mode: str = "rb") -> _CountingBytesIO:
+        open_count[0] += 1
+        if open_count[0] == 3:
+            raise OSError("second ranged read is unavailable")
+        return _CountingBytesIO(payload, transferred)
+
+    fs.open.side_effect = open_side_effect
+    files = [{"path": url, "name": "preview.payload", "size": len(payload), "human_size": f"{len(payload)} B"}]
+
+    with pytest.raises(ValueError, match="unable to inspect skipped object"):
+        _filter_scannable_cloud_files(files, fs=fs, max_sniff_bytes=len(payload))
+
+    assert open_count == [3]
+    assert transferred == [_CLOUD_CONTENT_SNIFF_BYTES]
 
 
 def test_filter_scannable_cloud_files_caps_json_probe_at_shared_sniff_budget() -> None:
@@ -1927,6 +1979,122 @@ def test_selective_cloud_download_caps_content_sniffing_at_max_size(
     assert "secret" not in error
     assert transferred == [32]
     fs.get.assert_not_called()
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+@pytest.mark.parametrize("probe_failure", ["size-proof", "prefix-extension"])
+@patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+@patch("fsspec.filesystem")
+def test_selective_cloud_download_preserves_prefix_only_pickle_route_after_optional_probe_failure(
+    mock_fs_class: MagicMock,
+    mock_analyze: AsyncMock,
+    tmp_path: Path,
+    probe_failure: str,
+    streaming: bool,
+) -> None:
+    url = "s3://bucket/models/"
+    file_url = "s3://bucket/models/evil.payload"
+    payload = make_incomplete_pickle_probe_payload(malicious=True)
+    transferred = [0]
+    open_count = [0]
+    fs = make_fs_mock()
+    fs.info.return_value = {"type": "file", "size": len(payload)}
+
+    def open_side_effect(_path: str, _mode: str = "rb") -> _CountingBytesIO:
+        open_count[0] += 1
+        if probe_failure == "prefix-extension" and open_count[0] == 3:
+            raise OSError("second ranged read is unavailable")
+        stream_type = _NoTailSeekCountingBytesIO if probe_failure == "size-proof" else _CountingBytesIO
+        return stream_type(payload, transferred)
+
+    fs.open.side_effect = open_side_effect
+    mock_fs_class.return_value = fs
+    mock_analyze.return_value = {
+        "type": "directory",
+        "file_count": 1,
+        "total_size": len(payload),
+        "human_size": f"{len(payload)} B",
+        "estimated_time": "instant",
+        "files": [{"path": file_url, "name": "evil.payload", "size": len(payload), "human_size": f"{len(payload)} B"}],
+    }
+    max_size = _CLOUD_CONTENT_SNIFF_BYTES + len(payload)
+
+    if streaming:
+        streamed = list(download_from_cloud_streaming(url, max_size=max_size, show_progress=False))
+        assert len(streamed) == 1
+        assert streamed[0][1] is True
+    else:
+        download_path = download_from_cloud(
+            url,
+            cache_dir=tmp_path,
+            max_size=max_size,
+            use_cache=False,
+            show_progress=False,
+        )
+        assert isinstance(download_path, Path)
+        assert download_path.exists()
+
+    assert transferred == [_CLOUD_CONTENT_SNIFF_BYTES + len(payload)]
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+@pytest.mark.parametrize("probe_failure", ["size-proof", "prefix-extension"])
+@patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+@patch("fsspec.filesystem")
+def test_selective_cloud_download_fails_closed_for_benign_near_match_after_optional_probe_failure(
+    mock_fs_class: MagicMock,
+    mock_analyze: AsyncMock,
+    tmp_path: Path,
+    probe_failure: str,
+    streaming: bool,
+) -> None:
+    url = "s3://bucket/models/"
+    file_url = "s3://bucket/models/preview.payload"
+    payload = make_incomplete_pickle_probe_payload(malicious=False)
+    transferred = [0]
+    open_count = [0]
+    fs = make_fs_mock()
+    fs.info.return_value = {"type": "file", "size": len(payload)}
+
+    def open_side_effect(_path: str, _mode: str = "rb") -> _CountingBytesIO:
+        open_count[0] += 1
+        if probe_failure == "prefix-extension" and open_count[0] == 3:
+            raise OSError("second ranged read is unavailable")
+        stream_type = _NoTailSeekCountingBytesIO if probe_failure == "size-proof" else _CountingBytesIO
+        return stream_type(payload, transferred)
+
+    fs.open.side_effect = open_side_effect
+    mock_fs_class.return_value = fs
+    mock_analyze.return_value = {
+        "type": "directory",
+        "file_count": 1,
+        "total_size": len(payload),
+        "human_size": f"{len(payload)} B",
+        "estimated_time": "instant",
+        "files": [
+            {
+                "path": file_url,
+                "name": "preview.payload",
+                "size": len(payload),
+                "human_size": f"{len(payload)} B",
+            }
+        ],
+    }
+    max_size = _CLOUD_CONTENT_SNIFF_BYTES + len(payload)
+
+    with pytest.raises(ValueError, match="unable to inspect skipped object"):
+        if streaming:
+            list(download_from_cloud_streaming(url, max_size=max_size, show_progress=False))
+        else:
+            download_from_cloud(
+                url,
+                cache_dir=tmp_path,
+                max_size=max_size,
+                use_cache=False,
+                show_progress=False,
+            )
+
+    assert transferred == [_CLOUD_CONTENT_SNIFF_BYTES]
 
 
 @pytest.mark.parametrize("streaming", [False, True])

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -30,6 +30,7 @@ from modelaudit.utils.sources.cloud_storage import (
     _CLOUD_CONTENT_SNIFF_BYTES,
     GCSCache,
     _build_safe_local_path,
+    _CloudContentSniffBudget,
     _filter_scannable_cloud_files,
     _run_coroutine_sync,
     analyze_cloud_target,
@@ -88,6 +89,31 @@ class _NoTailSeekCountingBytesIO(_CountingBytesIO):
         return super().seek(offset, whence)
 
 
+class _UnderreportedEndCountingBytesIO(_CountingBytesIO):
+    def __init__(self, payload: bytes, byte_counter: list[int], reported_size: int):
+        super().__init__(payload, byte_counter)
+        self._reported_size = reported_size
+
+    def seek(self, offset: int, whence: int = os.SEEK_SET) -> int:
+        if whence == os.SEEK_END:
+            return super().seek(self._reported_size + offset, os.SEEK_SET)
+        return super().seek(offset, whence)
+
+
+class _PartialReadThenErrorCountingBytesIO(_CountingBytesIO):
+    def __init__(self, payload: bytes, byte_counter: list[int], partial_bytes: int):
+        super().__init__(payload, byte_counter)
+        self._partial_bytes = partial_bytes
+        self._returned_partial = False
+
+    def read(self, size: int | None = -1) -> bytes:
+        if self._returned_partial:
+            raise OSError("connection reset after partial read")
+        self._returned_partial = True
+        requested_size = self._partial_bytes if size is None or size < 0 else min(size, self._partial_bytes)
+        return super().read(requested_size)
+
+
 def make_tar_payload() -> bytes:
     payload = b'cos\nsystem\n(S"echo pwned"\ntR.'
     output = io.BytesIO()
@@ -116,6 +142,16 @@ def make_incomplete_pickle_probe_payload(*, malicious: bool) -> bytes:
     operand = b"a" * _CLOUD_CONTENT_SNIFF_BYTES
     prefix = b"\x8c\x02os\x94\x8c\x06system\x94\x93\x94" if malicious else b"\x88\x89"
     return prefix + b"\x8d" + struct.pack("<Q", len(operand)) + operand + (b"0." if malicious else b".")
+
+
+def make_delayed_pickle_security_payload() -> bytes:
+    operand = b"a" * _CLOUD_CONTENT_SNIFF_BYTES
+    return (
+        b"\x88\x89\x8d"
+        + struct.pack("<Q", len(operand))
+        + operand
+        + b"0\x8c\x02os\x94\x8c\x06system\x94\x93\x94\x8c\x02id\x94\x85\x94R\x94."
+    )
 
 
 def make_coreml_payload(tmp_path: Path) -> bytes:
@@ -1490,6 +1526,85 @@ def test_filter_scannable_cloud_files_routes_large_protocolless_pickle_at_exact_
         {**files[0], "content_detected_format": "pickle"}
     ]
     assert transferred == [len(payload)]
+
+
+def test_filter_scannable_cloud_files_rejects_underreported_end_for_delayed_pickle_payload() -> None:
+    url = "s3://bucket/models/evil.payload"
+    payload = make_delayed_pickle_security_payload()
+    transferred = [0]
+    fs = make_fs_mock()
+    fs.open.side_effect = lambda _path, _mode="rb": _UnderreportedEndCountingBytesIO(
+        payload,
+        transferred,
+        _CLOUD_CONTENT_SNIFF_BYTES,
+    )
+    files = [{"path": url, "name": "evil.payload", "size": len(payload), "human_size": f"{len(payload)} B"}]
+
+    assert _filter_scannable_cloud_files(files, fs=fs, max_sniff_bytes=_CLOUD_CONTENT_SNIFF_BYTES) == [
+        {**files[0], "content_detected_format": PICKLE_ROUTING_INCONCLUSIVE_FORMAT}
+    ]
+
+    assert transferred == [_CLOUD_CONTENT_SNIFF_BYTES]
+
+
+def test_filter_scannable_cloud_files_probes_past_underreported_end_with_stale_metadata() -> None:
+    url = "s3://bucket/models/evil.payload"
+    payload = make_delayed_pickle_security_payload()
+    transferred = [0]
+    fs = make_fs_mock()
+    fs.open.side_effect = lambda _path, _mode="rb": _UnderreportedEndCountingBytesIO(
+        payload,
+        transferred,
+        _CLOUD_CONTENT_SNIFF_BYTES,
+    )
+    files = [{"path": url, "name": "evil.payload", "size": 1, "human_size": "1 B"}]
+
+    assert _filter_scannable_cloud_files(files, fs=fs, max_sniff_bytes=_CLOUD_CONTENT_SNIFF_BYTES + 1) == [
+        {**files[0], "content_detected_format": PICKLE_ROUTING_INCONCLUSIVE_FORMAT}
+    ]
+
+    assert transferred == [_CLOUD_CONTENT_SNIFF_BYTES + 1]
+
+
+def test_filter_scannable_cloud_files_routes_delayed_pickle_security_signal() -> None:
+    url = "s3://bucket/models/evil.payload"
+    payload = make_delayed_pickle_security_payload()
+    transferred = [0]
+    fs = make_fs_mock()
+    fs.open.side_effect = lambda _path, _mode="rb": _CountingBytesIO(payload, transferred)
+    files = [{"path": url, "name": "evil.payload", "size": len(payload), "human_size": f"{len(payload)} B"}]
+
+    assert _filter_scannable_cloud_files(files, fs=fs, max_sniff_bytes=len(payload)) == [
+        {**files[0], "content_detected_format": "pickle"}
+    ]
+
+    assert transferred == [len(payload)]
+
+
+def test_filter_scannable_cloud_files_charges_partial_prefix_extension_before_failure() -> None:
+    url = "s3://bucket/models/evil.payload"
+    payload = make_incomplete_pickle_probe_payload(malicious=True)
+    transferred = [0]
+    open_count = [0]
+    partial_bytes = 10
+    fs = make_fs_mock()
+
+    def open_side_effect(_path: str, _mode: str = "rb") -> _CountingBytesIO:
+        open_count[0] += 1
+        if open_count[0] == 3:
+            return _PartialReadThenErrorCountingBytesIO(payload, transferred, partial_bytes)
+        return _CountingBytesIO(payload, transferred)
+
+    fs.open.side_effect = open_side_effect
+    files = [{"path": url, "name": "evil.payload", "size": len(payload), "human_size": f"{len(payload)} B"}]
+    sniff_budget = _CloudContentSniffBudget(len(payload))
+
+    assert _filter_scannable_cloud_files(files, fs=fs, sniff_budget=sniff_budget) == [
+        {**files[0], "content_detected_format": "pickle"}
+    ]
+    assert open_count == [3]
+    assert transferred == [_CLOUD_CONTENT_SNIFF_BYTES + partial_bytes]
+    assert sniff_budget.remaining_bytes == len(payload) - transferred[0]
 
 
 def test_filter_scannable_cloud_files_preserves_prefix_only_pickle_route_without_tail_seek() -> None:

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -81,6 +81,13 @@ class _CountingBytesIO(io.BytesIO):
         return chunk
 
 
+class _NoTailSeekCountingBytesIO(_CountingBytesIO):
+    def seek(self, offset: int, whence: int = os.SEEK_SET) -> int:
+        if whence == os.SEEK_END:
+            raise OSError("end-relative seek is unavailable")
+        return super().seek(offset, whence)
+
+
 def make_tar_payload() -> bytes:
     payload = b'cos\nsystem\n(S"echo pwned"\ntR.'
     output = io.BytesIO()
@@ -1431,6 +1438,79 @@ def test_filter_scannable_cloud_files_skips_complete_benign_content_at_exact_sni
     files = [{"path": url, "name": "preview.payload", "size": len(payload), "human_size": "8 B"}]
 
     assert _filter_scannable_cloud_files(files, fs=fs, max_sniff_bytes=len(payload)) == []
+    assert transferred == [len(payload)]
+
+
+def test_filter_scannable_cloud_files_routes_protocolless_pickle_at_exact_sniff_budget() -> None:
+    url = "s3://bucket/models/evil.payload"
+    payload = b"\x8c\x02os\x94\x8c\x06system\x94\x93\x94\x8c\x02id\x94\x85\x94R\x94."
+    transferred = [0]
+    fs = make_fs_mock()
+    fs.open.side_effect = lambda _path, _mode="rb": _CountingBytesIO(payload, transferred)
+    files = [{"path": url, "name": "evil.payload", "size": len(payload), "human_size": f"{len(payload)} B"}]
+
+    assert _filter_scannable_cloud_files(files, fs=fs, max_sniff_bytes=len(payload)) == [
+        {**files[0], "content_detected_format": "pickle"}
+    ]
+    assert transferred == [len(payload)]
+
+
+def test_filter_scannable_cloud_files_reclassifies_complete_benign_content_beyond_initial_prefix() -> None:
+    url = "s3://bucket/models/preview.payload"
+    sniff_budget = _CLOUD_CONTENT_SNIFF_BYTES + 32
+    string_size = sniff_budget - 12
+    payload = b"\x88\x89\x8d" + struct.pack("<Q", string_size) + b"a" * string_size + b"."
+    transferred = [0]
+    fs = make_fs_mock()
+    fs.open.side_effect = lambda _path, _mode="rb": _CountingBytesIO(payload, transferred)
+    files = [{"path": url, "name": "preview.payload", "size": 1, "human_size": "1 B"}]
+
+    assert len(payload) == sniff_budget
+    assert _filter_scannable_cloud_files(files, fs=fs, max_sniff_bytes=sniff_budget) == []
+    assert transferred == [len(payload)]
+
+
+def test_filter_scannable_cloud_files_routes_large_protocolless_pickle_at_exact_sniff_budget() -> None:
+    url = "s3://bucket/models/evil.payload"
+    pickle_payload = b"\x8c\x02os\x94\x8c\x06system\x94\x93\x94\x8c\x02id\x94\x85\x94R\x94."
+    sniff_budget = _CLOUD_CONTENT_SNIFF_BYTES + 32
+    payload = pickle_payload + b"x" * (sniff_budget - len(pickle_payload))
+    transferred = [0]
+    fs = make_fs_mock()
+    fs.open.side_effect = lambda _path, _mode="rb": _CountingBytesIO(payload, transferred)
+    files = [{"path": url, "name": "evil.payload", "size": 1, "human_size": "1 B"}]
+
+    assert _filter_scannable_cloud_files(files, fs=fs, max_sniff_bytes=sniff_budget) == [
+        {**files[0], "content_detected_format": "pickle"}
+    ]
+    assert transferred == [len(payload)]
+
+
+def test_filter_scannable_cloud_files_keeps_pickle_route_without_tail_seek() -> None:
+    url = "s3://bucket/models/evil.payload"
+    payload = b"\x8c\x02os\x94\x8c\x06system\x94\x93\x94\x8c\x02id\x94\x85\x94R\x94."
+    transferred = [0]
+    fs = make_fs_mock()
+    fs.open.side_effect = lambda _path, _mode="rb": _NoTailSeekCountingBytesIO(payload, transferred)
+    files = [{"path": url, "name": "evil.payload", "size": len(payload), "human_size": f"{len(payload)} B"}]
+
+    assert _filter_scannable_cloud_files(files, fs=fs, max_sniff_bytes=len(payload)) == [
+        {**files[0], "content_detected_format": "pickle"}
+    ]
+    assert transferred == [len(payload)]
+
+
+def test_filter_scannable_cloud_files_fails_closed_for_ambiguous_prefix_without_tail_seek() -> None:
+    url = "s3://bucket/models/preview.payload"
+    payload = b"\x89PNG\r\n\x1a\n"
+    transferred = [0]
+    fs = make_fs_mock()
+    fs.open.side_effect = lambda _path, _mode="rb": _NoTailSeekCountingBytesIO(payload, transferred)
+    files = [{"path": url, "name": "preview.payload", "size": len(payload), "human_size": "8 B"}]
+
+    with pytest.raises(ValueError, match="unable to inspect skipped object"):
+        _filter_scannable_cloud_files(files, fs=fs, max_sniff_bytes=len(payload))
+
     assert transferred == [len(payload)]
 
 


### PR DESCRIPTION
## Summary
- distinguish complete cloud objects from budget-truncated prefixes before accepting protocol-less Pickle routing
- extend cached probes when the complete object fits the remaining shared sniff budget
- preserve an already strong prefix-only Pickle route when optional size proof or prefix extension is unavailable
- reject contradictory tail-size evidence and corroborate claimed EOF with one extra byte when budget permits
- charge every transferred sniff chunk immediately, including bytes returned before a later transport failure

## False-positive / false-negative audit
- exact-budget benign content is reclassified using the complete object when size can be proven
- exact-budget and delayed-security-opcode malicious Pickles remain routed
- an underreported `SEEK_END`/`tell()` result cannot suppress a dangerous tail
- stale-low metadata is covered by a one-byte EOF probe when capacity remains
- partial failed extension reads remain included in the later acquisition budget
- inconclusive benign near-matches still fail closed when optional proof is unavailable
- all reads remain bounded by the shared sniff budget

## Validation
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run --frozen pytest -q tests/utils/sources/test_cloud_storage.py`: **290 passed**
- scoped Ruff check and format: clean
- scoped mypy: clean
- `git diff --check`: clean

All inline review threads are resolved. Exact published head: `349f6c4781b04f5a260b72ef1f2839f66cdf4ce5`. Exact tree: `30b106bec1ce2a77d3b17f9816a2d854fd2777e0`.