### PR TITLE
fix(rules): attribute format mismatches to s901

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- attribute core format-mismatch findings directly to S901 instead of message-matching unrelated rules
+- attribute core file-type validation failures directly to S901 instead of message-matching unrelated rules
 - preserve sanitized CatBoost command context in SARIF without exposing injected or neighboring credential values
 - redact values compared against sensitive keys in generic exports and literal credential comparisons in CatBoost evidence
 - preserve critical PyTorch malformed-ZIP symlink findings, valid Python 3.10 streamed ZIP64 descriptors, and selected subtype findings from complete nested and concatenated HDF5 user-block ZIPs while retaining bounded fail-closed preflight checks and avoiding structure-only ZIP route probes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- attribute core format-mismatch findings directly to S901 instead of message-matching unrelated rules
 - classify unsafe PyTorch ZIP symlink targets as critical archive-link findings while preserving safe relative links
 - restore pickle CVE scan throughput, reprobe malformed stream separators, and route four-byte protocol-0 Joblib operands correctly
 - bound manifest embedded-Jinja template collection while preserving findings across deep branches, cycles, and shared YAML aliases

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -4159,6 +4159,7 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
                 "header_format": detail_header_format,
                 "file_type_validation_failed": not file_type_valid,
             },
+            rule_code="S901",
         )
 
     # Ensure bytes_scanned reflects the actual file size even when a scanner

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -4164,7 +4164,7 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
                 "header_format": detail_header_format,
                 "file_type_validation_failed": not file_type_valid,
             },
-            rule_code="S901",
+            rule_code="S901" if not file_type_valid else None,
         )
 
     # Ensure bytes_scanned reflects the actual file size even when a scanner

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import tarfile
 import zipfile
+import zlib
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -26,8 +27,10 @@ from modelaudit import core as core_module
 from modelaudit.analysis.unified_context import UnifiedMLContext
 from modelaudit.cache import get_cache_manager, reset_cache_manager
 from modelaudit.cache.optimized_config import normalize_material_scan_config
+from modelaudit.config import ModelAuditConfig, set_config
 from modelaudit.core import determine_exit_code, scan_file, scan_model_directory_or_file
 from modelaudit.models import ModelAuditResultModel
+from modelaudit.rules import Severity
 from modelaudit.scanners import (
     archive_dispatch,
     flax_msgpack_scanner,
@@ -8881,16 +8884,61 @@ def test_scan_file_routes_onnx_pb_by_content(tmp_path: Path) -> None:
 
 
 def test_scan_file_attributes_format_mismatch_to_s901(tmp_path: Path) -> None:
-    header_length = 0x9C78
-    metadata = b'{"tensor":{"dtype":"U8","shape":[1],"data_offsets":[0,1]}}'
-    metadata += b" " * (header_length - len(metadata))
     model_path = tmp_path / "model.safetensors"
-    model_path.write_bytes(struct.pack("<Q", header_length) + metadata + b"\x00")
+    malicious_pickle = b"cbuiltins\neval\n(S'1+1'\ntR."
+    model_path.write_bytes(zlib.compress(malicious_pickle))
 
     result = scan_file(str(model_path), config={"cache_scan_results": False})
-    format_check = next(check for check in result.checks if check.name == "Format Validation")
+    format_check = next(
+        check for check in result.checks if check.name == "Format Validation" and check.location == str(model_path)
+    )
+    format_issue = next(
+        issue for issue in result.issues if issue.message == format_check.message and issue.location == str(model_path)
+    )
 
+    assert format_check.status == CheckStatus.FAILED
     assert format_check.rule_code == "S901"
+    assert format_check.details == {
+        "extension_format": "safetensors",
+        "header_format": "zlib",
+        "file_type_validation_failed": True,
+    }
+    assert format_issue.rule_code == "S901"
+    assert any(issue.rule_code == "S104" and "builtins.eval" in issue.message for issue in result.issues)
+
+
+def test_scan_file_accepts_matching_zlib_format_without_mismatch(tmp_path: Path) -> None:
+    model_path = tmp_path / "model.zlib"
+    model_path.write_bytes(zlib.compress(b"benign model metadata"))
+
+    result = scan_file(str(model_path), config={"cache_scan_results": False})
+
+    assert result.scanner_name == "compressed"
+    assert result.success is True
+    assert not any(check.name == "Format Validation" for check in result.checks)
+    assert not any(issue.rule_code == "S901" for issue in result.issues)
+
+
+def test_scan_file_does_not_attribute_compatible_container_discrepancy_to_s901(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "model.pt")
+    rule_config = ModelAuditConfig()
+    rule_config.severity = {"S901": Severity.CRITICAL}
+    set_config(rule_config)
+
+    result = scan_file(str(model_path), config={"cache_scan_results": False})
+    format_check = next(
+        check for check in result.checks if check.name == "Format Validation" and check.location == str(model_path)
+    )
+    format_issue = next(
+        issue for issue in result.issues if issue.message == format_check.message and issue.location == str(model_path)
+    )
+
+    assert result.success is True
+    assert format_check.details["file_type_validation_failed"] is False
+    assert format_check.rule_code is None
+    assert format_check.severity == IssueSeverity.DEBUG
+    assert format_issue.rule_code is None
+    assert format_issue.severity == IssueSeverity.DEBUG
 
 
 def test_scan_file_detects_malicious_onnx_pb_by_content(tmp_path: Path) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8542,6 +8542,19 @@ def test_scan_file_routes_onnx_pb_by_content(tmp_path: Path) -> None:
     assert not any(check.name == "Format Validation" for check in result.checks)
 
 
+def test_scan_file_attributes_format_mismatch_to_s901(tmp_path: Path) -> None:
+    header_length = 0x9C78
+    metadata = b'{"tensor":{"dtype":"U8","shape":[1],"data_offsets":[0,1]}}'
+    metadata += b" " * (header_length - len(metadata))
+    model_path = tmp_path / "model.safetensors"
+    model_path.write_bytes(struct.pack("<Q", header_length) + metadata + b"\x00")
+
+    result = scan_file(str(model_path), config={"cache_scan_results": False})
+    format_check = next(check for check in result.checks if check.name == "Format Validation")
+
+    assert format_check.rule_code == "S901"
+
+
 def test_scan_file_detects_malicious_onnx_pb_by_content(tmp_path: Path) -> None:
     pytest.importorskip("onnx")
     onnx_pb = tmp_path / "malicious.pb"


### PR DESCRIPTION
## Summary

- assign failed core file-format validation checks directly to `S901`
- prevent incidental terms such as `zlib` from relabeling those checks as `S603`
- keep compatible container discrepancies at DEBUG without an S901 code, so severity overrides cannot promote benign wrappers
- retain existing message-based rule inference for legacy scanner checks

## Campaign evidence

A SafeTensors/zlib routing collision produced both an S901 mismatch and a duplicate S603 finding. Core emitted `Format Validation` without a rule code, so `ScanResult` selected the first catalog regex matching the message. The word `zlib` matched S603 before the later S901 mismatch rule.

The routing collision is handled separately in #1623. This PR uses a genuine zlib-wrapped malicious payload to isolate rule attribution from that routing fix.

## Validation

- focused attribution, malicious-positive, benign-negative, compatible-container, and ONNX routing regressions: 5 passed
- Ruff format and lint pass across required source and test paths
- mypy passes across 473 source files
- full non-slow/non-integration run reached 12,409 passed and 359 skipped; the two local failures were unrelated (read-only HOME cache access and a pre-existing shard-alias test)
