### PR TITLE
fix: calibrate legacy PyTorch storage persistent IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - stream bounded Llamafile runtime coverage across preview gaps and report incomplete runtime reads or bounds
+- treat canonical storage persistent IDs as informational only after legacy PyTorch framing, storage tuples, and storage payloads validate completely
 - prefer validated SafeTensors framing over invalid pickle and weak-magic collisions while retaining security-bearing pickle overlaps
 - scope both ONNX weight scanners to bounded semantic weight lineage across nested graphs, control flow, local functions, constants, Gather/Einsum, and static views; fail closed on ambiguous or sparse coverage; and evaluate extreme tails per conceptual output without suppressing repeated malicious patterns or flagging clean heavy tails
 - derive PyTorch ZIP pickle opcode summaries from exact opcode evidence instead of matching substrings in finding text

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -20,7 +20,7 @@ from modelaudit.detectors.suspicious_symbols import SUSPICIOUS_GLOBALS
 from modelaudit.utils.helpers.code_validation import validate_python_syntax
 
 from ..scanner_results import mark_inconclusive_scan_result
-from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, IssueSeverity, ScanResult, logger
+from .base import INCONCLUSIVE_SCAN_OUTCOME, BaseScanner, CheckStatus, IssueSeverity, ScanResult, logger
 from .picklescan_adapter import pickle_report_to_scan_result, scan_options_from_config
 
 _NESTED_PICKLE_HEADER_SEARCH_LIMIT_BYTES = 64 * 1024
@@ -916,9 +916,13 @@ def _legacy_pytorch_storage_records(
             elif opcode_name == "DUP":
                 if stack:
                     stack.append(stack[-1])
+            elif opcode_name == "PERSID":
+                return None
             elif opcode_name == "BINPERSID":
                 pid = stack.pop() if stack else unknown
                 is_storage, record = storage_record_from_pid(pid)
+                if not is_storage:
+                    return None
                 if is_storage:
                     if record is None or (record.key in records and records[record.key] != record):
                         return None
@@ -2240,6 +2244,52 @@ class PickleScanner(BaseScanner):
         result.metadata["last_pickle_end_pos"] = position_offset + layout.pickle_end
         if layout.storage_key_count > 0:
             result.metadata["legacy_pytorch_storage_payload_skipped"] = True
+
+    @staticmethod
+    def _is_legacy_pytorch_storage_persistent_id_record(
+        details: dict[str, Any],
+        trusted_storage_keys: set[str],
+    ) -> bool:
+        storage_key = details.get("pytorch_storage_key")
+        return (
+            details.get("pickle_rule_code") == "PERSISTENT_ID"
+            and details.get("opcode") == "BINPERSID"
+            and details.get("pytorch_storage_persistent_id") is True
+            and isinstance(storage_key, str)
+            and storage_key in trusted_storage_keys
+        )
+
+    @classmethod
+    def _downgrade_legacy_pytorch_storage_persistent_ids(
+        cls,
+        result: ScanResult,
+        layout: _LegacyPyTorchStreamLayout,
+    ) -> None:
+        """Treat canonical storage BINPERSID records as informational in validated legacy PyTorch streams."""
+        trusted_storage_keys = set(layout.storage_keys)
+        downgraded_count = 0
+        for check in result.checks:
+            if not cls._is_legacy_pytorch_storage_persistent_id_record(check.details, trusted_storage_keys):
+                continue
+            check.status = CheckStatus.PASSED
+            check.severity = IssueSeverity.INFO
+            check.message = "PyTorch storage persistent ID found in validated legacy PyTorch stream"
+            check.details["trusted_legacy_pytorch_context"] = True
+            downgraded_count += 1
+
+        result.issues = [
+            issue
+            for issue in result.issues
+            if not cls._is_legacy_pytorch_storage_persistent_id_record(issue.details, trusted_storage_keys)
+        ]
+        if downgraded_count:
+            result.metadata["legacy_pytorch_trusted_storage_persistent_id_count"] = downgraded_count
+            if (
+                not result.has_errors
+                and not result.has_warnings
+                and result.metadata.get("pickle_verdict") == "suspicious"
+            ):
+                result.metadata["pickle_verdict"] = "clean"
 
     @staticmethod
     def _mark_legacy_pytorch_storage_layout_incomplete(
@@ -3733,6 +3783,7 @@ class PickleScanner(BaseScanner):
                 if legacy_storage_valid:
                     assert legacy_layout.storage_end is not None
                     self._annotate_legacy_pytorch_layout(result, legacy_layout, position_offset=start_position)
+                    self._downgrade_legacy_pytorch_storage_persistent_ids(result, legacy_layout)
                     suffix_raw_limit = max(self._root_raw_scan_limit() - len(raw_data), 0)
                     try:
                         suffix_raw_data = self._scan_legacy_pytorch_seekable_suffix(
@@ -3787,6 +3838,7 @@ class PickleScanner(BaseScanner):
                 if legacy_storage_valid:
                     assert legacy_layout.storage_end is not None
                     self._annotate_legacy_pytorch_layout(result, legacy_layout)
+                    self._downgrade_legacy_pytorch_storage_persistent_ids(result, legacy_layout)
                     suffix = payload[legacy_layout.storage_end :]
                     self._scan_legacy_pytorch_suffix_bytes(
                         result,
@@ -3934,6 +3986,7 @@ class PickleScanner(BaseScanner):
                 if legacy_storage_valid:
                     assert legacy_layout.storage_end is not None
                     self._annotate_legacy_pytorch_layout(scan_result, legacy_layout)
+                    self._downgrade_legacy_pytorch_storage_persistent_ids(scan_result, legacy_layout)
                     suffix_raw_limit = max(self._root_raw_scan_limit() - len(detector_data), 0)
                     suffix_raw_data = self._scan_legacy_pytorch_file_suffix(
                         scan_result,

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -194,6 +194,61 @@ def _legacy_pytorch_object_stream(
     return bytes(object_stream)
 
 
+def _legacy_pytorch_storage_pid_tuple(
+    key: str,
+    storage_size: int,
+    *,
+    storage_type: bytes = b"ctorch\nByteStorage\n",
+    element_count: bytes | None = None,
+    extra_fields: bytes = b"",
+    view_metadata: bytes = b"N",
+) -> bytes:
+    encoded_key = key.encode("ascii")
+    encoded_count = element_count if element_count is not None else pickle.dumps(storage_size, protocol=2)[2:-1]
+    return (
+        b"("
+        + _binunicode(b"storage")
+        + storage_type
+        + _binunicode(encoded_key)
+        + _binunicode(b"cpu")
+        + encoded_count
+        + view_metadata
+        + extra_fields
+        + b"t"
+    )
+
+
+def _legacy_pytorch_object_stream_from_pid(pid_tuple: bytes) -> bytes:
+    return b"\x80\x02]" + pid_tuple + b"Qa."
+
+
+def _make_legacy_pytorch_container_with_object_stream(
+    storage_payload: bytes,
+    object_stream: bytes,
+    *,
+    storage_keys: tuple[str, ...] = ("0",),
+    declared_storage_size: int | None = None,
+) -> tuple[bytes, int]:
+    storage_size = len(storage_payload) if declared_storage_size is None else declared_storage_size
+    control_streams = (
+        pickle.dumps(0x1950A86A20F9469CFC6C, protocol=2),
+        pickle.dumps(1001, protocol=2),
+        pickle.dumps(
+            {
+                "protocol_version": 1001,
+                "little_endian": True,
+                "type_sizes": {"short": 2, "int": 4, "long": 8},
+            },
+            protocol=2,
+        ),
+        object_stream,
+        pickle.dumps(list(storage_keys), protocol=2),
+    )
+    pickle_end = sum(len(stream) for stream in control_streams)
+    storage_record = b"".join(storage_size.to_bytes(8, "little") + storage_payload for _key in storage_keys)
+    return b"".join(control_streams) + storage_record, pickle_end
+
+
 def _memoized_legacy_pytorch_object_stream(protocol: int) -> bytes:
     payload = bytearray(b"\x80" + bytes([protocol]) + b"]\x94")
     payload += b"(" + _short_binunicode(b"storage") + b"\x94"
@@ -230,6 +285,41 @@ def _make_legacy_pytorch_container(
     pickle_end = sum(len(stream) for stream in control_streams)
     storage_record = b"".join(storage_size.to_bytes(8, "little") + storage_payload for _key in storage_keys)
     return b"".join(control_streams) + storage_record, pickle_end
+
+
+def _persistent_id_checks(result: ScanResult, *, opcode: str | None = None) -> list[Any]:
+    return [
+        check
+        for check in result.checks
+        if check.details.get("pickle_rule_code") == "PERSISTENT_ID"
+        and (opcode is None or check.details.get("opcode") == opcode)
+    ]
+
+
+def _persistent_id_issues(result: ScanResult, *, opcode: str | None = None) -> list[Any]:
+    return [
+        issue
+        for issue in result.issues
+        if issue.details.get("pickle_rule_code") == "PERSISTENT_ID"
+        and (opcode is None or issue.details.get("opcode") == opcode)
+    ]
+
+
+def _trusted_legacy_storage_pid_checks(result: ScanResult) -> list[Any]:
+    return [check for check in result.checks if check.details.get("trusted_legacy_pytorch_context") is True]
+
+
+def _assert_legacy_storage_layout_incomplete(result: ScanResult) -> None:
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "legacy_pytorch_storage_layout_incomplete" in result.metadata["scan_outcome_reasons"]
+    assert not _trusted_legacy_storage_pid_checks(result)
+    assert any(
+        check.name == "Legacy PyTorch Storage Layout"
+        and check.status == CheckStatus.FAILED
+        and check.rule_code == "S902"
+        for check in result.checks
+    )
 
 
 @pytest.mark.parametrize("protocol", [4, 5])
@@ -1747,6 +1837,170 @@ def test_legacy_pytorch_container_accepts_historical_big_endian_storage_header(t
     assert result.metadata["legacy_pytorch_storage_end"] == len(big_endian_payload)
 
 
+def test_legacy_pytorch_container_trusts_canonical_storage_binpersid(tmp_path: Path) -> None:
+    payload, pickle_end = _make_legacy_pytorch_container(b"A" * 64)
+    path = tmp_path / "legacy-storage.pt"
+    path.write_bytes(payload)
+
+    result = PickleScanner().scan(str(path))
+
+    trusted_checks = _trusted_legacy_storage_pid_checks(result)
+    assert result.success is True
+    assert result.metadata["legacy_pytorch_container"] is True
+    assert result.metadata["legacy_pytorch_storage_start"] == pickle_end
+    assert result.metadata["legacy_pytorch_storage_end"] == len(payload)
+    assert result.metadata["legacy_pytorch_trusted_storage_persistent_id_count"] == 1
+    assert not _persistent_id_issues(result)
+    assert len(trusted_checks) == 1
+    assert trusted_checks[0].status == CheckStatus.PASSED
+    assert trusted_checks[0].severity == IssueSeverity.INFO
+    assert trusted_checks[0].rule_code == "S212"
+    assert trusted_checks[0].details["opcode"] == "BINPERSID"
+    assert trusted_checks[0].details["pytorch_storage_key"] == "0"
+
+
+def test_legacy_pytorch_bin_extension_uses_framing_not_suffix_for_storage_trust(tmp_path: Path) -> None:
+    payload, _pickle_end = _make_legacy_pytorch_container(b"A" * 64)
+    path = tmp_path / "pytorch_model.bin"
+    path.write_bytes(payload)
+
+    result = PickleScanner().scan(str(path))
+
+    assert result.success is True
+    assert result.metadata["legacy_pytorch_container"] is True
+    assert not _persistent_id_issues(result)
+    assert len(_trusted_legacy_storage_pid_checks(result)) == 1
+
+
+def test_bin_extension_alone_does_not_trust_pytorch_storage_binpersid(tmp_path: Path) -> None:
+    path = tmp_path / "pytorch_model.bin"
+    path.write_bytes(_legacy_pytorch_object_stream(("0",), 1))
+
+    result = PickleScanner().scan(str(path))
+
+    issues = _persistent_id_issues(result, opcode="BINPERSID")
+    assert result.metadata.get("legacy_pytorch_container") is not True
+    assert not _trusted_legacy_storage_pid_checks(result)
+    assert len(issues) == 1
+    assert issues[0].rule_code == "S212"
+    assert issues[0].details["pytorch_storage_key"] == "0"
+
+
+def test_legacy_pytorch_rejects_custom_persid_without_trusting_storage_pid(tmp_path: Path) -> None:
+    canonical_pid = _legacy_pytorch_storage_pid_tuple("0", 64)
+    object_stream = b"\x80\x02]Pexternal://weights\n" + b"a" + canonical_pid + b"Qa."
+    payload, _pickle_end = _make_legacy_pytorch_container_with_object_stream(b"A" * 64, object_stream)
+    path = tmp_path / "legacy-custom-persid.pt"
+    path.write_bytes(payload)
+
+    result = PickleScanner().scan(str(path))
+
+    _assert_legacy_storage_layout_incomplete(result)
+    issues = _persistent_id_issues(result, opcode="PERSID")
+    assert len(issues) == 1
+    assert issues[0].rule_code == "S212"
+    assert issues[0].details["opcode"] == "PERSID"
+
+
+def test_legacy_pytorch_rejects_extra_binpersid_without_trusting_first_storage_pid(tmp_path: Path) -> None:
+    canonical_pid = _legacy_pytorch_storage_pid_tuple("0", 64)
+    object_stream = b"\x80\x02]" + canonical_pid + b"Qa" + _binunicode(b"external://weights") + b"Qa."
+    payload, _pickle_end = _make_legacy_pytorch_container_with_object_stream(b"A" * 64, object_stream)
+    path = tmp_path / "legacy-extra-binpersid.pt"
+    path.write_bytes(payload)
+
+    result = PickleScanner().scan(str(path))
+
+    _assert_legacy_storage_layout_incomplete(result)
+    issues = _persistent_id_issues(result, opcode="BINPERSID")
+    assert len(issues) == 1
+    assert issues[0].rule_code == "S212"
+    assert issues[0].details["pytorch_storage_key"] == "0"
+    assert any(
+        check.details.get("pickle_notice_code") == "persistent_id_summary"
+        and check.details.get("persistent_id_count") == 2
+        for check in result.checks
+    )
+
+
+@pytest.mark.parametrize(
+    "pid_tuple",
+    [
+        _legacy_pytorch_storage_pid_tuple("0", 64, view_metadata=b""),
+        _legacy_pytorch_storage_pid_tuple("0", 64, element_count=b"\x88"),
+        _legacy_pytorch_storage_pid_tuple("0", 64, extra_fields=_binunicode(b"unexpected")),
+        _legacy_pytorch_storage_pid_tuple("0", 64, storage_type=_binunicode(b"torch.ByteStorage")),
+    ],
+    ids=["five-field", "bool-size", "extra-field", "string-storage-type"],
+)
+def test_legacy_pytorch_rejects_noncanonical_storage_pid_tuple(
+    tmp_path: Path,
+    pid_tuple: bytes,
+) -> None:
+    object_stream = _legacy_pytorch_object_stream_from_pid(pid_tuple)
+    payload, _pickle_end = _make_legacy_pytorch_container_with_object_stream(b"A" * 64, object_stream)
+    path = tmp_path / "legacy-noncanonical-storage.pt"
+    path.write_bytes(payload)
+
+    result = PickleScanner().scan(str(path))
+
+    _assert_legacy_storage_layout_incomplete(result)
+    assert _persistent_id_issues(result, opcode="BINPERSID")
+
+
+def test_legacy_pytorch_rejects_missing_storage_key_record_without_trusting_partial_pid(
+    tmp_path: Path,
+) -> None:
+    object_stream = _legacy_pytorch_object_stream(("0",), 64)
+    payload, _pickle_end = _make_legacy_pytorch_container_with_object_stream(
+        b"A" * 64,
+        object_stream,
+        storage_keys=("0", "1"),
+    )
+    path = tmp_path / "legacy-missing-storage-key.pt"
+    path.write_bytes(payload)
+
+    result = PickleScanner().scan(str(path))
+
+    _assert_legacy_storage_layout_incomplete(result)
+    issues = _persistent_id_issues(result, opcode="BINPERSID")
+    assert len(issues) == 1
+    assert issues[0].details["pytorch_storage_key"] == "0"
+
+
+def test_legacy_pytorch_rejects_unlisted_storage_key_record_without_trusting_pid(tmp_path: Path) -> None:
+    object_stream = _legacy_pytorch_object_stream(("1",), 64)
+    payload, _pickle_end = _make_legacy_pytorch_container_with_object_stream(
+        b"A" * 64,
+        object_stream,
+        storage_keys=("0",),
+    )
+    path = tmp_path / "legacy-unlisted-storage-key.pt"
+    path.write_bytes(payload)
+
+    result = PickleScanner().scan(str(path))
+
+    _assert_legacy_storage_layout_incomplete(result)
+    issues = _persistent_id_issues(result, opcode="BINPERSID")
+    assert len(issues) == 1
+    assert issues[0].details["pytorch_storage_key"] == "1"
+
+
+def test_legacy_pytorch_rejects_truncated_storage_payload_without_trusting_binpersid(
+    tmp_path: Path,
+) -> None:
+    payload, _pickle_end = _make_legacy_pytorch_container(b"A" * 64)
+    path = tmp_path / "legacy-truncated-storage.pt"
+    path.write_bytes(payload[:-1])
+
+    result = PickleScanner().scan(str(path))
+
+    _assert_legacy_storage_layout_incomplete(result)
+    issues = _persistent_id_issues(result, opcode="BINPERSID")
+    assert len(issues) == 1
+    assert issues[0].details["pytorch_storage_key"] == "0"
+
+
 def test_legacy_pytorch_seekable_stream_uses_control_stream_boundary() -> None:
     payload, pickle_end = _make_legacy_pytorch_container(b"A" * 512)
     stream = io.BytesIO(payload)
@@ -2132,6 +2386,8 @@ def test_truncated_legacy_pytorch_control_stream_remains_inconclusive(tmp_path: 
     assert result.metadata.get("legacy_pytorch_container") is not True
     assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
     assert "pickle_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+    assert not _trusted_legacy_storage_pid_checks(result)
+    assert "legacy_pytorch_storage_payload_skipped" not in result.metadata
 
 
 def test_legacy_pytorch_invalid_storage_header_fails_closed(tmp_path: Path) -> None:
@@ -2150,6 +2406,7 @@ def test_legacy_pytorch_invalid_storage_header_fails_closed(tmp_path: Path) -> N
     assert result.metadata["legacy_pytorch_control_streams"] is True
     assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
     assert "legacy_pytorch_storage_layout_incomplete" in result.metadata["scan_outcome_reasons"]
+    assert not _trusted_legacy_storage_pid_checks(result)
     assert any(
         check.name == "Legacy PyTorch Storage Layout"
         and check.status == CheckStatus.FAILED


### PR DESCRIPTION
## Summary

- Downgrade canonical PyTorch storage `BINPERSID` findings to informational only after ModelAudit has validated legacy PyTorch framing, the canonical storage persistent-ID tuple, and the referenced storage payload.
- Keep arbitrary/custom `PERSID` and non-storage `BINPERSID` records fail-closed by marking the legacy storage layout incomplete instead of applying contextual trust.
- Add focused regression coverage for trusted canonical storage IDs and malformed/malicious controls, plus a changelog entry.

## Root cause and security tradeoff

Legacy PyTorch binary files store tensor payload references as pickle persistent IDs. The standalone pickle engine correctly reports `PERSISTENT_ID`/`BINPERSID` as S212 because, outside context, persistent loaders can be attacker-controlled. ModelAudit already validates the broader legacy PyTorch container and storage payload layout, but it did not use that validated context to calibrate the canonical storage `BINPERSID` warning. That left canonical `torch.LongStorage` references in a fully validated legacy PyTorch binary as actionable false positives.

This PR applies trust only in the Python ModelAudit scanner, after all of these hold:

- legacy PyTorch control streams and storage records validate
- the persistent ID is canonical storage `BINPERSID`
- the storage key is present in the validated storage-key list
- the referenced storage payload is present and sized correctly

The standalone `modelaudit-picklescan` package remains conservative. Ambiguous evidence still fails closed.

## Real-model QA

Pinned model:

- `ProsusAI/finbert @ 4556d13015211d73dccd3fdd39d39232506f3e43`
- Verified current `hf://ProsusAI/finbert` SHA: `4556d13015211d73dccd3fdd39d39232506f3e43`

Before the fix on the required baseline, the pinned `pytorch_model.bin` reported actionable S212 for canonical `torch.LongStorage` `BINPERSID` key `94591118788240`.

Final local pinned artifact:

```bash
PROMPTFOO_DISABLE_TELEMETRY=1 uv run modelaudit scan /tmp/modelaudit-t20-pytorch_model.bin --format json --output /tmp/modelaudit-t20-final-local-bin.json --max-size 1GB --timeout 900 --no-whitelist --no-cache
```

Outcome: exit 0, `success=true`, `issues=0`, `failed_checks=0`, `pickle_verdict=clean`, `pickle_report_status=complete`, `legacy_pytorch_storage_key_count=202`, `legacy_pytorch_trusted_storage_persistent_id_count=1`. The S212 `BINPERSID` for key `94591118788240` is present as `passed`/`info` with `trusted_legacy_pytorch_context=true`.

Final pinned HF file:

```bash
PROMPTFOO_DISABLE_TELEMETRY=1 uv run modelaudit scan https://huggingface.co/ProsusAI/finbert/resolve/4556d13015211d73dccd3fdd39d39232506f3e43/pytorch_model.bin --format json --output /tmp/modelaudit-t20-final-hf-file.json --cache-dir /tmp/modelaudit-t20-final-hf-file-cache --max-size 1GB --timeout 900 --no-whitelist
```

Outcome: exit 0, `success=true`, `issues=0`, `failed_checks=0`, `pickle_verdict=clean`, `pickle_report_status=complete`, `legacy_pytorch_storage_key_count=202`, `legacy_pytorch_trusted_storage_persistent_id_count=1`.

Final HF streaming scan:

```bash
PROMPTFOO_DISABLE_TELEMETRY=1 uv run modelaudit scan hf://ProsusAI/finbert --stream --format json --output /tmp/modelaudit-t20-final-hf-stream.json --cache-dir /tmp/modelaudit-t20-final-hf-stream-cache --max-size 2GB --timeout 900 --no-whitelist
```

Outcome: exit 0, `success=true`, `has_errors=false`, `files_scanned=7`, `bytes_scanned=876193055`, `failed_checks=0`; the PyTorch file has `pickle_verdict=clean`, `pickle_report_status=complete`, `legacy_pytorch_storage_key_count=202`, `legacy_pytorch_trusted_storage_persistent_id_count=1`. The remaining 7 issues are informational README S309 URL/domain findings.

## Tests

```bash
PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_pickle_scanner.py -k "legacy_pytorch" --maxfail=1 -q
PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_pickle_scanner.py -q
PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest packages/modelaudit-picklescan/tests/test_api.py -k "persistent_id or pytorch_storage" -q
PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/scanners/test_picklescan_adapter.py tests/scanners/test_pytorch_zip_scanner.py -k "persistent_id or PERSISTENT_ID or storage_persistent" -q
PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_core.py -k "persistent or pytorch or pickle" -q
PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_streaming_scan.py -q
uv run ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
uv run ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
uv run mypy modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/
PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest -n auto --maxschedchunk=1 -m "not slow and not integration" --maxfail=1
git diff --check
```

Broad suite outcome: `18549 passed, 793 skipped, 40 warnings in 635.72s`.

## Malicious and malformed controls

Regression tests cover:

- `.bin` extension alone does not grant trust
- custom `PERSID`
- extra non-storage `BINPERSID`
- noncanonical storage tuple shapes and types
- missing storage-key records
- unlisted storage keys
- truncated storage payloads
- malformed legacy storage headers
- truncated control streams

All ambiguous cases retain warning or inconclusive behavior and do not set `trusted_legacy_pytorch_context`.
