### PR TITLE
fix(picklescan): reject padded short payload bypasses

### DIFF
--- a/packages/modelaudit-picklescan/rust/src/nested.rs
+++ b/packages/modelaudit-picklescan/rust/src/nested.rs
@@ -2281,7 +2281,31 @@ fn follows_terminal_base64_padding(value: &str, index: usize) -> bool {
         .iter()
         .rposition(|byte| *byte != b'=')
         .map_or(0, |position| position.saturating_add(1));
-    padding_start > 0 && base64_value(lookback[padding_start - 1]).is_some()
+    if padding_start == 0 || base64_value(lookback[padding_start - 1]).is_none() {
+        return false;
+    }
+
+    let padding_start = lookback_start.saturating_add(padding_start);
+    let data_scan_start = padding_start.saturating_sub(MAX_ENCODED_LITERAL_PREFIX_SCAN_BYTES);
+    let data_run_start = value.as_bytes()[data_scan_start..padding_start]
+        .iter()
+        .rposition(|byte| base64_value(*byte).is_none())
+        .map_or(data_scan_start, |position| {
+            data_scan_start.saturating_add(position).saturating_add(1)
+        });
+    if data_run_start == data_scan_start
+        && data_scan_start > 0
+        && value
+            .as_bytes()
+            .get(data_scan_start - 1)
+            .is_some_and(|byte| base64_value(*byte).is_some())
+    {
+        // The bounded scan cannot prove that this padding terminates an
+        // incomplete quartet, so keep the security-relevant suffix visible.
+        return false;
+    }
+
+    (padding_start - data_run_start) % 4 != 0
 }
 
 fn hex_prefix_has_pickle_prefix(value: &str) -> bool {
@@ -2830,6 +2854,39 @@ mod tests {
             strip_escaped_hex_markers("63 6f 73 0a 73 79 73 74 65 6d 0a 29 52 2e"),
             "636f730a73797374656d0a29522e"
         );
+        assert!(!follows_terminal_base64_padding("AAAA=ly4=", 5));
+        assert!(!follows_terminal_base64_padding("AAAA==ly4=", 6));
+        assert!(follows_terminal_base64_padding("AAA=ly4=", 4));
+        assert!(follows_terminal_base64_padding("AA==ly4=", 4));
+        assert_eq!(encoded_pickle_kind_at("AAAA=ly4=", 5), Some("base64"));
+        assert_eq!(encoded_pickle_kind_at("AAA=ly4=", 4), None);
+
+        let bounded_aligned_prefix = format!("{}=ly4=", "A".repeat(64));
+        assert!(!follows_terminal_base64_padding(
+            &bounded_aligned_prefix,
+            65
+        ));
+        assert_eq!(
+            encoded_pickle_kind_at(&bounded_aligned_prefix, 65),
+            Some("base64")
+        );
+
+        let bounded_terminal_prefix = format!("{}=ly4=", "A".repeat(63));
+        assert!(follows_terminal_base64_padding(
+            &bounded_terminal_prefix,
+            64
+        ));
+        assert_eq!(encoded_pickle_kind_at(&bounded_terminal_prefix, 64), None);
+
+        for (prefix_chars, padding_chars) in [(63, "=="), (66, "==")] {
+            let padded_prefix = format!("{}{}ly4=", "A".repeat(prefix_chars), padding_chars);
+            let payload_index = prefix_chars + padding_chars.len();
+            assert!(follows_terminal_base64_padding(
+                &padded_prefix,
+                payload_index
+            ));
+            assert_eq!(encoded_pickle_kind_at(&padded_prefix, payload_index), None);
+        }
     }
 
     #[test]

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -8032,7 +8032,8 @@ def test_scan_bytes_preserves_lenient_compact_base64_security_evidence(
     ],
 )
 def test_scan_bytes_ignores_compact_base64_tail_after_terminal_padding(encoded: str) -> None:
-    assert b"\x97." not in base64.b64decode(encoded)
+    assert encoded.endswith("ly4=")
+    assert base64.b64decode(encoded[-4:]) == b"\x97."
 
     report = scan_bytes(
         pickle.dumps({"metadata": encoded}, protocol=4),

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -8002,6 +8002,10 @@ def test_scan_bytes_preserves_compact_base64_execution_payload_detection(
         ("=TlEu", "PERSISTENT_ID"),
         ("!ly4!=", "S601"),
         ("!UAo!u", "PERSISTENT_ID"),
+        ("AAAA=ly4=", "S601"),
+        ("AAAA==ly4=", "S601"),
+        ("grou=ly4=", "S601"),
+        ("A" * 64 + "=ly4=", "S601"),
     ],
 )
 def test_scan_bytes_preserves_lenient_compact_base64_security_evidence(
@@ -8015,6 +8019,32 @@ def test_scan_bytes_preserves_lenient_compact_base64_security_evidence(
 
     assert report.verdict in {SafetyVerdict.SUSPICIOUS, SafetyVerdict.MALICIOUS}
     assert any(finding.rule_code == expected_rule for finding in report.findings)
+
+
+@pytest.mark.parametrize(
+    "encoded",
+    [
+        "AAA=ly4=",
+        "AA==ly4=",
+        "A" * 63 + "=ly4=",
+        "A" * 63 + "==ly4=",
+        "A" * 66 + "==ly4=",
+    ],
+)
+def test_scan_bytes_ignores_compact_base64_tail_after_terminal_padding(encoded: str) -> None:
+    assert b"\x97." not in base64.b64decode(encoded)
+
+    report = scan_bytes(
+        pickle.dumps({"metadata": encoded}, protocol=4),
+        source="terminal-padding-base64-tail.pkl",
+    )
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
+    assert report.findings == ()
+    assert all(
+        notice.code not in {"encoded_nested_payload_detected", "nested_pickle_incomplete"} for notice in report.notices
+    )
 
 
 def test_scan_bytes_preserves_four_byte_data_only_base64_boundary() -> None:


### PR DESCRIPTION
## Summary

This follows merged #1617 and fixes the Base64 terminal-padding bypass identified in `discussion_r3389660212`: `AAAA=ly4=` could preserve a valid short pickle suffix after an earlier `=` and evade the intended short-payload handling.

- Reject payload continuations after terminal Base64 padding.
- Add a benign terminal-padding negative regression.
- Cover the 64-byte boundary so bounded normalization cannot mask a continuation.

## Validation

- Standalone package Python: 2,334 passed, 7 skipped.
- Rust: 164 passed.
- `cargo clippy`, Ruff, and mypy: green.
- 754-case Base64 oracle: 0 mismatches.
- 160,940 Python stdlib lines: 0 new signals.