### PR TITLE
test(picklescan): make path-importer bounds and FIFO test cross-platform

### DIFF
--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -11468,7 +11468,7 @@ def test_effective_bytecode_validation_rejects_oversized_files_without_unbounded
 @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO files are not supported on this platform")
 def test_resolution_candidate_fingerprint_rejects_fifo(tmp_path: Path) -> None:
     source_path = tmp_path / "blocked_source.py"
-    os.mkfifo(source_path)
+    os.mkfifo(source_path)  # type: ignore[attr-defined]  # os.mkfifo is POSIX-only
 
     reusable, fingerprint = _resolution_candidate_fingerprint(source_path)
 

--- a/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
@@ -2450,7 +2450,11 @@ def test_file_finder_resolution_identity_caches_bounded_state_work(
         assert first_identity is not None
         first_work_count = work_count
         first_type_validation_count = type_validation_count
-        assert first_work_count <= len(finder_state["_path_cache"]) + 4
+        # Identity work spans both the exact path cache and the relaxed
+        # (lowercased) cache that FileFinder populates on case-insensitive
+        # filesystems (macOS/Windows); on case-sensitive filesystems the
+        # relaxed cache is empty, so this bound is unchanged on Linux.
+        assert first_work_count <= len(finder_state["_path_cache"]) + len(finder_state["_relaxed_path_cache"]) + 4
         assert first_type_validation_count == 1
         assert call_graph._file_finder_resolution_identity(finder, path_entry) == first_identity
         assert not work_count > first_work_count
@@ -2462,7 +2466,11 @@ def test_file_finder_resolution_identity_caches_bounded_state_work(
         replacement_work_count = work_count
         finder_state["_path_cache"] = set(finder_state["_path_cache"])
         assert call_graph._file_finder_resolution_identity(finder, path_entry) == first_identity
-        assert replacement_work_count < work_count <= replacement_work_count + len(finder_state["_path_cache"]) + 4
+        assert (
+            replacement_work_count
+            < work_count
+            <= replacement_work_count + len(finder_state["_path_cache"]) + len(finder_state["_relaxed_path_cache"]) + 4
+        )
         assert type_validation_count == first_type_validation_count + 1
         work_before_transition = work_count
         transitioned_cache = set(cast(frozenset[str], finder_state["_path_cache"]))
@@ -2480,7 +2488,10 @@ def test_file_finder_resolution_identity_caches_bounded_state_work(
             work_before_transition
             < work_count
             <= work_before_transition
-            + (call_graph._MAX_FILE_FINDER_RESOLUTION_ATTEMPTS * (len(transitioned_cache) + 4))
+            + (
+                call_graph._MAX_FILE_FINDER_RESOLUTION_ATTEMPTS
+                * (len(transitioned_cache) + len(finder_state["_relaxed_path_cache"]) + 4)
+            )
         )
 
         work_before_oversized = work_count


### PR DESCRIPTION
## Why

The `modelaudit-picklescan` release build matrix (`release-please.yml` → `build-picklescan-package`) builds and **tests** the package on Linux, macOS, and Windows. The in-progress 0.1.7 release build failed on every non-Linux leg, blocking the picklescan PyPI publish — and therefore the coordinated `modelaudit` 0.2.48 publish, which is gated on picklescan verifying on PyPI.

Two tests assumed a **case-sensitive filesystem**:

### 1. `test_file_finder_resolution_identity_caches_bounded_state_work` (macOS + Windows)
`_file_finder_resolution_identity` hashes both `_path_cache` and `_relaxed_path_cache` (call_graph.py:4351-4358). On case-insensitive filesystems (macOS/Windows) Python's `FileFinder` populates the relaxed (lowercased) cache, so the work roughly doubles — observed work `1028` against a `516` bound. The work bounds only counted `_path_cache`. Fixed by adding `len(_relaxed_path_cache)` to the three affected bounds, matching the existing `snapshot_validation_work` assertion two lines below. **On Linux the relaxed cache is empty, so the bounds are unchanged.**

### 2. `test_resolution_candidate_fingerprint_rejects_fifo` (Windows mypy)
`os.mkfifo` is POSIX-only, so `mypy --platform win32` flags `[attr-defined]`. The runtime `skipif(not hasattr(os, "mkfifo"))` already guards execution; added a targeted `# type: ignore[attr-defined]` matching existing precedent (`test_call_graph_import_statements.py:9821`).

## Validation (local, macOS arm64 — reproduced both failures)
- Full standalone suite: **2791 passed, 112 skipped** (was 2790 passed + 1 failed)
- `mypy src tests` and `mypy --platform win32 src tests`: clean
- `ruff check` + `ruff format --check`: clean
- Root-lane `ruff` + `mypy` on picklescan paths: clean

Test-only; no scanner/runtime behavior change. Unblocks the 0.2.48 / picklescan 0.1.7 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)