### PR TITLE
fix: keep ExecuTorch snapshots seekable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - preserve executable text-sidecar network findings for f-string calls, standard command wrappers, port-qualified Docker registries, and bounded xargs downloads while keeping prose references informational.
 - stabilize cache identity capture for compressed wrapper scans on Darwin `/private` path aliases and during unrelated temporary-file churn.
 - bound per-tensor and cumulative weight-distribution extraction before materializing PyTorch, HDF5, TensorFlow, and ONNX payloads
+- keep bounded ExecuTorch ZIP snapshots seekable on Python 3.10 so benign and malicious pickle members remain analyzable
 
 ## [0.2.47](https://github.com/promptfoo/modelaudit/compare/v0.2.46...v0.2.47) (2026-06-05)
 

--- a/modelaudit/scanners/executorch_scanner.py
+++ b/modelaudit/scanners/executorch_scanner.py
@@ -1,5 +1,6 @@
 """Scanner for ExecuTorch model files (.pte)."""
 
+import io
 import os
 import tempfile
 import zipfile
@@ -602,10 +603,11 @@ class ExecuTorchScanner(BaseScanner):
         opened_stat: os.stat_result,
     ) -> BinaryIO:
         """Copy one stable archive view before parsing attacker-controlled metadata."""
-        snapshot = cast(
-            BinaryIO,
-            tempfile.SpooledTemporaryFile(max_size=_ZIP_SNAPSHOT_MEMORY_LIMIT, mode="w+b"),  # noqa: SIM115
-        )
+        snapshot: BinaryIO
+        if opened_stat.st_size <= _ZIP_SNAPSHOT_MEMORY_LIMIT:
+            snapshot = io.BytesIO()
+        else:
+            snapshot = cast(BinaryIO, tempfile.TemporaryFile(mode="w+b"))  # noqa: SIM115
         try:
             source_handle.seek(0)
             remaining = opened_stat.st_size

--- a/tests/scanners/test_executorch_scanner.py
+++ b/tests/scanners/test_executorch_scanner.py
@@ -180,6 +180,9 @@ def test_executorch_scanner_safe_model(tmp_path: Path) -> None:
     result = scanner.scan(str(path))
     assert result.success is True
     assert result.bytes_scanned > 0
+    assert result.metadata["pickle_report_status"] == "complete"
+    assert result.metadata["pickle_verdict"] == "clean"
+    assert "scan_outcome_reasons" not in result.metadata
     critical = [i for i in result.issues if i.severity == IssueSeverity.CRITICAL]
     assert not critical
 
@@ -188,6 +191,10 @@ def test_executorch_scanner_malicious(tmp_path: Path) -> None:
     path = create_executorch_archive(tmp_path, malicious=True)
     scanner = ExecuTorchScanner()
     result = scanner.scan(str(path))
+    assert result.success is True
+    assert result.metadata["pickle_report_status"] == "complete"
+    assert result.metadata["pickle_verdict"] == "malicious"
+    assert "scan_outcome_reasons" not in result.metadata
     assert any(i.severity == IssueSeverity.CRITICAL for i in result.issues)
     assert any("eval" in i.message.lower() for i in result.issues)
 


### PR DESCRIPTION
## Summary

- keep bounded ExecuTorch ZIP snapshots seekable across Python 3.10+
- use in-memory `BytesIO` snapshots up to the existing 8 MiB limit and disk-backed `TemporaryFile` snapshots above it
- strengthen benign and malicious pickle regressions to require complete coverage and preserve critical detections

## Root cause

Python 3.10's `tempfile.SpooledTemporaryFile` does not expose `seekable()`. `zipfile._SharedFile` accesses that method when opening an archive member, so ordinary ExecuTorch ZIP scans failed closed with `executorch_zip_pickle_member_read_failed` before the embedded pickle could be analyzed.

## Security behavior

The snapshot remains bounded in memory, large archives remain disk-backed, source-stability checks are unchanged, and malicious embedded pickles still produce critical findings. The change restores coverage rather than bypassing fail-closed handling.

## Validation

- Python 3.10: `79 passed` in `tests/scanners/test_executorch_scanner.py`
- Python 3.11: `79 passed` in `tests/scanners/test_executorch_scanner.py`
- full Ruff check: clean
- full Ruff format check: clean
- targeted mypy for the modified scanner and tests: clean
- full mypy retains five pre-existing macOS `os.*xattr` stub errors in untouched CLI files