### PR TITLE
fix: preserve OpenVINO companions in HF streaming

### DIFF
--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -290,6 +290,7 @@ _DVC_EXCLUDED_PATHS_CONFIG_KEY = "_dvc_excluded_paths"
 _DVC_COVERAGE_ROOTS_CONFIG_KEY = "_dvc_coverage_roots"
 DVC_EXTERNAL_COVERED_PATHS_CONFIG_KEY = "_dvc_external_covered_paths"
 DVC_EXTERNAL_COVERED_DIRECTORIES_CONFIG_KEY = "_dvc_external_covered_directories"
+_OPENVINO_SCANNED_XML_COMPANIONS_CONFIG_KEY = "_openvino_scanned_xml_companions"
 
 
 def _record_incomplete_dvc_resolution(
@@ -647,6 +648,35 @@ def _is_openvino_xml_path(path: Path) -> bool:
         return OpenVinoScanner.can_handle(str(path))
     except Exception:
         return False
+
+
+def _openvino_xml_companion_key(path: Path) -> str:
+    """Return a stable lexical key for one scheduled OpenVINO XML scan."""
+    return os.path.normcase(os.path.normpath(str(Path(os.path.abspath(path)))))
+
+
+def _with_openvino_scanned_xml_companion(config: dict[str, Any], xml_path: Path) -> dict[str, Any]:
+    """Record an OpenVINO XML that will cover its same-stem weights sidecar."""
+    configured_companions = config.get(_OPENVINO_SCANNED_XML_COMPANIONS_CONFIG_KEY, ())
+    companion_keys = {
+        str(companion_key) for companion_key in configured_companions if isinstance(companion_key, (str, Path))
+    }
+    companion_keys.add(_openvino_xml_companion_key(xml_path))
+    updated_config = dict(config)
+    updated_config[_OPENVINO_SCANNED_XML_COMPANIONS_CONFIG_KEY] = tuple(sorted(companion_keys))
+    return updated_config
+
+
+def _openvino_xml_companion_will_be_scanned(xml_path: Path, config: dict[str, Any]) -> bool:
+    """Return whether this scan invocation scheduled the owning XML through OpenVINO."""
+    if not policy_from_config(config).allows("openvino"):
+        return False
+    configured_companions = config.get(_OPENVINO_SCANNED_XML_COMPANIONS_CONFIG_KEY, ())
+    if not isinstance(configured_companions, (list, tuple, set, frozenset)):
+        return False
+    return _openvino_xml_companion_key(xml_path) in {
+        str(companion_key) for companion_key in configured_companions if isinstance(companion_key, (str, Path))
+    }
 
 
 def _snapshot_file_identity(path: Path) -> _FileIdentitySnapshot | None:
@@ -2676,6 +2706,11 @@ def scan_model_directory_or_file(
             # family once. Shard scans already expand to sibling shards in the
             # advanced handler, so scanning each shard path would duplicate work.
             if scan_entries:
+                scheduled_openvino_xml_companions = {
+                    _openvino_xml_companion_key(Path(representative_file))
+                    for representative_file, _scanned_file_paths, _entry_shard_family_key in scan_entries
+                    if scanner_selection.allows("openvino") and _is_openvino_xml_path(Path(representative_file))
+                }
                 hash_sources: list[str] = []
                 seen_hash_sources: set[str] = set()
                 hash_source_by_path: dict[str, str] = {}
@@ -2772,6 +2807,12 @@ def scan_model_directory_or_file(
                                         shard_family_targets.get(shard_family_key, {}),
                                     )
                                 )
+                            openvino_owner = _openvino_weights_companion_owner(Path(representative_file))
+                            if (
+                                openvino_owner is not None
+                                and _openvino_xml_companion_key(openvino_owner) in scheduled_openvino_xml_companions
+                            ):
+                                file_config = _with_openvino_scanned_xml_companion(file_config, openvino_owner)
                             file_result = scan_file(representative_file, file_config)
                         finally:
                             _finish_phase_timing(phase_timings, "file_scan_dispatch", file_scan_started_at)
@@ -3652,7 +3693,7 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
         return sr
 
     openvino_owner = _openvino_weights_companion_owner(Path(path))
-    if openvino_owner is not None:
+    if openvino_owner is not None and _openvino_xml_companion_will_be_scanned(openvino_owner, config):
         sr = ScanResult(scanner_name="openvino")
         sr.bytes_scanned = file_size
         sr.metadata["file_size"] = file_size
@@ -4380,6 +4421,7 @@ def scan_model_streaming(
     validated_shard_targets: ValidatedShardTargets = {}
     preserved_openvino_companion_snapshots: dict[Path, _FileIdentitySnapshot] = {}
     consumed_openvino_companions: set[Path] = set()
+    hashed_stream_paths: set[Path] = set()
     preserve_shard_reconciliation_errors = False
 
     def delete_streamed_source(source_path: Path, context: str) -> None:
@@ -4474,6 +4516,66 @@ def scan_model_streaming(
             }
         )
 
+    def append_streamed_file_hash(
+        scan_path: Path,
+        scan_config: dict[str, Any],
+        *,
+        progress_label: str,
+    ) -> str | None:
+        """Hash one streamed source once before it can be deleted or consumed."""
+        nonlocal aggregate_hash_complete, top_level_hashed_bytes
+
+        scan_path_key = Path(os.path.abspath(scan_path))
+        if scan_path_key in hashed_stream_paths:
+            return None
+
+        defer_hash_for_max_total_size = _should_defer_hash_for_max_total_size(
+            scan_config,
+            hashed_bytes=top_level_hashed_bytes,
+        )
+        defer_hash_for_max_file_size = _should_defer_hash_for_max_file_size(str(scan_path), scan_config)
+        if defer_hash_for_max_total_size or defer_hash_for_max_file_size:
+            aggregate_hash_complete = False
+            return None
+        if _should_defer_hash_for_safetensors_header_limit(str(scan_path), scan_config):
+            return None
+
+        if progress_callback:
+            progress_callback(
+                f"Hashing {progress_label}",
+                (files_processed / (files_processed + 1)) * 100,
+            )
+        with suppress(OSError):
+            top_level_hashed_bytes += scan_path.stat().st_size
+        file_hash = compute_sha256_hash(scan_path)
+        file_hashes.append(file_hash)
+        hashed_stream_paths.add(scan_path_key)
+        return file_hash
+
+    def append_streamed_openvino_companion_hash(
+        xml_path: Path,
+        companion_path: Path,
+        scan_config: dict[str, Any],
+    ) -> None:
+        """Hash an OpenVINO sidecar only after preserving its directory boundary."""
+        nonlocal aggregate_hash_complete
+
+        if companion_path.is_symlink():
+            try:
+                resolved_companion = companion_path.resolve(strict=True)
+                model_dir = xml_path.resolve(strict=True).parent
+            except OSError:
+                aggregate_hash_complete = False
+                return
+            if not is_within_directory(str(model_dir), str(resolved_companion)):
+                aggregate_hash_complete = False
+                return
+        append_streamed_file_hash(
+            companion_path,
+            scan_config,
+            progress_label=companion_path.name,
+        )
+
     base_dir = Path(scan_root).resolve() if scan_root is not None else None
     hf_cache_root = _find_hf_cache_root(base_dir) if base_dir is not None else None
     is_hf_cache = base_dir is not None and hf_cache_root is not None
@@ -4550,16 +4652,23 @@ def scan_model_streaming(
                         logger.debug(f"Skipping non-model file: {source_path}")
                     continue
 
+                # Build config dict for scan_file
+                scan_config = {
+                    "timeout": timeout - int(time.time() - start_time),
+                    **scan_kwargs,
+                }
+
                 openvino_sidecar_owner = _openvino_weights_companion_owner(scan_path)
-                if openvino_sidecar_owner is not None:
+                if openvino_sidecar_owner is not None and scanner_selection.allows("openvino"):
                     is_lfs_sidecar, _lfs_info = check_lfs_pointer(str(scan_path))
                     if not is_lfs_sidecar:
+                        scan_config = _with_openvino_scanned_xml_companion(scan_config, openvino_sidecar_owner)
                         preserve_source_after_scan = True
                         sidecar_snapshot = _snapshot_file_identity(scan_path)
                         if sidecar_snapshot is not None:
                             preserved_openvino_companion_snapshots[Path(os.path.abspath(scan_path))] = sidecar_snapshot
 
-                if _is_openvino_xml_path(scan_path):
+                if scanner_selection.allows("openvino") and _is_openvino_xml_path(scan_path):
                     candidate_companion = scan_path.with_suffix(".bin")
                     if candidate_companion.exists() or candidate_companion.is_symlink():
                         openvino_scan_companion_path = candidate_companion
@@ -4579,11 +4688,6 @@ def scan_model_streaming(
                             preserve_shard_reconciliation_errors = True
                             aggregate_hash_complete = False
 
-                # Build config dict for scan_file
-                scan_config = {
-                    "timeout": timeout - int(time.time() - start_time),
-                    **scan_kwargs,
-                }
                 initial_shard_target = _snapshot_validated_shard_target(
                     str(source_path),
                     resolved_path=str(scan_path),
@@ -4618,28 +4722,17 @@ def scan_model_streaming(
                             files_processed += 1
                             continue
 
-                file_hash: str | None = None
-                defer_hash_for_max_total_size = _should_defer_hash_for_max_total_size(
+                file_hash = append_streamed_file_hash(
+                    scan_path,
                     scan_config,
-                    hashed_bytes=top_level_hashed_bytes,
+                    progress_label=source_path.name,
                 )
-                defer_hash_for_max_file_size = _should_defer_hash_for_max_file_size(str(scan_path), scan_config)
-                if defer_hash_for_max_total_size or defer_hash_for_max_file_size:
-                    aggregate_hash_complete = False
-                if (
-                    not _should_defer_hash_for_safetensors_header_limit(str(scan_path), scan_config)
-                    and not defer_hash_for_max_file_size
-                    and not defer_hash_for_max_total_size
-                ):
-                    if progress_callback:
-                        progress_callback(
-                            f"Hashing {source_path.name}",
-                            (files_processed / (files_processed + 1)) * 100,
-                        )
-                    with suppress(OSError):
-                        top_level_hashed_bytes += scan_path.stat().st_size
-                    file_hash = compute_sha256_hash(scan_path)
-                    file_hashes.append(file_hash)
+                if openvino_scan_companion_path is not None:
+                    append_streamed_openvino_companion_hash(
+                        scan_path,
+                        openvino_scan_companion_path,
+                        scan_config,
+                    )
 
                 # Scan the file
                 if progress_callback:

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -372,6 +372,15 @@ class _TrustedStreamShardRoot:
     token: object
 
 
+@dataclass(frozen=True)
+class _FileIdentitySnapshot:
+    """Stable identity fields for a path-sensitive companion file."""
+
+    lstat: tuple[int, int, int, int, int, int]
+    stat: tuple[int, int, int, int, int, int] | None
+    resolved_path: str | None
+
+
 def _make_trusted_stream_shard_root(path: FilePath) -> object:
     """Mark a persistent root selected by a trusted remote-source dispatcher."""
     return _TrustedStreamShardRoot(
@@ -616,6 +625,65 @@ def _snapshot_validated_shard_target(
         if trusted_family_group:
             target["family_group"] = trusted_family_group
     return {str(source.absolute()): target}
+
+
+def _openvino_weights_companion_owner(path: Path) -> Path | None:
+    """Return the OpenVINO XML that owns a same-stem .bin sidecar."""
+    try:
+        from modelaudit.scanners.openvino_scanner import openvino_xml_companion_for_weights
+
+        return openvino_xml_companion_for_weights(path)
+    except Exception:
+        return None
+
+
+def _is_openvino_xml_path(path: Path) -> bool:
+    """Return whether the path is a local OpenVINO XML model."""
+    if path.suffix.lower() != ".xml":
+        return False
+    try:
+        from modelaudit.scanners.openvino_scanner import OpenVinoScanner
+
+        return OpenVinoScanner.can_handle(str(path))
+    except Exception:
+        return False
+
+
+def _snapshot_file_identity(path: Path) -> _FileIdentitySnapshot | None:
+    """Snapshot path and target identity for TOCTOU-sensitive companion checks."""
+    try:
+        link_stat = os.lstat(path)
+    except OSError:
+        return None
+
+    stat_fields: tuple[int, int, int, int, int, int] | None = None
+    resolved_path: str | None = None
+    try:
+        target_stat = os.stat(path)
+        stat_fields = (
+            target_stat.st_dev,
+            target_stat.st_ino,
+            target_stat.st_mode,
+            target_stat.st_size,
+            target_stat.st_mtime_ns,
+            target_stat.st_ctime_ns,
+        )
+        resolved_path = str(path.resolve(strict=True))
+    except OSError:
+        pass
+
+    return _FileIdentitySnapshot(
+        lstat=(
+            link_stat.st_dev,
+            link_stat.st_ino,
+            link_stat.st_mode,
+            link_stat.st_size,
+            link_stat.st_mtime_ns,
+            link_stat.st_ctime_ns,
+        ),
+        stat=stat_fields,
+        resolved_path=resolved_path,
+    )
 
 
 def _validated_shard_family_scopes(
@@ -3582,6 +3650,26 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
         sr.finish(success=False)
         return sr
 
+    openvino_owner = _openvino_weights_companion_owner(Path(path))
+    if openvino_owner is not None:
+        sr = ScanResult(scanner_name="openvino")
+        sr.bytes_scanned = file_size
+        sr.metadata["file_size"] = file_size
+        sr.metadata["openvino_xml_companion"] = str(openvino_owner)
+        sr.add_check(
+            name="OpenVINO Weights Sidecar Routing",
+            passed=True,
+            message="OpenVINO weights sidecar covered by adjacent XML model scan",
+            severity=IssueSeverity.INFO,
+            location=path,
+            details={
+                "xml_companion": str(openvino_owner),
+                "sidecar_file": path,
+            },
+        )
+        sr.finish(success=True)
+        return sr
+
     hdf5_signature_offset = find_hdf5_signature_offset(path)
     safetensors_overlap_scanner_ids = detect_safetensors_overlap_scanner_ids(path)
     try:
@@ -4289,6 +4377,8 @@ def scan_model_streaming(
     nearby_license_cache: dict[str, list[str]] = {}
     pending_delete_failures: dict[Path, Exception] = {}
     validated_shard_targets: ValidatedShardTargets = {}
+    preserved_openvino_companion_snapshots: dict[Path, _FileIdentitySnapshot] = {}
+    consumed_openvino_companions: set[Path] = set()
     preserve_shard_reconciliation_errors = False
 
     def delete_streamed_source(source_path: Path, context: str) -> None:
@@ -4338,6 +4428,51 @@ def scan_model_streaming(
             }
         )
 
+    def record_openvino_companion_stability_failure(
+        xml_path: Path,
+        companion_path: Path,
+        reason: str,
+    ) -> None:
+        """Record a durable operational failure when a streamed OpenVINO sidecar changes."""
+        failure = ScanResult(scanner_name="openvino")
+        _mark_inconclusive_scan_outcome(failure, reason)
+        _mark_operational_scan_error(failure, reason)
+        failure.add_check(
+            name="OpenVINO Weights Companion Stability",
+            passed=False,
+            message="OpenVINO weights companion changed while preserving XML/BIN scan context",
+            severity=IssueSeverity.INFO,
+            location=str(companion_path),
+            details={
+                "xml_file": str(xml_path),
+                "companion_file": str(companion_path),
+                "analysis_incomplete": True,
+                "scan_outcome": "inconclusive",
+                "scan_outcome_reason": reason,
+            },
+        )
+        failure.finish(success=False)
+        results.aggregate_scan_result(
+            {
+                "bytes_scanned": 0,
+                "files_scanned": 0,
+                "has_errors": True,
+                "success": False,
+                "issues": _serialize_streamed_records(
+                    list(failure.issues),
+                    str(companion_path),
+                    str(companion_path),
+                ),
+                "checks": _serialize_streamed_records(
+                    list(failure.checks),
+                    str(companion_path),
+                    str(companion_path),
+                ),
+                "scanners": [failure.scanner_name],
+                "file_metadata": {str(companion_path): dict(failure.metadata)},
+            }
+        )
+
     base_dir = Path(scan_root).resolve() if scan_root is not None else None
     hf_cache_root = _find_hf_cache_root(base_dir) if base_dir is not None else None
     is_hf_cache = base_dir is not None and hf_cache_root is not None
@@ -4345,9 +4480,16 @@ def scan_model_streaming(
     try:
         for file_path, _is_last in file_generator:
             source_path = Path(file_path)
+            source_key = Path(os.path.abspath(source_path))
+            if source_key in consumed_openvino_companions:
+                continue
             scan_path = source_path
             report_path = str(source_path)
             pinned_scan_context: Any | None = None
+            preserve_source_after_scan = False
+            openvino_scan_companion_path: Path | None = None
+            openvino_scan_companion_key: Path | None = None
+            openvino_companion_pre_scan_identity: _FileIdentitySnapshot | None = None
 
             # Check for interruption before starting work on the yielded file.
             try:
@@ -4406,6 +4548,35 @@ def scan_model_streaming(
                     else:
                         logger.debug(f"Skipping non-model file: {source_path}")
                     continue
+
+                openvino_sidecar_owner = _openvino_weights_companion_owner(scan_path)
+                if openvino_sidecar_owner is not None:
+                    is_lfs_sidecar, _lfs_info = check_lfs_pointer(str(scan_path))
+                    if not is_lfs_sidecar:
+                        preserve_source_after_scan = True
+                        sidecar_snapshot = _snapshot_file_identity(scan_path)
+                        if sidecar_snapshot is not None:
+                            preserved_openvino_companion_snapshots[Path(os.path.abspath(scan_path))] = sidecar_snapshot
+
+                if _is_openvino_xml_path(scan_path):
+                    candidate_companion = scan_path.with_suffix(".bin")
+                    if candidate_companion.exists() or candidate_companion.is_symlink():
+                        openvino_scan_companion_path = candidate_companion
+                        openvino_scan_companion_key = Path(os.path.abspath(candidate_companion))
+                        openvino_companion_pre_scan_identity = _snapshot_file_identity(candidate_companion)
+                        preserved_snapshot = preserved_openvino_companion_snapshots.get(openvino_scan_companion_key)
+                        if (
+                            preserved_snapshot is not None
+                            and openvino_companion_pre_scan_identity is not None
+                            and preserved_snapshot != openvino_companion_pre_scan_identity
+                        ):
+                            record_openvino_companion_stability_failure(
+                                scan_path,
+                                candidate_companion,
+                                "openvino_weights_changed_before_xml_scan",
+                            )
+                            preserve_shard_reconciliation_errors = True
+                            aggregate_hash_complete = False
 
                 # Build config dict for scan_file
                 scan_config = {
@@ -4477,6 +4648,18 @@ def scan_model_streaming(
                     str(scan_path),
                     config=scan_config,
                 )
+                if (
+                    openvino_scan_companion_path is not None
+                    and openvino_companion_pre_scan_identity is not None
+                    and _snapshot_file_identity(openvino_scan_companion_path) != openvino_companion_pre_scan_identity
+                ):
+                    record_openvino_companion_stability_failure(
+                        scan_path,
+                        openvino_scan_companion_path,
+                        "openvino_weights_changed_during_xml_scan",
+                    )
+                    preserve_shard_reconciliation_errors = True
+                    aggregate_hash_complete = False
                 if pre_scan_shard_target:
                     _ensure_streamed_shard_coverage_placeholder(scan_result, source_path)
 
@@ -4591,7 +4774,12 @@ def scan_model_streaming(
                 if pinned_scan_context is not None:
                     pinned_scan_context.__exit__(None, None, None)
                 # Delete file after scanning if requested
-                delete_streamed_source(source_path, "after scanning")
+                if not preserve_source_after_scan:
+                    delete_streamed_source(source_path, "after scanning")
+                if openvino_scan_companion_path is not None and openvino_scan_companion_key is not None:
+                    delete_streamed_source(openvino_scan_companion_path, "after OpenVINO XML scan")
+                    consumed_openvino_companions.add(openvino_scan_companion_key)
+                    preserved_openvino_companion_snapshots.pop(openvino_scan_companion_key, None)
 
         _reconcile_cross_directory_shard_coverage(
             results,

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -2680,6 +2680,39 @@ def scan_model_directory_or_file(
                     seen_complete_hf_shard_families.add(family_dedupe_key)
                 scan_entries.append((representative_file, ordered_family_paths, shard_family_key))
 
+            openvino_companion_by_xml_key: dict[str, str] = {}
+            openvino_xml_key_by_companion_key: dict[str, str] = {}
+            if scanner_selection.allows("openvino"):
+                for representative_file, _scanned_file_paths, shard_family_key in scan_entries:
+                    if shard_family_key is not None:
+                        continue
+                    representative_path = Path(representative_file)
+                    if not _is_openvino_xml_path(representative_path):
+                        continue
+                    companion_path = representative_path.with_suffix(".bin")
+                    if not (companion_path.exists() or companion_path.is_symlink()):
+                        continue
+                    companion_owner = _openvino_weights_companion_owner(companion_path)
+                    xml_key = _openvino_xml_companion_key(representative_path)
+                    if companion_owner is None or _openvino_xml_companion_key(companion_owner) != xml_key:
+                        continue
+                    companion_key = _openvino_xml_companion_key(companion_path)
+                    companion_str = str(companion_path)
+                    openvino_companion_by_xml_key[xml_key] = companion_str
+                    openvino_xml_key_by_companion_key[companion_key] = xml_key
+                if openvino_companion_by_xml_key:
+                    augmented_scan_entries: list[_ScanEntry] = []
+                    for representative_file, scanned_file_paths, shard_family_key in scan_entries:
+                        representative_key = _openvino_xml_companion_key(Path(representative_file))
+                        if shard_family_key is None and representative_key in openvino_xml_key_by_companion_key:
+                            continue
+                        augmented_scanned_paths = list(scanned_file_paths)
+                        companion_path_str = openvino_companion_by_xml_key.get(representative_key)
+                        if companion_path_str is not None and companion_path_str not in augmented_scanned_paths:
+                            augmented_scanned_paths.append(companion_path_str)
+                        augmented_scan_entries.append((representative_file, augmented_scanned_paths, shard_family_key))
+                    scan_entries = augmented_scan_entries
+
             if isinstance(dvc_parent_file, str) and isinstance(dvc_remaining_total_size, int):
                 remaining_size = dvc_remaining_total_size
                 bounded_scan_entries: list[_ScanEntry] = []
@@ -4651,6 +4684,21 @@ def scan_model_streaming(
                         continue
                     scan_path = resolved_path
 
+                openvino_sidecar_owner = _openvino_weights_companion_owner(scan_path)
+                if (
+                    openvino_sidecar_owner is not None
+                    and scanner_selection.allows("openvino")
+                    and not scanning_deferred_openvino_sidecars
+                ):
+                    is_lfs_sidecar, _lfs_info = check_lfs_pointer(str(scan_path))
+                    if not is_lfs_sidecar:
+                        preserve_source_after_scan = True
+                        deferred_openvino_sidecars.setdefault(Path(os.path.abspath(scan_path)), source_path)
+                        sidecar_snapshot = _snapshot_file_identity(scan_path)
+                        if sidecar_snapshot is not None:
+                            preserved_openvino_companion_snapshots[Path(os.path.abspath(scan_path))] = sidecar_snapshot
+                        continue
+
                 if skip_file_types and should_skip_file(
                     str(source_path),
                     metadata_scanner_available=metadata_scanner_available,
@@ -4678,21 +4726,6 @@ def scan_model_streaming(
                     "timeout": timeout - int(time.time() - start_time),
                     **scan_kwargs,
                 }
-
-                openvino_sidecar_owner = _openvino_weights_companion_owner(scan_path)
-                if (
-                    openvino_sidecar_owner is not None
-                    and scanner_selection.allows("openvino")
-                    and not scanning_deferred_openvino_sidecars
-                ):
-                    is_lfs_sidecar, _lfs_info = check_lfs_pointer(str(scan_path))
-                    if not is_lfs_sidecar:
-                        preserve_source_after_scan = True
-                        deferred_openvino_sidecars.setdefault(Path(os.path.abspath(scan_path)), source_path)
-                        sidecar_snapshot = _snapshot_file_identity(scan_path)
-                        if sidecar_snapshot is not None:
-                            preserved_openvino_companion_snapshots[Path(os.path.abspath(scan_path))] = sidecar_snapshot
-                        continue
 
                 if scanner_selection.allows("openvino") and _is_openvino_xml_path(scan_path):
                     candidate_companion = scan_path.with_suffix(".bin")

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -725,6 +725,34 @@ def _snapshot_file_size(snapshot: _FileIdentitySnapshot | None) -> int:
     return stat_fields[3]
 
 
+def _openvino_xml_weights_companion(path: Path) -> Path | None:
+    """Return a local OpenVINO XML model's same-stem weights sidecar."""
+    if not _is_openvino_xml_path(path):
+        return None
+    companion_path = path.with_suffix(".bin")
+    return companion_path if companion_path.exists() or companion_path.is_symlink() else None
+
+
+def _snapshot_openvino_companion_for_hash(xml_path: Path, companion_path: Path) -> _FileIdentitySnapshot | None:
+    """Snapshot an OpenVINO sidecar only when hashing stays in the model directory."""
+    companion_snapshot = _snapshot_file_identity(companion_path)
+    if companion_snapshot is None:
+        return None
+    if not companion_path.is_symlink():
+        return companion_snapshot
+
+    try:
+        model_dir = xml_path.resolve(strict=True).parent
+    except OSError:
+        return None
+    if companion_snapshot.resolved_path is None or not is_within_directory(
+        str(model_dir),
+        companion_snapshot.resolved_path,
+    ):
+        return None
+    return companion_snapshot
+
+
 def _validated_shard_family_scopes(
     source_path: str,
     target: dict[str, int | str],
@@ -2680,6 +2708,46 @@ def scan_model_directory_or_file(
                     seen_complete_hf_shard_families.add(family_dedupe_key)
                 scan_entries.append((representative_file, ordered_family_paths, shard_family_key))
 
+            scheduled_openvino_companion_sizes: dict[str, int] = {}
+            if scanner_selection.allows("openvino"):
+                scheduled_companions_by_key: dict[str, str] = {}
+                for representative_file, _scanned_file_paths, _entry_shard_family_key in scan_entries:
+                    xml_path = Path(representative_file)
+                    companion_path = _openvino_xml_weights_companion(xml_path)
+                    if companion_path is None:
+                        continue
+                    companion_snapshot = _snapshot_openvino_companion_for_hash(xml_path, companion_path)
+                    if companion_snapshot is None:
+                        aggregate_hash_complete = False
+                        continue
+                    xml_key = _openvino_xml_companion_key(xml_path)
+                    companion_path_str = str(companion_path)
+                    scheduled_openvino_companion_sizes[xml_key] = _snapshot_file_size(companion_snapshot)
+                    scheduled_companions_by_key[_openvino_xml_companion_key(companion_path)] = companion_path_str
+
+                if scheduled_companions_by_key:
+                    expanded_scan_entries: list[_ScanEntry] = []
+                    for representative_file, scanned_file_paths, entry_shard_family_key in scan_entries:
+                        representative_key = _openvino_xml_companion_key(Path(representative_file))
+                        if representative_key in scheduled_companions_by_key:
+                            continue
+
+                        expanded_scanned_file_paths = list(scanned_file_paths)
+                        expanded_scanned_path_keys = {
+                            _openvino_xml_companion_key(Path(scanned_file_path))
+                            for scanned_file_path in expanded_scanned_file_paths
+                        }
+                        companion_path = _openvino_xml_weights_companion(Path(representative_file))
+                        if companion_path is not None:
+                            companion_key = _openvino_xml_companion_key(companion_path)
+                            scheduled_companion_path = scheduled_companions_by_key.get(companion_key)
+                            if scheduled_companion_path is not None and companion_key not in expanded_scanned_path_keys:
+                                expanded_scanned_file_paths.append(scheduled_companion_path)
+                        expanded_scan_entries.append(
+                            (representative_file, expanded_scanned_file_paths, entry_shard_family_key)
+                        )
+                    scan_entries = expanded_scan_entries
+
             if isinstance(dvc_parent_file, str) and isinstance(dvc_remaining_total_size, int):
                 remaining_size = dvc_remaining_total_size
                 bounded_scan_entries: list[_ScanEntry] = []
@@ -2822,6 +2890,10 @@ def scan_model_directory_or_file(
                             ):
                                 file_config = _with_openvino_scanned_xml_companion(file_config, openvino_owner)
                             file_result = scan_file(representative_file, file_config)
+                            file_result.bytes_scanned += scheduled_openvino_companion_sizes.get(
+                                _openvino_xml_companion_key(Path(representative_file)),
+                                0,
+                            )
                         finally:
                             _finish_phase_timing(phase_timings, "file_scan_dispatch", file_scan_started_at)
 
@@ -4651,29 +4723,8 @@ def scan_model_streaming(
                         continue
                     scan_path = resolved_path
 
-                if skip_file_types and should_skip_file(
-                    str(source_path),
-                    metadata_scanner_available=metadata_scanner_available,
-                    scanner_selection_extensions=scanner_selection_extensions,
-                ):
-                    filename_lower = source_path.name.lower()
-                    if filename_lower in LICENSE_FILES:
-                        try:
-                            license_metadata = collect_license_metadata(
-                                str(scan_path),
-                                nearby_license_cache=nearby_license_cache,
-                            )
-                            from .models import FileMetadataModel
-
-                            results.file_metadata[report_path] = FileMetadataModel(**license_metadata)
-                            logger.debug(f"Collected license metadata from skipped file: {source_path}")
-                        except Exception as e:
-                            logger.warning(f"Error collecting license metadata for {source_path}: {e}")
-                    else:
-                        logger.debug(f"Skipping non-model file: {source_path}")
-                    continue
-
-                # Build config dict for scan_file
+                # Build config before skip filtering so bin-first OpenVINO
+                # sidecars can wait for their selected XML owner.
                 scan_config = {
                     "timeout": timeout - int(time.time() - start_time),
                     **scan_kwargs,
@@ -4693,6 +4744,37 @@ def scan_model_streaming(
                         if sidecar_snapshot is not None:
                             preserved_openvino_companion_snapshots[Path(os.path.abspath(scan_path))] = sidecar_snapshot
                         continue
+
+                scan_unconsumed_openvino_sidecar = (
+                    openvino_sidecar_owner is not None
+                    and scanner_selection.allows("openvino")
+                    and scanning_deferred_openvino_sidecars
+                )
+                if (
+                    skip_file_types
+                    and not scan_unconsumed_openvino_sidecar
+                    and should_skip_file(
+                        str(source_path),
+                        metadata_scanner_available=metadata_scanner_available,
+                        scanner_selection_extensions=scanner_selection_extensions,
+                    )
+                ):
+                    filename_lower = source_path.name.lower()
+                    if filename_lower in LICENSE_FILES:
+                        try:
+                            license_metadata = collect_license_metadata(
+                                str(scan_path),
+                                nearby_license_cache=nearby_license_cache,
+                            )
+                            from .models import FileMetadataModel
+
+                            results.file_metadata[report_path] = FileMetadataModel(**license_metadata)
+                            logger.debug(f"Collected license metadata from skipped file: {source_path}")
+                        except Exception as e:
+                            logger.warning(f"Error collecting license metadata for {source_path}: {e}")
+                    else:
+                        logger.debug(f"Skipping non-model file: {source_path}")
+                    continue
 
                 if scanner_selection.allows("openvino") and _is_openvino_xml_path(scan_path):
                     candidate_companion = scan_path.with_suffix(".bin")

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -729,8 +729,12 @@ def _openvino_xml_weights_companion(path: Path) -> Path | None:
     """Return a local OpenVINO XML model's same-stem weights sidecar."""
     if not _is_openvino_xml_path(path):
         return None
-    companion_path = path.with_suffix(".bin")
-    return companion_path if companion_path.exists() or companion_path.is_symlink() else None
+    try:
+        from modelaudit.scanners.openvino_scanner import openvino_weights_companion_for_xml
+
+        return openvino_weights_companion_for_xml(path)
+    except Exception:
+        return None
 
 
 def _snapshot_openvino_companion_for_hash(xml_path: Path, companion_path: Path) -> _FileIdentitySnapshot | None:
@@ -4777,8 +4781,8 @@ def scan_model_streaming(
                     continue
 
                 if scanner_selection.allows("openvino") and _is_openvino_xml_path(scan_path):
-                    candidate_companion = scan_path.with_suffix(".bin")
-                    if candidate_companion.exists() or candidate_companion.is_symlink():
+                    candidate_companion = _openvino_xml_weights_companion(scan_path)
+                    if candidate_companion is not None:
                         openvino_scan_companion_path = candidate_companion
                         openvino_scan_companion_key = Path(os.path.abspath(candidate_companion))
                         openvino_companion_pre_scan_identity = _snapshot_file_identity(candidate_companion)

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -670,7 +670,8 @@ def _snapshot_file_identity(path: Path) -> _FileIdentitySnapshot | None:
         )
         resolved_path = str(path.resolve(strict=True))
     except OSError:
-        pass
+        # TOCTOU races or inaccessible symlink targets still leave a useful lstat snapshot.
+        logger.debug("Could not snapshot target identity for %s", path, exc_info=True)
 
     return _FileIdentitySnapshot(
         lstat=(

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -4484,7 +4484,7 @@ def scan_model_streaming(
     start_time = time.time()
     results = create_initial_audit_result()
     file_hashes: list[str] = []
-    hashed_stream_paths: set[Path] = set()
+    hashed_stream_file_instances: set[tuple[Path, _FileIdentitySnapshot]] = set()
     aggregate_hash_complete = True
     top_level_hashed_bytes = 0
     files_processed = 0
@@ -4611,7 +4611,8 @@ def scan_model_streaming(
         nonlocal aggregate_hash_complete, top_level_hashed_bytes
 
         scan_path_key = Path(os.path.abspath(scan_path))
-        if scan_path_key in hashed_stream_paths:
+        scan_path_identity = _snapshot_file_identity(scan_path)
+        if scan_path_identity is not None and (scan_path_key, scan_path_identity) in hashed_stream_file_instances:
             return None
 
         defer_hash_for_max_total_size = _should_defer_hash_for_max_total_size(
@@ -4634,7 +4635,8 @@ def scan_model_streaming(
             top_level_hashed_bytes += scan_path.stat().st_size
         file_hash = compute_sha256_hash(scan_path)
         file_hashes.append(file_hash)
-        hashed_stream_paths.add(scan_path_key)
+        if scan_path_identity is not None:
+            hashed_stream_file_instances.add((scan_path_key, scan_path_identity))
         return file_hash
 
     def append_streamed_openvino_companion_hash(

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -290,6 +290,7 @@ _DVC_EXCLUDED_PATHS_CONFIG_KEY = "_dvc_excluded_paths"
 _DVC_COVERAGE_ROOTS_CONFIG_KEY = "_dvc_coverage_roots"
 DVC_EXTERNAL_COVERED_PATHS_CONFIG_KEY = "_dvc_external_covered_paths"
 DVC_EXTERNAL_COVERED_DIRECTORIES_CONFIG_KEY = "_dvc_external_covered_directories"
+_OPENVINO_ALLOW_SIDECAR_ROUTING_CONFIG_KEY = "_openvino_allow_sidecar_routing"
 
 
 def _record_incomplete_dvc_resolution(
@@ -2728,6 +2729,10 @@ def scan_model_directory_or_file(
                         duplicate_paths_by_hash.setdefault(content_hash, []).append(file_path)
                 recorded_content_hashes: set[str] = set()
 
+                if scan_entries:
+                    config = dict(config)
+                    config[_OPENVINO_ALLOW_SIDECAR_ROUTING_CONFIG_KEY] = True
+
                 if len(scan_entries) > 1:
                     pickle_source_snapshot_stack.enter_context(shared_source_sensitive_caches())
 
@@ -3651,7 +3656,9 @@ def _scan_file_internal(path: str, config: dict[str, Any] | None = None) -> Scan
         sr.finish(success=False)
         return sr
 
-    openvino_owner = _openvino_weights_companion_owner(Path(path))
+    openvino_owner = None
+    if config.get(_OPENVINO_ALLOW_SIDECAR_ROUTING_CONFIG_KEY) is True and scanner_selection.allows("openvino"):
+        openvino_owner = _openvino_weights_companion_owner(Path(path))
     if openvino_owner is not None:
         sr = ScanResult(scanner_name="openvino")
         sr.bytes_scanned = file_size
@@ -4359,6 +4366,7 @@ def scan_model_streaming(
     start_time = time.time()
     results = create_initial_audit_result()
     file_hashes: list[str] = []
+    hashed_stream_paths: set[Path] = set()
     aggregate_hash_complete = True
     top_level_hashed_bytes = 0
     files_processed = 0
@@ -4584,6 +4592,8 @@ def scan_model_streaming(
                     "timeout": timeout - int(time.time() - start_time),
                     **scan_kwargs,
                 }
+                if openvino_sidecar_owner is not None or openvino_scan_companion_path is not None:
+                    scan_config[_OPENVINO_ALLOW_SIDECAR_ROUTING_CONFIG_KEY] = True
                 initial_shard_target = _snapshot_validated_shard_target(
                     str(source_path),
                     resolved_path=str(scan_path),
@@ -4640,6 +4650,29 @@ def scan_model_streaming(
                         top_level_hashed_bytes += scan_path.stat().st_size
                     file_hash = compute_sha256_hash(scan_path)
                     file_hashes.append(file_hash)
+                    hashed_stream_paths.add(Path(os.path.abspath(scan_path)))
+
+                if openvino_scan_companion_path is not None:
+                    companion_hash_key = Path(os.path.abspath(openvino_scan_companion_path))
+                    if companion_hash_key not in hashed_stream_paths:
+                        defer_companion_hash_for_max_total_size = _should_defer_hash_for_max_total_size(
+                            scan_config,
+                            hashed_bytes=top_level_hashed_bytes,
+                        )
+                        defer_companion_hash_for_max_file_size = _should_defer_hash_for_max_file_size(
+                            str(openvino_scan_companion_path),
+                            scan_config,
+                        )
+                        if defer_companion_hash_for_max_total_size or defer_companion_hash_for_max_file_size:
+                            aggregate_hash_complete = False
+                        elif not _should_defer_hash_for_safetensors_header_limit(
+                            str(openvino_scan_companion_path),
+                            scan_config,
+                        ):
+                            with suppress(OSError):
+                                top_level_hashed_bytes += openvino_scan_companion_path.stat().st_size
+                            file_hashes.append(compute_sha256_hash(openvino_scan_companion_path))
+                            hashed_stream_paths.add(companion_hash_key)
 
                 # Scan the file
                 if progress_callback:

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -717,6 +717,14 @@ def _snapshot_file_identity(path: Path) -> _FileIdentitySnapshot | None:
     )
 
 
+def _snapshot_file_size(snapshot: _FileIdentitySnapshot | None) -> int:
+    """Return the target size captured by a file identity snapshot."""
+    if snapshot is None:
+        return 0
+    stat_fields = snapshot.stat or snapshot.lstat
+    return stat_fields[3]
+
+
 def _validated_shard_family_scopes(
     source_path: str,
     target: dict[str, int | str],
@@ -4420,6 +4428,7 @@ def scan_model_streaming(
     pending_delete_failures: dict[Path, Exception] = {}
     validated_shard_targets: ValidatedShardTargets = {}
     preserved_openvino_companion_snapshots: dict[Path, _FileIdentitySnapshot] = {}
+    deferred_openvino_sidecars: dict[Path, Path] = {}
     consumed_openvino_companions: set[Path] = set()
     hashed_stream_paths: set[Path] = set()
     preserve_shard_reconciliation_errors = False
@@ -4581,7 +4590,18 @@ def scan_model_streaming(
     is_hf_cache = base_dir is not None and hf_cache_root is not None
 
     try:
-        for file_path, _is_last in file_generator:
+        file_iterator = iter(file_generator)
+        scanning_deferred_openvino_sidecars = False
+        while True:
+            try:
+                file_path, _is_last = next(file_iterator)
+            except StopIteration:
+                if not scanning_deferred_openvino_sidecars and deferred_openvino_sidecars:
+                    file_iterator = iter((sidecar_path, True) for sidecar_path in deferred_openvino_sidecars.values())
+                    scanning_deferred_openvino_sidecars = True
+                    continue
+                break
+
             source_path = Path(file_path)
             source_key = Path(os.path.abspath(source_path))
             if source_key in consumed_openvino_companions:
@@ -4593,6 +4613,7 @@ def scan_model_streaming(
             openvino_scan_companion_path: Path | None = None
             openvino_scan_companion_key: Path | None = None
             openvino_companion_pre_scan_identity: _FileIdentitySnapshot | None = None
+            openvino_companion_bytes_scanned = 0
 
             # Check for interruption before starting work on the yielded file.
             try:
@@ -4659,14 +4680,19 @@ def scan_model_streaming(
                 }
 
                 openvino_sidecar_owner = _openvino_weights_companion_owner(scan_path)
-                if openvino_sidecar_owner is not None and scanner_selection.allows("openvino"):
+                if (
+                    openvino_sidecar_owner is not None
+                    and scanner_selection.allows("openvino")
+                    and not scanning_deferred_openvino_sidecars
+                ):
                     is_lfs_sidecar, _lfs_info = check_lfs_pointer(str(scan_path))
                     if not is_lfs_sidecar:
-                        scan_config = _with_openvino_scanned_xml_companion(scan_config, openvino_sidecar_owner)
                         preserve_source_after_scan = True
+                        deferred_openvino_sidecars.setdefault(Path(os.path.abspath(scan_path)), source_path)
                         sidecar_snapshot = _snapshot_file_identity(scan_path)
                         if sidecar_snapshot is not None:
                             preserved_openvino_companion_snapshots[Path(os.path.abspath(scan_path))] = sidecar_snapshot
+                        continue
 
                 if scanner_selection.allows("openvino") and _is_openvino_xml_path(scan_path):
                     candidate_companion = scan_path.with_suffix(".bin")
@@ -4674,6 +4700,7 @@ def scan_model_streaming(
                         openvino_scan_companion_path = candidate_companion
                         openvino_scan_companion_key = Path(os.path.abspath(candidate_companion))
                         openvino_companion_pre_scan_identity = _snapshot_file_identity(candidate_companion)
+                        openvino_companion_bytes_scanned = _snapshot_file_size(openvino_companion_pre_scan_identity)
                         preserved_snapshot = preserved_openvino_companion_snapshots.get(openvino_scan_companion_key)
                         if (
                             preserved_snapshot is not None
@@ -4742,6 +4769,7 @@ def scan_model_streaming(
                     str(scan_path),
                     config=scan_config,
                 )
+                scan_result.bytes_scanned += openvino_companion_bytes_scanned
                 if (
                     openvino_scan_companion_path is not None
                     and openvino_companion_pre_scan_identity is not None
@@ -4873,6 +4901,7 @@ def scan_model_streaming(
                 if openvino_scan_companion_path is not None and openvino_scan_companion_key is not None:
                     delete_streamed_source(openvino_scan_companion_path, "after OpenVINO XML scan")
                     consumed_openvino_companions.add(openvino_scan_companion_key)
+                    deferred_openvino_sidecars.pop(openvino_scan_companion_key, None)
                     preserved_openvino_companion_snapshots.pop(openvino_scan_companion_key, None)
 
         _reconcile_cross_directory_shard_coverage(

--- a/modelaudit/scanners/openvino_scanner.py
+++ b/modelaudit/scanners/openvino_scanner.py
@@ -275,6 +275,51 @@ class OpenVinoScanner(BaseScanner):
                     "scan_outcome_reason": reason,
                 },
             )
+            return
+
+        self._scan_pickle_payload_sidecar(result, bin_path, bin_size)
+
+    def _scan_pickle_payload_sidecar(self, result: ScanResult, bin_path: Path, bin_size: int) -> None:
+        """Scan an OpenVINO weights sidecar when its content is actually pickle-formatted."""
+        try:
+            from modelaudit.utils.file.detection import detect_file_format_from_magic
+
+            if detect_file_format_from_magic(str(bin_path)) != "pickle":
+                return
+
+            from .pickle_scanner import PickleScanner
+
+            with bin_path.open("rb") as bin_file:
+                pickle_result = PickleScanner(config=self.config).scan_stream(
+                    bin_file,
+                    bin_size,
+                    source=str(bin_path),
+                )
+        except Exception as exc:
+            reason = "openvino_weights_pickle_scan_failed"
+            result.metadata["operational_error"] = True
+            result.metadata["operational_error_reason"] = reason
+            result.metadata["analysis_incomplete"] = True
+            result.metadata["scan_outcome"] = "inconclusive"
+            result.metadata["scan_outcome_reason"] = reason
+            result.add_check(
+                name="OpenVINO Weights Pickle Payload Scan",
+                passed=False,
+                message=f"Unable to inspect pickle-formatted OpenVINO weights sidecar: {exc}",
+                severity=IssueSeverity.INFO,
+                location=str(bin_path),
+                details={
+                    "exception_type": type(exc).__name__,
+                    "analysis_incomplete": True,
+                    "scan_outcome": "inconclusive",
+                    "scan_outcome_reason": reason,
+                },
+            )
+            return
+
+        pickle_result.bytes_scanned = 0
+        result.metadata["openvino_weights_pickle_payload_scanned"] = True
+        result.merge(pickle_result)
 
     @classmethod
     def can_handle(cls, path: str) -> bool:

--- a/modelaudit/scanners/openvino_scanner.py
+++ b/modelaudit/scanners/openvino_scanner.py
@@ -12,6 +12,7 @@ from typing import Any, ClassVar
 from urllib.parse import urlsplit, urlunsplit
 
 from modelaudit.detectors.suspicious_symbols import SUSPICIOUS_STRING_PATTERNS
+from modelaudit.scanner_selection import add_scanner_selection_skip_check, embedded_pickle_scanner
 
 from .base import BaseScanner, IssueSeverity, ScanResult
 
@@ -289,8 +290,23 @@ class OpenVinoScanner(BaseScanner):
 
             from .pickle_scanner import PickleScanner
 
+            pickle_scanner, scanner_selection = embedded_pickle_scanner(
+                self.config,
+                lambda config: PickleScanner(config=config),
+            )
+            if pickle_scanner is None:
+                add_scanner_selection_skip_check(
+                    result,
+                    str(bin_path),
+                    "pickle",
+                    scanner_selection,
+                    context="OpenVINO weights sidecar",
+                )
+                result.metadata["openvino_weights_pickle_payload_skipped"] = True
+                return
+
             with bin_path.open("rb") as bin_file:
-                pickle_result = PickleScanner(config=self.config).scan_stream(
+                pickle_result = pickle_scanner.scan_stream(
                     bin_file,
                     bin_size,
                     source=str(bin_path),

--- a/modelaudit/scanners/openvino_scanner.py
+++ b/modelaudit/scanners/openvino_scanner.py
@@ -374,5 +374,5 @@ class OpenVinoScanner(BaseScanner):
                         rule_code="S902",
                     )
 
-        result.finish(success=not result.has_errors)
+        result.finish(success=not result.has_errors and result.metadata.get("operational_error") is not True)
         return result

--- a/modelaudit/scanners/openvino_scanner.py
+++ b/modelaudit/scanners/openvino_scanner.py
@@ -374,5 +374,5 @@ class OpenVinoScanner(BaseScanner):
                         rule_code="S902",
                     )
 
-        result.finish(success=not result.has_errors)
+        result.finish(success=not result.has_errors and not bool(result.metadata.get("operational_error")))
         return result

--- a/modelaudit/scanners/openvino_scanner.py
+++ b/modelaudit/scanners/openvino_scanner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+import unicodedata
 from collections.abc import Iterator
 from io import BytesIO
 from pathlib import Path
@@ -51,6 +52,30 @@ def _is_contained_in(child: Path, parent: Path) -> bool:
         return True
     except ValueError:
         return False
+
+
+def _companion_filename_key(filename: str) -> str:
+    return unicodedata.normalize("NFC", filename).casefold()
+
+
+def _same_stem_companion(path: Path, suffix: str) -> Path:
+    expected_path = path.with_suffix(suffix)
+    if expected_path.exists() or expected_path.is_symlink():
+        return expected_path
+
+    expected_key = _companion_filename_key(expected_path.name)
+    try:
+        candidates = [
+            child
+            for child in path.parent.iterdir()
+            if _companion_filename_key(child.name) == expected_key and (child.exists() or child.is_symlink())
+        ]
+    except OSError:
+        return expected_path
+
+    if len(candidates) == 1:
+        return candidates[0]
+    return expected_path
 
 
 def _skip_doctype_declaration(xml_prefix: bytes, start_offset: int) -> int | None:
@@ -191,12 +216,27 @@ def openvino_xml_companion_for_weights(path: str | os.PathLike[str]) -> Path | N
     if weights_path.suffix.lower() != ".bin":
         return None
 
-    xml_path = weights_path.with_suffix(".xml")
+    xml_path = _same_stem_companion(weights_path, ".xml")
     if not xml_path.is_file():
         return None
     if not OpenVinoScanner.can_handle(str(xml_path)):
         return None
     return xml_path
+
+
+def openvino_weights_companion_for_xml(
+    path: str | os.PathLike[str],
+    *,
+    require_existing: bool = True,
+) -> Path | None:
+    """Return the same-stem OpenVINO weights sidecar for an XML path."""
+    xml_path = Path(path)
+    if xml_path.suffix.lower() != ".xml":
+        return None
+    weights_path = _same_stem_companion(xml_path, ".bin")
+    if require_existing and not (weights_path.exists() or weights_path.is_symlink()):
+        return None
+    return weights_path
 
 
 class OpenVinoScanner(BaseScanner):
@@ -264,7 +304,9 @@ class OpenVinoScanner(BaseScanner):
         result.metadata["xml_size"] = self.get_file_size(path)
 
         model_dir = Path(path).resolve().parent
-        bin_path = Path(os.path.splitext(path)[0] + ".bin")
+        bin_path = openvino_weights_companion_for_xml(path, require_existing=False)
+        if bin_path is None:
+            bin_path = Path(os.path.splitext(path)[0] + ".bin")
         if bin_path.is_symlink():
             resolved_bin_path = bin_path.resolve(strict=False)
             if not _is_contained_in(resolved_bin_path, model_dir):

--- a/modelaudit/scanners/openvino_scanner.py
+++ b/modelaudit/scanners/openvino_scanner.py
@@ -185,6 +185,20 @@ def _redact_url_reference(value: str) -> str:
     return _URL_REFERENCE_PATTERN.sub(replace_url, value)
 
 
+def openvino_xml_companion_for_weights(path: str | os.PathLike[str]) -> Path | None:
+    """Return the owning OpenVINO XML path for a same-stem weights sidecar."""
+    weights_path = Path(path)
+    if weights_path.suffix.lower() != ".bin":
+        return None
+
+    xml_path = weights_path.with_suffix(".xml")
+    if not xml_path.is_file():
+        return None
+    if not OpenVinoScanner.can_handle(str(xml_path)):
+        return None
+    return xml_path
+
+
 class OpenVinoScanner(BaseScanner):
     """Scanner for OpenVINO IR (.xml/.bin) model files."""
 
@@ -192,6 +206,35 @@ class OpenVinoScanner(BaseScanner):
     description = "Scans OpenVINO IR models for suspicious layers and external references"
     supported_extensions: ClassVar[list[str]] = [".xml"]
     CAN_HANDLE_MAX_PARSE_BYTES: ClassVar[int] = 1024 * 1024
+
+    def _record_bin_size(self, result: ScanResult, bin_path: Path) -> None:
+        bin_size = self.get_file_size(str(bin_path))
+        result.metadata["bin_size"] = bin_size
+
+        configured_limit = self.config.get("max_file_size", 0)
+        max_file_size = configured_limit if isinstance(configured_limit, int) and configured_limit > 0 else 0
+        if max_file_size and bin_size > max_file_size:
+            reason = "openvino_weights_file_size_exceeded"
+            result.metadata["operational_error"] = True
+            result.metadata["operational_error_reason"] = reason
+            result.metadata["analysis_incomplete"] = True
+            result.metadata["scan_outcome"] = "inconclusive"
+            result.metadata["scan_outcome_reason"] = reason
+            result.metadata["scan_outcome_reasons"] = [reason]
+            result.add_check(
+                name="OpenVINO Weights File Size Limit",
+                passed=False,
+                message=f"Associated .bin weights file too large to scan: {bin_size} bytes (max: {max_file_size})",
+                severity=IssueSeverity.INFO,
+                location=str(bin_path),
+                details={
+                    "file_size": bin_size,
+                    "max_file_size": max_file_size,
+                    "analysis_incomplete": True,
+                    "scan_outcome": "inconclusive",
+                    "scan_outcome_reason": reason,
+                },
+            )
 
     @classmethod
     def can_handle(cls, path: str) -> bool:
@@ -244,9 +287,9 @@ class OpenVinoScanner(BaseScanner):
                     ),
                 )
             elif bin_path.is_file():
-                result.metadata["bin_size"] = self.get_file_size(str(bin_path))
+                self._record_bin_size(result, bin_path)
         elif bin_path.is_file():
-            result.metadata["bin_size"] = self.get_file_size(str(bin_path))
+            self._record_bin_size(result, bin_path)
         else:
             result.add_check(
                 name="OpenVINO Weights File Check",

--- a/modelaudit/utils/helpers/cache_decorator.py
+++ b/modelaudit/utils/helpers/cache_decorator.py
@@ -95,14 +95,14 @@ def should_bypass_cache_for_sharded_model(file_path: str) -> bool:
 def should_bypass_cache_for_openvino_sidecar(file_path: str) -> bool:
     """Bypass XML-only cache keys when OpenVINO findings depend on a .bin sidecar."""
     try:
-        from ...scanners.openvino_scanner import OpenVinoScanner
+        from ...scanners.openvino_scanner import OpenVinoScanner, openvino_weights_companion_for_xml
     except Exception:
         return False
 
     if not OpenVinoScanner.can_handle(file_path):
         return False
-    weights_path = os.path.splitext(file_path)[0] + ".bin"
-    return os.path.isfile(weights_path) or os.path.islink(weights_path)
+    weights_path = openvino_weights_companion_for_xml(file_path)
+    return weights_path is not None and (weights_path.is_file() or weights_path.is_symlink())
 
 
 def _h5py_availability() -> bool:

--- a/modelaudit/utils/helpers/cache_decorator.py
+++ b/modelaudit/utils/helpers/cache_decorator.py
@@ -92,6 +92,19 @@ def should_bypass_cache_for_sharded_model(file_path: str) -> bool:
     return ShardedModelDetector.match_shard_filename(os.path.basename(file_path)) is not None
 
 
+def should_bypass_cache_for_openvino_sidecar(file_path: str) -> bool:
+    """Bypass XML-only cache keys when OpenVINO findings depend on a .bin sidecar."""
+    try:
+        from ...scanners.openvino_scanner import OpenVinoScanner
+    except Exception:
+        return False
+
+    if not OpenVinoScanner.can_handle(file_path):
+        return False
+    weights_path = os.path.splitext(file_path)[0] + ".bin"
+    return os.path.isfile(weights_path) or os.path.islink(weights_path)
+
+
 def _h5py_availability() -> bool:
     """Return whether Keras HDF5 analysis is available in this process."""
     try:
@@ -307,6 +320,10 @@ def cached_scan(cache_enabled_key: str = "cache_enabled", cache_dir_key: str = "
 
                 if should_bypass_cache_for_sharded_model(file_path):
                     logger.debug(f"Bypassing cache for sharded model family: {file_path}")
+                    return func(*args, **kwargs)
+
+                if should_bypass_cache_for_openvino_sidecar(file_path):
+                    logger.debug(f"Bypassing cache for OpenVINO sidecar-dependent scan: {file_path}")
                     return func(*args, **kwargs)
 
                 raw_config, _ = _extract_config_and_path(args, kwargs)

--- a/modelaudit/utils/sources/huggingface.py
+++ b/modelaudit/utils/sources/huggingface.py
@@ -807,9 +807,13 @@ def _include_huggingface_openvino_companions(
     revision: str,
     model_files: list[str],
     *,
+    include_openvino_companions: bool = True,
     deadline: float | None = None,
 ) -> list[str]:
     """Include exact OpenVINO XML/BIN companions before size checks and downloads."""
+    if not include_openvino_companions:
+        return model_files
+
     from modelaudit.utils.file.detection import XML_MODEL_INCONCLUSIVE_FORMAT
 
     repo_file_set = set(repo_files)
@@ -1895,6 +1899,10 @@ def download_model_streaming(
             repo_files,
             repo_revision,
             model_files,
+            include_openvino_companions=(
+                scannable_scanner_ids is None
+                or "openvino" in {str(scanner_id).lower() for scanner_id in scannable_scanner_ids}
+            ),
             deadline=deadline,
         )
         revision, selected_sizes = _ensure_huggingface_selection_within_max_size(

--- a/modelaudit/utils/sources/huggingface.py
+++ b/modelaudit/utils/sources/huggingface.py
@@ -1919,15 +1919,15 @@ def download_model_streaming(
             include_all_files=include_all_files,
             deadline=deadline,
         )
+        openvino_companion_suppression_enabled = scannable_scanner_ids is None or "openvino" in {
+            str(scanner_id).lower() for scanner_id in scannable_scanner_ids
+        }
         model_files = _include_huggingface_openvino_companions(
             repo_id,
             repo_files,
             repo_revision,
             model_files,
-            include_openvino_companions=(
-                scannable_scanner_ids is None
-                or "openvino" in {str(scanner_id).lower() for scanner_id in scannable_scanner_ids}
-            ),
+            include_openvino_companions=openvino_companion_suppression_enabled,
             deadline=deadline,
         )
         revision, selected_sizes = _ensure_huggingface_selection_within_max_size(
@@ -1946,11 +1946,15 @@ def download_model_streaming(
             download_path.mkdir(parents=True, exist_ok=True)
 
         selected_file_set = set(model_files)
-        openvino_companion_by_xml = {
-            filename: companion
-            for filename in model_files
-            if (companion := _openvino_bin_companion_name(filename, model_files)) in selected_file_set
-        }
+        openvino_companion_by_xml = (
+            {
+                filename: companion
+                for filename in model_files
+                if (companion := _openvino_bin_companion_name(filename, model_files)) in selected_file_set
+            }
+            if openvino_companion_suppression_enabled
+            else {}
+        )
         openvino_xml_by_companion = {companion: xml for xml, companion in openvino_companion_by_xml.items()}
 
         # Download each file one at a time. OpenVINO XML/BIN pairs are staged

--- a/modelaudit/utils/sources/huggingface.py
+++ b/modelaudit/utils/sources/huggingface.py
@@ -793,6 +793,48 @@ def _build_literal_allow_patterns(filenames: list[str]) -> list[str]:
     return [escape_glob(filename) for filename in filenames]
 
 
+def _openvino_bin_companion_name(filename: str) -> str | None:
+    """Return the exact same-stem OpenVINO weights filename for a repo XML path."""
+    remote_path = PurePosixPath(filename)
+    if remote_path.suffix.lower() != ".xml":
+        return None
+    return remote_path.with_suffix(".bin").as_posix()
+
+
+def _include_huggingface_openvino_companions(
+    repo_id: str,
+    repo_files: list[str],
+    revision: str,
+    model_files: list[str],
+    *,
+    deadline: float | None = None,
+) -> list[str]:
+    """Include exact OpenVINO XML/BIN companions before size checks and downloads."""
+    from modelaudit.utils.file.detection import XML_MODEL_INCONCLUSIVE_FORMAT
+
+    repo_file_set = set(repo_files)
+    selected_files = set(model_files)
+    expanded_files = list(model_files)
+    probe_budget = _HuggingFaceProbeBudget(
+        remaining_bytes=_HF_CONTENT_SNIFF_MAX_TOTAL_BYTES,
+        deadline=deadline,
+    )
+
+    for filename in model_files:
+        companion = _openvino_bin_companion_name(filename)
+        if companion is None or companion not in repo_file_set or companion in selected_files:
+            continue
+
+        detected_format = _detect_huggingface_content_route_format(repo_id, filename, revision, probe_budget)
+        if detected_format not in {"openvino", XML_MODEL_INCONCLUSIVE_FORMAT}:
+            continue
+
+        expanded_files.append(companion)
+        selected_files.add(companion)
+
+    return expanded_files
+
+
 def _extract_huggingface_repo_files(repo_info: Any) -> list[str] | None:
     """Extract repository filenames from a Hugging Face repository response."""
     siblings = getattr(repo_info, "siblings", None)
@@ -1673,6 +1715,13 @@ def download_model(
             model_extensions,
             deadline=deadline,
         )
+        model_files = _include_huggingface_openvino_companions(
+            repo_id,
+            repo_files,
+            repo_revision,
+            model_files,
+            deadline=deadline,
+        )
         if deadline is not None and time.monotonic() >= deadline:
             raise TimeoutError(f"Hugging Face acquisition timed out for {repo_id}")
 
@@ -1841,6 +1890,13 @@ def download_model_streaming(
             include_all_files=include_all_files,
             deadline=deadline,
         )
+        model_files = _include_huggingface_openvino_companions(
+            repo_id,
+            repo_files,
+            repo_revision,
+            model_files,
+            deadline=deadline,
+        )
         revision, selected_sizes = _ensure_huggingface_selection_within_max_size(
             repo_id,
             model_files,
@@ -1856,12 +1912,33 @@ def download_model_streaming(
             download_path = _build_huggingface_download_path(cache_dir, namespace, repo_name)
             download_path.mkdir(parents=True, exist_ok=True)
 
-        # Download each file one at a time
-        total_files = len(model_files)
-        downloaded_total_size = 0
-        for idx, filename in enumerate(model_files):
-            is_last = idx == total_files - 1
+        selected_file_set = set(model_files)
+        openvino_companion_by_xml = {
+            filename: companion
+            for filename in model_files
+            if (companion := _openvino_bin_companion_name(filename)) in selected_file_set
+        }
+        openvino_xml_by_companion = {companion: xml for xml, companion in openvino_companion_by_xml.items()}
 
+        # Download each file one at a time. OpenVINO XML/BIN pairs are staged
+        # together, then only the XML is yielded so the scanner owns the logical
+        # model and the weights sidecar is not routed as standalone PyTorch.
+        downloaded_total_size = 0
+        downloaded_paths: dict[str, Path] = {}
+        consumed_filenames: set[str] = set()
+        pending_yield: Path | None = None
+
+        def queue_yield(path: Path) -> Path | None:
+            nonlocal pending_yield
+            previous = pending_yield
+            pending_yield = path
+            return previous
+
+        def download_one_file(filename: str) -> Path:
+            nonlocal downloaded_total_size
+            cached_path = downloaded_paths.get(filename)
+            if cached_path is not None:
+                return cached_path
             if deadline is not None and time.monotonic() >= deadline:
                 raise TimeoutError(f"Hugging Face acquisition timed out for {repo_id}")
 
@@ -1912,7 +1989,43 @@ def download_model_streaming(
                 size_limit,
                 initial_size=downloaded_total_size,
             )
-            yield (downloaded_file, is_last)
+            downloaded_paths[filename] = downloaded_file
+            return downloaded_file
+
+        for filename in model_files:
+            if filename in consumed_filenames:
+                continue
+
+            if filename in openvino_xml_by_companion:
+                # Wait for the XML so we can prove it is an OpenVINO model
+                # before suppressing standalone analysis of the same-stem .bin.
+                continue
+
+            downloaded_file = download_one_file(filename)
+            companion = openvino_companion_by_xml.get(filename)
+            if companion is not None:
+                from modelaudit.scanners.openvino_scanner import OpenVinoScanner
+
+                if OpenVinoScanner.can_handle(str(downloaded_file)):
+                    download_one_file(companion)
+                    consumed_filenames.add(companion)
+                else:
+                    companion_path = download_one_file(companion)
+                    previous = queue_yield(downloaded_file)
+                    if previous is not None:
+                        yield (previous, False)
+                    previous = queue_yield(companion_path)
+                    if previous is not None:
+                        yield (previous, False)
+                    consumed_filenames.add(companion)
+                    continue
+
+            previous = queue_yield(downloaded_file)
+            if previous is not None:
+                yield (previous, False)
+
+        if pending_yield is not None:
+            yield (pending_yield, True)
 
     except Exception as e:
         raise Exception(

--- a/modelaudit/utils/sources/huggingface.py
+++ b/modelaudit/utils/sources/huggingface.py
@@ -1092,6 +1092,16 @@ def _select_streamable_hf_files(
                 )
             model_files.append(file_name)
 
+    exact_openvino_companion_candidates = (
+        {
+            companion
+            for selected_file in model_files
+            if (companion := _openvino_bin_companion_name(selected_file)) is not None
+        }
+        if selected_route_scanner_ids == {"openvino"}
+        else set()
+    )
+
     if sniff_renamed_files:
         inspected_files = 0
         probe_budget = _HuggingFaceProbeBudget(
@@ -1101,6 +1111,8 @@ def _select_streamable_hf_files(
         selected_files = set(model_files)
         for file_name in repo_files:
             if file_name in selected_files:
+                continue
+            if file_name in exact_openvino_companion_candidates:
                 continue
             if inspected_files >= _HF_CONTENT_SNIFF_MAX_FILES:
                 raise ValueError(

--- a/modelaudit/utils/sources/huggingface.py
+++ b/modelaudit/utils/sources/huggingface.py
@@ -8,6 +8,7 @@ import struct
 import subprocess
 import sys
 import time
+import unicodedata
 from collections.abc import Callable, Collection, Iterator
 from contextlib import suppress
 from dataclasses import dataclass, field
@@ -793,12 +794,24 @@ def _build_literal_allow_patterns(filenames: list[str]) -> list[str]:
     return [escape_glob(filename) for filename in filenames]
 
 
-def _openvino_bin_companion_name(filename: str) -> str | None:
+def _remote_companion_path_key(filename: str) -> str:
+    return unicodedata.normalize("NFC", filename).casefold()
+
+
+def _openvino_bin_companion_name(filename: str, repo_files: Collection[str] | None = None) -> str | None:
     """Return the exact same-stem OpenVINO weights filename for a repo XML path."""
     remote_path = PurePosixPath(filename)
     if remote_path.suffix.lower() != ".xml":
         return None
-    return remote_path.with_suffix(".bin").as_posix()
+    expected_companion = remote_path.with_suffix(".bin").as_posix()
+    if repo_files is None or expected_companion in repo_files:
+        return expected_companion
+
+    expected_key = _remote_companion_path_key(expected_companion)
+    candidates = [repo_file for repo_file in repo_files if _remote_companion_path_key(repo_file) == expected_key]
+    if len(candidates) == 1:
+        return candidates[0]
+    return expected_companion
 
 
 def _include_huggingface_openvino_companions(
@@ -825,7 +838,7 @@ def _include_huggingface_openvino_companions(
     )
 
     for filename in model_files:
-        companion = _openvino_bin_companion_name(filename)
+        companion = _openvino_bin_companion_name(filename, repo_files)
         if companion is None or companion not in repo_file_set or companion in selected_files:
             continue
 
@@ -1096,7 +1109,7 @@ def _select_streamable_hf_files(
         {
             companion
             for selected_file in model_files
-            if (companion := _openvino_bin_companion_name(selected_file)) is not None
+            if (companion := _openvino_bin_companion_name(selected_file, repo_files)) is not None
         }
         if selected_route_scanner_ids == {"openvino"}
         else set()
@@ -1936,7 +1949,7 @@ def download_model_streaming(
         openvino_companion_by_xml = {
             filename: companion
             for filename in model_files
-            if (companion := _openvino_bin_companion_name(filename)) in selected_file_set
+            if (companion := _openvino_bin_companion_name(filename, model_files)) in selected_file_set
         }
         openvino_xml_by_companion = {companion: xml for xml, companion in openvino_companion_by_xml.items()}
 

--- a/tests/scanners/test_openvino_scanner.py
+++ b/tests/scanners/test_openvino_scanner.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from modelaudit.core import determine_exit_code, scan_model_directory_or_file
+from modelaudit.core import determine_exit_code, scan_file, scan_model_directory_or_file
 from modelaudit.scanners.base import CheckStatus, IssueSeverity
 from modelaudit.scanners.openvino_scanner import OpenVinoScanner
 
@@ -343,6 +343,49 @@ def test_openvino_scanner_respects_configured_file_size_limit(tmp_path: Path) ->
 
     assert result.success is False
     assert any(check.name == "File Size Limit" for check in result.checks)
+
+
+def test_openvino_scanner_oversize_weights_fail_closed(tmp_path: Path) -> None:
+    """Direct XML scans must fail closed when bounded OpenVINO weights are skipped."""
+    xml_path = create_basic_model(tmp_path)
+    bin_path = tmp_path / "model.bin"
+    max_file_size = xml_path.stat().st_size + 1
+    bin_path.write_bytes(b"\x00" * (max_file_size + 1))
+
+    direct_result = scan_file(
+        str(xml_path),
+        config={"max_file_size": max_file_size, "cache_enabled": False},
+    )
+    cli_result = scan_model_directory_or_file(
+        str(xml_path),
+        max_file_size=max_file_size,
+        cache_enabled=False,
+    )
+
+    assert direct_result.success is False
+    assert direct_result.metadata["operational_error"] is True
+    assert direct_result.metadata["operational_error_reason"] == "openvino_weights_file_size_exceeded"
+    assert any(check.name == "OpenVINO Weights File Size Limit" for check in direct_result.checks)
+    assert cli_result.has_errors is True
+    assert determine_exit_code(cli_result) == 2
+
+
+def test_openvino_scanner_sidecar_cache_rescans_changed_weights(tmp_path: Path) -> None:
+    """OpenVINO XML cache entries must not hide changed same-stem weights metadata."""
+    xml_path = create_basic_model(tmp_path)
+    bin_path = tmp_path / "model.bin"
+    cache_config = {
+        "cache_enabled": True,
+        "cache_dir": str(tmp_path / "cache"),
+        "min_cache_file_size": 0,
+    }
+
+    first_result = scan_file(str(xml_path), config=cache_config)
+    bin_path.write_bytes(b"\x01" * 32)
+    second_result = scan_file(str(xml_path), config=cache_config)
+
+    assert first_result.metadata["bin_size"] == 10
+    assert second_result.metadata["bin_size"] == 32
 
 
 def test_openvino_scanner_detects_nested_external_library_references(tmp_path: Path) -> None:

--- a/tests/scanners/test_openvino_scanner.py
+++ b/tests/scanners/test_openvino_scanner.py
@@ -5,6 +5,7 @@ import pytest
 from modelaudit.core import determine_exit_code, scan_file, scan_model_directory_or_file
 from modelaudit.scanners.base import CheckStatus, IssueSeverity
 from modelaudit.scanners.openvino_scanner import OpenVinoScanner
+from tests.helpers import create_malicious_pickle
 
 
 def create_basic_model(dir_path: Path) -> Path:
@@ -58,6 +59,24 @@ def test_openvino_scanner_matches_casefolded_unicode_weights_companion(tmp_path:
     assert result.success is True
     assert result.metadata["bin_size"] == bin_path.stat().st_size
     assert not any("weights file not found" in check.message.lower() for check in result.checks)
+
+
+def test_openvino_scanner_detects_pickle_payload_in_weights_companion(tmp_path: Path) -> None:
+    """A valid OpenVINO XML must not hide pickle-formatted same-stem weights."""
+    xml_path = create_basic_model(tmp_path)
+    bin_path = create_malicious_pickle(tmp_path / "model.bin")
+
+    result = OpenVinoScanner().scan(str(xml_path))
+
+    assert result.success is False
+    assert result.metadata["openvino_weights_pickle_payload_scanned"] is True
+    assert "pickle" in result.metadata["scanner_dependency_ids"]
+    assert any(
+        issue.location == str(bin_path)
+        and issue.severity == IssueSeverity.CRITICAL
+        and ("os.system" in issue.message.lower() or "posix.system" in issue.message.lower())
+        for issue in result.issues
+    )
 
 
 def test_openvino_scanner_can_handle_long_xml_prolog(tmp_path: Path) -> None:

--- a/tests/scanners/test_openvino_scanner.py
+++ b/tests/scanners/test_openvino_scanner.py
@@ -345,6 +345,21 @@ def test_openvino_scanner_respects_configured_file_size_limit(tmp_path: Path) ->
     assert any(check.name == "File Size Limit" for check in result.checks)
 
 
+def test_openvino_scanner_oversized_bin_fails_closed(tmp_path: Path) -> None:
+    """Associated weights exceeding max_file_size make OpenVINO coverage incomplete."""
+    xml_path = create_basic_model(tmp_path)
+
+    result = OpenVinoScanner(config={"max_file_size": 8}).scan(str(xml_path))
+
+    assert result.success is False
+    assert result.metadata["operational_error_reason"] == "openvino_weights_file_size_exceeded"
+    assert any(
+        check.name == "OpenVINO Weights File Size Limit"
+        and check.details.get("scan_outcome_reason") == "openvino_weights_file_size_exceeded"
+        for check in result.checks
+    )
+
+
 def test_openvino_scanner_detects_nested_external_library_references(tmp_path: Path) -> None:
     """Nested layer config nodes should be checked for implementation/library references."""
     xml_path = tmp_path / "model.xml"

--- a/tests/scanners/test_openvino_scanner.py
+++ b/tests/scanners/test_openvino_scanner.py
@@ -45,6 +45,21 @@ def test_openvino_scanner_basic_model_has_zero_cli_exit(tmp_path: Path) -> None:
     )
 
 
+def test_openvino_scanner_matches_casefolded_unicode_weights_companion(tmp_path: Path) -> None:
+    """Case and Unicode normalization variants should still resolve the adjacent weights."""
+    xml_path = tmp_path / "Cafe\u0301-Model.XML"
+    bin_path = tmp_path / "CAF\u00c9-model.BIN"
+    xml_path.write_text("<net version='10'></net>", encoding="utf-8")
+    bin_path.write_bytes(b"weights")
+
+    result = OpenVinoScanner().scan(str(xml_path))
+
+    assert OpenVinoScanner.can_handle(str(xml_path)) is True
+    assert result.success is True
+    assert result.metadata["bin_size"] == bin_path.stat().st_size
+    assert not any("weights file not found" in check.message.lower() for check in result.checks)
+
+
 def test_openvino_scanner_can_handle_long_xml_prolog(tmp_path: Path) -> None:
     """OpenVINO XML routing should not depend on finding the root tag in the first 256 bytes."""
     xml_path = tmp_path / "model.xml"

--- a/tests/scanners/test_openvino_scanner.py
+++ b/tests/scanners/test_openvino_scanner.py
@@ -61,6 +61,26 @@ def test_openvino_scanner_matches_casefolded_unicode_weights_companion(tmp_path:
     assert not any("weights file not found" in check.message.lower() for check in result.checks)
 
 
+def test_openvino_scanner_casefolded_companion_cache_rescans_changed_weights(tmp_path: Path) -> None:
+    """Cache bypass must follow the actual normalized/casefolded OpenVINO companion."""
+    xml_path = tmp_path / "Cafe\u0301-Model.XML"
+    bin_path = tmp_path / "CAF\u00c9-model.BIN"
+    xml_path.write_text("<net version='10'></net>", encoding="utf-8")
+    bin_path.write_bytes(b"\x00" * 7)
+    cache_config = {
+        "cache_enabled": True,
+        "cache_dir": str(tmp_path / "cache"),
+        "min_cache_file_size": 0,
+    }
+
+    first_result = scan_file(str(xml_path), config=cache_config)
+    bin_path.write_bytes(b"\x01" * 33)
+    second_result = scan_file(str(xml_path), config=cache_config)
+
+    assert first_result.metadata["bin_size"] == 7
+    assert second_result.metadata["bin_size"] == 33
+
+
 def test_openvino_scanner_detects_pickle_payload_in_weights_companion(tmp_path: Path) -> None:
     """A valid OpenVINO XML must not hide pickle-formatted same-stem weights."""
     xml_path = create_basic_model(tmp_path)
@@ -77,6 +97,26 @@ def test_openvino_scanner_detects_pickle_payload_in_weights_companion(tmp_path: 
         and ("os.system" in issue.message.lower() or "posix.system" in issue.message.lower())
         for issue in result.issues
     )
+
+
+def test_openvino_scanner_honors_pickle_exclusion_for_weights_companion(tmp_path: Path) -> None:
+    """Embedded pickle scanning for OpenVINO weights must obey scanner selection."""
+    xml_path = create_basic_model(tmp_path)
+    bin_path = create_malicious_pickle(tmp_path / "model.bin")
+
+    result = OpenVinoScanner({"exclude_scanners": ["pickle"]}).scan(str(xml_path))
+
+    assert result.success is True
+    assert result.metadata["openvino_weights_pickle_payload_skipped"] is True
+    assert result.metadata["skipped_scanner_ids"] == ["pickle"]
+    assert any(
+        check.name == "Scanner Selection"
+        and check.location == str(bin_path)
+        and check.details.get("skipped_scanner_id") == "pickle"
+        and check.details.get("context") == "OpenVINO weights sidecar"
+        for check in result.checks
+    )
+    assert not any(issue.location == str(bin_path) for issue in result.issues)
 
 
 def test_openvino_scanner_can_handle_long_xml_prolog(tmp_path: Path) -> None:

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -1595,6 +1595,27 @@ def test_scan_model_streaming_openvino_bin_without_yielded_xml_fails_closed(tmp_
     assert any(issue.location == str(bin_path) and issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
 
 
+def test_scan_model_streaming_openvino_bin_before_xml_survives_extension_skip(tmp_path: Path) -> None:
+    """Selected OpenVINO streaming must preserve bin-first companions before extension skips."""
+    xml_path, bin_path = _write_openvino_pair(tmp_path)
+
+    result = scan_model_streaming(
+        file_generator=iter([(bin_path, False), (xml_path, True)]),
+        timeout=30,
+        delete_after_scan=True,
+        cache_enabled=False,
+        skip_file_types=True,
+        scanners=["openvino"],
+    )
+
+    assert determine_exit_code(result) == 0
+    assert result.scanner_names == ["openvino"]
+    assert result.file_metadata[str(xml_path)]["bin_size"] == 16
+    assert not xml_path.exists()
+    assert not bin_path.exists()
+    assert not any("weights file not found" in check.message.lower() for check in result.checks)
+
+
 def test_scan_model_directory_or_file_openvino_bin_sidecar_not_pytorch(tmp_path: Path) -> None:
     """Local directory scans should not route declared OpenVINO weights as PyTorch binaries."""
     xml_path, bin_path = _write_openvino_pair(tmp_path)
@@ -1605,6 +1626,35 @@ def test_scan_model_directory_or_file_openvino_bin_sidecar_not_pytorch(tmp_path:
     assert "pytorch_binary" not in result.scanner_names
     assert result.file_metadata[str(xml_path)]["bin_size"] == bin_path.stat().st_size
     assert not any(check.rule_code == "S901" for check in result.checks)
+
+
+def test_scan_model_directory_or_file_openvino_selection_hashes_companion(tmp_path: Path) -> None:
+    """Selected OpenVINO directory scans must hash same-stem weights with their XML."""
+    xml_path, bin_path = _write_openvino_pair(tmp_path)
+
+    first_result = scan_model_directory_or_file(
+        str(tmp_path),
+        cache_enabled=False,
+        skip_file_types=True,
+        scanners=["openvino"],
+    )
+    bin_path.write_bytes(b"\x01" * 16)
+    second_result = scan_model_directory_or_file(
+        str(tmp_path),
+        cache_enabled=False,
+        skip_file_types=True,
+        scanners=["openvino"],
+    )
+
+    assert determine_exit_code(first_result) == 0
+    assert determine_exit_code(second_result) == 0
+    assert first_result.files_scanned == 2
+    assert second_result.files_scanned == 2
+    assert first_result.file_metadata[str(xml_path)]["bin_size"] == 16
+    assert second_result.file_metadata[str(xml_path)]["bin_size"] == 16
+    assert first_result.content_hash is not None
+    assert second_result.content_hash is not None
+    assert first_result.content_hash != second_result.content_hash
 
 
 def test_openvino_bin_sidecar_respects_selected_pytorch_binary_scanner(tmp_path: Path) -> None:

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -34,6 +34,7 @@ from modelaudit.scanners.base import Issue, IssueSeverity, ScanResult
 from modelaudit.utils.file.detection import SAFETENSORS_ROUTING_HEADER_PARSE_BYTES
 from modelaudit.utils.helpers.file_iterator import iterate_files_streaming
 from modelaudit.utils.helpers.secure_hasher import compute_aggregate_hash
+from tests.helpers import create_malicious_pickle
 
 
 @pytest.fixture
@@ -1390,6 +1391,156 @@ def test_scan_model_streaming_does_not_reconcile_duplicate_shard_targets(
     assert result.success is False
     assert determine_exit_code(result) == 2
     assert any(check.details.get("scan_outcome_reason") == "missing_model_shards" for check in result.checks)
+
+
+def _write_openvino_pair(model_dir: Path, *, stem: str = "model", xml_content: str | None = None) -> tuple[Path, Path]:
+    xml_path = model_dir / f"{stem}.xml"
+    bin_path = model_dir / f"{stem}.bin"
+    xml_path.write_text(xml_content or "<net version='10'></net>", encoding="utf-8")
+    bin_path.write_bytes(b"\x00" * 16)
+    return xml_path, bin_path
+
+
+def test_scan_model_streaming_preserves_openvino_companion_when_bin_arrives_first(tmp_path: Path) -> None:
+    """A streamed OpenVINO .bin sidecar must not be deleted before its XML owner is scanned."""
+    xml_path, bin_path = _write_openvino_pair(tmp_path)
+
+    result = scan_model_streaming(
+        file_generator=iter([(bin_path, False), (xml_path, True)]),
+        timeout=30,
+        delete_after_scan=True,
+        cache_enabled=False,
+    )
+
+    assert determine_exit_code(result) == 0
+    assert "pytorch_binary" not in result.scanner_names
+    assert not xml_path.exists()
+    assert not bin_path.exists()
+    assert result.file_metadata[str(xml_path)]["bin_size"] == 16
+    assert not any(check.rule_code == "S701" for check in result.checks)
+    assert not any(check.rule_code == "S901" for check in result.checks)
+
+
+def test_scan_model_streaming_openvino_xml_with_prefetched_companion(tmp_path: Path) -> None:
+    """HF-style streaming can yield only XML after pre-staging the .bin companion."""
+    xml_path, bin_path = _write_openvino_pair(tmp_path)
+
+    result = scan_model_streaming(
+        file_generator=iter([(xml_path, True)]),
+        timeout=30,
+        delete_after_scan=True,
+        cache_enabled=False,
+    )
+
+    assert determine_exit_code(result) == 0
+    assert result.scanner_names == ["openvino"]
+    assert not xml_path.exists()
+    assert not bin_path.exists()
+    assert result.file_metadata[str(xml_path)]["bin_size"] == 16
+    assert not any("weights file not found" in check.message.lower() for check in result.checks)
+
+
+def test_scan_model_streaming_openvino_missing_companion_still_reports_s701(tmp_path: Path) -> None:
+    """Missing OpenVINO weights must not be suppressed by companion-preservation logic."""
+    xml_path = tmp_path / "model.xml"
+    xml_path.write_text("<net version='10'></net>", encoding="utf-8")
+
+    result = scan_model_streaming(
+        file_generator=iter([(xml_path, True)]),
+        timeout=30,
+        delete_after_scan=True,
+        cache_enabled=False,
+    )
+
+    assert any(
+        check.rule_code == "S701" and "weights file not found" in check.message.lower() for check in result.checks
+    )
+
+
+def test_scan_model_streaming_openvino_symlink_escape_fails_closed(
+    tmp_path: Path,
+    requires_symlinks: None,
+) -> None:
+    """A streamed OpenVINO weights symlink escaping the model dir remains a critical finding."""
+    model_dir = tmp_path / "model"
+    outside_dir = tmp_path / "outside"
+    model_dir.mkdir()
+    outside_dir.mkdir()
+    xml_path = model_dir / "model.xml"
+    bin_path = model_dir / "model.bin"
+    escaped_weights = outside_dir / "secret.bin"
+    xml_path.write_text("<net version='10'></net>", encoding="utf-8")
+    escaped_weights.write_bytes(b"secret-weights")
+    bin_path.symlink_to(escaped_weights)
+
+    result = scan_model_streaming(
+        file_generator=iter([(xml_path, True)]),
+        timeout=30,
+        delete_after_scan=True,
+        cache_enabled=False,
+    )
+
+    assert determine_exit_code(result) == 1
+    assert not xml_path.exists()
+    assert not bin_path.exists()
+    assert escaped_weights.exists()
+    assert any(
+        check.name == "OpenVINO Weights Symlink Boundary Check"
+        and check.severity == IssueSeverity.CRITICAL
+        and check.details.get("resolved_path") == str(escaped_weights.resolve())
+        for check in result.checks
+    )
+
+
+def test_scan_model_streaming_openvino_companion_swap_fails_closed(tmp_path: Path) -> None:
+    """A sidecar changed during XML scanning makes the streamed result operationally incomplete."""
+    xml_path, bin_path = _write_openvino_pair(tmp_path)
+    real_scan_file = scan_file
+
+    def swap_companion(path: str, config: dict[str, Any] | None = None) -> ScanResult:
+        if Path(path) == xml_path:
+            bin_path.write_bytes(b"changed")
+        return real_scan_file(path, config=config)
+
+    with patch("modelaudit.core.scan_file", side_effect=swap_companion):
+        result = scan_model_streaming(
+            file_generator=iter([(xml_path, True)]),
+            timeout=30,
+            delete_after_scan=False,
+            cache_enabled=False,
+        )
+
+    assert determine_exit_code(result) == 2
+    assert any(
+        check.name == "OpenVINO Weights Companion Stability"
+        and check.details.get("scan_outcome_reason") == "openvino_weights_changed_during_xml_scan"
+        for check in result.checks
+    )
+
+
+def test_scan_model_directory_or_file_openvino_bin_sidecar_not_pytorch(tmp_path: Path) -> None:
+    """Local directory scans should not route declared OpenVINO weights as PyTorch binaries."""
+    xml_path, bin_path = _write_openvino_pair(tmp_path)
+
+    result = scan_model_directory_or_file(str(tmp_path), cache_enabled=False, skip_file_types=True)
+
+    assert determine_exit_code(result) == 0
+    assert "pytorch_binary" not in result.scanner_names
+    assert result.file_metadata[str(xml_path)]["bin_size"] == bin_path.stat().st_size
+    assert not any(check.rule_code == "S901" for check in result.checks)
+
+
+def test_non_openvino_xml_near_match_does_not_hide_malicious_bin(tmp_path: Path) -> None:
+    """A same-stem .bin remains independently scanned when the XML is not OpenVINO."""
+    xml_path = tmp_path / "document.xml"
+    xml_path.write_text("<project><model name='not-openvino'/></project>", encoding="utf-8")
+    bin_path = create_malicious_pickle(tmp_path / "document.bin")
+
+    result = scan_model_directory_or_file(str(tmp_path), cache_enabled=False, skip_file_types=True)
+
+    assert determine_exit_code(result) == 1
+    assert "openvino" not in result.scanner_names
+    assert any(issue.location == str(bin_path) and issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
 
 
 def test_scan_model_streaming_skips_non_model_files(tmp_path: Path) -> None:

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -1563,7 +1563,7 @@ def test_scan_model_directory_or_file_openvino_bin_sidecar_not_pytorch(tmp_path:
 )
 def test_openvino_bin_sidecar_respects_scanner_selection(
     tmp_path: Path,
-    scanner_selection: dict[str, list[str]],
+    scanner_selection: dict[str, Any],
 ) -> None:
     """A filtered OpenVINO XML must not hide a selected malicious .bin scanner route."""
     _xml_path, bin_path = _write_openvino_pair(tmp_path)

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -1519,6 +1519,33 @@ def test_scan_model_streaming_openvino_prefetched_companion_changes_content_hash
     assert first_result.content_hash != second_result.content_hash
 
 
+def test_scan_model_streaming_hashes_reused_path_file_instances(tmp_path: Path) -> None:
+    """A streaming source may reuse one staging path for multiple distinct files."""
+    stage_path = tmp_path / "stage.txt"
+    first_payload = b"first streamed file"
+    second_payload = b"second streamed file"
+    stage_path.write_bytes(first_payload)
+    first_hash = compute_sha256_hash(stage_path)
+    stage_path.write_bytes(second_payload)
+    second_hash = compute_sha256_hash(stage_path)
+
+    def reused_path_generator() -> Iterator[tuple[Path, bool]]:
+        stage_path.write_bytes(first_payload)
+        yield stage_path, False
+        stage_path.write_bytes(second_payload)
+        yield stage_path, True
+
+    result = scan_model_streaming(
+        file_generator=reused_path_generator(),
+        timeout=30,
+        delete_after_scan=False,
+        cache_enabled=False,
+    )
+
+    assert determine_exit_code(result) == 0
+    assert result.content_hash == compute_aggregate_hash([first_hash, second_hash])
+
+
 def test_scan_model_streaming_openvino_prefetched_companion_counts_toward_max_total_size(tmp_path: Path) -> None:
     """HF-style XML-only yields must count staged OpenVINO weights against total scan caps."""
     xml_path, bin_path = _write_openvino_pair(tmp_path)

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -1595,6 +1595,27 @@ def test_scan_model_streaming_openvino_bin_without_yielded_xml_fails_closed(tmp_
     assert any(issue.location == str(bin_path) and issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
 
 
+def test_scan_model_streaming_selected_openvino_preserves_bin_before_skip_filter(tmp_path: Path) -> None:
+    """OpenVINO-only streaming must defer bin-first sidecars before extension filtering."""
+    xml_path, bin_path = _write_openvino_pair(tmp_path)
+
+    result = scan_model_streaming(
+        file_generator=iter([(bin_path, False), (xml_path, True)]),
+        timeout=30,
+        delete_after_scan=True,
+        cache_enabled=False,
+        skip_file_types=True,
+        scanners=["openvino"],
+    )
+
+    assert determine_exit_code(result) == 0
+    assert result.scanner_names == ["openvino"]
+    assert not xml_path.exists()
+    assert not bin_path.exists()
+    assert result.file_metadata[str(xml_path)]["bin_size"] == 16
+    assert not any(check.rule_code == "S701" for check in result.checks)
+
+
 def test_scan_model_directory_or_file_openvino_bin_sidecar_not_pytorch(tmp_path: Path) -> None:
     """Local directory scans should not route declared OpenVINO weights as PyTorch binaries."""
     xml_path, bin_path = _write_openvino_pair(tmp_path)
@@ -1605,6 +1626,50 @@ def test_scan_model_directory_or_file_openvino_bin_sidecar_not_pytorch(tmp_path:
     assert "pytorch_binary" not in result.scanner_names
     assert result.file_metadata[str(xml_path)]["bin_size"] == bin_path.stat().st_size
     assert not any(check.rule_code == "S901" for check in result.checks)
+
+
+def test_scan_model_directory_or_file_selected_openvino_sidecar_changes_content_hash(tmp_path: Path) -> None:
+    """OpenVINO-only directory scans must hash selected same-stem weights sidecars."""
+    xml_path, bin_path = _write_openvino_pair(tmp_path)
+    first_result = scan_model_directory_or_file(
+        str(tmp_path),
+        cache_enabled=False,
+        skip_file_types=True,
+        scanners=["openvino"],
+    )
+
+    bin_path.write_bytes(b"\x01" * 16)
+    second_result = scan_model_directory_or_file(
+        str(tmp_path),
+        cache_enabled=False,
+        skip_file_types=True,
+        scanners=["openvino"],
+    )
+
+    assert first_result.content_hash is not None
+    assert second_result.content_hash is not None
+    assert first_result.content_hash != second_result.content_hash
+    assert str(bin_path) in first_result.file_metadata
+    assert first_result.file_metadata[str(xml_path)]["bin_size"] == 16
+
+
+def test_scan_model_directory_or_file_selected_openvino_sidecar_counts_toward_max_total_size(tmp_path: Path) -> None:
+    """OpenVINO-only directory scans must count selected same-stem weights against total caps."""
+    _xml_path, bin_path = _write_openvino_pair(tmp_path)
+    bin_path.write_bytes(b"\x00" * 64)
+
+    result = scan_model_directory_or_file(
+        str(tmp_path),
+        cache_enabled=False,
+        skip_file_types=True,
+        scanners=["openvino"],
+        max_total_size=32,
+    )
+
+    assert determine_exit_code(result) == 2
+    assert result.bytes_scanned > 32
+    assert result.content_hash is None
+    assert any("Total scan size limit exceeded" in issue.message for issue in result.issues)
 
 
 def test_openvino_bin_sidecar_respects_selected_pytorch_binary_scanner(tmp_path: Path) -> None:

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -32,6 +32,7 @@ from modelaudit.models import FileMetadataModel, LicenseInfoModel, create_initia
 from modelaudit.scanners import safetensors_scanner
 from modelaudit.scanners.base import Issue, IssueSeverity, ScanResult
 from modelaudit.utils.file.detection import SAFETENSORS_ROUTING_HEADER_PARSE_BYTES
+from modelaudit.utils.helpers.file_hash import compute_sha256_hash
 from modelaudit.utils.helpers.file_iterator import iterate_files_streaming
 from modelaudit.utils.helpers.secure_hasher import compute_aggregate_hash
 from tests.helpers import create_malicious_pickle
@@ -1440,6 +1441,22 @@ def test_scan_model_streaming_openvino_xml_with_prefetched_companion(tmp_path: P
     assert not any("weights file not found" in check.message.lower() for check in result.checks)
 
 
+def test_scan_model_streaming_openvino_prefetched_companion_contributes_content_hash(tmp_path: Path) -> None:
+    """A staged OpenVINO .bin sidecar must remain part of the streaming aggregate hash."""
+    xml_path, bin_path = _write_openvino_pair(tmp_path)
+    expected_hash = compute_aggregate_hash([compute_sha256_hash(xml_path), compute_sha256_hash(bin_path)])
+
+    result = scan_model_streaming(
+        file_generator=iter([(xml_path, True)]),
+        timeout=30,
+        delete_after_scan=False,
+        cache_enabled=False,
+    )
+
+    assert determine_exit_code(result) == 0
+    assert result.content_hash == expected_hash
+
+
 def test_scan_model_streaming_openvino_missing_companion_still_reports_s701(tmp_path: Path) -> None:
     """Missing OpenVINO weights must not be suppressed by companion-preservation logic."""
     xml_path = tmp_path / "model.xml"
@@ -1528,6 +1545,27 @@ def test_scan_model_directory_or_file_openvino_bin_sidecar_not_pytorch(tmp_path:
     assert "pytorch_binary" not in result.scanner_names
     assert result.file_metadata[str(xml_path)]["bin_size"] == bin_path.stat().st_size
     assert not any(check.rule_code == "S901" for check in result.checks)
+
+
+def test_openvino_bin_sidecar_respects_scanner_selection(tmp_path: Path) -> None:
+    """A standalone .bin scanner must still run when OpenVINO is excluded."""
+    _xml_path, bin_path = _write_openvino_pair(tmp_path)
+    create_malicious_pickle(bin_path)
+
+    result = scan_model_directory_or_file(
+        str(tmp_path),
+        cache_enabled=False,
+        skip_file_types=True,
+        exclude_scanners=["openvino"],
+    )
+
+    assert "openvino" not in result.scanner_names
+    assert "pickle" in result.scanner_names
+    assert any(
+        check.name == "Scanner Selection" and check.details.get("skipped_scanner_id") == "openvino"
+        for check in result.checks
+    )
+    assert any(issue.location == str(bin_path) and issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
 
 
 def test_non_openvino_xml_near_match_does_not_hide_malicious_bin(tmp_path: Path) -> None:

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -1634,6 +1634,25 @@ def test_scan_model_streaming_openvino_bin_without_yielded_xml_fails_closed(tmp_
     assert any(issue.location == str(bin_path) and issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
 
 
+def test_scan_model_streaming_openvino_pickle_sidecar_reports_payload(tmp_path: Path) -> None:
+    """A yielded OpenVINO XML must still surface pickle payloads in its owned weights."""
+    xml_path, bin_path = _write_openvino_pair(tmp_path)
+    create_malicious_pickle(bin_path)
+
+    result = scan_model_streaming(
+        file_generator=iter([(xml_path, True)]),
+        timeout=30,
+        delete_after_scan=False,
+        cache_enabled=False,
+    )
+
+    assert determine_exit_code(result) == 1
+    assert result.scanner_names == ["openvino"]
+    assert result.file_metadata[str(xml_path)]["openvino_weights_pickle_payload_scanned"] is True
+    assert "pickle" in result.file_metadata[str(xml_path)]["scanner_dependency_ids"]
+    assert any(issue.location == str(bin_path) and issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+
+
 def test_scan_model_streaming_selected_openvino_preserves_bin_before_skip_filter(tmp_path: Path) -> None:
     """OpenVINO-only streaming must defer bin-first sidecars before extension filtering."""
     xml_path, bin_path = _write_openvino_pair(tmp_path)

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -1422,6 +1422,45 @@ def test_scan_model_streaming_preserves_openvino_companion_when_bin_arrives_firs
     assert not any(check.rule_code == "S901" for check in result.checks)
 
 
+def test_scan_model_streaming_preserves_path_sensitive_openvino_companions_with_duplicate_basenames(
+    tmp_path: Path,
+) -> None:
+    """Duplicate basenames in nested dirs must preserve and delete each exact sidecar."""
+    encoder_dir = tmp_path / "models" / "encoder"
+    decoder_dir = tmp_path / "models" / "decoder"
+    encoder_dir.mkdir(parents=True)
+    decoder_dir.mkdir(parents=True)
+    encoder_xml, encoder_bin = _write_openvino_pair(encoder_dir)
+    decoder_xml, decoder_bin = _write_openvino_pair(decoder_dir)
+    encoder_bin.write_bytes(b"e" * 11)
+    decoder_bin.write_bytes(b"d" * 23)
+
+    result = scan_model_streaming(
+        file_generator=iter(
+            [
+                (encoder_bin, False),
+                (decoder_bin, False),
+                (encoder_xml, False),
+                (decoder_xml, True),
+            ]
+        ),
+        timeout=30,
+        delete_after_scan=True,
+        cache_enabled=False,
+    )
+
+    assert determine_exit_code(result) == 0
+    assert "pytorch_binary" not in result.scanner_names
+    assert not encoder_xml.exists()
+    assert not encoder_bin.exists()
+    assert not decoder_xml.exists()
+    assert not decoder_bin.exists()
+    assert result.file_metadata[str(encoder_xml)]["bin_size"] == 11
+    assert result.file_metadata[str(decoder_xml)]["bin_size"] == 23
+    assert not any(check.rule_code == "S701" for check in result.checks)
+    assert not any(check.rule_code == "S901" for check in result.checks)
+
+
 def test_scan_model_streaming_openvino_xml_with_prefetched_companion(tmp_path: Path) -> None:
     """HF-style streaming can yield only XML after pre-staging the .bin companion."""
     xml_path, bin_path = _write_openvino_pair(tmp_path)
@@ -1615,6 +1654,32 @@ def test_scan_model_streaming_selected_openvino_preserves_bin_before_skip_filter
     assert result.file_metadata[str(xml_path)]["bin_size"] == 16
     assert not any("weights file not found" in check.message.lower() for check in result.checks)
     assert not any(check.rule_code == "S701" for check in result.checks)
+
+
+def test_scan_model_streaming_openvino_case_variant_companion(tmp_path: Path) -> None:
+    """OpenVINO companion ownership should allow one unambiguous suffix case variant."""
+    stem = "OpenVINO_Mod\u00e8le"
+    xml_path = tmp_path / f"{stem}.XML"
+    bin_path = tmp_path / f"{stem}.BIN"
+    xml_path.write_text("<net version='10'></net>", encoding="utf-8")
+    bin_path.write_bytes(b"\x00" * 16)
+
+    result = scan_model_streaming(
+        file_generator=iter([(bin_path, False), (xml_path, True)]),
+        timeout=30,
+        delete_after_scan=True,
+        cache_enabled=False,
+        skip_file_types=True,
+        scanners=["openvino"],
+    )
+
+    assert determine_exit_code(result) == 0
+    assert result.scanner_names == ["openvino"]
+    assert not xml_path.exists()
+    assert not bin_path.exists()
+    assert result.file_metadata[str(xml_path)]["bin_size"] == 16
+    assert not any(check.rule_code == "S701" for check in result.checks)
+    assert not any(check.name == "Scanner Selection" and check.location == str(bin_path) for check in result.checks)
 
 
 def test_scan_model_directory_or_file_openvino_bin_sidecar_not_pytorch(tmp_path: Path) -> None:

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -1440,6 +1440,29 @@ def test_scan_model_streaming_openvino_xml_with_prefetched_companion(tmp_path: P
     assert not any("weights file not found" in check.message.lower() for check in result.checks)
 
 
+def test_scan_model_streaming_openvino_prefetched_companion_changes_content_hash(tmp_path: Path) -> None:
+    """HF-style XML-only yields must include staged OpenVINO weights in the aggregate hash."""
+    xml_path, bin_path = _write_openvino_pair(tmp_path)
+    first_result = scan_model_streaming(
+        file_generator=iter([(xml_path, True)]),
+        timeout=30,
+        delete_after_scan=False,
+        cache_enabled=True,
+    )
+
+    bin_path.write_bytes(b"\x01" * 16)
+    second_result = scan_model_streaming(
+        file_generator=iter([(xml_path, True)]),
+        timeout=30,
+        delete_after_scan=False,
+        cache_enabled=True,
+    )
+
+    assert first_result.content_hash is not None
+    assert second_result.content_hash is not None
+    assert first_result.content_hash != second_result.content_hash
+
+
 def test_scan_model_streaming_openvino_missing_companion_still_reports_s701(tmp_path: Path) -> None:
     """Missing OpenVINO weights must not be suppressed by companion-preservation logic."""
     xml_path = tmp_path / "model.xml"
@@ -1481,6 +1504,7 @@ def test_scan_model_streaming_openvino_symlink_escape_fails_closed(
     )
 
     assert determine_exit_code(result) == 1
+    assert result.content_hash is None
     assert not xml_path.exists()
     assert not bin_path.exists()
     assert escaped_weights.exists()
@@ -1528,6 +1552,36 @@ def test_scan_model_directory_or_file_openvino_bin_sidecar_not_pytorch(tmp_path:
     assert "pytorch_binary" not in result.scanner_names
     assert result.file_metadata[str(xml_path)]["bin_size"] == bin_path.stat().st_size
     assert not any(check.rule_code == "S901" for check in result.checks)
+
+
+@pytest.mark.parametrize(
+    "scanner_selection",
+    [
+        {"scanners": ["pytorch_binary"]},
+        {"exclude_scanners": ["openvino"]},
+    ],
+)
+def test_openvino_bin_sidecar_respects_scanner_selection(
+    tmp_path: Path,
+    scanner_selection: dict[str, list[str]],
+) -> None:
+    """A filtered OpenVINO XML must not hide a selected malicious .bin scanner route."""
+    _xml_path, bin_path = _write_openvino_pair(tmp_path)
+    bin_path.write_bytes(b"\x00" * 128 + b"eval('1 + 1')" + b"\x00" * 128)
+
+    result = scan_model_directory_or_file(
+        str(tmp_path),
+        cache_enabled=False,
+        skip_file_types=True,
+        **scanner_selection,
+    )
+
+    assert determine_exit_code(result) == 1
+    assert "pytorch_binary" in result.scanner_names
+    assert any(
+        issue.location and issue.location.startswith(str(bin_path)) and issue.severity == IssueSeverity.WARNING
+        for issue in result.issues
+    )
 
 
 def test_non_openvino_xml_near_match_does_not_hide_malicious_bin(tmp_path: Path) -> None:

--- a/tests/test_streaming_scan.py
+++ b/tests/test_streaming_scan.py
@@ -1463,6 +1463,25 @@ def test_scan_model_streaming_openvino_prefetched_companion_changes_content_hash
     assert first_result.content_hash != second_result.content_hash
 
 
+def test_scan_model_streaming_openvino_prefetched_companion_counts_toward_max_total_size(tmp_path: Path) -> None:
+    """HF-style XML-only yields must count staged OpenVINO weights against total scan caps."""
+    xml_path, bin_path = _write_openvino_pair(tmp_path)
+    bin_path.write_bytes(b"\x00" * 64)
+
+    result = scan_model_streaming(
+        file_generator=iter([(xml_path, True)]),
+        timeout=30,
+        delete_after_scan=False,
+        cache_enabled=False,
+        max_total_size=32,
+    )
+
+    assert determine_exit_code(result) == 2
+    assert result.bytes_scanned > 32
+    assert result.content_hash is None
+    assert any("Total scan size limit exceeded" in issue.message for issue in result.issues)
+
+
 def test_scan_model_streaming_openvino_missing_companion_still_reports_s701(tmp_path: Path) -> None:
     """Missing OpenVINO weights must not be suppressed by companion-preservation logic."""
     xml_path = tmp_path / "model.xml"
@@ -1540,6 +1559,23 @@ def test_scan_model_streaming_openvino_companion_swap_fails_closed(tmp_path: Pat
         and check.details.get("scan_outcome_reason") == "openvino_weights_changed_during_xml_scan"
         for check in result.checks
     )
+
+
+def test_scan_model_streaming_openvino_bin_without_yielded_xml_fails_closed(tmp_path: Path) -> None:
+    """A bin-first stream cannot mark weights covered unless its OpenVINO XML is yielded."""
+    _xml_path, bin_path = _write_openvino_pair(tmp_path)
+    create_malicious_pickle(bin_path)
+
+    result = scan_model_streaming(
+        file_generator=iter([(bin_path, True)]),
+        timeout=30,
+        delete_after_scan=False,
+        cache_enabled=False,
+    )
+
+    assert determine_exit_code(result) == 1
+    assert "pickle" in result.scanner_names
+    assert any(issue.location == str(bin_path) and issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
 
 
 def test_scan_model_directory_or_file_openvino_bin_sidecar_not_pytorch(tmp_path: Path) -> None:

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -2127,6 +2127,74 @@ class TestModelDownloadStreaming:
         "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
         return_value=(
             [
+                "models/encoder/openvino_model.bin",
+                "models/encoder/openvino_model.xml",
+                "models/decoder/openvino_model.bin",
+                "models/decoder/openvino_model.xml",
+                "variants/\u00dcnicode-Model.bin",
+                "variants/\u00dcnicode-Model.xml",
+                "orphan/openvino_model.bin",
+            ],
+            _HF_TEST_REVISION,
+            None,
+        ),
+    )
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_model_streaming_prefetches_path_sensitive_openvino_companions(
+        self,
+        mock_hf_hub_download: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        mock_detect_content: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Duplicate basenames must stage only each XML's exact same-directory weights."""
+
+        def download_side_effect(*, filename: str, **_kwargs: object) -> str:
+            path = tmp_path / "huggingface" / "test" / "model" / filename
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if filename.endswith(".xml"):
+                path.write_text("<net version='10'></net>", encoding="utf-8")
+            else:
+                path.write_bytes(filename.encode("utf-8"))
+            return str(path)
+
+        mock_hf_hub_download.side_effect = download_side_effect
+        mock_detect_content.side_effect = lambda _repo_id, filename, _revision, _budget: (
+            "openvino" if filename.endswith(".xml") else None
+        )
+
+        results = list(
+            download_model_streaming(
+                "https://huggingface.co/test/model",
+                cache_dir=tmp_path,
+                scannable_extensions={".xml"},
+                scannable_scanner_ids={"openvino"},
+            )
+        )
+
+        download_root = tmp_path / "huggingface" / "test" / "model"
+        assert results == [
+            (download_root / "models" / "encoder" / "openvino_model.xml", False),
+            (download_root / "models" / "decoder" / "openvino_model.xml", False),
+            (download_root / "variants" / "\u00dcnicode-Model.xml", True),
+        ]
+        assert [call.kwargs["filename"] for call in mock_hf_hub_download.call_args_list] == [
+            "models/encoder/openvino_model.xml",
+            "models/encoder/openvino_model.bin",
+            "models/decoder/openvino_model.xml",
+            "models/decoder/openvino_model.bin",
+            "variants/\u00dcnicode-Model.xml",
+            "variants/\u00dcnicode-Model.bin",
+        ]
+        assert "orphan/openvino_model.bin" not in {
+            call.kwargs["filename"] for call in mock_hf_hub_download.call_args_list
+        }
+
+    @patch("modelaudit.utils.sources.huggingface._detect_huggingface_content_route_format")
+    @patch(
+        "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
+        return_value=(
+            [
                 "openvino/openvino_model.bin",
                 "openvino/openvino_model.xml",
                 "openvino/openvino_model_qint8_quantized.bin",
@@ -2181,6 +2249,66 @@ class TestModelDownloadStreaming:
             "openvino/openvino_model_qint8_quantized.bin",
         ]
         assert all(call.args[1].endswith(".xml") for call in mock_detect_content.call_args_list)
+
+    @patch("modelaudit.utils.sources.huggingface._detect_huggingface_content_route_format")
+    @patch(
+        "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
+        return_value=(
+            [
+                "a/OpenVINO_Mod\u00e8le.BIN",
+                "a/OpenVINO_Mod\u00e8le.XML",
+                "b/OpenVINO_Mod\u00e8le.BIN",
+                "b/OpenVINO_Mod\u00e8le.XML",
+            ],
+            _HF_TEST_REVISION,
+            None,
+        ),
+    )
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_model_streaming_prefetches_case_variant_duplicate_openvino_companions(
+        self,
+        mock_hf_hub_download: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        mock_detect_content: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """HF OpenVINO companion staging should keep duplicate basenames path-specific."""
+
+        def download_side_effect(*, filename: str, **_kwargs: object) -> str:
+            path = tmp_path / "huggingface" / "test" / "model" / filename
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if filename.endswith(".XML"):
+                path.write_text("<net version='10'></net>", encoding="utf-8")
+            else:
+                path.write_bytes(b"weights")
+            return str(path)
+
+        mock_hf_hub_download.side_effect = download_side_effect
+        mock_detect_content.side_effect = lambda _repo_id, filename, _revision, _budget: (
+            "openvino" if filename.endswith(".XML") else None
+        )
+
+        results = list(
+            download_model_streaming(
+                "https://huggingface.co/test/model",
+                cache_dir=tmp_path,
+                scannable_extensions={".xml"},
+                scannable_scanner_ids={"openvino"},
+            )
+        )
+
+        download_root = tmp_path / "huggingface" / "test" / "model"
+        assert results == [
+            (download_root / "a" / "OpenVINO_Mod\u00e8le.XML", False),
+            (download_root / "b" / "OpenVINO_Mod\u00e8le.XML", True),
+        ]
+        assert [call.kwargs["filename"] for call in mock_hf_hub_download.call_args_list] == [
+            "a/OpenVINO_Mod\u00e8le.XML",
+            "a/OpenVINO_Mod\u00e8le.BIN",
+            "b/OpenVINO_Mod\u00e8le.XML",
+            "b/OpenVINO_Mod\u00e8le.BIN",
+        ]
+        assert all(call.args[1].endswith(".XML") for call in mock_detect_content.call_args_list)
 
     @patch("modelaudit.utils.sources.huggingface._detect_huggingface_content_route_format")
     @patch(

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -2359,6 +2359,49 @@ class TestModelDownloadStreaming:
     @patch("modelaudit.utils.sources.huggingface._detect_huggingface_content_route_format")
     @patch(
         "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
+        return_value=(["openvino/model.xml", "openvino/model.bin"], _HF_TEST_REVISION, None),
+    )
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_model_streaming_yields_openvino_bin_when_openvino_not_selected(
+        self,
+        mock_hf_hub_download: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        mock_detect_content: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Selected .bin files must not be consumed as OpenVINO companions when OpenVINO is excluded."""
+
+        def download_side_effect(*, filename: str, **_kwargs: object) -> str:
+            path = tmp_path / "huggingface" / "test" / "model" / filename
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if filename.endswith(".xml"):
+                path.write_text("<net version='10'></net>", encoding="utf-8")
+            else:
+                path.write_bytes(b"pickle-or-pytorch-candidate")
+            return str(path)
+
+        mock_hf_hub_download.side_effect = download_side_effect
+
+        results = list(
+            download_model_streaming(
+                "https://huggingface.co/test/model",
+                cache_dir=tmp_path,
+                scannable_extensions={".xml", ".bin"},
+                scannable_scanner_ids={"pickle"},
+            )
+        )
+
+        download_root = tmp_path / "huggingface" / "test" / "model" / "openvino"
+        assert results == [(download_root / "model.xml", False), (download_root / "model.bin", True)]
+        assert [call.kwargs["filename"] for call in mock_hf_hub_download.call_args_list] == [
+            "openvino/model.xml",
+            "openvino/model.bin",
+        ]
+        mock_detect_content.assert_not_called()
+
+    @patch("modelaudit.utils.sources.huggingface._detect_huggingface_content_route_format")
+    @patch(
+        "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
         return_value=(["document.xml", "document.bin"], _HF_TEST_REVISION, None),
     )
     @patch("huggingface_hub.hf_hub_download")

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -2122,6 +2122,52 @@ class TestModelDownloadStreaming:
     @patch("modelaudit.utils.sources.huggingface._detect_huggingface_content_route_format")
     @patch(
         "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
+        return_value=(
+            ["openvino/openvino_model.bin", "openvino/openvino_model.xml", "README.md"],
+            _HF_TEST_REVISION,
+            None,
+        ),
+    )
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_model_streaming_manifest_selection_does_not_prefetch_openvino_bin_companion(
+        self,
+        mock_hf_hub_download: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        mock_detect_content: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Non-OpenVINO XML scans must not stage unrelated same-stem OpenVINO weights."""
+
+        def download_side_effect(*, filename: str, **_kwargs: object) -> str:
+            path = tmp_path / "huggingface" / "test" / "model" / filename
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("<net version='10'></net>", encoding="utf-8")
+            return str(path)
+
+        mock_hf_hub_download.side_effect = download_side_effect
+        mock_detect_content.side_effect = lambda _repo_id, filename, _revision, _budget: (
+            "openvino" if filename.endswith(".xml") else None
+        )
+
+        results = list(
+            download_model_streaming(
+                "https://huggingface.co/test/model",
+                cache_dir=tmp_path,
+                scannable_extensions={".xml"},
+                scannable_scanner_ids={"manifest"},
+            )
+        )
+
+        yielded_xml = tmp_path / "huggingface" / "test" / "model" / "openvino" / "openvino_model.xml"
+        assert results == [(yielded_xml, True)]
+        assert [call.kwargs["filename"] for call in mock_hf_hub_download.call_args_list] == [
+            "openvino/openvino_model.xml"
+        ]
+        mock_detect_content.assert_not_called()
+
+    @patch("modelaudit.utils.sources.huggingface._detect_huggingface_content_route_format")
+    @patch(
+        "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
         return_value=(["document.xml", "document.bin"], _HF_TEST_REVISION, None),
     )
     @patch("huggingface_hub.hf_hub_download")

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -2118,6 +2118,69 @@ class TestModelDownloadStreaming:
         assert call("test/model", "openvino/openvino_model.xml", _HF_TEST_REVISION, ANY) in (
             mock_detect_content.call_args_list
         )
+        assert call("test/model", "openvino/openvino_model.bin", _HF_TEST_REVISION, ANY) not in (
+            mock_detect_content.call_args_list
+        )
+
+    @patch("modelaudit.utils.sources.huggingface._detect_huggingface_content_route_format")
+    @patch(
+        "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
+        return_value=(
+            [
+                "openvino/openvino_model.bin",
+                "openvino/openvino_model.xml",
+                "openvino/openvino_model_qint8_quantized.bin",
+                "openvino/openvino_model_qint8_quantized.xml",
+            ],
+            _HF_TEST_REVISION,
+            None,
+        ),
+    )
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_model_streaming_prefetches_multiple_openvino_bin_companions(
+        self,
+        mock_hf_hub_download: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        mock_detect_content: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Pinned OpenVINO repositories can stage every exact XML/BIN pair before scanning."""
+
+        def download_side_effect(*, filename: str, **_kwargs: object) -> str:
+            path = tmp_path / "huggingface" / "test" / "model" / filename
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if filename.endswith(".xml"):
+                path.write_text("<net version='10'></net>", encoding="utf-8")
+            else:
+                path.write_bytes(b"weights")
+            return str(path)
+
+        mock_hf_hub_download.side_effect = download_side_effect
+        mock_detect_content.side_effect = lambda _repo_id, filename, _revision, _budget: (
+            "openvino" if filename.endswith(".xml") else None
+        )
+
+        results = list(
+            download_model_streaming(
+                "https://huggingface.co/test/model",
+                cache_dir=tmp_path,
+                scannable_extensions={".xml"},
+                scannable_scanner_ids={"openvino"},
+            )
+        )
+
+        download_root = tmp_path / "huggingface" / "test" / "model" / "openvino"
+        assert results == [
+            (download_root / "openvino_model.xml", False),
+            (download_root / "openvino_model_qint8_quantized.xml", True),
+        ]
+        assert [call.kwargs["filename"] for call in mock_hf_hub_download.call_args_list] == [
+            "openvino/openvino_model.xml",
+            "openvino/openvino_model.bin",
+            "openvino/openvino_model_qint8_quantized.xml",
+            "openvino/openvino_model_qint8_quantized.bin",
+        ]
+        assert all(call.args[1].endswith(".xml") for call in mock_detect_content.call_args_list)
 
     @patch("modelaudit.utils.sources.huggingface._detect_huggingface_content_route_format")
     @patch(

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -2067,6 +2067,101 @@ class TestModelDownloadStreaming:
             local_dir=str(tmp_path / "huggingface" / "test" / "model"),
         )
 
+    @patch("modelaudit.utils.sources.huggingface._detect_huggingface_content_route_format")
+    @patch(
+        "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
+        return_value=(
+            ["openvino/openvino_model.bin", "openvino/openvino_model.xml", "README.md"],
+            _HF_TEST_REVISION,
+            None,
+        ),
+    )
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_model_streaming_prefetches_openvino_bin_companion(
+        self,
+        mock_hf_hub_download: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        mock_detect_content: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """OpenVINO-only streaming must stage the exact .bin sidecar before yielding XML."""
+
+        def download_side_effect(*, filename: str, **_kwargs: object) -> str:
+            path = tmp_path / "huggingface" / "test" / "model" / filename
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if filename.endswith(".xml"):
+                path.write_text("<net version='10'></net>", encoding="utf-8")
+            else:
+                path.write_bytes(b"weights")
+            return str(path)
+
+        mock_hf_hub_download.side_effect = download_side_effect
+        mock_detect_content.side_effect = lambda _repo_id, filename, _revision, _budget: (
+            "openvino" if filename.endswith(".xml") else None
+        )
+
+        results = list(
+            download_model_streaming(
+                "https://huggingface.co/test/model",
+                cache_dir=tmp_path,
+                scannable_extensions={".xml"},
+                scannable_scanner_ids={"openvino"},
+            )
+        )
+
+        yielded_xml = tmp_path / "huggingface" / "test" / "model" / "openvino" / "openvino_model.xml"
+        assert results == [(yielded_xml, True)]
+        assert [call.kwargs["filename"] for call in mock_hf_hub_download.call_args_list] == [
+            "openvino/openvino_model.xml",
+            "openvino/openvino_model.bin",
+        ]
+        assert call("test/model", "openvino/openvino_model.xml", _HF_TEST_REVISION, ANY) in (
+            mock_detect_content.call_args_list
+        )
+
+    @patch("modelaudit.utils.sources.huggingface._detect_huggingface_content_route_format")
+    @patch(
+        "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",
+        return_value=(["document.xml", "document.bin"], _HF_TEST_REVISION, None),
+    )
+    @patch("huggingface_hub.hf_hub_download")
+    def test_download_model_streaming_yields_non_openvino_near_match_bin(
+        self,
+        mock_hf_hub_download: MagicMock,
+        _mock_list_repo_files: MagicMock,
+        _mock_detect_content: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """A non-OpenVINO XML must not hide a same-stem .bin from standalone scanning."""
+
+        def download_side_effect(*, filename: str, **_kwargs: object) -> str:
+            path = tmp_path / filename
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if filename.endswith(".xml"):
+                path.write_text("<project><model name='not-openvino'/></project>", encoding="utf-8")
+            else:
+                path.write_bytes(b"binary")
+            return str(path)
+
+        mock_hf_hub_download.side_effect = download_side_effect
+        _mock_detect_content.side_effect = lambda _repo_id, filename, _revision, _budget: (
+            "openvino" if filename.endswith(".xml") else None
+        )
+
+        results = list(
+            download_model_streaming(
+                "https://huggingface.co/test/model",
+                scannable_extensions={".xml"},
+                scannable_scanner_ids={"openvino"},
+            )
+        )
+
+        assert results == [(tmp_path / "document.xml", False), (tmp_path / "document.bin", True)]
+        assert [call.kwargs["filename"] for call in mock_hf_hub_download.call_args_list] == [
+            "document.xml",
+            "document.bin",
+        ]
+
     @patch("modelaudit.utils.sources.huggingface._get_model_extensions", return_value={".bin"})
     @patch(
         "modelaudit.utils.sources.huggingface._list_repo_files_with_timeout",


### PR DESCRIPTION
## Summary

Fixes Hugging Face OpenVINO XML/BIN companion handling so streaming and delete-after-scan workflows preserve the logical model pair. Selected OpenVINO XML files now pull in exact same-stem `.bin` companions before size checks, stream the XML as the logical scan unit, and keep the companion staged until the XML scan consumes it.

Root cause: HF streaming could select or yield OpenVINO XML/BIN files independently, so delete-after-scan could remove the `.bin` before the XML scanner checked it, producing false S701 missing-sidecar findings. Local scans could also route a declared OpenVINO weights `.bin` as generic PyTorch/binary/protobuf content, producing false S901 failures.

## Security tradeoffs

Standalone `.bin` routing is suppressed only for a same-stem `.xml` that is locally accepted by `OpenVinoScanner.can_handle()` and when OpenVINO is selected/allowed. Remote companion inclusion is likewise gated by bounded content routing of the XML as OpenVINO (or inconclusive XML model routing). Non-OpenVINO XML near-matches still yield and scan their `.bin` independently.

Fail-closed behavior is preserved: missing companions still report S701, symlink/path traversal companions remain critical, unconsumed deferred sidecars fall back to standalone scanning, and sidecars changed while preserved for XML scan produce an operationally incomplete exit 2 result. OpenVINO scanner-side max file size enforcement now also covers associated `.bin` weights.

## Validation

- `uv run ruff format modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> clean
- `uv run ruff check --fix modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> all checks passed
- `uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> success, no issues in 474 files
- Focused merged regressions -> `6 passed`
- Affected suite: `tests/scanners/test_openvino_scanner.py tests/test_streaming_scan.py tests/utils/sources/test_huggingface.py tests/test_scanner_selection.py tests/cache/test_cache_correctness.py` -> `569 passed, 5 skipped`
- Broad local suite: `PROMPTFOO_DISABLE_TELEMETRY=1 NO_ANALYTICS=1 uv run pytest -n auto -m "not slow and not integration" --maxfail=1` -> `17388 passed, 1292 skipped, 39 warnings in 809.04s`
- `git diff --check origin/main...HEAD` -> clean
- GitHub CI on `cb375ae849cfec011a6154c5724faf29b249706f` -> green, including Python 3.10, Quick Feedback Python 3.12, Python 3.13, Windows Python 3.11, lint, type check, CodeQL, docs, Docker CI, dependency audit, benchmarks, and `CI Success`
- Codex review on current head -> no major issues; no unresolved review threads

Pinned real-model QA command:

```bash
PROMPTFOO_DISABLE_TELEMETRY=1 NO_ANALYTICS=1 uv run python - <<'PY'
from __future__ import annotations

import json
from pathlib import Path
from tempfile import TemporaryDirectory

from huggingface_hub import snapshot_download

from modelaudit.core import determine_exit_code, scan_model_directory_or_file, scan_model_streaming
from modelaudit.utils.sources.huggingface import download_model_streaming

MODELS = [
    ("sentence-transformers/all-MiniLM-L6-v2", "1110a243fdf4706b3f48f1d95db1a4f5529b4d41"),
    ("sentence-transformers/all-mpnet-base-v2", "e8c3b32edf5434bc2275fc9bab85f82640a19130"),
]
OPENVINO_XML_BASENAMES = {"openvino_model.xml", "openvino_model_qint8_quantized.xml"}
MAX_BYTES = 800_000_000


def summarize(result):
    interesting = []
    for record in [*result.checks, *result.issues]:
        rule_code = getattr(record, "rule_code", None)
        message = getattr(record, "message", "")
        name = getattr(record, "name", None)
        if rule_code in {"S701", "S901"} or "weights file not found" in message.lower():
            interesting.append({"rule_code": rule_code, "name": name, "message": message, "location": getattr(record, "location", None)})
    return {
        "exit": determine_exit_code(result),
        "success": result.success,
        "has_errors": result.has_errors,
        "files_scanned": result.files_scanned,
        "scanners": result.scanner_names,
        "interesting": interesting,
    }


out = []
for repo_id, revision in MODELS:
    with TemporaryDirectory(prefix="modelaudit-t07-local-") as tmp:
        local_path = snapshot_download(repo_id=repo_id, revision=revision, allow_patterns=["openvino/*"], local_dir=Path(tmp) / "snapshot")
        local_result = scan_model_directory_or_file(local_path, cache_enabled=False, skip_file_types=True, max_file_size=MAX_BYTES)
    with TemporaryDirectory(prefix="modelaudit-t07-stream-") as tmp:
        stream_result = scan_model_streaming(
            download_model_streaming(
                f"https://huggingface.co/{repo_id}/tree/{revision}",
                cache_dir=Path(tmp),
                max_size=MAX_BYTES,
                scannable_extensions=set(),
                scannable_filenames=OPENVINO_XML_BASENAMES,
            ),
            timeout=300,
            delete_after_scan=True,
            cache_enabled=False,
            max_file_size=MAX_BYTES,
        )
    local_summary = summarize(local_result)
    stream_summary = summarize(stream_result)
    out.append({
        "repo_id": repo_id,
        "revision": revision,
        "local": local_summary,
        "streaming": stream_summary,
        "exit_agree": local_summary["exit"] == stream_summary["exit"],
        "no_missing_declared_companions": not local_summary["interesting"] and not stream_summary["interesting"],
    })
print(json.dumps(out, indent=2, sort_keys=True))
assert all(item["exit_agree"] for item in out)
assert all(item["no_missing_declared_companions"] for item in out)
assert all(item["local"]["exit"] == 0 and item["streaming"]["exit"] == 0 for item in out)
PY
```

Pinned real-model outcomes:

- `sentence-transformers/all-MiniLM-L6-v2 @ 1110a243fdf4706b3f48f1d95db1a4f5529b4d41`: local exit 0, streaming exit 0, both `scanners=["openvino"]`, no S701/S901/missing-sidecar records.
- `sentence-transformers/all-mpnet-base-v2 @ e8c3b32edf5434bc2275fc9bab85f82640a19130`: local exit 0, streaming exit 0, both `scanners=["openvino"]`, no S701/S901/missing-sidecar records.

Additional HF sweep QA on current head:

- `sentence-transformers/all-MiniLM-L12-v2 @ a50ef00143b4d5391434df20ae11632588ac25be`: local exit 0, streaming exit 0, `scanners=["openvino"]`, no S701/S901/missing-sidecar records.
- `intfloat/multilingual-e5-base @ d128750597153bb5987e10b1c3493a34e5a4502a`: local exit 0, streaming exit 0, `scanners=["openvino"]`, no S701/S901/missing-sidecar records. This model's selected OpenVINO files total `1,110,184,232` bytes, so the bounded validation used `MAX_BYTES=1_200_000_000` after confirming the 900 MB cap fails closed.
