### PR TITLE
fix(picklescan): validate canonical PyTorch ZIP tensor rebuilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- avoid CLI crashes when redirected stdout or stderr use legacy encodings that cannot represent styled separator glyphs
 - suppress canonical PyTorch tensor rebuild warnings only inside validated unloaded-runtime ZIP storage context when paired with the coordinated `modelaudit-picklescan` fix, while older allowed picklescan versions continue to fail closed with the warning
 - keep nested archive and PyTorch ZIP member hashes separate from parent artifact integrity hashes across JSON, cache, SARIF, SBOM, and streaming scans
 - suppress installed source-trusted inert Hugging Face training metadata and safe NumPy RNG-state reconstruction noise while keeping default-install, unresolved, rebound, or shadowed PyTorch ZIP framework metadata suspicious unless trusted source can be inspected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- suppress canonical PyTorch tensor rebuild warnings only inside validated unloaded-runtime ZIP storage context when paired with the coordinated `modelaudit-picklescan` fix, while older allowed picklescan versions continue to fail closed with the warning
 - keep nested archive and PyTorch ZIP member hashes separate from parent artifact integrity hashes across JSON, cache, SARIF, SBOM, and streaming scans
 - suppress installed source-trusted inert Hugging Face training metadata and safe NumPy RNG-state reconstruction noise while keeping default-install, unresolved, rebound, or shadowed PyTorch ZIP framework metadata suspicious unless trusted source can be inspected
 - contextualize SafeTensors license metadata so ordinary embedded license text does not produce URL or long-value noise while preserving malformed and executable metadata detections

--- a/modelaudit/cli.py
+++ b/modelaudit/cli.py
@@ -2123,6 +2123,18 @@ def style_text(text: str, **kwargs: Any) -> str:
     return text
 
 
+def _configure_unicode_safe_cli_streams() -> None:
+    """Keep decorative CLI text from crashing legacy redirected encodings."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(errors="backslashreplace")
+        except (OSError, TypeError, ValueError):
+            continue
+
+
 def _escape_terminal_text(value: Any) -> str:
     """Render control characters visibly before writing model-controlled text to terminals."""
     text = "" if value is None else str(value)
@@ -6223,6 +6235,7 @@ def debug(output_json: bool, verbose: bool) -> None:
 
 
 def main() -> None:
+    _configure_unicode_safe_cli_streams()
     if sys.version_info < (3, 10):  # noqa: UP036 — intentional safety net for bypassed requires-python
         click.echo(
             click.style(

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import binascii
 import hashlib
+import inspect
 import io
 import pickletools
 import re
@@ -2494,8 +2495,30 @@ class PickleScanner(BaseScanner):
 
         return None
 
-    def _scan_standalone_stream(self, file_obj: BinaryIO, file_size: int | None, *, source: str) -> ScanResult:
-        report = self._standalone_pickle_scanner.scan_stream(file_obj, source=source, size=file_size)
+    def _standalone_scan_stream_supports_pytorch_zip_context(self) -> bool:
+        try:
+            parameters = inspect.signature(self._standalone_pickle_scanner.scan_stream).parameters
+        except (TypeError, ValueError):
+            return False
+        return "_pytorch_zip_storage_member_sizes" in parameters
+
+    def _scan_standalone_stream(
+        self,
+        file_obj: BinaryIO,
+        file_size: int | None,
+        *,
+        source: str,
+        pytorch_zip_storage_member_sizes: Mapping[str, int] | None = None,
+    ) -> ScanResult:
+        if pytorch_zip_storage_member_sizes is not None and self._standalone_scan_stream_supports_pytorch_zip_context():
+            report = self._standalone_pickle_scanner.scan_stream(
+                file_obj,
+                source=source,
+                size=file_size,
+                _pytorch_zip_storage_member_sizes=pytorch_zip_storage_member_sizes,
+            )
+        else:
+            report = self._standalone_pickle_scanner.scan_stream(file_obj, source=source, size=file_size)
         result = pickle_report_to_scan_result(report, scanner_name=self.name, scanner=self)
         result.metadata["pickle_primary_engine"] = "rust"
         return result
@@ -4688,7 +4711,14 @@ class PickleScanner(BaseScanner):
         metadata.update(opcode_summary)
         return metadata
 
-    def scan_stream(self, file_obj: BinaryIO, file_size: int | None, source: str = "<stream>") -> ScanResult:
+    def scan_stream(
+        self,
+        file_obj: BinaryIO,
+        file_size: int | None,
+        source: str = "<stream>",
+        *,
+        _pytorch_zip_storage_member_sizes: Mapping[str, int] | None = None,
+    ) -> ScanResult:
         """Scan pickle bytes from an already-open stream."""
         self._prepare_scan_context(source)
         size_check = self._check_scan_stream_size_limit(file_size, source)
@@ -4714,7 +4744,12 @@ class PickleScanner(BaseScanner):
 
             control_probe_size = self._legacy_pytorch_control_probe_size(standalone_size)
             if deferred_size_check is None:
-                result = self._scan_standalone_stream(file_obj, standalone_size, source=source)
+                result = self._scan_standalone_stream(
+                    file_obj,
+                    standalone_size,
+                    source=source,
+                    pytorch_zip_storage_member_sizes=_pytorch_zip_storage_member_sizes,
+                )
                 if result.metadata.get("operational_error"):
                     return result
                 try:
@@ -4961,7 +4996,12 @@ class PickleScanner(BaseScanner):
                     allow_binary_tail_scan = False
             else:
                 rust_stream_size = len(payload) if stream_read.truncated else standalone_size
-                result = self._scan_standalone_stream(io.BytesIO(payload), rust_stream_size, source=source)
+                result = self._scan_standalone_stream(
+                    io.BytesIO(payload),
+                    rust_stream_size,
+                    source=source,
+                    pytorch_zip_storage_member_sizes=_pytorch_zip_storage_member_sizes,
+                )
                 self._annotate_legacy_pytorch_storage_persistent_id_details_from_payload(result, payload)
                 if _matches_legacy_pytorch_preamble(payload):
                     if deferred_size_check is not None and not (stream_read.truncated or stream_read.short_read):

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -122,6 +122,7 @@ class _PytorchStorageReferenceParse:
 class _ValidatedPytorchStorageDataPklMembers:
     storage_keys_by_data_pkl: dict[str, set[str]]
     persistent_id_downgrade_keys_by_data_pkl: dict[str, set[str]]
+    storage_member_sizes_by_data_pkl: dict[str, dict[str, int]]
 
 
 _TORCHSCRIPT_FORBIDDEN_AST_NAMES: frozenset[str] = frozenset(
@@ -531,6 +532,9 @@ class PyTorchZipScanner(BaseScanner):
                     path,
                     trusted_pytorch_storage_persistent_id_data_pkl_members=(
                         validated_storage_data_pkl_members.persistent_id_downgrade_keys_by_data_pkl
+                    ),
+                    pytorch_data_pickle_storage_sizes_by_data_pkl=(
+                        validated_storage_data_pkl_members.storage_member_sizes_by_data_pkl
                     ),
                 )
                 self._scan_nested_zip_members(zip_file, safe_entries, result, path)
@@ -2041,6 +2045,7 @@ class PyTorchZipScanner(BaseScanner):
         path: str,
         *,
         trusted_pytorch_storage_persistent_id_data_pkl_members: dict[str, set[str]],
+        pytorch_data_pickle_storage_sizes_by_data_pkl: dict[str, dict[str, int]],
     ) -> int:
         """Scan all discovered pickle files for malicious content"""
         bytes_scanned = 0
@@ -2060,6 +2065,7 @@ class PyTorchZipScanner(BaseScanner):
             name = self._get_zip_member_name(info)
             pickle_data_size = info.file_size
             pickle_source = f"{path}:{name}"
+            pytorch_data_pickle_storage_sizes = pytorch_data_pickle_storage_sizes_by_data_pkl.get(name)
 
             if self.pickle_scanner is None:
                 bytes_scanned += pickle_data_size
@@ -2106,6 +2112,7 @@ class PyTorchZipScanner(BaseScanner):
                         file_like,
                         len(data),
                         source=pickle_source,
+                        _pytorch_zip_storage_member_sizes=pytorch_data_pickle_storage_sizes,
                     )
             else:
                 # Stream to a spooled temp file to avoid OOM and provide seek()
@@ -2124,6 +2131,7 @@ class PyTorchZipScanner(BaseScanner):
                         spool,  # type: ignore[arg-type]
                         member_size,
                         source=pickle_source,
+                        _pytorch_zip_storage_member_sizes=pytorch_data_pickle_storage_sizes,
                     )
             sub_result.metadata.setdefault("archive_file_size", original_file_size)
             apply_pickle_member_context(sub_result, archive_path=path, member_name=name)
@@ -2312,6 +2320,7 @@ class PyTorchZipScanner(BaseScanner):
 
         trusted_members: dict[str, set[str]] = {}
         persistent_id_downgrade_members: dict[str, set[str]] = {}
+        storage_member_sizes_by_data_pkl: dict[str, dict[str, int]] = {}
         storage_reference_bytes_read = 0
         storage_reference_opcodes_remaining = [_PYTORCH_STORAGE_TRUST_MAX_OPCODES]
         for data_pkl_member, data_pkl_entries in entries_by_name.items():
@@ -2424,10 +2433,14 @@ class PyTorchZipScanner(BaseScanner):
                 and reference_parse.all_persistent_ids_are_pytorch_storage
             ):
                 persistent_id_downgrade_members[data_pkl_member] = trusted_storage_keys
+                storage_member_sizes_by_data_pkl[data_pkl_member] = {
+                    storage_key: storage_entries_by_key[storage_key].file_size for storage_key in trusted_storage_keys
+                }
 
         return _ValidatedPytorchStorageDataPklMembers(
             storage_keys_by_data_pkl=trusted_members,
             persistent_id_downgrade_keys_by_data_pkl=persistent_id_downgrade_members,
+            storage_member_sizes_by_data_pkl=storage_member_sizes_by_data_pkl,
         )
 
     def _record_storage_reference_validation_incomplete(

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -112,8 +112,18 @@ class _PickleGlobalRef:
 
 
 @dataclass(frozen=True)
+class _PytorchStorageRef:
+    module: str
+    name: str
+    location: str
+    element_count: int
+    item_size: int | None
+
+
+@dataclass(frozen=True)
 class _PytorchStorageReferenceParse:
     referenced_keys: set[str]
+    storage_refs_by_key: dict[str, _PytorchStorageRef]
     parse_complete: bool
     all_persistent_ids_are_pytorch_storage: bool
 
@@ -121,6 +131,7 @@ class _PytorchStorageReferenceParse:
 @dataclass(frozen=True)
 class _ValidatedPytorchStorageDataPklMembers:
     storage_keys_by_data_pkl: dict[str, set[str]]
+    storage_probe_keys_by_data_pkl: dict[str, set[str]]
     persistent_id_downgrade_keys_by_data_pkl: dict[str, set[str]]
     storage_member_sizes_by_data_pkl: dict[str, dict[str, int]]
 
@@ -227,6 +238,23 @@ _PYTORCH_STORAGE_GLOBAL_NAMES = frozenset(
 _PYTORCH_STORAGE_GLOBALS = frozenset(
     (module, name) for module in ("torch", "torch.storage") for name in _PYTORCH_STORAGE_GLOBAL_NAMES
 )
+_PYTORCH_STORAGE_ITEM_SIZES = {
+    "BFloat16Storage": 2,
+    "BoolStorage": 1,
+    "ByteStorage": 1,
+    "CharStorage": 1,
+    "ComplexDoubleStorage": 16,
+    "ComplexFloatStorage": 8,
+    "DoubleStorage": 8,
+    "FloatStorage": 4,
+    "HalfStorage": 2,
+    "IntStorage": 4,
+    "LongStorage": 8,
+    "QInt32Storage": 4,
+    "QInt8Storage": 1,
+    "QUInt8Storage": 1,
+    "ShortStorage": 2,
+}
 _PYTORCH_STORAGE_REDACTED_BINPERSID_PREVIEW = re.compile(
     r"^tuple\(str_span\(len=7\), global:(?P<module>[A-Za-z_][A-Za-z0-9_.]*)\.(?P<name>[A-Za-z_][A-Za-z0-9_]*)"
     r", str_span\(len=(?P<key_len>[0-9]+)\), str_span\(len=(?P<device_len>[0-9]+)\), int:(?P<size>[0-9]+)\)$"
@@ -516,9 +544,7 @@ class PyTorchZipScanner(BaseScanner):
                     zip_file,
                     safe_entries,
                     result,
-                    trusted_pytorch_storage_data_pkl_members=(
-                        validated_storage_data_pkl_members.storage_keys_by_data_pkl
-                    ),
+                    validated_pytorch_storage_data_pkl_members=validated_storage_data_pkl_members,
                 )
 
                 # Extract version info and check for CVE vulnerabilities
@@ -1397,7 +1423,7 @@ class PyTorchZipScanner(BaseScanner):
         safe_entries: list[zipfile.ZipInfo],
         result: ScanResult,
         *,
-        trusted_pytorch_storage_data_pkl_members: dict[str, set[str]] | None = None,
+        validated_pytorch_storage_data_pkl_members: _ValidatedPytorchStorageDataPklMembers | None = None,
     ) -> list[zipfile.ZipInfo]:
         """Discover pickle files in the ZIP archive"""
         pickle_files: list[zipfile.ZipInfo] = []
@@ -1422,16 +1448,15 @@ class PyTorchZipScanner(BaseScanner):
             if name.endswith(".pkl") or name == "data.pkl" or name.endswith("/data.pkl"):
                 add_pickle_entry(entry)
 
-        if trusted_pytorch_storage_data_pkl_members is None:
-            trusted_pytorch_storage_data_pkl_members = (
-                self._validated_pytorch_storage_data_pkl_members_from_data_pickle(
-                    zip_file,
-                    safe_entries,
-                    result,
-                ).storage_keys_by_data_pkl
+        if validated_pytorch_storage_data_pkl_members is None:
+            validated_pytorch_storage_data_pkl_members = (
+                self._validated_pytorch_storage_data_pkl_members_from_data_pickle(zip_file, safe_entries, result)
             )
         trusted_storage_blob_members = self._storage_blob_members_from_data_pkl_members(
-            trusted_pytorch_storage_data_pkl_members
+            validated_pytorch_storage_data_pkl_members.storage_keys_by_data_pkl
+        )
+        storage_probe_blob_members = self._storage_blob_members_from_data_pkl_members(
+            validated_pytorch_storage_data_pkl_members.storage_probe_keys_by_data_pkl
         )
 
         # Second pass: always sniff unselected members. A benign data.pkl must not
@@ -1447,6 +1472,13 @@ class PyTorchZipScanner(BaseScanner):
             try:
                 if name in trusted_storage_blob_members:
                     looks_like_pickle = self._trusted_storage_entry_looks_like_pickle(zip_file, entry, result)
+                elif name in storage_probe_blob_members:
+                    looks_like_pickle = self._trusted_storage_entry_looks_like_pickle(
+                        zip_file,
+                        entry,
+                        result,
+                        max_probe_bytes=_PICKLE_DISCOVERY_LONG_PROBE_BYTES,
+                    )
                 else:
                     looks_like_pickle = self._entry_looks_like_pickle(zip_file, entry, result)
                 if looks_like_pickle:
@@ -1836,6 +1868,8 @@ class PyTorchZipScanner(BaseScanner):
         zip_file: zipfile.ZipFile,
         entry: zipfile.ZipInfo,
         result: ScanResult,
+        *,
+        max_probe_bytes: int = _TRUSTED_STORAGE_PICKLE_PROBE_BYTES,
     ) -> bool:
         """Return True only for parse-confirmed pickle payloads in referenced tensor storage."""
         data_start = self._read_member_prefix(
@@ -1861,7 +1895,7 @@ class PyTorchZipScanner(BaseScanner):
             sample = self._read_member_prefix(
                 zip_file,
                 entry,
-                _TRUSTED_STORAGE_PICKLE_PROBE_BYTES,
+                max_probe_bytes,
                 phase="pickle_discovery",
                 result=result,
             )
@@ -2319,6 +2353,7 @@ class PyTorchZipScanner(BaseScanner):
             entries_by_name.setdefault(name, []).append(entry)
 
         trusted_members: dict[str, set[str]] = {}
+        storage_probe_members: dict[str, set[str]] = {}
         persistent_id_downgrade_members: dict[str, set[str]] = {}
         storage_member_sizes_by_data_pkl: dict[str, dict[str, int]] = {}
         storage_reference_bytes_read = 0
@@ -2425,23 +2460,45 @@ class PyTorchZipScanner(BaseScanner):
                 )
 
             trusted_storage_keys = referenced_keys & existing_storage_keys
-            if trusted_storage_keys:
-                trusted_members[data_pkl_member] = trusted_storage_keys
-            if (
-                trusted_storage_keys
-                and not missing_storage_keys
-                and reference_parse.all_persistent_ids_are_pytorch_storage
-            ):
-                persistent_id_downgrade_members[data_pkl_member] = trusted_storage_keys
+            storage_size_mismatch_keys = {
+                key
+                for key in trusted_storage_keys
+                if self._pytorch_storage_size_mismatches(
+                    storage_entries_by_key[key].file_size,
+                    reference_parse.storage_refs_by_key.get(key),
+                )
+            }
+            validated_storage_keys = trusted_storage_keys - storage_size_mismatch_keys
+            exact_trusted_storage_keys = (
+                validated_storage_keys if reference_parse.all_persistent_ids_are_pytorch_storage else set()
+            )
+            storage_probe_keys = trusted_storage_keys - exact_trusted_storage_keys
+            if exact_trusted_storage_keys:
+                trusted_members[data_pkl_member] = exact_trusted_storage_keys
+            if storage_probe_keys:
+                storage_probe_members[data_pkl_member] = storage_probe_keys
+            if exact_trusted_storage_keys and not missing_storage_keys:
+                persistent_id_downgrade_members[data_pkl_member] = exact_trusted_storage_keys
                 storage_member_sizes_by_data_pkl[data_pkl_member] = {
-                    storage_key: storage_entries_by_key[storage_key].file_size for storage_key in trusted_storage_keys
+                    storage_key: storage_entries_by_key[storage_key].file_size
+                    for storage_key in exact_trusted_storage_keys
                 }
 
         return _ValidatedPytorchStorageDataPklMembers(
             storage_keys_by_data_pkl=trusted_members,
+            storage_probe_keys_by_data_pkl=storage_probe_members,
             persistent_id_downgrade_keys_by_data_pkl=persistent_id_downgrade_members,
             storage_member_sizes_by_data_pkl=storage_member_sizes_by_data_pkl,
         )
+
+    @staticmethod
+    def _pytorch_storage_size_mismatches(
+        storage_size_bytes: int,
+        storage_ref: _PytorchStorageRef | None,
+    ) -> bool:
+        if storage_ref is None or storage_ref.item_size is None:
+            return True
+        return storage_size_bytes != storage_ref.element_count * storage_ref.item_size
 
     def _record_storage_reference_validation_incomplete(
         self,
@@ -2514,11 +2571,11 @@ class PyTorchZipScanner(BaseScanner):
         return None if "\\" in value else value
 
     @classmethod
-    def _storage_key_from_protocol0_persid_text(
+    def _storage_ref_from_protocol0_persid_text(
         cls,
         pid_text: Any,
         trusted_storage_keys: set[str] | None = None,
-    ) -> str | None:
+    ) -> tuple[str, _PytorchStorageRef] | None:
         text = cls._coerce_pickle_string_arg(pid_text)
         if text is None:
             return None
@@ -2543,7 +2600,25 @@ class PyTorchZipScanner(BaseScanner):
         storage_size = fields[4]
         if not storage_size.isascii() or not storage_size.isdecimal():
             return None
-        return storage_key
+        return (
+            storage_key,
+            _PytorchStorageRef(
+                module=module,
+                name=name,
+                location=cls._quoted_protocol0_field_value(fields[3]) or "",
+                element_count=int(storage_size),
+                item_size=_PYTORCH_STORAGE_ITEM_SIZES.get(name),
+            ),
+        )
+
+    @classmethod
+    def _storage_key_from_protocol0_persid_text(
+        cls,
+        pid_text: Any,
+        trusted_storage_keys: set[str] | None = None,
+    ) -> str | None:
+        storage_ref = cls._storage_ref_from_protocol0_persid_text(pid_text, trusted_storage_keys)
+        return storage_ref[0] if storage_ref is not None else None
 
     @staticmethod
     def _is_canonical_pytorch_zip_member_name(name: str) -> bool:
@@ -2564,6 +2639,7 @@ class PyTorchZipScanner(BaseScanner):
         memo: dict[int, Any] = {}
         stack: list[Any] = []
         referenced_keys: set[str] = set()
+        storage_refs_by_key: dict[str, _PytorchStorageRef] = {}
         all_persistent_ids_are_pytorch_storage = True
 
         def pop_marked_tuple() -> tuple[Any, ...] | None:
@@ -2590,7 +2666,7 @@ class PyTorchZipScanner(BaseScanner):
             except (TypeError, ValueError):
                 return None
 
-        def storage_key_from_pid(pid: Any) -> str | None:
+        def storage_ref_from_pid(pid: Any) -> tuple[str, _PytorchStorageRef] | None:
             if not isinstance(pid, tuple) or len(pid) != 5:
                 return None
             if pid[0] != "storage":
@@ -2611,16 +2687,25 @@ class PyTorchZipScanner(BaseScanner):
             storage_size = pid[4]
             if not isinstance(storage_size, int) or isinstance(storage_size, bool) or storage_size < 0:
                 return None
-            return storage_key
+            return (
+                storage_key,
+                _PytorchStorageRef(
+                    module=storage_type.module,
+                    name=storage_type.name,
+                    location=cls._coerce_pickle_string_arg(pid[3]) or "",
+                    element_count=storage_size,
+                    item_size=_PYTORCH_STORAGE_ITEM_SIZES.get(storage_type.name),
+                ),
+            )
 
         try:
             for opcode_count, (opcode, arg, _pos) in enumerate(pickletools.genops(pickle_data), start=1):
                 if opcode_budget_remaining is not None:
                     if opcode_budget_remaining[0] <= 0:
-                        return _PytorchStorageReferenceParse(set(), False, False)
+                        return _PytorchStorageReferenceParse(set(), {}, False, False)
                     opcode_budget_remaining[0] -= 1
                 if opcode_count > _PYTORCH_STORAGE_TRUST_MAX_OPCODES:
-                    return _PytorchStorageReferenceParse(set(), False, False)
+                    return _PytorchStorageReferenceParse(set(), {}, False, False)
                 opcode_name = opcode.name
                 if opcode_name in {"PROTO", "FRAME", "STOP"}:
                     continue
@@ -2694,27 +2779,38 @@ class PyTorchZipScanner(BaseScanner):
                         stack.append(stack[-1])
                 elif opcode_name == "BINPERSID":
                     pid = stack.pop() if stack else None
-                    storage_key = storage_key_from_pid(pid)
-                    if storage_key is not None:
+                    storage_ref = storage_ref_from_pid(pid)
+                    if storage_ref is not None:
+                        storage_key, ref = storage_ref
                         referenced_keys.add(storage_key)
+                        existing_ref = storage_refs_by_key.get(storage_key)
+                        if existing_ref is not None and existing_ref != ref:
+                            all_persistent_ids_are_pytorch_storage = False
+                        storage_refs_by_key[storage_key] = ref
                     else:
                         all_persistent_ids_are_pytorch_storage = False
                     stack.append(None)
                 elif opcode_name == "PERSID":
-                    storage_key = cls._storage_key_from_protocol0_persid_text(arg, trusted_storage_keys)
-                    if storage_key is not None:
+                    storage_ref = cls._storage_ref_from_protocol0_persid_text(arg, trusted_storage_keys)
+                    if storage_ref is not None:
+                        storage_key, ref = storage_ref
                         referenced_keys.add(storage_key)
+                        existing_ref = storage_refs_by_key.get(storage_key)
+                        if existing_ref is not None and existing_ref != ref:
+                            all_persistent_ids_are_pytorch_storage = False
+                        storage_refs_by_key[storage_key] = ref
                     else:
                         all_persistent_ids_are_pytorch_storage = False
                     stack.append(None)
                 else:
                     stack.clear()
                 if not within_limits():
-                    return _PytorchStorageReferenceParse(set(), False, False)
+                    return _PytorchStorageReferenceParse(set(), {}, False, False)
         except Exception:
-            return _PytorchStorageReferenceParse(set(), False, False)
+            return _PytorchStorageReferenceParse(set(), {}, False, False)
         return _PytorchStorageReferenceParse(
             referenced_keys=referenced_keys,
+            storage_refs_by_key=storage_refs_by_key,
             parse_complete=True,
             all_persistent_ids_are_pytorch_storage=all_persistent_ids_are_pytorch_storage,
         )

--- a/modelaudit/scanners/pytorch_zip_scanner.py
+++ b/modelaudit/scanners/pytorch_zip_scanner.py
@@ -208,6 +208,8 @@ _PYTORCH_STORAGE_TRUST_MAX_STACK_DEPTH = 1024
 _PYTORCH_STORAGE_TRUST_MAX_MEMO_ENTRIES = 100_000
 _PYTORCH_STORAGE_TRUST_MAX_TUPLE_WIDTH = 64
 _PYTORCH_STORAGE_TRUST_MAX_REFERENCED_KEYS = 10_000
+_PYTORCH_STORAGE_TRUST_MAX_TENSOR_INDEX = 2**63 - 1
+_PYTORCH_STORAGE_TRUST_MAX_TENSOR_INDEX_TEXT = str(_PYTORCH_STORAGE_TRUST_MAX_TENSOR_INDEX)
 _JIT_SCAN_MEMBER_MAX_BYTES = 32 * 1024 * 1024
 _PYTORCH_ZIP_INTEGRITY_PREFIX_BYTES = 8 * 1024 * 1024
 _PYTORCH_ZIP_HASH_CHUNK_BYTES = 1024 * 1024
@@ -254,6 +256,7 @@ _PYTORCH_STORAGE_ITEM_SIZES = {
     "QInt8Storage": 1,
     "QUInt8Storage": 1,
     "ShortStorage": 2,
+    "UntypedStorage": 1,
 }
 _PYTORCH_STORAGE_REDACTED_BINPERSID_PREVIEW = re.compile(
     r"^tuple\(str_span\(len=7\), global:(?P<module>[A-Za-z_][A-Za-z0-9_.]*)\.(?P<name>[A-Za-z_][A-Za-z0-9_]*)"
@@ -2570,6 +2573,20 @@ class PyTorchZipScanner(BaseScanner):
         value = field[1:-1]
         return None if "\\" in value else value
 
+    @staticmethod
+    def _parse_pytorch_storage_element_count_text(storage_size: str) -> int | None:
+        if not storage_size.isascii() or not storage_size.isdecimal():
+            return None
+        normalized = storage_size.lstrip("0") or "0"
+        if len(normalized) > len(_PYTORCH_STORAGE_TRUST_MAX_TENSOR_INDEX_TEXT):
+            return None
+        if (
+            len(normalized) == len(_PYTORCH_STORAGE_TRUST_MAX_TENSOR_INDEX_TEXT)
+            and normalized > _PYTORCH_STORAGE_TRUST_MAX_TENSOR_INDEX_TEXT
+        ):
+            return None
+        return int(normalized)
+
     @classmethod
     def _storage_ref_from_protocol0_persid_text(
         cls,
@@ -2597,8 +2614,8 @@ class PyTorchZipScanner(BaseScanner):
             return None
         if cls._quoted_protocol0_field_value(fields[3]) is None:
             return None
-        storage_size = fields[4]
-        if not storage_size.isascii() or not storage_size.isdecimal():
+        element_count = cls._parse_pytorch_storage_element_count_text(fields[4])
+        if element_count is None:
             return None
         return (
             storage_key,
@@ -2606,10 +2623,39 @@ class PyTorchZipScanner(BaseScanner):
                 module=module,
                 name=name,
                 location=cls._quoted_protocol0_field_value(fields[3]) or "",
-                element_count=int(storage_size),
+                element_count=element_count,
                 item_size=_PYTORCH_STORAGE_ITEM_SIZES.get(name),
             ),
         )
+
+    @classmethod
+    def _structural_storage_key_from_protocol0_persid_text(
+        cls,
+        pid_text: Any,
+        trusted_storage_keys: set[str] | None = None,
+    ) -> str | None:
+        text = cls._coerce_pickle_string_arg(pid_text)
+        if text is None:
+            return None
+        fields = cls._split_protocol0_persid_fields(text)
+        if fields is None or len(fields) < 4:
+            return None
+        if cls._quoted_protocol0_field_value(fields[0]) != "storage":
+            return None
+        storage_type_field = fields[1]
+        if not storage_type_field.startswith("<class '") or not storage_type_field.endswith("'>"):
+            return None
+        module, separator, name = storage_type_field[len("<class '") : -len("'>")].rpartition(".")
+        if not separator or (module, name) not in _PYTORCH_STORAGE_GLOBALS:
+            return None
+        storage_key = cls._quoted_protocol0_field_value(fields[2])
+        if storage_key is None or not cls._is_ascii_decimal_digits(storage_key):
+            return None
+        if trusted_storage_keys is not None and storage_key not in trusted_storage_keys:
+            return None
+        if cls._quoted_protocol0_field_value(fields[3]) is None:
+            return None
+        return storage_key
 
     @classmethod
     def _storage_key_from_protocol0_persid_text(
@@ -2685,7 +2731,12 @@ class PyTorchZipScanner(BaseScanner):
             if cls._coerce_pickle_string_arg(pid[3]) is None:
                 return None
             storage_size = pid[4]
-            if not isinstance(storage_size, int) or isinstance(storage_size, bool) or storage_size < 0:
+            if (
+                not isinstance(storage_size, int)
+                or isinstance(storage_size, bool)
+                or storage_size < 0
+                or storage_size > _PYTORCH_STORAGE_TRUST_MAX_TENSOR_INDEX
+            ):
                 return None
             return (
                 storage_key,
@@ -2697,6 +2748,24 @@ class PyTorchZipScanner(BaseScanner):
                     item_size=_PYTORCH_STORAGE_ITEM_SIZES.get(storage_type.name),
                 ),
             )
+
+        def structural_storage_key_from_pid(pid: Any) -> str | None:
+            if not isinstance(pid, tuple) or len(pid) < 4:
+                return None
+            if pid[0] != "storage":
+                return None
+            storage_type = pid[1]
+            if not (
+                isinstance(storage_type, _PickleGlobalRef)
+                and (storage_type.module, storage_type.name) in _PYTORCH_STORAGE_GLOBALS
+            ):
+                return None
+            storage_key = cls._coerce_pickle_string_arg(pid[2])
+            if storage_key is None or not cls._is_ascii_decimal_digits(storage_key):
+                return None
+            if trusted_storage_keys is not None and storage_key not in trusted_storage_keys:
+                return None
+            return storage_key if cls._coerce_pickle_string_arg(pid[3]) is not None else None
 
         try:
             for opcode_count, (opcode, arg, _pos) in enumerate(pickletools.genops(pickle_data), start=1):
@@ -2788,6 +2857,9 @@ class PyTorchZipScanner(BaseScanner):
                             all_persistent_ids_are_pytorch_storage = False
                         storage_refs_by_key[storage_key] = ref
                     else:
+                        structural_key = structural_storage_key_from_pid(pid)
+                        if structural_key is not None:
+                            referenced_keys.add(structural_key)
                         all_persistent_ids_are_pytorch_storage = False
                     stack.append(None)
                 elif opcode_name == "PERSID":
@@ -2800,6 +2872,12 @@ class PyTorchZipScanner(BaseScanner):
                             all_persistent_ids_are_pytorch_storage = False
                         storage_refs_by_key[storage_key] = ref
                     else:
+                        structural_key = cls._structural_storage_key_from_protocol0_persid_text(
+                            arg,
+                            trusted_storage_keys,
+                        )
+                        if structural_key is not None:
+                            referenced_keys.add(structural_key)
                         all_persistent_ids_are_pytorch_storage = False
                     stack.append(None)
                 else:

--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -9,6 +9,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- suppress canonical PyTorch tensor rebuild warnings only for validated unloaded-runtime ZIP `data.pkl` storage context
 - suppress installed source-trusted inert Hugging Face training metadata and safe NumPy ndarray reconstruction noise while keeping default-install, unresolved, rebound, or shadowed framework metadata suspicious
 - skip PyTorch ZIP tensor storage members referenced by `data.pkl` during hidden-pickle discovery while preserving inconclusive outcomes for ambiguous storage evidence
 - avoid critical `getattr` findings for proven Ultralytics `Detect.forward` reconstruction while preserving unsafe traversal controls

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -383,6 +383,13 @@ class _PytorchZipDataPickleTrust:
     canonical_tensor_rebuild_invocations: frozenset[tuple[int, int]]
 
 
+@dataclass(frozen=True)
+class _PytorchZipStorageEntries:
+    trusted_entry_ids: set[int]
+    storage_probe_entry_ids: set[int]
+    trusted_data_pkl_by_name: dict[str, _PytorchZipDataPickleTrust]
+
+
 _ABSTRACT_MARK = object()
 _ABSTRACT_UNKNOWN = object()
 
@@ -886,7 +893,7 @@ def _discover_pytorch_zip_pickle_entries(
         if _is_data_pickle_member(lowered) or lowered.endswith(_PICKLE_MEMBER_SUFFIXES):
             add_entry(entry)
 
-    trusted_storage_entry_ids, trusted_data_pkl_by_name, storage_notices = _validated_pytorch_storage_entry_ids(
+    storage_entries, storage_notices = _validated_pytorch_storage_entry_ids(
         archive,
         entries,
         source=source,
@@ -905,12 +912,21 @@ def _discover_pytorch_zip_pickle_entries(
     for candidate_index, entry in enumerate(candidates):
         _check_pytorch_zip_deadline(deadline)
         try:
-            if id(entry) in trusted_storage_entry_ids:
+            entry_id = id(entry)
+            if entry_id in storage_entries.trusted_entry_ids:
                 looks_like_pickle = _trusted_storage_zip_entry_looks_like_pickle(
                     archive,
                     entry,
                     probe_bytes_remaining,
                     deadline,
+                )
+            elif entry_id in storage_entries.storage_probe_entry_ids:
+                looks_like_pickle = _trusted_storage_zip_entry_looks_like_pickle(
+                    archive,
+                    entry,
+                    probe_bytes_remaining,
+                    deadline,
+                    max_probe_bytes=_PICKLE_DISCOVERY_LONG_PROBE_BYTES,
                 )
             else:
                 looks_like_pickle = _zip_entry_looks_like_pickle(archive, entry, probe_bytes_remaining, deadline)
@@ -930,7 +946,7 @@ def _discover_pytorch_zip_pickle_entries(
         except Exception as error:
             notices.append(_pytorch_zip_member_probe_notice(source=source, entry=entry, error=error))
 
-    return pickle_entries, tuple(notices), trusted_data_pkl_by_name
+    return pickle_entries, tuple(notices), storage_entries.trusted_data_pkl_by_name
 
 
 def _validated_pytorch_storage_entry_ids(
@@ -940,7 +956,7 @@ def _validated_pytorch_storage_entry_ids(
     source: str,
     options: ScanOptions,
     deadline: float,
-) -> tuple[set[int], dict[str, _PytorchZipDataPickleTrust], tuple[Notice, ...]]:
+) -> tuple[_PytorchZipStorageEntries, tuple[Notice, ...]]:
     members = [
         (entry.filename, entry)
         for entry in entries
@@ -951,6 +967,7 @@ def _validated_pytorch_storage_entry_ids(
         entries_by_name.setdefault(name, []).append(entry)
 
     trusted_entry_ids: set[int] = set()
+    storage_probe_entry_ids: set[int] = set()
     trusted_data_pkl_by_name: dict[str, _PytorchZipDataPickleTrust] = {}
     notices: list[Notice] = []
     storage_reference_bytes_read = 0
@@ -1088,17 +1105,31 @@ def _validated_pytorch_storage_entry_ids(
                     },
                 )
             )
-        if trusted_storage_keys and not missing_storage_keys and reference_parse.all_persistent_ids_are_pytorch_storage:
+        validated_storage_keys = trusted_storage_keys - storage_size_mismatch_keys
+        exact_trusted_storage_keys = (
+            validated_storage_keys if reference_parse.all_persistent_ids_are_pytorch_storage else set()
+        )
+        storage_probe_keys = trusted_storage_keys - exact_trusted_storage_keys
+        if exact_trusted_storage_keys and not missing_storage_keys:
             trusted_data_pkl_by_name[data_pkl_name] = _PytorchZipDataPickleTrust(
-                storage_keys=trusted_storage_keys,
+                storage_keys=exact_trusted_storage_keys,
                 canonical_tensor_rebuild_invocations=frozenset(
                     reference_parse.canonical_tensor_rebuild_invocations if not storage_size_mismatch_keys else set()
                 ),
             )
-        for storage_key in trusted_storage_keys:
+        for storage_key in exact_trusted_storage_keys:
             trusted_entry_ids.add(id(storage_entries_by_key[storage_key]))
+        for storage_key in storage_probe_keys:
+            storage_probe_entry_ids.add(id(storage_entries_by_key[storage_key]))
 
-    return trusted_entry_ids, trusted_data_pkl_by_name, tuple(notices)
+    return (
+        _PytorchZipStorageEntries(
+            trusted_entry_ids=trusted_entry_ids,
+            storage_probe_entry_ids=storage_probe_entry_ids,
+            trusted_data_pkl_by_name=trusted_data_pkl_by_name,
+        ),
+        tuple(notices),
+    )
 
 
 def _pytorch_storage_size_mismatches(
@@ -1123,17 +1154,21 @@ def _trusted_pytorch_data_pkl_from_storage_member_sizes(
         return None
     if not reference_parse.referenced_keys <= storage_member_sizes.keys():
         return None
-    storage_size_mismatch = any(
-        not isinstance(storage_member_sizes[key], int)
-        or isinstance(storage_member_sizes[key], bool)
-        or _pytorch_storage_size_mismatches(
+    validated_storage_keys = {
+        key
+        for key in reference_parse.referenced_keys
+        if isinstance(storage_member_sizes[key], int)
+        and not isinstance(storage_member_sizes[key], bool)
+        and not _pytorch_storage_size_mismatches(
             int(storage_member_sizes[key]),
             reference_parse.storage_refs_by_key.get(key),
         )
-        for key in reference_parse.referenced_keys
-    )
+    }
+    if not validated_storage_keys:
+        return None
+    storage_size_mismatch = validated_storage_keys != reference_parse.referenced_keys
     return _PytorchZipDataPickleTrust(
-        storage_keys=set(reference_parse.referenced_keys),
+        storage_keys=validated_storage_keys,
         canonical_tensor_rebuild_invocations=frozenset(
             reference_parse.canonical_tensor_rebuild_invocations if not storage_size_mismatch else set()
         ),
@@ -1207,6 +1242,8 @@ def _trusted_storage_zip_entry_looks_like_pickle(
     entry: zipfile.ZipInfo,
     probe_bytes_remaining: list[int],
     deadline: float,
+    *,
+    max_probe_bytes: int = _TRUSTED_STORAGE_PICKLE_PROBE_BYTES,
 ) -> bool:
     prefix = _read_zip_entry_probe(
         archive,
@@ -1227,7 +1264,7 @@ def _trusted_storage_zip_entry_looks_like_pickle(
         sample = _read_zip_entry_probe(
             archive,
             entry,
-            _TRUSTED_STORAGE_PICKLE_PROBE_BYTES,
+            max_probe_bytes,
             probe_bytes_remaining,
             deadline,
         )
@@ -1499,10 +1536,10 @@ def _quoted_protocol0_field_value(field: str) -> str | None:
     return None if "\\" in value else value
 
 
-def _storage_key_from_protocol0_persid_text(
+def _storage_ref_from_protocol0_persid_text(
     pid_text: Any,
     trusted_storage_keys: set[str] | None = None,
-) -> str | None:
+) -> _PytorchStorageRef | None:
     text = _coerce_pickle_string_arg(pid_text)
     if text is None:
         return None
@@ -1527,7 +1564,22 @@ def _storage_key_from_protocol0_persid_text(
     storage_size = fields[4]
     if not storage_size.isascii() or not storage_size.isdecimal():
         return None
-    return storage_key
+    return _PytorchStorageRef(
+        storage_key,
+        module,
+        name,
+        _quoted_protocol0_field_value(fields[3]) or "",
+        int(storage_size),
+        _PYTORCH_STORAGE_ITEM_SIZES.get(name),
+    )
+
+
+def _storage_key_from_protocol0_persid_text(
+    pid_text: Any,
+    trusted_storage_keys: set[str] | None = None,
+) -> str | None:
+    storage_ref = _storage_ref_from_protocol0_persid_text(pid_text, trusted_storage_keys)
+    return storage_ref.key if storage_ref is not None else None
 
 
 def _protocol0_persid_text_from_preview(preview: Any) -> str | None:
@@ -2037,9 +2089,13 @@ def _pytorch_storage_keys_from_pickle_bytes(
                     all_persistent_ids_are_pytorch_storage = False
                     stack.append(None)
             elif opcode_name == "PERSID":
-                storage_key = _storage_key_from_protocol0_persid_text(arg)
-                if storage_key is not None:
-                    referenced_keys.add(storage_key)
+                storage_ref = _storage_ref_from_protocol0_persid_text(arg)
+                if storage_ref is not None:
+                    referenced_keys.add(storage_ref.key)
+                    existing_ref = storage_refs_by_key.get(storage_ref.key)
+                    if existing_ref is not None and existing_ref != storage_ref:
+                        all_persistent_ids_are_pytorch_storage = False
+                    storage_refs_by_key[storage_ref.key] = storage_ref
                 else:
                     all_persistent_ids_are_pytorch_storage = False
                 invalidate_tensor_rebuild_proof()

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -8,10 +8,12 @@ import pickletools
 import tempfile
 import time
 import zipfile
+from _collections import OrderedDict as _CANONICAL_COLLECTIONS_ORDERED_DICT
 from collections.abc import Mapping
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from importlib import import_module
+from importlib import metadata as importlib_metadata
 from pathlib import Path
 from typing import Any, BinaryIO, cast
 
@@ -22,7 +24,10 @@ from .call_graph import (
     _begin_shared_source_report,
     _CallGraphAnalysisLimitError,
     _ensure_shared_source_snapshot_stable,
+    _find_module_spec_without_imports,
     _is_skippable_pytorch_storage_persistent_id_reference,
+    _module_spec_fields_without_hooks,
+    _runtime_module_attribute_without_hooks,
     class_static_attribute_lookup_is_proven_source_backed,
     find_analyzed_callable_call_graph_global_positions,
     find_dangerous_call_graphs,
@@ -105,6 +110,7 @@ _PYTORCH_STORAGE_TRUST_MAX_STACK_DEPTH = 1024
 _PYTORCH_STORAGE_TRUST_MAX_MEMO_ENTRIES = 100_000
 _PYTORCH_STORAGE_TRUST_MAX_TUPLE_WIDTH = 64
 _PYTORCH_STORAGE_TRUST_MAX_REFERENCED_KEYS = 10_000
+_PYTORCH_STORAGE_TRUST_MAX_TENSOR_INDEX = 2**63 - 1
 _RUST_EXTENSION_MODULE = "modelaudit_picklescan._rust"
 _MAX_INERT_INITIALIZATION_MODULES = 32
 _SAFE_NUMPY_RECONSTRUCT_MAX_PAYLOAD_BYTES = 10 * 1024 * 1024
@@ -135,6 +141,23 @@ _PYTORCH_STORAGE_GLOBAL_NAMES = frozenset(
 _PYTORCH_STORAGE_GLOBALS = frozenset(
     (module, name) for module in ("torch", "torch.storage") for name in _PYTORCH_STORAGE_GLOBAL_NAMES
 )
+_PYTORCH_STORAGE_ITEM_SIZES = {
+    "BFloat16Storage": 2,
+    "BoolStorage": 1,
+    "ByteStorage": 1,
+    "CharStorage": 1,
+    "ComplexDoubleStorage": 16,
+    "ComplexFloatStorage": 8,
+    "DoubleStorage": 8,
+    "FloatStorage": 4,
+    "HalfStorage": 2,
+    "IntStorage": 4,
+    "LongStorage": 8,
+    "QInt32Storage": 4,
+    "QInt8Storage": 1,
+    "QUInt8Storage": 1,
+    "ShortStorage": 2,
+}
 _TRUSTED_FRAMEWORK_REDUCE_REFERENCES = frozenset(
     {
         ("accelerate.utils.dataclasses", "DistributedType"),
@@ -297,6 +320,22 @@ class _PickleGlobalRef:
 
 
 @dataclass(frozen=True)
+class _PytorchStorageRef:
+    key: str
+    module: str
+    name: str
+    location: str
+    element_count: int
+    item_size: int | None
+
+
+@dataclass
+class _PytorchOrderedDictState:
+    mutated: bool = False
+    used_as_hooks: bool = False
+
+
+@dataclass(frozen=True)
 class _AbstractGlobal:
     module: str
     name: str
@@ -331,9 +370,17 @@ class _AbstractCallResult:
 @dataclass(frozen=True)
 class _PytorchStorageReferenceParse:
     referenced_keys: set[str]
+    storage_refs_by_key: dict[str, _PytorchStorageRef]
     storage_global_positions: set[int]
+    canonical_tensor_rebuild_invocations: set[tuple[int, int]]
     parse_complete: bool
     all_persistent_ids_are_pytorch_storage: bool
+
+
+@dataclass(frozen=True)
+class _PytorchZipDataPickleTrust:
+    storage_keys: set[str]
+    canonical_tensor_rebuild_invocations: frozenset[tuple[int, int]]
 
 
 _ABSTRACT_MARK = object()
@@ -374,6 +421,7 @@ class PickleScanner:
         source: str = "<stream>",
         size: int | None = None,
         enrich_call_graph: bool = True,
+        _pytorch_zip_storage_member_sizes: Mapping[str, int] | None = None,
     ) -> PickleReport:
         """Scan pickle bytes from the current position of a binary stream."""
         normalized_size = _normalize_stream_size(size)
@@ -431,6 +479,17 @@ class PickleScanner:
             position_offset=position_offset,
             enrich_call_graph=enrich_call_graph,
         )
+        if not stream_truncated and _pytorch_zip_storage_member_sizes is not None:
+            trusted_data_pkl = _trusted_pytorch_data_pkl_from_storage_member_sizes(
+                payload,
+                _pytorch_zip_storage_member_sizes,
+            )
+            if trusted_data_pkl is not None:
+                report = _without_trusted_pytorch_data_pkl_findings(
+                    report,
+                    trusted_data_pkl,
+                    remove_persistent_ids=False,
+                )
         if stream_truncated:
             if normalized_size is None:
                 return _with_unbounded_stream_notice(
@@ -522,14 +581,12 @@ class PickleScanner:
                 if not _has_pytorch_zip_metadata(entries):
                     return None
 
-                pickle_entries, discovery_notices, trusted_storage_keys_by_data_pkl = (
-                    _discover_pytorch_zip_pickle_entries(
-                        archive,
-                        entries,
-                        source=source,
-                        options=self.options,
-                        deadline=deadline,
-                    )
+                pickle_entries, discovery_notices, trusted_data_pkl_by_name = _discover_pytorch_zip_pickle_entries(
+                    archive,
+                    entries,
+                    source=source,
+                    options=self.options,
+                    deadline=deadline,
                 )
                 probe_budget_exhausted = any(
                     notice.code == "pytorch_zip_pickle_discovery_probe_budget" for notice in discovery_notices
@@ -604,11 +661,11 @@ class PickleScanner:
                                 size=entry.file_size,
                                 enrich_call_graph=enrich_call_graph,
                             )
-                        trusted_storage_keys = trusted_storage_keys_by_data_pkl.get(member_name)
-                        if trusted_storage_keys:
-                            member_report = _without_trusted_pytorch_storage_persistent_id_findings(
+                        trusted_data_pkl = trusted_data_pkl_by_name.get(member_name)
+                        if trusted_data_pkl is not None:
+                            member_report = _without_trusted_pytorch_data_pkl_findings(
                                 member_report,
-                                trusted_storage_keys,
+                                trusted_data_pkl,
                             )
                         reports.append(member_report)
                     except Exception as error:
@@ -808,7 +865,7 @@ def _discover_pytorch_zip_pickle_entries(
     source: str,
     options: ScanOptions,
     deadline: float,
-) -> tuple[list[zipfile.ZipInfo], tuple[Notice, ...], dict[str, set[str]]]:
+) -> tuple[list[zipfile.ZipInfo], tuple[Notice, ...], dict[str, _PytorchZipDataPickleTrust]]:
     pickle_entries: list[zipfile.ZipInfo] = []
     notices: list[Notice] = []
     seen_entries: set[int] = set()
@@ -829,7 +886,7 @@ def _discover_pytorch_zip_pickle_entries(
         if _is_data_pickle_member(lowered) or lowered.endswith(_PICKLE_MEMBER_SUFFIXES):
             add_entry(entry)
 
-    trusted_storage_entry_ids, trusted_storage_keys_by_data_pkl, storage_notices = _validated_pytorch_storage_entry_ids(
+    trusted_storage_entry_ids, trusted_data_pkl_by_name, storage_notices = _validated_pytorch_storage_entry_ids(
         archive,
         entries,
         source=source,
@@ -873,7 +930,7 @@ def _discover_pytorch_zip_pickle_entries(
         except Exception as error:
             notices.append(_pytorch_zip_member_probe_notice(source=source, entry=entry, error=error))
 
-    return pickle_entries, tuple(notices), trusted_storage_keys_by_data_pkl
+    return pickle_entries, tuple(notices), trusted_data_pkl_by_name
 
 
 def _validated_pytorch_storage_entry_ids(
@@ -883,7 +940,7 @@ def _validated_pytorch_storage_entry_ids(
     source: str,
     options: ScanOptions,
     deadline: float,
-) -> tuple[set[int], dict[str, set[str]], tuple[Notice, ...]]:
+) -> tuple[set[int], dict[str, _PytorchZipDataPickleTrust], tuple[Notice, ...]]:
     members = [
         (entry.filename, entry)
         for entry in entries
@@ -894,7 +951,7 @@ def _validated_pytorch_storage_entry_ids(
         entries_by_name.setdefault(name, []).append(entry)
 
     trusted_entry_ids: set[int] = set()
-    trusted_storage_keys_by_data_pkl: dict[str, set[str]] = {}
+    trusted_data_pkl_by_name: dict[str, _PytorchZipDataPickleTrust] = {}
     notices: list[Notice] = []
     storage_reference_bytes_read = 0
     storage_reference_opcodes_remaining = [min(_PYTORCH_STORAGE_TRUST_MAX_OPCODES, options.max_opcodes)]
@@ -992,6 +1049,14 @@ def _validated_pytorch_storage_entry_ids(
         referenced_storage_keys = reference_parse.referenced_keys
         existing_storage_keys = set(storage_entries_by_key)
         missing_storage_keys = referenced_storage_keys - existing_storage_keys
+        storage_size_mismatch_keys = {
+            key
+            for key in referenced_storage_keys & existing_storage_keys
+            if _pytorch_storage_size_mismatches(
+                storage_entries_by_key[key].file_size,
+                reference_parse.storage_refs_by_key.get(key),
+            )
+        }
         if missing_storage_keys:
             notices.append(
                 _pytorch_zip_storage_reference_validation_notice(
@@ -1007,12 +1072,72 @@ def _validated_pytorch_storage_entry_ids(
             )
 
         trusted_storage_keys = referenced_storage_keys & existing_storage_keys
+        if storage_size_mismatch_keys and reference_parse.canonical_tensor_rebuild_invocations:
+            notices.append(
+                _pytorch_zip_storage_reference_validation_notice(
+                    source=source,
+                    data_pkl_member=data_pkl_name,
+                    message=(
+                        "PyTorch ZIP data.pkl references tensor storage members with unexpected sizes "
+                        f"in {data_pkl_name}"
+                    ),
+                    code="pytorch_zip_storage_reference_size_mismatch",
+                    details={
+                        "storage_size_mismatch_keys": sorted(storage_size_mismatch_keys)[:10],
+                        "storage_size_mismatch_key_count": len(storage_size_mismatch_keys),
+                    },
+                )
+            )
         if trusted_storage_keys and not missing_storage_keys and reference_parse.all_persistent_ids_are_pytorch_storage:
-            trusted_storage_keys_by_data_pkl[data_pkl_name] = trusted_storage_keys
+            trusted_data_pkl_by_name[data_pkl_name] = _PytorchZipDataPickleTrust(
+                storage_keys=trusted_storage_keys,
+                canonical_tensor_rebuild_invocations=frozenset(
+                    reference_parse.canonical_tensor_rebuild_invocations if not storage_size_mismatch_keys else set()
+                ),
+            )
         for storage_key in trusted_storage_keys:
             trusted_entry_ids.add(id(storage_entries_by_key[storage_key]))
 
-    return trusted_entry_ids, trusted_storage_keys_by_data_pkl, tuple(notices)
+    return trusted_entry_ids, trusted_data_pkl_by_name, tuple(notices)
+
+
+def _pytorch_storage_size_mismatches(
+    storage_size_bytes: int,
+    storage_ref: _PytorchStorageRef | None,
+) -> bool:
+    if storage_ref is None or storage_ref.item_size is None:
+        return True
+    return storage_size_bytes != storage_ref.element_count * storage_ref.item_size
+
+
+def _trusted_pytorch_data_pkl_from_storage_member_sizes(
+    pickle_data: bytes,
+    storage_member_sizes: Mapping[str, int],
+) -> _PytorchZipDataPickleTrust | None:
+    reference_parse = _pytorch_storage_keys_from_pickle_bytes(pickle_data)
+    if (
+        not reference_parse.parse_complete
+        or not reference_parse.referenced_keys
+        or not reference_parse.all_persistent_ids_are_pytorch_storage
+    ):
+        return None
+    if not reference_parse.referenced_keys <= storage_member_sizes.keys():
+        return None
+    storage_size_mismatch = any(
+        not isinstance(storage_member_sizes[key], int)
+        or isinstance(storage_member_sizes[key], bool)
+        or _pytorch_storage_size_mismatches(
+            int(storage_member_sizes[key]),
+            reference_parse.storage_refs_by_key.get(key),
+        )
+        for key in reference_parse.referenced_keys
+    )
+    return _PytorchZipDataPickleTrust(
+        storage_keys=set(reference_parse.referenced_keys),
+        canonical_tensor_rebuild_invocations=frozenset(
+            reference_parse.canonical_tensor_rebuild_invocations if not storage_size_mismatch else set()
+        ),
+    )
 
 
 def _read_zip_entry_probe(
@@ -1439,32 +1564,145 @@ def _is_trusted_pytorch_storage_persistent_id_finding(
     return _storage_key_from_protocol0_persid_text(persid_text, trusted_storage_keys) is not None
 
 
-def _without_trusted_pytorch_storage_persistent_id_findings(
+def _without_trusted_pytorch_data_pkl_findings(
     report: PickleReport,
-    trusted_storage_keys: set[str],
+    trusted_data_pkl: _PytorchZipDataPickleTrust,
+    *,
+    remove_persistent_ids: bool = True,
 ) -> PickleReport:
     findings = tuple(
         finding
         for finding in report.findings
-        if not _is_trusted_pytorch_storage_persistent_id_finding(finding, trusted_storage_keys)
+        if not (
+            remove_persistent_ids
+            and _is_trusted_pytorch_storage_persistent_id_finding(finding, trusted_data_pkl.storage_keys)
+        )
+        and not _is_trusted_canonical_pytorch_tensor_rebuild_finding(report, finding, trusted_data_pkl)
     )
     if len(findings) == len(report.findings):
         return report
     verdict = report.verdict if findings else SafetyVerdict.CLEAN
     if not findings and report.status != ScanStatus.COMPLETE:
         verdict = SafetyVerdict.UNKNOWN
-    return PickleReport(
-        source=report.source,
-        status=report.status,
-        verdict=verdict,
-        findings=findings,
-        notices=report.notices,
-        errors=report.errors,
-        coverage=report.coverage,
-        metadata=report.metadata,
-        private_metadata=report.private_metadata,
-        duration_s=report.duration_s,
+    return replace(report, findings=findings, verdict=verdict)
+
+
+def _is_trusted_canonical_pytorch_tensor_rebuild_finding(
+    report: PickleReport,
+    finding: Finding,
+    trusted_data_pkl: _PytorchZipDataPickleTrust,
+) -> bool:
+    if (
+        report.status != ScanStatus.COMPLETE
+        or not trusted_data_pkl.canonical_tensor_rebuild_invocations
+        or finding.rule_code != "NON_ALLOWLISTED_GLOBAL"
+        or str(finding.details.get("module", "")) != "torch._utils"
+        or str(finding.details.get("name", "")) != "_rebuild_tensor_v2"
+        or module_is_loaded_without_import_hooks("torch")
+        or module_is_loaded_without_import_hooks("torch._utils")
+        or not _collections_ordered_dict_binding_is_canonical()
+        or not _torch_utils_origin_matches_installed_distribution()
+    ):
+        return False
+    metadata = report.metadata
+    if (
+        bool(metadata.get("import_references_truncated"))
+        or bool(metadata.get("callable_invocations_truncated"))
+        or bool(metadata.get("non_allowlisted_global_imports_truncated"))
+    ):
+        return False
+    position = _optional_int(finding.details.get("position"))
+    if position is None:
+        return False
+    if not _canonical_pytorch_tensor_rebuild_import_reference_matches(metadata.get("import_references"), position):
+        return False
+    return _canonical_pytorch_tensor_rebuild_invocations_match(
+        metadata.get("callable_invocations"),
+        position,
+        trusted_data_pkl.canonical_tensor_rebuild_invocations,
     )
+
+
+def _collections_ordered_dict_binding_is_canonical() -> bool:
+    return _runtime_module_attribute_without_hooks("collections", "OrderedDict") is _CANONICAL_COLLECTIONS_ORDERED_DICT
+
+
+def _torch_utils_origin_matches_installed_distribution() -> bool:
+    if import_only_module_requires_origin_review("torch._utils", "_rebuild_tensor_v2"):
+        return False
+    origins = _torch_and_utils_origins_without_imports()
+    if origins is None:
+        return False
+    try:
+        distribution = importlib_metadata.distribution("torch")
+        distribution_files = distribution.files
+        if distribution_files is None:
+            return False
+        owned_files = {str(file).replace("\\", "/") for file in distribution_files}
+        if not {"torch/__init__.py", "torch/_utils.py"} <= owned_files:
+            return False
+        expected_torch_origin = Path(str(distribution.locate_file("torch/__init__.py"))).resolve()
+        expected_torch_utils_origin = Path(str(distribution.locate_file("torch/_utils.py"))).resolve()
+    except (importlib_metadata.PackageNotFoundError, OSError, RuntimeError, ValueError):
+        return False
+    if module_is_loaded_without_import_hooks("torch") or module_is_loaded_without_import_hooks("torch._utils"):
+        return False
+    current_origins = _torch_and_utils_origins_without_imports()
+    if current_origins != origins:
+        return False
+    return (
+        Path(origins[0]).resolve() == expected_torch_origin
+        and Path(origins[1]).resolve() == expected_torch_utils_origin
+    )
+
+
+def _torch_and_utils_origins_without_imports() -> tuple[str, str] | None:
+    torch_spec = _find_module_spec_without_imports("torch")
+    torch_utils_spec = _find_module_spec_without_imports("torch._utils")
+    if torch_spec is None or torch_utils_spec is None:
+        return None
+    torch_origin, _torch_loader = _module_spec_fields_without_hooks(torch_spec)
+    torch_utils_origin, _torch_utils_loader = _module_spec_fields_without_hooks(torch_utils_spec)
+    if type(torch_origin) is not str or type(torch_utils_origin) is not str:
+        return None
+    return torch_origin, torch_utils_origin
+
+
+def _canonical_pytorch_tensor_rebuild_import_reference_matches(import_references: object, position: int) -> bool:
+    references = [
+        _mapping(raw_reference)
+        for raw_reference in _sequence(import_references)
+        if _optional_int(_mapping(raw_reference).get("position")) == position
+    ]
+    return bool(references) and all(
+        str(reference.get("module", "")) == "torch._utils"
+        and str(reference.get("name", "")) == "_rebuild_tensor_v2"
+        and str(reference.get("opcode", "")) == "GLOBAL"
+        for reference in references
+    )
+
+
+def _canonical_pytorch_tensor_rebuild_invocations_match(
+    callable_invocations: object,
+    position: int,
+    canonical_invocations: frozenset[tuple[int, int]],
+) -> bool:
+    observed_invocations: set[tuple[int, int]] = set()
+    for raw_invocation in _sequence(callable_invocations):
+        invocation = _mapping(raw_invocation)
+        if _optional_int(invocation.get("global_position")) != position:
+            continue
+        opcode_position = _optional_int(invocation.get("opcode_position"))
+        if (
+            str(invocation.get("module", "")) != "torch._utils"
+            or str(invocation.get("name", "")) != "_rebuild_tensor_v2"
+            or str(invocation.get("opcode", "")) != "REDUCE"
+            or invocation.get("positional_arg_count") != 6
+            or opcode_position is None
+        ):
+            return False
+        observed_invocations.add((position, opcode_position))
+    return bool(observed_invocations) and observed_invocations <= canonical_invocations
 
 
 def _pytorch_storage_keys_from_pickle_bytes(
@@ -1478,8 +1716,60 @@ def _pytorch_storage_keys_from_pickle_bytes(
     memo: dict[int, Any] = {}
     stack: list[Any] = []
     referenced_keys: set[str] = set()
+    storage_refs_by_key: dict[str, _PytorchStorageRef] = {}
     storage_global_positions: set[int] = set()
+    canonical_tensor_rebuild_invocations: set[tuple[int, int]] = set()
+    tensor_rebuild_uses: set[tuple[int, int]] = set()
+    tensor_rebuild_proof_valid = True
     all_persistent_ids_are_pytorch_storage = True
+
+    def invalidate_tensor_rebuild_proof() -> None:
+        nonlocal tensor_rebuild_proof_valid
+        tensor_rebuild_proof_valid = False
+
+    def clear_stack_after_malformed_provenance() -> None:
+        invalidate_tensor_rebuild_proof()
+        stack.clear()
+
+    def poison_stack_top() -> None:
+        invalidate_tensor_rebuild_proof()
+        stack[-1] = None
+
+    def mutate_tracked_ordered_dict(value: _PytorchOrderedDictState) -> None:
+        if value.used_as_hooks:
+            invalidate_tensor_rebuild_proof()
+        value.mutated = True
+
+    def ordered_dict_is_empty_hooks(value: object) -> bool:
+        if not isinstance(value, _PytorchOrderedDictState) or value.mutated:
+            return False
+        value.used_as_hooks = True
+        return True
+
+    def value_contains_tracked_provenance(value: object, seen: set[int] | None = None) -> bool:
+        if isinstance(value, _PytorchStorageRef | _PytorchOrderedDictState):
+            return True
+        if not isinstance(value, (tuple, list, dict)):
+            return False
+        if seen is None:
+            seen = set()
+        value_id = id(value)
+        if value_id in seen:
+            return False
+        seen.add(value_id)
+        if isinstance(value, dict):
+            return any(value_contains_tracked_provenance(item, seen) for item in value.items())
+        return any(value_contains_tracked_provenance(item, seen) for item in value)
+
+    def apply_setitems_to_target(items: tuple[tuple[Any, Any], ...]) -> None:
+        if isinstance(stack[-1], _PytorchStorageRef):
+            poison_stack_top()
+        elif isinstance(stack[-1], _PytorchOrderedDictState):
+            mutate_tracked_ordered_dict(stack[-1])
+        elif isinstance(stack[-1], dict):
+            stack[-1].update(items)
+        else:
+            poison_stack_top()
 
     def pop_marked_tuple() -> tuple[Any, ...] | None:
         items: list[Any] = []
@@ -1501,11 +1791,12 @@ def _pytorch_storage_keys_from_pickle_bytes(
 
     def memo_key(value: Any) -> int | None:
         try:
-            return int(value)
+            key = int(value)
         except (TypeError, ValueError):
             return None
+        return key if key >= 0 else None
 
-    def storage_key_from_pid(pid: Any) -> str | None:
+    def storage_ref_from_pid(pid: Any) -> _PytorchStorageRef | None:
         if not isinstance(pid, tuple) or len(pid) != 5:
             return None
         if pid[0] != "storage":
@@ -1519,13 +1810,66 @@ def _pytorch_storage_keys_from_pickle_bytes(
         storage_key = _coerce_pickle_string_arg(pid[2])
         if storage_key is None or storage_key == "":
             return None
-        if _coerce_pickle_string_arg(pid[3]) is None:
+        location = _coerce_pickle_string_arg(pid[3])
+        if location is None:
             return None
         storage_size = pid[4]
-        if not isinstance(storage_size, int) or isinstance(storage_size, bool) or storage_size < 0:
+        if (
+            not isinstance(storage_size, int)
+            or isinstance(storage_size, bool)
+            or storage_size < 0
+            or storage_size > _PYTORCH_STORAGE_TRUST_MAX_TENSOR_INDEX
+        ):
             return None
         storage_global_positions.add(storage_type.position)
-        return storage_key
+        return _PytorchStorageRef(
+            storage_key,
+            storage_type.module,
+            storage_type.name,
+            location,
+            storage_size,
+            _PYTORCH_STORAGE_ITEM_SIZES.get(storage_type.name),
+        )
+
+    def rebuild_tensor_v2_args_are_canonical(args: Any) -> bool:
+        return (
+            isinstance(args, tuple)
+            and len(args) == 6
+            and isinstance(args[0], _PytorchStorageRef)
+            and _pytorch_storage_ref_has_zip_size_proof(args[0])
+            and isinstance(args[1], int)
+            and not isinstance(args[1], bool)
+            and args[1] >= 0
+            and args[1] <= _PYTORCH_STORAGE_TRUST_MAX_TENSOR_INDEX
+            and _abstract_nonnegative_int_tuple(args[2])
+            and _abstract_nonnegative_int_tuple(args[3])
+            and len(args[2]) == len(args[3])
+            and isinstance(args[4], bool)
+            and ordered_dict_is_empty_hooks(args[5])
+            and _pytorch_tensor_view_fits_storage(args[0], args[1], args[2], args[3])
+        )
+
+    def reduce_result(function: Any, args: Any, reduce_position: int) -> Any:
+        if isinstance(function, _PickleGlobalRef) and (function.module, function.name) == (
+            "collections",
+            "OrderedDict",
+        ):
+            if args != () and value_contains_tracked_provenance(args):
+                invalidate_tensor_rebuild_proof()
+            return _PytorchOrderedDictState() if args == () else None
+        if isinstance(function, _PickleGlobalRef) and (function.module, function.name) == (
+            "torch._utils",
+            "_rebuild_tensor_v2",
+        ):
+            tensor_rebuild_uses.add((function.position, reduce_position))
+            if rebuild_tensor_v2_args_are_canonical(args):
+                canonical_tensor_rebuild_invocations.add((function.position, reduce_position))
+            else:
+                invalidate_tensor_rebuild_proof()
+            return None
+        if value_contains_tracked_provenance(function) or value_contains_tracked_provenance(args):
+            invalidate_tensor_rebuild_proof()
+        return None
 
     try:
         for opcode_count, (opcode, arg, _pos) in enumerate(pickletools.genops(pickle_data), start=1):
@@ -1533,13 +1877,17 @@ def _pytorch_storage_keys_from_pickle_bytes(
                 _check_pytorch_zip_deadline(deadline)
             if opcode_budget_remaining is not None:
                 if opcode_budget_remaining[0] <= 0:
-                    return _PytorchStorageReferenceParse(set(), set(), False, False)
+                    return _PytorchStorageReferenceParse(set(), {}, set(), set(), False, False)
                 opcode_budget_remaining[0] -= 1
             if opcode_count > _PYTORCH_STORAGE_TRUST_MAX_OPCODES:
-                return _PytorchStorageReferenceParse(set(), set(), False, False)
+                return _PytorchStorageReferenceParse(set(), {}, set(), set(), False, False)
             position = position_offset + (_pos if type(_pos) is int else 0)
             opcode_name = opcode.name
-            if opcode_name in {"PROTO", "FRAME", "STOP"}:
+            if opcode_name in {"PROTO", "FRAME"}:
+                continue
+            if opcode_name == "STOP":
+                if not isinstance(_pos, int) or _pos + 1 != len(pickle_data):
+                    invalidate_tensor_rebuild_proof()
                 continue
             if opcode_name == "MARK":
                 stack.append(marker)
@@ -1562,7 +1910,7 @@ def _pytorch_storage_keys_from_pickle_bytes(
                     stack.append(_PickleGlobalRef(parts[0], parts[1], position) if len(parts) == 2 else None)
             elif opcode_name == "STACK_GLOBAL":
                 if len(stack) < 2:
-                    stack.clear()
+                    clear_stack_after_malformed_provenance()
                     continue
                 name = _coerce_pickle_string_arg(stack.pop())
                 module = _coerce_pickle_string_arg(stack.pop())
@@ -1571,21 +1919,37 @@ def _pytorch_storage_keys_from_pickle_bytes(
                 )
             elif opcode_name == "EMPTY_TUPLE":
                 stack.append(())
+            elif opcode_name == "EMPTY_LIST":
+                stack.append([])
+            elif opcode_name == "EMPTY_DICT":
+                stack.append({})
             elif opcode_name == "TUPLE":
                 tuple_value = pop_marked_tuple()
                 if tuple_value is None:
-                    stack.clear()
+                    clear_stack_after_malformed_provenance()
                 else:
                     stack.append(tuple_value)
             elif opcode_name in {"TUPLE1", "TUPLE2", "TUPLE3"}:
                 tuple_size = int(opcode_name[-1])
                 if len(stack) < tuple_size:
-                    stack.clear()
+                    clear_stack_after_malformed_provenance()
                     continue
-                items = stack[-tuple_size:]
+                tuple_items = stack[-tuple_size:]
                 del stack[-tuple_size:]
-                stack.append(tuple(items))
-            elif opcode_name in {"BININT", "BININT1", "BININT2", "LONG", "LONG1", "LONG4", "INT"}:
+                stack.append(tuple(tuple_items))
+            elif opcode_name == "LIST":
+                list_items = pop_marked_tuple()
+                if list_items is None:
+                    clear_stack_after_malformed_provenance()
+                else:
+                    stack.append(list(list_items))
+            elif opcode_name == "DICT":
+                dict_items = pop_marked_tuple()
+                if dict_items is None or len(dict_items) % 2 != 0:
+                    clear_stack_after_malformed_provenance()
+                else:
+                    stack.append({dict_items[index]: dict_items[index + 1] for index in range(0, len(dict_items), 2)})
+            elif opcode_name in {"BININT", "BININT1", "BININT2", "LONG", "LONG1", "LONG4", "INT", "FLOAT", "BINFLOAT"}:
                 stack.append(arg)
             elif opcode_name == "NONE":
                 stack.append(None)
@@ -1595,46 +1959,130 @@ def _pytorch_storage_keys_from_pickle_bytes(
                 stack.append(False)
             elif opcode_name in {"BINPUT", "LONG_BINPUT", "PUT"}:
                 key = memo_key(arg)
-                if key is not None and stack:
+                if key is not None and stack and key not in memo:
                     memo[key] = stack[-1]
+                else:
+                    invalidate_tensor_rebuild_proof()
             elif opcode_name == "MEMOIZE":
-                if stack:
-                    memo[len(memo)] = stack[-1]
+                key = len(memo)
+                if stack and key not in memo:
+                    memo[key] = stack[-1]
+                else:
+                    invalidate_tensor_rebuild_proof()
             elif opcode_name in {"BINGET", "LONG_BINGET", "GET"}:
                 key = memo_key(arg)
-                stack.append(memo.get(key) if key is not None else None)
+                if key is None or key not in memo:
+                    invalidate_tensor_rebuild_proof()
+                    stack.append(None)
+                else:
+                    stack.append(memo[key])
             elif opcode_name == "POP":
                 if stack:
                     stack.pop()
+                else:
+                    invalidate_tensor_rebuild_proof()
             elif opcode_name == "POP_MARK":
-                pop_marked_tuple()
+                if pop_marked_tuple() is None:
+                    invalidate_tensor_rebuild_proof()
             elif opcode_name == "DUP":
                 if stack:
                     stack.append(stack[-1])
+                else:
+                    invalidate_tensor_rebuild_proof()
+            elif opcode_name == "APPEND":
+                if len(stack) < 2:
+                    clear_stack_after_malformed_provenance()
+                    continue
+                value = stack.pop()
+                if isinstance(stack[-1], list):
+                    stack[-1].append(value)
+                else:
+                    poison_stack_top()
+            elif opcode_name == "APPENDS":
+                appended_items = pop_marked_tuple()
+                if appended_items is None or not stack:
+                    clear_stack_after_malformed_provenance()
+                    continue
+                if isinstance(stack[-1], list):
+                    stack[-1].extend(appended_items)
+                else:
+                    poison_stack_top()
+            elif opcode_name == "SETITEM":
+                if len(stack) < 3:
+                    clear_stack_after_malformed_provenance()
+                    continue
+                value = stack.pop()
+                key = stack.pop()
+                apply_setitems_to_target(((key, value),))
+            elif opcode_name == "SETITEMS":
+                setitem_items = pop_marked_tuple()
+                if setitem_items is None or len(setitem_items) % 2 != 0 or not stack:
+                    clear_stack_after_malformed_provenance()
+                    continue
+                apply_setitems_to_target(
+                    tuple((setitem_items[index], setitem_items[index + 1]) for index in range(0, len(setitem_items), 2))
+                )
             elif opcode_name == "BINPERSID":
                 pid = stack.pop() if stack else None
-                storage_key = storage_key_from_pid(pid)
-                if storage_key is not None:
-                    referenced_keys.add(storage_key)
+                storage_ref = storage_ref_from_pid(pid)
+                if storage_ref is not None:
+                    referenced_keys.add(storage_ref.key)
+                    existing_ref = storage_refs_by_key.get(storage_ref.key)
+                    if existing_ref is not None and existing_ref != storage_ref:
+                        all_persistent_ids_are_pytorch_storage = False
+                        invalidate_tensor_rebuild_proof()
+                    storage_refs_by_key[storage_ref.key] = storage_ref
+                    stack.append(storage_ref)
                 else:
                     all_persistent_ids_are_pytorch_storage = False
-                stack.append(None)
+                    stack.append(None)
             elif opcode_name == "PERSID":
                 storage_key = _storage_key_from_protocol0_persid_text(arg)
                 if storage_key is not None:
                     referenced_keys.add(storage_key)
                 else:
                     all_persistent_ids_are_pytorch_storage = False
+                invalidate_tensor_rebuild_proof()
                 stack.append(None)
+            elif opcode_name == "REDUCE":
+                if len(stack) < 2:
+                    clear_stack_after_malformed_provenance()
+                    continue
+                args = stack.pop()
+                function = stack.pop()
+                stack.append(reduce_result(function, args, position))
+            elif opcode_name == "BUILD":
+                if len(stack) < 2:
+                    clear_stack_after_malformed_provenance()
+                    continue
+                state = stack.pop()
+                obj = stack.pop()
+                if isinstance(obj, _PytorchStorageRef):
+                    invalidate_tensor_rebuild_proof()
+                    stack.append(None)
+                elif isinstance(obj, _PytorchOrderedDictState):
+                    if state is not None:
+                        mutate_tracked_ordered_dict(obj)
+                    stack.append(obj)
+                else:
+                    if value_contains_tracked_provenance(obj) or value_contains_tracked_provenance(state):
+                        invalidate_tensor_rebuild_proof()
+                    stack.append(obj if state is None else None)
             else:
-                stack.clear()
+                clear_stack_after_malformed_provenance()
             if not within_limits():
-                return _PytorchStorageReferenceParse(set(), set(), False, False)
+                return _PytorchStorageReferenceParse(set(), {}, set(), set(), False, False)
     except Exception:
-        return _PytorchStorageReferenceParse(set(), set(), False, False)
+        return _PytorchStorageReferenceParse(set(), {}, set(), set(), False, False)
     return _PytorchStorageReferenceParse(
         referenced_keys=referenced_keys,
+        storage_refs_by_key=storage_refs_by_key,
         storage_global_positions=storage_global_positions,
+        canonical_tensor_rebuild_invocations=(
+            canonical_tensor_rebuild_invocations
+            if tensor_rebuild_proof_valid and tensor_rebuild_uses == canonical_tensor_rebuild_invocations
+            else set()
+        ),
         parse_complete=True,
         all_persistent_ids_are_pytorch_storage=all_persistent_ids_are_pytorch_storage,
     )
@@ -2366,7 +2814,7 @@ def _with_canonical_pytorch_storage_persistent_id_metadata(
     try:
         storage_reference_parse = _pytorch_storage_keys_from_pickle_bytes(payload, position_offset=position_offset)
     except Exception:
-        storage_reference_parse = _PytorchStorageReferenceParse(set(), set(), False, False)
+        storage_reference_parse = _PytorchStorageReferenceParse(set(), {}, set(), set(), False, False)
     trusted_storage_keys = storage_reference_parse.referenced_keys
     proven_canonical_storage_ids = (
         storage_reference_parse.parse_complete
@@ -3797,6 +4245,35 @@ def _numpy_ndarray_build_state_is_safe(state: object) -> bool:
 
 def _abstract_int_tuple_is_safe(value: object) -> bool:
     return isinstance(value, tuple) and all(isinstance(item, int) and not isinstance(item, bool) for item in value)
+
+
+def _abstract_nonnegative_int_tuple(value: object) -> bool:
+    return (
+        isinstance(value, tuple)
+        and len(value) <= _PYTORCH_STORAGE_TRUST_MAX_TUPLE_WIDTH
+        and all(
+            isinstance(item, int)
+            and not isinstance(item, bool)
+            and 0 <= item <= _PYTORCH_STORAGE_TRUST_MAX_TENSOR_INDEX
+            for item in value
+        )
+    )
+
+
+def _pytorch_storage_ref_has_zip_size_proof(storage: _PytorchStorageRef) -> bool:
+    return _is_ascii_decimal_digits(storage.key) and storage.location == "cpu" and storage.item_size is not None
+
+
+def _pytorch_tensor_view_fits_storage(
+    storage: _PytorchStorageRef,
+    offset: int,
+    size: tuple[int, ...],
+    stride: tuple[int, ...],
+) -> bool:
+    if any(dim == 0 for dim in size):
+        return offset <= storage.element_count
+    max_index = offset + sum((dim - 1) * item_stride for dim, item_stride in zip(size, stride, strict=True))
+    return max_index < storage.element_count
 
 
 def _abstract_bytes_value_is_safe(value: object) -> bool:

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -141,6 +141,7 @@ _PYTORCH_STORAGE_GLOBAL_NAMES = frozenset(
 _PYTORCH_STORAGE_GLOBALS = frozenset(
     (module, name) for module in ("torch", "torch.storage") for name in _PYTORCH_STORAGE_GLOBAL_NAMES
 )
+_PYTORCH_STORAGE_TRUST_MAX_TENSOR_INDEX_TEXT = str(_PYTORCH_STORAGE_TRUST_MAX_TENSOR_INDEX)
 _PYTORCH_STORAGE_ITEM_SIZES = {
     "BFloat16Storage": 2,
     "BoolStorage": 1,
@@ -157,6 +158,7 @@ _PYTORCH_STORAGE_ITEM_SIZES = {
     "QInt8Storage": 1,
     "QUInt8Storage": 1,
     "ShortStorage": 2,
+    "UntypedStorage": 1,
 }
 _TRUSTED_FRAMEWORK_REDUCE_REFERENCES = frozenset(
     {
@@ -913,20 +915,18 @@ def _discover_pytorch_zip_pickle_entries(
         _check_pytorch_zip_deadline(deadline)
         try:
             entry_id = id(entry)
+            storage_probe_bytes = None
             if entry_id in storage_entries.trusted_entry_ids:
-                looks_like_pickle = _trusted_storage_zip_entry_looks_like_pickle(
-                    archive,
-                    entry,
-                    probe_bytes_remaining,
-                    deadline,
-                )
+                storage_probe_bytes = _TRUSTED_STORAGE_PICKLE_PROBE_BYTES
             elif entry_id in storage_entries.storage_probe_entry_ids:
+                storage_probe_bytes = _PICKLE_DISCOVERY_LONG_PROBE_BYTES
+            if storage_probe_bytes is not None:
                 looks_like_pickle = _trusted_storage_zip_entry_looks_like_pickle(
                     archive,
                     entry,
                     probe_bytes_remaining,
                     deadline,
-                    max_probe_bytes=_PICKLE_DISCOVERY_LONG_PROBE_BYTES,
+                    max_probe_bytes=storage_probe_bytes,
                 )
             else:
                 looks_like_pickle = _zip_entry_looks_like_pickle(archive, entry, probe_bytes_remaining, deadline)
@@ -1154,24 +1154,19 @@ def _trusted_pytorch_data_pkl_from_storage_member_sizes(
         return None
     if not reference_parse.referenced_keys <= storage_member_sizes.keys():
         return None
-    validated_storage_keys = {
-        key
-        for key in reference_parse.referenced_keys
-        if isinstance(storage_member_sizes[key], int)
-        and not isinstance(storage_member_sizes[key], bool)
-        and not _pytorch_storage_size_mismatches(
+    if any(
+        not isinstance(storage_member_sizes[key], int)
+        or isinstance(storage_member_sizes[key], bool)
+        or _pytorch_storage_size_mismatches(
             int(storage_member_sizes[key]),
             reference_parse.storage_refs_by_key.get(key),
         )
-    }
-    if not validated_storage_keys:
+        for key in reference_parse.referenced_keys
+    ):
         return None
-    storage_size_mismatch = validated_storage_keys != reference_parse.referenced_keys
     return _PytorchZipDataPickleTrust(
-        storage_keys=validated_storage_keys,
-        canonical_tensor_rebuild_invocations=frozenset(
-            reference_parse.canonical_tensor_rebuild_invocations if not storage_size_mismatch else set()
-        ),
+        storage_keys=set(reference_parse.referenced_keys),
+        canonical_tensor_rebuild_invocations=frozenset(reference_parse.canonical_tensor_rebuild_invocations),
     )
 
 
@@ -1536,6 +1531,20 @@ def _quoted_protocol0_field_value(field: str) -> str | None:
     return None if "\\" in value else value
 
 
+def _parse_pytorch_storage_element_count_text(storage_size: str) -> int | None:
+    if not storage_size.isascii() or not storage_size.isdecimal():
+        return None
+    normalized = storage_size.lstrip("0") or "0"
+    if len(normalized) > len(_PYTORCH_STORAGE_TRUST_MAX_TENSOR_INDEX_TEXT):
+        return None
+    if (
+        len(normalized) == len(_PYTORCH_STORAGE_TRUST_MAX_TENSOR_INDEX_TEXT)
+        and normalized > _PYTORCH_STORAGE_TRUST_MAX_TENSOR_INDEX_TEXT
+    ):
+        return None
+    return int(normalized)
+
+
 def _storage_ref_from_protocol0_persid_text(
     pid_text: Any,
     trusted_storage_keys: set[str] | None = None,
@@ -1561,17 +1570,45 @@ def _storage_ref_from_protocol0_persid_text(
         return None
     if _quoted_protocol0_field_value(fields[3]) is None:
         return None
-    storage_size = fields[4]
-    if not storage_size.isascii() or not storage_size.isdecimal():
+    element_count = _parse_pytorch_storage_element_count_text(fields[4])
+    if element_count is None:
         return None
     return _PytorchStorageRef(
         storage_key,
         module,
         name,
         _quoted_protocol0_field_value(fields[3]) or "",
-        int(storage_size),
+        element_count,
         _PYTORCH_STORAGE_ITEM_SIZES.get(name),
     )
+
+
+def _structural_storage_key_from_protocol0_persid_text(
+    pid_text: Any,
+    trusted_storage_keys: set[str] | None = None,
+) -> str | None:
+    text = _coerce_pickle_string_arg(pid_text)
+    if text is None:
+        return None
+    fields = _split_protocol0_persid_fields(text)
+    if fields is None or len(fields) < 4:
+        return None
+    if _quoted_protocol0_field_value(fields[0]) != "storage":
+        return None
+    storage_type_field = fields[1]
+    if not storage_type_field.startswith("<class '") or not storage_type_field.endswith("'>"):
+        return None
+    module, separator, name = storage_type_field[len("<class '") : -len("'>")].rpartition(".")
+    if not separator or (module, name) not in _PYTORCH_STORAGE_GLOBALS:
+        return None
+    storage_key = _quoted_protocol0_field_value(fields[2])
+    if storage_key is None or not _is_ascii_decimal_digits(storage_key):
+        return None
+    if trusted_storage_keys is not None and storage_key not in trusted_storage_keys:
+        return None
+    if _quoted_protocol0_field_value(fields[3]) is None:
+        return None
+    return storage_key
 
 
 def _storage_key_from_protocol0_persid_text(
@@ -1883,6 +1920,22 @@ def _pytorch_storage_keys_from_pickle_bytes(
             _PYTORCH_STORAGE_ITEM_SIZES.get(storage_type.name),
         )
 
+    def structural_storage_key_from_pid(pid: Any) -> str | None:
+        if not isinstance(pid, tuple) or len(pid) < 4:
+            return None
+        if pid[0] != "storage":
+            return None
+        storage_type = pid[1]
+        if not (
+            isinstance(storage_type, _PickleGlobalRef)
+            and (storage_type.module, storage_type.name) in _PYTORCH_STORAGE_GLOBALS
+        ):
+            return None
+        storage_key = _coerce_pickle_string_arg(pid[2])
+        if storage_key is None or storage_key == "":
+            return None
+        return storage_key if _coerce_pickle_string_arg(pid[3]) is not None else None
+
     def rebuild_tensor_v2_args_are_canonical(args: Any) -> bool:
         return (
             isinstance(args, tuple)
@@ -2086,6 +2139,9 @@ def _pytorch_storage_keys_from_pickle_bytes(
                     storage_refs_by_key[storage_ref.key] = storage_ref
                     stack.append(storage_ref)
                 else:
+                    storage_key = structural_storage_key_from_pid(pid)
+                    if storage_key is not None:
+                        referenced_keys.add(storage_key)
                     all_persistent_ids_are_pytorch_storage = False
                     stack.append(None)
             elif opcode_name == "PERSID":
@@ -2097,6 +2153,9 @@ def _pytorch_storage_keys_from_pickle_bytes(
                         all_persistent_ids_are_pytorch_storage = False
                     storage_refs_by_key[storage_ref.key] = storage_ref
                 else:
+                    storage_key = _structural_storage_key_from_protocol0_persid_text(arg)
+                    if storage_key is not None:
+                        referenced_keys.add(storage_key)
                     all_persistent_ids_are_pytorch_storage = False
                 invalidate_tensor_rebuild_proof()
                 stack.append(None)

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -747,16 +747,6 @@ def _executable_value_functions(value: object) -> tuple[FunctionType, ...]:
     return ()
 
 
-def _extend_snapshot_functions(
-    functions: deque[FunctionType],
-    value: object,
-    traverse_function_module: str | None,
-) -> None:
-    for function in _executable_value_functions(value):
-        if traverse_function_module is None or function.__globals__.get("__name__") == traverse_function_module:
-            functions.append(function)
-
-
 def _type_member_without_hooks(class_: type[object], name: str) -> tuple[bool, object | None]:
     for base in type.__getattribute__(class_, "__mro__"):
         namespace = type.__getattribute__(base, "__dict__")
@@ -841,12 +831,7 @@ def _value_is_data_descriptor(value: object) -> bool:
     return False
 
 
-def _trusted_executable_value_snapshot(
-    value: object,
-    *,
-    allow_unresolved_attribute_paths: bool = False,
-    traverse_function_module: str | None = None,
-) -> _TrustedExecutableValueSnapshot:
+def _trusted_executable_value_snapshot(value: object) -> _TrustedExecutableValueSnapshot:
     referenced_globals: list[_FunctionReferencedGlobalsSnapshot] = []
     functions = deque(_executable_value_functions(value))
     seen_functions: set[FunctionType] = set()
@@ -899,8 +884,6 @@ def _trusted_executable_value_snapshot(
             for path in () if mutable_state_safe else attribute_paths.get(name, ()):
                 resolved, dependency, dispatch_dependencies = _runtime_attribute_path_without_hooks(global_value, path)
                 if not resolved:
-                    if allow_unresolved_attribute_paths:
-                        continue
                     return _runtime_value_snapshot(value), tuple(referenced_globals), False
                 dependency_snapshots.append(
                     (
@@ -909,9 +892,9 @@ def _trusted_executable_value_snapshot(
                         tuple(_runtime_value_snapshot(dispatch) for dispatch in dispatch_dependencies),
                     )
                 )
-                _extend_snapshot_functions(functions, dependency, traverse_function_module)
+                functions.extend(_executable_value_functions(dependency))
                 for dispatch in dispatch_dependencies:
-                    _extend_snapshot_functions(functions, dispatch, traverse_function_module)
+                    functions.extend(_executable_value_functions(dispatch))
             global_snapshots.append(
                 (
                     name,
@@ -930,9 +913,9 @@ def _trusted_executable_value_snapshot(
             )
         )
         for name in global_names:
-            _extend_snapshot_functions(functions, globals_namespace[name], traverse_function_module)
+            functions.extend(_executable_value_functions(globals_namespace[name]))
         for name in builtin_names:
-            _extend_snapshot_functions(functions, builtins_namespace[name], traverse_function_module)
+            functions.extend(_executable_value_functions(builtins_namespace[name]))
     return _runtime_value_snapshot(value), tuple(referenced_globals), True
 
 
@@ -1437,7 +1420,6 @@ _TRUSTED_FRAMEWORK_RECONSTRUCTION_REFERENCES = frozenset(
         ("torch.serialization", "_get_layout"),
     }
 )
-_TRUSTED_SOURCE_DEPENDENT_FRAMEWORK_RECONSTRUCTION_REFERENCES = frozenset({("torch._utils", "_rebuild_tensor_v2")})
 _TRUSTED_LOADED_EXTENSION_EXPORT_OWNERS = MappingProxyType(
     {
         ("numpy._core.multiarray", "_reconstruct"): ("numpy._core._multiarray_umath",),
@@ -2275,201 +2257,6 @@ def import_only_reference_is_proven_trusted_for_pickle_invocation(
         name,
         pickle_entrypoint_methods=entrypoint_methods,
         pickle_invokes_metaclass_call=invokes_metaclass_call,
-    ) or (
-        str(reference.get("opcode", "")) == "REDUCE"
-        and _loaded_site_package_framework_reconstruction_function_matches_trusted_source(
-            module_name,
-            name,
-        )
-    )
-
-
-def _loaded_site_package_framework_reconstruction_function_matches_trusted_source(
-    module_name: str,
-    name: str,
-) -> bool:
-    if (
-        module_name,
-        name,
-    ) not in _TRUSTED_SOURCE_DEPENDENT_FRAMEWORK_RECONSTRUCTION_REFERENCES or _trusted_module_origin_kind(
-        module_name
-    ) != "site_packages":
-        return False
-    module_state = _current_loaded_interpreter_module_state(module_name)
-    reference_state = _current_loaded_interpreter_reference_state(module_name, name)
-    _track_loaded_interpreter_module_state(module_name, module_state)
-    _track_loaded_interpreter_reference_state(module_name, name, reference_state)
-    if not module_state[0] or module_state[1] is None or module_state[2] is None or not reference_state[0]:
-        return False
-    if not _loaded_module_metadata_matches_spec_without_hooks(module_name, *module_state[1:]):
-        return False
-    value = reference_state[1]
-    return isinstance(value, FunctionType) and _trusted_framework_function_dependency_graph_matches_source(
-        value,
-        expected_module=module_name,
-        expected_name=name,
-    )
-
-
-def _trusted_framework_function_dependency_graph_matches_source(
-    function: FunctionType,
-    *,
-    expected_module: str,
-    expected_name: str,
-) -> bool:
-    if function.__globals__.get("__name__") != expected_module or function.__code__.co_name != _reference_leaf_name(
-        expected_name
-    ):
-        return False
-    snapshot = _trusted_executable_value_snapshot(
-        function,
-        allow_unresolved_attribute_paths=True,
-        traverse_function_module=expected_module,
-    )
-    return _trusted_source_dependent_executable_snapshot_matches_source(
-        snapshot,
-        expected_name=expected_name,
-    )
-
-
-def _trusted_source_dependent_executable_snapshot_matches_source(
-    snapshot: _TrustedExecutableValueSnapshot,
-    *,
-    expected_name: str,
-) -> bool:
-    if not snapshot[2] or not _trusted_framework_dependency_snapshot_matches_source(
-        snapshot[0],
-        expected_name=expected_name,
-    ):
-        return False
-    for function, globals_namespace, global_snapshots, builtins_namespace, builtin_snapshots in snapshot[1]:
-        if not _trusted_framework_function_matches_source_and_runtime_state(function):
-            return False
-        if type(globals_namespace) is not dict:
-            return False
-        if not _trusted_builtin_snapshots_match_import_runtime(builtins_namespace, builtin_snapshots):
-            return False
-        for _name, global_snapshot, dependency_snapshots, _mutable_state_safe in global_snapshots:
-            if not _trusted_framework_dependency_snapshot_matches_source(global_snapshot, expected_name=_name):
-                return False
-            for _path, dependency_snapshot, dispatch_snapshots in dependency_snapshots:
-                dependency_name = _path[-1] if _path else None
-                if not _trusted_framework_dependency_snapshot_matches_source(
-                    dependency_snapshot,
-                    expected_name=dependency_name,
-                ):
-                    return False
-                if any(
-                    not _trusted_framework_dependency_snapshot_matches_source(dispatch_snapshot)
-                    for dispatch_snapshot in dispatch_snapshots
-                ):
-                    return False
-    return True
-
-
-def _trusted_framework_dependency_snapshot_matches_source(
-    snapshot: _RuntimeValueSnapshot,
-    *,
-    expected_name: str | None = None,
-) -> bool:
-    value = snapshot[0]
-    function = snapshot[1]
-    if function is not None:
-        if expected_name is not None and function.__code__.co_name != _reference_leaf_name(expected_name):
-            return False
-        return _function_matches_own_trusted_source(function) and _runtime_function_snapshot_is_source_independent(
-            snapshot
-        )
-    if isinstance(value, BuiltinFunctionType):
-        module_name = BuiltinFunctionType.__getattribute__(value, "__module__")
-        function_name = BuiltinFunctionType.__getattribute__(value, "__name__")
-        return (
-            type(module_name) is str
-            and type(function_name) is str
-            and (expected_name is None or function_name == _reference_leaf_name(expected_name))
-            and _loaded_trusted_reference_identity_matches_source(module_name, function_name, value)
-        )
-    if type(value) is ModuleType:
-        module_name = ModuleType.__getattribute__(value, "__name__")
-        return type(module_name) is str and _loaded_trusted_module_matches_source(module_name)
-    if _runtime_value_is_class(value):
-        class_ = cast(type[object], value)
-        module_name = type.__getattribute__(class_, "__module__")
-        class_name = type.__getattribute__(class_, "__name__")
-        return (
-            type(module_name) is str
-            and type(class_name) is str
-            and (expected_name is None or class_name == _reference_leaf_name(expected_name))
-            and _loaded_trusted_reference_identity_matches_source(module_name, class_name, value)
-        )
-    return not _runtime_type_member_is_executable(value)
-
-
-def _trusted_builtin_snapshots_match_import_runtime(
-    builtins_namespace: object,
-    builtin_snapshots: tuple[tuple[str, _RuntimeValueSnapshot], ...],
-) -> bool:
-    if not builtin_snapshots:
-        return True
-    if type(_IMPORT_RUNTIME_BUILTINS) is not dict or builtins_namespace is not _IMPORT_RUNTIME_BUILTINS:
-        return False
-    for name, snapshot in builtin_snapshots:
-        expected = _IMPORT_RUNTIME_BUILTIN_VALUE_SNAPSHOTS.get(name)
-        if expected is None:
-            return False
-        if not _runtime_value_matches_snapshot(snapshot[0], expected) or not _runtime_value_matches_snapshot(
-            _IMPORT_RUNTIME_BUILTINS[name],
-            expected,
-        ):
-            return False
-    return True
-
-
-def _function_matches_own_trusted_source(function: FunctionType) -> bool:
-    globals_namespace = function.__globals__
-    if type(globals_namespace) is not dict:
-        return False
-    module_name = globals_namespace.get("__name__")
-    return (
-        type(module_name) is str
-        and _trusted_module_origin_kind(module_name) in {"stdlib", "site_packages"}
-        and _function_owner_matches_trusted_source(function, expected_module=module_name)
-    )
-
-
-def _trusted_framework_function_matches_source_and_runtime_state(function: FunctionType) -> bool:
-    return _function_matches_own_trusted_source(function) and _runtime_function_snapshot_is_source_independent(
-        _runtime_value_snapshot(function)
-    )
-
-
-def _loaded_trusted_reference_identity_matches_source(module_name: str, name: str, value: object) -> bool:
-    if _trusted_module_origin_kind(module_name) not in {"stdlib", "site_packages"}:
-        return False
-    module_state = _current_loaded_interpreter_module_state(module_name)
-    reference_state = _current_loaded_interpreter_reference_state(module_name, name)
-    _track_loaded_interpreter_module_state(module_name, module_state)
-    _track_loaded_interpreter_reference_state(module_name, name, reference_state)
-    return (
-        module_state[0]
-        and module_state[1] is not None
-        and module_state[2] is not None
-        and reference_state[0]
-        and reference_state[1] is value
-        and _loaded_module_metadata_matches_spec_without_hooks(module_name, *module_state[1:])
-    )
-
-
-def _loaded_trusted_module_matches_source(module_name: str) -> bool:
-    if _trusted_module_origin_kind(module_name) not in {"stdlib", "site_packages"}:
-        return False
-    module_state = _current_loaded_interpreter_module_state(module_name)
-    _track_loaded_interpreter_module_state(module_name, module_state)
-    return (
-        module_state[0]
-        and module_state[1] is not None
-        and module_state[2] is not None
-        and _loaded_module_metadata_matches_spec_without_hooks(module_name, *module_state[1:])
     )
 
 

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -747,6 +747,16 @@ def _executable_value_functions(value: object) -> tuple[FunctionType, ...]:
     return ()
 
 
+def _extend_snapshot_functions(
+    functions: deque[FunctionType],
+    value: object,
+    traverse_function_module: str | None,
+) -> None:
+    for function in _executable_value_functions(value):
+        if traverse_function_module is None or function.__globals__.get("__name__") == traverse_function_module:
+            functions.append(function)
+
+
 def _type_member_without_hooks(class_: type[object], name: str) -> tuple[bool, object | None]:
     for base in type.__getattribute__(class_, "__mro__"):
         namespace = type.__getattribute__(base, "__dict__")
@@ -831,7 +841,12 @@ def _value_is_data_descriptor(value: object) -> bool:
     return False
 
 
-def _trusted_executable_value_snapshot(value: object) -> _TrustedExecutableValueSnapshot:
+def _trusted_executable_value_snapshot(
+    value: object,
+    *,
+    allow_unresolved_attribute_paths: bool = False,
+    traverse_function_module: str | None = None,
+) -> _TrustedExecutableValueSnapshot:
     referenced_globals: list[_FunctionReferencedGlobalsSnapshot] = []
     functions = deque(_executable_value_functions(value))
     seen_functions: set[FunctionType] = set()
@@ -884,6 +899,8 @@ def _trusted_executable_value_snapshot(value: object) -> _TrustedExecutableValue
             for path in () if mutable_state_safe else attribute_paths.get(name, ()):
                 resolved, dependency, dispatch_dependencies = _runtime_attribute_path_without_hooks(global_value, path)
                 if not resolved:
+                    if allow_unresolved_attribute_paths:
+                        continue
                     return _runtime_value_snapshot(value), tuple(referenced_globals), False
                 dependency_snapshots.append(
                     (
@@ -892,9 +909,9 @@ def _trusted_executable_value_snapshot(value: object) -> _TrustedExecutableValue
                         tuple(_runtime_value_snapshot(dispatch) for dispatch in dispatch_dependencies),
                     )
                 )
-                functions.extend(_executable_value_functions(dependency))
+                _extend_snapshot_functions(functions, dependency, traverse_function_module)
                 for dispatch in dispatch_dependencies:
-                    functions.extend(_executable_value_functions(dispatch))
+                    _extend_snapshot_functions(functions, dispatch, traverse_function_module)
             global_snapshots.append(
                 (
                     name,
@@ -913,9 +930,9 @@ def _trusted_executable_value_snapshot(value: object) -> _TrustedExecutableValue
             )
         )
         for name in global_names:
-            functions.extend(_executable_value_functions(globals_namespace[name]))
+            _extend_snapshot_functions(functions, globals_namespace[name], traverse_function_module)
         for name in builtin_names:
-            functions.extend(_executable_value_functions(builtins_namespace[name]))
+            _extend_snapshot_functions(functions, builtins_namespace[name], traverse_function_module)
     return _runtime_value_snapshot(value), tuple(referenced_globals), True
 
 
@@ -1420,6 +1437,7 @@ _TRUSTED_FRAMEWORK_RECONSTRUCTION_REFERENCES = frozenset(
         ("torch.serialization", "_get_layout"),
     }
 )
+_TRUSTED_SOURCE_DEPENDENT_FRAMEWORK_RECONSTRUCTION_REFERENCES = frozenset({("torch._utils", "_rebuild_tensor_v2")})
 _TRUSTED_LOADED_EXTENSION_EXPORT_OWNERS = MappingProxyType(
     {
         ("numpy._core.multiarray", "_reconstruct"): ("numpy._core._multiarray_umath",),
@@ -2257,6 +2275,147 @@ def import_only_reference_is_proven_trusted_for_pickle_invocation(
         name,
         pickle_entrypoint_methods=entrypoint_methods,
         pickle_invokes_metaclass_call=invokes_metaclass_call,
+    ) or (
+        str(reference.get("opcode", "")) == "REDUCE"
+        and _loaded_site_package_framework_reconstruction_function_matches_trusted_source(
+            module_name,
+            name,
+        )
+    )
+
+
+def _loaded_site_package_framework_reconstruction_function_matches_trusted_source(
+    module_name: str,
+    name: str,
+) -> bool:
+    if (
+        module_name,
+        name,
+    ) not in _TRUSTED_SOURCE_DEPENDENT_FRAMEWORK_RECONSTRUCTION_REFERENCES or _trusted_module_origin_kind(
+        module_name
+    ) != "site_packages":
+        return False
+    module_state = _current_loaded_interpreter_module_state(module_name)
+    reference_state = _current_loaded_interpreter_reference_state(module_name, name)
+    _track_loaded_interpreter_module_state(module_name, module_state)
+    _track_loaded_interpreter_reference_state(module_name, name, reference_state)
+    if not module_state[0] or module_state[1] is None or module_state[2] is None or not reference_state[0]:
+        return False
+    if not _loaded_module_metadata_matches_spec_without_hooks(module_name, *module_state[1:]):
+        return False
+    value = reference_state[1]
+    return isinstance(value, FunctionType) and _trusted_framework_function_dependency_graph_matches_source(
+        value,
+        expected_module=module_name,
+        expected_name=name,
+    )
+
+
+def _trusted_framework_function_dependency_graph_matches_source(
+    function: FunctionType,
+    *,
+    expected_module: str,
+    expected_name: str,
+) -> bool:
+    if function.__globals__.get("__name__") != expected_module or function.__code__.co_name != _reference_leaf_name(
+        expected_name
+    ):
+        return False
+    snapshot = _trusted_executable_value_snapshot(
+        function,
+        allow_unresolved_attribute_paths=True,
+        traverse_function_module=expected_module,
+    )
+    return _trusted_source_dependent_executable_snapshot_matches_source(snapshot)
+
+
+def _trusted_source_dependent_executable_snapshot_matches_source(
+    snapshot: _TrustedExecutableValueSnapshot,
+) -> bool:
+    if not snapshot[2] or not _trusted_framework_dependency_snapshot_matches_source(snapshot[0]):
+        return False
+    for function, globals_namespace, global_snapshots, builtins_namespace, builtin_snapshots in snapshot[1]:
+        if not _function_matches_own_trusted_source(function):
+            return False
+        if type(globals_namespace) is not dict:
+            return False
+        if not _trusted_builtin_snapshots_match_import_runtime(builtins_namespace, builtin_snapshots):
+            return False
+        for _name, global_snapshot, dependency_snapshots, _mutable_state_safe in global_snapshots:
+            if not _trusted_framework_dependency_snapshot_matches_source(global_snapshot):
+                return False
+            for _path, dependency_snapshot, dispatch_snapshots in dependency_snapshots:
+                if not _trusted_framework_dependency_snapshot_matches_source(dependency_snapshot):
+                    return False
+                if any(
+                    not _trusted_framework_dependency_snapshot_matches_source(dispatch_snapshot)
+                    for dispatch_snapshot in dispatch_snapshots
+                ):
+                    return False
+    return True
+
+
+def _trusted_framework_dependency_snapshot_matches_source(
+    snapshot: _RuntimeValueSnapshot,
+) -> bool:
+    value = snapshot[0]
+    function = snapshot[1]
+    if function is not None:
+        return _function_matches_own_trusted_source(function)
+    if isinstance(value, BuiltinFunctionType):
+        module_name = BuiltinFunctionType.__getattribute__(value, "__module__")
+        return type(module_name) is str and _trusted_module_origin_kind(module_name) in {"stdlib", "site_packages"}
+    if type(value) is ModuleType:
+        module_name = ModuleType.__getattribute__(value, "__name__")
+        return type(module_name) is str and _loaded_trusted_module_matches_source(module_name)
+    if _runtime_value_is_class(value):
+        module_name = type.__getattribute__(cast(type[object], value), "__module__")
+        return type(module_name) is str and _trusted_module_origin_kind(module_name) in {"stdlib", "site_packages"}
+    return not _runtime_type_member_is_executable(value)
+
+
+def _trusted_builtin_snapshots_match_import_runtime(
+    builtins_namespace: object,
+    builtin_snapshots: tuple[tuple[str, _RuntimeValueSnapshot], ...],
+) -> bool:
+    if not builtin_snapshots:
+        return True
+    if type(_IMPORT_RUNTIME_BUILTINS) is not dict or builtins_namespace is not _IMPORT_RUNTIME_BUILTINS:
+        return False
+    for name, snapshot in builtin_snapshots:
+        expected = _IMPORT_RUNTIME_BUILTIN_VALUE_SNAPSHOTS.get(name)
+        if expected is None:
+            return False
+        if not _runtime_value_matches_snapshot(snapshot[0], expected) or not _runtime_value_matches_snapshot(
+            _IMPORT_RUNTIME_BUILTINS[name],
+            expected,
+        ):
+            return False
+    return True
+
+
+def _function_matches_own_trusted_source(function: FunctionType) -> bool:
+    globals_namespace = function.__globals__
+    if type(globals_namespace) is not dict:
+        return False
+    module_name = globals_namespace.get("__name__")
+    return (
+        type(module_name) is str
+        and _trusted_module_origin_kind(module_name) in {"stdlib", "site_packages"}
+        and _function_owner_matches_trusted_source(function, expected_module=module_name)
+    )
+
+
+def _loaded_trusted_module_matches_source(module_name: str) -> bool:
+    if _trusted_module_origin_kind(module_name) not in {"stdlib", "site_packages"}:
+        return False
+    module_state = _current_loaded_interpreter_module_state(module_name)
+    _track_loaded_interpreter_module_state(module_name, module_state)
+    return (
+        module_state[0]
+        and module_state[1] is not None
+        and module_state[2] is not None
+        and _loaded_module_metadata_matches_spec_without_hooks(module_name, *module_state[1:])
     )
 
 

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -2326,26 +2326,38 @@ def _trusted_framework_function_dependency_graph_matches_source(
         allow_unresolved_attribute_paths=True,
         traverse_function_module=expected_module,
     )
-    return _trusted_source_dependent_executable_snapshot_matches_source(snapshot)
+    return _trusted_source_dependent_executable_snapshot_matches_source(
+        snapshot,
+        expected_name=expected_name,
+    )
 
 
 def _trusted_source_dependent_executable_snapshot_matches_source(
     snapshot: _TrustedExecutableValueSnapshot,
+    *,
+    expected_name: str,
 ) -> bool:
-    if not snapshot[2] or not _trusted_framework_dependency_snapshot_matches_source(snapshot[0]):
+    if not snapshot[2] or not _trusted_framework_dependency_snapshot_matches_source(
+        snapshot[0],
+        expected_name=expected_name,
+    ):
         return False
     for function, globals_namespace, global_snapshots, builtins_namespace, builtin_snapshots in snapshot[1]:
-        if not _function_matches_own_trusted_source(function):
+        if not _trusted_framework_function_matches_source_and_runtime_state(function):
             return False
         if type(globals_namespace) is not dict:
             return False
         if not _trusted_builtin_snapshots_match_import_runtime(builtins_namespace, builtin_snapshots):
             return False
         for _name, global_snapshot, dependency_snapshots, _mutable_state_safe in global_snapshots:
-            if not _trusted_framework_dependency_snapshot_matches_source(global_snapshot):
+            if not _trusted_framework_dependency_snapshot_matches_source(global_snapshot, expected_name=_name):
                 return False
             for _path, dependency_snapshot, dispatch_snapshots in dependency_snapshots:
-                if not _trusted_framework_dependency_snapshot_matches_source(dependency_snapshot):
+                dependency_name = _path[-1] if _path else None
+                if not _trusted_framework_dependency_snapshot_matches_source(
+                    dependency_snapshot,
+                    expected_name=dependency_name,
+                ):
                     return False
                 if any(
                     not _trusted_framework_dependency_snapshot_matches_source(dispatch_snapshot)
@@ -2357,20 +2369,39 @@ def _trusted_source_dependent_executable_snapshot_matches_source(
 
 def _trusted_framework_dependency_snapshot_matches_source(
     snapshot: _RuntimeValueSnapshot,
+    *,
+    expected_name: str | None = None,
 ) -> bool:
     value = snapshot[0]
     function = snapshot[1]
     if function is not None:
-        return _function_matches_own_trusted_source(function)
+        if expected_name is not None and function.__code__.co_name != _reference_leaf_name(expected_name):
+            return False
+        return _function_matches_own_trusted_source(function) and _runtime_function_snapshot_is_source_independent(
+            snapshot
+        )
     if isinstance(value, BuiltinFunctionType):
         module_name = BuiltinFunctionType.__getattribute__(value, "__module__")
-        return type(module_name) is str and _trusted_module_origin_kind(module_name) in {"stdlib", "site_packages"}
+        function_name = BuiltinFunctionType.__getattribute__(value, "__name__")
+        return (
+            type(module_name) is str
+            and type(function_name) is str
+            and (expected_name is None or function_name == _reference_leaf_name(expected_name))
+            and _loaded_trusted_reference_identity_matches_source(module_name, function_name, value)
+        )
     if type(value) is ModuleType:
         module_name = ModuleType.__getattribute__(value, "__name__")
         return type(module_name) is str and _loaded_trusted_module_matches_source(module_name)
     if _runtime_value_is_class(value):
-        module_name = type.__getattribute__(cast(type[object], value), "__module__")
-        return type(module_name) is str and _trusted_module_origin_kind(module_name) in {"stdlib", "site_packages"}
+        class_ = cast(type[object], value)
+        module_name = type.__getattribute__(class_, "__module__")
+        class_name = type.__getattribute__(class_, "__name__")
+        return (
+            type(module_name) is str
+            and type(class_name) is str
+            and (expected_name is None or class_name == _reference_leaf_name(expected_name))
+            and _loaded_trusted_reference_identity_matches_source(module_name, class_name, value)
+        )
     return not _runtime_type_member_is_executable(value)
 
 
@@ -2403,6 +2434,29 @@ def _function_matches_own_trusted_source(function: FunctionType) -> bool:
         type(module_name) is str
         and _trusted_module_origin_kind(module_name) in {"stdlib", "site_packages"}
         and _function_owner_matches_trusted_source(function, expected_module=module_name)
+    )
+
+
+def _trusted_framework_function_matches_source_and_runtime_state(function: FunctionType) -> bool:
+    return _function_matches_own_trusted_source(function) and _runtime_function_snapshot_is_source_independent(
+        _runtime_value_snapshot(function)
+    )
+
+
+def _loaded_trusted_reference_identity_matches_source(module_name: str, name: str, value: object) -> bool:
+    if _trusted_module_origin_kind(module_name) not in {"stdlib", "site_packages"}:
+        return False
+    module_state = _current_loaded_interpreter_module_state(module_name)
+    reference_state = _current_loaded_interpreter_reference_state(module_name, name)
+    _track_loaded_interpreter_module_state(module_name, module_state)
+    _track_loaded_interpreter_reference_state(module_name, name, reference_state)
+    return (
+        module_state[0]
+        and module_state[1] is not None
+        and module_state[2] is not None
+        and reference_state[0]
+        and reference_state[1] is value
+        and _loaded_module_metadata_matches_spec_without_hooks(module_name, *module_state[1:])
     )
 
 

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -201,6 +201,18 @@ def _pickle_binint(value: int) -> bytes:
     return b"J" + value.to_bytes(4, "little", signed=True)
 
 
+def _float_storage_element_count_for_bytes(data: bytes) -> int:
+    assert len(data) % 4 == 0
+    return len(data) // 4
+
+
+def _float_storage_persistent_id_payload_for_bytes(key: str, data: bytes) -> bytes:
+    return _pytorch_storage_persistent_id_payload(
+        key,
+        size_opcode=_pickle_binint(_float_storage_element_count_for_bytes(data)),
+    )
+
+
 def _pickle_int_tuple(values: tuple[int, ...]) -> bytes:
     payload = b"".join(_pickle_binint(value) for value in values)
     if len(values) == 0:
@@ -408,7 +420,7 @@ def _pytorch_storage_protocol0_persistent_id_payload(
     key: str,
     *,
     storage_qualname: str = "torch.FloatStorage",
-    size: int = 1,
+    size: int | str = 1,
 ) -> bytes:
     return f"(dp0\nVx\np1\nP('storage', <class '{storage_qualname}'>, '{key}', 'cpu', {size})\ns.".encode("ascii")
 
@@ -457,7 +469,7 @@ def _frame_first_large_malicious_eval_pickle_payload() -> bytes:
 
 
 def _frame_first_raw_storage_bytes() -> bytes:
-    return b"\x95" + (10_000).to_bytes(8, "little") + (b"\x00" * 4096)
+    return b"\x95" + (10_000).to_bytes(8, "little") + (b"\x00" * 4095)
 
 
 def _large_length_prefixed_malicious_payload() -> bytes:
@@ -476,7 +488,7 @@ def _pickleish_tensor_storage_bytes() -> bytes:
 
 
 def _binary_magic_tensor_storage_bytes() -> bytes:
-    return b"\x80\x04\x00" + (b"\x00" * 128)
+    return b"\x80\x04\x00" + (b"\x00" * 129)
 
 
 def _writestr_preserving_member_name(archive: zipfile.ZipFile, member_name: str, data: bytes) -> None:
@@ -3688,7 +3700,7 @@ def test_scan_file_keeps_rebuild_tensor_v2_warning_for_hostile_meta_path(
             id="nondecimal-storage-key",
         ),
         pytest.param(
-            _pytorch_rebuild_tensor_v2_payload(storage_name="UntypedStorage"),
+            _pytorch_rebuild_tensor_v2_payload(storage_name="QUInt4x2Storage"),
             True,
             b"\x00" * 24,
             ScanStatus.COMPLETE,
@@ -4032,16 +4044,18 @@ def test_scan_file_detects_hidden_pytorch_zip_pickle_member_with_data_pickle(tmp
 
 def test_scan_file_does_not_route_benign_storage_blob_as_hidden_pickle(tmp_path: Path) -> None:
     archive_path = tmp_path / "model.pt"
+    storage_blob = _pickleish_tensor_storage_bytes()
     with zipfile.ZipFile(archive_path, "w") as archive:
-        archive.writestr("archive/data.pkl", _pytorch_storage_persistent_id_payload("0"))
+        archive.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
         archive.writestr("archive/version", "3\n")
         archive.writestr("archive/byteorder", "little")
-        archive.writestr("archive/data/0", _pickleish_tensor_storage_bytes())
+        archive.writestr("archive/data/0", storage_blob)
         archive.writestr("archive/notes", b"cat is a category label, not a GLOBAL opcode stream")
 
     report = scan_file(archive_path)
 
     assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
     assert list(report.metadata["pickle_files"]) == ["archive/data.pkl"]
     assert not any(finding.location is not None and "archive/data/0" in finding.location for finding in report.findings)
 
@@ -4068,43 +4082,74 @@ def test_scan_file_scans_size_mismatched_storage_blob_on_hidden_pickle_path(tmp_
     )
 
 
-def test_scan_file_does_not_route_binary_magic_storage_blob_without_opcode(tmp_path: Path) -> None:
+def test_scan_file_does_not_route_size_mismatched_benign_storage_blob(tmp_path: Path) -> None:
     archive_path = tmp_path / "model.pt"
+    storage_blob = _binary_magic_tensor_storage_bytes()
     with zipfile.ZipFile(archive_path, "w") as archive:
         archive.writestr("archive/data.pkl", _pytorch_storage_persistent_id_payload("0"))
         archive.writestr("archive/version", "3\n")
         archive.writestr("archive/byteorder", "little")
-        archive.writestr("archive/data/0", _binary_magic_tensor_storage_bytes())
+        archive.writestr("archive/data/0", storage_blob)
 
     report = scan_file(archive_path)
 
     assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.SUSPICIOUS
+    assert list(report.metadata["pickle_files"]) == ["archive/data.pkl"]
+    persistent_id_findings = [finding for finding in report.findings if finding.rule_code == "PERSISTENT_ID"]
+    assert persistent_id_findings
+    assert not any(finding.details.get("trusted_pytorch_archive_context") is True for finding in persistent_id_findings)
+    assert not any(finding.location is not None and "archive/data/0" in finding.location for finding in report.findings)
+
+
+def test_scan_file_does_not_route_binary_magic_storage_blob_without_opcode(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model.pt"
+    storage_blob = _binary_magic_tensor_storage_bytes()
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/data/0", storage_blob)
+
+    report = scan_file(archive_path)
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
     assert list(report.metadata["pickle_files"]) == ["archive/data.pkl"]
     assert not any(finding.location is not None and "archive/data/0" in finding.location for finding in report.findings)
 
 
 def test_scan_file_does_not_route_frame_first_storage_blob_without_opcode(tmp_path: Path) -> None:
     archive_path = tmp_path / "model.pt"
+    storage_blob = _frame_first_raw_storage_bytes()
     with zipfile.ZipFile(archive_path, "w") as archive:
-        archive.writestr("archive/data.pkl", _pytorch_storage_persistent_id_payload("0"))
+        archive.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
         archive.writestr("archive/version", "3\n")
         archive.writestr("archive/byteorder", "little")
-        archive.writestr("archive/data/0", _frame_first_raw_storage_bytes())
+        archive.writestr("archive/data/0", storage_blob)
 
     report = scan_file(archive_path)
 
     assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.CLEAN
     assert list(report.metadata["pickle_files"]) == ["archive/data.pkl"]
     assert not any(finding.location is not None and "archive/data/0" in finding.location for finding in report.findings)
 
 
 def test_scan_file_routes_protocol0_storage_blob_as_raw_storage(tmp_path: Path) -> None:
     archive_path = tmp_path / "model.pt"
+    storage_blob = _pickleish_tensor_storage_bytes()
     with zipfile.ZipFile(archive_path, "w") as archive:
-        archive.writestr("archive/data.pkl", _pytorch_storage_protocol0_persistent_id_payload("0"))
+        archive.writestr(
+            "archive/data.pkl",
+            _pytorch_storage_protocol0_persistent_id_payload(
+                "0",
+                size=_float_storage_element_count_for_bytes(storage_blob),
+            ),
+        )
         archive.writestr("archive/version", "3\n")
         archive.writestr("archive/byteorder", "little")
-        archive.writestr("archive/data/0", _pickleish_tensor_storage_bytes())
+        archive.writestr("archive/data/0", storage_blob)
 
     report = scan_file(archive_path)
 
@@ -4116,7 +4161,7 @@ def test_scan_file_routes_protocol0_storage_blob_as_raw_storage(tmp_path: Path) 
 def test_scan_file_trusts_protocol0_storage_persid_in_data_pkl(tmp_path: Path) -> None:
     archive_path = tmp_path / "model.pt"
     with zipfile.ZipFile(archive_path, "w") as archive:
-        archive.writestr("archive/data.pkl", _pytorch_storage_protocol0_persistent_id_payload("0"))
+        archive.writestr("archive/data.pkl", _pytorch_storage_protocol0_persistent_id_payload("0", size=2))
         archive.writestr("archive/version", "3\n")
         archive.writestr("archive/byteorder", "little")
         archive.writestr("archive/data/0", b"\x00" * 8)
@@ -4206,6 +4251,7 @@ def test_scan_file_keeps_noncanonical_protocol0_storage_persid_warning_in_data_p
 
 def test_scan_file_routes_torch_storage_untyped_storage_blob_as_raw_storage(tmp_path: Path) -> None:
     archive_path = tmp_path / "model.pt"
+    storage_blob = _pickleish_tensor_storage_bytes()
     with zipfile.ZipFile(archive_path, "w") as archive:
         archive.writestr(
             "archive/data.pkl",
@@ -4213,11 +4259,12 @@ def test_scan_file_routes_torch_storage_untyped_storage_blob_as_raw_storage(tmp_
                 "0",
                 storage_module="torch.storage",
                 storage_name="UntypedStorage",
+                size_opcode=_pickle_binint(len(storage_blob)),
             ),
         )
         archive.writestr("archive/version", "3\n")
         archive.writestr("archive/byteorder", "little")
-        archive.writestr("archive/data/0", _pickleish_tensor_storage_bytes())
+        archive.writestr("archive/data/0", storage_blob)
 
     report = scan_file(archive_path)
 
@@ -4297,6 +4344,40 @@ def test_scan_file_scans_referenced_storage_blob_with_frame_first_large_pickle(t
     )
 
 
+@pytest.mark.parametrize(
+    "data_pkl_payload",
+    [
+        _pytorch_storage_protocol0_persistent_id_payload("0", size="9" * 128),
+        _pytorch_storage_persistent_id_payload("0", size_opcode=b"\x88"),
+    ],
+    ids=["oversized-protocol0-count", "bool-binpersid-count"],
+)
+def test_scan_file_long_probes_invalid_count_storage_with_frame_first_pickle(
+    data_pkl_payload: bytes,
+    tmp_path: Path,
+) -> None:
+    archive_path = tmp_path / "model.pt"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", data_pkl_payload)
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/data/0", _frame_first_large_malicious_eval_pickle_payload())
+
+    report = scan_file(archive_path)
+
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert list(report.metadata["pickle_files"]) == ["archive/data.pkl", "archive/data/0"]
+    assert any(finding.rule_code == "PERSISTENT_ID" for finding in report.findings)
+    assert not any(finding.details.get("trusted_pytorch_archive_context") is True for finding in report.findings)
+    assert any(
+        finding.rule_code == "DANGEROUS_CALL"
+        and finding.location is not None
+        and f"{archive_path}:archive/data/0" in finding.location
+        and finding.details.get("import_reference") == "builtins.eval"
+        for finding in report.findings
+    )
+
+
 @pytest.mark.parametrize("storage_member", [r"archive\data\0", "/archive/data/0"])
 def test_scan_file_scans_noncanonical_referenced_storage_aliases(
     storage_member: str,
@@ -4354,6 +4435,7 @@ def test_scan_file_keeps_unreferenced_storage_lookalike_on_hidden_pickle_path(tm
         (_fake_byte_storage_persistent_id_payload("0"), True, None),
         (_pytorch_storage_persistent_id_payload("0", storage_name="FakeStorage"), True, None),
         (_pytorch_storage_protocol0_persistent_id_payload("0", storage_qualname="torch.FakeStorage"), True, None),
+        (_pytorch_storage_protocol0_persistent_id_payload("0", size="9" * 128), True, None),
         (_pytorch_storage_persistent_id_payload("0", size_opcode=b"\x88"), True, None),
         (_pytorch_storage_persistent_id_payload_with_extra_field("0"), True, None),
         (_pytorch_storage_persistent_id_payload("0")[:-1], True, "pytorch_zip_storage_reference_validation_failed"),

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -727,17 +727,33 @@ def _write_rebindable_trusted_torch_utils_package(site_packages: Path) -> None:
     )
 
 
-def _write_source_dependent_trusted_torch_utils_package(site_packages: Path) -> None:
+def _write_source_dependent_trusted_torch_utils_package(
+    site_packages: Path,
+    *,
+    default_callback: bool = False,
+) -> None:
     package_dir = site_packages / "torch"
     package_dir.mkdir(parents=True, exist_ok=True)
     (package_dir / "__init__.py").write_text("", encoding="utf-8")
+    rebuild_lines = (
+        [
+            "def _rebuild_tensor_v2(tensor, callback=None):",
+            "    if callback:",
+            "        return callback(tensor)",
+            "    return _restore_device_fake_mode(tensor)",
+        ]
+        if default_callback
+        else [
+            "def _rebuild_tensor_v2(tensor):",
+            "    return _restore_device_fake_mode(tensor)",
+        ]
+    )
     (package_dir / "_utils.py").write_text(
         "\n".join(
             [
                 "def _restore_device_fake_mode(tensor):",
                 "    return tensor",
-                "def _rebuild_tensor_v2(tensor):",
-                "    return _restore_device_fake_mode(tensor)",
+                *rebuild_lines,
                 "",
             ]
         ),
@@ -748,17 +764,20 @@ def _write_source_dependent_trusted_torch_utils_package(site_packages: Path) -> 
 def _scan_source_dependent_torch_rebuild_tensor_v2(
     tmp_path: Path,
     *,
+    payload_value: bytes = b"metadata",
     rebound_name: str = "",
     marker_text: str = "",
+    rebound_builtin: str = "",
+    default_marker_text: str = "",
 ) -> dict[str, Any]:
     payload_path = tmp_path / "poststartup-torch-rebuild-tensor-v2.pkl"
-    payload_path.write_bytes(_metadata_reduce_payload("torch._utils", "_rebuild_tensor_v2") + b".")
+    payload_path.write_bytes(_metadata_reduce_payload("torch._utils", "_rebuild_tensor_v2", payload_value) + b".")
     marker = tmp_path / f"{payload_path.stem}.marker"
     site_packages = tmp_path / "trusted-site-packages"
-    _write_source_dependent_trusted_torch_utils_package(site_packages)
+    _write_source_dependent_trusted_torch_utils_package(site_packages, default_callback=bool(default_marker_text))
 
     script = (
-        "import json, pickle, sys\n"
+        "import builtins, json, pickle, sys\n"
         "from pathlib import Path\n"
         "from modelaudit_picklescan import scan_file\n"
         "import torch._utils as torch_utils\n"
@@ -766,7 +785,12 @@ def _scan_source_dependent_torch_rebuild_tensor_v2(
         "rebound_name = sys.argv[2]\n"
         "marker = Path(sys.argv[3])\n"
         "marker_text = sys.argv[4]\n"
-        "if rebound_name:\n"
+        "rebound_builtin = sys.argv[5]\n"
+        "default_marker_text = sys.argv[6]\n"
+        "if rebound_name and rebound_builtin:\n"
+        "    torch_utils.marker = marker\n"
+        "    setattr(torch_utils, rebound_name, getattr(builtins, rebound_builtin))\n"
+        "elif rebound_name:\n"
         "    namespace = {'__name__': 'torch._utils', 'marker': marker, 'marker_text': marker_text}\n"
         "    source = (\n"
         "        f'def {rebound_name}(arg):\\n'\n"
@@ -775,9 +799,15 @@ def _scan_source_dependent_torch_rebuild_tensor_v2(
         "    )\n"
         "    exec(compile(source, str(Path(torch_utils.__file__)), 'exec'), namespace)\n"
         "    setattr(torch_utils, rebound_name, namespace[rebound_name])\n"
+        "if default_marker_text:\n"
+        "    class EvilDefault:\n"
+        "        def __bool__(self):\n"
+        "            marker.write_text(default_marker_text, encoding='utf-8')\n"
+        "            return False\n"
+        "    torch_utils._rebuild_tensor_v2.__defaults__ = (EvilDefault(),)\n"
         "report = scan_file(payload_path)\n"
         "marker_before_unpickle = marker.exists()\n"
-        "if rebound_name:\n"
+        "if rebound_name or default_marker_text:\n"
         "    pickle.loads(payload_path.read_bytes())\n"
         "print(json.dumps({\n"
         "    'status': report.status.value,\n"
@@ -795,7 +825,17 @@ def _scan_source_dependent_torch_rebuild_tensor_v2(
     )
 
     completed = subprocess.run(
-        [sys.executable, "-c", script, str(payload_path), rebound_name, str(marker), marker_text],
+        [
+            sys.executable,
+            "-c",
+            script,
+            str(payload_path),
+            rebound_name,
+            str(marker),
+            marker_text,
+            rebound_builtin,
+            default_marker_text,
+        ],
         check=False,
         env=_preimport_rebound_subprocess_env(tmp_path, site_packages),
         capture_output=True,
@@ -8332,6 +8372,23 @@ def test_scan_file_warns_when_late_loaded_framework_reconstruction_function_is_r
     )
 
 
+def test_scan_file_warns_when_late_loaded_framework_reconstruction_default_is_rebound(
+    tmp_path: Path,
+) -> None:
+    output = _scan_source_dependent_torch_rebuild_tensor_v2(
+        tmp_path,
+        default_marker_text="forged-default",
+    )
+    assert output["marker_before_unpickle"] is False
+    assert output["marker_after_unpickle"] is True
+    assert output["verdict"] in {SafetyVerdict.SUSPICIOUS.value, SafetyVerdict.MALICIOUS.value}
+    assert any(
+        finding["rule_code"] == "NON_ALLOWLISTED_GLOBAL"
+        and finding["import_reference"] == "torch._utils._rebuild_tensor_v2"
+        for finding in output["findings"]
+    )
+
+
 def test_scan_file_warns_when_late_loaded_framework_reconstruction_helper_is_rebound(
     tmp_path: Path,
 ) -> None:
@@ -8339,6 +8396,25 @@ def test_scan_file_warns_when_late_loaded_framework_reconstruction_helper_is_reb
         tmp_path,
         rebound_name="_restore_device_fake_mode",
         marker_text="forged-helper",
+    )
+    assert output["marker_before_unpickle"] is False
+    assert output["marker_after_unpickle"] is True
+    assert output["verdict"] in {SafetyVerdict.SUSPICIOUS.value, SafetyVerdict.MALICIOUS.value}
+    assert any(
+        finding["rule_code"] == "NON_ALLOWLISTED_GLOBAL"
+        and finding["import_reference"] == "torch._utils._rebuild_tensor_v2"
+        for finding in output["findings"]
+    )
+
+
+def test_scan_file_warns_when_late_loaded_framework_reconstruction_helper_is_rebound_to_builtin(
+    tmp_path: Path,
+) -> None:
+    output = _scan_source_dependent_torch_rebuild_tensor_v2(
+        tmp_path,
+        payload_value=b"marker.write_text('eval-helper', encoding='utf-8')",
+        rebound_name="_restore_device_fake_mode",
+        rebound_builtin="eval",
     )
     assert output["marker_before_unpickle"] is False
     assert output["marker_after_unpickle"] is True

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -38,7 +38,7 @@ from importlib.machinery import (
 from importlib.util import cache_from_source
 from pathlib import Path, PurePosixPath
 from types import CodeType, ModuleType
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -725,6 +725,85 @@ def _write_rebindable_trusted_torch_utils_package(site_packages: Path) -> None:
         ),
         encoding="utf-8",
     )
+
+
+def _write_source_dependent_trusted_torch_utils_package(site_packages: Path) -> None:
+    package_dir = site_packages / "torch"
+    package_dir.mkdir(parents=True, exist_ok=True)
+    (package_dir / "__init__.py").write_text("", encoding="utf-8")
+    (package_dir / "_utils.py").write_text(
+        "\n".join(
+            [
+                "def _restore_device_fake_mode(tensor):",
+                "    return tensor",
+                "def _rebuild_tensor_v2(tensor):",
+                "    return _restore_device_fake_mode(tensor)",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _scan_source_dependent_torch_rebuild_tensor_v2(
+    tmp_path: Path,
+    *,
+    rebound_name: str = "",
+    marker_text: str = "",
+) -> dict[str, Any]:
+    payload_path = tmp_path / "poststartup-torch-rebuild-tensor-v2.pkl"
+    payload_path.write_bytes(_metadata_reduce_payload("torch._utils", "_rebuild_tensor_v2") + b".")
+    marker = tmp_path / f"{payload_path.stem}.marker"
+    site_packages = tmp_path / "trusted-site-packages"
+    _write_source_dependent_trusted_torch_utils_package(site_packages)
+
+    script = (
+        "import json, pickle, sys\n"
+        "from pathlib import Path\n"
+        "from modelaudit_picklescan import scan_file\n"
+        "import torch._utils as torch_utils\n"
+        "payload_path = Path(sys.argv[1])\n"
+        "rebound_name = sys.argv[2]\n"
+        "marker = Path(sys.argv[3])\n"
+        "marker_text = sys.argv[4]\n"
+        "if rebound_name:\n"
+        "    namespace = {'__name__': 'torch._utils', 'marker': marker, 'marker_text': marker_text}\n"
+        "    source = (\n"
+        "        f'def {rebound_name}(arg):\\n'\n"
+        "        \"    marker.write_text(marker_text, encoding='utf-8')\\n\"\n"
+        "        '    return None\\n'\n"
+        "    )\n"
+        "    exec(compile(source, str(Path(torch_utils.__file__)), 'exec'), namespace)\n"
+        "    setattr(torch_utils, rebound_name, namespace[rebound_name])\n"
+        "report = scan_file(payload_path)\n"
+        "marker_before_unpickle = marker.exists()\n"
+        "if rebound_name:\n"
+        "    pickle.loads(payload_path.read_bytes())\n"
+        "print(json.dumps({\n"
+        "    'status': report.status.value,\n"
+        "    'verdict': report.verdict.value,\n"
+        "    'marker_before_unpickle': marker_before_unpickle,\n"
+        "    'marker_after_unpickle': marker.exists(),\n"
+        "    'findings': [\n"
+        "        {\n"
+        "            'rule_code': finding.rule_code,\n"
+        "            'import_reference': finding.details.get('import_reference'),\n"
+        "        }\n"
+        "        for finding in report.findings\n"
+        "    ],\n"
+        "}))\n"
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(payload_path), rebound_name, str(marker), marker_text],
+        check=False,
+        env=_preimport_rebound_subprocess_env(tmp_path, site_packages),
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    return cast(dict[str, Any], json.loads(completed.stdout))
 
 
 def _write_cross_module_rebind_target_package(site_packages: Path) -> None:
@@ -8218,6 +8297,55 @@ def test_scan_file_trusts_source_backed_framework_reference_imported_after_scann
     assert not any(
         finding["rule_code"] == "NON_ALLOWLISTED_GLOBAL"
         and finding["import_reference"] == "transformers.training_args.TrainingArguments"
+        for finding in output["findings"]
+    )
+
+
+def test_scan_file_trusts_source_dependent_framework_reconstruction_loaded_after_startup(
+    tmp_path: Path,
+) -> None:
+    output = _scan_source_dependent_torch_rebuild_tensor_v2(tmp_path)
+    assert output["status"] == ScanStatus.COMPLETE.value
+    assert output["verdict"] == SafetyVerdict.CLEAN.value
+    assert not any(
+        finding["rule_code"] == "NON_ALLOWLISTED_GLOBAL"
+        and finding["import_reference"] == "torch._utils._rebuild_tensor_v2"
+        for finding in output["findings"]
+    )
+
+
+def test_scan_file_warns_when_late_loaded_framework_reconstruction_function_is_rebound(
+    tmp_path: Path,
+) -> None:
+    output = _scan_source_dependent_torch_rebuild_tensor_v2(
+        tmp_path,
+        rebound_name="_rebuild_tensor_v2",
+        marker_text="forged-function",
+    )
+    assert output["marker_before_unpickle"] is False
+    assert output["marker_after_unpickle"] is True
+    assert output["verdict"] in {SafetyVerdict.SUSPICIOUS.value, SafetyVerdict.MALICIOUS.value}
+    assert any(
+        finding["rule_code"] == "NON_ALLOWLISTED_GLOBAL"
+        and finding["import_reference"] == "torch._utils._rebuild_tensor_v2"
+        for finding in output["findings"]
+    )
+
+
+def test_scan_file_warns_when_late_loaded_framework_reconstruction_helper_is_rebound(
+    tmp_path: Path,
+) -> None:
+    output = _scan_source_dependent_torch_rebuild_tensor_v2(
+        tmp_path,
+        rebound_name="_restore_device_fake_mode",
+        marker_text="forged-helper",
+    )
+    assert output["marker_before_unpickle"] is False
+    assert output["marker_after_unpickle"] is True
+    assert output["verdict"] in {SafetyVerdict.SUSPICIOUS.value, SafetyVerdict.MALICIOUS.value}
+    assert any(
+        finding["rule_code"] == "NON_ALLOWLISTED_GLOBAL"
+        and finding["import_reference"] == "torch._utils._rebuild_tensor_v2"
         for finding in output["findings"]
     )
 

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -4046,6 +4046,28 @@ def test_scan_file_does_not_route_benign_storage_blob_as_hidden_pickle(tmp_path:
     assert not any(finding.location is not None and "archive/data/0" in finding.location for finding in report.findings)
 
 
+def test_scan_file_scans_size_mismatched_storage_blob_on_hidden_pickle_path(tmp_path: Path) -> None:
+    archive_path = tmp_path / "model.pt"
+    hidden_payload = b"S'" + (b"A" * 5000) + b"'\n" + b"cposix\nsystem\n(S'echo hidden'\ntR."
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", _pytorch_storage_persistent_id_payload("0"))
+        archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        archive.writestr("archive/data/0", hidden_payload)
+
+    report = scan_file(archive_path)
+
+    assert report.status == ScanStatus.COMPLETE
+    assert report.verdict == SafetyVerdict.MALICIOUS
+    assert list(report.metadata["pickle_files"]) == ["archive/data.pkl", "archive/data/0"]
+    assert any(
+        finding.rule_code == "DANGEROUS_CALL"
+        and finding.location is not None
+        and f"{archive_path}:archive/data/0" in finding.location
+        for finding in report.findings
+    )
+
+
 def test_scan_file_does_not_route_binary_magic_storage_blob_without_opcode(tmp_path: Path) -> None:
     archive_path = tmp_path / "model.pt"
     with zipfile.ZipFile(archive_path, "w") as archive:

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -25,6 +25,7 @@ import tarfile
 import uuid
 import warnings
 import zipfile
+from importlib import metadata as importlib_metadata
 from importlib.abc import Loader
 from importlib.machinery import (
     BYTECODE_SUFFIXES,
@@ -192,6 +193,215 @@ def _pytorch_storage_persistent_id_payload(
         + size_opcode
         + b"tQ."
     )
+
+
+def _pickle_binint(value: int) -> bytes:
+    if 0 <= value <= 0xFF:
+        return b"K" + bytes([value])
+    return b"J" + value.to_bytes(4, "little", signed=True)
+
+
+def _pickle_int_tuple(values: tuple[int, ...]) -> bytes:
+    payload = b"".join(_pickle_binint(value) for value in values)
+    if len(values) == 0:
+        return b")"
+    if len(values) == 1:
+        return payload + b"\x85"
+    if len(values) == 2:
+        return payload + b"\x86"
+    if len(values) == 3:
+        return payload + b"\x87"
+    return b"(" + payload + b"t"
+
+
+def _pytorch_storage_binpersid_expr(
+    key: str = "0",
+    *,
+    storage_module: str = "torch",
+    storage_name: str = "LongStorage",
+    location: str = "cpu",
+    element_count: int = 3,
+) -> bytes:
+    return (
+        b"("
+        + _short_binunicode(b"storage")
+        + _short_binunicode(storage_module.encode("ascii"))
+        + _short_binunicode(storage_name.encode("ascii"))
+        + b"\x93"
+        + _short_binunicode(key.encode("ascii"))
+        + _short_binunicode(location.encode("ascii"))
+        + _pickle_binint(element_count)
+        + b"tQ"
+    )
+
+
+def _pytorch_empty_ordered_dict_reduce_expr() -> bytes:
+    return _global(b"collections", b"OrderedDict") + b")R"
+
+
+def _pytorch_rebuild_tensor_v2_payload(
+    *,
+    key: str = "0",
+    global_memo_expr: bytes = b"q\x00",
+    storage_module: str = "torch",
+    storage_name: str = "LongStorage",
+    location: str = "cpu",
+    storage_expr: bytes | None = None,
+    element_count: int = 3,
+    offset: int = 0,
+    size: tuple[int, ...] = (3,),
+    stride: tuple[int, ...] = (1,),
+    requires_grad: bool = False,
+    hooks_expr: bytes | None = None,
+    extra_arg_expr: bytes = b"",
+    trailing_ops: bytes = b"",
+) -> bytes:
+    hooks_payload = _pytorch_empty_ordered_dict_reduce_expr() if hooks_expr is None else hooks_expr
+    storage_payload = (
+        _pytorch_storage_binpersid_expr(
+            key,
+            storage_module=storage_module,
+            storage_name=storage_name,
+            location=location,
+            element_count=element_count,
+        )
+        if storage_expr is None
+        else storage_expr
+    )
+    return (
+        b"\x80\x04"
+        + _global(b"torch._utils", b"_rebuild_tensor_v2")
+        + global_memo_expr
+        + b"("
+        + storage_payload
+        + _pickle_binint(offset)
+        + _pickle_int_tuple(size)
+        + _pickle_int_tuple(stride)
+        + (b"\x88" if requires_grad else b"\x89")
+        + hooks_payload
+        + extra_arg_expr
+        + b"tR"
+        + trailing_ops
+        + b"."
+    )
+
+
+def _pytorch_rebuild_tensor_v2_reduce_expr(
+    *,
+    key: str = "0",
+    storage_module: str = "torch",
+    storage_name: str = "LongStorage",
+    location: str = "cpu",
+    element_count: int = 3,
+    offset: int = 0,
+    size: tuple[int, ...] = (3,),
+    stride: tuple[int, ...] = (1,),
+) -> bytes:
+    return (
+        b"h\x00("
+        + _pytorch_storage_binpersid_expr(
+            key,
+            storage_module=storage_module,
+            storage_name=storage_name,
+            location=location,
+            element_count=element_count,
+        )
+        + _pickle_binint(offset)
+        + _pickle_int_tuple(size)
+        + _pickle_int_tuple(stride)
+        + b"\x89"
+        + _pytorch_empty_ordered_dict_reduce_expr()
+        + b"tR"
+    )
+
+
+def _pytorch_rebuild_tensor_v2_payload_with_mutated_hooks() -> bytes:
+    return (
+        b"\x80\x04"
+        + _global(b"collections", b"OrderedDict")
+        + b")Rq\x01"
+        + b"h\x01"
+        + _short_binunicode(b"x")
+        + _short_binunicode(b"y")
+        + b"s"
+        + _global(b"torch._utils", b"_rebuild_tensor_v2")
+        + b"q\x00("
+        + _pytorch_storage_binpersid_expr()
+        + b"K\x00"
+        + _pickle_int_tuple((3,))
+        + _pickle_int_tuple((1,))
+        + b"\x89"
+        + b"h\x01"
+        + b"tR."
+    )
+
+
+def _write_pytorch_zip_data_pickle(
+    archive_path: Path,
+    data_pkl: bytes,
+    *,
+    include_storage: bool = True,
+    include_version: bool = True,
+    storage_bytes: bytes = b"\x00" * 24,
+) -> None:
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("archive/data.pkl", data_pkl)
+        if include_version:
+            archive.writestr("archive/version", "3\n")
+        archive.writestr("archive/byteorder", "little")
+        if include_storage:
+            archive.writestr("archive/data/0", storage_bytes)
+
+
+def _require_torch_distribution() -> None:
+    try:
+        importlib_metadata.distribution("torch")
+    except importlib_metadata.PackageNotFoundError:
+        pytest.skip("torch distribution not installed")
+
+
+def _torch_rebuild_tensor_v2_warnings(report: PickleReport) -> list[Finding]:
+    return [
+        finding
+        for finding in report.findings
+        if finding.rule_code == "NON_ALLOWLISTED_GLOBAL"
+        and finding.details.get("import_reference") == "torch._utils._rebuild_tensor_v2"
+    ]
+
+
+def _torch_rebuild_tensor_v2_warning_dicts(report: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        finding
+        for finding in cast(list[dict[str, Any]], report["findings"])
+        if finding.get("rule_code") == "NON_ALLOWLISTED_GLOBAL"
+        and cast(dict[str, Any], finding.get("details", {})).get("import_reference")
+        == "torch._utils._rebuild_tensor_v2"
+    ]
+
+
+def _scan_file_report_dict_subprocess(
+    path: Path,
+    *,
+    prelude: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    script = "\n".join(
+        (
+            *prelude,
+            "import json",
+            "import sys",
+            "from modelaudit_picklescan import scan_file",
+            "report = scan_file(sys.argv[1])",
+            "print(json.dumps(report.to_dict()))",
+        )
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PROMPTFOO_DISABLE_TELEMETRY": "1"},
+    )
+    return cast(dict[str, Any], json.loads(completed.stdout))
 
 
 def _pytorch_storage_protocol0_persistent_id_payload(
@@ -725,125 +935,6 @@ def _write_rebindable_trusted_torch_utils_package(site_packages: Path) -> None:
         ),
         encoding="utf-8",
     )
-
-
-def _write_source_dependent_trusted_torch_utils_package(
-    site_packages: Path,
-    *,
-    default_callback: bool = False,
-) -> None:
-    package_dir = site_packages / "torch"
-    package_dir.mkdir(parents=True, exist_ok=True)
-    (package_dir / "__init__.py").write_text("", encoding="utf-8")
-    rebuild_lines = (
-        [
-            "def _rebuild_tensor_v2(tensor, callback=None):",
-            "    if callback:",
-            "        return callback(tensor)",
-            "    return _restore_device_fake_mode(tensor)",
-        ]
-        if default_callback
-        else [
-            "def _rebuild_tensor_v2(tensor):",
-            "    return _restore_device_fake_mode(tensor)",
-        ]
-    )
-    (package_dir / "_utils.py").write_text(
-        "\n".join(
-            [
-                "def _restore_device_fake_mode(tensor):",
-                "    return tensor",
-                *rebuild_lines,
-                "",
-            ]
-        ),
-        encoding="utf-8",
-    )
-
-
-def _scan_source_dependent_torch_rebuild_tensor_v2(
-    tmp_path: Path,
-    *,
-    payload_value: bytes = b"metadata",
-    rebound_name: str = "",
-    marker_text: str = "",
-    rebound_builtin: str = "",
-    default_marker_text: str = "",
-) -> dict[str, Any]:
-    payload_path = tmp_path / "poststartup-torch-rebuild-tensor-v2.pkl"
-    payload_path.write_bytes(_metadata_reduce_payload("torch._utils", "_rebuild_tensor_v2", payload_value) + b".")
-    marker = tmp_path / f"{payload_path.stem}.marker"
-    site_packages = tmp_path / "trusted-site-packages"
-    _write_source_dependent_trusted_torch_utils_package(site_packages, default_callback=bool(default_marker_text))
-
-    script = (
-        "import builtins, json, pickle, sys\n"
-        "from pathlib import Path\n"
-        "from modelaudit_picklescan import scan_file\n"
-        "import torch._utils as torch_utils\n"
-        "payload_path = Path(sys.argv[1])\n"
-        "rebound_name = sys.argv[2]\n"
-        "marker = Path(sys.argv[3])\n"
-        "marker_text = sys.argv[4]\n"
-        "rebound_builtin = sys.argv[5]\n"
-        "default_marker_text = sys.argv[6]\n"
-        "if rebound_name and rebound_builtin:\n"
-        "    torch_utils.marker = marker\n"
-        "    setattr(torch_utils, rebound_name, getattr(builtins, rebound_builtin))\n"
-        "elif rebound_name:\n"
-        "    namespace = {'__name__': 'torch._utils', 'marker': marker, 'marker_text': marker_text}\n"
-        "    source = (\n"
-        "        f'def {rebound_name}(arg):\\n'\n"
-        "        \"    marker.write_text(marker_text, encoding='utf-8')\\n\"\n"
-        "        '    return None\\n'\n"
-        "    )\n"
-        "    exec(compile(source, str(Path(torch_utils.__file__)), 'exec'), namespace)\n"
-        "    setattr(torch_utils, rebound_name, namespace[rebound_name])\n"
-        "if default_marker_text:\n"
-        "    class EvilDefault:\n"
-        "        def __bool__(self):\n"
-        "            marker.write_text(default_marker_text, encoding='utf-8')\n"
-        "            return False\n"
-        "    torch_utils._rebuild_tensor_v2.__defaults__ = (EvilDefault(),)\n"
-        "report = scan_file(payload_path)\n"
-        "marker_before_unpickle = marker.exists()\n"
-        "if rebound_name or default_marker_text:\n"
-        "    pickle.loads(payload_path.read_bytes())\n"
-        "print(json.dumps({\n"
-        "    'status': report.status.value,\n"
-        "    'verdict': report.verdict.value,\n"
-        "    'marker_before_unpickle': marker_before_unpickle,\n"
-        "    'marker_after_unpickle': marker.exists(),\n"
-        "    'findings': [\n"
-        "        {\n"
-        "            'rule_code': finding.rule_code,\n"
-        "            'import_reference': finding.details.get('import_reference'),\n"
-        "        }\n"
-        "        for finding in report.findings\n"
-        "    ],\n"
-        "}))\n"
-    )
-
-    completed = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            script,
-            str(payload_path),
-            rebound_name,
-            str(marker),
-            marker_text,
-            rebound_builtin,
-            default_marker_text,
-        ],
-        check=False,
-        env=_preimport_rebound_subprocess_env(tmp_path, site_packages),
-        capture_output=True,
-        text=True,
-    )
-
-    assert completed.returncode == 0, completed.stderr
-    return cast(dict[str, Any], json.loads(completed.stdout))
 
 
 def _write_cross_module_rebind_target_package(site_packages: Path) -> None:
@@ -3221,6 +3312,519 @@ def test_scan_file_scans_pytorch_zip_data_pickle(tmp_path: Path) -> None:
     assert source_fingerprints["read_fingerprints"] == {}
     assert report.coverage.bytes_total == archive_path.stat().st_size
     assert report.coverage.bytes_scanned > 0
+
+
+def test_scan_file_suppresses_rebuild_tensor_v2_for_valid_canonical_pytorch_zip(tmp_path: Path) -> None:
+    _require_torch_distribution()
+    archive_path = tmp_path / "model.pt"
+    _write_pytorch_zip_data_pickle(archive_path, _pytorch_rebuild_tensor_v2_payload())
+
+    report = _scan_file_report_dict_subprocess(archive_path)
+
+    assert report["status"] == "complete"
+    assert report["verdict"] == "clean"
+    assert _torch_rebuild_tensor_v2_warning_dicts(report) == []
+    assert not any(finding["rule_code"] == "PERSISTENT_ID" for finding in report["findings"])
+
+
+def test_scan_file_suppresses_rebuild_tensor_v2_for_multiple_canonical_memo_uses(tmp_path: Path) -> None:
+    _require_torch_distribution()
+    archive_path = tmp_path / "model.pt"
+    data_pkl = (
+        b"\x80\x04"
+        + _global(b"torch._utils", b"_rebuild_tensor_v2")
+        + b"q\x00"
+        + _pytorch_rebuild_tensor_v2_reduce_expr()
+        + _pytorch_rebuild_tensor_v2_reduce_expr()
+        + b"."
+    )
+    _write_pytorch_zip_data_pickle(archive_path, data_pkl)
+
+    report = _scan_file_report_dict_subprocess(archive_path)
+
+    assert report["status"] == "complete"
+    assert report["verdict"] == "clean"
+    assert _torch_rebuild_tensor_v2_warning_dicts(report) == []
+
+
+def test_scan_file_suppresses_rebuild_tensor_v2_for_real_ordered_state_dict(tmp_path: Path) -> None:
+    _require_torch_distribution()
+    import torch
+
+    archive_path = tmp_path / "ordered-state.pt"
+    torch.save(collections.OrderedDict([("weight", torch.nn.Linear(3, 2).state_dict()["weight"])]), archive_path)
+
+    report = _scan_file_report_dict_subprocess(archive_path)
+
+    assert report["status"] == "complete"
+    assert report["verdict"] == "clean"
+    assert _torch_rebuild_tensor_v2_warning_dicts(report) == []
+
+
+def test_scan_bytes_keeps_rebuild_tensor_v2_warning_for_raw_data_pickle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _require_torch_distribution()
+    monkeypatch.delitem(sys.modules, "torch._utils", raising=False)
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+    _clear_source_sensitive_caches()
+    try:
+        report = scan_bytes(_pytorch_rebuild_tensor_v2_payload(), source="data.pkl")
+    finally:
+        _clear_source_sensitive_caches()
+
+    assert report.status == ScanStatus.COMPLETE
+    assert _torch_rebuild_tensor_v2_warnings(report)
+
+
+def test_scan_file_keeps_rebuild_tensor_v2_warning_when_torch_parent_is_loaded(
+    tmp_path: Path,
+) -> None:
+    _require_torch_distribution()
+    archive_path = tmp_path / "model.pt"
+    _write_pytorch_zip_data_pickle(archive_path, _pytorch_rebuild_tensor_v2_payload())
+
+    report = _scan_file_report_dict_subprocess(
+        archive_path,
+        prelude=(
+            "import sys",
+            "from types import ModuleType",
+            "sys.modules['torch'] = ModuleType('torch')",
+            "sys.modules.pop('torch._utils', None)",
+        ),
+    )
+
+    assert report["status"] == "inconclusive"
+    assert _torch_rebuild_tensor_v2_warning_dicts(report)
+
+
+def test_scan_file_keeps_rebuild_tensor_v2_warning_when_torch_utils_is_loaded(tmp_path: Path) -> None:
+    _require_torch_distribution()
+    archive_path = tmp_path / "model.pt"
+    _write_pytorch_zip_data_pickle(archive_path, _pytorch_rebuild_tensor_v2_payload())
+
+    report = _scan_file_report_dict_subprocess(archive_path, prelude=("import torch._utils",))
+
+    assert report["status"] == "complete"
+    assert _torch_rebuild_tensor_v2_warning_dicts(report)
+
+
+def test_scan_file_keeps_rebuild_tensor_v2_warning_for_shadowed_torch_distribution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _require_torch_distribution()
+    archive_path = tmp_path / "model.pt"
+    _write_pytorch_zip_data_pickle(archive_path, _pytorch_rebuild_tensor_v2_payload())
+    shadow_root = tmp_path / "shadow"
+    torch_dir = shadow_root / "torch"
+    torch_dir.mkdir(parents=True)
+    (torch_dir / "__init__.py").write_text("", encoding="utf-8")
+    (torch_dir / "_utils.py").write_text("def _rebuild_tensor_v2(*args):\n    return None\n", encoding="utf-8")
+    monkeypatch.syspath_prepend(str(shadow_root))
+    monkeypatch.delitem(sys.modules, "torch._utils", raising=False)
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+    _clear_source_sensitive_caches()
+    try:
+        report = scan_file(archive_path)
+    finally:
+        _clear_source_sensitive_caches()
+
+    assert report.status == ScanStatus.COMPLETE
+    assert _torch_rebuild_tensor_v2_warnings(report)
+
+
+def test_scan_file_keeps_rebuild_tensor_v2_warning_for_shadowed_torch_parent_with_real_utils(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _require_torch_distribution()
+    archive_path = tmp_path / "model.pt"
+    _write_pytorch_zip_data_pickle(archive_path, _pytorch_rebuild_tensor_v2_payload())
+    torch_distribution = importlib_metadata.distribution("torch")
+    real_utils = Path(str(torch_distribution.locate_file("torch/_utils.py"))).resolve()
+    shadow_root = tmp_path / "shadow-parent"
+    shadow_torch = shadow_root / "torch"
+    shadow_torch.mkdir(parents=True)
+    (shadow_torch / "__init__.py").write_text("value = 'shadow-parent'\n", encoding="utf-8")
+    try:
+        (shadow_torch / "_utils.py").symlink_to(real_utils)
+    except OSError as error:
+        pytest.skip(f"symlinks unavailable for shadow-parent test: {error}")
+    monkeypatch.syspath_prepend(str(shadow_root))
+    monkeypatch.delitem(sys.modules, "torch._utils", raising=False)
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+    _clear_source_sensitive_caches()
+    try:
+        report = scan_file(archive_path)
+    finally:
+        _clear_source_sensitive_caches()
+
+    assert report.status == ScanStatus.COMPLETE
+    assert _torch_rebuild_tensor_v2_warnings(report)
+
+
+def test_scan_file_keeps_rebuild_tensor_v2_warning_when_ordered_dict_is_rebound(tmp_path: Path) -> None:
+    _require_torch_distribution()
+    archive_path = tmp_path / "model.pt"
+    marker = tmp_path / "ordered_dict_marker"
+    _write_pytorch_zip_data_pickle(archive_path, _pytorch_rebuild_tensor_v2_payload())
+    script = "\n".join(
+        (
+            "import collections",
+            "import io",
+            "import json",
+            "import pickle",
+            "import sys",
+            "import zipfile",
+            "from pathlib import Path",
+            "marker = Path(sys.argv[2])",
+            "armed = False",
+            "class EvilOrderedDict(dict):",
+            "    def __init__(self, *args, **kwargs):",
+            "        if armed:",
+            "            marker.write_text('owned', encoding='utf-8')",
+            "        super().__init__(*args, **kwargs)",
+            "collections.OrderedDict = EvilOrderedDict",
+            "from modelaudit_picklescan import scan_file",
+            "report = scan_file(sys.argv[1]).to_dict()",
+            "before = marker.exists()",
+            "armed = True",
+            "with zipfile.ZipFile(sys.argv[1]) as archive:",
+            "    payload = archive.read('archive/data.pkl')",
+            "class Loader(pickle.Unpickler):",
+            "    def persistent_load(self, _pid):",
+            "        return object()",
+            "try:",
+            "    Loader(io.BytesIO(payload)).load()",
+            "except Exception:",
+            "    pass",
+            "print(json.dumps({'report': report, 'before': before, 'after': marker.exists()}))",
+        )
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(archive_path), str(marker)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PROMPTFOO_DISABLE_TELEMETRY": "1"},
+    )
+    observed = cast(dict[str, Any], json.loads(completed.stdout))
+    report = cast(dict[str, Any], observed["report"])
+
+    assert report["status"] == "complete"
+    assert _torch_rebuild_tensor_v2_warning_dicts(report)
+    assert observed["before"] is False
+    assert observed["after"] is True
+
+
+def test_scan_file_keeps_rebuild_tensor_v2_warning_for_hostile_collections_module_like(
+    tmp_path: Path,
+) -> None:
+    _require_torch_distribution()
+    archive_path = tmp_path / "model.pt"
+    marker = tmp_path / "collections_getattr_marker"
+    _write_pytorch_zip_data_pickle(archive_path, _pytorch_rebuild_tensor_v2_payload())
+    script = "\n".join(
+        (
+            "import collections",
+            "import json",
+            "import sys",
+            "from pathlib import Path",
+            "real_collections = collections",
+            "marker = Path(sys.argv[2])",
+            "class HostileCollections:",
+            "    def __getattr__(self, name):",
+            "        if name == 'OrderedDict':",
+            "            marker.write_text(name, encoding='utf-8')",
+            "        return getattr(real_collections, name)",
+            "from modelaudit_picklescan import scan_file",
+            "sys.modules['collections'] = HostileCollections()",
+            "report = scan_file(sys.argv[1]).to_dict()",
+            "print(json.dumps({'report': report, 'marker': marker.exists()}))",
+        )
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(archive_path), str(marker)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PROMPTFOO_DISABLE_TELEMETRY": "1"},
+    )
+    observed = cast(dict[str, Any], json.loads(completed.stdout))
+    report = cast(dict[str, Any], observed["report"])
+
+    assert report["status"] == "inconclusive"
+    assert _torch_rebuild_tensor_v2_warning_dicts(report)
+    assert observed["marker"] is False
+
+
+def test_scan_file_keeps_rebuild_tensor_v2_warning_when_distribution_lookup_loads_torch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _require_torch_distribution()
+    archive_path = tmp_path / "model.pt"
+    _write_pytorch_zip_data_pickle(archive_path, _pytorch_rebuild_tensor_v2_payload())
+    monkeypatch.delitem(sys.modules, "torch._utils", raising=False)
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+    original_distribution = package_api.importlib_metadata.distribution
+
+    def load_torch_during_distribution_lookup(name: str) -> Any:
+        distribution = original_distribution(name)
+        if name == "torch":
+            sys.modules["torch"] = ModuleType("torch")
+        return distribution
+
+    monkeypatch.setattr(
+        package_api.importlib_metadata,
+        "distribution",
+        load_torch_during_distribution_lookup,
+    )
+    _clear_source_sensitive_caches()
+    try:
+        report = scan_file(archive_path)
+    finally:
+        _clear_source_sensitive_caches()
+
+    assert report.status == ScanStatus.COMPLETE
+    assert _torch_rebuild_tensor_v2_warnings(report)
+
+
+def test_scan_file_keeps_rebuild_tensor_v2_warning_for_hostile_meta_path(
+    tmp_path: Path,
+) -> None:
+    _require_torch_distribution()
+    marker = tmp_path / "meta_path_torch_marker"
+    archive_path = tmp_path / "model.pt"
+    _write_pytorch_zip_data_pickle(archive_path, _pytorch_rebuild_tensor_v2_payload())
+
+    report = _scan_file_report_dict_subprocess(
+        archive_path,
+        prelude=(
+            "import sys",
+            "from importlib.abc import Loader",
+            "from importlib.machinery import ModuleSpec",
+            "from pathlib import Path",
+            f"marker = Path({str(marker)!r})",
+            f"torch_init_origin = {str(tmp_path / 'torch' / '__init__.py')!r}",
+            f"torch_utils_origin = {str(tmp_path / 'torch' / '_utils.py')!r}",
+            "class ShadowLoader(Loader):\n"
+            "    def create_module(self, spec):\n"
+            "        return None\n"
+            "    def exec_module(self, module):\n"
+            "        marker.write_text(module.__name__, encoding='utf-8')\n"
+            "        module.__dict__['_rebuild_tensor_v2'] = object()",
+            "class ShadowFinder:\n"
+            "    def find_spec(self, fullname, path=None, target=None):\n"
+            "        if fullname == 'torch':\n"
+            "            return ModuleSpec(fullname, ShadowLoader(), origin=torch_init_origin)\n"
+            "        if fullname == 'torch._utils':\n"
+            "            return ModuleSpec(fullname, ShadowLoader(), origin=torch_utils_origin)\n"
+            "        return None",
+            "sys.meta_path.insert(0, ShadowFinder())",
+            "sys.modules.pop('torch._utils', None)",
+            "sys.modules.pop('torch', None)",
+        ),
+    )
+
+    assert marker.exists() is False
+    assert report["status"] == "inconclusive"
+    assert _torch_rebuild_tensor_v2_warning_dicts(report)
+
+
+@pytest.mark.parametrize(
+    ("data_pkl", "include_storage", "storage_bytes", "expected_status"),
+    [
+        pytest.param(
+            _pytorch_rebuild_tensor_v2_payload(),
+            False,
+            b"\x00" * 24,
+            ScanStatus.COMPLETE,
+            id="missing-storage",
+        ),
+        pytest.param(
+            _pytorch_rebuild_tensor_v2_payload(hooks_expr=b""),
+            True,
+            b"\x00" * 24,
+            ScanStatus.COMPLETE,
+            id="five-args",
+        ),
+        pytest.param(
+            _pytorch_rebuild_tensor_v2_payload(extra_arg_expr=b"N"),
+            True,
+            b"\x00" * 24,
+            ScanStatus.COMPLETE,
+            id="seven-args",
+        ),
+        pytest.param(
+            _pytorch_rebuild_tensor_v2_payload(hooks_expr=b"}"),
+            True,
+            b"\x00" * 24,
+            ScanStatus.COMPLETE,
+            id="plain-dict-hooks",
+        ),
+        pytest.param(
+            _pytorch_rebuild_tensor_v2_payload(size=(4,)),
+            True,
+            b"\x00" * 24,
+            ScanStatus.COMPLETE,
+            id="out-of-bounds-view",
+        ),
+        pytest.param(
+            _pytorch_rebuild_tensor_v2_payload(location="cuda:0"),
+            True,
+            b"\x00" * 24,
+            ScanStatus.COMPLETE,
+            id="non-cpu-storage",
+        ),
+        pytest.param(
+            _pytorch_rebuild_tensor_v2_payload(key="k"),
+            True,
+            b"\x00" * 24,
+            ScanStatus.INCONCLUSIVE,
+            id="nondecimal-storage-key",
+        ),
+        pytest.param(
+            _pytorch_rebuild_tensor_v2_payload(storage_name="UntypedStorage"),
+            True,
+            b"\x00" * 24,
+            ScanStatus.COMPLETE,
+            id="unknown-item-size",
+        ),
+        pytest.param(
+            _pytorch_rebuild_tensor_v2_payload(storage_expr=b"Pid\n"),
+            True,
+            b"\x00" * 24,
+            ScanStatus.COMPLETE,
+            id="protocol0-persistent-id",
+        ),
+        pytest.param(
+            _pytorch_rebuild_tensor_v2_payload(trailing_ops=b"h\x00K\x01\x85R"),
+            True,
+            b"\x00" * 24,
+            ScanStatus.COMPLETE,
+            id="malformed-memo-reuse",
+        ),
+        pytest.param(
+            b"\x80\x04"
+            + _global(b"torch._utils", b"_rebuild_tensor_v2")
+            + b"q\x00"
+            + _pytorch_storage_binpersid_expr()
+            + b"q\x010"
+            + _global(b"builtins", b"tuple")
+            + b"h\x01\x85R0"
+            + _pytorch_rebuild_tensor_v2_reduce_expr()
+            + b".",
+            True,
+            b"\x00" * 24,
+            ScanStatus.COMPLETE,
+            id="storage-sentinel-escapes-unknown-reduce",
+        ),
+        pytest.param(
+            _pytorch_rebuild_tensor_v2_payload(global_memo_expr=b"q\x01\x94"),
+            True,
+            b"\x00" * 24,
+            ScanStatus.COMPLETE,
+            id="memoize-overwrites-sparse-memo-key",
+        ),
+        pytest.param(
+            _pytorch_rebuild_tensor_v2_payload() + b"\x80\x04N.",
+            True,
+            b"\x00" * 24,
+            ScanStatus.COMPLETE,
+            id="trailing-second-stream",
+        ),
+        pytest.param(
+            _pytorch_rebuild_tensor_v2_payload_with_mutated_hooks(),
+            True,
+            b"\x00" * 24,
+            ScanStatus.COMPLETE,
+            id="mutated-ordered-dict-hooks",
+        ),
+        pytest.param(
+            b"\x80\x04"
+            + _global(b"torch._utils", b"_rebuild_tensor_v2")
+            + b"q\x00"
+            + _pytorch_rebuild_tensor_v2_reduce_expr()
+            + _pytorch_rebuild_tensor_v2_reduce_expr(storage_name="DoubleStorage")
+            + b".",
+            True,
+            b"\x00" * 24,
+            ScanStatus.COMPLETE,
+            id="duplicate-key-different-storage-type",
+        ),
+        pytest.param(
+            _pytorch_rebuild_tensor_v2_payload(),
+            True,
+            b"\x00" * 16,
+            ScanStatus.INCONCLUSIVE,
+            id="storage-size-mismatch",
+        ),
+    ],
+)
+def test_scan_file_keeps_rebuild_tensor_v2_warning_for_noncanonical_zip_contexts(
+    data_pkl: bytes,
+    include_storage: bool,
+    storage_bytes: bytes,
+    expected_status: ScanStatus,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _require_torch_distribution()
+    monkeypatch.delitem(sys.modules, "torch._utils", raising=False)
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+    archive_path = tmp_path / "model.pt"
+    _write_pytorch_zip_data_pickle(
+        archive_path,
+        data_pkl,
+        include_storage=include_storage,
+        storage_bytes=storage_bytes,
+    )
+    _clear_source_sensitive_caches()
+    try:
+        report = scan_file(archive_path)
+    finally:
+        _clear_source_sensitive_caches()
+
+    assert report.status == expected_status
+    assert _torch_rebuild_tensor_v2_warnings(report)
+
+
+def test_trusted_rebuild_tensor_v2_cleanup_requires_complete_callable_metadata() -> None:
+    _require_torch_distribution()
+    report = scan_bytes(_pytorch_rebuild_tensor_v2_payload(), source="data.pkl")
+    warning = _torch_rebuild_tensor_v2_warnings(report)[0]
+    position = cast(int, warning.details["position"])
+    invocation = next(
+        invocation
+        for invocation in cast(tuple[dict[str, object], ...], report.metadata["callable_invocations"])
+        if invocation.get("global_position") == position
+    )
+    metadata = report.to_dict()["metadata"]
+    metadata["callable_invocations_truncated"] = True
+    truncated_report = PickleReport(
+        source=report.source,
+        status=report.status,
+        verdict=report.verdict,
+        findings=report.findings,
+        notices=report.notices,
+        errors=report.errors,
+        coverage=report.coverage,
+        metadata=metadata,
+        private_metadata=report.private_metadata,
+        duration_s=report.duration_s,
+    )
+    trusted_data_pkl = package_api._PytorchZipDataPickleTrust(
+        storage_keys={"0"},
+        canonical_tensor_rebuild_invocations=frozenset({(position, cast(int, invocation["opcode_position"]))}),
+    )
+
+    cleaned_report = package_api._without_trusted_pytorch_data_pkl_findings(truncated_report, trusted_data_pkl)
+
+    assert _torch_rebuild_tensor_v2_warnings(cleaned_report)
 
 
 def test_scan_file_combines_pytorch_zip_private_source_fingerprints(
@@ -8337,91 +8941,6 @@ def test_scan_file_trusts_source_backed_framework_reference_imported_after_scann
     assert not any(
         finding["rule_code"] == "NON_ALLOWLISTED_GLOBAL"
         and finding["import_reference"] == "transformers.training_args.TrainingArguments"
-        for finding in output["findings"]
-    )
-
-
-def test_scan_file_trusts_source_dependent_framework_reconstruction_loaded_after_startup(
-    tmp_path: Path,
-) -> None:
-    output = _scan_source_dependent_torch_rebuild_tensor_v2(tmp_path)
-    assert output["status"] == ScanStatus.COMPLETE.value
-    assert output["verdict"] == SafetyVerdict.CLEAN.value
-    assert not any(
-        finding["rule_code"] == "NON_ALLOWLISTED_GLOBAL"
-        and finding["import_reference"] == "torch._utils._rebuild_tensor_v2"
-        for finding in output["findings"]
-    )
-
-
-def test_scan_file_warns_when_late_loaded_framework_reconstruction_function_is_rebound(
-    tmp_path: Path,
-) -> None:
-    output = _scan_source_dependent_torch_rebuild_tensor_v2(
-        tmp_path,
-        rebound_name="_rebuild_tensor_v2",
-        marker_text="forged-function",
-    )
-    assert output["marker_before_unpickle"] is False
-    assert output["marker_after_unpickle"] is True
-    assert output["verdict"] in {SafetyVerdict.SUSPICIOUS.value, SafetyVerdict.MALICIOUS.value}
-    assert any(
-        finding["rule_code"] == "NON_ALLOWLISTED_GLOBAL"
-        and finding["import_reference"] == "torch._utils._rebuild_tensor_v2"
-        for finding in output["findings"]
-    )
-
-
-def test_scan_file_warns_when_late_loaded_framework_reconstruction_default_is_rebound(
-    tmp_path: Path,
-) -> None:
-    output = _scan_source_dependent_torch_rebuild_tensor_v2(
-        tmp_path,
-        default_marker_text="forged-default",
-    )
-    assert output["marker_before_unpickle"] is False
-    assert output["marker_after_unpickle"] is True
-    assert output["verdict"] in {SafetyVerdict.SUSPICIOUS.value, SafetyVerdict.MALICIOUS.value}
-    assert any(
-        finding["rule_code"] == "NON_ALLOWLISTED_GLOBAL"
-        and finding["import_reference"] == "torch._utils._rebuild_tensor_v2"
-        for finding in output["findings"]
-    )
-
-
-def test_scan_file_warns_when_late_loaded_framework_reconstruction_helper_is_rebound(
-    tmp_path: Path,
-) -> None:
-    output = _scan_source_dependent_torch_rebuild_tensor_v2(
-        tmp_path,
-        rebound_name="_restore_device_fake_mode",
-        marker_text="forged-helper",
-    )
-    assert output["marker_before_unpickle"] is False
-    assert output["marker_after_unpickle"] is True
-    assert output["verdict"] in {SafetyVerdict.SUSPICIOUS.value, SafetyVerdict.MALICIOUS.value}
-    assert any(
-        finding["rule_code"] == "NON_ALLOWLISTED_GLOBAL"
-        and finding["import_reference"] == "torch._utils._rebuild_tensor_v2"
-        for finding in output["findings"]
-    )
-
-
-def test_scan_file_warns_when_late_loaded_framework_reconstruction_helper_is_rebound_to_builtin(
-    tmp_path: Path,
-) -> None:
-    output = _scan_source_dependent_torch_rebuild_tensor_v2(
-        tmp_path,
-        payload_value=b"marker.write_text('eval-helper', encoding='utf-8')",
-        rebound_name="_restore_device_fake_mode",
-        rebound_builtin="eval",
-    )
-    assert output["marker_before_unpickle"] is False
-    assert output["marker_after_unpickle"] is True
-    assert output["verdict"] in {SafetyVerdict.SUSPICIOUS.value, SafetyVerdict.MALICIOUS.value}
-    assert any(
-        finding["rule_code"] == "NON_ALLOWLISTED_GLOBAL"
-        and finding["import_reference"] == "torch._utils._rebuild_tensor_v2"
         for finding in output["findings"]
     )
 

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -98,6 +98,18 @@ def _pickle_binint(value: int) -> bytes:
     return b"J" + value.to_bytes(4, "little", signed=True)
 
 
+def _float_storage_element_count_for_bytes(data: bytes) -> int:
+    assert len(data) % 4 == 0
+    return len(data) // 4
+
+
+def _float_storage_persistent_id_payload_for_bytes(key: str | bytes, data: bytes) -> bytes:
+    return _pytorch_storage_persistent_id_payload(
+        key,
+        size_opcode=_pickle_binint(_float_storage_element_count_for_bytes(data)),
+    )
+
+
 def _pickle_int_tuple(values: tuple[int, ...]) -> bytes:
     payload = b"".join(_pickle_binint(value) for value in values)
     if len(values) == 0:
@@ -682,7 +694,7 @@ def _frame_first_large_malicious_eval_pickle_payload() -> bytes:
 
 
 def _frame_first_raw_storage_bytes() -> bytes:
-    return b"\x95" + (10_000).to_bytes(8, "little") + (b"\x00" * 4096)
+    return b"\x95" + (10_000).to_bytes(8, "little") + (b"\x00" * 4095)
 
 
 def _short_binunicode(data: bytes) -> bytes:
@@ -762,7 +774,7 @@ def _pytorch_storage_protocol0_persistent_id_payload(
     key: str,
     *,
     storage_qualname: str = "torch.FloatStorage",
-    size: int = 1,
+    size: int | str = 1,
 ) -> bytes:
     return f"(dp0\nVx\np1\nP('storage', <class '{storage_qualname}'>, '{key}', 'cpu', {size})\ns.".encode("ascii")
 
@@ -783,10 +795,17 @@ def _private_actionable_failed_checks(scan_result: dict[str, Any]) -> list[dict[
     return [entry for entry in actionable_failed_checks if isinstance(entry, dict)]
 
 
-def _pytorch_storage_persistent_id_sequence_payload(keys: list[str]) -> bytes:
+def _pytorch_storage_persistent_id_sequence_payload(
+    keys: list[str],
+    *,
+    size_opcodes: dict[str, bytes] | None = None,
+) -> bytes:
     payload = b"\x80\x04]("
     for key in keys:
-        payload += _pytorch_storage_persistent_id_payload(key)[2:-1]
+        payload += _pytorch_storage_persistent_id_payload(
+            key,
+            size_opcode=(size_opcodes or {}).get(key, b"K\x01"),
+        )[2:-1]
     return payload + b"e."
 
 
@@ -917,7 +936,16 @@ def _write_sparse_pytorch_zip64_shard(path: Path, *, storage_size: int) -> None:
     with path.open("wb") as handle:
         entries.append(write_local_entry(handle, "archive/version", b"3\n"))
         entries.append(write_local_entry(handle, "archive/byteorder", b"little"))
-        entries.append(write_local_entry(handle, "archive/data.pkl", _pytorch_storage_persistent_id_payload("0")))
+        entries.append(
+            write_local_entry(
+                handle,
+                "archive/data.pkl",
+                _pytorch_storage_persistent_id_payload(
+                    "0",
+                    size_opcode=_pickle_binint(storage_size // 4),
+                ),
+            )
+        )
         entries.append(write_sparse_streamed_entry(handle, "archive/data/0", storage_size))
 
         central_directory_offset = handle.tell()
@@ -957,8 +985,13 @@ def _write_sparse_pytorch_zip64_shard(path: Path, *, storage_size: int) -> None:
         )
 
 
-def _pytorch_storage_persistent_id_payload_with_popped_key(key: str, popped_key: str) -> bytes:
-    payload = _pytorch_storage_persistent_id_payload(key)
+def _pytorch_storage_persistent_id_payload_with_popped_key(
+    key: str,
+    popped_key: str,
+    *,
+    size_opcode: bytes = b"K\x01",
+) -> bytes:
+    payload = _pytorch_storage_persistent_id_payload(key, size_opcode=size_opcode)
     popped_key_bytes = popped_key.encode("utf-8")
     assert len(popped_key_bytes) < 256
     assert payload.endswith(b"Q.")
@@ -1006,7 +1039,7 @@ def _pickleish_tensor_storage_bytes() -> bytes:
 
 
 def _binary_magic_tensor_storage_bytes() -> bytes:
-    return b"\x80\x04\x00" + (b"\x00" * 128)
+    return b"\x80\x04\x00" + (b"\x00" * 129)
 
 
 def _writestr_preserving_member_name(zip_file: zipfile.ZipFile, member_name: str, data: bytes) -> None:
@@ -2655,32 +2688,64 @@ def test_pytorch_zip_discovery_finds_hidden_storage_pickle_with_data_pkl(tmp_pat
 def test_pytorch_zip_discovery_skips_referenced_storage_blob_pickleish_bytes(tmp_path: Path) -> None:
     """A data.pkl-referenced tensor blob is raw storage, not a follow-on pickle stream."""
     model_path = tmp_path / "referenced_storage_pickleish_bytes.pt"
+    storage_blob = _pickleish_tensor_storage_bytes()
     with zipfile.ZipFile(model_path, "w") as zip_file:
         zip_file.writestr("archive/version", "3\n")
         zip_file.writestr("archive/byteorder", "little")
-        zip_file.writestr("archive/data.pkl", _pytorch_storage_persistent_id_payload("0"))
-        zip_file.writestr("archive/data/0", _pickleish_tensor_storage_bytes())
+        zip_file.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        zip_file.writestr("archive/data/0", storage_blob)
 
     result = PyTorchZipScanner().scan(str(model_path))
 
     assert result.success is True
+    assert result.metadata.get("pickle_verdict") == "clean"
     assert result.metadata["pickle_files"] == ["archive/data.pkl"]
+    assert any(check.details.get("trusted_pytorch_archive_context") is True for check in result.checks)
     assert not any(issue.details.get("pickle_filename") == "archive/data/0" for issue in result.issues)
     assert not any(check.details.get("pickle_filename") == "archive/data/0" for check in result.checks)
 
 
-def test_pytorch_zip_discovery_skips_referenced_storage_blob_binary_magic_without_opcode(tmp_path: Path) -> None:
-    model_path = tmp_path / "referenced_storage_binary_magic_bytes.pt"
+def test_pytorch_zip_discovery_does_not_route_size_mismatched_benign_storage_blob(
+    tmp_path: Path,
+) -> None:
+    model_path = tmp_path / "referenced_size_mismatched_benign_storage.pt"
+    storage_blob = _binary_magic_tensor_storage_bytes()
     with zipfile.ZipFile(model_path, "w") as zip_file:
         zip_file.writestr("archive/version", "3\n")
         zip_file.writestr("archive/byteorder", "little")
         zip_file.writestr("archive/data.pkl", _pytorch_storage_persistent_id_payload("0"))
-        zip_file.writestr("archive/data/0", _binary_magic_tensor_storage_bytes())
+        zip_file.writestr("archive/data/0", storage_blob)
 
     result = PyTorchZipScanner().scan(str(model_path))
 
     assert result.success is True
+    assert result.metadata.get("pickle_verdict") == "suspicious"
     assert result.metadata["pickle_files"] == ["archive/data.pkl"]
+    assert any(
+        issue.rule_code == "S212"
+        and issue.severity == IssueSeverity.WARNING
+        and issue.details.get("pickle_filename") == "archive/data.pkl"
+        for issue in result.issues
+    )
+    assert not any(check.details.get("trusted_pytorch_archive_context") is True for check in result.checks)
+    assert not any(issue.details.get("pickle_filename") == "archive/data/0" for issue in result.issues)
+
+
+def test_pytorch_zip_discovery_skips_referenced_storage_blob_binary_magic_without_opcode(tmp_path: Path) -> None:
+    model_path = tmp_path / "referenced_storage_binary_magic_bytes.pt"
+    storage_blob = _binary_magic_tensor_storage_bytes()
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        zip_file.writestr("archive/data/0", storage_blob)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert result.metadata.get("pickle_verdict") == "clean"
+    assert result.metadata["pickle_files"] == ["archive/data.pkl"]
+    assert any(check.details.get("trusted_pytorch_archive_context") is True for check in result.checks)
     assert not any(issue.details.get("pickle_filename") == "archive/data/0" for issue in result.issues)
     assert not any(check.details.get("pickle_filename") == "archive/data/0" for check in result.checks)
 
@@ -2689,27 +2754,37 @@ def test_pytorch_zip_discovery_skips_referenced_storage_blob_frame_first_without
     tmp_path: Path,
 ) -> None:
     model_path = tmp_path / "referenced_storage_frame_first_raw_bytes.pt"
+    storage_blob = _frame_first_raw_storage_bytes()
     with zipfile.ZipFile(model_path, "w") as zip_file:
         zip_file.writestr("archive/version", "3\n")
         zip_file.writestr("archive/byteorder", "little")
-        zip_file.writestr("archive/data.pkl", _pytorch_storage_persistent_id_payload("0"))
-        zip_file.writestr("archive/data/0", _frame_first_raw_storage_bytes())
+        zip_file.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        zip_file.writestr("archive/data/0", storage_blob)
 
     result = PyTorchZipScanner().scan(str(model_path))
 
     assert result.success is True
+    assert result.metadata.get("pickle_verdict") == "clean"
     assert result.metadata["pickle_files"] == ["archive/data.pkl"]
+    assert any(check.details.get("trusted_pytorch_archive_context") is True for check in result.checks)
     assert not any(issue.details.get("pickle_filename") == "archive/data/0" for issue in result.issues)
     assert not any(check.details.get("pickle_filename") == "archive/data/0" for check in result.checks)
 
 
 def test_pytorch_zip_discovery_trusts_protocol0_storage_persid(tmp_path: Path) -> None:
     model_path = tmp_path / "protocol0_referenced_storage.pt"
+    storage_blob = _pickleish_tensor_storage_bytes()
     with zipfile.ZipFile(model_path, "w") as zip_file:
         zip_file.writestr("archive/version", "3\n")
         zip_file.writestr("archive/byteorder", "little")
-        zip_file.writestr("archive/data.pkl", _pytorch_storage_protocol0_persistent_id_payload("0"))
-        zip_file.writestr("archive/data/0", _pickleish_tensor_storage_bytes())
+        zip_file.writestr(
+            "archive/data.pkl",
+            _pytorch_storage_protocol0_persistent_id_payload(
+                "0",
+                size=_float_storage_element_count_for_bytes(storage_blob),
+            ),
+        )
+        zip_file.writestr("archive/data/0", storage_blob)
 
     result = PyTorchZipScanner().scan(str(model_path))
 
@@ -2720,6 +2795,7 @@ def test_pytorch_zip_discovery_trusts_protocol0_storage_persid(tmp_path: Path) -
 
 def test_pytorch_zip_discovery_trusts_torch_storage_untyped_storage(tmp_path: Path) -> None:
     model_path = tmp_path / "referenced_untyped_storage_pickleish_bytes.pt"
+    storage_blob = _pickleish_tensor_storage_bytes()
     with zipfile.ZipFile(model_path, "w") as zip_file:
         zip_file.writestr("archive/version", "3\n")
         zip_file.writestr("archive/byteorder", "little")
@@ -2729,9 +2805,10 @@ def test_pytorch_zip_discovery_trusts_torch_storage_untyped_storage(tmp_path: Pa
                 "0",
                 storage_module="torch.storage",
                 storage_name="UntypedStorage",
+                size_opcode=_pickle_binint(len(storage_blob)),
             ),
         )
-        zip_file.writestr("archive/data/0", _pickleish_tensor_storage_bytes())
+        zip_file.writestr("archive/data/0", storage_blob)
 
     result = PyTorchZipScanner().scan(str(model_path))
 
@@ -2835,6 +2912,37 @@ def test_pytorch_zip_discovery_scans_referenced_storage_blob_with_frame_first_la
     )
 
 
+@pytest.mark.parametrize(
+    "data_pkl_payload",
+    [
+        _pytorch_storage_protocol0_persistent_id_payload("0", size="9" * 128),
+        _pytorch_storage_persistent_id_payload("0", size_opcode=b"\x88"),
+    ],
+    ids=["oversized-protocol0-count", "bool-binpersid-count"],
+)
+def test_pytorch_zip_discovery_long_probes_invalid_count_storage_with_frame_first_pickle(
+    data_pkl_payload: bytes,
+    tmp_path: Path,
+) -> None:
+    model_path = tmp_path / "referenced_storage_invalid_count_frame_first_pickle.pt"
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", data_pkl_payload)
+        zip_file.writestr("archive/data/0", _frame_first_large_malicious_eval_pickle_payload())
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert "archive/data/0" in result.metadata["pickle_files"]
+    assert not any(check.details.get("trusted_pytorch_archive_context") is True for check in result.checks)
+    assert any(
+        issue.severity == IssueSeverity.CRITICAL
+        and issue.details.get("pickle_filename") == "archive/data/0"
+        and "eval" in issue.message.lower()
+        for issue in result.issues
+    )
+
+
 @pytest.mark.parametrize("storage_member", [r"archive\data\0", "/archive/data/0"])
 def test_pytorch_zip_discovery_scans_noncanonical_referenced_storage_aliases(
     storage_member: str,
@@ -2877,6 +2985,7 @@ def test_pytorch_zip_discovery_scans_noncanonical_referenced_storage_aliases(
         (_fake_byte_storage_persistent_id_payload("0"), True, None),
         (_pytorch_storage_persistent_id_payload("0", storage_name="FakeStorage"), True, None),
         (_pytorch_storage_protocol0_persistent_id_payload("0", storage_qualname="torch.FakeStorage"), True, None),
+        (_pytorch_storage_protocol0_persistent_id_payload("0", size="9" * 128), True, None),
         (_pytorch_storage_persistent_id_payload("0", size_opcode=b"\x88"), True, None),
         (_pytorch_storage_persistent_id_payload_with_extra_field("0"), True, None),
         (_pytorch_storage_persistent_id_payload("0")[:-1], True, "pytorch_zip_storage_reference_validation_incomplete"),
@@ -3276,9 +3385,10 @@ def test_pytorch_zip_scanner_marks_over_budget_pe_header_offset_inconclusive(
 def test_pytorch_zip_scanner_does_not_treat_tensor_storage_bytes_as_executable_sidecar(tmp_path: Path) -> None:
     """Arbitrary tensor storage bytes are not evidence of an executable archive member."""
     model_path = create_mock_pytorch_zip(tmp_path / "tensor_bytes.pt", with_pickle=False, prefix="archive")
+    storage_blob = b"\x7fELF\x02\x01\x01\x00" + (b"\x00" * 64)
     with zipfile.ZipFile(model_path, "a") as zip_file:
-        zip_file.writestr("archive/data.pkl", _pytorch_storage_persistent_id_payload("0"))
-        zip_file.writestr("archive/data/0", b"\x7fELF\x02\x01\x01\x00" + (b"\x00" * 64))
+        zip_file.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        zip_file.writestr("archive/data/0", storage_blob)
 
     result = PyTorchZipScanner().scan(str(model_path))
 
@@ -3295,10 +3405,21 @@ def test_pytorch_zip_scanner_trusts_all_validated_tensor_storage_bytes_as_non_ex
     tmp_path: Path,
 ) -> None:
     model_path = create_mock_pytorch_zip(tmp_path / "multi_tensor_bytes.pt", with_pickle=False, prefix="archive")
+    first_storage_blob = b"\x00" * 64
+    second_storage_blob = b"\x7fELF\x02\x01\x01\x00" + (b"\x00" * 64)
     with zipfile.ZipFile(model_path, "a") as zip_file:
-        zip_file.writestr("archive/data.pkl", _pytorch_storage_persistent_id_sequence_payload(["0", "1"]))
-        zip_file.writestr("archive/data/0", b"\x00" * 64)
-        zip_file.writestr("archive/data/1", b"\x7fELF\x02\x01\x01\x00" + (b"\x00" * 64))
+        zip_file.writestr(
+            "archive/data.pkl",
+            _pytorch_storage_persistent_id_sequence_payload(
+                ["0", "1"],
+                size_opcodes={
+                    "0": _pickle_binint(_float_storage_element_count_for_bytes(first_storage_blob)),
+                    "1": _pickle_binint(_float_storage_element_count_for_bytes(second_storage_blob)),
+                },
+            ),
+        )
+        zip_file.writestr("archive/data/0", first_storage_blob)
+        zip_file.writestr("archive/data/1", second_storage_blob)
 
     result = PyTorchZipScanner().scan(str(model_path))
 
@@ -3314,9 +3435,10 @@ def test_pytorch_zip_scanner_trusts_all_validated_tensor_storage_bytes_as_non_ex
 def test_pytorch_zip_scanner_keeps_tensor_storage_trust_when_pickle_scanner_is_disabled(tmp_path: Path) -> None:
     """Scanner-only PyTorch ZIP scans still need trusted storage IDs to avoid tensor-byte false positives."""
     model_path = create_mock_pytorch_zip(tmp_path / "scanner_only_tensor_bytes.pt", with_pickle=False, prefix="archive")
+    storage_blob = b"\x7fELF\x02\x01\x01\x00" + (b"\x00" * 64)
     with zipfile.ZipFile(model_path, "a") as zip_file:
-        zip_file.writestr("archive/data.pkl", _pytorch_storage_persistent_id_payload("0"))
-        zip_file.writestr("archive/data/0", b"\x7fELF\x02\x01\x01\x00" + (b"\x00" * 64))
+        zip_file.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        zip_file.writestr("archive/data/0", storage_blob)
 
     result = PyTorchZipScanner(config={"scanners": ["pytorch_zip"]}).scan(str(model_path))
 
@@ -3366,9 +3488,10 @@ def test_pytorch_zip_scanner_probes_mixed_persid_storage_when_pickle_scanner_is_
 def test_pytorch_zip_scanner_probes_unreferenced_numeric_storage_lookalike(tmp_path: Path) -> None:
     """An unreferenced canonical-looking data member remains an executable sidecar."""
     model_path = create_mock_pytorch_zip(tmp_path / "unreferenced_tensor_bytes.pt", with_pickle=False, prefix="archive")
+    storage_blob = b"\x00" * 8
     with zipfile.ZipFile(model_path, "a") as zip_file:
-        zip_file.writestr("archive/data.pkl", _pytorch_storage_persistent_id_payload("0"))
-        zip_file.writestr("archive/data/0", b"\x00" * 8)
+        zip_file.writestr("archive/data.pkl", _float_storage_persistent_id_payload_for_bytes("0", storage_blob))
+        zip_file.writestr("archive/data/0", storage_blob)
         zip_file.writestr("archive/data/999", b"\x7fELF\x02\x01\x01\x00" + (b"\x00" * 64))
 
     result = PyTorchZipScanner().scan(str(model_path))
@@ -3386,7 +3509,10 @@ def test_pytorch_zip_scanner_only_probes_popped_storage_key_decoys(tmp_path: Pat
     """Scanner-only fallback trust must follow the actual BINPERSID operand."""
     model_path = create_mock_pytorch_zip(tmp_path / "popped_storage_decoy.pt", with_pickle=False, prefix="archive")
     with zipfile.ZipFile(model_path, "a") as zip_file:
-        zip_file.writestr("archive/data.pkl", _pytorch_storage_persistent_id_payload_with_popped_key("0", "999"))
+        zip_file.writestr(
+            "archive/data.pkl",
+            _pytorch_storage_persistent_id_payload_with_popped_key("0", "999", size_opcode=_pickle_binint(2)),
+        )
         zip_file.writestr("archive/data/0", b"\x00" * 8)
         zip_file.writestr("archive/data/999", b"\x7fELF\x02\x01\x01\x00" + (b"\x00" * 64))
 
@@ -9710,7 +9836,7 @@ def test_pytorch_zip_embedded_data_pkl_context_respects_pickle_read_limit(tmp_pa
 
 
 def test_pytorch_zip_scanner_trusts_protocol0_storage_persid_in_data_pkl(tmp_path: Path) -> None:
-    payload = _pytorch_storage_protocol0_persistent_id_payload("0")
+    payload = _pytorch_storage_protocol0_persistent_id_payload("0", size=2)
     model_path = create_mock_pytorch_zip(
         tmp_path / "protocol0_storage_persistent_id.pt",
         with_pickle=False,

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -16,7 +16,7 @@ from collections.abc import Iterator
 from importlib import metadata as importlib_metadata
 from pathlib import Path
 from types import ModuleType
-from typing import IO, Any
+from typing import IO, Any, BinaryIO, cast
 
 import pytest
 from modelaudit_picklescan.api import _source_backed_import_requires_initialization_proof
@@ -90,6 +90,25 @@ def _pickle_short_binunicode(value: bytes) -> bytes:
     if len(value) > 0xFF:
         raise ValueError("SHORT_BINUNICODE helper accepts at most 255 bytes")
     return b"\x8c" + bytes([len(value)]) + value
+
+
+def _pickle_binint(value: int) -> bytes:
+    if 0 <= value <= 0xFF:
+        return b"K" + bytes([value])
+    return b"J" + value.to_bytes(4, "little", signed=True)
+
+
+def _pickle_int_tuple(values: tuple[int, ...]) -> bytes:
+    payload = b"".join(_pickle_binint(value) for value in values)
+    if len(values) == 0:
+        return b")"
+    if len(values) == 1:
+        return payload + b"\x85"
+    if len(values) == 2:
+        return payload + b"\x86"
+    if len(values) == 3:
+        return payload + b"\x87"
+    return b"(" + payload + b"t"
 
 
 def _metadata_reduce_payload(module: str, name: str, value: bytes = b"metadata") -> bytes:
@@ -699,6 +718,46 @@ def _pytorch_storage_persistent_id_payload(
     )
 
 
+def _pytorch_storage_binpersid_expr(
+    key: str = "0",
+    *,
+    storage_module: str = "torch",
+    storage_name: str = "LongStorage",
+    location: str = "cpu",
+    element_count: int = 3,
+) -> bytes:
+    return (
+        b"("
+        + _short_binunicode(b"storage")
+        + _short_binunicode(storage_module.encode("ascii"))
+        + _short_binunicode(storage_name.encode("ascii"))
+        + b"\x93"
+        + _short_binunicode(key.encode("ascii"))
+        + _short_binunicode(location.encode("ascii"))
+        + _pickle_binint(element_count)
+        + b"tQ"
+    )
+
+
+def _pytorch_empty_ordered_dict_reduce_expr() -> bytes:
+    return _pickle_global("collections", "OrderedDict") + b")R"
+
+
+def _pytorch_rebuild_tensor_v2_payload() -> bytes:
+    return (
+        b"\x80\x04"
+        + _pickle_global("torch._utils", "_rebuild_tensor_v2")
+        + b"q\x00("
+        + _pytorch_storage_binpersid_expr()
+        + b"K\x00"
+        + _pickle_int_tuple((3,))
+        + _pickle_int_tuple((1,))
+        + b"\x89"
+        + _pytorch_empty_ordered_dict_reduce_expr()
+        + b"tR."
+    )
+
+
 def _pytorch_storage_protocol0_persistent_id_payload(
     key: str,
     *,
@@ -963,6 +1022,50 @@ def _write_zip_with_duplicate_data_pkl(zip_path: Path, first_payload: bytes, sec
             zipf.writestr("version", "3")
             zipf.writestr("data.pkl", first_payload)
             zipf.writestr("data.pkl", second_payload)
+
+
+def _require_torch_distribution() -> None:
+    try:
+        importlib_metadata.distribution("torch")
+    except importlib_metadata.PackageNotFoundError:
+        pytest.skip("torch distribution not installed")
+
+
+def _write_rebuild_tensor_v2_zip(zip_path: Path) -> None:
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        zipf.writestr("archive/version", "3\n")
+        zipf.writestr("archive/byteorder", "little")
+        zipf.writestr("archive/data.pkl", _pytorch_rebuild_tensor_v2_payload())
+        zipf.writestr("archive/data/0", b"\x00" * 24)
+
+
+def _scan_pytorch_zip_report_dict_subprocess(path: Path) -> dict[str, Any]:
+    script = "\n".join(
+        [
+            "import json",
+            "import sys",
+            "from modelaudit.scanners.pytorch_zip_scanner import PyTorchZipScanner",
+            "result = PyTorchZipScanner().scan(sys.argv[1])",
+            "print(json.dumps(result.to_dict(include_private_metadata=True)))",
+        ]
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PROMPTFOO_DISABLE_TELEMETRY": "1"},
+    )
+    return cast(dict[str, Any], json.loads(completed.stdout))
+
+
+def _rebuild_tensor_v2_issue_dicts(report: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        issue
+        for issue in report.get("issues", [])
+        if issue.get("details", {}).get("pickle_rule_code") == "NON_ALLOWLISTED_GLOBAL"
+        and issue.get("details", {}).get("import_reference") == "torch._utils._rebuild_tensor_v2"
+    ]
 
 
 def _write_pytorch_zip_with_symlink(zip_path: Path, link_name: str, target: str | bytes) -> None:
@@ -9506,6 +9609,83 @@ def test_pytorch_zip_scanner_trusts_storage_persistent_ids_in_data_pkl(tmp_path:
     serialized_result = result.to_dict(include_private_metadata=True)
     assert _private_actionable_failed_checks(serialized_result) == []
     assert should_cache_scan_result(serialized_result) is True
+
+
+def test_pytorch_zip_scanner_suppresses_rebuild_tensor_v2_in_embedded_data_pkl(tmp_path: Path) -> None:
+    _require_torch_distribution()
+    model_path = tmp_path / "rebuild_tensor_v2.pt"
+    _write_rebuild_tensor_v2_zip(model_path)
+
+    report = _scan_pytorch_zip_report_dict_subprocess(model_path)
+
+    assert report["success"] is True
+    assert report["has_warnings"] is False
+    assert report.get("metadata", {}).get("pickle_verdict") == "clean"
+    assert _rebuild_tensor_v2_issue_dicts(report) == []
+
+
+def test_pytorch_zip_embedded_context_falls_back_with_older_picklescan_scan_stream(tmp_path: Path) -> None:
+    _require_torch_distribution()
+    from modelaudit_picklescan import PickleScanner as StandalonePickleScanner
+
+    model_path = tmp_path / "rebuild_tensor_v2_old_picklescan.pt"
+    _write_rebuild_tensor_v2_zip(model_path)
+    scanner = PyTorchZipScanner()
+    assert scanner.pickle_scanner is not None
+    real_scanner = StandalonePickleScanner(options=scanner.pickle_scanner._standalone_pickle_scanner.options)
+
+    class OldStandalonePickleScanner:
+        options = real_scanner.options
+
+        def scan_stream(
+            self,
+            stream: BinaryIO,
+            *,
+            source: str = "<stream>",
+            size: int | None = None,
+            enrich_call_graph: bool = True,
+        ) -> Any:
+            return real_scanner.scan_stream(
+                stream,
+                source=source,
+                size=size,
+                enrich_call_graph=enrich_call_graph,
+            )
+
+    cast(Any, scanner.pickle_scanner)._standalone_pickle_scanner = OldStandalonePickleScanner()
+
+    result = scanner.scan(str(model_path))
+    report = result.to_dict()
+
+    assert result.success is True
+    assert result.has_errors is False
+    assert result.has_warnings is True
+    assert result.metadata.get("pickle_verdict") == "suspicious"
+    assert _rebuild_tensor_v2_issue_dicts(report)
+
+
+def test_pytorch_zip_embedded_data_pkl_context_respects_pickle_read_limit(tmp_path: Path) -> None:
+    _require_torch_distribution()
+    model_path = tmp_path / "rebuild_tensor_v2_limit.pt"
+    data_pkl = _pytorch_rebuild_tensor_v2_payload()
+    _write_rebuild_tensor_v2_zip(model_path)
+    scanner = PyTorchZipScanner()
+    assert scanner.pickle_scanner is not None
+    scanner.pickle_scanner.max_file_read_size = len(data_pkl) - 1
+
+    result = scanner.scan(str(model_path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "max_file_read_size_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "File Size Limit"
+        and check.status == CheckStatus.FAILED
+        and check.location == f"{model_path}:archive/data.pkl"
+        and check.details["file_size"] == len(data_pkl)
+        and check.details["max_file_read_size"] == len(data_pkl) - 1
+        for check in result.checks
+    )
 
 
 def test_pytorch_zip_scanner_trusts_protocol0_storage_persid_in_data_pkl(tmp_path: Path) -> None:

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -2774,6 +2774,27 @@ def test_pytorch_zip_discovery_scans_referenced_storage_blob_when_it_is_a_pickle
     )
 
 
+def test_pytorch_zip_discovery_scans_size_mismatched_storage_blob_on_hidden_pickle_path(
+    tmp_path: Path,
+) -> None:
+    model_path = tmp_path / "referenced_size_mismatched_storage_payload.pt"
+    hidden_payload = b"S'" + (b"A" * 5000) + b"'\n" + b"cposix\nsystem\n(S'echo hidden'\ntR."
+    with zipfile.ZipFile(model_path, "w") as zip_file:
+        zip_file.writestr("archive/version", "3\n")
+        zip_file.writestr("archive/byteorder", "little")
+        zip_file.writestr("archive/data.pkl", _pytorch_storage_persistent_id_payload("0"))
+        zip_file.writestr("archive/data/0", hidden_payload)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.success is False
+    assert result.metadata["pickle_files"] == ["archive/data.pkl", "archive/data/0"]
+    assert any(
+        issue.severity == IssueSeverity.CRITICAL and issue.details.get("pickle_filename") == "archive/data/0"
+        for issue in result.issues
+    )
+
+
 def test_pytorch_zip_discovery_scans_referenced_storage_blob_with_truncated_frame(
     tmp_path: Path,
 ) -> None:
@@ -9588,7 +9609,7 @@ def test_pytorch_zip_scanner_preserves_legacy_pickle_rule_codes_for_embedded_mem
 
 
 def test_pytorch_zip_scanner_trusts_storage_persistent_ids_in_data_pkl(tmp_path: Path) -> None:
-    payload = _pytorch_storage_persistent_id_payload("0")
+    payload = _pytorch_storage_persistent_id_payload("0", size_opcode=b"K\x02")
     model_path = create_mock_pytorch_zip(tmp_path / "storage_persistent_id.pt", with_pickle=False, prefix="archive")
     with zipfile.ZipFile(model_path, "a") as zipf:
         zipf.writestr("archive/data.pkl", payload)
@@ -9857,7 +9878,7 @@ def test_pytorch_zip_scanner_does_not_trust_noncanonical_protocol0_storage_persi
 
 
 def test_pytorch_zip_scanner_trusts_storage_persistent_ids_with_utf8_byte_key(tmp_path: Path) -> None:
-    payload = _pytorch_storage_persistent_id_payload(b"0")
+    payload = _pytorch_storage_persistent_id_payload(b"0", size_opcode=b"K\x02")
     model_path = create_mock_pytorch_zip(tmp_path / "storage_persistent_id_bytes.pt", with_pickle=False)
     with zipfile.ZipFile(model_path, "a") as zipf:
         zipf.writestr("version", "3")
@@ -9950,7 +9971,7 @@ def test_pytorch_zip_scanner_does_not_trust_storage_persistent_ids_with_unrelate
 
 
 def test_pytorch_zip_scanner_scopes_storage_persistent_id_trust_by_prefix(tmp_path: Path) -> None:
-    payload = _pytorch_storage_persistent_id_payload("0")
+    payload = _pytorch_storage_persistent_id_payload("0", size_opcode=b"K\x02")
     model_path = tmp_path / "mixed_storage_persistent_id.pt"
     with zipfile.ZipFile(model_path, "w") as zipf:
         zipf.writestr("good/version", "3")

--- a/tests/test_false_positive_fixes.py
+++ b/tests/test_false_positive_fixes.py
@@ -532,6 +532,56 @@ class TestFalsePositiveFixes:
             f"issues={result['issues']!r}; stdout={result['stdout']!r}; stderr={result['stderr']!r}"
         )
 
+    def test_real_cli_scan_survives_legacy_cp1252_output_encoding(self, tmp_path: Path) -> None:
+        """The production CLI should not crash on decorative text under cp1252 stdout."""
+        model_dir = tmp_path / "gpt2_model"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(
+            json.dumps({"model_type": "gpt2", "architectures": ["GPT2LMHeadModel"]}),
+            encoding="utf-8",
+        )
+        output_file = tmp_path / "report.json"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "\n".join(
+                    [
+                        "import runpy",
+                        "import sys",
+                        "if sys.platform == 'darwin':",
+                        "    import modelaudit.cli as cli",
+                        "    cli._darwin_fd_has_extended_acl = lambda _fd: False",
+                        "sys.argv = [",
+                        "    'modelaudit', 'scan', sys.argv[1],",
+                        "    '--format', 'json', '--output', sys.argv[2],",
+                        "]",
+                        "runpy.run_module('modelaudit', run_name='__main__')",
+                    ]
+                ),
+                str(model_dir),
+                str(output_file),
+            ],
+            check=False,
+            capture_output=True,
+            encoding="cp1252",
+            env={
+                **os.environ,
+                "PROMPTFOO_DISABLE_TELEMETRY": "1",
+                "NO_ANALYTICS": "1",
+                "PYTHONIOENCODING": "cp1252",
+            },
+        )
+
+        assert completed.returncode == 0, (
+            "CLI should tolerate legacy cp1252 redirected output; "
+            f"stdout={completed.stdout!r}; stderr={completed.stderr!r}"
+        )
+        assert "\\u2500" in completed.stdout
+        report = json.loads(output_file.read_text(encoding="utf-8"))
+        assert report.get("issues") == []
+        assert report.get("files_scanned", 0) >= 1
+
     def _run_cli_scan(self, path):
         """Helper method to run CLI scan and parse results."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
@@ -626,9 +676,7 @@ class TestFalsePositiveFixes:
                 ],
                 check=False,
                 capture_output=True,
-                text=True,
                 encoding="utf-8",
-                errors="replace",
                 env={
                     **os.environ,
                     "PROMPTFOO_DISABLE_TELEMETRY": "1",

--- a/tests/test_false_positive_fixes.py
+++ b/tests/test_false_positive_fixes.py
@@ -327,7 +327,10 @@ class TestFalsePositiveFixes:
         result = self._run_cli_scan_subprocess(str(bert_file))
 
         # Should not flag as executable
-        assert result["exit_code"] == 0, "BERT model with random MZ bytes should not be flagged"
+        assert result["exit_code"] == 0, (
+            "BERT model with random MZ bytes should not be flagged; "
+            f"issues={result['issues']!r}; stdout={result['stdout']!r}; stderr={result['stderr']!r}"
+        )
         assert not any("Windows executable" in issue.get("message", "") for issue in result["issues"]), (
             "Should not detect Windows executable in BERT model"
         )
@@ -503,9 +506,31 @@ class TestFalsePositiveFixes:
         result = self._run_cli_scan_subprocess(str(model_dir))
 
         # Should complete with no issues
-        assert result["exit_code"] == 0, "Complete GPT-2 model directory should scan clean"
+        assert result["exit_code"] == 0, (
+            "Complete GPT-2 model directory should scan clean; "
+            f"issues={result['issues']!r}; stdout={result['stdout']!r}; stderr={result['stderr']!r}"
+        )
         assert result["has_warnings"] is False, "GPT-2 model should not have warnings"
         assert result["has_errors"] is False, "GPT-2 model should not have errors"
+
+    def test_cli_subprocess_scan_forces_utf8_output_encoding(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fresh CLI subprocess scans must not inherit a legacy stdout encoding."""
+        monkeypatch.setenv("PYTHONIOENCODING", "cp1252")
+        model_dir = tmp_path / "gpt2_model"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(
+            json.dumps({"model_type": "gpt2", "architectures": ["GPT2LMHeadModel"]}),
+            encoding="utf-8",
+        )
+
+        result = self._run_cli_scan_subprocess(str(model_dir))
+
+        assert result["exit_code"] == 0, (
+            "CLI subprocess should force UTF-8 output even when parent requests cp1252; "
+            f"issues={result['issues']!r}; stdout={result['stdout']!r}; stderr={result['stderr']!r}"
+        )
 
     def _run_cli_scan(self, path):
         """Helper method to run CLI scan and parse results."""
@@ -602,10 +627,13 @@ class TestFalsePositiveFixes:
                 check=False,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 env={
                     **os.environ,
                     "PROMPTFOO_DISABLE_TELEMETRY": "1",
                     "NO_ANALYTICS": "1",
+                    "PYTHONIOENCODING": "utf-8",
                 },
             )
             try:

--- a/tests/test_false_positive_fixes.py
+++ b/tests/test_false_positive_fixes.py
@@ -7,8 +7,12 @@ false positive security alerts while maintaining detection of real threats.
 
 import contextlib
 import json
+import os
+import subprocess
+import sys
 import tempfile
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
@@ -286,7 +290,7 @@ class TestFalsePositiveFixes:
         has_extreme = any("extremely large weight values" in a["description"] for a in anomalies)
         assert has_outlier or has_extreme, "Should detect the injected anomaly"
 
-    def test_bert_model_no_false_positive_executables(self, tmp_path):
+    def test_bert_model_no_false_positive_executables(self, tmp_path: Path) -> None:
         """Test that BERT models with random MZ bytes don't trigger false positives."""
         if not HAS_TORCH:
             pytest.skip("torch not installed")
@@ -320,7 +324,7 @@ class TestFalsePositiveFixes:
             f.write(modified_data)
 
         # Scan the file
-        result = self._run_cli_scan(str(bert_file))
+        result = self._run_cli_scan_subprocess(str(bert_file))
 
         # Should not flag as executable
         assert result["exit_code"] == 0, "BERT model with random MZ bytes should not be flagged"
@@ -423,7 +427,7 @@ class TestFalsePositiveFixes:
             f"{[str(issue) for issue in scan_result.issues]}"
         )
 
-    def test_comprehensive_gpt2_model_scan(self, tmp_path):
+    def test_comprehensive_gpt2_model_scan(self, tmp_path: Path) -> None:
         """Comprehensive test simulating a complete GPT-2 model directory scan."""
         # Create a realistic GPT-2 model directory structure
         model_dir = tmp_path / "gpt2_model"
@@ -496,7 +500,7 @@ class TestFalsePositiveFixes:
                 optimizer_weights.create_dataset("iteration:0", data=[1000])
 
         # Scan the entire directory
-        result = self._run_cli_scan(str(model_dir))
+        result = self._run_cli_scan_subprocess(str(model_dir))
 
         # Should complete with no issues
         assert result["exit_code"] == 0, "Complete GPT-2 model directory should scan clean"
@@ -566,5 +570,63 @@ class TestFalsePositiveFixes:
 
         finally:
             # Clean up
+            with contextlib.suppress(FileNotFoundError):
+                Path(output_file).unlink()
+
+    def _run_cli_scan_subprocess(self, path: str) -> dict[str, Any]:
+        """Run CLI scan in a fresh process so fixture imports do not pollute scanner state."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            output_file = str(Path(f.name).resolve())
+
+        try:
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "\n".join(
+                        [
+                            "import sys",
+                            "import modelaudit.cli as cli",
+                            "if sys.platform == 'darwin':",
+                            "    cli._darwin_fd_has_extended_acl = lambda _fd: False",
+                            "sys.argv = [",
+                            "    'modelaudit', 'scan', sys.argv[1],",
+                            "    '--format', 'json', '--output', sys.argv[2],",
+                            "]",
+                            "cli.main()",
+                        ]
+                    ),
+                    path,
+                    output_file,
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "PROMPTFOO_DISABLE_TELEMETRY": "1",
+                    "NO_ANALYTICS": "1",
+                },
+            )
+            try:
+                with open(output_file) as f:
+                    scan_results = json.load(f)
+            except (FileNotFoundError, json.JSONDecodeError):
+                scan_results = {"issues": []}
+
+            issues = scan_results.get("issues", [])
+            has_warnings = any(issue.get("severity") in ["warning", "critical"] for issue in issues)
+            has_errors = any(issue.get("severity") == "critical" for issue in issues)
+
+            return {
+                "exit_code": completed.returncode,
+                "has_warnings": has_warnings,
+                "has_errors": has_errors,
+                "issues": issues,
+                "stdout": completed.stdout,
+                "stderr": completed.stderr,
+            }
+
+        finally:
             with contextlib.suppress(FileNotFoundError):
                 Path(output_file).unlink()


### PR DESCRIPTION
## Summary

Fixes the current-main Linux Python 3.11 false-positive failures from https://github.com/promptfoo/modelaudit/actions/runs/27462464942.

The original failing BERT/GPT2 integration tests were exiting 1 because otherwise clean PyTorch ZIP archives surfaced an invoked `NON_ALLOWLISTED_GLOBAL` warning for `torch._utils._rebuild_tensor_v2`. Windows was already healthy on current main after #1678, and the #1679 six.moves isolation did not address this production failure.

## Root Cause

PyTorch `torch.save(...)` ZIP archives encode tensors through `data.pkl` calls to `torch._utils._rebuild_tensor_v2` with tensor storage referenced through same-prefix `data/<key>` members. A raw pickle scan should still fail closed on that global, but a validated PyTorch ZIP archive can prove that a specific `_rebuild_tensor_v2` `REDUCE` is canonical tensor reconstruction rather than attacker-controlled executable dispatch.

The previous PR head `5df985e0` tried to solve this with generic source-dependent runtime trust. Review found that design too broad and bypass-prone, so this commit series supersedes it. The final design is not generic source trust.

## Fix

This PR adds a narrow structural proof for canonical PyTorch ZIP tensor rebuilds:

- Parse `data.pkl` with bounded sentinels for canonical storage persistent IDs, empty `collections.OrderedDict` hooks, and exact 6-arg `_rebuild_tensor_v2` `REDUCE` calls.
- Suppress only exact `_rebuild_tensor_v2` warning positions whose Python parser proof shows every use is canonical. Rust callable metadata may dedupe repeated calls, so the Python all-use proof remains authoritative.
- Require same-prefix ZIP invariants before cleanup: version member, exact `data.pkl`, canonical storage PIDs, no missing storage keys, known storage item size, decimal CPU storage keys, unique matching `data/<key>` members, and exact storage byte sizes.
- Use three storage-member probe states: exact-size canonical storage keeps the intentional 4 KiB storage probe; referenced but size-mismatched/unknown/invalid-count storage gets a 64 KiB storage-aware probe and no downgrade/suppression; unrelated entries keep the generic probe.
- Treat `torch.storage.UntypedStorage` as byte-sized for ZIP storage-size validation, matching installed PyTorch serialization.
- Preserve structurally identifiable storage keys with invalid/missing/oversized/unknown count metadata only for the untrusted long-probe bucket, never for trusted PID or rebuild cleanup.
- Keep raw `data.pkl`, missing/malformed storage, wrong arg counts, mutated hooks, out-of-bounds views, non-CPU/nondecimal/unknown-size storage, memo anomalies, trailing streams, loaded/rebound Torch, shadowed import state, hostile meta-path, older embedded picklescan, mismatched storage with padded hidden pickles, and invalid-count frame-first hidden pickles all fail-closed.
- Carry validated storage-size context through the existing root `PickleScanner.scan_stream` path for embedded PyTorch ZIP scanning, preserving stream limits and spool behavior.
- Preserve existing root trusted-storage PID observability by letting the root wrapper own persistent-ID downgrades.
- Reconfigure CLI stdout/stderr error handling at startup so redirected legacy encodings such as cp1252 escape decorative separator glyphs instead of crashing before JSON is written. The fresh subprocess regression helper still forces UTF-8 for scanner isolation.

## Trust Boundary

The accepted boundary is installed-distribution/startup integrity on a normal clean host: the suppression requires `torch` and `torch._utils` to be unloaded, hook-free specs for both parent and submodule, distribution manifest ownership for `torch/__init__.py` and `torch/_utils.py`, unchanged specs/origins across the distribution query, and the startup `collections.OrderedDict` binding read without user hooks.

A compromised trusted site-packages install or poisoned interpreter startup is out of scope for this cleanup; those remain part of the local runtime trust boundary. Normal artifact-controlled shadowing, loaded runtime mutation, and import-hook attacks stay suspicious.

## Compatibility

Root `modelaudit` still allows `modelaudit-picklescan>=0.1.4,<0.2.0` because the coordinated fixed picklescan release is not published yet. If the embedded sibling lacks the private validated-context support, root scanning falls back to the normal warning instead of crashing or silently cleaning the archive. Once the sibling release is published, this cleanup becomes active in the coordinated package set.

## Changelogs

Updated root `CHANGELOG.md` and `packages/modelaudit-picklescan/CHANGELOG.md` under `[Unreleased]`.

## LOC / Scope

Final PR diff vs `origin/main` at head `de93c7f57d865fcae307bd1f05a5f39b237ca78d`: 9 files, 2292 insertions / 165 deletions.

Exact split:

- Production/scanner sources: 945 additions / 113 deletions
- Tests: 1344 additions / 52 deletions
- Changelogs: 3 additions / 0 deletions

There is no `call_graph.py` diff versus `origin/main`. The additive commit also reverts the superseded old-head `call_graph.py` experiment from the branch history so the PR diff remains scoped to the validated-ZIP structural proof and storage-member probe hardening.

A final deletion review found a possible ~70-105 additional production-line reduction by consolidating exact/key-only PID parsers and removing root duplication. This PR intentionally retains the current package/root and strict-ref-vs-key-only split from `dac16b2d` to preserve independent-package/old-version compatibility and the reviewed trust semantics after terminal broad proof. The later `4335e747` helper commit is superseded by `de93c7f`'s production CLI output-encoding guard.

## Validation

Focused/local validation on head `dac16b2d27e05d53c1c3f9c0f9adc7d77a503a6e`, plus additive Windows/legacy-output validation on head `de93c7f57d865fcae307bd1f05a5f39b237ca78d`:

- `env -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 .venv/bin/python -m pytest packages/modelaudit-picklescan/tests/test_api.py::test_scan_file_long_probes_invalid_count_storage_with_frame_first_pickle -q` -> 2 passed
- `env -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 .venv/bin/python -m pytest tests/scanners/test_pytorch_zip_scanner.py::test_pytorch_zip_discovery_long_probes_invalid_count_storage_with_frame_first_pickle -q` -> 2 passed
- `env -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 .venv/bin/python -m pytest packages/modelaudit-picklescan/tests/test_api.py -k 'rebuild_tensor_v2 or pytorch_zip or pytorch_storage or protocol0 or storage_blob or storage_lookalike or size_mismatched_storage' -q` -> 103 passed
- `env -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 .venv/bin/python -m pytest tests/scanners/test_pytorch_zip_scanner.py -k 'pytorch_storage or trusted_storage or storage_persistent_id or tensor_storage or protocol0 or storage_blob or storage_lookalike or size_mismatched_storage or sparse_zip64' -q` -> 45 passed
- `env -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 .venv/bin/python -m pytest tests/scanners/test_pytorch_zip_scanner.py::test_pytorch_zip_regular_scan_sparse_zip64_storage_shard_is_bounded -q` -> 1 passed
- `env -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 .venv/bin/python -m pytest tests/scanners/test_pytorch_zip_scanner.py::test_pytorch_zip_discovery_trusts_torch_storage_untyped_storage packages/modelaudit-picklescan/tests/test_api.py::test_scan_file_suppresses_rebuild_tensor_v2_for_real_ordered_state_dict tests/test_false_positive_fixes.py::TestFalsePositiveFixes::test_bert_model_no_false_positive_executables tests/test_false_positive_fixes.py::TestFalsePositiveFixes::test_comprehensive_gpt2_model_scan -q` -> 4 passed
- Independent broad modified-file verification on the current WIP with no cache, unique basetemp, and xdist: `packages/modelaudit-picklescan/tests/test_api.py tests/scanners/test_pytorch_zip_scanner.py -n auto` -> 1816 passed, 8 skipped, 5 warnings in 171.15s
- `env -u VIRTUAL_ENV .venv/bin/ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> clean
- `env -u VIRTUAL_ENV .venv/bin/ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> clean
- `env -u VIRTUAL_ENV .venv/bin/mypy modelaudit/scanners/pytorch_zip_scanner.py packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py packages/modelaudit-picklescan/tests/test_api.py tests/scanners/test_pytorch_zip_scanner.py` -> clean
- Fresh default CLI on real `torch.nn.Linear(3,2).state_dict()` archive -> exit 0, no issues, no `_rebuild_tensor_v2` warning
- Same CLI with Torch preloaded -> exit 1, scanner success true, one `_rebuild_tensor_v2` warning
- `env -u VIRTUAL_ENV PROMPTFOO_DISABLE_TELEMETRY=1 NO_ANALYTICS=1 .venv/bin/python -m pytest tests/test_false_positive_fixes.py::TestFalsePositiveFixes::test_real_cli_scan_survives_legacy_cp1252_output_encoding tests/test_false_positive_fixes.py::TestFalsePositiveFixes::test_cli_subprocess_scan_forces_utf8_output_encoding tests/test_false_positive_fixes.py::TestFalsePositiveFixes::test_comprehensive_gpt2_model_scan tests/test_false_positive_fixes.py::TestFalsePositiveFixes::test_bert_model_no_false_positive_executables -q` -> 4 passed
- Simulated Windows dependency profile for GPT-2 helper (`HAS_TORCH=False`, `HAS_H5PY=False`, safetensors only) repeated 10 times on exact head -> 10 passed
- `.venv/bin/ruff check modelaudit/cli.py tests/test_false_positive_fixes.py` -> clean
- `.venv/bin/ruff format --check modelaudit/cli.py tests/test_false_positive_fixes.py` -> clean
- `.venv/bin/mypy --platform linux modelaudit/cli.py tests/test_false_positive_fixes.py` -> clean
- `.venv/bin/ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> clean
- `.venv/bin/ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> clean
- `.venv/bin/mypy --platform linux modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` -> 14 baseline errors in untouched files; touched-file mypy above is clean

## Local Caveats

- `uv run ruff` / `uv run mypy` on this macOS host can fail before running tools because `tensorrt-cu13-libs` is a Linux/NVIDIA placeholder wheel. The same ruff/mypy commands were run through the already-synced project `.venv`.
- Full local mypy reports baseline errors in untouched files under this macOS/ad-hoc `.venv` profile (`xattr` stubs locally; 14 Linux-platform errors in existing unrelated files).
- An interrupted full local pytest run surfaced cache-wrapper failures in unrelated files; prior investigation established these as baseline/local noise. The authoritative modified-file xdist run above was terminal green.
- The local macOS CLI subprocess helper patches the Darwin extended-ACL preflight only for local proof; Linux CI is the authoritative lane for the original failure.

## Coordination

- Supersedes old PR head `5df985e0` and its generic source-dependent runtime graph approach.
- Addresses review thread https://github.com/promptfoo/modelaudit/pull/1680#discussion_r3407954614 and the `UntypedStorage` review thread at head `dac16b2d27e05d53c1c3f9c0f9adc7d77a503a6e`.
- Addresses Windows Python 3.11 exact-head CI failure on run 27468086800 / job 81193905147 with a production CLI cp1252 output guard plus deterministic inherited-cp1252 subprocess coverage. Supersedes helper-only head `4335e7476ae5d1b370a1d70222023dd929e484f3`.
- Distinct from #1673, which is only a protocol-0 fail-closed regression.
- Does not merge this PR; waiting on exact-head CI and fresh review gates.
