### PR TITLE
fix: harden Flax regex streaming

### DIFF
--- a/modelaudit/scanners/flax_msgpack_scanner.py
+++ b/modelaudit/scanners/flax_msgpack_scanner.py
@@ -253,14 +253,46 @@ def _strip_stream_safe_whitespace_repeats(pattern: str) -> str:
 
 
 def _pattern_has_stream_unsafe_repeat(pattern: str) -> bool:
-    """Return whether bounded overlap cannot guarantee coverage for this regex."""
+    """Return whether bounded streaming search cannot safely execute this regex."""
     remaining = _strip_stream_safe_whitespace_repeats(pattern)
     parser = _get_regex_parser()
     if parser is not None:
         try:
-            _, max_width = parser.parse(remaining, re.IGNORECASE).getwidth()
+            parsed_pattern = parser.parse(pattern, re.IGNORECASE)
+            parsed_remaining = parser.parse(remaining, re.IGNORECASE)
         except Exception:
             return True
+        repeat_ops = {op for name in ("MAX_REPEAT", "MIN_REPEAT") if (op := getattr(parser, name, None)) is not None}
+        branch_op = getattr(parser, "BRANCH", None)
+        subpattern_op = getattr(parser, "SUBPATTERN", None)
+        assertion_ops = {
+            op for name in ("ASSERT", "ASSERT_NOT", "ATOMIC_GROUP") if (op := getattr(parser, name, None)) is not None
+        }
+
+        def has_ambiguous_repeat(subpattern: Any, *, inside_repeat: bool = False) -> bool:
+            for op, argument in subpattern.data:
+                if op in repeat_ops:
+                    repeated = argument[-1]
+                    if inside_repeat or has_ambiguous_repeat(repeated, inside_repeat=True):
+                        return True
+                    continue
+                if branch_op is not None and op is branch_op:
+                    if inside_repeat:
+                        return True
+                    if any(has_ambiguous_repeat(branch, inside_repeat=inside_repeat) for branch in argument[1]):
+                        return True
+                    continue
+                if subpattern_op is not None and op is subpattern_op:
+                    if has_ambiguous_repeat(argument[-1], inside_repeat=inside_repeat):
+                        return True
+                    continue
+                if op in assertion_ops and has_ambiguous_repeat(argument[-1], inside_repeat=inside_repeat):
+                    return True
+            return False
+
+        if has_ambiguous_repeat(parsed_pattern):
+            return True
+        _, max_width = parsed_remaining.getwidth()
         return max_width > _STREAM_TEXT_OVERLAP_CHARS
 
     escaped = False
@@ -290,6 +322,11 @@ def _pattern_has_stream_unsafe_repeat(pattern: str) -> bool:
             return True
         if remaining.startswith("(?P=", index):
             return True
+
+    if re.search(r"\((?:[^()\\]|\\.)*[|](?:[^()\\]|\\.)*\)\s*(?:[*+?]|\{)", remaining):
+        return True
+    if re.search(r"\((?:[^()\\]|\\.)*(?:[*+?]|\{[^}]+\})(?:[^()\\]|\\.)*\)\s*(?:[*+?]|\{)", remaining):
+        return True
 
     return len(remaining) > _STREAM_TEXT_OVERLAP_CHARS
 
@@ -493,7 +530,7 @@ class FlaxMsgpackScanner(BaseScanner):
         )
 
         # Enhanced suspicious patterns for JAX/Flax specific threats
-        self.suspicious_patterns = self.config.get(
+        configured_patterns = self.config.get(
             "suspicious_patterns",
             [
                 # Standard serialization attacks
@@ -523,12 +560,12 @@ class FlaxMsgpackScanner(BaseScanner):
                 # Dynamic code execution
                 _UNBOUNDED_GETATTR_PATTERN,
                 # Dangerous imports in serialized functions
-                r"import\s+subprocess",
                 r"from\s+subprocess\s+import",
                 r"import\s+sys",
                 r"from\s+os\s+import\s+system",
             ],
         )
+        self.suspicious_patterns = list(dict.fromkeys(configured_patterns))
         self._compiled_suspicious_patterns = tuple(
             (pattern, re.compile(pattern, re.IGNORECASE), pattern.lower()) for pattern in self.suspicious_patterns
         )
@@ -536,6 +573,14 @@ class FlaxMsgpackScanner(BaseScanner):
             pattern: _pattern_literal_anchors(pattern)
             for pattern in self.suspicious_patterns
             if _pattern_has_stream_unsafe_repeat(pattern)
+        }
+        self._stream_unsafe_anchor_matchers = {
+            pattern: (
+                None
+                if anchors is None
+                else tuple((anchor, re.compile(re.escape(anchor), re.IGNORECASE)) for anchor in anchors)
+            )
+            for pattern, anchors in self._stream_unsafe_pattern_anchors.items()
         }
 
         self.suspicious_keys = self.config.get(
@@ -970,17 +1015,16 @@ class FlaxMsgpackScanner(BaseScanner):
         evidence_value: Any | None = None,
     ) -> None:
         """Check string values for suspicious patterns that might indicate code injection."""
-        sample_value = value if evidence_value is None else evidence_value
-        for pattern, compiled_pattern, lowered_pattern in self._compiled_suspicious_patterns:
-            if compiled_pattern.search(value):
-                self._add_suspicious_string_check(
-                    pattern,
-                    lowered_pattern,
-                    sample_value,
-                    len(value),
-                    location,
-                    result,
-                )
+        self._analyze_streamed_text_chunks(
+            (value,),
+            location,
+            result,
+            full_length=len(value),
+            finding_location=location,
+            coverage_details={"text_length": len(value)},
+            check_jax_transform=False,
+            evidence_sample=evidence_value,
+        )
 
     @staticmethod
     def _suspicious_pattern_rule_code(lowered_pattern: str) -> str:
@@ -1026,14 +1070,15 @@ class FlaxMsgpackScanner(BaseScanner):
         if key in self.suspicious_keys:
             # Determine appropriate rule code based on key
             rule_code = "S201" if key.lower() == "__reduce__" else "S999"
+            safe_key = _redact_evidence_location(key)
 
             result.add_check(
                 name="Object Attribute Security Check",
                 passed=False,
-                message=f"Suspicious object attribute detected: {key}",
+                message=f"Suspicious object attribute detected: {safe_key}",
                 severity=IssueSeverity.CRITICAL,
                 location=_redact_evidence_location(location),
-                details={"suspicious_key": key},
+                details={"suspicious_key": safe_key},
                 rule_code=rule_code,
             )
             return
@@ -1878,6 +1923,7 @@ class FlaxMsgpackScanner(BaseScanner):
         coverage_details: dict[str, Any],
         check_jax_transform: bool,
         jax_location: str | None = None,
+        evidence_sample: Any | None = None,
     ) -> None:
         """Analyze decoded text with bounded regex windows and conservative coverage checks."""
         raw_tail = ""
@@ -1891,7 +1937,6 @@ class FlaxMsgpackScanner(BaseScanner):
 
         def inspect_windows(raw_window: str, normalized_window: str) -> None:
             raw_window_lower = raw_window.lower()
-            normalized_window_lower = normalized_window.lower()
             if check_jax_transform:
                 for transform in _DANGEROUS_JAX_TRANSFORMS:
                     if transform not in matched_transforms and transform in raw_window_lower:
@@ -1899,14 +1944,20 @@ class FlaxMsgpackScanner(BaseScanner):
             for pattern, compiled_pattern, lowered_pattern in self._compiled_suspicious_patterns:
                 if pattern in self._stream_unsafe_pattern_anchors:
                     anchors = self._stream_unsafe_pattern_anchors[pattern]
-                    window_has_all_anchors = anchors is None or all(
-                        anchor in normalized_window_lower for anchor in anchors
-                    )
+                    anchor_matchers = self._stream_unsafe_anchor_matchers[pattern]
                     if anchors is None:
                         unresolved_pattern_candidates.add(pattern)
+                        window_has_all_anchors = True
                     else:
                         seen_anchors = seen_pattern_anchors.setdefault(pattern, set())
-                        seen_anchors.update(anchor for anchor in anchors if anchor in normalized_window_lower)
+                        assert anchor_matchers is not None
+                        window_anchors = {
+                            anchor
+                            for anchor, matcher in anchor_matchers
+                            if matcher.search(normalized_window) is not None
+                        }
+                        seen_anchors.update(window_anchors)
+                        window_has_all_anchors = len(window_anchors) == len(anchors)
                         if len(seen_anchors) == len(anchors):
                             unresolved_pattern_candidates.add(pattern)
 
@@ -1954,7 +2005,7 @@ class FlaxMsgpackScanner(BaseScanner):
             self._add_suspicious_string_check(
                 pattern,
                 lowered_pattern,
-                sample,
+                sample if evidence_sample is None else evidence_sample,
                 decoded_chars,
                 finding_location,
                 result,

--- a/tests/scanners/test_flax_msgpack_scanner.py
+++ b/tests/scanners/test_flax_msgpack_scanner.py
@@ -1085,6 +1085,8 @@ def test_stream_repeat_fallback_without_re_parser(monkeypatch: pytest.MonkeyPatc
         r"(?P<name>foo)(?P=name)",
         r"BEGIN.{5000}END",
         r"\\s+",
+        r"(a+)+b",
+        r"(a|aa){20}b",
     ):
         assert _pattern_has_stream_unsafe_repeat(pattern) is True
 
@@ -1231,6 +1233,58 @@ def test_flax_msgpack_does_not_execute_stream_unsafe_regex_on_large_values(tmp_p
         result = scanner.scan(str(path))
 
         assert result.success is True
+
+
+@pytest.mark.parametrize("payload_size", [10_000, 70_000])
+def test_flax_msgpack_does_not_execute_ambiguous_custom_regex(
+    tmp_path: Path,
+    payload_size: int,
+) -> None:
+    class FailIfSearched:
+        def search(self, _value: str) -> None:
+            raise AssertionError("ambiguous regex must not be executed")
+
+    pattern = r"(a|aa){20}b"
+    path = tmp_path / f"ambiguous_regex_{payload_size}.msgpack"
+    create_msgpack_file(path, {"params": {"blob": "a" * payload_size}})
+    scanner = FlaxMsgpackScanner(config={"suspicious_patterns": [pattern]})
+    scanner._compiled_suspicious_patterns = ((pattern, cast(Any, FailIfSearched()), pattern.lower()),)
+
+    result = scanner.scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert FlaxMsgpackScanner.BINARY_PATTERN_INCONCLUSIVE_REASON in result.metadata["scan_outcome_reasons"]
+
+
+@pytest.mark.parametrize("as_binary", [False, True])
+def test_flax_msgpack_unsafe_pattern_anchors_preserve_unicode_ignorecase(
+    tmp_path: Path,
+    as_binary: bool,
+) -> None:
+    pattern = r"ss.*ii"
+    text = "\u017f\u017f" + ("x" * 70_000) + "\u0131\u0131"
+    payload: str | bytes = text.encode() if as_binary else text
+    path = tmp_path / f"unicode_anchors_{as_binary}.msgpack"
+    create_msgpack_file(path, {"params": {"blob": payload}})
+
+    result = FlaxMsgpackScanner(config={"suspicious_patterns": [pattern]}).scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    coverage = next(check for check in result.checks if check.name == "Flax MessagePack Binary Pattern Coverage")
+    assert coverage.details["pattern"] == pattern
+
+
+def test_flax_msgpack_unicode_unsafe_pattern_near_match_remains_clean(tmp_path: Path) -> None:
+    pattern = r"ss.*ii"
+    path = tmp_path / "unicode_anchor_near_match.msgpack"
+    create_msgpack_file(path, {"params": {"blob": "\u017f\u017f" + ("x" * 70_000)}})
+
+    result = FlaxMsgpackScanner(config={"suspicious_patterns": [pattern]}).scan(str(path))
+
+    assert result.success is True
+    assert FlaxMsgpackScanner.BINARY_PATTERN_INCONCLUSIVE_REASON not in result.metadata.get("scan_outcome_reasons", [])
 
 
 def test_flax_msgpack_streams_shape_validation_beyond_evidence_limit(tmp_path: Path) -> None:
@@ -2468,3 +2522,35 @@ def test_flax_msgpack_custom_long_suspicious_key_still_matches(tmp_path: Path) -
         and check.message == f"Suspicious object attribute detected: {suspicious_key}"
         for check in result.checks
     )
+
+
+def test_flax_msgpack_redacts_custom_suspicious_key_evidence(tmp_path: Path) -> None:
+    path = tmp_path / "custom_secret_key.msgpack"
+    secret = "CUSTOMKEYSECRET123456789"
+    suspicious_key = f"danger?token={secret}"
+    create_msgpack_file(path, {suspicious_key: "safe"})
+
+    result = FlaxMsgpackScanner(config={"suspicious_keys": {suspicious_key}}).scan(str(path))
+    serialized = result.to_json()
+
+    assert any(
+        check.name == "Object Attribute Security Check"
+        and check.message == "Suspicious object attribute detected: danger?token=<redacted>"
+        and check.details["suspicious_key"] == "danger?token=<redacted>"
+        for check in result.checks
+    )
+    assert secret not in serialized
+
+
+def test_flax_msgpack_deduplicates_configured_suspicious_patterns(tmp_path: Path) -> None:
+    path = tmp_path / "duplicate_pattern.msgpack"
+    create_msgpack_file(path, {"params": {"note": "import subprocess"}})
+
+    result = FlaxMsgpackScanner(config={"suspicious_patterns": [r"import\s+subprocess"] * 2}).scan(str(path))
+
+    findings = [
+        check
+        for check in result.checks
+        if check.name == "Code Pattern Security Check" and check.details["pattern"] == r"import\s+subprocess"
+    ]
+    assert len(findings) == 1


### PR DESCRIPTION
## Summary

- prevent ReDoS-prone custom patterns from executing on either small or streamed Flax MessagePack scalars
- preserve Python `re.IGNORECASE` semantics when proving unsafe-pattern anchors across chunks
- deduplicate configured suspicious patterns and redact custom suspicious-key evidence

## Security QA

- reproduced `(a+)+b` hanging on a 10,000-character scalar before the fix; the same scan now fails closed in about 0.01s
- reproduced a clean false negative for `ss.*ii` across Unicode long-s/dotless-i text and binary payloads; both now fail closed
- added a benign Unicode near-match regression to prevent noisy inconclusive results
- verified custom secret-bearing keys no longer leak through messages or details

## Validation

- `tests/scanners/test_flax_msgpack_scanner.py`: 158 passed
- `tests/scanners/test_jax_checkpoint_scanner.py`: 122 passed
- scoped Ruff check and format: clean
- scoped mypy: clean
- `git diff --check`: clean

Follow-up to #1589.