### PR TITLE
fix(security): restore archive and export findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- preserve PyTorch malformed-ZIP symlink findings and complete concatenated HDF5 user-block ZIP scans without weakening hidden-entry preflight checks
+- prevent exported source redaction from treating comparisons as assignments or leaking suffixes appended to quoted redaction markers
 - classify unsafe PyTorch ZIP symlink targets as critical archive-link findings while preserving safe relative links
 - restore pickle CVE scan throughput, reprobe malformed stream separators, and route four-byte protocol-0 Joblib operands correctly
 - bound manifest embedded-Jinja template collection while preserving findings across deep branches, cycles, and shared YAML aliases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- preserve PyTorch malformed-ZIP symlink findings, selected HDF5 user-block subtype scans, valid Python 3.10 streamed ZIP64 descriptors, and complete concatenated user-block ZIP scans without weakening preflight checks
+- preserve PyTorch malformed-ZIP symlink findings, selected HDF5 user-block subtype scans, valid Python 3.10 streamed ZIP64 descriptors, and complete nested and concatenated user-block ZIP scans without weakening preflight checks
 - prevent exported source redaction from treating comparisons as assignments or leaking suffixes appended to quoted redaction markers
 - classify unsafe PyTorch ZIP symlink targets as critical archive-link findings while preserving safe relative links
 - restore pickle CVE scan throughput, reprobe malformed stream separators, and route four-byte protocol-0 Joblib operands correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- preserve PyTorch malformed-ZIP symlink findings and complete concatenated HDF5 user-block ZIP scans without weakening hidden-entry preflight checks
+- preserve PyTorch malformed-ZIP symlink findings, selected HDF5 user-block subtype scans, valid Python 3.10 streamed ZIP64 descriptors, and complete concatenated user-block ZIP scans without weakening preflight checks
 - prevent exported source redaction from treating comparisons as assignments or leaking suffixes appended to quoted redaction markers
 - classify unsafe PyTorch ZIP symlink targets as critical archive-link findings while preserving safe relative links
 - restore pickle CVE scan throughput, reprobe malformed stream separators, and route four-byte protocol-0 Joblib operands correctly

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -1242,6 +1242,11 @@ def _select_hdf5_userblock_supplemental_scanner_id(
     config: dict[str, Any] | None = None,
 ) -> str | None:
     """Preserve the non-HDF5 scanner that owns a user-block prefix or path."""
+    if header_format == "zip":
+        # Complete user-block ZIP segments are routed independently below.
+        # Probing the full HDF5 file can reject valid concatenated archives
+        # because the final central directory intentionally omits earlier ZIPs.
+        return "zip"
     scanner_id = _select_non_hdf5_preferred_scanner_id(path, header_format, ext, config)
     if scanner_id is not None:
         return scanner_id
@@ -3574,15 +3579,20 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
         sr.finish(success=False)
         return sr
 
+    hdf5_signature_offset = find_hdf5_signature_offset(path)
     try:
         max_zip_entries = int(config.get("max_zip_entries", ZipScanner.DEFAULT_MAX_ENTRIES))
     except (TypeError, ValueError):
         max_zip_entries = ZipScanner.DEFAULT_MAX_ENTRIES
     max_zip_directory_size = ZipScanner.central_directory_size_limit(config)
-    if allows_zip_structure_analysis(scanner_selection, path) and ZipScanner.requires_preflight_result(
-        path,
-        max_zip_entries,
-        max_zip_directory_size,
+    if (
+        hdf5_signature_offset in (None, 0)
+        and allows_zip_structure_analysis(scanner_selection, path)
+        and ZipScanner.requires_preflight_result(
+            path,
+            max_zip_entries,
+            max_zip_directory_size,
+        )
     ):
         return ZipScanner(config=config).scan(path)
 
@@ -3684,8 +3694,6 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
             if nested_xgboost_route == "xgboost":
                 config[XGBOOST_CONTENT_ROUTED_UBJSON_CONFIG_KEY] = True
     is_xgboost_pickle_spoof = ext in _XGBOOST_BINARY_EXTENSIONS and header_format == "pickle"
-    hdf5_signature_offset = find_hdf5_signature_offset(path)
-
     # Record telemetry for file type detection
     detected_format = header_format if header_format != "unknown" else ext_format
     record_file_type_detected(path, detected_format)

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -38,6 +38,7 @@ from modelaudit.scanner_selection import (
     ScannerSelectionPolicy,
     add_scanner_selection_skip_check,
     allows_protobuf_model_candidate_analysis,
+    allows_zip_content_analysis,
     allows_zip_structure_analysis,
     make_scanner_selection_skip_result,
     normalize_scanner_selection_config,
@@ -1242,7 +1243,7 @@ def _select_hdf5_userblock_supplemental_scanner_id(
     config: dict[str, Any] | None = None,
 ) -> str | None:
     """Preserve the non-HDF5 scanner that owns a user-block prefix or path."""
-    if header_format == "zip":
+    if header_format in {"zip", EXECUTABLE_ZIP_POLYGLOT_FORMAT}:
         # Complete user-block ZIP segments are routed independently below.
         # Probing the full HDF5 file can reject valid concatenated archives
         # because the final central directory intentionally omits earlier ZIPs.
@@ -4004,10 +4005,10 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
                     result = make_scanner_selection_skip_result(path, candidate_scanner_id, scanner_selection)
                     if result.bytes_scanned == 0 and file_size > 0:
                         result.bytes_scanned = file_size
-                    userblock_zip_allowed = hdf5_signature_offset not in (None, 0) and (
-                        scanner_selection.allows("zip")
-                        or scanner_selection.allows(hdf5_userblock_supplemental_scanner_id)
-                    )
+                    userblock_zip_allowed = hdf5_signature_offset not in (
+                        None,
+                        0,
+                    ) and allows_zip_content_analysis(scanner_selection)
                     if userblock_zip_allowed:
                         assert hdf5_signature_offset is not None
                         result.scanner_name = "zip"
@@ -4108,11 +4109,7 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
 
     if hdf5_signature_offset not in (None, 0):
         assert hdf5_signature_offset is not None
-        userblock_zip_allowed = (
-            not scanner_selection.active
-            or scanner_selection.allows("zip")
-            or scanner_selection.allows(hdf5_userblock_supplemental_scanner_id)
-        )
+        userblock_zip_allowed = allows_zip_content_analysis(scanner_selection)
         if userblock_zip_allowed:
             merge_hdf5_userblock_zip_findings(
                 path,

--- a/modelaudit/integrations/source_redaction.py
+++ b/modelaudit/integrations/source_redaction.py
@@ -100,7 +100,7 @@ _EXPORT_ASSIGNMENT_RE = re.compile(
     rf"(?P<key_escape>\\?)(?P<quote>[\"'])"
     rf"(?P<quoted_key>{_EXPORT_KEY_TOKEN}(?:{_EXPORT_BRACKET_KEY})*)(?P=key_escape)(?P=quote)"
     rf"|(?P<key>{_EXPORT_KEY_TOKEN}(?:{_EXPORT_BRACKET_KEY})*))"
-    r"(?P<separator>\s*(?::|=|<<?-)\s*)",
+    r"(?P<separator>\s*(?::|(?<![=!<>])=(?!=)|<<?-)\s*)",
     re.IGNORECASE,
 )
 _EXPORT_EQUALS_KEY_RE = re.compile(
@@ -806,7 +806,9 @@ def _assignment_value_end(value: str, start: int, *, key: str) -> int:
         quote = value[value_start]
         quote_end = _find_closing_quote(value, value_start, quote)
         if quote_end >= 0:
-            return quote_end + 1
+            quoted_end = quote_end + 1
+            if quoted_end >= len(value) or value[quoted_end].isspace() or value[quoted_end] in ",;)}]":
+                return quoted_end
         start = value_start
     if value_start < len(value) and value[value_start] in {"|", ">"}:
         return _yaml_block_value_end(value, value_start)

--- a/modelaudit/scanner_selection.py
+++ b/modelaudit/scanner_selection.py
@@ -231,6 +231,13 @@ def allows_zip_structure_analysis(policy: ScannerSelectionPolicy, path: str | No
     return False
 
 
+def allows_zip_content_analysis(policy: ScannerSelectionPolicy) -> bool:
+    """Return whether selection permits a scanner that owns ZIP contents."""
+    if "zip" in policy.exclude_scanner_ids:
+        return False
+    return any(policy.allows(scanner_id) for scanner_id in _ZIP_CONTENT_ROUTED_SCANNER_IDS)
+
+
 def allows_protobuf_model_candidate_analyzer(policy: ScannerSelectionPolicy, scanner_id: str) -> bool:
     """Keep internal candidate delegation within the user's scanner policy."""
     if scanner_id not in _PROTOBUF_MODEL_CANDIDATE_ANALYZER_IDS:

--- a/modelaudit/scanners/archive_dispatch.py
+++ b/modelaudit/scanners/archive_dispatch.py
@@ -526,6 +526,7 @@ def merge_hdf5_userblock_zip_findings(
                     logical_start,
                     logical_end,
                     temp_suffix,
+                    required_zero_prefix_length=earliest_member_offset - logical_start,
                 )
             else:
                 temp_path = _copy_file_prefix_to_temp(path, logical_end, temp_suffix)
@@ -701,20 +702,35 @@ def _find_earliest_zip_member_offset(path: str, logical_end: int) -> int:
         return 0
 
 
-def _copy_file_range_to_temp(path: str, start: int, end: int, suffix: str) -> str:
+def _copy_file_range_to_temp(
+    path: str,
+    start: int,
+    end: int,
+    suffix: str,
+    *,
+    required_zero_prefix_length: int = 0,
+) -> str:
     """Copy exactly one validated archive range to a temporary file."""
+    range_length = end - start
+    if not 0 <= required_zero_prefix_length <= range_length:
+        raise OSError("HDF5 user-block ZIP has an invalid member offset")
     temp_path: str | None = None
     try:
         with open(path, "rb") as source, tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as temp_file:
             source.seek(start)
             temp_path = temp_file.name
-            remaining = end - start
+            remaining = range_length
+            zero_prefix_remaining = required_zero_prefix_length
             while remaining > 0:
                 chunk = source.read(min(1024 * 1024, remaining))
                 if not chunk:
                     raise OSError("HDF5 user-block ZIP ended before its validated logical EOF")
+                zero_prefix_chunk_length = min(len(chunk), zero_prefix_remaining)
+                if chunk[:zero_prefix_chunk_length].rstrip(b"\x00"):
+                    raise OSError("HDF5 user block contains non-padding content between ZIP segments")
                 temp_file.write(chunk)
                 remaining -= len(chunk)
+                zero_prefix_remaining -= zero_prefix_chunk_length
         return temp_path
     except BaseException:
         if temp_path is not None:

--- a/modelaudit/scanners/archive_dispatch.py
+++ b/modelaudit/scanners/archive_dispatch.py
@@ -517,8 +517,21 @@ def merge_hdf5_userblock_zip_findings(
                     has_trailing_content = True
                 trailing_bytes -= len(chunk)
 
+        logical_start = 0
         for logical_end in logical_zip_ends:
-            temp_path = _copy_file_prefix_to_temp(path, logical_end, temp_suffix)
+            if logical_start == 0:
+                temp_path = _copy_file_prefix_to_temp(path, logical_end, temp_suffix)
+            else:
+                temp_path = _copy_file_range_to_temp(
+                    path,
+                    logical_start,
+                    logical_end,
+                    temp_suffix,
+                )
+                if not zipfile.is_zipfile(temp_path):
+                    with suppress(OSError):
+                        os.unlink(temp_path)
+                    temp_path = _copy_file_prefix_to_temp(path, logical_end, temp_suffix)
             supplemental_result = ScanResult(scanner_name="zip")
             merge_executable_zip_container_findings(temp_path, supplemental_result, config, context=context)
             _replace_scan_result_path(supplemental_result, temp_path, path)
@@ -526,6 +539,7 @@ def merge_hdf5_userblock_zip_findings(
             with suppress(OSError):
                 os.unlink(temp_path)
             temp_path = None
+            logical_start = logical_end
         if has_trailing_content:
             reason = "hdf5_userblock_zip_trailing_content_unanalyzed"
             mark_inconclusive_scan_result(result, reason)
@@ -676,13 +690,14 @@ def _find_valid_zip_logical_ends(
     return logical_ends
 
 
-def _copy_file_prefix_to_temp(path: str, length: int, suffix: str) -> str:
-    """Copy exactly one validated archive prefix to a temporary file."""
+def _copy_file_range_to_temp(path: str, start: int, end: int, suffix: str) -> str:
+    """Copy exactly one validated archive range to a temporary file."""
     temp_path: str | None = None
     try:
         with open(path, "rb") as source, tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as temp_file:
+            source.seek(start)
             temp_path = temp_file.name
-            remaining = length
+            remaining = end - start
             while remaining > 0:
                 chunk = source.read(min(1024 * 1024, remaining))
                 if not chunk:
@@ -695,6 +710,11 @@ def _copy_file_prefix_to_temp(path: str, length: int, suffix: str) -> str:
             with suppress(OSError):
                 os.unlink(temp_path)
         raise
+
+
+def _copy_file_prefix_to_temp(path: str, length: int, suffix: str) -> str:
+    """Copy exactly one validated archive prefix to a temporary file."""
+    return _copy_file_range_to_temp(path, 0, length, suffix)
 
 
 def merge_flax_msgpack_overlap_findings(

--- a/modelaudit/scanners/archive_dispatch.py
+++ b/modelaudit/scanners/archive_dispatch.py
@@ -519,19 +519,16 @@ def merge_hdf5_userblock_zip_findings(
 
         logical_start = 0
         for logical_end in logical_zip_ends:
-            if logical_start == 0:
-                temp_path = _copy_file_prefix_to_temp(path, logical_end, temp_suffix)
-            else:
+            earliest_member_offset = _find_earliest_zip_member_offset(path, logical_end)
+            if logical_start > 0 and earliest_member_offset >= logical_start:
                 temp_path = _copy_file_range_to_temp(
                     path,
                     logical_start,
                     logical_end,
                     temp_suffix,
                 )
-                if not zipfile.is_zipfile(temp_path):
-                    with suppress(OSError):
-                        os.unlink(temp_path)
-                    temp_path = _copy_file_prefix_to_temp(path, logical_end, temp_suffix)
+            else:
+                temp_path = _copy_file_prefix_to_temp(path, logical_end, temp_suffix)
             supplemental_result = ScanResult(scanner_name="zip")
             merge_executable_zip_container_findings(temp_path, supplemental_result, config, context=context)
             _replace_scan_result_path(supplemental_result, temp_path, path)
@@ -688,6 +685,20 @@ def _find_valid_zip_logical_ends(
             if zipfile.is_zipfile(bounded_reader) and logical_end not in logical_ends:
                 logical_ends.append(logical_end)
     return logical_ends
+
+
+def _find_earliest_zip_member_offset(path: str, logical_end: int) -> int:
+    """Return the earliest central-directory member offset for a logical ZIP."""
+    try:
+        with open(path, "rb") as handle:
+            bounded_reader = _LogicalEOFReader(handle, logical_end)
+            with zipfile.ZipFile(bounded_reader) as archive:
+                return min(
+                    (entry.header_offset for entry in archive.infolist()),
+                    default=archive.start_dir,
+                )
+    except (OSError, zipfile.BadZipFile):
+        return 0
 
 
 def _copy_file_range_to_temp(path: str, start: int, end: int, suffix: str) -> str:

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -390,7 +390,11 @@ class PyTorchZipScanner(BaseScanner):
 
             from .zip_scanner import open_preflighted_zip
 
-            with open_preflighted_zip(path, self.config) as zip_file:
+            with open_preflighted_zip(
+                path,
+                self.config,
+                allow_local_entry_mismatch=True,
+            ) as zip_file:
                 # Validate ZIP entries and check for path traversal
                 safe_entries = self._validate_zip_entries(zip_file, result, path)
                 self._check_timeout()  # Check timeout after entry validation
@@ -3667,7 +3671,11 @@ class PyTorchZipScanner(BaseScanner):
         try:
             from .zip_scanner import open_preflighted_zip
 
-            with open_preflighted_zip(file_path, self.config) as zip_file:
+            with open_preflighted_zip(
+                file_path,
+                self.config,
+                allow_local_entry_mismatch=True,
+            ) as zip_file:
                 archive_entries = zip_file.infolist()
                 total_files = len(archive_entries)
                 entries_to_process = archive_entries[: self.max_archive_entries]

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -390,11 +390,7 @@ class PyTorchZipScanner(BaseScanner):
 
             from .zip_scanner import open_preflighted_zip
 
-            with open_preflighted_zip(
-                path,
-                self.config,
-                allow_local_entry_mismatch=True,
-            ) as zip_file:
+            with open_preflighted_zip(path, self.config) as zip_file:
                 # Validate ZIP entries and check for path traversal
                 safe_entries = self._validate_zip_entries(zip_file, result, path)
                 self._check_timeout()  # Check timeout after entry validation
@@ -3671,11 +3667,7 @@ class PyTorchZipScanner(BaseScanner):
         try:
             from .zip_scanner import open_preflighted_zip
 
-            with open_preflighted_zip(
-                file_path,
-                self.config,
-                allow_local_entry_mismatch=True,
-            ) as zip_file:
+            with open_preflighted_zip(file_path, self.config) as zip_file:
                 archive_entries = zip_file.infolist()
                 total_files = len(archive_entries)
                 entries_to_process = archive_entries[: self.max_archive_entries]

--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -80,12 +80,19 @@ class _ZipDirectoryMetadata:
 class _ZipCentralDirectoryEntry:
     filename: bytes
     flags: int
+    creator_system: int
+    external_attr: int
     compression_method: int
     crc32: int
     compressed_size: int
     uncompressed_size: int
     relative_local_offset: int
     uses_zip64_sizes: bool
+
+    @property
+    def is_symlink(self) -> bool:
+        """Return whether Unix mode metadata declares this entry as a symlink."""
+        return self.creator_system in _UNIX_MODE_ZIP_CREATOR_SYSTEMS and stat.S_ISLNK(self.external_attr >> 16)
 
 
 @dataclass(frozen=True)
@@ -102,6 +109,10 @@ class _InvalidZipDirectory(ValueError):
 
 class _ZipLocalEntryMismatch(_InvalidZipDirectory):
     """Raised when a central-directory entry does not match its local record."""
+
+    def __init__(self, message: str, entry: _ZipCentralDirectoryEntry):
+        super().__init__(message, routing_evidence=True)
+        self.entry = entry
 
 
 class _ZipCentralDirectorySizeExceeded(_InvalidZipDirectory):
@@ -544,6 +555,8 @@ class ZipScanner(BaseScanner):
         return _ZipCentralDirectoryEntry(
             filename=filename,
             flags=int.from_bytes(header[8:10], "little"),
+            creator_system=header[5],
+            external_attr=int.from_bytes(header[38:42], "little"),
             compression_method=int.from_bytes(header[10:12], "little"),
             crc32=int.from_bytes(header[16:20], "little"),
             compressed_size=compressed_size,
@@ -674,22 +687,31 @@ class ZipScanner(BaseScanner):
         if not uses_data_descriptor:
             return _ZipLocalEntryLayout(offset=local_header_offset, end_candidates=frozenset({data_end}))
 
-        uses_zip64_descriptor = entry.uses_zip64_sizes or local_uses_zip64_sizes
-        descriptor_size = 24 if uses_zip64_descriptor else 16
+        descriptor_widths = {entry.uses_zip64_sizes or local_uses_zip64_sizes}
+        local_zip64_data = cls._zip64_extra_field(extra)
+        if local_zip64_data is not None and len(local_zip64_data) >= 16:
+            # Python 3.10 can write zero local sizes with a ZIP64 extra field and
+            # still emit the 64-bit descriptor selected by force_zip64=True.
+            descriptor_widths.add(True)
+        descriptor_size = 24 if True in descriptor_widths else 16
         try:
             handle.seek(data_end)
             descriptor = handle.read(descriptor_size)
         except OSError as exc:
             raise _InvalidZipDirectory(f"ZIP data descriptor could not be read: {exc}") from exc
-        end_candidates = cls._data_descriptor_end_candidates(
-            descriptor,
-            data_end,
-            entry,
-            uses_zip64_sizes=uses_zip64_descriptor,
-        )
+        end_candidates: set[int] = set()
+        for uses_zip64_sizes in descriptor_widths:
+            end_candidates.update(
+                cls._data_descriptor_end_candidates(
+                    descriptor,
+                    data_end,
+                    entry,
+                    uses_zip64_sizes=uses_zip64_sizes,
+                )
+            )
         if not end_candidates:
             return None
-        return _ZipLocalEntryLayout(offset=local_header_offset, end_candidates=end_candidates)
+        return _ZipLocalEntryLayout(offset=local_header_offset, end_candidates=frozenset(end_candidates))
 
     @classmethod
     def _validate_declared_local_entry_layout(
@@ -721,7 +743,7 @@ class ZipScanner(BaseScanner):
             if not matching_layouts:
                 raise _ZipLocalEntryMismatch(
                     "ZIP central directory does not uniquely identify its local entry",
-                    routing_evidence=True,
+                    entry,
                 )
             if len(matching_layouts) != 1:
                 raise _InvalidZipDirectory(
@@ -1296,6 +1318,27 @@ class ZipScanner(BaseScanner):
                     "scan_outcome_reason": "zip_analysis_incomplete",
                 },
             )
+            if isinstance(error, _ZipLocalEntryMismatch) and error.entry.is_symlink:
+                encoding = "utf-8" if error.entry.flags & 0x0800 else "cp437"
+                entry_name = error.entry.filename.decode(encoding, errors="replace")
+                if len(entry_name) > 1024:
+                    entry_name = f"{entry_name[:1021]}..."
+                result.add_check(
+                    name="Symlink Safety Validation",
+                    passed=False,
+                    message=f"Symlink {entry_name} has inconsistent ZIP local metadata",
+                    severity=IssueSeverity.CRITICAL,
+                    rule_code="S406",
+                    location=f"{path}:{entry_name}",
+                    details={
+                        "entry": entry_name,
+                        "target": "<inconsistent-zip-metadata>",
+                        "target_class": "invalid",
+                        "compressed_size": error.entry.compressed_size,
+                        "uncompressed_size": error.entry.uncompressed_size,
+                        "analysis_incomplete": True,
+                    },
+                )
         mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
         result.finish(success=False)
         return result
@@ -2232,7 +2275,6 @@ def _open_preflighted_zip_handle(
     config: dict[str, Any] | None = None,
     *,
     require_zip: bool = True,
-    allow_local_entry_mismatch: bool = False,
 ) -> Iterator[tuple[BinaryIO, bool]]:
     """Open once, preflight that descriptor, and yield it with its ZIP routing state."""
     scanner = ZipScanner(config=config)
@@ -2245,10 +2287,6 @@ def _open_preflighted_zip_handle(
                 scanner.max_central_directory_size,
             )
         except _InvalidZipDirectory as exc:
-            if isinstance(exc, _ZipLocalEntryMismatch) and allow_local_entry_mismatch:
-                handle.seek(0)
-                yield handle, True
-                return
             if not require_zip:
                 handle.seek(0)
                 try:
@@ -2290,15 +2328,9 @@ def open_preflighted_zip_handle(
     config: dict[str, Any] | None = None,
     *,
     require_zip: bool = True,
-    allow_local_entry_mismatch: bool = False,
 ) -> Iterator[BinaryIO]:
     """Open once, preflight that descriptor, and yield it without a pathname race."""
-    with _open_preflighted_zip_handle(
-        path,
-        config,
-        require_zip=require_zip,
-        allow_local_entry_mismatch=allow_local_entry_mismatch,
-    ) as (handle, _is_zip):
+    with _open_preflighted_zip_handle(path, config, require_zip=require_zip) as (handle, _is_zip):
         yield handle
 
 
@@ -2306,16 +2338,7 @@ def open_preflighted_zip_handle(
 def open_preflighted_zip(
     path: str | os.PathLike[str],
     config: dict[str, Any] | None = None,
-    *,
-    allow_local_entry_mismatch: bool = False,
 ) -> Iterator[zipfile.ZipFile]:
     """Construct ``ZipFile`` only after preflighting the same open descriptor."""
-    with (
-        open_preflighted_zip_handle(
-            path,
-            config,
-            allow_local_entry_mismatch=allow_local_entry_mismatch,
-        ) as handle,
-        zipfile.ZipFile(handle, "r") as archive,
-    ):
+    with open_preflighted_zip_handle(path, config) as handle, zipfile.ZipFile(handle, "r") as archive:
         yield archive

--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -100,6 +100,10 @@ class _InvalidZipDirectory(ValueError):
         self.routing_evidence = routing_evidence
 
 
+class _ZipLocalEntryMismatch(_InvalidZipDirectory):
+    """Raised when a central-directory entry does not match its local record."""
+
+
 class _ZipCentralDirectorySizeExceeded(_InvalidZipDirectory):
     def __init__(self, directory_size: int, max_directory_size: int):
         super().__init__(
@@ -714,6 +718,11 @@ class ZipScanner(BaseScanner):
                 for candidate in candidates
                 if (layout := cls._local_entry_layout(handle, metadata, entry, candidate)) is not None
             ]
+            if not matching_layouts:
+                raise _ZipLocalEntryMismatch(
+                    "ZIP central directory does not uniquely identify its local entry",
+                    routing_evidence=True,
+                )
             if len(matching_layouts) != 1:
                 raise _InvalidZipDirectory(
                     "ZIP central directory does not uniquely identify its local entry",
@@ -2223,6 +2232,7 @@ def _open_preflighted_zip_handle(
     config: dict[str, Any] | None = None,
     *,
     require_zip: bool = True,
+    allow_local_entry_mismatch: bool = False,
 ) -> Iterator[tuple[BinaryIO, bool]]:
     """Open once, preflight that descriptor, and yield it with its ZIP routing state."""
     scanner = ZipScanner(config=config)
@@ -2235,6 +2245,10 @@ def _open_preflighted_zip_handle(
                 scanner.max_central_directory_size,
             )
         except _InvalidZipDirectory as exc:
+            if isinstance(exc, _ZipLocalEntryMismatch) and allow_local_entry_mismatch:
+                handle.seek(0)
+                yield handle, True
+                return
             if not require_zip:
                 handle.seek(0)
                 try:
@@ -2276,9 +2290,15 @@ def open_preflighted_zip_handle(
     config: dict[str, Any] | None = None,
     *,
     require_zip: bool = True,
+    allow_local_entry_mismatch: bool = False,
 ) -> Iterator[BinaryIO]:
     """Open once, preflight that descriptor, and yield it without a pathname race."""
-    with _open_preflighted_zip_handle(path, config, require_zip=require_zip) as (handle, _is_zip):
+    with _open_preflighted_zip_handle(
+        path,
+        config,
+        require_zip=require_zip,
+        allow_local_entry_mismatch=allow_local_entry_mismatch,
+    ) as (handle, _is_zip):
         yield handle
 
 
@@ -2286,7 +2306,16 @@ def open_preflighted_zip_handle(
 def open_preflighted_zip(
     path: str | os.PathLike[str],
     config: dict[str, Any] | None = None,
+    *,
+    allow_local_entry_mismatch: bool = False,
 ) -> Iterator[zipfile.ZipFile]:
     """Construct ``ZipFile`` only after preflighting the same open descriptor."""
-    with open_preflighted_zip_handle(path, config) as handle, zipfile.ZipFile(handle, "r") as archive:
+    with (
+        open_preflighted_zip_handle(
+            path,
+            config,
+            allow_local_entry_mismatch=allow_local_entry_mismatch,
+        ) as handle,
+        zipfile.ZipFile(handle, "r") as archive,
+    ):
         yield archive

--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -1304,44 +1304,54 @@ class ZipScanner(BaseScanner):
             self._add_central_directory_size_limit_check(result, path, error)
         else:
             assert error is not None
-            result.add_check(
-                name="ZIP Central Directory Preflight",
-                passed=False,
-                message=f"ZIP central-directory validation failed: {error}",
-                severity=IssueSeverity.INFO,
-                rule_code="S902",
-                location=path,
-                details={
-                    "exception": str(error),
-                    "exception_type": type(error).__name__,
-                    "analysis_incomplete": True,
-                    "scan_outcome_reason": "zip_analysis_incomplete",
-                },
-            )
-            if isinstance(error, _ZipLocalEntryMismatch) and error.entry.is_symlink:
-                encoding = "utf-8" if error.entry.flags & 0x0800 else "cp437"
-                entry_name = error.entry.filename.decode(encoding, errors="replace")
-                if len(entry_name) > 1024:
-                    entry_name = f"{entry_name[:1021]}..."
-                result.add_check(
-                    name="Symlink Safety Validation",
-                    passed=False,
-                    message=f"Symlink {entry_name} has inconsistent ZIP local metadata",
-                    severity=IssueSeverity.CRITICAL,
-                    rule_code="S406",
-                    location=f"{path}:{entry_name}",
-                    details={
-                        "entry": entry_name,
-                        "target": "<inconsistent-zip-metadata>",
-                        "target_class": "invalid",
-                        "compressed_size": error.entry.compressed_size,
-                        "uncompressed_size": error.entry.uncompressed_size,
-                        "analysis_incomplete": True,
-                    },
-                )
+            self._add_invalid_directory_checks(result, path, error)
         mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
         result.finish(success=False)
         return result
+
+    @staticmethod
+    def _add_invalid_directory_checks(
+        result: ScanResult,
+        path: str,
+        error: _InvalidZipDirectory,
+    ) -> None:
+        result.add_check(
+            name="ZIP Central Directory Preflight",
+            passed=False,
+            message=f"ZIP central-directory validation failed: {error}",
+            severity=IssueSeverity.INFO,
+            rule_code="S902",
+            location=path,
+            details={
+                "exception": str(error),
+                "exception_type": type(error).__name__,
+                "analysis_incomplete": True,
+                "scan_outcome_reason": "zip_analysis_incomplete",
+            },
+        )
+        if not isinstance(error, _ZipLocalEntryMismatch) or not error.entry.is_symlink:
+            return
+
+        encoding = "utf-8" if error.entry.flags & 0x0800 else "cp437"
+        entry_name = error.entry.filename.decode(encoding, errors="replace")
+        if len(entry_name) > 1024:
+            entry_name = f"{entry_name[:1021]}..."
+        result.add_check(
+            name="Symlink Safety Validation",
+            passed=False,
+            message=f"Symlink {entry_name} has inconsistent ZIP local metadata",
+            severity=IssueSeverity.CRITICAL,
+            rule_code="S406",
+            location=f"{path}:{entry_name}",
+            details={
+                "entry": entry_name,
+                "target": "<inconsistent-zip-metadata>",
+                "target_class": "invalid",
+                "compressed_size": error.entry.compressed_size,
+                "uncompressed_size": error.entry.uncompressed_size,
+                "analysis_incomplete": True,
+            },
+        )
 
     @staticmethod
     def _add_central_directory_size_limit_check(
@@ -1722,20 +1732,7 @@ class ZipScanner(BaseScanner):
                 result.finish(success=False)
                 return result
             except _InvalidZipDirectory as exc:
-                result.add_check(
-                    name="ZIP Central Directory Preflight",
-                    passed=False,
-                    message=f"ZIP central-directory validation failed: {exc}",
-                    severity=IssueSeverity.INFO,
-                    rule_code="S902",
-                    location=path,
-                    details={
-                        "exception": str(exc),
-                        "exception_type": type(exc).__name__,
-                        "analysis_incomplete": True,
-                        "scan_outcome_reason": "zip_analysis_incomplete",
-                    },
-                )
+                self._add_invalid_directory_checks(result, path, exc)
                 mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
                 result.finish(success=False)
                 return result

--- a/modelaudit/utils/file/handlers.py
+++ b/modelaudit/utils/file/handlers.py
@@ -136,6 +136,8 @@ def _pinned_windows_shard_scan_path(
     except _ShardPinUnavailableError:
         raise
     except OSError as error:
+        if pinned_scan is not None:
+            raise
         raise _ShardPinUnavailableError(str(error)) from error
     finally:
         if pinned_scan is not None and pinned_stat is not None and pinned_fd is not None:
@@ -235,6 +237,8 @@ def _pinned_shard_scan_path(
     except _ShardPinUnavailableError:
         raise
     except OSError as error:
+        if pinned_scan is not None:
+            raise
         raise _ShardPinUnavailableError(str(error)) from error
     finally:
         if pinned_scan is not None and pinned_stat is not None and source_fd is not None:

--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -78,6 +78,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- avoid rescanning complete encoded pickles at interior Base64 windows, and preserve raw nested-pickle analysis beyond the generic literal scan cap
 - preserve raw persistent-ID probes and later encoded payloads when byte literals also contain complete or unterminated Base64 pickles
 - scan encoded nested pickles in bounded byte and bytearray literals without treating benign execution-like text or complete encoded payloads as raw pickle fragments
 - continue probing encoded protocol 0 payloads after long line operands, lenient base64 separators, and wrapper alignment shifts while failing closed beyond bounded mid-scan coverage

--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -78,7 +78,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- avoid rescanning complete encoded pickles at interior Base64 windows, and preserve raw nested-pickle analysis beyond the generic literal scan cap
+- avoid rescanning complete encoded pickles at interior Base64 windows, and honor the string-literal scan cap during raw nested-pickle analysis
 - preserve raw persistent-ID probes and later encoded payloads when byte literals also contain complete or unterminated Base64 pickles
 - scan encoded nested pickles in bounded byte and bytearray literals without treating benign execution-like text or complete encoded payloads as raw pickle fragments
 - continue probing encoded protocol 0 payloads after long line operands, lenient base64 separators, and wrapper alignment shifts while failing closed beyond bounded mid-scan coverage

--- a/packages/modelaudit-picklescan/rust/src/state.rs
+++ b/packages/modelaudit-picklescan/rust/src/state.rs
@@ -1407,8 +1407,6 @@ impl<'a> ScanState<'a> {
                                     raw_position.saturating_add(cursor),
                                 );
                             }
-                        } else if bytes.len() <= self.options.max_nested_pickle_bytes {
-                            self.scan_raw_nested_pickle_bytes(bytes, raw_position);
                         } else if scan_limit > 0 {
                             self.scan_raw_nested_pickle_bytes(&bytes[..scan_limit], raw_position);
                             let suffix_start =
@@ -10463,26 +10461,29 @@ mod tests {
     }
 
     #[test]
-    fn raw_nested_pickle_uses_nested_budget_beyond_literal_scan_cap() {
-        let mut options = default_test_options();
-        options.max_string_literal_scan_chars = 8;
-        let mut nested = b"\x80\x04}\x94\x8c\x04code\x94X\x80\x00\x00\x00".to_vec();
-        nested.extend(std::iter::repeat_n(b'A', 128));
-        nested.extend_from_slice(b"\x94s.");
-        let mut payload = b"\x80\x04C".to_vec();
-        payload.push(nested.len() as u8);
-        payload.extend_from_slice(&nested);
-        payload.push(b'.');
+    fn raw_nested_pickle_respects_literal_scan_cap() {
+        for literal_scan_cap in [0, 8] {
+            let mut options = default_test_options();
+            options.max_string_literal_scan_chars = literal_scan_cap;
+            let mut nested = b"\x80\x04}\x94\x8c\x04code\x94X\x80\x00\x00\x00".to_vec();
+            nested.extend(std::iter::repeat_n(b'A', 128));
+            nested.extend_from_slice(b"\x94s.");
+            let mut payload = b"\x80\x04C".to_vec();
+            payload.push(nested.len() as u8);
+            payload.extend_from_slice(&nested);
+            payload.push(b'.');
 
-        let scan = run_test_scan("bounded-raw-nested.pkl", &payload, &options);
+            let scan = run_test_scan("bounded-raw-nested.pkl", &payload, &options);
 
-        assert_eq!(scan.status, ScanStatus::Inconclusive);
-        assert_eq!(scan.verdict, "malicious");
-        assert!(scan
-            .findings
-            .iter()
-            .any(|finding| finding.rule_code == Some("S213")));
-        assert!(has_notice_code(&scan, "nested_pickle_incomplete"));
+            assert_eq!(scan.status, ScanStatus::Inconclusive);
+            assert_eq!(scan.verdict, "unknown");
+            assert!(!scan
+                .findings
+                .iter()
+                .any(|finding| finding.rule_code == Some("S213")));
+            assert!(has_notice_code(&scan, "literal_scan_truncated"));
+            assert!(!has_notice_code(&scan, "nested_pickle_incomplete"));
+        }
     }
 
     #[test]

--- a/packages/modelaudit-picklescan/rust/src/state.rs
+++ b/packages/modelaudit-picklescan/rust/src/state.rs
@@ -1407,6 +1407,8 @@ impl<'a> ScanState<'a> {
                                     raw_position.saturating_add(cursor),
                                 );
                             }
+                        } else if bytes.len() <= self.options.max_nested_pickle_bytes {
+                            self.scan_raw_nested_pickle_bytes(bytes, raw_position);
                         } else if scan_limit > 0 {
                             self.scan_raw_nested_pickle_bytes(&bytes[..scan_limit], raw_position);
                             let suffix_start =
@@ -6257,6 +6259,9 @@ impl<'a> ScanState<'a> {
         {
             found_candidate |= self.scan_encoded_nested_pickle_candidate(value, position);
         }
+        if found_candidate && whole_literal_is_encoded_pickle {
+            return (true, true);
+        }
 
         let probe_windows =
             encoded_nested_literal_probe_windows_with_limit(value, max_window_chars);
@@ -10438,6 +10443,46 @@ mod tests {
             .iter()
             .any(|(key, value)| key == "nested_has_execution_opcode"
                 && matches!(value, DetailValue::Bool(true))));
+    }
+
+    #[test]
+    fn complete_encoded_nested_pickle_does_not_probe_interior_base64_windows() {
+        let options = default_test_options();
+        let encoded_counter = b"gASVNQAAAAAAAACMC2NvbGxlY3Rpb25zlIwHQ291bnRlcpSTlH2UKIwBYZRLA4wBYpRLAowBY5RLAXWFlFKULg==";
+        let mut payload = b"\x80\x04".to_vec();
+        payload.extend_from_slice(&short_binunicode(encoded_counter));
+        payload.push(b'.');
+
+        let scan = run_test_scan("encoded-counter.pkl", &payload, &options);
+
+        assert_eq!(scan.status, ScanStatus::Complete);
+        assert_eq!(scan.verdict, "clean");
+        assert!(scan.findings.is_empty());
+        assert!(has_notice_code(&scan, "encoded_nested_payload_detected"));
+        assert!(!has_notice_code(&scan, "nested_pickle_incomplete"));
+    }
+
+    #[test]
+    fn raw_nested_pickle_uses_nested_budget_beyond_literal_scan_cap() {
+        let mut options = default_test_options();
+        options.max_string_literal_scan_chars = 8;
+        let mut nested = b"\x80\x04}\x94\x8c\x04code\x94X\x80\x00\x00\x00".to_vec();
+        nested.extend(std::iter::repeat_n(b'A', 128));
+        nested.extend_from_slice(b"\x94s.");
+        let mut payload = b"\x80\x04C".to_vec();
+        payload.push(nested.len() as u8);
+        payload.extend_from_slice(&nested);
+        payload.push(b'.');
+
+        let scan = run_test_scan("bounded-raw-nested.pkl", &payload, &options);
+
+        assert_eq!(scan.status, ScanStatus::Inconclusive);
+        assert_eq!(scan.verdict, "malicious");
+        assert!(scan
+            .findings
+            .iter()
+            .any(|finding| finding.rule_code == Some("S213")));
+        assert!(has_notice_code(&scan, "nested_pickle_incomplete"));
     }
 
     #[test]

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -7649,7 +7649,7 @@ def test_scan_bytes_default_depth_surfaces_two_layer_encoded_nested_findings() -
     )
 
 
-def test_scan_bytes_marks_parent_inconclusive_when_nested_analysis_is_incomplete() -> None:
+def test_scan_bytes_respects_literal_cap_before_nested_analysis() -> None:
     nested_payload = pickle.dumps({"code": "A" * 128}, protocol=4)
 
     report = scan_bytes(
@@ -7659,14 +7659,17 @@ def test_scan_bytes_marks_parent_inconclusive_when_nested_analysis_is_incomplete
     )
 
     assert report.status == ScanStatus.INCONCLUSIVE
-    assert report.verdict == SafetyVerdict.MALICIOUS
-    assert any(finding.rule_code == "S213" for finding in report.findings)
+    assert report.verdict == SafetyVerdict.UNKNOWN
+    assert report.is_clean is False
+    assert not any(finding.rule_code == "S213" for finding in report.findings)
     assert any(
-        notice.code == "nested_pickle_incomplete"
-        and notice.details.get("nested_status") == ScanStatus.INCONCLUSIVE.value
+        notice.code == "literal_scan_truncated"
+        and notice.details.get("literal_type") == "bytes"
+        and notice.details.get("max_string_literal_scan_chars") == 8
         and notice.details.get("analysis_incomplete") is True
         for notice in report.notices
     )
+    assert not any(notice.code == "nested_pickle_incomplete" for notice in report.notices)
 
 
 def test_scan_bytes_flags_oversized_nested_pickle_prefix_without_deep_parse() -> None:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
@@ -31,6 +31,7 @@ def _posixpath_text_regex_cache_name() -> str:
         if name in posixpath.expandvars.__code__.co_names:
             return name
     pytest.skip("posixpath.expandvars has no recognized text regex cache")
+    raise AssertionError("unreachable")
 
 
 def _has_source_unavailable_notice(report: PickleReport, module: str, name: str) -> bool:

--- a/tests/integrations/test_sarif_redaction.py
+++ b/tests/integrations/test_sarif_redaction.py
@@ -485,6 +485,21 @@ def test_redact_source_text_handles_dense_credential_assignments() -> None:
     assert redacted.count("<redacted>") == 5_000
 
 
+def test_redact_source_text_does_not_treat_comparison_as_assignment() -> None:
+    text = 'config={"client_secret" == "public": "os.system(15)"}'
+
+    assert redact_source_text(text) == text
+
+
+def test_redact_source_text_consumes_suffix_after_quoted_marker() -> None:
+    text = 'client_secret="<redacted>"MARKER_SUFFIX_SECRET; visible=yes'
+
+    redacted = redact_source_text(text)
+
+    assert "MARKER_SUFFIX_SECRET" not in redacted
+    assert redacted == "client_secret=<redacted>; visible=yes"
+
+
 @pytest.mark.parametrize(
     "text",
     [

--- a/tests/scanners/test_catboost_evidence_redaction.py
+++ b/tests/scanners/test_catboost_evidence_redaction.py
@@ -1762,6 +1762,22 @@ def test_curl_user_complex_password_is_fully_redacted(credential: str, secret: s
             '"pass\u200bword' + (r"\(" * 26),
         ),
     ],
+    ids=[
+        "quoted-cert-unterminated",
+        "quoted-user-unterminated",
+        "substitution-user-unterminated",
+        "config-user-unterminated",
+        "quoted-cert-long-colons",
+        "quoted-user-long-colons",
+        "config-user-long-colons",
+        "cert-long-colons",
+        "cert-option-near-match",
+        "curl-executable-near-match",
+        "sensitive-argv-unterminated",
+        "cookie-header-unterminated",
+        "structured-value-unterminated",
+        "zero-width-key-unterminated",
+    ],
 )
 def test_command_credential_redaction_has_bounded_runtime(pattern_name: str, payload: str) -> None:
     code = (
@@ -1794,6 +1810,14 @@ def test_command_credential_redaction_has_bounded_runtime(pattern_name: str, pay
         "subprocess.run(" * 8_000,
         "a-" * 8_000,
         ("a-" * 8_000) + ':"',
+    ],
+    ids=[
+        "repeated-slash-curl",
+        "repeated-curl-prefix",
+        "split-curl",
+        "repeated-subprocess",
+        "repeated-option",
+        "repeated-option-quote",
     ],
 )
 def test_redaction_adversarial_inputs_have_bounded_runtime(payload: str) -> None:

--- a/tests/scanners/test_catboost_evidence_redaction.py
+++ b/tests/scanners/test_catboost_evidence_redaction.py
@@ -1780,6 +1780,7 @@ def test_command_credential_redaction_has_bounded_runtime(pattern_name: str, pay
         env={**os.environ, "PYTHONPATH": python_path},
         input=payload,
         text=True,
+        encoding="utf-8",
         timeout=5,
     )
 
@@ -1812,6 +1813,7 @@ def test_redaction_adversarial_inputs_have_bounded_runtime(payload: str) -> None
         env={**os.environ, "PYTHONPATH": python_path},
         input=payload,
         text=True,
+        encoding="utf-8",
         timeout=5,
     )
 

--- a/tests/scanners/test_catboost_scanner.py
+++ b/tests/scanners/test_catboost_scanner.py
@@ -1447,7 +1447,7 @@ def test_catboost_sarif_preserves_process_context_while_redacting_command_expres
     assert "bash -c" in sarif
     assert "--password <redacted>" in sarif
     assert "--user 'alice:<redacted>'" in sarif
-    assert "-ualice:<redacted>" in sarif
+    assert "client_secret=<redacted>" in sarif
     assert "collector.evil.example" in sarif
     assert "touch /tmp/pwned" in sarif
 

--- a/tests/scanners/test_keras_zip_scanner.py
+++ b/tests/scanners/test_keras_zip_scanner.py
@@ -8,6 +8,7 @@ The new .keras format is a ZIP archive containing:
 """
 
 import base64
+import builtins
 import json
 import marshal
 import stat
@@ -2101,6 +2102,15 @@ class TestKerasZipScanner:
             archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo replacement"\ntR.')
 
         original_scan_archive_members = keras_zip_scanner_module.ZipScanner.scan_archive_members
+        original_open = builtins.open
+        path_reopened = False
+
+        def redirect_path_open(file: Any, *args: Any, **kwargs: Any) -> Any:
+            nonlocal path_reopened
+            if str(file) == str(keras_path):
+                path_reopened = True
+                file = replacement_path
+            return original_open(file, *args, **kwargs)
 
         def replace_then_scan(
             scanner: keras_zip_scanner_module.ZipScanner,
@@ -2108,13 +2118,15 @@ class TestKerasZipScanner:
             archive: zipfile.ZipFile | None = None,
         ) -> ScanResult:
             assert archive is not None
-            replacement_path.replace(path)
-            return original_scan_archive_members(scanner, path, archive=archive)
+            with monkeypatch.context() as path_swap:
+                path_swap.setattr(builtins, "open", redirect_path_open)
+                return original_scan_archive_members(scanner, path, archive=archive)
 
         monkeypatch.setattr(keras_zip_scanner_module.ZipScanner, "scan_archive_members", replace_then_scan)
 
         result = KerasZipScanner().scan(str(keras_path))
 
+        assert path_reopened is False
         assert not any(issue.details.get("zip_entry") == "payload.pkl" for issue in result.issues)
         assert any(entry.get("path", "").endswith(":safe.txt") for entry in result.metadata["contents"])
         assert not any(entry.get("path", "").endswith(":payload.pkl") for entry in result.metadata["contents"])

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -6760,7 +6760,8 @@ def test_pytorch_zip_scanner_entry_limit_skips_late_entries(tmp_path: Path) -> N
         zipf.writestr("entry_0.txt", "data")
         zipf.writestr("entry_1.txt", "data")
         symlink_info = zipfile.ZipInfo("late_symlink")
-        symlink_info.external_attr = 0o120777 << 16
+        symlink_info.create_system = 3
+        symlink_info.external_attr = (stat.S_IFLNK | 0o777) << 16
         symlink_info.compress_type = zipfile.ZIP_STORED
         zipf.writestr(symlink_info, str(symlink_target))
 
@@ -7640,7 +7641,8 @@ def test_pytorch_zip_scanner_symlink_detection(tmp_path: Path) -> None:
         # S_IFLNK = 0o120000 (symlink)
         symlink_info = zipfile.ZipInfo("malicious_link")
         # Set external attributes to indicate symlink (Unix mode in upper 16 bits)
-        symlink_info.external_attr = 0o120777 << 16  # symlink with full permissions
+        symlink_info.create_system = 3
+        symlink_info.external_attr = (stat.S_IFLNK | 0o777) << 16
         symlink_info.compress_type = zipfile.ZIP_STORED
         zipf.writestr(symlink_info, "/etc/passwd")
 
@@ -7682,7 +7684,8 @@ def test_pytorch_zip_scanner_combined_security_controls(tmp_path: Path) -> None:
         zipf.writestr("version", "3")
         # Add a symlink entry before the entry cap, then enough entries to exceed a low limit.
         symlink_info = zipfile.ZipInfo("evil_link")
-        symlink_info.external_attr = 0o120777 << 16
+        symlink_info.create_system = 3
+        symlink_info.external_attr = (stat.S_IFLNK | 0o777) << 16
         symlink_info.compress_type = zipfile.ZIP_STORED
         zipf.writestr(symlink_info, str(symlink_target))
         for i in range(12):

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -6910,7 +6910,8 @@ def test_pytorch_zip_entry_limit_reads_selected_symlink_duplicate(tmp_path: Path
     symlink_target = tmp_path / "selected-target"
     with zipfile.ZipFile(zip_path, "w") as zipf:
         symlink_info = zipfile.ZipInfo("duplicate-entry")
-        symlink_info.external_attr = 0o120777 << 16
+        symlink_info.create_system = 3
+        symlink_info.external_attr = (stat.S_IFLNK | 0o777) << 16
         symlink_info.compress_type = zipfile.ZIP_STORED
         zipf.writestr(symlink_info, str(symlink_target))
         with pytest.warns(UserWarning, match="Duplicate name"):

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -6790,7 +6790,8 @@ def test_pytorch_zip_entry_validation_checks_timeout_between_members(
     with zipfile.ZipFile(zip_path, "w") as zipf:
         for index in range(3):
             symlink_info = zipfile.ZipInfo(f"link_{index}")
-            symlink_info.external_attr = 0o120777 << 16
+            symlink_info.create_system = 3
+            symlink_info.external_attr = (stat.S_IFLNK | 0o777) << 16
             symlink_info.compress_type = zipfile.ZIP_STORED
             zipf.writestr(symlink_info, str(tmp_path / f"target_{index}"))
 

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -7586,8 +7586,10 @@ def test_pytorch_zip_symlink_read_error_redacts_local_header_name(tmp_path: Path
         for check in result.checks
         if check.name == "Symlink Safety Validation" and check.details.get("entry") == central_name
     )
-    assert symlink_check.rule_code == "S902"
-    assert symlink_check.details["exception"] == "<redacted>"
+    assert symlink_check.status == CheckStatus.FAILED
+    assert symlink_check.severity == IssueSeverity.CRITICAL
+    assert symlink_check.rule_code == "S406"
+    assert symlink_check.details["target_class"] == "invalid"
     assert secret not in result.to_json()
 
 

--- a/tests/scanners/test_skops_scanner.py
+++ b/tests/scanners/test_skops_scanner.py
@@ -1,5 +1,6 @@
 """Tests for SkopsScanner covering CVE-2025-54412, CVE-2025-54413, CVE-2025-54886."""
 
+import builtins
 import os
 import stat
 import textwrap
@@ -1162,6 +1163,15 @@ class TestSkopsScannerEdgeCases:
             archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo replacement"\ntR.')
 
         original_scan_archive_members = zip_scanner_module.ZipScanner.scan_archive_members
+        original_open = builtins.open
+        path_reopened = False
+
+        def redirect_path_open(file: Any, *args: Any, **kwargs: Any) -> Any:
+            nonlocal path_reopened
+            if str(file) == str(skops_path):
+                path_reopened = True
+                file = replacement_path
+            return original_open(file, *args, **kwargs)
 
         def replace_then_scan(
             scanner: zip_scanner_module.ZipScanner,
@@ -1169,13 +1179,15 @@ class TestSkopsScannerEdgeCases:
             archive: zipfile.ZipFile | None = None,
         ) -> ScanResult:
             assert archive is not None
-            replacement_path.replace(path)
-            return original_scan_archive_members(scanner, path, archive=archive)
+            with monkeypatch.context() as path_swap:
+                path_swap.setattr(builtins, "open", redirect_path_open)
+                return original_scan_archive_members(scanner, path, archive=archive)
 
         monkeypatch.setattr(zip_scanner_module.ZipScanner, "scan_archive_members", replace_then_scan)
 
         result = SkopsScanner().scan(str(skops_path))
 
+        assert path_reopened is False
         assert not any(issue.details.get("zip_entry") == "payload.pkl" for issue in result.issues)
         assert any(entry.get("path", "").endswith(":safe.txt") for entry in result.metadata["contents"])
         assert not any(entry.get("path", "").endswith(":payload.pkl") for entry in result.metadata["contents"])

--- a/tests/scanners/test_weight_distribution_scanner.py
+++ b/tests/scanners/test_weight_distribution_scanner.py
@@ -1,3 +1,4 @@
+import builtins
 import os
 import pickle
 import sys
@@ -1053,6 +1054,9 @@ def test_pytorch_primary_load_reuses_budgeted_handle_after_path_replacement(
 
     fake_torch.Tensor = FakeTensor
     fake_torch.device = lambda value: value
+    budgeted_handle: Any = None
+    loaded_handle: Any = None
+    loaded_payload: bytes | None = None
 
     def fake_load(
         handle: Any,
@@ -1060,8 +1064,10 @@ def test_pytorch_primary_load_reuses_budgeted_handle_after_path_replacement(
         map_location: object,
         weights_only: bool = False,
     ) -> dict[str, object]:
+        nonlocal loaded_handle, loaded_payload
         del map_location, weights_only
-        assert handle.read() == original_payload
+        loaded_handle = handle
+        loaded_payload = handle.read()
         return {}
 
     fake_torch.load = fake_load
@@ -1069,16 +1075,32 @@ def test_pytorch_primary_load_reuses_budgeted_handle_after_path_replacement(
 
     scanner = WeightDistributionScanner({"enable_unsafe_torch_load": True})
     original_budget_check = scanner._pytorch_load_handle_within_budget
+    original_open = builtins.open
+    path_reopened = False
+
+    def redirect_path_open(file: Any, *args: Any, **kwargs: Any) -> Any:
+        nonlocal path_reopened
+        if str(file) == str(path):
+            path_reopened = True
+            file = replacement_path
+        return original_open(file, *args, **kwargs)
 
     def replace_path_after_budget(path_text: str, handle: Any, *, is_zip: bool) -> bool:
+        nonlocal budgeted_handle
         within_budget = original_budget_check(path_text, handle, is_zip=is_zip)
-        os.replace(replacement_path, path)
+        budgeted_handle = handle
+        monkeypatch.setattr(builtins, "open", redirect_path_open)
         return within_budget
 
     monkeypatch.setattr(scanner, "_pytorch_load_handle_within_budget", replace_path_after_budget)
 
     assert scanner._extract_pytorch_weights(str(path)) == {}
-    assert path.read_bytes() == replacement_payload
+    assert loaded_handle is budgeted_handle
+    assert loaded_payload == original_payload
+    assert path_reopened is False
+    with builtins.open(path, "rb") as reopened:
+        assert reopened.read() == replacement_payload
+    assert path_reopened is True
 
 
 def test_pytorch_zip_small_shared_sequence_is_not_treated_as_cycle(

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -7716,6 +7716,51 @@ class TestZipScanner:
         finally:
             os.unlink(tmp_path)
 
+    def test_mismatched_symlink_local_name_fails_closed_with_critical_finding(self, tmp_path: Path) -> None:
+        archive_path = tmp_path / "mismatched-symlink-name.zip"
+        secret = "SUPERSECRET_TOKEN_123"
+        local_name = f"password={secret}".encode()
+        central_name = "l" * len(local_name)
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            info = zipfile.ZipInfo(central_name)
+            info.create_system = 3
+            info.external_attr = (stat.S_IFLNK | 0o777) << 16
+            archive.writestr(info, "/etc/passwd")
+
+        with zipfile.ZipFile(archive_path) as archive:
+            local_header_offset = archive.getinfo(central_name).header_offset
+        archive_bytes = bytearray(archive_path.read_bytes())
+        assert archive_bytes[local_header_offset : local_header_offset + 4] == b"PK\x03\x04"
+        filename_size = int.from_bytes(
+            archive_bytes[local_header_offset + 26 : local_header_offset + 28],
+            "little",
+        )
+        assert filename_size == len(local_name)
+        filename_start = local_header_offset + 30
+        archive_bytes[filename_start : filename_start + filename_size] = local_name
+        archive_path.write_bytes(archive_bytes)
+
+        result = self.scanner.scan(str(archive_path))
+
+        preflight_check = next(check for check in result.checks if check.name == "ZIP Central Directory Preflight")
+        assert result.success is False
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "zip_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+        assert preflight_check.status == CheckStatus.FAILED
+        assert preflight_check.severity == IssueSeverity.INFO
+        assert preflight_check.rule_code == "S902"
+        symlink_check = next(
+            check
+            for check in result.checks
+            if check.name == "Symlink Safety Validation" and check.details.get("entry") == central_name
+        )
+        assert symlink_check.status == CheckStatus.FAILED
+        assert symlink_check.severity == IssueSeverity.CRITICAL
+        assert symlink_check.rule_code == "S406"
+        assert symlink_check.details["target"] == "<inconsistent-zip-metadata>"
+        assert symlink_check.details["target_class"] == "invalid"
+        assert secret not in result.to_json()
+
     def test_dos_entry_with_unix_symlink_bits_is_scanned_as_regular_file(self, tmp_path: Path) -> None:
         archive_path = tmp_path / "fake-symlink.zip"
         with zipfile.ZipFile(archive_path, "w") as archive:

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -1,3 +1,4 @@
+import builtins
 import bz2
 import gzip
 import importlib
@@ -9509,7 +9510,11 @@ class TestZipScanner:
             for check in exc_info.value.result.checks
         )
 
-    def test_archive_member_scan_reuses_open_archive_after_path_replacement(self, tmp_path: Path) -> None:
+    def test_archive_member_scan_reuses_open_archive_after_path_replacement(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         archive_path = tmp_path / "original.zip"
         replacement_path = tmp_path / "replacement.zip"
         with zipfile.ZipFile(archive_path, "w") as archive:
@@ -9517,10 +9522,21 @@ class TestZipScanner:
         with zipfile.ZipFile(replacement_path, "w") as archive:
             archive.writestr("payload.pkl", b'cos\nsystem\n(S"echo replacement"\ntR.')
 
+        original_open = builtins.open
+        path_reopened = False
+
+        def redirect_path_open(file: Any, *args: Any, **kwargs: Any) -> Any:
+            nonlocal path_reopened
+            if str(file) == str(archive_path):
+                path_reopened = True
+                file = replacement_path
+            return original_open(file, *args, **kwargs)
+
         with zipfile.ZipFile(archive_path) as archive:
-            os.replace(replacement_path, archive_path)
+            monkeypatch.setattr(builtins, "open", redirect_path_open)
             result = ZipScanner().scan_archive_members(str(archive_path), archive=archive)
 
+        assert path_reopened is False
         assert result.success is True
         assert not result.issues
         assert any(entry.get("path", "").endswith(":safe.txt") for entry in result.metadata["contents"])

--- a/tests/scanners/test_zip_scanner.py
+++ b/tests/scanners/test_zip_scanner.py
@@ -9041,12 +9041,49 @@ class TestZipScanner:
             member.write(b"safe")
 
         archive_path = tmp_path / "force_zip64_streamed.zip"
-        archive_path.write_bytes(archive_buffer.getvalue())
+        archive_bytes = bytearray(archive_buffer.getvalue())
+        local_header = archive_bytes.find(b"PK\x03\x04")
+        assert local_header >= 0
+        archive_bytes[local_header + 18 : local_header + 26] = b"\x00" * 8
+        archive_path.write_bytes(archive_bytes)
 
         result = ZipScanner().scan(str(archive_path))
 
         assert result.success is True
         assert not any(
+            check.name == "ZIP Central Directory Preflight" and check.status == CheckStatus.FAILED
+            for check in result.checks
+        )
+
+    def test_force_zip64_streamed_entry_rejects_invalid_64bit_descriptor(self, tmp_path: Path) -> None:
+        class NonSeekableBuffer(io.BytesIO):
+            def seek(self, *_args: Any, **_kwargs: Any) -> int:
+                raise io.UnsupportedOperation("not seekable")
+
+            def seekable(self) -> bool:
+                return False
+
+        archive_buffer = NonSeekableBuffer()
+        with (
+            zipfile.ZipFile(archive_buffer, "w") as archive,
+            archive.open("safe.txt", "w", force_zip64=True) as member,
+        ):
+            member.write(b"safe")
+
+        archive_bytes = bytearray(archive_buffer.getvalue())
+        local_header = archive_bytes.find(b"PK\x03\x04")
+        descriptor = archive_bytes.find(b"PK\x07\x08")
+        assert local_header >= 0
+        assert descriptor >= 0
+        archive_bytes[local_header + 18 : local_header + 26] = b"\x00" * 8
+        archive_bytes[descriptor + 12 : descriptor + 16] = (1).to_bytes(4, "little")
+        archive_path = tmp_path / "invalid-force-zip64-streamed.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ZipScanner().scan(str(archive_path))
+
+        assert result.success is False
+        assert any(
             check.name == "ZIP Central Directory Preflight" and check.status == CheckStatus.FAILED
             for check in result.checks
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -197,13 +197,14 @@ def test_format_scan_json_redacts_sources_without_corrupting_result_metadata() -
 
 
 def test_format_scan_json_preserves_pydantic_json_serialization() -> None:
+    model_path = Path("models") / "model.pkl"
     result = create_mock_scan_result(
         issues=[
             {
                 "message": "Serializable details",
                 "severity": "warning",
                 "details": {
-                    "path": Path("models/model.pkl"),
+                    "path": model_path,
                     "timestamp": datetime(2026, 6, 8, 12, 30, tzinfo=timezone.utc),
                 },
             }
@@ -213,7 +214,7 @@ def test_format_scan_json_preserves_pydantic_json_serialization() -> None:
     payload = json.loads(_format_scan_output(result, [], output_format="json", verbose=True))
 
     assert payload["issues"][0]["details"] == {
-        "path": "models/model.pkl",
+        "path": str(model_path),
         "timestamp": "2026-06-08T12:30:00Z",
     }
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2186,6 +2186,20 @@ def test_scan_file_selected_weight_distribution_enforces_zip_entry_preflight(
     )
 
 
+def _install_weight_distribution_test_scanner(monkeypatch: pytest.MonkeyPatch) -> None:
+    from modelaudit.scanners.weight_distribution_scanner import WeightDistributionScanner
+
+    original_loader = core_module._registry.load_scanner_by_id
+
+    def load_scanner_by_id(scanner_id: str) -> type[Any] | None:
+        if scanner_id == "weight_distribution":
+            return WeightDistributionScanner
+        return original_loader(scanner_id)
+
+    monkeypatch.setattr(core_module._registry, "load_scanner_by_id", load_scanner_by_id)
+    monkeypatch.setattr(WeightDistributionScanner, "can_handle", classmethod(lambda _cls, _path: True))
+
+
 def test_scan_file_selected_weight_distribution_routes_within_entry_limit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -2194,6 +2208,8 @@ def test_scan_file_selected_weight_distribution_routes_within_entry_limit(
     with zipfile.ZipFile(archive_path, "w") as archive:
         archive.writestr("archive/data.pkl", b"data")
         archive.writestr("archive/version", b"1")
+
+    _install_weight_distribution_test_scanner(monkeypatch)
 
     def fake_weight_scan(_self: Any, path: str) -> ScanResult:
         assert path == str(archive_path)
@@ -2205,11 +2221,6 @@ def test_scan_file_selected_weight_distribution_routes_within_entry_limit(
         "modelaudit.scanners.weight_distribution_scanner.WeightDistributionScanner.scan",
         fake_weight_scan,
     )
-    monkeypatch.setattr(
-        "modelaudit.scanners.weight_distribution_scanner.WeightDistributionScanner.can_handle",
-        classmethod(lambda _cls, _path: True),
-    )
-
     result = scan_file(
         str(archive_path),
         config={"scanners": ["weight_distribution"], "max_zip_entries": 2, "cache_enabled": False},

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4310,6 +4310,38 @@ def test_scan_file_honors_zip_only_selection_for_hdf5_userblock(tmp_path: Path) 
     )
 
 
+def test_scan_file_honors_pytorch_zip_only_selection_for_hdf5_userblock(tmp_path: Path) -> None:
+    polyglot = tmp_path / "selected-pytorch-zip-userblock.h5"
+    _create_misnamed_zip(
+        polyglot,
+        {
+            "archive/data.pkl": pickle.dumps(
+                {"endpoint": "http://attacker.example/model"},
+                protocol=4,
+            ),
+            "archive/version": b"3\n",
+            "archive/byteorder": b"little",
+        },
+    )
+    _append_hdf5_userblock_candidate(polyglot, plausible=True)
+
+    result = scan_file(
+        str(polyglot),
+        config={"scanners": ["pytorch_zip"], "cache_scan_results": False},
+    )
+
+    assert any(
+        check.name == "Network Communication Detection"
+        and check.status == CheckStatus.FAILED
+        and check.location == f"{polyglot}:archive/data.pkl"
+        for check in result.checks
+    )
+    assert not any(
+        check.name == "Scanner Selection" and check.details.get("skipped_scanner_id") == "pytorch_zip"
+        for check in result.checks
+    )
+
+
 def test_scan_file_honors_zip_only_selection_for_large_hdf5_userblock(tmp_path: Path) -> None:
     polyglot = tmp_path / "selected-large-zip-userblock.h5"
     _create_misnamed_zip(polyglot, {"payload.pkl": _build_malicious_pickle()})
@@ -4595,6 +4627,24 @@ def test_scan_file_does_not_use_suffix_only_supplemental_scanner_for_hdf5_userbl
     assert result.success is True
     assert "supplemental_scanners" not in result.metadata
     assert all(check.name != "Format Validation" for check in result.checks)
+
+
+def test_scan_file_does_not_run_extension_only_zip_analyzer_for_hdf5_userblock(tmp_path: Path) -> None:
+    h5py = pytest.importorskip("h5py")
+    model_path = tmp_path / "benign-userblock.h5"
+    with h5py.File(model_path, "w", userblock_size=512) as h5_file:
+        h5_file.attrs["model_config"] = json.dumps({"class_name": "Sequential", "config": {"layers": []}})
+    with model_path.open("r+b") as model_file:
+        model_file.write(b"PK\x03\x04corrupt-near-match")
+
+    result = scan_file(
+        str(model_path),
+        config={"scanners": ["weight_distribution"], "cache_scan_results": False},
+    )
+
+    assert result.success is True
+    assert "hdf5_userblock_zip_scan_failed" not in result.metadata.get("scan_outcome_reasons", [])
+    assert all(check.name != "HDF5 User Block ZIP Analysis" for check in result.checks)
 
 
 def test_scan_file_routes_runtime_h5py_failure_for_extensionless_userblock(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4561,6 +4561,37 @@ def test_scan_file_preserves_earlier_concatenated_hdf5_userblock_zip(
     assert any(item.get("path") == f"{polyglot}:README.txt" for item in result.metadata["contents"])
 
 
+@pytest.mark.parametrize("malicious", [False, True], ids=["benign", "malicious"])
+def test_scan_file_preserves_outer_members_before_nested_hdf5_userblock_zip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    malicious: bool,
+) -> None:
+    nested_zip = io.BytesIO()
+    with zipfile.ZipFile(nested_zip, "w") as archive:
+        archive.writestr("README-inner.txt", b"benign nested archive")
+
+    polyglot = tmp_path / "nested-zip-userblock.h5"
+    _create_misnamed_zip(
+        polyglot,
+        {
+            "payload.pkl": _build_malicious_pickle() if malicious else pickle.dumps({"weights": [1, 2, 3]}),
+            "nested.zip": nested_zip.getvalue(),
+        },
+    )
+    _append_hdf5_userblock_candidate(polyglot, plausible=True)
+    monkeypatch.setattr("modelaudit.scanners.keras_h5_scanner.HAS_H5PY", False)
+
+    result = scan_file(str(polyglot), config={"cache_scan_results": False})
+
+    if malicious:
+        _assert_system_pickle_detected(result, "payload.pkl")
+    else:
+        assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
+    nested_entry = next(item for item in result.metadata["contents"] if item.get("path") == f"{polyglot}:nested.zip")
+    assert any(item.get("path", "").endswith(":README-inner.txt") for item in nested_entry["contents"])
+
+
 def test_large_hdf5_userblock_copies_only_validated_zip_prefix(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2193,6 +2193,7 @@ def test_scan_file_selected_weight_distribution_routes_within_entry_limit(
     archive_path = tmp_path / "within-entry-limit.pt"
     with zipfile.ZipFile(archive_path, "w") as archive:
         archive.writestr("archive/data.pkl", b"data")
+        archive.writestr("archive/version", b"1")
 
     def fake_weight_scan(_self: Any, path: str) -> ScanResult:
         assert path == str(archive_path)
@@ -2204,10 +2205,14 @@ def test_scan_file_selected_weight_distribution_routes_within_entry_limit(
         "modelaudit.scanners.weight_distribution_scanner.WeightDistributionScanner.scan",
         fake_weight_scan,
     )
+    monkeypatch.setattr(
+        "modelaudit.scanners.weight_distribution_scanner.WeightDistributionScanner.can_handle",
+        classmethod(lambda _cls, _path: True),
+    )
 
     result = scan_file(
         str(archive_path),
-        config={"scanners": ["weight_distribution"], "max_zip_entries": 1, "cache_enabled": False},
+        config={"scanners": ["weight_distribution"], "max_zip_entries": 2, "cache_enabled": False},
     )
 
     assert result.scanner_name == "weight_distribution"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4561,6 +4561,84 @@ def test_scan_file_preserves_earlier_concatenated_hdf5_userblock_zip(
     assert any(item.get("path") == f"{polyglot}:README.txt" for item in result.metadata["contents"])
 
 
+@pytest.mark.parametrize("zip64", [False, True], ids=["standard", "zip64"])
+@pytest.mark.parametrize("malicious_gap", [False, True], ids=["zero-padding", "malicious-gap"])
+def test_hdf5_userblock_concatenated_zip_gap_requires_padding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    zip64: bool,
+    malicious_gap: bool,
+) -> None:
+    first_zip = tmp_path / "first.zip"
+    second_zip = tmp_path / "second.zip"
+    _create_misnamed_zip(first_zip, {"README-first.txt": b"first archive"})
+    if zip64:
+        with monkeypatch.context() as zip64_patch:
+            zip64_patch.setattr(zipfile, "ZIP_FILECOUNT_LIMIT", 0)
+            _create_misnamed_zip(second_zip, {"README-second.txt": b"second archive"})
+    else:
+        _create_misnamed_zip(second_zip, {"README-second.txt": b"second archive"})
+    assert (b"PK\x06\x06" in second_zip.read_bytes()) is zip64
+
+    gap = bytes(32)
+    if malicious_gap:
+        gap = bytes(8) + _build_malicious_pickle() + bytes(8)
+    polyglot = tmp_path / "inter-segment-gap-userblock.h5"
+    polyglot.write_bytes(first_zip.read_bytes() + gap + second_zip.read_bytes())
+    signature_offset = _append_hdf5_userblock_candidate(polyglot, plausible=True)
+    result = ScanResult(scanner_name="keras_h5")
+    result.finish(success=True)
+
+    archive_dispatch.merge_hdf5_userblock_zip_findings(
+        str(polyglot),
+        result,
+        {"cache_scan_results": False},
+        signature_offset,
+        context="test HDF5 user block",
+    )
+
+    if malicious_gap:
+        assert result.success is False
+        assert "hdf5_userblock_zip_scan_failed" in result.metadata["scan_outcome_reasons"]
+        assert any(
+            check.name == "HDF5 User Block ZIP Analysis"
+            and check.status == CheckStatus.FAILED
+            and "non-padding content between ZIP segments" in check.message
+            for check in result.checks
+        )
+
+        cache_dir = tmp_path / "cache"
+        config = {
+            "cache_enabled": True,
+            "cache_dir": str(cache_dir),
+            "min_cache_file_size": 0,
+        }
+        monkeypatch.setattr("modelaudit.scanners.keras_h5_scanner.HAS_H5PY", False)
+        reset_cache_manager()
+        try:
+            for _ in range(2):
+                scanned = scan_file(str(polyglot), config=config)
+                assert scanned.success is False
+                assert "hdf5_userblock_zip_scan_failed" in scanned.metadata["scan_outcome_reasons"]
+                assert any(
+                    check.name == "HDF5 User Block ZIP Analysis"
+                    and check.status == CheckStatus.FAILED
+                    and "non-padding content between ZIP segments" in check.message
+                    for check in scanned.checks
+                )
+
+            assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+            aggregate = scan_model_directory_or_file(str(polyglot), config=config)
+            assert determine_exit_code(aggregate) == 2
+            assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+        finally:
+            reset_cache_manager()
+    else:
+        assert result.success is True
+        assert "hdf5_userblock_zip_scan_failed" not in result.metadata.get("scan_outcome_reasons", [])
+        assert any(item.get("path") == f"{polyglot}:README-second.txt" for item in result.metadata["contents"])
+
+
 @pytest.mark.parametrize("malicious", [False, True], ids=["benign", "malicious"])
 def test_scan_file_preserves_outer_members_before_nested_hdf5_userblock_zip(
     tmp_path: Path,

--- a/tests/test_scanner_selection.py
+++ b/tests/test_scanner_selection.py
@@ -17,6 +17,7 @@ from modelaudit.cli import cli
 from modelaudit.core import scan_file, scan_model_directory_or_file
 from modelaudit.scanner_registry_metadata import get_scanner_registry_metadata
 from modelaudit.scanner_selection import (
+    allows_zip_content_analysis,
     allows_zip_structure_analysis,
     collect_suppressed_preferred_scanners,
     normalize_scanner_selection_config,
@@ -115,6 +116,20 @@ def test_zip_structure_analysis_honors_explicit_zip_exclusion() -> None:
     policy = resolve_scanner_selection_policy(exclude_scanners=["zip"])
 
     assert allows_zip_structure_analysis(policy, "archive.zip") is False
+
+
+def test_zip_content_analysis_requires_a_content_owner() -> None:
+    extension_analyzer = resolve_scanner_selection_policy(scanners=["weight_distribution"])
+    subtype_owner = resolve_scanner_selection_policy(scanners=["pytorch_zip"])
+    excluded_container = resolve_scanner_selection_policy(
+        scanners=["pytorch_zip"],
+        exclude_scanners=["zip"],
+    )
+
+    assert allows_zip_structure_analysis(extension_analyzer, "model.h5") is True
+    assert allows_zip_content_analysis(extension_analyzer) is False
+    assert allows_zip_content_analysis(subtype_owner) is True
+    assert allows_zip_content_analysis(excluded_container) is False
 
 
 def test_normalize_scanner_selection_config_reuses_normalized_payload(

--- a/tests/utils/file/test_advanced_file_handler.py
+++ b/tests/utils/file/test_advanced_file_handler.py
@@ -1647,6 +1647,10 @@ class TestAdvancedFileHandler:
             }
 
         monkeypatch.setattr(ShardedModelDetector, "detect_shards", classmethod(stable_detect_shards))
+        monkeypatch.setattr(
+            "modelaudit.utils.file.handlers._supports_reliable_shard_cache_identity",
+            lambda: True,
+        )
         scanner = RecordingShardScanner({"cache_enabled": True, "cache_dir": str(cache_dir)})
 
         reset_cache_manager()

--- a/tests/utils/file/test_advanced_file_handler.py
+++ b/tests/utils/file/test_advanced_file_handler.py
@@ -1676,10 +1676,10 @@ class TestAdvancedFileHandler:
             check.name == "Malicious Shard Payload" and check.status == CheckStatus.FAILED for check in second.checks
         )
 
+    @pytest.mark.skipif(os.name == "nt", reason="Windows bypasses sharded caching without reliable sibling identity")
     def test_cached_advanced_scan_keys_selected_model_config(
         self,
         tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Adding, changing, or removing the selected config must select matching shard results."""
         shard_one = tmp_path / "checkpoint_1.pt"
@@ -1699,10 +1699,6 @@ class TestAdvancedFileHandler:
                 scanned_paths.append(shard_path)
                 return super().scan(shard_path)
 
-        monkeypatch.setattr(
-            "modelaudit.utils.file.handlers._supports_reliable_shard_cache_identity",
-            lambda: True,
-        )
         scanner = RecordingShardScanner({"cache_enabled": True, "cache_dir": str(tmp_path / "cache")})
 
         reset_cache_manager()

--- a/tests/utils/file/test_advanced_file_handler.py
+++ b/tests/utils/file/test_advanced_file_handler.py
@@ -1676,7 +1676,10 @@ class TestAdvancedFileHandler:
             check.name == "Malicious Shard Payload" and check.status == CheckStatus.FAILED for check in second.checks
         )
 
-    @pytest.mark.skipif(os.name == "nt", reason="Windows bypasses sharded caching without reliable sibling identity")
+    @pytest.mark.skipif(
+        os.name == "nt" or sys.platform == "darwin",
+        reason="Requires descriptor-bound sharded caching with reliable sibling identity",
+    )
     def test_cached_advanced_scan_keys_selected_model_config(
         self,
         tmp_path: Path,

--- a/tests/utils/file/test_advanced_file_handler.py
+++ b/tests/utils/file/test_advanced_file_handler.py
@@ -1679,6 +1679,7 @@ class TestAdvancedFileHandler:
     def test_cached_advanced_scan_keys_selected_model_config(
         self,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Adding, changing, or removing the selected config must select matching shard results."""
         shard_one = tmp_path / "checkpoint_1.pt"
@@ -1698,6 +1699,10 @@ class TestAdvancedFileHandler:
                 scanned_paths.append(shard_path)
                 return super().scan(shard_path)
 
+        monkeypatch.setattr(
+            "modelaudit.utils.file.handlers._supports_reliable_shard_cache_identity",
+            lambda: True,
+        )
         scanner = RecordingShardScanner({"cache_enabled": True, "cache_dir": str(tmp_path / "cache")})
 
         reset_cache_manager()

--- a/tests/utils/file/test_advanced_file_handler.py
+++ b/tests/utils/file/test_advanced_file_handler.py
@@ -1,6 +1,7 @@
 """Tests for advanced file handler."""
 
 import os
+import sys
 import tempfile
 from collections import Counter
 from contextvars import ContextVar
@@ -676,6 +677,7 @@ class TestShardedModelDetector:
             for check in result.checks
         )
 
+    @pytest.mark.skipif(sys.platform == "darwin", reason="macOS lacks traversable descriptor-bound scan paths")
     def test_shard_target_swap_during_scan_discards_clean_result(
         self,
         tmp_path: Path,
@@ -698,6 +700,7 @@ class TestShardedModelDetector:
             def scan(self, shard_path: str) -> ScanResult:
                 path = Path(shard_path)
                 result = ScanResult(scanner_name=self.name)
+                scanned_payloads.append(path.read_bytes())
                 if path.name == original_target.name:
                     preserved_target = tmp_path / "preserved-malicious.pt"
                     original_target.rename(preserved_target)
@@ -708,7 +711,6 @@ class TestShardedModelDetector:
                         message=path.name,
                         severity=IssueSeverity.INFO,
                     )
-                scanned_payloads.append(path.read_bytes())
                 result.finish(success=True)
                 return result
 
@@ -721,6 +723,8 @@ class TestShardedModelDetector:
         assert any(check.name == "Shard Scan" and check.status == CheckStatus.FAILED for check in result.checks)
         assert not any(check.name == "Clean Replacement Accepted" for check in result.checks)
 
+    @pytest.mark.skipif(sys.platform == "darwin", reason="macOS lacks traversable descriptor-bound scan paths")
+    @pytest.mark.skipif(os.name == "nt", reason="Windows open-handle pinning prevents target replacement")
     def test_shard_target_swap_during_scan_preserves_security_findings(
         self,
         tmp_path: Path,
@@ -765,6 +769,8 @@ class TestShardedModelDetector:
         )
         assert any(issue.message == "Malicious shard payload detected" for issue in result.issues)
 
+    @pytest.mark.skipif(sys.platform == "darwin", reason="macOS lacks traversable descriptor-bound scan paths")
+    @pytest.mark.skipif(os.name == "nt", reason="Windows open-handle pinning prevents target replacement")
     def test_shard_target_aba_during_scan_cannot_hide_malicious_content(
         self,
         tmp_path: Path,
@@ -815,6 +821,35 @@ class TestShardedModelDetector:
         assert b"benign" not in scanned_payloads
         assert result.success is False
         assert any(check.name == "Malicious Shard Payload" for check in result.checks)
+
+    @pytest.mark.skipif(sys.platform == "darwin", reason="macOS lacks traversable descriptor-bound scan paths")
+    def test_shard_scanner_os_error_after_pinning_is_scan_error(self, tmp_path: Path) -> None:
+        """A scanner read failure after pinning is not a pin-setup failure."""
+        shard_one = tmp_path / "checkpoint_1.pt"
+        shard_two = tmp_path / "checkpoint_2.pt"
+        shard_one.write_bytes(b"first")
+        shard_two.write_bytes(b"second")
+        scanned_payloads: list[bytes] = []
+
+        class FailingScanner:
+            name = "failing_scanner"
+
+            def scan(self, shard_path: str) -> ScanResult:
+                scanned_payloads.append(Path(shard_path).read_bytes())
+                raise OSError("scanner read failed")
+
+        result = AdvancedFileHandler(str(shard_one), FailingScanner()).scan()
+
+        assert set(scanned_payloads) == {b"first", b"second"}
+        assert result.success is False
+        assert "shard_scan_error" in result.metadata["scan_outcome_reasons"]
+        assert "shard_pin_unavailable" not in result.metadata["scan_outcome_reasons"]
+        assert any(
+            check.name == "Shard Scan"
+            and check.status == CheckStatus.FAILED
+            and check.details["exception_type"] == "OSError"
+            for check in result.checks
+        )
 
     @pytest.mark.skipif(os.name == "nt", reason="Windows uses open-handle hard-link pinning")
     def test_shard_pin_unavailable_fails_explicitly(


### PR DESCRIPTION
## Summary

- let the PyTorch ZIP scanner inspect central/local size mismatches so malformed symlink targets still produce security findings, while generic ZIP scans continue to reject hidden or ambiguous entries
- distinguish nested ZIP end records from independent concatenated HDF5 user-block archives so outer members remain covered while each validated archive is scanned
- prevent exported source redaction from treating comparisons as assignments or leaking suffixes appended to quoted redaction markers
- make CatBoost subprocess tests explicitly UTF-8 on Windows and satisfy the standalone picklescan type-check lane
- stop rescanning complete encoded pickles at interior Base64 windows and honor the configured string-literal cap during raw nested-pickle analysis

## Validation

- `ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `mypy --platform linux modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- 1,703 ZIP and PyTorch ZIP scanner tests
- 838 SARIF redaction and CatBoost tests
- 12 focused HDF5 user-block routing and boundary tests
- 57 standalone picklescan safe-spec tests
- 163 Rust scanner tests
- 2,244 standalone picklescan Python tests
- exact nested-pickle regressions under Python 3.13

The full fast suite reached 5,918 passes before xdist stopped on three cache-state failures. One passed immediately when rerun serially; the other two reproduce unchanged on `origin/main` with the same macOS interpreter.
