### PR TITLE
fix(picklescan): preserve POSIX ctime checks

### DIFF
--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -16,6 +16,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - restore Windows call-graph detection by reconciling descriptor and path stats with a cross-view identity that omits `st_ctime` (Windows reports it differently across stat methods); previously every stdlib callable source read failed closed on Windows, collapsing call-graph verdicts to inconclusive
+- preserve POSIX `st_ctime` in call-graph source-read identity checks so same-size, same-mtime inode-reuse swaps still fail closed
 
 ## [0.1.7](https://github.com/promptfoo/modelaudit/compare/modelaudit-picklescan-v0.1.6...modelaudit-picklescan-v0.1.7) (2026-06-24)
 

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -3796,21 +3796,23 @@ def _stat_identity(file_stat: os.stat_result) -> tuple[int, int, int, int, int, 
     )
 
 
-def _cross_view_file_stat_identity(file_stat: os.stat_result) -> tuple[int, int, int, int, int]:
+def _cross_view_file_stat_identity(file_stat: os.stat_result) -> tuple[int, ...]:
     # Cross-view comparison spans a descriptor stat and a path stat. Windows path
     # stat derives executable bits from the suffix (descriptor stat cannot) and
     # reports st_ctime mirroring st_mtime while descriptor stat reports the true
-    # creation time, so both fields are stat-method dependent and excluded here.
-    # On POSIX these fields agree across views, so omitting them is a no-op there;
-    # st_dev/st_ino still pin the exact file and st_size/st_mtime still catch
-    # mutation, so cross-view swap and tamper detection is preserved.
-    return (
+    # creation time, so both fields are stat-method dependent and excluded there.
+    # POSIX reports ctime consistently across views, where it helps catch a
+    # same-size, same-mtime replacement that reuses the original inode.
+    identity = (
         file_stat.st_dev,
         file_stat.st_ino,
         stat.S_IFMT(file_stat.st_mode),
         file_stat.st_size,
         file_stat.st_mtime_ns,
     )
+    if os.name == "nt":
+        return identity
+    return (*identity, file_stat.st_ctime_ns)
 
 
 def _zipimport_bounded_central_directory_names(

--- a/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
@@ -45,6 +45,24 @@ def _clear_call_graph_caches() -> None:
         function.cache_clear()
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Windows ctime differs across stat views")
+def test_cross_view_file_identity_keeps_posix_ctime() -> None:
+    """POSIX cross-view checks must detect metadata-only inode reuse."""
+    original = SimpleNamespace(
+        st_dev=1,
+        st_ino=2,
+        st_mode=0o100644,
+        st_size=3,
+        st_mtime_ns=4,
+        st_ctime_ns=5,
+    )
+    replaced = SimpleNamespace(**{**vars(original), "st_ctime_ns": 6})
+
+    assert call_graph._cross_view_file_stat_identity(
+        cast(os.stat_result, original)
+    ) != call_graph._cross_view_file_stat_identity(cast(os.stat_result, replaced))
+
+
 def _posixpath_text_regex_cache_name() -> str:
     for name in ("_varsub", "_varprog"):
         if name in posixpath.expandvars.__code__.co_names:


### PR DESCRIPTION
## Summary

- keep Windows descriptor/path stat reconciliation unchanged
- preserve POSIX `st_ctime` in cross-view source identity checks
- add a regression test for same-size, same-mtime inode-reuse detection

## Why

The Windows portability fix intentionally omits `st_ctime` because Windows reports it differently for descriptor and path stats. Applying that omission on POSIX weakens the source-read TOCTOU guard: a replacement that reuses the same inode and preserves size/mtime can only be distinguished by `st_ctime`.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=/Users/mdangelo/.codex/worktrees/c184/modelaudit/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py -q`
- `PYTHONPATH=/Users/mdangelo/.codex/worktrees/c184/modelaudit/packages/modelaudit-picklescan/src /Users/mdangelo/code/modelaudit/.venv/bin/ruff check packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py`
- `PYTHONPATH=/Users/mdangelo/.codex/worktrees/c184/modelaudit/packages/modelaudit-picklescan/src /Users/mdangelo/code/modelaudit/.venv/bin/ruff format --check packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py`
- `PYTHONPATH=/Users/mdangelo/.codex/worktrees/c184/modelaudit/packages/modelaudit-picklescan/src /Users/mdangelo/code/modelaudit/.venv/bin/mypy packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py`
