### PR TITLE
fix(onnx): classify custom operator domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- assign ONNX custom operator domains to a dedicated framework rule instead of the HTTP-client S302 rule
+- assign ONNX custom operator domains to the dedicated S1111 framework rule instead of the HTTP-client S302 rule
 - preserve sanitized CatBoost command context in SARIF without exposing injected or neighboring credential values
 - redact values compared against sensitive keys in generic exports and literal credential comparisons in CatBoost evidence
 - preserve critical PyTorch malformed-ZIP symlink findings, valid Python 3.10 streamed ZIP64 descriptors, and selected subtype findings from complete nested and concatenated HDF5 user-block ZIPs while retaining bounded fail-closed preflight checks and avoiding structure-only ZIP route probes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- assign ONNX custom operator domains to a dedicated framework rule instead of the HTTP-client S302 rule
 - classify unsafe PyTorch ZIP symlink targets as critical archive-link findings while preserving safe relative links
 - restore pickle CVE scan throughput, reprobe malformed stream separators, and route four-byte protocol-0 Joblib operands correctly
 - bound manifest embedded-Jinja template collection while preserving findings across deep branches, cycles, and shared YAML aliases

--- a/RULES.md
+++ b/RULES.md
@@ -33,7 +33,7 @@ modelaudit scan --suppress S101 --severity S301=HIGH model.pkl
 
 ## Rule Catalog
 
-The catalog currently contains 113 rules.
+The catalog currently contains 114 rules.
 
 ### Module And Import Security
 
@@ -190,18 +190,19 @@ The catalog currently contains 113 rules.
 
 ### Framework-Specific Risks
 
-| Code    | Default severity | Name                        | Description                           |
-| ------- | ---------------- | --------------------------- | ------------------------------------- |
-| `S1101` | HIGH             | PyTorch unsafe load         | torch.load without weights_only=True  |
-| `S1102` | MEDIUM           | TensorFlow SavedModel risks | TensorFlow SavedModel security issues |
-| `S1103` | MEDIUM           | Keras Lambda layers         | Keras Lambda layers with code         |
-| `S1104` | LOW              | ONNX opset version          | ONNX version compatibility issue      |
-| `S1105` | MEDIUM           | JAX compilation risks       | JAX JIT compilation security          |
-| `S1106` | MEDIUM           | MXNet custom operators      | MXNet custom operator risks           |
-| `S1107` | MEDIUM           | PaddlePaddle dynamic graph  | PaddlePaddle dynamic mode risks       |
-| `S1108` | MEDIUM           | CoreML custom layers        | CoreML custom layer risks             |
-| `S1109` | MEDIUM           | TensorRT plugins            | TensorRT plugin security              |
-| `S1110` | LOW              | GGUF/GGML format risks      | GGUF/GGML format security issues      |
+| Code    | Default severity | Name                         | Description                                                         |
+| ------- | ---------------- | ---------------------------- | ------------------------------------------------------------------- |
+| `S1101` | HIGH             | PyTorch unsafe load          | torch.load without weights_only=True                                |
+| `S1102` | MEDIUM           | TensorFlow SavedModel risks  | TensorFlow SavedModel security issues                               |
+| `S1103` | MEDIUM           | Keras Lambda layers          | Keras Lambda layers with code                                       |
+| `S1104` | LOW              | ONNX opset version           | ONNX version compatibility issue                                    |
+| `S1105` | MEDIUM           | JAX compilation risks        | JAX JIT compilation security                                        |
+| `S1106` | MEDIUM           | MXNet custom operators       | MXNet custom operator risks                                         |
+| `S1107` | MEDIUM           | PaddlePaddle dynamic graph   | PaddlePaddle dynamic mode risks                                     |
+| `S1108` | MEDIUM           | CoreML custom layers         | CoreML custom layer risks                                           |
+| `S1109` | MEDIUM           | TensorRT plugins             | TensorRT plugin security                                            |
+| `S1110` | LOW              | GGUF/GGML format risks       | GGUF/GGML format security issues                                    |
+| `S1111` | INFO             | ONNX custom operator domains | ONNX model may depend on an external custom operator implementation |
 
 ## Maintenance
 

--- a/modelaudit/rule_catalog.py
+++ b/modelaudit/rule_catalog.py
@@ -810,7 +810,12 @@ RULE_CATALOG: tuple[RuleCatalogEntry, ...] = (
         code="S1111",
         name="ONNX custom operator domains",
         severity="INFO",
-        description="ONNX model depends on an external custom operator implementation",
-        patterns=(r"onnx.*custom.*operator", r"custom operator domain", r"custom.*onnx.*domain"),
+        description="ONNX model may depend on an external custom operator implementation",
+        patterns=(
+            r"onnx.*custom.*operator",
+            r"custom onnx operator",
+            r"custom operator domain",
+            r"custom.*onnx.*domain",
+        ),
     ),
 )

--- a/modelaudit/rule_catalog.py
+++ b/modelaudit/rule_catalog.py
@@ -806,4 +806,11 @@ RULE_CATALOG: tuple[RuleCatalogEntry, ...] = (
         description="GGUF/GGML format security issues",
         patterns=(r"gguf", r"ggml", r"llama.*format"),
     ),
+    RuleCatalogEntry(
+        code="S1111",
+        name="ONNX custom operator domains",
+        severity="INFO",
+        description="ONNX model depends on an external custom operator implementation",
+        patterns=(r"onnx.*custom.*operator", r"custom operator domain", r"custom.*onnx.*domain"),
+    ),
 )

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -59,6 +59,7 @@ STANDARD_ONNX_DOMAINS: frozenset[str] = frozenset(
         "ai.onnx.preview.training",
     }
 )
+SCHEMA_VALIDATED_ONNX_DOMAINS: frozenset[str] = frozenset({"ai.onnx.preview"})
 ONNX_STRUCTURE_INCONCLUSIVE_REASON = "onnx_structure_validation_failed"
 ONNX_RAW_DETECTION_INCONCLUSIVE_REASON = "onnx_raw_detection_analysis_incomplete"
 ONNX_WEIGHT_DISTRIBUTION_INCONCLUSIVE_REASON = "onnx_weight_distribution_analysis_incomplete"
@@ -135,14 +136,90 @@ def _iter_graph_nodes(graph: Any) -> Any:
 
 def _iter_model_graphs(model: Any) -> Any:
     """Yield graph-bearing ONNX model fields that may declare operators."""
-    yield model.graph
+    for graph, _opset_versions in _iter_model_graphs_with_opsets(model):
+        yield graph
+
+
+def _iter_model_graphs_with_opsets(model: Any) -> Any:
+    """Yield model graphs with the operator-set versions governing each graph."""
+    model_opset_versions = {opset.domain or "": int(opset.version) for opset in getattr(model, "opset_import", [])}
+    yield model.graph, model_opset_versions
     for function in getattr(model, "functions", []):
-        yield function
+        function_opset_versions = {
+            opset.domain or "": int(opset.version) for opset in getattr(function, "opset_import", [])
+        }
+        yield function, function_opset_versions
         for attribute in getattr(function, "attribute_proto", []):
-            yield from _iter_attribute_graphs(attribute)
+            for graph in _iter_attribute_graphs(attribute):
+                yield graph, function_opset_versions
     for training_info in getattr(model, "training_info", []):
-        yield training_info.initialization
-        yield training_info.algorithm
+        yield training_info.initialization, model_opset_versions
+        yield training_info.algorithm, model_opset_versions
+
+
+def _model_local_function_identifiers(model: Any) -> frozenset[tuple[str, str, str]]:
+    """Return identifiers for functions implemented inside the ONNX model."""
+    return frozenset(
+        (
+            function.domain or "",
+            function.name or "",
+            getattr(function, "overload", "") or "",
+        )
+        for function in getattr(model, "functions", [])
+    )
+
+
+def _operator_identifier(node: Any) -> tuple[str, str, str]:
+    """Return an ONNX operator's domain, name, and overload identity."""
+    return (node.domain or "", node.op_type or "", getattr(node, "overload", "") or "")
+
+
+def _has_operator_schema(op_type: str, version: int, domain: str) -> bool:
+    """Return whether the installed ONNX release registers an operator schema."""
+    try:
+        import onnx
+
+        return bool(onnx.defs.has(op_type, version, domain))
+    except Exception as exc:  # pragma: no cover - fail closed on optional API errors
+        logger.debug("Unable to validate ONNX operator schema %s::%s at version %s: %s", domain, op_type, version, exc)
+        return False
+
+
+def _is_schema_validated_operator(node: Any, opset_versions: dict[str, int]) -> bool:
+    """Return whether this graph's imports register the preview operator."""
+    domain = node.domain or ""
+    version = opset_versions.get(domain)
+    return bool(
+        domain in SCHEMA_VALIDATED_ONNX_DOMAINS
+        and not (getattr(node, "overload", "") or "")
+        and version is not None
+        and _has_operator_schema(node.op_type or "", version, domain)
+    )
+
+
+def _is_external_custom_operator(
+    node: Any,
+    local_function_identifiers: frozenset[tuple[str, str, str]],
+    opset_versions: dict[str, int],
+) -> bool:
+    """Return True for non-standard operators without a model-local implementation."""
+    domain = node.domain or ""
+    return bool(
+        domain
+        and domain not in STANDARD_ONNX_DOMAINS
+        and _operator_identifier(node) not in local_function_identifiers
+        and not _is_schema_validated_operator(node, opset_versions)
+    )
+
+
+def _is_explicit_custom_operator(
+    node: Any,
+    local_function_identifiers: frozenset[tuple[str, str, str]],
+) -> bool:
+    """Return whether an actual graph node carries the raw custom-op marker."""
+    return bool(
+        "custom_op" in (node.op_type or "").casefold() and _operator_identifier(node) not in local_function_identifiers
+    )
 
 
 def _iter_graph_and_subgraphs(graph: Any) -> Any:
@@ -247,6 +324,26 @@ def _confirmed_python_operator_findings(findings: list[Any], model: Any) -> list
             continue
         confirmed.append(finding)
     return confirmed
+
+
+def _confirmed_onnx_operator_findings(findings: list[Any], model: Any) -> list[Any]:
+    """Let parsed graph checks own custom-op findings when inventory is readable."""
+    confirmed = _confirmed_python_operator_findings(findings, model)
+    if not any(_jit_finding_type(finding) == "custom_operator" for finding in confirmed):
+        return confirmed
+
+    try:
+        if hasattr(model, "HasField") and not model.HasField("graph"):
+            return confirmed
+        for graph in _iter_model_graphs(model):
+            for node in _iter_graph_nodes(graph):
+                _operator_identifier(node)
+    except Exception as exc:  # pragma: no cover - defensive: keep finding if unsure
+        logger.debug("Unable to validate ONNX custom operator finding against graph: %s", exc)
+        return confirmed
+
+    logger.debug("Suppressing raw-byte ONNX custom_operator finding in favor of parsed graph checks")
+    return [finding for finding in confirmed if _jit_finding_type(finding) != "custom_operator"]
 
 
 def _is_windows_absolute_path(path: str) -> bool:
@@ -528,7 +625,7 @@ class OnnxScanner(BaseScanner):
                     )
                 else:
                     self.add_jit_script_findings(
-                        _confirmed_python_operator_findings(jit_findings, model),
+                        _confirmed_onnx_operator_findings(jit_findings, model),
                         result,
                         model_type="onnx",
                         context=path,
@@ -600,29 +697,45 @@ class OnnxScanner(BaseScanner):
 
     def _check_custom_ops(self, model: Any, path: str, result: ScanResult) -> None:
         custom_domains = set()
+        local_function_identifiers = _model_local_function_identifiers(model)
+        custom_operators_found = 0
         python_ops_found = False
         safe_nodes = 0
         nodes_checked = 0
 
-        for graph in _iter_model_graphs(model):
+        for graph, opset_versions in _iter_model_graphs_with_opsets(model):
             for node in _iter_graph_nodes(graph):
                 nodes_checked += 1
                 # Check for interrupts periodically during node processing.
                 self.check_interrupted()
                 is_python_operator = _is_python_operator(node.op_type or "")
-                if node.domain and node.domain not in STANDARD_ONNX_DOMAINS:
-                    custom_domains.add(node.domain)
+                is_external_custom_operator = _is_external_custom_operator(
+                    node,
+                    local_function_identifiers,
+                    opset_versions,
+                )
+                is_explicit_custom_operator = _is_explicit_custom_operator(node, local_function_identifiers)
+                if is_external_custom_operator or is_explicit_custom_operator:
+                    custom_operators_found += 1
+                    if is_external_custom_operator:
+                        custom_domains.add(node.domain)
+                        message = (
+                            f"Model references custom operator domain '{node.domain}'. "
+                            "This is metadata only - ensure operators are from trusted sources before installation."
+                        )
+                    else:
+                        message = (
+                            f"Model references custom operator '{node.op_type}' in the standard ONNX domain. "
+                            "Ensure its implementation is from a trusted source before installation."
+                        )
 
-                    # All custom domains are INFO - they're metadata, not executable code
+                    # All custom operators are INFO - they're metadata, not executable code
                     # Security risk is in runtime environment (installing malicious operators)
                     # not in the ONNX file itself
                     result.add_check(
                         name="Custom Operator Domain Check",
                         passed=False,
-                        message=(
-                            f"Model references custom operator domain '{node.domain}'. "
-                            f"This is metadata only - ensure operators are from trusted sources before installation."
-                        ),
+                        message=message,
                         severity=IssueSeverity.INFO,
                         location=f"{path} (node: {node.name})",
                         rule_code="S1111",
@@ -630,7 +743,7 @@ class OnnxScanner(BaseScanner):
                             "op_type": node.op_type,
                             "domain": node.domain,
                             "security_note": (
-                                "Custom domains indicate dependencies on external operator implementations. "
+                                "Custom operators may depend on external operator implementations. "
                                 "ONNX files cannot execute code - risk is in runtime environment if malicious "
                                 "operators are installed. Verify operator packages before installation."
                             ),
@@ -648,15 +761,15 @@ class OnnxScanner(BaseScanner):
                         rule_code="S902",
                         details={"op_type": node.op_type, "domain": node.domain},
                     )
-                elif not node.domain or node.domain in STANDARD_ONNX_DOMAINS:
+                elif not is_external_custom_operator and not is_explicit_custom_operator:
                     safe_nodes += 1
 
         # Record successful checks for safe operators
-        if safe_nodes > 0 and not custom_domains:
+        if safe_nodes > 0 and custom_operators_found == 0:
             result.add_check(
                 name="Custom Operator Domain Check",
                 passed=True,
-                message="All operators use standard ONNX domains",
+                message="All operators use standard ONNX domains or model-local function implementations",
                 location=path,
                 details={"safe_nodes": safe_nodes},
                 rule_code=None,  # Passing check
@@ -1237,8 +1350,18 @@ class OnnxScanner(BaseScanner):
             metadata["operators"] = operators
 
             # Custom domains
+            local_function_identifiers = _model_local_function_identifiers(model)
             custom_domains = sorted(
-                {node.domain for node in model.graph.node if node.domain and node.domain not in STANDARD_ONNX_DOMAINS}
+                {
+                    node.domain
+                    for graph, opset_versions in _iter_model_graphs_with_opsets(model)
+                    for node in _iter_graph_nodes(graph)
+                    if _is_external_custom_operator(
+                        node,
+                        local_function_identifiers,
+                        opset_versions,
+                    )
+                }
             )
             if custom_domains:
                 metadata["custom_domains"] = custom_domains

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -625,7 +625,7 @@ class OnnxScanner(BaseScanner):
                         ),
                         severity=IssueSeverity.INFO,
                         location=f"{path} (node: {node.name})",
-                        rule_code="S302",
+                        rule_code="S1111",
                         details={
                             "op_type": node.op_type,
                             "domain": node.domain,

--- a/modelaudit/scanners/rule_mapper.py
+++ b/modelaudit/scanners/rule_mapper.py
@@ -129,6 +129,10 @@ def get_embedded_code_rule_code(code_type: str) -> str | None:
         return _rule("S109")
     elif "native library loading" in code_lower or "ctypes" in code_lower:
         return _rule("S110")
+    elif "onnx" in code_lower and (
+        "custom_operator" in code_lower or "custom operator" in code_lower or "custom onnx operator" in code_lower
+    ):
+        return _rule("S1111")
     elif "torchscript" in code_lower or "jit" in code_lower:
         return _rule("S510")
     elif (

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -20,6 +20,7 @@ from modelaudit.scanners.base import FORMAT_VALIDATION_CONFIG_KEY, INCONCLUSIVE_
 from modelaudit.scanners.onnx_scanner import (
     ONNX_STRUCTURE_INCONCLUSIVE_REASON,
     OnnxScanner,
+    _confirmed_onnx_operator_findings,
     _confirmed_python_operator_findings,
 )
 from modelaudit.utils.file.detection import PROTOBUF_MODEL_CANDIDATE_FORMAT
@@ -51,6 +52,7 @@ def create_onnx_model(
     missing_external: bool = False,
     tensor_shape: tuple[int, ...] = (1,),
     include_initializer: bool = True,
+    custom_opset_version: int | None = None,
 ) -> Path:
     X = helper.make_tensor_value_info("input", TensorProto.FLOAT, list(tensor_shape) or [1])
     Y = helper.make_tensor_value_info("output", TensorProto.FLOAT, list(tensor_shape) or [1])
@@ -96,7 +98,16 @@ def create_onnx_model(
         initializers.append(tensor)
 
     graph = helper.make_graph([node], "graph", [X], [Y], initializer=initializers)
-    model = helper.make_model(graph)
+    if custom and custom_opset_version is not None:
+        model = helper.make_model(
+            graph,
+            opset_imports=[
+                helper.make_opsetid("", 13),
+                helper.make_opsetid(custom_domain, custom_opset_version),
+            ],
+        )
+    else:
+        model = helper.make_model(graph)
     path = tmp_path / "model.onnx"
     onnx.save(model, str(path))
     return path
@@ -288,6 +299,8 @@ def create_onnx_model_with_function_default_external_tensor_attribute(
     attribute_kind: str,
     external_tensor: str = "values",
     missing_external: bool = False,
+    function_domain: str = "local",
+    function_name: str = "ExternalDefault",
 ) -> Path:
     assert attribute_kind in {"dense", "sparse"}
     assert external_tensor in {"values", "indices"}
@@ -320,8 +333,8 @@ def create_onnx_model_with_function_default_external_tensor_attribute(
         ]
     )
     function = helper.make_function(
-        "local",
-        "ExternalDefault",
+        function_domain,
+        function_name,
         [],
         ["Y"],
         [node],
@@ -329,7 +342,7 @@ def create_onnx_model_with_function_default_external_tensor_attribute(
         attribute_protos=[helper.make_attribute(attr_name, attr_value)],
     )
     graph = helper.make_graph(
-        [helper.make_node("ExternalDefault", [], ["Y"], domain="local")],
+        [helper.make_node(function_name, [], ["Y"], domain=function_domain)],
         "graph",
         [],
         [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])],
@@ -337,7 +350,7 @@ def create_onnx_model_with_function_default_external_tensor_attribute(
     model = helper.make_model(
         graph,
         functions=[function],
-        opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid("local", 1)],
+        opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid(function_domain, 1)],
     )
     model.ir_version = 9
     path = tmp_path / f"function_default_{attribute_kind}_external.onnx"
@@ -350,6 +363,73 @@ def create_onnx_model_with_function_default_external_tensor_attribute(
             struct.pack("f" if external_tensor == "values" else "q", 1 if external_tensor == "values" else 0)
         )
 
+    return path
+
+
+def create_onnx_model_with_function_overload(
+    tmp_path: Path,
+    *,
+    function_overload: str,
+    call_overload: str,
+) -> Path:
+    function = helper.make_function(
+        "local",
+        "Transform",
+        ["X"],
+        ["Y"],
+        [helper.make_node("Identity", ["X"], ["Y"])],
+        [helper.make_opsetid("", 13)],
+        overload=function_overload,
+    )
+    graph = helper.make_graph(
+        [helper.make_node("Transform", ["X"], ["Y"], domain="local", overload=call_overload)],
+        "graph",
+        [helper.make_tensor_value_info("X", TensorProto.FLOAT, [1])],
+        [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])],
+    )
+    model = helper.make_model(
+        graph,
+        functions=[function],
+        opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid("local", 1)],
+    )
+    model.ir_version = 10
+    path = tmp_path / f"function_overload_{function_overload}_{call_overload}.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
+def create_onnx_model_with_function_preview_operator(
+    tmp_path: Path,
+    *,
+    include_unimported_model_preview: bool = False,
+) -> Path:
+    function = helper.make_function(
+        "local",
+        "PreviewWrapper",
+        ["X"],
+        ["Y"],
+        [helper.make_node("FlexAttention", ["X"], ["Y"], domain="ai.onnx.preview")],
+        [helper.make_opsetid("", 13), helper.make_opsetid("ai.onnx.preview", 1)],
+    )
+    graph_nodes = [helper.make_node("PreviewWrapper", ["X"], ["Y"], domain="local")]
+    output_name = "Y"
+    if include_unimported_model_preview:
+        graph_nodes.append(helper.make_node("FlexAttention", ["Y"], ["Z"], domain="ai.onnx.preview"))
+        output_name = "Z"
+    graph = helper.make_graph(
+        graph_nodes,
+        "graph",
+        [helper.make_tensor_value_info("X", TensorProto.FLOAT, [1])],
+        [helper.make_tensor_value_info(output_name, TensorProto.FLOAT, [1])],
+    )
+    model = helper.make_model(
+        graph,
+        functions=[function],
+        opset_imports=[helper.make_opsetid("", 13), helper.make_opsetid("local", 1)],
+    )
+    model.ir_version = 10
+    path = tmp_path / "function_preview_operator.onnx"
+    onnx.save(model, str(path))
     return path
 
 
@@ -598,6 +678,159 @@ def test_onnx_scanner_standard_preview_training_domain_not_flagged(tmp_path: Pat
     assert "ai.onnx.preview.training" not in metadata_custom_domains
 
 
+def test_onnx_scanner_registered_ai_onnx_preview_operator_not_flagged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def registered_schema(op_type: str, version: int, domain: str) -> bool:
+        return (domain, op_type, version) == ("ai.onnx.preview", "FlexAttention", 1)
+
+    monkeypatch.setattr("modelaudit.scanners.onnx_scanner._has_operator_schema", registered_schema)
+    model_path = create_onnx_model(
+        tmp_path,
+        custom=True,
+        custom_domain="ai.onnx.preview",
+        custom_op_type="FlexAttention",
+        custom_opset_version=1,
+    )
+    result, custom_domain_checks, metadata_custom_domains = _scan_and_extract_custom_domains(model_path)
+    assert len(custom_domain_checks) == 0, (
+        f"Expected no custom-domain finding for ai.onnx.preview. Checks: {[c.message for c in result.checks]}"
+    )
+    assert "ai.onnx.preview" not in metadata_custom_domains
+
+
+def test_onnx_scanner_unknown_ai_onnx_preview_operator_still_flagged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("modelaudit.scanners.onnx_scanner._has_operator_schema", lambda *_args: False)
+    model_path = create_onnx_model(
+        tmp_path,
+        custom=True,
+        custom_domain="ai.onnx.preview",
+        custom_op_type="UnknownKernel",
+        custom_opset_version=1,
+    )
+
+    _result, custom_domain_checks, metadata_custom_domains = _scan_and_extract_custom_domains(model_path)
+
+    assert len(custom_domain_checks) == 1
+    assert custom_domain_checks[0].rule_code == "S1111"
+    assert custom_domain_checks[0].details["op_type"] == "UnknownKernel"
+    assert "ai.onnx.preview" in metadata_custom_domains
+
+
+def test_onnx_scanner_preview_schema_rejects_nonempty_overload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def registered_schema(op_type: str, version: int, domain: str) -> bool:
+        return (domain, op_type, version) == ("ai.onnx.preview", "FlexAttention", 1)
+
+    monkeypatch.setattr("modelaudit.scanners.onnx_scanner._has_operator_schema", registered_schema)
+    model_path = create_onnx_model(
+        tmp_path,
+        custom=True,
+        custom_domain="ai.onnx.preview",
+        custom_op_type="FlexAttention",
+        custom_opset_version=1,
+    )
+    model = onnx.load(str(model_path))
+    model.graph.node[0].overload = "unregistered"
+    onnx.save(model, str(model_path))
+
+    _result, custom_domain_checks, metadata_custom_domains = _scan_and_extract_custom_domains(model_path)
+
+    assert len(custom_domain_checks) == 1
+    assert custom_domain_checks[0].rule_code == "S1111"
+    assert "ai.onnx.preview" in metadata_custom_domains
+
+
+def test_onnx_scanner_function_body_uses_function_opset_imports(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def registered_schema(op_type: str, version: int, domain: str) -> bool:
+        return (domain, op_type, version) == ("ai.onnx.preview", "FlexAttention", 1)
+
+    monkeypatch.setattr("modelaudit.scanners.onnx_scanner._has_operator_schema", registered_schema)
+    model_path = create_onnx_model_with_function_preview_operator(tmp_path)
+
+    _result, custom_domain_checks, metadata_custom_domains = _scan_and_extract_custom_domains(model_path)
+
+    assert custom_domain_checks == []
+    assert "ai.onnx.preview" not in metadata_custom_domains
+
+
+def test_onnx_scanner_function_opset_does_not_authorize_model_graph(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def registered_schema(op_type: str, version: int, domain: str) -> bool:
+        return (domain, op_type, version) == ("ai.onnx.preview", "FlexAttention", 1)
+
+    monkeypatch.setattr("modelaudit.scanners.onnx_scanner._has_operator_schema", registered_schema)
+    model_path = create_onnx_model_with_function_preview_operator(
+        tmp_path,
+        include_unimported_model_preview=True,
+    )
+
+    _result, custom_domain_checks, metadata_custom_domains = _scan_and_extract_custom_domains(model_path)
+
+    assert len(custom_domain_checks) == 1
+    assert custom_domain_checks[0].rule_code == "S1111"
+    assert custom_domain_checks[0].details["op_type"] == "FlexAttention"
+    assert "ai.onnx.preview" in metadata_custom_domains
+
+
+def test_onnx_scanner_model_local_function_not_flagged_as_external(tmp_path: Path) -> None:
+    model_path = create_onnx_model_with_function_default_external_tensor_attribute(
+        tmp_path,
+        external_path="weights.bin",
+        attribute_kind="dense",
+        function_domain="ai.onnx.contrib",
+        function_name="custom_op",
+    )
+
+    result, custom_domain_checks, metadata_custom_domains = _scan_and_extract_custom_domains(model_path)
+
+    assert custom_domain_checks == []
+    assert result.metadata.get("custom_domains", []) == []
+    assert "ai.onnx.contrib" not in metadata_custom_domains
+    assert not [issue for issue in result.issues if issue.details.get("type") == "custom_operator"]
+
+
+def test_onnx_scanner_matching_model_local_function_overload_not_flagged(tmp_path: Path) -> None:
+    model_path = create_onnx_model_with_function_overload(
+        tmp_path,
+        function_overload="float",
+        call_overload="float",
+    )
+
+    result, custom_domain_checks, metadata_custom_domains = _scan_and_extract_custom_domains(model_path)
+
+    assert result.success is True
+    assert custom_domain_checks == []
+    assert "local" not in metadata_custom_domains
+
+
+def test_onnx_scanner_mismatched_model_local_function_overload_still_flagged(tmp_path: Path) -> None:
+    model_path = create_onnx_model_with_function_overload(
+        tmp_path,
+        function_overload="float",
+        call_overload="integer",
+    )
+
+    _result, custom_domain_checks, metadata_custom_domains = _scan_and_extract_custom_domains(model_path)
+
+    assert len(custom_domain_checks) == 1
+    assert custom_domain_checks[0].rule_code == "S1111"
+    assert custom_domain_checks[0].details["op_type"] == "Transform"
+    assert custom_domain_checks[0].details["domain"] == "local"
+    assert "local" in metadata_custom_domains
+
+
 def test_onnx_scanner_custom_domain_still_flagged(tmp_path: Path) -> None:
     model_path = create_onnx_model(
         tmp_path,
@@ -605,11 +838,31 @@ def test_onnx_scanner_custom_domain_still_flagged(tmp_path: Path) -> None:
         custom_domain="com.evil.ops",
         custom_op_type="BackdoorOp",
     )
-    _result, custom_domain_checks, metadata_custom_domains = _scan_and_extract_custom_domains(model_path)
+    result, custom_domain_checks, metadata_custom_domains = _scan_and_extract_custom_domains(model_path)
     assert len(custom_domain_checks) > 0, "Expected custom domain finding for com.evil.ops"
     assert any(c.details.get("domain") == "com.evil.ops" for c in custom_domain_checks)
     assert all(c.rule_code == "S1111" for c in custom_domain_checks)
+    assert all(c.severity == IssueSeverity.INFO for c in custom_domain_checks)
+    assert "com.evil.ops" in result.metadata["custom_domains"]
     assert "com.evil.ops" in metadata_custom_domains
+
+
+def test_onnx_scanner_custom_operator_emits_one_domain_rule(tmp_path: Path) -> None:
+    model_path = create_onnx_model(
+        tmp_path,
+        custom=True,
+        custom_domain="ai.onnx.contrib",
+        custom_op_type="custom_op",
+    )
+
+    result = OnnxScanner().scan(str(model_path))
+    custom_operator_issues = [issue for issue in result.issues if issue.rule_code == "S1111"]
+
+    assert len(custom_operator_issues) == 1
+    assert custom_operator_issues[0].severity == IssueSeverity.INFO
+    assert custom_operator_issues[0].details["domain"] == "ai.onnx.contrib"
+    assert not [issue for issue in result.issues if issue.details.get("type") == "custom_operator"]
+    assert not any(issue.rule_code == "S510" for issue in result.issues)
 
 
 def test_onnx_scanner_ai_onnx_ml_subdomain_still_flagged(tmp_path: Path) -> None:
@@ -828,6 +1081,23 @@ def test_onnx_scanner_skips_graph_confirmation_without_python_operator_candidate
     assert accessed == []
 
 
+def test_onnx_scanner_custom_operator_confirmation_fails_closed() -> None:
+    class UnreadableModel:
+        @property
+        def graph(self) -> Any:
+            raise RuntimeError("operator inventory unavailable")
+
+    findings = [{"type": "custom_operator", "message": "Custom ONNX operator detected"}]
+
+    assert _confirmed_onnx_operator_findings(findings, UnreadableModel()) == findings
+
+
+def test_onnx_scanner_custom_operator_confirmation_keeps_finding_without_graph() -> None:
+    findings = [{"type": "custom_operator", "message": "Custom ONNX operator detected"}]
+
+    assert _confirmed_onnx_operator_findings(findings, onnx.ModelProto()) == findings
+
+
 def test_onnx_scanner_pyop_bytes_in_weight_data_not_flagged(tmp_path: Path) -> None:
     """A clean ai.onnx-only model is not flagged when weight bytes spell 'PyOp'."""
     model_path = _save_model_with_int8_weight(tmp_path, _PYOP_WEIGHT_BYTES)
@@ -836,6 +1106,38 @@ def test_onnx_scanner_pyop_bytes_in_weight_data_not_flagged(tmp_path: Path) -> N
 
     assert result.success is True
     assert _python_operator_issues(result) == []
+
+
+@pytest.mark.parametrize(
+    "weight_bytes",
+    [b"\x00custom_op\x00", b"\x00ai.onnx.contrib\x00"],
+    ids=["custom-op-marker", "contrib-domain-marker"],
+)
+def test_onnx_scanner_custom_op_marker_in_weight_data_not_flagged(tmp_path: Path, weight_bytes: bytes) -> None:
+    """Raw custom-op marker bytes in weights do not imply a graph operator."""
+    model_path = _save_model_with_int8_weight(tmp_path, weight_bytes)
+
+    result = OnnxScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert not [issue for issue in result.issues if issue.details.get("type") == "custom_operator"]
+    assert not [check for check in result.checks if check.rule_code == "S1111" and check.status == CheckStatus.FAILED]
+
+
+def test_onnx_scanner_explicit_custom_op_in_standard_domain_still_flagged(tmp_path: Path) -> None:
+    model_path = create_onnx_model(
+        tmp_path,
+        custom=True,
+        custom_domain="",
+        custom_op_type="custom_op",
+    )
+
+    result = OnnxScanner().scan(str(model_path))
+    custom_operator_issues = [issue for issue in result.issues if issue.rule_code == "S1111"]
+
+    assert len(custom_operator_issues) == 1
+    assert custom_operator_issues[0].severity == IssueSeverity.INFO
+    assert custom_operator_issues[0].details["op_type"] == "custom_op"
 
 
 def test_onnx_scanner_real_pyop_node_still_flagged_despite_weight_bytes(tmp_path: Path) -> None:
@@ -883,12 +1185,17 @@ def test_onnx_scanner_subgraph_pyop_still_flagged(tmp_path: Path) -> None:
     model_path = tmp_path / "subgraph.onnx"
     onnx.save(model, str(model_path))
 
-    result = OnnxScanner().scan(str(model_path))
+    scanner = OnnxScanner()
+    result = scanner.scan(str(model_path))
+    metadata = scanner.extract_metadata(str(model_path))
 
     assert result.success is False
     python_operator_issues = _python_operator_issues(result)
     assert python_operator_issues
     assert all(issue.severity == IssueSeverity.CRITICAL for issue in python_operator_issues)
+    assert result.metadata["custom_domains"] == ["com.attacker"]
+    assert metadata["custom_domains"] == ["com.attacker"]
+    assert all(check.rule_code == "S1111" for check in _failed_custom_domain_checks(result))
 
 
 def test_onnx_scanner_subgraph_snake_python_op_still_flagged(tmp_path: Path) -> None:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -608,6 +608,7 @@ def test_onnx_scanner_custom_domain_still_flagged(tmp_path: Path) -> None:
     _result, custom_domain_checks, metadata_custom_domains = _scan_and_extract_custom_domains(model_path)
     assert len(custom_domain_checks) > 0, "Expected custom domain finding for com.evil.ops"
     assert any(c.details.get("domain") == "com.evil.ops" for c in custom_domain_checks)
+    assert all(c.rule_code == "S1111" for c in custom_domain_checks)
     assert "com.evil.ops" in metadata_custom_domains
 
 

--- a/tests/scanners/test_rule_mapper.py
+++ b/tests/scanners/test_rule_mapper.py
@@ -41,9 +41,10 @@ def test_embedded_code_rule_maps_dynamic_module_execution_before_executable_text
     [
         ("Web browser launch detected", "S109"),
         ("Native library loading detected", "S110"),
+        ("Custom ONNX operator detected", "S1111"),
     ],
 )
-def test_embedded_code_rule_maps_browser_and_native_loading(message: str, expected_rule_code: str) -> None:
+def test_embedded_code_rule_maps_specific_finding_types(message: str, expected_rule_code: str) -> None:
     assert get_embedded_code_rule_code(message) == expected_rule_code
 
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -87,7 +87,7 @@ class TestRuleRegistry:
         assert "S101" in rules
         assert "S1110" in rules
 
-    def test_get_rules_by_range(self):
+    def test_get_rules_by_range(self) -> None:
         """Test getting rules by numeric range."""
         # Get code execution rules (S100-S199)
         rules = RuleRegistry.get_rules_by_range(100, 199)

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -96,6 +96,9 @@ class TestRuleRegistry:
         assert "S110" in rules
         assert "S201" not in rules  # Pickle rule, not in range
 
+        framework_rules = RuleRegistry.get_rules_by_range(1100, 1199)
+        assert "S1111" in framework_rules
+
         # Get pickle rules (S200-S299)
         rules = RuleRegistry.get_rules_by_range(200, 299)
         assert all(200 <= int(code[1:]) <= 299 for code in rules)


### PR DESCRIPTION
## Summary

- add S1111 for ONNX custom operator-domain dependencies
- stop labeling custom-domain metadata as HTTP-client usage (S302)
- retain the existing informational severity and metadata-only wording

## Campaign evidence

Three ONNX exports produced 54 accurate custom-domain observations for `com.microsoft`, but each was assigned S302. S302's catalog title and description are specifically for `requests`/`urllib` HTTP operations, so downstream reports presented unrelated taxonomy for an otherwise valid finding.

## Validation

- focused ONNX standard/custom-domain tests pass
- rule-registry range and catalog uniqueness tests pass
- Ruff format and lint pass on changed Python files
- mypy passes on changed Python files
