### PR TITLE
fix(safetensors): prefer bounded framing over zlib magic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- preserve valid bounded SafeTensors routing when header lengths resemble compression magic
+- preserve bounded and fail-closed SafeTensors routing when header lengths resemble compression magic
 - preserve sanitized CatBoost command context in SARIF without exposing injected or neighboring credential values
 - redact values compared against sensitive keys in generic exports and literal credential comparisons in CatBoost evidence
 - preserve critical PyTorch malformed-ZIP symlink findings, valid Python 3.10 streamed ZIP64 descriptors, and selected subtype findings from complete nested and concatenated HDF5 user-block ZIPs while retaining bounded fail-closed preflight checks and avoiding structure-only ZIP route probes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- preserve valid bounded SafeTensors routing when header lengths resemble compression magic
 - classify unsafe PyTorch ZIP symlink targets as critical archive-link findings while preserving safe relative links
 - restore pickle CVE scan throughput, reprobe malformed stream separators, and route four-byte protocol-0 Joblib operands correctly
 - bound manifest embedded-Jinja template collection while preserving findings across deep branches, cycles, and shared YAML aliases

--- a/modelaudit/scanners/safetensors_scanner.py
+++ b/modelaudit/scanners/safetensors_scanner.py
@@ -515,7 +515,7 @@ class SafeTensorsScanner(BaseScanner):
 
                 try:
                     header = json.loads(header_bytes.decode("utf-8"))
-                except (UnicodeDecodeError, json.JSONDecodeError) as e:
+                except (UnicodeDecodeError, json.JSONDecodeError, RecursionError, ValueError) as e:
                     result.add_check(
                         name="SafeTensors JSON Parse",
                         passed=False,

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -1968,23 +1968,11 @@ def _is_safetensors_routing_candidate(path: Path | None, magic8: bytes, file_siz
         parsed_header = json.loads(header.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError):
         return False
+    except (RecursionError, ValueError):
+        # Parsing limits are inconclusive, so retain the fail-closed scanner route.
+        return True
 
     return isinstance(parsed_header, dict)
-
-
-def _has_bounded_safetensors_framing(path: Path | None, magic8: bytes, file_size: int) -> bool:
-    """Return whether a complete bounded SafeTensors JSON header owns the file."""
-    if len(magic8) < 8:
-        return False
-    try:
-        header_len = struct.unpack("<Q", magic8)[0]
-    except struct.error:
-        return False
-    return header_len <= SAFETENSORS_ROUTING_HEADER_PARSE_BYTES and _is_safetensors_routing_candidate(
-        path,
-        magic8,
-        file_size,
-    )
 
 
 def should_defer_safetensors_header_limit_hash(path: str, max_header_bytes: int) -> bool:
@@ -4070,7 +4058,7 @@ def detect_format_from_magic_bytes(
     """Detect file format using Python 3.10+ pattern matching on magic bytes."""
     compression_format = _detect_compression_format(magic16)
     if compression_format:
-        if _has_bounded_safetensors_framing(file_path, magic8, file_size):
+        if _is_safetensors_routing_candidate(file_path, magic8, file_size):
             return "safetensors"
         return compression_format
 
@@ -4602,6 +4590,8 @@ def detect_file_format(path: str) -> str:
         return llamafile_format
 
     compression_format = _detect_compression_format(header)
+    if compression_format and _is_safetensors_routing_candidate(file_path, magic8, size):
+        return "safetensors"
     has_known_container_magic = (
         _has_zip_magic(magic4)
         or magic8.startswith(_SEVENZIP_MAGIC)
@@ -4667,8 +4657,6 @@ def detect_file_format(path: str) -> str:
     if _looks_like_uncompressed_tar_header(header):
         return _detect_tar_route(path) or "tar"
     if compression_format:
-        if _has_bounded_safetensors_framing(file_path, magic8, size):
-            return "safetensors"
         tar_route = _detect_tar_route(path)
         if tar_route is not None:
             return tar_route

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -1972,6 +1972,21 @@ def _is_safetensors_routing_candidate(path: Path | None, magic8: bytes, file_siz
     return isinstance(parsed_header, dict)
 
 
+def _has_bounded_safetensors_framing(path: Path | None, magic8: bytes, file_size: int) -> bool:
+    """Return whether a complete bounded SafeTensors JSON header owns the file."""
+    if len(magic8) < 8:
+        return False
+    try:
+        header_len = struct.unpack("<Q", magic8)[0]
+    except struct.error:
+        return False
+    return header_len <= SAFETENSORS_ROUTING_HEADER_PARSE_BYTES and _is_safetensors_routing_candidate(
+        path,
+        magic8,
+        file_size,
+    )
+
+
 def should_defer_safetensors_header_limit_hash(path: str, max_header_bytes: int) -> bool:
     """Return whether recognized bounded routing will fail before full-file hashing is useful."""
     file_path = Path(path)
@@ -4055,6 +4070,8 @@ def detect_format_from_magic_bytes(
     """Detect file format using Python 3.10+ pattern matching on magic bytes."""
     compression_format = _detect_compression_format(magic16)
     if compression_format:
+        if _has_bounded_safetensors_framing(file_path, magic8, file_size):
+            return "safetensors"
         return compression_format
 
     # Use pattern matching for cleaner magic byte detection
@@ -4650,6 +4667,8 @@ def detect_file_format(path: str) -> str:
     if _looks_like_uncompressed_tar_header(header):
         return _detect_tar_route(path) or "tar"
     if compression_format:
+        if _has_bounded_safetensors_framing(file_path, magic8, size):
+            return "safetensors"
         tar_route = _detect_tar_route(path)
         if tar_route is not None:
             return tar_route

--- a/tests/scanners/test_safetensors_scanner.py
+++ b/tests/scanners/test_safetensors_scanner.py
@@ -14,6 +14,7 @@ pytest.importorskip("safetensors")
 
 from safetensors.numpy import save_file
 
+from modelaudit.cache import get_cache_manager, reset_cache_manager
 from modelaudit.core import determine_exit_code, scan_file, scan_model_directory_or_file
 from modelaudit.scanners.base import DEFAULT_MAX_FILE_READ_SIZE, INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity
 from modelaudit.scanners.safetensors_scanner import SAFETENSORS_READ_INCONCLUSIVE_REASON, SafeTensorsScanner
@@ -598,6 +599,42 @@ def test_zlib_shaped_header_keeps_safetensors_security_routing(tmp_path: Path) -
     assert file_path.read_bytes()[:2] == b"\x78\x9c"
     assert result.scanner_name == "safetensors"
     assert any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+
+
+def test_zlib_shaped_deep_header_fails_closed(tmp_path: Path) -> None:
+    file_path = tmp_path / "deep-zlib-shaped.unknown"
+    header_len = 0x9C78
+    depth = 10_000
+    header = b'{"a":' + (b"[" * depth) + b"0" + (b"]" * depth) + b"}"
+    write_raw_safetensors_header(file_path, header + b" " * (header_len - len(header)), b"\x00")
+
+    cache_dir = tmp_path / "cache"
+    config = {
+        "cache_enabled": True,
+        "cache_dir": str(cache_dir),
+        "min_cache_file_size": 0,
+    }
+
+    reset_cache_manager()
+    try:
+        result = scan_file(str(file_path), config=config)
+        repeated_result = scan_file(str(file_path), config=config)
+        assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+    finally:
+        reset_cache_manager()
+
+    aggregate = scan_model_directory_or_file(str(file_path), cache_scan_results=False)
+
+    parse_check = next(check for check in result.checks if check.name == "SafeTensors JSON Parse")
+    assert file_path.read_bytes()[:2] == b"\x78\x9c"
+    assert result.scanner_name == "safetensors"
+    assert result.success is False
+    assert repeated_result.success is False
+    assert parse_check.status == CheckStatus.FAILED
+    assert parse_check.details["exception_type"] == "RecursionError"
+    assert "maximum recursion depth exceeded" in parse_check.message
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert determine_exit_code(aggregate) == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/scanners/test_safetensors_scanner.py
+++ b/tests/scanners/test_safetensors_scanner.py
@@ -577,6 +577,29 @@ def test_safetensors_with_torch7_like_metadata_keeps_safetensors_routing(tmp_pat
     assert determine_exit_code(aggregate) == 1
 
 
+def test_zlib_shaped_header_keeps_safetensors_security_routing(tmp_path: Path) -> None:
+    file_path = tmp_path / "zlib-shaped-header.unknown"
+    header_len = 0x9C78
+    header = json.dumps(
+        {
+            "__metadata__": {"description": "<script>alert('xss')</script>"},
+            "tensor": {
+                "dtype": "U8",
+                "shape": [1],
+                "data_offsets": [0, 1],
+            },
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+    write_raw_safetensors_header(file_path, header + b" " * (header_len - len(header)), b"\x00")
+
+    result = scan_file(str(file_path))
+
+    assert file_path.read_bytes()[:2] == b"\x78\x9c"
+    assert result.scanner_name == "safetensors"
+    assert any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+
+
 @pytest.mark.parametrize(
     ("dtype", "expected_size"),
     [("BOOL", 4), ("BF16", 8), ("F8_E4M3", 4), ("F8_E5M2", 4), ("F16", 8), ("F32", 16), ("F64", 32)],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7030,12 +7030,22 @@ def test_scan_file_routes_misnamed_keras_hdf5_by_header(tmp_path: Path) -> None:
     assert any("CVE-2025-9905" in issue.message for issue in result.issues)
 
 
+@pytest.mark.parametrize(
+    ("filename", "header_len"),
+    [
+        ("weights.jpg", SAFETENSORS_ROUTING_HEADER_PARSE_BYTES + 1),
+        ("zlib-shaped.unknown", SAFETENSORS_ROUTING_HEADER_PARSE_BYTES + 0x9C78),
+    ],
+    ids=["generic", "zlib-shaped"],
+)
 def test_scan_file_routes_oversized_renamed_safetensors_to_inconclusive_scan(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    filename: str,
+    header_len: int,
 ) -> None:
-    disguised_safetensors = tmp_path / "weights.jpg"
-    _write_sparse_oversized_safetensors_candidate(disguised_safetensors)
+    disguised_safetensors = tmp_path / filename
+    _write_sparse_oversized_safetensors_candidate(disguised_safetensors, header_len=header_len)
     monkeypatch.setattr(
         safetensors_scanner.SafeTensorsScanner,
         "calculate_file_hashes",
@@ -7053,12 +7063,22 @@ def test_scan_file_routes_oversized_renamed_safetensors_to_inconclusive_scan(
     assert limit_check.severity == IssueSeverity.INFO
 
 
+@pytest.mark.parametrize(
+    ("filename", "header_len"),
+    [
+        ("weights.jpg", SAFETENSORS_ROUTING_HEADER_PARSE_BYTES + 1),
+        ("zlib-shaped.unknown", SAFETENSORS_ROUTING_HEADER_PARSE_BYTES + 0x9C78),
+    ],
+    ids=["generic", "zlib-shaped"],
+)
 def test_scan_top_level_oversized_renamed_safetensors_fails_before_hashing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    filename: str,
+    header_len: int,
 ) -> None:
-    disguised_safetensors = tmp_path / "weights.jpg"
-    _write_sparse_oversized_safetensors_candidate(disguised_safetensors)
+    disguised_safetensors = tmp_path / filename
+    _write_sparse_oversized_safetensors_candidate(disguised_safetensors, header_len=header_len)
     monkeypatch.setattr(
         safetensors_scanner.SafeTensorsScanner,
         "calculate_file_hashes",
@@ -10192,12 +10212,22 @@ def test_scan_file_incomplete_xml_routing_result_is_not_cached(tmp_path: Path) -
         reset_cache_manager()
 
 
+@pytest.mark.parametrize(
+    ("filename", "header_len"),
+    [
+        ("oversized.safetensors", (1024 * 1024) + 1),
+        ("zlib-shaped.unknown", SAFETENSORS_ROUTING_HEADER_PARSE_BYTES + 0x9C78),
+    ],
+    ids=["native-suffix", "zlib-shaped"],
+)
 def test_scan_file_inconclusive_safetensors_header_limit_result_is_not_cached(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    filename: str,
+    header_len: int,
 ) -> None:
-    payload = tmp_path / "oversized.safetensors"
-    _write_sparse_oversized_safetensors_candidate(payload, header_len=(1024 * 1024) + 1)
+    payload = tmp_path / filename
+    _write_sparse_oversized_safetensors_candidate(payload, header_len=header_len)
     cache_dir = tmp_path / "cache"
     config = {
         "cache_enabled": True,

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -174,9 +174,11 @@ def _proto_length_field(field_number: int, payload: bytes) -> bytes:
     return _encode_proto_varint((field_number << 3) | 2) + _encode_proto_varint(len(payload)) + payload
 
 
-def _write_sparse_oversized_safetensors_candidate(path: Path) -> None:
+def _write_sparse_oversized_safetensors_candidate(
+    path: Path,
+    header_len: int = SAFETENSORS_ROUTING_HEADER_PARSE_BYTES + 1,
+) -> None:
     """Write framing beyond the routing parse budget without allocating its header."""
-    header_len = SAFETENSORS_ROUTING_HEADER_PARSE_BYTES + 1
     with path.open("wb") as handle:
         handle.write(struct.pack("<Q", header_len))
         handle.write(b"{")
@@ -703,8 +705,29 @@ def test_detect_zlib_shaped_safetensors_header_remains_safetensors(tmp_path: Pat
     header_length = 0x9C78
     metadata = b'{"tensor":{"dtype":"U8","shape":[1],"data_offsets":[0,1]}}'
     metadata += b" " * (header_length - len(metadata))
-    safetensors_path = tmp_path / "zlib-shaped-header.unknown"
+    safetensors_path = tmp_path / "zlib-shaped-header.zlib"
     safetensors_path.write_bytes(struct.pack("<Q", header_length) + metadata + b"\x00")
+
+    assert safetensors_path.read_bytes()[:2] == b"\x78\x9c"
+    assert detect_file_format_from_magic(str(safetensors_path)) == "safetensors"
+    assert detect_file_format_for_skip_filter(str(safetensors_path)) == "safetensors"
+    assert detect_file_format(str(safetensors_path)) == "safetensors"
+
+
+def test_detect_genuine_zlib_payload_remains_zlib(tmp_path: Path) -> None:
+    zlib_path = tmp_path / "genuine-zlib.unknown"
+    zlib_path.write_bytes(zlib.compress(b'{"tensor":{"dtype":"U8"}}'))
+
+    assert zlib_path.read_bytes()[:2] == b"\x78\x9c"
+    assert detect_file_format_from_magic(str(zlib_path)) == "zlib"
+    assert detect_file_format_for_skip_filter(str(zlib_path)) == "zlib"
+    assert detect_file_format(str(zlib_path)) == "zlib"
+
+
+def test_detect_oversized_zlib_shaped_safetensors_candidate_remains_safetensors(tmp_path: Path) -> None:
+    header_length = SAFETENSORS_ROUTING_HEADER_PARSE_BYTES + 0x9C78
+    safetensors_path = tmp_path / "oversized-zlib-shaped.unknown"
+    _write_sparse_oversized_safetensors_candidate(safetensors_path, header_length)
 
     assert safetensors_path.read_bytes()[:2] == b"\x78\x9c"
     assert detect_file_format_from_magic(str(safetensors_path)) == "safetensors"

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -699,6 +699,19 @@ def test_detect_pickle_shaped_safetensors_header_remains_safetensors(tmp_path: P
     assert detect_file_format(str(safetensors_path)) == "safetensors"
 
 
+def test_detect_zlib_shaped_safetensors_header_remains_safetensors(tmp_path: Path) -> None:
+    header_length = 0x9C78
+    metadata = b'{"tensor":{"dtype":"U8","shape":[1],"data_offsets":[0,1]}}'
+    metadata += b" " * (header_length - len(metadata))
+    safetensors_path = tmp_path / "zlib-shaped-header.unknown"
+    safetensors_path.write_bytes(struct.pack("<Q", header_length) + metadata + b"\x00")
+
+    assert safetensors_path.read_bytes()[:2] == b"\x78\x9c"
+    assert detect_file_format_from_magic(str(safetensors_path)) == "safetensors"
+    assert detect_file_format_for_skip_filter(str(safetensors_path)) == "safetensors"
+    assert detect_file_format(str(safetensors_path)) == "safetensors"
+
+
 def test_detect_file_format_from_magic_json_not_misrouted_as_safetensors(tmp_path: Path) -> None:
     json_path = tmp_path / "config.unknown"
     json_path.write_text('{"name":"model","version":1}', encoding="utf-8")


### PR DESCRIPTION
## Summary

- recognize a complete, bounded SafeTensors JSON header before accepting weak compression magic
- preserve SafeTensors security scanning when the little-endian header length begins with zlib bytes (`78 9c`)
- retain existing routing for genuine zlib payloads

## Root cause

File routing checked compression magic before strong SafeTensors framing. A valid SafeTensors header length such as `0x9c78` therefore looked like zlib and bypassed the SafeTensors scanner.

## Validation

- `PROMPTFOO_DISABLE_TELEMETRY=1 PYTHONPATH=$PWD /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/scanners/test_safetensors_scanner.py tests/utils/file/test_filetype.py -q` (`383 passed`)
- `PYTHONPATH=$PWD /Users/mdangelo/code/modelaudit/.venv/bin/python -m mypy modelaudit/utils/file/detection.py tests/scanners/test_safetensors_scanner.py tests/utils/file/test_filetype.py` (`Success: no issues found`)
- Ruff check, Ruff format check, and `git diff --check` passed

The regression test demonstrates that the `78 9c` fixture now reaches the SafeTensors scanner and still reports malicious metadata, while the existing compression-routing suite covers genuine zlib controls.