### PR TITLE
fix(jit): bound passive reference replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- bound embedded Python assignment-line probes, deduplicate exact extraction windows, and fast-path proven passive priority references without weakening incomplete-analysis reporting
 - avoid CLI crashes when redirected stdout or stderr use legacy encodings that cannot represent styled separator glyphs
 - suppress canonical PyTorch tensor rebuild warnings only inside validated unloaded-runtime ZIP storage context when paired with the coordinated `modelaudit-picklescan` fix, while older allowed picklescan versions continue to fail closed with the warning
 - keep nested archive and PyTorch ZIP member hashes separate from parent artifact integrity hashes across JSON, cache, SARIF, SBOM, and streaming scans

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -286,9 +286,13 @@ _PRIORITY_EMBEDDED_PYTHON_IMPORT_START_PATTERN = re.compile(
     rb"from\s+(?:" + _PRIORITY_EMBEDDED_PYTHON_MODULE_PATTERN + rb")(?:[.\s]|\\\r?\n|$)"
     rb")"
 )
+_PASSIVE_PRIORITY_PRINT_ASSIGNMENT_PATTERN = re.compile(
+    rb"([A-Za-z_]\w*)\s*=\s*print\s*\(\s*([A-Za-z_]\w*)\s*\.\s*([A-Za-z_]\w*)\s*\)"
+)
 _EMBEDDED_PYTHON_ASSIGNMENT_OPERATOR_PATTERN = rb"(?://=|<<=|>>=|\*\*=|[-+*/%@&|^]=|=)"
+# Keep LF excluded so each greedy bounded probe stays on one physical line.
 _EMBEDDED_PYTHON_ASSIGNMENT_VALUE_LINE_PATTERN = (
-    rb"(?=[^\x00-\x08\x0b-\x1f\x7f]{0,"
+    rb"(?=[^\x00-\x08\x0a-\x1f\x7f]{0,"
     + str(_MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES).encode("ascii")
     + rb"}(?:\r?\n|$))"
 )
@@ -641,6 +645,8 @@ def _priority_import_sites(bounded: bytes) -> list[tuple[int, int | None]]:
     sites: list[tuple[int, int | None]] = []
     matches = iter(_PRIORITY_EMBEDDED_PYTHON_IMPORT_START_PATTERN.finditer(bounded.lower()))
     match = next(matches, None)
+    if match is None:
+        return sites
     line_start = 0
     multiline_quote: bytes | None = None
     for line in bounded.splitlines(keepends=True):
@@ -660,6 +666,8 @@ def _priority_import_sites(bounded: bytes) -> list[tuple[int, int | None]]:
                     continue
                 sites.append((offset, header_start))
             match = next(matches, None)
+        if match is None:
+            break
         multiline_quote = _multiline_string_state_after_line(line, multiline_quote)
         line_start = line_end
     return sites
@@ -1650,6 +1658,20 @@ def _simple_priority_forwarding_usage(
                 namespace_modules[local_name] = module_name
             line_start = line_end
             continue
+        passive_print_match = _PASSIVE_PRIORITY_PRINT_ASSIGNMENT_PATTERN.fullmatch(structural_line)
+        if passive_print_match is not None:
+            target_name = passive_print_match.group(1).decode("utf-8")
+            namespace_name = passive_print_match.group(2).decode("utf-8")
+            member_name = passive_print_match.group(3).decode("utf-8")
+            module_name = namespace_modules.get(namespace_name)
+            if module_name is None or f"{module_name}.{member_name}" not in rule_codes_by_reference:
+                return None
+            namespace_modules.pop(target_name, None)
+            rule_codes_by_name.pop(target_name, None)
+            line_start = line_end
+            continue
+        if re.search(rb"\bprint\b", structural_line) is not None:
+            return None
         forwarding = _simple_forwarded_alias_assignment(structural_line)
         if forwarding is not None:
             target_name, dependency_name, expression = forwarding
@@ -1686,6 +1708,11 @@ def _simple_priority_forwarding_usage(
                     [(line_start, line_end)],
                     frozenset(rule_code for root_name in matched_roots for rule_code in rule_codes_by_name[root_name]),
                 )
+            if identifiers.isdisjoint(tracked_names) and all(
+                not _python_structural_line_bytes(remaining_line).strip()
+                for remaining_line in candidate[line_end:].splitlines()
+            ):
+                return [], frozenset()
             return None
         elif (
             not identifiers.isdisjoint(tracked_names)
@@ -10638,12 +10665,17 @@ def _append_single_window_prefix_context_windows(
             extraction_windows.append((context + b"\n" + bounded[start:], True))
 
 
+def _deduplicated_extraction_windows(windows: list[tuple[bytes, bool]]) -> list[tuple[bytes, bool]]:
+    """Preserve the first copy of each exact analysis window."""
+    return list(dict.fromkeys(windows))
+
+
 def _embedded_python_extraction_windows(data: bytes) -> list[tuple[bytes, bool]]:
     windows = _embedded_python_scan_windows(data)
     if len(windows) == 1:
         extraction_windows = [(windows[0], False), *_contextual_priority_framed_windows(windows[0])]
         _append_single_window_prefix_context_windows(extraction_windows, windows[0])
-        return extraction_windows
+        return _deduplicated_extraction_windows(extraction_windows)
 
     prefix, tail = windows
     extraction_windows = [(prefix, False), *_contextual_priority_framed_windows(prefix), (tail, False)]
@@ -10717,7 +10749,7 @@ def _embedded_python_extraction_windows(data: bytes) -> list[tuple[bytes, bool]]
         contextual_windows = [] if proved_rule_codes else _contextual_priority_framed_windows(contextual_source)
         fallback_contextual_windows = [] if proved_rule_codes else [*contextual_windows, (contextual_source, True)]
         extraction_windows[0:0] = [*targeted_contextual_windows, *fallback_contextual_windows]
-    return extraction_windows
+    return _deduplicated_extraction_windows(extraction_windows)
 
 
 def _contextual_priority_framed_windows(data: bytes) -> list[tuple[bytes, bool]]:

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -2308,7 +2308,9 @@ class TestJITScriptDetector:
 
         assert any(f.type == "code_execution_pattern" and f.pattern == expected_pattern for f in findings)
 
-    def test_scan_model_ignores_long_passive_reference_chain_with_bounded_replay(self) -> None:
+    def test_scan_model_ignores_long_passive_reference_chain_with_bounded_replay(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         detector = JITScriptDetector()
         padding_line = b"# pad\n"
         padding = padding_line * (
@@ -2319,10 +2321,49 @@ class TestJITScriptDetector:
         )
         source = b"\x00\xffimport runpy as rp\n" + padding + bindings + b"(value_39999)('safe')\n" + padding
 
+        original_extraction_windows = jit_script_module._embedded_python_extraction_windows
+
+        def assert_unique_extraction_windows(data: bytes) -> list[tuple[bytes, bool]]:
+            windows = original_extraction_windows(data)
+            assert len(windows) == len(set(windows))
+            return windows
+
+        def reject_heavy_replay(*_args: object, **_kwargs: object) -> bool:
+            raise AssertionError("proven passive forwarding must not enter heavyweight replay")
+
+        monkeypatch.setattr(jit_script_module, "_embedded_python_extraction_windows", assert_unique_extraction_windows)
+        monkeypatch.setattr(jit_script_module, "_late_assignment_binds_builtins_mapping", reject_heavy_replay)
+
         findings = detector.scan_model(source, "pytorch", "payload.bin")
 
         assert not any(
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
+        )
+        incomplete_reasons = {
+            finding.details.get("reason") for finding in findings if finding.type == "analysis_incomplete"
+        }
+        assert {
+            jit_script_module._EMBEDDED_PYTHON_BYTE_LIMIT_REASON,
+            jit_script_module._EMBEDDED_PYTHON_SNIPPET_LIMIT_REASON,
+        } <= incomplete_reasons
+
+    @pytest.mark.parametrize(
+        "binding",
+        [
+            b"print = rp.run_path\nvalue_0 = print(rp.run_path)\n",
+            b"value_0 = print(rp.run_path('payload.py'))\n",
+        ],
+    )
+    def test_scan_model_does_not_treat_executing_print_shapes_as_passive(self, binding: bytes) -> None:
+        detector = JITScriptDetector()
+        forwards = b"".join(f"value_{index} = value_{index - 1}\n".encode() for index in range(1, 64))
+        source = b"\x00\xffimport runpy as rp\n" + binding + forwards + b"value_63('safe')\n"
+
+        findings = detector.scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            finding.type == "code_execution_pattern" and finding.pattern == "Dynamic module execution detected"
+            for finding in findings
         )
 
     def test_scan_model_detects_forwarded_conditional_alias_beyond_replay_budget(self) -> None:


### PR DESCRIPTION
## Summary

- keep embedded-Python assignment probes on one physical line and stop priority-import scanning after the final match
- fast-path only proven passive `print(priority_namespace.member)` forwarding while sending shadowed, nested, or ambiguous forms through conservative replay
- deduplicate exact extraction windows and preserve fail-closed byte/snippet budget findings
- strengthen the 40,000-hop benign/malicious regressions without skipping or shrinking their coverage

## Root cause

Main Python CI runs `27470538561` and `27472058165` both exhausted the 75-minute Python 3.12 job timeout. In the latter run, the malicious bounded-replay case took about 508 seconds and the passive case remained active for more than 1,462 seconds before cancellation.

Local profiling reproduced the behavior without xdist or runner stalls. The 1.05 MB fixture crossed the production scan-window boundary, causing overlapping replay passes; two contextual windows were exact duplicates. A greedy assignment-value probe also crossed physical lines, and the conservative replay fallback repeatedly analyzed simple passive forwarding chains. Coverage tracing amplified that production work.

This patch keeps the adversarial fixture and all existing analysis budgets. Exact-window deduplication and the passive proof are deliberately narrow; any shadowing, nested call, control flow, ambiguity, or later executable statement retains the existing conservative path.

## Security behavior

- the long direct `runpy.run_path` alias chain still reports dynamic module execution
- canonical `print(rp.run_path)` remains a passive reference, not a false positive
- `print = rp.run_path` and nested `print(rp.run_path(...))` shapes still report dynamic module execution
- over-budget benign analysis still reports both byte-limit and snippet-limit `analysis_incomplete` reasons
- the regression asserts unique extraction windows and prevents proven passive forwarding from entering heavyweight late-assignment replay

## Performance

| Workload | Before | After |
| --- | ---: | ---: |
| Passive 40,000-hop node, Python 3.12 without coverage | 60.89s | 6.88s |
| Passive 40,000-hop node, Python 3.12 with coverage | >1,462s on main before cancellation | 21.20s |
| Malicious + passive nodes together with coverage and xdist | did not fit the main job budget | 62.07s |

## Change size

| Surface | Added | Deleted | Net |
| --- | ---: | ---: | ---: |
| Production | 35 | 3 | +32 |
| Tests | 42 | 1 | +41 |
| Changelog | 1 | 0 | +1 |

## Validation

- [x] exact malicious/passive covered reproducer: `2 passed in 62.07s`
- [x] focused benign, malicious, shadowed-print, nested-call, and budget regressions: `4 passed in 13.41s`
- [x] full JIT detector file: `1821 passed in 469.77s`
- [x] Ruff format: `422 files left unchanged`
- [x] Ruff check: clean
- [x] full mypy: `Success: no issues found in 477 source files`
- [x] required non-slow/non-integration suite: `20850 passed, 787 skipped in 1376.35s`
- [x] independent full PR-review and simplification lanes: no validated code findings

