### PR TITLE
fix: deep-merge partial auth config updates

### DIFF
--- a/modelaudit/auth/config.py
+++ b/modelaudit/auth/config.py
@@ -26,6 +26,7 @@ API_HOST_ALLOWED_HOSTS_ENV = "MODELAUDIT_API_ALLOWED_HOSTS"
 _API_HOST_ENV_VARS = ("MODELAUDIT_API_HOST", "API_HOST")
 _PROMPTFOO_API_HOST_SUFFIX = "promptfoo.app"
 _DNS_LABEL_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+_DEEP_MERGE_CONFIG_SECTIONS = frozenset({"account", "cloud"})
 
 
 def _normalize_api_hostname(hostname: str) -> str:
@@ -264,7 +265,7 @@ class CloudConfig:
 
     def delete(self) -> None:
         """Delete cloud configuration."""
-        write_global_config_partial({"cloud": {}})
+        write_global_config_partial({"cloud": None})
 
     def _save_config(self) -> None:
         """Save cloud configuration."""
@@ -409,6 +410,18 @@ def write_global_config(config: GlobalConfig) -> None:
         pass
 
 
+def _deep_merge_config_dicts(current: dict[str, Any], updates: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge nested config dictionaries without dropping siblings."""
+    merged = dict(current)
+    for key, value in updates.items():
+        existing_value = merged.get(key)
+        if isinstance(existing_value, dict) and isinstance(value, dict):
+            merged[key] = _deep_merge_config_dicts(existing_value, value)
+        else:
+            merged[key] = value
+    return merged
+
+
 def write_global_config_partial(partial_config: dict[str, Any]) -> None:
     """Merge partial configuration into existing config."""
     current_config = read_global_config()
@@ -416,11 +429,16 @@ def write_global_config_partial(partial_config: dict[str, Any]) -> None:
 
     # Merge the partial config
     for key, value in partial_config.items():
-        if value is not None:
-            current_data[key] = value
-        else:
+        if value is None:
             # Remove the property if value is None
             current_data.pop(key, None)
+            continue
+
+        existing_value = current_data.get(key)
+        if key in _DEEP_MERGE_CONFIG_SECTIONS and isinstance(existing_value, dict) and isinstance(value, dict):
+            current_data[key] = _deep_merge_config_dicts(existing_value, value)
+        else:
+            current_data[key] = value
 
     write_global_config(GlobalConfig(current_data))
 

--- a/tests/test_auth_config.py
+++ b/tests/test_auth_config.py
@@ -238,6 +238,113 @@ def test_write_global_config_uses_private_file_permissions(
         assert stat.S_IMODE(config_file.stat().st_mode) == 0o600
 
 
+def test_write_global_config_partial_preserves_account_siblings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_dir = tmp_path / "config"
+    fallback_dir = tmp_path / "home" / ".promptfoo"
+    _patch_config_paths(auth_config, monkeypatch, config_dir, fallback_dir)
+
+    auth_config.write_global_config(
+        auth_config.GlobalConfig(
+            {
+                "id": "fixed-id",
+                "account": {
+                    "email": "old@example.com",
+                    "name": "Keep Me",
+                    "organization": "promptfoo",
+                },
+                "cloud": {"apiKey": "secret"},
+            }
+        )
+    )
+
+    auth_config.write_global_config_partial({"account": {"email": "new@example.com"}})
+
+    written = yaml.safe_load((config_dir / "promptfoo.yaml").read_text())
+
+    assert written["account"] == {
+        "email": "new@example.com",
+        "name": "Keep Me",
+        "organization": "promptfoo",
+    }
+    assert written["cloud"] == {"apiKey": "secret"}
+
+
+def test_write_global_config_partial_deep_merges_cloud_section(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_dir = tmp_path / "config"
+    fallback_dir = tmp_path / "home" / ".promptfoo"
+    _patch_config_paths(auth_config, monkeypatch, config_dir, fallback_dir)
+
+    auth_config.write_global_config(
+        auth_config.GlobalConfig(
+            {
+                "id": "fixed-id",
+                "account": {"email": "user@example.com"},
+                "cloud": {
+                    "apiHost": "https://old-api.example",
+                    "apiKey": "old-token",
+                    "featureFlags": {"beta": True, "region": "eu"},
+                    "customField": "keep-me",
+                },
+            }
+        )
+    )
+
+    auth_config.write_global_config_partial(
+        {
+            "cloud": {
+                "apiHost": "https://new-api.example",
+                "featureFlags": {"region": "us"},
+            }
+        }
+    )
+
+    written = yaml.safe_load((config_dir / "promptfoo.yaml").read_text())
+
+    assert written["cloud"] == {
+        "apiHost": "https://new-api.example",
+        "apiKey": "old-token",
+        "featureFlags": {"beta": True, "region": "us"},
+        "customField": "keep-me",
+    }
+    assert written["account"] == {"email": "user@example.com"}
+
+
+def test_cloud_config_delete_clears_cloud_section_without_touching_account(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_dir = tmp_path / "config"
+    fallback_dir = tmp_path / "home" / ".promptfoo"
+    _patch_config_paths(auth_config, monkeypatch, config_dir, fallback_dir)
+
+    auth_config.write_global_config(
+        auth_config.GlobalConfig(
+            {
+                "id": "fixed-id",
+                "account": {"email": "user@example.com", "name": "Keep Me"},
+                "cloud": {
+                    "apiHost": "https://api.promptfoo.app",
+                    "apiKey": "secret-token",
+                    "customField": "remove-me",
+                },
+            }
+        )
+    )
+
+    auth_config.CloudConfig().delete()
+
+    written = yaml.safe_load((config_dir / "promptfoo.yaml").read_text())
+
+    assert written["account"] == {"email": "user@example.com", "name": "Keep Me"}
+    assert written["cloud"] == {}
+
+
 @pytest.mark.parametrize(
     ("api_host", "expected"),
     [


### PR DESCRIPTION
## Summary
- deep-merge partial writes for the nested `account` and `cloud` config sections instead of replacing the whole section
- keep whole-section clearing explicit by routing `CloudConfig.delete()` through the top-level delete path
- add regressions that prove partial account and cloud updates preserve sibling settings, including nested cloud dictionaries

## Root cause
`write_global_config_partial()` only merged at the top level. Any partial update shaped like `{"account": {...}}` or `{"cloud": {...}}` replaced the entire nested object, which could silently drop sibling settings already stored in the config file.

## Behavior
- `account` and `cloud` now deep-merge nested dictionaries
- top-level `None` still clears a whole section
- nested `None` values are treated as ordinary assignments, not delete commands

## Impact
Partial auth/config updates stop clobbering unrelated sibling settings, so updating a single account or cloud field no longer makes nearby config disappear.

## Validation
- `uv run ruff format modelaudit/auth/config.py tests/test_auth_config.py`
- `uv run ruff check --fix modelaudit/auth/config.py tests/test_auth_config.py`
- `uv run mypy modelaudit/auth/config.py tests/test_auth_config.py`
- `PROMPTFOO_DISABLE_TELEMETRY=1 uv run pytest tests/test_auth_config.py`
