### PR TITLE
test(tar): stabilize terminal gzip fixture

### DIFF
--- a/tests/scanners/test_tar_scanner.py
+++ b/tests/scanners/test_tar_scanner.py
@@ -3,6 +3,7 @@ import io
 import lzma
 import os
 import pickle
+import random
 import tarfile
 import tempfile
 import zipfile
@@ -3253,7 +3254,7 @@ class TestTarScanner:
         archive_path = tmp_path / "terminal-empty-member.tar.gz"
         raw_tar = io.BytesIO()
         with tarfile.open(fileobj=raw_tar, mode="w") as archive:
-            payload = os.urandom(128 * 1024)
+            payload = random.Random(0).randbytes(128 * 1024)
             info = tarfile.TarInfo("weights.bin")
             info.size = len(payload)
             archive.addfile(info, io.BytesIO(payload))


### PR DESCRIPTION
## Summary
- replace random terminal-gzip fixture bytes with deterministic high-entropy bytes
- prevent the gzip ratio test from occasionally triggering unrelated zlib spoofing/decode safeguards

## Evidence
- latest Nightly CI run 28995888179 failed only tests/scanners/test_tar_scanner.py::TestTarScanner::test_terminal_empty_gzip_member_is_excluded_once_from_ratio
- sampled the original random fixture locally and reproduced a failure at iteration 74 when weights.bin began with zlib-looking bytes

## Validation
- exact failing node: 8 repeated passes
- tests/scanners/test_tar_scanner.py: 199 passed, 1 skipped
- ruff format/check: passed
- mypy tests/scanners/test_tar_scanner.py: passed

## Environment note
- fresh uv test setup is blocked on macOS arm64 by unavailable tensorrt-cu13-libs
- broad fallback pytest is blocked by a missing compiled modelaudit_picklescan._rust extension; broad fallback mypy reports pre-existing errors outside this diff