### PR TITLE
fix(routing): keep media out of serialized scanners

### DIFF
--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -11,7 +11,7 @@ import sys
 import tarfile
 import zipfile
 import zlib
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from io import BytesIO, StringIO
 from pathlib import Path, PurePosixPath
@@ -289,6 +289,7 @@ _FLAX_MSGPACK_PROBE_LENGTH_SIZES = {
 VALID_MEDIA_ROUTING_FORMAT = "valid_media"
 MEDIA_ROUTE_READ_BYTES = FLAX_MSGPACK_STRUCTURE_READ_BYTES
 MEDIA_ROUTE_TAIL_READ_BYTES = 64 * 1024
+_MEDIA_ROUTE_MAX_PNG_CHUNKS = 4096
 _MEDIA_ROUTING_SUFFIXES = frozenset({".jpeg", ".jpg", ".png"})
 _MEDIA_TRAILING_PADDING = b"\x00\t\n\r "
 _PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
@@ -5420,6 +5421,41 @@ def _find_bounded_png_end(sample: bytes) -> int | None:
     return None
 
 
+def _find_png_end_with_reader(file_size: int, read_at: Callable[[int, int], bytes]) -> int | None:
+    """Return the first byte after a complete PNG stream using sparse bounded reads."""
+    if file_size < len(_PNG_SIGNATURE) + 12:
+        return None
+    try:
+        if read_at(0, len(_PNG_SIGNATURE)) != _PNG_SIGNATURE:
+            return None
+
+        offset = len(_PNG_SIGNATURE)
+        saw_ihdr = False
+        for _ in range(_MEDIA_ROUTE_MAX_PNG_CHUNKS):
+            if offset + 8 > file_size:
+                return None
+            chunk_header = read_at(offset, 8)
+            if len(chunk_header) != 8:
+                return None
+            chunk_length = int.from_bytes(chunk_header[:4], "big")
+            chunk_type = chunk_header[4:8]
+            chunk_end = offset + 12 + chunk_length
+            if chunk_end > file_size:
+                return None
+            if not saw_ihdr:
+                if chunk_type != b"IHDR" or chunk_length != 13:
+                    return None
+                saw_ihdr = True
+            elif chunk_type == b"IHDR":
+                return None
+            if chunk_type == _PNG_IEND_CHUNK:
+                return chunk_end if chunk_length == 0 else None
+            offset = chunk_end
+    except OSError:
+        return None
+    return None
+
+
 def _find_bounded_jpeg_end(sample: bytes) -> int | None:
     """Return the first byte after a complete bounded JPEG stream."""
     if not sample.startswith(b"\xff\xd8"):
@@ -5472,6 +5508,16 @@ def _find_bounded_jpeg_end(sample: bytes) -> int | None:
     return None
 
 
+def _detect_complete_media_route_from_trailing(trailing: bytes, *, sample_is_prefix: bool) -> str | None:
+    """Classify bytes after a complete media stream."""
+    pickle_route = _detect_media_pickle_polyglot_route(trailing, sample_is_prefix=sample_is_prefix)
+    if pickle_route is not None:
+        return pickle_route
+    if sample_is_prefix or trailing.lstrip(_MEDIA_TRAILING_PADDING):
+        return PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+    return VALID_MEDIA_ROUTING_FORMAT
+
+
 def _could_start_bounded_media_route(file_path: Path, sample: bytes) -> bool:
     """Return whether bounded bytes plausibly begin a supported media stream."""
     if file_path.suffix.lower() not in _MEDIA_ROUTING_SUFFIXES:
@@ -5510,12 +5556,7 @@ def _detect_bounded_media_route_from_sample(
         return None
     if media_end is None:
         return None
-    pickle_route = _detect_media_pickle_polyglot_route(sample[media_end:], sample_is_prefix=sample_is_prefix)
-    if pickle_route is not None:
-        return pickle_route
-    if sample_is_prefix:
-        return None
-    return VALID_MEDIA_ROUTING_FORMAT
+    return _detect_complete_media_route_from_trailing(sample[media_end:], sample_is_prefix=sample_is_prefix)
 
 
 def _detect_bounded_media_route_from_edges(file_path: Path, prefix: bytes, tail: bytes) -> str | None:
@@ -5523,7 +5564,7 @@ def _detect_bounded_media_route_from_edges(file_path: Path, prefix: bytes, tail:
     if not prefix or not tail or not _could_start_bounded_media_route(file_path, prefix):
         return None
 
-    prefix_route = _detect_bounded_media_route_from_sample(file_path, prefix, sample_is_prefix=True)
+    prefix_route = _detect_bounded_media_route_from_sample(file_path, prefix, sample_is_prefix=tail != prefix)
     if prefix_route is not None:
         return prefix_route
 
@@ -5548,6 +5589,33 @@ def _detect_bounded_media_route_from_edges(file_path: Path, prefix: bytes, tail:
     return VALID_MEDIA_ROUTING_FORMAT
 
 
+def _read_local_media_range(file_path: Path, sample: bytes, offset: int, size: int) -> bytes:
+    if size <= 0:
+        return b""
+    end = offset + size
+    if offset >= 0 and end <= len(sample):
+        return sample[offset:end]
+    with file_path.open("rb") as handle:
+        handle.seek(offset)
+        return handle.read(size)
+
+
+def _detect_seekable_png_media_route(file_path: Path, file_size: int, sample: bytes) -> str | None:
+    media_end = _find_png_end_with_reader(
+        file_size,
+        lambda offset, size: _read_local_media_range(file_path, sample, offset, size),
+    )
+    if media_end is None:
+        return PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+
+    trailing_size = file_size - media_end
+    if trailing_size <= 0:
+        return VALID_MEDIA_ROUTING_FORMAT
+    read_size = min(trailing_size, MEDIA_ROUTE_READ_BYTES + 1)
+    trailing = _read_local_media_range(file_path, sample, media_end, read_size)
+    return _detect_complete_media_route_from_trailing(trailing, sample_is_prefix=trailing_size > len(trailing))
+
+
 def _detect_bounded_media_route(file_path: Path, file_size: int) -> str | None:
     """Inspect a bounded complete media sample before serialized fallback routing."""
     if file_path.suffix.lower() not in _MEDIA_ROUTING_SUFFIXES:
@@ -5556,11 +5624,20 @@ def _detect_bounded_media_route(file_path: Path, file_size: int) -> str | None:
         sample = read_magic_bytes(str(file_path), min(file_size, MEDIA_ROUTE_READ_BYTES + 1))
     except OSError:
         return None
-    return _detect_bounded_media_route_from_sample(
+    sample_route = _detect_bounded_media_route_from_sample(
         file_path,
         sample,
         sample_is_prefix=file_size > len(sample),
     )
+    if sample_route is not None:
+        return sample_route
+    if (
+        file_size > len(sample)
+        and sample.startswith(_PNG_SIGNATURE)
+        and _could_start_bounded_media_route(file_path, sample)
+    ):
+        return _detect_seekable_png_media_route(file_path, file_size, sample)
+    return None
 
 
 def _could_be_content_routed_flax_msgpack(file_path: Path) -> bool:

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -5470,6 +5470,27 @@ def _find_bounded_jpeg_end(sample: bytes) -> int | None:
     return None
 
 
+def _could_start_bounded_media_route(file_path: Path, sample: bytes) -> bool:
+    """Return whether bounded bytes plausibly begin a supported media stream."""
+    if file_path.suffix.lower() not in _MEDIA_ROUTING_SUFFIXES:
+        return False
+    if sample.startswith(_PNG_SIGNATURE):
+        return (
+            len(sample) >= len(_PNG_SIGNATURE) + 8
+            and sample[len(_PNG_SIGNATURE) : len(_PNG_SIGNATURE) + 8] == b"\x00\x00\x00\rIHDR"
+        )
+    return (
+        len(sample) >= 4
+        and sample.startswith(b"\xff\xd8")
+        and sample[2] == 0xFF
+        and sample[3]
+        not in {
+            0x00,
+            0xFF,
+        }
+    )
+
+
 def _detect_bounded_media_route_from_sample(
     file_path: Path,
     sample: bytes,
@@ -5477,8 +5498,7 @@ def _detect_bounded_media_route_from_sample(
     sample_is_prefix: bool,
 ) -> str | None:
     """Return clean-media or strong media/pickle polyglot routing evidence."""
-    ext = file_path.suffix.lower()
-    if ext not in _MEDIA_ROUTING_SUFFIXES:
+    if not _could_start_bounded_media_route(file_path, sample):
         return None
     if sample.startswith(_PNG_SIGNATURE):
         media_end = _find_bounded_png_end(sample)
@@ -5498,23 +5518,20 @@ def _detect_bounded_media_route_from_sample(
 
 def _detect_bounded_media_route_from_edges(file_path: Path, prefix: bytes, tail: bytes) -> str | None:
     """Return bounded media routing evidence from remote head and tail probes."""
-    ext = file_path.suffix.lower()
-    if ext not in _MEDIA_ROUTING_SUFFIXES or not prefix or not tail:
+    if not prefix or not tail or not _could_start_bounded_media_route(file_path, prefix):
         return None
 
+    prefix_route = _detect_bounded_media_route_from_sample(file_path, prefix, sample_is_prefix=True)
+    if prefix_route is not None:
+        return prefix_route
+
     if prefix.startswith(_PNG_SIGNATURE):
-        if len(prefix) < len(_PNG_SIGNATURE) + 8 or prefix[len(_PNG_SIGNATURE) : len(_PNG_SIGNATURE) + 8] != (
-            b"\x00\x00\x00\rIHDR"
-        ):
-            return None
-        media_end = tail.rfind(_PNG_IEND_TRAILER)
+        media_end = tail.find(_PNG_IEND_TRAILER)
         if media_end < 0:
             return None
         media_end += len(_PNG_IEND_TRAILER)
     elif prefix.startswith(b"\xff\xd8"):
-        if len(prefix) < 4 or prefix[2] != 0xFF or prefix[3] in {0x00, 0xFF}:
-            return None
-        media_end = tail.rfind(b"\xff\xd9")
+        media_end = tail.find(b"\xff\xd9")
         if media_end < 0:
             return None
         media_end += 2
@@ -5524,6 +5541,8 @@ def _detect_bounded_media_route_from_edges(file_path: Path, prefix: bytes, tail:
     pickle_route = _detect_media_pickle_polyglot_route(tail[media_end:], sample_is_prefix=False)
     if pickle_route is not None:
         return pickle_route
+    if tail[media_end:].lstrip(_MEDIA_TRAILING_PADDING):
+        return None
     return VALID_MEDIA_ROUTING_FORMAT
 
 

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -290,6 +290,8 @@ VALID_MEDIA_ROUTING_FORMAT = "valid_media"
 MEDIA_ROUTE_READ_BYTES = FLAX_MSGPACK_STRUCTURE_READ_BYTES
 MEDIA_ROUTE_TAIL_READ_BYTES = 64 * 1024
 _MEDIA_ROUTE_MAX_PNG_CHUNKS = 4096
+_PNG_CRC_READ_CHUNK_BYTES = 64 * 1024
+_JPEG_SCAN_READ_CHUNK_BYTES = 64 * 1024
 _MEDIA_ROUTING_SUFFIXES = frozenset({".jpeg", ".jpg", ".png"})
 _MEDIA_TRAILING_PADDING = b"\x00\t\n\r "
 _PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
@@ -5415,10 +5417,39 @@ def _find_bounded_png_end(sample: bytes) -> int | None:
             saw_ihdr = True
         elif chunk_type == b"IHDR":
             return None
+        chunk_payload_start = offset + 8
+        chunk_payload_end = chunk_payload_start + chunk_length
+        expected_crc = int.from_bytes(sample[chunk_payload_end:chunk_end], "big")
+        actual_crc = zlib.crc32(chunk_type + sample[chunk_payload_start:chunk_payload_end]) & 0xFFFFFFFF
+        if actual_crc != expected_crc:
+            return None
         if chunk_type == _PNG_IEND_CHUNK:
             return chunk_end if chunk_length == 0 else None
         offset = chunk_end
     return None
+
+
+def _png_chunk_crc_matches_with_reader(
+    chunk_type: bytes,
+    chunk_length: int,
+    payload_offset: int,
+    read_at: Callable[[int, int], bytes],
+) -> bool:
+    checksum = zlib.crc32(chunk_type)
+    remaining = chunk_length
+    offset = payload_offset
+    while remaining > 0:
+        read_size = min(remaining, _PNG_CRC_READ_CHUNK_BYTES)
+        payload = read_at(offset, read_size)
+        if len(payload) != read_size:
+            return False
+        checksum = zlib.crc32(payload, checksum)
+        offset += read_size
+        remaining -= read_size
+    expected_crc = read_at(payload_offset + chunk_length, 4)
+    if len(expected_crc) != 4:
+        return False
+    return (checksum & 0xFFFFFFFF) == int.from_bytes(expected_crc, "big")
 
 
 def _find_png_end_with_reader(file_size: int, read_at: Callable[[int, int], bytes]) -> int | None:
@@ -5448,9 +5479,98 @@ def _find_png_end_with_reader(file_size: int, read_at: Callable[[int, int], byte
                 saw_ihdr = True
             elif chunk_type == b"IHDR":
                 return None
+            if not _png_chunk_crc_matches_with_reader(chunk_type, chunk_length, offset + 8, read_at):
+                return None
             if chunk_type == _PNG_IEND_CHUNK:
                 return chunk_end if chunk_length == 0 else None
             offset = chunk_end
+    except OSError:
+        return None
+    return None
+
+
+def _find_jpeg_end_with_reader(file_size: int, read_at: Callable[[int, int], bytes]) -> int | None:
+    """Return the first byte after a complete JPEG stream using bounded reads."""
+    if file_size < 4:
+        return None
+
+    def read_exact(offset: int, size: int) -> bytes:
+        data = read_at(offset, size)
+        if len(data) != size:
+            raise OSError("short JPEG read")
+        return data
+
+    try:
+        if read_exact(0, 2) != b"\xff\xd8":
+            return None
+
+        offset = 2
+        while offset < file_size:
+            if read_exact(offset, 1) != b"\xff":
+                return None
+            while offset < file_size and read_exact(offset, 1) == b"\xff":
+                offset += 1
+            if offset >= file_size:
+                return None
+            marker = read_exact(offset, 1)[0]
+            offset += 1
+            if marker == 0x00:
+                return None
+            if marker == 0xD9:
+                return offset
+            if marker in _JPEG_STANDALONE_MARKERS:
+                continue
+            if offset + 2 > file_size:
+                return None
+            segment_length = int.from_bytes(read_exact(offset, 2), "big")
+            if segment_length < 2:
+                return None
+            segment_end = offset + segment_length
+            if segment_end > file_size:
+                return None
+            if marker != 0xDA:
+                offset = segment_end
+                continue
+
+            offset = segment_end
+            while offset < file_size:
+                chunk = read_at(offset, min(_JPEG_SCAN_READ_CHUNK_BYTES, file_size - offset))
+                if not chunk:
+                    return None
+                index = 0
+                advanced_to_next_chunk = False
+                while True:
+                    marker_index = chunk.find(b"\xff", index)
+                    if marker_index < 0:
+                        offset += len(chunk)
+                        advanced_to_next_chunk = True
+                        break
+                    marker_offset = offset + marker_index
+                    if marker_offset + 1 >= file_size:
+                        return None
+                    marker = read_exact(marker_offset + 1, 1)[0]
+                    if marker == 0x00 or 0xD0 <= marker <= 0xD7:
+                        next_index = marker_index + 2
+                        if next_index >= len(chunk):
+                            offset = marker_offset + 2
+                            advanced_to_next_chunk = True
+                            break
+                        index = next_index
+                        continue
+                    if marker == 0xD9:
+                        return marker_offset + 2
+                    if marker == 0xFF:
+                        next_index = marker_index + 1
+                        if next_index >= len(chunk):
+                            offset = marker_offset + 1
+                            advanced_to_next_chunk = True
+                            break
+                        index = next_index
+                        continue
+                    offset = marker_offset
+                    break
+                if not advanced_to_next_chunk:
+                    break
     except OSError:
         return None
     return None
@@ -5586,7 +5706,7 @@ def _detect_bounded_media_route_from_edges(file_path: Path, prefix: bytes, tail:
         return pickle_route
     if tail[media_end:].lstrip(_MEDIA_TRAILING_PADDING):
         return None
-    return VALID_MEDIA_ROUTING_FORMAT
+    return PICKLE_ROUTING_INCONCLUSIVE_FORMAT
 
 
 def _read_local_media_range(file_path: Path, sample: bytes, offset: int, size: int) -> bytes:
@@ -5616,6 +5736,22 @@ def _detect_seekable_png_media_route(file_path: Path, file_size: int, sample: by
     return _detect_complete_media_route_from_trailing(trailing, sample_is_prefix=trailing_size > len(trailing))
 
 
+def _detect_seekable_jpeg_media_route(file_path: Path, file_size: int, sample: bytes) -> str | None:
+    media_end = _find_jpeg_end_with_reader(
+        file_size,
+        lambda offset, size: _read_local_media_range(file_path, sample, offset, size),
+    )
+    if media_end is None:
+        return PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+
+    trailing_size = file_size - media_end
+    if trailing_size <= 0:
+        return VALID_MEDIA_ROUTING_FORMAT
+    read_size = min(trailing_size, MEDIA_ROUTE_READ_BYTES + 1)
+    trailing = _read_local_media_range(file_path, sample, media_end, read_size)
+    return _detect_complete_media_route_from_trailing(trailing, sample_is_prefix=trailing_size > len(trailing))
+
+
 def _detect_bounded_media_route(file_path: Path, file_size: int) -> str | None:
     """Inspect a bounded complete media sample before serialized fallback routing."""
     if file_path.suffix.lower() not in _MEDIA_ROUTING_SUFFIXES:
@@ -5631,12 +5767,10 @@ def _detect_bounded_media_route(file_path: Path, file_size: int) -> str | None:
     )
     if sample_route is not None:
         return sample_route
-    if (
-        file_size > len(sample)
-        and sample.startswith(_PNG_SIGNATURE)
-        and _could_start_bounded_media_route(file_path, sample)
-    ):
+    if sample.startswith(_PNG_SIGNATURE) and _could_start_bounded_media_route(file_path, sample):
         return _detect_seekable_png_media_route(file_path, file_size, sample)
+    if sample.startswith(b"\xff\xd8") and _could_start_bounded_media_route(file_path, sample):
+        return _detect_seekable_jpeg_media_route(file_path, file_size, sample)
     return None
 
 

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -284,6 +284,13 @@ _FLAX_MSGPACK_PROBE_LENGTH_SIZES = {
     0xDA: (2, 0),
     0xDB: (4, 0),
 }
+VALID_MEDIA_ROUTING_FORMAT = "valid_media"
+MEDIA_ROUTE_READ_BYTES = FLAX_MSGPACK_STRUCTURE_READ_BYTES
+_MEDIA_ROUTING_SUFFIXES = frozenset({".jpeg", ".jpg", ".png"})
+_MEDIA_TRAILING_PADDING = b"\x00\t\n\r "
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+_PNG_IEND_CHUNK = b"IEND"
+_JPEG_STANDALONE_MARKERS = frozenset((0x01, 0xD8, 0xD9, *range(0xD0, 0xD8)))
 MXNET_SYMBOL_SIGNATURE_READ_BYTES = 10 * 1024 * 1024
 MXNET_SYMBOL_ROUTING_INCONCLUSIVE_FORMAT = "mxnet_symbol_routing_inconclusive"
 _UTF8_BOM = b"\xef\xbb\xbf"
@@ -5362,6 +5369,146 @@ def _preserve_inconclusive_protobuf_model_routing(file_path: Path, file_size: in
     ) and not _is_complete_bounded_printable_text(file_path, file_size)
 
 
+def _detect_media_pickle_polyglot_route(trailing: bytes, *, sample_is_prefix: bool) -> str | None:
+    """Return a pickle route only for strong serialized bytes after valid media."""
+    candidate = trailing.lstrip(_MEDIA_TRAILING_PADDING)
+    if not candidate:
+        return None
+    if _looks_like_binary_pickle_protocol(candidate[:4]):
+        if _has_bounded_binary_pickle_security_signal(candidate):
+            return "pickle"
+        return PICKLE_ROUTING_INCONCLUSIVE_FORMAT if sample_is_prefix else None
+    protocol_less_state = _classify_protocolless_binary_pickle_security_signal(
+        candidate,
+        sample_is_prefix=sample_is_prefix,
+    )
+    if protocol_less_state is True:
+        return "pickle"
+    if protocol_less_state is None:
+        return PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+    if _looks_like_proto0_or_1_pickle(candidate, sample_is_prefix=sample_is_prefix):
+        return "pickle"
+    return None
+
+
+def _find_bounded_png_end(sample: bytes) -> int | None:
+    """Return the first byte after a complete bounded PNG stream."""
+    if not sample.startswith(_PNG_SIGNATURE):
+        return None
+
+    offset = len(_PNG_SIGNATURE)
+    saw_ihdr = False
+    while offset + 12 <= len(sample):
+        chunk_length = int.from_bytes(sample[offset : offset + 4], "big")
+        chunk_type = sample[offset + 4 : offset + 8]
+        chunk_end = offset + 12 + chunk_length
+        if chunk_end > len(sample):
+            return None
+        if not saw_ihdr:
+            if chunk_type != b"IHDR" or chunk_length != 13:
+                return None
+            saw_ihdr = True
+        elif chunk_type == b"IHDR":
+            return None
+        if chunk_type == _PNG_IEND_CHUNK:
+            return chunk_end if chunk_length == 0 else None
+        offset = chunk_end
+    return None
+
+
+def _find_bounded_jpeg_end(sample: bytes) -> int | None:
+    """Return the first byte after a complete bounded JPEG stream."""
+    if not sample.startswith(b"\xff\xd8"):
+        return None
+
+    offset = 2
+    while offset < len(sample):
+        if sample[offset] != 0xFF:
+            return None
+        while offset < len(sample) and sample[offset] == 0xFF:
+            offset += 1
+        if offset >= len(sample):
+            return None
+        marker = sample[offset]
+        offset += 1
+        if marker == 0x00:
+            return None
+        if marker == 0xD9:
+            return offset
+        if marker in _JPEG_STANDALONE_MARKERS:
+            continue
+        if offset + 2 > len(sample):
+            return None
+        segment_length = int.from_bytes(sample[offset : offset + 2], "big")
+        if segment_length < 2:
+            return None
+        segment_end = offset + segment_length
+        if segment_end > len(sample):
+            return None
+        if marker != 0xDA:
+            offset = segment_end
+            continue
+
+        offset = segment_end
+        while offset < len(sample):
+            marker_offset = sample.find(b"\xff", offset)
+            if marker_offset < 0 or marker_offset + 1 >= len(sample):
+                return None
+            marker = sample[marker_offset + 1]
+            if marker == 0x00 or 0xD0 <= marker <= 0xD7:
+                offset = marker_offset + 2
+                continue
+            if marker == 0xD9:
+                return marker_offset + 2
+            if marker == 0xFF:
+                offset = marker_offset + 1
+                continue
+            offset = marker_offset
+            break
+    return None
+
+
+def _detect_bounded_media_route_from_sample(
+    file_path: Path,
+    sample: bytes,
+    *,
+    sample_is_prefix: bool,
+) -> str | None:
+    """Return clean-media or strong media/pickle polyglot routing evidence."""
+    ext = file_path.suffix.lower()
+    if ext not in _MEDIA_ROUTING_SUFFIXES:
+        return None
+    if sample.startswith(_PNG_SIGNATURE):
+        media_end = _find_bounded_png_end(sample)
+    elif sample.startswith(b"\xff\xd8"):
+        media_end = _find_bounded_jpeg_end(sample)
+    else:
+        return None
+    if media_end is None:
+        return None
+    pickle_route = _detect_media_pickle_polyglot_route(sample[media_end:], sample_is_prefix=sample_is_prefix)
+    if pickle_route is not None:
+        return pickle_route
+    if sample_is_prefix:
+        return None
+    return VALID_MEDIA_ROUTING_FORMAT
+
+
+def _detect_bounded_media_route(file_path: Path, file_size: int) -> str | None:
+    """Inspect a bounded complete media sample before serialized fallback routing."""
+    if file_path.suffix.lower() not in _MEDIA_ROUTING_SUFFIXES:
+        return None
+    try:
+        sample = read_magic_bytes(str(file_path), min(file_size, MEDIA_ROUTE_READ_BYTES + 1))
+    except OSError:
+        return None
+    return _detect_bounded_media_route_from_sample(
+        file_path,
+        sample,
+        sample_is_prefix=file_size > len(sample),
+    )
+
+
 def _could_be_content_routed_flax_msgpack(file_path: Path) -> bool:
     """Route declared Flax formats and renamed candidates without claiming overlaps."""
     ext = file_path.suffix.lower()
@@ -5370,6 +5517,8 @@ def _could_be_content_routed_flax_msgpack(file_path: Path) -> bool:
     try:
         size = file_path.stat().st_size
     except OSError:
+        return False
+    if _detect_bounded_media_route(file_path, size) is not None:
         return False
     if ext not in _FLAX_MSGPACK_SCANNER_SUFFIXES:
         json_document_probe = _probe_complete_structured_json_document(file_path, size)
@@ -5551,6 +5700,12 @@ def detect_format_from_magic_bytes(
         return safetensors_route
     if structural_torch7_route:
         return "torch7"
+    if file_path is not None:
+        media_route = _detect_bounded_media_route(file_path, file_size)
+        if media_route == VALID_MEDIA_ROUTING_FORMAT:
+            return "unknown"
+        if media_route is not None:
+            return media_route
     if _looks_like_binary_pickle_protocol(magic4) and (
         file_path is None or not _could_be_content_routed_flax_msgpack(file_path)
     ):
@@ -5715,6 +5870,12 @@ def detect_file_format_from_magic(path: str) -> str:
                     return tar_route
             if format_result != "unknown":
                 return format_result
+
+            media_route = _detect_bounded_media_route(file_path, size)
+            if media_route == VALID_MEDIA_ROUTING_FORMAT:
+                return "unknown"
+            if media_route is not None:
+                return media_route
 
             # Protocol 0/1 pickle payloads can evade short magic-byte checks.
             # Probe a bounded prefix and require a valid opcode stream.
@@ -5890,6 +6051,12 @@ def detect_file_format_for_skip_filter(path: str) -> str:
         if format_result != "unknown":
             return format_result
 
+        media_route = _detect_bounded_media_route(file_path, size)
+        if media_route == VALID_MEDIA_ROUTING_FORMAT:
+            return "unknown"
+        if media_route is not None:
+            return media_route
+
         if _could_start_proto0_or_1_pickle(prefix):
             max_probe_size = min(size, PROTO0_1_MAX_PROBE_BYTES)
             if len(prefix) < max_probe_size:
@@ -6047,6 +6214,11 @@ def detect_file_format(path: str) -> str:
             return safetensors_route
         if structural_torch7_route:
             return "torch7"
+        media_route = _detect_bounded_media_route(file_path, size)
+        if media_route == VALID_MEDIA_ROUTING_FORMAT:
+            return "unknown"
+        if media_route is not None:
+            return media_route
         could_be_flax = _could_be_content_routed_flax_msgpack(file_path)
         if _looks_like_binary_pickle_protocol(magic4) and not could_be_flax:
             return "pickle"

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -286,10 +286,12 @@ _FLAX_MSGPACK_PROBE_LENGTH_SIZES = {
 }
 VALID_MEDIA_ROUTING_FORMAT = "valid_media"
 MEDIA_ROUTE_READ_BYTES = FLAX_MSGPACK_STRUCTURE_READ_BYTES
+MEDIA_ROUTE_TAIL_READ_BYTES = 64 * 1024
 _MEDIA_ROUTING_SUFFIXES = frozenset({".jpeg", ".jpg", ".png"})
 _MEDIA_TRAILING_PADDING = b"\x00\t\n\r "
 _PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 _PNG_IEND_CHUNK = b"IEND"
+_PNG_IEND_TRAILER = b"\x00\x00\x00\x00IEND\xaeB`\x82"
 _JPEG_STANDALONE_MARKERS = frozenset((0x01, 0xD8, 0xD9, *range(0xD0, 0xD8)))
 MXNET_SYMBOL_SIGNATURE_READ_BYTES = 10 * 1024 * 1024
 MXNET_SYMBOL_ROUTING_INCONCLUSIVE_FORMAT = "mxnet_symbol_routing_inconclusive"
@@ -5491,6 +5493,37 @@ def _detect_bounded_media_route_from_sample(
         return pickle_route
     if sample_is_prefix:
         return None
+    return VALID_MEDIA_ROUTING_FORMAT
+
+
+def _detect_bounded_media_route_from_edges(file_path: Path, prefix: bytes, tail: bytes) -> str | None:
+    """Return bounded media routing evidence from remote head and tail probes."""
+    ext = file_path.suffix.lower()
+    if ext not in _MEDIA_ROUTING_SUFFIXES or not prefix or not tail:
+        return None
+
+    if prefix.startswith(_PNG_SIGNATURE):
+        if len(prefix) < len(_PNG_SIGNATURE) + 8 or prefix[len(_PNG_SIGNATURE) : len(_PNG_SIGNATURE) + 8] != (
+            b"\x00\x00\x00\rIHDR"
+        ):
+            return None
+        media_end = tail.rfind(_PNG_IEND_TRAILER)
+        if media_end < 0:
+            return None
+        media_end += len(_PNG_IEND_TRAILER)
+    elif prefix.startswith(b"\xff\xd8"):
+        if len(prefix) < 4 or prefix[2] != 0xFF or prefix[3] in {0x00, 0xFF}:
+            return None
+        media_end = tail.rfind(b"\xff\xd9")
+        if media_end < 0:
+            return None
+        media_end += 2
+    else:
+        return None
+
+    pickle_route = _detect_media_pickle_polyglot_route(tail[media_end:], sample_is_prefix=False)
+    if pickle_route is not None:
+        return pickle_route
     return VALID_MEDIA_ROUTING_FORMAT
 
 

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -290,6 +290,7 @@ VALID_MEDIA_ROUTING_FORMAT = "valid_media"
 MEDIA_ROUTE_READ_BYTES = FLAX_MSGPACK_STRUCTURE_READ_BYTES
 MEDIA_ROUTE_TAIL_READ_BYTES = 64 * 1024
 _MEDIA_ROUTE_MAX_PNG_CHUNKS = 4096
+_MEDIA_STRUCTURAL_PROOF_READ_BYTES = 10 * 1024 * 1024
 _PNG_CRC_READ_CHUNK_BYTES = 64 * 1024
 _JPEG_SCAN_READ_CHUNK_BYTES = 64 * 1024
 _MEDIA_ROUTING_SUFFIXES = frozenset({".jpeg", ".jpg", ".png"})
@@ -5462,6 +5463,7 @@ def _find_png_end_with_reader(file_size: int, read_at: Callable[[int, int], byte
 
         offset = len(_PNG_SIGNATURE)
         saw_ihdr = False
+        crc_bytes_checked = 0
         for _ in range(_MEDIA_ROUTE_MAX_PNG_CHUNKS):
             if offset + 8 > file_size:
                 return None
@@ -5479,8 +5481,12 @@ def _find_png_end_with_reader(file_size: int, read_at: Callable[[int, int], byte
                 saw_ihdr = True
             elif chunk_type == b"IHDR":
                 return None
+            crc_proof_bytes = chunk_length + 4
+            if crc_bytes_checked + crc_proof_bytes > _MEDIA_STRUCTURAL_PROOF_READ_BYTES:
+                return None
             if not _png_chunk_crc_matches_with_reader(chunk_type, chunk_length, offset + 8, read_at):
                 return None
+            crc_bytes_checked += crc_proof_bytes
             if chunk_type == _PNG_IEND_CHUNK:
                 return chunk_end if chunk_length == 0 else None
             offset = chunk_end
@@ -5495,9 +5501,21 @@ def _find_jpeg_end_with_reader(file_size: int, read_at: Callable[[int, int], byt
         return None
 
     def read_exact(offset: int, size: int) -> bytes:
-        data = read_at(offset, size)
+        data = read_limited(offset, size)
         if len(data) != size:
             raise OSError("short JPEG read")
+        return data
+
+    bytes_requested = 0
+
+    def read_limited(offset: int, size: int) -> bytes:
+        nonlocal bytes_requested
+        if size <= 0:
+            return b""
+        if bytes_requested + size > _MEDIA_STRUCTURAL_PROOF_READ_BYTES:
+            raise OSError("bounded JPEG proof exceeded")
+        data = read_at(offset, size)
+        bytes_requested += size
         return data
 
     try:
@@ -5534,7 +5552,7 @@ def _find_jpeg_end_with_reader(file_size: int, read_at: Callable[[int, int], byt
 
             offset = segment_end
             while offset < file_size:
-                chunk = read_at(offset, min(_JPEG_SCAN_READ_CHUNK_BYTES, file_size - offset))
+                chunk = read_limited(offset, min(_JPEG_SCAN_READ_CHUNK_BYTES, file_size - offset))
                 if not chunk:
                     return None
                 index = 0

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -5665,16 +5665,12 @@ def _could_start_bounded_media_route(file_path: Path, sample: bytes) -> bool:
             len(sample) >= len(_PNG_SIGNATURE) + 8
             and sample[len(_PNG_SIGNATURE) : len(_PNG_SIGNATURE) + 8] == b"\x00\x00\x00\rIHDR"
         )
-    return (
-        len(sample) >= 4
-        and sample.startswith(b"\xff\xd8")
-        and sample[2] == 0xFF
-        and sample[3]
-        not in {
-            0x00,
-            0xFF,
-        }
-    )
+    if len(sample) < 3 or not sample.startswith(b"\xff\xd8") or sample[2] != 0xFF:
+        return False
+    marker_offset = 2
+    while marker_offset < len(sample) and sample[marker_offset] == 0xFF:
+        marker_offset += 1
+    return marker_offset >= len(sample) or sample[marker_offset] != 0x00
 
 
 def _detect_bounded_media_route_from_sample(

--- a/modelaudit/utils/sources/huggingface.py
+++ b/modelaudit/utils/sources/huggingface.py
@@ -710,9 +710,11 @@ def _detect_huggingface_content_route_format(
         _MEDIA_ROUTING_SUFFIXES,
         _TFLITE_CONTENT_ROUTE_BLOCKED_EXTENSIONS,
         MEDIA_ROUTE_TAIL_READ_BYTES,
+        PICKLE_ROUTING_INCONCLUSIVE_FORMAT,
         PROTO0_1_MAX_PROBE_BYTES,
         VALID_MEDIA_ROUTING_FORMAT,
         _allows_renamed_binary_content_route,
+        _could_start_bounded_media_route,
         _could_start_proto0_or_1_pickle,
         _detect_bounded_media_route_from_edges,
         _is_cntk_signature,
@@ -765,6 +767,8 @@ def _detect_huggingface_content_route_format(
             return None
         if media_route is not None:
             return media_route
+        if _could_start_bounded_media_route(remote_path, prefix):
+            return PICKLE_ROUTING_INCONCLUSIVE_FORMAT
 
     if _could_start_proto0_or_1_pickle(prefix):
         pickle_probe = _read_huggingface_probe(

--- a/modelaudit/utils/sources/huggingface.py
+++ b/modelaudit/utils/sources/huggingface.py
@@ -632,10 +632,14 @@ def _detect_huggingface_content_route_format(
         return None
 
     from modelaudit.utils.file.detection import (
+        _MEDIA_ROUTING_SUFFIXES,
         _TFLITE_CONTENT_ROUTE_BLOCKED_EXTENSIONS,
+        MEDIA_ROUTE_READ_BYTES,
         PROTO0_1_MAX_PROBE_BYTES,
+        VALID_MEDIA_ROUTING_FORMAT,
         _allows_renamed_binary_content_route,
         _could_start_proto0_or_1_pickle,
+        _detect_bounded_media_route_from_sample,
         _is_cntk_signature,
         _is_content_routed_lightgbm_signature,
         _looks_like_proto0_or_1_pickle,
@@ -671,6 +675,30 @@ def _detect_huggingface_content_route_format(
     mxnet_route = _detect_huggingface_mxnet_symbol_route(repo_id, filename, revision, budget, prefix)
     if mxnet_route is not None:
         return mxnet_route
+
+    if remote_path.suffix.lower() in _MEDIA_ROUTING_SUFFIXES:
+        media_probe = _read_huggingface_probe(
+            repo_id,
+            filename,
+            revision,
+            budget,
+            prefix,
+            MEDIA_ROUTE_READ_BYTES + 1,
+        )
+        media_route = _detect_bounded_media_route_from_sample(
+            remote_path,
+            media_probe,
+            sample_is_prefix=_huggingface_sample_is_prefix(
+                budget,
+                filename,
+                media_probe,
+                MEDIA_ROUTE_READ_BYTES + 1,
+            ),
+        )
+        if media_route == VALID_MEDIA_ROUTING_FORMAT:
+            return None
+        if media_route is not None:
+            return media_route
 
     if _could_start_proto0_or_1_pickle(prefix):
         pickle_probe = _read_huggingface_probe(

--- a/modelaudit/utils/sources/huggingface.py
+++ b/modelaudit/utils/sources/huggingface.py
@@ -231,6 +231,81 @@ def _read_huggingface_probe(
     return _read_huggingface_prefix(repo_id, filename, revision, budget, max_bytes)
 
 
+def _read_huggingface_tail(
+    repo_id: str,
+    filename: str,
+    revision: str,
+    budget: _HuggingFaceProbeBudget,
+    prefix: bytes,
+    max_bytes: int,
+) -> bytes:
+    """Read a bounded remote tail when the earlier prefix proved the file size."""
+    file_size = budget.file_sizes.get(filename)
+    if file_size is None or max_bytes <= 0:
+        return b""
+    if file_size <= len(prefix):
+        return prefix[-max_bytes:]
+
+    read_size = min(file_size, max_bytes)
+    start_offset = file_size - read_size
+    if start_offset == 0:
+        return _read_huggingface_probe(repo_id, filename, revision, budget, prefix, read_size)[-read_size:]
+
+    budget.reserve(repo_id, read_size)
+    try:
+        import re
+
+        import requests
+        from huggingface_hub import hf_hub_url
+        from huggingface_hub.utils import build_hf_headers
+
+        file_url = hf_hub_url(repo_id=repo_id, filename=filename, revision=revision)
+        headers = build_hf_headers(
+            token=None,
+            headers={
+                "Range": f"bytes={start_offset}-{file_size - 1}",
+                "Accept-Encoding": "identity",
+            },
+        )
+        with requests.get(
+            file_url,
+            headers=headers,
+            stream=True,
+            timeout=budget.request_timeout(repo_id),
+            allow_redirects=True,
+        ) as response:
+            response.raise_for_status()
+            chunks: list[bytes] = []
+            total = 0
+            for chunk in response.iter_content(chunk_size=read_size):
+                budget.check_deadline(repo_id)
+                if not chunk:
+                    continue
+                chunks.append(chunk)
+                total += len(chunk)
+                if total >= read_size:
+                    break
+            tail = b"".join(chunks)[:read_size]
+            content_range = getattr(response, "headers", {}).get("Content-Range", "")
+            match = re.fullmatch(r"bytes (\d+)-(\d+)/(\d+)", content_range.strip(), flags=re.IGNORECASE)
+            if getattr(response, "status_code", None) != 206 or match is None:
+                raise ValueError("tail Hugging Face response omitted a valid Content-Range")
+            reported_start, reported_end, reported_size = (int(value) for value in match.groups())
+            if (
+                reported_start != start_offset
+                or reported_end != file_size - 1
+                or reported_size != file_size
+                or len(tail) != read_size
+            ):
+                raise ValueError("tail Hugging Face response reported an inconsistent Content-Range")
+        return tail
+    except Exception as exc:
+        raise ValueError(
+            "Hugging Face selective filtering incomplete: unable to inspect skipped file "
+            f"{repo_id}/{filename} ({type(exc).__name__})"
+        ) from exc
+
+
 def _looks_like_safetensors_prefix(
     repo_id: str,
     filename: str,
@@ -634,12 +709,12 @@ def _detect_huggingface_content_route_format(
     from modelaudit.utils.file.detection import (
         _MEDIA_ROUTING_SUFFIXES,
         _TFLITE_CONTENT_ROUTE_BLOCKED_EXTENSIONS,
-        MEDIA_ROUTE_READ_BYTES,
+        MEDIA_ROUTE_TAIL_READ_BYTES,
         PROTO0_1_MAX_PROBE_BYTES,
         VALID_MEDIA_ROUTING_FORMAT,
         _allows_renamed_binary_content_route,
         _could_start_proto0_or_1_pickle,
-        _detect_bounded_media_route_from_sample,
+        _detect_bounded_media_route_from_edges,
         _is_cntk_signature,
         _is_content_routed_lightgbm_signature,
         _looks_like_proto0_or_1_pickle,
@@ -677,24 +752,15 @@ def _detect_huggingface_content_route_format(
         return mxnet_route
 
     if remote_path.suffix.lower() in _MEDIA_ROUTING_SUFFIXES:
-        media_probe = _read_huggingface_probe(
+        media_tail = _read_huggingface_tail(
             repo_id,
             filename,
             revision,
             budget,
             prefix,
-            MEDIA_ROUTE_READ_BYTES + 1,
+            MEDIA_ROUTE_TAIL_READ_BYTES,
         )
-        media_route = _detect_bounded_media_route_from_sample(
-            remote_path,
-            media_probe,
-            sample_is_prefix=_huggingface_sample_is_prefix(
-                budget,
-                filename,
-                media_probe,
-                MEDIA_ROUTE_READ_BYTES + 1,
-            ),
-        )
+        media_route = _detect_bounded_media_route_from_edges(remote_path, prefix, media_tail)
         if media_route == VALID_MEDIA_ROUTING_FORMAT:
             return None
         if media_route is not None:

--- a/modelaudit/utils/sources/huggingface.py
+++ b/modelaudit/utils/sources/huggingface.py
@@ -306,6 +306,171 @@ def _read_huggingface_tail(
         ) from exc
 
 
+def _read_huggingface_range(
+    repo_id: str,
+    filename: str,
+    revision: str,
+    budget: _HuggingFaceProbeBudget,
+    prefix: bytes,
+    start_offset: int,
+    max_bytes: int,
+) -> bytes:
+    """Read a bounded remote byte range, reusing the cached prefix when possible."""
+    file_size = budget.file_sizes.get(filename)
+    if file_size is None or max_bytes <= 0 or start_offset < 0 or start_offset >= file_size:
+        return b""
+
+    read_size = min(max_bytes, file_size - start_offset)
+    end_offset = start_offset + read_size
+    if end_offset <= len(prefix):
+        return prefix[start_offset:end_offset]
+
+    chunks: list[bytes] = []
+    remote_start = start_offset
+    if start_offset < len(prefix):
+        chunks.append(prefix[start_offset:])
+        remote_start = len(prefix)
+
+    remote_size = read_size - sum(len(chunk) for chunk in chunks)
+    if remote_size <= 0:
+        return b"".join(chunks)[:read_size]
+
+    remote_end = remote_start + remote_size - 1
+    budget.reserve(repo_id, remote_size)
+    try:
+        import re
+
+        import requests
+        from huggingface_hub import hf_hub_url
+        from huggingface_hub.utils import build_hf_headers
+
+        file_url = hf_hub_url(repo_id=repo_id, filename=filename, revision=revision)
+        headers = build_hf_headers(
+            token=None,
+            headers={
+                "Range": f"bytes={remote_start}-{remote_end}",
+                "Accept-Encoding": "identity",
+            },
+        )
+        with requests.get(
+            file_url,
+            headers=headers,
+            stream=True,
+            timeout=budget.request_timeout(repo_id),
+            allow_redirects=True,
+        ) as response:
+            response.raise_for_status()
+            remote_chunks: list[bytes] = []
+            total = 0
+            for chunk in response.iter_content(chunk_size=remote_size):
+                budget.check_deadline(repo_id)
+                if not chunk:
+                    continue
+                remote_chunks.append(chunk)
+                total += len(chunk)
+                if total >= remote_size:
+                    break
+            remote_payload = b"".join(remote_chunks)[:remote_size]
+            content_range = getattr(response, "headers", {}).get("Content-Range", "")
+            match = re.fullmatch(r"bytes (\d+)-(\d+)/(\d+)", content_range.strip(), flags=re.IGNORECASE)
+            if getattr(response, "status_code", None) != 206 or match is None:
+                raise ValueError("range Hugging Face response omitted a valid Content-Range")
+            reported_start, reported_end, reported_size = (int(value) for value in match.groups())
+            if (
+                reported_start != remote_start
+                or reported_end != remote_end
+                or reported_size != file_size
+                or len(remote_payload) != remote_size
+            ):
+                raise ValueError("range Hugging Face response reported an inconsistent Content-Range")
+            chunks.append(remote_payload)
+        return b"".join(chunks)[:read_size]
+    except Exception as exc:
+        raise ValueError(
+            "Hugging Face selective filtering incomplete: unable to inspect skipped file "
+            f"{repo_id}/{filename} ({type(exc).__name__})"
+        ) from exc
+
+
+def _detect_huggingface_png_media_route(
+    repo_id: str,
+    filename: str,
+    revision: str,
+    budget: _HuggingFaceProbeBudget,
+    prefix: bytes,
+) -> str | None:
+    """Return a PNG media route by walking chunk framing with sparse range reads."""
+    from modelaudit.utils.file.detection import (
+        _PNG_SIGNATURE,
+        MEDIA_ROUTE_READ_BYTES,
+        MEDIA_ROUTE_TAIL_READ_BYTES,
+        PICKLE_ROUTING_INCONCLUSIVE_FORMAT,
+        VALID_MEDIA_ROUTING_FORMAT,
+        _detect_complete_media_route_from_trailing,
+        _find_png_end_with_reader,
+    )
+
+    if not prefix.startswith(_PNG_SIGNATURE):
+        return None
+    file_size = budget.file_sizes.get(filename)
+    if file_size is None:
+        return PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+
+    tail: bytes | None = None
+    tail_start = file_size
+    range_windows: list[tuple[int, bytes]] = []
+
+    def read_at(offset: int, size: int) -> bytes:
+        nonlocal tail, tail_start
+        end_offset = offset + size
+        if end_offset <= len(prefix):
+            return prefix[offset:end_offset]
+        if tail is None:
+            tail = _read_huggingface_tail(
+                repo_id,
+                filename,
+                revision,
+                budget,
+                prefix,
+                MEDIA_ROUTE_TAIL_READ_BYTES,
+            )
+            tail_start = file_size - len(tail)
+        if tail_start <= offset and end_offset <= tail_start + len(tail):
+            return tail[offset - tail_start : end_offset - tail_start]
+        if offset < len(prefix) and len(prefix) >= tail_start and end_offset <= tail_start + len(tail):
+            prefix_part = prefix[offset : min(end_offset, len(prefix))]
+            tail_part_start = max(len(prefix), tail_start)
+            tail_part = tail[tail_part_start - tail_start : end_offset - tail_start]
+            return prefix_part + tail_part
+        for window_start, window in range_windows:
+            if window_start <= offset and end_offset <= window_start + len(window):
+                return window[offset - window_start : end_offset - window_start]
+        window_size = min(MEDIA_ROUTE_TAIL_READ_BYTES, file_size - offset)
+        window = _read_huggingface_range(repo_id, filename, revision, budget, prefix, offset, window_size)
+        range_windows.append((offset, window))
+        return window[:size]
+
+    try:
+        media_end = _find_png_end_with_reader(
+            file_size,
+            read_at,
+        )
+    except ValueError:
+        return PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+    if media_end is None:
+        return PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+
+    trailing_size = file_size - media_end
+    if trailing_size <= 0:
+        return VALID_MEDIA_ROUTING_FORMAT
+    read_size = min(trailing_size, MEDIA_ROUTE_READ_BYTES + 1)
+    try:
+        trailing = read_at(media_end, read_size)
+    except ValueError:
+        return PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+    return _detect_complete_media_route_from_trailing(trailing, sample_is_prefix=trailing_size > len(trailing))
+
+
 def _looks_like_safetensors_prefix(
     repo_id: str,
     filename: str,
@@ -754,15 +919,17 @@ def _detect_huggingface_content_route_format(
         return mxnet_route
 
     if remote_path.suffix.lower() in _MEDIA_ROUTING_SUFFIXES:
-        media_tail = _read_huggingface_tail(
-            repo_id,
-            filename,
-            revision,
-            budget,
-            prefix,
-            MEDIA_ROUTE_TAIL_READ_BYTES,
-        )
-        media_route = _detect_bounded_media_route_from_edges(remote_path, prefix, media_tail)
+        media_route = _detect_huggingface_png_media_route(repo_id, filename, revision, budget, prefix)
+        if media_route is None:
+            media_tail = _read_huggingface_tail(
+                repo_id,
+                filename,
+                revision,
+                budget,
+                prefix,
+                MEDIA_ROUTE_TAIL_READ_BYTES,
+            )
+            media_route = _detect_bounded_media_route_from_edges(remote_path, prefix, media_tail)
         if media_route == VALID_MEDIA_ROUTING_FORMAT:
             return None
         if media_route is not None:

--- a/modelaudit/utils/sources/huggingface.py
+++ b/modelaudit/utils/sources/huggingface.py
@@ -471,6 +471,81 @@ def _detect_huggingface_png_media_route(
     return _detect_complete_media_route_from_trailing(trailing, sample_is_prefix=trailing_size > len(trailing))
 
 
+def _detect_huggingface_jpeg_media_route(
+    repo_id: str,
+    filename: str,
+    revision: str,
+    budget: _HuggingFaceProbeBudget,
+    prefix: bytes,
+) -> str | None:
+    """Return a JPEG media route by walking marker structure with sparse range reads."""
+    from modelaudit.utils.file.detection import (
+        MEDIA_ROUTE_READ_BYTES,
+        MEDIA_ROUTE_TAIL_READ_BYTES,
+        PICKLE_ROUTING_INCONCLUSIVE_FORMAT,
+        VALID_MEDIA_ROUTING_FORMAT,
+        _detect_complete_media_route_from_trailing,
+        _find_jpeg_end_with_reader,
+    )
+
+    if not prefix.startswith(b"\xff\xd8"):
+        return None
+    file_size = budget.file_sizes.get(filename)
+    if file_size is None:
+        return PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+
+    tail: bytes | None = None
+    tail_start = file_size
+    range_windows: list[tuple[int, bytes]] = []
+
+    def read_at(offset: int, size: int) -> bytes:
+        nonlocal tail, tail_start
+        end_offset = offset + size
+        if end_offset <= len(prefix):
+            return prefix[offset:end_offset]
+        if tail is None:
+            tail = _read_huggingface_tail(
+                repo_id,
+                filename,
+                revision,
+                budget,
+                prefix,
+                MEDIA_ROUTE_TAIL_READ_BYTES,
+            )
+            tail_start = file_size - len(tail)
+        if tail_start <= offset and end_offset <= tail_start + len(tail):
+            return tail[offset - tail_start : end_offset - tail_start]
+        if offset < len(prefix) and len(prefix) >= tail_start and end_offset <= tail_start + len(tail):
+            prefix_part = prefix[offset : min(end_offset, len(prefix))]
+            tail_part_start = max(len(prefix), tail_start)
+            tail_part = tail[tail_part_start - tail_start : end_offset - tail_start]
+            return prefix_part + tail_part
+        for window_start, window in range_windows:
+            if window_start <= offset and end_offset <= window_start + len(window):
+                return window[offset - window_start : end_offset - window_start]
+        window_size = min(MEDIA_ROUTE_TAIL_READ_BYTES, file_size - offset)
+        window = _read_huggingface_range(repo_id, filename, revision, budget, prefix, offset, window_size)
+        range_windows.append((offset, window))
+        return window[:size]
+
+    try:
+        media_end = _find_jpeg_end_with_reader(file_size, read_at)
+    except ValueError:
+        return PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+    if media_end is None:
+        return PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+
+    trailing_size = file_size - media_end
+    if trailing_size <= 0:
+        return VALID_MEDIA_ROUTING_FORMAT
+    read_size = min(trailing_size, MEDIA_ROUTE_READ_BYTES + 1)
+    try:
+        trailing = read_at(media_end, read_size)
+    except ValueError:
+        return PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+    return _detect_complete_media_route_from_trailing(trailing, sample_is_prefix=trailing_size > len(trailing))
+
+
 def _looks_like_safetensors_prefix(
     repo_id: str,
     filename: str,
@@ -920,6 +995,8 @@ def _detect_huggingface_content_route_format(
 
     if remote_path.suffix.lower() in _MEDIA_ROUTING_SUFFIXES:
         media_route = _detect_huggingface_png_media_route(repo_id, filename, revision, budget, prefix)
+        if media_route is None:
+            media_route = _detect_huggingface_jpeg_media_route(repo_id, filename, revision, budget, prefix)
         if media_route is None:
             media_tail = _read_huggingface_tail(
                 repo_id,

--- a/tests/helpers/file_creators.py
+++ b/tests/helpers/file_creators.py
@@ -5,12 +5,53 @@ These utilities create various model file formats for testing purposes.
 All functions accept a Path and create the file at that location.
 """
 
+import base64
 import json
 import pickle
 import struct
 import zipfile
+import zlib
 from pathlib import Path
 from typing import Any
+
+_VALID_JPEG_1X1 = base64.b64decode(
+    "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////"
+    "2wBDAf//////////////////////////////////////////////////////////////////////////////////////"
+    "wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAP/xAAVEAEBAAAAAAAAAAAAAAAAAAAAAf/"
+    "aAAwDAQACEAMQAAAB/8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQABBQJ//8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/"
+    "aAAgBAwEBPwF//8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAgBAgEBPwF//9k="
+)
+_MALICIOUS_PICKLE = bytes.fromhex(
+    "80059525000000000000008c05706f736978948c0673797374656d9493948c0a6563686f2070776e656494859452942e"
+)
+
+
+def _png_chunk(chunk_type: bytes, payload: bytes) -> bytes:
+    checksum = zlib.crc32(chunk_type + payload) & 0xFFFFFFFF
+    return struct.pack(">I", len(payload)) + chunk_type + payload + struct.pack(">I", checksum)
+
+
+_VALID_PNG_1X1 = (
+    b"\x89PNG\r\n\x1a\n"
+    + _png_chunk(b"IHDR", struct.pack(">IIBBBBB", 1, 1, 8, 6, 0, 0, 0))
+    + _png_chunk(b"IDAT", zlib.compress(b"\x00\x00\x00\x00\x00"))
+    + _png_chunk(b"IEND", b"")
+)
+
+
+def valid_png_bytes() -> bytes:
+    """Return a complete 1x1 PNG fixture for media-routing regressions."""
+    return _VALID_PNG_1X1
+
+
+def valid_jpeg_bytes() -> bytes:
+    """Return a complete 1x1 JPEG fixture for media-routing regressions."""
+    return _VALID_JPEG_1X1
+
+
+def malicious_pickle_bytes() -> bytes:
+    """Return a tiny binary pickle payload that resolves to os.system."""
+    return _MALICIOUS_PICKLE
 
 
 def _tar_octal_field(value: int, length: int) -> bytes:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -215,6 +215,25 @@ def _build_malicious_pickle(*, protocol: int | None = None) -> bytes:
     return pickle.dumps(DangerousPayload(), protocol=protocol)
 
 
+def test_scan_file_padded_media_pickle_polyglot_fails_closed(tmp_path: Path) -> None:
+    media_path = tmp_path / "padded-polyglot.png"
+    media_path.write_bytes(
+        valid_png_bytes() + (b"\0" * (file_detection.MEDIA_ROUTE_READ_BYTES + 2)) + _build_malicious_pickle()
+    )
+
+    result = scan_file(str(media_path), config={"cache_scan_results": False})
+
+    assert result.success is False
+    assert result.scanner_name == "unknown"
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert any(
+        check.name == "Pickle Routing"
+        and check.status == CheckStatus.FAILED
+        and check.details["format"] == file_detection.PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+        for check in result.checks
+    )
+
+
 def _build_protocolless_binary_malicious_pickle() -> bytes:
     """Build a binary pickle gadget without the optional PROTO opcode."""
     return b"\x8c\x02os\x94\x8c\x06system\x94\x93\x94\x8c\x02id\x94\x85\x94R\x94."

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -74,6 +74,7 @@ from tests.helpers import (
     prefix_mock_onnx_with_unknown_field,
     prefix_mock_onnx_with_unknown_group,
 )
+from tests.helpers.file_creators import valid_jpeg_bytes, valid_png_bytes
 
 _SYSTEM_GLOBAL_NAMES = ("os.system", "posix.system", "nt.system")
 
@@ -336,6 +337,43 @@ def _write_gzip_safetensors_polyglot(
     assert json.loads(payload[8:header_end].decode("utf-8"))
     assert gzip.decompress(gzip_member) == uncompressed
     path.write_bytes(payload)
+
+
+@pytest.mark.parametrize(
+    ("filename", "payload"),
+    [("preview.png", valid_png_bytes()), ("preview.jpg", valid_jpeg_bytes())],
+    ids=["png", "jpg"],
+)
+def test_scan_file_valid_media_is_unknown_not_serialized(tmp_path: Path, filename: str, payload: bytes) -> None:
+    media_path = tmp_path / filename
+    media_path.write_bytes(payload)
+
+    result = scan_file(str(media_path), config={"cache_scan_results": False})
+
+    assert result.scanner_name == "unknown"
+    assert result.issues == []
+
+
+def test_directory_scan_skips_valid_media_assets(tmp_path: Path) -> None:
+    (tmp_path / "preview.png").write_bytes(valid_png_bytes())
+    (tmp_path / "teaser.jpg").write_bytes(valid_jpeg_bytes())
+
+    result = scan_model_directory_or_file(str(tmp_path), cache_scan_results=False)
+
+    assert result.files_scanned == 0
+    assert "pickle" not in result.scanner_names
+    assert "flax_msgpack" not in result.scanner_names
+    assert "jax_checkpoint" not in result.scanner_names
+
+
+def test_scan_file_media_pickle_polyglot_detects_system_global(tmp_path: Path) -> None:
+    media_path = tmp_path / "polyglot.png"
+    media_path.write_bytes(valid_png_bytes() + _build_malicious_pickle())
+
+    result = scan_file(str(media_path), config={"cache_scan_results": False})
+
+    assert result.scanner_name == "pickle"
+    _assert_system_pickle_issue(result)
 
 
 def _require_tf_protos() -> None:

--- a/tests/test_directory_file_filtering.py
+++ b/tests/test_directory_file_filtering.py
@@ -36,6 +36,7 @@ from tests.helpers import (
     prefix_mock_onnx_with_unknown_field,
     prefix_mock_onnx_with_unknown_group,
 )
+from tests.helpers.file_creators import valid_jpeg_bytes
 
 
 def _require_tf_protos() -> None:
@@ -727,7 +728,7 @@ class TestDirectoryFileFiltering:
     def test_real_images_remain_skipped(self, tmp_path: Path) -> None:
         """Content sniffing should not promote ordinary media files into the scan set."""
         image_path = tmp_path / "cover.jpg"
-        image_path.write_bytes(b"\xff\xd8\xff\xe0" + b"jpeg")
+        image_path.write_bytes(valid_jpeg_bytes())
 
         results = scan_model_directory_or_file(str(tmp_path))
 

--- a/tests/utils/file/test_file_filter.py
+++ b/tests/utils/file/test_file_filter.py
@@ -34,7 +34,10 @@ from tests.helpers.file_creators import (
     create_mock_mxnet_symbol,
     create_mock_onnx,
     create_v7_tar_archive,
+    malicious_pickle_bytes,
     prefix_mock_onnx_with_unknown_field,
+    valid_jpeg_bytes,
+    valid_png_bytes,
 )
 
 
@@ -185,6 +188,44 @@ class TestFileFilter:
 
         for file in skip_files:
             assert should_skip_file(file), f"Should skip {file}"
+
+    @pytest.mark.parametrize(
+        ("filename", "payload"),
+        [
+            ("preview.png", valid_png_bytes()),
+            ("preview.jpg", valid_jpeg_bytes()),
+            ("preview.jpeg", valid_jpeg_bytes()),
+        ],
+        ids=["png", "jpg", "jpeg"],
+    )
+    def test_valid_media_stays_skipped_by_default_prefilter(
+        self,
+        tmp_path: Path,
+        filename: str,
+        payload: bytes,
+    ) -> None:
+        media_path = tmp_path / filename
+        media_path.write_bytes(payload)
+
+        assert detect_file_format_for_skip_filter(str(media_path)) == "unknown"
+        assert should_skip_file(str(media_path)) is True
+
+    @pytest.mark.parametrize(
+        ("filename", "payload"),
+        [("polyglot.png", valid_png_bytes()), ("polyglot.jpg", valid_jpeg_bytes())],
+        ids=["png", "jpg"],
+    )
+    def test_media_pickle_polyglot_bypasses_default_prefilter(
+        self,
+        tmp_path: Path,
+        filename: str,
+        payload: bytes,
+    ) -> None:
+        media_path = tmp_path / filename
+        media_path.write_bytes(payload + malicious_pickle_bytes())
+
+        assert detect_file_format_for_skip_filter(str(media_path)) == "pickle"
+        assert should_skip_file(str(media_path)) is False
 
     def test_allow_model_extensions(self):
         """Test that model extensions are not skipped."""

--- a/tests/utils/file/test_file_filter.py
+++ b/tests/utils/file/test_file_filter.py
@@ -229,6 +229,14 @@ class TestFileFilter:
         assert detect_file_format_for_skip_filter(str(media_path)) == "pickle"
         assert should_skip_file(str(media_path)) is False
 
+    def test_jpeg_fill_byte_media_pickle_polyglot_bypasses_default_prefilter(self, tmp_path: Path) -> None:
+        media_path = tmp_path / "fill-polyglot.jpg"
+        jpeg_with_fill = valid_jpeg_bytes()[:3] + b"\xff" + valid_jpeg_bytes()[3:]
+        media_path.write_bytes(jpeg_with_fill + malicious_pickle_bytes())
+
+        assert detect_file_format_for_skip_filter(str(media_path)) == "pickle"
+        assert should_skip_file(str(media_path)) is False
+
     def test_padded_media_pickle_polyglot_bypasses_default_prefilter(self, tmp_path: Path) -> None:
         media_path = tmp_path / "padded-polyglot.png"
         media_path.write_bytes(valid_png_bytes() + (b"\0" * (MEDIA_ROUTE_READ_BYTES + 2)) + malicious_pickle_bytes())

--- a/tests/utils/file/test_file_filter.py
+++ b/tests/utils/file/test_file_filter.py
@@ -236,6 +236,29 @@ class TestFileFilter:
         assert detect_file_format_for_skip_filter(str(media_path)) == PICKLE_ROUTING_INCONCLUSIVE_FORMAT
         assert should_skip_file(str(media_path)) is False
 
+    @pytest.mark.parametrize(
+        ("filename", "payload"),
+        [
+            ("bad-crc.png", bytes(bytearray(valid_png_bytes())[:-1] + bytes([valid_png_bytes()[-1] ^ 0x01]))),
+            (
+                "forged-tail.jpg",
+                b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00" + b"\0" * 32 + b"\xff\xd9",
+            ),
+        ],
+        ids=["png-crc", "jpeg-tail"],
+    )
+    def test_malformed_media_headers_bypass_default_prefilter(
+        self,
+        tmp_path: Path,
+        filename: str,
+        payload: bytes,
+    ) -> None:
+        media_path = tmp_path / filename
+        media_path.write_bytes(payload)
+
+        assert detect_file_format_for_skip_filter(str(media_path)) == PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+        assert should_skip_file(str(media_path)) is False
+
     def test_allow_model_extensions(self):
         """Test that model extensions are not skipped."""
         model_files = [
@@ -358,7 +381,7 @@ class TestFileFilter:
         disguised_legacy_tar = create_v7_tar_archive(tmp_path / "legacy-tar.jpg")
 
         real_image = tmp_path / "cover.jpg"
-        real_image.write_bytes(b"\xff\xd8\xff\xe0" + b"jpeg")
+        real_image.write_bytes(valid_jpeg_bytes())
 
         assert not should_skip_file(str(disguised_pickle))
         assert not should_skip_file(str(disguised_protocol0_pickle))

--- a/tests/utils/file/test_file_filter.py
+++ b/tests/utils/file/test_file_filter.py
@@ -18,7 +18,9 @@ from modelaudit.utils.file.detection import (
     JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES,
     LLAMAFILE_ROUTE_SCAN_BYTES,
     LLAMAFILE_ROUTE_TAIL_SCAN_BYTES,
+    MEDIA_ROUTE_READ_BYTES,
     MXNET_SYMBOL_SIGNATURE_READ_BYTES,
+    PICKLE_ROUTING_INCONCLUSIVE_FORMAT,
     PROTOBUF_MODEL_CANDIDATE_FORMAT,
     SAFETENSORS_ROUTING_HEADER_PARSE_BYTES,
     TENSORFLOW_PROTOBUF_ROUTING_INCONCLUSIVE_FORMAT,
@@ -225,6 +227,13 @@ class TestFileFilter:
         media_path.write_bytes(payload + malicious_pickle_bytes())
 
         assert detect_file_format_for_skip_filter(str(media_path)) == "pickle"
+        assert should_skip_file(str(media_path)) is False
+
+    def test_padded_media_pickle_polyglot_bypasses_default_prefilter(self, tmp_path: Path) -> None:
+        media_path = tmp_path / "padded-polyglot.png"
+        media_path.write_bytes(valid_png_bytes() + (b"\0" * (MEDIA_ROUTE_READ_BYTES + 2)) + malicious_pickle_bytes())
+
+        assert detect_file_format_for_skip_filter(str(media_path)) == PICKLE_ROUTING_INCONCLUSIVE_FORMAT
         assert should_skip_file(str(media_path)) is False
 
     def test_allow_model_extensions(self):

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -288,6 +288,25 @@ def test_malformed_media_headers_fail_closed(tmp_path: Path, filename: str, payl
     assert detect_file_format_for_skip_filter(str(media_path)) == PICKLE_ROUTING_INCONCLUSIVE_FORMAT
 
 
+def test_png_crc_reader_refuses_oversized_payload_before_unbounded_read() -> None:
+    def png_chunk(chunk_type: bytes, payload: bytes) -> bytes:
+        checksum = zlib.crc32(chunk_type + payload) & 0xFFFFFFFF
+        return len(payload).to_bytes(4, "big") + chunk_type + payload + checksum.to_bytes(4, "big")
+
+    ihdr = png_chunk(b"IHDR", struct.pack(">IIBBBBB", 1, 1, 8, 6, 0, 0, 0))
+    oversized_idat_length = file_detection._MEDIA_STRUCTURAL_PROOF_READ_BYTES + 1
+    prefix = b"\x89PNG\r\n\x1a\n" + ihdr + oversized_idat_length.to_bytes(4, "big") + b"IDAT"
+    idat_payload_offset = len(prefix)
+    file_size = idat_payload_offset + oversized_idat_length + 4
+
+    def read_at(offset: int, size: int) -> bytes:
+        if offset >= idat_payload_offset:
+            pytest.fail("oversized PNG CRC proof attempted to read chunk payload")
+        return prefix[offset : offset + size]
+
+    assert file_detection._find_png_end_with_reader(file_size, read_at) is None
+
+
 def test_detect_file_format_zip(tmp_path):
     """Test detecting a ZIP file format."""
     # Create a ZIP file

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -47,7 +47,14 @@ from tests.helpers import (
     prefix_mock_onnx_with_unknown_field,
     prefix_mock_onnx_with_unknown_group,
 )
-from tests.helpers.file_creators import _coreml_field_bytes, _coreml_field_varint, create_v7_tar_archive
+from tests.helpers.file_creators import (
+    _coreml_field_bytes,
+    _coreml_field_varint,
+    create_v7_tar_archive,
+    malicious_pickle_bytes,
+    valid_jpeg_bytes,
+    valid_png_bytes,
+)
 
 
 def _ubjson_key(key: bytes) -> bytes:
@@ -216,6 +223,38 @@ def test_detect_file_format_large_directory(tmp_path):
         (tf_dir / f"file_{i}.txt").write_text("x")
 
     assert detect_file_format(str(tf_dir)) == "tensorflow_directory"
+
+
+@pytest.mark.parametrize(
+    ("filename", "payload"),
+    [
+        ("preview.png", valid_png_bytes()),
+        ("preview.jpg", valid_jpeg_bytes()),
+        ("preview.jpeg", valid_jpeg_bytes()),
+    ],
+    ids=["png", "jpg", "jpeg"],
+)
+def test_valid_media_do_not_route_to_serialized_formats(tmp_path: Path, filename: str, payload: bytes) -> None:
+    media_path = tmp_path / filename
+    media_path.write_bytes(payload)
+
+    assert detect_file_format(str(media_path)) == "unknown"
+    assert detect_file_format_from_magic(str(media_path)) == "unknown"
+    assert detect_file_format_for_skip_filter(str(media_path)) == "unknown"
+
+
+@pytest.mark.parametrize(
+    ("filename", "payload"),
+    [("polyglot.png", valid_png_bytes()), ("polyglot.jpg", valid_jpeg_bytes())],
+    ids=["png", "jpg"],
+)
+def test_media_pickle_polyglot_keeps_pickle_route(tmp_path: Path, filename: str, payload: bytes) -> None:
+    media_path = tmp_path / filename
+    media_path.write_bytes(payload + malicious_pickle_bytes())
+
+    assert detect_file_format(str(media_path)) == "pickle"
+    assert detect_file_format_from_magic(str(media_path)) == "pickle"
+    assert detect_file_format_for_skip_filter(str(media_path)) == "pickle"
 
 
 def test_detect_file_format_zip(tmp_path):

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -259,6 +259,16 @@ def test_media_pickle_polyglot_keeps_pickle_route(tmp_path: Path, filename: str,
     assert detect_file_format_for_skip_filter(str(media_path)) == "pickle"
 
 
+def test_jpeg_fill_byte_media_pickle_polyglot_keeps_pickle_route(tmp_path: Path) -> None:
+    media_path = tmp_path / "fill-polyglot.jpg"
+    jpeg_with_fill = valid_jpeg_bytes()[:3] + b"\xff" + valid_jpeg_bytes()[3:]
+    media_path.write_bytes(jpeg_with_fill + malicious_pickle_bytes())
+
+    assert detect_file_format(str(media_path)) == "pickle"
+    assert detect_file_format_from_magic(str(media_path)) == "pickle"
+    assert detect_file_format_for_skip_filter(str(media_path)) == "pickle"
+
+
 def test_padded_media_pickle_polyglot_fails_closed_past_probe_limit(tmp_path: Path) -> None:
     media_path = tmp_path / "padded-polyglot.png"
     media_path.write_bytes(valid_png_bytes() + (b"\0" * (MEDIA_ROUTE_READ_BYTES + 2)) + malicious_pickle_bytes())

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -21,9 +21,11 @@ from modelaudit.utils.file.detection import (
     FLAX_MSGPACK_STRUCTURE_READ_BYTES,
     JAX_JSON_CHECKPOINT_ROUTING_READ_BYTES,
     JAX_JSON_CHECKPOINT_STRUCTURE_READ_BYTES,
+    MEDIA_ROUTE_READ_BYTES,
     MXNET_SYMBOL_ROUTING_INCONCLUSIVE_FORMAT,
     MXNET_SYMBOL_SIGNATURE_READ_BYTES,
     NEMO_ROUTING_INCONCLUSIVE_FORMAT,
+    PICKLE_ROUTING_INCONCLUSIVE_FORMAT,
     PROTO0_1_MAX_PROBE_BYTES,
     PROTOBUF_MODEL_CANDIDATE_FORMAT,
     SAFETENSORS_ROUTING_HEADER_PARSE_BYTES,
@@ -255,6 +257,15 @@ def test_media_pickle_polyglot_keeps_pickle_route(tmp_path: Path, filename: str,
     assert detect_file_format(str(media_path)) == "pickle"
     assert detect_file_format_from_magic(str(media_path)) == "pickle"
     assert detect_file_format_for_skip_filter(str(media_path)) == "pickle"
+
+
+def test_padded_media_pickle_polyglot_fails_closed_past_probe_limit(tmp_path: Path) -> None:
+    media_path = tmp_path / "padded-polyglot.png"
+    media_path.write_bytes(valid_png_bytes() + (b"\0" * (MEDIA_ROUTE_READ_BYTES + 2)) + malicious_pickle_bytes())
+
+    assert detect_file_format(str(media_path)) == PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+    assert detect_file_format_from_magic(str(media_path)) == PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+    assert detect_file_format_for_skip_filter(str(media_path)) == PICKLE_ROUTING_INCONCLUSIVE_FORMAT
 
 
 def test_detect_file_format_zip(tmp_path):

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -268,6 +268,26 @@ def test_padded_media_pickle_polyglot_fails_closed_past_probe_limit(tmp_path: Pa
     assert detect_file_format_for_skip_filter(str(media_path)) == PICKLE_ROUTING_INCONCLUSIVE_FORMAT
 
 
+@pytest.mark.parametrize(
+    ("filename", "payload"),
+    [
+        ("bad-crc.png", bytes(bytearray(valid_png_bytes())[:-1] + bytes([valid_png_bytes()[-1] ^ 0x01]))),
+        (
+            "forged-tail.jpg",
+            b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00" + b"\0" * 32 + b"\xff\xd9",
+        ),
+    ],
+    ids=["png-crc", "jpeg-tail"],
+)
+def test_malformed_media_headers_fail_closed(tmp_path: Path, filename: str, payload: bytes) -> None:
+    media_path = tmp_path / filename
+    media_path.write_bytes(payload)
+
+    assert detect_file_format(str(media_path)) == PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+    assert detect_file_format_from_magic(str(media_path)) == PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+    assert detect_file_format_for_skip_filter(str(media_path)) == PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+
+
 def test_detect_file_format_zip(tmp_path):
     """Test detecting a ZIP file format."""
     # Create a ZIP file

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -9,6 +9,7 @@ import subprocess
 import tarfile
 import time
 import zipfile
+import zlib
 from collections.abc import Callable, Iterator
 from io import BytesIO
 from pathlib import Path
@@ -18,7 +19,7 @@ from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 
-from modelaudit.utils.file.detection import detect_file_format_for_skip_filter
+from modelaudit.utils.file.detection import MEDIA_ROUTE_TAIL_READ_BYTES, detect_file_format_for_skip_filter
 from modelaudit.utils.sources._huggingface_download_worker import _run_operation as _run_huggingface_worker_operation
 from modelaudit.utils.sources.huggingface import (
     _get_huggingface_path_sizes,
@@ -88,6 +89,17 @@ def _make_executable_zip_polyglot_payload() -> bytes:
     with zipfile.ZipFile(payload, "w") as archive:
         archive.writestr("model.pkl", b"payload")
     return b"\x7fELF" + b"\x02\x01\x01\x00" + (b"\x00" * 56) + payload.getvalue()
+
+
+def _png_chunk(chunk_type: bytes, payload: bytes) -> bytes:
+    checksum = zlib.crc32(chunk_type + payload) & 0xFFFFFFFF
+    return len(payload).to_bytes(4, "big") + chunk_type + payload + checksum.to_bytes(4, "big")
+
+
+def _make_large_valid_png_payload() -> bytes:
+    png = valid_png_bytes()
+    text_chunk = _png_chunk(b"tEXt", b"Comment\x00" + (b"x" * MEDIA_ROUTE_TAIL_READ_BYTES))
+    return png[:-12] + text_chunk + png[-12:]
 
 
 def _ubjson_key(key: bytes) -> bytes:
@@ -1253,6 +1265,44 @@ class TestModelDownload:
 
         assert mock_snapshot_download.call_args.kwargs["allow_patterns"] == ["model.safetensors", "payload.png"]
         assert detect_file_format_for_skip_filter(str(download_path / "payload.png")) == "pickle"
+
+    @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".safetensors"})
+    @patch(
+        "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
+        return_value=(["model.safetensors", "preview.png"], _HF_TEST_REVISION, None),
+    )
+    @patch("requests.get")
+    @patch("huggingface_hub.snapshot_download")
+    def test_download_model_bounds_large_media_tail_probe(
+        self,
+        mock_snapshot_download: MagicMock,
+        mock_requests_get: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        _mock_get_extensions: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        download_path = tmp_path / "download"
+        download_path.mkdir()
+        (download_path / "model.safetensors").write_bytes(b"weights")
+        payload = _make_large_valid_png_payload()
+        tail_start = len(payload) - MEDIA_ROUTE_TAIL_READ_BYTES
+        mock_snapshot_download.return_value = str(download_path)
+        mock_requests_get.side_effect = [
+            _FakeRangeResponse(payload[: 8 * 1024], headers={"Content-Length": str(len(payload))}),
+            _FakeRangeResponse(
+                payload[-MEDIA_ROUTE_TAIL_READ_BYTES:],
+                headers={"Content-Range": f"bytes {tail_start}-{len(payload) - 1}/{len(payload)}"},
+                status_code=206,
+            ),
+        ]
+
+        download_model("https://huggingface.co/test/model")
+
+        assert mock_snapshot_download.call_args.kwargs["allow_patterns"] == ["model.safetensors"]
+        assert [request.kwargs["headers"]["Range"] for request in mock_requests_get.call_args_list] == [
+            "bytes=0-8191",
+            f"bytes={tail_start}-{len(payload) - 1}",
+        ]
 
     @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".safetensors"})
     @patch(

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -121,6 +121,19 @@ def _make_forged_png_tail_payload() -> bytes:
     return png[:33] + oversized_idat_header + padding + png[-12:]
 
 
+def _make_invalid_png_crc_payload() -> bytes:
+    payload = bytearray(valid_png_bytes())
+    payload[-1] ^= 0x01
+    return bytes(payload)
+
+
+def _make_forged_jpeg_tail_payload() -> bytes:
+    app0_header = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
+    prefix_padding = b"\0" * ((8 * 1024) - len(app0_header))
+    tail_padding = b"\0" * (MEDIA_ROUTE_TAIL_READ_BYTES + 32)
+    return app0_header + prefix_padding + malicious_pickle_bytes() + tail_padding + b"\xff\xd9" + b"\0" * 8
+
+
 def _ubjson_key(key: bytes) -> bytes:
     return b"U" + bytes([len(key)]) + key
 
@@ -1409,6 +1422,70 @@ class TestModelDownload:
             "pickle",
             PICKLE_ROUTING_INCONCLUSIVE_FORMAT,
         }
+
+    @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".safetensors"})
+    @patch(
+        "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
+        return_value=(["model.safetensors", "payload.png"], _HF_TEST_REVISION, None),
+    )
+    @patch("requests.get")
+    @patch("huggingface_hub.snapshot_download")
+    def test_download_model_preserves_remote_png_with_invalid_crc(
+        self,
+        mock_snapshot_download: MagicMock,
+        mock_requests_get: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        _mock_get_extensions: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        download_path = tmp_path / "download"
+        download_path.mkdir()
+        (download_path / "model.safetensors").write_bytes(b"weights")
+        payload = _make_invalid_png_crc_payload()
+        (download_path / "payload.png").write_bytes(payload)
+        mock_snapshot_download.return_value = str(download_path)
+        mock_requests_get.return_value = _FakeRangeResponse(payload)
+
+        download_model("https://huggingface.co/test/model")
+
+        assert mock_snapshot_download.call_args.kwargs["allow_patterns"] == ["model.safetensors", "payload.png"]
+        assert (
+            detect_file_format_for_skip_filter(str(download_path / "payload.png")) == PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+        )
+
+    @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".safetensors"})
+    @patch(
+        "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
+        return_value=(["model.safetensors", "payload.jpg"], _HF_TEST_REVISION, None),
+    )
+    @patch("requests.get")
+    @patch("huggingface_hub.snapshot_download")
+    def test_download_model_preserves_forged_remote_jpeg_tail(
+        self,
+        mock_snapshot_download: MagicMock,
+        mock_requests_get: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        _mock_get_extensions: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        download_path = tmp_path / "download"
+        download_path.mkdir()
+        (download_path / "model.safetensors").write_bytes(b"weights")
+        payload = _make_forged_jpeg_tail_payload()
+        tail_start = len(payload) - MEDIA_ROUTE_TAIL_READ_BYTES
+        (download_path / "payload.jpg").write_bytes(payload)
+        mock_snapshot_download.return_value = str(download_path)
+        mock_requests_get.side_effect = [
+            _FakeRangeResponse(payload[: 8 * 1024], headers={"Content-Length": str(len(payload))}),
+            _fake_content_range_response(payload, tail_start, len(payload) - 1),
+        ]
+
+        download_model("https://huggingface.co/test/model")
+
+        assert mock_snapshot_download.call_args.kwargs["allow_patterns"] == ["model.safetensors", "payload.jpg"]
+        assert (
+            detect_file_format_for_skip_filter(str(download_path / "payload.jpg")) == PICKLE_ROUTING_INCONCLUSIVE_FORMAT
+        )
 
     @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".safetensors"})
     @patch(

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -43,6 +43,7 @@ from modelaudit.utils.sources.huggingface import (
 )
 from modelaudit.utils.tensorflow_compat import has_tensorflow_protobuf_stubs
 from tests.helpers import create_mock_coreml, create_mock_onnx
+from tests.helpers.file_creators import malicious_pickle_bytes, valid_jpeg_bytes, valid_png_bytes
 
 _HF_TEST_REVISION = "a" * 40
 
@@ -1196,6 +1197,62 @@ class TestModelDownload:
 
         assert mock_snapshot_download.call_args.kwargs["allow_patterns"] == ["model.safetensors", "payload.jpg"]
         assert detect_file_format_for_skip_filter(str(download_path / "payload.jpg")) == "rknn"
+
+    @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".safetensors"})
+    @patch(
+        "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
+        return_value=(["model.safetensors", "preview.png", "preview.jpg"], _HF_TEST_REVISION, None),
+    )
+    @patch("requests.get")
+    @patch("huggingface_hub.snapshot_download")
+    def test_download_model_excludes_valid_media_from_content_routing(
+        self,
+        mock_snapshot_download: MagicMock,
+        mock_requests_get: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        _mock_get_extensions: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        download_path = tmp_path / "download"
+        download_path.mkdir()
+        (download_path / "model.safetensors").write_bytes(b"weights")
+        mock_snapshot_download.return_value = str(download_path)
+        mock_requests_get.side_effect = [
+            _FakeRangeResponse(valid_png_bytes()),
+            _FakeRangeResponse(valid_jpeg_bytes()),
+        ]
+
+        download_model("https://huggingface.co/test/model")
+
+        assert mock_snapshot_download.call_args.kwargs["allow_patterns"] == ["model.safetensors"]
+
+    @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".safetensors"})
+    @patch(
+        "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
+        return_value=(["model.safetensors", "payload.png"], _HF_TEST_REVISION, None),
+    )
+    @patch("requests.get")
+    @patch("huggingface_hub.snapshot_download")
+    def test_download_model_includes_media_pickle_polyglot(
+        self,
+        mock_snapshot_download: MagicMock,
+        mock_requests_get: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        _mock_get_extensions: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        download_path = tmp_path / "download"
+        download_path.mkdir()
+        (download_path / "model.safetensors").write_bytes(b"weights")
+        payload = valid_png_bytes() + malicious_pickle_bytes()
+        (download_path / "payload.png").write_bytes(payload)
+        mock_snapshot_download.return_value = str(download_path)
+        mock_requests_get.return_value = _FakeRangeResponse(payload)
+
+        download_model("https://huggingface.co/test/model")
+
+        assert mock_snapshot_download.call_args.kwargs["allow_patterns"] == ["model.safetensors", "payload.png"]
+        assert detect_file_format_for_skip_filter(str(download_path / "payload.png")) == "pickle"
 
     @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".safetensors"})
     @patch(

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -19,7 +19,11 @@ from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 
-from modelaudit.utils.file.detection import MEDIA_ROUTE_TAIL_READ_BYTES, detect_file_format_for_skip_filter
+from modelaudit.utils.file.detection import (
+    MEDIA_ROUTE_TAIL_READ_BYTES,
+    PICKLE_ROUTING_INCONCLUSIVE_FORMAT,
+    detect_file_format_for_skip_filter,
+)
 from modelaudit.utils.sources._huggingface_download_worker import _run_operation as _run_huggingface_worker_operation
 from modelaudit.utils.sources.huggingface import (
     _get_huggingface_path_sizes,
@@ -74,6 +78,14 @@ class _FakeRangeResponse:
         yield self.payload[:chunk_size]
 
 
+def _fake_content_range_response(payload: bytes, start: int, end: int) -> _FakeRangeResponse:
+    return _FakeRangeResponse(
+        payload[start : end + 1],
+        headers={"Content-Range": f"bytes {start}-{end}/{len(payload)}"},
+        status_code=206,
+    )
+
+
 def _make_tar_payload() -> bytes:
     payload = BytesIO()
     with tarfile.open(fileobj=payload, mode="w") as archive:
@@ -100,6 +112,13 @@ def _make_large_valid_png_payload() -> bytes:
     png = valid_png_bytes()
     text_chunk = _png_chunk(b"tEXt", b"Comment\x00" + (b"x" * MEDIA_ROUTE_TAIL_READ_BYTES))
     return png[:-12] + text_chunk + png[-12:]
+
+
+def _make_forged_png_tail_payload() -> bytes:
+    png = valid_png_bytes()
+    oversized_idat_header = (10 * 1024 * 1024).to_bytes(4, "big") + b"IDAT"
+    padding = b"\0" * (MEDIA_ROUTE_TAIL_READ_BYTES + 32)
+    return png[:33] + oversized_idat_header + padding + png[-12:]
 
 
 def _ubjson_key(key: bytes) -> bytes:
@@ -637,7 +656,7 @@ class TestModelDownload:
         def get_side_effect(url: str, **_kwargs: object) -> _FakeRangeResponse:
             if url.endswith("/evil.payload"):
                 return _FakeRangeResponse(b"\x08\x00\x00\x00TFL3" + b"\x00" * 16)
-            return _FakeRangeResponse(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+            return _FakeRangeResponse(valid_png_bytes())
 
         mock_requests_get.side_effect = get_side_effect
 
@@ -1318,11 +1337,7 @@ class TestModelDownload:
         mock_snapshot_download.return_value = str(download_path)
         mock_requests_get.side_effect = [
             _FakeRangeResponse(payload[: 8 * 1024], headers={"Content-Length": str(len(payload))}),
-            _FakeRangeResponse(
-                payload[-MEDIA_ROUTE_TAIL_READ_BYTES:],
-                headers={"Content-Range": f"bytes {tail_start}-{len(payload) - 1}/{len(payload)}"},
-                status_code=206,
-            ),
+            _fake_content_range_response(payload, tail_start, len(payload) - 1),
         ]
 
         download_model("https://huggingface.co/test/model")
@@ -1353,11 +1368,7 @@ class TestModelDownload:
         mock_snapshot_download.return_value = str(download_path)
         mock_requests_get.side_effect = [
             _FakeRangeResponse(payload[: 8 * 1024], headers={"Content-Length": str(len(payload))}),
-            _FakeRangeResponse(
-                payload[-MEDIA_ROUTE_TAIL_READ_BYTES:],
-                headers={"Content-Range": f"bytes {tail_start}-{len(payload) - 1}/{len(payload)}"},
-                status_code=206,
-            ),
+            _fake_content_range_response(payload, tail_start, len(payload) - 1),
         ]
 
         download_model("https://huggingface.co/test/model")
@@ -1367,6 +1378,37 @@ class TestModelDownload:
             "bytes=0-8191",
             f"bytes={tail_start}-{len(payload) - 1}",
         ]
+
+    @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".safetensors"})
+    @patch(
+        "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
+        return_value=(["model.safetensors", "payload.png"], _HF_TEST_REVISION, None),
+    )
+    @patch("requests.get")
+    @patch("huggingface_hub.snapshot_download")
+    def test_download_model_preserves_forged_remote_png_tail(
+        self,
+        mock_snapshot_download: MagicMock,
+        mock_requests_get: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        _mock_get_extensions: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        download_path = tmp_path / "download"
+        download_path.mkdir()
+        (download_path / "model.safetensors").write_bytes(b"weights")
+        payload = _make_forged_png_tail_payload()
+        (download_path / "payload.png").write_bytes(payload)
+        mock_snapshot_download.return_value = str(download_path)
+        mock_requests_get.return_value = _fake_content_range_response(payload, 0, (8 * 1024) - 1)
+
+        download_model("https://huggingface.co/test/model")
+
+        assert mock_snapshot_download.call_args.kwargs["allow_patterns"] == ["model.safetensors", "payload.png"]
+        assert detect_file_format_for_skip_filter(str(download_path / "payload.png")) in {
+            "pickle",
+            PICKLE_ROUTING_INCONCLUSIVE_FORMAT,
+        }
 
     @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".safetensors"})
     @patch(
@@ -2258,7 +2300,7 @@ class TestModelDownloadStreaming:
         def get_side_effect(url: str, **_kwargs: object) -> _FakeRangeResponse:
             if url.endswith("/evil.payload"):
                 return _FakeRangeResponse(b"\x08\x00\x00\x00TFL3" + b"\x00" * 16)
-            return _FakeRangeResponse(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+            return _FakeRangeResponse(valid_png_bytes())
 
         def download_side_effect(*, repo_id: str, filename: str, **_kwargs: object) -> str:
             assert repo_id == "test/model"

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -1269,6 +1269,70 @@ class TestModelDownload:
     @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".safetensors"})
     @patch(
         "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
+        return_value=(["model.safetensors", "payload.png"], _HF_TEST_REVISION, None),
+    )
+    @patch("requests.get")
+    @patch("huggingface_hub.snapshot_download")
+    def test_download_model_includes_media_pickle_polyglot_with_fake_png_iend(
+        self,
+        mock_snapshot_download: MagicMock,
+        mock_requests_get: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        _mock_get_extensions: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        download_path = tmp_path / "download"
+        download_path.mkdir()
+        (download_path / "model.safetensors").write_bytes(b"weights")
+        payload = valid_png_bytes() + malicious_pickle_bytes() + valid_png_bytes()[-12:]
+        (download_path / "payload.png").write_bytes(payload)
+        mock_snapshot_download.return_value = str(download_path)
+        mock_requests_get.return_value = _FakeRangeResponse(payload)
+
+        download_model("https://huggingface.co/test/model")
+
+        assert mock_snapshot_download.call_args.kwargs["allow_patterns"] == ["model.safetensors", "payload.png"]
+        assert detect_file_format_for_skip_filter(str(download_path / "payload.png")) == "pickle"
+
+    @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".safetensors"})
+    @patch(
+        "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
+        return_value=(["model.safetensors", "payload.png"], _HF_TEST_REVISION, None),
+    )
+    @patch("requests.get")
+    @patch("huggingface_hub.snapshot_download")
+    def test_download_model_includes_padded_media_pickle_polyglot(
+        self,
+        mock_snapshot_download: MagicMock,
+        mock_requests_get: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        _mock_get_extensions: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        download_path = tmp_path / "download"
+        download_path.mkdir()
+        (download_path / "model.safetensors").write_bytes(b"weights")
+        payload = valid_png_bytes() + malicious_pickle_bytes() + (b"\0" * (MEDIA_ROUTE_TAIL_READ_BYTES + 1))
+        tail_start = len(payload) - MEDIA_ROUTE_TAIL_READ_BYTES
+        (download_path / "payload.png").write_bytes(payload)
+        mock_snapshot_download.return_value = str(download_path)
+        mock_requests_get.side_effect = [
+            _FakeRangeResponse(payload[: 8 * 1024], headers={"Content-Length": str(len(payload))}),
+            _FakeRangeResponse(
+                payload[-MEDIA_ROUTE_TAIL_READ_BYTES:],
+                headers={"Content-Range": f"bytes {tail_start}-{len(payload) - 1}/{len(payload)}"},
+                status_code=206,
+            ),
+        ]
+
+        download_model("https://huggingface.co/test/model")
+
+        assert mock_snapshot_download.call_args.kwargs["allow_patterns"] == ["model.safetensors", "payload.png"]
+        assert detect_file_format_for_skip_filter(str(download_path / "payload.png")) == "pickle"
+
+    @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".safetensors"})
+    @patch(
+        "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
         return_value=(["model.safetensors", "preview.png"], _HF_TEST_REVISION, None),
     )
     @patch("requests.get")

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -86,6 +86,18 @@ def _fake_content_range_response(payload: bytes, start: int, end: int) -> _FakeR
     )
 
 
+def _fake_range_responder(payload: bytes) -> Callable[[str], _FakeRangeResponse]:
+    def get_response(_url: str, **kwargs: object) -> _FakeRangeResponse:
+        headers = cast(dict[str, str], kwargs.get("headers", {}))
+        range_header = headers.get("Range", "")
+        if range_header.startswith("bytes="):
+            start_text, end_text = range_header.removeprefix("bytes=").split("-", 1)
+            return _fake_content_range_response(payload, int(start_text), int(end_text))
+        return _FakeRangeResponse(payload)
+
+    return get_response
+
+
 def _make_tar_payload() -> bytes:
     payload = BytesIO()
     with tarfile.open(fileobj=payload, mode="w") as archive:
@@ -132,6 +144,13 @@ def _make_forged_jpeg_tail_payload() -> bytes:
     prefix_padding = b"\0" * ((8 * 1024) - len(app0_header))
     tail_padding = b"\0" * (MEDIA_ROUTE_TAIL_READ_BYTES + 32)
     return app0_header + prefix_padding + malicious_pickle_bytes() + tail_padding + b"\xff\xd9" + b"\0" * 8
+
+
+def _make_large_valid_jpeg_payload() -> bytes:
+    app0_header = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
+    scan_header = b"\xff\xda\x00\x08\x01\x01\x00\x00?\x00"
+    entropy = b"\x11" * ((8 * 1024) + MEDIA_ROUTE_TAIL_READ_BYTES)
+    return app0_header + scan_header + entropy + b"\xff\xd9"
 
 
 def _ubjson_key(key: bytes) -> bytes:
@@ -1486,6 +1505,32 @@ class TestModelDownload:
         assert (
             detect_file_format_for_skip_filter(str(download_path / "payload.jpg")) == PICKLE_ROUTING_INCONCLUSIVE_FORMAT
         )
+
+    @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".safetensors"})
+    @patch(
+        "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
+        return_value=(["model.safetensors", "preview.jpg"], _HF_TEST_REVISION, None),
+    )
+    @patch("requests.get")
+    @patch("huggingface_hub.snapshot_download")
+    def test_download_model_excludes_large_remote_jpeg_with_bounded_structural_proof(
+        self,
+        mock_snapshot_download: MagicMock,
+        mock_requests_get: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        _mock_get_extensions: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        download_path = tmp_path / "download"
+        download_path.mkdir()
+        (download_path / "model.safetensors").write_bytes(b"weights")
+        payload = _make_large_valid_jpeg_payload()
+        mock_snapshot_download.return_value = str(download_path)
+        mock_requests_get.side_effect = _fake_range_responder(payload)
+
+        download_model("https://huggingface.co/test/model")
+
+        assert mock_snapshot_download.call_args.kwargs["allow_patterns"] == ["model.safetensors"]
 
     @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".safetensors"})
     @patch(


### PR DESCRIPTION
## Summary
- keep bounded valid PNG/JPEG media sidecars out of serialized content routing
- preserve strong media/pickle polyglot detection as `pickle`
- apply the same media verdict to Hugging Face selective routing

## Validation
- `.venv/bin/python -m pytest tests/utils/file/test_filetype.py -k "valid_media_do_not_route_to_serialized_formats or media_pickle_polyglot_keeps_pickle_route" -q`
- `.venv/bin/python -m pytest tests/utils/file/test_file_filter.py -k "valid_media_stays_skipped_by_default_prefilter or media_pickle_polyglot_bypasses_default_prefilter" -q`
- `.venv/bin/python -m pytest tests/utils/sources/test_huggingface.py -k "valid_media_from_content_routing or includes_media_pickle_polyglot" -q`
- `.venv/bin/python -m pytest tests/test_core.py -k "valid_media_is_unknown_not_serialized or directory_scan_skips_valid_media_assets or media_pickle_polyglot_detects_system_global" -q`
- `.venv/bin/python -m pytest tests/utils/file/test_filetype.py tests/utils/file/test_file_filter.py tests/utils/sources/test_huggingface.py -q`
- `.venv/bin/ruff check modelaudit/utils/file/detection.py modelaudit/utils/sources/huggingface.py tests/helpers/file_creators.py tests/test_core.py tests/utils/file/test_file_filter.py tests/utils/file/test_filetype.py tests/utils/sources/test_huggingface.py`
- `.venv/bin/ruff format --check modelaudit/utils/file/detection.py modelaudit/utils/sources/huggingface.py tests/helpers/file_creators.py tests/test_core.py tests/utils/file/test_file_filter.py tests/utils/file/test_filetype.py tests/utils/sources/test_huggingface.py`

## Real QA
- verified valid media from pinned revisions for `nvidia/LocateAnything-3B`, `nvidia/nemotron-3.5-asr-streaming-0.6b`, `BAAI/bge-m3`, and `sapientinc/HRM-Text-1B` all route `unknown` locally and are excluded from HF content routing
- ran `modelaudit scan --no-cache --format json` against pinned `BAAI/bge-m3@5617a9f61b028005a4858fdac845db406aefb181/long.jpg`; it scanned clean with no serialized scanner names
