### PR TITLE
fix(picklescan): harden encoded byte probes

### DIFF
--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -78,6 +78,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- preserve raw persistent-ID probes and later encoded payloads when byte literals also contain complete or unterminated Base64 pickles
 - scan encoded nested pickles in bounded byte and bytearray literals without treating benign execution-like text or complete encoded payloads as raw pickle fragments
 - continue probing encoded protocol 0 payloads after long line operands, lenient base64 separators, and wrapper alignment shifts while failing closed beyond bounded mid-scan coverage
 - reject nested-pickle analysis budgets below two bytes, recognize explicit protocol 0 headers, and use bounded structural probes to avoid prose false positives without missing valid suffixes

--- a/packages/modelaudit-picklescan/rust/src/nested.rs
+++ b/packages/modelaudit-picklescan/rust/src/nested.rs
@@ -147,10 +147,9 @@ fn decoded_pickle_payloads(decoded: &[u8], max_nested_pickle_bytes: usize) -> Ve
     let remaining = &decoded[search_start..];
     let remaining_is_complete = pickle_payload_extent_result(remaining, max_nested_pickle_bytes)
         .is_ok_and(|extent| extent.is_some());
-    if search_start > 0
-        && remaining.len() <= max_nested_pickle_bytes
+    if remaining.len() <= max_nested_pickle_bytes
         && !remaining_is_complete
-        && has_structurally_valid_execution_prefix(remaining)
+        && has_high_confidence_truncated_execution_prefix(remaining)
     {
         let payload_len = remaining.len().min(max_nested_pickle_bytes);
         payloads.push((remaining[..payload_len].to_vec(), true));
@@ -170,8 +169,12 @@ fn decoded_pickle_payloads(decoded: &[u8], max_nested_pickle_bytes: usize) -> Ve
                 Err(error) if error.is_structured_protocol0_line_operand_limit() => {
                     (probe.len(), true)
                 }
-                Ok(None) | Err(_) if has_structurally_valid_execution_prefix(probe) => {
-                    (probe.len().min(max_nested_pickle_bytes), true)
+                Ok(None) | Err(_)
+                    if (has_binary_pickle_prefix(probe)
+                        || protocol0_global_or_inst_prefix_has_import_reference_lines(probe))
+                        && has_high_confidence_truncated_execution_prefix(probe) =>
+                {
+                    (probe.len(), true)
                 }
                 Ok(None) | Err(_) => continue,
             };
@@ -186,6 +189,15 @@ fn decoded_pickle_payloads(decoded: &[u8], max_nested_pickle_bytes: usize) -> Ve
         }
     }
     payloads
+}
+
+fn has_high_confidence_truncated_execution_prefix(value: &[u8]) -> bool {
+    let first_is_persid =
+        parse_opcode(value, 0, value.len()).is_ok_and(|opcode| opcode.name == "PERSID");
+    first_is_persid
+        || ((has_binary_pickle_prefix(value)
+            || protocol0_global_or_inst_prefix_has_import_reference_lines(value))
+            && has_structurally_valid_execution_prefix(value))
 }
 
 pub(crate) fn detect_oversized_encoded_pickle_prefixes(
@@ -900,7 +912,46 @@ pub(crate) fn encoded_nested_literal_probe_windows_with_limit(
         }
     }
 
-    let long_line_windows = embedded_long_protocol0_base64_probe_windows(value, max_window_chars);
+    let prefix_is_complete_long_protocol0 = encoded_base64_first_byte(value.as_bytes())
+        .is_some_and(is_protocol0_long_line_probe_opcode)
+        && base64_protocol0_line_has_terminator(value, 0, 0)
+        && base64_prefix_has_complete_protocol0_line(value, value.len());
+    let confirmed_spans = if value
+        .as_bytes()
+        .first()
+        .is_none_or(|byte| base64_value(*byte).is_none())
+        || prefix_has_base64_pickle
+        || prefix_is_complete_long_protocol0
+    {
+        confirmed_base64_pickle_spans(value.as_bytes(), max_window_chars)
+    } else {
+        Vec::new()
+    };
+    for (start, end) in confirmed_spans.iter().copied() {
+        push_unique_window(&mut windows, value[start..end].to_string());
+    }
+    if confirmed_spans.len() >= MAX_NESTED_PAYLOAD_PROBES {
+        limit_exceeded = true;
+        limit_exceeded_encoding = Some("base64");
+    }
+
+    let leading_base64_prefix = take_base64_literal_prefix(value, value.len());
+    let leading_prefix_is_exact_pickle = (prefix_has_base64_pickle
+        || prefix_is_complete_long_protocol0)
+        && decode_possible_encoded_pickle(leading_base64_prefix, max_window_chars)
+            .iter()
+            .any(|decoded| {
+                base64_prefix_len_for_payload(leading_base64_prefix, &decoded.payload)
+                    == Some(leading_base64_prefix.len())
+            });
+    let padded_prefix_end =
+        if leading_base64_prefix.ends_with('=') && leading_prefix_is_exact_pickle {
+            leading_base64_prefix.len()
+        } else {
+            0
+        };
+    let long_line_windows =
+        embedded_long_protocol0_base64_probe_windows(&value[padded_prefix_end..], max_window_chars);
     for candidate in long_line_windows.windows.into_iter().rev() {
         if windows.iter().any(|window| window.value == candidate.value) {
             continue;
@@ -925,8 +976,15 @@ pub(crate) fn encoded_nested_literal_probe_windows_with_limit(
     }
 
     let mid_scan_len = value.len().min(MAX_ENCODED_LITERAL_MID_SCAN_BYTES);
-    for index in 0..mid_scan_len {
+    for index in padded_prefix_end..mid_scan_len {
         if !value.is_char_boundary(index) {
+            continue;
+        }
+        if confirmed_spans.len() < MAX_NESTED_PAYLOAD_PROBES
+            && confirmed_spans
+                .iter()
+                .any(|(start, end)| *start <= index && index < *end)
+        {
             continue;
         }
         if let Some(encoding) = encoded_pickle_prefix_probe_limit_kind_at(value, index) {
@@ -990,6 +1048,14 @@ pub(crate) fn encoded_literal_may_contain_pickle(value: &str) -> bool {
     }
     if encoded_structural_prefix_has_pickle_prefix(stripped) {
         return true;
+    }
+    let leading_base64_token = take_base64_literal_prefix(stripped, stripped.len());
+    if leading_base64_token.len() == stripped.len()
+        && encoded_base64_first_byte(stripped.as_bytes())
+            .is_some_and(is_protocol0_long_line_probe_opcode)
+        && !base64_protocol0_line_has_terminator(stripped, 0, 0)
+    {
+        return false;
     }
 
     let suffix_probe = take_last_chars(stripped, ENCODED_LITERAL_PROBE_CHARS);
@@ -1325,7 +1391,11 @@ fn encoded_pickle_kind_at(value: &str, index: usize) -> Option<&'static str> {
     }
 
     let probe = take_bytes_str_slice(suffix, MAX_ENCODED_LITERAL_PREFIX_SCAN_BYTES);
-    let base64_has_pickle_prefix = if starts_base64_token_at(value, index) {
+    let starts_base64_token = starts_base64_token_at(value, index);
+    if !starts_base64_token && follows_terminal_base64_padding(value, index) {
+        return None;
+    }
+    let base64_has_pickle_prefix = if starts_base64_token {
         base64_prefix_has_pickle_prefix(probe)
     } else {
         base64_prefix_has_nested_probe_prefix(probe, MAX_ENCODED_LITERAL_PREFIX_SCAN_BYTES)
@@ -1356,12 +1426,16 @@ fn encoded_pickle_prefix_probe_limit_kind_at(value: &str, index: usize) -> Optio
 
     let probe = take_bytes_str_slice(suffix, MAX_ENCODED_LITERAL_PREFIX_SCAN_BYTES);
     let starts_base64_token = starts_base64_token_at(value, index);
-    let probe_has_base64_pickle = if starts_base64_token {
+    let base64_after_padding =
+        !starts_base64_token && follows_terminal_base64_padding(value, index);
+    let probe_has_base64_pickle = if base64_after_padding {
+        false
+    } else if starts_base64_token {
         base64_prefix_has_pickle_prefix(probe)
     } else {
         base64_prefix_has_nested_probe_prefix(probe, MAX_ENCODED_LITERAL_PREFIX_SCAN_BYTES)
     };
-    if starts_base64_pickle && !probe_has_base64_pickle {
+    if starts_base64_pickle && !base64_after_padding && !probe_has_base64_pickle {
         let suffix_has_base64_pickle = if starts_base64_token {
             base64_prefix_has_pickle_prefix_with_limit(suffix, suffix.len())
         } else {
@@ -1607,6 +1681,230 @@ pub(crate) fn is_strict_base64_literal(value: &[u8]) -> bool {
         && value.len() % 4 == 0
 }
 
+fn high_confidence_raw_persistent_id_prefix_end(value: &[u8]) -> Option<usize> {
+    let mut index = 0usize;
+    let mut stack_depth = 0usize;
+    let mut mark_depths = Vec::new();
+    for _ in 0..MAX_NESTED_PAYLOAD_PROBES {
+        if index >= value.len() {
+            return None;
+        }
+        // Strict Base64 cannot contain the newline required by protocol-0 line operands.
+        // Reject these opcodes before parse_opcode performs a linear terminator search.
+        if matches!(
+            value[index],
+            b'F' | b'I' | b'L' | b'P' | b'S' | b'V' | b'g' | b'p' | b'c' | b'i'
+        ) {
+            return None;
+        }
+        let parsed = match parse_opcode(value, index, value.len()) {
+            Ok(parsed) => parsed,
+            Err(_) => return None,
+        };
+        if !validate_pickle_stack_effect(&parsed, &mut stack_depth, &mut mark_depths) {
+            return None;
+        }
+        match parsed.name {
+            "PERSID" | "BINPERSID" => return Some(parsed.next),
+            "INST" | "REDUCE" | "NEWOBJ" | "NEWOBJ_EX" | "OBJ" | "BUILD" => return None,
+            _ => {}
+        }
+        index = parsed.next;
+        if parsed.name == "STOP" {
+            return None;
+        }
+    }
+    value[index..].contains(&b'Q').then_some(index)
+}
+
+pub(crate) fn strict_base64_literal_raw_execution_probe_offsets(
+    value: &[u8],
+    _max_nested_pickle_bytes: usize,
+) -> NestedProbeOffsets {
+    if !is_strict_base64_literal(value) {
+        return NestedProbeOffsets {
+            offsets: Vec::new(),
+            limit_exceeded: false,
+        };
+    }
+    let mut offsets = Vec::new();
+    let mut q_offsets = value
+        .iter()
+        .enumerate()
+        .filter_map(|(index, byte)| (*byte == b'Q').then_some(index))
+        .peekable();
+    for (offset, byte) in value.iter().enumerate() {
+        if !is_pickle_prefix_start_byte(*byte) {
+            continue;
+        }
+        while q_offsets.peek().is_some_and(|q_offset| *q_offset < offset) {
+            q_offsets.next();
+        }
+        if q_offsets.peek().is_none() {
+            continue;
+        }
+        if high_confidence_raw_persistent_id_prefix_end(&value[offset..]).is_some() {
+            if offsets.len() >= MAX_NESTED_PAYLOAD_PROBES {
+                return NestedProbeOffsets {
+                    offsets,
+                    limit_exceeded: true,
+                };
+            }
+            offsets.push(offset);
+        }
+    }
+    NestedProbeOffsets {
+        offsets,
+        limit_exceeded: false,
+    }
+}
+
+pub(crate) fn strict_base64_literal_raw_execution_probe_offset(
+    value: &[u8],
+    max_nested_pickle_bytes: usize,
+) -> Option<usize> {
+    strict_base64_literal_raw_execution_probe_offsets(value, max_nested_pickle_bytes)
+        .offsets
+        .into_iter()
+        .next()
+}
+
+pub(crate) fn strict_base64_literal_has_encoded_pickle_candidate(value: &[u8]) -> bool {
+    let Ok(text) = std::str::from_utf8(value) else {
+        return false;
+    };
+    if value.len() > NESTED_STRUCTURAL_PROBE_BYTES {
+        if is_strict_base64_literal(value)
+            && encoded_base64_first_byte(text.as_bytes())
+                .is_some_and(is_protocol0_long_line_probe_opcode)
+            && !base64_protocol0_line_has_terminator(text, 0, 0)
+        {
+            return false;
+        }
+        return encoded_literal_may_contain_pickle(text);
+    }
+    (0..text.len()).any(|index| {
+        if !text.is_char_boundary(index) {
+            return false;
+        }
+        let suffix = &text[index..];
+        encoded_pickle_kind_at(text, index).is_some()
+            || (encoded_base64_first_byte(suffix.as_bytes())
+                .is_some_and(is_protocol0_long_line_probe_opcode)
+                && base64_prefix_has_complete_protocol0_line(suffix, suffix.len()))
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn strict_base64_literal_has_raw_execution_probe(
+    value: &[u8],
+    max_nested_pickle_bytes: usize,
+) -> bool {
+    strict_base64_literal_has_encoded_pickle_candidate(value)
+        && strict_base64_literal_raw_execution_probe_offset(value, max_nested_pickle_bytes)
+            .is_some()
+}
+
+fn base64_prefix_len_for_payload(value: &str, payload: &[u8]) -> Option<usize> {
+    let unpadded_len =
+        payload
+            .len()
+            .checked_div(3)?
+            .checked_mul(4)?
+            .checked_add(match payload.len() % 3 {
+                0 => 0,
+                1 => 2,
+                _ => 3,
+            })?;
+    let padded_len = payload
+        .len()
+        .checked_add(2)?
+        .checked_div(3)?
+        .checked_mul(4)?;
+    for candidate_len in [padded_len, unpadded_len] {
+        let Some(candidate) = value.get(..candidate_len) else {
+            continue;
+        };
+        let next_is_base64 = value
+            .as_bytes()
+            .get(candidate_len)
+            .is_some_and(|byte| base64_value(*byte).is_some());
+        if candidate_len == unpadded_len && candidate_len % 4 != 0 && next_is_base64 {
+            continue;
+        }
+        if !is_strict_base64_literal(candidate.as_bytes()) {
+            continue;
+        }
+        if canonical_base64_candidate(candidate)
+            .as_deref()
+            .and_then(decode_base64)
+            .as_deref()
+            == Some(payload)
+        {
+            return Some(candidate_len);
+        }
+    }
+    None
+}
+
+pub(crate) fn confirmed_base64_pickle_spans(
+    value: &[u8],
+    max_nested_pickle_bytes: usize,
+) -> Vec<(usize, usize)> {
+    let mut spans = Vec::new();
+    let Ok(text) = std::str::from_utf8(value) else {
+        return spans;
+    };
+    let mut candidate_count = 0usize;
+    let scan_len = value.len().min(MAX_ENCODED_LITERAL_MID_SCAN_BYTES);
+    let mut index = 0usize;
+    while index < scan_len {
+        if !text.is_char_boundary(index) {
+            index += 1;
+            continue;
+        }
+        let suffix = &text[index..];
+        if !encoded_base64_first_byte(&value[index..value.len().min(index + 2)])
+            .is_some_and(is_pickle_prefix_start_byte)
+        {
+            index += 1;
+            continue;
+        }
+        candidate_count += 1;
+        if candidate_count > MAX_NESTED_PAYLOAD_PROBES {
+            break;
+        }
+        let starts_long_protocol0_pickle = encoded_base64_first_byte(suffix.as_bytes())
+            .is_some_and(is_protocol0_long_line_probe_opcode)
+            && base64_prefix_has_complete_protocol0_line(suffix, suffix.len());
+        if encoded_pickle_kind_at(text, index) != Some("base64") && !starts_long_protocol0_pickle {
+            index += 1;
+            continue;
+        }
+        let mut confirmed_end = None;
+        for decoded in decode_possible_encoded_pickle(suffix, max_nested_pickle_bytes) {
+            let Some(token_len) = base64_prefix_len_for_payload(suffix, &decoded.payload) else {
+                continue;
+            };
+            let token = &suffix.as_bytes()[..token_len];
+            if strict_base64_literal_raw_execution_probe_offset(token, max_nested_pickle_bytes)
+                .is_some_and(|raw_offset| raw_offset <= 16)
+            {
+                continue;
+            }
+            confirmed_end = Some(index.saturating_add(token_len));
+            break;
+        }
+        if let Some(end) = confirmed_end {
+            spans.push((index, end));
+            index = end;
+        } else {
+            index += 1;
+        }
+    }
+    spans
+}
+
 fn is_hex_candidate(value: &str) -> bool {
     !value.is_empty() && value.bytes().all(is_hex_byte)
 }
@@ -1715,9 +2013,19 @@ fn starts_base64_token_at(value: &str, index: usize) -> bool {
         || value.as_bytes().get(index - 1).is_some_and(|byte| {
             !matches!(
                 *byte,
-                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'+' | b'/' | b'='
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'+' | b'/'
             )
         })
+}
+
+fn follows_terminal_base64_padding(value: &str, index: usize) -> bool {
+    const PADDING_SUFFIX_LOOKBACK_BYTES: usize = 64;
+
+    value.as_bytes()[index.saturating_sub(PADDING_SUFFIX_LOOKBACK_BYTES)..index]
+        .iter()
+        .rev()
+        .find(|byte| !matches!(**byte, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'+' | b'/'))
+        .is_some_and(|byte| *byte == b'=')
 }
 
 fn hex_prefix_has_pickle_prefix(value: &str) -> bool {
@@ -2744,6 +3052,36 @@ mod tests {
     }
 
     #[test]
+    fn decoded_payloads_ignore_unstructured_execution_opcode_near_matches() {
+        for payload in [
+            b"\x80\x04N.README".as_slice(),
+            b"(README is ordinary text",
+            b"README is ordinary text",
+            b"G12345678Q ordinary text",
+            b"J1234Q ordinary text",
+            b"K1Q ordinary text",
+            b"NQ ordinary text",
+        ] {
+            assert!(!decoded_pickle_payloads(payload, payload.len() + 16)
+                .iter()
+                .any(|(_, analysis_incomplete)| *analysis_incomplete));
+        }
+    }
+
+    #[test]
+    fn execution_fallback_requires_valid_pickle_structure() {
+        assert!(has_structurally_valid_execution_prefix(b"Pevil\n"));
+        assert!(has_structurally_valid_execution_prefix(
+            b"cos\nsystem\n(S'id'\ntR"
+        ));
+        assert!(!has_structurally_valid_execution_prefix(b"RREADME"));
+        assert!(!has_structurally_valid_execution_prefix(
+            b"(README is ordinary text"
+        ));
+        assert!(has_structurally_valid_execution_prefix(b"NQAAgAROLgAAAAAA"));
+    }
+
+    #[test]
     fn decoded_payloads_ignore_truncated_data_only_scalars() {
         for payload in [
             b"F1".as_slice(),
@@ -2766,6 +3104,83 @@ mod tests {
         assert!(!is_strict_base64_literal(b"=gAR9Lg="));
         assert!(!is_strict_base64_literal(b"g=AR9Lg="));
         assert!(!is_strict_base64_literal(b"gAR9Lg===="));
+        assert!(strict_base64_literal_has_raw_execution_probe(
+            b"NQAAAAAAgAROLg==",
+            TEST_MAX_NESTED_PICKLE_BYTES,
+        ));
+        assert!(strict_base64_literal_has_raw_execution_probe(
+            b"NNQAgAROLgAAAAAA",
+            TEST_MAX_NESTED_PICKLE_BYTES,
+        ));
+        assert!(strict_base64_literal_has_raw_execution_probe(
+            b"N0NQgAROLgAAAAAA",
+            TEST_MAX_NESTED_PICKLE_BYTES,
+        ));
+        assert!(strict_base64_literal_has_raw_execution_probe(
+            b"AAAANQAAAAAAgAROLg==",
+            TEST_MAX_NESTED_PICKLE_BYTES,
+        ));
+        let mut separated_raw_probe = b"NQ".to_vec();
+        separated_raw_probe.extend_from_slice(&[b'A'; 18]);
+        separated_raw_probe.extend_from_slice(b"VkFBQUFBQUFBQUFBQUFBQUEKLg==");
+        assert!(strict_base64_literal_has_raw_execution_probe(
+            &separated_raw_probe,
+            TEST_MAX_NESTED_PICKLE_BYTES,
+        ));
+        let mut long_raw_probe = Vec::new();
+        for _ in 0..6 {
+            long_raw_probe.extend_from_slice(b"C+");
+            long_raw_probe.extend_from_slice(&[b'A'; 43]);
+        }
+        long_raw_probe.extend_from_slice(b"QgAROLgAAAAAA");
+        assert!(strict_base64_literal_has_raw_execution_probe(
+            &long_raw_probe,
+            TEST_MAX_NESTED_PICKLE_BYTES,
+        ));
+        let mut opcode_budget_raw_probe = b"N".to_vec();
+        opcode_budget_raw_probe.extend_from_slice(&[b'2'; 80]);
+        opcode_budget_raw_probe.extend_from_slice(b"QgAROLgAAAAAA");
+        assert!(strict_base64_literal_has_raw_execution_probe(
+            &opcode_budget_raw_probe,
+            TEST_MAX_NESTED_PICKLE_BYTES,
+        ));
+        assert!(!strict_base64_literal_has_raw_execution_probe(
+            b"KFJFQURNRSBpcyBvcmRpbmFyeSB0ZXh0",
+            TEST_MAX_NESTED_PICKLE_BYTES,
+        ));
+        assert!(!strict_base64_literal_has_raw_execution_probe(
+            b"ordinaryCNQHtext",
+            TEST_MAX_NESTED_PICKLE_BYTES,
+        ));
+        assert!(!strict_base64_literal_has_raw_execution_probe(
+            &vec![b'V'; 500_000],
+            TEST_MAX_NESTED_PICKLE_BYTES,
+        ));
+        assert!(!strict_base64_literal_has_raw_execution_probe(
+            &[b"junk".repeat(25_000), b"Q".to_vec()].concat(),
+            TEST_MAX_NESTED_PICKLE_BYTES,
+        ));
+        assert_eq!(
+            confirmed_base64_pickle_spans(b"!VkFBQUFBQUFBQUFBQUFBQUEKLg==ab", 64),
+            vec![(1, 29)]
+        );
+        let long_scalar = concat!(
+            "VkFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB",
+            "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB",
+            "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB",
+            "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB",
+            "QUFBQUFBQUFBQUFBQUFBQUFBCi4=",
+        );
+        assert_eq!(
+            confirmed_base64_pickle_spans(
+                format!("!{long_scalar}ab").as_bytes(),
+                TEST_MAX_NESTED_PICKLE_BYTES,
+            ),
+            vec![(1, 1 + long_scalar.len())]
+        );
+        assert!(confirmed_base64_pickle_spans(b"gAR9LgNQ", 64).is_empty());
+        assert!(confirmed_base64_pickle_spans(b"=gAR9Lg=", 64).is_empty());
+        assert!(confirmed_base64_pickle_spans(b"NQAAAAAAgAROLg==", 64).is_empty());
     }
 
     #[test]

--- a/packages/modelaudit-picklescan/rust/src/state.rs
+++ b/packages/modelaudit-picklescan/rust/src/state.rs
@@ -10,15 +10,16 @@ use crate::expansion::{
     ExpansionHeuristicState,
 };
 use crate::nested::{
-    bounded_truncated_pickle_prefix_requires_fail_closed, decode_possible_encoded_pickle,
-    detect_oversized_encoded_pickle_prefixes, encoded_literal_may_contain_pickle,
-    encoded_nested_literal_probe_coverage_incomplete,
+    bounded_truncated_pickle_prefix_requires_fail_closed, confirmed_base64_pickle_spans,
+    decode_possible_encoded_pickle, detect_oversized_encoded_pickle_prefixes,
+    encoded_literal_may_contain_pickle, encoded_nested_literal_probe_coverage_incomplete,
     encoded_nested_literal_probe_windows_with_limit, encoded_nested_window_char_limit,
     encoded_pickle_consumes_literal, has_binary_pickle_prefix, has_execution_opcode,
-    has_pickle_prefix, is_strict_base64_literal, looks_like_pickle_payload,
-    nested_pickle_probe_offsets, pickle_payload_extent_result,
-    protocol0_global_or_inst_prefix_has_import_reference_lines, DecodedNestedPayload,
-    NestedProbeOffsets, MAX_NESTED_PAYLOAD_PROBES,
+    has_pickle_prefix, looks_like_pickle_payload, nested_pickle_probe_offsets,
+    pickle_payload_extent_result, protocol0_global_or_inst_prefix_has_import_reference_lines,
+    strict_base64_literal_has_encoded_pickle_candidate,
+    strict_base64_literal_raw_execution_probe_offsets, DecodedNestedPayload, NestedProbeOffsets,
+    MAX_NESTED_PAYLOAD_PROBES,
 };
 use crate::nested_surface::{
     encoded_nested_payload_finding, is_allowlisted_nested_constructor_ref,
@@ -1306,14 +1307,158 @@ impl<'a> ScanState<'a> {
                     let bytes = &self.payload[start..end];
                     let encoded_nested_pickle_outcome =
                         self.scan_encoded_nested_pickle_bytes_literal(bytes, position);
-                    let strict_base64_literal = is_strict_base64_literal(bytes);
-                    // Complete raw pickles require STOP ('.'), which is outside the
-                    // base64 alphabet. After a decoded candidate is confirmed, raw
-                    // parsing of a strict token can only produce truncated phantoms.
-                    let skip_raw_scan = encoded_nested_pickle_outcome.1
-                        || (encoded_nested_pickle_outcome.0 && strict_base64_literal);
+                    let sanitize = |slice: &[u8]| {
+                        slice
+                            .iter()
+                            .map(|byte| {
+                                if byte.is_ascii() {
+                                    char::from(*byte)
+                                } else {
+                                    '!'
+                                }
+                            })
+                            .collect::<String>()
+                    };
+                    let scan_limit = bytes.len().min(self.options.max_string_literal_scan_chars);
+                    let strict_base64_literal =
+                        bytes.len() <= scan_limit && crate::nested::is_strict_base64_literal(bytes);
+                    let strict_base64_has_encoded_candidate = strict_base64_literal
+                        && (encoded_nested_pickle_outcome.0
+                            || strict_base64_literal_has_encoded_pickle_candidate(bytes));
+                    let raw_execution_probes = if strict_base64_has_encoded_candidate {
+                        strict_base64_literal_raw_execution_probe_offsets(
+                            bytes,
+                            self.options.max_nested_pickle_bytes,
+                        )
+                    } else {
+                        NestedProbeOffsets {
+                            offsets: Vec::new(),
+                            limit_exceeded: false,
+                        }
+                    };
+                    let mut excluded_spans = if bytes.len() <= scan_limit
+                        && (encoded_nested_pickle_outcome.0 || strict_base64_has_encoded_candidate)
+                    {
+                        let sanitized_bytes = sanitize(bytes);
+                        confirmed_base64_pickle_spans(
+                            sanitized_bytes.as_bytes(),
+                            self.options.max_nested_pickle_bytes,
+                        )
+                    } else {
+                        Vec::new()
+                    };
+                    let strict_text = strict_base64_literal
+                        .then(|| std::str::from_utf8(bytes).ok())
+                        .flatten();
+                    let mut raw_execution_probe_offset = raw_execution_probes
+                        .offsets
+                        .iter()
+                        .copied()
+                        .find(|raw_offset| {
+                            let encoded_before = strict_text.is_some_and(|text| {
+                                *raw_offset > 0
+                                    && encoded_pickle_consumes_literal(&text[..*raw_offset])
+                            });
+                            let encoded_after = excluded_spans
+                                .iter()
+                                .any(|(span_start, _)| *span_start > *raw_offset);
+                            let near_encoded_start =
+                                *raw_offset <= 16 && strict_base64_has_encoded_candidate;
+                            encoded_before || encoded_after || near_encoded_start
+                        });
+                    if raw_execution_probe_offset.is_none() && raw_execution_probes.limit_exceeded {
+                        raw_execution_probe_offset =
+                            raw_execution_probes.offsets.first().copied().or(Some(0));
+                    }
+                    if let Some(raw_offset) = raw_execution_probe_offset {
+                        excluded_spans.retain(|(span_start, span_end)| {
+                            !(*span_start <= raw_offset
+                                && raw_offset < *span_end
+                                && raw_offset <= span_start.saturating_add(16))
+                        });
+                    }
+                    let has_raw_execution_probe = raw_execution_probe_offset.is_some();
+                    let skip_raw_scan = if strict_base64_literal {
+                        !has_raw_execution_probe
+                    } else {
+                        encoded_nested_pickle_outcome.1
+                    };
                     if !skip_raw_scan {
-                        self.scan_raw_nested_pickle_bytes(bytes, self.position_offset + start);
+                        let raw_position = self.position_offset.saturating_add(start);
+                        let persistent_id_findings_before = self
+                            .findings
+                            .iter()
+                            .filter(|finding| finding.rule_code == Some("PERSISTENT_ID"))
+                            .count();
+                        if bytes.len() <= scan_limit {
+                            let mut cursor = 0usize;
+                            for (span_start, span_end) in excluded_spans.iter().copied() {
+                                if cursor < span_start {
+                                    self.scan_raw_nested_pickle_bytes(
+                                        &bytes[cursor..span_start],
+                                        raw_position.saturating_add(cursor),
+                                    );
+                                }
+                                cursor = cursor.max(span_end);
+                            }
+                            if cursor < bytes.len() {
+                                self.scan_raw_nested_pickle_bytes(
+                                    &bytes[cursor..],
+                                    raw_position.saturating_add(cursor),
+                                );
+                            }
+                        } else if scan_limit > 0 {
+                            self.scan_raw_nested_pickle_bytes(&bytes[..scan_limit], raw_position);
+                            let suffix_start =
+                                bytes.len().saturating_sub(scan_limit).max(scan_limit);
+                            if suffix_start < bytes.len() {
+                                self.scan_raw_nested_pickle_bytes(
+                                    &bytes[suffix_start..],
+                                    raw_position.saturating_add(suffix_start),
+                                );
+                            }
+                        }
+                        if let Some(raw_offset) = raw_execution_probe_offset {
+                            let raw_probe_is_excluded =
+                                excluded_spans.iter().any(|(span_start, span_end)| {
+                                    *span_start <= raw_offset && raw_offset < *span_end
+                                });
+                            let persistent_id_findings_after = self
+                                .findings
+                                .iter()
+                                .filter(|finding| finding.rule_code == Some("PERSISTENT_ID"))
+                                .count();
+                            if !raw_probe_is_excluded
+                                && persistent_id_findings_after == persistent_id_findings_before
+                            {
+                                let probe_end = excluded_spans
+                                    .iter()
+                                    .find_map(|(span_start, _)| {
+                                        (*span_start > raw_offset).then_some(*span_start)
+                                    })
+                                    .unwrap_or(bytes.len());
+                                if raw_offset < probe_end {
+                                    let probe = &bytes[raw_offset..probe_end];
+                                    let probe_position = raw_position.saturating_add(raw_offset);
+                                    let surface_outcome = self.surface_nested_pickle_findings(
+                                        probe,
+                                        "raw",
+                                        probe_position,
+                                    );
+                                    if !surface_outcome.depth_limited {
+                                        self.add_nested_payload_finding(
+                                            raw_nested_payload_finding(
+                                                probe.len(),
+                                                probe_position,
+                                                true,
+                                                true,
+                                            ),
+                                            true,
+                                        );
+                                    }
+                                }
+                            }
+                        }
                     }
                     self.push_stack_value(StackValue::Bytes { start, end });
                 } else {

--- a/packages/modelaudit-picklescan/tests/test_protocol0_line_operands.py
+++ b/packages/modelaudit-picklescan/tests/test_protocol0_line_operands.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import os
 import pickle
 import time
 from collections.abc import Mapping
@@ -441,7 +442,199 @@ def test_scan_bytes_keeps_raw_scan_after_invalid_base64_padding(
 
 
 @pytest.mark.parametrize("container", [bytes, bytearray])
-@pytest.mark.parametrize("decoded", [b"Pevil\nAAAAAAAA", b"\x80\x04N.Pevil\n"])
+def test_scan_bytes_ignores_benign_suffix_after_padded_base64_pickle(
+    container: type[bytes] | type[bytearray],
+) -> None:
+    benign_encoded = base64.b64encode(_benign_long_scalar_protocol0_pickle(b"V"))
+    payload = container(benign_encoded + b"ab")
+
+    report = scan_bytes(
+        pickle.dumps(payload, protocol=5),
+        source=f"base64-benign-raw-suffix-{container.__name__}.pkl",
+    )
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert report.findings == ()
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [b" ", b"# ", b"!", b"prefix:", b"\xff", b"A", b"AA", b"AAA", b"junk", b"prefix"],
+)
+@pytest.mark.parametrize("container", [bytes, bytearray])
+def test_scan_bytes_ignores_benign_wrapped_padded_base64_suffix(
+    container: type[bytes] | type[bytearray],
+    prefix: bytes,
+) -> None:
+    benign_encoded = base64.b64encode(_benign_long_scalar_protocol0_pickle(b"V"))
+    payload = container(prefix + benign_encoded + b"ab")
+
+    report = scan_bytes(
+        pickle.dumps(payload, protocol=5),
+        source=f"wrapped-base64-benign-suffix-{container.__name__}.pkl",
+    )
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert report.findings == ()
+
+
+@pytest.mark.parametrize("container", [bytes, bytearray])
+@pytest.mark.parametrize(
+    "raw_payload",
+    [
+        b"NQAAgAROLgAAAAAA",
+        b"NQAAAAAAgAROLg==",
+        b"NNQAgAROLgAAAAAA",
+        b"NNNQgAROLgAAAAAA",
+        b"N0NQgAROLgAAAAAA",
+        b"AAAANQAAgAROLgAAAAAA",
+        b"AAAANQAAAAAAgAROLg==",
+        (b"A" * 16) + b"NQAAAAAAgAROLg==",
+        b"BBBBNQAAAAAAgAROLg==",
+        b"NQ" + (b"A" * 18) + base64.b64encode(b"V" + (b"A" * 300) + b"\n."),
+        ((b"C+" + (b"A" * 43)) * 6) + b"QgAROLgAAAAAA",
+        b"N" + (b"2" * 80) + b"QgAROLgAAAAAA",
+        b"K1QgAROLgAAAAAA",
+        b"M12QgAROLg==",
+        b"J1234QgAROLgAAAAAA",
+        b"G12345678QgAROLgAAAAAA",
+        b"N2QgAROLgAAAAAA",
+        b"C+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAgAROLgAAAA",
+        b"U+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAgAROLgAAAA",
+    ],
+)
+def test_scan_bytes_preserves_raw_execution_inside_strict_base64_token(
+    container: type[bytes] | type[bytearray],
+    raw_payload: bytes,
+) -> None:
+    payload = container(raw_payload)
+
+    report = scan_bytes(
+        pickle.dumps(payload, protocol=5),
+        source=f"strict-base64-with-raw-persid-{container.__name__}.pkl",
+    )
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert any(finding.rule_code == "PERSISTENT_ID" for finding in report.findings)
+    assert any(
+        finding.rule_code == "S213" and finding.details.get("analysis_incomplete") is True
+        for finding in report.findings
+    )
+
+
+@pytest.mark.parametrize("container", [bytes, bytearray])
+@pytest.mark.parametrize("raw_suffix", [b"NQ", b"NNQ", b"N0NQ"])
+def test_scan_bytes_preserves_raw_execution_after_unpadded_base64_pickle(
+    container: type[bytes] | type[bytearray],
+    raw_suffix: bytes,
+) -> None:
+    benign_encoded = base64.b64encode(b"V" + (b"A" * 300) + b"\n.")
+    assert not benign_encoded.endswith(b"=")
+    payload = container(benign_encoded + raw_suffix)
+
+    report = scan_bytes(
+        pickle.dumps(payload, protocol=5),
+        source=f"unpadded-base64-raw-suffix-{container.__name__}.pkl",
+    )
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert any(finding.rule_code == "PERSISTENT_ID" for finding in report.findings)
+
+
+@pytest.mark.parametrize("container", [bytes, bytearray])
+def test_scan_bytes_keeps_multiple_benign_base64_tokens_clean(
+    container: type[bytes] | type[bytearray],
+) -> None:
+    benign_encoded = base64.b64encode(_benign_long_scalar_protocol0_pickle(b"V"))
+    payload = container(benign_encoded + b"ab!" + benign_encoded)
+
+    report = scan_bytes(
+        pickle.dumps(payload, protocol=5),
+        source=f"multiple-benign-base64-tokens-{container.__name__}.pkl",
+    )
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert report.findings == ()
+
+
+@pytest.mark.parametrize("container", [bytes, bytearray])
+def test_scan_bytes_detects_malicious_base64_token_after_padded_token(
+    container: type[bytes] | type[bytearray],
+) -> None:
+    benign_encoded = base64.b64encode(pickle.dumps(None, protocol=4))
+    malicious_encoded = base64.b64encode(pickle.dumps(os.system, protocol=4))
+    payload = container(benign_encoded + malicious_encoded)
+
+    report = scan_bytes(
+        pickle.dumps(payload, protocol=5),
+        source=f"padded-token-before-malicious-{container.__name__}.pkl",
+    )
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert any(finding.rule_code == "DANGEROUS_GLOBAL" for finding in report.findings)
+
+
+@pytest.mark.parametrize("container", [bytes, bytearray])
+def test_scan_bytes_keeps_repeated_raw_execution_near_matches_clean(
+    container: type[bytes] | type[bytearray],
+) -> None:
+    payload = container(b"ordinaryCNQHtext" * 65)
+
+    report = scan_bytes(
+        pickle.dumps(payload, protocol=5),
+        source=f"repeated-raw-near-match-{container.__name__}.pkl",
+    )
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert report.findings == ()
+
+
+@pytest.mark.parametrize("container", [bytes, bytearray])
+def test_scan_bytes_detects_malicious_token_after_unterminated_base64_scalar(
+    container: type[bytes] | type[bytearray],
+) -> None:
+    unterminated_scalar = base64.b64encode(b"VAAAA")
+    malicious_encoded = base64.b64encode(_long_scalar_before_reduce_protocol0_pickle(b"V"))
+    payload = container(unterminated_scalar + b"!" + malicious_encoded)
+
+    report = scan_bytes(
+        pickle.dumps(payload, protocol=5),
+        source=f"unterminated-prefix-before-malicious-{container.__name__}.pkl",
+    )
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert any(finding.rule_code == "DANGEROUS_CALL" for finding in report.findings)
+
+
+@pytest.mark.parametrize("container", [bytes, bytearray])
+def test_scan_bytes_detects_binary_pickle_inside_unterminated_base64_scalar(
+    container: type[bytes] | type[bytearray],
+) -> None:
+    payload = container(base64.b64encode(b"S" + pickle.dumps(os.system, protocol=4)))
+
+    report = scan_bytes(
+        pickle.dumps(payload, protocol=5),
+        source=f"unterminated-scalar-with-binary-pickle-{container.__name__}.pkl",
+    )
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert any(finding.rule_code == "DANGEROUS_GLOBAL" for finding in report.findings)
+
+
+@pytest.mark.parametrize("container", [bytes, bytearray])
+@pytest.mark.parametrize(
+    "decoded",
+    [b"Pevil\nAAAAAAAA", b"\x80\x04N.Pevil\n", b"README\x80\x04NQ"],
+)
 def test_scan_bytes_fails_closed_for_encoded_truncated_execution_prefixes(
     container: type[bytes] | type[bytearray],
     decoded: bytes,
@@ -464,6 +657,33 @@ def test_scan_bytes_fails_closed_for_encoded_truncated_execution_prefixes(
     assert not any(notice.code == "encoded_nested_payload_truncated" for notice in report.notices)
 
 
+@pytest.mark.parametrize("container", [bytes, bytearray])
+@pytest.mark.parametrize(
+    "decoded",
+    [
+        b"\x80\x04N.README",
+        b"(README is ordinary text",
+        b"README is ordinary text",
+        b"ordinary CNQH text",
+        b"junkPevil\n",
+    ],
+)
+def test_scan_bytes_keeps_encoded_execution_opcode_near_matches_clean(
+    container: type[bytes] | type[bytearray],
+    decoded: bytes,
+) -> None:
+    encoded = container(base64.b64encode(decoded))
+
+    report = scan_bytes(
+        pickle.dumps(encoded, protocol=5),
+        source=f"encoded-execution-near-match-{container.__name__}.pkl",
+    )
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert report.findings == ()
+
+
 def test_scan_bytes_bounds_unterminated_protocol0_base64_scalar_runtime() -> None:
     encoded = base64.b64encode(b"V" + (b"A" * 100_000))
 
@@ -475,6 +695,23 @@ def test_scan_bytes_bounds_unterminated_protocol0_base64_scalar_runtime() -> Non
     elapsed = time.monotonic() - started
 
     assert elapsed < 2.0
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert report.findings == ()
+
+
+def test_scan_bytes_bounds_strict_base64_junk_runtime() -> None:
+    payload = (b"junk" * 25_000) + b"Q"
+
+    started = time.monotonic()
+    report = scan_bytes(
+        pickle.dumps(payload, protocol=5),
+        source="bounded-strict-base64-junk.pkl",
+        options=ScanOptions(timeout_s=0.05),
+    )
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 1.0
     assert report.status == ScanStatus.COMPLETE
     assert report.verdict == SafetyVerdict.CLEAN
     assert report.findings == ()
@@ -492,6 +729,28 @@ def test_scan_bytes_bounds_valid_utf8_encoded_byte_literal_prefilter() -> None:
     elapsed = time.monotonic() - started
 
     assert elapsed < 1.0
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict != SafetyVerdict.CLEAN
+    assert any(notice.code == "literal_scan_truncated" for notice in report.notices)
+
+
+@pytest.mark.parametrize("container", [bytes, bytearray])
+@pytest.mark.parametrize("payload_bytes", [b"UA" * 2_500_000, b"N" * 5_000_000])
+def test_scan_bytes_bounds_valid_utf8_byte_literal_runtime(
+    container: type[bytes] | type[bytearray],
+    payload_bytes: bytes,
+) -> None:
+    payload = container(payload_bytes)
+
+    started = time.monotonic()
+    report = scan_bytes(
+        pickle.dumps(payload, protocol=5),
+        source=f"bounded-valid-utf8-{container.__name__}.pkl",
+        options=ScanOptions(max_string_literal_scan_chars=1024),
+    )
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 2.0
     assert report.status == ScanStatus.INCONCLUSIVE
     assert report.verdict != SafetyVerdict.CLEAN
     assert any(notice.code == "literal_scan_truncated" for notice in report.notices)


### PR DESCRIPTION
## Summary

Follow-up to #1602 that hardens encoded byte-literal scanning without weakening persistent-ID detection.

- preserve later encoded pickle candidates after an unterminated leading Base64 scalar
- distinguish confirmed encoded spans from raw persistent-ID polyglots across arbitrary wrapper and filler lengths
- fail closed for offset truncated executable pickles while keeping README-like near-matches clean
- scan adjacent Base64 tokens after terminal padding
- bound strict Base64 raw-probe and terminal-padding scans without imposing bypassable distance caps
- retain current `main` behavior from #1603

## Validation

- `218 passed` in the changed Python test module
- `161 passed` Rust tests
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- Ruff and mypy on the changed Python test
- 100 KB strict-Base64 junk ending in `Q` completes cleanly in 0.037 seconds
- adversarial sweep: 8 malicious filler-gap variants detected; >64-opcode and adjacent-padded-token bypasses detected; 300 benign encoded variants stayed non-malicious
- no full local suite, per review policy