### PR TITLE
fix(picklescan): bound hidden ZIP probe bytes

### DIFF
--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -91,6 +91,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - detect nested pickles accepted by permissive base64 and hex decoders, and fail
   closed when decoded prefixes leave over-budget encoded tails
 - Invalidate cached call-graph analysis when Python sources, import hooks, loaded module origins, or parent package markers change.
+- bound aggregate decompressed bytes used to probe PyTorch ZIP members for hidden pickles
 - fail closed when PyTorch ZIP archives exceed the standalone pickle-member scan budget
 - detect dangerous call-like strings split across newline-separated statements
 - scan raw nested pickle payloads carried inside Unicode string literals

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -79,6 +79,7 @@ _PROTO0_1_TRIVIAL_LEADING_OPCODES = frozenset(
     }
 )
 _MAX_PYTORCH_ZIP_ENTRIES = 10_000
+_MAX_PYTORCH_ZIP_PICKLE_DISCOVERY_PROBE_BYTES = 4 * 1024 * 1024
 _MAX_PYTORCH_ZIP_PICKLE_MEMBERS = 256
 _MAX_PYTORCH_ZIP_PICKLE_MEMBER_BYTES = 512 * 1024 * 1024
 _MAX_PYTORCH_ZIP_PICKLE_TOTAL_MEMBER_BYTES = 512 * 1024 * 1024
@@ -108,6 +109,10 @@ class _StreamShortReadError(ValueError):
         self.expected_size = expected_size
         self.bytes_read = bytes_read
         self.partial_payload = partial_payload
+
+
+class _PickleDiscoveryProbeBudgetExceeded(ValueError):
+    """Raised when another hidden ZIP-member probe would exceed the byte budget."""
 
 
 class PickleScanner:
@@ -289,9 +294,27 @@ class PickleScanner:
                 return None
 
             pickle_entries, discovery_notices = _discover_pytorch_zip_pickle_entries(archive, entries, source=source)
-            if not _is_pytorch_zip_archive(entries, discovered_pickle_entries=pickle_entries):
+            probe_budget_exhausted = any(
+                notice.code == "pytorch_zip_pickle_discovery_probe_budget" for notice in discovery_notices
+            )
+            if (
+                not _is_pytorch_zip_archive(
+                    entries,
+                    discovered_pickle_entries=pickle_entries,
+                )
+                and not probe_budget_exhausted
+            ):
                 return None
             if not pickle_entries:
+                if probe_budget_exhausted:
+                    return _combine_pytorch_zip_reports(
+                        source=source,
+                        size=size,
+                        entry_count=len(entries),
+                        pickle_entries=[],
+                        member_reports=[],
+                        extra_notices=discovery_notices,
+                    )
                 return _pytorch_zip_notice_report(
                     source=source,
                     size=size,
@@ -530,6 +553,7 @@ def _discover_pytorch_zip_pickle_entries(
     pickle_entries: list[zipfile.ZipInfo] = []
     notices: list[Notice] = []
     seen_entries: set[int] = set()
+    candidates: list[zipfile.ZipInfo] = []
 
     def add_entry(entry: zipfile.ZipInfo) -> None:
         entry_id = id(entry)
@@ -549,24 +573,70 @@ def _discover_pytorch_zip_pickle_entries(
     for entry in entries:
         if entry.is_dir() or id(entry) in seen_entries:
             continue
+        candidates.append(entry)
+
+    probe_bytes_remaining = [_MAX_PYTORCH_ZIP_PICKLE_DISCOVERY_PROBE_BYTES]
+    probed_member_count = 0
+    for candidate_index, entry in enumerate(candidates):
         try:
-            if _zip_entry_looks_like_pickle(archive, entry):
+            if _zip_entry_looks_like_pickle(archive, entry, probe_bytes_remaining):
                 add_entry(entry)
+            probed_member_count += 1
+        except _PickleDiscoveryProbeBudgetExceeded:
+            notices.append(
+                _pytorch_zip_pickle_discovery_probe_budget_notice(
+                    source=source,
+                    probe_bytes_read=(_MAX_PYTORCH_ZIP_PICKLE_DISCOVERY_PROBE_BYTES - probe_bytes_remaining[0]),
+                    probed_member_count=probed_member_count,
+                    skipped_entries=candidates[candidate_index:],
+                )
+            )
+            break
         except Exception as error:
             notices.append(_pytorch_zip_member_probe_notice(source=source, entry=entry, error=error))
 
     return pickle_entries, tuple(notices)
 
 
-def _zip_entry_looks_like_pickle(archive: zipfile.ZipFile, entry: zipfile.ZipInfo) -> bool:
+def _read_zip_entry_probe(
+    archive: zipfile.ZipFile,
+    entry: zipfile.ZipInfo,
+    max_bytes: int,
+    probe_bytes_remaining: list[int],
+) -> bytes:
+    expected_bytes = min(max(entry.file_size, 0), max_bytes)
+    if expected_bytes == 0:
+        return b""
+    if expected_bytes > probe_bytes_remaining[0]:
+        raise _PickleDiscoveryProbeBudgetExceeded
+
     with archive.open(entry, "r") as member:
-        prefix = member.read(_PICKLE_DISCOVERY_SHORT_PROBE_BYTES)
+        sample = member.read(min(max_bytes, probe_bytes_remaining[0]))
+    probe_bytes_remaining[0] -= len(sample)
+    return sample
+
+
+def _zip_entry_looks_like_pickle(
+    archive: zipfile.ZipFile,
+    entry: zipfile.ZipInfo,
+    probe_bytes_remaining: list[int],
+) -> bool:
+    prefix = _read_zip_entry_probe(
+        archive,
+        entry,
+        _PICKLE_DISCOVERY_SHORT_PROBE_BYTES,
+        probe_bytes_remaining,
+    )
     if not prefix:
         return False
 
     if prefix.startswith(_PICKLE_BINARY_PROTOCOL_PREFIXES):
-        with archive.open(entry, "r") as member:
-            sample = member.read(_PICKLE_DISCOVERY_LONG_PROBE_BYTES)
+        sample = _read_zip_entry_probe(
+            archive,
+            entry,
+            _PICKLE_DISCOVERY_LONG_PROBE_BYTES,
+            probe_bytes_remaining,
+        )
         return _looks_like_binary_pickle_prefix(sample, sample_is_prefix=entry.file_size > len(sample))
 
     if prefix[0] not in _PROTO0_1_START_BYTES:
@@ -574,8 +644,12 @@ def _zip_entry_looks_like_pickle(archive: zipfile.ZipFile, entry: zipfile.ZipInf
 
     sample = prefix
     if entry.file_size > len(prefix):
-        with archive.open(entry, "r") as member:
-            sample = member.read(_PICKLE_DISCOVERY_LONG_PROBE_BYTES)
+        sample = _read_zip_entry_probe(
+            archive,
+            entry,
+            _PICKLE_DISCOVERY_LONG_PROBE_BYTES,
+            probe_bytes_remaining,
+        )
     return _looks_like_proto0_or_1_pickle(sample, sample_is_prefix=entry.file_size > len(sample))
 
 
@@ -726,6 +800,32 @@ def _pytorch_zip_entry_limit_report(*, source: str, size: int, entry_count: int)
         details={
             "entry_count": entry_count,
             "max_entries": _MAX_PYTORCH_ZIP_ENTRIES,
+            "analysis_incomplete": True,
+        },
+    )
+
+
+def _pytorch_zip_pickle_discovery_probe_budget_notice(
+    *,
+    source: str,
+    probe_bytes_read: int,
+    probed_member_count: int,
+    skipped_entries: list[zipfile.ZipInfo],
+) -> Notice:
+    return Notice(
+        message=(
+            "PyTorch ZIP analysis stopped hidden pickle-member discovery because the archive exceeds the "
+            "standalone aggregate decompressed probe-byte budget"
+        ),
+        severity=Severity.INFO,
+        location=source,
+        code="pytorch_zip_pickle_discovery_probe_budget",
+        details={
+            "probe_bytes_read": probe_bytes_read,
+            "max_probe_bytes": _MAX_PYTORCH_ZIP_PICKLE_DISCOVERY_PROBE_BYTES,
+            "probed_member_count": probed_member_count,
+            "skipped_member_count": len(skipped_entries),
+            "skipped_members": [entry.filename for entry in skipped_entries[:10]],
             "analysis_incomplete": True,
         },
     )

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -1728,6 +1728,112 @@ def test_scan_file_does_not_route_large_trivial_proto0_text_as_hidden_pickle(tmp
     assert list(report.metadata["pickle_files"]) == ["archive/data.pkl"]
 
 
+def test_scan_file_stops_hidden_pickle_discovery_at_aggregate_probe_budget(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    probe_budget = package_api._PICKLE_DISCOVERY_SHORT_PROBE_BYTES + package_api._PICKLE_DISCOVERY_LONG_PROBE_BYTES
+    monkeypatch.setattr(
+        package_api,
+        "_MAX_PYTORCH_ZIP_PICKLE_DISCOVERY_PROBE_BYTES",
+        probe_budget,
+        raising=False,
+    )
+    archive_path = tmp_path / "hidden-probe-budget.pt"
+    decoy = b"I0\n0" * 20_000
+    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("archive/decoy-0", decoy)
+        archive.writestr("archive/decoy-1", decoy)
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+
+    decompressed_probe_bytes = 0
+    original_read = zipfile.ZipExtFile.read
+
+    def count_probe_bytes(member: zipfile.ZipExtFile, size: int = -1) -> bytes:
+        nonlocal decompressed_probe_bytes
+        data = original_read(member, size)
+        if str(member.name).startswith("archive/decoy-"):
+            decompressed_probe_bytes += len(data)
+        return data
+
+    monkeypatch.setattr(zipfile.ZipExtFile, "read", count_probe_bytes)
+
+    report = scan_file(archive_path)
+
+    assert decompressed_probe_bytes == probe_budget
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.UNKNOWN
+    assert report.metadata["analysis_incomplete"] is True
+    assert report.coverage.raw_scan_complete is False
+    assert report.coverage.opcode_scan_complete is False
+    budget_notices = [notice for notice in report.notices if notice.code == "pytorch_zip_pickle_discovery_probe_budget"]
+    assert len(budget_notices) == 1
+    assert budget_notices[0].details["analysis_incomplete"] is True
+    assert budget_notices[0].details["probe_bytes_read"] == probe_budget
+    assert budget_notices[0].details["max_probe_bytes"] == probe_budget
+    assert budget_notices[0].details["probed_member_count"] == 1
+    assert budget_notices[0].details["skipped_member_count"] == 3
+    assert next(iter(budget_notices[0].details["skipped_members"])) == "archive/decoy-1"
+
+
+def test_scan_file_detects_hidden_pickle_at_aggregate_probe_budget_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    hidden_payload = b"cposix\nsystem\n(S'echo hidden'\ntR."
+    probe_budget = len("3\n") + len("little") + package_api._PICKLE_DISCOVERY_SHORT_PROBE_BYTES + len(hidden_payload)
+    monkeypatch.setattr(
+        package_api,
+        "_MAX_PYTORCH_ZIP_PICKLE_DISCOVERY_PROBE_BYTES",
+        probe_budget,
+        raising=False,
+    )
+    archive_path = tmp_path / "hidden-probe-boundary.pt"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/payload", hidden_payload)
+
+    report = scan_file(archive_path)
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert list(report.metadata["pickle_files"]) == ["archive/payload"]
+    assert any(finding.rule_code == "DANGEROUS_CALL" for finding in report.findings)
+    assert all(notice.code != "pytorch_zip_pickle_discovery_probe_budget" for notice in report.notices)
+
+
+def test_scan_file_keeps_small_benign_archive_complete_at_aggregate_probe_budget_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    version = b"3\n"
+    byteorder = b"little"
+    notes = b"weights"
+    probe_budget = len(version) + len(byteorder) + len(notes)
+    monkeypatch.setattr(
+        package_api,
+        "_MAX_PYTORCH_ZIP_PICKLE_DISCOVERY_PROBE_BYTES",
+        probe_budget,
+        raising=False,
+    )
+    archive_path = tmp_path / "benign-probe-boundary.pt"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}, protocol=4))
+        archive.writestr("archive/version", version)
+        archive.writestr("archive/byteorder", byteorder)
+        archive.writestr("archive/notes", notes)
+
+    report = scan_file(archive_path)
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert report.is_clean
+    assert "analysis_incomplete" not in report.metadata
+    assert all(notice.code != "pytorch_zip_pickle_discovery_probe_budget" for notice in report.notices)
+
+
 def test_scan_file_marks_hidden_pytorch_zip_probe_failure_inconclusive(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

- cap aggregate decompressed bytes used while probing PyTorch ZIP members for hidden pickles
- fail closed with an explicit incomplete-analysis notice when the discovery budget is exhausted
- preserve detection at the exact budget boundary and preserve complete outcomes for small benign archives

## Root cause

Hidden-member discovery bounded each read but did not bound the aggregate decompressed bytes across archive members. An archive with many compressed decoys could therefore force repeated decompression before the existing member-scan limits applied.

## Validation

- `PROMPTFOO_DISABLE_TELEMETRY=1 PYTHONPATH=$PWD/packages/modelaudit-picklescan/src /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest packages/modelaudit-picklescan/tests/test_api.py -q` (`541 passed`)
- focused aggregate-budget regressions (`3 passed`)
- Ruff check and Ruff format check passed
- mypy passed for the changed implementation and tests
- `git diff --check` passed

The regressions assert the exact decompressed-byte ceiling, malicious hidden-pickle detection at the boundary, and a clean complete result for a small benign archive. Budget exhaustion now produces `ScanStatus.INCONCLUSIVE`, `SafetyVerdict.UNKNOWN`, and `analysis_incomplete=True` rather than a false clean result.