### PR TITLE
fix: make cloud download paths Windows-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- encode native cloud object-key delimiters into collision-resistant, Windows-safe local download paths
 - restrict manual Docker publishes to validated immutable version tags and their matching Git release refs before registry login or push
 - harden cloud acquisition size caps, HTTPS/R2 auto-default routing, and directory metadata failures
 - detect operator attrgetter, itemgetter, and methodcaller archive-member Python paths to command execution while preserving benign accessor names

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -117,6 +117,11 @@ _TFLITE_MAGIC_BYTES = b"TFL3"
 _MSGPACK_CONTAINER_MARKERS = frozenset((*range(0x80, 0x90), 0xDE, 0xDF))
 _MAX_CLOUD_METADATA_ERROR_SAMPLES = 3
 _MAX_CLOUD_METADATA_ERROR_DISPLAY_CHARS = 512
+_CLOUD_LOCAL_PATH_ESCAPE_CHARS = frozenset('<>:"/\\|?*%#')
+_WINDOWS_RESERVED_LOCAL_PATH_NAMES = frozenset(
+    {"con", "prn", "aux", "nul"} | {f"com{index}" for index in range(1, 10)} | {f"lpt{index}" for index in range(1, 10)}
+)
+_CLOUD_LOCAL_IDENTITY_HASH_CHARS = 16
 _AWS_REGION_HOST_PART = r"[a-z][a-z0-9]*(?:-[a-z0-9]+)+-\d"
 _AWS_S3_DNS_SUFFIX = (
     r"(?:amazonaws\.com(?:\.cn)?|amazonaws\.eu|c2s\.ic\.gov|sc2s\.sgov\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)"
@@ -541,6 +546,44 @@ def _cloud_url_basename(url: str) -> str:
     except Exception:
         path = url
     return Path(path).name
+
+
+def _encode_cloud_local_character(character: str) -> str:
+    """Return a reversible ASCII encoding for one local-path character."""
+    return "".join(f"%{byte:02X}" for byte in character.encode("utf-8", errors="surrogatepass"))
+
+
+def _cloud_local_path_component(component: str) -> str:
+    """Map one cloud key component to a collision-resistant Windows-safe name."""
+    if not component:
+        return component
+
+    trailing_start = len(component.rstrip(" ."))
+    encoded_parts: list[str] = []
+    changed = False
+    for index, character in enumerate(component):
+        if character in _CLOUD_LOCAL_PATH_ESCAPE_CHARS or ord(character) < 0x20 or index >= trailing_start:
+            encoded_parts.append(_encode_cloud_local_character(character))
+            changed = True
+        else:
+            encoded_parts.append(character)
+
+    encoded = "".join(encoded_parts)
+    reserved_stem = component.rstrip(" .").split(".", 1)[0].casefold()
+    if reserved_stem in _WINDOWS_RESERVED_LOCAL_PATH_NAMES:
+        encoded = f"{_encode_cloud_local_character(component[0])}{encoded[1:]}"
+        changed = True
+
+    if not changed:
+        return component
+
+    # The digest keeps transformed case variants distinct on case-insensitive filesystems.
+    identity = hashlib.sha256(component.encode("utf-8", errors="surrogatepass")).hexdigest()
+    identity = identity[:_CLOUD_LOCAL_IDENTITY_HASH_CHARS]
+    suffix = Path(encoded).suffix
+    if suffix and "%" not in suffix and len(suffix) <= 32:
+        return f"{encoded[: -len(suffix)]}~{identity}{suffix}"
+    return f"{encoded}~{identity}"
 
 
 def _remove_path(path: Path) -> None:
@@ -2021,9 +2064,14 @@ def _build_safe_local_path(base_url: str, file_url: str, download_path: Path) ->
     if not relative_path:
         raise ValueError(f"Invalid cloud object path: {file_url}")
 
-    resolved_path, is_safe = _resolve_cloud_path(relative_path, download_path)
+    _, is_safe = _resolve_cloud_path(relative_path, download_path)
     if not is_safe:
         raise ValueError(f"Path traversal attempt detected in cloud object path: {file_url}")
+
+    local_relative_path = "/".join(_cloud_local_path_component(component) for component in relative_path.split("/"))
+    resolved_path, is_safe = _resolve_cloud_path(local_relative_path, download_path)
+    if not is_safe:
+        raise ValueError(f"Encoded cloud object path escaped download directory: {file_url}")
 
     local_path = Path(resolved_path)
     if not _is_within_directory(download_path, local_path):
@@ -2386,7 +2434,7 @@ def download_from_cloud(
                 download_file()
         else:
             # Single file download
-            file_name = _cloud_url_basename(url)
+            file_name = _cloud_local_path_component(_cloud_url_basename(fs_url))
             local_file = download_path / file_name
             download_budget = _CloudDownloadBudget(max_size) if max_size else None
             if cache:

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -2,6 +2,7 @@ import asyncio
 import io
 import json
 import logging
+import ntpath
 import os
 import stat
 import struct
@@ -2327,7 +2328,37 @@ def test_download_from_cloud_preserves_native_query_text_in_local_path(
     result = download_from_cloud(url, cache_dir=tmp_path, use_cache=False, show_progress=False)
 
     assert isinstance(result, Path)
-    assert result.name == "model?variant.bin"
+    assert result.name.startswith("model%3Fvariant~")
+    assert result.suffix == ".bin"
+    assert not any(character in result.name for character in '<>:"/\\|?*')
+    fs.get.assert_called_once_with(url, str(result))
+
+
+@patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)
+@patch("modelaudit.utils.sources.cloud_storage.check_disk_space")
+@patch("fsspec.filesystem")
+def test_download_from_cloud_omits_https_credentials_from_local_path(
+    mock_fs: MagicMock, mock_disk_space: MagicMock, mock_analyze: AsyncMock, tmp_path: Path
+) -> None:
+    url = "https://bucket.s3.amazonaws.com/model.bin?X-Amz-Signature=secret#access_token=fragment-secret"
+    fs = make_fs_mock()
+    fs.info.return_value = {"type": "file", "size": 1024}
+    fs.get.side_effect = lambda _src, dst: Path(dst).write_bytes(b"data")
+    mock_fs.return_value = fs
+    mock_analyze.return_value = {
+        "type": "file",
+        "size": 1024,
+        "name": "model.bin",
+        "human_size": "1.0 KB",
+        "estimated_time": "1 second",
+    }
+    mock_disk_space.return_value = (True, "")
+
+    result = download_from_cloud(url, cache_dir=tmp_path, use_cache=False, show_progress=False)
+
+    assert result == tmp_path / "model.bin"
+    assert "secret" not in str(result)
+    assert "access_token" not in str(result)
     fs.get.assert_called_once_with(url, str(result))
 
 
@@ -2352,9 +2383,15 @@ def test_build_safe_local_path_preserves_literal_object_delimiters(tmp_path: Pat
     question_path = _build_safe_local_path(base_url, f"{base_url}/model?one.pkl", tmp_path)
     fragment_path = _build_safe_local_path(base_url, f"{base_url}/model#two.pkl", tmp_path)
 
-    assert question_path == tmp_path / "model?one.pkl"
-    assert fragment_path == tmp_path / "model#two.pkl"
+    assert question_path.parent == tmp_path
+    assert fragment_path.parent == tmp_path
+    assert question_path.name.startswith("model%3Fone~")
+    assert fragment_path.name.startswith("model%23two~")
+    assert question_path.suffix == ".pkl"
+    assert fragment_path.suffix == ".pkl"
     assert question_path != fragment_path
+    assert not any(character in question_path.name for character in '<>:"/\\|?*')
+    assert not any(character in fragment_path.name for character in '<>:"/\\|?*')
 
 
 def test_build_safe_local_path_preserves_sensitive_looking_native_key_text(tmp_path: Path) -> None:
@@ -2362,9 +2399,46 @@ def test_build_safe_local_path_preserves_sensitive_looking_native_key_text(tmp_p
     first = _build_safe_local_path(base_url, f"{base_url}/model.pkl?X-Amz-Signature=one", tmp_path)
     second = _build_safe_local_path(base_url, f"{base_url}/model.pkl?X-Amz-Signature=two", tmp_path)
 
-    assert first == tmp_path / "model.pkl?X-Amz-Signature=one"
-    assert second == tmp_path / "model.pkl?X-Amz-Signature=two"
+    assert first.name.startswith("model.pkl%3FX-Amz-Signature=one~")
+    assert second.name.startswith("model.pkl%3FX-Amz-Signature=two~")
     assert first != second
+
+
+def test_build_safe_local_path_distinguishes_literal_and_encoded_native_key_text(tmp_path: Path) -> None:
+    base_url = "s3://bucket/models"
+
+    literal = _build_safe_local_path(base_url, f"{base_url}/model?variant.pkl", tmp_path)
+    encoded = _build_safe_local_path(base_url, f"{base_url}/model%3Fvariant.pkl", tmp_path)
+
+    assert "%3F" in literal.name
+    assert "%253F" in encoded.name
+    assert literal != encoded
+
+
+def test_build_safe_local_path_distinguishes_native_keys_on_case_insensitive_filesystems(tmp_path: Path) -> None:
+    base_url = "s3://bucket/models"
+
+    lower = _build_safe_local_path(base_url, f"{base_url}/model?variant.pkl", tmp_path)
+    upper = _build_safe_local_path(base_url, f"{base_url}/model?Variant.pkl", tmp_path)
+
+    assert ntpath.normcase(lower.name) != ntpath.normcase(upper.name)
+
+
+def test_build_safe_local_path_preserves_windows_safe_name(tmp_path: Path) -> None:
+    base_url = "s3://bucket/models"
+
+    assert _build_safe_local_path(base_url, f"{base_url}/model.pkl", tmp_path) == tmp_path / "model.pkl"
+
+
+def test_build_safe_local_path_encodes_windows_reserved_name(tmp_path: Path) -> None:
+    base_url = "s3://bucket/models"
+
+    local_path = _build_safe_local_path(base_url, f"{base_url}/CON.pkl", tmp_path)
+
+    assert local_path.parent == tmp_path
+    assert local_path.name.startswith("%43ON~")
+    assert local_path.suffix == ".pkl"
+    assert local_path.stem.casefold() != "con"
 
 
 @patch("modelaudit.utils.sources.cloud_storage.analyze_cloud_target", new_callable=AsyncMock)


### PR DESCRIPTION
## Summary

- encode native cloud object-key delimiters into deterministic Windows-safe local path components
- preserve readable key information and file extensions while adding an exact-component digest to prevent transformed-name collisions on case-insensitive filesystems
- leave already-safe local names unchanged and continue excluding HTTPS query and fragment credentials
- cover single-file, directory, reserved-device-name, literal-vs-encoded, and case-insensitive collision behavior

## Root cause

Native `s3://`, `gs://`, `gcs://`, and `r2://` URLs correctly preserve raw `?` and `#` bytes because they are part of the provider object key. The download path reused those bytes as a local filename, so Windows rejected the path and the retry wrapper surfaced a `RetryError`. Stripping the bytes would target the wrong remote object, so the local representation now percent-escapes unsafe bytes and binds transformed names to the exact source component.

## Validation

- `PROMPTFOO_DISABLE_TELEMETRY=1 .venv/bin/python -m pytest tests/utils/sources/test_cloud_storage.py -q` (`276 passed`)
- `.venv/bin/ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `.venv/bin/ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `.venv/bin/mypy modelaudit/utils/sources/cloud_storage.py tests/utils/sources/test_cloud_storage.py`
- `git diff --check`

The required broad parallel suite reached `3,402 passed, 2 skipped` before stopping on five unrelated current-main cache/compressed/ExecuTorch failures. Full local macOS mypy retains the existing five `os.*xattr` stub errors in untouched files.