### PR TITLE
fix(onnx): reduce weight anomaly noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- scope both ONNX weight scanners to bounded semantic initializer lineage, preserve left, batched, and grouped outputs without tensor copies, fail closed on ambiguous coverage, and suppress clean statistical tails without masking repeated malicious patterns
+- scope both ONNX weight scanners to bounded semantic weight lineage across nested graphs, control flow, local functions, constants, Gather/Einsum, and static views; fail closed on ambiguous or sparse coverage; and evaluate extreme tails per conceptual output without suppressing repeated malicious patterns or flagging clean heavy tails
 - preserve sanitized CatBoost command context in SARIF without exposing injected or neighboring credential values
 - redact values compared against sensitive keys in generic exports and literal credential comparisons in CatBoost evidence
 - preserve critical PyTorch malformed-ZIP symlink findings, valid Python 3.10 streamed ZIP64 descriptors, and selected subtype findings from complete nested and concatenated HDF5 user-block ZIPs while retaining bounded fail-closed preflight checks and avoiding structure-only ZIP route probes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- scope ONNX weight-distribution analysis to semantic neural-network weights and suppress isolated statistical-tail alerts while preserving repeated malicious patterns
+- scope ONNX weight analysis to semantic neural-network weights, preserve left-operand and grouped outputs without tensor copies, and use per-output robust evidence to suppress clean statistical tails without masking repeated malicious patterns
 - classify unsafe PyTorch ZIP symlink targets as critical archive-link findings while preserving safe relative links
 - restore pickle CVE scan throughput, reprobe malformed stream separators, and route four-byte protocol-0 Joblib operands correctly
 - bound manifest embedded-Jinja template collection while preserving findings across deep branches, cycles, and shared YAML aliases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- scope ONNX weight-distribution analysis to semantic neural-network weights and suppress isolated statistical-tail alerts while preserving repeated malicious patterns
 - classify unsafe PyTorch ZIP symlink targets as critical archive-link findings while preserving safe relative links
 - restore pickle CVE scan throughput, reprobe malformed stream separators, and route four-byte protocol-0 Joblib operands correctly
 - bound manifest embedded-Jinja template collection while preserving findings across deep branches, cycles, and shared YAML aliases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- scope ONNX weight analysis to semantic neural-network weights, preserve left-operand and grouped outputs without tensor copies, and use per-output robust evidence to suppress clean statistical tails without masking repeated malicious patterns
+- scope both ONNX weight scanners to bounded semantic initializer lineage, preserve left, batched, and grouped outputs without tensor copies, fail closed on ambiguous coverage, and suppress clean statistical tails without masking repeated malicious patterns
 - classify unsafe PyTorch ZIP symlink targets as critical archive-link findings while preserving safe relative links
 - restore pickle CVE scan throughput, reprobe malformed stream separators, and route four-byte protocol-0 Joblib operands correctly
 - bound manifest embedded-Jinja template collection while preserving findings across deep branches, cycles, and shared YAML aliases

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -102,6 +102,7 @@ _QUANTIZED_WEIGHT_OPERATORS: frozenset[str] = frozenset(
         "QuantizeLinear",
     },
 )
+_RECURRENT_WEIGHT_OPERATORS: frozenset[str] = frozenset({"GRU", "LSTM", "RNN"})
 
 
 def _check_onnx() -> bool:
@@ -156,6 +157,12 @@ def _onnx_text_attribute(node: Any, name: str) -> str | None:
     return None
 
 
+def _onnx_gather_axis(node: Any, rank: int) -> int | None:
+    axis = _onnx_int_attribute(node, "axis")
+    axis = axis if axis >= 0 else rank + axis
+    return axis if 0 <= axis < rank else None
+
+
 def _onnx_weight_output_axes(node: Any, input_index: int, rank: int) -> tuple[tuple[int, ...] | None, str]:
     """Classify an initializer consumer for statistical weight analysis."""
     op_type = node.op_type
@@ -196,6 +203,13 @@ def _onnx_weight_output_axes(node: Any, input_index: int, rank: int) -> tuple[tu
             return None, "unsupported_weight_rank"
         return (1,), "eligible_conv_transpose_weight"
 
+    if op_type in _RECURRENT_WEIGHT_OPERATORS:
+        if input_index not in {1, 2}:
+            return None, "non_weight_input"
+        if rank != 3:
+            return None, "unsupported_weight_rank"
+        return (0, 1), "eligible_recurrent_weight"
+
     if op_type == "Einsum":
         equation = _onnx_text_attribute(node, "equation")
         if equation is None or "..." in equation or equation.count("->") != 1:
@@ -222,11 +236,10 @@ def _onnx_weight_output_axes(node: Any, input_index: int, rank: int) -> tuple[tu
             return None, "non_weight_input"
         if rank < 2:
             return None, "unsupported_weight_rank"
-        axis = _onnx_int_attribute(node, "axis")
-        axis = axis if axis >= 0 else rank + axis
-        if axis < 0 or axis >= rank:
+        axis = _onnx_gather_axis(node, rank)
+        if axis is None:
             return None, "unsupported_weight_axis"
-        return (axis,), "eligible_gather_table"
+        return tuple(candidate for candidate in range(rank) if candidate != axis), "eligible_gather_table"
     if op_type in _QUANTIZED_WEIGHT_OPERATORS:
         return None, "quantized_operator"
     if op_type in {
@@ -483,6 +496,7 @@ class _OnnxWeightConsumerGroup:
 
 @dataclass(frozen=True)
 class _OnnxWeightAnalysisSpec:
+    initializer_index: int
     analysis_id: int
     weights: Any
     output_axes: tuple[int, ...]
@@ -695,9 +709,23 @@ def _onnx_potential_weight_input(node: Any, input_index: int) -> bool:
         return input_index in {0, 1}
     if node.op_type in {"Conv", "ConvTranspose"}:
         return input_index == 1
+    if node.op_type in _RECURRENT_WEIGHT_OPERATORS:
+        return input_index in {1, 2}
     if node.op_type == "Gather":
         return input_index == 0
     return node.op_type == "Einsum"
+
+
+def _onnx_activation_input_candidate(node: Any, input_index: int) -> bool:
+    if getattr(node, "domain", "") not in _STANDARD_NEURAL_NETWORK_DOMAINS:
+        return False
+    if node.op_type in {"Einsum", "Gemm", "MatMul"}:
+        return True
+    if node.op_type in {"Conv", "ConvTranspose"}:
+        return input_index == 0
+    if node.op_type in _RECURRENT_WEIGHT_OPERATORS:
+        return input_index not in {1, 2}
+    return node.op_type == "Gather" and input_index == 1
 
 
 def _build_onnx_weight_analysis_plan(
@@ -722,6 +750,7 @@ def _build_onnx_weight_analysis_plan(
     }
     initializers: list[Any] = []
     initializer_graph_indexes: list[int] = []
+    initializer_source_indexes: dict[tuple[Any, ...], int] = {}
     empty_names, duplicate_names, invalid_name_samples = _onnx_initializer_name_issues(graph, plan)
     invalid_name_count = empty_names + duplicate_names
     if invalid_name_count:
@@ -781,16 +810,27 @@ def _build_onnx_weight_analysis_plan(
         *,
         shape: tuple[int, ...] | None = None,
         unresolved_reason: str | None = None,
+        source_key: tuple[Any, ...] | None = None,
     ) -> _OnnxWeightLineage:
+        resolved_shape = shape if shape is not None else tuple(int(dimension) for dimension in initializer.dims)
+        if source_key is not None and source_key in initializer_source_indexes:
+            return _OnnxWeightLineage(
+                initializer_index=initializer_source_indexes[source_key],
+                shape=resolved_shape,
+                unresolved_reason=unresolved_reason,
+            )
+
         initializer_index = len(initializers)
         initializers.append(initializer)
         initializer_graph_indexes.append(graph_index)
         groups.append({})
         terminal_consumer_counts.append(0)
         transform_counts.append(0)
+        if source_key is not None:
+            initializer_source_indexes[source_key] = initializer_index
         return _OnnxWeightLineage(
             initializer_index=initializer_index,
-            shape=shape if shape is not None else tuple(int(dimension) for dimension in initializer.dims),
+            shape=resolved_shape,
             unresolved_reason=unresolved_reason,
         )
 
@@ -1069,11 +1109,23 @@ def _build_onnx_weight_analysis_plan(
                 continue
             if existing == lineage:
                 continue
+            reasons = {
+                reason for reason in (existing.unresolved_reason, lineage.unresolved_reason) if reason is not None
+            }
+            stronger_reasons = reasons - {"dynamic_activation_lineage"}
+            if len(stronger_reasons) == 1:
+                unresolved_reason = next(iter(stronger_reasons))
+            elif stronger_reasons:
+                unresolved_reason = ambiguous_reason
+            elif reasons:
+                unresolved_reason = "dynamic_activation_lineage"
+            else:
+                unresolved_reason = ambiguous_reason
             target[initializer_index] = _OnnxWeightLineage(
                 initializer_index=initializer_index,
                 shape=None,
                 transforms=existing.transforms,
-                unresolved_reason=existing.unresolved_reason or lineage.unresolved_reason or ambiguous_reason,
+                unresolved_reason=unresolved_reason,
             )
 
     def walk_graph(
@@ -1083,10 +1135,12 @@ def _build_onnx_weight_analysis_plan(
         inherited_dynamic_values: set[str],
         *,
         root_graph: bool,
+        source_scope: tuple[Any, ...],
         bound_lineages: dict[str, dict[int, _OnnxWeightLineage]] | None = None,
         bound_constants: dict[str, Any] | None = None,
         bound_dynamic_values: set[str] | None = None,
         bound_attributes: dict[str, Any] | None = None,
+        bound_attribute_keys: dict[str, tuple[Any, ...]] | None = None,
         function_depth: int = 0,
     ) -> tuple[list[dict[int, _OnnxWeightLineage]], list[bool]]:
         nonlocal graph_counter, node_counter, total_consumer_count
@@ -1108,19 +1162,37 @@ def _build_onnx_weight_analysis_plan(
         constants.update(bound_constants or {})
         dynamic_values.update(bound_dynamic_values or set())
         attribute_bindings = bound_attributes or {}
+        attribute_binding_keys = bound_attribute_keys or {}
 
         def resolve_attribute(attribute: Any) -> Any | None:
             reference_name = str(getattr(attribute, "ref_attr_name", ""))
             return attribute_bindings.get(reference_name) if reference_name else attribute
 
-        for initializer in getattr(current_graph, "initializer", ()):
+        def attribute_source_key(
+            attribute: Any,
+            node_position: int,
+            attribute_position: int,
+        ) -> tuple[Any, ...]:
+            reference_name = str(getattr(attribute, "ref_attr_name", ""))
+            if reference_name:
+                return attribute_binding_keys.get(
+                    reference_name,
+                    (*source_scope, "unresolved_attribute_reference", reference_name),
+                )
+            return (*source_scope, "node", node_position, "attribute", attribute_position)
+
+        for initializer_position, initializer in enumerate(getattr(current_graph, "initializer", ())):
             if initializer.name:
                 name = str(initializer.name)
-                lineage = register_initializer(initializer, current_graph_index)
+                lineage = register_initializer(
+                    initializer,
+                    current_graph_index,
+                    source_key=(*source_scope, "initializer", initializer_position),
+                )
                 value_lineages[name] = {lineage.initializer_index: lineage}
                 constants[name] = initializer
                 dynamic_values.discard(name)
-        for sparse_initializer in getattr(current_graph, "sparse_initializer", ()):
+        for sparse_position, sparse_initializer in enumerate(getattr(current_graph, "sparse_initializer", ())):
             if sparse_initializer.values.name:
                 name = str(sparse_initializer.values.name)
                 lineage = register_initializer(
@@ -1128,6 +1200,7 @@ def _build_onnx_weight_analysis_plan(
                     current_graph_index,
                     shape=tuple(int(dimension) for dimension in sparse_initializer.dims),
                     unresolved_reason="sparse_initializer_unsupported",
+                    source_key=(*source_scope, "sparse_initializer", sparse_position),
                 )
                 value_lineages[name] = {lineage.initializer_index: lineage}
                 dynamic_values.discard(name)
@@ -1137,7 +1210,7 @@ def _build_onnx_weight_analysis_plan(
             if name and name not in value_lineages and name not in constants:
                 dynamic_values.add(name)
 
-        for node in getattr(current_graph, "node", ()):
+        for local_node_index, node in enumerate(getattr(current_graph, "node", ())):
             current_node_index = node_counter
             node_counter += 1
             supported_transform = getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS and node.op_type in {
@@ -1150,6 +1223,8 @@ def _build_onnx_weight_analysis_plan(
                 "Unsqueeze",
             }
             all_input_lineages: dict[int, _OnnxWeightLineage] = {}
+            terminal_weight_lineages: set[int] = set()
+            activation_input_lineages: set[int] = set()
             input_names = [str(input_name) for input_name in node.input if input_name]
             has_dynamic_input = any(
                 input_name in dynamic_values or (input_name not in value_lineages and input_name not in constants)
@@ -1158,23 +1233,68 @@ def _build_onnx_weight_analysis_plan(
             has_referenced_attributes = any(
                 getattr(attribute, "ref_attr_name", "") for attribute in getattr(node, "attribute", ())
             )
+            resolved_weight_input_indexes = {
+                input_index
+                for input_index, input_name in enumerate(node.input)
+                for lineage in value_lineages.get(str(input_name), {}).values()
+                if lineage.unresolved_reason is None
+                and _onnx_weight_output_axes(node, input_index, len(lineage.shape or ()))[0] is not None
+            }
+            lineage_input_indexes = {
+                input_index for input_index, input_name in enumerate(node.input) if value_lineages.get(str(input_name))
+            }
+            dynamic_activation_input_indexes = {
+                input_index
+                for input_index, input_name in enumerate(node.input)
+                if value_lineages.get(str(input_name))
+                and all(
+                    lineage.unresolved_reason == "dynamic_activation_lineage"
+                    for lineage in value_lineages[str(input_name)].values()
+                )
+            }
+            all_lineage_inputs_are_activation_contraction = (
+                getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
+                and node.op_type in {"Einsum", "MatMul"}
+                and len(lineage_input_indexes) >= 2
+                and lineage_input_indexes == dynamic_activation_input_indexes
+            )
 
             for input_index, input_name in enumerate(node.input):
                 input_lineages = value_lineages.get(str(input_name), {})
+                merge_lineages(
+                    all_input_lineages,
+                    input_lineages,
+                    ambiguous_reason="ambiguous_operator_input_lineage",
+                )
+                potential_weight_input = _onnx_potential_weight_input(node, input_index)
                 for initializer_index, lineage in input_lineages.items():
-                    all_input_lineages.setdefault(initializer_index, lineage)
                     if supported_transform and input_index == 0:
                         continue
+                    if potential_weight_input:
+                        terminal_weight_lineages.add(initializer_index)
                     terminal_consumer_counts[initializer_index] += 1
                     total_consumer_count += 1
                     if lineage.unresolved_reason is not None:
-                        if _onnx_potential_weight_input(node, input_index):
+                        opposite_resolved_weight = any(
+                            resolved_index != input_index for resolved_index in resolved_weight_input_indexes
+                        )
+                        prior_layer_activation = lineage.unresolved_reason == "dynamic_activation_lineage"
+                        recognized_activation_input = (
+                            prior_layer_activation
+                            and _onnx_activation_input_candidate(node, input_index)
+                            and (opposite_resolved_weight or all_lineage_inputs_are_activation_contraction)
+                        )
+                        if recognized_activation_input:
+                            if opposite_resolved_weight:
+                                activation_input_lineages.add(initializer_index)
+                            record_exclusion(initializer_index, "dynamic_activation_input", node, input_index)
+                        elif potential_weight_input:
                             record_unresolved_lineage(lineage, node, current_node_index, input_index)
                         else:
                             record_exclusion(initializer_index, "unresolved_lineage_consumer", node, input_index)
                         continue
                     if has_referenced_attributes and not (supported_transform and input_index == 0):
-                        if _onnx_potential_weight_input(node, input_index):
+                        if potential_weight_input:
                             record_unresolved_lineage(
                                 _OnnxWeightLineage(
                                     initializer_index=initializer_index,
@@ -1196,7 +1316,7 @@ def _build_onnx_weight_analysis_plan(
                         continue
                     output_axes, reason = _onnx_weight_output_axes(node, input_index, len(lineage.shape or ()))
                     if output_axes is None:
-                        if reason != "non_weight_input" and _onnx_potential_weight_input(node, input_index):
+                        if reason != "non_weight_input" and potential_weight_input:
                             record_unresolved_lineage(
                                 _OnnxWeightLineage(
                                     initializer_index=initializer_index,
@@ -1212,14 +1332,25 @@ def _build_onnx_weight_analysis_plan(
                             record_exclusion(initializer_index, reason, node, input_index)
                         continue
                     add_consumer_group(lineage, node, current_node_index, input_index, output_axes)
+                    if node.op_type == "Gather":
+                        gather_axis = _onnx_gather_axis(node, len(lineage.shape or ()))
+                        if gather_axis is not None and (gather_axis,) != output_axes:
+                            add_consumer_group(
+                                lineage,
+                                node,
+                                current_node_index,
+                                input_index,
+                                (gather_axis,),
+                            )
 
             subgraph_results: list[tuple[list[dict[int, _OnnxWeightLineage]], list[bool]]] = []
-            for attribute in getattr(node, "attribute", ()):
+            for attribute_position, attribute in enumerate(getattr(node, "attribute", ())):
                 resolved_attribute = resolve_attribute(attribute)
                 if resolved_attribute is None:
                     plan.record_coverage_gap("unresolved_function_attribute")
                     continue
-                for subgraph in _iter_attribute_graphs(resolved_attribute):
+                resolved_attribute_key = attribute_source_key(attribute, local_node_index, attribute_position)
+                for subgraph_position, subgraph in enumerate(_iter_attribute_graphs(resolved_attribute)):
                     subgraph_bound_lineages: dict[str, dict[int, _OnnxWeightLineage]] = {}
                     subgraph_bound_constants: dict[str, Any] = {}
                     subgraph_bound_dynamic: set[str] = set()
@@ -1246,21 +1377,22 @@ def _build_onnx_weight_analysis_plan(
                             constants,
                             dynamic_values,
                             root_graph=False,
+                            source_scope=(*resolved_attribute_key, "graph", subgraph_position),
                             bound_lineages=subgraph_bound_lineages,
                             bound_constants=subgraph_bound_constants,
                             bound_dynamic_values=subgraph_bound_dynamic,
                             bound_attributes=attribute_bindings,
+                            bound_attribute_keys=attribute_binding_keys,
                             function_depth=function_depth,
                         ),
                     )
 
-            function = functions.get(
-                (
-                    str(getattr(node, "domain", "")),
-                    str(getattr(node, "op_type", "")),
-                    str(getattr(node, "overload", "")),
-                ),
+            function_key = (
+                str(getattr(node, "domain", "")),
+                str(getattr(node, "op_type", "")),
+                str(getattr(node, "overload", "")),
             )
+            function = functions.get(function_key)
             if function is not None and function_depth >= _ONNX_WEIGHT_TRANSFORM_DEPTH_LIMIT:
                 plan.record_coverage_gap("function_call_depth_limit")
                 for input_index, input_name in enumerate(node.input):
@@ -1281,13 +1413,27 @@ def _build_onnx_weight_analysis_plan(
                 function_bound_lineages: dict[str, dict[int, _OnnxWeightLineage]] = {}
                 function_bound_constants: dict[str, Any] = {}
                 function_bound_dynamic: set[str] = set()
-                function_bound_attributes = {
-                    str(attribute.name): attribute for attribute in getattr(function, "attribute_proto", ())
-                }
-                for attribute in getattr(node, "attribute", ()):
+                function_source_scope = ("function", *function_key)
+                function_bound_attributes: dict[str, Any] = {}
+                function_bound_attribute_keys: dict[str, tuple[Any, ...]] = {}
+                for default_position, attribute in enumerate(getattr(function, "attribute_proto", ())):
+                    attribute_name = str(attribute.name)
+                    function_bound_attributes[attribute_name] = attribute
+                    function_bound_attribute_keys[attribute_name] = (
+                        *function_source_scope,
+                        "default_attribute",
+                        default_position,
+                    )
+                for attribute_position, attribute in enumerate(getattr(node, "attribute", ())):
                     resolved_attribute = resolve_attribute(attribute)
                     if resolved_attribute is not None:
-                        function_bound_attributes[str(attribute.name)] = resolved_attribute
+                        attribute_name = str(attribute.name)
+                        function_bound_attributes[attribute_name] = resolved_attribute
+                        function_bound_attribute_keys[attribute_name] = attribute_source_key(
+                            attribute,
+                            local_node_index,
+                            attribute_position,
+                        )
                 for parent_input, function_input in zip(node.input, function.input, strict=False):
                     parent_name = str(parent_input)
                     function_input_name = _onnx_value_name(function_input)
@@ -1304,10 +1450,12 @@ def _build_onnx_weight_analysis_plan(
                         constants,
                         dynamic_values,
                         root_graph=False,
+                        source_scope=function_source_scope,
                         bound_lineages=function_bound_lineages,
                         bound_constants=function_bound_constants,
                         bound_dynamic_values=function_bound_dynamic,
                         bound_attributes=function_bound_attributes,
+                        bound_attribute_keys=function_bound_attribute_keys,
                         function_depth=function_depth + 1,
                     ),
                 )
@@ -1320,16 +1468,30 @@ def _build_onnx_weight_analysis_plan(
                     output_lineages[initializer_index] = transformed_lineage(lineage, node, constants)
             elif (
                 all_input_lineages
-                and not has_dynamic_input
                 and node.op_type not in _QUANTIZED_WEIGHT_OPERATORS
                 and function is None
+                and not subgraph_results
             ):
+                carries_dynamic_activation = bool(terminal_weight_lineages) and has_dynamic_input
+                carries_dynamic_activation |= any(
+                    lineage.unresolved_reason == "dynamic_activation_lineage" for lineage in all_input_lineages.values()
+                )
                 for initializer_index, lineage in all_input_lineages.items():
+                    if initializer_index in activation_input_lineages:
+                        continue
+                    unresolved_reason = lineage.unresolved_reason
+                    if unresolved_reason is None:
+                        if carries_dynamic_activation:
+                            unresolved_reason = "dynamic_activation_lineage"
+                        else:
+                            unresolved_reason = (
+                                "dynamic_input_lineage" if has_dynamic_input else "unsupported_lineage_operator"
+                            )
                     output_lineages[initializer_index] = _OnnxWeightLineage(
                         initializer_index=initializer_index,
                         shape=None,
                         transforms=lineage.transforms,
-                        unresolved_reason=lineage.unresolved_reason or "unsupported_lineage_operator",
+                        unresolved_reason=unresolved_reason,
                     )
 
             output_lineages = bounded_lineages(output_lineages)
@@ -1339,7 +1501,8 @@ def _build_onnx_weight_analysis_plan(
                 constant_tensor = None
                 sparse_constant = None
                 unresolved_constant_attribute = False
-                for attribute in node.attribute:
+                constant_source_key: tuple[Any, ...] | None = None
+                for attribute_position, attribute in enumerate(node.attribute):
                     resolved_attribute = resolve_attribute(attribute)
                     if resolved_attribute is None:
                         unresolved_constant_attribute = True
@@ -1385,6 +1548,10 @@ def _build_onnx_weight_analysis_plan(
                         except (AttributeError, ValueError):
                             sparse_constant = None
                     if constant_tensor is not None or sparse_constant is not None:
+                        constant_source_key = (
+                            "constant_value",
+                            *attribute_source_key(attribute, local_node_index, attribute_position),
+                        )
                         break
                 output_names = [str(output_name) for output_name in node.output if output_name]
                 if len(output_names) != 1:
@@ -1392,7 +1559,11 @@ def _build_onnx_weight_analysis_plan(
                 elif constant_tensor is not None:
                     name = output_names[0]
                     constant_tensor.name = name
-                    lineage = register_initializer(constant_tensor, current_graph_index)
+                    lineage = register_initializer(
+                        constant_tensor,
+                        current_graph_index,
+                        source_key=constant_source_key,
+                    )
                     constants[name] = constant_tensor
                     constant_output_lineages[name] = {lineage.initializer_index: lineage}
                     constant_output_names.add(name)
@@ -1404,6 +1575,7 @@ def _build_onnx_weight_analysis_plan(
                         current_graph_index,
                         shape=tuple(int(dimension) for dimension in sparse_constant.dims),
                         unresolved_reason="sparse_constant_unsupported",
+                        source_key=constant_source_key,
                     )
                     constant_output_lineages[name] = {lineage.initializer_index: lineage}
                     constant_output_names.add(name)
@@ -1415,6 +1587,7 @@ def _build_onnx_weight_analysis_plan(
                         unresolved_tensor,
                         current_graph_index,
                         unresolved_reason="unresolved_constant_attribute",
+                        source_key=(*source_scope, "node", local_node_index, "unresolved_constant"),
                     )
                     constant_output_lineages[name] = {lineage.initializer_index: lineage}
                     constant_output_names.add(name)
@@ -1481,7 +1654,7 @@ def _build_onnx_weight_analysis_plan(
             [_onnx_value_name(graph_output) in dynamic_values for graph_output in current_graph.output],
         )
 
-    walk_graph(graph, {}, {}, set(), root_graph=True)
+    walk_graph(graph, {}, {}, set(), root_graph=True, source_scope=("root_graph",))
 
     for initializer_index, _initializer in enumerate(initializers):
         if terminal_consumer_counts[initializer_index] == 0 and not groups[initializer_index]:
@@ -1602,6 +1775,7 @@ def _build_onnx_weight_analysis_plan(
                 }
                 plan.specs.append(
                     _OnnxWeightAnalysisSpec(
+                        initializer_index=initializer_index,
                         analysis_id=analysis_id,
                         weights=analysis_weights,
                         output_axes=conceptual_output_axes,

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -6,6 +6,7 @@ import ntpath
 import os
 import re
 from collections.abc import Callable, Iterable
+from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar
@@ -92,6 +93,69 @@ _ONNX_WEIGHT_RESHAPE_RANK_LIMIT = 64
 _ONNX_WEIGHT_METADATA_TEXT_LIMIT = 256
 _ONNX_WEIGHT_METADATA_SEQUENCE_LIMIT = 64
 _STANDARD_NEURAL_NETWORK_DOMAINS: frozenset[str] = frozenset({"", "ai.onnx"})
+_SAME_TYPE_ELEMENTWISE_OPERATORS: frozenset[str] = frozenset(
+    {
+        "Add",
+        "Div",
+        "Max",
+        "Mean",
+        "Min",
+        "Mod",
+        "Mul",
+        "PRelu",
+        "Sub",
+        "Sum",
+        "Where",
+    }
+)
+_SAME_TYPE_UNARY_ELEMENTWISE_OPERATORS: frozenset[str] = frozenset(
+    {
+        "Abs",
+        "Acos",
+        "Acosh",
+        "Asin",
+        "Asinh",
+        "Atan",
+        "Atanh",
+        "BitwiseNot",
+        "Ceil",
+        "Celu",
+        "Cos",
+        "Cosh",
+        "Elu",
+        "Erf",
+        "Exp",
+        "Floor",
+        "Gelu",
+        "HardSigmoid",
+        "HardSwish",
+        "Hardmax",
+        "LeakyRelu",
+        "Log",
+        "LogSoftmax",
+        "LpNormalization",
+        "Mish",
+        "Neg",
+        "Not",
+        "Reciprocal",
+        "Relu",
+        "Round",
+        "Selu",
+        "Sigmoid",
+        "Sign",
+        "Sin",
+        "Sinh",
+        "Softplus",
+        "Softmax",
+        "Softsign",
+        "Sqrt",
+        "Shrink",
+        "Swish",
+        "Tan",
+        "Tanh",
+        "ThresholdedRelu",
+    }
+)
 _QUANTIZED_WEIGHT_OPERATORS: frozenset[str] = frozenset(
     {
         "ConvInteger",
@@ -241,6 +305,12 @@ def _onnx_weight_output_axes(node: Any, input_index: int, rank: int) -> tuple[tu
         if axis is None:
             return None, "unsupported_weight_axis"
         return tuple(candidate for candidate in range(rank) if candidate != axis), "eligible_gather_table"
+    if op_type == "PRelu":
+        if input_index != 1:
+            return None, "non_weight_input"
+        if rank < 2:
+            return None, "unsupported_weight_rank"
+        return (rank - 1,), "eligible_prelu_slope"
     if op_type in _QUANTIZED_WEIGHT_OPERATORS:
         return None, "quantized_operator"
     if op_type in {
@@ -574,6 +644,7 @@ class _OnnxWeightTransform:
 class _OnnxWeightLineage:
     initializer_index: int
     shape: tuple[int, ...] | None
+    data_type: int | None
     transforms: tuple[_OnnxWeightTransform, ...] = ()
     unresolved_reason: str | None = None
 
@@ -799,9 +870,22 @@ def _onnx_initializer_name_issues(
     return empty_count, duplicate_count, samples
 
 
-def _onnx_potential_weight_input(node: Any, input_index: int) -> bool:
-    if getattr(node, "domain", "") not in _STANDARD_NEURAL_NETWORK_DOMAINS:
-        return False
+def _onnx_potential_weight_input(
+    node: Any,
+    input_index: int,
+    *,
+    is_model_local_function: bool = False,
+    is_registered_standard_operator: bool = True,
+) -> bool:
+    """Return whether initializer lineage at this input needs weight coverage."""
+    domain = getattr(node, "domain", "")
+    if domain not in _STANDARD_NEURAL_NETWORK_DOMAINS:
+        # ONNX-ML operators store learned parameters in attributes; tensor inputs are data.
+        if is_registered_standard_operator and domain == "ai.onnx.ml":
+            return False
+        return not is_model_local_function and (
+            domain in STANDARD_ONNX_DOMAINS or domain in SCHEMA_VALIDATED_ONNX_DOMAINS
+        )
     if node.op_type in {"Gemm", "MatMul"}:
         return input_index in {0, 1}
     if node.op_type in {"Conv", "ConvTranspose"}:
@@ -810,7 +894,9 @@ def _onnx_potential_weight_input(node: Any, input_index: int) -> bool:
         return input_index in {1, 2}
     if node.op_type == "Gather":
         return input_index == 0
-    return node.op_type == "Einsum"
+    if node.op_type == "PRelu":
+        return input_index == 1
+    return node.op_type == "Einsum" or not is_registered_standard_operator
 
 
 def _onnx_activation_input_candidate(node: Any, input_index: int) -> bool:
@@ -823,6 +909,11 @@ def _onnx_activation_input_candidate(node: Any, input_index: int) -> bool:
     if node.op_type in _RECURRENT_WEIGHT_OPERATORS:
         return input_index not in {1, 2}
     return node.op_type == "Gather" and input_index == 1
+
+
+def _onnx_opaque_activation_input_candidate(node: Any, _input_index: int) -> bool:
+    """Recognize opaque-domain inputs whose schema fixes an activation-only role."""
+    return getattr(node, "domain", "") == "ai.onnx.ml"
 
 
 def _build_onnx_weight_analysis_plan(
@@ -845,10 +936,60 @@ def _build_onnx_weight_analysis_plan(
         ): function
         for function in getattr(model, "functions", ())
     }
+    model_opset_versions = {
+        str(getattr(opset, "domain", "") or ""): int(opset.version) for opset in getattr(model, "opset_import", ())
+    }
+    training_infos = list(getattr(model, "training_info", ()))
+    analysis_graph_roots: list[tuple[tuple[Any, ...], Any]] = [(("root_graph",), graph)]
+    for training_index, training_info in enumerate(training_infos):
+        for field_name in ("initialization", "algorithm"):
+            training_graph = getattr(training_info, field_name)
+            if training_graph.node or training_graph.initializer or training_graph.sparse_initializer:
+                analysis_graph_roots.append((("training_info", training_index, field_name), training_graph))
     initializers: list[Any] = []
     initializer_graph_indexes: list[int] = []
     initializer_source_indexes: dict[tuple[Any, ...], int] = {}
-    empty_names, duplicate_names, invalid_name_samples = _onnx_initializer_name_issues(graph, plan)
+    empty_names = 0
+    duplicate_names = 0
+    invalid_name_samples: list[dict[str, Any]] = []
+    for _source_scope, analysis_graph in analysis_graph_roots:
+        graph_empty_names, graph_duplicate_names, graph_invalid_name_samples = _onnx_initializer_name_issues(
+            analysis_graph,
+            plan,
+        )
+        empty_names += graph_empty_names
+        duplicate_names += graph_duplicate_names
+        remaining_sample_count = _ONNX_WEIGHT_METADATA_SAMPLE_LIMIT - len(invalid_name_samples)
+        invalid_name_samples.extend(graph_invalid_name_samples[:remaining_sample_count])
+    main_initializer_names = {
+        str(initializer.name) for initializer in getattr(graph, "initializer", ()) if initializer.name
+    }
+    main_initializer_names.update(
+        str(sparse_initializer.values.name)
+        for sparse_initializer in getattr(graph, "sparse_initializer", ())
+        if sparse_initializer.values.name
+    )
+    for training_index, training_info in enumerate(training_infos):
+        algorithm_initializer_names = {
+            str(initializer.name)
+            for initializer in getattr(training_info.algorithm, "initializer", ())
+            if initializer.name
+        }
+        algorithm_initializer_names.update(
+            str(sparse_initializer.values.name)
+            for sparse_initializer in getattr(training_info.algorithm, "sparse_initializer", ())
+            if sparse_initializer.values.name
+        )
+        for name in sorted(main_initializer_names & algorithm_initializer_names):
+            duplicate_names += 1
+            if len(invalid_name_samples) < _ONNX_WEIGHT_METADATA_SAMPLE_LIMIT:
+                invalid_name_samples.append(
+                    {
+                        "graph_index": training_index,
+                        "reason": "duplicate_combined_training_initializer_name",
+                        **_bounded_onnx_metadata_fields(plan, "initializer", name),
+                    },
+                )
     invalid_name_count = empty_names + duplicate_names
     if invalid_name_count:
         plan.record_coverage_gap("invalid_initializer_names", invalid_name_count)
@@ -892,6 +1033,41 @@ def _build_onnx_weight_analysis_plan(
         )
         if hasattr(onnx.TensorProto, name)
     }
+
+    def lineage_could_be_weight(lineage: _OnnxWeightLineage) -> bool:
+        return (lineage.data_type is None or lineage.data_type in floating_types) and (
+            lineage.shape is None or len(lineage.shape) >= 2
+        )
+
+    def value_info_shape(value_info: Any) -> tuple[int, ...] | None:
+        try:
+            tensor_type = value_info.type.tensor_type
+            if not tensor_type.HasField("shape"):
+                return None
+            dimensions: list[int] = []
+            for dimension in tensor_type.shape.dim:
+                if not dimension.HasField("dim_value"):
+                    return None
+                dimensions.append(int(dimension.dim_value))
+            return tuple(dimensions)
+        except (AttributeError, TypeError, ValueError):
+            return None
+
+    def broadcast_shapes(shapes: Iterable[tuple[int, ...] | None]) -> tuple[int, ...] | None:
+        concrete_shapes = list(shapes)
+        if not concrete_shapes or any(shape is None for shape in concrete_shapes):
+            return None
+        known_shapes = [shape for shape in concrete_shapes if shape is not None]
+        output_rank = max((len(shape) for shape in known_shapes), default=0)
+        output_dimensions: list[int] = []
+        for offset in range(1, output_rank + 1):
+            dimensions = [shape[-offset] if len(shape) >= offset else 1 for shape in known_shapes]
+            non_singleton_dimensions = {dimension for dimension in dimensions if dimension != 1}
+            if len(non_singleton_dimensions) > 1:
+                return None
+            output_dimensions.append(next(iter(non_singleton_dimensions), 1))
+        return tuple(reversed(output_dimensions))
+
     groups: list[dict[tuple[Any, ...], _OnnxWeightConsumerGroup]] = []
     eligible_initializer_indexes: set[int] = set()
     terminal_consumer_counts: list[int] = []
@@ -900,6 +1076,7 @@ def _build_onnx_weight_analysis_plan(
     consumer_sample_count = 0
     node_counter = 0
     graph_counter = 0
+    schema_cache: dict[tuple[str, str, int], bool] = {}
 
     def register_initializer(
         initializer: Any,
@@ -914,6 +1091,7 @@ def _build_onnx_weight_analysis_plan(
             return _OnnxWeightLineage(
                 initializer_index=initializer_source_indexes[source_key],
                 shape=resolved_shape,
+                data_type=int(initializer.data_type),
                 unresolved_reason=unresolved_reason,
             )
 
@@ -928,6 +1106,7 @@ def _build_onnx_weight_analysis_plan(
         return _OnnxWeightLineage(
             initializer_index=initializer_index,
             shape=resolved_shape,
+            data_type=int(initializer.data_type),
             unresolved_reason=unresolved_reason,
         )
 
@@ -985,6 +1164,30 @@ def _build_onnx_weight_analysis_plan(
             },
         )
 
+    def record_training_binding_gap(
+        lineage: _OnnxWeightLineage,
+        *,
+        binding_kind: str,
+        state_name: str,
+    ) -> None:
+        eligible_initializer_indexes.add(lineage.initializer_index)
+        plan.record_coverage_gap("unresolved_initializer_lineage")
+        if len(plan.unresolved_lineage_samples) >= _ONNX_WEIGHT_METADATA_SAMPLE_LIMIT:
+            return
+        initializer = initializers[lineage.initializer_index]
+        plan.unresolved_lineage_samples.append(
+            {
+                **_bounded_onnx_metadata_fields(plan, "initializer", initializer.name),
+                "initializer_graph_index": initializer_graph_indexes[lineage.initializer_index],
+                **_bounded_onnx_metadata_fields(plan, "consumer_op", "TrainingInfoBinding"),
+                **_bounded_onnx_metadata_fields(plan, "consumer_node", state_name),
+                "consumer_node_index": -1,
+                "consumer_input_index": 0,
+                "reason": f"unresolved_{binding_kind}_binding",
+                "lineage_transform_count": len(lineage.transforms),
+            },
+        )
+
     def add_consumer_group(
         lineage: _OnnxWeightLineage,
         node: Any,
@@ -1037,40 +1240,42 @@ def _build_onnx_weight_analysis_plan(
         node: Any,
         constants: dict[str, Any],
     ) -> _OnnxWeightLineage:
-        if lineage.unresolved_reason is not None:
-            return lineage
         if any(getattr(attribute, "ref_attr_name", "") for attribute in getattr(node, "attribute", ())):
             return _OnnxWeightLineage(
                 initializer_index=lineage.initializer_index,
                 shape=None,
+                data_type=lineage.data_type,
                 transforms=lineage.transforms,
-                unresolved_reason="referenced_function_attribute",
+                unresolved_reason=lineage.unresolved_reason or "referenced_function_attribute",
             )
         if node.op_type == "Identity":
             return lineage
         if node.op_type == "Cast":
-            initializer = initializers[lineage.initializer_index]
-            if _onnx_int_attribute(node, "to", -1) == int(initializer.data_type):
+            target_data_type = _onnx_int_attribute(node, "to", -1)
+            if target_data_type == lineage.data_type:
                 return lineage
             return _OnnxWeightLineage(
                 initializer_index=lineage.initializer_index,
-                shape=None,
+                shape=lineage.shape,
+                data_type=target_data_type if target_data_type >= 0 else None,
                 transforms=lineage.transforms,
-                unresolved_reason="dtype_changing_cast_lineage",
+                unresolved_reason=lineage.unresolved_reason or "dtype_changing_cast_lineage",
             )
         if len(lineage.transforms) >= _ONNX_WEIGHT_TRANSFORM_DEPTH_LIMIT:
             return _OnnxWeightLineage(
                 initializer_index=lineage.initializer_index,
                 shape=None,
+                data_type=lineage.data_type,
                 transforms=lineage.transforms,
-                unresolved_reason="lineage_transform_depth_limit",
+                unresolved_reason=lineage.unresolved_reason or "lineage_transform_depth_limit",
             )
         if lineage.shape is None:
             return _OnnxWeightLineage(
                 initializer_index=lineage.initializer_index,
                 shape=None,
+                data_type=lineage.data_type,
                 transforms=lineage.transforms,
-                unresolved_reason="lineage_shape_unavailable",
+                unresolved_reason=lineage.unresolved_reason or "lineage_shape_unavailable",
             )
 
         output_shape: tuple[int, ...]
@@ -1082,8 +1287,9 @@ def _build_onnx_weight_analysis_plan(
                 return _OnnxWeightLineage(
                     initializer_index=lineage.initializer_index,
                     shape=None,
+                    data_type=lineage.data_type,
                     transforms=lineage.transforms,
-                    unresolved_reason="invalid_flatten_lineage",
+                    unresolved_reason=lineage.unresolved_reason or "invalid_flatten_lineage",
                 )
             output_shape = (math.prod(lineage.shape[:axis]), math.prod(lineage.shape[axis:]))
             transform = _OnnxWeightTransform("Reshape", output_shape)
@@ -1093,8 +1299,9 @@ def _build_onnx_weight_analysis_plan(
                 return _OnnxWeightLineage(
                     initializer_index=lineage.initializer_index,
                     shape=None,
+                    data_type=lineage.data_type,
                     transforms=lineage.transforms,
-                    unresolved_reason=f"unresolved_{node.op_type.lower()}_lineage",
+                    unresolved_reason=lineage.unresolved_reason or f"unresolved_{node.op_type.lower()}_lineage",
                 )
             if node.op_type == "Squeeze":
                 normalized_axes = tuple(axis if axis >= 0 else len(lineage.shape) + axis for axis in axes)
@@ -1108,8 +1315,9 @@ def _build_onnx_weight_analysis_plan(
                     return _OnnxWeightLineage(
                         initializer_index=lineage.initializer_index,
                         shape=None,
+                        data_type=lineage.data_type,
                         transforms=lineage.transforms,
-                        unresolved_reason="invalid_squeeze_lineage",
+                        unresolved_reason=lineage.unresolved_reason or "invalid_squeeze_lineage",
                     )
                 output_shape = tuple(
                     dimension for index, dimension in enumerate(lineage.shape) if index not in normalized_axes
@@ -1125,8 +1333,9 @@ def _build_onnx_weight_analysis_plan(
                     return _OnnxWeightLineage(
                         initializer_index=lineage.initializer_index,
                         shape=None,
+                        data_type=lineage.data_type,
                         transforms=lineage.transforms,
-                        unresolved_reason="invalid_unsqueeze_lineage",
+                        unresolved_reason=lineage.unresolved_reason or "invalid_unsqueeze_lineage",
                     )
                 source_dimensions = iter(lineage.shape)
                 output_shape = tuple(
@@ -1145,8 +1354,9 @@ def _build_onnx_weight_analysis_plan(
                 return _OnnxWeightLineage(
                     initializer_index=lineage.initializer_index,
                     shape=None,
+                    data_type=lineage.data_type,
                     transforms=lineage.transforms,
-                    unresolved_reason="invalid_transpose_lineage",
+                    unresolved_reason=lineage.unresolved_reason or "invalid_transpose_lineage",
                 )
             if permutation == tuple(range(len(lineage.shape))):
                 return lineage
@@ -1169,8 +1379,9 @@ def _build_onnx_weight_analysis_plan(
                 return _OnnxWeightLineage(
                     initializer_index=lineage.initializer_index,
                     shape=None,
+                    data_type=lineage.data_type,
                     transforms=lineage.transforms,
-                    unresolved_reason="unresolved_reshape_lineage",
+                    unresolved_reason=lineage.unresolved_reason or "unresolved_reshape_lineage",
                 )
             output_shape = resolved_shape
             transform = _OnnxWeightTransform("Reshape", output_shape)
@@ -1181,7 +1392,9 @@ def _build_onnx_weight_analysis_plan(
         return _OnnxWeightLineage(
             initializer_index=lineage.initializer_index,
             shape=output_shape,
+            data_type=lineage.data_type,
             transforms=(*lineage.transforms, transform),
+            unresolved_reason=lineage.unresolved_reason,
         )
 
     def bounded_lineages(lineages: dict[int, _OnnxWeightLineage]) -> dict[int, _OnnxWeightLineage]:
@@ -1221,9 +1434,33 @@ def _build_onnx_weight_analysis_plan(
             target[initializer_index] = _OnnxWeightLineage(
                 initializer_index=initializer_index,
                 shape=None,
+                data_type=existing.data_type if existing.data_type == lineage.data_type else None,
                 transforms=existing.transforms,
                 unresolved_reason=unresolved_reason,
             )
+
+    def has_registered_standard_operator(node: Any, opset_versions: dict[str, int]) -> bool:
+        domain = str(getattr(node, "domain", "") or "")
+        schema_domain = "" if domain == "ai.onnx" else domain
+        version = opset_versions.get(domain)
+        if version is None and domain in {"", "ai.onnx"}:
+            version = opset_versions.get("ai.onnx" if domain == "" else "")
+        if version is None:
+            return False
+        key = (schema_domain, str(getattr(node, "op_type", "")), version)
+        if key not in schema_cache:
+            try:
+                schema_cache[key] = bool(onnx.defs.has(key[1], version, schema_domain))
+            except Exception as exc:  # pragma: no cover - fail closed on optional API errors
+                logger.debug(
+                    "Unable to validate ONNX operator schema %s::%s at version %s: %s",
+                    schema_domain,
+                    key[1],
+                    version,
+                    exc,
+                )
+                schema_cache[key] = False
+        return schema_cache[key]
 
     def walk_graph(
         current_graph: Any,
@@ -1233,12 +1470,20 @@ def _build_onnx_weight_analysis_plan(
         *,
         root_graph: bool,
         source_scope: tuple[Any, ...],
+        opset_versions: dict[str, int],
         bound_lineages: dict[str, dict[int, _OnnxWeightLineage]] | None = None,
         bound_constants: dict[str, Any] | None = None,
         bound_dynamic_values: set[str] | None = None,
         bound_attributes: dict[str, Any] | None = None,
         bound_attribute_keys: dict[str, tuple[Any, ...]] | None = None,
         function_depth: int = 0,
+        fail_on_unbound_inputs: bool = False,
+        captured_state: tuple[
+            dict[str, dict[int, _OnnxWeightLineage]],
+            dict[str, Any],
+            set[str],
+        ]
+        | None = None,
     ) -> tuple[list[dict[int, _OnnxWeightLineage]], list[bool]]:
         nonlocal graph_counter, node_counter, total_consumer_count
         current_graph_index = graph_counter
@@ -1260,6 +1505,25 @@ def _build_onnx_weight_analysis_plan(
         dynamic_values.update(bound_dynamic_values or set())
         attribute_bindings = bound_attributes or {}
         attribute_binding_keys = bound_attribute_keys or {}
+        known_value_shapes: dict[str, tuple[int, ...]] = {}
+        for value_info in (
+            *getattr(current_graph, "input", ()),
+            *getattr(current_graph, "value_info", ()),
+            *getattr(current_graph, "output", ()),
+        ):
+            name = _onnx_value_name(value_info)
+            shape = value_info_shape(value_info)
+            if name and shape is not None:
+                known_value_shapes[name] = shape
+        for name, lineages in value_lineages.items():
+            lineage_shapes = {lineage.shape for lineage in lineages.values()}
+            if len(lineage_shapes) == 1 and None not in lineage_shapes:
+                known_value_shapes[name] = next(iter(lineage_shapes))  # type: ignore[arg-type]
+        for name, constant in constants.items():
+            try:
+                known_value_shapes[name] = tuple(int(dimension) for dimension in constant.dims)
+            except (AttributeError, TypeError, ValueError):
+                continue
 
         def resolve_attribute(attribute: Any) -> Any | None:
             reference_name = str(getattr(attribute, "ref_attr_name", ""))
@@ -1289,6 +1553,7 @@ def _build_onnx_weight_analysis_plan(
                 value_lineages[name] = {lineage.initializer_index: lineage}
                 constants[name] = initializer
                 dynamic_values.discard(name)
+                known_value_shapes[name] = lineage.shape or ()
         for sparse_position, sparse_initializer in enumerate(getattr(current_graph, "sparse_initializer", ())):
             if sparse_initializer.values.name:
                 name = str(sparse_initializer.values.name)
@@ -1301,6 +1566,7 @@ def _build_onnx_weight_analysis_plan(
                 )
                 value_lineages[name] = {lineage.initializer_index: lineage}
                 dynamic_values.discard(name)
+                known_value_shapes[name] = lineage.shape or ()
 
         for graph_input in getattr(current_graph, "input", ()):
             name = _onnx_value_name(graph_input)
@@ -1310,6 +1576,16 @@ def _build_onnx_weight_analysis_plan(
         for local_node_index, node in enumerate(getattr(current_graph, "node", ())):
             current_node_index = node_counter
             node_counter += 1
+            function_key = (
+                str(getattr(node, "domain", "")),
+                str(getattr(node, "op_type", "")),
+                str(getattr(node, "overload", "")),
+            )
+            is_model_local_function = function_key in functions
+            is_registered_standard_operator = is_model_local_function or has_registered_standard_operator(
+                node,
+                opset_versions,
+            )
             supported_transform = getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS and node.op_type in {
                 "Cast",
                 "Flatten",
@@ -1323,6 +1599,14 @@ def _build_onnx_weight_analysis_plan(
             terminal_weight_lineages: set[int] = set()
             activation_input_lineages: set[int] = set()
             input_names = [str(input_name) for input_name in node.input if input_name]
+            if fail_on_unbound_inputs:
+                for input_name in input_names:
+                    if (
+                        input_name not in dynamic_values
+                        and input_name not in value_lineages
+                        and input_name not in constants
+                    ):
+                        plan.record_coverage_gap("unresolved_training_graph_input")
             has_dynamic_input = any(
                 input_name in dynamic_values or (input_name not in value_lineages and input_name not in constants)
                 for input_name in input_names
@@ -1358,13 +1642,50 @@ def _build_onnx_weight_analysis_plan(
 
             for input_index, input_name in enumerate(node.input):
                 input_lineages = value_lineages.get(str(input_name), {})
-                merge_lineages(
-                    all_input_lineages,
-                    input_lineages,
-                    ambiguous_reason="ambiguous_operator_input_lineage",
+                is_array_feature_selector = (
+                    is_registered_standard_operator
+                    and getattr(node, "domain", "") == "ai.onnx.ml"
+                    and node.op_type == "ArrayFeatureExtractor"
+                    and input_index == 1
                 )
-                potential_weight_input = _onnx_potential_weight_input(node, input_index)
+                is_non_data_standard_input = (
+                    is_registered_standard_operator
+                    and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
+                    and ((node.op_type == "Clip" and input_index > 0) or (node.op_type == "Where" and input_index == 0))
+                )
+                if not is_array_feature_selector and not is_non_data_standard_input:
+                    merge_lineages(
+                        all_input_lineages,
+                        input_lineages,
+                        ambiguous_reason="ambiguous_operator_input_lineage",
+                    )
                 for initializer_index, lineage in input_lineages.items():
+                    invalid_clip_bound = (
+                        is_registered_standard_operator
+                        and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
+                        and node.op_type == "Clip"
+                        and input_index > 0
+                        and lineage.shape != ()
+                    )
+                    if invalid_clip_bound:
+                        record_unresolved_lineage(
+                            _OnnxWeightLineage(
+                                initializer_index=initializer_index,
+                                shape=lineage.shape,
+                                data_type=lineage.data_type,
+                                transforms=lineage.transforms,
+                                unresolved_reason="invalid_clip_bound_shape",
+                            ),
+                            node,
+                            current_node_index,
+                            input_index,
+                        )
+                    potential_weight_input = _onnx_potential_weight_input(
+                        node,
+                        input_index,
+                        is_model_local_function=is_model_local_function,
+                        is_registered_standard_operator=is_registered_standard_operator,
+                    ) and lineage_could_be_weight(lineage)
                     if supported_transform and input_index == 0:
                         continue
                     if potential_weight_input:
@@ -1376,10 +1697,15 @@ def _build_onnx_weight_analysis_plan(
                             resolved_index != input_index for resolved_index in resolved_weight_input_indexes
                         )
                         prior_layer_activation = lineage.unresolved_reason == "dynamic_activation_lineage"
-                        recognized_activation_input = (
-                            prior_layer_activation
-                            and _onnx_activation_input_candidate(node, input_index)
-                            and (opposite_resolved_weight or all_lineage_inputs_are_activation_contraction)
+                        recognized_activation_input = prior_layer_activation and (
+                            (
+                                is_registered_standard_operator
+                                and _onnx_opaque_activation_input_candidate(node, input_index)
+                            )
+                            or (
+                                _onnx_activation_input_candidate(node, input_index)
+                                and (opposite_resolved_weight or all_lineage_inputs_are_activation_contraction)
+                            )
                         )
                         if recognized_activation_input:
                             if opposite_resolved_weight:
@@ -1396,6 +1722,7 @@ def _build_onnx_weight_analysis_plan(
                                 _OnnxWeightLineage(
                                     initializer_index=initializer_index,
                                     shape=None,
+                                    data_type=lineage.data_type,
                                     transforms=lineage.transforms,
                                     unresolved_reason="referenced_function_attribute",
                                 ),
@@ -1418,6 +1745,7 @@ def _build_onnx_weight_analysis_plan(
                                 _OnnxWeightLineage(
                                     initializer_index=initializer_index,
                                     shape=None,
+                                    data_type=lineage.data_type,
                                     transforms=lineage.transforms,
                                     unresolved_reason="unsupported_weight_consumer",
                                 ),
@@ -1439,6 +1767,22 @@ def _build_onnx_weight_analysis_plan(
                                 input_index,
                                 (gather_axis,),
                             )
+                    elif node.op_type == "PRelu":
+                        slope_shape = lineage.shape or ()
+                        slope_axes = {axis for axis, dimension in enumerate(slope_shape) if dimension != 1}
+                        singleton_axes = [axis for axis, dimension in enumerate(slope_shape) if dimension == 1]
+                        if singleton_axes:
+                            primary_axis = output_axes[0]
+                            slope_axes.add(primary_axis if slope_shape[primary_axis] == 1 else singleton_axes[0])
+                        for slope_axis in sorted(slope_axes):
+                            if (slope_axis,) != output_axes:
+                                add_consumer_group(
+                                    lineage,
+                                    node,
+                                    current_node_index,
+                                    input_index,
+                                    (slope_axis,),
+                                )
 
             subgraph_results: list[tuple[list[dict[int, _OnnxWeightLineage]], list[bool]]] = []
             for attribute_position, attribute in enumerate(getattr(node, "attribute", ())):
@@ -1475,20 +1819,17 @@ def _build_onnx_weight_analysis_plan(
                             dynamic_values,
                             root_graph=False,
                             source_scope=(*resolved_attribute_key, "graph", subgraph_position),
+                            opset_versions=opset_versions,
                             bound_lineages=subgraph_bound_lineages,
                             bound_constants=subgraph_bound_constants,
                             bound_dynamic_values=subgraph_bound_dynamic,
                             bound_attributes=attribute_bindings,
                             bound_attribute_keys=attribute_binding_keys,
                             function_depth=function_depth,
+                            fail_on_unbound_inputs=fail_on_unbound_inputs,
                         ),
                     )
 
-            function_key = (
-                str(getattr(node, "domain", "")),
-                str(getattr(node, "op_type", "")),
-                str(getattr(node, "overload", "")),
-            )
             function = functions.get(function_key)
             if function is not None and function_depth >= _ONNX_WEIGHT_TRANSFORM_DEPTH_LIMIT:
                 plan.record_coverage_gap("function_call_depth_limit")
@@ -1498,6 +1839,7 @@ def _build_onnx_weight_analysis_plan(
                             _OnnxWeightLineage(
                                 initializer_index=initializer_index,
                                 shape=None,
+                                data_type=lineage.data_type,
                                 transforms=lineage.transforms,
                                 unresolved_reason="function_call_depth_limit",
                             ),
@@ -1548,12 +1890,18 @@ def _build_onnx_weight_analysis_plan(
                         dynamic_values,
                         root_graph=False,
                         source_scope=function_source_scope,
+                        opset_versions={
+                            str(getattr(opset, "domain", "") or ""): int(opset.version)
+                            for opset in getattr(function, "opset_import", ())
+                        }
+                        or opset_versions,
                         bound_lineages=function_bound_lineages,
                         bound_constants=function_bound_constants,
                         bound_dynamic_values=function_bound_dynamic,
                         bound_attributes=function_bound_attributes,
                         bound_attribute_keys=function_bound_attribute_keys,
                         function_depth=function_depth + 1,
+                        fail_on_unbound_inputs=fail_on_unbound_inputs,
                     ),
                 )
 
@@ -1569,7 +1917,52 @@ def _build_onnx_weight_analysis_plan(
                 and function is None
                 and not subgraph_results
             ):
+                same_type_elementwise = (
+                    is_registered_standard_operator
+                    and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
+                    and node.op_type in _SAME_TYPE_ELEMENTWISE_OPERATORS
+                )
+                same_type_unary_elementwise = (
+                    is_registered_standard_operator
+                    and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
+                    and node.op_type in _SAME_TYPE_UNARY_ELEMENTWISE_OPERATORS
+                    and len(input_names) == 1
+                )
+                clip_operator = (
+                    is_registered_standard_operator
+                    and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
+                    and node.op_type == "Clip"
+                )
+                pow_operator = (
+                    is_registered_standard_operator
+                    and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
+                    and node.op_type == "Pow"
+                )
+                prelu_data_is_activation = (
+                    is_registered_standard_operator
+                    and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
+                    and node.op_type == "PRelu"
+                    and bool(input_names)
+                    and (
+                        input_names[0] in dynamic_values
+                        or (
+                            bool(value_lineages.get(input_names[0]))
+                            and all(
+                                lineage.unresolved_reason == "dynamic_activation_lineage"
+                                for lineage in value_lineages[input_names[0]].values()
+                            )
+                        )
+                    )
+                )
+                elementwise_output_shape = (
+                    broadcast_shapes(known_value_shapes.get(input_name) for input_name in input_names)
+                    if same_type_elementwise or same_type_unary_elementwise or pow_operator
+                    else known_value_shapes.get(input_names[0])
+                    if clip_operator and input_names
+                    else None
+                )
                 carries_dynamic_activation = bool(terminal_weight_lineages) and has_dynamic_input
+                carries_dynamic_activation |= prelu_data_is_activation
                 carries_dynamic_activation |= any(
                     lineage.unresolved_reason == "dynamic_activation_lineage" for lineage in all_input_lineages.values()
                 )
@@ -1586,7 +1979,12 @@ def _build_onnx_weight_analysis_plan(
                             )
                     output_lineages[initializer_index] = _OnnxWeightLineage(
                         initializer_index=initializer_index,
-                        shape=None,
+                        shape=elementwise_output_shape,
+                        data_type=(
+                            lineage.data_type
+                            if same_type_elementwise or same_type_unary_elementwise or clip_operator
+                            else None
+                        ),
                         transforms=lineage.transforms,
                         unresolved_reason=unresolved_reason,
                     )
@@ -1724,6 +2122,7 @@ def _build_onnx_weight_analysis_plan(
                         initializer_index: _OnnxWeightLineage(
                             initializer_index=initializer_index,
                             shape=None,
+                            data_type=None,
                             transforms=lineage.transforms,
                             unresolved_reason=lineage.unresolved_reason or "dynamic_subgraph_output_lineage",
                         )
@@ -1732,8 +2131,14 @@ def _build_onnx_weight_analysis_plan(
                 per_output_lineages = bounded_lineages(per_output_lineages)
                 if per_output_lineages:
                     value_lineages[name] = per_output_lineages
+                    lineage_shapes = {lineage.shape for lineage in per_output_lineages.values()}
+                    if len(lineage_shapes) == 1 and None not in lineage_shapes:
+                        known_value_shapes[name] = next(iter(lineage_shapes))  # type: ignore[arg-type]
                 else:
                     value_lineages.pop(name, None)
+                    if name in constants:
+                        with suppress(AttributeError, TypeError, ValueError):
+                            known_value_shapes[name] = tuple(int(dimension) for dimension in constants[name].dims)
 
                 mapped_subgraph_output = bool(subgraph_results) and output_index < len(subgraph_output_dynamic)
                 output_is_dynamic = (
@@ -1746,12 +2151,170 @@ def _build_onnx_weight_analysis_plan(
                 else:
                     dynamic_values.discard(name)
 
+        if captured_state is not None:
+            captured_state[0].clear()
+            captured_state[0].update(value_lineages)
+            captured_state[1].clear()
+            captured_state[1].update(constants)
+            captured_state[2].clear()
+            captured_state[2].update(dynamic_values)
+
         return (
             [dict(value_lineages.get(_onnx_value_name(graph_output), {})) for graph_output in current_graph.output],
             [_onnx_value_name(graph_output) in dynamic_values for graph_output in current_graph.output],
         )
 
-    walk_graph(graph, {}, {}, set(), root_graph=True, source_scope=("root_graph",))
+    root_state_lineages: dict[str, dict[int, _OnnxWeightLineage]] = {}
+    root_state_constants: dict[str, Any] = {}
+    root_state_dynamic: set[str] = set()
+    root_output_lineages, _root_output_dynamic = walk_graph(
+        graph,
+        {},
+        {},
+        set(),
+        root_graph=True,
+        source_scope=("root_graph",),
+        opset_versions=model_opset_versions,
+        captured_state=(root_state_lineages, root_state_constants, root_state_dynamic),
+    )
+
+    main_initializer_lineages: dict[str, dict[int, _OnnxWeightLineage]] = {}
+    for initializer_position, initializer in enumerate(getattr(graph, "initializer", ())):
+        source_key = ("root_graph", "initializer", initializer_position)
+        initializer_index = initializer_source_indexes.get(source_key)
+        if initializer_index is None or not initializer.name:
+            continue
+        name = str(initializer.name)
+        main_initializer_lineages[name] = {
+            initializer_index: _OnnxWeightLineage(
+                initializer_index=initializer_index,
+                shape=tuple(int(dimension) for dimension in initializer.dims),
+                data_type=int(initializer.data_type),
+            )
+        }
+    for sparse_position, sparse_initializer in enumerate(getattr(graph, "sparse_initializer", ())):
+        source_key = ("root_graph", "sparse_initializer", sparse_position)
+        initializer_index = initializer_source_indexes.get(source_key)
+        if initializer_index is None or not sparse_initializer.values.name:
+            continue
+        name = str(sparse_initializer.values.name)
+        main_initializer_lineages[name] = {
+            initializer_index: _OnnxWeightLineage(
+                initializer_index=initializer_index,
+                shape=tuple(int(dimension) for dimension in sparse_initializer.dims),
+                data_type=int(sparse_initializer.values.data_type),
+                unresolved_reason="sparse_initializer_unsupported",
+            )
+        }
+
+    root_output_lineages_by_name = {
+        _onnx_value_name(graph_output): lineages
+        for graph_output, lineages in zip(graph.output, root_output_lineages, strict=False)
+    }
+    training_graph_results: dict[
+        tuple[Any, ...],
+        tuple[Any, list[dict[int, _OnnxWeightLineage]], list[bool]],
+    ] = {}
+    algorithm_initializer_lineages: dict[int, dict[str, dict[int, _OnnxWeightLineage]]] = {}
+    for source_scope, training_graph in analysis_graph_roots[1:]:
+        is_algorithm = source_scope[2] == "algorithm"
+        output_lineages, output_dynamic = walk_graph(
+            training_graph,
+            root_state_lineages if is_algorithm else {},
+            root_state_constants if is_algorithm else {},
+            root_state_dynamic if is_algorithm else set(),
+            root_graph=True,
+            source_scope=source_scope,
+            opset_versions=model_opset_versions,
+            fail_on_unbound_inputs=True,
+        )
+        training_graph_results[source_scope] = (training_graph, output_lineages, output_dynamic)
+        if not is_algorithm:
+            continue
+        training_index = int(source_scope[1])
+        local_initializers: dict[str, dict[int, _OnnxWeightLineage]] = {}
+        for initializer_position, initializer in enumerate(getattr(training_graph, "initializer", ())):
+            source_key = (*source_scope, "initializer", initializer_position)
+            initializer_index = initializer_source_indexes.get(source_key)
+            if initializer_index is None or not initializer.name:
+                continue
+            lineage = _OnnxWeightLineage(
+                initializer_index=initializer_index,
+                shape=tuple(int(dimension) for dimension in initializer.dims),
+                data_type=int(initializer.data_type),
+            )
+            local_initializers[str(initializer.name)] = {initializer_index: lineage}
+        for sparse_position, sparse_initializer in enumerate(getattr(training_graph, "sparse_initializer", ())):
+            source_key = (*source_scope, "sparse_initializer", sparse_position)
+            initializer_index = initializer_source_indexes.get(source_key)
+            if initializer_index is None or not sparse_initializer.values.name:
+                continue
+            lineage = _OnnxWeightLineage(
+                initializer_index=initializer_index,
+                shape=tuple(int(dimension) for dimension in sparse_initializer.dims),
+                data_type=int(sparse_initializer.values.data_type),
+                unresolved_reason="sparse_initializer_unsupported",
+            )
+            local_initializers[str(sparse_initializer.values.name)] = {initializer_index: lineage}
+        algorithm_initializer_lineages[training_index] = local_initializers
+
+    for training_index, training_info in enumerate(training_infos):
+        for binding_kind, graph_field, bindings in (
+            ("initialization", "initialization", training_info.initialization_binding),
+            ("update", "algorithm", training_info.update_binding),
+        ):
+            source_scope = ("training_info", training_index, graph_field)
+            graph_result = training_graph_results.get(source_scope)
+            output_lineages_by_name: dict[str, dict[int, _OnnxWeightLineage]] = {}
+            if graph_result is not None:
+                training_graph, output_lineages, _output_dynamic = graph_result
+                output_lineages_by_name = {
+                    _onnx_value_name(graph_output): lineages
+                    for graph_output, lineages in zip(training_graph.output, output_lineages, strict=False)
+                }
+            target_lineages_by_name = dict(main_initializer_lineages)
+            target_lineages_by_name.update(algorithm_initializer_lineages.get(training_index, {}))
+            for binding in bindings:
+                state_name = str(binding.key)
+                source_name = str(binding.value)
+                source_lineages = output_lineages_by_name.get(source_name, {})
+                if binding_kind == "update" and not source_lineages:
+                    source_lineages = root_output_lineages_by_name.get(source_name, {})
+                target_lineages = target_lineages_by_name.get(state_name, {})
+                if not target_lineages:
+                    plan.record_coverage_gap("unresolved_training_binding")
+                target_has_weight_role = any(
+                    lineage_could_be_weight(lineage)
+                    or initializer_index in eligible_initializer_indexes
+                    or bool(groups[initializer_index])
+                    for initializer_index, lineage in target_lineages.items()
+                )
+                consumed_lineages = dict(target_lineages)
+                consumed_lineages.update(source_lineages)
+                for initializer_index, _lineage in consumed_lineages.items():
+                    terminal_consumer_counts[initializer_index] += 1
+                    total_consumer_count += 1
+                gap_lineages = (
+                    source_lineages
+                    if target_has_weight_role and source_lineages
+                    else {
+                        initializer_index: lineage
+                        for initializer_index, lineage in source_lineages.items()
+                        if lineage_could_be_weight(lineage)
+                    }
+                )
+                if target_has_weight_role and not source_lineages:
+                    gap_lineages = target_lineages
+                if gap_lineages:
+                    for lineage in gap_lineages.values():
+                        record_training_binding_gap(
+                            lineage,
+                            binding_kind=binding_kind,
+                            state_name=state_name,
+                        )
+                else:
+                    for initializer_index in consumed_lineages:
+                        record_exclusion(initializer_index, "non_weight_training_binding")
 
     for initializer_index, _initializer in enumerate(initializers):
         if terminal_consumer_counts[initializer_index] == 0 and not groups[initializer_index]:

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -3,6 +3,7 @@
 import logging
 import math
 import ntpath
+import numbers
 import os
 import re
 from collections.abc import Callable, Iterable
@@ -92,6 +93,7 @@ _ONNX_WEIGHT_TRANSFORM_DEPTH_LIMIT = 32
 _ONNX_WEIGHT_RESHAPE_RANK_LIMIT = 64
 _ONNX_WEIGHT_METADATA_TEXT_LIMIT = 256
 _ONNX_WEIGHT_METADATA_SEQUENCE_LIMIT = 64
+_ONNX_WEIGHT_DEFAULT_MAX_ARRAY_SIZE = 100 * 1024 * 1024
 _STANDARD_NEURAL_NETWORK_DOMAINS: frozenset[str] = frozenset({"", "ai.onnx"})
 _SAME_TYPE_ELEMENTWISE_OPERATORS: frozenset[str] = frozenset(
     {
@@ -744,6 +746,26 @@ def _onnx_inline_storage_nbytes(initializer: Any) -> int:
     return raw_bytes + typed_bytes
 
 
+def _onnx_tensor_uses_external_storage(initializer: Any, *, onnx: Any) -> bool:
+    if getattr(initializer, "data_location", None) == onnx.TensorProto.EXTERNAL:
+        return True
+    return bool(getattr(initializer, "external_data", ())) and _onnx_inline_storage_nbytes(initializer) == 0
+
+
+def _configured_onnx_weight_array_limit(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        return _ONNX_WEIGHT_DEFAULT_MAX_ARRAY_SIZE
+    try:
+        numeric_value = float(value)
+    except (OverflowError, TypeError, ValueError):
+        return _ONNX_WEIGHT_DEFAULT_MAX_ARRAY_SIZE
+    if not math.isfinite(numeric_value) or numeric_value < 0:
+        return _ONNX_WEIGHT_DEFAULT_MAX_ARRAY_SIZE
+    if numeric_value == 0:
+        return None
+    return max(int(numeric_value), 1)
+
+
 def _resolve_onnx_reshape_shape(
     input_shape: tuple[int, ...],
     shape_initializer: Any,
@@ -759,8 +781,7 @@ def _resolve_onnx_reshape_shape(
         or element_count > _ONNX_WEIGHT_RESHAPE_RANK_LIMIT
         or int(getattr(shape_initializer, "data_type", -1)) != int(onnx.TensorProto.INT64)
         or _onnx_inline_storage_nbytes(shape_initializer) > _ONNX_WEIGHT_RESHAPE_RANK_LIMIT * 8
-        or getattr(shape_initializer, "data_location", None) == getattr(onnx.TensorProto, "EXTERNAL", 1)
-        or bool(getattr(shape_initializer, "external_data", ()))
+        or _onnx_tensor_uses_external_storage(shape_initializer, onnx=onnx)
     ):
         return None
 
@@ -812,8 +833,7 @@ def _resolve_onnx_axes(node: Any, constants: dict[str, Any], *, onnx: Any) -> tu
         or element_count > _ONNX_WEIGHT_RESHAPE_RANK_LIMIT
         or int(getattr(axes_initializer, "data_type", -1)) != int(onnx.TensorProto.INT64)
         or _onnx_inline_storage_nbytes(axes_initializer) > _ONNX_WEIGHT_RESHAPE_RANK_LIMIT * 8
-        or getattr(axes_initializer, "data_location", None) == getattr(onnx.TensorProto, "EXTERNAL", 1)
-        or bool(getattr(axes_initializer, "external_data", ()))
+        or _onnx_tensor_uses_external_storage(axes_initializer, onnx=onnx)
     ):
         return None
     try:
@@ -2331,7 +2351,7 @@ def _build_onnx_weight_analysis_plan(
         initializer_groups = groups[initializer_index]
         if not initializer_groups:
             continue
-        if initializer.data_location == onnx.TensorProto.EXTERNAL or bool(initializer.external_data):
+        if _onnx_tensor_uses_external_storage(initializer, onnx=onnx):
             plan.external_initializers_skipped += 1
             continue
 
@@ -3243,15 +3263,8 @@ class OnnxScanner(BaseScanner):
             )
             return
 
-        configured_max_array_size = self.config.get("max_array_size", 100 * 1024 * 1024)
-        max_array_size = (
-            int(configured_max_array_size)
-            if isinstance(configured_max_array_size, (int, float))
-            and not isinstance(configured_max_array_size, bool)
-            and math.isfinite(float(configured_max_array_size))
-            and configured_max_array_size > 0
-            else None
-        )
+        configured_max_array_size = self.config.get("max_array_size", _ONNX_WEIGHT_DEFAULT_MAX_ARRAY_SIZE)
+        max_array_size = _configured_onnx_weight_array_limit(configured_max_array_size)
 
         def inline_storage_fits_budget(initializer: Any, _name: str, _estimated_bytes: int) -> bool:
             return max_array_size is None or _onnx_inline_storage_nbytes(initializer) <= max_array_size

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -5,7 +5,7 @@ import math
 import ntpath
 import os
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar
@@ -91,6 +91,17 @@ _ONNX_WEIGHT_RESHAPE_RANK_LIMIT = 64
 _ONNX_WEIGHT_METADATA_TEXT_LIMIT = 256
 _ONNX_WEIGHT_METADATA_SEQUENCE_LIMIT = 64
 _STANDARD_NEURAL_NETWORK_DOMAINS: frozenset[str] = frozenset({"", "ai.onnx"})
+_QUANTIZED_WEIGHT_OPERATORS: frozenset[str] = frozenset(
+    {
+        "ConvInteger",
+        "DequantizeLinear",
+        "DynamicQuantizeLinear",
+        "MatMulInteger",
+        "QLinearConv",
+        "QLinearMatMul",
+        "QuantizeLinear",
+    },
+)
 
 
 def _check_onnx() -> bool:
@@ -133,6 +144,18 @@ def _onnx_int_attribute(node: Any, name: str, default: int = 0) -> int:
     return default
 
 
+def _onnx_text_attribute(node: Any, name: str) -> str | None:
+    """Read a UTF-8 ONNX string attribute without importing ONNX eagerly."""
+    for attribute in getattr(node, "attribute", []):
+        if attribute.name != name:
+            continue
+        try:
+            return bytes(attribute.s).decode("utf-8")
+        except (AttributeError, UnicodeDecodeError):
+            return None
+    return None
+
+
 def _onnx_weight_output_axes(node: Any, input_index: int, rank: int) -> tuple[tuple[int, ...] | None, str]:
     """Classify an initializer consumer for statistical weight analysis."""
     op_type = node.op_type
@@ -173,11 +196,53 @@ def _onnx_weight_output_axes(node: Any, input_index: int, rank: int) -> tuple[tu
             return None, "unsupported_weight_rank"
         return (1,), "eligible_conv_transpose_weight"
 
-    if op_type == "Gather" and input_index == 0:
-        return None, "embedding_table"
-    if op_type in {"ConvInteger", "MatMulInteger", "QLinearConv", "QLinearMatMul"}:
+    if op_type == "Einsum":
+        equation = _onnx_text_attribute(node, "equation")
+        if equation is None or "..." in equation or equation.count("->") != 1:
+            return None, "unsupported_einsum_equation"
+        input_expression, output_expression = (part.strip() for part in equation.split("->", 1))
+        input_terms = [term.strip() for term in input_expression.split(",")]
+        if input_index >= len(input_terms):
+            return None, "unsupported_einsum_equation"
+        weight_term = input_terms[input_index]
+        if (
+            len(input_terms) != len(getattr(node, "input", ()))
+            or len(weight_term) != rank
+            or len(set(weight_term)) != len(weight_term)
+            or len(set(output_expression)) != len(output_expression)
+        ):
+            return None, "unsupported_einsum_equation"
+        output_axes = tuple(index for index, label in enumerate(weight_term) if label in output_expression)
+        if not output_axes or len(output_axes) == rank:
+            return None, "unsupported_einsum_orientation"
+        return output_axes, "eligible_einsum_weight"
+
+    if op_type == "Gather":
+        if input_index != 0:
+            return None, "non_weight_input"
+        if rank < 2:
+            return None, "unsupported_weight_rank"
+        axis = _onnx_int_attribute(node, "axis")
+        axis = axis if axis >= 0 else rank + axis
+        if axis < 0 or axis >= rank:
+            return None, "unsupported_weight_axis"
+        return (axis,), "eligible_gather_table"
+    if op_type in _QUANTIZED_WEIGHT_OPERATORS:
         return None, "quantized_operator"
-    if op_type in {"Add", "Mul", "Sub", "Div", "Reshape", "Shape", "Slice", "Transpose"}:
+    if op_type in {
+        "Add",
+        "Cast",
+        "Div",
+        "Flatten",
+        "Mul",
+        "Reshape",
+        "Shape",
+        "Slice",
+        "Squeeze",
+        "Sub",
+        "Transpose",
+        "Unsqueeze",
+    }:
         return None, "bookkeeping_constant"
     return None, "unsupported_consumer"
 
@@ -201,9 +266,13 @@ def _iter_graph_nodes(graph: Any) -> Any:
                 yield from _iter_graph_nodes(subgraph)
 
 
+def _onnx_value_name(value: Any) -> str:
+    return str(getattr(value, "name", value))
+
+
 def _graph_declared_value_names(graph: Any) -> set[str]:
     """Return names that shadow values captured from an enclosing ONNX graph."""
-    declared = {value.name for value in getattr(graph, "input", []) if value.name}
+    declared = {_onnx_value_name(value) for value in getattr(graph, "input", []) if _onnx_value_name(value)}
     declared.update(initializer.name for initializer in getattr(graph, "initializer", []) if initializer.name)
     for sparse_initializer in getattr(graph, "sparse_initializer", []):
         if sparse_initializer.values.name:
@@ -543,6 +612,35 @@ def _resolve_onnx_reshape_shape(
     return tuple(normalized)
 
 
+def _resolve_onnx_axes(node: Any, constants: dict[str, Any], *, onnx: Any) -> tuple[int, ...] | None:
+    for attribute in getattr(node, "attribute", ()):
+        if attribute.name == "axes":
+            return tuple(int(value) for value in attribute.ints)
+    if len(getattr(node, "input", ())) < 2:
+        return ()
+
+    axes_initializer = constants.get(str(node.input[1]))
+    if axes_initializer is None:
+        return None
+    dims = tuple(int(dimension) for dimension in getattr(axes_initializer, "dims", ()))
+    element_count = math.prod(dims) if dims else 0
+    if (
+        len(dims) != 1
+        or element_count < 0
+        or element_count > _ONNX_WEIGHT_RESHAPE_RANK_LIMIT
+        or int(getattr(axes_initializer, "data_type", -1)) != int(onnx.TensorProto.INT64)
+        or _onnx_inline_storage_nbytes(axes_initializer) > _ONNX_WEIGHT_RESHAPE_RANK_LIMIT * 8
+        or getattr(axes_initializer, "data_location", None) == getattr(onnx.TensorProto, "EXTERNAL", 1)
+        or bool(getattr(axes_initializer, "external_data", ()))
+    ):
+        return None
+    try:
+        axes = tuple(int(value) for value in onnx.numpy_helper.to_array(axes_initializer).reshape(-1).tolist())
+    except Exception:
+        return None
+    return axes if len(axes) == element_count else None
+
+
 def _onnx_initializer_name_issues(
     graph: Any,
     plan: _OnnxWeightAnalysisPlan,
@@ -597,7 +695,9 @@ def _onnx_potential_weight_input(node: Any, input_index: int) -> bool:
         return input_index in {0, 1}
     if node.op_type in {"Conv", "ConvTranspose"}:
         return input_index == 1
-    return False
+    if node.op_type == "Gather":
+        return input_index == 0
+    return node.op_type == "Einsum"
 
 
 def _build_onnx_weight_analysis_plan(
@@ -612,7 +712,16 @@ def _build_onnx_weight_analysis_plan(
     """Build a bounded, semantically oriented plan for ONNX weight analysis."""
     plan = _OnnxWeightAnalysisPlan()
     graph = model.graph
-    initializers = list(getattr(graph, "initializer", ()))
+    functions = {
+        (
+            str(getattr(function, "domain", "")),
+            str(getattr(function, "name", "")),
+            str(getattr(function, "overload", "")),
+        ): function
+        for function in getattr(model, "functions", ())
+    }
+    initializers: list[Any] = []
+    initializer_graph_indexes: list[int] = []
     empty_names, duplicate_names, invalid_name_samples = _onnx_initializer_name_issues(graph, plan)
     invalid_name_count = empty_names + duplicate_names
     if invalid_name_count:
@@ -642,7 +751,6 @@ def _build_onnx_weight_analysis_plan(
         }
         return plan
 
-    initializer_indexes = {str(initializer.name): index for index, initializer in enumerate(initializers)}
     floating_types = {
         int(getattr(onnx.TensorProto, name))
         for name in (
@@ -658,13 +766,33 @@ def _build_onnx_weight_analysis_plan(
         )
         if hasattr(onnx.TensorProto, name)
     }
-    groups: list[dict[tuple[Any, ...], _OnnxWeightConsumerGroup]] = [{} for _ in initializers]
+    groups: list[dict[tuple[Any, ...], _OnnxWeightConsumerGroup]] = []
     eligible_initializer_indexes: set[int] = set()
-    terminal_consumer_counts = [0] * len(initializers)
-    transform_counts = [0] * len(initializers)
+    terminal_consumer_counts: list[int] = []
+    transform_counts: list[int] = []
     total_consumer_count = 0
     consumer_sample_count = 0
     node_counter = 0
+    graph_counter = 0
+
+    def register_initializer(
+        initializer: Any,
+        graph_index: int,
+        *,
+        shape: tuple[int, ...] | None = None,
+        unresolved_reason: str | None = None,
+    ) -> _OnnxWeightLineage:
+        initializer_index = len(initializers)
+        initializers.append(initializer)
+        initializer_graph_indexes.append(graph_index)
+        groups.append({})
+        terminal_consumer_counts.append(0)
+        transform_counts.append(0)
+        return _OnnxWeightLineage(
+            initializer_index=initializer_index,
+            shape=shape if shape is not None else tuple(int(dimension) for dimension in initializer.dims),
+            unresolved_reason=unresolved_reason,
+        )
 
     def record_exclusion(
         initializer_index: int,
@@ -678,6 +806,7 @@ def _build_onnx_weight_analysis_plan(
         initializer = initializers[initializer_index]
         sample: dict[str, Any] = {
             **_bounded_onnx_metadata_fields(plan, "initializer", initializer.name),
+            "initializer_graph_index": initializer_graph_indexes[initializer_index],
             "reason": reason,
             **_bounded_onnx_integer_sequence("stored_shape", initializer.dims),
         }
@@ -709,6 +838,7 @@ def _build_onnx_weight_analysis_plan(
         plan.unresolved_lineage_samples.append(
             {
                 **_bounded_onnx_metadata_fields(plan, "initializer", initializer.name),
+                "initializer_graph_index": initializer_graph_indexes[lineage.initializer_index],
                 **_bounded_onnx_metadata_fields(plan, "consumer_op", node.op_type),
                 **_bounded_onnx_metadata_fields(plan, "consumer_node", node.name),
                 "consumer_node_index": node_index,
@@ -772,6 +902,25 @@ def _build_onnx_weight_analysis_plan(
     ) -> _OnnxWeightLineage:
         if lineage.unresolved_reason is not None:
             return lineage
+        if any(getattr(attribute, "ref_attr_name", "") for attribute in getattr(node, "attribute", ())):
+            return _OnnxWeightLineage(
+                initializer_index=lineage.initializer_index,
+                shape=None,
+                transforms=lineage.transforms,
+                unresolved_reason="referenced_function_attribute",
+            )
+        if node.op_type == "Identity":
+            return lineage
+        if node.op_type == "Cast":
+            initializer = initializers[lineage.initializer_index]
+            if _onnx_int_attribute(node, "to", -1) == int(initializer.data_type):
+                return lineage
+            return _OnnxWeightLineage(
+                initializer_index=lineage.initializer_index,
+                shape=None,
+                transforms=lineage.transforms,
+                unresolved_reason="dtype_changing_cast_lineage",
+            )
         if len(lineage.transforms) >= _ONNX_WEIGHT_TRANSFORM_DEPTH_LIMIT:
             return _OnnxWeightLineage(
                 initializer_index=lineage.initializer_index,
@@ -787,9 +936,66 @@ def _build_onnx_weight_analysis_plan(
                 unresolved_reason="lineage_shape_unavailable",
             )
 
-        if node.op_type == "Identity":
-            transform = _OnnxWeightTransform("Identity")
-            output_shape = lineage.shape
+        output_shape: tuple[int, ...]
+        transform: _OnnxWeightTransform
+        if node.op_type == "Flatten":
+            axis = _onnx_int_attribute(node, "axis", 1)
+            axis = axis if axis >= 0 else len(lineage.shape) + axis
+            if axis < 0 or axis > len(lineage.shape):
+                return _OnnxWeightLineage(
+                    initializer_index=lineage.initializer_index,
+                    shape=None,
+                    transforms=lineage.transforms,
+                    unresolved_reason="invalid_flatten_lineage",
+                )
+            output_shape = (math.prod(lineage.shape[:axis]), math.prod(lineage.shape[axis:]))
+            transform = _OnnxWeightTransform("Reshape", output_shape)
+        elif node.op_type in {"Squeeze", "Unsqueeze"}:
+            axes = _resolve_onnx_axes(node, constants, onnx=onnx)
+            if axes is None:
+                return _OnnxWeightLineage(
+                    initializer_index=lineage.initializer_index,
+                    shape=None,
+                    transforms=lineage.transforms,
+                    unresolved_reason=f"unresolved_{node.op_type.lower()}_lineage",
+                )
+            if node.op_type == "Squeeze":
+                normalized_axes = tuple(axis if axis >= 0 else len(lineage.shape) + axis for axis in axes)
+                if not normalized_axes:
+                    normalized_axes = tuple(index for index, dimension in enumerate(lineage.shape) if dimension == 1)
+                if (
+                    len(set(normalized_axes)) != len(normalized_axes)
+                    or any(axis < 0 or axis >= len(lineage.shape) for axis in normalized_axes)
+                    or any(lineage.shape[axis] != 1 for axis in normalized_axes)
+                ):
+                    return _OnnxWeightLineage(
+                        initializer_index=lineage.initializer_index,
+                        shape=None,
+                        transforms=lineage.transforms,
+                        unresolved_reason="invalid_squeeze_lineage",
+                    )
+                output_shape = tuple(
+                    dimension for index, dimension in enumerate(lineage.shape) if index not in normalized_axes
+                )
+            else:
+                output_rank = len(lineage.shape) + len(axes)
+                normalized_axes = tuple(axis if axis >= 0 else output_rank + axis for axis in axes)
+                if (
+                    not normalized_axes
+                    or len(set(normalized_axes)) != len(normalized_axes)
+                    or any(axis < 0 or axis >= output_rank for axis in normalized_axes)
+                ):
+                    return _OnnxWeightLineage(
+                        initializer_index=lineage.initializer_index,
+                        shape=None,
+                        transforms=lineage.transforms,
+                        unresolved_reason="invalid_unsqueeze_lineage",
+                    )
+                source_dimensions = iter(lineage.shape)
+                output_shape = tuple(
+                    1 if index in normalized_axes else next(source_dimensions) for index in range(output_rank)
+                )
+            transform = _OnnxWeightTransform("Reshape", output_shape)
         elif node.op_type == "Transpose":
             permutation = tuple(
                 int(value)
@@ -805,9 +1011,11 @@ def _build_onnx_weight_analysis_plan(
                     transforms=lineage.transforms,
                     unresolved_reason="invalid_transpose_lineage",
                 )
+            if permutation == tuple(range(len(lineage.shape))):
+                return lineage
             transform = _OnnxWeightTransform("Transpose", permutation)
             output_shape = tuple(lineage.shape[index] for index in permutation)
-        else:
+        else:  # Reshape
             shape_name = str(node.input[1]) if len(node.input) > 1 else ""
             shape_initializer = constants.get(shape_name)
             resolved_shape = (
@@ -830,6 +1038,9 @@ def _build_onnx_weight_analysis_plan(
             output_shape = resolved_shape
             transform = _OnnxWeightTransform("Reshape", output_shape)
 
+        if output_shape == lineage.shape:
+            return lineage
+
         return _OnnxWeightLineage(
             initializer_index=lineage.initializer_index,
             shape=output_shape,
@@ -845,38 +1056,108 @@ def _build_onnx_weight_analysis_plan(
         )
         return dict(sorted(lineages.items())[:_ONNX_WEIGHT_LINEAGES_PER_VALUE_LIMIT])
 
+    def merge_lineages(
+        target: dict[int, _OnnxWeightLineage],
+        source: dict[int, _OnnxWeightLineage],
+        *,
+        ambiguous_reason: str,
+    ) -> None:
+        for initializer_index, lineage in source.items():
+            existing = target.get(initializer_index)
+            if existing is None:
+                target[initializer_index] = lineage
+                continue
+            if existing == lineage:
+                continue
+            target[initializer_index] = _OnnxWeightLineage(
+                initializer_index=initializer_index,
+                shape=None,
+                transforms=existing.transforms,
+                unresolved_reason=existing.unresolved_reason or lineage.unresolved_reason or ambiguous_reason,
+            )
+
     def walk_graph(
         current_graph: Any,
         inherited_lineages: dict[str, dict[int, _OnnxWeightLineage]],
         inherited_constants: dict[str, Any],
+        inherited_dynamic_values: set[str],
         *,
         root_graph: bool,
-    ) -> None:
-        nonlocal node_counter, total_consumer_count
+        bound_lineages: dict[str, dict[int, _OnnxWeightLineage]] | None = None,
+        bound_constants: dict[str, Any] | None = None,
+        bound_dynamic_values: set[str] | None = None,
+        bound_attributes: dict[str, Any] | None = None,
+        function_depth: int = 0,
+    ) -> tuple[list[dict[int, _OnnxWeightLineage]], list[bool]]:
+        nonlocal graph_counter, node_counter, total_consumer_count
+        current_graph_index = graph_counter
+        graph_counter += 1
         if root_graph:
             value_lineages = dict(inherited_lineages)
             constants = dict(inherited_constants)
+            dynamic_values = set(inherited_dynamic_values)
         else:
             declared_names = _graph_declared_value_names(current_graph)
             value_lineages = {
                 name: lineages for name, lineages in inherited_lineages.items() if name not in declared_names
             }
             constants = {name: value for name, value in inherited_constants.items() if name not in declared_names}
+            dynamic_values = {name for name in inherited_dynamic_values if name not in declared_names}
+
+        value_lineages.update(bound_lineages or {})
+        constants.update(bound_constants or {})
+        dynamic_values.update(bound_dynamic_values or set())
+        attribute_bindings = bound_attributes or {}
+
+        def resolve_attribute(attribute: Any) -> Any | None:
+            reference_name = str(getattr(attribute, "ref_attr_name", ""))
+            return attribute_bindings.get(reference_name) if reference_name else attribute
 
         for initializer in getattr(current_graph, "initializer", ()):
             if initializer.name:
-                constants[str(initializer.name)] = initializer
+                name = str(initializer.name)
+                lineage = register_initializer(initializer, current_graph_index)
+                value_lineages[name] = {lineage.initializer_index: lineage}
+                constants[name] = initializer
+                dynamic_values.discard(name)
+        for sparse_initializer in getattr(current_graph, "sparse_initializer", ()):
+            if sparse_initializer.values.name:
+                name = str(sparse_initializer.values.name)
+                lineage = register_initializer(
+                    sparse_initializer.values,
+                    current_graph_index,
+                    shape=tuple(int(dimension) for dimension in sparse_initializer.dims),
+                    unresolved_reason="sparse_initializer_unsupported",
+                )
+                value_lineages[name] = {lineage.initializer_index: lineage}
+                dynamic_values.discard(name)
+
+        for graph_input in getattr(current_graph, "input", ()):
+            name = _onnx_value_name(graph_input)
+            if name and name not in value_lineages and name not in constants:
+                dynamic_values.add(name)
 
         for node in getattr(current_graph, "node", ()):
             current_node_index = node_counter
             node_counter += 1
             supported_transform = getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS and node.op_type in {
+                "Cast",
+                "Flatten",
                 "Identity",
-                "Transpose",
                 "Reshape",
+                "Squeeze",
+                "Transpose",
+                "Unsqueeze",
             }
-            roots_consumed_as_weights: set[int] = set()
             all_input_lineages: dict[int, _OnnxWeightLineage] = {}
+            input_names = [str(input_name) for input_name in node.input if input_name]
+            has_dynamic_input = any(
+                input_name in dynamic_values or (input_name not in value_lineages and input_name not in constants)
+                for input_name in input_names
+            )
+            has_referenced_attributes = any(
+                getattr(attribute, "ref_attr_name", "") for attribute in getattr(node, "attribute", ())
+            )
 
             for input_index, input_name in enumerate(node.input):
                 input_lineages = value_lineages.get(str(input_name), {})
@@ -892,16 +1173,144 @@ def _build_onnx_weight_analysis_plan(
                         else:
                             record_exclusion(initializer_index, "unresolved_lineage_consumer", node, input_index)
                         continue
+                    if has_referenced_attributes and not (supported_transform and input_index == 0):
+                        if _onnx_potential_weight_input(node, input_index):
+                            record_unresolved_lineage(
+                                _OnnxWeightLineage(
+                                    initializer_index=initializer_index,
+                                    shape=None,
+                                    transforms=lineage.transforms,
+                                    unresolved_reason="referenced_function_attribute",
+                                ),
+                                node,
+                                current_node_index,
+                                input_index,
+                            )
+                        else:
+                            record_exclusion(
+                                initializer_index,
+                                "referenced_function_attribute_consumer",
+                                node,
+                                input_index,
+                            )
+                        continue
                     output_axes, reason = _onnx_weight_output_axes(node, input_index, len(lineage.shape or ()))
                     if output_axes is None:
-                        record_exclusion(initializer_index, reason, node, input_index)
+                        if reason != "non_weight_input" and _onnx_potential_weight_input(node, input_index):
+                            record_unresolved_lineage(
+                                _OnnxWeightLineage(
+                                    initializer_index=initializer_index,
+                                    shape=None,
+                                    transforms=lineage.transforms,
+                                    unresolved_reason="unsupported_weight_consumer",
+                                ),
+                                node,
+                                current_node_index,
+                                input_index,
+                            )
+                        else:
+                            record_exclusion(initializer_index, reason, node, input_index)
                         continue
                     add_consumer_group(lineage, node, current_node_index, input_index, output_axes)
-                    roots_consumed_as_weights.add(initializer_index)
 
+            subgraph_results: list[tuple[list[dict[int, _OnnxWeightLineage]], list[bool]]] = []
             for attribute in getattr(node, "attribute", ()):
-                for subgraph in _iter_attribute_graphs(attribute):
-                    walk_graph(subgraph, value_lineages, constants, root_graph=False)
+                resolved_attribute = resolve_attribute(attribute)
+                if resolved_attribute is None:
+                    plan.record_coverage_gap("unresolved_function_attribute")
+                    continue
+                for subgraph in _iter_attribute_graphs(resolved_attribute):
+                    subgraph_bound_lineages: dict[str, dict[int, _OnnxWeightLineage]] = {}
+                    subgraph_bound_constants: dict[str, Any] = {}
+                    subgraph_bound_dynamic: set[str] = set()
+                    input_pairs: Iterable[tuple[Any, Any]]
+                    if node.op_type == "Loop":
+                        input_pairs = zip(node.input[2:], subgraph.input[2:], strict=False)
+                    elif node.op_type == "Scan":
+                        input_pairs = zip(node.input, subgraph.input, strict=False)
+                    else:
+                        input_pairs = ()
+                    for parent_input, graph_input in input_pairs:
+                        parent_name = str(parent_input)
+                        graph_input_name = _onnx_value_name(graph_input)
+                        if parent_name in value_lineages:
+                            subgraph_bound_lineages[graph_input_name] = value_lineages[parent_name]
+                        if parent_name in constants:
+                            subgraph_bound_constants[graph_input_name] = constants[parent_name]
+                        if parent_name in dynamic_values:
+                            subgraph_bound_dynamic.add(graph_input_name)
+                    subgraph_results.append(
+                        walk_graph(
+                            subgraph,
+                            value_lineages,
+                            constants,
+                            dynamic_values,
+                            root_graph=False,
+                            bound_lineages=subgraph_bound_lineages,
+                            bound_constants=subgraph_bound_constants,
+                            bound_dynamic_values=subgraph_bound_dynamic,
+                            bound_attributes=attribute_bindings,
+                            function_depth=function_depth,
+                        ),
+                    )
+
+            function = functions.get(
+                (
+                    str(getattr(node, "domain", "")),
+                    str(getattr(node, "op_type", "")),
+                    str(getattr(node, "overload", "")),
+                ),
+            )
+            if function is not None and function_depth >= _ONNX_WEIGHT_TRANSFORM_DEPTH_LIMIT:
+                plan.record_coverage_gap("function_call_depth_limit")
+                for input_index, input_name in enumerate(node.input):
+                    for initializer_index, lineage in value_lineages.get(str(input_name), {}).items():
+                        record_unresolved_lineage(
+                            _OnnxWeightLineage(
+                                initializer_index=initializer_index,
+                                shape=None,
+                                transforms=lineage.transforms,
+                                unresolved_reason="function_call_depth_limit",
+                            ),
+                            node,
+                            current_node_index,
+                            input_index,
+                        )
+                function = None
+            if function is not None:
+                function_bound_lineages: dict[str, dict[int, _OnnxWeightLineage]] = {}
+                function_bound_constants: dict[str, Any] = {}
+                function_bound_dynamic: set[str] = set()
+                function_bound_attributes = {
+                    str(attribute.name): attribute for attribute in getattr(function, "attribute_proto", ())
+                }
+                for attribute in getattr(node, "attribute", ()):
+                    resolved_attribute = resolve_attribute(attribute)
+                    if resolved_attribute is not None:
+                        function_bound_attributes[str(attribute.name)] = resolved_attribute
+                for parent_input, function_input in zip(node.input, function.input, strict=False):
+                    parent_name = str(parent_input)
+                    function_input_name = _onnx_value_name(function_input)
+                    if parent_name in value_lineages:
+                        function_bound_lineages[function_input_name] = value_lineages[parent_name]
+                    if parent_name in constants:
+                        function_bound_constants[function_input_name] = constants[parent_name]
+                    if parent_name in dynamic_values:
+                        function_bound_dynamic.add(function_input_name)
+                subgraph_results.append(
+                    walk_graph(
+                        function,
+                        value_lineages,
+                        constants,
+                        dynamic_values,
+                        root_graph=False,
+                        bound_lineages=function_bound_lineages,
+                        bound_constants=function_bound_constants,
+                        bound_dynamic_values=function_bound_dynamic,
+                        bound_attributes=function_bound_attributes,
+                        function_depth=function_depth + 1,
+                    ),
+                )
 
             output_lineages: dict[int, _OnnxWeightLineage] = {}
             if supported_transform:
@@ -909,10 +1318,13 @@ def _build_onnx_weight_analysis_plan(
                 for initializer_index, lineage in data_lineages.items():
                     transform_counts[initializer_index] += 1
                     output_lineages[initializer_index] = transformed_lineage(lineage, node, constants)
-            else:
+            elif (
+                all_input_lineages
+                and not has_dynamic_input
+                and node.op_type not in _QUANTIZED_WEIGHT_OPERATORS
+                and function is None
+            ):
                 for initializer_index, lineage in all_input_lineages.items():
-                    if initializer_index in roots_consumed_as_weights:
-                        continue
                     output_lineages[initializer_index] = _OnnxWeightLineage(
                         initializer_index=initializer_index,
                         shape=None,
@@ -921,37 +1333,155 @@ def _build_onnx_weight_analysis_plan(
                     )
 
             output_lineages = bounded_lineages(output_lineages)
-            for output_name in node.output:
-                if output_name and output_lineages:
-                    value_lineages[str(output_name)] = output_lineages
-
+            constant_output_names: set[str] = set()
+            constant_output_lineages: dict[str, dict[int, _OnnxWeightLineage]] = {}
             if getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS and node.op_type == "Constant":
                 constant_tensor = None
+                sparse_constant = None
+                unresolved_constant_attribute = False
                 for attribute in node.attribute:
-                    if attribute.name != "value":
+                    resolved_attribute = resolve_attribute(attribute)
+                    if resolved_attribute is None:
+                        unresolved_constant_attribute = True
                         continue
-                    try:
-                        if attribute.HasField("t"):
-                            constant_tensor = attribute.t
-                    except (AttributeError, ValueError):
-                        constant_tensor = None
-                    break
-                if constant_tensor is not None:
-                    for output_name in node.output:
-                        if output_name:
-                            constants[str(output_name)] = constant_tensor
+                    if attribute.name == "value":
+                        try:
+                            if resolved_attribute.HasField("t"):
+                                constant_tensor = resolved_attribute.t
+                        except (AttributeError, ValueError):
+                            constant_tensor = None
+                    elif attribute.name == "value_ints":
+                        constant_tensor = onnx.helper.make_tensor(
+                            "",
+                            onnx.TensorProto.INT64,
+                            [len(resolved_attribute.ints)],
+                            list(resolved_attribute.ints),
+                        )
+                    elif attribute.name == "value_int":
+                        constant_tensor = onnx.helper.make_tensor(
+                            "",
+                            onnx.TensorProto.INT64,
+                            [],
+                            [resolved_attribute.i],
+                        )
+                    elif attribute.name == "value_floats":
+                        constant_tensor = onnx.helper.make_tensor(
+                            "",
+                            onnx.TensorProto.FLOAT,
+                            [len(resolved_attribute.floats)],
+                            list(resolved_attribute.floats),
+                        )
+                    elif attribute.name == "value_float":
+                        constant_tensor = onnx.helper.make_tensor(
+                            "",
+                            onnx.TensorProto.FLOAT,
+                            [],
+                            [resolved_attribute.f],
+                        )
+                    elif attribute.name == "sparse_value":
+                        try:
+                            if resolved_attribute.HasField("sparse_tensor"):
+                                sparse_constant = resolved_attribute.sparse_tensor
+                        except (AttributeError, ValueError):
+                            sparse_constant = None
+                    if constant_tensor is not None or sparse_constant is not None:
+                        break
+                output_names = [str(output_name) for output_name in node.output if output_name]
+                if len(output_names) != 1:
+                    plan.record_coverage_gap("invalid_constant_outputs")
+                elif constant_tensor is not None:
+                    name = output_names[0]
+                    constant_tensor.name = name
+                    lineage = register_initializer(constant_tensor, current_graph_index)
+                    constants[name] = constant_tensor
+                    constant_output_lineages[name] = {lineage.initializer_index: lineage}
+                    constant_output_names.add(name)
+                elif sparse_constant is not None:
+                    name = output_names[0]
+                    sparse_constant.values.name = name
+                    lineage = register_initializer(
+                        sparse_constant.values,
+                        current_graph_index,
+                        shape=tuple(int(dimension) for dimension in sparse_constant.dims),
+                        unresolved_reason="sparse_constant_unsupported",
+                    )
+                    constant_output_lineages[name] = {lineage.initializer_index: lineage}
+                    constant_output_names.add(name)
+                elif unresolved_constant_attribute:
+                    name = output_names[0]
+                    unresolved_tensor = onnx.TensorProto()
+                    unresolved_tensor.name = name
+                    lineage = register_initializer(
+                        unresolved_tensor,
+                        current_graph_index,
+                        unresolved_reason="unresolved_constant_attribute",
+                    )
+                    constant_output_lineages[name] = {lineage.initializer_index: lineage}
+                    constant_output_names.add(name)
 
-    root_lineages = {
-        name: {
-            initializer_index: _OnnxWeightLineage(
-                initializer_index=initializer_index,
-                shape=tuple(int(dimension) for dimension in initializers[initializer_index].dims),
-            ),
-        }
-        for name, initializer_index in initializer_indexes.items()
-    }
-    root_constants = {str(initializer.name): initializer for initializer in initializers}
-    walk_graph(graph, root_lineages, root_constants, root_graph=True)
+            subgraph_output_lineages: list[dict[int, _OnnxWeightLineage]] = [{} for _ in node.output]
+            subgraph_output_dynamic = [False for _ in node.output]
+            subgraph_output_offset = 1 if node.op_type == "Loop" else 0
+            for graph_output_lineages, graph_output_dynamic in subgraph_results:
+                for output_index in range(len(node.output)):
+                    graph_output_index = output_index + subgraph_output_offset
+                    if graph_output_index >= len(graph_output_lineages):
+                        continue
+                    merge_lineages(
+                        subgraph_output_lineages[output_index],
+                        graph_output_lineages[graph_output_index],
+                        ambiguous_reason="ambiguous_subgraph_output_lineage",
+                    )
+                    subgraph_output_dynamic[output_index] |= graph_output_dynamic[graph_output_index]
+
+            for output_index, output_name in enumerate(node.output):
+                if not output_name:
+                    continue
+                name = str(output_name)
+                per_output_lineages = dict(output_lineages)
+                merge_lineages(
+                    per_output_lineages,
+                    constant_output_lineages.get(name, {}),
+                    ambiguous_reason="ambiguous_constant_output_lineage",
+                )
+                merge_lineages(
+                    per_output_lineages,
+                    subgraph_output_lineages[output_index],
+                    ambiguous_reason="ambiguous_subgraph_output_lineage",
+                )
+                if subgraph_output_dynamic[output_index] and per_output_lineages:
+                    per_output_lineages = {
+                        initializer_index: _OnnxWeightLineage(
+                            initializer_index=initializer_index,
+                            shape=None,
+                            transforms=lineage.transforms,
+                            unresolved_reason=lineage.unresolved_reason or "dynamic_subgraph_output_lineage",
+                        )
+                        for initializer_index, lineage in per_output_lineages.items()
+                    }
+                per_output_lineages = bounded_lineages(per_output_lineages)
+                if per_output_lineages:
+                    value_lineages[name] = per_output_lineages
+                else:
+                    value_lineages.pop(name, None)
+
+                mapped_subgraph_output = bool(subgraph_results) and output_index < len(subgraph_output_dynamic)
+                output_is_dynamic = (
+                    subgraph_output_dynamic[output_index]
+                    if mapped_subgraph_output and per_output_lineages
+                    else has_dynamic_input or (not per_output_lineages and name not in constant_output_names)
+                )
+                if output_is_dynamic:
+                    dynamic_values.add(name)
+                else:
+                    dynamic_values.discard(name)
+
+        return (
+            [dict(value_lineages.get(_onnx_value_name(graph_output), {})) for graph_output in current_graph.output],
+            [_onnx_value_name(graph_output) in dynamic_values for graph_output in current_graph.output],
+        )
+
+    walk_graph(graph, {}, {}, set(), root_graph=True)
 
     for initializer_index, _initializer in enumerate(initializers):
         if terminal_consumer_counts[initializer_index] == 0 and not groups[initializer_index]:
@@ -1043,6 +1573,7 @@ def _build_onnx_weight_analysis_plan(
                 context = {
                     "analysis_id": analysis_id,
                     **_bounded_onnx_metadata_fields(plan, "initializer", initializer.name),
+                    "initializer_graph_index": initializer_graph_indexes[initializer_index],
                     "consumer_op": first_consumer["op"],
                     "consumer_op_length": first_consumer["op_length"],
                     "consumer_op_truncated": first_consumer["op_truncated"],
@@ -1871,11 +2402,16 @@ class OnnxScanner(BaseScanner):
             and configured_max_array_size > 0
             else None
         )
+
+        def inline_storage_fits_budget(initializer: Any, _name: str, _estimated_bytes: int) -> bool:
+            return max_array_size is None or _onnx_inline_storage_nbytes(initializer) <= max_array_size
+
         plan = _build_onnx_weight_analysis_plan(
             model,
             onnx=onnx,
             np=np,
             max_array_size=max_array_size,
+            pre_materialization_check=inline_storage_fits_budget,
         )
         result.metadata["onnx_weight_distribution_semantics"] = plan.metadata
 
@@ -1912,7 +2448,8 @@ class OnnxScanner(BaseScanner):
             return
 
         try:
-            from scipy import stats as _stats  # noqa: F401
+            if any(spec.matrix_analysis for spec in plan.specs):
+                from scipy import stats as _stats  # noqa: F401
 
             # Lazy-import the weight distribution scanner to avoid circular deps
             # and heavy library loads when the scanner is not needed.

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -5,6 +5,8 @@ import math
 import ntpath
 import os
 import re
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -81,6 +83,13 @@ _OP_TYPE_TOKEN_PATTERN = re.compile(
     r"[A-Z]+(?=[A-Z][a-z0-9]|[^A-Za-z0-9]|$)|[A-Z]?[a-z0-9]+",
 )
 _ONNX_WEIGHT_METADATA_SAMPLE_LIMIT = 100
+_ONNX_WEIGHT_CONSUMER_SAMPLE_LIMIT = 20
+_ONNX_WEIGHT_ANALYSIS_GROUP_LIMIT = 100
+_ONNX_WEIGHT_LINEAGES_PER_VALUE_LIMIT = 32
+_ONNX_WEIGHT_TRANSFORM_DEPTH_LIMIT = 32
+_ONNX_WEIGHT_RESHAPE_RANK_LIMIT = 64
+_ONNX_WEIGHT_METADATA_TEXT_LIMIT = 256
+_ONNX_WEIGHT_METADATA_SEQUENCE_LIMIT = 64
 _STANDARD_NEURAL_NETWORK_DOMAINS: frozenset[str] = frozenset({"", "ai.onnx"})
 
 
@@ -124,7 +133,7 @@ def _onnx_int_attribute(node: Any, name: str, default: int = 0) -> int:
     return default
 
 
-def _onnx_weight_output_axis(node: Any, input_index: int, rank: int) -> tuple[int | None, str]:
+def _onnx_weight_output_axes(node: Any, input_index: int, rank: int) -> tuple[tuple[int, ...] | None, str]:
     """Classify an initializer consumer for statistical weight analysis."""
     op_type = node.op_type
     domain = getattr(node, "domain", "")
@@ -137,31 +146,32 @@ def _onnx_weight_output_axis(node: Any, input_index: int, rank: int) -> tuple[in
         if rank != 2:
             return None, "unsupported_weight_rank"
         if input_index == 0:
-            return (1 if _onnx_int_attribute(node, "transA") else 0), "eligible_gemm_left_weight"
-        return (0 if _onnx_int_attribute(node, "transB") else 1), "eligible_gemm_weight"
+            return (1 if _onnx_int_attribute(node, "transA") else 0,), "eligible_gemm_left_weight"
+        return (0 if _onnx_int_attribute(node, "transB") else 1,), "eligible_gemm_weight"
 
     if op_type == "MatMul":
         if input_index not in {0, 1}:
             return None, "non_weight_input"
         if rank < 2:
             return None, "unsupported_weight_rank"
+        batch_axes = tuple(range(rank - 2))
         if input_index == 0:
-            return rank - 2, "eligible_matmul_left_weight"
-        return rank - 1, "eligible_matmul_weight"
+            return (*batch_axes, rank - 2), "eligible_matmul_left_weight"
+        return (*batch_axes, rank - 1), "eligible_matmul_weight"
 
     if op_type == "Conv":
         if input_index != 1:
             return None, "non_weight_input"
         if rank < 3:
             return None, "unsupported_weight_rank"
-        return 0, "eligible_conv_weight"
+        return (0,), "eligible_conv_weight"
 
     if op_type == "ConvTranspose":
         if input_index != 1:
             return None, "non_weight_input"
         if rank < 3:
             return None, "unsupported_weight_rank"
-        return 1, "eligible_conv_transpose_weight"
+        return (1,), "eligible_conv_transpose_weight"
 
     if op_type == "Gather" and input_index == 0:
         return None, "embedding_table"
@@ -201,28 +211,6 @@ def _graph_declared_value_names(graph: Any) -> set[str]:
     for node in getattr(graph, "node", []):
         declared.update(output_name for output_name in node.output if output_name)
     return declared
-
-
-def _iter_captured_initializer_consumers(
-    graph: Any,
-    initializer_names: set[str],
-    *,
-    root_graph: bool = False,
-) -> Any:
-    """Yield consumers of visible initializers across nested control-flow graphs."""
-    visible_names = initializer_names
-    if not root_graph:
-        visible_names = initializer_names - _graph_declared_value_names(graph)
-    if not visible_names:
-        return
-
-    for node in getattr(graph, "node", []):
-        for input_index, input_name in enumerate(node.input):
-            if input_name in visible_names:
-                yield node, input_index, input_name
-        for attribute in getattr(node, "attribute", []):
-            for subgraph in _iter_attribute_graphs(attribute):
-                yield from _iter_captured_initializer_consumers(subgraph, visible_names)
 
 
 def _iter_model_graphs(model: Any) -> Any:
@@ -395,6 +383,741 @@ def _tensor_data_type_to_np_dtype(data_type: int) -> Any:
         return np.dtype(mapping.TENSOR_TYPE_MAP[data_type].np_dtype)
 
     raise ValueError(f"Unsupported ONNX tensor dtype mapping API for data_type={data_type}")
+
+
+@dataclass(frozen=True)
+class _OnnxWeightTransform:
+    kind: str
+    parameters: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True)
+class _OnnxWeightLineage:
+    initializer_index: int
+    shape: tuple[int, ...] | None
+    transforms: tuple[_OnnxWeightTransform, ...] = ()
+    unresolved_reason: str | None = None
+
+
+@dataclass
+class _OnnxWeightConsumerGroup:
+    lineage: _OnnxWeightLineage
+    node: Any
+    node_index: int
+    input_index: int
+    output_axes: tuple[int, ...]
+    analysis_kind: str
+    group: int
+    consumer_count: int = 0
+    consumers: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _OnnxWeightAnalysisSpec:
+    analysis_id: int
+    weights: Any
+    output_axes: tuple[int, ...]
+    matrix_analysis: bool
+    context: dict[str, Any]
+
+
+@dataclass
+class _OnnxWeightAnalysisPlan:
+    specs: list[_OnnxWeightAnalysisSpec] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    coverage_gaps: dict[str, int] = field(default_factory=dict)
+    eligible_initializer_count: int = 0
+    analyzed_initializer_count: int = 0
+    external_initializers_skipped: int = 0
+    oversized_initializers_skipped: int = 0
+    extraction_failures: int = 0
+    string_truncation_count: int = 0
+    exclusion_counts: dict[str, int] = field(default_factory=dict)
+    exclusion_samples: list[dict[str, Any]] = field(default_factory=list)
+    unresolved_lineage_samples: list[dict[str, Any]] = field(default_factory=list)
+
+    def record_coverage_gap(self, reason: str, count: int = 1) -> None:
+        self.coverage_gaps[reason] = self.coverage_gaps.get(reason, 0) + count
+
+
+def _bounded_onnx_metadata_text(plan: _OnnxWeightAnalysisPlan, value: Any) -> tuple[str, int, bool]:
+    text = str(value)
+    original_length = len(text)
+    if original_length <= _ONNX_WEIGHT_METADATA_TEXT_LIMIT:
+        return text, original_length, False
+
+    marker = "...<truncated>"
+    plan.string_truncation_count += 1
+    return (
+        text[: _ONNX_WEIGHT_METADATA_TEXT_LIMIT - len(marker)] + marker,
+        original_length,
+        True,
+    )
+
+
+def _bounded_onnx_metadata_fields(
+    plan: _OnnxWeightAnalysisPlan,
+    field_name: str,
+    value: Any,
+) -> dict[str, Any]:
+    text, original_length, truncated = _bounded_onnx_metadata_text(plan, value)
+    return {
+        field_name: text,
+        f"{field_name}_length": original_length,
+        f"{field_name}_truncated": truncated,
+    }
+
+
+def _bounded_onnx_integer_sequence(field_name: str, values: Any) -> dict[str, Any]:
+    value_count = len(values)
+    sequence = [int(values[index]) for index in range(min(value_count, _ONNX_WEIGHT_METADATA_SEQUENCE_LIMIT))]
+    return {
+        field_name: sequence,
+        f"{field_name}_count": value_count,
+        f"{field_name}_truncated": value_count > _ONNX_WEIGHT_METADATA_SEQUENCE_LIMIT,
+    }
+
+
+def _onnx_inline_storage_nbytes(initializer: Any) -> int:
+    raw_bytes = len(getattr(initializer, "raw_data", b""))
+    typed_bytes = 0
+    for field_name, itemsize in (
+        ("float_data", 4),
+        ("int32_data", 4),
+        ("int64_data", 8),
+        ("double_data", 8),
+        ("uint64_data", 8),
+    ):
+        typed_bytes += len(getattr(initializer, field_name, ())) * itemsize
+    typed_bytes += sum(len(value) for value in getattr(initializer, "string_data", ()))
+    return raw_bytes + typed_bytes
+
+
+def _resolve_onnx_reshape_shape(
+    input_shape: tuple[int, ...],
+    shape_initializer: Any,
+    *,
+    allowzero: bool,
+    onnx: Any,
+) -> tuple[int, ...] | None:
+    dims = tuple(int(dimension) for dimension in getattr(shape_initializer, "dims", ()))
+    element_count = math.prod(dims) if dims else 0
+    if (
+        len(dims) != 1
+        or element_count < 0
+        or element_count > _ONNX_WEIGHT_RESHAPE_RANK_LIMIT
+        or int(getattr(shape_initializer, "data_type", -1)) != int(onnx.TensorProto.INT64)
+        or _onnx_inline_storage_nbytes(shape_initializer) > _ONNX_WEIGHT_RESHAPE_RANK_LIMIT * 8
+        or getattr(shape_initializer, "data_location", None) == getattr(onnx.TensorProto, "EXTERNAL", 1)
+        or bool(getattr(shape_initializer, "external_data", ()))
+    ):
+        return None
+
+    try:
+        target_values = onnx.numpy_helper.to_array(shape_initializer).reshape(-1).tolist()
+        target = [int(value) for value in target_values]
+    except Exception:
+        return None
+    if len(target) != element_count or any(value < -1 for value in target) or target.count(-1) > 1:
+        return None
+    if allowzero and -1 in target and 0 in target:
+        return None
+
+    normalized: list[int] = []
+    for index, value in enumerate(target):
+        if value == 0 and not allowzero:
+            if index >= len(input_shape):
+                return None
+            normalized.append(int(input_shape[index]))
+        else:
+            normalized.append(value)
+
+    input_size = math.prod(input_shape)
+    known_size = math.prod(value for value in normalized if value != -1)
+    if -1 in normalized:
+        if known_size <= 0 or input_size % known_size != 0:
+            return None
+        normalized[normalized.index(-1)] = input_size // known_size
+    elif math.prod(normalized) != input_size:
+        return None
+    return tuple(normalized)
+
+
+def _onnx_initializer_name_issues(
+    graph: Any,
+    plan: _OnnxWeightAnalysisPlan,
+) -> tuple[int, int, list[dict[str, Any]]]:
+    empty_count = 0
+    duplicate_count = 0
+    samples: list[dict[str, Any]] = []
+
+    def walk(current_graph: Any, graph_index: int) -> int:
+        nonlocal empty_count, duplicate_count
+        names = [str(initializer.name) for initializer in getattr(current_graph, "initializer", ())]
+        names.extend(
+            str(sparse_initializer.values.name)
+            for sparse_initializer in getattr(current_graph, "sparse_initializer", ())
+        )
+        seen: set[str] = set()
+        duplicated: set[str] = set()
+        for name in names:
+            if not name:
+                empty_count += 1
+                if len(samples) < _ONNX_WEIGHT_METADATA_SAMPLE_LIMIT:
+                    samples.append({"graph_index": graph_index, "reason": "empty_initializer_name"})
+                continue
+            if name in seen:
+                duplicate_count += 1
+                if name not in duplicated and len(samples) < _ONNX_WEIGHT_METADATA_SAMPLE_LIMIT:
+                    samples.append(
+                        {
+                            "graph_index": graph_index,
+                            "reason": "duplicate_initializer_name",
+                            **_bounded_onnx_metadata_fields(plan, "initializer", name),
+                        },
+                    )
+                duplicated.add(name)
+            seen.add(name)
+
+        next_graph_index = graph_index + 1
+        for node in getattr(current_graph, "node", ()):
+            for attribute in getattr(node, "attribute", ()):
+                for subgraph in _iter_attribute_graphs(attribute):
+                    next_graph_index = walk(subgraph, next_graph_index)
+        return next_graph_index
+
+    walk(graph, 0)
+    return empty_count, duplicate_count, samples
+
+
+def _onnx_potential_weight_input(node: Any, input_index: int) -> bool:
+    if getattr(node, "domain", "") not in _STANDARD_NEURAL_NETWORK_DOMAINS:
+        return False
+    if node.op_type in {"Gemm", "MatMul"}:
+        return input_index in {0, 1}
+    if node.op_type in {"Conv", "ConvTranspose"}:
+        return input_index == 1
+    return False
+
+
+def _build_onnx_weight_analysis_plan(
+    model: Any,
+    *,
+    onnx: Any,
+    np: Any,
+    max_array_size: int | None,
+    pre_materialization_check: Callable[[Any, str, int], bool] | None = None,
+    retain_array_check: Callable[[str, int], bool] | None = None,
+) -> _OnnxWeightAnalysisPlan:
+    """Build a bounded, semantically oriented plan for ONNX weight analysis."""
+    plan = _OnnxWeightAnalysisPlan()
+    graph = model.graph
+    initializers = list(getattr(graph, "initializer", ()))
+    empty_names, duplicate_names, invalid_name_samples = _onnx_initializer_name_issues(graph, plan)
+    invalid_name_count = empty_names + duplicate_names
+    if invalid_name_count:
+        plan.record_coverage_gap("invalid_initializer_names", invalid_name_count)
+        plan.metadata = {
+            "eligible_initializer_count": 0,
+            "analyzed_layer_count": 0,
+            "eligible": [],
+            "eligible_metadata_truncated": False,
+            "exclusion_counts": {},
+            "exclusion_samples": [],
+            "exclusion_metadata_truncated": False,
+            "consumer_count": 0,
+            "consumer_metadata_sample_count": 0,
+            "consumer_metadata_truncated": False,
+            "unresolved_lineage_samples": [],
+            "unresolved_lineage_metadata_truncated": False,
+            "initializer_name_validation": {
+                "empty_name_count": empty_names,
+                "duplicate_name_count": duplicate_names,
+                "samples": invalid_name_samples,
+                "samples_truncated": invalid_name_count > len(invalid_name_samples),
+            },
+            "coverage_gaps": dict(plan.coverage_gaps),
+            "metadata_string_truncation_count": plan.string_truncation_count,
+            "metadata_strings_truncated": plan.string_truncation_count > 0,
+        }
+        return plan
+
+    initializer_indexes = {str(initializer.name): index for index, initializer in enumerate(initializers)}
+    floating_types = {
+        int(getattr(onnx.TensorProto, name))
+        for name in (
+            "FLOAT",
+            "FLOAT16",
+            "DOUBLE",
+            "BFLOAT16",
+            "FLOAT8E4M3FN",
+            "FLOAT8E4M3FNUZ",
+            "FLOAT8E5M2",
+            "FLOAT8E5M2FNUZ",
+            "FLOAT4E2M1",
+        )
+        if hasattr(onnx.TensorProto, name)
+    }
+    groups: list[dict[tuple[Any, ...], _OnnxWeightConsumerGroup]] = [{} for _ in initializers]
+    eligible_initializer_indexes: set[int] = set()
+    terminal_consumer_counts = [0] * len(initializers)
+    transform_counts = [0] * len(initializers)
+    total_consumer_count = 0
+    consumer_sample_count = 0
+    node_counter = 0
+
+    def record_exclusion(
+        initializer_index: int,
+        reason: str,
+        node: Any | None = None,
+        input_index: int | None = None,
+    ) -> None:
+        plan.exclusion_counts[reason] = plan.exclusion_counts.get(reason, 0) + 1
+        if len(plan.exclusion_samples) >= _ONNX_WEIGHT_METADATA_SAMPLE_LIMIT:
+            return
+        initializer = initializers[initializer_index]
+        sample: dict[str, Any] = {
+            **_bounded_onnx_metadata_fields(plan, "initializer", initializer.name),
+            "reason": reason,
+            **_bounded_onnx_integer_sequence("stored_shape", initializer.dims),
+        }
+        if node is not None:
+            sample.update(_bounded_onnx_metadata_fields(plan, "consumer_op", node.op_type))
+            sample.update(_bounded_onnx_metadata_fields(plan, "consumer_node", node.name))
+            sample["consumer_input_index"] = input_index
+        plan.exclusion_samples.append(sample)
+
+    def consumer_metadata(node: Any, node_index: int, input_index: int) -> dict[str, Any]:
+        return {
+            **_bounded_onnx_metadata_fields(plan, "op", node.op_type),
+            **_bounded_onnx_metadata_fields(plan, "node", node.name),
+            "node_index": node_index,
+            "input_index": input_index,
+        }
+
+    def record_unresolved_lineage(
+        lineage: _OnnxWeightLineage,
+        node: Any,
+        node_index: int,
+        input_index: int,
+    ) -> None:
+        eligible_initializer_indexes.add(lineage.initializer_index)
+        plan.record_coverage_gap("unresolved_initializer_lineage")
+        if len(plan.unresolved_lineage_samples) >= _ONNX_WEIGHT_METADATA_SAMPLE_LIMIT:
+            return
+        initializer = initializers[lineage.initializer_index]
+        plan.unresolved_lineage_samples.append(
+            {
+                **_bounded_onnx_metadata_fields(plan, "initializer", initializer.name),
+                **_bounded_onnx_metadata_fields(plan, "consumer_op", node.op_type),
+                **_bounded_onnx_metadata_fields(plan, "consumer_node", node.name),
+                "consumer_node_index": node_index,
+                "consumer_input_index": input_index,
+                "reason": lineage.unresolved_reason or "unknown_lineage",
+                "lineage_transform_count": len(lineage.transforms),
+            },
+        )
+
+    def add_consumer_group(
+        lineage: _OnnxWeightLineage,
+        node: Any,
+        node_index: int,
+        input_index: int,
+        output_axes: tuple[int, ...],
+    ) -> None:
+        nonlocal consumer_sample_count
+        initializer = initializers[lineage.initializer_index]
+        if int(initializer.data_type) not in floating_types:
+            record_exclusion(lineage.initializer_index, "non_floating_weight", node, input_index)
+            return
+
+        analysis_kind = (
+            "tensor" if node.op_type in {"Conv", "ConvTranspose"} or len(lineage.shape or ()) > 2 else "matrix"
+        )
+        group_value = _onnx_int_attribute(node, "group", 1) if node.op_type in {"Conv", "ConvTranspose"} else 1
+        signature = (
+            lineage.transforms,
+            node.op_type,
+            input_index,
+            output_axes,
+            analysis_kind,
+            group_value,
+        )
+        initializer_groups = groups[lineage.initializer_index]
+        consumer_group = initializer_groups.get(signature)
+        if consumer_group is None:
+            if len(initializer_groups) >= _ONNX_WEIGHT_ANALYSIS_GROUP_LIMIT:
+                plan.record_coverage_gap("initializer_analysis_group_limit")
+                return
+            consumer_group = _OnnxWeightConsumerGroup(
+                lineage=lineage,
+                node=node,
+                node_index=node_index,
+                input_index=input_index,
+                output_axes=output_axes,
+                analysis_kind=analysis_kind,
+                group=group_value,
+            )
+            initializer_groups[signature] = consumer_group
+        consumer_group.consumer_count += 1
+        if len(consumer_group.consumers) < _ONNX_WEIGHT_CONSUMER_SAMPLE_LIMIT:
+            consumer_group.consumers.append(consumer_metadata(node, node_index, input_index))
+            consumer_sample_count += 1
+        eligible_initializer_indexes.add(lineage.initializer_index)
+
+    def transformed_lineage(
+        lineage: _OnnxWeightLineage,
+        node: Any,
+        constants: dict[str, Any],
+    ) -> _OnnxWeightLineage:
+        if lineage.unresolved_reason is not None:
+            return lineage
+        if len(lineage.transforms) >= _ONNX_WEIGHT_TRANSFORM_DEPTH_LIMIT:
+            return _OnnxWeightLineage(
+                initializer_index=lineage.initializer_index,
+                shape=None,
+                transforms=lineage.transforms,
+                unresolved_reason="lineage_transform_depth_limit",
+            )
+        if lineage.shape is None:
+            return _OnnxWeightLineage(
+                initializer_index=lineage.initializer_index,
+                shape=None,
+                transforms=lineage.transforms,
+                unresolved_reason="lineage_shape_unavailable",
+            )
+
+        if node.op_type == "Identity":
+            transform = _OnnxWeightTransform("Identity")
+            output_shape = lineage.shape
+        elif node.op_type == "Transpose":
+            permutation = tuple(
+                int(value)
+                for value in next(
+                    (attribute.ints for attribute in node.attribute if attribute.name == "perm"),
+                    tuple(reversed(range(len(lineage.shape)))),
+                )
+            )
+            if sorted(permutation) != list(range(len(lineage.shape))):
+                return _OnnxWeightLineage(
+                    initializer_index=lineage.initializer_index,
+                    shape=None,
+                    transforms=lineage.transforms,
+                    unresolved_reason="invalid_transpose_lineage",
+                )
+            transform = _OnnxWeightTransform("Transpose", permutation)
+            output_shape = tuple(lineage.shape[index] for index in permutation)
+        else:
+            shape_name = str(node.input[1]) if len(node.input) > 1 else ""
+            shape_initializer = constants.get(shape_name)
+            resolved_shape = (
+                _resolve_onnx_reshape_shape(
+                    lineage.shape,
+                    shape_initializer,
+                    allowzero=bool(_onnx_int_attribute(node, "allowzero")),
+                    onnx=onnx,
+                )
+                if shape_initializer is not None
+                else None
+            )
+            if resolved_shape is None:
+                return _OnnxWeightLineage(
+                    initializer_index=lineage.initializer_index,
+                    shape=None,
+                    transforms=lineage.transforms,
+                    unresolved_reason="unresolved_reshape_lineage",
+                )
+            output_shape = resolved_shape
+            transform = _OnnxWeightTransform("Reshape", output_shape)
+
+        return _OnnxWeightLineage(
+            initializer_index=lineage.initializer_index,
+            shape=output_shape,
+            transforms=(*lineage.transforms, transform),
+        )
+
+    def bounded_lineages(lineages: dict[int, _OnnxWeightLineage]) -> dict[int, _OnnxWeightLineage]:
+        if len(lineages) <= _ONNX_WEIGHT_LINEAGES_PER_VALUE_LIMIT:
+            return lineages
+        plan.record_coverage_gap(
+            "lineages_per_value_limit",
+            len(lineages) - _ONNX_WEIGHT_LINEAGES_PER_VALUE_LIMIT,
+        )
+        return dict(sorted(lineages.items())[:_ONNX_WEIGHT_LINEAGES_PER_VALUE_LIMIT])
+
+    def walk_graph(
+        current_graph: Any,
+        inherited_lineages: dict[str, dict[int, _OnnxWeightLineage]],
+        inherited_constants: dict[str, Any],
+        *,
+        root_graph: bool,
+    ) -> None:
+        nonlocal node_counter, total_consumer_count
+        if root_graph:
+            value_lineages = dict(inherited_lineages)
+            constants = dict(inherited_constants)
+        else:
+            declared_names = _graph_declared_value_names(current_graph)
+            value_lineages = {
+                name: lineages for name, lineages in inherited_lineages.items() if name not in declared_names
+            }
+            constants = {name: value for name, value in inherited_constants.items() if name not in declared_names}
+
+        for initializer in getattr(current_graph, "initializer", ()):
+            if initializer.name:
+                constants[str(initializer.name)] = initializer
+
+        for node in getattr(current_graph, "node", ()):
+            current_node_index = node_counter
+            node_counter += 1
+            supported_transform = getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS and node.op_type in {
+                "Identity",
+                "Transpose",
+                "Reshape",
+            }
+            roots_consumed_as_weights: set[int] = set()
+            all_input_lineages: dict[int, _OnnxWeightLineage] = {}
+
+            for input_index, input_name in enumerate(node.input):
+                input_lineages = value_lineages.get(str(input_name), {})
+                for initializer_index, lineage in input_lineages.items():
+                    all_input_lineages.setdefault(initializer_index, lineage)
+                    if supported_transform and input_index == 0:
+                        continue
+                    terminal_consumer_counts[initializer_index] += 1
+                    total_consumer_count += 1
+                    if lineage.unresolved_reason is not None:
+                        if _onnx_potential_weight_input(node, input_index):
+                            record_unresolved_lineage(lineage, node, current_node_index, input_index)
+                        else:
+                            record_exclusion(initializer_index, "unresolved_lineage_consumer", node, input_index)
+                        continue
+                    output_axes, reason = _onnx_weight_output_axes(node, input_index, len(lineage.shape or ()))
+                    if output_axes is None:
+                        record_exclusion(initializer_index, reason, node, input_index)
+                        continue
+                    add_consumer_group(lineage, node, current_node_index, input_index, output_axes)
+                    roots_consumed_as_weights.add(initializer_index)
+
+            for attribute in getattr(node, "attribute", ()):
+                for subgraph in _iter_attribute_graphs(attribute):
+                    walk_graph(subgraph, value_lineages, constants, root_graph=False)
+
+            output_lineages: dict[int, _OnnxWeightLineage] = {}
+            if supported_transform:
+                data_lineages = value_lineages.get(str(node.input[0]), {}) if node.input else {}
+                for initializer_index, lineage in data_lineages.items():
+                    transform_counts[initializer_index] += 1
+                    output_lineages[initializer_index] = transformed_lineage(lineage, node, constants)
+            else:
+                for initializer_index, lineage in all_input_lineages.items():
+                    if initializer_index in roots_consumed_as_weights:
+                        continue
+                    output_lineages[initializer_index] = _OnnxWeightLineage(
+                        initializer_index=initializer_index,
+                        shape=None,
+                        transforms=lineage.transforms,
+                        unresolved_reason=lineage.unresolved_reason or "unsupported_lineage_operator",
+                    )
+
+            output_lineages = bounded_lineages(output_lineages)
+            for output_name in node.output:
+                if output_name and output_lineages:
+                    value_lineages[str(output_name)] = output_lineages
+
+            if getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS and node.op_type == "Constant":
+                constant_tensor = None
+                for attribute in node.attribute:
+                    if attribute.name != "value":
+                        continue
+                    try:
+                        if attribute.HasField("t"):
+                            constant_tensor = attribute.t
+                    except (AttributeError, ValueError):
+                        constant_tensor = None
+                    break
+                if constant_tensor is not None:
+                    for output_name in node.output:
+                        if output_name:
+                            constants[str(output_name)] = constant_tensor
+
+    root_lineages = {
+        name: {
+            initializer_index: _OnnxWeightLineage(
+                initializer_index=initializer_index,
+                shape=tuple(int(dimension) for dimension in initializers[initializer_index].dims),
+            ),
+        }
+        for name, initializer_index in initializer_indexes.items()
+    }
+    root_constants = {str(initializer.name): initializer for initializer in initializers}
+    walk_graph(graph, root_lineages, root_constants, root_graph=True)
+
+    for initializer_index, _initializer in enumerate(initializers):
+        if terminal_consumer_counts[initializer_index] == 0 and not groups[initializer_index]:
+            reason = (
+                "unconsumed_transformed_initializer" if transform_counts[initializer_index] else "unused_initializer"
+            )
+            record_exclusion(initializer_index, reason)
+
+    analyzed_initializer_indexes: set[int] = set()
+    eligible_metadata: list[dict[str, Any]] = []
+    analysis_id = 0
+    for initializer_index in sorted(eligible_initializer_indexes):
+        initializer = initializers[initializer_index]
+        initializer_groups = groups[initializer_index]
+        if not initializer_groups:
+            continue
+        if initializer.data_location == onnx.TensorProto.EXTERNAL or bool(initializer.external_data):
+            plan.external_initializers_skipped += 1
+            continue
+
+        try:
+            numel = math.prod(int(dimension) for dimension in initializer.dims)
+            itemsize = int(_tensor_data_type_to_np_dtype(initializer.data_type).itemsize)
+            estimated_bytes = numel * itemsize
+            if estimated_bytes < 0 or (
+                max_array_size is not None and max_array_size > 0 and estimated_bytes > max_array_size
+            ):
+                plan.oversized_initializers_skipped += 1
+                continue
+            bounded_name, _, _ = _bounded_onnx_metadata_text(plan, initializer.name)
+            if pre_materialization_check is not None and not pre_materialization_check(
+                initializer,
+                bounded_name,
+                estimated_bytes,
+            ):
+                plan.oversized_initializers_skipped += 1
+                continue
+
+            array = onnx.numpy_helper.to_array(initializer)
+            if retain_array_check is not None and not retain_array_check(bounded_name, int(array.nbytes)):
+                plan.oversized_initializers_skipped += 1
+                continue
+
+            transformed_views: dict[tuple[_OnnxWeightTransform, ...], Any] = {(): array}
+            for consumer_group in initializer_groups.values():
+                transformed = transformed_views.get(consumer_group.lineage.transforms)
+                if transformed is None:
+                    transformed = array
+                    for transform in consumer_group.lineage.transforms:
+                        if transform.kind == "Identity":
+                            continue
+                        if transform.kind == "Transpose":
+                            transformed = np.transpose(transformed, axes=transform.parameters)
+                        elif transform.kind == "Reshape":
+                            transformed = np.reshape(transformed, transform.parameters)
+                        if transformed.size and not np.shares_memory(array, transformed):
+                            raise RuntimeError("ONNX weight lineage transform requires a full-tensor copy")
+                    transformed_views[consumer_group.lineage.transforms] = transformed
+
+                output_axes = consumer_group.output_axes
+                tensor_weights = transformed
+                conceptual_output_axes = output_axes
+                if consumer_group.node.op_type == "ConvTranspose":
+                    group_value = consumer_group.group
+                    if group_value <= 0 or int(transformed.shape[0]) % group_value != 0:
+                        raise ValueError("ConvTranspose initializer has an incompatible group")
+                    tensor_weights = transformed.reshape(
+                        group_value,
+                        int(transformed.shape[0]) // group_value,
+                        *transformed.shape[1:],
+                    )
+                    conceptual_output_axes = (0, 2)
+                if tensor_weights.size and not np.shares_memory(array, tensor_weights):
+                    raise RuntimeError("ONNX weight analysis requires a full-tensor copy")
+
+                matrix_analysis = consumer_group.analysis_kind == "matrix"
+                analysis_weights = tensor_weights
+                if matrix_analysis:
+                    if len(output_axes) != 1 or transformed.ndim != 2:
+                        raise ValueError("Matrix weight analysis requires exactly one output axis")
+                    analysis_weights = np.moveaxis(transformed, output_axes[0], -1)
+                    conceptual_output_axes = (analysis_weights.ndim - 1,)
+                input_axes = tuple(axis for axis in range(analysis_weights.ndim) if axis not in conceptual_output_axes)
+                analysis_shape = [
+                    math.prod(int(analysis_weights.shape[axis]) for axis in input_axes),
+                    math.prod(int(analysis_weights.shape[axis]) for axis in conceptual_output_axes),
+                ]
+                first_consumer = consumer_group.consumers[0]
+                context = {
+                    "analysis_id": analysis_id,
+                    **_bounded_onnx_metadata_fields(plan, "initializer", initializer.name),
+                    "consumer_op": first_consumer["op"],
+                    "consumer_op_length": first_consumer["op_length"],
+                    "consumer_op_truncated": first_consumer["op_truncated"],
+                    "consumer_node": first_consumer["node"],
+                    "consumer_node_length": first_consumer["node_length"],
+                    "consumer_node_truncated": first_consumer["node_truncated"],
+                    "consumer_node_index": consumer_group.node_index,
+                    "consumer_input_index": consumer_group.input_index,
+                    "output_axis": output_axes[-1],
+                    **_bounded_onnx_integer_sequence("output_axes", output_axes),
+                    "analysis_kind": consumer_group.analysis_kind,
+                    "group": consumer_group.group,
+                    **_bounded_onnx_integer_sequence("stored_shape", initializer.dims),
+                    **_bounded_onnx_integer_sequence("transformed_shape", transformed.shape),
+                    "analysis_shape": analysis_shape,
+                    **_bounded_onnx_integer_sequence("conceptual_output_axes", conceptual_output_axes),
+                    "analysis_storage_shares_memory": bool(
+                        array.size == 0 or np.shares_memory(array, analysis_weights)
+                    ),
+                    "analysis_materialization": "zero_copy_view_chunked_reduction",
+                    "lineage": [transform.kind for transform in consumer_group.lineage.transforms],
+                    "lineage_transform_count": len(consumer_group.lineage.transforms),
+                    "consumer_count": consumer_group.consumer_count,
+                    "consumers": consumer_group.consumers,
+                    "consumers_truncated": consumer_group.consumer_count > len(consumer_group.consumers),
+                }
+                plan.specs.append(
+                    _OnnxWeightAnalysisSpec(
+                        analysis_id=analysis_id,
+                        weights=analysis_weights,
+                        output_axes=conceptual_output_axes,
+                        matrix_analysis=matrix_analysis,
+                        context=context,
+                    ),
+                )
+                analysis_id += 1
+                analyzed_initializer_indexes.add(initializer_index)
+                if len(eligible_metadata) < _ONNX_WEIGHT_METADATA_SAMPLE_LIMIT:
+                    eligible_metadata.append(context)
+        except Exception as exc:
+            plan.extraction_failures += 1
+            bounded_name, _, _ = _bounded_onnx_metadata_text(plan, initializer.name)
+            logger.warning(
+                "Failed to prepare ONNX initializer '%s' for distribution analysis (%s)",
+                bounded_name,
+                type(exc).__name__,
+            )
+
+    plan.eligible_initializer_count = len(eligible_initializer_indexes)
+    plan.analyzed_initializer_count = len(analyzed_initializer_indexes)
+    plan.metadata = {
+        "eligible_initializer_count": plan.eligible_initializer_count,
+        "analyzed_layer_count": len(plan.specs),
+        "eligible": eligible_metadata,
+        "eligible_metadata_truncated": len(plan.specs) > len(eligible_metadata),
+        "exclusion_counts": plan.exclusion_counts,
+        "exclusion_samples": plan.exclusion_samples,
+        "exclusion_metadata_truncated": sum(plan.exclusion_counts.values()) > len(plan.exclusion_samples),
+        "consumer_count": total_consumer_count,
+        "consumer_metadata_sample_count": consumer_sample_count,
+        "consumer_metadata_truncated": total_consumer_count > consumer_sample_count,
+        "unresolved_lineage_samples": plan.unresolved_lineage_samples,
+        "unresolved_lineage_metadata_truncated": plan.coverage_gaps.get("unresolved_initializer_lineage", 0)
+        > len(plan.unresolved_lineage_samples),
+        "coverage_gaps": dict(plan.coverage_gaps),
+        "metadata_string_truncation_count": plan.string_truncation_count,
+        "metadata_strings_truncated": plan.string_truncation_count > 0,
+        "initializer_name_validation": {
+            "empty_name_count": 0,
+            "duplicate_name_count": 0,
+            "samples": [],
+            "samples_truncated": False,
+        },
+    }
+    return plan
 
 
 def _parse_external_data_extent(info: dict[str, str], key: str) -> int | None:
@@ -1125,14 +1848,7 @@ class OnnxScanner(BaseScanner):
                     )
 
     def _check_weight_distribution(self, model: Any, path: str, result: ScanResult) -> None:
-        """Extract weights from ONNX initializers and run weight distribution analysis.
-
-        The model is already loaded with load_external_data=False, so external-data
-        tensors have no raw bytes and must be skipped. Only floating-point tensors
-        used as weights by supported neural-network operators are analyzed. This
-        avoids applying output-neuron statistics to embeddings, quantized codes,
-        biases, and shape/bookkeeping constants.
-        """
+        """Run bounded semantic weight analysis over eligible ONNX initializers."""
         try:
             import numpy as np
             import onnx
@@ -1146,238 +1862,53 @@ class OnnxScanner(BaseScanner):
             )
             return
 
-        # Max in-memory array size (default 100 MB)
-        max_array_size = self.config.get("max_array_size", 100 * 1024 * 1024)
+        configured_max_array_size = self.config.get("max_array_size", 100 * 1024 * 1024)
+        max_array_size = (
+            int(configured_max_array_size)
+            if isinstance(configured_max_array_size, (int, float))
+            and not isinstance(configured_max_array_size, bool)
+            and math.isfinite(float(configured_max_array_size))
+            and configured_max_array_size > 0
+            else None
+        )
+        plan = _build_onnx_weight_analysis_plan(
+            model,
+            onnx=onnx,
+            np=np,
+            max_array_size=max_array_size,
+        )
+        result.metadata["onnx_weight_distribution_semantics"] = plan.metadata
 
-        initializers = {initializer.name: initializer for initializer in model.graph.initializer}
-        consumers: dict[str, list[tuple[int, Any, int]]] = {name: [] for name in initializers}
-        for node_index, (node, input_index, input_name) in enumerate(
-            _iter_captured_initializer_consumers(model.graph, set(initializers), root_graph=True),
-        ):
-            consumers[input_name].append((node_index, node, input_index))
-
-        floating_types = {
-            int(getattr(onnx.TensorProto, name))
-            for name in (
-                "FLOAT",
-                "FLOAT16",
-                "DOUBLE",
-                "BFLOAT16",
-                "FLOAT8E4M3FN",
-                "FLOAT8E4M3FNUZ",
-                "FLOAT8E5M2",
-                "FLOAT8E5M2FNUZ",
-                "FLOAT4E2M1",
-            )
-            if hasattr(onnx.TensorProto, name)
-        }
-
-        eligible_initializers = 0
-        external_initializers_skipped = 0
-        oversized_initializers_skipped = 0
-        extraction_failures = 0
-        weights_info: dict[str, Any] = {}
-        tensor_weight_specs: dict[str, tuple[Any, tuple[int, ...]]] = {}
-        layer_contexts: dict[str, dict[str, Any]] = {}
-        analyzed_initializer_names: set[str] = set()
-        eligible_metadata: list[dict[str, Any]] = []
-        exclusion_counts: dict[str, int] = {}
-        exclusion_samples: list[dict[str, Any]] = []
-
-        def record_exclusion(
-            initializer: Any, reason: str, node: Any | None = None, input_index: int | None = None
-        ) -> None:
-            exclusion_counts[reason] = exclusion_counts.get(reason, 0) + 1
-            if len(exclusion_samples) >= _ONNX_WEIGHT_METADATA_SAMPLE_LIMIT:
-                return
-            exclusion: dict[str, Any] = {
-                "initializer": initializer.name,
-                "reason": reason,
-                "stored_shape": [int(dim) for dim in initializer.dims],
-            }
-            if node is not None:
-                exclusion.update(
-                    {
-                        "consumer_op": node.op_type,
-                        "consumer_node": node.name,
-                        "consumer_input_index": input_index,
-                    },
-                )
-            exclusion_samples.append(exclusion)
-
-        for initializer_name, initializer in initializers.items():
-            try:
-                self.check_interrupted()
-
-                initializer_consumers = consumers[initializer_name]
-                if not initializer_consumers:
-                    record_exclusion(initializer, "unused_initializer")
-                    continue
-
-                semantic_contexts: list[dict[str, Any]] = []
-                for node_index, node, input_index in initializer_consumers:
-                    output_axis, reason = _onnx_weight_output_axis(node, input_index, len(initializer.dims))
-                    if output_axis is None:
-                        record_exclusion(initializer, reason, node, input_index)
-                        continue
-                    if int(initializer.data_type) not in floating_types:
-                        record_exclusion(initializer, "non_floating_weight", node, input_index)
-                        continue
-                    semantic_contexts.append(
-                        {
-                            "initializer": initializer.name,
-                            "consumer_op": node.op_type,
-                            "consumer_node": node.name,
-                            "consumer_node_index": node_index,
-                            "consumer_input_index": input_index,
-                            "output_axis": output_axis,
-                            "analysis_kind": (
-                                "tensor"
-                                if node.op_type in {"Conv", "ConvTranspose"}
-                                or (len(initializer.dims) > 2 and output_axis != len(initializer.dims) - 1)
-                                else "matrix"
-                            ),
-                            "group": (
-                                _onnx_int_attribute(node, "group", 1)
-                                if node.op_type in {"Conv", "ConvTranspose"}
-                                else 1
-                            ),
-                            "stored_shape": [int(dim) for dim in initializer.dims],
-                        },
-                    )
-
-                if not semantic_contexts:
-                    continue
-                eligible_initializers += 1
-
-                # Skip external-data tensors — their bytes were not loaded.
-                if initializer.data_location == onnx.TensorProto.EXTERNAL:
-                    external_initializers_skipped += 1
-                    continue
-
-                # Pre-check estimated size before materializing the array.
-                # Use math.prod for arbitrary-precision arithmetic (np.prod
-                # can silently overflow for very large dimension products).
-                numel = math.prod(int(dim) for dim in initializer.dims)
-                itemsize = int(_tensor_data_type_to_np_dtype(initializer.data_type).itemsize)
-                estimated_bytes = numel * itemsize
-                if max_array_size and max_array_size > 0 and estimated_bytes > max_array_size:
-                    oversized_initializers_skipped += 1
-                    continue
-
-                array = onnx.numpy_helper.to_array(initializer)
-                contexts_by_analysis: dict[tuple[str, int, int], list[dict[str, Any]]] = {}
-                for context in semantic_contexts:
-                    analysis_key = (
-                        str(context["analysis_kind"]),
-                        int(context["output_axis"]),
-                        int(context["group"]),
-                    )
-                    contexts_by_analysis.setdefault(analysis_key, []).append(context)
-
-                for (analysis_kind, output_axis, group), axis_contexts in contexts_by_analysis.items():
-                    layer_name = initializer.name
-                    if len(contexts_by_analysis) > 1:
-                        layer_name = f"{initializer.name}@output_axis={output_axis}"
-                    if layer_name in weights_info or layer_name in tensor_weight_specs:
-                        layer_name = f"{layer_name},kind={analysis_kind},group={group}"
-
-                    analysis_shape: list[int]
-                    conceptual_output_axes: tuple[int, ...]
-                    shares_storage = True
-                    if analysis_kind == "tensor":
-                        tensor_array = array
-                        conceptual_output_axes = (output_axis,)
-                        if axis_contexts[0]["consumer_op"] == "ConvTranspose":
-                            if group <= 0 or int(array.shape[0]) % group != 0:
-                                raise ValueError(
-                                    f"ConvTranspose initializer {initializer.name!r} has incompatible group {group}"
-                                )
-                            tensor_array = array.reshape(group, int(array.shape[0]) // group, *array.shape[1:])
-                            conceptual_output_axes = (0, 2)
-                        shares_storage = bool(array.size == 0 or np.shares_memory(array, tensor_array))
-                        if not shares_storage:
-                            raise RuntimeError(
-                                f"Weight analysis for initializer {initializer.name!r} would copy the full tensor"
-                            )
-                        input_axes = tuple(
-                            axis for axis in range(tensor_array.ndim) if axis not in conceptual_output_axes
-                        )
-                        analysis_shape = [
-                            math.prod(int(tensor_array.shape[axis]) for axis in input_axes),
-                            math.prod(int(tensor_array.shape[axis]) for axis in conceptual_output_axes),
-                        ]
-                        tensor_weight_specs[layer_name] = (tensor_array, conceptual_output_axes)
-                    else:
-                        analysis_array = np.moveaxis(array, output_axis, -1)
-                        if analysis_array.ndim > 2:
-                            analysis_array = analysis_array.reshape(-1, analysis_array.shape[-1])
-                        shares_storage = bool(array.size == 0 or np.shares_memory(array, analysis_array))
-                        if not shares_storage:
-                            raise RuntimeError(
-                                f"Weight analysis for initializer {initializer.name!r} would copy the full tensor"
-                            )
-                        conceptual_output_axes = (analysis_array.ndim - 1,)
-                        analysis_shape = [int(dim) for dim in analysis_array.shape]
-                        weights_info[layer_name] = analysis_array
-                    context = {
-                        **axis_contexts[0],
-                        "analysis_shape": analysis_shape,
-                        "conceptual_output_axes": list(conceptual_output_axes),
-                        "analysis_storage_shares_memory": shares_storage,
-                        "analysis_materialization": "zero_copy_view_chunked_reduction",
-                        "consumers": [
-                            {
-                                "op": item["consumer_op"],
-                                "node": item["consumer_node"],
-                                "node_index": item["consumer_node_index"],
-                                "input_index": item["consumer_input_index"],
-                            }
-                            for item in axis_contexts
-                        ],
-                    }
-                    layer_contexts[layer_name] = context
-                    analyzed_initializer_names.add(initializer_name)
-                    if len(eligible_metadata) < _ONNX_WEIGHT_METADATA_SAMPLE_LIMIT:
-                        eligible_metadata.append(context)
-            except Exception as e:
-                extraction_failures += 1
-                logger.warning(
-                    "Failed to extract ONNX initializer '%s' for distribution analysis: %s",
-                    initializer.name,
-                    e,
-                )
-                continue
-
-        analyzed_layer_count = len(weights_info) + len(tensor_weight_specs)
-        result.metadata["onnx_weight_distribution_semantics"] = {
-            "eligible_initializer_count": eligible_initializers,
-            "analyzed_layer_count": analyzed_layer_count,
-            "eligible": eligible_metadata,
-            "eligible_metadata_truncated": analyzed_layer_count > len(eligible_metadata),
-            "exclusion_counts": exclusion_counts,
-            "exclusion_samples": exclusion_samples,
-            "exclusion_metadata_truncated": sum(exclusion_counts.values()) > len(exclusion_samples),
-        }
-
-        if external_initializers_skipped or oversized_initializers_skipped or extraction_failures:
+        coverage_incomplete = bool(
+            plan.coverage_gaps
+            or plan.external_initializers_skipped
+            or plan.oversized_initializers_skipped
+            or plan.extraction_failures
+        )
+        if coverage_incomplete:
+            reason = "partial_initializer_coverage"
+            if plan.coverage_gaps and not (
+                plan.external_initializers_skipped or plan.oversized_initializers_skipped or plan.extraction_failures
+            ):
+                reason = next(iter(plan.coverage_gaps)) if len(plan.coverage_gaps) == 1 else "multiple_coverage_gaps"
             self._mark_weight_distribution_incomplete(
                 result,
                 path,
-                reason="partial_initializer_coverage",
+                reason=reason,
                 message="Weight distribution analysis skipped one or more eligible ONNX initializers",
                 details={
-                    "eligible_initializers": eligible_initializers,
-                    "analyzed_initializers": len(analyzed_initializer_names),
-                    "external_initializers_skipped": external_initializers_skipped,
-                    "oversized_initializers_skipped": oversized_initializers_skipped,
-                    "extraction_failures": extraction_failures,
+                    "eligible_initializers": plan.eligible_initializer_count,
+                    "analyzed_initializers": plan.analyzed_initializer_count,
+                    "external_initializers_skipped": plan.external_initializers_skipped,
+                    "oversized_initializers_skipped": plan.oversized_initializers_skipped,
+                    "extraction_failures": plan.extraction_failures,
+                    "coverage_gaps": plan.coverage_gaps,
+                    "unresolved_lineage_samples": plan.unresolved_lineage_samples,
                     "max_array_size": max_array_size,
                 },
             )
 
-        if not weights_info and not tensor_weight_specs:
-            # Nothing to analyse (external-only model, or all tensors too small / too large).
+        if not plan.specs:
             return
 
         try:
@@ -1396,39 +1927,12 @@ class OnnxScanner(BaseScanner):
             )
             return
 
-        # Delegate the actual statistical analysis to WeightDistributionScanner.
         try:
             wd_scanner = WeightDistributionScanner(self.config)
-            anomalies = wd_scanner._analyze_weight_distributions(weights_info)
-            for layer_name, (tensor_weights, output_axes) in tensor_weight_specs.items():
-                anomalies.extend(
-                    wd_scanner._analyze_tensor_weight_extremes(
-                        layer_name,
-                        tensor_weights,
-                        output_axes=output_axes,
-                    ),
-                )
-
-            for anomaly in anomalies:
+            analyzed = wd_scanner._analyze_onnx_weight_specs(plan.specs)
+            for anomaly, spec in analyzed:
                 details = dict(anomaly["details"])
-                layer_name = str(details.get("layer", ""))
-                layer_context = layer_contexts.get(layer_name)
-                if layer_context is not None:
-                    details.update(
-                        {
-                            "initializer": layer_context["initializer"],
-                            "consumer_op": layer_context["consumer_op"],
-                            "consumer_node": layer_context["consumer_node"],
-                            "consumer_input_index": layer_context["consumer_input_index"],
-                            "output_axis": layer_context["output_axis"],
-                            "stored_shape": layer_context["stored_shape"],
-                            "analysis_shape": layer_context["analysis_shape"],
-                            "conceptual_output_axes": layer_context["conceptual_output_axes"],
-                            "group": layer_context["group"],
-                            "analysis_storage_shares_memory": layer_context["analysis_storage_shares_memory"],
-                            "analysis_materialization": layer_context["analysis_materialization"],
-                        },
-                    )
+                details.update(spec.context)
                 result.add_check(
                     name="Weight Distribution Anomaly Detection",
                     passed=False,
@@ -1439,26 +1943,26 @@ class OnnxScanner(BaseScanner):
                     why=anomaly.get("why"),
                 )
 
-            result.metadata["layers_analyzed"] = analyzed_layer_count
-            result.metadata["anomalies_found"] = len(anomalies)
-            if extraction_failures > 0:
-                result.metadata["weight_extraction_failures"] = extraction_failures
+            result.metadata["layers_analyzed"] = len(plan.specs)
+            result.metadata["anomalies_found"] = len(analyzed)
+            if plan.extraction_failures > 0:
+                result.metadata["weight_extraction_failures"] = plan.extraction_failures
         except Exception as e:
-            logger.warning(f"Weight distribution analysis failed: {e}")
+            logger.warning("Weight distribution analysis failed (%s)", type(e).__name__)
             result.add_check(
                 name="Weight Distribution Analysis",
                 passed=False,
-                message=f"Weight distribution analysis failed: {e!s}",
+                message=f"Weight distribution analysis failed ({type(e).__name__})",
                 severity=IssueSeverity.DEBUG,
                 location=path,
-                details={"exception": str(e), "exception_type": type(e).__name__},
+                details={"exception_type": type(e).__name__},
             )
             self._mark_weight_distribution_incomplete(
                 result,
                 path,
                 reason="analysis_failed",
-                message=f"Weight distribution analysis failed: {e!s}",
-                details={"exception": str(e), "exception_type": type(e).__name__},
+                message=f"Weight distribution analysis failed ({type(e).__name__})",
+                details={"exception_type": type(e).__name__},
             )
 
     def _mark_weight_distribution_incomplete(

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -132,17 +132,21 @@ def _onnx_weight_output_axis(node: Any, input_index: int, rank: int) -> tuple[in
         return None, "custom_domain_consumer"
 
     if op_type == "Gemm":
-        if input_index != 1:
+        if input_index not in {0, 1}:
             return None, "non_weight_input"
         if rank != 2:
             return None, "unsupported_weight_rank"
+        if input_index == 0:
+            return (1 if _onnx_int_attribute(node, "transA") else 0), "eligible_gemm_left_weight"
         return (0 if _onnx_int_attribute(node, "transB") else 1), "eligible_gemm_weight"
 
     if op_type == "MatMul":
-        if input_index != 1:
+        if input_index not in {0, 1}:
             return None, "non_weight_input"
         if rank < 2:
             return None, "unsupported_weight_rank"
+        if input_index == 0:
+            return rank - 2, "eligible_matmul_left_weight"
         return rank - 1, "eligible_matmul_weight"
 
     if op_type == "Conv":
@@ -185,6 +189,40 @@ def _iter_graph_nodes(graph: Any) -> Any:
         for attribute in node.attribute:
             for subgraph in _iter_attribute_graphs(attribute):
                 yield from _iter_graph_nodes(subgraph)
+
+
+def _graph_declared_value_names(graph: Any) -> set[str]:
+    """Return names that shadow values captured from an enclosing ONNX graph."""
+    declared = {value.name for value in getattr(graph, "input", []) if value.name}
+    declared.update(initializer.name for initializer in getattr(graph, "initializer", []) if initializer.name)
+    for sparse_initializer in getattr(graph, "sparse_initializer", []):
+        if sparse_initializer.values.name:
+            declared.add(sparse_initializer.values.name)
+    for node in getattr(graph, "node", []):
+        declared.update(output_name for output_name in node.output if output_name)
+    return declared
+
+
+def _iter_captured_initializer_consumers(
+    graph: Any,
+    initializer_names: set[str],
+    *,
+    root_graph: bool = False,
+) -> Any:
+    """Yield consumers of visible initializers across nested control-flow graphs."""
+    visible_names = initializer_names
+    if not root_graph:
+        visible_names = initializer_names - _graph_declared_value_names(graph)
+    if not visible_names:
+        return
+
+    for node in getattr(graph, "node", []):
+        for input_index, input_name in enumerate(node.input):
+            if input_name in visible_names:
+                yield node, input_index, input_name
+        for attribute in getattr(node, "attribute", []):
+            for subgraph in _iter_attribute_graphs(attribute):
+                yield from _iter_captured_initializer_consumers(subgraph, visible_names)
 
 
 def _iter_model_graphs(model: Any) -> Any:
@@ -1113,10 +1151,10 @@ class OnnxScanner(BaseScanner):
 
         initializers = {initializer.name: initializer for initializer in model.graph.initializer}
         consumers: dict[str, list[tuple[int, Any, int]]] = {name: [] for name in initializers}
-        for node_index, node in enumerate(model.graph.node):
-            for input_index, input_name in enumerate(node.input):
-                if input_name in consumers:
-                    consumers[input_name].append((node_index, node, input_index))
+        for node_index, (node, input_index, input_name) in enumerate(
+            _iter_captured_initializer_consumers(model.graph, set(initializers), root_graph=True),
+        ):
+            consumers[input_name].append((node_index, node, input_index))
 
         floating_types = {
             int(getattr(onnx.TensorProto, name))
@@ -1139,7 +1177,9 @@ class OnnxScanner(BaseScanner):
         oversized_initializers_skipped = 0
         extraction_failures = 0
         weights_info: dict[str, Any] = {}
+        tensor_weight_specs: dict[str, tuple[Any, tuple[int, ...]]] = {}
         layer_contexts: dict[str, dict[str, Any]] = {}
+        analyzed_initializer_names: set[str] = set()
         eligible_metadata: list[dict[str, Any]] = []
         exclusion_counts: dict[str, int] = {}
         exclusion_samples: list[dict[str, Any]] = []
@@ -1191,6 +1231,17 @@ class OnnxScanner(BaseScanner):
                             "consumer_node_index": node_index,
                             "consumer_input_index": input_index,
                             "output_axis": output_axis,
+                            "analysis_kind": (
+                                "tensor"
+                                if node.op_type in {"Conv", "ConvTranspose"}
+                                or (len(initializer.dims) > 2 and output_axis != len(initializer.dims) - 1)
+                                else "matrix"
+                            ),
+                            "group": (
+                                _onnx_int_attribute(node, "group", 1)
+                                if node.op_type in {"Conv", "ConvTranspose"}
+                                else 1
+                            ),
                             "stored_shape": [int(dim) for dim in initializer.dims],
                         },
                     )
@@ -1215,20 +1266,66 @@ class OnnxScanner(BaseScanner):
                     continue
 
                 array = onnx.numpy_helper.to_array(initializer)
-                contexts_by_axis: dict[int, list[dict[str, Any]]] = {}
+                contexts_by_analysis: dict[tuple[str, int, int], list[dict[str, Any]]] = {}
                 for context in semantic_contexts:
-                    contexts_by_axis.setdefault(int(context["output_axis"]), []).append(context)
+                    analysis_key = (
+                        str(context["analysis_kind"]),
+                        int(context["output_axis"]),
+                        int(context["group"]),
+                    )
+                    contexts_by_analysis.setdefault(analysis_key, []).append(context)
 
-                for output_axis, axis_contexts in contexts_by_axis.items():
+                for (analysis_kind, output_axis, group), axis_contexts in contexts_by_analysis.items():
                     layer_name = initializer.name
-                    if len(contexts_by_axis) > 1:
+                    if len(contexts_by_analysis) > 1:
                         layer_name = f"{initializer.name}@output_axis={output_axis}"
-                    analysis_array = np.moveaxis(array, output_axis, -1)
-                    if analysis_array.ndim > 2:
-                        analysis_array = analysis_array.reshape(-1, analysis_array.shape[-1])
+                    if layer_name in weights_info or layer_name in tensor_weight_specs:
+                        layer_name = f"{layer_name},kind={analysis_kind},group={group}"
+
+                    analysis_shape: list[int]
+                    conceptual_output_axes: tuple[int, ...]
+                    shares_storage = True
+                    if analysis_kind == "tensor":
+                        tensor_array = array
+                        conceptual_output_axes = (output_axis,)
+                        if axis_contexts[0]["consumer_op"] == "ConvTranspose":
+                            if group <= 0 or int(array.shape[0]) % group != 0:
+                                raise ValueError(
+                                    f"ConvTranspose initializer {initializer.name!r} has incompatible group {group}"
+                                )
+                            tensor_array = array.reshape(group, int(array.shape[0]) // group, *array.shape[1:])
+                            conceptual_output_axes = (0, 2)
+                        shares_storage = bool(array.size == 0 or np.shares_memory(array, tensor_array))
+                        if not shares_storage:
+                            raise RuntimeError(
+                                f"Weight analysis for initializer {initializer.name!r} would copy the full tensor"
+                            )
+                        input_axes = tuple(
+                            axis for axis in range(tensor_array.ndim) if axis not in conceptual_output_axes
+                        )
+                        analysis_shape = [
+                            math.prod(int(tensor_array.shape[axis]) for axis in input_axes),
+                            math.prod(int(tensor_array.shape[axis]) for axis in conceptual_output_axes),
+                        ]
+                        tensor_weight_specs[layer_name] = (tensor_array, conceptual_output_axes)
+                    else:
+                        analysis_array = np.moveaxis(array, output_axis, -1)
+                        if analysis_array.ndim > 2:
+                            analysis_array = analysis_array.reshape(-1, analysis_array.shape[-1])
+                        shares_storage = bool(array.size == 0 or np.shares_memory(array, analysis_array))
+                        if not shares_storage:
+                            raise RuntimeError(
+                                f"Weight analysis for initializer {initializer.name!r} would copy the full tensor"
+                            )
+                        conceptual_output_axes = (analysis_array.ndim - 1,)
+                        analysis_shape = [int(dim) for dim in analysis_array.shape]
+                        weights_info[layer_name] = analysis_array
                     context = {
                         **axis_contexts[0],
-                        "analysis_shape": [int(dim) for dim in analysis_array.shape],
+                        "analysis_shape": analysis_shape,
+                        "conceptual_output_axes": list(conceptual_output_axes),
+                        "analysis_storage_shares_memory": shares_storage,
+                        "analysis_materialization": "zero_copy_view_chunked_reduction",
                         "consumers": [
                             {
                                 "op": item["consumer_op"],
@@ -1239,8 +1336,8 @@ class OnnxScanner(BaseScanner):
                             for item in axis_contexts
                         ],
                     }
-                    weights_info[layer_name] = analysis_array
                     layer_contexts[layer_name] = context
+                    analyzed_initializer_names.add(initializer_name)
                     if len(eligible_metadata) < _ONNX_WEIGHT_METADATA_SAMPLE_LIMIT:
                         eligible_metadata.append(context)
             except Exception as e:
@@ -1252,11 +1349,12 @@ class OnnxScanner(BaseScanner):
                 )
                 continue
 
+        analyzed_layer_count = len(weights_info) + len(tensor_weight_specs)
         result.metadata["onnx_weight_distribution_semantics"] = {
             "eligible_initializer_count": eligible_initializers,
-            "analyzed_layer_count": len(weights_info),
+            "analyzed_layer_count": analyzed_layer_count,
             "eligible": eligible_metadata,
-            "eligible_metadata_truncated": len(weights_info) > len(eligible_metadata),
+            "eligible_metadata_truncated": analyzed_layer_count > len(eligible_metadata),
             "exclusion_counts": exclusion_counts,
             "exclusion_samples": exclusion_samples,
             "exclusion_metadata_truncated": sum(exclusion_counts.values()) > len(exclusion_samples),
@@ -1270,7 +1368,7 @@ class OnnxScanner(BaseScanner):
                 message="Weight distribution analysis skipped one or more eligible ONNX initializers",
                 details={
                     "eligible_initializers": eligible_initializers,
-                    "analyzed_initializers": len(weights_info),
+                    "analyzed_initializers": len(analyzed_initializer_names),
                     "external_initializers_skipped": external_initializers_skipped,
                     "oversized_initializers_skipped": oversized_initializers_skipped,
                     "extraction_failures": extraction_failures,
@@ -1278,7 +1376,7 @@ class OnnxScanner(BaseScanner):
                 },
             )
 
-        if not weights_info:
+        if not weights_info and not tensor_weight_specs:
             # Nothing to analyse (external-only model, or all tensors too small / too large).
             return
 
@@ -1302,6 +1400,14 @@ class OnnxScanner(BaseScanner):
         try:
             wd_scanner = WeightDistributionScanner(self.config)
             anomalies = wd_scanner._analyze_weight_distributions(weights_info)
+            for layer_name, (tensor_weights, output_axes) in tensor_weight_specs.items():
+                anomalies.extend(
+                    wd_scanner._analyze_tensor_weight_extremes(
+                        layer_name,
+                        tensor_weights,
+                        output_axes=output_axes,
+                    ),
+                )
 
             for anomaly in anomalies:
                 details = dict(anomaly["details"])
@@ -1317,6 +1423,10 @@ class OnnxScanner(BaseScanner):
                             "output_axis": layer_context["output_axis"],
                             "stored_shape": layer_context["stored_shape"],
                             "analysis_shape": layer_context["analysis_shape"],
+                            "conceptual_output_axes": layer_context["conceptual_output_axes"],
+                            "group": layer_context["group"],
+                            "analysis_storage_shares_memory": layer_context["analysis_storage_shares_memory"],
+                            "analysis_materialization": layer_context["analysis_materialization"],
                         },
                     )
                 result.add_check(
@@ -1329,7 +1439,7 @@ class OnnxScanner(BaseScanner):
                     why=anomaly.get("why"),
                 )
 
-            result.metadata["layers_analyzed"] = len(weights_info)
+            result.metadata["layers_analyzed"] = analyzed_layer_count
             result.metadata["anomalies_found"] = len(anomalies)
             if extraction_failures > 0:
                 result.metadata["weight_extraction_failures"] = extraction_failures

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -80,6 +80,8 @@ _PYTHON_OPERATOR_PATTERN = re.compile(
 _OP_TYPE_TOKEN_PATTERN = re.compile(
     r"[A-Z]+(?=[A-Z][a-z0-9]|[^A-Za-z0-9]|$)|[A-Z]?[a-z0-9]+",
 )
+_ONNX_WEIGHT_METADATA_SAMPLE_LIMIT = 100
+_STANDARD_NEURAL_NETWORK_DOMAINS: frozenset[str] = frozenset({"", "ai.onnx"})
 
 
 def _check_onnx() -> bool:
@@ -112,6 +114,58 @@ def _is_python_operator(op_type: str) -> bool:
         if token == "py" and next_token in {"op", "func"}:
             return True
     return False
+
+
+def _onnx_int_attribute(node: Any, name: str, default: int = 0) -> int:
+    """Read an integer ONNX node attribute without importing ONNX eagerly."""
+    for attribute in getattr(node, "attribute", []):
+        if attribute.name == name:
+            return int(attribute.i)
+    return default
+
+
+def _onnx_weight_output_axis(node: Any, input_index: int, rank: int) -> tuple[int | None, str]:
+    """Classify an initializer consumer for statistical weight analysis."""
+    op_type = node.op_type
+    domain = getattr(node, "domain", "")
+    if domain not in _STANDARD_NEURAL_NETWORK_DOMAINS:
+        return None, "custom_domain_consumer"
+
+    if op_type == "Gemm":
+        if input_index != 1:
+            return None, "non_weight_input"
+        if rank != 2:
+            return None, "unsupported_weight_rank"
+        return (0 if _onnx_int_attribute(node, "transB") else 1), "eligible_gemm_weight"
+
+    if op_type == "MatMul":
+        if input_index != 1:
+            return None, "non_weight_input"
+        if rank < 2:
+            return None, "unsupported_weight_rank"
+        return rank - 1, "eligible_matmul_weight"
+
+    if op_type == "Conv":
+        if input_index != 1:
+            return None, "non_weight_input"
+        if rank < 3:
+            return None, "unsupported_weight_rank"
+        return 0, "eligible_conv_weight"
+
+    if op_type == "ConvTranspose":
+        if input_index != 1:
+            return None, "non_weight_input"
+        if rank < 3:
+            return None, "unsupported_weight_rank"
+        return 1, "eligible_conv_transpose_weight"
+
+    if op_type == "Gather" and input_index == 0:
+        return None, "embedding_table"
+    if op_type in {"ConvInteger", "MatMulInteger", "QLinearConv", "QLinearMatMul"}:
+        return None, "quantized_operator"
+    if op_type in {"Add", "Mul", "Sub", "Div", "Reshape", "Shape", "Slice", "Transpose"}:
+        return None, "bookkeeping_constant"
+    return None, "unsupported_consumer"
 
 
 def _iter_attribute_graphs(attribute: Any) -> Any:
@@ -1036,11 +1090,13 @@ class OnnxScanner(BaseScanner):
         """Extract weights from ONNX initializers and run weight distribution analysis.
 
         The model is already loaded with load_external_data=False, so external-data
-        tensors have no raw bytes and must be skipped.  Only inline 2-D+ tensors
-        (conv kernels, linear layers, embeddings) are relevant for distribution
-        analysis; 1-D tensors (biases, batch-norm params) are excluded.
+        tensors have no raw bytes and must be skipped. Only floating-point tensors
+        used as weights by supported neural-network operators are analyzed. This
+        avoids applying output-neuron statistics to embeddings, quantized codes,
+        biases, and shape/bookkeeping constants.
         """
         try:
+            import numpy as np
             import onnx
         except Exception as e:
             self._mark_weight_distribution_incomplete(
@@ -1055,17 +1111,91 @@ class OnnxScanner(BaseScanner):
         # Max in-memory array size (default 100 MB)
         max_array_size = self.config.get("max_array_size", 100 * 1024 * 1024)
 
+        initializers = {initializer.name: initializer for initializer in model.graph.initializer}
+        consumers: dict[str, list[tuple[int, Any, int]]] = {name: [] for name in initializers}
+        for node_index, node in enumerate(model.graph.node):
+            for input_index, input_name in enumerate(node.input):
+                if input_name in consumers:
+                    consumers[input_name].append((node_index, node, input_index))
+
+        floating_types = {
+            int(getattr(onnx.TensorProto, name))
+            for name in (
+                "FLOAT",
+                "FLOAT16",
+                "DOUBLE",
+                "BFLOAT16",
+                "FLOAT8E4M3FN",
+                "FLOAT8E4M3FNUZ",
+                "FLOAT8E5M2",
+                "FLOAT8E5M2FNUZ",
+                "FLOAT4E2M1",
+            )
+            if hasattr(onnx.TensorProto, name)
+        }
+
         eligible_initializers = 0
         external_initializers_skipped = 0
         oversized_initializers_skipped = 0
         extraction_failures = 0
         weights_info: dict[str, Any] = {}
-        for initializer in model.graph.initializer:
+        layer_contexts: dict[str, dict[str, Any]] = {}
+        eligible_metadata: list[dict[str, Any]] = []
+        exclusion_counts: dict[str, int] = {}
+        exclusion_samples: list[dict[str, Any]] = []
+
+        def record_exclusion(
+            initializer: Any, reason: str, node: Any | None = None, input_index: int | None = None
+        ) -> None:
+            exclusion_counts[reason] = exclusion_counts.get(reason, 0) + 1
+            if len(exclusion_samples) >= _ONNX_WEIGHT_METADATA_SAMPLE_LIMIT:
+                return
+            exclusion: dict[str, Any] = {
+                "initializer": initializer.name,
+                "reason": reason,
+                "stored_shape": [int(dim) for dim in initializer.dims],
+            }
+            if node is not None:
+                exclusion.update(
+                    {
+                        "consumer_op": node.op_type,
+                        "consumer_node": node.name,
+                        "consumer_input_index": input_index,
+                    },
+                )
+            exclusion_samples.append(exclusion)
+
+        for initializer_name, initializer in initializers.items():
             try:
                 self.check_interrupted()
 
-                # Only 2-D+ tensors are interesting for distribution analysis.
-                if len(initializer.dims) < 2:
+                initializer_consumers = consumers[initializer_name]
+                if not initializer_consumers:
+                    record_exclusion(initializer, "unused_initializer")
+                    continue
+
+                semantic_contexts: list[dict[str, Any]] = []
+                for node_index, node, input_index in initializer_consumers:
+                    output_axis, reason = _onnx_weight_output_axis(node, input_index, len(initializer.dims))
+                    if output_axis is None:
+                        record_exclusion(initializer, reason, node, input_index)
+                        continue
+                    if int(initializer.data_type) not in floating_types:
+                        record_exclusion(initializer, "non_floating_weight", node, input_index)
+                        continue
+                    semantic_contexts.append(
+                        {
+                            "initializer": initializer.name,
+                            "consumer_op": node.op_type,
+                            "consumer_node": node.name,
+                            "consumer_node_index": node_index,
+                            "consumer_input_index": input_index,
+                            "output_axis": output_axis,
+                            "stored_shape": [int(dim) for dim in initializer.dims],
+                        },
+                    )
+
+                if not semantic_contexts:
                     continue
                 eligible_initializers += 1
 
@@ -1085,8 +1215,34 @@ class OnnxScanner(BaseScanner):
                     continue
 
                 array = onnx.numpy_helper.to_array(initializer)
+                contexts_by_axis: dict[int, list[dict[str, Any]]] = {}
+                for context in semantic_contexts:
+                    contexts_by_axis.setdefault(int(context["output_axis"]), []).append(context)
 
-                weights_info[initializer.name] = array
+                for output_axis, axis_contexts in contexts_by_axis.items():
+                    layer_name = initializer.name
+                    if len(contexts_by_axis) > 1:
+                        layer_name = f"{initializer.name}@output_axis={output_axis}"
+                    analysis_array = np.moveaxis(array, output_axis, -1)
+                    if analysis_array.ndim > 2:
+                        analysis_array = analysis_array.reshape(-1, analysis_array.shape[-1])
+                    context = {
+                        **axis_contexts[0],
+                        "analysis_shape": [int(dim) for dim in analysis_array.shape],
+                        "consumers": [
+                            {
+                                "op": item["consumer_op"],
+                                "node": item["consumer_node"],
+                                "node_index": item["consumer_node_index"],
+                                "input_index": item["consumer_input_index"],
+                            }
+                            for item in axis_contexts
+                        ],
+                    }
+                    weights_info[layer_name] = analysis_array
+                    layer_contexts[layer_name] = context
+                    if len(eligible_metadata) < _ONNX_WEIGHT_METADATA_SAMPLE_LIMIT:
+                        eligible_metadata.append(context)
             except Exception as e:
                 extraction_failures += 1
                 logger.warning(
@@ -1095,6 +1251,16 @@ class OnnxScanner(BaseScanner):
                     e,
                 )
                 continue
+
+        result.metadata["onnx_weight_distribution_semantics"] = {
+            "eligible_initializer_count": eligible_initializers,
+            "analyzed_layer_count": len(weights_info),
+            "eligible": eligible_metadata,
+            "eligible_metadata_truncated": len(weights_info) > len(eligible_metadata),
+            "exclusion_counts": exclusion_counts,
+            "exclusion_samples": exclusion_samples,
+            "exclusion_metadata_truncated": sum(exclusion_counts.values()) > len(exclusion_samples),
+        }
 
         if external_initializers_skipped or oversized_initializers_skipped or extraction_failures:
             self._mark_weight_distribution_incomplete(
@@ -1138,13 +1304,28 @@ class OnnxScanner(BaseScanner):
             anomalies = wd_scanner._analyze_weight_distributions(weights_info)
 
             for anomaly in anomalies:
+                details = dict(anomaly["details"])
+                layer_name = str(details.get("layer", ""))
+                layer_context = layer_contexts.get(layer_name)
+                if layer_context is not None:
+                    details.update(
+                        {
+                            "initializer": layer_context["initializer"],
+                            "consumer_op": layer_context["consumer_op"],
+                            "consumer_node": layer_context["consumer_node"],
+                            "consumer_input_index": layer_context["consumer_input_index"],
+                            "output_axis": layer_context["output_axis"],
+                            "stored_shape": layer_context["stored_shape"],
+                            "analysis_shape": layer_context["analysis_shape"],
+                        },
+                    )
                 result.add_check(
                     name="Weight Distribution Anomaly Detection",
                     passed=False,
                     message=anomaly["description"],
                     severity=anomaly["severity"],
                     location=path,
-                    details=anomaly["details"],
+                    details=details,
                     why=anomaly.get("why"),
                 )
 

--- a/modelaudit/scanners/weight_distribution_scanner.py
+++ b/modelaudit/scanners/weight_distribution_scanner.py
@@ -396,7 +396,10 @@ class WeightDistributionScanner(BaseScanner):
     def _configured_byte_limit(value: Any, *, fallback: int | None = None) -> int | None:
         if isinstance(value, bool) or not isinstance(value, numbers.Real):
             return fallback
-        numeric_value = float(value)
+        try:
+            numeric_value = float(value)
+        except (OverflowError, TypeError, ValueError):
+            return fallback
         if not math.isfinite(numeric_value):
             return fallback
         if numeric_value == 0:
@@ -1673,8 +1676,9 @@ class WeightDistributionScanner(BaseScanner):
 
                 initializer_name = str(initializer.name)
                 external_location = getattr(getattr(onnx, "TensorProto", None), "EXTERNAL", 1)
-                if getattr(initializer, "data_location", None) == external_location or bool(
-                    getattr(initializer, "external_data", ())
+                if getattr(initializer, "data_location", None) == external_location or (
+                    bool(getattr(initializer, "external_data", ()))
+                    and self._onnx_inline_storage_nbytes(onnx, initializer) == 0
                 ):
                     self._record_extraction_incomplete(
                         "onnx_external_initializer_skipped",

--- a/modelaudit/scanners/weight_distribution_scanner.py
+++ b/modelaudit/scanners/weight_distribution_scanner.py
@@ -1790,7 +1790,10 @@ class WeightDistributionScanner(BaseScanner):
 
     def _analyze_onnx_weight_specs(self, specs: list[Any]) -> list[tuple[dict[str, Any], Any]]:
         """Analyze collision-proof ONNX specs using their semantic output axes."""
-        matrix_weights = {spec.analysis_id: spec.weights for spec in specs if spec.matrix_analysis}
+        matrix_weights: dict[int, Any] = {}
+        for spec in specs:
+            if spec.matrix_analysis:
+                matrix_weights.setdefault(spec.initializer_index, spec.weights)
         architecture_analysis = self._analyze_architecture_properties(matrix_weights)
         analyzed: list[tuple[dict[str, Any], Any]] = []
         for spec in specs:

--- a/modelaudit/scanners/weight_distribution_scanner.py
+++ b/modelaudit/scanners/weight_distribution_scanner.py
@@ -29,10 +29,16 @@ _EXTREME_WEIGHT_MIN_EFFECT_RATIO = 2.0
 _EXTREME_WEIGHT_MIN_PER_OUTPUT = 5
 _EXTREME_WEIGHT_LOCALIZATION_MIN_PER_OUTPUT = 2
 _EXTREME_WEIGHT_ROBUST_MAD_MULTIPLIER = 30.0
+_EXTREME_WEIGHT_ROBUST_SUPPORT_MAD_MULTIPLIER = 10.0
+_EXTREME_WEIGHT_MIN_ROBUST_TAIL_CONCENTRATION = 0.5
+_EXTREME_WEIGHT_CLASSICAL_SUPPORT_STD_MULTIPLIER = 0.5
+_EXTREME_WEIGHT_MIN_CLASSICAL_TAIL_CONCENTRATION = 0.5
 _EXTREME_WEIGHT_ROBUST_FALLBACK_MIN_PER_OUTPUT = 5
 _NORMAL_MAD_SCALE_FACTOR = 1.4826
 _EXTREME_WEIGHT_ANALYSIS_CHUNK_BYTES = 8 * 1024 * 1024
 _EXTREME_WEIGHT_ROBUST_SAMPLE_SIZE = 256 * 1024
+_EXTREME_WEIGHT_OUTPUT_SCRATCH_ARRAYS = 20
+_OUTPUT_NORM_ROBUST_Z_THRESHOLD = 10.0
 _PICKLE_OBJECT_OPCODES = frozenset(
     {
         "BINBYTES",
@@ -227,6 +233,23 @@ class WeightDistributionScanner(BaseScanner):
                         location=path,
                         details={"extension": ext},
                         rule_code="S801",
+                    )
+                    result.finish(success=False)
+                    return result
+
+            if onnx_plan is not None and any(spec.matrix_analysis for spec in onnx_plan.specs):
+                try:
+                    from scipy import stats as _stats  # noqa: F401
+                except Exception as exc:
+                    self._record_extraction_incomplete(
+                        "missing_weight_distribution_dependency",
+                        dependency="scipy",
+                        exception_type=type(exc).__name__,
+                    )
+                    self._mark_analysis_incomplete(
+                        result,
+                        path,
+                        message=f"Weight distribution analysis dependency unavailable: {exc!s}",
                     )
                     result.finish(success=False)
                     return result
@@ -1952,11 +1975,23 @@ class WeightDistributionScanner(BaseScanner):
         output_norms = np.linalg.norm(weights, axis=0)  # L2 norm of each output neuron
         if len(output_norms) > 1:
             z_scores = np.abs(stats.zscore(output_norms))
-            outlier_indices = np.where(z_scores > z_score_threshold)[0]
+            z_score_outliers = (z_scores > z_score_threshold) | np.isclose(
+                z_scores, z_score_threshold, rtol=1e-5, atol=0.0
+            )
+            norm_median = float(np.median(output_norms))
+            norm_mad_scale = _NORMAL_MAD_SCALE_FACTOR * float(np.median(np.abs(output_norms - norm_median)))
+            if norm_mad_scale > 0:
+                robust_norm_outliers = (
+                    np.abs(output_norms - norm_median) / norm_mad_scale
+                ) > _OUTPUT_NORM_ROBUST_Z_THRESHOLD
+            else:
+                robust_norm_outliers = output_norms > norm_median
+            outlier_indices = np.flatnonzero(z_score_outliers | robust_norm_outliers)
 
             # Only flag if the number of outliers is reasonable
             outlier_percentage = len(outlier_indices) / n_outputs
-            if len(outlier_indices) > 0 and outlier_percentage < outlier_percentage_threshold:
+            max_outlier_outputs = max(3, int(n_outputs * outlier_percentage_threshold))
+            if 0 < len(outlier_indices) <= max_outlier_outputs:
                 anomalies.append(
                     {
                         "description": f"Layer '{layer_name}' has {len(outlier_indices)} output neurons with "
@@ -2003,7 +2038,10 @@ class WeightDistributionScanner(BaseScanner):
                     dissimilar_neurons.append((i, max_similarity))
 
             # Only flag if we have a small number of dissimilar neurons (< 5% or max 3)
-            if 0 < len(dissimilar_neurons) <= max(3, int(0.05 * n_outputs)):
+            if 0 < len(dissimilar_neurons) < n_outputs and len(dissimilar_neurons) <= max(
+                3,
+                int(0.05 * n_outputs),
+            ):
                 for neuron_idx, max_sim in dissimilar_neurons:
                     anomalies.append(
                         {
@@ -2080,14 +2118,27 @@ class WeightDistributionScanner(BaseScanner):
         analysis_itemsize = 8
         max_work_values = max(1, _EXTREME_WEIGHT_ANALYSIS_CHUNK_BYTES // analysis_itemsize)
         input_values_per_output = math.prod(int(dimension) for dimension in input_shape)
-        outputs_per_chunk = max(
+        max_scratch_outputs = max(1, max_work_values // _EXTREME_WEIGHT_OUTPUT_SCRATCH_ARRAYS)
+        output_block_budget = max(
             1,
             min(
-                int(output_shape[-1]),
+                n_outputs,
                 max_work_values // max(1, input_values_per_output),
+                max_scratch_outputs,
             ),
         )
-        input_block_budget = max(1, max_work_values // outputs_per_chunk)
+        output_block_shape = [1] * len(output_shape)
+        remaining_output_values = output_block_budget
+        for axis in reversed(range(len(output_shape))):
+            block_length = min(int(output_shape[axis]), remaining_output_values)
+            output_block_shape[axis] = max(1, block_length)
+            remaining_output_values = max(1, remaining_output_values // output_block_shape[axis])
+        output_block_counts = tuple(
+            math.ceil(int(dimension) / block_length)
+            for dimension, block_length in zip(output_shape, output_block_shape, strict=True)
+        )
+
+        input_block_budget = max(1, max_work_values // output_block_budget)
         input_block_shape = [1] * len(input_shape)
         remaining_block_values = input_block_budget
         for axis in reversed(range(len(input_shape))):
@@ -2101,22 +2152,32 @@ class WeightDistributionScanner(BaseScanner):
 
         def magnitudes_as_float64(chunk: Any) -> Any:
             magnitudes = np.empty(chunk.shape, dtype=np.float64)
-            np.absolute(chunk, out=magnitudes, casting="unsafe")
+            if np.issubdtype(np.asarray(chunk).dtype, np.signedinteger):
+                # Integer absolute-value ufuncs overflow on the signed minimum.
+                np.copyto(magnitudes, chunk, casting="unsafe")
+                np.absolute(magnitudes, out=magnitudes)
+            else:
+                np.absolute(chunk, out=magnitudes, casting="unsafe")
             return magnitudes
 
         def iter_output_groups() -> Any:
-            prefix_shape = output_shape[:-1]
-            prefix_count = math.prod(int(dimension) for dimension in prefix_shape) if prefix_shape else 1
-            for prefix_index in range(prefix_count):
-                prefix = (
-                    tuple(int(value) for value in np.unravel_index(prefix_index, prefix_shape)) if prefix_shape else ()
+            for block_index in np.ndindex(*output_block_counts):
+                output_starts = tuple(
+                    index * block_length for index, block_length in zip(block_index, output_block_shape, strict=True)
                 )
-                for output_start in range(0, int(output_shape[-1]), outputs_per_chunk):
-                    output_end = min(int(output_shape[-1]), output_start + outputs_per_chunk)
-                    flat_output_start = prefix_index * int(output_shape[-1]) + output_start
-                    yield flat_output_start, prefix, output_start, output_end
+                output_ends = tuple(
+                    min(int(output_shape[axis]), start + output_block_shape[axis])
+                    for axis, start in enumerate(output_starts)
+                )
+                output_slices = tuple(slice(start, end) for start, end in zip(output_starts, output_ends, strict=True))
+                output_count = math.prod(end - start for start, end in zip(output_starts, output_ends, strict=True))
+                flat_output_start = 0
+                for axis, start in enumerate(output_starts):
+                    flat_output_start *= int(output_shape[axis])
+                    flat_output_start += start
+                yield flat_output_start, output_slices, output_count
 
-        def iter_group_chunks(prefix: tuple[int, ...], output_start: int, output_end: int) -> Any:
+        def iter_group_chunks(output_slices: tuple[slice, ...]) -> Any:
             for block_index in np.ndindex(*input_block_counts):
                 input_slices = tuple(
                     slice(
@@ -2127,35 +2188,7 @@ class WeightDistributionScanner(BaseScanner):
                         zip(block_index, input_block_shape, strict=True),
                     )
                 )
-                yield output_last_view[input_slices + prefix + (slice(output_start, output_end),)]
-
-        total_values = int(weights.size)
-        sample_step = max(1, math.ceil(total_values / _EXTREME_WEIGHT_ROBUST_SAMPLE_SIZE))
-        sample_parts: list[Any] = []
-        logical_offset = 0
-        magnitude_sum = 0.0
-        magnitude_square_sum = 0.0
-        for _flat_output_start, prefix, output_start, output_end in iter_output_groups():
-            for chunk in iter_group_chunks(prefix, output_start, output_end):
-                chunk_magnitudes = magnitudes_as_float64(chunk)
-                magnitude_sum += float(np.sum(chunk_magnitudes, dtype=np.float64))
-                first_sample = (-logical_offset) % sample_step
-                if first_sample < chunk_magnitudes.size:
-                    sample_parts.append(np.asarray(chunk_magnitudes.flat[first_sample::sample_step]))
-                logical_offset += int(chunk_magnitudes.size)
-                np.square(chunk_magnitudes, out=chunk_magnitudes)
-                magnitude_square_sum += float(np.sum(chunk_magnitudes, dtype=np.float64))
-
-        mean_magnitude = magnitude_sum / total_values
-        variance = max(0.0, magnitude_square_sum / total_values - mean_magnitude * mean_magnitude)
-        std_magnitude = math.sqrt(variance)
-        threshold = mean_magnitude + self.weight_magnitude_threshold * std_magnitude
-
-        robust_sample = np.concatenate(sample_parts)[:_EXTREME_WEIGHT_ROBUST_SAMPLE_SIZE]
-        robust_median = float(np.median(robust_sample))
-        robust_mad = float(np.median(np.abs(robust_sample - robust_median)))
-        robust_scale = _NORMAL_MAD_SCALE_FACTOR * robust_mad
-        robust_threshold = robust_median + _EXTREME_WEIGHT_ROBUST_MAD_MULTIPLIER * robust_scale
+                yield output_last_view[input_slices + output_slices]
 
         reduction_axes = tuple(range(len(input_shape)))
         max_affected_outputs = max(1, int(0.001 * n_outputs))
@@ -2164,89 +2197,298 @@ class WeightDistributionScanner(BaseScanner):
         total_affected = 0
         tail_affected_outputs = 0
         num_extreme_weights = 0
+        num_nonfinite_weights = 0
         max_extreme_weights_per_output = 0
         max_weight = 0.0
         max_effect_ratio = 0.0
-        for flat_output_start, prefix, output_start, output_end in iter_output_groups():
-            output_count = output_end - output_start
+        representative_threshold = 0.0
+        representative_robust_median = 0.0
+        representative_robust_scale = 0.0
+        representative_robust_threshold = 0.0
+        representative_set = False
+        for flat_output_start, output_slices, output_count in iter_output_groups():
+            sample_values_per_output = max(
+                1,
+                min(
+                    input_values_per_output,
+                    _EXTREME_WEIGHT_ROBUST_SAMPLE_SIZE // output_count,
+                ),
+            )
+            sample_step = max(1, math.ceil(input_values_per_output / sample_values_per_output))
+            sample_parts: list[Any] = []
+            input_logical_offset = 0
+            nonfinite_counts = np.zeros(output_count, dtype=np.int64)
+            per_output_max = np.zeros(output_count, dtype=np.float64)
+            normalized_sums = np.zeros(output_count, dtype=np.float64)
+            normalized_square_sums = np.zeros(output_count, dtype=np.float64)
+
+            for chunk in iter_group_chunks(output_slices):
+                chunk_magnitudes = magnitudes_as_float64(chunk).reshape(
+                    *chunk.shape[: len(input_shape)],
+                    output_count,
+                )
+                flat_magnitudes = chunk_magnitudes.reshape(-1, output_count)
+                first_sample = (-input_logical_offset) % sample_step
+                if first_sample < flat_magnitudes.shape[0]:
+                    sample_parts.append(np.array(flat_magnitudes[first_sample::sample_step], copy=True))
+                input_logical_offset += int(flat_magnitudes.shape[0])
+
+                finite_mask = np.isfinite(chunk_magnitudes)
+                nonfinite_counts += chunk_magnitudes.size // output_count - np.asarray(
+                    np.count_nonzero(finite_mask, axis=reduction_axes)
+                ).reshape(-1)
+                chunk_magnitudes[~finite_mask] = 0.0
+                chunk_max = np.asarray(np.max(chunk_magnitudes, axis=reduction_axes)).reshape(-1)
+                scale_increased = chunk_max > per_output_max
+                if np.any(scale_increased):
+                    scale_ratios = np.ones(output_count, dtype=np.float64)
+                    np.divide(
+                        per_output_max,
+                        chunk_max,
+                        out=scale_ratios,
+                        where=scale_increased,
+                    )
+                    normalized_sums[scale_increased] *= scale_ratios[scale_increased]
+                    normalized_square_sums[scale_increased] *= np.square(scale_ratios[scale_increased])
+                    per_output_max[scale_increased] = chunk_max[scale_increased]
+
+                scale_view = per_output_max.reshape((1,) * len(input_shape) + (output_count,))
+                np.divide(
+                    chunk_magnitudes,
+                    scale_view,
+                    out=chunk_magnitudes,
+                    where=scale_view > 0,
+                )
+                normalized_sums += np.asarray(
+                    np.sum(chunk_magnitudes, axis=reduction_axes, dtype=np.float64),
+                ).reshape(-1)
+                np.square(chunk_magnitudes, out=chunk_magnitudes)
+                normalized_square_sums += np.asarray(
+                    np.sum(chunk_magnitudes, axis=reduction_axes, dtype=np.float64),
+                ).reshape(-1)
+
+            finite_counts = input_values_per_output - nonfinite_counts
+            normalized_means = np.zeros(output_count, dtype=np.float64)
+            normalized_second_moments = np.zeros(output_count, dtype=np.float64)
+            np.divide(normalized_sums, finite_counts, out=normalized_means, where=finite_counts > 0)
+            np.divide(
+                normalized_square_sums,
+                finite_counts,
+                out=normalized_second_moments,
+                where=finite_counts > 0,
+            )
+            normalized_variances = normalized_second_moments - np.square(normalized_means)
+            np.maximum(normalized_variances, 0.0, out=normalized_variances)
+            normalized_stds = np.sqrt(normalized_variances)
+            normalized_thresholds = normalized_means + self.weight_magnitude_threshold * normalized_stds
+            normalized_classical_support_thresholds = (
+                normalized_means + _EXTREME_WEIGHT_CLASSICAL_SUPPORT_STD_MULTIPLIER * normalized_stds
+            )
+            with np.errstate(over="ignore", invalid="ignore"):
+                classical_thresholds = per_output_max * normalized_thresholds
+                classical_support_thresholds = per_output_max * normalized_classical_support_thresholds
+
+            robust_medians = np.zeros(output_count, dtype=np.float64)
+            robust_scales = np.zeros(output_count, dtype=np.float64)
+            if sample_parts:
+                robust_sample = np.concatenate(sample_parts, axis=0)
+                finite_sample_mask = np.isfinite(robust_sample)
+                valid_sample_outputs = np.any(finite_sample_mask, axis=0)
+                robust_sample[~finite_sample_mask] = np.nan
+                if np.any(valid_sample_outputs):
+                    valid_samples = robust_sample[:, valid_sample_outputs]
+                    valid_medians = np.nanmedian(valid_samples, axis=0)
+                    robust_medians[valid_sample_outputs] = valid_medians
+                    valid_deviations = np.abs(valid_samples - valid_medians)
+                    robust_scales[valid_sample_outputs] = _NORMAL_MAD_SCALE_FACTOR * np.nanmedian(
+                        valid_deviations,
+                        axis=0,
+                    )
+
+            with np.errstate(over="ignore", invalid="ignore"):
+                robust_thresholds = robust_medians + _EXTREME_WEIGHT_ROBUST_MAD_MULTIPLIER * robust_scales
+                robust_support_thresholds = (
+                    robust_medians + _EXTREME_WEIGHT_ROBUST_SUPPORT_MAD_MULTIPLIER * robust_scales
+                )
+
+            classical_counts = np.zeros(output_count, dtype=np.int64)
+            classical_support_counts = np.zeros(output_count, dtype=np.int64)
             classical_robust_counts = np.zeros(output_count, dtype=np.int64)
             robust_counts = np.zeros(output_count, dtype=np.int64)
-            per_output_max = np.zeros(output_count, dtype=np.float64)
-            for chunk in iter_group_chunks(prefix, output_start, output_end):
-                chunk_magnitudes = magnitudes_as_float64(chunk)
-                robust_mask = (
-                    chunk_magnitudes > robust_threshold if robust_scale > 0 else chunk_magnitudes > robust_median
+            robust_support_counts = np.zeros(output_count, dtype=np.int64)
+            inclusive_zero_mad = (robust_scales == 0) & (robust_medians > 0)
+            inclusive_zero_mad_view = inclusive_zero_mad.reshape((1,) * len(input_shape) + (output_count,))
+            robust_threshold_view = robust_thresholds.reshape((1,) * len(input_shape) + (output_count,))
+            robust_support_threshold_view = robust_support_thresholds.reshape(
+                (1,) * len(input_shape) + (output_count,),
+            )
+            classical_threshold_view = classical_thresholds.reshape(
+                (1,) * len(input_shape) + (output_count,),
+            )
+            classical_support_threshold_view = classical_support_thresholds.reshape(
+                (1,) * len(input_shape) + (output_count,),
+            )
+            for chunk in iter_group_chunks(output_slices):
+                chunk_magnitudes = magnitudes_as_float64(chunk).reshape(
+                    *chunk.shape[: len(input_shape)],
+                    output_count,
                 )
+                chunk_magnitudes[~np.isfinite(chunk_magnitudes)] = 0.0
+                robust_mask = chunk_magnitudes > robust_threshold_view
+                robust_mask |= (chunk_magnitudes >= robust_threshold_view) & inclusive_zero_mad_view
                 robust_counts += np.asarray(np.count_nonzero(robust_mask, axis=reduction_axes)).reshape(-1)
-                classical_mask = chunk_magnitudes > threshold
+                robust_support_mask = chunk_magnitudes > robust_support_threshold_view
+                robust_support_mask |= (chunk_magnitudes >= robust_support_threshold_view) & inclusive_zero_mad_view
+                robust_support_counts += np.asarray(
+                    np.count_nonzero(robust_support_mask, axis=reduction_axes),
+                ).reshape(-1)
+                classical_mask = chunk_magnitudes > classical_threshold_view
+                classical_counts += np.asarray(
+                    np.count_nonzero(classical_mask, axis=reduction_axes),
+                ).reshape(-1)
+                classical_support_mask = chunk_magnitudes > classical_support_threshold_view
+                classical_support_counts += np.asarray(
+                    np.count_nonzero(classical_support_mask, axis=reduction_axes),
+                ).reshape(-1)
                 classical_mask &= robust_mask
                 classical_robust_counts += np.asarray(
                     np.count_nonzero(classical_mask, axis=reduction_axes),
                 ).reshape(-1)
-                per_output_max = np.maximum(
-                    per_output_max,
-                    np.asarray(np.max(chunk_magnitudes, axis=reduction_axes)).reshape(-1),
-                )
 
             tail_affected_outputs += int(
-                np.count_nonzero(classical_robust_counts >= _EXTREME_WEIGHT_LOCALIZATION_MIN_PER_OUTPUT),
+                np.count_nonzero(
+                    (robust_counts >= _EXTREME_WEIGHT_LOCALIZATION_MIN_PER_OUTPUT)
+                    | (classical_counts >= _EXTREME_WEIGHT_LOCALIZATION_MIN_PER_OUTPUT)
+                    | (nonfinite_counts > 0),
+                ),
             )
 
-            if threshold > 0:
-                per_output_effect_ratios = per_output_max / threshold
-            else:
-                per_output_effect_ratios = np.where(per_output_max > 0, np.inf, 0.0)
-
-            classical_effect_qualified = (classical_robust_counts >= _EXTREME_WEIGHT_MIN_PER_OUTPUT) & (
-                per_output_effect_ratios >= _EXTREME_WEIGHT_MIN_EFFECT_RATIO
+            per_output_effect_ratios = np.zeros(output_count, dtype=np.float64)
+            np.divide(
+                per_output_max,
+                classical_thresholds,
+                out=per_output_effect_ratios,
+                where=classical_thresholds > 0,
             )
-            robust_fallback_qualified = classical_robust_counts >= _EXTREME_WEIGHT_ROBUST_FALLBACK_MIN_PER_OUTPUT
-            qualified_indices = np.flatnonzero(classical_effect_qualified | robust_fallback_qualified)
+            per_output_effect_ratios[(classical_thresholds == 0) & (per_output_max > 0)] = np.inf
+
+            robust_tail_concentrations = np.zeros(output_count, dtype=np.float64)
+            np.divide(
+                robust_counts,
+                robust_support_counts,
+                out=robust_tail_concentrations,
+                where=robust_support_counts > 0,
+            )
+            concentrated_robust_tails = robust_tail_concentrations >= _EXTREME_WEIGHT_MIN_ROBUST_TAIL_CONCENTRATION
+            classical_tail_concentrations = np.zeros(output_count, dtype=np.float64)
+            np.divide(
+                classical_counts,
+                classical_support_counts,
+                out=classical_tail_concentrations,
+                where=classical_support_counts > 0,
+            )
+            concentrated_classical_tails = (
+                classical_tail_concentrations >= _EXTREME_WEIGHT_MIN_CLASSICAL_TAIL_CONCENTRATION
+            )
+
+            classical_effect_qualified = (
+                (classical_counts >= _EXTREME_WEIGHT_MIN_PER_OUTPUT)
+                & (per_output_effect_ratios >= _EXTREME_WEIGHT_MIN_EFFECT_RATIO)
+                & concentrated_classical_tails
+            )
+            robust_fallback_counts = np.where(inclusive_zero_mad, classical_robust_counts, robust_counts)
+            robust_fallback_qualified = (
+                robust_fallback_counts >= _EXTREME_WEIGHT_ROBUST_FALLBACK_MIN_PER_OUTPUT
+            ) & concentrated_robust_tails
+            classical_fallback_qualified = (
+                classical_counts >= _EXTREME_WEIGHT_ROBUST_FALLBACK_MIN_PER_OUTPUT
+            ) & concentrated_classical_tails
+            nonfinite_qualified = nonfinite_counts > 0
+            qualified_indices = np.flatnonzero(
+                classical_effect_qualified
+                | robust_fallback_qualified
+                | classical_fallback_qualified
+                | nonfinite_qualified,
+            )
             if len(qualified_indices) == 0:
                 continue
 
-            qualified_counts = classical_robust_counts[qualified_indices]
+            finite_qualified_counts = np.maximum(
+                classical_counts[qualified_indices],
+                robust_fallback_counts[qualified_indices],
+            )
+            qualified_counts = finite_qualified_counts + nonfinite_counts[qualified_indices]
             total_affected += len(qualified_indices)
             num_extreme_weights += int(np.sum(qualified_counts))
+            num_nonfinite_weights += int(np.sum(nonfinite_counts[qualified_indices]))
             max_extreme_weights_per_output = max(max_extreme_weights_per_output, int(np.max(qualified_counts)))
             max_weight = max(max_weight, float(np.max(per_output_max[qualified_indices])))
-            max_effect_ratio = max(max_effect_ratio, float(np.max(per_output_effect_ratios[qualified_indices])))
 
             for local_output_index in qualified_indices:
                 output_index = flat_output_start + int(local_output_index)
                 if len(affected_neurons) < 10:
                     affected_neurons.append(output_index)
+                effect_ratio = float(per_output_effect_ratios[local_output_index])
+                if not representative_set or effect_ratio > max_effect_ratio:
+                    representative_set = True
+                    max_effect_ratio = effect_ratio
+                    representative_threshold = float(classical_thresholds[local_output_index])
+                    representative_robust_median = float(robust_medians[local_output_index])
+                    representative_robust_scale = float(robust_scales[local_output_index])
+                    representative_robust_threshold = float(robust_thresholds[local_output_index])
                 if len(evidence) >= 10:
                     continue
-                effect_ratio = float(per_output_effect_ratios[local_output_index])
                 robust_effect_ratio = (
-                    float((per_output_max[local_output_index] - robust_median) / robust_scale)
-                    if robust_scale > 0
+                    float(
+                        (per_output_max[local_output_index] - robust_medians[local_output_index])
+                        / robust_scales[local_output_index]
+                    )
+                    if robust_scales[local_output_index] > 0
                     else None
                 )
                 if classical_effect_qualified[local_output_index] and robust_fallback_qualified[local_output_index]:
                     detection_path = "classical_and_robust"
                 elif classical_effect_qualified[local_output_index]:
                     detection_path = "classical_effect"
-                else:
+                elif robust_fallback_qualified[local_output_index]:
                     detection_path = "robust_small_tensor_fallback"
+                elif classical_fallback_qualified[local_output_index]:
+                    detection_path = "concentrated_classical_fallback"
+                else:
+                    detection_path = "nonfinite_values"
+                if nonfinite_qualified[local_output_index] and detection_path != "nonfinite_values":
+                    detection_path = f"{detection_path}_and_nonfinite"
                 evidence.append(
                     {
                         "output_index": output_index,
+                        "classical_count": int(classical_counts[local_output_index]),
+                        "classical_support_count": int(classical_support_counts[local_output_index]),
+                        "classical_tail_concentration": float(classical_tail_concentrations[local_output_index]),
                         "classical_robust_count": int(classical_robust_counts[local_output_index]),
                         "robust_count": int(robust_counts[local_output_index]),
+                        "robust_support_count": int(robust_support_counts[local_output_index]),
+                        "robust_tail_concentration": float(robust_tail_concentrations[local_output_index]),
+                        "nonfinite_count": int(nonfinite_counts[local_output_index]),
+                        "threshold": float(classical_thresholds[local_output_index]),
+                        "robust_median_magnitude": float(robust_medians[local_output_index]),
+                        "robust_mad_scale": float(robust_scales[local_output_index]),
+                        "robust_threshold": float(robust_thresholds[local_output_index]),
                         "max_to_threshold_ratio": effect_ratio if np.isfinite(effect_ratio) else None,
                         "robust_effect_ratio": robust_effect_ratio,
                         "detection_path": detection_path,
                     },
                 )
 
-        if total_affected == 0 or tail_affected_outputs > max_affected_outputs:
+        if total_affected == 0:
             return []
+
+        description = f"Layer '{layer_name}' has neurons with extremely large weight values"
+        if num_nonfinite_weights:
+            description = f"Layer '{layer_name}' has neurons with non-finite or extremely large weight values"
 
         return [
             {
-                "description": f"Layer '{layer_name}' has neurons with extremely large weight values",
+                "description": description,
                 "severity": IssueSeverity.INFO,
                 "details": {
                     "layer": layer_name,
@@ -2254,19 +2496,25 @@ class WeightDistributionScanner(BaseScanner):
                     "total_affected": total_affected,
                     "tail_affected_outputs": tail_affected_outputs,
                     "num_extreme_weights": num_extreme_weights,
-                    "threshold": threshold,
+                    "num_nonfinite_weights": num_nonfinite_weights,
+                    "threshold": representative_threshold,
+                    "threshold_scope": "per_output",
                     "max_weight": max_weight,
                     "max_to_threshold_ratio": max_effect_ratio if np.isfinite(max_effect_ratio) else None,
                     "max_extreme_weights_per_output": max_extreme_weights_per_output,
                     "affected_output_limit": max_affected_outputs,
-                    "localized": tail_affected_outputs <= max_affected_outputs,
+                    "localized": total_affected <= max_affected_outputs,
                     "minimum_effect_ratio": _EXTREME_WEIGHT_MIN_EFFECT_RATIO,
                     "minimum_extreme_weights_per_output": _EXTREME_WEIGHT_MIN_PER_OUTPUT,
                     "localization_minimum_per_output": _EXTREME_WEIGHT_LOCALIZATION_MIN_PER_OUTPUT,
-                    "robust_median_magnitude": robust_median,
-                    "robust_mad_scale": robust_scale,
-                    "robust_threshold": robust_threshold,
+                    "robust_median_magnitude": representative_robust_median,
+                    "robust_mad_scale": representative_robust_scale,
+                    "robust_threshold": representative_robust_threshold,
                     "robust_mad_multiplier": _EXTREME_WEIGHT_ROBUST_MAD_MULTIPLIER,
+                    "robust_support_mad_multiplier": _EXTREME_WEIGHT_ROBUST_SUPPORT_MAD_MULTIPLIER,
+                    "minimum_robust_tail_concentration": _EXTREME_WEIGHT_MIN_ROBUST_TAIL_CONCENTRATION,
+                    "classical_support_std_multiplier": _EXTREME_WEIGHT_CLASSICAL_SUPPORT_STD_MULTIPLIER,
+                    "minimum_classical_tail_concentration": _EXTREME_WEIGHT_MIN_CLASSICAL_TAIL_CONCENTRATION,
                     "robust_fallback_minimum_per_output": _EXTREME_WEIGHT_ROBUST_FALLBACK_MIN_PER_OUTPUT,
                     "per_output_evidence": evidence,
                     "total_outputs": n_outputs,
@@ -2274,9 +2522,9 @@ class WeightDistributionScanner(BaseScanner):
                 },
                 "why": (
                     "Repeated weight values that are materially beyond both classical and robust distribution "
-                    "baselines can cause numerical instability, overflow attacks, or encode hidden data. Evidence "
-                    "is evaluated independently per output so unrelated coefficients cannot create or suppress an "
-                    "alert."
+                    "baselines, and non-finite weights, can cause numerical instability, overflow attacks, or encode "
+                    "hidden data. Evidence and thresholds are evaluated independently per output so unrelated "
+                    "coefficients cannot create or suppress an alert."
                 ),
             },
         ]

--- a/modelaudit/scanners/weight_distribution_scanner.py
+++ b/modelaudit/scanners/weight_distribution_scanner.py
@@ -1605,6 +1605,11 @@ class WeightDistributionScanner(BaseScanner):
             logger.warning("Failed to build semantic ONNX weight plan for %s (%s)", path, type(exc).__name__)
             raise RuntimeError(f"Failed to extract ONNX weights from {path}") from exc
 
+        if plan.oversized_initializers_skipped:
+            self._record_extraction_incomplete(
+                "onnx_initializer_size_limit",
+                oversized_initializers_skipped=plan.oversized_initializers_skipped,
+            )
         if plan.external_initializers_skipped:
             self._record_extraction_incomplete(
                 "onnx_external_initializer_skipped",
@@ -2338,10 +2343,18 @@ class WeightDistributionScanner(BaseScanner):
                 )
                 chunk_magnitudes[~np.isfinite(chunk_magnitudes)] = 0.0
                 robust_mask = chunk_magnitudes > robust_threshold_view
-                robust_mask |= (chunk_magnitudes >= robust_threshold_view) & inclusive_zero_mad_view
+                robust_mask |= (
+                    (chunk_magnitudes >= robust_threshold_view)
+                    & inclusive_zero_mad_view
+                    & (chunk_magnitudes > classical_threshold_view)
+                )
                 robust_counts += np.asarray(np.count_nonzero(robust_mask, axis=reduction_axes)).reshape(-1)
                 robust_support_mask = chunk_magnitudes > robust_support_threshold_view
-                robust_support_mask |= (chunk_magnitudes >= robust_support_threshold_view) & inclusive_zero_mad_view
+                robust_support_mask |= (
+                    (chunk_magnitudes >= robust_support_threshold_view)
+                    & inclusive_zero_mad_view
+                    & (chunk_magnitudes > classical_support_threshold_view)
+                )
                 robust_support_counts += np.asarray(
                     np.count_nonzero(robust_support_mask, axis=reduction_axes),
                 ).reshape(-1)

--- a/modelaudit/scanners/weight_distribution_scanner.py
+++ b/modelaudit/scanners/weight_distribution_scanner.py
@@ -197,6 +197,7 @@ class WeightDistributionScanner(BaseScanner):
         self.extraction_incomplete_reasons = []
         self.extraction_incomplete_details = {}
         self.retained_tensor_bytes = 0
+        onnx_plan: Any | None = None
 
         try:
             # Extract weights based on file format
@@ -212,7 +213,9 @@ class WeightDistributionScanner(BaseScanner):
                 elif ext == ".pb":
                     weights_info = self._extract_tensorflow_weights(path)
                 elif ext == ".onnx":
-                    weights_info = self._extract_onnx_weights(path)
+                    onnx_plan = self._extract_semantic_onnx_weight_plan(path)
+                    weights_info = {spec.analysis_id: spec.weights for spec in onnx_plan.specs}
+                    result.metadata["onnx_weight_distribution_semantics"] = onnx_plan.metadata
                 elif ext == ".safetensors":
                     weights_info = self._extract_safetensors_weights(path)
                 else:
@@ -262,23 +265,31 @@ class WeightDistributionScanner(BaseScanner):
                 return result
 
             # Analyze the weights
-            anomalies = self._analyze_weight_distributions(weights_info)
+            analyzed_onnx: list[tuple[dict[str, Any], Any]] | None = None
+            if onnx_plan is not None:
+                analyzed_onnx = self._analyze_onnx_weight_specs(onnx_plan.specs)
+                anomalies = [anomaly for anomaly, _spec in analyzed_onnx]
+            else:
+                anomalies = self._analyze_weight_distributions(weights_info)
 
             # Add issues for any anomalies found
-            for anomaly in anomalies:
+            for anomaly_index, anomaly in enumerate(anomalies):
+                details = dict(anomaly["details"])
+                if analyzed_onnx is not None:
+                    details.update(analyzed_onnx[anomaly_index][1].context)
                 result.add_check(
                     name="Weight Distribution Anomaly Detection",
                     passed=False,
                     message=anomaly["description"],
                     severity=anomaly["severity"],
                     location=path,
-                    details=anomaly["details"],
+                    details=details,
                     why=anomaly.get("why"),
                     rule_code="S801",
                 )
 
             # Add metadata
-            result.metadata["layers_analyzed"] = len(weights_info)
+            result.metadata["layers_analyzed"] = len(onnx_plan.specs) if onnx_plan is not None else len(weights_info)
             result.metadata["anomalies_found"] = len(anomalies)
 
             result.bytes_scanned = file_size
@@ -1500,6 +1511,95 @@ class WeightDistributionScanner(BaseScanner):
         typed_bytes += sum(len(value) for value in getattr(initializer, "string_data", ()))
         return raw_bytes * packed_multiplier + typed_bytes
 
+    def _extract_semantic_onnx_weight_plan(self, path: str) -> Any:
+        """Build the same bounded semantic ONNX plan used by ``OnnxScanner``."""
+        try:
+            import numpy as np
+            import onnx
+
+            from modelaudit.scanners.onnx_scanner import (
+                _build_onnx_weight_analysis_plan,
+                _OnnxWeightAnalysisPlan,
+            )
+        except ImportError as exc:
+            raise RuntimeError("ONNX semantic weight analysis dependencies are unavailable") from exc
+
+        max_total_bytes = self._max_total_tensor_bytes()
+        model_size = os.path.getsize(path)
+        if max_total_bytes is not None and model_size > max_total_bytes:
+            self._record_extraction_incomplete(
+                "onnx_model_size_limit",
+                failed_tensors=[path],
+                oversized_tensors=1,
+                tensor_nbytes=model_size,
+                max_total_tensor_bytes=max_total_bytes,
+            )
+            plan = _OnnxWeightAnalysisPlan()
+            plan.record_coverage_gap("onnx_model_size_limit")
+            plan.metadata = {
+                "eligible_initializer_count": 0,
+                "analyzed_layer_count": 0,
+                "eligible": [],
+                "eligible_metadata_truncated": False,
+                "exclusion_counts": {},
+                "exclusion_samples": [],
+                "exclusion_metadata_truncated": False,
+                "coverage_gaps": dict(plan.coverage_gaps),
+            }
+            return plan
+
+        try:
+            model = onnx.load(path, load_external_data=False)  # type: ignore[possibly-unresolved-reference]
+
+            def pre_materialization_check(initializer: Any, name: str, estimated_bytes: int) -> bool:
+                inline_storage_nbytes = self._onnx_inline_storage_nbytes(onnx, initializer)
+                if not self._tensor_fits_budget(
+                    "onnx_initializer_storage_size_limit",
+                    name,
+                    tensor_nbytes=inline_storage_nbytes,
+                ):
+                    return False
+                return self._tensor_fits_budget(
+                    "onnx_initializer_size_limit",
+                    name,
+                    tensor_nbytes=estimated_bytes,
+                )
+
+            plan = _build_onnx_weight_analysis_plan(
+                model,
+                onnx=onnx,
+                np=np,
+                max_array_size=None,
+                pre_materialization_check=pre_materialization_check,
+                retain_array_check=lambda name, nbytes: self._tensor_fits_budget(
+                    "onnx_initializer_size_limit",
+                    name,
+                    tensor_nbytes=nbytes,
+                    retain=True,
+                ),
+            )
+        except Exception as exc:
+            logger.warning("Failed to build semantic ONNX weight plan for %s (%s)", path, type(exc).__name__)
+            raise RuntimeError(f"Failed to extract ONNX weights from {path}") from exc
+
+        if plan.external_initializers_skipped:
+            self._record_extraction_incomplete(
+                "onnx_external_initializer_skipped",
+                external_reference_tensors=plan.external_initializers_skipped,
+            )
+        if plan.extraction_failures:
+            self._record_extraction_incomplete(
+                "onnx_initializer_read_failed",
+                tensor_read_failures=plan.extraction_failures,
+            )
+        for reason, count in plan.coverage_gaps.items():
+            self._record_extraction_incomplete(
+                f"onnx_{reason}",
+                coverage_gap_count=count,
+                unresolved_lineage_samples=plan.unresolved_lineage_samples,
+            )
+        return plan
+
     def _extract_onnx_weights(self, path: str) -> dict[str, Any]:
         """Extract weights from ONNX model files.
 
@@ -1665,7 +1765,25 @@ class WeightDistributionScanner(BaseScanner):
 
         return anomalies
 
-    def _analyze_architecture_properties(self, weights_info: dict[str, Any]) -> dict[str, Any]:
+    def _analyze_onnx_weight_specs(self, specs: list[Any]) -> list[tuple[dict[str, Any], Any]]:
+        """Analyze collision-proof ONNX specs using their semantic output axes."""
+        matrix_weights = {spec.analysis_id: spec.weights for spec in specs if spec.matrix_analysis}
+        architecture_analysis = self._analyze_architecture_properties(matrix_weights)
+        analyzed: list[tuple[dict[str, Any], Any]] = []
+        for spec in specs:
+            layer_name = str(spec.context["initializer"])
+            if spec.matrix_analysis:
+                anomalies = self._analyze_layer_weights(layer_name, spec.weights, architecture_analysis)
+            else:
+                anomalies = self._analyze_tensor_weight_extremes(
+                    layer_name,
+                    spec.weights,
+                    output_axes=spec.output_axes,
+                )
+            analyzed.extend((anomaly, spec) for anomaly in anomalies)
+        return analyzed
+
+    def _analyze_architecture_properties(self, weights_info: dict[Any, Any]) -> dict[str, Any]:
         """
         Analyze the mathematical and architectural properties to determine model characteristics.
         Uses structural analysis rather than name-based detection to avoid security bypasses.

--- a/modelaudit/scanners/weight_distribution_scanner.py
+++ b/modelaudit/scanners/weight_distribution_scanner.py
@@ -27,6 +27,11 @@ _MAX_NUMERIC_SCALAR_BYTES = 16
 _MIN_NUMPY_ARRAY_BUDGET_BYTES = 256
 _EXTREME_WEIGHT_MIN_EFFECT_RATIO = 2.0
 _EXTREME_WEIGHT_MIN_PER_OUTPUT = 2
+_EXTREME_WEIGHT_ROBUST_MAD_MULTIPLIER = 30.0
+_EXTREME_WEIGHT_ROBUST_FALLBACK_MIN_PER_OUTPUT = 3
+_NORMAL_MAD_SCALE_FACTOR = 1.4826
+_EXTREME_WEIGHT_ANALYSIS_CHUNK_BYTES = 8 * 1024 * 1024
+_EXTREME_WEIGHT_ROBUST_SAMPLE_SIZE = 256 * 1024
 _PICKLE_OBJECT_OPCODES = frozenset(
     {
         "BINBYTES",
@@ -1902,54 +1907,250 @@ class WeightDistributionScanner(BaseScanner):
                         },
                     )
 
-        # 3. Check for extreme weight values
-        weight_magnitudes = np.abs(weights)
-        mean_magnitude = np.mean(weight_magnitudes)
-        std_magnitude = np.std(weight_magnitudes)
+        # 3. Check for extreme weight values. Keep the decision per output so
+        # unrelated tails cannot supply or suppress another output's evidence.
+        anomalies.extend(self._analyze_tensor_weight_extremes(layer_name, weights, output_axes=(1,)))
+
+        return anomalies
+
+    def _analyze_tensor_weight_extremes(
+        self,
+        layer_name: str,
+        weights: Any,
+        *,
+        output_axes: tuple[int, ...],
+    ) -> list[dict[str, Any]]:
+        """Detect repeated extreme values without materializing a reordered tensor.
+
+        ``output_axes`` identifies the dimensions that form distinct output
+        neurons. Every other dimension is reduced as that output's weight vector.
+        This supports grouped convolution layouts while keeping the original
+        tensor storage order.
+        """
+        try:
+            import numpy as np
+        except ImportError:
+            return []
+
+        if len(weights.shape) < 2 or weights.size == 0:
+            return []
+
+        rank = len(weights.shape)
+        normalized_output_axes = tuple(axis if axis >= 0 else rank + axis for axis in output_axes)
+        if (
+            not normalized_output_axes
+            or len(set(normalized_output_axes)) != len(normalized_output_axes)
+            or any(axis < 0 or axis >= rank for axis in normalized_output_axes)
+        ):
+            raise ValueError(f"Invalid output axes {output_axes!r} for weight rank {rank}")
+
+        input_axes = tuple(axis for axis in range(rank) if axis not in normalized_output_axes)
+        if not input_axes or any(int(weights.shape[axis]) == 0 for axis in input_axes):
+            return []
+
+        n_outputs = math.prod(int(weights.shape[axis]) for axis in normalized_output_axes)
+        if n_outputs == 0:
+            return []
+
+        destination_axes = tuple(range(rank - len(normalized_output_axes), rank))
+        output_last_view = np.moveaxis(weights, normalized_output_axes, destination_axes)
+        input_shape = output_last_view.shape[: rank - len(normalized_output_axes)]
+        output_shape = output_last_view.shape[rank - len(normalized_output_axes) :]
+        # Magnitudes and squared magnitudes are accumulated in float64 so
+        # narrow source dtypes cannot overflow before the reduction.
+        analysis_itemsize = 8
+        max_work_values = max(1, _EXTREME_WEIGHT_ANALYSIS_CHUNK_BYTES // analysis_itemsize)
+        input_values_per_output = math.prod(int(dimension) for dimension in input_shape)
+        outputs_per_chunk = max(
+            1,
+            min(
+                int(output_shape[-1]),
+                max_work_values // max(1, input_values_per_output),
+            ),
+        )
+        input_block_budget = max(1, max_work_values // outputs_per_chunk)
+        input_block_shape = [1] * len(input_shape)
+        remaining_block_values = input_block_budget
+        for axis in reversed(range(len(input_shape))):
+            block_length = min(int(input_shape[axis]), remaining_block_values)
+            input_block_shape[axis] = max(1, block_length)
+            remaining_block_values = max(1, remaining_block_values // input_block_shape[axis])
+        input_block_counts = tuple(
+            math.ceil(int(dimension) / block_length)
+            for dimension, block_length in zip(input_shape, input_block_shape, strict=True)
+        )
+
+        def magnitudes_as_float64(chunk: Any) -> Any:
+            magnitudes = np.empty(chunk.shape, dtype=np.float64)
+            np.absolute(chunk, out=magnitudes, casting="unsafe")
+            return magnitudes
+
+        def iter_output_groups() -> Any:
+            prefix_shape = output_shape[:-1]
+            prefix_count = math.prod(int(dimension) for dimension in prefix_shape) if prefix_shape else 1
+            for prefix_index in range(prefix_count):
+                prefix = (
+                    tuple(int(value) for value in np.unravel_index(prefix_index, prefix_shape)) if prefix_shape else ()
+                )
+                for output_start in range(0, int(output_shape[-1]), outputs_per_chunk):
+                    output_end = min(int(output_shape[-1]), output_start + outputs_per_chunk)
+                    flat_output_start = prefix_index * int(output_shape[-1]) + output_start
+                    yield flat_output_start, prefix, output_start, output_end
+
+        def iter_group_chunks(prefix: tuple[int, ...], output_start: int, output_end: int) -> Any:
+            for block_index in np.ndindex(*input_block_counts):
+                input_slices = tuple(
+                    slice(
+                        index * block_length,
+                        min(int(input_shape[axis]), (index + 1) * block_length),
+                    )
+                    for axis, (index, block_length) in enumerate(
+                        zip(block_index, input_block_shape, strict=True),
+                    )
+                )
+                yield output_last_view[input_slices + prefix + (slice(output_start, output_end),)]
+
+        total_values = int(weights.size)
+        sample_step = max(1, math.ceil(total_values / _EXTREME_WEIGHT_ROBUST_SAMPLE_SIZE))
+        sample_parts: list[Any] = []
+        logical_offset = 0
+        magnitude_sum = 0.0
+        magnitude_square_sum = 0.0
+        for _flat_output_start, prefix, output_start, output_end in iter_output_groups():
+            for chunk in iter_group_chunks(prefix, output_start, output_end):
+                chunk_magnitudes = magnitudes_as_float64(chunk)
+                magnitude_sum += float(np.sum(chunk_magnitudes, dtype=np.float64))
+                first_sample = (-logical_offset) % sample_step
+                if first_sample < chunk_magnitudes.size:
+                    sample_parts.append(np.asarray(chunk_magnitudes.flat[first_sample::sample_step]))
+                logical_offset += int(chunk_magnitudes.size)
+                np.square(chunk_magnitudes, out=chunk_magnitudes)
+                magnitude_square_sum += float(np.sum(chunk_magnitudes, dtype=np.float64))
+
+        mean_magnitude = magnitude_sum / total_values
+        variance = max(0.0, magnitude_square_sum / total_values - mean_magnitude * mean_magnitude)
+        std_magnitude = math.sqrt(variance)
         threshold = mean_magnitude + self.weight_magnitude_threshold * std_magnitude
 
-        extreme_weights = np.where(weight_magnitudes > threshold)
-        if len(extreme_weights[0]) > 0:
-            # Group by output neuron
-            neurons_with_extreme_weights, per_output_counts = np.unique(extreme_weights[1], return_counts=True)
-            max_affected_outputs = max(1, int(0.001 * n_outputs))
-            max_extreme_per_output = int(np.max(per_output_counts))
-            max_weight = float(np.max(weight_magnitudes[extreme_weights]))
-            effect_ratio = max_weight / float(threshold) if threshold > 0 else 0.0
+        robust_sample = np.concatenate(sample_parts)[:_EXTREME_WEIGHT_ROBUST_SAMPLE_SIZE]
+        robust_median = float(np.median(robust_sample))
+        robust_mad = float(np.median(np.abs(robust_sample - robust_median)))
+        robust_scale = _NORMAL_MAD_SCALE_FACTOR * robust_mad
+        robust_threshold = robust_median + _EXTREME_WEIGHT_ROBUST_MAD_MULTIPLIER * robust_scale
 
-            # Ordinary distribution tails often produce one barely-over-threshold
-            # coefficient in several columns. Require a repeated, materially large
-            # effect localized to a genuinely small output subset.
-            if (
-                len(neurons_with_extreme_weights) <= max_affected_outputs
-                and max_extreme_per_output >= _EXTREME_WEIGHT_MIN_PER_OUTPUT
-                and effect_ratio >= _EXTREME_WEIGHT_MIN_EFFECT_RATIO
-            ):
-                anomalies.append(
+        reduction_axes = tuple(range(len(input_shape)))
+        max_affected_outputs = max(1, int(0.001 * n_outputs))
+        affected_neurons: list[int] = []
+        evidence: list[dict[str, Any]] = []
+        total_affected = 0
+        num_extreme_weights = 0
+        max_extreme_weights_per_output = 0
+        max_weight = 0.0
+        max_effect_ratio = 0.0
+        for flat_output_start, prefix, output_start, output_end in iter_output_groups():
+            output_count = output_end - output_start
+            classical_robust_counts = np.zeros(output_count, dtype=np.int64)
+            robust_counts = np.zeros(output_count, dtype=np.int64)
+            per_output_max = np.zeros(output_count, dtype=np.float64)
+            for chunk in iter_group_chunks(prefix, output_start, output_end):
+                chunk_magnitudes = magnitudes_as_float64(chunk)
+                robust_mask = (
+                    chunk_magnitudes > robust_threshold if robust_scale > 0 else chunk_magnitudes > robust_median
+                )
+                robust_counts += np.asarray(np.count_nonzero(robust_mask, axis=reduction_axes)).reshape(-1)
+                classical_mask = chunk_magnitudes > threshold
+                classical_mask &= robust_mask
+                classical_robust_counts += np.asarray(
+                    np.count_nonzero(classical_mask, axis=reduction_axes),
+                ).reshape(-1)
+                per_output_max = np.maximum(
+                    per_output_max,
+                    np.asarray(np.max(chunk_magnitudes, axis=reduction_axes)).reshape(-1),
+                )
+
+            if threshold > 0:
+                per_output_effect_ratios = per_output_max / threshold
+            else:
+                per_output_effect_ratios = np.where(per_output_max > 0, np.inf, 0.0)
+
+            classical_effect_qualified = (classical_robust_counts >= _EXTREME_WEIGHT_MIN_PER_OUTPUT) & (
+                per_output_effect_ratios >= _EXTREME_WEIGHT_MIN_EFFECT_RATIO
+            )
+            robust_fallback_qualified = classical_robust_counts >= _EXTREME_WEIGHT_ROBUST_FALLBACK_MIN_PER_OUTPUT
+            qualified_indices = np.flatnonzero(classical_effect_qualified | robust_fallback_qualified)
+            if len(qualified_indices) == 0:
+                continue
+
+            qualified_counts = classical_robust_counts[qualified_indices]
+            total_affected += len(qualified_indices)
+            num_extreme_weights += int(np.sum(qualified_counts))
+            max_extreme_weights_per_output = max(max_extreme_weights_per_output, int(np.max(qualified_counts)))
+            max_weight = max(max_weight, float(np.max(per_output_max[qualified_indices])))
+            max_effect_ratio = max(max_effect_ratio, float(np.max(per_output_effect_ratios[qualified_indices])))
+
+            for local_output_index in qualified_indices:
+                output_index = flat_output_start + int(local_output_index)
+                if len(affected_neurons) < 10:
+                    affected_neurons.append(output_index)
+                if len(evidence) >= 10:
+                    continue
+                effect_ratio = float(per_output_effect_ratios[local_output_index])
+                robust_effect_ratio = (
+                    float((per_output_max[local_output_index] - robust_median) / robust_scale)
+                    if robust_scale > 0
+                    else None
+                )
+                if classical_effect_qualified[local_output_index] and robust_fallback_qualified[local_output_index]:
+                    detection_path = "classical_and_robust"
+                elif classical_effect_qualified[local_output_index]:
+                    detection_path = "classical_effect"
+                else:
+                    detection_path = "robust_small_tensor_fallback"
+                evidence.append(
                     {
-                        "description": f"Layer '{layer_name}' has neurons with extremely large weight values",
-                        "severity": IssueSeverity.INFO,
-                        "details": {
-                            "layer": layer_name,
-                            "affected_neurons": neurons_with_extreme_weights.tolist()[:10],  # Limit list
-                            "total_affected": len(neurons_with_extreme_weights),
-                            "num_extreme_weights": len(extreme_weights[0]),
-                            "threshold": float(threshold),
-                            "max_weight": max_weight,
-                            "max_to_threshold_ratio": effect_ratio,
-                            "max_extreme_weights_per_output": max_extreme_per_output,
-                            "affected_output_limit": max_affected_outputs,
-                            "minimum_effect_ratio": _EXTREME_WEIGHT_MIN_EFFECT_RATIO,
-                            "minimum_extreme_weights_per_output": _EXTREME_WEIGHT_MIN_PER_OUTPUT,
-                            "total_outputs": n_outputs,
-                            "analysis_method": "structural_analysis",
-                        },
-                        "why": (
-                            "Weight values that are orders of magnitude larger than typical can cause numerical "
-                            "instability, overflow attacks, or may encode hidden data. Detection uses statistical "
-                            "analysis rather than name-based classification to avoid security bypasses."
-                        ),
+                        "output_index": output_index,
+                        "classical_robust_count": int(classical_robust_counts[local_output_index]),
+                        "robust_count": int(robust_counts[local_output_index]),
+                        "max_to_threshold_ratio": effect_ratio if np.isfinite(effect_ratio) else None,
+                        "robust_effect_ratio": robust_effect_ratio,
+                        "detection_path": detection_path,
                     },
                 )
 
-        return anomalies
+        if total_affected == 0:
+            return []
+
+        return [
+            {
+                "description": f"Layer '{layer_name}' has neurons with extremely large weight values",
+                "severity": IssueSeverity.INFO,
+                "details": {
+                    "layer": layer_name,
+                    "affected_neurons": affected_neurons,
+                    "total_affected": total_affected,
+                    "num_extreme_weights": num_extreme_weights,
+                    "threshold": threshold,
+                    "max_weight": max_weight,
+                    "max_to_threshold_ratio": max_effect_ratio if np.isfinite(max_effect_ratio) else None,
+                    "max_extreme_weights_per_output": max_extreme_weights_per_output,
+                    "affected_output_limit": max_affected_outputs,
+                    "localized": total_affected <= max_affected_outputs,
+                    "minimum_effect_ratio": _EXTREME_WEIGHT_MIN_EFFECT_RATIO,
+                    "minimum_extreme_weights_per_output": _EXTREME_WEIGHT_MIN_PER_OUTPUT,
+                    "robust_median_magnitude": robust_median,
+                    "robust_mad_scale": robust_scale,
+                    "robust_threshold": robust_threshold,
+                    "robust_mad_multiplier": _EXTREME_WEIGHT_ROBUST_MAD_MULTIPLIER,
+                    "robust_fallback_minimum_per_output": _EXTREME_WEIGHT_ROBUST_FALLBACK_MIN_PER_OUTPUT,
+                    "per_output_evidence": evidence,
+                    "total_outputs": n_outputs,
+                    "analysis_method": "per_output_robust_analysis",
+                },
+                "why": (
+                    "Repeated weight values that are materially beyond both classical and robust distribution "
+                    "baselines can cause numerical instability, overflow attacks, or encode hidden data. Evidence "
+                    "is evaluated independently per output so unrelated coefficients cannot create or suppress an "
+                    "alert."
+                ),
+            },
+        ]

--- a/modelaudit/scanners/weight_distribution_scanner.py
+++ b/modelaudit/scanners/weight_distribution_scanner.py
@@ -26,9 +26,10 @@ _MAX_RESTRICTED_PICKLE_MEMO_ENTRIES = 100_000
 _MAX_NUMERIC_SCALAR_BYTES = 16
 _MIN_NUMPY_ARRAY_BUDGET_BYTES = 256
 _EXTREME_WEIGHT_MIN_EFFECT_RATIO = 2.0
-_EXTREME_WEIGHT_MIN_PER_OUTPUT = 2
+_EXTREME_WEIGHT_MIN_PER_OUTPUT = 5
+_EXTREME_WEIGHT_LOCALIZATION_MIN_PER_OUTPUT = 2
 _EXTREME_WEIGHT_ROBUST_MAD_MULTIPLIER = 30.0
-_EXTREME_WEIGHT_ROBUST_FALLBACK_MIN_PER_OUTPUT = 3
+_EXTREME_WEIGHT_ROBUST_FALLBACK_MIN_PER_OUTPUT = 5
 _NORMAL_MAD_SCALE_FACTOR = 1.4826
 _EXTREME_WEIGHT_ANALYSIS_CHUNK_BYTES = 8 * 1024 * 1024
 _EXTREME_WEIGHT_ROBUST_SAMPLE_SIZE = 256 * 1024
@@ -2043,6 +2044,7 @@ class WeightDistributionScanner(BaseScanner):
         affected_neurons: list[int] = []
         evidence: list[dict[str, Any]] = []
         total_affected = 0
+        tail_affected_outputs = 0
         num_extreme_weights = 0
         max_extreme_weights_per_output = 0
         max_weight = 0.0
@@ -2067,6 +2069,10 @@ class WeightDistributionScanner(BaseScanner):
                     per_output_max,
                     np.asarray(np.max(chunk_magnitudes, axis=reduction_axes)).reshape(-1),
                 )
+
+            tail_affected_outputs += int(
+                np.count_nonzero(classical_robust_counts >= _EXTREME_WEIGHT_LOCALIZATION_MIN_PER_OUTPUT),
+            )
 
             if threshold > 0:
                 per_output_effect_ratios = per_output_max / threshold
@@ -2117,7 +2123,7 @@ class WeightDistributionScanner(BaseScanner):
                     },
                 )
 
-        if total_affected == 0:
+        if total_affected == 0 or tail_affected_outputs > max_affected_outputs:
             return []
 
         return [
@@ -2128,15 +2134,17 @@ class WeightDistributionScanner(BaseScanner):
                     "layer": layer_name,
                     "affected_neurons": affected_neurons,
                     "total_affected": total_affected,
+                    "tail_affected_outputs": tail_affected_outputs,
                     "num_extreme_weights": num_extreme_weights,
                     "threshold": threshold,
                     "max_weight": max_weight,
                     "max_to_threshold_ratio": max_effect_ratio if np.isfinite(max_effect_ratio) else None,
                     "max_extreme_weights_per_output": max_extreme_weights_per_output,
                     "affected_output_limit": max_affected_outputs,
-                    "localized": total_affected <= max_affected_outputs,
+                    "localized": tail_affected_outputs <= max_affected_outputs,
                     "minimum_effect_ratio": _EXTREME_WEIGHT_MIN_EFFECT_RATIO,
                     "minimum_extreme_weights_per_output": _EXTREME_WEIGHT_MIN_PER_OUTPUT,
+                    "localization_minimum_per_output": _EXTREME_WEIGHT_LOCALIZATION_MIN_PER_OUTPUT,
                     "robust_median_magnitude": robust_median,
                     "robust_mad_scale": robust_scale,
                     "robust_threshold": robust_threshold,

--- a/modelaudit/scanners/weight_distribution_scanner.py
+++ b/modelaudit/scanners/weight_distribution_scanner.py
@@ -25,6 +25,8 @@ _MAX_RESTRICTED_PICKLE_OPCODES = 500_000
 _MAX_RESTRICTED_PICKLE_MEMO_ENTRIES = 100_000
 _MAX_NUMERIC_SCALAR_BYTES = 16
 _MIN_NUMPY_ARRAY_BUDGET_BYTES = 256
+_EXTREME_WEIGHT_MIN_EFFECT_RATIO = 2.0
+_EXTREME_WEIGHT_MIN_PER_OUTPUT = 2
 _PICKLE_OBJECT_OPCODES = frozenset(
     {
         "BINBYTES",
@@ -1909,9 +1911,20 @@ class WeightDistributionScanner(BaseScanner):
         extreme_weights = np.where(weight_magnitudes > threshold)
         if len(extreme_weights[0]) > 0:
             # Group by output neuron
-            neurons_with_extreme_weights = np.unique(extreme_weights[1])
-            # Only flag if very few neurons affected (< 0.1% or max 5)
-            if len(neurons_with_extreme_weights) <= max(5, int(0.001 * n_outputs)):
+            neurons_with_extreme_weights, per_output_counts = np.unique(extreme_weights[1], return_counts=True)
+            max_affected_outputs = max(1, int(0.001 * n_outputs))
+            max_extreme_per_output = int(np.max(per_output_counts))
+            max_weight = float(np.max(weight_magnitudes[extreme_weights]))
+            effect_ratio = max_weight / float(threshold) if threshold > 0 else 0.0
+
+            # Ordinary distribution tails often produce one barely-over-threshold
+            # coefficient in several columns. Require a repeated, materially large
+            # effect localized to a genuinely small output subset.
+            if (
+                len(neurons_with_extreme_weights) <= max_affected_outputs
+                and max_extreme_per_output >= _EXTREME_WEIGHT_MIN_PER_OUTPUT
+                and effect_ratio >= _EXTREME_WEIGHT_MIN_EFFECT_RATIO
+            ):
                 anomalies.append(
                     {
                         "description": f"Layer '{layer_name}' has neurons with extremely large weight values",
@@ -1922,7 +1935,12 @@ class WeightDistributionScanner(BaseScanner):
                             "total_affected": len(neurons_with_extreme_weights),
                             "num_extreme_weights": len(extreme_weights[0]),
                             "threshold": float(threshold),
-                            "max_weight": float(np.max(weight_magnitudes)),
+                            "max_weight": max_weight,
+                            "max_to_threshold_ratio": effect_ratio,
+                            "max_extreme_weights_per_output": max_extreme_per_output,
+                            "affected_output_limit": max_affected_outputs,
+                            "minimum_effect_ratio": _EXTREME_WEIGHT_MIN_EFFECT_RATIO,
+                            "minimum_extreme_weights_per_output": _EXTREME_WEIGHT_MIN_PER_OUTPUT,
                             "total_outputs": n_outputs,
                             "analysis_method": "structural_analysis",
                         },

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -20,6 +20,7 @@ from modelaudit.detectors.network_comm import NetworkCommDetector
 from modelaudit.scanners.base import FORMAT_VALIDATION_CONFIG_KEY, INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity
 from modelaudit.scanners.onnx_scanner import (
     ONNX_STRUCTURE_INCONCLUSIVE_REASON,
+    ONNX_WEIGHT_DISTRIBUTION_INCONCLUSIVE_REASON,
     OnnxScanner,
     _confirmed_onnx_operator_findings,
     _confirmed_python_operator_findings,
@@ -56,6 +57,7 @@ def create_onnx_model(
     include_initializer: bool = True,
     initializer_consumer: str | None = None,
     custom_opset_version: int | None = None,
+    custom_uses_initializer: bool = False,
 ) -> Path:
     X = helper.make_tensor_value_info("input", TensorProto.FLOAT, list(tensor_shape) or [1])
     Y = helper.make_tensor_value_info("output", TensorProto.FLOAT, list(tensor_shape) or [1])
@@ -64,7 +66,7 @@ def create_onnx_model(
     elif custom:
         node = helper.make_node(
             custom_op_type,
-            ["input"],
+            ["input", "W"] if custom_uses_initializer else ["input"],
             ["output"],
             domain=custom_domain,
             name="custom",
@@ -249,6 +251,428 @@ def create_transformed_onnx_weight_model(
     model.ir_version = 8
     onnx.checker.check_model(model)
     path = tmp_path / f"{transform.lower()}-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_training_transformed_weight_model(tmp_path: Path, *, transform: str) -> Path:
+    analysis_weights = np.zeros((100, 10), dtype=np.float32)
+    analysis_weights[50:55, 3] = 10.0
+    if transform == "Reshape":
+        initializers = [
+            onnx.numpy_helper.from_array(analysis_weights.reshape(-1), name="W"),
+            onnx.numpy_helper.from_array(np.asarray(analysis_weights.shape, dtype=np.int64), name="shape"),
+        ]
+        transform_nodes = [helper.make_node("Reshape", ["W", "shape"], ["X"])]
+    elif transform == "Cast":
+        initializers = [onnx.numpy_helper.from_array(analysis_weights.astype(np.int64), name="W")]
+        transform_nodes = [helper.make_node("Cast", ["W"], ["X"], to=TensorProto.FLOAT)]
+    elif transform == "CastReshape":
+        initializers = [
+            onnx.numpy_helper.from_array(analysis_weights.astype(np.int64).reshape(-1), name="W"),
+            onnx.numpy_helper.from_array(np.asarray(analysis_weights.shape, dtype=np.int64), name="shape"),
+        ]
+        transform_nodes = [
+            helper.make_node("Cast", ["W"], ["W_float"], to=TensorProto.FLOAT),
+            helper.make_node("Reshape", ["W_float", "shape"], ["X"]),
+        ]
+    else:
+        raise ValueError(f"Unsupported transform: {transform}")
+
+    main_input = helper.make_tensor_value_info("main_input", TensorProto.FLOAT, [1])
+    main_output = helper.make_tensor_value_info("main_output", TensorProto.FLOAT, [1])
+    main_graph = helper.make_graph(
+        [helper.make_node("Identity", ["main_input"], ["main_output"])],
+        "main_graph",
+        [main_input],
+        [main_output],
+    )
+    adam = helper.make_node(
+        "Adam",
+        ["R", "T", "X", "G", "V", "H"],
+        ["X_new", "V_new", "H_new"],
+        domain="ai.onnx.preview.training",
+    )
+    algorithm = helper.make_graph(
+        [*transform_nodes, adam],
+        "transformed_training_weight",
+        [
+            helper.make_tensor_value_info("R", TensorProto.FLOAT, []),
+            helper.make_tensor_value_info("T", TensorProto.INT64, []),
+            helper.make_tensor_value_info("G", TensorProto.FLOAT, [100, 10]),
+            helper.make_tensor_value_info("V", TensorProto.FLOAT, [100, 10]),
+            helper.make_tensor_value_info("H", TensorProto.FLOAT, [100, 10]),
+        ],
+        [
+            helper.make_tensor_value_info("X_new", TensorProto.FLOAT, [100, 10]),
+            helper.make_tensor_value_info("V_new", TensorProto.FLOAT, [100, 10]),
+            helper.make_tensor_value_info("H_new", TensorProto.FLOAT, [100, 10]),
+        ],
+        initializer=initializers,
+    )
+    training_info = onnx.TrainingInfoProto()
+    training_info.algorithm.CopyFrom(algorithm)
+    model = helper.make_model(
+        main_graph,
+        opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid("ai.onnx.preview.training", 1)],
+    )
+    model.ir_version = 8
+    model.training_info.append(training_info)
+    onnx.checker.check_model(model)
+    path = tmp_path / f"training-{transform.lower()}-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_nonweight_transformed_matmul_model(tmp_path: Path, *, transform: str) -> Path:
+    weights = np.zeros((10, 10), dtype=np.float32)
+    weights[3:8, 4] = 10.0
+    if transform == "Reshape":
+        initializers = [
+            onnx.numpy_helper.from_array(weights, name="W"),
+            onnx.numpy_helper.from_array(np.asarray([100], dtype=np.int64), name="shape"),
+        ]
+        nodes = [
+            helper.make_node("Reshape", ["W", "shape"], ["W_view"]),
+            helper.make_node("MatMul", ["X", "W_view"], ["Y"]),
+        ]
+        graph_inputs = [helper.make_tensor_value_info("X", TensorProto.FLOAT, [100])]
+        graph_outputs = [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [])]
+    elif transform == "Cast":
+        initializers = [onnx.numpy_helper.from_array(weights, name="W")]
+        nodes = [
+            helper.make_node("Cast", ["W"], ["W_view"], to=TensorProto.INT64),
+            helper.make_node("MatMul", ["X", "W_view"], ["Y"]),
+        ]
+        graph_inputs = [helper.make_tensor_value_info("X", TensorProto.INT64, [1, 10])]
+        graph_outputs = [helper.make_tensor_value_info("Y", TensorProto.INT64, [1, 10])]
+    else:
+        raise ValueError(f"Unsupported transform: {transform}")
+
+    graph = helper.make_graph(nodes, "nonweight_transform", graph_inputs, graph_outputs, initializer=initializers)
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / f"nonweight-{transform.lower()}.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_zipmap_classifier_model(tmp_path: Path) -> Path:
+    weights = onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="W")
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100])
+    map_type = helper.make_map_type_proto(
+        TensorProto.INT64,
+        helper.make_tensor_type_proto(TensorProto.FLOAT, []),
+    )
+    probabilities = helper.make_value_info("probabilities", helper.make_sequence_type_proto(map_type))
+    nodes = [
+        helper.make_node("MatMul", ["X", "W"], ["logits"]),
+        helper.make_node(
+            "ZipMap",
+            ["logits"],
+            ["probabilities"],
+            domain="ai.onnx.ml",
+            classlabels_int64s=list(range(10)),
+        ),
+    ]
+    graph = helper.make_graph(nodes, "zipmap_classifier", [X], [probabilities], initializer=[weights])
+    model = helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid("ai.onnx.ml", 3)],
+    )
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "zipmap-classifier.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_training_info_weight_model(tmp_path: Path) -> Path:
+    main_input = helper.make_tensor_value_info("main_input", TensorProto.FLOAT, [1])
+    main_output = helper.make_tensor_value_info("main_output", TensorProto.FLOAT, [1])
+    main_graph = helper.make_graph(
+        [helper.make_node("Identity", ["main_input"], ["main_output"])],
+        "main_graph",
+        [main_input],
+        [main_output],
+    )
+
+    weights = np.zeros((100, 10), dtype=np.float32)
+    weights[50:55, 3] = 10.0
+    algorithm_inputs = [
+        helper.make_tensor_value_info("R", TensorProto.FLOAT, []),
+        helper.make_tensor_value_info("T", TensorProto.INT64, []),
+        helper.make_tensor_value_info("G", TensorProto.FLOAT, [100, 10]),
+        helper.make_tensor_value_info("V", TensorProto.FLOAT, [100, 10]),
+        helper.make_tensor_value_info("H", TensorProto.FLOAT, [100, 10]),
+    ]
+    algorithm_outputs = [
+        helper.make_tensor_value_info("X_new", TensorProto.FLOAT, [100, 10]),
+        helper.make_tensor_value_info("V_new", TensorProto.FLOAT, [100, 10]),
+        helper.make_tensor_value_info("H_new", TensorProto.FLOAT, [100, 10]),
+    ]
+    algorithm = helper.make_graph(
+        [
+            helper.make_node(
+                "Adam",
+                ["R", "T", "X", "G", "V", "H"],
+                ["X_new", "V_new", "H_new"],
+                domain="ai.onnx.preview.training",
+            )
+        ],
+        "training_algorithm",
+        algorithm_inputs,
+        algorithm_outputs,
+        initializer=[onnx.numpy_helper.from_array(weights, name="X")],
+    )
+    training_info = onnx.TrainingInfoProto()
+    training_info.algorithm.CopyFrom(algorithm)
+    model = helper.make_model(
+        main_graph,
+        opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid("ai.onnx.preview.training", 1)],
+    )
+    model.ir_version = 8
+    model.training_info.append(training_info)
+    onnx.checker.check_model(model)
+    path = tmp_path / "training-info-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_cross_training_info_weight_model(tmp_path: Path) -> Path:
+    main_input = helper.make_tensor_value_info("main_input", TensorProto.FLOAT, [1])
+    main_output = helper.make_tensor_value_info("main_output", TensorProto.FLOAT, [1])
+    main_graph = helper.make_graph(
+        [helper.make_node("Identity", ["main_input"], ["main_output"])],
+        "main_graph",
+        [main_input],
+        [main_output],
+    )
+
+    weights = np.zeros((100, 10), dtype=np.float32)
+    weights[50:55, 3] = 10.0
+    first_algorithm = helper.make_graph(
+        [helper.make_node("Identity", ["W"], ["W_seeded"])],
+        "first_training_algorithm",
+        [],
+        [helper.make_tensor_value_info("W_seeded", TensorProto.FLOAT, [100, 10])],
+        initializer=[onnx.numpy_helper.from_array(weights, name="W")],
+    )
+    first_training_info = onnx.TrainingInfoProto()
+    first_training_info.algorithm.CopyFrom(first_algorithm)
+    first_binding = first_training_info.update_binding.add()
+    first_binding.key = "W"
+    first_binding.value = "W_seeded"
+
+    second_algorithm = helper.make_graph(
+        [
+            helper.make_node(
+                "Adam",
+                ["R", "T", "W", "G", "V", "H"],
+                ["W_updated", "V_updated", "H_updated"],
+                domain="ai.onnx.preview.training",
+            )
+        ],
+        "second_training_algorithm",
+        [
+            helper.make_tensor_value_info("R", TensorProto.FLOAT, []),
+            helper.make_tensor_value_info("T", TensorProto.INT64, []),
+            helper.make_tensor_value_info("G", TensorProto.FLOAT, [100, 10]),
+            helper.make_tensor_value_info("V", TensorProto.FLOAT, [100, 10]),
+            helper.make_tensor_value_info("H", TensorProto.FLOAT, [100, 10]),
+        ],
+        [
+            helper.make_tensor_value_info("W_updated", TensorProto.FLOAT, [100, 10]),
+            helper.make_tensor_value_info("V_updated", TensorProto.FLOAT, [100, 10]),
+            helper.make_tensor_value_info("H_updated", TensorProto.FLOAT, [100, 10]),
+        ],
+    )
+    second_training_info = onnx.TrainingInfoProto()
+    second_training_info.algorithm.CopyFrom(second_algorithm)
+    second_binding = second_training_info.update_binding.add()
+    second_binding.key = "W"
+    second_binding.value = "W_updated"
+
+    model = helper.make_model(
+        main_graph,
+        opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid("ai.onnx.preview.training", 1)],
+    )
+    model.ir_version = 8
+    model.training_info.extend([first_training_info, second_training_info])
+    onnx.checker.check_model(model)
+    path = tmp_path / "cross-training-info-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_training_initialization_reset_model(tmp_path: Path) -> Path:
+    main_input = helper.make_tensor_value_info("main_input", TensorProto.FLOAT, [1])
+    main_output = helper.make_tensor_value_info("main_output", TensorProto.FLOAT, [1])
+    main_weights = onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="W")
+    main_graph = helper.make_graph(
+        [helper.make_node("Identity", ["main_input"], ["main_output"])],
+        "main_graph",
+        [main_input],
+        [main_output],
+        initializer=[main_weights],
+    )
+
+    reset_weights = np.zeros((100, 10), dtype=np.float32)
+    reset_weights[50:55, 3] = 10.0
+    reset_tensor = onnx.numpy_helper.from_array(reset_weights, name="reset_value")
+    initialization = helper.make_graph(
+        [helper.make_node("Constant", [], ["W_reset"], value=reset_tensor)],
+        "training_initialization",
+        [],
+        [helper.make_tensor_value_info("W_reset", TensorProto.FLOAT, [100, 10])],
+    )
+    training_info = onnx.TrainingInfoProto()
+    training_info.initialization.CopyFrom(initialization)
+    binding = training_info.initialization_binding.add()
+    binding.key = "W"
+    binding.value = "W_reset"
+
+    model = helper.make_model(main_graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    model.training_info.append(training_info)
+    onnx.checker.check_model(model)
+    path = tmp_path / "training-initialization-reset.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_read_only_main_initializer_training_model(tmp_path: Path) -> Path:
+    main_input = helper.make_tensor_value_info("main_input", TensorProto.FLOAT, [1])
+    main_output = helper.make_tensor_value_info("main_output", TensorProto.FLOAT, [1])
+    weights = onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="W")
+    main_graph = helper.make_graph(
+        [helper.make_node("Identity", ["main_input"], ["main_output"])],
+        "main_graph",
+        [main_input],
+        [main_output],
+        initializer=[weights],
+    )
+    algorithm = helper.make_graph(
+        [helper.make_node("Identity", ["W"], ["snapshot"])],
+        "read_only_training_algorithm",
+        [],
+        [helper.make_tensor_value_info("snapshot", TensorProto.FLOAT, [100, 10])],
+    )
+    training_info = onnx.TrainingInfoProto()
+    training_info.algorithm.CopyFrom(algorithm)
+    model = helper.make_model(main_graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    model.training_info.append(training_info)
+    onnx.checker.check_model(model)
+    path = tmp_path / "read-only-main-initializer-training.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_non_weight_training_update_model(
+    tmp_path: Path,
+    *,
+    data_type: int,
+    op_type: str,
+    shape: tuple[int, ...] = (),
+    opset_version: int = 13,
+) -> Path:
+    numpy_dtype = (
+        np.bool_ if data_type == TensorProto.BOOL else np.float32 if data_type == TensorProto.FLOAT else np.int64
+    )
+    state = onnx.numpy_helper.from_array(np.ones(shape, dtype=numpy_dtype), name="state")
+    algorithm_initializers = []
+    if op_type in {
+        "BitwiseNot",
+        "Celu",
+        "Gelu",
+        "Hardmax",
+        "LogSoftmax",
+        "LpNormalization",
+        "Neg",
+        "Not",
+        "Round",
+        "Shrink",
+        "Softmax",
+        "Swish",
+    }:
+        node_inputs = ["state"]
+    elif op_type == "Where":
+        condition = onnx.numpy_helper.from_array(np.ones(shape, dtype=np.bool_), name="condition")
+        alternative = onnx.numpy_helper.from_array(np.ones(shape, dtype=numpy_dtype), name="alternative")
+        algorithm_initializers.extend([condition, alternative])
+        node_inputs = ["condition", "state", "alternative"]
+    else:
+        delta = onnx.numpy_helper.from_array(np.ones(shape, dtype=numpy_dtype), name="delta")
+        algorithm_initializers.append(delta)
+        node_inputs = ["state", "delta"]
+    main_input = helper.make_tensor_value_info("main_input", TensorProto.FLOAT, [1])
+    main_output = helper.make_tensor_value_info("main_output", TensorProto.FLOAT, [1])
+    main_graph = helper.make_graph(
+        [helper.make_node("Identity", ["main_input"], ["main_output"])],
+        "main_graph",
+        [main_input],
+        [main_output],
+        initializer=[state],
+    )
+    algorithm = helper.make_graph(
+        [helper.make_node(op_type, node_inputs, ["state_new"])],
+        "non_weight_training_update",
+        [],
+        [helper.make_tensor_value_info("state_new", data_type, list(shape))],
+        initializer=algorithm_initializers,
+    )
+    training_info = onnx.TrainingInfoProto()
+    training_info.algorithm.CopyFrom(algorithm)
+    binding = training_info.update_binding.add()
+    binding.key = "state"
+    binding.value = "state_new"
+    model = helper.make_model(main_graph, opset_imports=[helper.make_opsetid("", opset_version)])
+    model.ir_version = 8
+    model.training_info.append(training_info)
+    onnx.checker.check_model(model)
+    path = tmp_path / f"non-weight-{op_type.lower()}-training-update.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_flat_training_initialization_reset_model(tmp_path: Path) -> Path:
+    stored_weights = np.zeros(1000, dtype=np.float32)
+    shape = onnx.numpy_helper.from_array(np.asarray([100, 10], dtype=np.int64), name="shape")
+    weights = onnx.numpy_helper.from_array(stored_weights, name="W")
+    main_input = helper.make_tensor_value_info("main_input", TensorProto.FLOAT, [1, 100])
+    main_output = helper.make_tensor_value_info("main_output", TensorProto.FLOAT, [1, 10])
+    main_graph = helper.make_graph(
+        [
+            helper.make_node("Reshape", ["W", "shape"], ["W_matrix"]),
+            helper.make_node("MatMul", ["main_input", "W_matrix"], ["main_output"]),
+        ],
+        "main_graph",
+        [main_input],
+        [main_output],
+        initializer=[weights, shape],
+    )
+
+    reset_weights = np.zeros(1000, dtype=np.float32)
+    reset_weights.reshape(100, 10)[50:55, 3] = 10.0
+    reset_tensor = onnx.numpy_helper.from_array(reset_weights, name="reset_value")
+    initialization = helper.make_graph(
+        [helper.make_node("Constant", [], ["reset"], value=reset_tensor)],
+        "flat_training_initialization",
+        [],
+        [helper.make_tensor_value_info("reset", TensorProto.FLOAT, [1000])],
+    )
+    training_info = onnx.TrainingInfoProto()
+    training_info.initialization.CopyFrom(initialization)
+    binding = training_info.initialization_binding.add()
+    binding.key = "W"
+    binding.value = "reset"
+    model = helper.make_model(main_graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    model.training_info.append(training_info)
+    onnx.checker.check_model(model)
+    path = tmp_path / "flat-training-initialization-reset.onnx"
     onnx.save(model, str(path))
     return path
 
@@ -1841,6 +2265,8 @@ def test_onnx_scanner_standard_ai_onnx_ml_domain_not_flagged(tmp_path: Path) -> 
         f"Expected no custom-domain finding for ai.onnx.ml. Checks: {[c.message for c in result.checks]}"
     )
     assert "ai.onnx.ml" not in metadata_custom_domains
+    assert result.success is True
+    assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
 
 
 def test_onnx_scanner_standard_preview_training_domain_not_flagged(tmp_path: Path) -> None:
@@ -1855,6 +2281,8 @@ def test_onnx_scanner_standard_preview_training_domain_not_flagged(tmp_path: Pat
         f"Expected no custom-domain finding for ai.onnx.preview.training. Checks: {[c.message for c in result.checks]}"
     )
     assert "ai.onnx.preview.training" not in metadata_custom_domains
+    assert result.success is True
+    assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
 
 
 def test_onnx_scanner_registered_ai_onnx_preview_operator_not_flagged(
@@ -1877,6 +2305,671 @@ def test_onnx_scanner_registered_ai_onnx_preview_operator_not_flagged(
         f"Expected no custom-domain finding for ai.onnx.preview. Checks: {[c.message for c in result.checks]}"
     )
     assert "ai.onnx.preview" not in metadata_custom_domains
+    assert result.success is True
+    assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+
+
+def test_onnx_scanner_registered_onnx_ml_static_data_stays_clean(tmp_path: Path) -> None:
+    data = onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="data")
+    output = helper.make_tensor_value_info("output", TensorProto.FLOAT, [100, 10])
+    normalizer = helper.make_node("Normalizer", ["data"], ["output"], domain="ai.onnx.ml")
+    graph = helper.make_graph([normalizer], "onnx_ml_static_data", [], [output], initializer=[data])
+    model = helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid("ai.onnx.ml", 3)],
+    )
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    model_path = tmp_path / "onnx-ml-static-data.onnx"
+    onnx.save(model, str(model_path))
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+    semantics = result.metadata["onnx_weight_distribution_semantics"]
+    assert semantics["eligible_initializer_count"] == 0
+    assert semantics["coverage_gaps"] == {}
+
+
+def test_onnx_scanner_static_onnx_ml_output_used_as_weight_fails_closed(tmp_path: Path) -> None:
+    left_data = np.zeros((100, 100), dtype=np.float32)
+    left_data[0, 0] = 1e20
+    initializers = [
+        onnx.numpy_helper.from_array(left_data, name="left_data"),
+        onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="right_weight"),
+    ]
+    output = helper.make_tensor_value_info("output", TensorProto.FLOAT, [100, 10])
+    nodes = [
+        helper.make_node("Normalizer", ["left_data"], ["left_normalized"], domain="ai.onnx.ml"),
+        helper.make_node("MatMul", ["left_normalized", "right_weight"], ["output"]),
+    ]
+    graph = helper.make_graph(nodes, "onnx_ml_static_weight_path", [], [output], initializer=initializers)
+    model = helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid("ai.onnx.ml", 3)],
+    )
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    model_path = tmp_path / "onnx-ml-static-weight-path.onnx"
+    onnx.save(model, str(model_path))
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is False
+    coverage_checks = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+    assert len(coverage_checks) == 1
+    assert coverage_checks[0].details["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
+    semantics = result.metadata["onnx_weight_distribution_semantics"]
+    assert semantics["eligible_initializer_count"] == 2
+    assert semantics["analyzed_layer_count"] == 1
+
+
+def test_onnx_scanner_onnx_ml_bookkeeping_initializer_stays_clean(tmp_path: Path) -> None:
+    features = helper.make_tensor_value_info("features", TensorProto.FLOAT, [1, 2])
+    output = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, 1])
+    indices = helper.make_tensor("indices", TensorProto.INT64, [1], [0])
+    node = helper.make_node(
+        "ArrayFeatureExtractor",
+        ["features", "indices"],
+        ["output"],
+        domain="ai.onnx.ml",
+    )
+    graph = helper.make_graph([node], "feature_extractor", [features], [output], initializer=[indices])
+    model = helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid("ai.onnx.ml", 3)],
+    )
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    model_path = tmp_path / "array-feature-extractor.onnx"
+    onnx.save(model, str(model_path))
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+    semantics = result.metadata["onnx_weight_distribution_semantics"]
+    assert semantics["eligible_initializer_count"] == 0
+    assert semantics["coverage_gaps"] == {}
+
+
+@pytest.mark.parametrize("transform", ["Add", "Sub", "Abs"])
+def test_onnx_scanner_transformed_onnx_ml_bookkeeping_initializer_stays_clean(
+    tmp_path: Path,
+    transform: str,
+) -> None:
+    features = helper.make_tensor_value_info("features", TensorProto.FLOAT, [1, 2])
+    output = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, 1])
+    indices = helper.make_tensor("indices", TensorProto.INT64, [1], [0])
+    graph_inputs = [features]
+    if transform == "Abs":
+        transform_node = helper.make_node(transform, ["indices"], ["dynamic_indices"])
+    else:
+        graph_inputs.append(helper.make_tensor_value_info("offset", TensorProto.INT64, [1]))
+        transform_node = helper.make_node(transform, ["indices", "offset"], ["dynamic_indices"])
+    nodes = [
+        transform_node,
+        helper.make_node(
+            "ArrayFeatureExtractor",
+            ["features", "dynamic_indices"],
+            ["output"],
+            domain="ai.onnx.ml",
+        ),
+    ]
+    graph = helper.make_graph(nodes, "transformed_feature_extractor", graph_inputs, [output], [indices])
+    model = helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid("ai.onnx.ml", 3)],
+    )
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    model_path = tmp_path / "transformed-array-feature-extractor.onnx"
+    onnx.save(model, str(model_path))
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+    semantics = result.metadata["onnx_weight_distribution_semantics"]
+    assert semantics["eligible_initializer_count"] == 0
+    assert semantics["coverage_gaps"] == {}
+
+
+def test_onnx_scanner_onnx_ml_selector_does_not_taint_downstream_weights(tmp_path: Path) -> None:
+    features = helper.make_tensor_value_info("features", TensorProto.FLOAT, [1, 4])
+    output = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, 3])
+    indices = helper.make_tensor("indices", TensorProto.INT64, [2], [0, 1])
+    weights = onnx.numpy_helper.from_array(np.zeros((2, 3), dtype=np.float32), name="W")
+    nodes = [
+        helper.make_node(
+            "ArrayFeatureExtractor",
+            ["features", "indices"],
+            ["selected"],
+            domain="ai.onnx.ml",
+        ),
+        helper.make_node("MatMul", ["selected", "W"], ["output"]),
+    ]
+    graph = helper.make_graph(nodes, "feature_selection_matmul", [features], [output], [indices, weights])
+    model = helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid("ai.onnx.ml", 3)],
+    )
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    model_path = tmp_path / "feature-selection-matmul.onnx"
+    onnx.save(model, str(model_path))
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+    semantics = result.metadata["onnx_weight_distribution_semantics"]
+    assert semantics["eligible_initializer_count"] == 1
+    assert semantics["analyzed_layer_count"] == 1
+    assert semantics["coverage_gaps"] == {}
+
+
+@pytest.mark.parametrize("transform", ["Reshape", "Cast", "CastReshape"])
+def test_onnx_scanner_training_consumer_uses_effective_lineage_shape_and_dtype(
+    tmp_path: Path,
+    transform: str,
+) -> None:
+    model_path = create_training_transformed_weight_model(tmp_path, transform=transform)
+
+    result = OnnxScanner().scan(str(model_path))
+
+    coverage_checks = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+    assert result.success is False
+    assert len(coverage_checks) == 1
+    assert coverage_checks[0].details["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
+
+
+@pytest.mark.parametrize("transform", ["Reshape", "Cast"])
+def test_onnx_scanner_nonweight_effective_transform_stays_clean(tmp_path: Path, transform: str) -> None:
+    model_path = create_nonweight_transformed_matmul_model(tmp_path, transform=transform)
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+    semantics = result.metadata["onnx_weight_distribution_semantics"]
+    assert semantics["eligible_initializer_count"] == 0
+    assert semantics["coverage_gaps"] == {}
+
+
+def test_onnx_scanner_zipmap_activation_lineage_stays_clean(tmp_path: Path) -> None:
+    model_path = create_zipmap_classifier_model(tmp_path)
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+    semantics = result.metadata["onnx_weight_distribution_semantics"]
+    assert semantics["eligible_initializer_count"] == 1
+    assert semantics["analyzed_layer_count"] == 1
+    assert semantics["coverage_gaps"] == {}
+
+
+def test_onnx_scanner_training_graph_opaque_weight_consumer_fails_closed(tmp_path: Path) -> None:
+    model_path = create_training_info_weight_model(tmp_path)
+
+    result = OnnxScanner().scan(str(model_path))
+
+    coverage_checks = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+    assert result.success is False
+    assert len(coverage_checks) == 1
+    assert coverage_checks[0].details["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
+    semantics = result.metadata["onnx_weight_distribution_semantics"]
+    assert semantics["eligible_initializer_count"] == 1
+    assert semantics["unresolved_lineage_samples"][0]["consumer_op"] == "Adam"
+
+
+def test_onnx_scanner_read_only_main_initializer_is_visible_to_training_graph(tmp_path: Path) -> None:
+    model_path = create_read_only_main_initializer_training_model(tmp_path)
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+    semantics = result.metadata["onnx_weight_distribution_semantics"]
+    assert semantics["eligible_initializer_count"] == 0
+    assert semantics["coverage_gaps"] == {}
+
+
+@pytest.mark.parametrize(
+    ("data_type", "op_type", "shape", "opset_version"),
+    [
+        pytest.param(TensorProto.INT64, "Sub", (), 13, id="integer-counter"),
+        pytest.param(TensorProto.FLOAT, "Add", (), 13, id="floating-learning-rate"),
+        pytest.param(TensorProto.FLOAT, "Neg", (), 13, id="unary-negation"),
+        pytest.param(TensorProto.FLOAT, "Round", (), 13, id="unary-rounding"),
+        pytest.param(TensorProto.FLOAT, "Clip", (), 13, id="clipped-scalar"),
+        pytest.param(TensorProto.FLOAT, "Celu", (), 13, id="celu-scalar"),
+        pytest.param(TensorProto.FLOAT, "Shrink", (), 13, id="shrunk-scalar"),
+        pytest.param(TensorProto.FLOAT, "PRelu", (), 13, id="prelu-scalar"),
+        pytest.param(TensorProto.FLOAT, "Sum", (), 13, id="summed-scalar"),
+        pytest.param(TensorProto.FLOAT, "Pow", (), 13, id="powered-scalar"),
+        pytest.param(TensorProto.FLOAT, "Where", (), 13, id="selected-scalar"),
+        pytest.param(TensorProto.FLOAT, "Softmax", (3,), 13, id="softmax-vector"),
+        pytest.param(TensorProto.FLOAT, "LogSoftmax", (3,), 13, id="log-softmax-vector"),
+        pytest.param(TensorProto.FLOAT, "Hardmax", (3,), 13, id="hardmax-vector"),
+        pytest.param(TensorProto.FLOAT, "LpNormalization", (3,), 13, id="normalized-vector"),
+        pytest.param(TensorProto.FLOAT, "Gelu", (), 20, id="gelu-scalar"),
+        pytest.param(TensorProto.FLOAT, "Swish", (), 24, id="swish-scalar"),
+        pytest.param(TensorProto.INT64, "BitwiseNot", (), 18, id="bitwise-not-scalar"),
+        pytest.param(TensorProto.BOOL, "Not", (), 13, id="not-scalar"),
+    ],
+)
+def test_onnx_scanner_non_weight_training_update_stays_clean(
+    tmp_path: Path,
+    data_type: int,
+    op_type: str,
+    shape: tuple[int, ...],
+    opset_version: int,
+) -> None:
+    model_path = create_non_weight_training_update_model(
+        tmp_path,
+        data_type=data_type,
+        op_type=op_type,
+        shape=shape,
+        opset_version=opset_version,
+    )
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+    semantics = result.metadata["onnx_weight_distribution_semantics"]
+    assert semantics["eligible_initializer_count"] == 0
+    assert semantics["coverage_gaps"] == {}
+
+
+@pytest.mark.parametrize(
+    "parameter_shape",
+    [
+        pytest.param((), id="scalar"),
+        pytest.param((100,), id="vector"),
+        pytest.param((1, 100), id="matrix"),
+    ],
+)
+def test_onnx_scanner_dynamic_prelu_slope_stays_clean(
+    tmp_path: Path,
+    parameter_shape: tuple[int, ...],
+) -> None:
+    activation = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100])
+    output = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 10])
+    parameter = onnx.numpy_helper.from_array(np.ones(parameter_shape, dtype=np.float32), name="parameter")
+    weights = onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="W")
+    graph = helper.make_graph(
+        [
+            helper.make_node("PRelu", ["X", "parameter"], ["activation"]),
+            helper.make_node("MatMul", ["activation", "W"], ["Y"]),
+        ],
+        "dynamic_prelu_slope",
+        [activation],
+        [output],
+        [parameter, weights],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    model_path = tmp_path / "dynamic-prelu-slope.onnx"
+    onnx.save(model, str(model_path))
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+    semantics = result.metadata["onnx_weight_distribution_semantics"]
+    expected_eligible = 2 if len(parameter_shape) >= 2 else 1
+    expected_analyzed = 3 if len(parameter_shape) >= 2 else 1
+    assert semantics["eligible_initializer_count"] == expected_eligible
+    assert semantics["analyzed_layer_count"] == expected_analyzed
+    assert semantics["coverage_gaps"] == {}
+
+
+@pytest.mark.parametrize("transposed", [False, True])
+def test_onnx_scanner_malicious_matrix_prelu_slope_remains_detected(
+    tmp_path: Path,
+    transposed: bool,
+) -> None:
+    slope_values = np.zeros((100, 10), dtype=np.float32)
+    slope_values[50:55, 3] = 10.0
+    if transposed:
+        slope_values = slope_values.T
+    rows, columns = slope_values.shape
+    activation = helper.make_tensor_value_info("X", TensorProto.FLOAT, [rows, columns])
+    output = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [rows, 3])
+    slope = onnx.numpy_helper.from_array(slope_values, name="slope")
+    weights = onnx.numpy_helper.from_array(np.zeros((columns, 3), dtype=np.float32), name="W")
+    graph = helper.make_graph(
+        [
+            helper.make_node("PRelu", ["X", "slope"], ["activation"]),
+            helper.make_node("MatMul", ["activation", "W"], ["Y"]),
+        ],
+        "malicious_matrix_prelu_slope",
+        [activation],
+        [output],
+        [slope, weights],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    model_path = tmp_path / "malicious-matrix-prelu-slope.onnx"
+    onnx.save(model, str(model_path))
+
+    result = OnnxScanner().scan(str(model_path))
+
+    extreme_checks = [
+        check
+        for check in result.checks
+        if check.name == "Weight Distribution Anomaly Detection" and "extremely large weight values" in check.message
+    ]
+    assert len(extreme_checks) == 1
+    assert extreme_checks[0].details["initializer"] == "slope"
+    assert extreme_checks[0].details["consumer_op"] == "PRelu"
+    assert extreme_checks[0].details["consumer_input_index"] == 1
+    assert extreme_checks[0].details["affected_neurons"] == [3]
+    assert extreme_checks[0].details["output_axis"] == (0 if transposed else 1)
+    semantics = result.metadata["onnx_weight_distribution_semantics"]
+    assert semantics["coverage_gaps"] == {}
+
+
+@pytest.mark.parametrize("slope_shape", [(100, 1, 1), (1, 100, 1, 1)])
+def test_onnx_scanner_prelu_singleton_axes_do_not_duplicate_findings(
+    tmp_path: Path,
+    slope_shape: tuple[int, ...],
+) -> None:
+    slope_values = np.zeros(slope_shape, dtype=np.float32)
+    non_singleton_axis = slope_shape.index(100)
+    outlier_slice: list[int | slice] = [0] * len(slope_shape)
+    outlier_slice[non_singleton_axis] = slice(50, 55)
+    slope_values[tuple(outlier_slice)] = 10.0
+    activation = helper.make_tensor_value_info("X", TensorProto.FLOAT, list(slope_shape))
+    output = helper.make_tensor_value_info("Y", TensorProto.FLOAT, list(slope_shape))
+    slope = onnx.numpy_helper.from_array(slope_values, name="slope")
+    graph = helper.make_graph(
+        [helper.make_node("PRelu", ["X", "slope"], ["Y"])],
+        "prelu_singleton_axes",
+        [activation],
+        [output],
+        [slope],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    model_path = tmp_path / "prelu-singleton-axes.onnx"
+    onnx.save(model, str(model_path))
+
+    result = OnnxScanner().scan(str(model_path))
+
+    extreme_checks = [
+        check
+        for check in result.checks
+        if check.name == "Weight Distribution Anomaly Detection" and "extremely large weight values" in check.message
+    ]
+    assert len(extreme_checks) == 1
+    assert extreme_checks[0].details["initializer"] == "slope"
+    semantics = result.metadata["onnx_weight_distribution_semantics"]
+    assert semantics["eligible_initializer_count"] == 1
+    assert semantics["analyzed_layer_count"] == 2
+    assert semantics["coverage_gaps"] == {}
+
+
+def test_onnx_scanner_matrix_clip_bound_fails_closed(tmp_path: Path) -> None:
+    scalar = helper.make_tensor_value_info("X", TensorProto.FLOAT, [])
+    output = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [])
+    matrix_bound = onnx.numpy_helper.from_array(np.zeros((2, 2), dtype=np.float32), name="minimum")
+    graph = helper.make_graph(
+        [helper.make_node("Clip", ["X", "minimum"], ["Y"])],
+        "invalid_matrix_clip_bound",
+        [scalar],
+        [output],
+        [matrix_bound],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    model_path = tmp_path / "matrix-clip-bound.onnx"
+    onnx.save(model, str(model_path))
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is False
+    coverage_checks = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+    assert len(coverage_checks) == 1
+    assert coverage_checks[0].details["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
+    samples = result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+    assert {sample["reason"] for sample in samples} == {"invalid_clip_bound_shape"}
+
+
+def test_onnx_scanner_transformed_non_scalar_clip_bound_fails_closed(tmp_path: Path) -> None:
+    scalar = helper.make_tensor_value_info("X", TensorProto.FLOAT, [])
+    output = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [])
+    matrix_bound = onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="minimum_matrix")
+    vector_shape = onnx.numpy_helper.from_array(np.asarray([1000], dtype=np.int64), name="vector_shape")
+    graph = helper.make_graph(
+        [
+            helper.make_node("Reshape", ["minimum_matrix", "vector_shape"], ["minimum"]),
+            helper.make_node("Clip", ["X", "minimum"], ["Y"]),
+        ],
+        "transformed_invalid_clip_bound",
+        [scalar],
+        [output],
+        [matrix_bound, vector_shape],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    model_path = tmp_path / "transformed-non-scalar-clip-bound.onnx"
+    onnx.save(model, str(model_path))
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is False
+    coverage_checks = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+    assert len(coverage_checks) == 1
+    assert coverage_checks[0].details["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
+    samples = result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+    assert {sample["reason"] for sample in samples} == {"invalid_clip_bound_shape"}
+
+
+@pytest.mark.parametrize(
+    ("op_type", "opset_version"),
+    [
+        pytest.param("Gelu", 20, id="gelu"),
+        pytest.param("Swish", 24, id="swish"),
+    ],
+)
+def test_onnx_scanner_static_matrix_unary_output_used_as_weight_fails_closed(
+    tmp_path: Path,
+    op_type: str,
+    opset_version: int,
+) -> None:
+    data = onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="data")
+    weights = onnx.numpy_helper.from_array(np.zeros((10, 3), dtype=np.float32), name="W")
+    output = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [100, 3])
+    graph = helper.make_graph(
+        [
+            helper.make_node(op_type, ["data"], ["transformed"]),
+            helper.make_node("MatMul", ["transformed", "W"], ["Y"]),
+        ],
+        f"static_{op_type.lower()}_weight_path",
+        [],
+        [output],
+        [data, weights],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", opset_version)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    model_path = tmp_path / f"static-{op_type.lower()}-weight-path.onnx"
+    onnx.save(model, str(model_path))
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is False
+    coverage_checks = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+    assert len(coverage_checks) == 1
+    assert coverage_checks[0].details["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
+
+
+@pytest.mark.parametrize("op_type", ["RandomNormalLike", "RandomUniformLike"])
+def test_onnx_scanner_random_like_dtype_override_used_as_weight_fails_closed(
+    tmp_path: Path,
+    op_type: str,
+) -> None:
+    shape_seed = onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.int64), name="shape_seed")
+    activation = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100])
+    output = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 10])
+    graph = helper.make_graph(
+        [
+            helper.make_node(op_type, ["shape_seed"], ["generated_weight"], dtype=TensorProto.FLOAT),
+            helper.make_node("MatMul", ["X", "generated_weight"], ["Y"]),
+        ],
+        f"{op_type.lower()}_weight_path",
+        [activation],
+        [output],
+        [shape_seed],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 22)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    model_path = tmp_path / f"{op_type.lower()}-weight-path.onnx"
+    onnx.save(model, str(model_path))
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is False
+    coverage_checks = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+    assert len(coverage_checks) == 1
+    assert coverage_checks[0].details["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
+
+
+def test_onnx_scanner_pow_exponent_dtype_override_used_as_weight_fails_closed(tmp_path: Path) -> None:
+    exponent = onnx.numpy_helper.from_array(np.ones((100, 10), dtype=np.int64), name="exponent")
+    base = helper.make_tensor_value_info("base", TensorProto.FLOAT, [100, 10])
+    activation = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100])
+    output = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 10])
+    graph = helper.make_graph(
+        [
+            helper.make_node("Pow", ["base", "exponent"], ["generated_weight"]),
+            helper.make_node("MatMul", ["X", "generated_weight"], ["Y"]),
+        ],
+        "pow_exponent_weight_path",
+        [base, activation],
+        [output],
+        [exponent],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    model_path = tmp_path / "pow-exponent-weight-path.onnx"
+    onnx.save(model, str(model_path))
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is False
+    coverage_checks = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+    assert len(coverage_checks) == 1
+    assert coverage_checks[0].details["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
+
+
+def test_onnx_scanner_cross_training_info_weight_state_fails_closed(tmp_path: Path) -> None:
+    model_path = create_cross_training_info_weight_model(tmp_path)
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is False
+    coverage_checks = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+    assert len(coverage_checks) == 1
+    semantics = result.metadata["onnx_weight_distribution_semantics"]
+    assert semantics["eligible_initializer_count"] == 1
+    assert semantics["coverage_gaps"]["unresolved_training_graph_input"] == 1
+    assert semantics["coverage_gaps"]["unresolved_training_binding"] == 1
+
+
+def test_onnx_scanner_training_initialization_binding_fails_closed(tmp_path: Path) -> None:
+    model_path = create_training_initialization_reset_model(tmp_path)
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is False
+    coverage_checks = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+    assert len(coverage_checks) == 1
+    semantics = result.metadata["onnx_weight_distribution_semantics"]
+    assert semantics["eligible_initializer_count"] == 1
+    assert any(
+        sample["reason"] == "unresolved_initialization_binding" for sample in semantics["unresolved_lineage_samples"]
+    )
+
+
+def test_onnx_scanner_flat_weight_initialization_binding_fails_closed(tmp_path: Path) -> None:
+    model_path = create_flat_training_initialization_reset_model(tmp_path)
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is False
+    coverage_checks = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+    assert len(coverage_checks) == 1
+    semantics = result.metadata["onnx_weight_distribution_semantics"]
+    assert semantics["eligible_initializer_count"] == 2
+    assert any(
+        sample["initializer"] == "reset" and sample["reason"] == "unresolved_initialization_binding"
+        for sample in semantics["unresolved_lineage_samples"]
+    )
+
+
+def test_onnx_scanner_combined_training_initializer_collision_fails_closed(tmp_path: Path) -> None:
+    model_path = create_flat_training_initialization_reset_model(tmp_path)
+    model = onnx.load(str(model_path))
+    colliding_algorithm = helper.make_graph(
+        [],
+        "colliding_training_algorithm",
+        [],
+        [],
+        initializer=[onnx.numpy_helper.from_array(np.asarray(1.0, dtype=np.float32), name="W")],
+    )
+    model.training_info[0].algorithm.CopyFrom(colliding_algorithm)
+    onnx.checker.check_model(model)
+    onnx.save(model, str(model_path))
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is False
+    coverage_checks = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+    assert len(coverage_checks) == 1
+    assert coverage_checks[0].details["coverage_gaps"] == {"invalid_initializer_names": 1}
+    validation = result.metadata["onnx_weight_distribution_semantics"]["initializer_name_validation"]
+    assert validation["duplicate_name_count"] == 1
+    assert validation["samples"][0]["reason"] == "duplicate_combined_training_initializer_name"
+
+
+def test_onnx_scanner_unknown_default_domain_matrix_consumer_fails_closed(tmp_path: Path) -> None:
+    model_path = create_onnx_model(
+        tmp_path,
+        custom=True,
+        custom_domain="",
+        custom_op_type="OpaqueKernel",
+        custom_uses_initializer=True,
+        tensor_shape=(100, 10),
+    )
+    model = onnx.load(str(model_path))
+    weights = np.zeros((100, 10), dtype=np.float32)
+    weights[50:55, 3] = 10.0
+    model.graph.initializer[0].CopyFrom(onnx.numpy_helper.from_array(weights, name="W"))
+    onnx.save(model, str(model_path))
+
+    result = OnnxScanner().scan(str(model_path))
+
+    coverage_checks = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+    assert result.success is False
+    assert not [check for check in result.checks if check.rule_code == "S1111" and check.status == CheckStatus.FAILED]
+    assert len(coverage_checks) == 1
+    assert coverage_checks[0].details["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
+    sample = result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"][0]
+    assert sample["consumer_op"] == "OpaqueKernel"
+    assert sample["reason"] == "unsupported_weight_consumer"
 
 
 def test_onnx_scanner_unknown_ai_onnx_preview_operator_still_flagged(
@@ -3248,6 +4341,20 @@ class TestWeightDistributionCoverage:
         finally:
             reset_cache_manager()
 
+    def test_training_weight_coverage_gap_is_uncached_inconclusive(self, tmp_path: Path) -> None:
+        model_path = create_training_info_weight_model(tmp_path)
+
+        direct = OnnxScanner().scan(str(model_path))
+
+        coverage_checks = self._coverage_checks(direct)
+        assert len(coverage_checks) == 1
+        assert (
+            coverage_checks[0].message == "Weight distribution analysis skipped one or more eligible ONNX initializers"
+        )
+        assert direct.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert ONNX_WEIGHT_DISTRIBUTION_INCONCLUSIVE_REASON in direct.metadata["scan_outcome_reasons"]
+        self._assert_uncached_inconclusive_exit2(model_path, tmp_path / "cache")
+
     def test_missing_weight_distribution_dependency_ignores_model_without_initializers(
         self,
         tmp_path: Path,
@@ -3404,6 +4511,52 @@ class TestWeightDistributionCoverage:
         assert coverage_checks[0].details["oversized_initializers_skipped"] == 1
         assert coverage_checks[0].details["analyzed_initializers"] == 0
         self._assert_uncached_inconclusive_exit2(model_path, tmp_path / "cache", max_array_size=1)
+
+    def test_standalone_invalid_initializer_size_is_uncached_inconclusive(self, tmp_path: Path) -> None:
+        invalid_weight = onnx.TensorProto()
+        invalid_weight.name = "W"
+        invalid_weight.data_type = TensorProto.FLOAT
+        invalid_weight.dims.extend([-1, 4])
+        graph = helper.make_graph(
+            [helper.make_node("MatMul", ["X", "W"], ["Y"])],
+            "negative_initializer_dimension",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 1])],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 4])],
+            initializer=[invalid_weight],
+        )
+        model_path = tmp_path / "negative-initializer-dimension.onnx"
+        onnx.save(helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)]), str(model_path))
+
+        direct = WeightDistributionScanner({"max_array_size": 1}).scan(str(model_path))
+
+        assert direct.success is False
+        assert direct.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "weight_distribution_analysis_incomplete" in direct.metadata["scan_outcome_reasons"]
+        analysis_check = next(check for check in direct.checks if check.name == "Weight Distribution Analysis")
+        assert analysis_check.details["oversized_initializers_skipped"] == 1
+
+        cache_dir = tmp_path / "standalone-cache"
+        reset_cache_manager()
+        try:
+            results = [
+                scan_model_directory_or_file(
+                    str(model_path),
+                    recursive=False,
+                    scanners=["weight_distribution"],
+                    max_array_size=1,
+                    cache_enabled=True,
+                    cache_dir=str(cache_dir),
+                    min_cache_file_size=0,
+                )
+                for _ in range(2)
+            ]
+            for result in results:
+                assert result.success is False
+                assert determine_exit_code(result) == 2
+                assert result.file_metadata[str(model_path)]["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+            assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+        finally:
+            reset_cache_manager()
 
     def test_inline_storage_is_bounded_before_materialization(
         self,

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -477,16 +477,21 @@ def create_control_flow_captured_weight_model(
     return path
 
 
-def create_control_flow_shadowed_weight_model(tmp_path: Path, outer_weights: np.ndarray) -> Path:
+def create_control_flow_shadowed_weight_model(
+    tmp_path: Path,
+    outer_weights: np.ndarray,
+    *,
+    local_weights: np.ndarray | None = None,
+) -> Path:
     """Create an If graph where a local W shadows an unused outer W."""
     outer_weight_tensor = onnx.numpy_helper.from_array(outer_weights, name="W")
-    local_weights = np.zeros_like(outer_weights)
+    branch_weights = np.zeros_like(outer_weights) if local_weights is None else local_weights
     X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, outer_weights.shape[0]])
     Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, outer_weights.shape[1]])
     condition = helper.make_tensor_value_info("condition", TensorProto.BOOL, [])
 
     def make_branch(name: str) -> Any:
-        local_weight_tensor = onnx.numpy_helper.from_array(local_weights, name="W")
+        local_weight_tensor = onnx.numpy_helper.from_array(branch_weights, name="W")
         branch_output = helper.make_tensor_value_info(f"{name}_output", TensorProto.FLOAT, [1, outer_weights.shape[1]])
         node = helper.make_node("MatMul", ["X", "W"], [f"{name}_output"], name=f"{name}_linear")
         return helper.make_graph([node], name, [], [branch_output], initializer=[local_weight_tensor])
@@ -510,6 +515,309 @@ def create_control_flow_shadowed_weight_model(tmp_path: Path, outer_weights: np.
     model.ir_version = 8
     onnx.checker.check_model(model)
     path = tmp_path / "shadowed-captured-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_control_flow_returned_weight_model(tmp_path: Path, weights: np.ndarray) -> Path:
+    """Create an If that returns a captured weight to an outer MatMul."""
+    initializer = onnx.numpy_helper.from_array(weights, name="W")
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, weights.shape[0]])
+    condition = helper.make_tensor_value_info("condition", TensorProto.BOOL, [])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, weights.shape[1]])
+
+    def make_branch(name: str) -> Any:
+        output_name = f"{name}_weight"
+        output = helper.make_tensor_value_info(output_name, TensorProto.FLOAT, list(weights.shape))
+        return helper.make_graph(
+            [helper.make_node("Identity", ["W"], [output_name], name=f"{name}_identity")],
+            name,
+            [],
+            [output],
+        )
+
+    nodes = [
+        helper.make_node(
+            "If",
+            ["condition"],
+            ["selected_weight"],
+            name="select_weight",
+            then_branch=make_branch("then"),
+            else_branch=make_branch("else"),
+        ),
+        helper.make_node("MatMul", ["X", "selected_weight"], ["Y"], name="linear"),
+    ]
+    graph = helper.make_graph(nodes, "returned_weight_graph", [condition, X], [Y], initializer=[initializer])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "returned-control-flow-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_loop_carried_weight_model(tmp_path: Path, weights: np.ndarray) -> Path:
+    """Create a Loop whose body consumes a weight through a formal input."""
+    initializer = onnx.numpy_helper.from_array(weights, name="W")
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, weights.shape[0]])
+    trip_count = helper.make_tensor_value_info("trip_count", TensorProto.INT64, [])
+    condition = helper.make_tensor_value_info("condition", TensorProto.BOOL, [])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, weights.shape[1]])
+    iteration = helper.make_tensor_value_info("iteration", TensorProto.INT64, [])
+    body_condition = helper.make_tensor_value_info("body_condition", TensorProto.BOOL, [])
+    state_weight = helper.make_tensor_value_info("state_weight", TensorProto.FLOAT, list(weights.shape))
+    condition_output = helper.make_tensor_value_info("condition_output", TensorProto.BOOL, [])
+    weight_output = helper.make_tensor_value_info("weight_output", TensorProto.FLOAT, list(weights.shape))
+    body = helper.make_graph(
+        [
+            helper.make_node("Identity", ["body_condition"], ["condition_output"]),
+            helper.make_node("MatMul", ["X", "state_weight"], ["body_projection"], name="body_linear"),
+            helper.make_node("Identity", ["state_weight"], ["weight_output"]),
+        ],
+        "loop_body",
+        [iteration, body_condition, state_weight],
+        [condition_output, weight_output],
+    )
+    nodes = [
+        helper.make_node(
+            "Loop",
+            ["trip_count", "condition", "W"],
+            ["final_weight"],
+            name="carry_weight",
+            body=body,
+        ),
+        helper.make_node("MatMul", ["X", "final_weight"], ["Y"], name="outer_linear"),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "loop_carried_weight_graph",
+        [trip_count, condition, X],
+        [Y],
+        initializer=[initializer],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "loop-carried-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_activation_bookkeeping_model(tmp_path: Path, *, malicious: bool) -> Path:
+    """Create a linear stack whose activation path also consumes a bias."""
+    first_weight = np.zeros((100, 100), dtype=np.float32)
+    second_weight = np.zeros((100, 10), dtype=np.float32)
+    if malicious:
+        second_weight[50:55, 3] = 10.0
+    initializers = [
+        onnx.numpy_helper.from_array(first_weight, name="W1"),
+        onnx.numpy_helper.from_array(np.zeros(100, dtype=np.float32), name="bias"),
+        onnx.numpy_helper.from_array(second_weight, name="W2"),
+    ]
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 10])
+    nodes = [
+        helper.make_node("MatMul", ["X", "W1"], ["hidden"], name="first_linear"),
+        helper.make_node("Add", ["hidden", "bias"], ["biased"], name="bias_add"),
+        helper.make_node("Relu", ["biased"], ["activated"], name="activation"),
+        helper.make_node("MatMul", ["activated", "W2"], ["Y"], name="second_linear"),
+    ]
+    graph = helper.make_graph(nodes, "activation_bookkeeping_graph", [X], [Y], initializer=initializers)
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / ("malicious-activation-bookkeeping.onnx" if malicious else "benign-activation-bookkeeping.onnx")
+    onnx.save(model, str(path))
+    return path
+
+
+def create_einsum_weight_model(tmp_path: Path, weights: np.ndarray) -> Path:
+    initializer = onnx.numpy_helper.from_array(weights, name="W")
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, weights.shape[0]])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, weights.shape[1]])
+    node = helper.make_node("Einsum", ["X", "W"], ["Y"], name="linear", equation="bi,io->bo")
+    graph = helper.make_graph([node], "einsum_weight_graph", [X], [Y], initializer=[initializer])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "einsum-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_qdq_weight_model(tmp_path: Path) -> Path:
+    quantized_weight = onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.int8), name="W")
+    scale = onnx.numpy_helper.from_array(np.asarray(0.1, dtype=np.float32), name="scale")
+    zero_point = onnx.numpy_helper.from_array(np.asarray(0, dtype=np.int8), name="zero_point")
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 10])
+    nodes = [
+        helper.make_node("DequantizeLinear", ["W", "scale", "zero_point"], ["dequantized_weight"]),
+        helper.make_node("MatMul", ["X", "dequantized_weight"], ["Y"]),
+    ]
+    graph = helper.make_graph(nodes, "qdq_weight_graph", [X], [Y], initializer=[quantized_weight, scale, zero_point])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "qdq-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_sparse_weight_model(tmp_path: Path) -> Path:
+    values = helper.make_tensor("W", TensorProto.FLOAT, [5], vals=[10.0] * 5)
+    indices = helper.make_tensor(
+        "W_indices",
+        TensorProto.INT64,
+        [5],
+        vals=[row * 10 + 3 for row in range(50, 55)],
+    )
+    sparse_weight = helper.make_sparse_tensor(values, indices, [100, 10])
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 10])
+    node = helper.make_node("MatMul", ["X", "W"], ["Y"], name="linear")
+    graph = helper.make_graph([node], "sparse_weight_graph", [X], [Y], sparse_initializer=[sparse_weight])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "sparse-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_constant_weight_model(tmp_path: Path, weights: np.ndarray) -> Path:
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, weights.shape[0]])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, weights.shape[1]])
+    weight_tensor = onnx.numpy_helper.from_array(weights)
+    nodes = [
+        helper.make_node("Constant", [], ["W"], name="weight_constant", value=weight_tensor),
+        helper.make_node("MatMul", ["X", "W"], ["Y"], name="linear"),
+    ]
+    graph = helper.make_graph(nodes, "constant_weight_graph", [X], [Y])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "constant-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_local_function_weight_model(tmp_path: Path, weights: np.ndarray) -> Path:
+    domain = "modelaudit.test"
+    initializer = onnx.numpy_helper.from_array(weights, name="W")
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, weights.shape[0]])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, weights.shape[1]])
+    function = helper.make_function(
+        domain,
+        "Linear",
+        ["function_input", "function_weight"],
+        ["function_output"],
+        [helper.make_node("MatMul", ["function_input", "function_weight"], ["function_output"])],
+        [helper.make_opsetid("", 13)],
+    )
+    call = helper.make_node("Linear", ["X", "W"], ["Y"], domain=domain, name="local_linear")
+    graph = helper.make_graph([call], "local_function_graph", [X], [Y], initializer=[initializer])
+    model = helper.make_model(
+        graph,
+        functions=[function],
+        opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid(domain, 1)],
+    )
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "local-function-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_local_function_default_weight_model(tmp_path: Path, weights: np.ndarray) -> Path:
+    domain = "modelaudit.test"
+    attribute_name = "default_weight"
+    constant = helper.make_node("Constant", [], ["function_weight"])
+    constant.attribute.extend(
+        [
+            onnx.AttributeProto(
+                name="value",
+                ref_attr_name=attribute_name,
+                type=onnx.AttributeProto.TENSOR,
+            ),
+        ],
+    )
+    function = helper.make_function(
+        domain,
+        "DefaultWeight",
+        [],
+        ["function_weight"],
+        [constant],
+        [helper.make_opsetid("", 13)],
+        attribute_protos=[helper.make_attribute(attribute_name, onnx.numpy_helper.from_array(weights))],
+    )
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, weights.shape[0]])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, weights.shape[1]])
+    nodes = [
+        helper.make_node("DefaultWeight", [], ["W"], domain=domain),
+        helper.make_node("MatMul", ["X", "W"], ["Y"]),
+    ]
+    graph = helper.make_graph(nodes, "local_function_default_weight_graph", [X], [Y])
+    model = helper.make_model(
+        graph,
+        functions=[function],
+        opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid(domain, 1)],
+    )
+    model.ir_version = 9
+    onnx.checker.check_model(model)
+    path = tmp_path / "local-function-default-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_static_shape_transform_weight_model(
+    tmp_path: Path,
+    analysis_weights: np.ndarray,
+    *,
+    transform: str,
+) -> Path:
+    assert transform in {"Flatten", "ReshapeValueInts", "Squeeze", "Unsqueeze"}
+    nodes: list[Any] = []
+    initializers: list[Any] = []
+    if transform in {"Flatten", "ReshapeValueInts"}:
+        stored_weights = analysis_weights.reshape(10, 10, analysis_weights.shape[1]).copy()
+    elif transform == "Squeeze":
+        stored_weights = analysis_weights.reshape(1, *analysis_weights.shape).copy()
+    else:
+        stored_weights = analysis_weights.copy()
+    initializers.append(onnx.numpy_helper.from_array(stored_weights, name="W"))
+
+    if transform == "Flatten":
+        nodes.append(helper.make_node("Flatten", ["W"], ["W_view"], axis=2))
+        input_shape = [1, analysis_weights.shape[0]]
+    elif transform == "ReshapeValueInts":
+        nodes.extend(
+            [
+                helper.make_node("Constant", [], ["shape"], value_ints=list(analysis_weights.shape)),
+                helper.make_node("Reshape", ["W", "shape"], ["W_view"]),
+            ],
+        )
+        input_shape = [1, analysis_weights.shape[0]]
+    elif transform == "Squeeze":
+        axes = onnx.numpy_helper.from_array(np.asarray([0], dtype=np.int64), name="axes")
+        initializers.append(axes)
+        nodes.append(helper.make_node("Squeeze", ["W", "axes"], ["W_view"]))
+        input_shape = [1, analysis_weights.shape[0]]
+    else:
+        axes = onnx.numpy_helper.from_array(np.asarray([0], dtype=np.int64), name="axes")
+        initializers.append(axes)
+        nodes.append(helper.make_node("Unsqueeze", ["W", "axes"], ["W_view"]))
+        input_shape = [1, 1, analysis_weights.shape[0]]
+
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, input_shape)
+    output_shape = [1, analysis_weights.shape[1]] if transform != "Unsqueeze" else [1, 1, analysis_weights.shape[1]]
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, output_shape)
+    nodes.append(helper.make_node("MatMul", ["X", "W_view"], ["Y"], name="linear"))
+    graph = helper.make_graph(nodes, "static_shape_transform_graph", [X], [Y], initializer=initializers)
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / f"{transform.lower()}-weight.onnx"
     onnx.save(model, str(path))
     return path
 
@@ -2240,6 +2548,49 @@ class TestWeightDistributionCoverage:
         assert coverage_checks[0].details["coverage_gap"] == "missing_dependency"
         self._assert_uncached_inconclusive_exit2(model_path, tmp_path / "cache")
 
+    def test_standalone_missing_scipy_is_uncached_inconclusive(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        model_path = create_onnx_model(tmp_path, tensor_shape=(2, 2), initializer_consumer="MatMul")
+        monkeypatch.setitem(sys.modules, "scipy", None)
+
+        direct = WeightDistributionScanner().scan(str(model_path))
+
+        assert direct.success is False
+        assert direct.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert "weight_distribution_analysis_incomplete" in direct.metadata["scan_outcome_reasons"]
+        reset_cache_manager()
+        cache_dir = tmp_path / "standalone-cache"
+        try:
+            first = scan_model_directory_or_file(
+                str(model_path),
+                recursive=False,
+                scanners=["weight_distribution"],
+                cache_enabled=True,
+                cache_dir=str(cache_dir),
+                min_cache_file_size=0,
+            )
+            second = scan_model_directory_or_file(
+                str(model_path),
+                recursive=False,
+                scanners=["weight_distribution"],
+                cache_enabled=True,
+                cache_dir=str(cache_dir),
+                min_cache_file_size=0,
+            )
+
+            metadata = second.file_metadata[str(model_path)]
+            assert first.success is False
+            assert second.success is False
+            assert determine_exit_code(first) == 2
+            assert determine_exit_code(second) == 2
+            assert metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+            assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+        finally:
+            reset_cache_manager()
+
     def test_external_weight_distribution_tensors_are_inconclusive(self, tmp_path: Path) -> None:
         model_path = create_onnx_model(
             tmp_path,
@@ -2287,6 +2638,38 @@ class TestWeightDistributionCoverage:
         assert coverage_checks[0].details["analyzed_initializers"] == 0
         self._assert_uncached_inconclusive_exit2(model_path, tmp_path / "cache", max_array_size=1)
 
+    def test_inline_storage_is_bounded_before_materialization(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        tensor = onnx.TensorProto()
+        tensor.name = "W"
+        tensor.data_type = TensorProto.FLOAT
+        tensor.dims.extend([1, 1])
+        tensor.float_data.extend([1.0] * 100)
+        X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 1])
+        Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 1])
+        node = helper.make_node("MatMul", ["X", "W"], ["Y"])
+        model = helper.make_model(helper.make_graph([node], "oversized_inline", [X], [Y], initializer=[tensor]))
+        model_path = tmp_path / "oversized-inline.onnx"
+        onnx.save(model, str(model_path))
+        original_to_array = onnx.numpy_helper.to_array
+
+        def guarded_to_array(initializer: Any, *args: Any, **kwargs: Any) -> Any:
+            if initializer.name == "W":
+                raise AssertionError("oversized inline tensor must not be materialized")
+            return original_to_array(initializer, *args, **kwargs)
+
+        monkeypatch.setattr(onnx.numpy_helper, "to_array", guarded_to_array)
+        result = OnnxScanner({"max_array_size": 8}).scan(str(model_path))
+
+        coverage = self._coverage_checks(result)
+        assert result.success is False
+        assert len(coverage) == 1
+        assert coverage[0].details["oversized_initializers_skipped"] == 1
+        assert coverage[0].details["extraction_failures"] == 0
+
 
 class TestWeightDistributionSemantics:
     """Regression tests for ONNX initializer semantics and output axes."""
@@ -2318,7 +2701,6 @@ class TestWeightDistributionSemantics:
     @pytest.mark.parametrize(
         ("op_type", "weights", "expected_reason"),
         [
-            ("Gather", np.zeros((2, 384), dtype=np.float32), "embedding_table"),
             ("MatMulInteger", np.full((128, 1), 127, dtype=np.int8), "quantized_operator"),
             ("Mul", np.zeros((288, 1), dtype=np.float32), "bookkeeping_constant"),
             ("Add", np.zeros((288, 1), dtype=np.float32), "bookkeeping_constant"),
@@ -2341,6 +2723,31 @@ class TestWeightDistributionSemantics:
         assert semantics["analyzed_layer_count"] == 0
         assert semantics["exclusion_counts"][expected_reason] == 1
         assert semantics["exclusion_samples"][0]["initializer"] == "W"
+
+    def test_gather_embedding_rows_use_the_token_axis(self, tmp_path: Path) -> None:
+        weights = np.zeros((100, 100), dtype=np.float32)
+        weights[3, 50:55] = 10.0
+        model_path = create_onnx_weight_model(tmp_path, weights, op_type="Gather")
+
+        result = OnnxScanner().scan(str(model_path))
+
+        checks = self._extreme_checks(result)
+        assert len(checks) == 1
+        assert checks[0].details["output_axis"] == 0
+        assert checks[0].details["analysis_shape"] == [100, 100]
+        assert checks[0].details["affected_neurons"] == [3]
+
+    def test_clean_gather_embedding_table_stays_clean(self, tmp_path: Path) -> None:
+        weights = np.random.default_rng(20260610).normal(0.0, 0.02, size=(100, 100)).astype(np.float32)
+        model_path = create_onnx_weight_model(tmp_path, weights, op_type="Gather")
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is True
+        assert self._extreme_checks(result) == []
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible_initializer_count"] == 1
+        assert semantics["analyzed_layer_count"] == 1
 
     @pytest.mark.parametrize(("op_type", "trans_b"), [("MatMul", False), ("Gemm", False), ("Gemm", True)])
     def test_malicious_repeated_extreme_weights_remain_detected(
@@ -2372,7 +2779,7 @@ class TestWeightDistributionSemantics:
         assert details["affected_neurons"] == [3]
         assert details["num_extreme_weights"] == 5
         assert details["max_extreme_weights_per_output"] == 5
-        assert details["max_to_threshold_ratio"] >= 2.0
+        assert details["max_to_threshold_ratio"] > 1.0
 
     @pytest.mark.parametrize("op_type", ["Gemm", "MatMul"])
     def test_left_input_equivalent_graph_is_analyzed(self, tmp_path: Path, op_type: str) -> None:
@@ -2516,12 +2923,167 @@ class TestWeightDistributionSemantics:
 
         assert self._extreme_checks(result) == []
         semantics = result.metadata["onnx_weight_distribution_semantics"]
-        assert semantics["eligible_initializer_count"] == 0
-        assert semantics["analyzed_layer_count"] == 0
+        assert semantics["eligible_initializer_count"] == 2
+        assert semantics["analyzed_layer_count"] == 2
+        assert {context["initializer_graph_index"] for context in semantics["eligible"]} == {1, 2}
         assert semantics["exclusion_counts"]["unused_initializer"] == 1
 
-    @pytest.mark.parametrize("transform", ["Identity", "Transpose", "Reshape"])
-    def test_supported_initializer_lineage_reaches_matmul(self, tmp_path: Path, transform: str) -> None:
+    def test_subgraph_local_malicious_weights_are_analyzed(self, tmp_path: Path) -> None:
+        outer_weights = np.zeros((100, 100), dtype=np.float32)
+        local_weights = np.zeros_like(outer_weights)
+        local_weights[50:55, 3] = 10.0
+        model_path = create_control_flow_shadowed_weight_model(
+            tmp_path,
+            outer_weights,
+            local_weights=local_weights,
+        )
+
+        result = OnnxScanner().scan(str(model_path))
+
+        checks = self._extreme_checks(result)
+        assert len(checks) == 2
+        assert {check.details["initializer_graph_index"] for check in checks} == {1, 2}
+        assert all(check.details["affected_neurons"] == [3] for check in checks)
+
+    @pytest.mark.parametrize(
+        "model_factory",
+        [create_control_flow_returned_weight_model, create_loop_carried_weight_model],
+    )
+    def test_weight_lineage_crosses_control_flow_boundaries(
+        self,
+        tmp_path: Path,
+        model_factory: Any,
+    ) -> None:
+        weights = np.zeros((100, 10), dtype=np.float32)
+        weights[50:55, 3] = 10.0
+        model_path = model_factory(tmp_path, weights)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        checks = self._extreme_checks(result)
+        assert len(checks) == 1
+        assert checks[0].details["affected_neurons"] == [3]
+        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+
+    @pytest.mark.parametrize("malicious", [False, True])
+    def test_dynamic_activation_paths_do_not_propagate_bookkeeping_lineage(
+        self,
+        tmp_path: Path,
+        malicious: bool,
+    ) -> None:
+        model_path = create_activation_bookkeeping_model(tmp_path, malicious=malicious)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is True
+        assert len(self._extreme_checks(result)) == int(malicious)
+        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["exclusion_counts"]["bookkeeping_constant"] == 1
+
+    @pytest.mark.parametrize("malicious", [False, True])
+    def test_standard_einsum_weights_are_oriented_and_analyzed(self, tmp_path: Path, malicious: bool) -> None:
+        weights = np.zeros((100, 10), dtype=np.float32)
+        if malicious:
+            weights[50:55, 3] = 10.0
+        model_path = create_einsum_weight_model(tmp_path, weights)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is True
+        checks = self._extreme_checks(result)
+        assert len(checks) == int(malicious)
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible"][0]["consumer_op"] == "Einsum"
+        assert semantics["eligible"][0]["output_axes"] == [1]
+
+    def test_qdq_weight_path_remains_a_clean_quantized_exclusion(self, tmp_path: Path) -> None:
+        model_path = create_qdq_weight_model(tmp_path)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is True
+        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible_initializer_count"] == 0
+        assert semantics["exclusion_counts"]["quantized_operator"] == 3
+
+    def test_sparse_weight_lineage_fails_closed(self, tmp_path: Path) -> None:
+        model_path = create_sparse_weight_model(tmp_path)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert result.success is False
+        assert len(coverage) == 1
+        assert coverage[0].details["coverage_gap"] == "unresolved_initializer_lineage"
+        assert coverage[0].details["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible_initializer_count"] == 1
+        assert semantics["unresolved_lineage_samples"][0]["reason"] == "sparse_initializer_unsupported"
+
+    @pytest.mark.parametrize(
+        "model_factory",
+        [
+            create_constant_weight_model,
+            create_local_function_weight_model,
+            create_local_function_default_weight_model,
+        ],
+    )
+    @pytest.mark.parametrize("malicious", [False, True])
+    def test_static_and_function_weight_roots_are_analyzed(
+        self,
+        tmp_path: Path,
+        model_factory: Any,
+        malicious: bool,
+    ) -> None:
+        weights = np.zeros((100, 10), dtype=np.float32)
+        if malicious:
+            weights[50:55, 3] = 10.0
+        model_path = model_factory(tmp_path, weights)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is True
+        checks = self._extreme_checks(result)
+        assert len(checks) == int(malicious)
+        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+        assert result.metadata["onnx_weight_distribution_semantics"]["analyzed_layer_count"] == 1
+
+    @pytest.mark.parametrize("transform", ["Flatten", "ReshapeValueInts", "Squeeze", "Unsqueeze"])
+    @pytest.mark.parametrize("malicious", [False, True])
+    def test_static_shape_weight_transforms_preserve_detection_without_clean_noise(
+        self,
+        tmp_path: Path,
+        transform: str,
+        malicious: bool,
+    ) -> None:
+        weights = np.zeros((100, 10), dtype=np.float32)
+        if malicious:
+            weights[50:55, 3] = 10.0
+        model_path = create_static_shape_transform_weight_model(tmp_path, weights, transform=transform)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is True
+        assert len(self._extreme_checks(result)) == int(malicious)
+        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+
+    @pytest.mark.parametrize(
+        ("transform", "expected_lineage"),
+        [
+            ("Identity", []),
+            ("Cast", []),
+            ("Transpose", ["Transpose"]),
+            ("Reshape", ["Reshape"]),
+        ],
+    )
+    def test_supported_initializer_lineage_reaches_matmul(
+        self,
+        tmp_path: Path,
+        transform: str,
+        expected_lineage: list[str],
+    ) -> None:
         weights = np.zeros((100, 10), dtype=np.float32)
         weights[50:55, 3] = 10.0
         model_path = create_transformed_onnx_weight_model(tmp_path, weights, transform=transform)
@@ -2531,11 +3093,11 @@ class TestWeightDistributionSemantics:
         checks = self._extreme_checks(result)
         assert len(checks) == 1
         assert checks[0].details["affected_neurons"] == [3]
-        assert checks[0].details["lineage"] == [transform]
-        assert checks[0].details["lineage_transform_count"] == 1
+        assert checks[0].details["lineage"] == expected_lineage
+        assert checks[0].details["lineage_transform_count"] == len(expected_lineage)
         assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
 
-    @pytest.mark.parametrize("transform", ["Cast", "ReshapeDynamic"])
+    @pytest.mark.parametrize("transform", ["ReshapeDynamic"])
     def test_unsupported_initializer_lineage_fails_closed(self, tmp_path: Path, transform: str) -> None:
         weights = np.zeros((100, 10), dtype=np.float32)
         weights[50:55, 3] = 10.0
@@ -2647,20 +3209,25 @@ class TestWeightDistributionSemantics:
         assert standalone_checks[0].details["analysis_shape"] == integrated_check.details["analysis_shape"] == [100, 10]
         assert standalone_checks[0].details["affected_neurons"] == integrated_check.details["affected_neurons"] == [3]
 
-    def test_standalone_onnx_scanner_matches_semantic_exclusions(self, tmp_path: Path) -> None:
-        weights = np.zeros((100, 10), dtype=np.float32)
-        weights[50:55, 3] = 10.0
+    def test_standalone_onnx_scanner_matches_gather_orientation(self, tmp_path: Path) -> None:
+        weights = np.zeros((100, 100), dtype=np.float32)
+        weights[3, 50:55] = 10.0
         model_path = create_onnx_weight_model(tmp_path, weights, op_type="Gather")
 
         standalone = WeightDistributionScanner().scan(str(model_path))
 
-        assert not any(
-            check.name == "Weight Distribution Anomaly Detection" and "extremely large weight values" in check.message
+        checks = [
+            check
             for check in standalone.checks
-        )
+            if check.name == "Weight Distribution Anomaly Detection"
+            and "extremely large weight values" in check.message
+        ]
+        assert len(checks) == 1
+        assert checks[0].details["output_axis"] == 0
+        assert checks[0].details["affected_neurons"] == [3]
         semantics = standalone.metadata["onnx_weight_distribution_semantics"]
-        assert semantics["eligible_initializer_count"] == 0
-        assert semantics["exclusion_counts"] == {"embedding_table": 1}
+        assert semantics["eligible_initializer_count"] == 1
+        assert semantics["analyzed_layer_count"] == 1
 
 
 class TestRawDetectorCoverage:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -22,6 +22,7 @@ from modelaudit.scanners.onnx_scanner import (
     ONNX_STRUCTURE_INCONCLUSIVE_REASON,
     ONNX_WEIGHT_DISTRIBUTION_INCONCLUSIVE_REASON,
     OnnxScanner,
+    _configured_onnx_weight_array_limit,
     _confirmed_onnx_operator_findings,
     _confirmed_python_operator_findings,
 )
@@ -4590,6 +4591,50 @@ class TestWeightDistributionCoverage:
         assert coverage[0].details["oversized_initializers_skipped"] == 1
         assert coverage[0].details["extraction_failures"] == 0
 
+    @pytest.mark.parametrize(
+        "invalid_limit",
+        ["unbounded", pytest.param(10**1000, id="oversized-integer")],
+    )
+    def test_invalid_array_limit_uses_default_before_materialization(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        invalid_limit: Any,
+    ) -> None:
+        tensor = onnx.TensorProto()
+        tensor.name = "W"
+        tensor.data_type = TensorProto.FLOAT
+        tensor.dims.extend([32768, 1024])
+        tensor.raw_data = b"\0\0\0\0"
+        X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 32768])
+        Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 1024])
+        node = helper.make_node("MatMul", ["X", "W"], ["Y"])
+        model = helper.make_model(
+            helper.make_graph([node], "invalid_array_limit", [X], [Y], initializer=[tensor]),
+            opset_imports=[helper.make_opsetid("", 13)],
+        )
+        model.ir_version = 8
+        model_path = tmp_path / "invalid-array-limit.onnx"
+        onnx.save(model, str(model_path))
+        original_to_array = onnx.numpy_helper.to_array
+
+        def guarded_to_array(initializer: Any, *args: Any, **kwargs: Any) -> Any:
+            if initializer.name == "W":
+                raise AssertionError("default-bounded tensor must not be materialized")
+            return original_to_array(initializer, *args, **kwargs)
+
+        monkeypatch.setattr(onnx.numpy_helper, "to_array", guarded_to_array)
+        result = OnnxScanner({"max_array_size": invalid_limit}).scan(str(model_path))
+
+        coverage = self._coverage_checks(result)
+        assert len(coverage) == 1
+        assert coverage[0].details["max_array_size"] == 100 * 1024 * 1024
+        assert coverage[0].details["oversized_initializers_skipped"] == 1
+        assert coverage[0].details["extraction_failures"] == 0
+
+    def test_zero_array_limit_remains_explicitly_unlimited(self) -> None:
+        assert _configured_onnx_weight_array_limit(0) is None
+
 
 class TestWeightDistributionSemantics:
     """Regression tests for ONNX initializer semantics and output axes."""
@@ -4780,6 +4825,34 @@ class TestWeightDistributionSemantics:
         assert details["num_extreme_weights"] == 5
         assert details["max_extreme_weights_per_output"] == 5
         assert details["max_to_threshold_ratio"] > 1.0
+
+    @pytest.mark.parametrize("malicious", [False, True])
+    def test_stale_external_metadata_does_not_hide_inline_weights(
+        self,
+        tmp_path: Path,
+        malicious: bool,
+    ) -> None:
+        weights = np.random.default_rng(20260610).normal(0.0, 0.02, size=(100, 10)).astype(np.float32)
+        if malicious:
+            weights.fill(0.0)
+            weights[50:55, 3] = 10.0
+        model_path = create_onnx_weight_model(tmp_path, weights, op_type="MatMul")
+        model = onnx.load(str(model_path), load_external_data=False)
+        initializer = model.graph.initializer[0]
+        initializer.external_data.append(StringStringEntryProto(key="location", value="stale.bin"))
+        initializer.data_location = TensorProto.DEFAULT
+        onnx.save(model, str(model_path))
+        (tmp_path / "stale.bin").write_bytes(weights.tobytes())
+
+        result = OnnxScanner().scan(str(model_path))
+
+        if not malicious:
+            assert result.success is True
+        assert len(self._extreme_checks(result)) == int(malicious)
+        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible_initializer_count"] == 1
+        assert semantics["analyzed_layer_count"] == 1
 
     @pytest.mark.parametrize("op_type", ["Gemm", "MatMul"])
     def test_left_input_equivalent_graph_is_analyzed(self, tmp_path: Path, op_type: str) -> None:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -156,7 +156,15 @@ def create_transformed_onnx_weight_model(
     transform: str,
 ) -> Path:
     """Create a MatMul whose weight reaches it through one intermediate operator."""
-    assert transform in {"Identity", "Transpose", "Reshape", "ReshapeDynamic", "AddDynamic", "Cast"}
+    assert transform in {
+        "Identity",
+        "Transpose",
+        "Reshape",
+        "ReshapeDynamic",
+        "AddDynamic",
+        "Cast",
+        "CastFloat16",
+    }
     initializers: list[Any] = []
     if transform == "Transpose":
         stored_weights = analysis_weights.T.copy()
@@ -204,12 +212,13 @@ def create_transformed_onnx_weight_model(
             "Cast",
             ["W"],
             ["W_view"],
-            name="unsupported_weight_cast",
-            to=TensorProto.FLOAT,
+            name="weight_cast",
+            to=TensorProto.FLOAT16 if transform == "CastFloat16" else TensorProto.FLOAT,
         )
 
-    X = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, analysis_weights.shape[0]])
-    Y = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, analysis_weights.shape[1]])
+    value_type = TensorProto.FLOAT16 if transform == "CastFloat16" else TensorProto.FLOAT
+    X = helper.make_tensor_value_info("input", value_type, [1, analysis_weights.shape[0]])
+    Y = helper.make_tensor_value_info("output", value_type, [1, analysis_weights.shape[1]])
     graph_inputs = [X]
     if transform == "ReshapeDynamic":
         graph_inputs.append(helper.make_tensor_value_info("dynamic_shape", TensorProto.INT64, [2]))
@@ -454,6 +463,34 @@ def create_recurrent_dynamic_weight_model(tmp_path: Path) -> Path:
     model.ir_version = 8
     onnx.checker.check_model(model)
     path = tmp_path / "recurrent-dynamic-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_projected_dynamic_matmul_weight_model(tmp_path: Path, *, left: bool) -> Path:
+    """Use a projected runtime value as a later left- or right-hand MatMul weight."""
+    projection = onnx.numpy_helper.from_array(np.zeros((100, 100), dtype=np.float32), name="P")
+    if left:
+        seed = helper.make_tensor_value_info("weight_seed", TensorProto.FLOAT, [10, 100])
+        X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [100, 1])
+        Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [10, 1])
+        generator_inputs = ["weight_seed", "P"]
+        linear_inputs = ["W_dynamic", "X"]
+    else:
+        seed = helper.make_tensor_value_info("weight_seed", TensorProto.FLOAT, [100, 10])
+        X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100])
+        Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 10])
+        generator_inputs = ["P", "weight_seed"]
+        linear_inputs = ["X", "W_dynamic"]
+    nodes = [
+        helper.make_node("MatMul", generator_inputs, ["W_dynamic"], name="generate_weight"),
+        helper.make_node("MatMul", linear_inputs, ["Y"], name="linear"),
+    ]
+    graph = helper.make_graph(nodes, "projected_dynamic_weight_graph", [seed, X], [Y], initializer=[projection])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / f"projected-dynamic-matmul-weight-{left}.onnx"
     onnx.save(model, str(path))
     return path
 
@@ -3645,7 +3682,7 @@ class TestWeightDistributionSemantics:
         assert checks[0].details["lineage_transform_count"] == len(expected_lineage)
         assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
 
-    @pytest.mark.parametrize("transform", ["ReshapeDynamic"])
+    @pytest.mark.parametrize("transform", ["ReshapeDynamic", "CastFloat16"])
     def test_unsupported_initializer_lineage_fails_closed(self, tmp_path: Path, transform: str) -> None:
         weights = np.zeros((100, 10), dtype=np.float32)
         weights[50:55, 3] = 10.0
@@ -3714,6 +3751,24 @@ class TestWeightDistributionSemantics:
         assert sample["reason"] == "dynamic_activation_lineage"
         assert sample["consumer_op"] == "GRU"
         assert sample["consumer_input_index"] == 1
+
+    @pytest.mark.parametrize("left", [False, True])
+    def test_projected_dynamic_matmul_weight_fails_closed(self, tmp_path: Path, left: bool) -> None:
+        model_path = create_projected_dynamic_matmul_weight_model(tmp_path, left=left)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert self._extreme_checks(result) == []
+        assert result.success is False
+        assert len(coverage) == 1
+        assert coverage[0].details["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
+        samples = result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+        assert len(samples) == 1
+        assert samples[0]["initializer"] == "P"
+        assert samples[0]["reason"] == "dynamic_activation_lineage"
+        assert samples[0]["consumer_op"] == "MatMul"
+        assert samples[0]["consumer_input_index"] == (0 if left else 1)
 
     def test_broadcast_dynamic_weight_lineage_fails_closed(self, tmp_path: Path) -> None:
         model_path = create_broadcast_dynamic_weight_model(tmp_path)

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -156,7 +156,7 @@ def create_transformed_onnx_weight_model(
     transform: str,
 ) -> Path:
     """Create a MatMul whose weight reaches it through one intermediate operator."""
-    assert transform in {"Identity", "Transpose", "Reshape", "ReshapeDynamic", "Cast"}
+    assert transform in {"Identity", "Transpose", "Reshape", "ReshapeDynamic", "AddDynamic", "Cast"}
     initializers: list[Any] = []
     if transform == "Transpose":
         stored_weights = analysis_weights.T.copy()
@@ -192,6 +192,13 @@ def create_transformed_onnx_weight_model(
             ["W_view"],
             name="dynamic_weight_reshape",
         )
+    elif transform == "AddDynamic":
+        transform_node = helper.make_node(
+            "Add",
+            ["W", "dynamic_delta"],
+            ["W_view"],
+            name="dynamic_weight_add",
+        )
     else:
         transform_node = helper.make_node(
             "Cast",
@@ -206,6 +213,10 @@ def create_transformed_onnx_weight_model(
     graph_inputs = [X]
     if transform == "ReshapeDynamic":
         graph_inputs.append(helper.make_tensor_value_info("dynamic_shape", TensorProto.INT64, [2]))
+    elif transform == "AddDynamic":
+        graph_inputs.append(
+            helper.make_tensor_value_info("dynamic_delta", TensorProto.FLOAT, list(analysis_weights.shape))
+        )
     matmul = helper.make_node("MatMul", ["input", "W_view"], ["output"], name="linear")
     graph = helper.make_graph(
         [transform_node, matmul],
@@ -218,6 +229,259 @@ def create_transformed_onnx_weight_model(
     model.ir_version = 8
     onnx.checker.check_model(model)
     path = tmp_path / f"{transform.lower()}-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_recurrent_weight_model(
+    tmp_path: Path,
+    *,
+    op_type: str,
+    target_input_index: int,
+    distributed_near_match: bool,
+) -> Path:
+    """Create a bidirectional recurrent operator with a targeted W or R pattern."""
+    gate_multiplier = {"RNN": 1, "GRU": 3, "LSTM": 4}[op_type]
+    directions = 2
+    hidden_size = 100
+    input_size = 100
+    gate_hidden_size = gate_multiplier * hidden_size
+    input_weights = np.zeros((directions, gate_hidden_size, input_size), dtype=np.float32)
+    recurrent_weights = np.zeros((directions, gate_hidden_size, hidden_size), dtype=np.float32)
+    target = input_weights if target_input_index == 1 else recurrent_weights
+    if distributed_near_match:
+        target[1, 3:8, 50] = 10.0
+    else:
+        target[1, 3, 50:55] = 10.0
+
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 1, input_size])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, directions, 1, hidden_size])
+    initializers = [
+        onnx.numpy_helper.from_array(input_weights, name="W"),
+        onnx.numpy_helper.from_array(recurrent_weights, name="R"),
+    ]
+    node = helper.make_node(
+        op_type,
+        ["X", "W", "R"],
+        ["Y"],
+        name=f"bidirectional_{op_type.lower()}",
+        direction="bidirectional",
+        hidden_size=hidden_size,
+    )
+    graph = helper.make_graph([node], f"{op_type.lower()}_weight_graph", [X], [Y], initializer=initializers)
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 14)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / f"{op_type.lower()}-{target_input_index}-{distributed_near_match}.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_broadcast_dynamic_weight_model(tmp_path: Path) -> Path:
+    """Create a runtime-derived matrix weight from a broadcast vector initializer."""
+    vector = onnx.numpy_helper.from_array(np.zeros(10, dtype=np.float32), name="W")
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100])
+    delta = helper.make_tensor_value_info("dynamic_delta", TensorProto.FLOAT, [100, 10])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 10])
+    nodes = [
+        helper.make_node("Add", ["W", "dynamic_delta"], ["W_view"], name="broadcast_weight_add"),
+        helper.make_node("MatMul", ["X", "W_view"], ["Y"], name="linear"),
+    ]
+    graph = helper.make_graph(nodes, "broadcast_dynamic_weight_graph", [X, delta], [Y], initializer=[vector])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "broadcast-dynamic-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_computed_weight_model(tmp_path: Path) -> Path:
+    """Create a matrix weight computed from two static initializers."""
+    left = onnx.numpy_helper.from_array(np.zeros((100, 100), dtype=np.float32), name="A")
+    right = onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="B")
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 10])
+    nodes = [
+        helper.make_node("MatMul", ["A", "B"], ["W_view"], name="compute_weight"),
+        helper.make_node("MatMul", ["X", "W_view"], ["Y"], name="linear"),
+    ]
+    graph = helper.make_graph(nodes, "computed_weight_graph", [X], [Y], initializer=[left, right])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "computed-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_dynamic_left_weight_model(tmp_path: Path) -> Path:
+    """Create a runtime-derived left MatMul weight with a resolved right weight."""
+    left = onnx.numpy_helper.from_array(np.zeros((100, 100), dtype=np.float32), name="W")
+    right = onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="R")
+    delta = helper.make_tensor_value_info("dynamic_delta", TensorProto.FLOAT, [100, 100])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [100, 10])
+    nodes = [
+        helper.make_node("Add", ["W", "dynamic_delta"], ["W_view"], name="dynamic_left_weight_add"),
+        helper.make_node("MatMul", ["W_view", "R"], ["Y"], name="linear"),
+    ]
+    graph = helper.make_graph(nodes, "dynamic_left_weight_graph", [delta], [Y], initializer=[left, right])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "dynamic-left-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_left_weight_stack_model(tmp_path: Path) -> Path:
+    """Create two clean MatMuls with weights on the left and activations on the right."""
+    first = onnx.numpy_helper.from_array(np.zeros((100, 100), dtype=np.float32), name="W1")
+    second = onnx.numpy_helper.from_array(np.zeros((10, 100), dtype=np.float32), name="W2")
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [100, 1])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [10, 1])
+    nodes = [
+        helper.make_node("MatMul", ["W1", "X"], ["hidden"], name="left_linear_1"),
+        helper.make_node("MatMul", ["W2", "hidden"], ["Y"], name="left_linear_2"),
+    ]
+    graph = helper.make_graph(nodes, "left_weight_stack", [X], [Y], initializer=[first, second])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "left-weight-stack.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_left_weight_gemm_stack_model(tmp_path: Path) -> Path:
+    """Create two clean Gemms with weights on the left and activations on the right."""
+    first = onnx.numpy_helper.from_array(np.zeros((100, 100), dtype=np.float32), name="W1")
+    second = onnx.numpy_helper.from_array(np.zeros((10, 100), dtype=np.float32), name="W2")
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [100, 1])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [10, 1])
+    nodes = [
+        helper.make_node("Gemm", ["W1", "X"], ["hidden"], name="left_gemm_1"),
+        helper.make_node("Gemm", ["W2", "hidden"], ["Y"], name="left_gemm_2"),
+    ]
+    graph = helper.make_graph(nodes, "left_weight_gemm_stack", [X], [Y], initializer=[first, second])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "left-weight-gemm-stack.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_attention_score_model(tmp_path: Path) -> Path:
+    """Create a clean Q/K/V attention block with activation-only MatMuls."""
+    query_weight = onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="Wq")
+    key_weight = onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="Wk")
+    value_weight = onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="Wv")
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 10])
+    nodes = [
+        helper.make_node("MatMul", ["X", "Wq"], ["Q"], name="query_projection"),
+        helper.make_node("MatMul", ["X", "Wk"], ["K"], name="key_projection"),
+        helper.make_node("MatMul", ["X", "Wv"], ["V"], name="value_projection"),
+        helper.make_node("Transpose", ["K"], ["Kt"], name="transpose_key", perm=[1, 0]),
+        helper.make_node("MatMul", ["Q", "Kt"], ["scores"], name="attention_scores"),
+        helper.make_node("Softmax", ["scores"], ["probabilities"], name="attention_probabilities", axis=-1),
+        helper.make_node("MatMul", ["probabilities", "V"], ["Y"], name="attention_context"),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "attention_score_graph",
+        [X],
+        [Y],
+        initializer=[query_weight, key_weight, value_weight],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "attention-score.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_einsum_attention_score_model(tmp_path: Path) -> Path:
+    """Create clean query/key projections contracted by Einsum."""
+    query_weight = onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="Wq")
+    key_weight = onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="Wk")
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 2, 100])
+    scores = helper.make_tensor_value_info("scores", TensorProto.FLOAT, [1, 2, 2])
+    nodes = [
+        helper.make_node("MatMul", ["X", "Wq"], ["Q"], name="query_projection"),
+        helper.make_node("MatMul", ["X", "Wk"], ["K"], name="key_projection"),
+        helper.make_node("Einsum", ["Q", "K"], ["scores"], name="attention_scores", equation="bid,bjd->bij"),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "einsum_attention_score_graph",
+        [X],
+        [scores],
+        initializer=[query_weight, key_weight],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "einsum-attention-score.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_recurrent_dynamic_weight_model(tmp_path: Path) -> Path:
+    """Create a GRU whose W input is generated at runtime."""
+    hidden_size = 100
+    projection = onnx.numpy_helper.from_array(np.zeros((1, 100, 100), dtype=np.float32), name="P")
+    recurrent = onnx.numpy_helper.from_array(np.zeros((1, 300, 100), dtype=np.float32), name="R")
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 1, 100])
+    seed = helper.make_tensor_value_info("weight_seed", TensorProto.FLOAT, [1, 300, 100])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 1, 1, hidden_size])
+    nodes = [
+        helper.make_node("MatMul", ["weight_seed", "P"], ["W_dynamic"], name="generate_weight"),
+        helper.make_node(
+            "GRU",
+            ["X", "W_dynamic", "R"],
+            ["Y"],
+            name="gru",
+            hidden_size=hidden_size,
+        ),
+    ]
+    graph = helper.make_graph(
+        nodes, "recurrent_dynamic_weight_graph", [X, seed], [Y], initializer=[projection, recurrent]
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 14)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "recurrent-dynamic-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_mixed_activation_and_raw_lineage_model(tmp_path: Path) -> Path:
+    """Mix a prior activation with a raw dynamic initializer dependency."""
+    shared_weight = onnx.numpy_helper.from_array(np.zeros((100, 100), dtype=np.float32), name="W")
+    output_weight = onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="R")
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [100, 100])
+    delta = helper.make_tensor_value_info("dynamic_delta", TensorProto.FLOAT, [100, 100])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [100, 10])
+    nodes = [
+        helper.make_node("MatMul", ["X", "W"], ["activation"], name="activation_projection"),
+        helper.make_node("Add", ["W", "dynamic_delta"], ["raw_dynamic"], name="raw_dynamic_weight"),
+        helper.make_node("Add", ["activation", "raw_dynamic"], ["mixed"], name="mix_lineages"),
+        helper.make_node("MatMul", ["mixed", "R"], ["Y"], name="linear"),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "mixed_activation_raw_lineage_graph",
+        [X, delta],
+        [Y],
+        initializer=[shared_weight, output_weight],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "mixed-activation-raw-lineage.onnx"
     onnx.save(model, str(path))
     return path
 
@@ -603,7 +867,7 @@ def create_loop_carried_weight_model(tmp_path: Path, weights: np.ndarray) -> Pat
     return path
 
 
-def create_activation_bookkeeping_model(tmp_path: Path, *, malicious: bool) -> Path:
+def create_activation_bookkeeping_model(tmp_path: Path, *, malicious: bool, rank_two_bias: bool = False) -> Path:
     """Create a linear stack whose activation path also consumes a bias."""
     first_weight = np.zeros((100, 100), dtype=np.float32)
     second_weight = np.zeros((100, 10), dtype=np.float32)
@@ -611,7 +875,10 @@ def create_activation_bookkeeping_model(tmp_path: Path, *, malicious: bool) -> P
         second_weight[50:55, 3] = 10.0
     initializers = [
         onnx.numpy_helper.from_array(first_weight, name="W1"),
-        onnx.numpy_helper.from_array(np.zeros(100, dtype=np.float32), name="bias"),
+        onnx.numpy_helper.from_array(
+            np.zeros((1, 100) if rank_two_bias else 100, dtype=np.float32),
+            name="bias",
+        ),
         onnx.numpy_helper.from_array(second_weight, name="W2"),
     ]
     X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100])
@@ -626,7 +893,9 @@ def create_activation_bookkeeping_model(tmp_path: Path, *, malicious: bool) -> P
     model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
     model.ir_version = 8
     onnx.checker.check_model(model)
-    path = tmp_path / ("malicious-activation-bookkeeping.onnx" if malicious else "benign-activation-bookkeeping.onnx")
+    path = tmp_path / (
+        f"{'malicious' if malicious else 'benign'}-activation-bookkeeping-{'2d' if rank_two_bias else '1d'}.onnx"
+    )
     onnx.save(model, str(path))
     return path
 
@@ -766,6 +1035,159 @@ def create_local_function_default_weight_model(tmp_path: Path, weights: np.ndarr
     model.ir_version = 9
     onnx.checker.check_model(model)
     path = tmp_path / "local-function-default-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_repeated_local_function_default_weight_model(tmp_path: Path, weights: np.ndarray) -> Path:
+    """Create two calls to one function-local default Constant weight."""
+    domain = "modelaudit.test"
+    attribute_name = "default_weight"
+    constant = helper.make_node("Constant", [], ["function_weight"])
+    constant.attribute.extend(
+        [
+            onnx.AttributeProto(
+                name="value",
+                ref_attr_name=attribute_name,
+                type=onnx.AttributeProto.TENSOR,
+            ),
+        ],
+    )
+    function = helper.make_function(
+        domain,
+        "DefaultWeight",
+        [],
+        ["function_weight"],
+        [constant],
+        [helper.make_opsetid("", 13)],
+        attribute_protos=[helper.make_attribute(attribute_name, onnx.numpy_helper.from_array(weights))],
+    )
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, weights.shape[0]])
+    Y1 = helper.make_tensor_value_info("Y1", TensorProto.FLOAT, [1, weights.shape[1]])
+    Y2 = helper.make_tensor_value_info("Y2", TensorProto.FLOAT, [1, weights.shape[1]])
+    nodes = [
+        helper.make_node("DefaultWeight", [], ["W1"], domain=domain, name="default_weight_1"),
+        helper.make_node("DefaultWeight", [], ["W2"], domain=domain, name="default_weight_2"),
+        helper.make_node("MatMul", ["X", "W1"], ["Y1"], name="linear_1"),
+        helper.make_node("MatMul", ["X", "W2"], ["Y2"], name="linear_2"),
+    ]
+    graph = helper.make_graph(nodes, "repeated_local_function_default_graph", [X], [Y1, Y2])
+    model = helper.make_model(
+        graph,
+        functions=[function],
+        opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid(domain, 1)],
+    )
+    model.ir_version = 9
+    onnx.checker.check_model(model)
+    path = tmp_path / "repeated-local-function-default-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_many_local_function_weight_overrides_model(tmp_path: Path, *, call_count: int = 100) -> Path:
+    """Create many distinct function attribute weights with a malicious final binding."""
+    domain = "modelaudit.test"
+    attribute_name = "weight_values"
+    flat_constant = helper.make_node("Constant", [], ["flat_weight"])
+    flat_constant.attribute.extend(
+        [
+            onnx.AttributeProto(
+                name="value_floats",
+                ref_attr_name=attribute_name,
+                type=onnx.AttributeProto.FLOATS,
+            ),
+        ],
+    )
+    shape_constant = helper.make_node("Constant", [], ["weight_shape"], value_ints=[100, 10])
+    reshape = helper.make_node("Reshape", ["flat_weight", "weight_shape"], ["function_weight"])
+    function = helper.make_function(
+        domain,
+        "OverrideWeight",
+        [],
+        ["function_weight"],
+        [flat_constant, shape_constant, reshape],
+        [helper.make_opsetid("", 13)],
+        attributes=[attribute_name],
+    )
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 10])
+    nodes: list[Any] = []
+    for call_index in range(call_count):
+        values = np.zeros((100, 10), dtype=np.float32)
+        if call_index == call_count - 1:
+            values[50:55, 3] = 10.0
+        call = helper.make_node(
+            "OverrideWeight",
+            [],
+            [f"W{call_index}"],
+            domain=domain,
+            name=f"override_weight_{call_index}",
+        )
+        call.attribute.extend([helper.make_attribute(attribute_name, values.reshape(-1).tolist())])
+        nodes.extend(
+            [
+                call,
+                helper.make_node(
+                    "MatMul",
+                    ["X", f"W{call_index}"],
+                    ["Y" if call_index == call_count - 1 else f"unused_Y{call_index}"],
+                    name=f"linear_{call_index}",
+                ),
+            ],
+        )
+    graph = helper.make_graph(nodes, "many_function_overrides_graph", [X], [Y])
+    model = helper.make_model(
+        graph,
+        functions=[function],
+        opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid(domain, 1)],
+    )
+    model.ir_version = 9
+    onnx.checker.check_model(model)
+    path = tmp_path / "many-local-function-weight-overrides.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_many_if_branch_weight_model(tmp_path: Path, *, branch_count: int = 20) -> Path:
+    """Create many branch-local weights with a malicious final then-branch."""
+    condition = helper.make_tensor_value_info("condition", TensorProto.BOOL, [])
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 10])
+    nodes: list[Any] = []
+
+    def branch_graph(name: str, weights: np.ndarray) -> Any:
+        branch_output = helper.make_tensor_value_info("branch_output", TensorProto.FLOAT, [1, 10])
+        constant = helper.make_node(
+            "Constant",
+            [],
+            ["W"],
+            value=onnx.numpy_helper.from_array(weights),
+        )
+        matmul = helper.make_node("MatMul", ["X", "W"], ["branch_output"])
+        return helper.make_graph([constant, matmul], name, [], [branch_output])
+
+    for branch_index in range(branch_count):
+        then_weights = np.zeros((100, 10), dtype=np.float32)
+        if branch_index == branch_count - 1:
+            then_weights[50:55, 3] = 10.0
+        else_weights = np.zeros((100, 10), dtype=np.float32)
+        output_name = "Y" if branch_index == branch_count - 1 else f"unused_Y{branch_index}"
+        nodes.append(
+            helper.make_node(
+                "If",
+                ["condition"],
+                [output_name],
+                name=f"conditional_{branch_index}",
+                then_branch=branch_graph(f"then_{branch_index}", then_weights),
+                else_branch=branch_graph(f"else_{branch_index}", else_weights),
+            ),
+        )
+
+    graph = helper.make_graph(nodes, "many_if_branch_weights", [condition, X], [Y])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "many-if-branch-weights.onnx"
     onnx.save(model, str(path))
     return path
 
@@ -2724,9 +3146,22 @@ class TestWeightDistributionSemantics:
         assert semantics["exclusion_counts"][expected_reason] == 1
         assert semantics["exclusion_samples"][0]["initializer"] == "W"
 
-    def test_gather_embedding_rows_use_the_token_axis(self, tmp_path: Path) -> None:
+    def test_gather_embedding_uses_non_indexed_feature_axes(self, tmp_path: Path) -> None:
+        weights = np.zeros((100, 10), dtype=np.float32)
+        weights[50:55, 3] = 10.0
+        model_path = create_onnx_weight_model(tmp_path, weights, op_type="Gather")
+
+        result = OnnxScanner().scan(str(model_path))
+
+        checks = self._extreme_checks(result)
+        assert len(checks) == 1
+        assert checks[0].details["output_axis"] == 1
+        assert checks[0].details["analysis_shape"] == [100, 10]
+        assert checks[0].details["affected_neurons"] == [3]
+
+    def test_gather_rare_entry_poison_remains_detected(self, tmp_path: Path) -> None:
         weights = np.zeros((100, 100), dtype=np.float32)
-        weights[3, 50:55] = 10.0
+        weights[3, 30:35] = 10.0
         model_path = create_onnx_weight_model(tmp_path, weights, op_type="Gather")
 
         result = OnnxScanner().scan(str(model_path))
@@ -2734,8 +3169,20 @@ class TestWeightDistributionSemantics:
         checks = self._extreme_checks(result)
         assert len(checks) == 1
         assert checks[0].details["output_axis"] == 0
-        assert checks[0].details["analysis_shape"] == [100, 100]
         assert checks[0].details["affected_neurons"] == [3]
+
+    def test_gather_subthreshold_entry_near_match_stays_clean(self, tmp_path: Path) -> None:
+        weights = np.zeros((100, 10), dtype=np.float32)
+        weights[3, 3:7] = 10.0
+        model_path = create_onnx_weight_model(tmp_path, weights, op_type="Gather")
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is True
+        assert self._extreme_checks(result) == []
+        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert {tuple(context["output_axes"]) for context in semantics["eligible"]} == {(0,), (1,)}
 
     def test_clean_gather_embedding_table_stays_clean(self, tmp_path: Path) -> None:
         weights = np.random.default_rng(20260610).normal(0.0, 0.02, size=(100, 100)).astype(np.float32)
@@ -2747,7 +3194,62 @@ class TestWeightDistributionSemantics:
         assert self._extreme_checks(result) == []
         semantics = result.metadata["onnx_weight_distribution_semantics"]
         assert semantics["eligible_initializer_count"] == 1
-        assert semantics["analyzed_layer_count"] == 1
+        assert semantics["analyzed_layer_count"] == 2
+
+    @pytest.mark.parametrize(("op_type", "gate_multiplier"), [("RNN", 1), ("GRU", 3), ("LSTM", 4)])
+    @pytest.mark.parametrize("target_input_index", [1, 2])
+    def test_recurrent_weight_vectors_are_analyzed(
+        self,
+        tmp_path: Path,
+        op_type: str,
+        gate_multiplier: int,
+        target_input_index: int,
+    ) -> None:
+        model_path = create_recurrent_weight_model(
+            tmp_path,
+            op_type=op_type,
+            target_input_index=target_input_index,
+            distributed_near_match=False,
+        )
+
+        result = OnnxScanner().scan(str(model_path))
+
+        checks = self._extreme_checks(result)
+        assert len(checks) == 1
+        details = checks[0].details
+        assert details["initializer"] == ("W" if target_input_index == 1 else "R")
+        assert details["consumer_op"] == op_type
+        assert details["consumer_input_index"] == target_input_index
+        assert details["output_axes"] == [0, 1]
+        assert details["analysis_shape"] == [100, 2 * gate_multiplier * 100]
+        assert details["affected_neurons"] == [gate_multiplier * 100 + 3]
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible_initializer_count"] == 2
+        assert semantics["analyzed_layer_count"] == 2
+
+    @pytest.mark.parametrize("op_type", ["RNN", "GRU", "LSTM"])
+    @pytest.mark.parametrize("target_input_index", [1, 2])
+    def test_recurrent_extremes_distributed_across_outputs_stay_clean(
+        self,
+        tmp_path: Path,
+        op_type: str,
+        target_input_index: int,
+    ) -> None:
+        model_path = create_recurrent_weight_model(
+            tmp_path,
+            op_type=op_type,
+            target_input_index=target_input_index,
+            distributed_near_match=True,
+        )
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is True
+        assert self._extreme_checks(result) == []
+        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible_initializer_count"] == 2
+        assert semantics["analyzed_layer_count"] == 2
 
     @pytest.mark.parametrize(("op_type", "trans_b"), [("MatMul", False), ("Gemm", False), ("Gemm", True)])
     def test_malicious_repeated_extreme_weights_remain_detected(
@@ -2965,13 +3467,19 @@ class TestWeightDistributionSemantics:
         assert checks[0].details["affected_neurons"] == [3]
         assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
 
+    @pytest.mark.parametrize("rank_two_bias", [False, True])
     @pytest.mark.parametrize("malicious", [False, True])
     def test_dynamic_activation_paths_do_not_propagate_bookkeeping_lineage(
         self,
         tmp_path: Path,
         malicious: bool,
+        rank_two_bias: bool,
     ) -> None:
-        model_path = create_activation_bookkeeping_model(tmp_path, malicious=malicious)
+        model_path = create_activation_bookkeeping_model(
+            tmp_path,
+            malicious=malicious,
+            rank_two_bias=rank_two_bias,
+        )
 
         result = OnnxScanner().scan(str(model_path))
 
@@ -3050,6 +3558,46 @@ class TestWeightDistributionSemantics:
         assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
         assert result.metadata["onnx_weight_distribution_semantics"]["analyzed_layer_count"] == 1
 
+    def test_repeated_function_constant_is_one_physical_initializer(self, tmp_path: Path) -> None:
+        weights = np.zeros((100, 10), dtype=np.float32)
+        model_path = create_repeated_local_function_default_weight_model(tmp_path, weights)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is True
+        assert self._extreme_checks(result) == []
+        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible_initializer_count"] == 1
+        assert semantics["analyzed_layer_count"] == 1
+        assert semantics["eligible"][0]["consumer_count"] == 2
+
+    def test_distinct_function_attribute_bindings_do_not_alias(self, tmp_path: Path) -> None:
+        model_path = create_many_local_function_weight_overrides_model(tmp_path)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        checks = self._extreme_checks(result)
+        assert len(checks) == 1
+        assert checks[0].details["affected_neurons"] == [3]
+        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible_initializer_count"] == 100
+        assert semantics["analyzed_layer_count"] == 100
+
+    def test_distinct_branch_local_constants_do_not_alias(self, tmp_path: Path) -> None:
+        model_path = create_many_if_branch_weight_model(tmp_path)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        checks = self._extreme_checks(result)
+        assert len(checks) == 1
+        assert checks[0].details["affected_neurons"] == [3]
+        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible_initializer_count"] == 40
+        assert semantics["analyzed_layer_count"] == 40
+
     @pytest.mark.parametrize("transform", ["Flatten", "ReshapeValueInts", "Squeeze", "Unsqueeze"])
     @pytest.mark.parametrize("malicious", [False, True])
     def test_static_shape_weight_transforms_preserve_detection_without_clean_noise(
@@ -3114,6 +3662,130 @@ class TestWeightDistributionSemantics:
         semantics = result.metadata["onnx_weight_distribution_semantics"]
         assert semantics["eligible_initializer_count"] == 1
         assert semantics["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
+
+    def test_dynamic_mixed_weight_lineage_fails_closed(self, tmp_path: Path) -> None:
+        weights = np.zeros((100, 10), dtype=np.float32)
+        weights[50:55, 3] = 10.0
+        model_path = create_transformed_onnx_weight_model(tmp_path, weights, transform="AddDynamic")
+
+        result = OnnxScanner().scan(str(model_path))
+
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert self._extreme_checks(result) == []
+        assert result.success is False
+        assert len(coverage) == 1
+        assert coverage[0].details["coverage_gap"] == "unresolved_initializer_lineage"
+        assert coverage[0].details["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible_initializer_count"] == 1
+        sample = semantics["unresolved_lineage_samples"][0]
+        assert sample["reason"] == "dynamic_input_lineage"
+        assert sample["consumer_op"] == "MatMul"
+        assert sample["consumer_input_index"] == 1
+
+    def test_dynamic_left_weight_lineage_fails_closed(self, tmp_path: Path) -> None:
+        model_path = create_dynamic_left_weight_model(tmp_path)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert self._extreme_checks(result) == []
+        assert result.success is False
+        assert len(coverage) == 1
+        assert coverage[0].details["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
+        sample = result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"][0]
+        assert sample["initializer"] == "W"
+        assert sample["reason"] == "dynamic_input_lineage"
+        assert sample["consumer_op"] == "MatMul"
+        assert sample["consumer_input_index"] == 0
+
+    def test_recurrent_dynamic_weight_slot_fails_closed(self, tmp_path: Path) -> None:
+        model_path = create_recurrent_dynamic_weight_model(tmp_path)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert self._extreme_checks(result) == []
+        assert result.success is False
+        assert len(coverage) == 1
+        assert coverage[0].details["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
+        sample = result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"][0]
+        assert sample["initializer"] == "P"
+        assert sample["reason"] == "dynamic_activation_lineage"
+        assert sample["consumer_op"] == "GRU"
+        assert sample["consumer_input_index"] == 1
+
+    def test_broadcast_dynamic_weight_lineage_fails_closed(self, tmp_path: Path) -> None:
+        model_path = create_broadcast_dynamic_weight_model(tmp_path)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert self._extreme_checks(result) == []
+        assert result.success is False
+        assert len(coverage) == 1
+        assert coverage[0].details["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
+        sample = result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"][0]
+        assert sample["reason"] == "dynamic_input_lineage"
+        assert sample["consumer_op"] == "MatMul"
+        assert sample["consumer_input_index"] == 1
+
+    def test_computed_weight_lineage_fails_closed(self, tmp_path: Path) -> None:
+        model_path = create_computed_weight_model(tmp_path)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert self._extreme_checks(result) == []
+        assert result.success is False
+        assert len(coverage) == 1
+        assert coverage[0].details["coverage_gaps"] == {"unresolved_initializer_lineage": 2}
+        samples = result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+        assert {sample["initializer"] for sample in samples} == {"A", "B"}
+        assert {sample["reason"] for sample in samples} == {"unsupported_lineage_operator"}
+        assert {sample["consumer_input_index"] for sample in samples} == {1}
+
+    def test_raw_dynamic_taint_is_not_laundered_by_activation_lineage(self, tmp_path: Path) -> None:
+        model_path = create_mixed_activation_and_raw_lineage_model(tmp_path)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert self._extreme_checks(result) == []
+        assert result.success is False
+        assert len(coverage) == 1
+        assert coverage[0].details["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
+        samples = result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+        assert len(samples) == 1
+        assert samples[0]["initializer"] == "W"
+        assert samples[0]["reason"] == "dynamic_input_lineage"
+        assert samples[0]["consumer_input_index"] == 0
+
+    @pytest.mark.parametrize(
+        ("model_factory", "expected_layers"),
+        [
+            (create_left_weight_stack_model, 2),
+            (create_left_weight_gemm_stack_model, 2),
+            (create_attention_score_model, 3),
+            (create_einsum_attention_score_model, 2),
+        ],
+    )
+    def test_prior_layer_activations_are_not_reclassified_as_weights(
+        self,
+        tmp_path: Path,
+        model_factory: Any,
+        expected_layers: int,
+    ) -> None:
+        model_path = model_factory(tmp_path)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is True
+        assert self._extreme_checks(result) == []
+        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible_initializer_count"] == expected_layers
+        assert semantics["analyzed_layer_count"] == expected_layers
 
     def test_internal_analysis_ids_cannot_collide_with_initializer_names(self, tmp_path: Path) -> None:
         model_path = create_collision_named_weight_model(tmp_path)
@@ -3210,8 +3882,8 @@ class TestWeightDistributionSemantics:
         assert standalone_checks[0].details["affected_neurons"] == integrated_check.details["affected_neurons"] == [3]
 
     def test_standalone_onnx_scanner_matches_gather_orientation(self, tmp_path: Path) -> None:
-        weights = np.zeros((100, 100), dtype=np.float32)
-        weights[3, 50:55] = 10.0
+        weights = np.zeros((100, 10), dtype=np.float32)
+        weights[50:55, 3] = 10.0
         model_path = create_onnx_weight_model(tmp_path, weights, op_type="Gather")
 
         standalone = WeightDistributionScanner().scan(str(model_path))
@@ -3223,11 +3895,11 @@ class TestWeightDistributionSemantics:
             and "extremely large weight values" in check.message
         ]
         assert len(checks) == 1
-        assert checks[0].details["output_axis"] == 0
+        assert checks[0].details["output_axis"] == 1
         assert checks[0].details["affected_neurons"] == [3]
         semantics = standalone.metadata["onnx_weight_distribution_semantics"]
         assert semantics["eligible_initializer_count"] == 1
-        assert semantics["analyzed_layer_count"] == 1
+        assert semantics["analyzed_layer_count"] == 2
 
 
 class TestRawDetectorCoverage:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -23,6 +23,7 @@ from modelaudit.scanners.onnx_scanner import (
     OnnxScanner,
     _confirmed_python_operator_findings,
 )
+from modelaudit.scanners.weight_distribution_scanner import WeightDistributionScanner
 from modelaudit.utils.file.detection import PROTOBUF_MODEL_CANDIDATE_FORMAT
 
 
@@ -144,6 +145,189 @@ def create_onnx_weight_model(
     model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
     model.ir_version = 8
     path = tmp_path / filename
+    onnx.save(model, str(path))
+    return path
+
+
+def create_transformed_onnx_weight_model(
+    tmp_path: Path,
+    analysis_weights: np.ndarray,
+    *,
+    transform: str,
+) -> Path:
+    """Create a MatMul whose weight reaches it through one intermediate operator."""
+    assert transform in {"Identity", "Transpose", "Reshape", "ReshapeDynamic", "Cast"}
+    initializers: list[Any] = []
+    if transform == "Transpose":
+        stored_weights = analysis_weights.T.copy()
+    elif transform == "Reshape":
+        stored_weights = analysis_weights.reshape(10, 10, analysis_weights.shape[1]).copy()
+    else:
+        stored_weights = analysis_weights.copy()
+    initializers.append(onnx.numpy_helper.from_array(stored_weights, name="W"))
+
+    if transform == "Identity":
+        transform_node = helper.make_node("Identity", ["W"], ["W_view"], name="weight_identity")
+    elif transform == "Transpose":
+        transform_node = helper.make_node(
+            "Transpose",
+            ["W"],
+            ["W_view"],
+            name="weight_transpose",
+            perm=[1, 0],
+        )
+    elif transform == "Reshape":
+        shape = np.asarray(analysis_weights.shape, dtype=np.int64)
+        initializers.append(onnx.numpy_helper.from_array(shape, name="weight_shape"))
+        transform_node = helper.make_node(
+            "Reshape",
+            ["W", "weight_shape"],
+            ["W_view"],
+            name="weight_reshape",
+        )
+    elif transform == "ReshapeDynamic":
+        transform_node = helper.make_node(
+            "Reshape",
+            ["W", "dynamic_shape"],
+            ["W_view"],
+            name="dynamic_weight_reshape",
+        )
+    else:
+        transform_node = helper.make_node(
+            "Cast",
+            ["W"],
+            ["W_view"],
+            name="unsupported_weight_cast",
+            to=TensorProto.FLOAT,
+        )
+
+    X = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, analysis_weights.shape[0]])
+    Y = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, analysis_weights.shape[1]])
+    graph_inputs = [X]
+    if transform == "ReshapeDynamic":
+        graph_inputs.append(helper.make_tensor_value_info("dynamic_shape", TensorProto.INT64, [2]))
+    matmul = helper.make_node("MatMul", ["input", "W_view"], ["output"], name="linear")
+    graph = helper.make_graph(
+        [transform_node, matmul],
+        "transformed_weight_graph",
+        graph_inputs,
+        [Y],
+        initializer=initializers,
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / f"{transform.lower()}-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_batched_matmul_weight_model(tmp_path: Path, weights: np.ndarray, *, left: bool) -> Path:
+    """Create a batched MatMul initializer on either operand."""
+    weight_tensor = onnx.numpy_helper.from_array(weights, name="W")
+    if left:
+        X = helper.make_tensor_value_info("input", TensorProto.FLOAT, [weights.shape[0], weights.shape[2], 1])
+        Y = helper.make_tensor_value_info("output", TensorProto.FLOAT, [weights.shape[0], weights.shape[1], 1])
+        node_inputs = ["W", "input"]
+    else:
+        X = helper.make_tensor_value_info("input", TensorProto.FLOAT, [weights.shape[0], 1, weights.shape[1]])
+        Y = helper.make_tensor_value_info("output", TensorProto.FLOAT, [weights.shape[0], 1, weights.shape[2]])
+        node_inputs = ["input", "W"]
+    node = helper.make_node("MatMul", node_inputs, ["output"], name="batched_linear")
+    graph = helper.make_graph([node], "batched_matmul_graph", [X], [Y], initializer=[weight_tensor])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / ("batched-left-matmul.onnx" if left else "batched-right-matmul.onnx")
+    onnx.save(model, str(path))
+    return path
+
+
+def create_collision_named_weight_model(tmp_path: Path) -> Path:
+    """Create initializer names that collide with the former synthesized keys."""
+    base_name = "W"
+    intermediate_name = "W@output_axis=1"
+    crafted_name = "W@output_axis=1,kind=matrix,group=1"
+    initializers = [
+        onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name=base_name),
+        onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name=crafted_name),
+        onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name=intermediate_name),
+    ]
+    right_input = helper.make_tensor_value_info("right_input", TensorProto.FLOAT, [1, 100])
+    left_input = helper.make_tensor_value_info("left_input", TensorProto.FLOAT, [10, 1])
+    outputs = [
+        helper.make_tensor_value_info("base_right", TensorProto.FLOAT, [1, 10]),
+        helper.make_tensor_value_info("base_left", TensorProto.FLOAT, [100, 1]),
+        helper.make_tensor_value_info("crafted_output", TensorProto.FLOAT, [1, 10]),
+        helper.make_tensor_value_info("intermediate_output", TensorProto.FLOAT, [1, 10]),
+    ]
+    nodes = [
+        helper.make_node("MatMul", ["right_input", base_name], ["base_right"], name="base_right_node"),
+        helper.make_node("MatMul", [base_name, "left_input"], ["base_left"], name="base_left_node"),
+        helper.make_node(
+            "MatMul",
+            ["right_input", crafted_name],
+            ["crafted_output"],
+            name="crafted_node",
+        ),
+        helper.make_node(
+            "MatMul",
+            ["right_input", intermediate_name],
+            ["intermediate_output"],
+            name="intermediate_node",
+        ),
+    ]
+    graph = helper.make_graph(nodes, "collision_graph", [right_input, left_input], outputs, initializer=initializers)
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "collision-named-weights.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_many_consumer_weight_model(tmp_path: Path, *, consumer_count: int) -> Path:
+    """Create bounded-metadata pressure with long attacker-controlled names."""
+    initializer_name = "initializer-" + "x" * 1000
+    weights = np.zeros((100, 10), dtype=np.float32)
+    weights[50:55, 3] = 10.0
+    initializer = onnx.numpy_helper.from_array(weights, name=initializer_name)
+    X = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, 100])
+    output_names = [f"output_{index}" for index in range(consumer_count)]
+    Y = helper.make_tensor_value_info(output_names[-1], TensorProto.FLOAT, [1, 10])
+    nodes = [
+        helper.make_node(
+            "MatMul",
+            ["input", initializer_name],
+            [output_name],
+            name=f"consumer-{index}-" + "y" * 1000,
+        )
+        for index, output_name in enumerate(output_names)
+    ]
+    graph = helper.make_graph(nodes, "many_consumer_graph", [X], [Y], initializer=[initializer])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "many-consumer-weights.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_invalid_initializer_name_model(tmp_path: Path, *, duplicate: bool) -> Path:
+    """Serialize an invalid graph so the scanner must reject ambiguous names itself."""
+    X = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, 2])
+    Y = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, 2])
+    node = helper.make_node("Identity", ["input"], ["output"], name="identity")
+    initializer_name = "W" if duplicate else ""
+    initializers = [
+        onnx.numpy_helper.from_array(np.zeros((2, 2), dtype=np.float32), name=initializer_name),
+    ]
+    if duplicate:
+        initializers.append(onnx.numpy_helper.from_array(np.ones((2, 2), dtype=np.float32), name="W"))
+    graph = helper.make_graph([node], "invalid_initializer_names", [X], [Y], initializer=initializers)
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    path = tmp_path / ("duplicate-initializers.onnx" if duplicate else "empty-initializer.onnx")
     onnx.save(model, str(path))
     return path
 
@@ -2335,6 +2519,148 @@ class TestWeightDistributionSemantics:
         assert semantics["eligible_initializer_count"] == 0
         assert semantics["analyzed_layer_count"] == 0
         assert semantics["exclusion_counts"]["unused_initializer"] == 1
+
+    @pytest.mark.parametrize("transform", ["Identity", "Transpose", "Reshape"])
+    def test_supported_initializer_lineage_reaches_matmul(self, tmp_path: Path, transform: str) -> None:
+        weights = np.zeros((100, 10), dtype=np.float32)
+        weights[50:55, 3] = 10.0
+        model_path = create_transformed_onnx_weight_model(tmp_path, weights, transform=transform)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        checks = self._extreme_checks(result)
+        assert len(checks) == 1
+        assert checks[0].details["affected_neurons"] == [3]
+        assert checks[0].details["lineage"] == [transform]
+        assert checks[0].details["lineage_transform_count"] == 1
+        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+
+    @pytest.mark.parametrize("transform", ["Cast", "ReshapeDynamic"])
+    def test_unsupported_initializer_lineage_fails_closed(self, tmp_path: Path, transform: str) -> None:
+        weights = np.zeros((100, 10), dtype=np.float32)
+        weights[50:55, 3] = 10.0
+        model_path = create_transformed_onnx_weight_model(tmp_path, weights, transform=transform)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert self._extreme_checks(result) == []
+        assert result.success is False
+        assert len(coverage) == 1
+        assert coverage[0].details["coverage_gap"] == "unresolved_initializer_lineage"
+        assert coverage[0].details["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible_initializer_count"] == 1
+        assert semantics["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
+
+    def test_internal_analysis_ids_cannot_collide_with_initializer_names(self, tmp_path: Path) -> None:
+        model_path = create_collision_named_weight_model(tmp_path)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        contexts = semantics["eligible"]
+        assert semantics["eligible_initializer_count"] == 3
+        assert semantics["analyzed_layer_count"] == 4
+        assert [context["analysis_id"] for context in contexts] == [0, 1, 2, 3]
+        assert len({context["analysis_id"] for context in contexts}) == 4
+        assert {context["initializer"] for context in contexts} == {
+            "W",
+            "W@output_axis=1",
+            "W@output_axis=1,kind=matrix,group=1",
+        }
+
+    @pytest.mark.parametrize("left", [False, True])
+    def test_batched_matmul_preserves_batch_outputs(self, tmp_path: Path, left: bool) -> None:
+        weights = np.zeros((2, 10, 100), dtype=np.float32) if left else np.zeros((2, 100, 10), dtype=np.float32)
+        if left:
+            weights[1, 3, 50:55] = 10.0
+        else:
+            weights[1, 50:55, 3] = 10.0
+        model_path = create_batched_matmul_weight_model(tmp_path, weights, left=left)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        checks = self._extreme_checks(result)
+        assert len(checks) == 1
+        details = checks[0].details
+        expected_output_axes = [0, 1] if left else [0, 2]
+        assert details["output_axes"] == expected_output_axes
+        assert details["conceptual_output_axes"] == expected_output_axes
+        assert details["analysis_shape"] == [100, 20]
+        assert details["total_outputs"] == 20
+        assert details["affected_neurons"] == [13]
+
+    def test_consumer_and_string_metadata_are_bounded_with_counts(self, tmp_path: Path) -> None:
+        model_path = create_many_consumer_weight_model(tmp_path, consumer_count=30)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        context = semantics["eligible"][0]
+        assert semantics["consumer_count"] == 30
+        assert semantics["consumer_metadata_sample_count"] == 20
+        assert semantics["consumer_metadata_truncated"] is True
+        assert semantics["metadata_strings_truncated"] is True
+        assert context["consumer_count"] == 30
+        assert len(context["consumers"]) == 20
+        assert context["consumers_truncated"] is True
+        assert context["initializer_truncated"] is True
+        assert context["initializer_length"] > len(context["initializer"])
+        assert len(context["initializer"]) <= 256
+        assert all(len(consumer["node"]) <= 256 for consumer in context["consumers"])
+        checks = self._extreme_checks(result)
+        assert len(checks) == 1
+        assert len(checks[0].message) < 400
+
+    @pytest.mark.parametrize("duplicate", [False, True])
+    def test_invalid_initializer_names_fail_closed(self, tmp_path: Path, duplicate: bool) -> None:
+        model_path = create_invalid_initializer_name_model(tmp_path, duplicate=duplicate)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        validation = result.metadata["onnx_weight_distribution_semantics"]["initializer_name_validation"]
+        assert result.success is False
+        assert len(coverage) == 1
+        assert coverage[0].details["coverage_gap"] == "invalid_initializer_names"
+        assert validation["duplicate_name_count"] == int(duplicate)
+        assert validation["empty_name_count"] == int(not duplicate)
+
+    def test_standalone_onnx_scanner_matches_semantic_orientation(self, tmp_path: Path) -> None:
+        weights = np.zeros((10, 100), dtype=np.float32)
+        weights[3, 50:55] = 10.0
+        model_path = create_onnx_weight_model(tmp_path, weights, op_type="Gemm", trans_b=True)
+
+        integrated = OnnxScanner().scan(str(model_path))
+        standalone = WeightDistributionScanner().scan(str(model_path))
+
+        integrated_check = self._extreme_checks(integrated)[0]
+        standalone_checks = [
+            check
+            for check in standalone.checks
+            if check.name == "Weight Distribution Anomaly Detection"
+            and "extremely large weight values" in check.message
+        ]
+        assert len(standalone_checks) == 1
+        assert standalone_checks[0].details["output_axis"] == integrated_check.details["output_axis"] == 0
+        assert standalone_checks[0].details["analysis_shape"] == integrated_check.details["analysis_shape"] == [100, 10]
+        assert standalone_checks[0].details["affected_neurons"] == integrated_check.details["affected_neurons"] == [3]
+
+    def test_standalone_onnx_scanner_matches_semantic_exclusions(self, tmp_path: Path) -> None:
+        weights = np.zeros((100, 10), dtype=np.float32)
+        weights[50:55, 3] = 10.0
+        model_path = create_onnx_weight_model(tmp_path, weights, op_type="Gather")
+
+        standalone = WeightDistributionScanner().scan(str(model_path))
+
+        assert not any(
+            check.name == "Weight Distribution Anomaly Detection" and "extremely large weight values" in check.message
+            for check in standalone.checks
+        )
+        semantics = standalone.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible_initializer_count"] == 0
+        assert semantics["exclusion_counts"] == {"embedding_table": 1}
 
 
 class TestRawDetectorCoverage:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -8,6 +8,7 @@ import pytest
 # Skip if onnx is not available before importing it
 pytest.importorskip("onnx")
 
+import numpy as np
 import onnx
 from onnx import TensorProto, helper
 from onnx.onnx_ml_pb2 import StringStringEntryProto
@@ -51,20 +52,22 @@ def create_onnx_model(
     missing_external: bool = False,
     tensor_shape: tuple[int, ...] = (1,),
     include_initializer: bool = True,
+    initializer_consumer: str | None = None,
 ) -> Path:
     X = helper.make_tensor_value_info("input", TensorProto.FLOAT, list(tensor_shape) or [1])
     Y = helper.make_tensor_value_info("output", TensorProto.FLOAT, list(tensor_shape) or [1])
-    node = (
-        helper.make_node(
+    if initializer_consumer is not None:
+        node = helper.make_node(initializer_consumer, ["input", "W"], ["output"], name="weighted")
+    elif custom:
+        node = helper.make_node(
             custom_op_type,
             ["input"],
             ["output"],
             domain=custom_domain,
             name="custom",
         )
-        if custom
-        else helper.make_node("Relu", ["input"], ["output"], name="relu")
-    )
+    else:
+        node = helper.make_node("Relu", ["input"], ["output"], name="relu")
 
     initializers: list[Any] = []
     if include_initializer and external:
@@ -98,6 +101,49 @@ def create_onnx_model(
     graph = helper.make_graph([node], "graph", [X], [Y], initializer=initializers)
     model = helper.make_model(graph)
     path = tmp_path / "model.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_onnx_weight_model(
+    tmp_path: Path,
+    weights: np.ndarray,
+    *,
+    op_type: str,
+    trans_b: bool = False,
+    filename: str = "weighted.onnx",
+) -> Path:
+    """Create a small valid ONNX graph with the supplied initializer consumer."""
+    weight_tensor = onnx.numpy_helper.from_array(weights, name="W")
+    if op_type == "Gemm":
+        input_features = weights.shape[1] if trans_b else weights.shape[0]
+        output_features = weights.shape[0] if trans_b else weights.shape[1]
+        X = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, input_features])
+        Y = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, output_features])
+        node = helper.make_node("Gemm", ["input", "W"], ["output"], name="linear", transB=int(trans_b))
+    elif op_type == "MatMul":
+        X = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, weights.shape[0]])
+        Y = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, weights.shape[1]])
+        node = helper.make_node("MatMul", ["input", "W"], ["output"], name="linear")
+    elif op_type == "Gather":
+        X = helper.make_tensor_value_info("input", TensorProto.INT64, [1])
+        Y = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, weights.shape[1]])
+        node = helper.make_node("Gather", ["W", "input"], ["output"], name="embedding")
+    elif op_type == "MatMulInteger":
+        X = helper.make_tensor_value_info("input", TensorProto.INT8, [1, weights.shape[0]])
+        Y = helper.make_tensor_value_info("output", TensorProto.INT32, [1, weights.shape[1]])
+        node = helper.make_node("MatMulInteger", ["input", "W"], ["output"], name="quantized_linear")
+    elif op_type in {"Add", "Mul"}:
+        X = helper.make_tensor_value_info("input", TensorProto.FLOAT, list(weights.shape))
+        Y = helper.make_tensor_value_info("output", TensorProto.FLOAT, list(weights.shape))
+        node = helper.make_node(op_type, ["input", "W"], ["output"], name="bookkeeping")
+    else:  # pragma: no cover - test helper guard
+        raise AssertionError(f"unsupported test operator: {op_type}")
+
+    graph = helper.make_graph([node], "weighted_graph", [X], [Y], initializer=[weight_tensor])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    path = tmp_path / filename
     onnx.save(model, str(path))
     return path
 
@@ -1789,12 +1835,29 @@ class TestWeightDistributionCoverage:
         assert "scan_outcome" not in result.metadata
         assert self._coverage_checks(result) == []
 
-    def test_missing_weight_distribution_dependency_is_inconclusive(
+    def test_missing_weight_distribution_dependency_ignores_unused_2d_initializers(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         model_path = create_onnx_model(tmp_path, tensor_shape=(2, 2))
+        monkeypatch.setitem(sys.modules, "scipy", None)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is True
+        assert "scan_outcome" not in result.metadata
+        assert result.metadata["onnx_weight_distribution_semantics"]["exclusion_counts"] == {
+            "unused_initializer": 1,
+        }
+        assert self._coverage_checks(result) == []
+
+    def test_missing_weight_distribution_dependency_is_inconclusive(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        model_path = create_onnx_model(tmp_path, tensor_shape=(2, 2), initializer_consumer="MatMul")
         monkeypatch.setitem(sys.modules, "scipy", None)
 
         result = OnnxScanner().scan(str(model_path))
@@ -1818,6 +1881,7 @@ class TestWeightDistributionCoverage:
             external_path="weights.bin",
             external_file_bytes=struct.pack("ffff", 1.0, 2.0, 3.0, 4.0),
             tensor_shape=(2, 2),
+            initializer_consumer="MatMul",
         )
 
         result = OnnxScanner().scan(str(model_path))
@@ -1838,7 +1902,7 @@ class TestWeightDistributionCoverage:
         self._assert_uncached_inconclusive_exit2(model_path, tmp_path / "cache")
 
     def test_oversized_weight_distribution_tensors_are_inconclusive(self, tmp_path: Path) -> None:
-        model_path = create_onnx_model(tmp_path, tensor_shape=(2, 2))
+        model_path = create_onnx_model(tmp_path, tensor_shape=(2, 2), initializer_consumer="MatMul")
 
         result = OnnxScanner({"max_array_size": 1}).scan(str(model_path))
 
@@ -1856,6 +1920,93 @@ class TestWeightDistributionCoverage:
         assert coverage_checks[0].details["oversized_initializers_skipped"] == 1
         assert coverage_checks[0].details["analyzed_initializers"] == 0
         self._assert_uncached_inconclusive_exit2(model_path, tmp_path / "cache", max_array_size=1)
+
+
+class TestWeightDistributionSemantics:
+    """Regression tests for ONNX initializer semantics and output axes."""
+
+    @staticmethod
+    def _extreme_checks(result: Any) -> list[Any]:
+        return [
+            check
+            for check in result.checks
+            if check.name == "Weight Distribution Anomaly Detection"
+            and "extremely large weight values" in check.message
+        ]
+
+    def test_gemm_transposed_weight_uses_the_real_output_axis(self, tmp_path: Path) -> None:
+        weights = np.linspace(-0.1, 0.1, 384, dtype=np.float32).reshape(1, 384)
+        model_path = create_onnx_weight_model(tmp_path, weights, op_type="Gemm", trans_b=True)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert self._extreme_checks(result) == []
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible_initializer_count"] == 1
+        assert semantics["analyzed_layer_count"] == 1
+        assert semantics["eligible"][0]["consumer_op"] == "Gemm"
+        assert semantics["eligible"][0]["output_axis"] == 0
+        assert semantics["eligible"][0]["stored_shape"] == [1, 384]
+        assert semantics["eligible"][0]["analysis_shape"] == [384, 1]
+
+    @pytest.mark.parametrize(
+        ("op_type", "weights", "expected_reason"),
+        [
+            ("Gather", np.zeros((2, 384), dtype=np.float32), "embedding_table"),
+            ("MatMulInteger", np.full((128, 1), 127, dtype=np.int8), "quantized_operator"),
+            ("Mul", np.zeros((288, 1), dtype=np.float32), "bookkeeping_constant"),
+            ("Add", np.zeros((288, 1), dtype=np.float32), "bookkeeping_constant"),
+        ],
+    )
+    def test_non_neuron_initializers_are_semantically_excluded(
+        self,
+        tmp_path: Path,
+        op_type: str,
+        weights: np.ndarray,
+        expected_reason: str,
+    ) -> None:
+        model_path = create_onnx_weight_model(tmp_path, weights, op_type=op_type)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert self._extreme_checks(result) == []
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible_initializer_count"] == 0
+        assert semantics["analyzed_layer_count"] == 0
+        assert semantics["exclusion_counts"][expected_reason] == 1
+        assert semantics["exclusion_samples"][0]["initializer"] == "W"
+
+    @pytest.mark.parametrize(("op_type", "trans_b"), [("MatMul", False), ("Gemm", False), ("Gemm", True)])
+    def test_malicious_repeated_extreme_weights_remain_detected(
+        self,
+        tmp_path: Path,
+        op_type: str,
+        trans_b: bool,
+    ) -> None:
+        analysis_weights = np.zeros((100, 10), dtype=np.float32)
+        analysis_weights[50:55, 3] = 10.0
+        stored_weights = analysis_weights.T if trans_b else analysis_weights
+        model_path = create_onnx_weight_model(
+            tmp_path,
+            stored_weights,
+            op_type=op_type,
+            trans_b=trans_b,
+        )
+
+        result = OnnxScanner().scan(str(model_path))
+
+        checks = self._extreme_checks(result)
+        assert len(checks) == 1
+        details = checks[0].details
+        assert details["initializer"] == "W"
+        assert details["consumer_op"] == op_type
+        assert details["consumer_input_index"] == 1
+        assert details["output_axis"] == (0 if trans_b else 1)
+        assert details["analysis_shape"] == [100, 10]
+        assert details["affected_neurons"] == [3]
+        assert details["num_extreme_weights"] == 5
+        assert details["max_extreme_weights_per_output"] == 5
+        assert details["max_to_threshold_ratio"] >= 2.0
 
 
 class TestRawDetectorCoverage:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -148,6 +148,188 @@ def create_onnx_weight_model(
     return path
 
 
+def create_left_equivalent_linear_model(
+    tmp_path: Path,
+    analysis_weights: np.ndarray,
+    *,
+    op_type: str,
+) -> Path:
+    """Encode X @ W as transpose(W.T @ transpose(X))."""
+    assert op_type in {"Gemm", "MatMul"}
+    stored_weights = analysis_weights.T.copy()
+    weight_tensor = onnx.numpy_helper.from_array(stored_weights, name="W")
+    X = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, analysis_weights.shape[0]])
+    Y = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, analysis_weights.shape[1]])
+    nodes = [
+        helper.make_node("Transpose", ["input"], ["input_t"], name="transpose_input", perm=[1, 0]),
+        helper.make_node(op_type, ["W", "input_t"], ["output_t"], name="left_linear"),
+        helper.make_node("Transpose", ["output_t"], ["output"], name="transpose_output", perm=[1, 0]),
+    ]
+    graph = helper.make_graph(nodes, "left_equivalent_graph", [X], [Y], initializer=[weight_tensor])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / f"left-equivalent-{op_type.lower()}.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_onnx_conv_weight_model(
+    tmp_path: Path,
+    weights: np.ndarray,
+    *,
+    transpose: bool,
+    group: int = 1,
+    filename: str = "conv-weighted.onnx",
+) -> Path:
+    """Create a valid Conv or ConvTranspose graph with inline weights."""
+    op_type = "ConvTranspose" if transpose else "Conv"
+    weight_tensor = onnx.numpy_helper.from_array(weights, name="W")
+    input_channels = weights.shape[0] if transpose else weights.shape[1] * group
+    output_channels = weights.shape[1] * group if transpose else weights.shape[0]
+    X = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, input_channels, 8, 8])
+    spatial_size = 8 + weights.shape[2] - 1 if transpose else 8 - weights.shape[2] + 1
+    Y = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, output_channels, spatial_size, spatial_size])
+    node = helper.make_node(op_type, ["input", "W"], ["output"], name="convolution", group=group)
+    graph = helper.make_graph([node], "conv_weight_graph", [X], [Y], initializer=[weight_tensor])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / filename
+    onnx.save(model, str(path))
+    return path
+
+
+def create_control_flow_captured_weight_model(
+    tmp_path: Path,
+    weights: np.ndarray,
+    *,
+    control_flow_op: str,
+) -> Path:
+    """Create a checker-valid control-flow graph whose body captures W."""
+    weight_tensor = onnx.numpy_helper.from_array(weights, name="W")
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, weights.shape[0]])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, weights.shape[1]])
+
+    if control_flow_op == "If":
+        condition = helper.make_tensor_value_info("condition", TensorProto.BOOL, [])
+
+        def make_branch(name: str) -> Any:
+            branch_output = helper.make_tensor_value_info(f"{name}_output", TensorProto.FLOAT, [1, weights.shape[1]])
+            node = helper.make_node("MatMul", ["X", "W"], [f"{name}_output"], name=f"{name}_linear")
+            return helper.make_graph([node], name, [], [branch_output])
+
+        control_node = helper.make_node(
+            "If",
+            ["condition"],
+            ["Y"],
+            name="control",
+            then_branch=make_branch("then"),
+            else_branch=make_branch("else"),
+        )
+        graph_inputs = [condition, X]
+        graph_outputs = [Y]
+    elif control_flow_op == "Loop":
+        trip_count = helper.make_tensor_value_info("trip_count", TensorProto.INT64, [])
+        condition = helper.make_tensor_value_info("condition", TensorProto.BOOL, [])
+        iteration = helper.make_tensor_value_info("iteration", TensorProto.INT64, [])
+        body_condition = helper.make_tensor_value_info("body_condition", TensorProto.BOOL, [])
+        state_input = helper.make_tensor_value_info("state_input", TensorProto.FLOAT, [1, weights.shape[0]])
+        condition_output = helper.make_tensor_value_info("condition_output", TensorProto.BOOL, [])
+        state_output = helper.make_tensor_value_info("state_output", TensorProto.FLOAT, [1, weights.shape[1]])
+        body = helper.make_graph(
+            [
+                helper.make_node("Identity", ["body_condition"], ["condition_output"]),
+                helper.make_node("MatMul", ["state_input", "W"], ["state_output"], name="loop_linear"),
+            ],
+            "loop_body",
+            [iteration, body_condition, state_input],
+            [condition_output, state_output],
+        )
+        control_node = helper.make_node(
+            "Loop",
+            ["trip_count", "condition", "X"],
+            ["Y"],
+            name="control",
+            body=body,
+        )
+        graph_inputs = [trip_count, condition, X]
+        graph_outputs = [Y]
+    elif control_flow_op == "Scan":
+        scan_values = helper.make_tensor_value_info("scan_values", TensorProto.FLOAT, [2, 1, weights.shape[0]])
+        scan_outputs = helper.make_tensor_value_info("scan_outputs", TensorProto.FLOAT, [2, 1, weights.shape[0]])
+        state_input = helper.make_tensor_value_info("state_input", TensorProto.FLOAT, [1, weights.shape[0]])
+        scan_input = helper.make_tensor_value_info("scan_input", TensorProto.FLOAT, [1, weights.shape[0]])
+        state_output = helper.make_tensor_value_info("state_output", TensorProto.FLOAT, [1, weights.shape[1]])
+        scan_output = helper.make_tensor_value_info("scan_output", TensorProto.FLOAT, [1, weights.shape[0]])
+        body = helper.make_graph(
+            [
+                helper.make_node("MatMul", ["state_input", "W"], ["state_output"], name="scan_linear"),
+                helper.make_node("Identity", ["scan_input"], ["scan_output"]),
+            ],
+            "scan_body",
+            [state_input, scan_input],
+            [state_output, scan_output],
+        )
+        control_node = helper.make_node(
+            "Scan",
+            ["X", "scan_values"],
+            ["Y", "scan_outputs"],
+            name="control",
+            body=body,
+            num_scan_inputs=1,
+        )
+        graph_inputs = [X, scan_values]
+        graph_outputs = [Y, scan_outputs]
+    else:  # pragma: no cover - test helper guard
+        raise AssertionError(f"Unsupported control-flow operator: {control_flow_op}")
+
+    graph = helper.make_graph([control_node], "control_graph", graph_inputs, graph_outputs, initializer=[weight_tensor])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / f"captured-{control_flow_op.lower()}.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_control_flow_shadowed_weight_model(tmp_path: Path, outer_weights: np.ndarray) -> Path:
+    """Create an If graph where a local W shadows an unused outer W."""
+    outer_weight_tensor = onnx.numpy_helper.from_array(outer_weights, name="W")
+    local_weights = np.zeros_like(outer_weights)
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, outer_weights.shape[0]])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, outer_weights.shape[1]])
+    condition = helper.make_tensor_value_info("condition", TensorProto.BOOL, [])
+
+    def make_branch(name: str) -> Any:
+        local_weight_tensor = onnx.numpy_helper.from_array(local_weights, name="W")
+        branch_output = helper.make_tensor_value_info(f"{name}_output", TensorProto.FLOAT, [1, outer_weights.shape[1]])
+        node = helper.make_node("MatMul", ["X", "W"], [f"{name}_output"], name=f"{name}_linear")
+        return helper.make_graph([node], name, [], [branch_output], initializer=[local_weight_tensor])
+
+    control_node = helper.make_node(
+        "If",
+        ["condition"],
+        ["Y"],
+        name="control",
+        then_branch=make_branch("then"),
+        else_branch=make_branch("else"),
+    )
+    graph = helper.make_graph(
+        [control_node],
+        "control_graph",
+        [condition, X],
+        [Y],
+        initializer=[outer_weight_tensor],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / "shadowed-captured-weight.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
 def create_python_onnx_model(tmp_path: Path) -> Path:
     X = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1])
     Y = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1])
@@ -2007,6 +2189,152 @@ class TestWeightDistributionSemantics:
         assert details["num_extreme_weights"] == 5
         assert details["max_extreme_weights_per_output"] == 5
         assert details["max_to_threshold_ratio"] >= 2.0
+
+    @pytest.mark.parametrize("op_type", ["Gemm", "MatMul"])
+    def test_left_input_equivalent_graph_is_analyzed(self, tmp_path: Path, op_type: str) -> None:
+        analysis_weights = np.zeros((100, 10), dtype=np.float32)
+        analysis_weights[50:55, 3] = 10.0
+        model_path = create_left_equivalent_linear_model(tmp_path, analysis_weights, op_type=op_type)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        checks = self._extreme_checks(result)
+        assert len(checks) == 1
+        details = checks[0].details
+        assert details["consumer_op"] == op_type
+        assert details["consumer_input_index"] == 0
+        assert details["output_axis"] == 0
+        assert details["stored_shape"] == [10, 100]
+        assert details["analysis_shape"] == [100, 10]
+        assert details["affected_neurons"] == [3]
+        assert details["analysis_storage_shares_memory"] is True
+
+    def test_small_binary_head_uses_robust_fallback(self, tmp_path: Path) -> None:
+        weights = np.zeros((50, 2), dtype=np.float32)
+        weights[:5, 0] = 1_000_000.0
+        model_path = create_onnx_weight_model(tmp_path, weights, op_type="MatMul")
+
+        result = OnnxScanner().scan(str(model_path))
+
+        checks = self._extreme_checks(result)
+        assert len(checks) == 1
+        assert checks[0].details["affected_neurons"] == [0]
+        assert checks[0].details["max_to_threshold_ratio"] < 2.0
+
+    def test_nonqualifying_decoy_does_not_suppress_malicious_output(self, tmp_path: Path) -> None:
+        weights = np.zeros((100, 10), dtype=np.float32)
+        weights[50:55, 3] = 10.0
+        weights[0, 4] = 3.0
+        model_path = create_onnx_weight_model(tmp_path, weights, op_type="MatMul")
+
+        result = OnnxScanner().scan(str(model_path))
+
+        checks = self._extreme_checks(result)
+        assert len(checks) == 1
+        assert checks[0].details["affected_neurons"] == [3]
+        assert checks[0].details["num_extreme_weights"] == 5
+
+    def test_grouped_conv_transpose_uses_all_conceptual_outputs_without_clean_fp(self, tmp_path: Path) -> None:
+        weights = np.random.default_rng(42).normal(size=(4, 3, 3, 3)).astype(np.float32)
+        model_path = create_onnx_conv_weight_model(tmp_path, weights, transpose=True, group=2)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert [check for check in result.checks if check.name == "Weight Distribution Anomaly Detection"] == []
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["analyzed_layer_count"] == 1
+        context = semantics["eligible"][0]
+        assert context["stored_shape"] == [4, 3, 3, 3]
+        assert context["analysis_shape"] == [18, 6]
+        assert context["conceptual_output_axes"] == [0, 2]
+        assert context["group"] == 2
+        assert context["analysis_storage_shares_memory"] is True
+        assert context["analysis_materialization"] == "zero_copy_view_chunked_reduction"
+
+    def test_grouped_conv_transpose_retains_malicious_output_detection(self, tmp_path: Path) -> None:
+        weights = np.zeros((4, 3, 3, 3), dtype=np.float32)
+        weights[2:4, 1, 0:3, 0] = 10.0
+        model_path = create_onnx_conv_weight_model(tmp_path, weights, transpose=True, group=2)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        checks = self._extreme_checks(result)
+        assert len(checks) == 1
+        details = checks[0].details
+        assert details["analysis_shape"] == [18, 6]
+        assert details["affected_neurons"] == [4]
+        assert details["num_extreme_weights"] == 6
+        assert details["group"] == 2
+        assert details["analysis_storage_shares_memory"] is True
+
+    def test_grouped_conv_transpose_analysis_only_uses_zero_copy_moveaxis(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        weights = np.random.default_rng(7).normal(size=(4, 3, 3, 3)).astype(np.float32)
+        model_path = create_onnx_conv_weight_model(tmp_path, weights, transpose=True, group=2)
+
+        original_moveaxis = np.moveaxis
+        moveaxis_calls = 0
+
+        def checked_moveaxis(*args: Any, **kwargs: Any) -> Any:
+            nonlocal moveaxis_calls
+            moveaxis_calls += 1
+            moved = original_moveaxis(*args, **kwargs)
+            assert np.shares_memory(args[0], moved)
+            return moved
+
+        monkeypatch.setattr(np, "moveaxis", checked_moveaxis)
+        result = OnnxScanner().scan(str(model_path))
+
+        assert moveaxis_calls == 1
+        assert (
+            result.metadata["onnx_weight_distribution_semantics"]["eligible"][0]["analysis_storage_shares_memory"]
+            is True
+        )
+        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+
+    @pytest.mark.parametrize("control_flow_op", ["If", "Loop", "Scan"])
+    def test_control_flow_subgraph_captures_outer_weight_initializer(
+        self,
+        tmp_path: Path,
+        control_flow_op: str,
+    ) -> None:
+        weights = np.zeros((100, 100), dtype=np.float32)
+        weights[50:55, 3] = 10.0
+        model_path = create_control_flow_captured_weight_model(
+            tmp_path,
+            weights,
+            control_flow_op=control_flow_op,
+        )
+
+        result = OnnxScanner().scan(str(model_path))
+
+        checks = self._extreme_checks(result)
+        assert len(checks) == 1
+        details = checks[0].details
+        assert details["initializer"] == "W"
+        assert details["consumer_op"] == "MatMul"
+        assert details["consumer_input_index"] == 1
+        assert details["analysis_shape"] == [100, 100]
+        assert details["affected_neurons"] == [3]
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible_initializer_count"] == 1
+        assert semantics["analyzed_layer_count"] == 1
+
+    def test_subgraph_local_initializer_shadows_outer_weight(self, tmp_path: Path) -> None:
+        outer_weights = np.zeros((100, 100), dtype=np.float32)
+        outer_weights[50:55, 3] = 10.0
+        model_path = create_control_flow_shadowed_weight_model(tmp_path, outer_weights)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert self._extreme_checks(result) == []
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible_initializer_count"] == 0
+        assert semantics["analyzed_layer_count"] == 0
+        assert semantics["exclusion_counts"]["unused_initializer"] == 1
 
 
 class TestRawDetectorCoverage:

--- a/tests/scanners/test_weight_distribution_scanner.py
+++ b/tests/scanners/test_weight_distribution_scanner.py
@@ -1294,6 +1294,14 @@ def test_onnx_external_and_unknown_initializers_fail_closed_before_materializati
             external_data=[],
         ),
         types.SimpleNamespace(
+            name="stale_external_metadata_weight",
+            dims=[2, 2],
+            data_type=1,
+            data_location=0,
+            external_data=[object()],
+            raw_data=b"x" * 16,
+        ),
+        types.SimpleNamespace(
             name="custom_numeric_weight",
             dims=[2, 2],
             data_type=16,
@@ -1326,8 +1334,8 @@ def test_onnx_external_and_unknown_initializers_fail_closed_before_materializati
     scanner = WeightDistributionScanner()
     weights = scanner._extract_onnx_weights(str(path))
 
-    assert list(weights) == ["valid_weight", "custom_numeric_weight"]
-    assert materialized == ["valid_weight", "custom_numeric_weight"]
+    assert list(weights) == ["valid_weight", "stale_external_metadata_weight", "custom_numeric_weight"]
+    assert materialized == ["valid_weight", "stale_external_metadata_weight", "custom_numeric_weight"]
     assert scanner.extraction_incomplete_reasons == [
         "onnx_external_initializer_skipped",
         "onnx_initializer_size_limit",
@@ -1487,7 +1495,10 @@ class TestWeightDistributionScanner:
         assert scanner._max_tensor_bytes() == 1
         assert scanner._max_total_tensor_bytes() == 32
 
-    @pytest.mark.parametrize("invalid_limit", [True, False, "unbounded", -1, float("inf"), float("nan")])
+    @pytest.mark.parametrize(
+        "invalid_limit",
+        [True, False, "unbounded", -1, float("inf"), float("nan"), pytest.param(10**1000, id="oversized-integer")],
+    )
     def test_invalid_tensor_byte_limit_uses_secure_default(self, invalid_limit: Any) -> None:
         scanner = WeightDistributionScanner({"max_array_size": invalid_limit})
 

--- a/tests/scanners/test_weight_distribution_scanner.py
+++ b/tests/scanners/test_weight_distribution_scanner.py
@@ -1810,6 +1810,63 @@ class TestWeightDistributionScanner:
         assert extreme["details"]["affected_neurons"] == [3]
         assert extreme["details"]["minimum_extreme_weights_per_output"] == 5
 
+    def test_extreme_value_check_ignores_nonzero_constant_matrix(self) -> None:
+        import numpy as np
+
+        weights = np.full((100, 10), 3.0, dtype=np.float32)
+
+        anomalies = WeightDistributionScanner()._analyze_layer_weights(
+            "constant_matrix",
+            weights,
+            self._create_mock_architecture_analysis(is_llm=False),
+        )
+
+        assert not any("extremely large weight values" in anomaly["description"] for anomaly in anomalies)
+
+    def test_extreme_value_check_does_not_count_constant_outputs_as_robust_tails(self) -> None:
+        import numpy as np
+
+        weights = np.ones((100, 10), dtype=np.float32)
+        weights[50:55, 3] = 10.0
+
+        anomalies = WeightDistributionScanner()._analyze_layer_weights(
+            "constant_outputs_with_target",
+            weights,
+            self._create_mock_architecture_analysis(is_llm=False),
+        )
+
+        extreme = next(anomaly for anomaly in anomalies if "extremely large weight values" in anomaly["description"])
+        assert extreme["details"]["affected_neurons"] == [3]
+        assert extreme["details"]["tail_affected_outputs"] == 1
+        evidence = extreme["details"]["per_output_evidence"][0]
+        assert evidence["robust_count"] == 5
+        assert evidence["robust_support_count"] == 5
+
+    def test_extreme_value_check_preserves_sampled_zero_mad_plateau(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import numpy as np
+
+        monkeypatch.setattr(
+            "modelaudit.scanners.weight_distribution_scanner._EXTREME_WEIGHT_ROBUST_SAMPLE_SIZE",
+            32,
+        )
+        weights = np.zeros((352, 1), dtype=np.float32)
+        weights[::11, 0] = 10_000.0
+
+        anomalies = WeightDistributionScanner()._analyze_tensor_weight_extremes(
+            "sampled_zero_mad_plateau",
+            weights,
+            output_axes=(1,),
+        )
+
+        extreme = next(anomaly for anomaly in anomalies if "extremely large weight values" in anomaly["description"])
+        evidence = extreme["details"]["per_output_evidence"][0]
+        assert evidence["robust_median_magnitude"] == 10_000.0
+        assert evidence["robust_mad_scale"] == 0.0
+        assert evidence["robust_count"] == 32
+
     def test_extreme_value_check_detects_single_output_with_contaminated_threshold(self) -> None:
         import numpy as np
 

--- a/tests/scanners/test_weight_distribution_scanner.py
+++ b/tests/scanners/test_weight_distribution_scanner.py
@@ -1436,6 +1436,44 @@ class TestWeightDistributionScanner:
         assert scanner.weight_magnitude_threshold == 2.0
         assert scanner.max_array_size == 50 * 1024 * 1024
 
+    def test_onnx_semantic_views_count_physical_initializer_once(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import numpy as np
+
+        weights = np.broadcast_to(np.asarray(0.0, dtype=np.float32), (5120, 5120))
+        specs = [
+            types.SimpleNamespace(
+                initializer_index=7,
+                analysis_id=analysis_id,
+                weights=weights,
+                output_axes=(output_axis,),
+                matrix_analysis=True,
+                context={"initializer": "embedding"},
+            )
+            for analysis_id, output_axis in enumerate((0, 1))
+        ]
+        captured_architectures: list[dict[str, Any]] = []
+        scanner = WeightDistributionScanner()
+
+        def capture_architecture(
+            _layer_name: str,
+            _weights: Any,
+            architecture_analysis: dict[str, Any],
+        ) -> list[dict[str, Any]]:
+            captured_architectures.append(dict(architecture_analysis))
+            return []
+
+        monkeypatch.setattr(scanner, "_analyze_layer_weights", capture_architecture)
+
+        assert scanner._analyze_onnx_weight_specs(specs) == []
+        assert len(captured_architectures) == 2
+        for architecture in captured_architectures:
+            assert architecture["total_parameters"] == 5120 * 5120
+            assert architecture["layer_count"] == 1
+            assert architecture["is_likely_llm"] is False
+
     def test_numeric_byte_limit_config_is_coerced(self) -> None:
         import numpy as np
 

--- a/tests/scanners/test_weight_distribution_scanner.py
+++ b/tests/scanners/test_weight_distribution_scanner.py
@@ -1562,7 +1562,19 @@ class TestWeightDistributionScanner:
         assert dissimilar_anomaly is not None
         assert dissimilar_anomaly["details"]["neuron_index"] == 9
 
-    def test_analyze_layer_weights_extreme_values(self):
+    def test_analyze_layer_weights_ignores_fully_dissimilar_small_head(self) -> None:
+        import numpy as np
+
+        weights = np.eye(3, dtype=np.float32)
+        anomalies = WeightDistributionScanner()._analyze_layer_weights(
+            "three_class_head",
+            weights,
+            self._create_mock_architecture_analysis(is_llm=False),
+        )
+
+        assert not any("dissimilar weights" in anomaly["description"] for anomaly in anomalies)
+
+    def test_analyze_layer_weights_extreme_values(self) -> None:
         """Test detection of extreme weight values"""
         import numpy as np
 
@@ -1587,7 +1599,7 @@ class TestWeightDistributionScanner:
         assert 3 in extreme_anomaly["details"]["affected_neurons"]
         assert extreme_anomaly["details"]["num_extreme_weights"] == 5
         assert extreme_anomaly["details"]["max_extreme_weights_per_output"] == 5
-        assert extreme_anomaly["details"]["max_to_threshold_ratio"] >= 2.0
+        assert extreme_anomaly["details"]["threshold_scope"] == "per_output"
 
     def test_extreme_value_check_ignores_ordinary_gaussian_tails(self) -> None:
         import numpy as np
@@ -1654,6 +1666,44 @@ class TestWeightDistributionScanner:
         assert extreme["details"]["affected_neurons"] == [3]
         assert extreme["details"]["num_extreme_weights"] == 5
 
+    def test_extreme_value_check_detects_target_despite_larger_decoy_output(self) -> None:
+        import numpy as np
+
+        scanner = WeightDistributionScanner()
+        weights = np.zeros((100, 10), dtype=np.float32)
+        weights[50:55, 3] = 10.0
+        weights[0, 4] = 1_000_000.0
+
+        anomalies = scanner._analyze_layer_weights(
+            "large_decoy_output",
+            weights,
+            self._create_mock_architecture_analysis(is_llm=False),
+        )
+
+        extreme = next(anomaly for anomaly in anomalies if "extremely large weight values" in anomaly["description"])
+        assert extreme["details"]["affected_neurons"] == [3]
+        assert extreme["details"]["total_affected"] == 1
+
+    def test_extreme_value_check_detects_target_despite_two_value_decoy_output(self) -> None:
+        import numpy as np
+
+        scanner = WeightDistributionScanner()
+        weights = np.zeros((100, 10), dtype=np.float32)
+        weights[50:55, 3] = 10.0
+        weights[60:62, 4] = 10.0
+
+        anomalies = scanner._analyze_layer_weights(
+            "two_value_decoy_output",
+            weights,
+            self._create_mock_architecture_analysis(is_llm=False),
+        )
+
+        extreme = next(anomaly for anomaly in anomalies if "extremely large weight values" in anomaly["description"])
+        assert extreme["details"]["affected_neurons"] == [3]
+        assert extreme["details"]["total_affected"] == 1
+        assert extreme["details"]["tail_affected_outputs"] == 2
+        assert extreme["details"]["localized"] is True
+
     def test_extreme_value_conditions_cannot_mix_across_outputs(self) -> None:
         import numpy as np
 
@@ -1670,7 +1720,7 @@ class TestWeightDistributionScanner:
 
         assert not any("extremely large weight values" in anomaly["description"] for anomaly in anomalies)
 
-    def test_extreme_value_check_ignores_widespread_tail_outputs(self) -> None:
+    def test_extreme_value_check_reports_two_poisoned_outputs_as_nonlocalized(self) -> None:
         import numpy as np
 
         scanner = WeightDistributionScanner()
@@ -1684,7 +1734,11 @@ class TestWeightDistributionScanner:
             self._create_mock_architecture_analysis(is_llm=False),
         )
 
-        assert not any("extremely large weight values" in anomaly["description"] for anomaly in anomalies)
+        extreme = next(anomaly for anomaly in anomalies if "extremely large weight values" in anomaly["description"])
+        assert extreme["details"]["affected_neurons"] == [3, 4]
+        assert extreme["details"]["total_affected"] == 2
+        assert extreme["details"]["affected_output_limit"] == 1
+        assert extreme["details"]["localized"] is False
 
     def test_extreme_value_check_ignores_two_value_material_tail(self) -> None:
         import numpy as np
@@ -1717,6 +1771,80 @@ class TestWeightDistributionScanner:
         extreme = next(anomaly for anomaly in anomalies if "extremely large weight values" in anomaly["description"])
         assert extreme["details"]["affected_neurons"] == [3]
         assert extreme["details"]["minimum_extreme_weights_per_output"] == 5
+
+    def test_extreme_value_check_detects_single_output_with_contaminated_threshold(self) -> None:
+        import numpy as np
+
+        scanner = WeightDistributionScanner()
+        weights = np.zeros((50, 1), dtype=np.float64)
+        weights[:5, 0] = 10.0
+
+        anomalies = scanner._analyze_tensor_weight_extremes(
+            "single_output_contaminated_threshold",
+            weights,
+            output_axes=(1,),
+        )
+
+        extreme = next(anomaly for anomaly in anomalies if "extremely large weight values" in anomaly["description"])
+        assert extreme["details"]["affected_neurons"] == [0]
+        assert extreme["details"]["per_output_evidence"][0]["detection_path"] == "robust_small_tensor_fallback"
+
+    @pytest.mark.parametrize("nonfinite_value", [float("nan"), float("inf"), float("-inf")])
+    def test_extreme_value_check_reports_nonfinite_without_suppressing_finite_target(
+        self,
+        nonfinite_value: float,
+    ) -> None:
+        import numpy as np
+
+        scanner = WeightDistributionScanner()
+        weights = np.zeros((100, 10), dtype=np.float64)
+        weights[50:55, 3] = 10.0
+        weights[0, 4] = nonfinite_value
+
+        anomalies = scanner._analyze_tensor_weight_extremes(
+            "nonfinite_decoy",
+            weights,
+            output_axes=(1,),
+        )
+
+        extreme = next(anomaly for anomaly in anomalies if "extremely large weight values" in anomaly["description"])
+        assert extreme["details"]["affected_neurons"] == [3, 4]
+        assert extreme["details"]["num_nonfinite_weights"] == 1
+        assert extreme["details"]["per_output_evidence"][1]["detection_path"] == "nonfinite_values"
+
+    def test_extreme_value_check_handles_finite_float64_square_overflow(self) -> None:
+        import numpy as np
+
+        scanner = WeightDistributionScanner()
+        weights = np.zeros((100, 10), dtype=np.float64)
+        weights[50:55, 3] = 1e154
+
+        anomalies = scanner._analyze_tensor_weight_extremes(
+            "finite_float64_extremes",
+            weights,
+            output_axes=(1,),
+        )
+
+        extreme = next(anomaly for anomaly in anomalies if "extremely large weight values" in anomaly["description"])
+        assert extreme["details"]["affected_neurons"] == [3]
+        assert np.isfinite(extreme["details"]["threshold"])
+
+    def test_extreme_value_check_handles_signed_integer_minimum(self) -> None:
+        import numpy as np
+
+        scanner = WeightDistributionScanner()
+        weights = np.zeros((100, 10), dtype=np.int64)
+        weights[50:55, 3] = np.iinfo(np.int64).min
+
+        anomalies = scanner._analyze_tensor_weight_extremes(
+            "signed_integer_minimum",
+            weights,
+            output_axes=(1,),
+        )
+
+        extreme = next(anomaly for anomaly in anomalies if "extremely large weight values" in anomaly["description"])
+        assert extreme["details"]["affected_neurons"] == [3]
+        assert extreme["details"]["max_weight"] > 0
 
     @pytest.mark.parametrize(
         ("degrees_of_freedom", "seed", "shape"),
@@ -1769,6 +1897,67 @@ class TestWeightDistributionScanner:
         )
 
         assert not any("extremely large weight values" in anomaly["description"] for anomaly in anomalies)
+
+    @pytest.mark.parametrize("distribution", ["student_t", "lognormal"])
+    def test_extreme_value_check_ignores_large_clean_single_output_heavy_tail(
+        self,
+        distribution: str,
+    ) -> None:
+        import numpy as np
+
+        random = np.random.default_rng(12345)
+        if distribution == "student_t":
+            weights = random.standard_t(3, size=(100_000, 1))
+        else:
+            weights = random.lognormal(size=(100_000, 1))
+
+        anomalies = WeightDistributionScanner()._analyze_tensor_weight_extremes(
+            f"clean_{distribution}",
+            weights,
+            output_axes=(1,),
+        )
+
+        assert not any("extremely large weight values" in anomaly["description"] for anomaly in anomalies)
+
+    @pytest.mark.parametrize("sample_offset", [0, 1])
+    def test_extreme_value_check_cannot_be_evaded_by_regular_sample_alignment(self, sample_offset: int) -> None:
+        import numpy as np
+
+        weights = np.zeros((262_144 * 11, 1), dtype=np.float32)
+        sampled_tail = weights[sample_offset::11, 0]
+        sampled_tail[:] = np.linspace(9_000.0, 10_000.0, sampled_tail.size, dtype=np.float32)
+
+        anomalies = WeightDistributionScanner()._analyze_tensor_weight_extremes(
+            "sample_alignment",
+            weights,
+            output_axes=(1,),
+        )
+
+        extreme = next(anomaly for anomaly in anomalies if "extremely large weight values" in anomaly["description"])
+        assert extreme["details"]["affected_neurons"] == [0]
+
+    def test_tensor_extreme_analysis_batches_noncontiguous_output_prefixes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import numpy as np
+
+        weights = np.zeros((2, 100, 6_000), dtype=np.float32)
+        weights[1, 50:55, 777] = 10_000.0
+
+        def fail_unravel_index(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("output prefixes should be processed in bounded blocks")
+
+        monkeypatch.setattr(np, "unravel_index", fail_unravel_index)
+
+        anomalies = WeightDistributionScanner()._analyze_tensor_weight_extremes(
+            "noncontiguous_output_prefixes",
+            weights,
+            output_axes=(0, 2),
+        )
+
+        extreme = next(anomaly for anomaly in anomalies if "extremely large weight values" in anomaly["description"])
+        assert extreme["details"]["affected_neurons"] == [6_777]
 
     def test_tensor_extreme_analysis_bounds_temporary_chunks(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import numpy as np

--- a/tests/scanners/test_weight_distribution_scanner.py
+++ b/tests/scanners/test_weight_distribution_scanner.py
@@ -404,8 +404,8 @@ def test_partial_hdf5_weight_extraction_preserves_analyzed_findings(tmp_path: Pa
     import numpy as np
 
     path = tmp_path / "partial_external_weights.h5"
-    anomalous_weights = np.zeros((2, 10), dtype=np.float32)
-    anomalous_weights[0, 0] = 1000.0
+    anomalous_weights = np.zeros((100, 10), dtype=np.float32)
+    anomalous_weights[50:55, 0] = 1000.0
 
     with h5py.File(path, "w") as hdf5_file:
         hdf5_file.create_dataset("model_weights/a_dense/weight:0", data=anomalous_weights)
@@ -1563,6 +1563,38 @@ class TestWeightDistributionScanner:
         )
         assert extreme_anomaly is not None
         assert 3 in extreme_anomaly["details"]["affected_neurons"]
+        assert extreme_anomaly["details"]["num_extreme_weights"] == 5
+        assert extreme_anomaly["details"]["max_extreme_weights_per_output"] == 5
+        assert extreme_anomaly["details"]["max_to_threshold_ratio"] >= 2.0
+
+    def test_extreme_value_check_ignores_ordinary_gaussian_tails(self) -> None:
+        import numpy as np
+
+        scanner = WeightDistributionScanner()
+        weights = np.random.default_rng(20260609).normal(size=(2, 384))
+
+        anomalies = scanner._analyze_layer_weights(
+            "ordinary_projection",
+            weights,
+            self._create_mock_architecture_analysis(is_llm=False),
+        )
+
+        assert not any("extremely large weight values" in anomaly["description"] for anomaly in anomalies)
+
+    def test_extreme_value_check_requires_repeated_values_per_output(self) -> None:
+        import numpy as np
+
+        scanner = WeightDistributionScanner()
+        weights = np.zeros((100, 10), dtype=np.float32)
+        weights[50, 3] = 100.0
+
+        anomalies = scanner._analyze_layer_weights(
+            "single_scalar",
+            weights,
+            self._create_mock_architecture_analysis(is_llm=False),
+        )
+
+        assert not any("extremely large weight values" in anomaly["description"] for anomaly in anomalies)
 
     @pytest.mark.skipif(False, reason="Dynamic skip - see test method")
     def test_pytorch_model_scan(self, tmp_path: Path) -> None:

--- a/tests/scanners/test_weight_distribution_scanner.py
+++ b/tests/scanners/test_weight_distribution_scanner.py
@@ -1648,7 +1648,7 @@ class TestWeightDistributionScanner:
 
         assert not any("extremely large weight values" in anomaly["description"] for anomaly in anomalies)
 
-    def test_extreme_value_alert_is_monotonic_across_qualifying_outputs(self) -> None:
+    def test_extreme_value_check_ignores_widespread_tail_outputs(self) -> None:
         import numpy as np
 
         scanner = WeightDistributionScanner()
@@ -1662,11 +1662,9 @@ class TestWeightDistributionScanner:
             self._create_mock_architecture_analysis(is_llm=False),
         )
 
-        extreme = next(anomaly for anomaly in anomalies if "extremely large weight values" in anomaly["description"])
-        assert extreme["details"]["affected_neurons"] == [3, 4]
-        assert extreme["details"]["localized"] is False
+        assert not any("extremely large weight values" in anomaly["description"] for anomaly in anomalies)
 
-    def test_extreme_value_check_preserves_two_value_material_effect(self) -> None:
+    def test_extreme_value_check_ignores_two_value_material_tail(self) -> None:
         import numpy as np
 
         scanner = WeightDistributionScanner()
@@ -1679,23 +1677,71 @@ class TestWeightDistributionScanner:
             self._create_mock_architecture_analysis(is_llm=False),
         )
 
+        assert not any("extremely large weight values" in anomaly["description"] for anomaly in anomalies)
+
+    def test_extreme_value_check_preserves_five_value_material_effect(self) -> None:
+        import numpy as np
+
+        scanner = WeightDistributionScanner()
+        weights = np.zeros((100, 10), dtype=np.float32)
+        weights[50:55, 3] = 10.0
+
+        anomalies = scanner._analyze_layer_weights(
+            "five_repeated_values",
+            weights,
+            self._create_mock_architecture_analysis(is_llm=False),
+        )
+
         extreme = next(anomaly for anomaly in anomalies if "extremely large weight values" in anomaly["description"])
         assert extreme["details"]["affected_neurons"] == [3]
-        assert extreme["details"]["per_output_evidence"][0]["detection_path"] == "classical_effect"
+        assert extreme["details"]["minimum_extreme_weights_per_output"] == 5
 
-    @pytest.mark.parametrize(("degrees_of_freedom", "seed"), [(3, 94), (5, 26), (7, 785)])
+    @pytest.mark.parametrize(
+        ("degrees_of_freedom", "seed", "shape"),
+        [
+            (3, 94, (50, 2)),
+            (5, 26, (50, 2)),
+            (7, 785, (50, 2)),
+            (3, 3, (256, 64)),
+            (3, 22, (512, 64)),
+            (3, 1, (1024, 64)),
+        ],
+    )
     def test_extreme_value_check_ignores_deterministic_clean_heavy_tails(
         self,
         degrees_of_freedom: int,
         seed: int,
+        shape: tuple[int, int],
     ) -> None:
         import numpy as np
 
         scanner = WeightDistributionScanner()
-        weights = np.random.default_rng(seed).standard_t(degrees_of_freedom, size=(50, 2))
+        weights = np.random.default_rng(seed).standard_t(degrees_of_freedom, size=shape)
 
         anomalies = scanner._analyze_layer_weights(
             f"clean_student_t_df{degrees_of_freedom}",
+            weights,
+            self._create_mock_architecture_analysis(is_llm=False),
+        )
+
+        assert not any("extremely large weight values" in anomaly["description"] for anomaly in anomalies)
+
+    @pytest.mark.parametrize(
+        ("seed", "shape"),
+        [(1, (256, 64)), (2, (256, 64)), (25, (512, 64)), (48, (128, 512))],
+    )
+    def test_extreme_value_check_ignores_deterministic_clean_lognormal_tails(
+        self,
+        seed: int,
+        shape: tuple[int, int],
+    ) -> None:
+        import numpy as np
+
+        scanner = WeightDistributionScanner()
+        weights = np.random.default_rng(seed).lognormal(size=shape)
+
+        anomalies = scanner._analyze_layer_weights(
+            "clean_lognormal",
             weights,
             self._create_mock_architecture_analysis(is_llm=False),
         )

--- a/tests/scanners/test_weight_distribution_scanner.py
+++ b/tests/scanners/test_weight_distribution_scanner.py
@@ -1596,6 +1596,169 @@ class TestWeightDistributionScanner:
 
         assert not any("extremely large weight values" in anomaly["description"] for anomaly in anomalies)
 
+    def test_extreme_value_check_detects_small_binary_head_with_contaminated_threshold(self) -> None:
+        import numpy as np
+
+        scanner = WeightDistributionScanner()
+        weights = np.zeros((50, 2), dtype=np.float32)
+        weights[:5, 0] = 1_000_000.0
+
+        anomalies = scanner._analyze_layer_weights(
+            "small_binary_head",
+            weights,
+            self._create_mock_architecture_analysis(is_llm=False),
+        )
+
+        extreme = next(anomaly for anomaly in anomalies if "extremely large weight values" in anomaly["description"])
+        assert extreme["details"]["affected_neurons"] == [0]
+        assert extreme["details"]["max_to_threshold_ratio"] < 2.0
+        assert extreme["details"]["per_output_evidence"][0]["detection_path"] == "robust_small_tensor_fallback"
+
+    def test_extreme_value_check_ignores_nonqualifying_decoy_output(self) -> None:
+        import numpy as np
+
+        scanner = WeightDistributionScanner()
+        weights = np.zeros((100, 10), dtype=np.float32)
+        weights[50:55, 3] = 10.0
+        weights[0, 4] = 3.0
+
+        anomalies = scanner._analyze_layer_weights(
+            "decoy_output",
+            weights,
+            self._create_mock_architecture_analysis(is_llm=False),
+        )
+
+        extreme = next(anomaly for anomaly in anomalies if "extremely large weight values" in anomaly["description"])
+        assert extreme["details"]["affected_neurons"] == [3]
+        assert extreme["details"]["num_extreme_weights"] == 5
+
+    def test_extreme_value_conditions_cannot_mix_across_outputs(self) -> None:
+        import numpy as np
+
+        scanner = WeightDistributionScanner()
+        weights = np.zeros((100, 2000), dtype=np.float32)
+        weights[0, 0] = 100.0
+        weights[0:2, 1] = 0.70
+
+        anomalies = scanner._analyze_layer_weights(
+            "cross_output_mismatch",
+            weights,
+            self._create_mock_architecture_analysis(is_llm=False),
+        )
+
+        assert not any("extremely large weight values" in anomaly["description"] for anomaly in anomalies)
+
+    def test_extreme_value_alert_is_monotonic_across_qualifying_outputs(self) -> None:
+        import numpy as np
+
+        scanner = WeightDistributionScanner()
+        weights = np.zeros((100, 10), dtype=np.float32)
+        weights[50:55, 3] = 10.0
+        weights[60:65, 4] = 10.0
+
+        anomalies = scanner._analyze_layer_weights(
+            "two_affected_outputs",
+            weights,
+            self._create_mock_architecture_analysis(is_llm=False),
+        )
+
+        extreme = next(anomaly for anomaly in anomalies if "extremely large weight values" in anomaly["description"])
+        assert extreme["details"]["affected_neurons"] == [3, 4]
+        assert extreme["details"]["localized"] is False
+
+    def test_extreme_value_check_preserves_two_value_material_effect(self) -> None:
+        import numpy as np
+
+        scanner = WeightDistributionScanner()
+        weights = np.zeros((100, 10), dtype=np.float32)
+        weights[50:52, 3] = 10.0
+
+        anomalies = scanner._analyze_layer_weights(
+            "two_repeated_values",
+            weights,
+            self._create_mock_architecture_analysis(is_llm=False),
+        )
+
+        extreme = next(anomaly for anomaly in anomalies if "extremely large weight values" in anomaly["description"])
+        assert extreme["details"]["affected_neurons"] == [3]
+        assert extreme["details"]["per_output_evidence"][0]["detection_path"] == "classical_effect"
+
+    @pytest.mark.parametrize(("degrees_of_freedom", "seed"), [(3, 94), (5, 26), (7, 785)])
+    def test_extreme_value_check_ignores_deterministic_clean_heavy_tails(
+        self,
+        degrees_of_freedom: int,
+        seed: int,
+    ) -> None:
+        import numpy as np
+
+        scanner = WeightDistributionScanner()
+        weights = np.random.default_rng(seed).standard_t(degrees_of_freedom, size=(50, 2))
+
+        anomalies = scanner._analyze_layer_weights(
+            f"clean_student_t_df{degrees_of_freedom}",
+            weights,
+            self._create_mock_architecture_analysis(is_llm=False),
+        )
+
+        assert not any("extremely large weight values" in anomaly["description"] for anomaly in anomalies)
+
+    def test_tensor_extreme_analysis_bounds_temporary_chunks(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import numpy as np
+
+        scanner = WeightDistributionScanner()
+        weights = np.zeros((1024, 4096), dtype=np.float32)
+        weights[:5, 3] = 1_000_000.0
+        original_absolute = np.absolute
+        work_buffer_sizes: list[int] = []
+
+        def tracked_absolute(value: Any, *args: Any, **kwargs: Any) -> Any:
+            output = kwargs.get("out")
+            if output is not None:
+                work_buffer_sizes.append(int(getattr(output, "nbytes", 0)))
+            return original_absolute(value, *args, **kwargs)
+
+        monkeypatch.setattr(np, "absolute", tracked_absolute)
+        anomalies = scanner._analyze_tensor_weight_extremes("large_tensor", weights, output_axes=(1,))
+
+        assert any("extremely large weight values" in anomaly["description"] for anomaly in anomalies)
+        assert max(work_buffer_sizes) <= 8 * 1024 * 1024
+
+    def test_tensor_extreme_analysis_chunks_single_wide_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import numpy as np
+
+        scanner = WeightDistributionScanner()
+        weights = np.zeros((1_100_000, 1), dtype=np.float32)
+        weights[:5, 0] = 1_000_000.0
+        original_absolute = np.absolute
+        work_buffer_sizes: list[int] = []
+
+        def tracked_absolute(value: Any, *args: Any, **kwargs: Any) -> Any:
+            output = kwargs.get("out")
+            if output is not None:
+                work_buffer_sizes.append(int(getattr(output, "nbytes", 0)))
+            return original_absolute(value, *args, **kwargs)
+
+        monkeypatch.setattr(np, "absolute", tracked_absolute)
+        anomalies = scanner._analyze_tensor_weight_extremes("wide_output", weights, output_axes=(1,))
+
+        assert any("extremely large weight values" in anomaly["description"] for anomaly in anomalies)
+        assert len(work_buffer_sizes) > 2
+        assert max(work_buffer_sizes) <= 8 * 1024 * 1024
+
+    def test_tensor_extreme_analysis_does_not_overflow_float16_squares(self) -> None:
+        import numpy as np
+
+        scanner = WeightDistributionScanner()
+        weights = np.zeros((100, 10), dtype=np.float16)
+        weights[50:55, 3] = np.float16(10_000)
+
+        anomalies = scanner._analyze_tensor_weight_extremes("float16_tensor", weights, output_axes=(1,))
+
+        extreme = next(anomaly for anomaly in anomalies if "extremely large weight values" in anomaly["description"])
+        assert extreme["details"]["affected_neurons"] == [3]
+        assert np.isfinite(extreme["details"]["threshold"])
+        assert np.isfinite(extreme["details"]["max_to_threshold_ratio"])
+
     @pytest.mark.skipif(False, reason="Dynamic skip - see test method")
     def test_pytorch_model_scan(self, tmp_path: Path) -> None:
         """Test scanning a PyTorch model with anomalous weights"""


### PR DESCRIPTION
## Summary

- analyze floating-point ONNX weights through bounded semantic lineage across nested graphs, control flow, local functions, constants, training graphs, registered operators, and static view transforms
- orient Gemm, MatMul, convolution, embedding, recurrent, PRelu, batched, and grouped tensors by conceptual axes without full-tensor copies
- fail closed on ambiguous, dynamically derived, sparse, external, oversized, malformed, or otherwise incomplete eligible-weight coverage
- evaluate classical and robust extreme-tail evidence independently per output while suppressing constant-baseline and ordinary small-head noise
- keep malformed array limits bounded and analyze present inline tensor bytes even when stale external-data metadata remains

## Motivation

A pinned 19-model Hugging Face ONNX cohort (718,907,420 bytes) produced 28 S802 alerts. The original evidence showed semantic-axis mistakes and ordinary statistical tails, while review found that early noise filters could also suppress real multi-output, nested-graph, recurrent, transformed-weight, training-graph, and contaminated-threshold findings. This revision narrows benign noise without weakening those security paths.

## Validation

- `357 passed, 17 skipped` across the full ONNX and weight-distribution scanner modules
- `14 passed` in the focused invalid-limit, external-storage, malicious-positive, and benign-negative regression set
- full Ruff format/check and mypy pass (`474` source files)
- malicious-positive and benign-negative regressions cover runtime-derived weights, mixed dtypes, registered standard/ONNX-ML operators, PRelu axis invariance, TrainingInfo scope/bindings, malformed Clip bounds, extraction limits, stale external metadata, and zero-MAD statistics
- the parallel pre-commit suite reached `10338 passed, 799 skipped` before stopping on one unrelated PyTorch opcode-count test from the latest main merge; its editable Rust extension predated that merge, and the exact test passes after rebuilding the extension from current source

Fresh Codex review requested for exact head `72b7bba5361111a0dd687ed5c32f92977ee32057` after merging current `main` (`37289644f219a57e4c043dcc083c3eea434aaca3`).