### PR TITLE
fix(picklescan): scan encoded byte literals

### DIFF
--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -78,6 +78,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- scan encoded nested pickles in byte and bytearray literals without treating complete encoded payloads as raw pickle fragments
 - continue probing encoded protocol 0 payloads after long line operands, lenient base64 separators, and wrapper alignment shifts while failing closed beyond bounded mid-scan coverage
 - reject nested-pickle analysis budgets below two bytes, recognize explicit protocol 0 headers, and use bounded structural probes to avoid prose false positives without missing valid suffixes
 - preserve fail-closed nested protocol 0 analysis after `INST` opcodes

--- a/packages/modelaudit-picklescan/rust/src/nested.rs
+++ b/packages/modelaudit-picklescan/rust/src/nested.rs
@@ -144,6 +144,19 @@ fn decoded_pickle_payloads(decoded: &[u8], max_nested_pickle_bytes: usize) -> Ve
         Ok(None) | Err(_) => {}
     }
 
+    let remaining = &decoded[search_start..];
+    let remaining_is_complete = pickle_payload_extent_result(remaining, max_nested_pickle_bytes)
+        .is_ok_and(|extent| extent.is_some());
+    if search_start > 0
+        && remaining.len() <= max_nested_pickle_bytes
+        && !remaining_is_complete
+        && has_execution_opcode(remaining)
+    {
+        let payload_len = remaining.len().min(max_nested_pickle_bytes);
+        payloads.push((remaining[..payload_len].to_vec(), true));
+        return payloads;
+    }
+
     let mut seen_spans = Vec::new();
     for offset in nested_pickle_probe_offsets_unbounded(&decoded[search_start..]) {
         let offset = search_start.saturating_add(offset);
@@ -156,6 +169,9 @@ fn decoded_pickle_payloads(decoded: &[u8], max_nested_pickle_bytes: usize) -> Ve
                 Ok(Some(payload_len)) => (payload_len, false),
                 Err(error) if error.is_structured_protocol0_line_operand_limit() => {
                     (probe.len(), true)
+                }
+                Ok(None) | Err(_) if has_execution_opcode(probe) => {
+                    (probe.len().min(max_nested_pickle_bytes), true)
                 }
                 Ok(None) | Err(_) => continue,
             };
@@ -1537,6 +1553,25 @@ fn base64_candidate_unpadded(value: &str) -> Option<&str> {
     Some(unpadded)
 }
 
+pub(crate) fn is_strict_base64_literal(value: &[u8]) -> bool {
+    let Some(padding_start) = value.iter().position(|byte| *byte == b'=') else {
+        return !value.is_empty()
+            && value.len() % 4 != 1
+            && value.iter().all(
+                |byte| matches!(*byte, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'+' | b'/'),
+            );
+    };
+    let (unpadded, padding) = value.split_at(padding_start);
+    !unpadded.is_empty()
+        && unpadded.len() % 4 != 1
+        && unpadded
+            .iter()
+            .all(|byte| matches!(*byte, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'+' | b'/'))
+        && padding.len() <= 2
+        && padding.iter().all(|byte| *byte == b'=')
+        && value.len() % 4 == 0
+}
+
 fn is_hex_candidate(value: &str) -> bool {
     !value.is_empty() && value.bytes().all(is_hex_byte)
 }
@@ -1572,7 +1607,7 @@ fn base64_structural_prefix_has_pickle_prefix(value: &str) -> bool {
         value,
         MAX_ENCODED_LITERAL_PREFIX_SCAN_BYTES,
         max_encoded_chars,
-    )
+    ) || base64_prefix_has_complete_protocol0_line(value, MAX_ENCODED_LITERAL_PREFIX_SCAN_BYTES)
 }
 
 fn base64_prefix_has_pickle_prefix_with_limit(value: &str, max_input_bytes: usize) -> bool {
@@ -1580,7 +1615,7 @@ fn base64_prefix_has_pickle_prefix_with_limit(value: &str, max_input_bytes: usiz
         value,
         max_input_bytes,
         ENCODED_LITERAL_PROBE_CHARS,
-    ) || base64_prefix_has_complete_protocol0_line(value, max_input_bytes)
+    )
 }
 
 fn base64_prefix_has_pickle_prefix_with_probe_chars(
@@ -1614,7 +1649,6 @@ fn base64_prefix_has_nested_probe_prefix(value: &str, max_input_bytes: usize) ->
                 .and_then(decode_base64)
                 .is_some_and(|decoded| has_nested_probe_prefix(&decoded))
         })
-        || base64_prefix_has_complete_protocol0_line(value, max_input_bytes)
 }
 
 fn base64_prefix_has_complete_protocol0_line(value: &str, max_input_bytes: usize) -> bool {
@@ -2370,7 +2404,7 @@ mod tests {
             let payload = long_protocol0_line_payload_for_test(opcode);
             let encoded = encode_base64_for_test(&payload);
 
-            assert!(base64_prefix_has_pickle_prefix(&encoded));
+            assert!(base64_structural_prefix_has_pickle_prefix(&encoded));
             assert!(
                 decode_possible_encoded_pickle(&encoded, TEST_MAX_NESTED_PICKLE_BYTES)
                     .iter()
@@ -2447,6 +2481,33 @@ mod tests {
                     char::from(opcode)
                 );
             }
+        }
+    }
+
+    #[test]
+    fn encoded_probe_windows_keep_benign_long_scalar_candidates_at_decoded_offsets() {
+        let mut payload = b"V".to_vec();
+        payload.extend(std::iter::repeat_n(
+            b'A',
+            PROTOCOL0_SCALAR_PREFIX_PROBE_BYTES + 1,
+        ));
+        payload.extend_from_slice(b"\n.");
+
+        for prefix_len in 1..3usize {
+            let mut wrapped = vec![b'X'; prefix_len];
+            wrapped.extend_from_slice(&payload);
+            let encoded = encode_base64_for_test(&wrapped);
+
+            assert!(encoded_literal_may_contain_pickle(&encoded));
+            let windows = encoded_nested_literal_probe_windows(&encoded, encoded.len());
+            assert!(
+                windows.iter().any(|window| {
+                    decode_possible_encoded_pickle(window, TEST_MAX_NESTED_PICKLE_BYTES)
+                        .iter()
+                        .any(|candidate| candidate.payload == payload)
+                }),
+                "missing benign payload at decoded offset {prefix_len}: {windows:?}",
+            );
         }
     }
 
@@ -2626,6 +2687,42 @@ mod tests {
         let error = pickle_payload_extent_result(&payload, payload.len() + 16)
             .expect_err("overlong protocol 0 string should preserve its parse error");
         assert!(!error.is_structured_protocol0_line_operand_limit());
+    }
+
+    #[test]
+    fn decoded_payloads_preserve_truncated_execution_prefixes() {
+        for payload in [b"Pevil\nAAAAAAAA".as_slice(), b"\x80\x04N.Pevil\n"] {
+            let decoded = decoded_pickle_payloads(payload, payload.len() + 16);
+
+            assert!(decoded.iter().any(|(candidate, analysis_incomplete)| {
+                *analysis_incomplete && candidate.starts_with(b"Pevil\n")
+            }));
+        }
+    }
+
+    #[test]
+    fn decoded_payloads_ignore_truncated_data_only_scalars() {
+        for payload in [
+            b"F1".as_slice(),
+            b"I1",
+            b"L1",
+            b"S'value'",
+            b"Vvalue",
+            b"g0",
+            b"p0",
+        ] {
+            assert!(decoded_pickle_payloads(payload, payload.len() + 16).is_empty());
+        }
+    }
+
+    #[test]
+    fn strict_base64_literals_require_terminal_canonical_padding() {
+        assert!(is_strict_base64_literal(b"gAR9Lg=="));
+        assert!(is_strict_base64_literal(b"gAR9Lg"));
+        assert!(!is_strict_base64_literal(b"gAR9Lg==NQ"));
+        assert!(!is_strict_base64_literal(b"=gAR9Lg="));
+        assert!(!is_strict_base64_literal(b"g=AR9Lg="));
+        assert!(!is_strict_base64_literal(b"gAR9Lg===="));
     }
 
     #[test]

--- a/packages/modelaudit-picklescan/rust/src/state.rs
+++ b/packages/modelaudit-picklescan/rust/src/state.rs
@@ -15,9 +15,10 @@ use crate::nested::{
     encoded_nested_literal_probe_coverage_incomplete,
     encoded_nested_literal_probe_windows_with_limit, encoded_nested_window_char_limit,
     encoded_pickle_consumes_literal, has_binary_pickle_prefix, has_execution_opcode,
-    has_pickle_prefix, looks_like_pickle_payload, nested_pickle_probe_offsets,
-    pickle_payload_extent_result, protocol0_global_or_inst_prefix_has_import_reference_lines,
-    DecodedNestedPayload, NestedProbeOffsets, MAX_NESTED_PAYLOAD_PROBES,
+    has_pickle_prefix, is_strict_base64_literal, looks_like_pickle_payload,
+    nested_pickle_probe_offsets, pickle_payload_extent_result,
+    protocol0_global_or_inst_prefix_has_import_reference_lines, DecodedNestedPayload,
+    NestedProbeOffsets, MAX_NESTED_PAYLOAD_PROBES,
 };
 use crate::nested_surface::{
     encoded_nested_payload_finding, is_allowlisted_nested_constructor_ref,
@@ -1303,7 +1304,73 @@ impl<'a> ScanState<'a> {
             "BINBYTES" | "BINBYTES8" | "SHORT_BINBYTES" | "BYTEARRAY8" => {
                 if let Some((start, end)) = opcode.arg.byte_span(self.payload.len()) {
                     let bytes = &self.payload[start..end];
-                    self.scan_raw_nested_pickle_bytes(bytes, self.position_offset + start);
+                    let encoded_nested_pickle_outcome = match std::str::from_utf8(bytes) {
+                        Ok(value) => {
+                            if self.is_large_uninteresting_repeated_literal(value) {
+                                (false, false)
+                            } else {
+                                self.scan_encoded_nested_pickle_literal_outcome(value, position)
+                            }
+                        }
+                        Err(_) => {
+                            let sanitize = |slice: &[u8]| {
+                                slice
+                                    .iter()
+                                    .map(|byte| {
+                                        if byte.is_ascii() {
+                                            char::from(*byte)
+                                        } else {
+                                            '!'
+                                        }
+                                    })
+                                    .collect::<String>()
+                            };
+                            let scan_limit =
+                                bytes.len().min(self.options.max_string_literal_scan_chars);
+                            if scan_limit == bytes.len() {
+                                let value = sanitize(bytes);
+                                if self.is_large_uninteresting_repeated_literal(&value) {
+                                    (false, false)
+                                } else {
+                                    self.scan_encoded_nested_pickle_literal_outcome(
+                                        &value, position,
+                                    )
+                                }
+                            } else {
+                                let mut found_candidate = false;
+                                if scan_limit > 0 {
+                                    for slice in
+                                        [&bytes[..scan_limit], &bytes[bytes.len() - scan_limit..]]
+                                    {
+                                        let value = sanitize(slice);
+                                        if !self.is_large_uninteresting_repeated_literal(&value) {
+                                            found_candidate |= self
+                                                .scan_encoded_nested_pickle_literal_outcome(
+                                                    &value, position,
+                                                )
+                                                .0;
+                                        }
+                                    }
+                                }
+                                self.record_literal_scan_truncated(
+                                    "bytes",
+                                    bytes.len(),
+                                    "encoded_nested_pickle",
+                                    position,
+                                );
+                                (found_candidate, false)
+                            }
+                        }
+                    };
+                    let strict_base64_literal = is_strict_base64_literal(bytes);
+                    // Complete raw pickles require STOP ('.'), which is outside the
+                    // base64 alphabet. After a decoded candidate is confirmed, raw
+                    // parsing of a strict token can only produce truncated phantoms.
+                    let skip_raw_scan = encoded_nested_pickle_outcome.1
+                        || (encoded_nested_pickle_outcome.0 && strict_base64_literal);
+                    if !skip_raw_scan {
+                        self.scan_raw_nested_pickle_bytes(bytes, self.position_offset + start);
+                    }
                     self.push_stack_value(StackValue::Bytes { start, end });
                 } else {
                     self.push_stack_value(StackValue::Bytes { start: 0, end: 0 });
@@ -6000,8 +6067,17 @@ impl<'a> ScanState<'a> {
     }
 
     fn scan_encoded_nested_pickle_literal(&mut self, value: &str, position: usize) -> bool {
+        self.scan_encoded_nested_pickle_literal_outcome(value, position)
+            .1
+    }
+
+    fn scan_encoded_nested_pickle_literal_outcome(
+        &mut self,
+        value: &str,
+        position: usize,
+    ) -> (bool, bool) {
         if !encoded_literal_may_contain_pickle(value) {
-            return false;
+            return (false, false);
         }
 
         let whole_literal_is_encoded_pickle = encoded_pickle_consumes_literal(value);
@@ -6065,11 +6141,11 @@ impl<'a> ScanState<'a> {
         }
 
         if found_candidate {
-            return whole_literal_is_encoded_pickle;
+            return (true, whole_literal_is_encoded_pickle);
         }
 
         if probe_coverage_incomplete || probe_limit_exceeded {
-            return false;
+            return (false, false);
         }
 
         if value.len() > self.options.max_string_literal_scan_chars
@@ -6082,7 +6158,7 @@ impl<'a> ScanState<'a> {
                 position,
             );
         }
-        whole_literal_is_encoded_pickle
+        (false, whole_literal_is_encoded_pickle)
     }
 
     fn scan_encoded_nested_pickle_candidate(&mut self, value: &str, position: usize) -> bool {

--- a/packages/modelaudit-picklescan/tests/test_protocol0_line_operands.py
+++ b/packages/modelaudit-picklescan/tests/test_protocol0_line_operands.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import pickle
+import time
 from collections.abc import Mapping
 
 import pytest
@@ -41,6 +42,13 @@ def _long_scalar_before_reduce_protocol0_pickle(opcode: bytes) -> bytes:
     else:
         scalar = b"V" + (b"A" * 257) + b"\n"
     return scalar + b"0cos\nsystem\n(S'id'\ntR."
+
+
+def _benign_long_scalar_protocol0_pickle(opcode: bytes) -> bytes:
+    prefix = _long_scalar_before_reduce_protocol0_pickle(opcode).split(b"cos\nsystem\n", maxsplit=1)[0]
+    if prefix.endswith(b"0"):
+        prefix = prefix[:-1]
+    return prefix + b"."
 
 
 def test_scan_bytes_accepts_exact_limit_protocol0_line_operand() -> None:
@@ -216,6 +224,240 @@ def test_scan_bytes_detects_base64_pickle_at_each_decoded_offset(
     assert report.status == ScanStatus.COMPLETE
     assert report.verdict == SafetyVerdict.MALICIOUS
     assert any(finding.rule_code == "DANGEROUS_CALL" for finding in report.findings)
+
+
+@pytest.mark.parametrize("container", [bytes, bytearray])
+def test_scan_bytes_detects_base64_long_protocol0_pickle_in_byte_literals(
+    container: type[bytes] | type[bytearray],
+) -> None:
+    nested_payload = _long_scalar_before_reduce_protocol0_pickle(b"V")
+    encoded = container(base64.b64encode(nested_payload))
+
+    report = scan_bytes(
+        pickle.dumps(encoded, protocol=5),
+        source=f"base64-long-protocol0-{container.__name__}.pkl",
+    )
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert any(
+        finding.rule_code == "DANGEROUS_CALL"
+        and finding.details.get("module") == "os"
+        and finding.details.get("name") == "system"
+        for finding in report.findings
+    )
+
+
+@pytest.mark.parametrize("container", [bytes, bytearray])
+@pytest.mark.parametrize("invalid_utf8_position", ["prefix", "suffix"])
+def test_scan_bytes_detects_base64_byte_literals_with_invalid_utf8_wrappers(
+    container: type[bytes] | type[bytearray],
+    invalid_utf8_position: str,
+) -> None:
+    nested_payload = _long_scalar_before_reduce_protocol0_pickle(b"V")
+    encoded = base64.b64encode(nested_payload)
+    wrapped = b"\xff" + encoded if invalid_utf8_position == "prefix" else encoded + b"\xff"
+
+    report = scan_bytes(
+        pickle.dumps(container(wrapped), protocol=5),
+        source=f"wrapped-base64-{container.__name__}.pkl",
+    )
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert any(
+        finding.rule_code == "DANGEROUS_CALL"
+        and finding.details.get("module") == "os"
+        and finding.details.get("name") == "system"
+        for finding in report.findings
+    )
+
+
+@pytest.mark.parametrize("container", [bytes, bytearray])
+@pytest.mark.parametrize("invalid_utf8_position", ["prefix", "suffix"])
+def test_scan_bytes_detects_over_budget_invalid_utf8_wrapped_base64_byte_literals(
+    container: type[bytes] | type[bytearray],
+    invalid_utf8_position: str,
+) -> None:
+    nested_payload = _long_scalar_before_reduce_protocol0_pickle(b"V")
+    encoded = base64.b64encode(nested_payload)
+    scan_limit = len(encoded) + 8
+    padding = b"\xff" * (scan_limit + 1)
+    wrapped = padding + encoded if invalid_utf8_position == "prefix" else encoded + padding
+
+    report = scan_bytes(
+        pickle.dumps(container(wrapped), protocol=5),
+        source=f"over-budget-wrapped-base64-{container.__name__}.pkl",
+        options=ScanOptions(max_string_literal_scan_chars=scan_limit),
+    )
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert any(finding.rule_code == "DANGEROUS_CALL" for finding in report.findings)
+    assert any(notice.code == "literal_scan_truncated" for notice in report.notices)
+
+
+@pytest.mark.parametrize("container", [bytes, bytearray])
+def test_scan_bytes_fails_closed_for_invalid_utf8_encoded_payload_hidden_beyond_literal_budget(
+    container: type[bytes] | type[bytearray],
+) -> None:
+    encoded = base64.b64encode(_long_scalar_before_reduce_protocol0_pickle(b"V"))
+    scan_limit = 64
+    padding = b"\xff" * (scan_limit + 1)
+    wrapped = padding + encoded + padding
+
+    report = scan_bytes(
+        pickle.dumps(container(wrapped), protocol=5),
+        source=f"hidden-over-budget-base64-{container.__name__}.pkl",
+        options=ScanOptions(max_string_literal_scan_chars=scan_limit),
+    )
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict != SafetyVerdict.CLEAN
+    assert any(notice.code == "literal_scan_truncated" for notice in report.notices)
+
+
+@pytest.mark.parametrize("container", [bytes, bytearray])
+@pytest.mark.parametrize("decoded_prefix", [b"", b"X", b"junk"])
+def test_scan_bytes_keeps_benign_base64_byte_literals_clean(
+    container: type[bytes] | type[bytearray],
+    decoded_prefix: bytes,
+) -> None:
+    encoded = container(base64.b64encode(decoded_prefix + _benign_long_scalar_protocol0_pickle(b"V")))
+
+    report = scan_bytes(
+        pickle.dumps(encoded, protocol=5),
+        source=f"benign-base64-{container.__name__}.pkl",
+    )
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert report.findings == ()
+
+
+@pytest.mark.parametrize("container", [bytes, bytearray])
+@pytest.mark.parametrize("invalid_utf8_position", ["prefix", "suffix"])
+def test_scan_bytes_keeps_benign_base64_byte_literals_with_invalid_utf8_clean(
+    container: type[bytes] | type[bytearray],
+    invalid_utf8_position: str,
+) -> None:
+    encoded = base64.b64encode(_benign_long_scalar_protocol0_pickle(b"V"))
+    wrapped = b"\xff" + encoded if invalid_utf8_position == "prefix" else encoded + b"\xff"
+
+    report = scan_bytes(
+        pickle.dumps(container(wrapped), protocol=5),
+        source=f"benign-wrapped-base64-{container.__name__}.pkl",
+    )
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert report.findings == ()
+
+
+@pytest.mark.parametrize("container", [bytes, bytearray])
+@pytest.mark.parametrize("encoded_first", [False, True])
+def test_scan_bytes_keeps_raw_nested_scan_for_mixed_encoded_byte_literals(
+    container: type[bytes] | type[bytearray],
+    encoded_first: bool,
+) -> None:
+    benign_encoded = base64.b64encode(_benign_long_scalar_protocol0_pickle(b"V"))
+    raw_malicious = b"cos\nsystem\n(S'id'\ntR."
+    payload = benign_encoded + b"!" + raw_malicious if encoded_first else raw_malicious + b"!" + benign_encoded
+
+    report = scan_bytes(
+        pickle.dumps(container(payload), protocol=5),
+        source=f"mixed-encoded-raw-{container.__name__}.pkl",
+    )
+
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert any(
+        finding.rule_code == "DANGEROUS_CALL"
+        and finding.details.get("module") == "os"
+        and finding.details.get("name") == "system"
+        for finding in report.findings
+    )
+
+
+@pytest.mark.parametrize("container", [bytes, bytearray])
+def test_scan_bytes_keeps_fail_closed_raw_scan_for_truncated_persid_after_encoded_literal(
+    container: type[bytes] | type[bytearray],
+) -> None:
+    benign_encoded = base64.b64encode(_benign_long_scalar_protocol0_pickle(b"V"))
+    payload = benign_encoded + b"!Pevil\n"
+
+    report = scan_bytes(
+        pickle.dumps(container(payload), protocol=5),
+        source=f"encoded-plus-truncated-persid-{container.__name__}.pkl",
+    )
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert any(finding.rule_code == "PERSISTENT_ID" for finding in report.findings)
+    assert any(
+        finding.rule_code == "S213" and finding.details.get("analysis_incomplete") is True
+        for finding in report.findings
+    )
+
+
+@pytest.mark.parametrize("container", [bytes, bytearray])
+def test_scan_bytes_keeps_raw_scan_after_invalid_base64_padding(
+    container: type[bytes] | type[bytearray],
+) -> None:
+    benign_encoded = base64.b64encode(_benign_long_scalar_protocol0_pickle(b"V"))
+    payload = benign_encoded + b"NQ"
+
+    report = scan_bytes(
+        pickle.dumps(container(payload), protocol=5),
+        source=f"base64-invalid-padding-raw-suffix-{container.__name__}.pkl",
+    )
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert any(finding.rule_code == "PERSISTENT_ID" for finding in report.findings)
+    assert any(
+        finding.rule_code == "S213" and finding.details.get("analysis_incomplete") is True
+        for finding in report.findings
+    )
+
+
+@pytest.mark.parametrize("container", [bytes, bytearray])
+@pytest.mark.parametrize("decoded", [b"Pevil\nAAAAAAAA", b"\x80\x04N.Pevil\n"])
+def test_scan_bytes_fails_closed_for_encoded_truncated_execution_prefixes(
+    container: type[bytes] | type[bytearray],
+    decoded: bytes,
+) -> None:
+    encoded = container(base64.b64encode(decoded))
+
+    report = scan_bytes(
+        pickle.dumps(encoded, protocol=5),
+        source=f"encoded-truncated-execution-{container.__name__}.pkl",
+    )
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert any(finding.rule_code == "PERSISTENT_ID" for finding in report.findings)
+    assert any(
+        finding.rule_code == "S601" and finding.details.get("analysis_incomplete") is True
+        for finding in report.findings
+    )
+    assert any(notice.code == "nested_pickle_incomplete" for notice in report.notices)
+    assert not any(notice.code == "encoded_nested_payload_truncated" for notice in report.notices)
+
+
+def test_scan_bytes_bounds_unterminated_protocol0_base64_scalar_runtime() -> None:
+    encoded = base64.b64encode(b"V" + (b"A" * 100_000))
+
+    started = time.monotonic()
+    report = scan_bytes(
+        pickle.dumps(encoded, protocol=5),
+        source="unterminated-protocol0-base64-byte-literal.pkl",
+    )
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 2.0
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert report.findings == ()
 
 
 @pytest.mark.parametrize("opcode", [b"g", b"p"])


### PR DESCRIPTION
## Summary

- scan base64 and hex nested pickle candidates inside `bytes` and `bytearray` literals, including bounded invalid-UTF-8 wrappers
- fail closed for decoded truncated execution-bearing pickle prefixes while keeping data-only and execution-like benign near-matches clean
- require stack-valid pickle structure before promoting incomplete decoded suffixes
- validate terminal base64 padding before suppressing raw scanning
- enforce `max_string_literal_scan_chars` before valid- and invalid-UTF-8 byte-literal encoded probes
- remove a quadratic long protocol-0 probe path

Follow-up security review of #1594 after it merged.

## False-positive / false-negative audit

- fixed both review-thread false positives for `b'\x80\x04N.README'` and decoded `(README...` text
- base64 and hex benign regressions cover both `bytes` and `bytearray`
- truncated `PERSID` and dangerous protocol-0 call prefixes still fail closed
- raw malicious suffixes remain visible when an encoded candidate shares the same byte literal
- invalid base64 padding cannot suppress raw nested scanning
- valid UTF-8 byte literals now use the same bounded prefix/suffix coverage policy as invalid UTF-8 literals
- a 1 MiB valid-UTF-8 adversarial token with a 64-byte literal limit dropped from about 389 ms and a false clean result to about 8 ms with an inconclusive truncation notice

## Validation

- `tests/test_protocol0_line_operands.py`: 125 passed
- `tests/test_nested_budget_limits.py`: 344 passed
- `tests/test_api.py tests/test_options.py`: 560 passed, 2 skipped for removed Python 3.13 stdlib audio modules
- `cargo test --manifest-path Cargo.toml`: 159 passed
- Cargo clippy and format checks passed
- focused Ruff and mypy checks passed
- package lock and `git diff --check` passed
- current `main` integrated at `23b6ca20a2c857eeb37f0835aa6d2e60c4f8b31e`
- exact remote tree verified: `a278adc91196453722aa41f7ee9b6f3c50775003`
- published head: `27bc4bf4b7843764cea2aac08d4394b00ccb1dec`

The full local suite was intentionally left to CI per the PR-audit workflow.