### PR TITLE
fix(pytorch): aggregate exact pickle opcodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- derive PyTorch ZIP pickle opcode summaries from exact opcode evidence instead of matching substrings in finding text
 - classify unsafe PyTorch ZIP symlink targets as critical archive-link findings while preserving safe relative links
 - restore pickle CVE scan throughput, reprobe malformed stream separators, and route four-byte protocol-0 Joblib operands correctly
 - bound manifest embedded-Jinja template collection while preserving findings across deep branches, cycles, and shared YAML aliases

--- a/modelaudit/rule_catalog.py
+++ b/modelaudit/rule_catalog.py
@@ -111,14 +111,18 @@ RULE_CATALOG: tuple[RuleCatalogEntry, ...] = (
         name="Pickle OBJ opcode",
         severity="CRITICAL",
         description="Object construction via pickle OBJ",
-        patterns=(r"pickle.*OBJ", r"OBJ.*opcode", r"dangerous.*OBJ"),
+        patterns=(r"pickle.*\bOBJ\b", r"\bOBJ\b.*opcode", r"dangerous.*\bOBJ\b"),
     ),
     RuleCatalogEntry(
         code="S204",
         name="Pickle NEWOBJ opcode",
         severity="CRITICAL",
         description="New-style class construction via pickle NEWOBJ",
-        patterns=(r"pickle.*NEWOBJ", r"NEWOBJ.*opcode", r"dangerous.*NEWOBJ"),
+        patterns=(
+            r"pickle.*\bNEWOBJ(?:_EX)?\b",
+            r"\bNEWOBJ(?:_EX)?\b.*opcode",
+            r"dangerous.*\bNEWOBJ(?:_EX)?\b",
+        ),
     ),
     RuleCatalogEntry(
         code="S205",

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -2121,20 +2121,24 @@ class PickleScanner(BaseScanner):
                 *(segment_values if isinstance(segment_values, list) else []),
             ]
         combined_lists["protocols"] = list(dict.fromkeys(combined_lists["protocols"]))
-        combined_opcode_counts: dict[str, int] = {}
-        for metadata in (result.metadata, segment_result.metadata):
-            opcode_counts = metadata.get("opcode_counts")
-            if not isinstance(opcode_counts, dict):
-                continue
-            for opcode, count in opcode_counts.items():
-                if isinstance(opcode, str) and isinstance(count, int):
-                    combined_opcode_counts[opcode] = combined_opcode_counts.get(opcode, 0) + count
+        combined_opcode_count_maps: dict[str, dict[str, int]] = {}
+        for count_key in ("opcode_counts", "nested_opcode_counts", "follow_on_opcode_counts"):
+            combined_counts: dict[str, int] = {}
+            for metadata in (result.metadata, segment_result.metadata):
+                opcode_counts = metadata.get(count_key)
+                if not isinstance(opcode_counts, dict):
+                    continue
+                for opcode, count in opcode_counts.items():
+                    if isinstance(opcode, str) and isinstance(count, int):
+                        combined_counts[opcode] = combined_counts.get(opcode, 0) + count
+            combined_opcode_count_maps[count_key] = combined_counts
+        combined_opcode_counts = combined_opcode_count_maps["opcode_counts"]
         control_verdict = result.metadata.get("pickle_verdict")
         segment_verdict = segment_result.metadata.get("pickle_verdict")
 
         result.merge(segment_result)
         result.metadata.update(combined_lists)
-        result.metadata["opcode_counts"] = combined_opcode_counts
+        result.metadata.update(combined_opcode_count_maps)
         result.metadata["opcode_count"] = sum(combined_opcode_counts.values())
         result.metadata["globals_count"] = sum(
             value

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -67,6 +67,7 @@ _PICKLE_CODE_EXECUTION_OPCODE_RISKS = (
     ("INST", "Class instantiation code execution"),
     ("OBJ", "Object creation code execution"),
     ("NEWOBJ", "New-style object creation"),
+    ("NEWOBJ_EX", "Extended new-style object creation"),
     ("STACK_GLOBAL", "Dynamic import and attribute access"),
     ("GLOBAL", "Module import and attribute access"),
     ("BUILD", "__setstate__ method exploitation"),
@@ -3525,20 +3526,13 @@ class PyTorchZipScanner(BaseScanner):
         import_analysis = self._analyze_pickle_imports(pickle_result)
 
         # Check if the pickle scan found any dangerous opcodes
-        dangerous_opcodes_found: list[str] = []
-        code_execution_risks: list[str] = []
-        opcode_counts: dict[str, int] = {}
+        opcode_counts = self._pickle_code_execution_opcode_counts(pickle_result)
+        dangerous_opcodes_found = list(opcode_counts)
+        code_execution_risks = [risk for opcode, risk in _PICKLE_CODE_EXECUTION_OPCODE_RISKS if opcode in opcode_counts]
 
         # Analyze the pickle scan results for dangerous patterns
         for issue in pickle_result.issues:
             issue_msg = issue.message.lower()
-            issue_details = issue.details or {}
-
-            for opcode, risk in _PICKLE_CODE_EXECUTION_OPCODE_RISKS:
-                if self._issue_reports_pickle_opcode(issue_msg, issue_details, opcode):
-                    dangerous_opcodes_found.append(opcode)
-                    opcode_counts[opcode] = opcode_counts.get(opcode, 0) + 1
-                    code_execution_risks.append(risk)
 
             # Look for any code execution patterns
             if any(pattern in issue_msg for pattern in ["exec", "eval", "import", "subprocess", "__import__"]):
@@ -3601,7 +3595,7 @@ class PyTorchZipScanner(BaseScanner):
                     "cve_id": self.CVE_2025_32434_ID,
                     "opcode_counts": opcode_counts,
                     "total_dangerous_opcodes": sum(opcode_counts.values()),
-                    "unique_opcode_types": list(set(dangerous_opcodes_found)),
+                    "unique_opcode_types": dangerous_opcodes_found,
                     "code_execution_risks": list(set(code_execution_risks)),
                     "import_analysis": import_analysis,
                     "safetensors_available": has_safetensors,
@@ -3646,27 +3640,100 @@ class PyTorchZipScanner(BaseScanner):
                 },
             )
 
-    @staticmethod
-    def _issue_reports_pickle_opcode(issue_message: str, issue_details: dict[str, Any], opcode: str) -> bool:
-        """Match exact opcode evidence without treating ordinary word fragments as opcodes."""
-        for key in ("opcode", "opcode_name"):
-            value = issue_details.get(key)
-            if isinstance(value, str) and value.upper() == opcode:
-                return True
+    @classmethod
+    def _pickle_code_execution_opcode_counts(cls, pickle_result: ScanResult) -> dict[str, int]:
+        """Return exact counts for dangerous opcode types backed by findings."""
+        evidence_counts: dict[str, int] = {}
+        supporting_evidence_counts: dict[str, int] = {}
+        for issue in pickle_result.issues:
+            issue_details = issue.details or {}
+            target_counts = (
+                supporting_evidence_counts if issue_details.get("supporting_rule_code") is True else evidence_counts
+            )
+            for opcode, _risk in _PICKLE_CODE_EXECUTION_OPCODE_RISKS:
+                count = cls._issue_pickle_opcode_count(issue.message, issue_details, opcode)
+                if count > 0:
+                    target_counts[opcode] = target_counts.get(opcode, 0) + count
 
-        raw_opcodes = issue_details.get("opcodes")
-        if isinstance(raw_opcodes, (list, tuple, set)) and any(
-            isinstance(value, str) and value.upper() == opcode for value in raw_opcodes
-        ):
-            return True
+        for opcode, count in supporting_evidence_counts.items():
+            evidence_counts.setdefault(opcode, count)
+
+        issue_import_references = {
+            import_reference
+            for issue in pickle_result.issues
+            if isinstance((import_reference := (issue.details or {}).get("import_reference")), str)
+        }
+        raw_callable_invocations = pickle_result.metadata.get("callable_invocations")
+        if issue_import_references and isinstance(raw_callable_invocations, list):
+            dangerous_opcodes = {opcode for opcode, _risk in _PICKLE_CODE_EXECUTION_OPCODE_RISKS}
+            for invocation in raw_callable_invocations:
+                if (
+                    not isinstance(invocation, dict)
+                    or invocation.get("import_reference") not in issue_import_references
+                ):
+                    continue
+                invocation_opcode = invocation.get("opcode")
+                if isinstance(invocation_opcode, str) and invocation_opcode.upper() in dangerous_opcodes:
+                    evidence_counts.setdefault(invocation_opcode.upper(), 1)
+
+        raw_metadata_counts = pickle_result.metadata.get("opcode_counts")
+        if not isinstance(raw_metadata_counts, dict):
+            return evidence_counts
+
+        opcode_counts: dict[str, int] = {}
+        for opcode, evidence_count in evidence_counts.items():
+            metadata_count = next(
+                (
+                    value
+                    for key, value in raw_metadata_counts.items()
+                    if isinstance(key, str)
+                    and key.upper() == opcode
+                    and isinstance(value, int)
+                    and not isinstance(value, bool)
+                    and value > 0
+                ),
+                None,
+            )
+            opcode_counts[opcode] = metadata_count if metadata_count is not None else evidence_count
+        return opcode_counts
+
+    @staticmethod
+    def _issue_pickle_opcode_count(issue_message: str, issue_details: dict[str, Any], opcode: str) -> int:
+        """Read structured opcode evidence, with a narrow legacy-message fallback."""
+        has_structured_evidence = False
 
         raw_opcode_counts = issue_details.get("opcode_counts")
         if isinstance(raw_opcode_counts, dict):
-            count = raw_opcode_counts.get(opcode)
-            if isinstance(count, int) and not isinstance(count, bool) and count > 0:
-                return True
+            for key, value in raw_opcode_counts.items():
+                if not isinstance(key, str) or not key:
+                    continue
+                has_structured_evidence = True
+                if key.upper() == opcode and isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                    return value
 
-        return re.search(rf"(?<![A-Z0-9_]){re.escape(opcode)}(?![A-Z0-9_])", issue_message.upper()) is not None
+        for key in ("opcode", "opcode_name"):
+            value = issue_details.get(key)
+            if isinstance(value, str) and value:
+                has_structured_evidence = True
+                if value.upper() == opcode:
+                    return 1
+
+        raw_opcodes = issue_details.get("opcodes")
+        if isinstance(raw_opcodes, (list, tuple, set)):
+            opcode_values = [value for value in raw_opcodes if isinstance(value, str) and value]
+            has_structured_evidence = has_structured_evidence or bool(opcode_values)
+            count = sum(value.upper() == opcode for value in opcode_values)
+            if count > 0:
+                return count
+
+        if has_structured_evidence:
+            return 0
+
+        escaped_opcode = re.escape(opcode)
+        explicit_opcode_pattern = (
+            rf"(?<![A-Z0-9_])(?:{escaped_opcode}\s+OPCODES?|OPCODES?\s*[:=]?\s*{escaped_opcode})(?![A-Z0-9_])"
+        )
+        return int(re.search(explicit_opcode_pattern, issue_message.upper()) is not None)
 
     def extract_metadata(self, file_path: str) -> dict[str, Any]:
         """Extract PyTorch ZIP (torch.save format) metadata."""

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -3645,6 +3645,15 @@ class PyTorchZipScanner(BaseScanner):
         """Return exact counts for dangerous opcode types backed by findings."""
         evidence_counts: dict[str, int] = {}
         supporting_evidence_counts: dict[str, int] = {}
+        raw_metadata_counts = pickle_result.metadata.get("opcode_counts")
+        has_metadata_build = isinstance(raw_metadata_counts, dict) and any(
+            isinstance(key, str)
+            and key.upper() == "BUILD"
+            and isinstance(value, int)
+            and not isinstance(value, bool)
+            and value > 0
+            for key, value in raw_metadata_counts.items()
+        )
         for issue in pickle_result.issues:
             issue_details = issue.details or {}
             target_counts = (
@@ -3655,28 +3664,33 @@ class PyTorchZipScanner(BaseScanner):
                 if count > 0:
                     target_counts[opcode] = target_counts.get(opcode, 0) + count
 
+            if issue.rule_code == "S207" and has_metadata_build:
+                target_counts.setdefault("BUILD", 1)
+
         for opcode, count in supporting_evidence_counts.items():
             evidence_counts.setdefault(opcode, count)
 
-        issue_import_references = {
-            import_reference
-            for issue in pickle_result.issues
-            if isinstance((import_reference := (issue.details or {}).get("import_reference")), str)
-        }
+        issue_import_references: set[str] = set()
+        for issue in pickle_result.issues:
+            issue_details = issue.details or {}
+            for reference_key in ("import_reference", "opener_import_reference", "writer_import_reference"):
+                import_reference = issue_details.get(reference_key)
+                if isinstance(import_reference, str) and import_reference:
+                    issue_import_references.add(import_reference)
+
         raw_callable_invocations = pickle_result.metadata.get("callable_invocations")
         if issue_import_references and isinstance(raw_callable_invocations, list):
             dangerous_opcodes = {opcode for opcode, _risk in _PICKLE_CODE_EXECUTION_OPCODE_RISKS}
             for invocation in raw_callable_invocations:
-                if (
-                    not isinstance(invocation, dict)
-                    or invocation.get("import_reference") not in issue_import_references
-                ):
+                if not isinstance(invocation, dict):
+                    continue
+                invocation_reference = invocation.get("import_reference")
+                if invocation_reference not in issue_import_references:
                     continue
                 invocation_opcode = invocation.get("opcode")
                 if isinstance(invocation_opcode, str) and invocation_opcode.upper() in dangerous_opcodes:
                     evidence_counts.setdefault(invocation_opcode.upper(), 1)
 
-        raw_metadata_counts = pickle_result.metadata.get("opcode_counts")
         if not isinstance(raw_metadata_counts, dict):
             return evidence_counts
 

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -72,6 +72,7 @@ _PICKLE_CODE_EXECUTION_OPCODE_RISKS = (
     ("GLOBAL", "Module import and attribute access"),
     ("BUILD", "__setstate__ method exploitation"),
 )
+_PICKLE_NESTED_EXECUTION_OPCODES = frozenset({"REDUCE", "INST", "OBJ", "NEWOBJ", "NEWOBJ_EX", "BUILD"})
 
 
 @dataclass(frozen=True)
@@ -3529,6 +3530,17 @@ class PyTorchZipScanner(BaseScanner):
         opcode_counts = self._pickle_code_execution_opcode_counts(pickle_result)
         dangerous_opcodes_found = list(opcode_counts)
         code_execution_risks = [risk for opcode, risk in _PICKLE_CODE_EXECUTION_OPCODE_RISKS if opcode in opcode_counts]
+        nested_execution_opcode_evidence = self._has_nested_pickle_execution_opcode_evidence(pickle_result)
+        nested_execution_rule_code = next(
+            (
+                issue.rule_code
+                for issue in pickle_result.issues
+                if (issue.details or {}).get("nested_has_execution_opcode") is True and issue.rule_code is not None
+            ),
+            None,
+        )
+        if nested_execution_opcode_evidence:
+            code_execution_risks.append("Nested pickle code execution opcodes")
 
         # Analyze the pickle scan results for dangerous patterns
         for issue in pickle_result.issues:
@@ -3584,11 +3596,20 @@ class PyTorchZipScanner(BaseScanner):
 
             # Create opcode summary for evidence
             opcode_summary = ", ".join(f"{op}({count})" for op, count in opcode_counts.items())
+            evidence_summary = (
+                f"{opcode_summary} opcodes detected"
+                if opcode_summary
+                else (
+                    "nested pickle code-execution opcodes detected"
+                    if nested_execution_opcode_evidence
+                    else "code-execution patterns detected without attributable opcode metadata"
+                )
+            )
 
             pytorch_result.add_check(
                 name="CVE-2025-32434 Pickle Format Security Analysis",
                 passed=False,
-                message=f"{message_prefix}: {opcode_summary} opcodes detected",
+                message=f"{message_prefix}: {evidence_summary}",
                 severity=severity,
                 location=f"{model_path}:{pickle_name}",
                 details={
@@ -3597,6 +3618,7 @@ class PyTorchZipScanner(BaseScanner):
                     "total_dangerous_opcodes": sum(opcode_counts.values()),
                     "unique_opcode_types": dangerous_opcodes_found,
                     "code_execution_risks": list(set(code_execution_risks)),
+                    "nested_execution_opcode_evidence": nested_execution_opcode_evidence,
                     "import_analysis": import_analysis,
                     "safetensors_available": has_safetensors,
                     "assessment": (
@@ -3612,6 +3634,9 @@ class PyTorchZipScanner(BaseScanner):
                     "affected_pytorch_versions": "All versions ≤2.5.1",
                     "fixed_in": f"PyTorch {self.CVE_2025_32434_FIX_VERSION}",
                 },
+                rule_code=nested_execution_rule_code
+                if not opcode_counts and nested_execution_opcode_evidence
+                else None,
             )
 
         else:
@@ -3640,19 +3665,45 @@ class PyTorchZipScanner(BaseScanner):
                 },
             )
 
+    @staticmethod
+    def _has_nested_pickle_execution_opcode_evidence(pickle_result: ScanResult) -> bool:
+        return any((issue.details or {}).get("nested_has_execution_opcode") is True for issue in pickle_result.issues)
+
+    @staticmethod
+    def _metadata_pickle_opcode_count(opcode: str, *raw_count_maps: object) -> int | None:
+        total = 0
+        found = False
+        for raw_counts in raw_count_maps:
+            if not isinstance(raw_counts, dict):
+                continue
+            for key, value in raw_counts.items():
+                if (
+                    isinstance(key, str)
+                    and key.upper() == opcode
+                    and isinstance(value, int)
+                    and not isinstance(value, bool)
+                    and value > 0
+                ):
+                    total += value
+                    found = True
+        return total if found else None
+
     @classmethod
     def _pickle_code_execution_opcode_counts(cls, pickle_result: ScanResult) -> dict[str, int]:
         """Return exact counts for dangerous opcode types backed by findings."""
         evidence_counts: dict[str, int] = {}
         supporting_evidence_counts: dict[str, int] = {}
         raw_metadata_counts = pickle_result.metadata.get("opcode_counts")
-        has_metadata_build = isinstance(raw_metadata_counts, dict) and any(
-            isinstance(key, str)
-            and key.upper() == "BUILD"
-            and isinstance(value, int)
-            and not isinstance(value, bool)
-            and value > 0
-            for key, value in raw_metadata_counts.items()
+        raw_nested_counts = pickle_result.metadata.get("nested_opcode_counts")
+        raw_follow_on_counts = pickle_result.metadata.get("follow_on_opcode_counts")
+        has_metadata_build = (
+            cls._metadata_pickle_opcode_count(
+                "BUILD",
+                raw_metadata_counts,
+                raw_nested_counts,
+                raw_follow_on_counts,
+            )
+            is not None
         )
         for issue in pickle_result.issues:
             issue_details = issue.details or {}
@@ -3673,7 +3724,12 @@ class PyTorchZipScanner(BaseScanner):
         issue_import_references: set[str] = set()
         for issue in pickle_result.issues:
             issue_details = issue.details or {}
-            for reference_key in ("import_reference", "opener_import_reference", "writer_import_reference"):
+            for reference_key in (
+                "import_reference",
+                "invocation_import_reference",
+                "opener_import_reference",
+                "writer_import_reference",
+            ):
                 import_reference = issue_details.get(reference_key)
                 if isinstance(import_reference, str) and import_reference:
                     issue_import_references.add(import_reference)
@@ -3691,22 +3747,21 @@ class PyTorchZipScanner(BaseScanner):
                 if isinstance(invocation_opcode, str) and invocation_opcode.upper() in dangerous_opcodes:
                     evidence_counts.setdefault(invocation_opcode.upper(), 1)
 
-        if not isinstance(raw_metadata_counts, dict):
-            return evidence_counts
+        if cls._has_nested_pickle_execution_opcode_evidence(pickle_result):
+            for opcode, _risk in _PICKLE_CODE_EXECUTION_OPCODE_RISKS:
+                if opcode not in _PICKLE_NESTED_EXECUTION_OPCODES:
+                    continue
+                metadata_count = cls._metadata_pickle_opcode_count(opcode, raw_nested_counts)
+                if metadata_count is not None:
+                    evidence_counts.setdefault(opcode, metadata_count)
 
         opcode_counts: dict[str, int] = {}
         for opcode, evidence_count in evidence_counts.items():
-            metadata_count = next(
-                (
-                    value
-                    for key, value in raw_metadata_counts.items()
-                    if isinstance(key, str)
-                    and key.upper() == opcode
-                    and isinstance(value, int)
-                    and not isinstance(value, bool)
-                    and value > 0
-                ),
-                None,
+            metadata_count = cls._metadata_pickle_opcode_count(
+                opcode,
+                raw_metadata_counts,
+                raw_nested_counts,
+                raw_follow_on_counts,
             )
             opcode_counts[opcode] = metadata_count if metadata_count is not None else evidence_count
         return opcode_counts

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -62,6 +62,15 @@ _EXECUTABLE_MEMBER_PROBE_BYTES = 1024
 _TORCHSCRIPT_FORBIDDEN_SOURCE_PATTERN = re.compile(
     r"(?im)(?:^\s*(?:import|from)\s+|\b(?:__import__|eval|exec|compile|open)\s*\(|\b(?:os|subprocess|socket|requests)\s*\.)"
 )
+_PICKLE_CODE_EXECUTION_OPCODE_RISKS = (
+    ("REDUCE", "__reduce__ method exploitation"),
+    ("INST", "Class instantiation code execution"),
+    ("OBJ", "Object creation code execution"),
+    ("NEWOBJ", "New-style object creation"),
+    ("STACK_GLOBAL", "Dynamic import and attribute access"),
+    ("GLOBAL", "Module import and attribute access"),
+    ("BUILD", "__setstate__ method exploitation"),
+)
 
 
 @dataclass(frozen=True)
@@ -3525,35 +3534,11 @@ class PyTorchZipScanner(BaseScanner):
             issue_msg = issue.message.lower()
             issue_details = issue.details or {}
 
-            # Look for specific dangerous opcodes
-            if "reduce" in issue_msg or "REDUCE" in str(issue_details):
-                dangerous_opcodes_found.append("REDUCE")
-                opcode_counts["REDUCE"] = opcode_counts.get("REDUCE", 0) + 1
-                code_execution_risks.append("__reduce__ method exploitation")
-            if "inst" in issue_msg or "INST" in str(issue_details):
-                dangerous_opcodes_found.append("INST")
-                opcode_counts["INST"] = opcode_counts.get("INST", 0) + 1
-                code_execution_risks.append("Class instantiation code execution")
-            if "obj" in issue_msg or "OBJ" in str(issue_details):
-                dangerous_opcodes_found.append("OBJ")
-                opcode_counts["OBJ"] = opcode_counts.get("OBJ", 0) + 1
-                code_execution_risks.append("Object creation code execution")
-            if "newobj" in issue_msg or "NEWOBJ" in str(issue_details):
-                dangerous_opcodes_found.append("NEWOBJ")
-                opcode_counts["NEWOBJ"] = opcode_counts.get("NEWOBJ", 0) + 1
-                code_execution_risks.append("New-style object creation")
-            if "stack_global" in issue_msg or "STACK_GLOBAL" in str(issue_details):
-                dangerous_opcodes_found.append("STACK_GLOBAL")
-                opcode_counts["STACK_GLOBAL"] = opcode_counts.get("STACK_GLOBAL", 0) + 1
-                code_execution_risks.append("Dynamic import and attribute access")
-            if "global" in issue_msg or "GLOBAL" in str(issue_details):
-                dangerous_opcodes_found.append("GLOBAL")
-                opcode_counts["GLOBAL"] = opcode_counts.get("GLOBAL", 0) + 1
-                code_execution_risks.append("Module import and attribute access")
-            if "build" in issue_msg or "BUILD" in str(issue_details):
-                dangerous_opcodes_found.append("BUILD")
-                opcode_counts["BUILD"] = opcode_counts.get("BUILD", 0) + 1
-                code_execution_risks.append("__setstate__ method exploitation")
+            for opcode, risk in _PICKLE_CODE_EXECUTION_OPCODE_RISKS:
+                if self._issue_reports_pickle_opcode(issue_msg, issue_details, opcode):
+                    dangerous_opcodes_found.append(opcode)
+                    opcode_counts[opcode] = opcode_counts.get(opcode, 0) + 1
+                    code_execution_risks.append(risk)
 
             # Look for any code execution patterns
             if any(pattern in issue_msg for pattern in ["exec", "eval", "import", "subprocess", "__import__"]):
@@ -3634,6 +3619,7 @@ class PyTorchZipScanner(BaseScanner):
                     "fixed_in": f"PyTorch {self.CVE_2025_32434_FIX_VERSION}",
                 },
             )
+
         else:
             # No dangerous opcodes found - add informational check
             pytorch_result.add_check(
@@ -3659,6 +3645,28 @@ class PyTorchZipScanner(BaseScanner):
                     ),
                 },
             )
+
+    @staticmethod
+    def _issue_reports_pickle_opcode(issue_message: str, issue_details: dict[str, Any], opcode: str) -> bool:
+        """Match exact opcode evidence without treating ordinary word fragments as opcodes."""
+        for key in ("opcode", "opcode_name"):
+            value = issue_details.get(key)
+            if isinstance(value, str) and value.upper() == opcode:
+                return True
+
+        raw_opcodes = issue_details.get("opcodes")
+        if isinstance(raw_opcodes, (list, tuple, set)) and any(
+            isinstance(value, str) and value.upper() == opcode for value in raw_opcodes
+        ):
+            return True
+
+        raw_opcode_counts = issue_details.get("opcode_counts")
+        if isinstance(raw_opcode_counts, dict):
+            count = raw_opcode_counts.get(opcode)
+            if isinstance(count, int) and not isinstance(count, bool) and count > 0:
+                return True
+
+        return re.search(rf"(?<![A-Z0-9_]){re.escape(opcode)}(?![A-Z0-9_])", issue_message.upper()) is not None
 
     def extract_metadata(self, file_path: str) -> dict[str, Any]:
         """Extract PyTorch ZIP (torch.save format) metadata."""

--- a/modelaudit/scanners/rule_mapper.py
+++ b/modelaudit/scanners/rule_mapper.py
@@ -97,7 +97,7 @@ def get_pickle_opcode_rule_code(opcode_name: str) -> str | None:
         return _rule("S202")
     elif opcode_upper == "OBJ":
         return _rule("S203")
-    elif opcode_upper == "NEWOBJ":
+    elif opcode_upper in {"NEWOBJ", "NEWOBJ_EX"}:
         return _rule("S204")
     elif opcode_upper == "STACK_GLOBAL":
         return _rule("S205")

--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `modelaudit-picklescan` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+
+- preserve nested and aliased callable opcode evidence for downstream scanners
+
 ## [0.1.6](https://github.com/promptfoo/modelaudit/compare/modelaudit-picklescan-v0.1.5...modelaudit-picklescan-v0.1.6) (2026-06-05)
 
 ### Bug Fixes

--- a/packages/modelaudit-picklescan/rust/src/nested.rs
+++ b/packages/modelaudit-picklescan/rust/src/nested.rs
@@ -282,10 +282,12 @@ fn oversized_decoded_pickle_prefix_requires_fail_closed(
         })
 }
 
+#[cfg(test)]
 pub(crate) fn looks_like_pickle_payload(value: &[u8], max_bytes: usize) -> bool {
     pickle_payload_extent(value, max_bytes).is_some()
 }
 
+#[cfg(test)]
 pub(crate) fn pickle_payload_extent(value: &[u8], max_bytes: usize) -> Option<usize> {
     pickle_payload_extent_result(value, max_bytes)
         .ok()

--- a/packages/modelaudit-picklescan/rust/src/state.rs
+++ b/packages/modelaudit-picklescan/rust/src/state.rs
@@ -15,8 +15,8 @@ use crate::nested::{
     encoded_literal_may_contain_pickle, encoded_nested_literal_probe_coverage_incomplete,
     encoded_nested_literal_probe_windows_with_limit, encoded_nested_window_char_limit,
     encoded_pickle_consumes_literal, has_binary_pickle_prefix, has_execution_opcode,
-    has_pickle_prefix, looks_like_pickle_payload, nested_pickle_probe_offsets,
-    pickle_payload_extent_result, protocol0_global_or_inst_prefix_has_import_reference_lines,
+    has_pickle_prefix, nested_pickle_probe_offsets, pickle_payload_extent_result,
+    protocol0_global_or_inst_prefix_has_import_reference_lines,
     strict_base64_literal_has_encoded_pickle_candidate,
     strict_base64_literal_raw_execution_probe_offsets, DecodedNestedPayload, NestedProbeOffsets,
     MAX_NESTED_PAYLOAD_PROBES,
@@ -554,6 +554,8 @@ pub(crate) struct ScanState<'a> {
     non_allowlisted_global_imports: Vec<PendingGlobalImportFinding>,
     opcode_count: usize,
     opcode_counts: HashMap<&'static str, usize>,
+    nested_opcode_counts: HashMap<&'static str, usize>,
+    follow_on_opcode_counts: HashMap<&'static str, usize>,
     global_count: usize,
     bytes_scanned: usize,
     first_pickle_end_pos: Option<usize>,
@@ -622,6 +624,8 @@ impl<'a> ScanState<'a> {
             non_allowlisted_global_imports: Vec::new(),
             opcode_count: 0,
             opcode_counts: HashMap::new(),
+            nested_opcode_counts: HashMap::new(),
+            follow_on_opcode_counts: HashMap::new(),
             global_count: 0,
             bytes_scanned: 0,
             first_pickle_end_pos: None,
@@ -7441,9 +7445,22 @@ impl<'a> ScanState<'a> {
         }
         let nested_incomplete = !nested_scan.status.is_complete();
         let nested_import_references = std::mem::take(&mut nested_scan.import_references);
+        let nested_root_opcode_counts = std::mem::take(&mut nested_scan.opcode_counts);
+        let nested_descendant_opcode_counts = std::mem::take(&mut nested_scan.nested_opcode_counts);
+        let nested_follow_on_opcode_counts =
+            std::mem::take(&mut nested_scan.follow_on_opcode_counts);
         self.merge_follow_on_import_references(
             nested_import_references,
             nested_scan.import_references_truncated,
+        );
+        Self::merge_opcode_counts(&mut self.nested_opcode_counts, nested_root_opcode_counts);
+        Self::merge_opcode_counts(
+            &mut self.nested_opcode_counts,
+            nested_descendant_opcode_counts,
+        );
+        Self::merge_opcode_counts(
+            &mut self.nested_opcode_counts,
+            nested_follow_on_opcode_counts,
         );
 
         for nested_finding in nested_scan.findings {
@@ -7669,9 +7686,10 @@ impl<'a> ScanState<'a> {
             .min(start_index.saturating_add(self.options.post_budget_scan_bytes));
         let tail = &self.payload[start_index..scan_end];
         let probe_offsets = nested_pickle_probe_offsets(tail);
+        let mut skip_offsets_before = start_index;
         for relative_offset in probe_offsets.offsets {
             let absolute_offset = start_index.saturating_add(relative_offset);
-            if absolute_offset <= start_index {
+            if absolute_offset <= start_index || absolute_offset < skip_offsets_before {
                 continue;
             }
             let candidate = &self.payload[absolute_offset..scan_end];
@@ -7679,12 +7697,13 @@ impl<'a> ScanState<'a> {
                 return;
             }
             let candidate_probe_len = candidate.len().min(self.options.max_nested_pickle_bytes);
-            if !looks_like_pickle_payload(
+            let Ok(Some(candidate_len)) = pickle_payload_extent_result(
                 &candidate[..candidate_probe_len],
                 self.options.max_nested_pickle_bytes,
-            ) {
+            ) else {
                 continue;
-            }
+            };
+            let candidate = &candidate[..candidate_len];
             let nested_source = format!(
                 "{} (follow-on pickle stream at pos {})",
                 self.source,
@@ -7700,7 +7719,14 @@ impl<'a> ScanState<'a> {
                 Some(self.deadline),
             );
             follow_on_scan.run();
+            skip_offsets_before =
+                skip_offsets_before.max(absolute_offset.saturating_add(candidate_len));
             let had_findings = !follow_on_scan.findings.is_empty();
+            let follow_on_root_opcode_counts = std::mem::take(&mut follow_on_scan.opcode_counts);
+            let follow_on_nested_opcode_counts =
+                std::mem::take(&mut follow_on_scan.nested_opcode_counts);
+            let recursive_follow_on_opcode_counts =
+                std::mem::take(&mut follow_on_scan.follow_on_opcode_counts);
             for finding in follow_on_scan.findings {
                 self.add_finding(finding);
             }
@@ -7711,6 +7737,18 @@ impl<'a> ScanState<'a> {
             self.merge_follow_on_callable_invocations(
                 follow_on_scan.callable_invocations,
                 follow_on_scan.callable_invocations_truncated,
+            );
+            Self::merge_opcode_counts(
+                &mut self.follow_on_opcode_counts,
+                follow_on_root_opcode_counts,
+            );
+            Self::merge_opcode_counts(
+                &mut self.follow_on_opcode_counts,
+                follow_on_nested_opcode_counts,
+            );
+            Self::merge_opcode_counts(
+                &mut self.follow_on_opcode_counts,
+                recursive_follow_on_opcode_counts,
             );
             if had_findings {
                 self.add_notice(Notice {
@@ -7732,6 +7770,15 @@ impl<'a> ScanState<'a> {
                 });
                 return;
             }
+        }
+    }
+
+    fn merge_opcode_counts(
+        target: &mut HashMap<&'static str, usize>,
+        counts: HashMap<&'static str, usize>,
+    ) {
+        for (opcode, count) in counts {
+            *target.entry(opcode).or_insert(0) += count;
         }
     }
 
@@ -7924,6 +7971,16 @@ impl<'a> ScanState<'a> {
             opcode_counts.set_item(opcode, count)?;
         }
         metadata.set_item("opcode_counts", opcode_counts)?;
+        let nested_opcode_counts = PyDict::new(py);
+        for (opcode, count) in &self.nested_opcode_counts {
+            nested_opcode_counts.set_item(opcode, count)?;
+        }
+        metadata.set_item("nested_opcode_counts", nested_opcode_counts)?;
+        let follow_on_opcode_counts = PyDict::new(py);
+        for (opcode, count) in &self.follow_on_opcode_counts {
+            follow_on_opcode_counts.set_item(opcode, count)?;
+        }
+        metadata.set_item("follow_on_opcode_counts", follow_on_opcode_counts)?;
         metadata.set_item("globals_count", self.global_count)?;
         let import_references = PyList::empty(py);
         for reference in &self.import_references {

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -2114,6 +2114,12 @@ def _call_graph_finding_to_report_finding(report: PickleReport, finding: CallGra
             "sink": finding.sink,
             "call_path": list(finding.call_path),
             "analysis": "python_call_graph",
+            **(
+                {"invocation_import_reference": finding.invocation_import_reference}
+                if finding.invocation_import_reference is not None
+                else {}
+            ),
+            **({"opcode": finding.invocation_opcode} if finding.invocation_opcode is not None else {}),
         },
         why=(
             "The pickle imports a Python wrapper whose source code reaches a known RCE-capable primitive when invoked."

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1602,6 +1602,8 @@ class CallGraphFinding:
     import_reference: str
     sink: str
     call_path: tuple[str, ...]
+    invocation_import_reference: str | None = None
+    invocation_opcode: str | None = None
 
 
 @dataclass(frozen=True)
@@ -1762,6 +1764,12 @@ def find_dangerous_call_graphs(
                 import_reference=f"{module}.{name}",
                 sink=sink,
                 call_path=sink_path,
+                invocation_import_reference=(
+                    str(reference["invocation_import_reference"])
+                    if reference.get("invocation_import_reference")
+                    else None
+                ),
+                invocation_opcode=str(reference["opcode"]) if reference.get("opcode") else None,
             )
         )
         if len(findings) >= _MAX_IMPORT_REFERENCES:
@@ -2479,6 +2487,7 @@ def _iter_callable_invocation_references(callable_invocations: object | None) ->
             continue
         opcode = str(item.get("opcode", ""))
         positional_arg_count = item.get("positional_arg_count")
+        invocation_import_reference = f"{module}.{name}"
         for reference_module, reference_name in (
             (module, name),
             *_callable_singleton_aliases(module, name),
@@ -2498,6 +2507,7 @@ def _iter_callable_invocation_references(callable_invocations: object | None) ->
             reference["module"] = reference_module
             reference["name"] = reference_name
             reference["import_reference"] = f"{reference_module}.{reference_name}"
+            reference["invocation_import_reference"] = invocation_import_reference
             normalized.append(reference)
     return tuple(normalized)
 

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -658,6 +658,45 @@ def test_scan_bytes_detects_follow_on_malicious_pickle_streams(separator: bytes)
     assert report.verdict == SafetyVerdict.MALICIOUS
     assert any(notice.code == "follow_on_stream_detected" for notice in report.notices)
     assert any(finding.details.get("import_reference") in SYSTEM_GLOBALS for finding in report.findings)
+    assert report.metadata["follow_on_opcode_counts"]["REDUCE"] == 1
+
+
+def test_scan_bytes_counts_each_follow_on_opcode_once() -> None:
+    follow_on = b"\x80\x04cclick\nopen_file\n)\x810cclick\nopen_file\n)\x810cclick\necho\n)R."
+    payload = pickle.dumps({"safe": True}, protocol=4) + (b"\x00" * 64) + follow_on
+
+    report = scan_bytes(payload, source="follow-on-exact-counts.pkl")
+
+    assert report.metadata["follow_on_opcode_counts"]["GLOBAL"] == 3
+    assert report.metadata["follow_on_opcode_counts"]["NEWOBJ"] == 2
+    assert report.metadata["follow_on_opcode_counts"]["REDUCE"] == 1
+
+
+def test_scan_bytes_counts_separate_follow_on_streams_once() -> None:
+    click_stream = b"\x80\x04cclick\nopen_file\n)\x810cclick\nopen_file\n)\x810cclick\necho\n)R."
+    help_stream = b"\x80\x04\x8c\x08builtins\x8c\x04help\x93)R."
+    padding = b"\x00" * 64
+    payload = pickle.dumps({"safe": True}, protocol=4) + padding + click_stream + padding + help_stream
+
+    report = scan_bytes(payload, source="separate-follow-on-exact-counts.pkl")
+
+    counts = report.metadata["follow_on_opcode_counts"]
+    assert counts["PROTO"] == 2
+    assert counts["STOP"] == 2
+    assert counts["GLOBAL"] == 3
+    assert counts["NEWOBJ"] == 2
+    assert counts["REDUCE"] == 2
+    assert counts["STACK_GLOBAL"] == 1
+
+
+def test_scan_bytes_follow_on_callable_alias_import_without_invocation_has_no_call_graph_finding() -> None:
+    import_only = b"\x80\x04\x8c\x08builtins\x8c\x04help\x93."
+    payload = pickle.dumps({"safe": True}, protocol=4) + (b"\x00" * 64) + import_only
+
+    report = scan_bytes(payload, source="follow-on-callable-alias-import.pkl")
+
+    assert not any(finding.rule_code == "DANGEROUS_CALL_GRAPH" for finding in report.findings)
+    assert report.metadata["follow_on_opcode_counts"]["STACK_GLOBAL"] == 1
 
 
 @pytest.mark.parametrize(
@@ -935,6 +974,19 @@ def test_scan_bytes_recurses_into_nested_persid_payload() -> None:
         finding.rule_code == "PERSISTENT_ID" and finding.details.get("opcode") == "PERSID"
         for finding in report.findings
     )
+
+
+def test_scan_bytes_merges_nested_opcode_counts_without_flattening_invocations() -> None:
+    inner = b"\x80\x04cclick\nopen_file\n)\x810cclick\nopen_file\n)\x810cclick\necho\n)R."
+    outer = pickle.dumps({"inner": inner}, protocol=4)
+
+    report = scan_bytes(outer, source="nested-callable-invocations.pkl")
+
+    assert not report.metadata.get("callable_invocations")
+    assert "NEWOBJ" not in report.metadata["opcode_counts"]
+    assert "REDUCE" not in report.metadata["opcode_counts"]
+    assert report.metadata["nested_opcode_counts"]["NEWOBJ"] == 2
+    assert report.metadata["nested_opcode_counts"]["REDUCE"] == 1
 
 
 def test_scan_bytes_continues_raw_nested_scan_after_data_only_payload() -> None:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -3078,6 +3078,7 @@ def test_call_graph_models_builtins_help_singleton_invocations() -> None:
         {
             "module": "builtins",
             "name": "help",
+            "opcode": "REDUCE",
             "positional_arg_count": 0,
         }
     ]
@@ -3091,6 +3092,8 @@ def test_call_graph_models_builtins_help_singleton_invocations() -> None:
     assert findings[0].name == "_Helper.__call__"
     assert findings[0].sink == "builtins.__import__"
     assert findings[0].call_path == ("_sitebuiltins._Helper.__call__", "builtins.__import__")
+    assert findings[0].invocation_import_reference == "builtins.help"
+    assert findings[0].invocation_opcode == "REDUCE"
 
 
 def test_scan_bytes_ignores_benign_torch_extension_metadata_globals() -> None:
@@ -3788,6 +3791,9 @@ def test_scan_bytes_blocks_builtins_help_singleton_import_rce(tmp_path: Path) ->
         and invocation.get("positional_arg_count") == 0
         for invocation in report.metadata.get("callable_invocations", [])
     )
+    call_graph_finding = next(finding for finding in report.findings if finding.rule_code == "DANGEROUS_CALL_GRAPH")
+    assert call_graph_finding.details["invocation_import_reference"] == "builtins.help"
+    assert call_graph_finding.details["opcode"] == "REDUCE"
 
     assert not marker.exists()
     child_code = """

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -2058,6 +2058,33 @@ def test_legacy_pytorch_container_scans_pickle_after_large_storage(tmp_path: Pat
     assert issue.details["global_position"] == reference["position"]
 
 
+def test_merge_standalone_pickle_segment_adds_scoped_opcode_counts() -> None:
+    scanner = PickleScanner()
+    result = ScanResult(scanner_name=scanner.name, scanner=scanner)
+    result.metadata.update(
+        {
+            "opcode_counts": {"PROTO": 1},
+            "nested_opcode_counts": {"NEWOBJ": 1},
+            "follow_on_opcode_counts": {"REDUCE": 1},
+        }
+    )
+    segment_result = ScanResult(scanner_name=scanner.name, scanner=scanner)
+    segment_result.metadata.update(
+        {
+            "opcode_counts": {"STOP": 1},
+            "nested_opcode_counts": {"NEWOBJ": 2},
+            "follow_on_opcode_counts": {"REDUCE": 2},
+        }
+    )
+
+    scanner._merge_standalone_pickle_segment(result, segment_result, segment_start=10)
+
+    assert result.metadata["opcode_counts"] == {"PROTO": 1, "STOP": 1}
+    assert result.metadata["nested_opcode_counts"] == {"NEWOBJ": 3}
+    assert result.metadata["follow_on_opcode_counts"] == {"REDUCE": 3}
+    assert result.metadata["opcode_count"] == 2
+
+
 def test_legacy_pytorch_complete_suffix_pickles_are_not_retreated_as_binary_tail(tmp_path: Path) -> None:
     payload, _pickle_end = _make_legacy_pytorch_container(b"A")
     storage_end = len(payload)

--- a/tests/scanners/test_picklescan_adapter.py
+++ b/tests/scanners/test_picklescan_adapter.py
@@ -17,6 +17,7 @@ from modelaudit_picklescan import (
 )
 
 from modelaudit.cache.cache_policy import should_cache_scan_result
+from modelaudit.config.rule_config import ModelAuditConfig, set_config
 from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, IssueSeverity
 from modelaudit.scanners.executorch_scanner import ExecuTorchScanner
 from modelaudit.scanners.picklescan_adapter import (
@@ -423,6 +424,7 @@ def test_pickle_report_to_scan_result_falls_back_for_unmapped_persistent_id_opco
         ("PERSISTENT_ID", {"opcode": "BINPERSID"}, "S212"),
         ("PERSISTENT_ID", {"opcode": "CUSTOM_PERSISTENT_OPCODE"}, "S212"),
         ("DANGEROUS_CALL", {"opcode": "REDUCE"}, "S201"),
+        ("DANGEROUS_CALL", {"opcode": "NEWOBJ_EX"}, "S204"),
         ("DANGEROUS_CALL", {"module": "sys", "name": "exit"}, "S102"),
         ("DANGEROUS_CALL", {"module": "builtins", "name": "exec"}, "S104"),
         ("DANGEROUS_CALL", {"module": "custom", "name": "loader"}, "S201"),
@@ -469,6 +471,36 @@ def test_pickle_report_to_scan_result_maps_pickle_rule_codes_to_legacy_namespace
     assert len(result.issues) == 1
     assert result.issues[0].rule_code == expected_legacy_rule_code
     assert result.issues[0].details["pickle_rule_code"] == pickle_rule_code
+
+
+def test_pickle_report_to_scan_result_does_not_suppress_newobj_ex_as_reduce() -> None:
+    set_config(ModelAuditConfig(suppress={"S201"}))
+    report = PickleReport(
+        source="newobj-ex.pkl",
+        status=ScanStatus.COMPLETE,
+        verdict=SafetyVerdict.MALICIOUS,
+        findings=(
+            Finding(
+                message="Found NEWOBJ_EX opcode invoking dangerous global: custom.loader",
+                severity=Severity.CRITICAL,
+                location="newobj-ex.pkl (pos 1)",
+                rule_code="DANGEROUS_CALL",
+                details={
+                    "opcode": "NEWOBJ_EX",
+                    "module": "custom",
+                    "name": "loader",
+                    "import_reference": "custom.loader",
+                },
+            ),
+        ),
+        metadata={"opcode_counts": {"NEWOBJ_EX": 1}},
+    )
+
+    result = pickle_report_to_scan_result(report)
+
+    assert len(result.issues) == 1
+    assert result.issues[0].rule_code == "S204"
+    assert result.issues[0].details["opcode"] == "NEWOBJ_EX"
 
 
 def test_pickle_report_to_scan_result_emits_passed_import_checks() -> None:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -21,6 +21,7 @@ from modelaudit.detectors.suspicious_symbols import CVE_COMBINED_PATTERNS
 from modelaudit.scanner_results import INCONCLUSIVE_SCAN_OUTCOME, Check, ScanResult, mark_inconclusive_scan_result
 from modelaudit.scanners.archive_dispatch import NESTED_SCAN_CALLBACK_CONFIG_KEY
 from modelaudit.scanners.base import CheckStatus, IssueSeverity
+from modelaudit.scanners.pickle_scanner import PickleScanner
 from modelaudit.scanners.pytorch_zip_scanner import PyTorchZipScanner
 from tests.helpers import create_mock_pytorch_zip
 
@@ -8022,6 +8023,25 @@ def _weights_only_analysis_check(result: ScanResult) -> Check:
     return next(check for check in result.checks if check.name == "CVE-2025-32434 Pickle Format Security Analysis")
 
 
+def _legacy_s207_pickle_result(opcode_counts: dict[str, int]) -> ScanResult:
+    scanner = PickleScanner()
+    result = ScanResult(scanner_name="pickle", scanner=scanner)
+    result.metadata["opcode_counts"] = opcode_counts
+    result.metadata["import_references"] = [
+        {
+            "import_reference": "__main__.CustomModel",
+            "module": "__main__",
+            "name": "CustomModel",
+            "opcode": "STACK_GLOBAL",
+            "position": 42,
+            "is_dangerous": False,
+        }
+    ]
+    scanner._add_root_legacy_metadata_detectors(result, "data.pkl")
+    assert any(issue.rule_code == "S207" for issue in result.issues)
+    return result
+
+
 def test_pytorch_zip_cve_2025_32434_empty_imports_stay_suspicious(tmp_path: Path) -> None:
     """Dangerous opcodes without import evidence must not be downgraded to INFO."""
     scanner = PyTorchZipScanner()
@@ -8132,6 +8152,119 @@ def test_pytorch_zip_cve_2025_32434_retains_supporting_only_opcode_evidence(tmp_
     assert check.status == CheckStatus.FAILED
     assert check.severity == IssueSeverity.CRITICAL
     assert check.details["opcode_counts"] == {"NEWOBJ_EX": 1}
+
+
+def test_pytorch_zip_cve_2025_32434_correlates_file_write_call_graph_invocations(tmp_path: Path) -> None:
+    pickle_result = ScanResult(scanner_name="pickle")
+    pickle_result.metadata["opcode_counts"] = {"NEWOBJ": 1, "REDUCE": 1}
+    pickle_result.metadata["callable_invocations"] = [
+        {"import_reference": "click.open_file", "module": "click", "name": "open_file", "opcode": "NEWOBJ"},
+        {"import_reference": "click.echo", "module": "click", "name": "echo", "opcode": "REDUCE"},
+    ]
+    pickle_result.add_check(
+        name="Standalone Pickle Finding",
+        passed=False,
+        message=(
+            "Pickle globals 'click.open_file' and 'click.echo' can open and write "
+            "attacker-controlled files through the installed call graph"
+        ),
+        severity=IssueSeverity.CRITICAL,
+        details={
+            "pickle_rule_code": "DANGEROUS_CALL_GRAPH_FILE_WRITE",
+            "module": "click",
+            "name": "echo",
+            "import_reference": "click.echo",
+            "opener_module": "click",
+            "opener_name": "open_file",
+            "opener_import_reference": "click.open_file",
+        },
+    )
+    pytorch_result = ScanResult(scanner_name="pytorch_zip")
+
+    PyTorchZipScanner()._add_weights_only_safety_warnings(
+        pickle_result,
+        pytorch_result,
+        str(tmp_path / "model.pt"),
+        "data.pkl",
+    )
+
+    check = _weights_only_analysis_check(pytorch_result)
+    assert check.status == CheckStatus.FAILED
+    assert check.details["opcode_counts"] == {"NEWOBJ": 1, "REDUCE": 1}
+
+
+def test_pytorch_zip_cve_2025_32434_reports_real_file_write_call_graph_invocations(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "file_write.pt", with_pickle=False)
+    with zipfile.ZipFile(model_path, "a") as zipf:
+        zipf.writestr("data.pkl", b"\x80\x04cclick\nopen_file\n)\x810cclick\necho\n)R.")
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert any(issue.details.get("pickle_rule_code") == "DANGEROUS_CALL_GRAPH_FILE_WRITE" for issue in result.issues)
+    check = _weights_only_analysis_check(result)
+    assert check.status == CheckStatus.FAILED
+    assert check.details["opcode_counts"] == {"NEWOBJ": 1, "REDUCE": 1}
+
+
+def test_pytorch_zip_cve_2025_32434_file_write_imports_without_invocation_stay_clean(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "file_write_imports.pt", with_pickle=False)
+    with zipfile.ZipFile(model_path, "a") as zipf:
+        zipf.writestr("data.pkl", b"\x80\x04cclick\nopen_file\ncclick\necho\n\x86.")
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    check = _weights_only_analysis_check(result)
+    assert check.status == CheckStatus.PASSED
+    assert check.details["dangerous_opcodes_found"] is False
+
+
+def test_pytorch_zip_cve_2025_32434_includes_s207_metadata_build_evidence(tmp_path: Path) -> None:
+    pickle_result = _legacy_s207_pickle_result({"STACK_GLOBAL": 1, "BUILD": 1})
+    pytorch_result = ScanResult(scanner_name="pytorch_zip")
+
+    PyTorchZipScanner()._add_weights_only_safety_warnings(
+        pickle_result,
+        pytorch_result,
+        str(tmp_path / "model.pt"),
+        "data.pkl",
+    )
+
+    check = _weights_only_analysis_check(pytorch_result)
+    assert check.status == CheckStatus.FAILED
+    assert check.details["opcode_counts"] == {"STACK_GLOBAL": 1, "BUILD": 1}
+
+
+def test_pytorch_zip_cve_2025_32434_does_not_invent_build_for_s207(tmp_path: Path) -> None:
+    pickle_result = _legacy_s207_pickle_result({"STACK_GLOBAL": 1})
+    pytorch_result = ScanResult(scanner_name="pytorch_zip")
+
+    PyTorchZipScanner()._add_weights_only_safety_warnings(
+        pickle_result,
+        pytorch_result,
+        str(tmp_path / "model.pt"),
+        "data.pkl",
+    )
+
+    check = _weights_only_analysis_check(pytorch_result)
+    assert check.status == CheckStatus.FAILED
+    assert check.details["opcode_counts"] == {"STACK_GLOBAL": 1}
+
+
+def test_pytorch_zip_cve_2025_32434_ignores_unreported_build_metadata(tmp_path: Path) -> None:
+    pickle_result = ScanResult(scanner_name="pickle")
+    pickle_result.metadata["opcode_counts"] = {"BUILD": 1}
+    pytorch_result = ScanResult(scanner_name="pytorch_zip")
+
+    PyTorchZipScanner()._add_weights_only_safety_warnings(
+        pickle_result,
+        pytorch_result,
+        str(tmp_path / "model.pt"),
+        "data.pkl",
+    )
+
+    check = _weights_only_analysis_check(pytorch_result)
+    assert check.status == CheckStatus.PASSED
+    assert check.details["dangerous_opcodes_found"] is False
 
 
 def test_pytorch_zip_cve_2025_32434_ignores_benign_opcode_near_matches(tmp_path: Path) -> None:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -27,6 +27,15 @@ from tests.helpers import create_mock_pytorch_zip
 _ASSETS_DIR = Path(__file__).resolve().parents[1] / "assets"
 
 
+class _NewObjExImportGadget:
+    def __new__(cls, *, module_name: str) -> "_NewObjExImportGadget":
+        __import__(module_name)
+        return super().__new__(cls)
+
+    def __getnewargs_ex__(self) -> tuple[tuple[object, ...], dict[str, object]]:
+        return (), {"module_name": "subprocess"}
+
+
 def _corrupt_zip_member_crc(zip_path: Path, member_name: str) -> None:
     """Patch ZIP headers so one member reports an incorrect CRC without changing data."""
     with zipfile.ZipFile(zip_path, "r") as zip_file:
@@ -59,6 +68,10 @@ def _malicious_eval_pickle_payload() -> bytes:
             return (eval, ("print('pwned')",))
 
     return pickle.dumps({"payload": MaliciousClass()})
+
+
+def _malicious_newobj_ex_pickle_payload() -> bytes:
+    return pickle.dumps(object.__new__(_NewObjExImportGadget), protocol=4)
 
 
 def _malicious_proto0_system_payload() -> bytes:
@@ -8023,7 +8036,7 @@ def test_pytorch_zip_cve_2025_32434_empty_imports_stay_suspicious(tmp_path: Path
     assert check.details["import_analysis"]["total_imports"] == 0
 
 
-def test_pytorch_zip_cve_2025_32434_ignores_opcode_name_substrings(tmp_path: Path) -> None:
+def test_pytorch_zip_cve_2025_32434_ignores_opcode_name_substrings_and_prose(tmp_path: Path) -> None:
     pickle_result = _pickle_result_with_reduce("numpy.core.multiarray._reconstruct")
     pickle_result.add_check(
         name="Dangerous Pickle Call Graph",
@@ -8048,7 +8061,8 @@ def test_pytorch_zip_cve_2025_32434_ignores_opcode_name_substrings(tmp_path: Pat
     )
 
     check = _weights_only_analysis_check(pytorch_result)
-    assert check.details["opcode_counts"] == {"REDUCE": 1, "GLOBAL": 1}
+    assert check.details["opcode_counts"] == {"REDUCE": 1}
+    assert "GLOBAL" not in check.details["unique_opcode_types"]
     assert "INST" not in check.details["unique_opcode_types"]
     assert "OBJ" not in check.details["unique_opcode_types"]
 
@@ -8073,6 +8087,74 @@ def test_pytorch_zip_cve_2025_32434_does_not_double_count_stack_global(tmp_path:
 
     check = _weights_only_analysis_check(pytorch_result)
     assert check.details["opcode_counts"] == {"STACK_GLOBAL": 1}
+
+
+def test_pytorch_zip_cve_2025_32434_reports_newobj_ex(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "newobj_ex.pt", with_pickle=False)
+    with zipfile.ZipFile(model_path, "a") as zipf:
+        zipf.writestr("data.pkl", _malicious_newobj_ex_pickle_payload())
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    check = _weights_only_analysis_check(result)
+    assert check.status == CheckStatus.FAILED
+    assert check.details["opcode_counts"] == {"STACK_GLOBAL": 1, "NEWOBJ_EX": 1}
+    assert check.details["total_dangerous_opcodes"] == 2
+    assert set(check.details["unique_opcode_types"]) == {"STACK_GLOBAL", "NEWOBJ_EX"}
+    assert "NEWOBJ" not in check.details["unique_opcode_types"]
+    assert "OBJ" not in check.details["unique_opcode_types"]
+
+
+def test_pytorch_zip_cve_2025_32434_retains_supporting_only_opcode_evidence(tmp_path: Path) -> None:
+    pickle_result = ScanResult(scanner_name="pickle")
+    pickle_result.metadata["opcode_counts"] = {"NEWOBJ_EX": 1}
+    pickle_result.add_check(
+        name="NEWOBJ_EX Opcode Safety Check",
+        passed=False,
+        message="Found NEWOBJ_EX opcode invoking dangerous global: builtins.compile",
+        severity=IssueSeverity.CRITICAL,
+        details={
+            "opcode": "NEWOBJ_EX",
+            "import_reference": "builtins.compile",
+            "supporting_rule_code": True,
+        },
+    )
+    pytorch_result = ScanResult(scanner_name="pytorch_zip")
+
+    PyTorchZipScanner()._add_weights_only_safety_warnings(
+        pickle_result,
+        pytorch_result,
+        str(tmp_path / "model.pt"),
+        "data.pkl",
+    )
+
+    check = _weights_only_analysis_check(pytorch_result)
+    assert check.status == CheckStatus.FAILED
+    assert check.severity == IssueSeverity.CRITICAL
+    assert check.details["opcode_counts"] == {"NEWOBJ_EX": 1}
+
+
+def test_pytorch_zip_cve_2025_32434_ignores_benign_opcode_near_matches(tmp_path: Path) -> None:
+    pickle_result = ScanResult(scanner_name="pickle")
+    pickle_result.add_check(
+        name="Pickle Metadata Diagnostic",
+        passed=False,
+        message=("Global build analysis reduced an installed object with newobject and stack_globalized metadata"),
+        severity=IssueSeverity.INFO,
+        details={"analysis": "metadata_diagnostic"},
+    )
+    pytorch_result = ScanResult(scanner_name="pytorch_zip")
+
+    PyTorchZipScanner()._add_weights_only_safety_warnings(
+        pickle_result,
+        pytorch_result,
+        str(tmp_path / "model.pt"),
+        "data.pkl",
+    )
+
+    check = _weights_only_analysis_check(pytorch_result)
+    assert check.status == CheckStatus.PASSED
+    assert check.details["dangerous_opcodes_found"] is False
 
 
 @pytest.mark.parametrize(

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import pickle
 import stat
@@ -8042,6 +8043,26 @@ def _legacy_s207_pickle_result(opcode_counts: dict[str, int]) -> ScanResult:
     return result
 
 
+@pytest.mark.parametrize(
+    ("message", "details", "opcode", "expected_count"),
+    [
+        ("ignored", {"opcode_name": "BUILD"}, "BUILD", 1),
+        ("ignored", {"opcodes": ["OBJ", "OBJ", "REDUCE"]}, "OBJ", 2),
+        ("ignored", {"opcode_counts": {"NEWOBJ_EX": 2}}, "NEWOBJ_EX", 2),
+        ("Found GLOBAL opcode", {}, "GLOBAL", 1),
+        ("Found NEWOBJ_EXTRA opcode", {}, "NEWOBJ", 0),
+        ("Found BUILD opcode", {"opcode_counts": {"BUILD": True}}, "BUILD", 0),
+    ],
+)
+def test_pytorch_zip_cve_2025_32434_reads_exact_opcode_evidence(
+    message: str,
+    details: dict[str, Any],
+    opcode: str,
+    expected_count: int,
+) -> None:
+    assert PyTorchZipScanner._issue_pickle_opcode_count(message, details, opcode) == expected_count
+
+
 def test_pytorch_zip_cve_2025_32434_empty_imports_stay_suspicious(tmp_path: Path) -> None:
     """Dangerous opcodes without import evidence must not be downgraded to INFO."""
     scanner = PyTorchZipScanner()
@@ -8118,6 +8139,7 @@ def test_pytorch_zip_cve_2025_32434_reports_newobj_ex(tmp_path: Path) -> None:
 
     check = _weights_only_analysis_check(result)
     assert check.status == CheckStatus.FAILED
+    assert check.rule_code == "S204"
     assert check.details["opcode_counts"] == {"STACK_GLOBAL": 1, "NEWOBJ_EX": 1}
     assert check.details["total_dangerous_opcodes"] == 2
     assert set(check.details["unique_opcode_types"]) == {"STACK_GLOBAL", "NEWOBJ_EX"}
@@ -8204,6 +8226,177 @@ def test_pytorch_zip_cve_2025_32434_reports_real_file_write_call_graph_invocatio
     check = _weights_only_analysis_check(result)
     assert check.status == CheckStatus.FAILED
     assert check.details["opcode_counts"] == {"NEWOBJ": 1, "REDUCE": 1}
+
+
+def test_pytorch_zip_cve_2025_32434_reports_nested_execution_opcode_counts(tmp_path: Path) -> None:
+    inner = b"\x80\x04cclick\nopen_file\n)\x810cclick\nopen_file\n)\x810cclick\necho\n)R."
+    model_path = create_mock_pytorch_zip(tmp_path / "nested_file_write.pt", with_pickle=False)
+    with zipfile.ZipFile(model_path, "a") as zipf:
+        zipf.writestr("data.pkl", pickle.dumps({"payload": inner}, protocol=4))
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert any(issue.details.get("nested_has_execution_opcode") is True for issue in result.issues)
+    check = _weights_only_analysis_check(result)
+    assert check.status == CheckStatus.FAILED
+    assert check.details["opcode_counts"] == {"NEWOBJ": 2, "REDUCE": 1}
+
+
+def test_pytorch_zip_cve_2025_32434_does_not_correlate_separate_nested_streams(tmp_path: Path) -> None:
+    opener = b"\x80\x04cclick\nopen_file\n)\x81."
+    writer = b"\x80\x04cclick\necho\n)R."
+    model_path = create_mock_pytorch_zip(tmp_path / "separate_nested_streams.pt", with_pickle=False)
+    with zipfile.ZipFile(model_path, "a") as zipf:
+        zipf.writestr("data.pkl", pickle.dumps({"opener": opener, "writer": writer}, protocol=4))
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert not any(
+        issue.details.get("pickle_rule_code") == "DANGEROUS_CALL_GRAPH_FILE_WRITE" for issue in result.issues
+    )
+    check = _weights_only_analysis_check(result)
+    assert check.status == CheckStatus.FAILED
+    assert check.details["opcode_counts"] == {"NEWOBJ": 1, "REDUCE": 1}
+
+
+def test_pytorch_zip_cve_2025_32434_reports_encoded_nested_execution_opcodes(tmp_path: Path) -> None:
+    inner = b"\x80\x04cclick\nopen_file\n)\x810cclick\necho\n)R."
+    model_path = create_mock_pytorch_zip(tmp_path / "encoded_nested.pt", with_pickle=False)
+    with zipfile.ZipFile(model_path, "a") as zipf:
+        zipf.writestr("data.pkl", pickle.dumps({"payload": base64.b64encode(inner).decode()}, protocol=4))
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert any(
+        issue.rule_code == "S601" and issue.details.get("nested_has_execution_opcode") is True
+        for issue in result.issues
+    )
+    check = _weights_only_analysis_check(result)
+    assert check.status == CheckStatus.FAILED
+    assert check.details["opcode_counts"] == {"NEWOBJ": 1, "REDUCE": 1}
+
+
+def test_pytorch_zip_cve_2025_32434_nested_evidence_does_not_unlock_outer_opcodes(tmp_path: Path) -> None:
+    pickle_result = ScanResult(scanner_name="pickle")
+    pickle_result.metadata["opcode_counts"] = {"STACK_GLOBAL": 1, "REDUCE": 1}
+    pickle_result.metadata["nested_opcode_counts"] = {"NEWOBJ": 1}
+    pickle_result.add_check(
+        name="Standalone Pickle Finding",
+        passed=False,
+        message="Nested pickle payload detected",
+        severity=IssueSeverity.CRITICAL,
+        details={"nested_has_execution_opcode": True},
+        rule_code="S213",
+    )
+    pytorch_result = ScanResult(scanner_name="pytorch_zip")
+
+    PyTorchZipScanner()._add_weights_only_safety_warnings(
+        pickle_result,
+        pytorch_result,
+        str(tmp_path / "model.pt"),
+        "data.pkl",
+    )
+
+    check = _weights_only_analysis_check(pytorch_result)
+    assert check.status == CheckStatus.FAILED
+    assert check.details["opcode_counts"] == {"NEWOBJ": 1}
+
+
+@pytest.mark.parametrize("nested_rule_code", ["S213", "S601"])
+def test_pytorch_zip_cve_2025_32434_fails_closed_for_legacy_nested_execution_evidence(
+    tmp_path: Path,
+    nested_rule_code: str,
+) -> None:
+    pickle_result = ScanResult(scanner_name="pickle")
+    pickle_result.add_check(
+        name="Standalone Pickle Finding",
+        passed=False,
+        message="Nested pickle payload detected",
+        severity=IssueSeverity.CRITICAL,
+        details={"nested_has_execution_opcode": True},
+        rule_code=nested_rule_code,
+    )
+    pytorch_result = ScanResult(scanner_name="pytorch_zip")
+
+    PyTorchZipScanner()._add_weights_only_safety_warnings(
+        pickle_result,
+        pytorch_result,
+        str(tmp_path / "model.pt"),
+        "data.pkl",
+    )
+
+    check = _weights_only_analysis_check(pytorch_result)
+    assert check.status == CheckStatus.FAILED
+    assert check.rule_code == nested_rule_code
+    assert check.details["opcode_counts"] == {}
+    assert check.details["nested_execution_opcode_evidence"] is True
+
+
+def test_pytorch_zip_cve_2025_32434_correlates_callable_singleton_alias(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "callable_alias.pt", with_pickle=False)
+    with zipfile.ZipFile(model_path, "a") as zipf:
+        zipf.writestr("data.pkl", b"\x80\x04\x8c\x08builtins\x8c\x04help\x93)R.")
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert any(
+        issue.details.get("pickle_rule_code") == "DANGEROUS_CALL_GRAPH"
+        and issue.details.get("invocation_import_reference") == "builtins.help"
+        and issue.details.get("opcode") == "REDUCE"
+        for issue in result.issues
+    )
+    check = _weights_only_analysis_check(result)
+    assert check.status == CheckStatus.FAILED
+    assert check.details["opcode_counts"] == {"REDUCE": 1}
+
+
+def test_pytorch_zip_cve_2025_32434_correlates_all_callable_singleton_alias_invocations(tmp_path: Path) -> None:
+    pickle_result = ScanResult(scanner_name="pickle")
+    pickle_result.metadata["opcode_counts"] = {"NEWOBJ": 1, "REDUCE": 1}
+    pickle_result.metadata["callable_invocations"] = [
+        {"import_reference": "builtins.help", "opcode": "NEWOBJ"},
+        {"import_reference": "builtins.help", "opcode": "REDUCE"},
+    ]
+    pickle_result.add_check(
+        name="Standalone Pickle Finding",
+        passed=False,
+        message=(
+            "Pickle global '_sitebuiltins._Helper.__call__' reaches dangerous Python primitive "
+            "'builtins.__import__' through the installed call graph"
+        ),
+        severity=IssueSeverity.CRITICAL,
+        details={
+            "import_reference": "_sitebuiltins._Helper.__call__",
+            "invocation_import_reference": "builtins.help",
+            "opcode": "REDUCE",
+        },
+    )
+    pytorch_result = ScanResult(scanner_name="pytorch_zip")
+
+    PyTorchZipScanner()._add_weights_only_safety_warnings(
+        pickle_result,
+        pytorch_result,
+        str(tmp_path / "model.pt"),
+        "data.pkl",
+    )
+
+    check = _weights_only_analysis_check(pytorch_result)
+    assert check.status == CheckStatus.FAILED
+    assert check.details["opcode_counts"] == {"NEWOBJ": 1, "REDUCE": 1}
+
+
+def test_pytorch_zip_cve_2025_32434_callable_singleton_import_without_invocation_stays_clean(
+    tmp_path: Path,
+) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "callable_alias_import.pt", with_pickle=False)
+    with zipfile.ZipFile(model_path, "a") as zipf:
+        zipf.writestr("data.pkl", b"\x80\x04\x8c\x08builtins\x8c\x04help\x93.")
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    check = _weights_only_analysis_check(result)
+    assert check.status == CheckStatus.PASSED
+    assert check.details["dangerous_opcodes_found"] is False
 
 
 def test_pytorch_zip_cve_2025_32434_file_write_imports_without_invocation_stay_clean(tmp_path: Path) -> None:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -8016,6 +8016,58 @@ def test_pytorch_zip_cve_2025_32434_empty_imports_stay_suspicious(tmp_path: Path
     assert check.details["import_analysis"]["total_imports"] == 0
 
 
+def test_pytorch_zip_cve_2025_32434_ignores_opcode_name_substrings(tmp_path: Path) -> None:
+    pickle_result = _pickle_result_with_reduce("numpy.core.multiarray._reconstruct")
+    pickle_result.add_check(
+        name="Dangerous Pickle Call Graph",
+        passed=False,
+        message=(
+            "Pickle global 'numpy.core.multiarray._reconstruct' reaches dangerous Python "
+            "primitive 'builtins.__import__' through the installed call graph"
+        ),
+        severity=IssueSeverity.CRITICAL,
+        details={
+            "import_reference": "numpy.core.multiarray._reconstruct",
+            "analysis": "python_call_graph",
+        },
+    )
+    pytorch_result = ScanResult(scanner_name="pytorch_zip")
+
+    PyTorchZipScanner()._add_weights_only_safety_warnings(
+        pickle_result,
+        pytorch_result,
+        str(tmp_path / "model.pt"),
+        "data.pkl",
+    )
+
+    check = _weights_only_analysis_check(pytorch_result)
+    assert check.details["opcode_counts"] == {"REDUCE": 1, "GLOBAL": 1}
+    assert "INST" not in check.details["unique_opcode_types"]
+    assert "OBJ" not in check.details["unique_opcode_types"]
+
+
+def test_pytorch_zip_cve_2025_32434_does_not_double_count_stack_global(tmp_path: Path) -> None:
+    pickle_result = ScanResult(scanner_name="pickle")
+    pickle_result.add_check(
+        name="Dangerous Pickle Opcode",
+        passed=False,
+        message="STACK_GLOBAL opcode detected",
+        severity=IssueSeverity.WARNING,
+        details={"opcode": "STACK_GLOBAL"},
+    )
+    pytorch_result = ScanResult(scanner_name="pytorch_zip")
+
+    PyTorchZipScanner()._add_weights_only_safety_warnings(
+        pickle_result,
+        pytorch_result,
+        str(tmp_path / "model.pt"),
+        "data.pkl",
+    )
+
+    check = _weights_only_analysis_check(pytorch_result)
+    assert check.details["opcode_counts"] == {"STACK_GLOBAL": 1}
+
+
 @pytest.mark.parametrize(
     "import_reference",
     [

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -533,7 +533,8 @@ class TestRulePatterns:
             ("pickle opcode REDUCE detected", "S201"),
             ("dangerous INST opcode", "S202"),
             ("pickle OBJ found", "S203"),
-            ("NEWOBJ opcode", "S203"),  # Matches OBJ pattern first
+            ("NEWOBJ opcode", "S204"),
+            ("NEWOBJ_EX opcode", "S204"),
             ("STACK_GLOBAL opcode", "S205"),
             ("GLOBAL opcode imports module", "S206"),
         ]


### PR DESCRIPTION
## Summary

- derive PyTorch ZIP pickle opcode summaries from exact opcode evidence
- stop treating substrings in prose as pickle opcodes
- avoid double-counting `STACK_GLOBAL` as `GLOBAL`

## Campaign evidence

The Hugging Face campaign reported `INST` in four FairFace RNG-state artifacts even though the underlying pickle evidence contained no `INST` opcode. The aggregate was produced by matching `inst` inside the phrase "through the installed call graph".

The same substring logic also counted `STACK_GLOBAL` as both `STACK_GLOBAL` and `GLOBAL`.

## Validation

- `pytest -q tests/scanners/test_pytorch_zip_scanner.py -k 'cve_2025_32434'` (`23 passed`)
- `ruff format --check modelaudit/scanners/pytorch_zip_scanner.py tests/scanners/test_pytorch_zip_scanner.py`
- `ruff check modelaudit/scanners/pytorch_zip_scanner.py tests/scanners/test_pytorch_zip_scanner.py`
- `mypy modelaudit/scanners/pytorch_zip_scanner.py tests/scanners/test_pytorch_zip_scanner.py`
