### PR TITLE
fix: harden pickle CVE stream probing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- restore pickle CVE scan throughput, reprobe malformed stream separators, and route four-byte protocol-0 Joblib operands correctly
 - bound manifest embedded-Jinja template collection while preserving findings across deep branches, cycles, and shared YAML aliases
 - bound Jinja static render analysis and fail closed on CPU-heavy aliased, recursive, container-wrapped, and arithmetic range probes when sandbox workers are unavailable
 - restrict auth bearer-token validation to trusted Promptfoo API hosts unless custom hosts are explicitly configured

--- a/modelaudit/scanners/joblib_scanner.py
+++ b/modelaudit/scanners/joblib_scanner.py
@@ -64,7 +64,7 @@ _TRUNCATED_RAW_PICKLE_SIGNAL_OPCODES = frozenset(
 )
 _PICKLE_OPCODE_BY_BYTE = {ord(opcode.code): opcode for opcode in pickletools.opcodes}
 _PICKLE_TWO_LINE_ARGUMENT_OPCODES = frozenset({"GLOBAL", "INST"})
-_PICKLE_LENGTH_PREFIX_BYTES = {-2: 1, -3: 2, -4: 4, -5: 8}
+_PICKLE_LENGTH_PREFIX_BYTES = {-2: 1, -3: 4, -4: 4, -5: 8}
 
 
 def _next_pickle_opcode_offset(data: bytes, offset: int, opcode: Any) -> int | None:

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -329,6 +329,14 @@ _CVE_RAW_SCAN_SEEDS: tuple[bytes, ...] = (
     b"unpickl",
     b"untyped_storage",
 )
+_CVE_2026_24747_SYSTEM_RAW_SEEDS: tuple[bytes, ...] = (
+    b"os.system",
+    b"posix.system",
+    b"nt.system",
+    b"cos\nsystem\n",
+    b"cposix\nsystem\n",
+    b"cnt\nsystem\n",
+)
 _COPYREG_EXTENSION_OPCODES = (b"\x82", b"\x83", b"\x84")
 
 
@@ -479,19 +487,25 @@ def _looks_like_pickle(data: bytes) -> bool:
     }
 
 
-def _probe_pickle_stream(stream: io.BytesIO, offset: int = 0) -> tuple[int | None, int]:
+def _probe_pickle_stream(stream: io.BytesIO, offset: int = 0) -> tuple[int | None, int, bool]:
     stream.seek(offset)
+    parsed_opcode = False
     try:
         for opcode, _arg, position in pickletools.genops(stream):
+            parsed_opcode = True
             if opcode.name == "STOP":
                 extent = None if position is None else position + 1 - offset
-                return extent, max(1, stream.tell() - offset)
+                return extent, max(1, stream.tell() - offset), parsed_opcode
     except Exception:
         pass
-    return None, max(1, stream.tell() - offset)
+    return None, max(1, stream.tell() - offset), parsed_opcode
 
 
-def _pickle_cve_streams(data: bytes) -> tuple[tuple[_PickleCveStream, ...], bool]:
+def _pickle_cve_streams(
+    data: bytes,
+    *,
+    first_stream_extent: int | None = None,
+) -> tuple[tuple[_PickleCveStream, ...], bool]:
     streams: list[_PickleCveStream] = []
     probe = io.BytesIO(data)
     offset = 0
@@ -503,13 +517,21 @@ def _pickle_cve_streams(data: bytes) -> tuple[tuple[_PickleCveStream, ...], bool
         if offset >= len(data):
             break
 
-        extent, consumed = _probe_pickle_stream(probe, offset)
         if len(streams) >= _MAX_CVE_PICKLE_STREAMS:
             return tuple(streams), True
+        extent: int | None
+        consumed: int
+        parsed_opcode: bool
+        if offset == 0 and isinstance(first_stream_extent, int) and 0 < first_stream_extent <= len(data):
+            extent = first_stream_extent
+            consumed = first_stream_extent
+            parsed_opcode = True
+        else:
+            extent, consumed, parsed_opcode = _probe_pickle_stream(probe, offset)
         if extent is None:
             end = min(len(data), offset + consumed)
             streams.append(_PickleCveStream(data[offset:end], offset, True))
-            offset = end
+            offset = end if parsed_opcode else offset + 1
             continue
 
         streams.append(_PickleCveStream(data[offset : offset + extent], offset, False))
@@ -2396,7 +2418,13 @@ class PickleScanner(BaseScanner):
         present_bytes: frozenset[int] | None = None,
     ) -> None:
         """Add CVE attribution checks from a bounded raw pickle scan window."""
-        streams, stream_limit_exceeded = _pickle_cve_streams(data)
+        first_pickle_end_pos = result.metadata.get("first_pickle_end_pos")
+        first_stream_extent = (
+            first_pickle_end_pos
+            if isinstance(first_pickle_end_pos, int) and 0 < first_pickle_end_pos <= len(data)
+            else None
+        )
+        streams, stream_limit_exceeded = _pickle_cve_streams(data, first_stream_extent=first_stream_extent)
         result.metadata["pickle_cve_streams_analyzed"] = len(streams)
         if stream_limit_exceeded:
             reason = "pickle_cve_stream_limit_exceeded"
@@ -2425,35 +2453,65 @@ class PickleScanner(BaseScanner):
             reference.get("import_reference") in {"os.system", "posix.system", "nt.system"}
             for reference in import_references
         )
+        has_rebuild_tensor_global = _result_has_rebuild_tensor_global(result)
         lower = data.lower() if lower_data is None else lower_data
         if present_bytes is None:
             present_bytes = frozenset(lower)
         has_raw_cve_seed = _contains_any_seed_lowered(lower, _CVE_RAW_SCAN_SEEDS, present_bytes)
-        # Encoded STACK_GLOBAL operands are not contiguous raw-text seeds. Use
-        # a cheap candidate gate before running the Python stack model twice.
         has_raw_setitem_opcode = ord("s") in present_bytes or ord("u") in present_bytes
+        has_setitem_candidate = has_setitem_opcode or has_raw_setitem_opcode
+        has_rebuild_tensor_candidate = has_rebuild_tensor_global or b"_rebuild_tensor" in lower
+        has_system_candidate = has_dangerous_system_global or any(
+            seed in lower for seed in _CVE_2026_24747_SYSTEM_RAW_SEEDS
+        )
+        has_stack_global_candidate = opcode_counts.get("STACK_GLOBAL", 0) > 0 or b"\x93" in data
+        if has_stack_global_candidate and b"system" in lower:
+            has_system_candidate = has_system_candidate or b"os" in lower or b"posix" in lower or b"nt" in lower
+        has_escaped_string_operand = b"S'\\" in data or b'S"\\' in data or b"V\\" in data
+        if has_stack_global_candidate and has_escaped_string_operand:
+            has_system_candidate = True
+            has_rebuild_tensor_candidate = True
+        should_analyze_setitems = has_setitem_candidate and (has_rebuild_tensor_candidate or has_system_candidate)
         if (
             not has_raw_cve_seed
             and not (has_setitem_opcode and has_dangerous_system_global)
-            and not has_raw_setitem_opcode
+            and not should_analyze_setitems
         ):
             result.metadata["pickle_cve_raw_detector_skipped"] = True
             return
 
-        stream_setitem_analyses = [
-            (
-                _analyze_pickle_setitem_entries(
-                    stream.payload,
-                    global_needles=("_rebuild_tensor",),
-                    literal_needles=("_rebuild_tensor",),
-                ),
-                _analyze_pickle_setitem_entries(
-                    stream.payload,
-                    global_needles=("os.system", "posix.system", "nt.system"),
-                ),
+        no_setitem_abuse = _PickleSetitemAnalysis(
+            saw_setitem=False,
+            confirmed_dangerous_target=False,
+            suspicious_entry_on_unknown_target=False,
+            parse_incomplete=False,
+        )
+        stream_setitem_analyses: list[tuple[_PickleSetitemAnalysis, _PickleSetitemAnalysis]] = []
+        for stream in streams:
+            if not should_analyze_setitems:
+                stream_setitem_analyses.append((no_setitem_abuse, no_setitem_abuse))
+                continue
+            candidate_analysis = _analyze_pickle_setitem_entries(
+                stream.payload,
+                global_needles=("_rebuild_tensor", "os.system", "posix.system", "nt.system"),
+                literal_needles=("_rebuild_tensor",),
             )
-            for stream in streams
-        ]
+            if not candidate_analysis.has_abuse:
+                stream_setitem_analyses.append((candidate_analysis, candidate_analysis))
+                continue
+            stream_setitem_analyses.append(
+                (
+                    _analyze_pickle_setitem_entries(
+                        stream.payload,
+                        global_needles=("_rebuild_tensor",),
+                        literal_needles=("_rebuild_tensor",),
+                    ),
+                    _analyze_pickle_setitem_entries(
+                        stream.payload,
+                        global_needles=("os.system", "posix.system", "nt.system"),
+                    ),
+                )
+            )
         has_stream_setitem_evidence = any(
             rebuild_analysis.has_abuse or dangerous_system_analysis.has_abuse
             for rebuild_analysis, dangerous_system_analysis in stream_setitem_analyses
@@ -2489,14 +2547,17 @@ class PickleScanner(BaseScanner):
         attribution_context: dict[tuple[str, str], tuple[int, int, bool]] = {}
         dangerous_system_context: tuple[int, int, bool] | None = None
         for stream_index, (stream, setitem_analyses) in enumerate(zip(streams, stream_setitem_analyses, strict=True)):
-            try:
-                stream_attributions = analyze_cve_patterns(
-                    stream.payload.decode("utf-8", errors="ignore"),
-                    stream.payload,
-                )
-            except Exception as error:
-                logger.warning("Error checking pickle stream CVE patterns: %s", error)
-                stream_attributions = []
+            if len(streams) == 1 and stream.offset == 0 and stream.payload == data:
+                stream_attributions = attributions
+            else:
+                try:
+                    stream_attributions = analyze_cve_patterns(
+                        stream.payload.decode("utf-8", errors="ignore"),
+                        stream.payload,
+                    )
+                except Exception as error:
+                    logger.warning("Error checking pickle stream CVE patterns: %s", error)
+                    stream_attributions = []
             for attribution in stream_attributions:
                 if attribution.cve_id != "CVE-2026-24747" or any(
                     "setitem" in pattern.lower() for pattern in attribution.patterns_matched

--- a/tests/detectors/test_cve_detection.py_cases/test_pickle_binunicode8_setitem.py
+++ b/tests/detectors/test_cve_detection.py_cases/test_pickle_binunicode8_setitem.py
@@ -181,6 +181,24 @@ def test_escaped_stack_global_operands_do_not_depend_on_raw_seed_or_result_metad
     )
 
 
+def test_escaped_rebuild_stack_global_does_not_depend_on_result_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(pickle_scanner, "_result_opcode_counts", lambda _result: {})
+    monkeypatch.setattr(pickle_scanner, "_result_import_references", lambda _result: [])
+    pickle_bytes = b"S'\\x74orch._utils'\nS'\\x5frebuild_tensor_v2'\n\x93)RS'key'\nS'value'\ns."
+    path = tmp_path / "escaped-rebuild-stack-global.pkl"
+    path.write_bytes(pickle_bytes)
+
+    result = PickleScanner().scan(str(path))
+
+    assert any(
+        check.name == "CVE-2026-24747 Pattern Detection" and check.details.get("pickle_stream_index") == 0
+        for check in result.checks
+    )
+
+
 def test_no_binunicode8_setitem_false_positive(tmp_path: Path) -> None:
     pickle_bytes = b"\x80\x04}" + _binunicode8("key") + _binunicode8("value") + b"s."
     test_file = tmp_path / "normal_dict_binunicode8_setitem.pkl"
@@ -329,6 +347,20 @@ def test_detects_rebuild_tensor_setitem_after_unrecognized_separator(tmp_path: P
         and check.details.get("pickle_stream_parse_incomplete") is False
         for check in result.checks
     )
+
+
+@pytest.mark.parametrize("separator", [b"B", b"X"])
+def test_detects_rebuild_tensor_after_failed_separator_probe(tmp_path: Path, separator: bytes) -> None:
+    first_stream = pickle.dumps(None, protocol=4)
+    malicious_stream = (
+        b"S'\\x74orch._utils'\nS'\\x5frebuild_tensor_v2'\n\x93)R" + _binunicode8("key") + _binunicode8("value") + b"s."
+    )
+    path = tmp_path / "later-stream-after-failed-probe.pkl"
+    path.write_bytes(first_stream + separator + malicious_stream)
+
+    result = PickleScanner().scan(str(path))
+
+    assert any(check.rule_code == "S209" for check in result.checks)
 
 
 def test_detects_protocol_zero_rebuild_tensor_setitem_in_later_pickle_stream(tmp_path: Path) -> None:
@@ -526,6 +558,82 @@ def test_seedless_pickle_skips_python_setitem_analysis(
 
     assert result.success is True
     assert result.metadata["pickle_cve_raw_detector_skipped"] is True
+
+
+def test_unrelated_cve_seed_skips_python_setitem_analysis(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fail_setitem_analysis(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("unrelated CVE seeds should not run Python SETITEM analysis")
+
+    monkeypatch.setattr(pickle_scanner, "_analyze_pickle_setitem_entries", fail_setitem_analysis)
+    path = tmp_path / "safe-framework-metadata.pkl"
+    path.write_bytes(
+        pickle.dumps(
+            {
+                "framework": "pytorch",
+                "storage_type": "torch.storage",
+                "binary_metadata": b"\x93\\",
+                "safe": "value",
+            },
+            protocol=4,
+        )
+    )
+
+    result = PickleScanner().scan(str(path))
+
+    assert result.success is True
+    assert _cve_2026_24747_issues(result) == []
+
+
+def test_benign_rebuild_key_uses_one_candidate_stack_pass(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    original_analysis = pickle_scanner._analyze_pickle_setitem_entries
+    calls = 0
+
+    def count_setitem_analysis(
+        data: bytes,
+        *,
+        global_needles: tuple[str, ...],
+        literal_needles: tuple[str, ...] = (),
+    ) -> pickle_scanner._PickleSetitemAnalysis:
+        nonlocal calls
+        calls += 1
+        return original_analysis(
+            data,
+            global_needles=global_needles,
+            literal_needles=literal_needles,
+        )
+
+    monkeypatch.setattr(pickle_scanner, "_analyze_pickle_setitem_entries", count_setitem_analysis)
+    path = tmp_path / "benign-rebuild-key.pkl"
+    path.write_bytes(b"\x80\x04}" + _binunicode8("_rebuild_tensor") + _binunicode8("ordinary value") + b"s.")
+
+    result = PickleScanner().scan(str(path))
+
+    assert result.success is True
+    assert _cve_2026_24747_issues(result) == []
+    assert calls == 1
+
+
+def test_pickle_cve_streams_reuses_reported_first_stream_extent(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = pickle.dumps({"safe": True}, protocol=4)
+
+    def fail_stream_probe(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("reported first stream extent should avoid reparsing")
+
+    monkeypatch.setattr(pickle_scanner, "_probe_pickle_stream", fail_stream_probe)
+
+    streams, limit_exceeded = pickle_scanner._pickle_cve_streams(
+        payload,
+        first_stream_extent=len(payload),
+    )
+
+    assert streams == (pickle_scanner._PickleCveStream(payload, 0, False),)
+    assert limit_exceeded is False
 
 
 def test_pickle_cve_stream_limit_allows_exact_limit(tmp_path: Path) -> None:

--- a/tests/scanners/test_joblib_scanner_codecs.py
+++ b/tests/scanners/test_joblib_scanner_codecs.py
@@ -337,6 +337,28 @@ def test_raw_pickle_classifier_skips_large_unicode_operands_without_genops(
     assert JoblibScanner()._looks_like_raw_pickle_payload(payload) is True
 
 
+@pytest.mark.parametrize(
+    "leading_operand",
+    [
+        b"T" + (4).to_bytes(4, "little") + b"safe",
+        b"\x8b" + (1).to_bytes(4, "little") + b"\x01",
+    ],
+)
+def test_scan_detects_raw_protocol0_pickle_after_four_byte_length_operand(
+    tmp_path: Path,
+    leading_operand: bytes,
+) -> None:
+    payload = leading_operand + b"0cos\nsystem\n(S'echo owned'\ntR."
+
+    assert JoblibScanner()._looks_like_raw_pickle_payload(payload) is True
+
+    result = _scan_payload(tmp_path, payload, "four_byte_length_operand.joblib")
+
+    assert result.success is False
+    assert _has_system_reduce_failure(result)
+    assert _compression_failures(result) == []
+
+
 def test_scan_accepts_raw_protocol4_primitive_pickle_joblib(tmp_path: Path) -> None:
     payload = pickle.dumps(7, protocol=4)
 


### PR DESCRIPTION
## Summary

- restore pickle CVE scan throughput by reusing parsed stream extents and target-specific analysis
- reprobe malformed zero-opcode stream separators without splitting real incomplete pickle streams
- treat protocol-0 BINSTRING and LONG4 operands as four-byte length-prefixed when routing Joblib tails
- add malicious-positive and benign near-match regressions for the post-merge findings on #1524

## Validation

- `278 passed` across the three associated test files
- targeted Ruff format/check clean
- targeted mypy clean
- representative checkpoint scan median: 73.2 ms, versus 110.8 ms after #1524 and 71.4 ms before it
- no full local suite run, per maintenance workflow

Addresses the two post-merge review findings on #1524.