### PR TITLE
fix(jit): bound alias replay before safe runpy calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- keep JIT alias replay linear as builtin-helper alias state grows, preserving bounded analysis for attacker-controlled model content
 - inspect oversized ONNX protobuf structure from descriptor-bound, memory- and result-bounded file-backed reads; preserve external-data security checks while explicitly reporting deferred schema, raw-detector, weight-analysis, and content-hash coverage
 - treat dotted package versions in README and model-card pip install commands as informational without downgrading active URLs
 - bound embedded Python assignment-line probes, deduplicate exact extraction windows, and fast-path proven passive priority references without weakening incomplete-analysis reporting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- keep JIT alias replay linear as builtin-helper alias state grows, preserving bounded analysis for attacker-controlled model content
+- keep JIT alias replay linear, including multiline builtin-helper continuations, as alias state grows while preserving bounded analysis for attacker-controlled model content
 - inspect oversized ONNX protobuf structure from descriptor-bound, memory- and result-bounded file-backed reads; preserve external-data security checks while explicitly reporting deferred schema, raw-detector, weight-analysis, and content-hash coverage
 - treat dotted package versions in README and model-card pip install commands as informational without downgrading active URLs
 - bound embedded Python assignment-line probes, deduplicate exact extraction windows, and fast-path proven passive priority references without weakening incomplete-analysis reporting

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -1727,6 +1727,21 @@ def _simple_priority_forwarding_usage(
     return [], frozenset()
 
 
+def _canonical_builtin_helper_aliases_in(
+    identifiers: Collection[str],
+    canonical_aliases: Mapping[str, str],
+    helper_names: Collection[str],
+    *,
+    excluded_aliases: Collection[str] = (),
+) -> set[str]:
+    """Return matching helper aliases by inspecting only identifiers in the statement."""
+    return {
+        identifier
+        for identifier in identifiers
+        if canonical_aliases.get(identifier) in helper_names and identifier not in excluded_aliases
+    }
+
+
 def _priority_alias_usage_lines(
     candidate: bytes,
     aliases: frozenset[bytes],
@@ -3749,12 +3764,13 @@ def _priority_alias_usage_lines(
                 may_bind_namespace_update = (
                     b"__dict__" in line
                     or b"vars" in line
-                    or not _python_identifier_names(line).isdisjoint(
-                        {
-                            name
-                            for name, helper_name in canonical_builtin_helper_aliases.items()
-                            if helper_name == "vars" and name not in shadowed_builtin_helper_names
-                        }
+                    or bool(
+                        _canonical_builtin_helper_aliases_in(
+                            _python_identifier_names(line),
+                            canonical_builtin_helper_aliases,
+                            {"vars"},
+                            excluded_aliases=shadowed_builtin_helper_names,
+                        )
                     )
                     or (
                         (b".update" in line or b"__ior__" in line)
@@ -4287,12 +4303,10 @@ def _priority_alias_usage_lines(
                         )
                     )
                     alias_dependencies.update(
-                        referenced_identifiers.intersection(
-                            {
-                                name
-                                for name, helper_name in canonical_builtin_helper_aliases.items()
-                                if helper_name == "vars"
-                            }
+                        _canonical_builtin_helper_aliases_in(
+                            referenced_identifiers,
+                            canonical_builtin_helper_aliases,
+                            {"vars"},
                         )
                     )
                 if descriptor_reference is not None:
@@ -4818,12 +4832,10 @@ def _priority_alias_usage_lines(
                     | builtin_dict_descriptor_setdefault_aliases
                 )
                 or bool(
-                    member_identifiers.intersection(
-                        {
-                            name
-                            for name, helper_name in canonical_builtin_helper_aliases.items()
-                            if helper_name == "setattr"
-                        }
+                    _canonical_builtin_helper_aliases_in(
+                        member_identifiers,
+                        canonical_builtin_helper_aliases,
+                        {"setattr"},
                     )
                 )
             )
@@ -4903,14 +4915,13 @@ def _priority_alias_usage_lines(
             else frozenset()
         )
         tracked_priority_aliases = aliases | priority_aliases
-        has_canonical_namespace_helper_use = has_priority_reference_syntax and not _python_identifier_names(
-            line
-        ).isdisjoint(
-            {
-                name
-                for name, helper_name in canonical_builtin_helper_aliases.items()
-                if helper_name in {"getattr", "vars"} and name not in shadowed_builtin_helper_names
-            }
+        has_canonical_namespace_helper_use = has_priority_reference_syntax and bool(
+            _canonical_builtin_helper_aliases_in(
+                _python_identifier_names(line),
+                canonical_builtin_helper_aliases,
+                {"getattr", "vars"},
+                excluded_aliases=shadowed_builtin_helper_names,
+            )
         )
         getattr_member = (
             _priority_getattr_alias_member(

--- a/modelaudit/detectors/jit_script.py
+++ b/modelaudit/detectors/jit_script.py
@@ -8912,18 +8912,32 @@ def _line_calls_fail_closed_runpy_member(
 
 def _line_starts_continued_priority_getattr(
     code_line: bytes,
-    canonical_builtin_helper_aliases: dict[str, str] | None = None,
+    canonical_builtin_helper_aliases: Mapping[str, str] | None = None,
     shadowed_builtin_helper_names: set[str] | None = None,
 ) -> bool:
     if re.fullmatch(rb"\s*(?:builtins\s*\.\s*)?getattr\s*(?:\\\s*|\(\s*)", code_line) is not None:
         return True
+    identifiers = _python_identifier_names(code_line)
+    reference_match = re.fullmatch(rb"\s*(?P<reference>\S+?)\s*(?:\\\s*|\(\s*)", code_line)
+    if reference_match is not None:
+        try:
+            reference = reference_match.group("reference").decode("utf-8")
+        except UnicodeDecodeError:
+            pass
+        else:
+            if reference.isidentifier():
+                identifiers.add(reference)
     blocked_helpers = shadowed_builtin_helper_names or set()
+    helper_aliases = _canonical_builtin_helper_aliases_in(
+        identifiers,
+        canonical_builtin_helper_aliases or {},
+        {"getattr"},
+        excluded_aliases=blocked_helpers,
+    )
     return any(
         "." not in reference
-        and helper_name == "getattr"
-        and reference not in blocked_helpers
         and re.fullmatch(rb"\s*" + re.escape(reference.encode("utf-8")) + rb"\s*(?:\\\s*|\(\s*)", code_line) is not None
-        for reference, helper_name in (canonical_builtin_helper_aliases or {}).items()
+        for reference in helper_aliases
     )
 
 

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -2,6 +2,7 @@
 
 import ast
 import json
+from collections.abc import Iterator, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,25 @@ from modelaudit.detectors import jit_script as jit_script_module
 from modelaudit.detectors.jit_script import JITScriptDetector, detect_jit_script_risks
 
 _PRIORITY_USAGE_STRESS_LINES = 10
+
+
+class _CountingAliasMapping(Mapping[str, str]):
+    def __init__(self, aliases: dict[str, str]) -> None:
+        self._aliases = aliases
+        self.lookups = 0
+        self.iterations = 0
+
+    def __getitem__(self, key: str) -> str:
+        self.lookups += 1
+        return self._aliases[key]
+
+    def __iter__(self) -> Iterator[str]:
+        for key in self._aliases:
+            self.iterations += 1
+            yield key
+
+    def __len__(self) -> int:
+        return len(self._aliases)
 
 
 class TestJITScriptDetector:
@@ -6303,6 +6323,52 @@ class TestJITScriptDetector:
         assert not any(
             f.type == "code_execution_pattern" and f.pattern == "Dynamic module execution detected" for f in findings
         )
+
+    @pytest.mark.parametrize("identifier_count", [25, 50, 100])
+    def test_canonical_builtin_helper_lookup_scales_with_current_identifiers(self, identifier_count: int) -> None:
+        identifiers = {f"helper_{index}" for index in range(identifier_count)}
+        aliases = _CountingAliasMapping(
+            {
+                **dict.fromkeys(identifiers, "vars"),
+                **{f"unrelated_{index}": "getattr" for index in range(identifier_count * 8)},
+            }
+        )
+
+        matched = jit_script_module._canonical_builtin_helper_aliases_in(
+            identifiers,
+            aliases,
+            {"vars"},
+        )
+
+        assert matched == identifiers
+        assert aliases.lookups == identifier_count
+        assert aliases.iterations == 0
+
+    def test_scan_model_detects_runpy_call_after_builtins_alias_helper_noise(self) -> None:
+        aliases = b"".join(f"bi_{index} = builtins\n".encode() for index in range(64))
+        helper_writes = b"bi_0.setattr = lambda *args: None\n" * 64
+        source = b"import runpy as rp\nimport builtins\n" + aliases + helper_writes + b"rp.run_path('payload.py')\n"
+
+        findings = JITScriptDetector().scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            finding.type == "code_execution_pattern" and finding.pattern == "Dynamic module execution detected"
+            for finding in findings
+        )
+
+    def test_scan_model_keeps_safe_runpy_call_clean_after_builtins_alias_helper_noise(self) -> None:
+        aliases = b"".join(f"bi_{index} = builtins\n".encode() for index in range(64))
+        helper_writes = b"bi_0.setattr = lambda *args: None\n" * 64
+        source = (
+            b"import runpy as rp\nimport builtins\n"
+            + aliases
+            + helper_writes
+            + b"rp.run_path = print\nrp.run_path('safe')\n"
+        )
+
+        findings = JITScriptDetector().scan_model(source, "pytorch", "payload.bin")
+
+        assert not any(finding.type in {"code_execution_pattern", "analysis_incomplete"} for finding in findings)
 
     def test_scan_model_detects_tail_framed_runpy_member_restore_with_prefix_context(self) -> None:
         detector = JITScriptDetector()

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -6344,10 +6344,17 @@ class TestJITScriptDetector:
         assert aliases.lookups == identifier_count
         assert aliases.iterations == 0
 
-    def test_scan_model_detects_runpy_call_after_builtins_alias_helper_noise(self) -> None:
+    def test_scan_model_detects_tail_runpy_call_after_builtins_alias_helper_noise(self) -> None:
+        padding = b"# pad\n" * (jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(b"# pad\n") + 8)
         aliases = b"".join(f"bi_{index} = builtins\n".encode() for index in range(64))
         helper_writes = b"bi_0.setattr = lambda *args: None\n" * 64
-        source = b"import runpy as rp\nimport builtins\n" + aliases + helper_writes + b"rp.run_path('payload.py')\n"
+        source = (
+            b"\x00\xffimport runpy as rp\nimport builtins\n"
+            + aliases
+            + helper_writes
+            + padding
+            + b"\x00\xff((rp).run_path)('payload.py')\n"
+        )
 
         findings = JITScriptDetector().scan_model(source, "pytorch", "payload.bin")
 

--- a/tests/detectors/test_jit_script_detector.py
+++ b/tests/detectors/test_jit_script_detector.py
@@ -15,7 +15,7 @@ _PRIORITY_USAGE_STRESS_LINES = 10
 
 
 class _CountingAliasMapping(Mapping[str, str]):
-    def __init__(self, aliases: dict[str, str]) -> None:
+    def __init__(self, aliases: Mapping[str, str]) -> None:
         self._aliases = aliases
         self.lookups = 0
         self.iterations = 0
@@ -6343,6 +6343,110 @@ class TestJITScriptDetector:
         assert matched == identifiers
         assert aliases.lookups == identifier_count
         assert aliases.iterations == 0
+
+    @pytest.mark.parametrize("alias_count", [25, 50, 100])
+    def test_multiline_builtins_alias_continuation_lookup_is_linear(
+        self, alias_count: int, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        original_line_check = jit_script_module._line_starts_continued_priority_getattr
+        calls = 0
+        lookups = 0
+        iterations = 0
+        alias_map_sizes: list[int] = []
+
+        def counted_line_check(
+            code_line: bytes,
+            canonical_builtin_helper_aliases: Mapping[str, str] | None = None,
+            shadowed_builtin_helper_names: set[str] | None = None,
+        ) -> bool:
+            nonlocal calls, lookups, iterations
+            calls += 1
+            alias_map_sizes.append(len(canonical_builtin_helper_aliases or {}))
+            counted_aliases = _CountingAliasMapping(canonical_builtin_helper_aliases or {})
+            result = original_line_check(code_line, counted_aliases, shadowed_builtin_helper_names)
+            lookups += counted_aliases.lookups
+            iterations += counted_aliases.iterations
+            return result
+
+        monkeypatch.setattr(
+            jit_script_module,
+            "_line_starts_continued_priority_getattr",
+            counted_line_check,
+        )
+        candidate = b"".join(f"bi_{index} = (\n    builtins\n)\n".encode() for index in range(alias_count))
+
+        usage_lines, proved_rule_codes = jit_script_module._priority_alias_usage_lines(
+            candidate,
+            frozenset({b"rp"}),
+            0,
+        )
+
+        assert usage_lines == []
+        assert proved_rule_codes == frozenset()
+        assert calls == 3 * alias_count
+        assert lookups == 2 * alias_count
+        assert iterations == 0
+        assert alias_map_sizes[-1] == 4 * alias_count + 8
+
+    @pytest.mark.parametrize(
+        ("helper_transition", "endpoint", "expect_dynamic_finding"),
+        [
+            pytest.param(
+                b"",
+                b"read_member(\n    rp,\n    'run_path'\n)('payload.py')\n",
+                True,
+                id="malicious",
+            ),
+            pytest.param(
+                b"read_member = len\n",
+                b"read_member(\n    []\n)\n",
+                False,
+                id="safe-rebound",
+            ),
+        ],
+    )
+    def test_scan_model_preserves_multiline_getattr_alias_state_after_alias_noise(
+        self, helper_transition: bytes, endpoint: bytes, expect_dynamic_finding: bool
+    ) -> None:
+        padding = b"# pad\n" * (jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(b"# pad\n") + 8)
+        aliases = b"".join(f"bi_{index} = (\n    builtins\n)\n".encode() for index in range(16))
+        source = (
+            b"\x00\xffimport runpy as rp\nimport builtins\nread_member = builtins.getattr\n"
+            + aliases
+            + padding
+            + helper_transition
+            + endpoint
+            + padding
+        )
+
+        findings = JITScriptDetector().scan_model(source, "pytorch", "payload.bin")
+        has_dynamic_finding = any(
+            finding.type == "code_execution_pattern" and finding.pattern == "Dynamic module execution detected"
+            for finding in findings
+        )
+
+        assert has_dynamic_finding is expect_dynamic_finding
+        if not expect_dynamic_finding:
+            assert not any(finding.type == "analysis_incomplete" for finding in findings)
+
+    def test_scan_model_detects_multiline_unicode_getattr_alias_after_alias_noise(self) -> None:
+        padding = b"# pad\n" * (jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(b"# pad\n") + 8)
+        aliases = b"".join(f"bi_{index} = (\n    builtins\n)\n".encode() for index in range(16))
+        source = (
+            b"\x00\xffimport runpy as rp\n"
+            + "from builtins import getattr as réad\n".encode()
+            + aliases
+            + padding
+            + "réad(\n    rp,\n    'run_path'\n)('payload.py')\n".encode()
+            + padding
+        )
+
+        findings = JITScriptDetector().scan_model(source, "pytorch", "payload.bin")
+
+        assert any(
+            finding.type == "code_execution_pattern" and finding.pattern == "Dynamic module execution detected"
+            for finding in findings
+        )
 
     def test_scan_model_detects_tail_runpy_call_after_builtins_alias_helper_noise(self) -> None:
         padding = b"# pad\n" * (jit_script_module._MAX_PRIORITY_EMBEDDED_PYTHON_SNIPPET_BYTES // len(b"# pad\n") + 8)


### PR DESCRIPTION
## Summary

- replace all five quadratic reverse scans over accumulated builtins-helper aliases with bounded current-statement identifier lookups
- preserve UTF-8 helper aliases, helper shadowing, uncertain bindings, kill semantics, and fail-closed JIT analysis
- add deterministic live-map scaling coverage plus multiline malicious, Unicode, and safe-rebound controls

## Why

Python 3.12 coverage exposed an attacker-controlled complexity bug in JIT embedded-Python analysis. With 4,000 builtins aliases, the old implementation performed about 32 million alias-map iterations; two exact tests exceeded the 75-minute main-branch coverage job. The same fixtures completed in roughly five seconds without coverage, confirming production work was quadratic even though coverage amplified it.

Independent review found a fifth reverse scan in multiline `getattr` continuation replay. The repair now limits all five sites to identifiers present in the current bounded statement and performs direct alias-map lookups. It does not cap or discard security state and does not use `no_cover`.

## Linear and semantic proof

- live multiline replay at N=25/50/100 performs exactly `3N` continuation calls, `2N` direct map lookups, zero full-map iterations, and reaches `4N+8` retained aliases
- the old fifth path performs `6N^2+26N` alias-map iterations on the same inputs
- 100,000 seeded mixed ASCII/Unicode old-vs-new comparisons produced zero mismatches, including direct, saved, dotted, blocked, near-match, parenthesis, and backslash forms
- 300,000 independent comparisons for the four earlier lookup conversions produced zero mismatches
- static review finds five shared current-identifier lookup sites and no remaining reverse iteration over canonical helper alias state

## Validation

- exact Python 3.12 coverage/xdist stress pair: `2 passed in 147.80s`
- complete focused JIT detector file: `1,832 passed in 381.34s`
- full non-slow/non-integration suite: `19,340 passed, 1,394 skipped, 40 warnings in 558.59s`
- independent malicious, safe-rebound, shadowing, uncertainty, kill, restore, Unicode, and fail-closed controls: green
- full Ruff check/format: green across `422` files
- full mypy: green across `477` source files
- `git diff --check`: green
- current `main@67d5692a700efced8f9de9a141b6a251eb85d0ad` is included additively

## Diff size

- production: `+55/-30`
- tests: `+177/-0`
- changelog: `+1/-0`
- total: `+233/-30` across 3 files

Fresh exact-head Codex review and GitHub CI are required before merge. This PR is the production prerequisite for rerunning PR #1682's five unchanged coverage shards.
