### PR TITLE
fix(picklescan): restore Windows call-graph detection via cross-view stat identity

### DIFF
--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `modelaudit-picklescan` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+
+- restore Windows call-graph detection by reconciling descriptor and path stats with a cross-view identity that omits `st_ctime` (Windows reports it differently across stat methods); previously every stdlib callable source read failed closed on Windows, collapsing call-graph verdicts to inconclusive
+
 ## [0.1.7](https://github.com/promptfoo/modelaudit/compare/modelaudit-picklescan-v0.1.6...modelaudit-picklescan-v0.1.7) (2026-06-24)
 
 ### Bug Fixes

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -3796,15 +3796,20 @@ def _stat_identity(file_stat: os.stat_result) -> tuple[int, int, int, int, int, 
     )
 
 
-def _cross_view_file_stat_identity(file_stat: os.stat_result) -> tuple[int, int, int, int, int, int]:
-    # Windows path stat derives executable bits from the suffix; descriptor stat cannot.
+def _cross_view_file_stat_identity(file_stat: os.stat_result) -> tuple[int, int, int, int, int]:
+    # Cross-view comparison spans a descriptor stat and a path stat. Windows path
+    # stat derives executable bits from the suffix (descriptor stat cannot) and
+    # reports st_ctime mirroring st_mtime while descriptor stat reports the true
+    # creation time, so both fields are stat-method dependent and excluded here.
+    # On POSIX these fields agree across views, so omitting them is a no-op there;
+    # st_dev/st_ino still pin the exact file and st_size/st_mtime still catch
+    # mutation, so cross-view swap and tamper detection is preserved.
     return (
         file_stat.st_dev,
         file_stat.st_ino,
         stat.S_IFMT(file_stat.st_mode),
         file_stat.st_size,
         file_stat.st_mtime_ns,
-        file_stat.st_ctime_ns,
     )
 
 
@@ -4524,7 +4529,13 @@ def _read_bounded_regular_file(path: Path, max_bytes: int | None) -> tuple[bytes
             path_stat = path.stat()
         except OSError as error:
             raise OSError(f"source candidate path changed while being read: {path}") from error
-        if len({_stat_identity(before), _stat_identity(after), _stat_identity(path_stat)}) != 1:
+        # before/after share the descriptor view, so compare them with the full
+        # identity. path_stat is a path view; reconcile it with the cross-view
+        # identity that omits fields Windows reports differently across stat
+        # methods (st_ctime, permission bits).
+        if _stat_identity(before) != _stat_identity(after) or _cross_view_file_stat_identity(
+            before
+        ) != _cross_view_file_stat_identity(path_stat):
             raise OSError(f"source candidate changed while being read: {path}")
         if max_bytes is not None and len(content) > max_bytes:
             raise _SourceReadTooLargeError(f"source candidate exceeds {max_bytes} bytes: {path}")
@@ -4617,7 +4628,15 @@ def _read_candidate_fingerprint(
     finally:
         os.close(file_descriptor)
 
-    if len({_stat_identity(value) for value in (before, opened, after, path_after)}) != 1:
+    # opened/after share the descriptor view and before/path_after share the path
+    # view, so each pair uses the full identity. The two views are reconciled with
+    # the cross-view identity (Windows reports st_ctime and permission bits
+    # differently across stat methods).
+    if (
+        _stat_identity(opened) != _stat_identity(after)
+        or _stat_identity(before) != _stat_identity(path_after)
+        or _cross_view_file_stat_identity(before) != _cross_view_file_stat_identity(opened)
+    ):
         return False, None
     if require_complete and len(source) > read_limit:
         return False, None

--- a/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
@@ -2166,6 +2166,15 @@ def test_relative_zip_preflight_preserves_symlink_parent_traversal(
     assert cache_key == "link/../modules.zip"
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "CPython's zipimport normalizes '..' member-prefix segments on Windows, so the "
+        "POSIX literal-segment contract this test asserts does not hold there. The scanner "
+        "mirrors each platform's zipimporter (it collapses the prefix on Windows to match), "
+        "so exclusion stays aligned with what Windows would actually import."
+    ),
+)
 @pytest.mark.parametrize("relative", [False, True], ids=["absolute", "relative"])
 @pytest.mark.parametrize("include_module", [False, True], ids=["near-match", "module"])
 def test_zip_preflight_preserves_literal_dot_segments(

--- a/packages/modelaudit-picklescan/tests/test_known_size_streams.py
+++ b/packages/modelaudit-picklescan/tests/test_known_size_streams.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import io
 import os
 import pickle
@@ -174,7 +175,11 @@ def test_scan_file_keeps_plain_descriptor_after_path_replacement(
     original_is_zipfile = package_api.zipfile.is_zipfile
 
     def replace_and_check_zipfile(candidate: Any) -> bool:
-        replacement_path.replace(payload_path)
+        # Windows refuses to replace a file that the scanner holds open; the
+        # scanner keeps reading its original descriptor either way, which is the
+        # property under test.
+        with contextlib.suppress(OSError):
+            replacement_path.replace(payload_path)
         return original_is_zipfile(candidate)
 
     monkeypatch.setattr(package_api.zipfile, "is_zipfile", replace_and_check_zipfile)
@@ -202,7 +207,11 @@ def test_scan_file_keeps_zip_descriptor_after_path_replacement(
     original_is_zipfile = package_api.zipfile.is_zipfile
 
     def replace_and_check_zipfile(candidate: Any) -> bool:
-        replacement_path.replace(archive_path)
+        # Windows refuses to replace a file that the scanner holds open; the
+        # scanner keeps reading its original descriptor either way, which is the
+        # property under test.
+        with contextlib.suppress(OSError):
+            replacement_path.replace(archive_path)
         return original_is_zipfile(candidate)
 
     monkeypatch.setattr(package_api.zipfile, "is_zipfile", replace_and_check_zipfile)

--- a/packages/modelaudit-picklescan/tests/test_protocol0_line_operands.py
+++ b/packages/modelaudit-picklescan/tests/test_protocol0_line_operands.py
@@ -735,7 +735,14 @@ def test_scan_bytes_bounds_valid_utf8_encoded_byte_literal_prefilter() -> None:
 
 
 @pytest.mark.parametrize("container", [bytes, bytearray])
-@pytest.mark.parametrize("payload_bytes", [b"UA" * 2_500_000, b"N" * 5_000_000])
+@pytest.mark.parametrize(
+    "payload_bytes",
+    [b"UA" * 2_500_000, b"N" * 5_000_000],
+    # Multi-megabyte parametrized values become the test id, which pytest writes
+    # into PYTEST_CURRENT_TEST; Windows rejects env vars over 32767 chars, so give
+    # the cases short ids.
+    ids=["utf8_pair_5mb", "ascii_n_5mb"],
+)
 def test_scan_bytes_bounds_valid_utf8_byte_literal_runtime(
     container: type[bytes] | type[bytearray],
     payload_bytes: bytes,


### PR DESCRIPTION
## Summary

The standalone `modelaudit-picklescan` release matrix builds and **tests** on Windows. Its call-graph RCE detection was almost entirely broken there — a single `st_ctime` stat bug caused **390 test failures on Windows** (all passing on Linux/macOS) and blocked the 0.1.7 / coordinated 0.2.48 release.

## Root cause

On Windows, `os.fstat(fd)` and `os.stat(path)` report `st_ctime` **differently** — the handle stat returns the true NTFS creation time, while the path stat mirrors `st_mtime`. The TOCTOU source-read guards (`_read_bounded_regular_file`, `_read_candidate_fingerprint`) compared a descriptor stat against a path stat using the full `_stat_identity` (which includes `st_ctime`), so they **always** raised `source candidate changed while being read`.

Result: every stdlib callable source was "unreadable" on Windows → `_safe_call_graph_entrypoints` returned empty → call-graph analysis went **INCONCLUSIVE**. Malicious payloads dropped `MALICIOUS → SUSPICIOUS`; benign stdlib refs reported `INCONCLUSIVE` instead of `COMPLETE`. (Diagnosed by instrumenting the resolution chain on a windows-latest runner.)

## Fix

- `_cross_view_file_stat_identity` now omits `st_ctime` in addition to permission bits (it already dropped the suffix-derived exec bits for the same cross-method reason). **On POSIX both fields agree across stat views, so this is a no-op there**; `st_dev`/`st_ino` still pin the exact file and `st_size`/`st_mtime` still catch mutation, so cross-view swap/tamper detection is fully preserved.
- `_read_bounded_regular_file` / `_read_candidate_fingerprint` compare **same-view** stats (descriptor-vs-descriptor, path-vs-path) with the full identity and reconcile the **path-vs-descriptor** view with the cross-view identity.

## Tests (Windows portability only; no behavior change on POSIX)

- Short parametrize `ids=` for `test_scan_bytes_bounds_valid_utf8_byte_literal_runtime` — the 5 MB param became the nodeid, which pytest writes into `PYTEST_CURRENT_TEST`; Windows rejects env vars over 32767 chars (8 errors).
- `test_zip_preflight_preserves_literal_dot_segments` marked **POSIX-only**: CPython zipimport normalizes `..` member prefixes on Windows, and the scanner correctly mirrors each platform's zipimporter, so the literal-segment contract is POSIX-specific. (I confirmed forcing literal preservation would **under-detect** near-match modules on Windows, so the scanner code is unchanged.)
- Path-replacement tests tolerate Windows refusing to replace a file the scanner holds open; the descriptor-keeping property still holds.

## Validation

- **windows-latest full standalone suite: 2764 passed, 139 skipped, 0 failed** (was 390 failed). Verified via a temporary diagnostic workflow on a `diag/**` branch (not included here).
- Local (macOS): standalone suite **2791 passed** (unchanged baseline → POSIX no-op), `mypy` (default + `--platform win32`), `ruff`, root-lane `mypy`/`ruff` all clean.

Unblocks the modelaudit-picklescan 0.1.7 / modelaudit 0.2.48 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)