### PR TITLE
fix: preserve active HF findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- keep concrete active execution, runtime-extension, and blacklist findings from being downgraded by Hugging Face whitelists
 - keep same-fragment command/network correlations and relayed fail-closed findings active across Hugging Face whitelists
 - validate Joblib NumPy wrapper state and scan resumed pickle opcodes around raw array payloads without flagging inert array bytes.
 - bound CatBoost command-evidence redaction work and cover distant, shell-concatenated, wrapped, and netrc curl credentials

--- a/modelaudit/scanners/base.py
+++ b/modelaudit/scanners/base.py
@@ -112,6 +112,22 @@ _WHITELIST_DOWNGRADE_EXEMPT_CHECK_NAMES: Final[frozenset[str]] = frozenset(
     }
 )
 _WHITELIST_DOWNGRADE_EXEMPT_CORRELATION_DETAIL = "same_fragment_correlation"
+_WHITELIST_DOWNGRADE_EXEMPT_CRITICAL_CHECK_NAMES: Final[frozenset[str]] = frozenset(
+    {
+        "Blacklist Pattern Check",
+        "Command Indicator Check",
+        "CoreML Custom Layer Check",
+        "CoreML Custom Model Class Check",
+        "Embedded PE Detection",
+        "External Library Reference Check",
+        "Protobuf String Injection Check",
+        "Python Operator Detection",
+        "Serialized Expression Payload Detection",
+        "Suspicious Layer Type Detection",
+        "TorchServe Handler Static Analysis",
+        "Torch7 Lua Execution Primitive Analysis",
+    }
+)
 # Word-boundary matching prevents incidental substrings (e.g. "executable" inside
 # "ExecuTorch", "rce" inside "force") from suppressing whitelist downgrades.
 _WHITELIST_DOWNGRADE_EXEMPT_KEYWORD_PATTERN: Final[re.Pattern[str]] = re.compile(
@@ -248,6 +264,7 @@ class BaseScanner(ABC):
     @staticmethod
     def _whitelist_downgrade_exempt(
         *,
+        severity: IssueSeverity,
         details: dict[str, Any] | None,
         result_metadata: dict[str, Any] | None = None,
         message: str | None,
@@ -267,6 +284,9 @@ class BaseScanner(ABC):
             check_name in _WHITELIST_DOWNGRADE_EXEMPT_CHECK_NAMES
             and details.get(_WHITELIST_DOWNGRADE_EXEMPT_CORRELATION_DETAIL) is True
         ):
+            return True
+
+        if severity == IssueSeverity.CRITICAL and check_name in _WHITELIST_DOWNGRADE_EXEMPT_CRITICAL_CHECK_NAMES:
             return True
 
         if rule_code and (rule_code.startswith("S2") or rule_code in _WHITELIST_DOWNGRADE_EXEMPT_RULE_CODES):
@@ -299,6 +319,7 @@ class BaseScanner(ABC):
             return False
 
         if self._whitelist_downgrade_exempt(
+            severity=severity,
             details=details,
             result_metadata=result_metadata,
             message=message,

--- a/tests/scanners/test_base_scanner.py
+++ b/tests/scanners/test_base_scanner.py
@@ -608,6 +608,85 @@ def test_whitelist_downgrades_unconfirmed_command_network_correlation(check_name
     assert result.checks[0].severity == IssueSeverity.INFO
 
 
+@pytest.mark.parametrize(
+    "check_name",
+    [
+        "Blacklist Pattern Check",
+        "Command Indicator Check",
+        "CoreML Custom Layer Check",
+        "CoreML Custom Model Class Check",
+        "Embedded PE Detection",
+        "External Library Reference Check",
+        "Protobuf String Injection Check",
+        "Python Operator Detection",
+        "Serialized Expression Payload Detection",
+        "Suspicious Layer Type Detection",
+        "TorchServe Handler Static Analysis",
+        "Torch7 Lua Execution Primitive Analysis",
+    ],
+)
+def test_whitelist_does_not_downgrade_active_critical_checks(check_name: str) -> None:
+    """Concrete active-payload criticals must still fail whitelisted HF scans."""
+    from modelaudit.whitelists import POPULAR_MODELS
+
+    scanner = MockScanner()
+    scanner.context = UnifiedMLContext(
+        file_path=Path("/tmp/test.pkl"),
+        file_size=100,
+        file_type=".pkl",
+        model_id=next(iter(POPULAR_MODELS)),
+        model_source="huggingface",
+    )
+
+    result = scanner._create_result()
+    result.add_check(
+        name=check_name,
+        passed=False,
+        message="Concrete active execution or runtime-extension evidence detected",
+        severity=IssueSeverity.CRITICAL,
+    )
+
+    assert result.issues[0].severity == IssueSeverity.CRITICAL
+    assert result.issues[0].details.get("whitelist_downgrade") is None
+    assert result.checks[0].severity == IssueSeverity.CRITICAL
+
+
+@pytest.mark.parametrize(
+    "check_name",
+    [
+        "Blacklist Pattern Check",
+        "Command Indicator Check",
+        "Protobuf String Injection Check",
+        "Serialized Expression Payload Detection",
+        "Torch7 Lua Execution Primitive Analysis",
+    ],
+)
+def test_whitelist_still_downgrades_warning_variants_of_active_check_names(check_name: str) -> None:
+    """Documentation, operational, or uncorrelated warning variants stay whitelist eligible."""
+    from modelaudit.whitelists import POPULAR_MODELS
+
+    scanner = MockScanner()
+    scanner.context = UnifiedMLContext(
+        file_path=Path("/tmp/test.pkl"),
+        file_size=100,
+        file_type=".pkl",
+        model_id=next(iter(POPULAR_MODELS)),
+        model_source="huggingface",
+    )
+
+    result = scanner._create_result()
+    result.add_check(
+        name=check_name,
+        passed=False,
+        message="Uncorrelated or documentation-context indicator detected",
+        severity=IssueSeverity.WARNING,
+    )
+
+    assert result.issues[0].severity == IssueSeverity.INFO
+    assert result.issues[0].details.get("whitelist_downgrade") is True
+    assert result.checks[0].severity == IssueSeverity.INFO
+
+
 def test_whitelist_still_downgrades_rknn_command_only_near_match() -> None:
     """The RKNN correlation exemption must not cover command-only indicators."""
     from modelaudit.whitelists import POPULAR_MODELS


### PR DESCRIPTION
## Summary
- follow up on #1551's whitelist review by preserving additional concrete CRITICAL execution and runtime-extension findings
- keep explicit blacklist hits, direct command payloads, embedded PE files, custom runtime hooks, Python operators, and handler execution from being downgraded solely by trusted Hugging Face provenance
- scope exemptions to exact check names at CRITICAL severity so warning, documentation, operational, and near-match findings remain whitelist-eligible
- retain #1551's producer-supplied `same_fragment_correlation` requirement unchanged

## False-positive / false-negative audit
- malicious positives remain CRITICAL for LightGBM, Torch7, R serialization, TensorRT PE, CoreML custom code, OpenVINO runtime extensions, ONNX Python operators, TorchServe handlers, TensorFlow protobuf command injection, and explicit blacklist findings
- warning variants of shared check names still downgrade to INFO
- benign OpenVINO, TorchServe, TensorFlow protobuf, blacklist-boundary, and correlation near matches remain clean

## Validation
- current main: `603c782fb8d4b0120be430589a4a1ca046b76709`
- head: `7daac2107a37bc8ea030005bf1e86e715ce05400`
- exact verified tree: `a6bc9004a0a56b170422221b7ae94a2af5afcbcd`
- associated scanner/base/cache tests: `781 passed`
- scoped Ruff check/format, mypy, and `git diff --check`: clean
- local ONNX producer tests were unavailable because the optional `onnx` package is not installed; the exact-name whitelist behavior is covered in the base-scanner regression and CI owns the optional-dependency lane
- full suite intentionally left to CI per review workflow