### PR TITLE
fix(safetensors): accept empty tensor offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- allow specification-valid empty SafeTensors tensors while preserving offset and size validation
+- allow specification-valid empty SafeTensors tensors while preserving deterministic range checks and rejecting size overflow
 - classify unsafe PyTorch ZIP symlink targets as critical archive-link findings while preserving safe relative links
 - restore pickle CVE scan throughput, reprobe malformed stream separators, and route four-byte protocol-0 Joblib operands correctly
 - bound manifest embedded-Jinja template collection while preserving findings across deep branches, cycles, and shared YAML aliases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- allow specification-valid empty SafeTensors tensors while preserving offset and size validation
 - classify unsafe PyTorch ZIP symlink targets as critical archive-link findings while preserving safe relative links
 - restore pickle CVE scan throughput, reprobe malformed stream separators, and route four-byte protocol-0 Joblib operands correctly
 - bound manifest embedded-Jinja template collection while preserving findings across deep branches, cycles, and shared YAML aliases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- allow specification-valid empty SafeTensors tensors while preserving deterministic range checks and rejecting size overflow
+- allow equal offsets for supported empty SafeTensors tensors while preserving deterministic range checks and rejecting native size overflow
 - preserve sanitized CatBoost command context in SARIF without exposing injected or neighboring credential values
 - redact values compared against sensitive keys in generic exports and literal credential comparisons in CatBoost evidence
 - preserve critical PyTorch malformed-ZIP symlink findings, valid Python 3.10 streamed ZIP64 descriptors, and selected subtype findings from complete nested and concatenated HDF5 user-block ZIPs while retaining bounded fail-closed preflight checks and avoiding structure-only ZIP route probes

--- a/modelaudit/scanners/safetensors_scanner.py
+++ b/modelaudit/scanners/safetensors_scanner.py
@@ -878,12 +878,13 @@ class SafeTensorsScanner(BaseScanner):
             if dim > _MAX_PLATFORM_USIZE or (dim and total > _MAX_PLATFORM_USIZE // dim):
                 return None
             total *= dim
-        if total > _MAX_PLATFORM_USIZE // bits:
-            return None
         total_bits = total * bits
         if total_bits % 8:
             return None
-        return total_bits // 8
+        total_bytes = total_bits // 8
+        if total_bytes > _MAX_PLATFORM_USIZE:
+            return None
+        return total_bytes
 
     def _detect_metadata_injection_attacks(
         self,

--- a/modelaudit/scanners/safetensors_scanner.py
+++ b/modelaudit/scanners/safetensors_scanner.py
@@ -33,6 +33,7 @@ _DTYPE_SIZES = {
     "U64": 8,
 }
 MAX_HEADER_BYTES = 16 * 1024 * 1024
+_MAX_PLATFORM_USIZE = (1 << (8 * struct.calcsize("P"))) - 1
 SAFETENSORS_HEADER_INCONCLUSIVE_REASON = "safetensors_header_validation_failed"
 SAFETENSORS_STRUCTURE_INCONCLUSIVE_REASON = "safetensors_structure_validation_failed"
 SAFETENSORS_HEADER_LIMIT_INCONCLUSIVE_REASON = "safetensors_header_size_limit_exceeded"
@@ -862,7 +863,11 @@ class SafeTensorsScanner(BaseScanner):
         for dim in shape:
             if not isinstance(dim, int) or isinstance(dim, bool) or dim < 0:
                 return None
+            if dim > _MAX_PLATFORM_USIZE or (dim and total > _MAX_PLATFORM_USIZE // dim):
+                return None
             total *= dim
+        if total > _MAX_PLATFORM_USIZE // size:
+            return None
         return total * size
 
     def _detect_metadata_injection_attacks(

--- a/modelaudit/scanners/safetensors_scanner.py
+++ b/modelaudit/scanners/safetensors_scanner.py
@@ -733,7 +733,7 @@ class SafeTensorsScanner(BaseScanner):
                         )
 
                 # Check offset continuity
-                offsets.sort(key=lambda x: x[0])
+                offsets.sort()
                 last_end = 0
                 has_gap_or_overlap = False
                 for begin, end in offsets:

--- a/modelaudit/scanners/safetensors_scanner.py
+++ b/modelaudit/scanners/safetensors_scanner.py
@@ -633,7 +633,7 @@ class SafeTensorsScanner(BaseScanner):
                         structural_validation_failed = True
                         continue
 
-                    if begin < 0 or end <= begin or end > data_size:
+                    if begin < 0 or end < begin or end > data_size:
                         result.add_check(
                             name="Tensor Offset Validation",
                             passed=False,

--- a/modelaudit/scanners/safetensors_scanner.py
+++ b/modelaudit/scanners/safetensors_scanner.py
@@ -14,23 +14,23 @@ from modelaudit.detectors.suspicious_symbols import SUSPICIOUS_METADATA_PATTERNS
 from ..core_results import mark_operational_scan_error
 from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, CheckStatus, IssueSeverity, ScanResult
 
-# Map SafeTensors dtypes to byte sizes for integrity checking
-_DTYPE_SIZES = {
-    "BOOL": 1,
-    "BF16": 2,
-    "F16": 2,
-    "F32": 4,
-    "F64": 8,
-    "F8_E4M3": 1,
-    "F8_E5M2": 1,
-    "I8": 1,
-    "I16": 2,
-    "I32": 4,
-    "I64": 8,
-    "U8": 1,
-    "U16": 2,
-    "U32": 4,
-    "U64": 8,
+# Map supported SafeTensors dtypes to bit sizes for integrity checking
+_DTYPE_BITS = {
+    "BOOL": 8,
+    "BF16": 16,
+    "F16": 16,
+    "F32": 32,
+    "F64": 64,
+    "F8_E4M3": 8,
+    "F8_E5M2": 8,
+    "I8": 8,
+    "I16": 16,
+    "I32": 32,
+    "I64": 64,
+    "U8": 8,
+    "U16": 16,
+    "U32": 32,
+    "U64": 64,
 }
 MAX_HEADER_BYTES = 16 * 1024 * 1024
 _MAX_PLATFORM_USIZE = (1 << (8 * struct.calcsize("P"))) - 1
@@ -634,14 +634,26 @@ class SafeTensorsScanner(BaseScanner):
                         structural_validation_failed = True
                         continue
 
-                    if begin < 0 or end < begin or end > data_size:
+                    if (
+                        begin < 0
+                        or end < begin
+                        or begin > _MAX_PLATFORM_USIZE
+                        or end > _MAX_PLATFORM_USIZE
+                        or end > data_size
+                    ):
                         result.add_check(
                             name="Tensor Offset Validation",
                             passed=False,
                             message=f"Tensor {name} offsets out of bounds",
                             severity=IssueSeverity.CRITICAL,
                             location=path,
-                            details={"tensor": name, "begin": begin, "end": end, "data_size": data_size},
+                            details={
+                                "tensor": name,
+                                "begin": begin,
+                                "end": end,
+                                "data_size": data_size,
+                                "max_platform_offset": _MAX_PLATFORM_USIZE,
+                            },
                         )
                         continue
                     else:
@@ -656,7 +668,7 @@ class SafeTensorsScanner(BaseScanner):
                     offsets.append((begin, end))
 
                     # Validate dtype/shape size
-                    if not isinstance(dtype, str) or dtype not in _DTYPE_SIZES:
+                    if not isinstance(dtype, str) or dtype not in _DTYPE_BITS:
                         result.add_check(
                             name="Tensor Dtype Validation",
                             passed=False,
@@ -854,11 +866,11 @@ class SafeTensorsScanner(BaseScanner):
     @staticmethod
     def _expected_size(dtype: str | None, shape: Any) -> int | None:
         """Return expected tensor byte size from dtype and shape."""
-        if dtype not in _DTYPE_SIZES:
+        if dtype not in _DTYPE_BITS:
             return None
         if not isinstance(shape, list):
             return None
-        size = _DTYPE_SIZES[dtype]
+        bits = _DTYPE_BITS[dtype]
         total = 1
         for dim in shape:
             if not isinstance(dim, int) or isinstance(dim, bool) or dim < 0:
@@ -866,9 +878,12 @@ class SafeTensorsScanner(BaseScanner):
             if dim > _MAX_PLATFORM_USIZE or (dim and total > _MAX_PLATFORM_USIZE // dim):
                 return None
             total *= dim
-        if total > _MAX_PLATFORM_USIZE // size:
+        if total > _MAX_PLATFORM_USIZE // bits:
             return None
-        return total * size
+        total_bits = total * bits
+        if total_bits % 8:
+            return None
+        return total_bits // 8
 
     def _detect_metadata_injection_attacks(
         self,

--- a/tests/scanners/test_safetensors_scanner.py
+++ b/tests/scanners/test_safetensors_scanner.py
@@ -135,7 +135,7 @@ def test_zero_length_offsets_require_empty_shape(tmp_path: Path) -> None:
     )
 
 
-def test_empty_tensor_offset_order_does_not_create_false_overlap(tmp_path: Path) -> None:
+def test_empty_tensor_offset_sort_matches_safetensors(tmp_path: Path) -> None:
     file_path = tmp_path / "empty_tensor_before_nonempty_range.safetensors"
     write_raw_safetensors(
         file_path,
@@ -146,8 +146,12 @@ def test_empty_tensor_offset_order_does_not_create_false_overlap(tmp_path: Path)
         b"\x00",
     )
 
+    with safe_open(str(file_path), framework="np") as handle:
+        assert set(handle.keys()) == {"empty", "nonempty"}
+
     result = SafeTensorsScanner().scan(str(file_path))
 
+    assert result.success is True
     assert result.metadata.get("scan_outcome") != "inconclusive"
     assert not any(
         check.status == CheckStatus.FAILED and check.name == "Offset Continuity Check" for check in result.checks
@@ -213,11 +217,13 @@ def test_zero_before_large_dimensions_remains_valid_empty_shape(tmp_path: Path) 
     assert result.metadata.get("scan_outcome") != INCONCLUSIVE_SCAN_OUTCOME
 
 
-def test_tensor_size_overflow_uses_native_bit_width(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_tensor_size_overflow_uses_native_byte_width(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("modelaudit.scanners.safetensors_scanner._MAX_PLATFORM_USIZE", 15)
 
-    assert SafeTensorsScanner._expected_size("U8", [1]) == 1
-    assert SafeTensorsScanner._expected_size("U8", [2]) is None
+    assert SafeTensorsScanner._expected_size("U8", [15]) == 15
+    assert SafeTensorsScanner._expected_size("U8", [16]) is None
+    assert SafeTensorsScanner._expected_size("U16", [7]) == 14
+    assert SafeTensorsScanner._expected_size("U16", [8]) is None
 
 
 def test_offsets_must_fit_native_usize(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/scanners/test_safetensors_scanner.py
+++ b/tests/scanners/test_safetensors_scanner.py
@@ -12,7 +12,7 @@ import pytest
 # Skip if safetensors is not available before importing it
 pytest.importorskip("safetensors")
 
-from safetensors.numpy import save_file
+from safetensors.numpy import load_file, save_file
 
 from modelaudit.core import determine_exit_code, scan_file, scan_model_directory_or_file
 from modelaudit.scanners.base import DEFAULT_MAX_FILE_READ_SIZE, INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity
@@ -74,6 +74,64 @@ def test_valid_safetensors_file(tmp_path: Path) -> None:
     header_limit_check = next((check for check in result.checks if check.name == "Header Size Limit"), None)
     assert header_limit_check is not None
     assert header_limit_check.status.value == "passed"
+
+
+def test_valid_empty_tensor_offsets(tmp_path: Path) -> None:
+    file_path = tmp_path / "empty_tensor.safetensors"
+    save_file(
+        {
+            "empty": np.empty((0,), dtype=np.float32),
+            "value": np.ones((1,), dtype=np.float32),
+        },
+        str(file_path),
+    )
+
+    with file_path.open("rb") as handle:
+        header_len = struct.unpack("<Q", handle.read(8))[0]
+        header = json.loads(handle.read(header_len))
+
+    assert header["empty"]["data_offsets"][0] == header["empty"]["data_offsets"][1]
+    assert load_file(str(file_path))["empty"].shape == (0,)
+
+    result = SafeTensorsScanner().scan(str(file_path))
+
+    assert result.success is True
+    assert not result.has_errors
+    assert any(
+        check.name == "Tensor Offset Validation"
+        and check.details.get("tensor") == "empty"
+        and check.status == CheckStatus.PASSED
+        for check in result.checks
+    )
+    assert any(
+        check.name == "Tensor Size Consistency Check"
+        and check.details.get("tensor") == "empty"
+        and check.details.get("size") == 0
+        and check.status == CheckStatus.PASSED
+        for check in result.checks
+    )
+
+
+def test_zero_length_offsets_require_empty_shape(tmp_path: Path) -> None:
+    file_path = tmp_path / "invalid_zero_length_tensor.safetensors"
+    write_raw_safetensors(
+        file_path,
+        {"not_empty": {"dtype": "F32", "shape": [1], "data_offsets": [0, 0]}},
+        b"",
+    )
+
+    result = SafeTensorsScanner().scan(str(file_path))
+
+    assert result.success is False
+    assert any(
+        check.name == "Tensor Size Consistency Check"
+        and check.details.get("tensor") == "not_empty"
+        and check.details.get("expected_size") == 4
+        and check.details.get("actual_size") == 0
+        and check.severity == IssueSeverity.CRITICAL
+        and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
 
 
 def test_valid_empty_safetensors_custom_metadata(tmp_path: Path) -> None:

--- a/tests/scanners/test_safetensors_scanner.py
+++ b/tests/scanners/test_safetensors_scanner.py
@@ -12,6 +12,7 @@ import pytest
 # Skip if safetensors is not available before importing it
 pytest.importorskip("safetensors")
 
+from safetensors import SafetensorError, safe_open
 from safetensors.numpy import load_file, save_file
 
 from modelaudit.core import determine_exit_code, scan_file, scan_model_directory_or_file
@@ -151,6 +152,65 @@ def test_empty_tensor_offset_order_does_not_create_false_overlap(tmp_path: Path)
     assert not any(
         check.status == CheckStatus.FAILED and check.name == "Offset Continuity Check" for check in result.checks
     )
+
+
+@pytest.mark.parametrize(
+    ("dtype", "shape"),
+    [
+        ("U8", [1 << (8 * struct.calcsize("P") - 1), 2, 0]),
+        ("U16", [1 << (8 * struct.calcsize("P") - 1)]),
+        ("U8", [1 << (8 * struct.calcsize("P")), 0]),
+    ],
+)
+def test_shape_size_overflow_cannot_be_masked_by_zero_dimension(
+    tmp_path: Path,
+    dtype: str,
+    shape: list[int],
+) -> None:
+    file_path = tmp_path / "overflow_masked_empty_tensor.safetensors"
+    write_raw_safetensors(
+        file_path,
+        {"tensor": {"dtype": dtype, "shape": shape, "data_offsets": [0, 0]}},
+        b"",
+    )
+
+    with pytest.raises(SafetensorError, match=r"overflow|invalid JSON"):
+        safe_open(str(file_path), framework="np")
+
+    result = SafeTensorsScanner().scan(str(file_path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert any(
+        check.name == "Tensor Size Computation Check"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("shape") == shape
+        for check in result.checks
+    )
+
+
+def test_zero_before_large_dimensions_remains_valid_empty_shape(tmp_path: Path) -> None:
+    file_path = tmp_path / "zero_first_large_empty_tensor.safetensors"
+    shape = [0, 1 << (8 * struct.calcsize("P") - 1), 2]
+    write_raw_safetensors(
+        file_path,
+        {
+            "tensor": {
+                "dtype": "U8",
+                "shape": shape,
+                "data_offsets": [0, 0],
+            }
+        },
+        b"",
+    )
+
+    with safe_open(str(file_path), framework="np") as handle:
+        assert handle.get_slice("tensor").get_shape() == shape
+
+    result = SafeTensorsScanner().scan(str(file_path))
+
+    assert result.success is True
+    assert result.metadata.get("scan_outcome") != INCONCLUSIVE_SCAN_OUTCOME
 
 
 def test_valid_empty_safetensors_custom_metadata(tmp_path: Path) -> None:

--- a/tests/scanners/test_safetensors_scanner.py
+++ b/tests/scanners/test_safetensors_scanner.py
@@ -134,6 +134,25 @@ def test_zero_length_offsets_require_empty_shape(tmp_path: Path) -> None:
     )
 
 
+def test_empty_tensor_offset_order_does_not_create_false_overlap(tmp_path: Path) -> None:
+    file_path = tmp_path / "empty_tensor_before_nonempty_range.safetensors"
+    write_raw_safetensors(
+        file_path,
+        {
+            "nonempty": {"dtype": "U8", "shape": [1], "data_offsets": [0, 1]},
+            "empty": {"dtype": "U8", "shape": [0], "data_offsets": [0, 0]},
+        },
+        b"\x00",
+    )
+
+    result = SafeTensorsScanner().scan(str(file_path))
+
+    assert result.metadata.get("scan_outcome") != "inconclusive"
+    assert not any(
+        check.status == CheckStatus.FAILED and check.name == "Offset Continuity Check" for check in result.checks
+    )
+
+
 def test_valid_empty_safetensors_custom_metadata(tmp_path: Path) -> None:
     """An empty string-to-string map is valid custom metadata."""
     file_path = tmp_path / "empty_metadata.safetensors"

--- a/tests/scanners/test_safetensors_scanner.py
+++ b/tests/scanners/test_safetensors_scanner.py
@@ -174,7 +174,7 @@ def test_shape_size_overflow_cannot_be_masked_by_zero_dimension(
         b"",
     )
 
-    with pytest.raises(SafetensorError, match=r"overflow|invalid JSON"):
+    with pytest.raises(SafetensorError, match=r"(?i)(overflow|invalid.*(?:header|json))"):
         safe_open(str(file_path), framework="np")
 
     result = SafeTensorsScanner().scan(str(file_path))
@@ -211,6 +211,34 @@ def test_zero_before_large_dimensions_remains_valid_empty_shape(tmp_path: Path) 
 
     assert result.success is True
     assert result.metadata.get("scan_outcome") != INCONCLUSIVE_SCAN_OUTCOME
+
+
+def test_tensor_size_overflow_uses_native_bit_width(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("modelaudit.scanners.safetensors_scanner._MAX_PLATFORM_USIZE", 15)
+
+    assert SafeTensorsScanner._expected_size("U8", [1]) == 1
+    assert SafeTensorsScanner._expected_size("U8", [2]) is None
+
+
+def test_offsets_must_fit_native_usize(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    file_path = tmp_path / "native_offset_overflow.safetensors"
+    write_raw_safetensors(
+        file_path,
+        {"empty": {"dtype": "U8", "shape": [0], "data_offsets": [4, 4]}},
+        b"\x00" * 4,
+    )
+    monkeypatch.setattr("modelaudit.scanners.safetensors_scanner._MAX_PLATFORM_USIZE", 3)
+
+    result = SafeTensorsScanner().scan(str(file_path))
+
+    assert result.success is False
+    assert any(
+        check.name == "Tensor Offset Validation"
+        and check.status == CheckStatus.FAILED
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details.get("max_platform_offset") == 3
+        for check in result.checks
+    )
 
 
 def test_valid_empty_safetensors_custom_metadata(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- accept equal SafeTensors offsets for supported empty tensors
- retain negative-offset, reversed-range, upper-bound, shape, continuity, and full-data-coverage checks
- match upstream native `usize` offset and bit-size overflow validation
- add an official `safetensors.numpy` round-trip regression, malformed zero-byte negative control, deterministic equal-start ordering coverage, and simulated native-width regressions

## Real-world reproduction

The AgentBox Hugging Face audit found the same false-positive critical finding in three pinned FP8 artifacts from:

`Comfy-Org/Wan_2.2_ComfyUI_Repackaged@f97505f0d38bea4897c970db66cb5f97f73676de`

The `scaled_fp8` tensor has shape `[0]` and equal in-bounds offsets. The pinned control artifact is 14,296,064,656 bytes with SHA-256 `aa2f6b6f4cfc8a75a273a075db31730530f93320a996b153b8825205c3a3c498`. Its exact 181,600-byte header prefix has SHA-256 `fa2be54fd2d897749cd61fcadfdefead28fe958b9376d8d5ec91bd68289da031`.

The [SafeTensors format specification](https://github.com/huggingface/safetensors#format) explicitly permits tensors with a zero dimension and defines stored byte size as `END - BEGIN`.

After this change, a sparse exact-header replay passes offset and size validation with no issues. A tensor with shape `[1]` and offsets `[0, 0]` still fails critically because its expected four bytes do not match the zero-byte range.

## Validation

- `67 passed` in `tests/scanners/test_safetensors_scanner.py` with both `safetensors==0.7.0` and the supported floor `safetensors==0.4.0`
- full Ruff format and autofix lint passes (`418 files`)
- full mypy pass (`473 source files`)
- benign empty-tensor round trip, malformed nonempty zero-byte range, and malicious metadata paths all pass their focused regressions
- broader non-slow suite reached `12,890 passed, 381 skipped` before two local baseline/environment failures: the read-only sandbox blocks `/home/dev-user/.modelaudit` (the cache test passes with writable `HOME`), and a merged-main cached-shard alias test fails independently of the tensor-entry delta; fresh CI is the authoritative cross-platform run
