### PR TITLE
fix(scripts): contain corpus QA output paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- reject corpus-QA lock identifiers and paths that escape download, member, or tool-output roots
 - classify unsafe PyTorch ZIP symlink targets as critical archive-link findings while preserving safe relative links
 - restore pickle CVE scan throughput, reprobe malformed stream separators, and route four-byte protocol-0 Joblib operands correctly
 - bound manifest embedded-Jinja template collection while preserving findings across deep branches, cycles, and shared YAML aliases

--- a/scripts/large_pickle_corpus_qa.py
+++ b/scripts/large_pickle_corpus_qa.py
@@ -675,6 +675,10 @@ def _contained_output_path(root: Path, *parts: str | Path) -> Path:
     return candidate
 
 
+def _validated_lock_entry_path(entry: Mapping[str, Any]) -> tuple[str, Path]:
+    return _validated_artifact_id(entry["id"]), _validated_remote_path(entry["path"])
+
+
 def _entry_to_lock(entry: CorpusEntry, *, corpus_root: Path) -> dict[str, Any]:
     return {
         **asdict(entry),
@@ -811,8 +815,7 @@ def _download_entry(
     direct_fallback: bool,
     direct_only: bool,
 ) -> dict[str, Any]:
-    artifact_id = _validated_artifact_id(entry["id"])
-    relative_path = _validated_remote_path(entry["path"])
+    artifact_id, relative_path = _validated_lock_entry_path(entry)
 
     try:
         from huggingface_hub import hf_hub_download
@@ -1339,16 +1342,23 @@ def cmd_download(args: argparse.Namespace) -> int:
     downloaded_bytes = 0
     budget_bytes = int(float(args.budget_gb) * 1024 * 1024 * 1024) if args.budget_gb is not None else None
     updated = []
+    download_failed = False
     for entry in entries:
         if selected_ids is not None and str(entry.get("id")) not in selected_ids:
             updated.append(entry)
             continue
-        remote_size = entry.get("remote_size_bytes")
-        if budget_bytes is not None and isinstance(remote_size, int) and downloaded_bytes + remote_size > budget_bytes:
-            entry["download_status"] = "skipped_budget"
-            updated.append(entry)
-            continue
         try:
+            _validated_lock_entry_path(entry)
+            remote_size = entry.get("remote_size_bytes")
+            if (
+                budget_bytes is not None
+                and isinstance(remote_size, int)
+                and downloaded_bytes + remote_size > budget_bytes
+            ):
+                entry["download_status"] = "skipped_budget"
+                entry.pop("download_error", None)
+                updated.append(entry)
+                continue
             entry = _download_entry(
                 entry,
                 corpus_root=corpus_root,
@@ -1358,7 +1368,9 @@ def cmd_download(args: argparse.Namespace) -> int:
             )
             downloaded_bytes += int(entry.get("downloaded_size_bytes") or 0)
             entry["download_status"] = "ok"
+            entry.pop("download_error", None)
         except Exception as error:
+            download_failed = True
             entry["download_status"] = "error"
             entry["download_error"] = f"{type(error).__name__}: {error}"
         updated.append(entry)
@@ -1369,7 +1381,7 @@ def cmd_download(args: argparse.Namespace) -> int:
         extra=_lock_extra_metadata(lock_payload),
     )
     print(f"Updated {lock_path}; downloaded {downloaded_bytes} bytes")
-    return 1 if any(entry.get("download_status") == "error" for entry in updated) else 0
+    return 1 if download_failed else 0
 
 
 def cmd_classify(args: argparse.Namespace) -> int:

--- a/scripts/large_pickle_corpus_qa.py
+++ b/scripts/large_pickle_corpus_qa.py
@@ -1573,7 +1573,21 @@ def cmd_scan(args: argparse.Namespace) -> int:
     _write_benchmark_csv(run_dir / "benchmark-summary.csv", all_scan_rows, all_third_party_rows)
     _write_report(run_dir, all_scan_rows, all_third_party_rows)
     print(f"Wrote QA run to {run_dir}")
+    scan_error_count = sum(1 for row in all_scan_rows if _scan_row_has_error(row))
+    if scan_error_count:
+        print(
+            f"QA scan failed with {scan_error_count} scan error(s); see {scan_results_path}",
+            file=sys.stderr,
+        )
+        return 2
     return 1 if _has_blocking_drift(all_scan_rows) and args.fail_on_drift else 0
+
+
+def _scan_row_has_error(row: Mapping[str, Any]) -> bool:
+    if row.get("status") == "error":
+        return True
+    result = row.get("result")
+    return isinstance(result, Mapping) and result.get("status") == "error"
 
 
 def _rows_by_artifact_and_scanner(rows: Iterable[Mapping[str, Any]]) -> dict[tuple[str, str], dict[str, Any]]:

--- a/scripts/large_pickle_corpus_qa.py
+++ b/scripts/large_pickle_corpus_qa.py
@@ -27,7 +27,7 @@ from collections import Counter, defaultdict
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
 from urllib.error import HTTPError
 from urllib.parse import quote
@@ -645,6 +645,7 @@ def _validated_artifact_id(value: object) -> str:
         or artifact_id in {".", ".."}
         or "/" in artifact_id
         or "\\" in artifact_id
+        or PureWindowsPath(artifact_id).drive
         or Path(artifact_id).is_absolute()
     ):
         raise ValueError(f"unsafe corpus artifact id: {artifact_id!r}")
@@ -653,15 +654,17 @@ def _validated_artifact_id(value: object) -> str:
 
 def _validated_remote_path(value: object) -> Path:
     raw_path = str(value)
+    raw_parts = raw_path.split("/")
     remote_path = PurePosixPath(raw_path)
     if (
         not raw_path
         or "\\" in raw_path
         or remote_path.is_absolute()
-        or any(part in {"", ".", ".."} for part in remote_path.parts)
+        or PureWindowsPath(raw_path).drive
+        or any(part in {"", ".", ".."} for part in raw_parts)
     ):
         raise ValueError(f"unsafe corpus artifact path: {raw_path!r}")
-    return Path(*remote_path.parts)
+    return Path(*raw_parts)
 
 
 def _contained_output_path(root: Path, *parts: str | Path) -> Path:
@@ -768,7 +771,7 @@ def _direct_download_entry(entry: Mapping[str, Any], local_path: Path) -> Path:
     repo_id = str(entry["repo_id"])
     filename = str(entry["path"])
     url = f"https://huggingface.co/{repo_id}/resolve/{revision}/{quote(filename, safe='/')}"
-    part_path = local_path.with_name(f"{local_path.name}.part")
+    part_path = _contained_output_path(local_path.parent, f"{local_path.name}.part")
     local_path.parent.mkdir(parents=True, exist_ok=True)
 
     expected_size = entry.get("remote_size_bytes")
@@ -1081,7 +1084,7 @@ def _is_package_scannable_path(path: Path, classification: Mapping[str, Any]) ->
 def _iter_pickle_zip_members(path: Path, *, run_dir: Path, artifact_id: str) -> Iterator[tuple[str, Path]]:
     try:
         with zipfile.ZipFile(path) as archive:
-            for member in archive.infolist():
+            for member_index, member in enumerate(archive.infolist()):
                 if member.is_dir():
                     continue
                 member_name = member.filename
@@ -1090,7 +1093,7 @@ def _iter_pickle_zip_members(path: Path, *, run_dir: Path, artifact_id: str) -> 
                     lowered.endswith((".pkl", ".pickle")) or lowered.endswith("/data.pkl") or lowered == "data.pkl"
                 ):
                     continue
-                member_path = _member_file_path(run_dir, artifact_id, member_name)
+                member_path = _member_file_path(run_dir, artifact_id, member_name, member_index=member_index)
                 member_path.parent.mkdir(parents=True, exist_ok=True)
                 try:
                     with archive.open(member) as source, member_path.open("wb") as target:
@@ -1103,9 +1106,10 @@ def _iter_pickle_zip_members(path: Path, *, run_dir: Path, artifact_id: str) -> 
         return
 
 
-def _member_file_path(run_dir: Path, artifact_id: str, member_name: str) -> Path:
+def _member_file_path(run_dir: Path, artifact_id: str, member_name: str, *, member_index: int) -> Path:
     artifact_id = _validated_artifact_id(artifact_id)
-    safe_member_name = member_name.replace("/", "__").replace("\\", "__")
+    member_digest = hashlib.sha256(member_name.encode("utf-8")).hexdigest()
+    safe_member_name = f"{member_index:08d}-{member_digest}.pkl"
     return _contained_output_path(run_dir, "members", artifact_id, safe_member_name)
 
 

--- a/scripts/large_pickle_corpus_qa.py
+++ b/scripts/large_pickle_corpus_qa.py
@@ -27,7 +27,7 @@ from collections import Counter, defaultdict
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 from urllib.error import HTTPError
 from urllib.parse import quote
@@ -638,6 +638,40 @@ def _entry_local_path(corpus_root: Path, entry: CorpusEntry) -> Path:
     return corpus_root / "raw" / entry.id / entry.path
 
 
+def _validated_artifact_id(value: object) -> str:
+    artifact_id = str(value)
+    if (
+        not artifact_id
+        or artifact_id in {".", ".."}
+        or "/" in artifact_id
+        or "\\" in artifact_id
+        or Path(artifact_id).is_absolute()
+    ):
+        raise ValueError(f"unsafe corpus artifact id: {artifact_id!r}")
+    return artifact_id
+
+
+def _validated_remote_path(value: object) -> Path:
+    raw_path = str(value)
+    remote_path = PurePosixPath(raw_path)
+    if (
+        not raw_path
+        or "\\" in raw_path
+        or remote_path.is_absolute()
+        or any(part in {"", ".", ".."} for part in remote_path.parts)
+    ):
+        raise ValueError(f"unsafe corpus artifact path: {raw_path!r}")
+    return Path(*remote_path.parts)
+
+
+def _contained_output_path(root: Path, *parts: str | Path) -> Path:
+    resolved_root = root.resolve()
+    candidate = resolved_root.joinpath(*parts).resolve()
+    if candidate != resolved_root and resolved_root not in candidate.parents:
+        raise ValueError(f"corpus path escapes output root: {candidate}")
+    return candidate
+
+
 def _entry_to_lock(entry: CorpusEntry, *, corpus_root: Path) -> dict[str, Any]:
     return {
         **asdict(entry),
@@ -774,14 +808,18 @@ def _download_entry(
     direct_fallback: bool,
     direct_only: bool,
 ) -> dict[str, Any]:
+    artifact_id = _validated_artifact_id(entry["id"])
+    relative_path = _validated_remote_path(entry["path"])
+
     try:
         from huggingface_hub import hf_hub_download
     except Exception as error:  # pragma: no cover - depends on optional import state
         raise RuntimeError("huggingface_hub is required for downloads") from error
 
-    local_dir = corpus_root / "raw" / str(entry["id"])
+    raw_root = _contained_output_path(corpus_root, "raw")
+    local_dir = _contained_output_path(raw_root, artifact_id)
     local_dir.mkdir(parents=True, exist_ok=True)
-    expected_path = local_dir / str(entry["path"])
+    expected_path = _contained_output_path(local_dir, relative_path)
     expected_size = entry.get("remote_size_bytes")
     if expected_path.exists() and isinstance(expected_size, int) and expected_path.stat().st_size == expected_size:
         return _finalize_downloaded_entry(entry, expected_path)
@@ -794,12 +832,12 @@ def _download_entry(
     try:
         downloaded = hf_hub_download(
             repo_id=str(entry["repo_id"]),
-            filename=str(entry["path"]),
+            filename=relative_path.as_posix(),
             revision=str(entry.get("revision") or "main"),
             local_dir=local_dir,
             etag_timeout=etag_timeout_s,
         )
-        local_path = Path(downloaded)
+        local_path = _contained_output_path(local_dir, Path(downloaded).resolve().relative_to(local_dir.resolve()))
     except Exception:
         if not direct_fallback:
             raise
@@ -994,8 +1032,9 @@ def _scan_third_party(
     run_dir: Path,
     timeout_s: float,
 ) -> dict[str, Any]:
+    artifact_id = _validated_artifact_id(artifact_id)
     tool_path = _tool_path(spec, tools_root)
-    output_path = run_dir / "third-party-raw" / artifact_id / f"{spec.name}.json"
+    output_path = _contained_output_path(run_dir, "third-party-raw", artifact_id, f"{spec.name}.json")
     output_path.parent.mkdir(parents=True, exist_ok=True)
     command = _tool_command(spec, tool_path=tool_path, artifact_path=path, output_path=output_path)
     try:
@@ -1065,8 +1104,9 @@ def _iter_pickle_zip_members(path: Path, *, run_dir: Path, artifact_id: str) -> 
 
 
 def _member_file_path(run_dir: Path, artifact_id: str, member_name: str) -> Path:
+    artifact_id = _validated_artifact_id(artifact_id)
     safe_member_name = member_name.replace("/", "__").replace("\\", "__")
-    return run_dir / "members" / artifact_id / safe_member_name
+    return _contained_output_path(run_dir, "members", artifact_id, safe_member_name)
 
 
 def _malicious_reduce_payload() -> bytes:
@@ -1355,7 +1395,21 @@ def _scan_records_for_entry(
     third_party_timeout_s: float,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     path = Path(str(entry["local_path"]))
-    artifact_id = str(entry["id"])
+    try:
+        artifact_id = _validated_artifact_id(entry["id"])
+    except ValueError as error:
+        return (
+            [
+                {
+                    "artifact_id": str(entry.get("id")),
+                    "scanner": "harness",
+                    "mode": "invalid-lock-entry",
+                    "status": "error",
+                    "error": f"{type(error).__name__}: {error}",
+                }
+            ],
+            [],
+        )
     scan_rows: list[dict[str, Any]] = []
     third_party_rows: list[dict[str, Any]] = []
     if not path.exists():

--- a/tests/scripts/test_large_pickle_corpus_qa.py
+++ b/tests/scripts/test_large_pickle_corpus_qa.py
@@ -346,6 +346,98 @@ def test_classify_preserves_lock_selection_metadata(tmp_path: Path) -> None:
     assert payload["entries"][0]["classification"]["exists"] is True
 
 
+def test_scan_fails_closed_for_unsafe_lock_id(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    artifact_path = tmp_path / "artifact.pkl"
+    artifact_path.write_bytes(b"\x80\x04N.")
+    lock_path = tmp_path / "lock.json"
+    run_dir = tmp_path / "run"
+    large_pickle_corpus_qa._write_lock(
+        lock_path,
+        [{"id": "../escaped", "local_path": str(artifact_path)}],
+        tier="custom",
+    )
+
+    exit_code = large_pickle_corpus_qa.main(
+        [
+            "scan",
+            "--lock",
+            str(lock_path),
+            "--out",
+            str(run_dir),
+            "--no-synthetic",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    scan_rows = large_pickle_corpus_qa._read_jsonl(run_dir / "scan-results.jsonl")
+    assert exit_code == 2
+    assert "QA scan failed with 1 scan error(s)" in captured.err
+    assert len(scan_rows) == 1
+    assert scan_rows[0]["scanner"] == "harness"
+    assert scan_rows[0]["mode"] == "invalid-lock-entry"
+    assert scan_rows[0]["status"] == "error"
+    assert scan_rows[0]["error"] == "ValueError: unsafe corpus artifact id: '../escaped'"
+
+
+def test_scan_error_exit_takes_precedence_over_blocking_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    artifact_path = tmp_path / "artifact.pkl"
+    artifact_path.write_bytes(b"\x80\x04N.")
+    lock_path = tmp_path / "lock.json"
+    run_dir = tmp_path / "run"
+    large_pickle_corpus_qa._write_lock(
+        lock_path,
+        [{"id": "A01", "local_path": str(artifact_path)}],
+        tier="custom",
+    )
+    scan_rows = [
+        {
+            "artifact_id": "A01",
+            "scanner": "modelaudit-picklescan",
+            "mode": "rust",
+            "result": {"status": "error", "verdict": "unknown", "success": False, "rule_codes": []},
+        },
+        {
+            "artifact_id": "A01",
+            "scanner": "modelaudit-root",
+            "mode": "default:rust",
+            "result": {"status": "complete", "verdict": "clean", "success": True, "rule_codes": []},
+        },
+    ]
+
+    def fake_scan_records_for_entry(
+        *_args: object, **_kwargs: object
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        return scan_rows, []
+
+    monkeypatch.setattr(large_pickle_corpus_qa, "_scan_records_for_entry", fake_scan_records_for_entry)
+
+    exit_code = large_pickle_corpus_qa.main(
+        [
+            "scan",
+            "--lock",
+            str(lock_path),
+            "--out",
+            str(run_dir),
+            "--no-synthetic",
+            "--fail-on-drift",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    drift = json.loads((run_dir / "parity-drift.json").read_text(encoding="utf-8"))
+    assert exit_code == 2
+    assert "QA scan failed with 1 scan error(s)" in captured.err
+    assert drift["drift_count"] == 1
+    assert drift["drifts"][0]["delta"] == "status_drift"
+
+
 def test_parity_drift_detects_root_false_negative() -> None:
     rows = [
         {

--- a/tests/scripts/test_large_pickle_corpus_qa.py
+++ b/tests/scripts/test_large_pickle_corpus_qa.py
@@ -170,6 +170,95 @@ def test_download_entry_rejects_unsafe_lock_paths_before_writing(
     assert not corpus_root.exists()
 
 
+def test_download_validates_unsafe_entry_before_budget_skip(tmp_path: Path) -> None:
+    corpus_root = tmp_path / "corpus"
+    lock_path = tmp_path / "lock.json"
+    large_pickle_corpus_qa._write_lock(
+        lock_path,
+        [
+            {
+                "id": "../escaped",
+                "repo_id": "trusted/model",
+                "path": "model.pkl",
+                "revision": "main",
+                "remote_size_bytes": 1,
+            }
+        ],
+        tier="custom",
+    )
+
+    exit_code = large_pickle_corpus_qa.main(
+        [
+            "download",
+            "--lock",
+            str(lock_path),
+            "--corpus-root",
+            str(corpus_root),
+            "--budget-gb",
+            "0",
+            "--direct-only",
+        ]
+    )
+
+    entry = json.loads(lock_path.read_text(encoding="utf-8"))["entries"][0]
+    assert exit_code == 1
+    assert entry["download_status"] == "error"
+    assert entry["download_error"] == "ValueError: unsafe corpus artifact id: '../escaped'"
+    assert not corpus_root.exists()
+
+
+def test_download_keeps_safe_selected_over_budget_entry_skipped(tmp_path: Path) -> None:
+    corpus_root = tmp_path / "corpus"
+    lock_path = tmp_path / "lock.json"
+    large_pickle_corpus_qa._write_lock(
+        lock_path,
+        [
+            {
+                "id": "A01",
+                "repo_id": "trusted/model",
+                "path": "checkpoint-2148/pytorch_model.bin",
+                "revision": "main",
+                "remote_size_bytes": 1,
+                "download_status": "error",
+                "download_error": "stale selected error",
+            },
+            {
+                "id": "A02",
+                "repo_id": "trusted/other-model",
+                "path": "model.pkl",
+                "revision": "main",
+                "remote_size_bytes": 1,
+                "download_status": "error",
+                "download_error": "unselected prior error",
+            },
+        ],
+        tier="custom",
+    )
+
+    exit_code = large_pickle_corpus_qa.main(
+        [
+            "download",
+            "--lock",
+            str(lock_path),
+            "--corpus-root",
+            str(corpus_root),
+            "--budget-gb",
+            "0",
+            "--direct-only",
+            "--ids",
+            "A01",
+        ]
+    )
+
+    selected, unselected = json.loads(lock_path.read_text(encoding="utf-8"))["entries"]
+    assert exit_code == 0
+    assert selected["download_status"] == "skipped_budget"
+    assert "download_error" not in selected
+    assert unselected["download_status"] == "error"
+    assert unselected["download_error"] == "unselected prior error"
+    assert not corpus_root.exists()
+
+
 def test_download_entry_keeps_safe_nested_path_inside_artifact_root(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/scripts/test_large_pickle_corpus_qa.py
+++ b/tests/scripts/test_large_pickle_corpus_qa.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import json
 import zipfile
 from argparse import Namespace
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -79,19 +81,76 @@ def test_iter_pickle_zip_members_extracts_data_pickle_and_skips_near_matches(tmp
     assert scan_row["result"]["critical_count"] >= 1
 
 
+def test_pickle_zip_member_paths_are_unique_portable_and_contained(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model.zip"
+    malicious_payload = large_pickle_corpus_qa.raw_os_system_reduce_payload()
+    benign_payload = b"\x80\x04N."
+    member_names = ["../../data.pkl", "..__..__data.pkl", "evil?.pkl", "duplicate.pkl", "duplicate.pkl"]
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr(member_names[0], malicious_payload)
+        archive.writestr(member_names[1], benign_payload)
+        archive.writestr(member_names[2], benign_payload)
+        archive.writestr(member_names[3], malicious_payload)
+        with pytest.warns(UserWarning, match="Duplicate name"):
+            archive.writestr(member_names[4], benign_payload)
+
+    members = list(
+        large_pickle_corpus_qa._iter_pickle_zip_members(
+            archive_path,
+            run_dir=tmp_path,
+            artifact_id="A01",
+        )
+    )
+
+    assert [member_name for member_name, _member_path in members] == member_names
+    member_paths = [member_path for _member_name, member_path in members]
+    member_root = (tmp_path / "members" / "A01").resolve()
+    assert len(set(member_paths)) == len(member_names)
+    assert all(member_path.parent == member_root for member_path in member_paths)
+    assert all(member_path.name.endswith(".pkl") for member_path in member_paths)
+    assert member_paths[0].read_bytes() == malicious_payload
+    assert member_paths[1].read_bytes() == benign_payload
+    assert member_paths[3].read_bytes() == malicious_payload
+    assert member_paths[4].read_bytes() == benign_payload
+
+    for member_index in (0, 3):
+        malicious_scan = large_pickle_corpus_qa._scan_package(
+            member_paths[member_index],
+            engine="rust",
+            artifact_id=f"A01:{member_names[member_index]}",
+        )
+        assert malicious_scan["result"]["critical_count"] >= 1
+    for member_index in (1, 4):
+        benign_scan = large_pickle_corpus_qa._scan_package(
+            member_paths[member_index],
+            engine="rust",
+            artifact_id=f"A01:{member_names[member_index]}",
+        )
+        assert benign_scan["result"]["critical_count"] == 0
+
+
 @pytest.mark.parametrize(
     ("artifact_id", "artifact_path"),
     [
         ("../escaped", "model.pkl"),
+        ("C:escaped", "model.pkl"),
         ("A01", "../../escaped.pkl"),
         ("A01", "/tmp/escaped.pkl"),
+        ("A01", "C:/escaped.pkl"),
+        ("A01", "C:escaped.pkl"),
+        ("A01", "."),
+        ("A01", "nested/./model.pkl"),
+        ("A01", "nested//model.pkl"),
+        ("A01", r"..\..\escaped.pkl"),
+        ("A01", r"\\server\share\escaped.pkl"),
     ],
 )
-def test_download_entry_rejects_lock_paths_outside_corpus_root(
+def test_download_entry_rejects_unsafe_lock_paths_before_writing(
     tmp_path: Path,
     artifact_id: str,
     artifact_path: str,
 ) -> None:
+    corpus_root = tmp_path / "corpus"
     entry = {
         "id": artifact_id,
         "repo_id": "trusted/model",
@@ -102,18 +161,107 @@ def test_download_entry_rejects_lock_paths_outside_corpus_root(
     with pytest.raises(ValueError, match="unsafe corpus artifact"):
         large_pickle_corpus_qa._download_entry(
             entry,
-            corpus_root=tmp_path / "corpus",
+            corpus_root=corpus_root,
             etag_timeout_s=1,
             direct_fallback=False,
             direct_only=True,
         )
 
-    assert not (tmp_path / "escaped.pkl").exists()
+    assert not corpus_root.exists()
+
+
+def test_download_entry_keeps_safe_nested_path_inside_artifact_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    corpus_root = tmp_path / "corpus"
+    entry = {
+        "id": "A01",
+        "repo_id": "trusted/model",
+        "path": "checkpoint-2148/pytorch_model.bin",
+        "revision": "main",
+    }
+
+    def fake_direct_download(_entry: Mapping[str, Any], local_path: Path) -> Path:
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        local_path.write_bytes(b"benign model")
+        return local_path
+
+    monkeypatch.setattr(large_pickle_corpus_qa, "_direct_download_entry", fake_direct_download)
+
+    result = large_pickle_corpus_qa._download_entry(
+        entry,
+        corpus_root=corpus_root,
+        etag_timeout_s=1,
+        direct_fallback=False,
+        direct_only=True,
+    )
+
+    artifact_root = (corpus_root / "raw" / "A01").resolve()
+    expected_path = artifact_root / "checkpoint-2148" / "pytorch_model.bin"
+    assert Path(result["local_path"]) == expected_path
+    assert expected_path.is_relative_to(artifact_root)
+    assert expected_path.read_bytes() == b"benign model"
+
+
+def test_download_entry_rejects_symlink_escape(
+    tmp_path: Path,
+    requires_symlinks: None,
+) -> None:
+    corpus_root = tmp_path / "corpus"
+    artifact_root = corpus_root / "raw" / "A01"
+    artifact_root.mkdir(parents=True)
+    outside_root = tmp_path / "outside"
+    outside_root.mkdir()
+    (artifact_root / "checkpoint-2148").symlink_to(outside_root, target_is_directory=True)
+    entry = {
+        "id": "A01",
+        "repo_id": "trusted/model",
+        "path": "checkpoint-2148/pytorch_model.bin",
+        "revision": "main",
+    }
+
+    with pytest.raises(ValueError, match="escapes output root"):
+        large_pickle_corpus_qa._download_entry(
+            entry,
+            corpus_root=corpus_root,
+            etag_timeout_s=1,
+            direct_fallback=False,
+            direct_only=True,
+        )
+
+    assert not (outside_root / "pytorch_model.bin").exists()
+
+
+def test_direct_download_rejects_symlinked_partial_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    requires_symlinks: None,
+) -> None:
+    output_dir = tmp_path / "corpus" / "raw" / "A01"
+    output_dir.mkdir(parents=True)
+    local_path = output_dir / "model.pkl"
+    outside_path = tmp_path / "outside.pkl"
+    outside_path.write_bytes(b"unchanged")
+    local_path.with_name("model.pkl.part").symlink_to(outside_path)
+
+    def fail_urlopen(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("download must not start for an escaping partial path")
+
+    monkeypatch.setattr(large_pickle_corpus_qa, "urlopen", fail_urlopen)
+
+    with pytest.raises(ValueError, match="escapes output root"):
+        large_pickle_corpus_qa._direct_download_entry(
+            {"repo_id": "trusted/model", "path": "model.pkl", "revision": "main"},
+            local_path,
+        )
+
+    assert outside_path.read_bytes() == b"unchanged"
 
 
 def test_pickle_member_path_rejects_artifact_id_escape(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="unsafe corpus artifact id"):
-        large_pickle_corpus_qa._member_file_path(tmp_path / "run", "../escaped", "data.pkl")
+        large_pickle_corpus_qa._member_file_path(tmp_path / "run", "../escaped", "data.pkl", member_index=0)
 
     assert not (tmp_path / "escaped").exists()
 

--- a/tests/scripts/test_large_pickle_corpus_qa.py
+++ b/tests/scripts/test_large_pickle_corpus_qa.py
@@ -5,6 +5,8 @@ import zipfile
 from argparse import Namespace
 from pathlib import Path
 
+import pytest
+
 from scripts import large_pickle_corpus_qa
 
 
@@ -75,6 +77,61 @@ def test_iter_pickle_zip_members_extracts_data_pickle_and_skips_near_matches(tmp
 
     scan_row = large_pickle_corpus_qa._scan_package(member_path, engine="rust", artifact_id="A01:data.pkl")
     assert scan_row["result"]["critical_count"] >= 1
+
+
+@pytest.mark.parametrize(
+    ("artifact_id", "artifact_path"),
+    [
+        ("../escaped", "model.pkl"),
+        ("A01", "../../escaped.pkl"),
+        ("A01", "/tmp/escaped.pkl"),
+    ],
+)
+def test_download_entry_rejects_lock_paths_outside_corpus_root(
+    tmp_path: Path,
+    artifact_id: str,
+    artifact_path: str,
+) -> None:
+    entry = {
+        "id": artifact_id,
+        "repo_id": "trusted/model",
+        "path": artifact_path,
+        "revision": "main",
+    }
+
+    with pytest.raises(ValueError, match="unsafe corpus artifact"):
+        large_pickle_corpus_qa._download_entry(
+            entry,
+            corpus_root=tmp_path / "corpus",
+            etag_timeout_s=1,
+            direct_fallback=False,
+            direct_only=True,
+        )
+
+    assert not (tmp_path / "escaped.pkl").exists()
+
+
+def test_pickle_member_path_rejects_artifact_id_escape(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unsafe corpus artifact id"):
+        large_pickle_corpus_qa._member_file_path(tmp_path / "run", "../escaped", "data.pkl")
+
+    assert not (tmp_path / "escaped").exists()
+
+
+def test_third_party_output_rejects_artifact_id_escape(tmp_path: Path) -> None:
+    spec = next(iter(large_pickle_corpus_qa.TOOL_SPECS.values()))
+
+    with pytest.raises(ValueError, match="unsafe corpus artifact id"):
+        large_pickle_corpus_qa._scan_third_party(
+            tmp_path / "artifact.pkl",
+            artifact_id="../escaped",
+            spec=spec,
+            tools_root=tmp_path / "tools",
+            run_dir=tmp_path / "run",
+            timeout_s=1,
+        )
+
+    assert not (tmp_path / "third-party-raw").exists()
 
 
 def test_preflight_offline_writes_lockfile(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- validate corpus artifact IDs and remote paths before importing download dependencies
- resolve all generated download, member, and third-party output paths beneath their intended roots
- reject absolute paths, traversal components, separators in IDs, and symlink escapes
- return an explicit harness error for invalid lock entries

## Tests

- `pytest tests/scripts/test_large_pickle_corpus_qa.py -q` (`21 passed`)
- `ruff check scripts/large_pickle_corpus_qa.py tests/scripts/test_large_pickle_corpus_qa.py`
- `ruff format --check scripts/large_pickle_corpus_qa.py tests/scripts/test_large_pickle_corpus_qa.py`
- `mypy --explicit-package-bases scripts/large_pickle_corpus_qa.py tests/scripts/test_large_pickle_corpus_qa.py`
- `git diff --check`
