### PR TITLE
ci: shard Nightly correctness tests across runners

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,14 +10,20 @@ permissions:
   contents: read
 
 jobs:
-  full-matrix:
-    name: Full Tests (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+  correctness:
+    name: Correctness (${{ matrix.os }}, Python ${{ matrix.python-version }}, Shard ${{ matrix.shard }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        shard: [0, 1]
+        exclude:
+          - { os: windows-latest, python-version: "3.10" }
+          - { os: windows-latest, python-version: "3.12" }
+          - { os: windows-latest, python-version: "3.13" }
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -38,19 +44,15 @@ jobs:
 
       - name: Sync dependencies
         run: |
-          uv sync --extra all-ci
+          uv sync --extra ${{ matrix.os == 'windows-latest' && 'all-ci-windows' || 'all-ci' }}
 
-      - name: Run standalone picklescan Rust tests
+      - name: Run correctness shard (fast + slow + integration)
         run: |
-          cargo test --manifest-path packages/modelaudit-picklescan/Cargo.toml
+          uv run pytest -n auto -m "not performance" --modelaudit-shard-count 2 --modelaudit-shard-index ${{ matrix.shard }} --tb=short --durations=20
 
-      - name: Run all tests (fast + slow + integration + performance)
-        run: |
-          uv run pytest -n auto --tb=short --durations=20
-
-  windows-full:
-    name: Windows Full Tests (Python 3.11)
-    runs-on: windows-latest
+  performance:
+    name: Performance Tests (Python 3.11, single process)
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - name: Checkout repo
@@ -58,6 +60,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
 
       - name: Pin Python version
         run: |
@@ -70,12 +74,45 @@ jobs:
 
       - name: Sync dependencies
         run: |
-          uv sync --extra all-ci-windows
+          uv sync --extra all-ci
 
-      - name: Run standalone picklescan Rust tests
+      - name: Run performance tests once without xdist
+        run: |
+          uv run pytest -n 0 -m performance --tb=short --durations=20
+
+  picklescan-rust:
+    name: Standalone Picklescan Rust Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Run standalone picklescan Rust tests once
         run: |
           cargo test --manifest-path packages/modelaudit-picklescan/Cargo.toml
 
-      - name: Run all Windows tests except performance benchmarks
+  nightly-success:
+    name: Nightly Success
+    needs: [correctness, performance, picklescan-rust]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every Nightly lane to succeed
+        env:
+          CORRECTNESS_RESULT: ${{ needs.correctness.result }}
+          PERFORMANCE_RESULT: ${{ needs.performance.result }}
+          PICKLESCAN_RUST_RESULT: ${{ needs.picklescan-rust.result }}
         run: |
-          uv run pytest -n auto -m "not performance" --tb=short --durations=20
+          for result in "$CORRECTNESS_RESULT" "$PERFORMANCE_RESULT" "$PICKLESCAN_RUST_RESULT"; do
+            if [[ "$result" != "success" ]]; then
+              echo "Required Nightly lane did not succeed: $result"
+              exit 1
+            fi
+          done

--- a/tests/test_perf_workflow.py
+++ b/tests/test_perf_workflow.py
@@ -172,21 +172,6 @@ def test_perf_workflow_runs_retained_memory_guard_as_blocking_step() -> None:
     assert "tests/test_performance_benchmarks.py::TestPerformanceBenchmarks::test_memory_usage_stability" in run
 
 
-def test_nightly_windows_lane_defers_performance_benchmarks_to_linux() -> None:
-    workflow = _load_workflow("nightly.yml")
-    jobs = _jobs(workflow)
-
-    linux_steps = jobs["full-matrix"]["steps"]
-    assert isinstance(linux_steps, list)
-    linux_run = _step_by_name(linux_steps, "Run all tests (fast + slow + integration + performance)")["run"]
-    assert '-m "not performance"' not in linux_run
-
-    windows_steps = jobs["windows-full"]["steps"]
-    assert isinstance(windows_steps, list)
-    windows_run = _step_by_name(windows_steps, "Run all Windows tests except performance benchmarks")["run"]
-    assert '-m "not performance"' in windows_run
-
-
 def test_docs_workflow_passes_changed_files_to_prettier_as_json() -> None:
     workflow = _load_workflow("docs-check.yml")
     raw_workflow = cast(dict[Any, Any], workflow)

--- a/tests/test_xdist_status.py
+++ b/tests/test_xdist_status.py
@@ -8,6 +8,7 @@ from types import ModuleType
 from typing import Any, cast
 
 import pytest
+import yaml
 
 from tests.xdist_status import (
     REPORT_INTERVAL_ENV,
@@ -30,6 +31,21 @@ def _load_root_conftest() -> ModuleType:
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _load_nightly_workflow() -> dict[str, Any]:
+    workflow_path = Path(__file__).parents[1] / ".github" / "workflows" / "nightly.yml"
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    return workflow
+
+
+def _step_by_name(job: dict[str, Any], name: str) -> dict[str, Any]:
+    steps = cast(list[dict[str, Any]], job["steps"])
+    for step in steps:
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"Step {name!r} not found")
 
 
 def test_collect_long_running_worker_statuses_sorts_by_elapsed_desc(
@@ -234,6 +250,78 @@ def test_nodeid_sharding_is_stable_disjoint_and_exhaustive() -> None:
     assert set(first_assignment) == set(range(5))
     for nodeid in nodeids:
         assert sum(root_conftest._nodeid_shard(nodeid, 5) == index for index in range(5)) == 1
+
+
+def test_nightly_correctness_matrix_uses_exhaustive_two_way_shards() -> None:
+    jobs = _load_nightly_workflow()["jobs"]
+    correctness = jobs["correctness"]
+
+    assert correctness["timeout-minutes"] == 45
+    assert correctness["runs-on"] == "${{ matrix.os }}"
+    assert correctness["strategy"]["fail-fast"] is False
+    matrix = correctness["strategy"]["matrix"]
+    assert matrix == {
+        "os": ["ubuntu-latest", "windows-latest"],
+        "python-version": ["3.10", "3.11", "3.12", "3.13"],
+        "shard": [0, 1],
+        "exclude": [
+            {"os": "windows-latest", "python-version": "3.10"},
+            {"os": "windows-latest", "python-version": "3.12"},
+            {"os": "windows-latest", "python-version": "3.13"},
+        ],
+    }
+    assert "3.11" in matrix["python-version"]
+    assert "uv python pin ${{ matrix.python-version }}" in _step_by_name(correctness, "Pin Python version")["run"]
+
+    sync_run = _step_by_name(correctness, "Sync dependencies")["run"]
+    assert "matrix.os == 'windows-latest'" in sync_run
+    assert "'all-ci-windows' || 'all-ci'" in sync_run
+
+    run = _step_by_name(correctness, "Run correctness shard (fast + slow + integration)")["run"]
+    assert run.count('-m "not performance"') == 1
+    assert "-m performance" not in run
+    assert "pytest -n auto" in run
+    assert "--modelaudit-shard-count 2" in run
+    assert "--modelaudit-shard-index ${{ matrix.shard }}" in run
+    assert "tests" not in run.split()
+    for fail_fast_option in (" -x", "--maxfail", "--ignore", "--deselect"):
+        assert fail_fast_option not in run
+
+
+def test_nightly_runs_unsharded_performance_and_rust_once_and_fails_closed() -> None:
+    jobs = _load_nightly_workflow()["jobs"]
+
+    performance = jobs["performance"]
+    assert performance["timeout-minutes"] == 45
+    assert performance["runs-on"] == "ubuntu-latest"
+    assert "strategy" not in performance
+    assert _step_by_name(performance, "Pin Python version")["run"].strip() == "uv python pin 3.11"
+    performance_run = _step_by_name(performance, "Run performance tests once without xdist")["run"]
+    assert performance_run.count("pytest -n 0 -m performance") == 1
+    assert '-m "not performance"' not in performance_run
+    assert "--modelaudit-shard" not in performance_run
+    assert "tests" not in performance_run.split()
+    for fail_fast_option in (" -x", "--maxfail", "--ignore", "--deselect"):
+        assert fail_fast_option not in performance_run
+
+    assert "strategy" not in jobs["picklescan-rust"]
+    rust_run = _step_by_name(jobs["picklescan-rust"], "Run standalone picklescan Rust tests once")["run"]
+    assert "cargo test --manifest-path packages/modelaudit-picklescan/Cargo.toml" in rust_run
+
+    gate = jobs["nightly-success"]
+    assert gate["if"] == "always()"
+    assert gate["needs"] == ["correctness", "performance", "picklescan-rust"]
+    check_step = _step_by_name(gate, "Require every Nightly lane to succeed")
+    assert check_step["env"] == {
+        "CORRECTNESS_RESULT": "${{ needs.correctness.result }}",
+        "PERFORMANCE_RESULT": "${{ needs.performance.result }}",
+        "PICKLESCAN_RUST_RESULT": "${{ needs.picklescan-rust.result }}",
+    }
+    assert 'if [[ "$result" != "success" ]]' in check_step["run"]
+    assert max(job["timeout-minutes"] for job in jobs.values()) == 45
+    for job in jobs.values():
+        assert "continue-on-error" not in job
+        assert all("continue-on-error" not in step for step in job["steps"])
 
 
 def test_nodeid_sharding_rejects_non_positive_count() -> None:


### PR DESCRIPTION
## Summary

- split Nightly correctness coverage into two deterministic shards for Linux Python 3.10-3.13 and Windows Python 3.11
- run the performance suite once on Linux Python 3.11 without xdist
- keep the Rust scanner lane single-run and make the aggregate Nightly Success gate fail closed across every shard

## Why

Nightly run 27520168440 cancelled all five full-test jobs at the 45-minute limit after reaching only 87-94% completion. The suite has grown from roughly 10,487 to 23,117 collected tests, so duplicating all correctness and performance coverage on every Python lane no longer fits the existing budget. Sharding reduces wall-clock time while preserving the same test surface and keeping performance tests isolated from xdist.

## Validation

- 22 focused workflow-contract tests
- Ruff check and format check
- focused mypy
- actionlint 1.7.12
- Prettier 3.8.3
- `git diff --check`

Merge remains gated on exact-head PR CI and a manually dispatched exact-head Nightly run.