### PR TITLE
test(cache): stabilize ancestor swap regression

### DIFF
--- a/tests/cache/test_cache_correctness.py
+++ b/tests/cache/test_cache_correctness.py
@@ -118,6 +118,38 @@ def _identity_kwargs(cache: ScanResultsCache, file_path: str) -> dict[str, Any]:
     }
 
 
+def _wait_for_ancestor_identity_to_settle(cache: ScanResultsCache, file_path: Path) -> None:
+    previous = cache._capture_ancestor_identity(str(file_path))
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        time.sleep(0.02)
+        current = cache._capture_ancestor_identity(str(file_path))
+        if ScanResultsCache._ancestor_identity_matches(previous, current):
+            return
+        previous = current
+    pytest.fail(f"ancestor identity did not settle for {file_path}")
+
+
+def _scope_cache_ancestor_identity_to_tree(
+    cache: ScanResultsCache,
+    root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_capture = cache._capture_ancestor_identity
+    root_path = Path(os.path.abspath(root))
+
+    def capture_ancestor_identity(file_path: str) -> AncestorIdentity:
+        identity = original_capture(file_path)
+        entries = tuple(
+            entry
+            for entry in identity
+            if (entry_path := Path(entry[0])) == root_path or root_path in entry_path.parents
+        )
+        return AncestorIdentity(entries)
+
+    monkeypatch.setattr(cache, "_capture_ancestor_identity", capture_ancestor_identity)
+
+
 def test_cache_config_hash_preserves_128_bits(tmp_path: Path) -> None:
     """Attacker-influenced scan context must not collapse to a short cache identity."""
     cache = ScanResultsCache(str(tmp_path / "cache"))
@@ -1067,7 +1099,10 @@ def test_batch_prefetch_bypasses_symlink_before_key_generation(
     batch_ops.prefetch_cache_metadata([str(symlink_path)])
 
 
-def test_cache_manager_cached_scan_does_not_cache_ancestor_directory_swap(tmp_path: Path) -> None:
+def test_cache_manager_cached_scan_does_not_cache_ancestor_directory_swap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     trees_root = tmp_path / "trees"
     live_root = trees_root / "live"
     decoy_root = trees_root / "decoy"
@@ -1082,6 +1117,8 @@ def test_cache_manager_cached_scan_does_not_cache_ancestor_directory_swap(tmp_pa
     held_root = trees_root / "held"
 
     cache_manager = get_cache_manager(str(tmp_path / "cache"), enabled=True)
+    assert cache_manager.cache is not None
+    _scope_cache_ancestor_identity_to_tree(cache_manager.cache, trees_root, monkeypatch)
     version_context = build_cache_version_context({"timeout": 30})
     calls = {"count": 0}
     swap_blocked = {"value": False}
@@ -1113,6 +1150,7 @@ def test_cache_manager_cached_scan_does_not_cache_ancestor_directory_swap(tmp_pa
     else:
         assert swap_blocked["value"] is False
         assert cache_manager.get_stats()["total_entries"] == 0
+    _wait_for_ancestor_identity_to_settle(cache_manager.cache, malicious_path)
     second = cache_manager.cached_scan(str(malicious_path), scan, version_context=version_context)
 
     assert first["payload_prefix"] == ("evil!:" if os.name == "nt" else "clean:")
@@ -1139,6 +1177,8 @@ def test_unmonitored_platform_does_not_cache_higher_ancestor_swap(
     held_root = trees_root / "held"
 
     cache_manager = get_cache_manager(str(tmp_path / "cache"), enabled=True)
+    assert cache_manager.cache is not None
+    _scope_cache_ancestor_identity_to_tree(cache_manager.cache, trees_root, monkeypatch)
     version_context = build_cache_version_context({"timeout": 30})
     calls = {"count": 0}
     monkeypatch.setattr(sys, "platform", "darwin")
@@ -1155,9 +1195,11 @@ def test_unmonitored_platform_does_not_cache_higher_ancestor_swap(
         return {"payload_prefix": Path(path).read_bytes()[:6].decode("utf-8")}
 
     first = cache_manager.cached_scan(str(malicious_path), scan, version_context=version_context)
+    assert first["payload_prefix"] == "clean:"
+    assert cache_manager.get_stats()["total_entries"] == 0
+    _wait_for_ancestor_identity_to_settle(cache_manager.cache, malicious_path)
     second = cache_manager.cached_scan(str(malicious_path), scan, version_context=version_context)
 
-    assert first["payload_prefix"] == "clean:"
     assert second["payload_prefix"] == "evil!:"
     assert calls["count"] == 2
     assert cache_manager.get_stats()["total_entries"] == 1


### PR DESCRIPTION
## Summary
- Stabilizes the cache ancestor-swap regression tests by scoping ancestor identity to the test-owned tree before the forced swap.
- Waits for that test-owned ancestor identity to settle before asserting the second stable scan stores one entry.
- Leaves production cache identity checks unchanged.

## Root Cause
Windows run https://github.com/promptfoo/modelaudit/actions/runs/27453832607 failed `tests/cache/test_cache_correctness.py::test_unmonitored_platform_does_not_cache_higher_ancestor_swap` because the test expected the second rescan to cache after a fail-safe first store rejection, but the test captured ancestor identity through shared runner temp ancestors. Under Windows plus xdist, unrelated temp-root churn can keep invalidating the second store, so `total_entries` stays `0`.

This is separate from Linux Python 3.11. The exact Linux log shows only the two `tests/test_false_positive_fixes.py` exit-code assertions. Open PR #1673 (`fix/legacy-pytorch-storage-tail`) already owns that PyTorch false-positive scope, so this PR does not duplicate it.

## Validation
- Exact-head PR CI at `8859d1ab025b3a1718eb5759dc98a2172cbf19c6`: all checks are `SUCCESS` or `SKIPPED`, including Windows Tests (Python 3.11), Quick Feedback (Python 3.12), Test Python 3.10, Test Python 3.13, Lint and Format, Type Check, and CI Success.
- `PYTHONPATH=/Users/mdangelo/.codex/worktrees/66c1/modelaudit:/Users/mdangelo/.codex/worktrees/66c1/modelaudit/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/.virtualenvs/openai/bin/python -m pytest tests/cache/test_cache_correctness.py::test_cache_manager_cached_scan_does_not_cache_ancestor_directory_swap tests/cache/test_cache_correctness.py::test_unmonitored_platform_does_not_cache_higher_ancestor_swap tests/cache/test_cache_correctness.py::test_store_result_rejects_changed_ancestor_identity_when_file_identity_matches -q -vv`
- `PYTHONPATH=/Users/mdangelo/.codex/worktrees/66c1/modelaudit:/Users/mdangelo/.codex/worktrees/66c1/modelaudit/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/.virtualenvs/openai/bin/python -m pytest tests/cache/test_cache_correctness.py::test_cache_manager_cached_scan_does_not_cache_ancestor_directory_swap tests/cache/test_cache_correctness.py::test_unmonitored_platform_does_not_cache_higher_ancestor_swap -n auto -q -vv`
- `UV_CACHE_DIR=/private/tmp/modelaudit-uv-cache uv run --no-sync ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/private/tmp/modelaudit-uv-cache uv run --no-sync ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `UV_CACHE_DIR=/private/tmp/modelaudit-uv-cache uv run --no-sync mypy tests/cache/test_cache_correctness.py`

## Residual Risk
- Windows Server 2025 / Python 3.11 is not locally reproducible from macOS; exact-head PR CI passed that lane and is the authoritative proof.
- Local `uv sync --extra all-ci` is blocked by unsupported macOS TensorRT packages, so local ruff/mypy used `--no-sync` and focused pytest used explicit `PYTHONPATH`.
- Full-tree mypy under the local ad hoc toolchain reports existing `os.*xattr` stub errors while PR CI Type Check is green; not branch-owned.
