### PR TITLE
fix: accept gzip-framed NeMo archives

### DIFF
--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -92,6 +92,7 @@ from modelaudit.utils.file.detection import (
     detect_mxnet_symbol_content_route,
     detect_pytorch_binary_supplemental_format,
     detect_xgboost_ubjson_content_route,
+    gzip_tar_trailing_data_status,
     is_executorch_archive,
     is_keras_zip_archive,
     is_pytorch_zip_archive,
@@ -149,6 +150,7 @@ logger = logging.getLogger("modelaudit.core")
 _add_asset_to_results = core_results.add_asset_to_results
 _add_error_asset_to_results = core_results.add_error_asset_to_results
 _DIRECTORY_PRECOUNT_CHILD_LIMIT = 1000
+_COMPRESSED_TAR_STREAM_INCOMPLETE_REASON = "tar_compressed_stream_incomplete"
 
 
 def _count_immediate_children_up_to(path: Path, limit: int) -> int:
@@ -3810,6 +3812,20 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
         except OSError as e:
             file_type_valid = True
             format_probe_error = e
+    gzip_tar_trailing_status = (
+        gzip_tar_trailing_data_status(
+            path,
+            max_decompressed_bytes=config.get("compressed_max_decompressed_bytes"),
+            max_decompression_ratio=config.get("compressed_max_decompression_ratio"),
+        )
+        if (
+            format_probe_error is None
+            and ext == ".nemo"
+            and magic_format == "gzip"
+            and header_format in {"gzip", "nemo", "tar"}
+        )
+        else None
+    )
     discrepancy_msg = None
 
     if not file_type_valid:
@@ -3924,7 +3940,7 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
             elif use_large_handler:
                 logger.debug(f"File size optimization: {path} ({file_size:,} bytes)")
                 result = scan_large_file(path, scanner, progress_callback, timeout)
-            elif is_xgboost_pickle_spoof:
+            elif is_xgboost_pickle_spoof or (scanner_id == "nemo" and gzip_tar_trailing_status is not None):
                 result = scanner.scan(path)
             else:
                 result = scanner.scan_with_cache(path)
@@ -3992,7 +4008,11 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
                 elif use_large_handler:
                     logger.debug(f"File size optimization: {path} ({file_size:,} bytes)")
                     result = scan_large_file(path, scanner, progress_callback, timeout)
-                elif unavailable_preferred_scanner_id is not None or is_xgboost_pickle_spoof:
+                elif (
+                    unavailable_preferred_scanner_id is not None
+                    or is_xgboost_pickle_spoof
+                    or (scanner_class.name == "nemo" and gzip_tar_trailing_status is not None)
+                ):
                     result = scanner.scan(path)
                 else:
                     result = scanner.scan_with_cache(path)
@@ -4126,6 +4146,29 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
 
     if is_xgboost_pickle_spoof:
         _mark_xgboost_pickle_extension_spoof(result, path, ext)
+
+    if gzip_tar_trailing_status is not None and result.scanner_name == "nemo":
+        has_integrity_check = any(
+            check.name == "Compressed TAR Stream Integrity" and check.rule_code == "S902" for check in result.checks
+        )
+        if not has_integrity_check:
+            integrity_message = (
+                "Compressed TAR stream contains non-zero trailing data after archive EOF"
+                if gzip_tar_trailing_status == "nonzero"
+                else "Compressed TAR stream could not be fully validated after archive EOF"
+            )
+            result.add_check(
+                name="Compressed TAR Stream Integrity",
+                passed=False,
+                message=integrity_message,
+                severity=IssueSeverity.WARNING,
+                location=path,
+                details={"compression": "gzip", "stream_tail_status": gzip_tar_trailing_status},
+                rule_code="S902",
+            )
+            _mark_inconclusive_scan_outcome(result, _COMPRESSED_TAR_STREAM_INCOMPLETE_REASON)
+            _mark_operational_scan_error(result, _COMPRESSED_TAR_STREAM_INCOMPLETE_REASON)
+            result.success = False
 
     if (
         skipped_preferred_scanner_id == "flax_msgpack"

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -1234,13 +1234,25 @@ def _select_non_hdf5_preferred_scanner_id(
     if ext in _R_SERIALIZED_EXTENSIONS and header_format in _COMPRESSED_HEADER_FORMATS | {"r_serialized"}:
         return "r_serialized"
 
-    if ext == ".nemo" and (
-        header_format == "tar"
-        or (header_format == "gzip" and validate_file_type_with_formats(path, header_format, "nemo"))
-    ):
-        return "nemo"
+    if ext == ".nemo":
+        if header_format == "tar":
+            return "nemo"
+        if header_format == "gzip" and (
+            _gzip_tar_trailing_status_for_config(path, config) is not None
+            or validate_file_type_with_formats(path, header_format, "nemo")
+        ):
+            return "nemo"
 
     return _registry.get_scanner_id_for_header_format(header_format)
+
+
+def _gzip_tar_trailing_status_for_config(path: str, config: dict[str, Any] | None) -> str | None:
+    """Return invalid/nonzero gzip TAR tail status using configured compressed-wrapper limits."""
+    return gzip_tar_trailing_data_status(
+        path,
+        max_decompressed_bytes=config.get("compressed_max_decompressed_bytes") if config is not None else None,
+        max_decompression_ratio=config.get("compressed_max_decompression_ratio") if config is not None else None,
+    )
 
 
 def _select_hdf5_userblock_supplemental_scanner_id(
@@ -1346,6 +1358,7 @@ def _preferred_scanner_can_handle(
     scanner_id: str,
     header_format: str,
     path: str,
+    config: dict[str, Any] | None = None,
 ) -> bool:
     """Honor trusted header routing even when scanner can_handle is suffix-gated."""
     if scanner_id == "keras_h5" and find_hdf5_signature_offset(path) is not None:
@@ -1363,6 +1376,9 @@ def _preferred_scanner_can_handle(
         "skops",
         "torchserve_mar",
     }:
+        return True
+
+    if scanner_id == "nemo" and header_format == "gzip" and _gzip_tar_trailing_status_for_config(path, config):
         return True
 
     if scanner_class.can_handle(path):
@@ -3813,11 +3829,7 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
             file_type_valid = True
             format_probe_error = e
     gzip_tar_trailing_status = (
-        gzip_tar_trailing_data_status(
-            path,
-            max_decompressed_bytes=config.get("compressed_max_decompressed_bytes"),
-            max_decompression_ratio=config.get("compressed_max_decompression_ratio"),
-        )
+        _gzip_tar_trailing_status_for_config(path, config)
         if (
             format_probe_error is None
             and ext == ".nemo"
@@ -3915,7 +3927,7 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
         and scanner_id
         and (
             scanner_id == trusted_flax_overlap_scanner_id
-            or _preferred_scanner_can_handle(preferred_scanner, scanner_id, header_format, path)
+            or _preferred_scanner_can_handle(preferred_scanner, scanner_id, header_format, path, config)
         )
     ):
         logger.debug(

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -3833,7 +3833,7 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
         if (
             format_probe_error is None
             and ext == ".nemo"
-            and magic_format == "gzip"
+            and (header_format == "gzip" or magic_format == "gzip")
             and header_format in {"gzip", "nemo", "tar"}
         )
         else None

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -1232,7 +1232,10 @@ def _select_non_hdf5_preferred_scanner_id(
     if ext in _R_SERIALIZED_EXTENSIONS and header_format in _COMPRESSED_HEADER_FORMATS | {"r_serialized"}:
         return "r_serialized"
 
-    if header_format == "tar" and ext == ".nemo":
+    if ext == ".nemo" and (
+        header_format == "tar"
+        or (header_format == "gzip" and validate_file_type_with_formats(path, header_format, "nemo"))
+    ):
         return "nemo"
 
     return _registry.get_scanner_id_for_header_format(header_format)

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -6465,9 +6465,12 @@ def validate_file_type_with_formats(path: str, header_format: str, ext_format: s
                 return False
             return header_format == expected_codec
 
-        # NeMo files are TAR archives with a dedicated or structurally recognized route.
-        if ext_format == "nemo" and header_format in {"tar", "nemo"}:
-            return True
+        # NeMo files are TAR archives, commonly carried in gzip-compressed TAR wrappers.
+        if ext_format == "nemo":
+            if header_format in {"tar", "nemo"}:
+                return True
+            if header_format == "gzip":
+                return _is_tar_archive(path)
 
         # ExecuTorch files may be ZIP archives or valid FlatBuffers binaries.
         if ext_format == "executorch":

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -65,6 +65,7 @@ _TensorFlowProtoRoute = Literal[
     "inconclusive",
 ]
 _TensorFlowOuterHint = Literal["unknown", "tf_metagraph", "tf_savedmodel"]
+_GzipTarTrailingStatus = Literal["invalid", "nonzero"]
 _TORCH7_SIGNATURE_READ_BYTES = 4096
 _TORCH7_ASCII_HEADER_MAX_LINE_BYTES = 4096
 _LIGHTGBM_SIGNATURE_READ_BYTES = 8192
@@ -173,6 +174,9 @@ _TAR_USTAR_MAGIC_SIZE = 5
 _TAR_USTAR_MIN_BYTES = _TAR_USTAR_OFFSET + _TAR_USTAR_MAGIC_SIZE
 _TAR_CHECKSUM_OFFSET = 148
 _TAR_CHECKSUM_SIZE = 8
+_TAR_GZIP_POST_EOF_TRAILING_READ_BYTES = 64 * 1024
+_TAR_GZIP_DEFAULT_MAX_TRAILING_DECOMPRESSED_BYTES = 512 * 1024 * 1024
+_TAR_GZIP_DEFAULT_MAX_TRAILING_DECOMPRESSION_RATIO = 250.0
 _TAR_NUMERIC_FIELD_SLICES = (
     (100, 108),  # mode
     (108, 116),  # uid
@@ -3793,6 +3797,97 @@ def _resolve_tar_hardlink_fallback_member(
     return None
 
 
+def _normalize_positive_int(value: Any, default: int) -> int:
+    if isinstance(value, bool):
+        return default
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError):
+        return default
+    return normalized if normalized > 0 else default
+
+
+def _normalize_positive_float(value: Any, default: float) -> float:
+    if isinstance(value, bool):
+        return default
+    try:
+        normalized = float(value)
+    except (TypeError, ValueError):
+        return default
+    return normalized if normalized > 0 else default
+
+
+def _gzip_tar_trailing_data_status(
+    path: Path,
+    *,
+    max_decompressed_bytes: int | None = None,
+    max_decompression_ratio: float | None = None,
+) -> _GzipTarTrailingStatus | None:
+    """Return proven gzip TAR stream-tail status after the TAR EOF padding."""
+    decompressed_limit = _normalize_positive_int(
+        max_decompressed_bytes,
+        _TAR_GZIP_DEFAULT_MAX_TRAILING_DECOMPRESSED_BYTES,
+    )
+    ratio_limit = _normalize_positive_float(
+        max_decompression_ratio,
+        _TAR_GZIP_DEFAULT_MAX_TRAILING_DECOMPRESSION_RATIO,
+    )
+    try:
+        compressed_size = path.stat().st_size
+        with path.open("rb") as raw:
+            if raw.read(len(_GZIP_MAGIC)) != _GZIP_MAGIC:
+                return None
+            raw.seek(0)
+            with tarfile.open(fileobj=raw, mode="r:gz") as archive:
+                archive.getmembers()
+                trailing_size = 0
+                while True:
+                    trailing = archive.fileobj.read(_TAR_GZIP_POST_EOF_TRAILING_READ_BYTES)
+                    if not trailing:
+                        return None
+                    if any(byte != 0 for byte in trailing):
+                        return "nonzero"
+
+                    trailing_size += len(trailing)
+                    if trailing_size > decompressed_limit:
+                        return "invalid"
+                    if compressed_size > 0 and trailing_size / compressed_size > ratio_limit:
+                        return "invalid"
+    except (EOFError, OSError, tarfile.TarError, zlib.error):
+        return "invalid"
+
+
+def has_gzip_tar_nonzero_trailing_data(
+    path: str,
+    *,
+    max_decompressed_bytes: int | None = None,
+    max_decompression_ratio: float | None = None,
+) -> bool:
+    """Return whether a gzip TAR has non-zero trailing data after archive EOF."""
+    return (
+        gzip_tar_trailing_data_status(
+            path,
+            max_decompressed_bytes=max_decompressed_bytes,
+            max_decompression_ratio=max_decompression_ratio,
+        )
+        == "nonzero"
+    )
+
+
+def gzip_tar_trailing_data_status(
+    path: str,
+    *,
+    max_decompressed_bytes: int | None = None,
+    max_decompression_ratio: float | None = None,
+) -> _GzipTarTrailingStatus | None:
+    """Return proven gzip TAR stream-tail status after archive EOF."""
+    return _gzip_tar_trailing_data_status(
+        Path(path),
+        max_decompressed_bytes=max_decompressed_bytes,
+        max_decompression_ratio=max_decompression_ratio,
+    )
+
+
 def _detect_tar_route(path: str) -> str | None:
     """Return the safe content route for a valid TAR-backed artifact."""
     file_path = Path(path)
@@ -3945,7 +4040,10 @@ def is_nemo_archive(path: str) -> bool:
 def _is_tar_archive(path: str) -> bool:
     """Return whether a path is a TAR archive, including compressed wrappers."""
     try:
-        return tarfile.is_tarfile(path)
+        if not tarfile.is_tarfile(path):
+            return False
+        file_path = Path(path)
+        return _gzip_tar_trailing_data_status(file_path) is None
     except Exception:
         return False
 

--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -3837,6 +3837,12 @@ def _gzip_tar_trailing_data_status(
         with path.open("rb") as raw:
             if raw.read(len(_GZIP_MAGIC)) != _GZIP_MAGIC:
                 return None
+            try:
+                is_tar = tarfile.is_tarfile(path)
+            except (EOFError, tarfile.TarError):
+                return None
+            if not is_tar:
+                return None
             raw.seek(0)
             with tarfile.open(fileobj=raw, mode="r:gz") as archive:
                 archive.getmembers()

--- a/tests/scanners/test_nemo_scanner.py
+++ b/tests/scanners/test_nemo_scanner.py
@@ -1,11 +1,12 @@
 """Tests for CVE-2025-23304: NVIDIA NeMo Hydra _target_ injection."""
 
+import gzip
 import io
 import pickle
 import tarfile
 import zipfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import pytest
 
@@ -24,6 +25,7 @@ from modelaudit.scanners.nemo_scanner import NemoScanner, _get_nested_scanner_fo
 from modelaudit.utils.file import detection as file_detection
 
 _TMP_PATH_MARKER = "__MODELAUDIT_TMP__/"
+_NemoTarWriteMode = Literal["w", "w:gz"]
 
 
 def _create_nemo_file_from_bytes(
@@ -31,10 +33,11 @@ def _create_nemo_file_from_bytes(
     config_bytes: bytes,
     filename: str = "model.nemo",
     config_name: str = "model_config.yaml",
+    mode: _NemoTarWriteMode = "w",
 ) -> Path:
     """Helper to create a .nemo tar file with the given YAML config."""
     nemo_path = tmp_path / filename
-    with tarfile.open(nemo_path, "w") as tar:
+    with tarfile.open(nemo_path, mode) as tar:
         info = tarfile.TarInfo(name=config_name)
         info.size = len(config_bytes)
         tar.addfile(info, io.BytesIO(config_bytes))
@@ -46,16 +49,17 @@ def _create_nemo_file(
     config_dict: dict[str, Any] | None,
     filename: str = "model.nemo",
     config_name: str = "model_config.yaml",
+    mode: _NemoTarWriteMode = "w",
 ) -> Path:
     """Helper to create a .nemo tar file with the given YAML config."""
     if config_dict is None:
         nemo_path = tmp_path / filename
-        with tarfile.open(nemo_path, "w"):
+        with tarfile.open(nemo_path, mode):
             pass
         return nemo_path
 
     config_bytes = yaml.safe_dump(config_dict).encode() if HAS_YAML else b"{}"
-    return _create_nemo_file_from_bytes(tmp_path, config_bytes, filename=filename, config_name=config_name)
+    return _create_nemo_file_from_bytes(tmp_path, config_bytes, filename=filename, config_name=config_name, mode=mode)
 
 
 def _add_tar_bytes(tar: tarfile.TarFile, name: str, payload: bytes) -> None:
@@ -124,6 +128,48 @@ class TestNemoScannerBasic:
         ]
         assert len(mismatch_checks) == 0
 
+    def test_gzip_framed_nemo_does_not_trigger_s901(self, tmp_path: Path) -> None:
+        """Valid gzip-compressed .nemo tar archives should not be flagged as spoofed."""
+        path = _create_nemo_file(tmp_path, {"model": {"_target_": "nemo.Model"}}, mode="w:gz")
+
+        direct_result = NemoScanner().scan(str(path))
+        aggregate_result = scan_file(str(path), config={"cache_scan_results": False})
+
+        direct_s901 = [check for check in direct_result.checks if check.rule_code == "S901"]
+        aggregate_s901 = [check for check in aggregate_result.checks if check.rule_code == "S901"]
+
+        assert direct_s901 == []
+        assert aggregate_s901 == []
+        assert aggregate_result.scanner_name == "nemo"
+
+    def test_malformed_gzip_nemo_still_reports_s901(self, tmp_path: Path) -> None:
+        """A .nemo suffix plus gzip magic is not enough unless it is a valid TAR."""
+        path = tmp_path / "model.nemo"
+        path.write_bytes(b"\x1f\x8b\x08\x00truncated")
+
+        result = scan_file(str(path), config={"cache_scan_results": False})
+
+        s901_checks = [check for check in result.checks if check.rule_code == "S901"]
+        assert s901_checks
+        assert any(
+            check.details.get("extension_format") == "nemo" and check.details.get("header_format") == "gzip"
+            for check in s901_checks
+        )
+
+    def test_gzip_non_tar_nemo_still_reports_s901(self, tmp_path: Path) -> None:
+        """A valid gzip stream with non-TAR content is still a spoofed .nemo container."""
+        path = tmp_path / "model.nemo"
+        path.write_bytes(gzip.compress(b"not a tar archive"))
+
+        result = scan_file(str(path), config={"cache_scan_results": False})
+
+        s901_checks = [check for check in result.checks if check.rule_code == "S901"]
+        assert s901_checks
+        assert any(
+            check.details.get("extension_format") == "nemo" and check.details.get("header_format") == "gzip"
+            for check in s901_checks
+        )
+
     def test_missing_yaml_dependency_is_reported_as_warning(self, tmp_path, monkeypatch):
         """Missing PyYAML should be a non-passing warning, not a pass."""
         path = _create_nemo_file(tmp_path, {"model": "test"})
@@ -177,6 +223,19 @@ class TestNemoArchiveVulnerabilityCoverage:
         assert details["cwe"] == "CWE-23"
         assert "remediation" in details
 
+    def test_gzip_framed_member_path_traversal_still_detected(self, tmp_path: Path) -> None:
+        nemo_path = tmp_path / "traversal.nemo"
+        with tarfile.open(nemo_path, "w:gz") as tar:
+            _add_tar_bytes(tar, "model_config.yaml", b"model: safe\n")
+            _add_tar_bytes(tar, "../../evil.txt", b"overwrite")
+
+        result = NemoScanner().scan(str(nemo_path))
+
+        assert not [check for check in result.checks if check.rule_code == "S901"]
+        cve_checks = [check for check in result.checks if check.details.get("cve_id") == "CVE-2025-23360"]
+        assert len(cve_checks) == 1
+        assert cve_checks[0].severity == IssueSeverity.CRITICAL
+
     def test_absolute_member_path_traversal_detects_cve_2025_23250(self, tmp_path: Path) -> None:
         nemo_path = tmp_path / "absolute.nemo"
         with tarfile.open(nemo_path, "w") as tar:
@@ -202,6 +261,23 @@ class TestNemoArchiveVulnerabilityCoverage:
 
         result = NemoScanner().scan(str(nemo_path))
 
+        cve_checks = [check for check in result.checks if check.details.get("cve_id") == "CVE-2025-23360"]
+        assert len(cve_checks) == 1
+        assert cve_checks[0].details["entry"] == "weights_link"
+        assert cve_checks[0].details["target"] == "../../outside_weights.ckpt"
+
+    def test_gzip_framed_symlink_escape_still_detected(self, tmp_path: Path) -> None:
+        nemo_path = tmp_path / "symlink.nemo"
+        with tarfile.open(nemo_path, "w:gz") as tar:
+            _add_tar_bytes(tar, "model_config.yaml", b"model: safe\n")
+            link_info = tarfile.TarInfo(name="weights_link")
+            link_info.type = tarfile.SYMTYPE
+            link_info.linkname = "../../outside_weights.ckpt"
+            tar.addfile(link_info)
+
+        result = NemoScanner().scan(str(nemo_path))
+
+        assert not [check for check in result.checks if check.rule_code == "S901"]
         cve_checks = [check for check in result.checks if check.details.get("cve_id") == "CVE-2025-23360"]
         assert len(cve_checks) == 1
         assert cve_checks[0].details["entry"] == "weights_link"
@@ -234,6 +310,19 @@ class TestNemoArchiveVulnerabilityCoverage:
         assert details["cwe"] == "CWE-502"
         assert "CVE-2026-24157" in details["related_cves"]
         assert details["nested_scanner"] == "pickle"
+
+    def test_gzip_framed_malicious_checkpoint_still_detected(self, tmp_path: Path) -> None:
+        nemo_path = tmp_path / "checkpoint-rce.nemo"
+        with tarfile.open(nemo_path, "w:gz") as tar:
+            _add_tar_bytes(tar, "model_config.yaml", b"model: safe\n")
+            _add_tar_bytes(tar, "model_weights.ckpt", _build_malicious_pickle())
+
+        result = NemoScanner().scan(str(nemo_path))
+
+        assert not [check for check in result.checks if check.rule_code == "S901"]
+        cve_checks = [check for check in result.checks if check.details.get("cve_id") == "CVE-2025-23249"]
+        assert len(cve_checks) == 1
+        assert cve_checks[0].severity == IssueSeverity.CRITICAL
 
     def test_torch7_checkpoint_with_pt_suffix_detects_nemo_deserialization_cve(self, tmp_path: Path) -> None:
         nemo_path = tmp_path / "torch7-checkpoint-rce.nemo"
@@ -6455,6 +6544,20 @@ class TestCVE202523304HydraTarget:
 
         suspicious = [c for c in result.checks if "Suspicious File" in c.name]
         assert len(suspicious) > 0, "Should detect executable in archive"
+
+    def test_gzip_framed_executable_file_in_archive_flagged(self, tmp_path: Path) -> None:
+        """Executable archive member checks still run after accepting gzip framing."""
+        nemo_path = tmp_path / "model.nemo"
+        with tarfile.open(nemo_path, "w:gz") as tar:
+            config_bytes = yaml.dump({"model": {"_target_": "nemo.Model"}}).encode()
+            _add_tar_bytes(tar, "config.yaml", config_bytes)
+            _add_tar_bytes(tar, "exploit.sh", b"#!/bin/bash\nrm -rf /")
+
+        result = NemoScanner().scan(str(nemo_path))
+
+        assert not [check for check in result.checks if check.rule_code == "S901"]
+        suspicious = [check for check in result.checks if "Suspicious File" in check.name]
+        assert len(suspicious) > 0
 
     def test_no_yaml_configs_fail_closed_as_inconclusive(self, tmp_path: Path) -> None:
         """Archives with no YAML should not report a clean complete scan."""

--- a/tests/scanners/test_nemo_scanner.py
+++ b/tests/scanners/test_nemo_scanner.py
@@ -417,6 +417,49 @@ class TestNemoScannerBasic:
         finally:
             reset_cache_manager()
 
+    def test_truncated_gzip_nemo_keeps_s902_when_magic_route_is_tar(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Mixed gzip header and TAR magic routing must still validate the gzip tail."""
+        path = tmp_path / "truncated-gzip-magic-tar.nemo"
+        payload = _build_nemo_tar_bytes(b"model:\n  _target_: nemo.Model\n")
+        path.write_bytes(payload[:-1])
+        monkeypatch.setattr("modelaudit.core.detect_file_format", lambda _path: "gzip")
+        monkeypatch.setattr("modelaudit.core.detect_file_format_from_magic", lambda _path: "tar")
+
+        direct_result = scan_file(str(path), config={"cache_scan_results": False})
+        aggregate_result = scan_model_directory_or_file(str(path), config={"cache_scan_results": False})
+
+        integrity_checks = [
+            check
+            for check in direct_result.checks
+            if check.name == "Compressed TAR Stream Integrity" and check.status == CheckStatus.FAILED
+        ]
+        assert direct_result.scanner_name == "nemo"
+        assert direct_result.success is False
+        assert integrity_checks
+        assert integrity_checks[0].rule_code == "S902"
+        assert aggregate_result.scanner_names == ["nemo"]
+        assert aggregate_result.success is False
+        assert determine_exit_code(aggregate_result) == 2
+
+        cache_dir = tmp_path / "cache"
+        reset_cache_manager()
+        try:
+            cached_aggregate = scan_model_directory_or_file(
+                str(path),
+                cache_enabled=True,
+                cache_dir=str(cache_dir),
+                min_cache_file_size=0,
+            )
+
+            assert cached_aggregate.success is False
+            assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+        finally:
+            reset_cache_manager()
+
     def test_missing_yaml_dependency_is_reported_as_warning(self, tmp_path, monkeypatch):
         """Missing PyYAML should be a non-passing warning, not a pass."""
         path = _create_nemo_file(tmp_path, {"model": "test"})

--- a/tests/scanners/test_nemo_scanner.py
+++ b/tests/scanners/test_nemo_scanner.py
@@ -68,6 +68,13 @@ def _add_tar_bytes(tar: tarfile.TarFile, name: str, payload: bytes) -> None:
     tar.addfile(info, io.BytesIO(payload))
 
 
+def _build_nemo_tar_bytes(config_bytes: bytes, *, mode: _NemoTarWriteMode = "w:gz") -> bytes:
+    archive = io.BytesIO()
+    with tarfile.open(fileobj=archive, mode=mode) as tar:
+        _add_tar_bytes(tar, "model_config.yaml", config_bytes)
+    return archive.getvalue()
+
+
 def _materialize_tmp_paths(value: Any, tmp_path: Path) -> Any:
     """Replace fixture path markers without relying on host-global temp paths."""
     if isinstance(value, str) and value.startswith(_TMP_PATH_MARKER):
@@ -206,6 +213,166 @@ class TestNemoScannerBasic:
             check.details.get("extension_format") == "nemo" and check.details.get("header_format") == "gzip"
             for check in s901_checks
         )
+
+    def test_concatenated_gzip_nemo_fails_closed_after_tar_eof(self, tmp_path: Path) -> None:
+        """A second gzip member after TAR EOF must not be hidden by direct NeMo ownership."""
+        path = tmp_path / "concat.nemo"
+        path.write_bytes(
+            _build_nemo_tar_bytes(b"model:\n  _target_: nemo.Model\n")
+            + _build_nemo_tar_bytes(b"model:\n  _target_: os.system\n  command: echo pwned\n")
+        )
+
+        direct_result = scan_file(str(path), config={"cache_scan_results": False})
+        aggregate_result = scan_model_directory_or_file(str(path), config={"cache_scan_results": False})
+
+        integrity_checks = [
+            check
+            for check in direct_result.checks
+            if check.name == "Compressed TAR Stream Integrity" and check.status == CheckStatus.FAILED
+        ]
+        assert direct_result.scanner_name == "nemo"
+        assert direct_result.success is False
+        assert integrity_checks
+        assert integrity_checks[0].rule_code == "S902"
+        assert "non-zero trailing data" in integrity_checks[0].message
+        assert aggregate_result.success is False
+        assert determine_exit_code(aggregate_result) == 2
+
+        cache_dir = tmp_path / "cache"
+        reset_cache_manager()
+        try:
+            cached_aggregate = scan_model_directory_or_file(
+                str(path),
+                cache_enabled=True,
+                cache_dir=str(cache_dir),
+                min_cache_file_size=0,
+            )
+
+            assert cached_aggregate.success is False
+            assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+        finally:
+            reset_cache_manager()
+
+    def test_concatenated_gzip_nemo_raw_member_fails_closed_after_tar_eof(self, tmp_path: Path) -> None:
+        """A non-TAR gzip member after TAR EOF must not be hidden by direct NeMo ownership."""
+        path = _create_nemo_file(tmp_path, {"model": {"_target_": "nemo.Model"}}, mode="w:gz")
+        path.write_bytes(path.read_bytes() + gzip.compress(_build_malicious_pickle()))
+
+        direct_result = scan_file(str(path), config={"cache_scan_results": False})
+        aggregate_result = scan_model_directory_or_file(str(path), config={"cache_scan_results": False})
+
+        integrity_checks = [
+            check
+            for check in direct_result.checks
+            if check.name == "Compressed TAR Stream Integrity" and check.status == CheckStatus.FAILED
+        ]
+        assert file_detection.validate_file_type(str(path)) is False
+        assert direct_result.scanner_name == "nemo"
+        assert direct_result.success is False
+        assert integrity_checks
+        assert integrity_checks[0].rule_code == "S902"
+        assert "non-zero trailing data" in integrity_checks[0].message
+        assert aggregate_result.success is False
+        assert determine_exit_code(aggregate_result) != 0
+
+        cache_dir = tmp_path / "cache"
+        reset_cache_manager()
+        try:
+            cached_aggregate = scan_model_directory_or_file(
+                str(path),
+                cache_enabled=True,
+                cache_dir=str(cache_dir),
+                min_cache_file_size=0,
+            )
+
+            assert cached_aggregate.success is False
+            assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+        finally:
+            reset_cache_manager()
+
+    def test_concatenated_gzip_nemo_detects_nonzero_tail_after_zero_padding(self, tmp_path: Path) -> None:
+        """Post-EOF validation must not stop before hidden non-zero gzip member data."""
+        path = _create_nemo_file(tmp_path, {"model": {"_target_": "nemo.Model"}}, mode="w:gz")
+        path.write_bytes(path.read_bytes() + gzip.compress((b"\0" * (64 * 1024 + 1)) + _build_malicious_pickle()))
+
+        result = scan_file(
+            str(path),
+            config={
+                "cache_scan_results": False,
+                "compressed_max_decompressed_bytes": 2 * 1024 * 1024,
+                "compressed_max_decompression_ratio": 100000.0,
+            },
+        )
+
+        integrity_checks = [
+            check
+            for check in result.checks
+            if check.name == "Compressed TAR Stream Integrity" and check.status == CheckStatus.FAILED
+        ]
+        assert result.scanner_name == "nemo"
+        assert result.success is False
+        assert integrity_checks
+        assert integrity_checks[0].rule_code == "S902"
+        assert "non-zero trailing data" in integrity_checks[0].message
+
+    def test_zero_tail_gzip_nemo_fails_closed_when_post_eof_tail_exceeds_limit(self, tmp_path: Path) -> None:
+        """All-zero post-EOF gzip data is still incomplete when policy limits prevent full validation."""
+        path = _create_nemo_file(tmp_path, {"model": {"_target_": "nemo.Model"}}, mode="w:gz")
+        path.write_bytes(path.read_bytes() + gzip.compress(b"\0" * (128 * 1024)))
+
+        result = scan_file(
+            str(path),
+            config={
+                "cache_scan_results": False,
+                "compressed_max_decompressed_bytes": 64 * 1024,
+                "compressed_max_decompression_ratio": 100000.0,
+            },
+        )
+
+        integrity_checks = [
+            check
+            for check in result.checks
+            if check.name == "Compressed TAR Stream Integrity" and check.status == CheckStatus.FAILED
+        ]
+        assert result.scanner_name == "nemo"
+        assert result.success is False
+        assert integrity_checks
+        assert integrity_checks[0].rule_code == "S902"
+        assert "could not be fully validated" in integrity_checks[0].message
+
+    def test_truncated_gzip_nemo_fails_closed_after_tar_eof(self, tmp_path: Path) -> None:
+        """A readable TAR prefix is not enough when the outer gzip stream is incomplete."""
+        path = tmp_path / "truncated.nemo"
+        payload = _build_nemo_tar_bytes(b"model:\n  _target_: nemo.Model\n")
+        path.write_bytes(payload[:-1])
+
+        result = scan_file(str(path), config={"cache_scan_results": False})
+
+        integrity_checks = [
+            check
+            for check in result.checks
+            if check.name == "Compressed TAR Stream Integrity" and check.status == CheckStatus.FAILED
+        ]
+        assert result.scanner_name == "nemo"
+        assert result.success is False
+        assert integrity_checks
+        assert integrity_checks[0].rule_code == "S902"
+        assert "could not be fully validated" in integrity_checks[0].message
+
+        cache_dir = tmp_path / "cache"
+        reset_cache_manager()
+        try:
+            cached_aggregate = scan_model_directory_or_file(
+                str(path),
+                cache_enabled=True,
+                cache_dir=str(cache_dir),
+                min_cache_file_size=0,
+            )
+
+            assert cached_aggregate.success is False
+            assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+        finally:
+            reset_cache_manager()
 
     def test_missing_yaml_dependency_is_reported_as_warning(self, tmp_path, monkeypatch):
         """Missing PyYAML should be a non-passing warning, not a pass."""

--- a/tests/scanners/test_nemo_scanner.py
+++ b/tests/scanners/test_nemo_scanner.py
@@ -374,6 +374,49 @@ class TestNemoScannerBasic:
         finally:
             reset_cache_manager()
 
+    def test_truncated_gzip_nemo_keeps_nemo_ownership_when_header_stays_gzip(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Retained gzip headers with invalid TAR tails still fail closed as NeMo-owned scans."""
+        path = tmp_path / "truncated-retained-gzip.nemo"
+        payload = _build_nemo_tar_bytes(b"model:\n  _target_: nemo.Model\n")
+        path.write_bytes(payload[:-1])
+        monkeypatch.setattr("modelaudit.core.detect_file_format", lambda _path: "gzip")
+
+        direct_result = scan_file(str(path), config={"cache_scan_results": False})
+        aggregate_result = scan_model_directory_or_file(str(path), config={"cache_scan_results": False})
+
+        integrity_checks = [
+            check
+            for check in direct_result.checks
+            if check.name == "Compressed TAR Stream Integrity" and check.status == CheckStatus.FAILED
+        ]
+        assert direct_result.scanner_name == "nemo"
+        assert direct_result.success is False
+        assert integrity_checks
+        assert integrity_checks[0].rule_code == "S902"
+        assert "could not be fully validated" in integrity_checks[0].message
+        assert aggregate_result.scanner_names == ["nemo"]
+        assert aggregate_result.success is False
+        assert determine_exit_code(aggregate_result) == 2
+
+        cache_dir = tmp_path / "cache"
+        reset_cache_manager()
+        try:
+            cached_aggregate = scan_model_directory_or_file(
+                str(path),
+                cache_enabled=True,
+                cache_dir=str(cache_dir),
+                min_cache_file_size=0,
+            )
+
+            assert cached_aggregate.success is False
+            assert get_cache_manager(str(cache_dir), enabled=True).get_stats()["total_entries"] == 0
+        finally:
+            reset_cache_manager()
+
     def test_missing_yaml_dependency_is_reported_as_warning(self, tmp_path, monkeypatch):
         """Missing PyYAML should be a non-passing warning, not a pass."""
         path = _create_nemo_file(tmp_path, {"model": "test"})

--- a/tests/scanners/test_nemo_scanner.py
+++ b/tests/scanners/test_nemo_scanner.py
@@ -128,19 +128,54 @@ class TestNemoScannerBasic:
         ]
         assert len(mismatch_checks) == 0
 
-    def test_gzip_framed_nemo_does_not_trigger_s901(self, tmp_path: Path) -> None:
-        """Valid gzip-compressed .nemo tar archives should not be flagged as spoofed."""
+    def test_gzip_framed_nemo_keeps_nemo_ownership_when_header_stays_gzip(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Validated gzip TARs remain NeMo-owned when routing retains gzip framing."""
         path = _create_nemo_file(tmp_path, {"model": {"_target_": "nemo.Model"}}, mode="w:gz")
+        monkeypatch.setattr("modelaudit.core.detect_file_format", lambda _path: "gzip")
 
-        direct_result = NemoScanner().scan(str(path))
-        aggregate_result = scan_file(str(path), config={"cache_scan_results": False})
+        file_result = scan_file(str(path), config={"cache_scan_results": False})
+        aggregate_result = scan_model_directory_or_file(str(path), config={"cache_scan_results": False})
 
-        direct_s901 = [check for check in direct_result.checks if check.rule_code == "S901"]
-        aggregate_s901 = [check for check in aggregate_result.checks if check.rule_code == "S901"]
+        assert file_result.scanner_name == "nemo"
+        assert not [check for check in file_result.checks if check.rule_code == "S901"]
+        assert aggregate_result.scanner_names == ["nemo"]
+        assert not [issue for issue in aggregate_result.issues if issue.severity == IssueSeverity.CRITICAL]
+        assert determine_exit_code(aggregate_result) == 0
 
-        assert direct_s901 == []
-        assert aggregate_s901 == []
-        assert aggregate_result.scanner_name == "nemo"
+    def test_gzip_framed_malicious_nemo_keeps_nemo_findings_when_header_stays_gzip(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Retained gzip framing must not hide NeMo Hydra findings from either API."""
+        path = _create_nemo_file_from_bytes(
+            tmp_path,
+            b"model:\n  _target_: os.system\n  command: echo pwned\n",
+            mode="w:gz",
+        )
+        monkeypatch.setattr("modelaudit.core.detect_file_format", lambda _path: "gzip")
+
+        file_result = scan_file(str(path), config={"cache_scan_results": False})
+        aggregate_result = scan_model_directory_or_file(str(path), config={"cache_scan_results": False})
+
+        assert file_result.scanner_name == "nemo"
+        assert any(
+            check.name == "CVE-2025-23304: Dangerous Hydra _target_"
+            and check.status == CheckStatus.FAILED
+            and check.severity == IssueSeverity.CRITICAL
+            and check.details.get("target") == "os.system"
+            for check in file_result.checks
+        )
+        assert aggregate_result.scanner_names == ["nemo"]
+        assert any(
+            issue.severity == IssueSeverity.CRITICAL and issue.details.get("target") == "os.system"
+            for issue in aggregate_result.issues
+        )
+        assert determine_exit_code(aggregate_result) == 1
 
     def test_malformed_gzip_nemo_still_reports_s901(self, tmp_path: Path) -> None:
         """A .nemo suffix plus gzip magic is not enough unless it is a valid TAR."""
@@ -150,6 +185,7 @@ class TestNemoScannerBasic:
         result = scan_file(str(path), config={"cache_scan_results": False})
 
         s901_checks = [check for check in result.checks if check.rule_code == "S901"]
+        assert result.scanner_name == "compressed"
         assert s901_checks
         assert any(
             check.details.get("extension_format") == "nemo" and check.details.get("header_format") == "gzip"
@@ -164,6 +200,7 @@ class TestNemoScannerBasic:
         result = scan_file(str(path), config={"cache_scan_results": False})
 
         s901_checks = [check for check in result.checks if check.rule_code == "S901"]
+        assert result.scanner_name == "compressed"
         assert s901_checks
         assert any(
             check.details.get("extension_format") == "nemo" and check.details.get("header_format") == "gzip"

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -3641,6 +3641,22 @@ def test_validate_file_type(tmp_path):
         tar.addfile(info, io.BytesIO(content))
     assert validate_file_type(str(nemo_path)) is True
 
+    gzip_nemo_path = tmp_path / "compressed.nemo"
+    with tarfile.open(gzip_nemo_path, "w:gz") as tar:
+        info = tarfile.TarInfo(name="model_config.yaml")
+        content = b"model: test\n"
+        info.size = len(content)
+        tar.addfile(info, io.BytesIO(content))
+    assert validate_file_type(str(gzip_nemo_path)) is True
+
+    malformed_gzip_nemo_path = tmp_path / "malformed.nemo"
+    malformed_gzip_nemo_path.write_bytes(b"\x1f\x8b\x08\x00truncated")
+    assert validate_file_type(str(malformed_gzip_nemo_path)) is False
+
+    gzip_non_tar_nemo_path = tmp_path / "gzip-non-tar.nemo"
+    gzip_non_tar_nemo_path.write_bytes(gzip.compress(b"not a tar archive"))
+    assert validate_file_type(str(gzip_non_tar_nemo_path)) is False
+
     # Small file should be valid (can't determine magic bytes)
     small_file = tmp_path / "small.h5"
     small_file.write_bytes(b"hi")


### PR DESCRIPTION
## Summary

- Accept `.nemo` files whose magic bytes identify gzip only when the container is also a valid TAR archive.
- Preserve default NeMo scanner ownership when routing sees the outer gzip framing.
- Keep malformed gzip and valid gzip-with-non-TAR-content `.nemo` files as S901 mismatches.
- Add gzip-framed NeMo regressions for traversal, symlink escape, malicious checkpoint, and executable archive member controls.

## Root Cause

The pinned NeMo model is a valid gzip-compressed TAR archive with a `.nemo` suffix. Existing validation accepted `.nemo` when magic/header detection returned `tar` or `nemo`, but not when the outer framing returned `gzip`, so scanner preflight reported S901 despite NeMo/TAR parsing being able to open the file safely.

Default routing also needed the same constrained exception: when header detection retains `gzip`, the scanner selector must keep validated `.nemo` gzip TARs owned by the NeMo scanner rather than falling back to the generic compressed scanner.

The fix is deliberately narrow: `.nemo` plus `gzip` is accepted only after `tarfile.is_tarfile()` succeeds through `_is_tar_archive(path)`. This avoids blessing gzip by suffix and preserves fail-closed behavior for malformed or ambiguous containers.

## Security Tradeoffs

- Preserved archive safety: TAR preflight, traversal checks, symlink/hardlink escape checks, checkpoint nested scanning, and executable member scanning still run.
- Preserved spoofing detection: truncated gzip and valid gzip streams containing non-TAR payloads still produce S901.
- Did not broaden `.nemo` validation to bzip2/xz or generic compressed wrappers; this PR is scoped to the observed gzip container framing.

## Real Model QA

Pinned model:

```bash
HF_HUB_DISABLE_TELEMETRY=1 uv run python - <<'PY'
from huggingface_hub import HfApi
repo = "nvidia/nemotron-3.5-asr-streaming-0.6b"
rev = "24b151a851dd15909e1fc611b11bb2da52b9fc81"
info = HfApi().repo_info(repo, revision=rev, files_metadata=True)
print(info.sha)
for sibling in info.siblings:
    if sibling.rfilename.endswith(".nemo"):
        print(sibling.rfilename, sibling.size)
PY
```

Outcome: revision matched `24b151a851dd15909e1fc611b11bb2da52b9fc81`; `.nemo` artifact was `nemotron-3.5-asr-streaming-0.6b.nemo` with size `2368284501`.

Baseline `ab6e58ebe587197b2b46866c69f7d41d75e08a55`:

```bash
PROMPTFOO_DISABLE_TELEMETRY=1 HF_HUB_DISABLE_TELEMETRY=1 uv run modelaudit scan --no-cache --quiet --format json --scanners nemo --output baseline-nemo-scan.json /path/to/nemotron-3.5-asr-streaming-0.6b.nemo
```

Outcome: exit `1`, `s901_count=4`; S901 details included `extension_format=nemo`, `header_format=gzip`.

Fixed branch local-file scan:

```bash
PROMPTFOO_DISABLE_TELEMETRY=1 HF_HUB_DISABLE_TELEMETRY=1 uv run modelaudit scan --no-cache --quiet --format json --scanners nemo --output fixed-nemo-scan.json /path/to/nemotron-3.5-asr-streaming-0.6b.nemo
```

Outcome: exit `1`, `s901_count=0`; remaining issue was `S902` decompressed-size policy (`2553098240 > 536870912`), confirming archive safety still applies.

Fixed branch end-to-end pinned HF file scan, with default scanner routing:

```bash
PROMPTFOO_DISABLE_TELEMETRY=1 HF_HUB_DISABLE_TELEMETRY=1 uv run modelaudit scan --no-cache --quiet --format json --max-size 3GB --timeout 1800 --output fixed-hf-end-to-end-default.json https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b/resolve/24b151a851dd15909e1fc611b11bb2da52b9fc81/nemotron-3.5-asr-streaming-0.6b.nemo
```

Outcome: exit `1`, `scanner_names=["nemo"]`, `s901_count=0`; remaining issue was `S902` decompressed-size policy.

## Validation

```bash
uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_nemo_scanner.py::TestNemoScannerBasic::test_gzip_framed_nemo_keeps_nemo_ownership_when_header_stays_gzip tests/scanners/test_nemo_scanner.py::TestNemoScannerBasic::test_gzip_framed_malicious_nemo_keeps_nemo_findings_when_header_stays_gzip tests/scanners/test_nemo_scanner.py::TestNemoScannerBasic::test_malformed_gzip_nemo_still_reports_s901 tests/scanners/test_nemo_scanner.py::TestNemoScannerBasic::test_gzip_non_tar_nemo_still_reports_s901 tests/scanners/test_nemo_scanner.py::TestNemoArchiveVulnerabilityCoverage::test_gzip_framed_member_path_traversal_still_detected tests/scanners/test_nemo_scanner.py::TestNemoArchiveVulnerabilityCoverage::test_gzip_framed_symlink_escape_still_detected tests/scanners/test_nemo_scanner.py::TestNemoArchiveVulnerabilityCoverage::test_gzip_framed_malicious_checkpoint_still_detected tests/scanners/test_nemo_scanner.py::TestCVE202523304HydraTarget::test_gzip_framed_executable_file_in_archive_flagged tests/utils/file/test_filetype.py::test_validate_file_type
PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_nemo_scanner.py tests/utils/file/test_filetype.py
PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1
uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
git diff --check
```

Results:

- Focused regression set: `9 passed`
- Current-head affected files: `1493 passed, 11 skipped`
- Pre-merge broad local lane: `16889 passed, 1298 skipped, 30 warnings`
- Ruff format/check, mypy, and `git diff --check`: clean
