### PR TITLE
test(ci): tolerate deadline rounding on Windows

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import hashlib
 import importlib
 import json
 import logging
+import math
 import os
 import re
 import stat
@@ -6356,6 +6357,10 @@ def test_get_huggingface_file_metadata_fails_closed_when_deadline_expires() -> N
 
 def test_get_huggingface_file_metadata_uses_deadline_worker() -> None:
     """Direct-file metadata SDK calls should be bounded by the shared acquisition deadline."""
+    timeout_seconds = 7.0
+    # Crossing this binary exponent boundary reproduces the Windows cancellation roundoff.
+    monotonic_now = 4095.1
+    assert (monotonic_now + timeout_seconds) - monotonic_now > timeout_seconds
 
     def run_worker(
         operation: str,
@@ -6369,8 +6374,9 @@ def test_get_huggingface_file_metadata_uses_deadline_worker() -> None:
         assert operation_kwargs["filenames"] == ["model.bin"]
         assert operation_kwargs["requested_revision"] == "main"
         assert operation_kwargs["resolved_revision"] is None
-        assert 0 < operation_kwargs["request_timeout"] <= 7
-        assert 0 < deadline - cli_module.time.monotonic() <= 7
+        deadline_roundoff = math.ulp(deadline)
+        assert 0 < operation_kwargs["request_timeout"] <= timeout_seconds + deadline_roundoff
+        assert 0 < deadline - cli_module.time.monotonic() <= timeout_seconds + deadline_roundoff
         return {
             "value": {
                 "revision": _HF_TEST_REVISION,
@@ -6379,6 +6385,7 @@ def test_get_huggingface_file_metadata_uses_deadline_worker() -> None:
         }
 
     with (
+        patch("modelaudit.cli.time.monotonic", return_value=monotonic_now),
         patch("huggingface_hub.HfApi") as mock_hf_api,
         patch(
             "modelaudit.utils.sources.huggingface._run_huggingface_worker_with_deadline", side_effect=run_worker
@@ -6388,7 +6395,7 @@ def test_get_huggingface_file_metadata_uses_deadline_worker() -> None:
             "test/model",
             "main",
             "model.bin",
-            timeout_seconds=7,
+            timeout_seconds=timeout_seconds,
         )
 
     assert metadata == {"size_bytes": 2048, "resolved_revision": _HF_TEST_REVISION}


### PR DESCRIPTION
## Summary

- reproduce the Windows deadline cancellation deterministically at a large monotonic clock value
- tolerate at most one ULP at the timeout upper boundary
- retain positive-deadline and no-material-overrun assertions

This is test-only: production files `+0`. No changelog entry is needed.

## CI evidence

- Source PR: #1665, whose diff does not touch `tests/test_cli.py` or `modelaudit/cli.py`
- Failed run/job: https://github.com/promptfoo/modelaudit/actions/runs/27481969067/job/81231206817
- Runner: Windows Server 2025, image `windows-2025-vs2026` version `20260608.135.2`
- Failure: after 14,198 tests passed, `test_get_huggingface_file_metadata_uses_deadline_worker` observed `7.000000000000455` for a seven-second request timeout

The deterministic clock value in this regression produces that exact cancellation result. The assertion permits only `math.ulp(deadline)` above the configured timeout while still requiring both remaining deadline values to be positive.

## Validation

- focused deadline tests: `2 passed`
- Ruff format: `422 files left unchanged`
- Ruff check: passed
- mypy: `Success: no issues found in 477 source files`
- non-slow/non-integration suite: `19,329 passed, 1,394 skipped`
- owner merge-safety review and simplification pass: no findings

## Merge sequencing

Hold merge behind #1682. After #1682 lands, merge newest `main` additively into this branch, rerun exact-head review and CI, then wait for coordinator release.
