### PR TITLE
fix(ci): raise test job timeout for instrumented main lane

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -457,7 +457,10 @@ jobs:
     # Only run if Python files changed
     if: github.ref == 'refs/heads/main' || needs.changes.outputs.python == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    # The main-branch Python 3.12 step runs the fast suite under branch
+    # coverage, which costs ~3x the uninstrumented lanes (~25 min); the
+    # tracer overhead concentrates in CPU-bound detector replay tests.
+    timeout-minutes: 75
     strategy:
       matrix:
         # For PRs, only test min and max Python versions to save time


### PR DESCRIPTION
## Summary

- raise the `test` job timeout from 35 to 75 minutes so the main-branch Python 3.12 coverage lane can complete

## Root cause

The main-only "fast tests with coverage" step measures the suite under **branch coverage**, which costs ~3x the uninstrumented lanes (measured locally: 16:36 instrumented vs ~6 min uninstrumented; the uninstrumented CI siblings take 22-26 min). The overhead concentrates in CPU-bound detector replay tests (e.g. `tests/detectors/test_jit_script_detector.py`, 1,818 tests) that compile fresh code objects per iteration, which defeats both the C tracer and the `sysmon` core (benchmarked 3.0x vs 2.7x — switching cores does not recover the budget).

Since the detector suites grew, every push to main has had `Test Python 3.12` killed at the 35-minute cap (most recently [run 27274096829](https://github.com/promptfoo/modelaudit/actions/runs/27274096829), cancelled at 35m13s while the sibling 3.10/3.11/3.13 lanes passed in 22-26 min). The failure was previously masked because earlier jobs in the workflow failed first.

## Why not alternatives

- `COVERAGE_CORE=sysmon`: benchmarked — only ~10% faster because the replay tests constantly execute fresh code objects; branch coverage also forces a fallback to the C tracer on Python ≤3.13.
- Excluding the detector file from instrumentation: loses its coverage data and still leaves a ~50 min lane; not worth the fidelity loss.
- The durable fix is reducing the intrinsic cost of the replay tests — left as a follow-up.

## Validation

- Local: full fast suite under branch coverage completes with the same failure set as uninstrumented (no coverage-induced failures), 996s locally → projected ~55-65 min on a 4-vCPU runner, within the new 75-minute cap.
- Uninstrumented matrix versions are unaffected (they finish in ~25 min regardless of the cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)