### PR TITLE
test(picklescan): match next signature in loaded-mutation test

### DIFF
--- a/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
@@ -1077,8 +1077,11 @@ def test_loaded_trusted_function_builtin_mutation_is_not_allowlisted(
     assert type(builtins_namespace) is dict
     original_next = builtins_namespace["next"]
 
-    def hostile_next(iterator: object) -> object:
-        return cast(Any, original_next)(iterator)
+    # Mirror the real next signature (iterator[, default]); replacing the global
+    # builtin with a one-arg stand-in would make the scanner's own next(it, default)
+    # calls raise during analysis (platform/sys.path dependent), erroring the scan.
+    def hostile_next(iterator: object, *args: object) -> object:
+        return cast(Any, original_next)(iterator, *args)
 
     monkeypatch.setitem(builtins_namespace, "next", hostile_next)
     _clear_call_graph_caches()


### PR DESCRIPTION
## Summary

The `modelaudit-picklescan` release build matrix tests on Windows, where `test_loaded_trusted_function_builtin_mutation_is_not_allowlisted` failed **deterministically**, blocking the 0.1.8 / coordinated 0.2.49 publish.

## Root cause

The test replaces the **global `next` builtin** with a one-argument stand-in (`hostile_next(iterator)`). The scanner's own call-graph analysis internally calls `next(iterator, default)` (two-arg form) on a code path that is taken when `sys.path[0]` is the tests directory and **cwd is absent from `sys.path`** — the case under `pytest` (the release-matrix command) but not `python -m pytest`. That raised `TypeError`, returning `ScanStatus.ERROR` → `UNKNOWN` instead of the expected `SUSPICIOUS`.

This is a **test bug**, not a product or Windows-detection issue — the scanner's `next(it, default)` usage is correct; the test's stand-in was signature-incompatible. (Diagnosed by instrumenting the failing test on a windows-latest runner.)

## Fix

`hostile_next` now mirrors `next`'s real `(iterator[, default])` signature. Detection still fires (it is a different object than the trusted baseline), and the scanner's internal `next` calls no longer crash.

## Validation

- **windows-latest, exact release-matrix command (`pytest -n auto tests`): full standalone suite 2765 passed, 0 failed** — previously failed deterministically (4/4 rounds). Verified via a temporary diagnostic workflow (not included).
- Local (macOS): the test passes; `mypy` + `ruff` clean.

Unblocks the modelaudit-picklescan 0.1.8 / modelaudit 0.2.49 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)