### PR TITLE
fix(hashing): preserve deadline responsiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- preserve scan timeout responsiveness during deadline-bound file hashing while retaining 8 MiB reads for unbounded hashing paths
 - require patched `msgpack>=1.2.1` so default and optional installs avoid the `Unpacker` reuse crash advisory
 - stream large TAR and compressed-TAR model archives through TAR-specific inspection instead of generic whole-file read rejection, bound shared nested NeMo work after aggregate-budget exhaustion, preserve reachable findings at TAR and compressed-wrapper scan limits, preserve trusted HDF5 findings when overlapping TAR routing is inconclusive, prove compressed-stream ownership before bounding HDF5 user-block scans, and cap accepted compressed-wrapper zero padding
 - prove large valid Hugging Face `tokenizer.json` files with bounded EOF streaming so they do not fail closed as MXNet/JAX overlap, while explicitly failing closed when ownership exceeds the EOF proof cap

--- a/modelaudit/core.py
+++ b/modelaudit/core.py
@@ -200,6 +200,7 @@ _COMPRESSED_TAR_STREAM_INCOMPLETE_REASON = "tar_compressed_stream_incomplete"
 _HDF5_TAR_PREFIX_OWNERSHIP_INCOMPLETE_REASON = "hdf5_tar_prefix_ownership_incomplete"
 _HDF5_COMPRESSED_PREFIX_OWNERSHIP_INCOMPLETE_REASON = "hdf5_compressed_prefix_ownership_incomplete"
 _STREAMING_SOURCE_INTERRUPTED_REASON = "streaming_source_interrupted"
+_DEADLINE_HASH_READ_CHUNK_SIZE = 8 * 1024
 
 
 def _repository_member_path_for_scan(scan_path: str, scan_root: Path | None) -> str | None:
@@ -2868,10 +2869,11 @@ def _calculate_file_hash(file_path: str, *, deadline: float | None = None) -> st
                 raise OSError(f"File changed before hashing: {file_path}")
 
             hash_sha256 = hashlib.sha256()
+            read_chunk_size = _DEADLINE_HASH_READ_CHUNK_SIZE if deadline is not None else DEFAULT_READ_CHUNK_SIZE
             while True:
                 if deadline is not None and time.time() > deadline:
                     raise TimeoutError(f"File hashing timed out: {file_path}")
-                chunk = source.read(DEFAULT_READ_CHUNK_SIZE)
+                chunk = source.read(read_chunk_size)
                 if not chunk:
                     break
                 hash_sha256.update(chunk)

--- a/tests/scanners/test_base_scanner.py
+++ b/tests/scanners/test_base_scanner.py
@@ -3,7 +3,7 @@ import logging
 import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import pytest
 
@@ -197,16 +197,42 @@ def test_base_scanner_get_file_size(tmp_path):
     assert size == len(content)
 
 
-def test_base_scanner_calculate_file_hashes_spans_chunks(tmp_path):
+def test_base_scanner_calculate_file_hashes_spans_chunks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Hashing must be output-identical across the chunked read boundary."""
     content = (b"modelaudit-hash-payload" * 4096) + bytes(DEFAULT_READ_CHUNK_SIZE + 7)
     assert len(content) > DEFAULT_READ_CHUNK_SIZE
 
     test_file = tmp_path / "model.test"
     test_file.write_bytes(content)
+    read_sizes: list[int] = []
+
+    class RecordingReader:
+        def __init__(self) -> None:
+            self.offset = 0
+
+        def __enter__(self) -> "RecordingReader":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def read(self, size: int = -1) -> bytes:
+            read_sizes.append(size)
+            chunk = content[self.offset : self.offset + size]
+            self.offset += len(chunk)
+            return chunk
+
+    def recording_open(*_args: Any, **_kwargs: Any) -> RecordingReader:
+        return RecordingReader()
+
+    monkeypatch.setattr("builtins.open", recording_open)
 
     hashes = MockScanner().calculate_file_hashes(str(test_file))
 
+    assert read_sizes == [DEFAULT_READ_CHUNK_SIZE] * 3
     assert hashes["md5"] == hashlib.md5(content).hexdigest()
     assert hashes["sha256"] == hashlib.sha256(content).hexdigest()
     assert hashes["sha512"] == hashlib.sha512(content).hexdigest()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2063,7 +2063,10 @@ def test_calculate_file_hash_rejects_fifo_swap_without_blocking(
     assert swapped is True
 
 
-def test_calculate_file_hash_spans_chunks(tmp_path: Path) -> None:
+def test_calculate_file_hash_spans_chunks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Dedup hashing must be output-identical across the chunked read boundary."""
     from modelaudit.scanners.base import DEFAULT_READ_CHUNK_SIZE
 
@@ -2072,8 +2075,76 @@ def test_calculate_file_hash_spans_chunks(tmp_path: Path) -> None:
 
     source_path = tmp_path / "dedup-asset.bin"
     source_path.write_bytes(content)
+    real_fdopen = os.fdopen
+    read_sizes: list[int] = []
+
+    class RecordingReader:
+        def __init__(self, handle: Any) -> None:
+            self.handle = handle
+
+        def __enter__(self) -> RecordingReader:
+            return self
+
+        def __exit__(self, *args: Any) -> Any:
+            return self.handle.__exit__(*args)
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self.handle, name)
+
+        def read(self, size: int = -1) -> bytes:
+            read_sizes.append(size)
+            return cast(bytes, self.handle.read(size))
+
+    def recording_fdopen(*args: Any, **kwargs: Any) -> RecordingReader:
+        return RecordingReader(real_fdopen(*args, **kwargs))
+
+    monkeypatch.setattr(core_module.os, "fdopen", recording_fdopen)
 
     assert core_module._calculate_file_hash(str(source_path)) == hashlib.sha256(content).hexdigest()
+    assert read_sizes == [DEFAULT_READ_CHUNK_SIZE] * 3
+
+
+def test_calculate_file_hash_preserves_deadline_check_granularity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deadline-bound hashing must not block on an 8 MiB read between checks."""
+    source_path = tmp_path / "deadline-asset.bin"
+    source_path.write_bytes(b"x" * (core_module._DEADLINE_HASH_READ_CHUNK_SIZE + 1))
+    real_fdopen = os.fdopen
+    read_sizes: list[int] = []
+    now = 0.0
+
+    class DeadlineReader:
+        def __init__(self, handle: Any) -> None:
+            self.handle = handle
+
+        def __enter__(self) -> DeadlineReader:
+            return self
+
+        def __exit__(self, *args: Any) -> Any:
+            return self.handle.__exit__(*args)
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self.handle, name)
+
+        def read(self, size: int = -1) -> bytes:
+            nonlocal now
+            read_sizes.append(size)
+            chunk = cast(bytes, self.handle.read(size))
+            now += len(chunk) / core_module._DEADLINE_HASH_READ_CHUNK_SIZE
+            return chunk
+
+    def deadline_fdopen(*args: Any, **kwargs: Any) -> DeadlineReader:
+        return DeadlineReader(real_fdopen(*args, **kwargs))
+
+    monkeypatch.setattr(core_module.os, "fdopen", deadline_fdopen)
+    monkeypatch.setattr(core_module.time, "time", lambda: now)
+
+    with pytest.raises(TimeoutError, match="File hashing timed out"):
+        core_module._calculate_file_hash(str(source_path), deadline=0.5)
+
+    assert read_sizes == [core_module._DEADLINE_HASH_READ_CHUNK_SIZE]
 
 
 def test_filtered_savedmodel_owner_asset_updates_aggregate_hash_and_accounting(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #1709 that resolves the remaining P2 review items without reverting its hashing performance improvement.

- keep 8 MiB reads for unbounded hashing, while using 8 KiB reads when a scan deadline is active so timeout checks remain responsive
- make the chunk-size regression tests assert the actual requested read sizes, so the prior 8 KiB implementation would fail them
- add focused deadline-granularity coverage and apply the required pytest fixture/return annotations
- document the timeout-responsiveness fix under `[Unreleased]`

## Validation

- focused hashing regressions: 3 passed
- related regular-hash and scanner suites: 64 passed, 1 skipped; 113 passed
- combined base-scanner/regular-scan suite: 174 passed, 1 skipped
- Ruff check and format: clean
- mypy on touched files: clean
- full mypy with the Linux target used by CI: 479 source files clean
- independent pre-push review gate: 2 native review passes plus separate verifier, no findings

The broad local fast-suite run reached 4,041 passing tests before unrelated cache-state/resource-pressure failures in untouched code. Exact reruns and diff inspection confirmed those failures are outside this change; the relevant hashing suites above are green.

## Maintainer disposition

Superseded by #1734, which preserves the normal 8 MiB throughput path, adds bounded adaptive reads for short deadlines, passed the full exact-head CI suite, and was independently reviewed before merge as f23e1c03. Closing this earlier fixed-8-KiB approach to avoid the normal-scan performance regression.