### PR TITLE
fix(picklescan): resolve loaded extension exports directly

### DIFF
--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -9,6 +9,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- avoid routing trusted NumPy extension reconstruction exports through module `__getattr__` fallbacks while preserving legacy dotted-`GLOBAL` hook detection
 - preserve nested and aliased callable opcode evidence for downstream scanners
 
 ## [0.1.6](https://github.com/promptfoo/modelaudit/compare/modelaudit-picklescan-v0.1.5...modelaudit-picklescan-v0.1.6) (2026-06-05)
@@ -84,7 +85,6 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- avoid routing trusted NumPy extension reconstruction exports through module `__getattr__` fallbacks while preserving legacy dotted-`GLOBAL` hook detection
 - ignore single-quartet Base64 pickle prefixes in ordinary text while preserving explicit payloads and security evidence
 - honor the string-literal scan cap during bounded raw nested-pickle analysis and avoid duplicate probes inside complete encoded pickles
 - preserve raw persistent-ID probes and later encoded payloads when byte literals also contain complete or unterminated Base64 pickles

--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -78,7 +78,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- avoid routing loaded extension-exported pickle callables through module `__getattr__` fallbacks
+- avoid routing trusted NumPy extension reconstruction exports through module `__getattr__` fallbacks while preserving legacy dotted-`GLOBAL` hook detection
 - honor the string-literal scan cap during bounded raw nested-pickle analysis and avoid duplicate probes inside complete encoded pickles
 - preserve raw persistent-ID probes and later encoded payloads when byte literals also contain complete or unterminated Base64 pickles
 - scan encoded nested pickles in bounded byte and bytearray literals without treating benign execution-like text or complete encoded payloads as raw pickle fragments

--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -78,6 +78,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- avoid routing loaded extension-exported pickle callables through module `__getattr__` fallbacks
 - preserve raw persistent-ID probes and later encoded payloads when byte literals also contain complete or unterminated Base64 pickles
 - scan encoded nested pickles in bounded byte and bytearray literals without treating benign execution-like text or complete encoded payloads as raw pickle fragments
 - continue probing encoded protocol 0 payloads after long line operands, lenient base64 separators, and wrapper alignment shifts while failing closed beyond bounded mid-scan coverage

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1317,6 +1317,20 @@ _TRUSTED_FRAMEWORK_RECONSTRUCTION_REFERENCES = frozenset(
         ("torch.serialization", "_get_layout"),
     }
 )
+_TRUSTED_LOADED_EXTENSION_EXPORT_OWNERS = MappingProxyType(
+    {
+        ("numpy._core.multiarray", "_reconstruct"): ("numpy._core._multiarray_umath",),
+        ("numpy._core.multiarray", "scalar"): ("numpy._core._multiarray_umath",),
+        ("numpy.core.multiarray", "_reconstruct"): (
+            "numpy.core._multiarray_umath",
+            "numpy._core._multiarray_umath",
+        ),
+        ("numpy.core.multiarray", "scalar"): (
+            "numpy.core._multiarray_umath",
+            "numpy._core._multiarray_umath",
+        ),
+    }
+)
 _TRUSTED_IMPORT_ONLY_REFERENCES |= _TRUSTED_FRAMEWORK_RECONSTRUCTION_REFERENCES
 _TRUSTED_UNRESOLVED_IMPORT_ONLY_REFERENCES = (
     frozenset(
@@ -4179,26 +4193,37 @@ def _resolve_dotted_module_getattr_target(
         return None
     if _resolve_wildcard_reexport_alias(module_name, first_component) is not None:
         return None
-    return _resolve_module_getattr_target(module_name, first_component, analysis)
+    return _resolve_module_getattr_target(
+        module_name,
+        first_component,
+        analysis,
+        allow_loaded_extension_bypass=False,
+    )
 
 
 def _resolve_module_getattr_target(
     module_name: str,
     qualified_name: str,
     analysis: _ModuleAnalysis,
+    *,
+    allow_loaded_extension_bypass: bool = True,
 ) -> str | None:
     if qualified_name in analysis.direct_names:
         return None
 
     module_getattr = f"{module_name}.__getattr__"
     if module_getattr in analysis.calls_by_function:
-        if _loaded_extension_callable_bypasses_module_getattr(module_name, qualified_name):
+        if allow_loaded_extension_bypass and _loaded_extension_callable_bypasses_module_getattr(
+            module_name, qualified_name
+        ):
             return None
         return module_getattr
 
     alias_target = analysis.aliases.get("__getattr__")
     if alias_target is not None and alias_target != module_getattr:
-        if _loaded_extension_callable_bypasses_module_getattr(module_name, qualified_name):
+        if allow_loaded_extension_bypass and _loaded_extension_callable_bypasses_module_getattr(
+            module_name, qualified_name
+        ):
             return None
         return _resolve_alias_function_target(alias_target)
     return None
@@ -4207,9 +4232,26 @@ def _resolve_module_getattr_target(
 def _loaded_extension_callable_bypasses_module_getattr(module_name: str, name: str) -> bool:
     # PEP 562 hooks run only after normal module lookup misses; compatibility
     # wrappers can populate extension exports without a statically visible bind.
+    expected_owner_names = _TRUSTED_LOADED_EXTENSION_EXPORT_OWNERS.get((module_name, name))
+    if expected_owner_names is None:
+        return False
     state = _current_loaded_interpreter_reference_state(module_name, name)
     _track_loaded_interpreter_reference_state(module_name, name, state)
-    return state[0] and type(state[1]) is BuiltinFunctionType
+    value = state[1]
+    if not state[0] or type(value) is not BuiltinFunctionType:
+        return False
+    callable_name = BuiltinFunctionType.__getattribute__(value, "__name__")
+    callable_owner = BuiltinFunctionType.__getattribute__(value, "__self__")
+    if callable_name != name or type(callable_owner) is not ModuleType:
+        return False
+    for owner_name in expected_owner_names:
+        owner_loaded, owner_module, _ = _loaded_module_state_without_hooks(owner_name)
+        if not owner_loaded or owner_module is not callable_owner:
+            continue
+        owner_state = _loaded_reference_state_without_hooks(callable_owner, name)
+        _track_loaded_interpreter_reference_state(owner_name, name, owner_state)
+        return owner_state[0] and owner_state[1] is value
+    return False
 
 
 def _resolve_alias_function_target(alias_target: str) -> str | None:

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -35,7 +35,15 @@ from importlib.machinery import (
 from importlib.metadata import distribution, packages_distributions
 from importlib.util import MAGIC_NUMBER, cache_from_source, source_hash
 from pathlib import Path
-from types import CodeType, FunctionType, GetSetDescriptorType, MappingProxyType, MethodType, ModuleType
+from types import (
+    BuiltinFunctionType,
+    CodeType,
+    FunctionType,
+    GetSetDescriptorType,
+    MappingProxyType,
+    MethodType,
+    ModuleType,
+)
 from typing import Any, Protocol, TypeVar, cast
 from zipimport import zipimporter
 
@@ -4184,12 +4192,24 @@ def _resolve_module_getattr_target(
 
     module_getattr = f"{module_name}.__getattr__"
     if module_getattr in analysis.calls_by_function:
+        if _loaded_extension_callable_bypasses_module_getattr(module_name, qualified_name):
+            return None
         return module_getattr
 
     alias_target = analysis.aliases.get("__getattr__")
     if alias_target is not None and alias_target != module_getattr:
+        if _loaded_extension_callable_bypasses_module_getattr(module_name, qualified_name):
+            return None
         return _resolve_alias_function_target(alias_target)
     return None
+
+
+def _loaded_extension_callable_bypasses_module_getattr(module_name: str, name: str) -> bool:
+    # PEP 562 hooks run only after normal module lookup misses; compatibility
+    # wrappers can populate extension exports without a statically visible bind.
+    state = _current_loaded_interpreter_reference_state(module_name, name)
+    _track_loaded_interpreter_reference_state(module_name, name, state)
+    return state[0] and type(state[1]) is BuiltinFunctionType
 
 
 def _resolve_alias_function_target(alias_target: str) -> str | None:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import _imp
 import os
+import pickle
 import posixpath
 import subprocess
 import sys
@@ -11,7 +12,7 @@ import tarfile
 from collections.abc import Iterator
 from importlib.machinery import BuiltinImporter, FileFinder, FrozenImporter, ModuleSpec, PathFinder
 from pathlib import Path
-from types import FunctionType, ModuleType
+from types import BuiltinFunctionType, FunctionType, ModuleType
 from typing import Any, cast
 
 import pytest
@@ -1646,30 +1647,156 @@ def test_loaded_extension_export_does_not_fall_through_module_getattr(
     module_name = "modelaudit_tp_extension_export"
     module_path = tmp_path / f"{module_name}.py"
     module_path.write_text(
-        "def __getattr__(name=None):\n"
-        "    import modelaudit_tp_extension_dependency\n"
-        "    return modelaudit_tp_extension_dependency.resolve(name)\n",
+        "import os\ndef __getattr__(name=None):\n    os.system('')\n    return None\n",
         encoding="utf-8",
     )
+    monkeypatch.syspath_prepend(str(tmp_path))
     spec = spec_from_file_location(module_name, module_path)
     assert spec is not None and spec.loader is not None
     loaded_module = module_from_spec(spec)
     monkeypatch.setitem(sys.modules, module_name, loaded_module)
     spec.loader.exec_module(loaded_module)
     namespace = ModuleType.__getattribute__(loaded_module, "__dict__")
-    namespace["_reconstruct"] = _codecs.encode
+    namespace["encode"] = _codecs.encode
+    _clear_call_graph_caches()
+    assert call_graph._loaded_extension_callable_bypasses_module_getattr(module_name, "encode") is False
+    monkeypatch.setattr(
+        call_graph,
+        "_TRUSTED_LOADED_EXTENSION_EXPORT_OWNERS",
+        {(module_name, "encode"): ("os",)},
+    )
+    assert call_graph._loaded_extension_callable_bypasses_module_getattr(module_name, "encode") is False
+    monkeypatch.setattr(
+        call_graph,
+        "_TRUSTED_LOADED_EXTENSION_EXPORT_OWNERS",
+        {(module_name, "encode"): ("_codecs",)},
+    )
     reference = {
         "module": module_name,
-        "name": "_reconstruct",
-        "import_reference": f"{module_name}._reconstruct",
+        "name": "encode",
+        "import_reference": f"{module_name}.encode",
         "opcode": "REDUCE",
         "positional_arg_count": 3,
     }
     _clear_call_graph_caches()
 
     try:
+        bypasses_getattr = call_graph._loaded_extension_callable_bypasses_module_getattr(module_name, "encode")
         findings = call_graph.find_dangerous_call_graphs([reference], [reference])
     finally:
         _clear_call_graph_caches()
 
+    assert bypasses_getattr is True
     assert findings == ()
+
+
+def test_loaded_dangerous_builtin_cannot_impersonate_trusted_extension_export(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from importlib.util import module_from_spec, spec_from_file_location
+
+    module_name = "modelaudit_tp_dangerous_extension_export"
+    module_path = tmp_path / f"{module_name}.py"
+    module_path.write_text(
+        "import os\ndef __getattr__(name=None):\n    os.system('true')\n    return None\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    spec = spec_from_file_location(module_name, module_path)
+    assert spec is not None and spec.loader is not None
+    loaded_module = module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, loaded_module)
+    spec.loader.exec_module(loaded_module)
+    namespace = ModuleType.__getattribute__(loaded_module, "__dict__")
+    namespace["_reconstruct"] = os.system
+    owner = BuiltinFunctionType.__getattribute__(os.system, "__self__")
+    assert type(owner) is ModuleType
+    owner_name = ModuleType.__getattribute__(owner, "__name__")
+    monkeypatch.setattr(
+        call_graph,
+        "_TRUSTED_LOADED_EXTENSION_EXPORT_OWNERS",
+        {(module_name, "_reconstruct"): (owner_name,)},
+    )
+    reference = {
+        "module": module_name,
+        "name": "_reconstruct",
+        "import_reference": f"{module_name}._reconstruct",
+        "opcode": "REDUCE",
+        "positional_arg_count": 1,
+    }
+    _clear_call_graph_caches()
+
+    try:
+        bypasses_getattr = call_graph._loaded_extension_callable_bypasses_module_getattr(module_name, "_reconstruct")
+        findings = call_graph.find_dangerous_call_graphs([reference], [reference])
+    finally:
+        _clear_call_graph_caches()
+
+    assert bypasses_getattr is False
+    assert len(findings) == 1
+    assert findings[0].sink == "os.system"
+
+
+def test_loaded_extension_export_does_not_hide_legacy_dotted_module_getattr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import _codecs
+    from importlib.util import module_from_spec, spec_from_file_location
+
+    module_name = "modelaudit_tp_legacy_dotted_extension_export"
+    module_path = tmp_path / f"{module_name}.py"
+    module_path.write_text(
+        "import os\ncalls = []\ndef __getattr__(name=None):\n"
+        "    calls.append(name)\n    os.system('')\n    return None\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    spec = spec_from_file_location(module_name, module_path)
+    assert spec is not None and spec.loader is not None
+    loaded_module = module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, loaded_module)
+    spec.loader.exec_module(loaded_module)
+    namespace = ModuleType.__getattribute__(loaded_module, "__dict__")
+    namespace["encode"] = _codecs.encode
+    monkeypatch.setattr(
+        call_graph,
+        "_TRUSTED_LOADED_EXTENSION_EXPORT_OWNERS",
+        {(module_name, "encode"): ("_codecs",)},
+    )
+    system_calls: list[str] = []
+
+    def fake_system(command: str) -> int:
+        system_calls.append(command)
+        return 0
+
+    monkeypatch.setattr(os, "system", fake_system)
+    reference = {
+        "module": module_name,
+        "name": "encode.missing",
+        "import_reference": f"{module_name}.encode.missing",
+        "opcode": "GLOBAL",
+    }
+    _clear_call_graph_caches()
+
+    try:
+        bypasses_exact_export = call_graph._loaded_extension_callable_bypasses_module_getattr(module_name, "encode")
+        findings = call_graph.find_dangerous_call_graphs([reference], [])
+        payload = f"c{module_name}\nencode.missing\n.".encode()
+        report = package_api.scan_bytes(payload, source="legacy-dotted-extension-export.pkl")
+        runtime_calls = cast(list[str], namespace["calls"])
+        assert runtime_calls == []
+        loaded = pickle.loads(payload)
+    finally:
+        _clear_call_graph_caches()
+
+    assert bypasses_exact_export is True
+    assert loaded is None
+    assert runtime_calls == ["encode.missing"]
+    assert system_calls == [""]
+    assert len(findings) == 1
+    assert findings[0].sink == "os.system"
+    public_findings = [finding for finding in report.findings if finding.rule_code == "DANGEROUS_CALL_GRAPH"]
+    assert len(public_findings) == 1
+    assert public_findings[0].details["sink"] == "os.system"

--- a/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
@@ -1635,14 +1635,32 @@ def test_late_loaded_builtin_with_canonical_spec_fails_closed(
         _clear_call_graph_caches()
 
 
-def test_numpy_extension_export_does_not_fall_through_module_getattr() -> None:
-    from numpy.core import multiarray
+def test_loaded_extension_export_does_not_fall_through_module_getattr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import _codecs
+    from importlib.util import module_from_spec, spec_from_file_location
 
-    assert multiarray._reconstruct is not None
+    module_name = "modelaudit_tp_extension_export"
+    module_path = tmp_path / f"{module_name}.py"
+    module_path.write_text(
+        "def __getattr__(name=None):\n"
+        "    import modelaudit_tp_extension_dependency\n"
+        "    return modelaudit_tp_extension_dependency.resolve(name)\n",
+        encoding="utf-8",
+    )
+    spec = spec_from_file_location(module_name, module_path)
+    assert spec is not None and spec.loader is not None
+    loaded_module = module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, loaded_module)
+    spec.loader.exec_module(loaded_module)
+    namespace = ModuleType.__getattribute__(loaded_module, "__dict__")
+    namespace["_reconstruct"] = _codecs.encode
     reference = {
-        "module": "numpy.core.multiarray",
+        "module": module_name,
         "name": "_reconstruct",
-        "import_reference": "numpy.core.multiarray._reconstruct",
+        "import_reference": f"{module_name}._reconstruct",
         "opcode": "REDUCE",
         "positional_arg_count": 3,
     }

--- a/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
@@ -1633,3 +1633,24 @@ def test_late_loaded_builtin_with_canonical_spec_fails_closed(
         assert call_graph._import_module_can_execute_user_code(module) is True
     finally:
         _clear_call_graph_caches()
+
+
+def test_numpy_extension_export_does_not_fall_through_module_getattr() -> None:
+    from numpy.core import multiarray
+
+    assert multiarray._reconstruct is not None
+    reference = {
+        "module": "numpy.core.multiarray",
+        "name": "_reconstruct",
+        "import_reference": "numpy.core.multiarray._reconstruct",
+        "opcode": "REDUCE",
+        "positional_arg_count": 3,
+    }
+    _clear_call_graph_caches()
+
+    try:
+        findings = call_graph.find_dangerous_call_graphs([reference], [reference])
+    finally:
+        _clear_call_graph_caches()
+
+    assert findings == ()


### PR DESCRIPTION
## Summary

- restrict the loaded-extension `__getattr__` bypass to verified NumPy `_reconstruct` and `scalar` exports
- preserve sink detection for dangerous builtins and legacy dotted `GLOBAL` lookups
- add dependency-free benign-negative, malicious-positive, and public scan regressions

## Validation

- resolver regression module: 60 passed
- standalone picklescan suite after merging latest `main`: 2328 passed, 7 skipped
- Rust: fmt/check/clippy plus 164 tests
- full Ruff and mypy gates
- NumPy 1.26.4 and 2.4.4 runtime probes
- wheel build, Twine check, and isolated install smoke

The root non-slow suite reached 11,617 passes before a merged-main cross-directory shard test failed under the local sandbox's `/proc/self/fd` path remapping; GitHub CI will validate that test on the normal runner filesystem.