### PR TITLE
fix(cache): reuse stat without breaking public overrides

### DIFF
--- a/modelaudit/cache/cache_manager.py
+++ b/modelaudit/cache/cache_manager.py
@@ -84,7 +84,6 @@ class CacheManager:
         if not self.enabled or not self.cache:
             return None
 
-        file_identity: ScannedFileIdentity | None = None
         if (
             getattr(self.get_cached_result_with_identity, "__func__", None)
             is CacheManager.get_cached_result_with_identity
@@ -95,18 +94,18 @@ class CacheManager:
                 version_context=version_context,
                 include_private_metadata=include_private_metadata,
             )
-        else:
-            # Preserve the established override contract for subclasses and monkeypatches.
-            cached_result, file_identity = self.get_cached_result_with_identity(
-                file_path,
-                version_context=version_context,
-                include_private_metadata=include_private_metadata,
-            )
-
-        try:
             if cached_result is not None and not cached_scan_result_dependencies_available(cached_result):
                 logger.debug(f"Bypassing cached result with unavailable scanner dependencies: {Path(file_path).name}")
                 return None
+            return cached_result
+
+        # Preserve the established override contract for subclasses and monkeypatches.
+        cached_result, file_identity = self.get_cached_result_with_identity(
+            file_path,
+            version_context=version_context,
+            include_private_metadata=include_private_metadata,
+        )
+        try:
             return cached_result
         finally:
             if file_identity is not None:

--- a/modelaudit/cache/cache_manager.py
+++ b/modelaudit/cache/cache_manager.py
@@ -84,16 +84,16 @@ class CacheManager:
         if not self.enabled or not self.cache:
             return None
 
-        cached_result, file_identity = self.get_cached_result_with_identity(
+        cached_result = self.cache.get_cached_result_with_stat(
             file_path,
+            stat_result,
             version_context=version_context,
             include_private_metadata=include_private_metadata,
         )
-        try:
-            return cached_result
-        finally:
-            if file_identity is not None:
-                self.cache.release_ancestor_identity(file_identity[-1])
+        if cached_result is not None and not cached_scan_result_dependencies_available(cached_result):
+            logger.debug(f"Bypassing cached result with unavailable scanner dependencies: {Path(file_path).name}")
+            return None
+        return cached_result
 
     def get_cached_result_with_identity(
         self,

--- a/modelaudit/cache/cache_manager.py
+++ b/modelaudit/cache/cache_manager.py
@@ -84,16 +84,33 @@ class CacheManager:
         if not self.enabled or not self.cache:
             return None
 
-        cached_result = self.cache.get_cached_result_with_stat(
-            file_path,
-            stat_result,
-            version_context=version_context,
-            include_private_metadata=include_private_metadata,
-        )
-        if cached_result is not None and not cached_scan_result_dependencies_available(cached_result):
-            logger.debug(f"Bypassing cached result with unavailable scanner dependencies: {Path(file_path).name}")
-            return None
-        return cached_result
+        file_identity: ScannedFileIdentity | None = None
+        if (
+            getattr(self.get_cached_result_with_identity, "__func__", None)
+            is CacheManager.get_cached_result_with_identity
+        ):
+            cached_result = self.cache.get_cached_result_with_stat(
+                file_path,
+                stat_result,
+                version_context=version_context,
+                include_private_metadata=include_private_metadata,
+            )
+        else:
+            # Preserve the established override contract for subclasses and monkeypatches.
+            cached_result, file_identity = self.get_cached_result_with_identity(
+                file_path,
+                version_context=version_context,
+                include_private_metadata=include_private_metadata,
+            )
+
+        try:
+            if cached_result is not None and not cached_scan_result_dependencies_available(cached_result):
+                logger.debug(f"Bypassing cached result with unavailable scanner dependencies: {Path(file_path).name}")
+                return None
+            return cached_result
+        finally:
+            if file_identity is not None:
+                self.cache.release_ancestor_identity(file_identity[-1])
 
     def get_cached_result_with_identity(
         self,

--- a/modelaudit/cache/scan_results_cache.py
+++ b/modelaudit/cache/scan_results_cache.py
@@ -457,7 +457,10 @@ class ScanResultsCache:
         Returns:
             Cached scan result dictionary if found and valid, None otherwise
         """
-        if getattr(self.get_cached_result_with_identity, "__func__", None) is ScanResultsCache.get_cached_result_with_identity:
+        if (
+            getattr(self.get_cached_result_with_identity, "__func__", None)
+            is ScanResultsCache.get_cached_result_with_identity
+        ):
             cached_result, file_identity = self._get_cached_result_with_identity(
                 file_path,
                 version_context=version_context,

--- a/modelaudit/cache/scan_results_cache.py
+++ b/modelaudit/cache/scan_results_cache.py
@@ -457,7 +457,7 @@ class ScanResultsCache:
         Returns:
             Cached scan result dictionary if found and valid, None otherwise
         """
-        if type(self).get_cached_result_with_identity is ScanResultsCache.get_cached_result_with_identity:
+        if getattr(self.get_cached_result_with_identity, "__func__", None) is ScanResultsCache.get_cached_result_with_identity:
             cached_result, file_identity = self._get_cached_result_with_identity(
                 file_path,
                 version_context=version_context,
@@ -504,7 +504,10 @@ class ScanResultsCache:
                 logger.debug("Bypassing scan-result cache lookup for symlinked path %s", file_path)
                 return None, None
 
-            if file_stat is not None and type(self).capture_file_identity is ScanResultsCache.capture_file_identity:
+            if (
+                file_stat is not None
+                and getattr(self.capture_file_identity, "__func__", None) is ScanResultsCache.capture_file_identity
+            ):
                 file_identity = self._capture_file_identity(file_path, file_stat=file_stat)
             else:
                 # Preserve legacy subclasses that override the established signature.

--- a/modelaudit/cache/scan_results_cache.py
+++ b/modelaudit/cache/scan_results_cache.py
@@ -457,11 +457,20 @@ class ScanResultsCache:
         Returns:
             Cached scan result dictionary if found and valid, None otherwise
         """
-        cached_result, file_identity = self.get_cached_result_with_identity(
-            file_path,
-            version_context=version_context,
-            include_private_metadata=include_private_metadata,
-        )
+        if type(self).get_cached_result_with_identity is ScanResultsCache.get_cached_result_with_identity:
+            cached_result, file_identity = self._get_cached_result_with_identity(
+                file_path,
+                version_context=version_context,
+                file_stat=file_stat,
+                include_private_metadata=include_private_metadata,
+            )
+        else:
+            # Preserve the established override contract for subclasses.
+            cached_result, file_identity = self.get_cached_result_with_identity(
+                file_path,
+                version_context=version_context,
+                include_private_metadata=include_private_metadata,
+            )
         if file_identity is not None:
             self.release_ancestor_identity(file_identity[-1])
         return cached_result
@@ -474,13 +483,32 @@ class ScanResultsCache:
         include_private_metadata: bool = False,
     ) -> tuple[dict[str, Any] | None, ScannedFileIdentity | None]:
         """Return a cache lookup plus the monitored identity reusable by a miss scan."""
+        return self._get_cached_result_with_identity(
+            file_path,
+            version_context=version_context,
+            file_stat=None,
+            include_private_metadata=include_private_metadata,
+        )
+
+    def _get_cached_result_with_identity(
+        self,
+        file_path: str,
+        version_context: dict[str, Any] | None,
+        *,
+        file_stat: os.stat_result | None,
+        include_private_metadata: bool,
+    ) -> tuple[dict[str, Any] | None, ScannedFileIdentity | None]:
         file_identity: ScannedFileIdentity | None = None
         try:
             if self._path_has_symlink_component(file_path):
                 logger.debug("Bypassing scan-result cache lookup for symlinked path %s", file_path)
                 return None, None
 
-            file_identity = self.capture_file_identity(file_path)
+            if file_stat is not None and type(self).capture_file_identity is ScanResultsCache.capture_file_identity:
+                file_identity = self._capture_file_identity(file_path, file_stat=file_stat)
+            else:
+                # Preserve legacy subclasses that override the established signature.
+                file_identity = self.capture_file_identity(file_path)
             file_stat, file_hash, _change_token, _ancestor_identity = file_identity
             cache_key, _content_hash = self._generate_cache_key_material(
                 file_path,
@@ -856,12 +884,22 @@ class ScanResultsCache:
 
     def capture_file_identity(self, file_path: str) -> ScannedFileIdentity:
         """Capture a stable stat, content hash, and platform change token before scanning."""
+        return self._capture_file_identity(file_path, file_stat=None)
+
+    def _capture_file_identity(
+        self,
+        file_path: str,
+        *,
+        file_stat: os.stat_result | None,
+    ) -> ScannedFileIdentity:
         if self._path_has_symlink_component(file_path):
             raise ValueError(f"Symlinked paths are not cacheable: {file_path}")
 
         last_change_error: ValueError | None = None
+        stat_hint = file_stat
         for _capture_attempt in range(_MAX_IDENTITY_CAPTURE_ATTEMPTS):
-            preliminary_stat = os.stat(file_path)
+            preliminary_stat = stat_hint if stat_hint is not None else os.stat(file_path)
+            stat_hint = None
             probe = self._get_change_clock_probe(file_path, preliminary_stat.st_dev)
             preliminary_change_token = self._get_file_change_token(file_path, preliminary_stat)
             preliminary_ancestor_identity = self._capture_ancestor_identity(file_path)

--- a/tests/cache/test_cache_correctness.py
+++ b/tests/cache/test_cache_correctness.py
@@ -750,6 +750,25 @@ def test_cache_manager_forwards_stat_to_existing_cache_api(
     assert cache_manager.get_cached_result_with_stat(str(file_path), provided_stat) == expected
     assert observed_stats == [provided_stat]
 
+    override_expected = {**expected, "scanner": "manager-override"}
+    override_identity = cache_manager.cache.capture_file_identity(str(file_path))
+    manager_override_called = False
+
+    def legacy_manager_lookup(
+        path: str,
+        version_context: dict[str, Any] | None = None,
+        *,
+        include_private_metadata: bool = False,
+    ) -> Any:
+        nonlocal manager_override_called
+        manager_override_called = True
+        return override_expected, override_identity
+
+    monkeypatch.setattr(cache_manager, "get_cached_result_with_identity", legacy_manager_lookup)
+
+    assert cache_manager.get_cached_result_with_stat(str(file_path), provided_stat) == override_expected
+    assert manager_override_called is True
+
 
 def test_cached_scan_does_not_store_result_after_post_scan_replacement(tmp_path: Path) -> None:
     file_path = _make_cacheable_file(tmp_path, name="race.dat")

--- a/tests/cache/test_cache_correctness.py
+++ b/tests/cache/test_cache_correctness.py
@@ -765,6 +765,10 @@ def test_cache_manager_forwards_stat_to_existing_cache_api(
         return override_expected, override_identity
 
     monkeypatch.setattr(cache_manager, "get_cached_result_with_identity", legacy_manager_lookup)
+    monkeypatch.setattr(
+        "modelaudit.cache.cache_manager.cached_scan_result_dependencies_available",
+        lambda _result: False,
+    )
 
     assert cache_manager.get_cached_result_with_stat(str(file_path), provided_stat) == override_expected
     assert manager_override_called is True

--- a/tests/cache/test_cache_correctness.py
+++ b/tests/cache/test_cache_correctness.py
@@ -671,6 +671,86 @@ def test_cache_manager_reuses_lookup_identity_for_miss(
     assert capture_calls == 1
 
 
+def test_stat_aware_lookup_reuses_hint_without_changing_public_override_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    file_path = _make_cacheable_file(tmp_path, name="stat-aware.cache")
+    provided_stat = os.stat(file_path)
+    cache = ScanResultsCache(str(tmp_path / "scan-cache"))
+    observed_stats: list[os.stat_result | None] = []
+    original_capture = cache._capture_file_identity
+
+    def capture_with_record(path: str, *, file_stat: os.stat_result | None) -> Any:
+        observed_stats.append(file_stat)
+        return original_capture(path, file_stat=file_stat)
+
+    monkeypatch.setattr(cache, "_capture_file_identity", capture_with_record)
+
+    assert cache.get_cached_result_with_stat(str(file_path), provided_stat) is None
+    assert observed_stats == [provided_stat]
+
+    class LegacyIdentityLookupCache(ScanResultsCache):
+        lookup_called = False
+
+        def get_cached_result_with_identity(
+            self,
+            path: str,
+            version_context: dict[str, Any] | None = None,
+            *,
+            include_private_metadata: bool = False,
+        ) -> Any:
+            self.lookup_called = True
+            return None, None
+
+    legacy_lookup_cache = LegacyIdentityLookupCache(str(tmp_path / "legacy-lookup-cache"))
+
+    assert legacy_lookup_cache.get_cached_result_with_stat(str(file_path), provided_stat) is None
+    assert legacy_lookup_cache.lookup_called is True
+
+    class LegacyCaptureCache(ScanResultsCache):
+        capture_called = False
+
+        def capture_file_identity(self, path: str) -> Any:
+            self.capture_called = True
+            return super().capture_file_identity(path)
+
+    legacy_capture_cache = LegacyCaptureCache(str(tmp_path / "legacy-capture-cache"))
+
+    assert legacy_capture_cache.get_cached_result_with_stat(str(file_path), provided_stat) is None
+    assert legacy_capture_cache.capture_called is True
+
+
+def test_cache_manager_forwards_stat_to_existing_cache_api(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    file_path = _make_cacheable_file(tmp_path, name="manager-stat.cache")
+    cache_manager = get_cache_manager(str(tmp_path / "cache"), enabled=True)
+    assert cache_manager.cache is not None
+    provided_stat = os.stat(file_path)
+    expected = {"checks": [], "issues": [], "metadata": {}, "scanner": "test", "success": True}
+    observed_stats: list[os.stat_result] = []
+
+    def lookup_with_stat(
+        path: str,
+        file_stat: os.stat_result,
+        version_context: dict[str, Any] | None = None,
+        *,
+        include_private_metadata: bool = False,
+    ) -> Any:
+        assert path == str(file_path)
+        assert version_context is None
+        assert include_private_metadata is False
+        observed_stats.append(file_stat)
+        return expected
+
+    monkeypatch.setattr(cache_manager.cache, "get_cached_result_with_stat", lookup_with_stat)
+
+    assert cache_manager.get_cached_result_with_stat(str(file_path), provided_stat) == expected
+    assert observed_stats == [provided_stat]
+
+
 def test_cached_scan_does_not_store_result_after_post_scan_replacement(tmp_path: Path) -> None:
     file_path = _make_cacheable_file(tmp_path, name="race.dat")
     clean_payload = b"clean:" + (b"x" * 2042)


### PR DESCRIPTION
## Summary

Replace #1720 with a backwards-compatible implementation of the same stat-reuse fix.

- reuse the caller-provided stat in the native cache identity path
- keep the established public `get_cached_result_with_identity()` and `capture_file_identity()` signatures unchanged
- preserve subclass and instance override behavior by falling back to the legacy call path
- route the cache manager through the existing public stat-aware cache API
- cover native stat forwarding plus legacy identity/capture overrides

## Compatibility

This deliberately keeps the stat hint behind private helpers. Existing subclasses and monkeypatches with the old public method signatures continue to work; they retain their previous behavior and simply do not receive the new optimization.

## Validation

Exact-head GitHub CI is required before merge. Independent review of #1720 identified the compatibility gap this replacement closes.