### PR TITLE
fix(jinja2): detect lipsum and get_flashed_messages __globals__ SSTI gadgets

### DIFF
--- a/modelaudit/detectors/suspicious_symbols.py
+++ b/modelaudit/detectors/suspicious_symbols.py
@@ -924,6 +924,13 @@ JINJA2_SSTI_PATTERNS = {
         # Request/application context access (web frameworks)
         r"request\.application\.__globals__",  # Flask request object
         r"config\.__class__\.__init__\.__globals__",  # Config object globals
+        # Default Jinja2 / Flask globals that also expose __globals__ (SSTI gadgets)
+        r"lipsum\.__globals__",  # Via lipsum (a default Jinja2 global)
+        r"get_flashed_messages\.__globals__",  # Via Flask get_flashed_messages global
+        # Generic attribute-access reach into __globals__ (e.g. x.__globals__.os),
+        # which Jinja2 resolves via getattr then getitem but which evades the
+        # __globals__[ subscript pattern above; also covers future gadget objects
+        r"\.__globals__",  # Any attribute access to __globals__
         # Module globals access
         r"\._module\.__builtins__",  # Module builtins
         r"sys\.modules\[",  # Access loaded modules

--- a/tests/scanners/test_jinja2_template_scanner.py
+++ b/tests/scanners/test_jinja2_template_scanner.py
@@ -213,6 +213,27 @@ class TestJinja2TemplateScannerPatternCategories:
         patterns = {c.details.get("pattern_type") for c in failed_checks if c.details}
         assert "global_access" in patterns or "object_traversal" in patterns
 
+    def test_detects_lipsum_and_get_flashed_messages_gadgets(self, tmp_path: Path) -> None:
+        """Global-access gadgets via lipsum / get_flashed_messages should be flagged.
+
+        These reach __globals__ through the dotted attribute form, which Jinja2
+        resolves via getattr then getitem, so they carry no __globals__[ subscript
+        and no separately-flagged sink. Benign marker only, no exploit chain.
+        """
+        for name, gadget in (
+            ("lipsum", "{{ lipsum.__globals__.os }}"),
+            ("get_flashed_messages", "{{ get_flashed_messages.__globals__.os }}"),
+        ):
+            template_file = tmp_path / f"{name}.jinja"
+            template_file.write_text(gadget)
+
+            result = Jinja2TemplateScanner().scan(str(template_file))
+
+            failed_checks = [c for c in result.checks if c.status == CheckStatus.FAILED]
+            assert failed_checks, f"{name} gadget should be flagged"
+            patterns = {c.details.get("pattern_type") for c in failed_checks if c.details}
+            assert "global_access" in patterns, f"{name}: {patterns}"
+
     def test_detects_builtins_access(self, tmp_path: Path) -> None:
         """Test detection of __builtins__ access patterns."""
         template_file = tmp_path / "builtins.jinja"


### PR DESCRIPTION
### What

Adds the `lipsum.__globals__` and `get_flashed_messages.__globals__` global-access gadgets to `JINJA2_SSTI_PATTERNS["global_access"]`, plus a generic `\.__globals__` attribute pattern, and a regression test.

This is a detection-quality improvement (a gadget-enumeration completeness gap), not a security-vulnerability report. The classic weaponized forms are already caught today, so nothing here is a practical bypass. Per `SECURITY.md` this is the "detection quality / obfuscation outside implemented coverage" category, so I'm filing it as a normal PR rather than a private advisory.

### Why

The `global_access` list already enumerates the sibling gadgets `cycler`, `joiner`, `namespace`, `request.application`, and `config`, but not `lipsum` or `get_flashed_messages`, both staples of public Jinja2 SSTI references. `lipsum` is a default Jinja2 global, so it's reachable in a plain chat-template render (the same pattern set the GGUF `tokenizer.chat_template` path uses).

Two gaps, one fix:

1. **Gadget list consistency.** `lipsum` / `get_flashed_messages` were the only common global-access gadgets missing while their siblings are present.
2. **Dotted `__globals__` reach.** The existing `__globals__[` pattern only catches the subscript form. Jinja2 resolves `a.b` by attribute then item, so `x.__globals__.os` is a working construct whose source text contains no `__globals__[` and matched nothing before this change. The added `\.__globals__` pattern closes that generically and covers future gadget objects.

Scope note: a fully weaponized payload usually still self-flags through its sink (e.g. `os.popen(` / `eval(`), which is a separate `critical_injection` pattern, so this is a completeness/consistency hardening rather than a bypass fix. The sandboxed render probe is unaffected.

### Testing

`tests/scanners/test_jinja2_template_scanner.py::TestJinja2TemplateScannerPatternCategories::test_detects_lipsum_and_get_flashed_messages_gadgets` scans `{{ lipsum.__globals__.os }}` and `{{ get_flashed_messages.__globals__.os }}` (benign markers, no exploit chain) and asserts both are flagged as `global_access`. It fails on `main` (both produce zero findings) and passes with this change. Existing benign-template false-positive tests still pass (benign chat templates don't reference `__globals__`).

`uv run ruff check`, `uv run ruff format --check`, and `uv run mypy` on the changed files are clean; the jinja2 scanner + detector suites pass.

No operational exploit payloads are included; the gadget families referenced are long-public SSTI knowledge.
