### PR TITLE
fix(picklescan): resolve reviewed runtime guards

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1021,9 +1021,11 @@ jobs:
         run: |
           uv run --with ruff ruff check --select I src tests
 
-      - name: Check standalone package formatting with Ruff
+      - name: Show standalone package formatting changes
         run: |
-          uv run --with ruff ruff format --check src tests
+          uv run --with ruff ruff format src tests
+          git diff -- src tests
+          exit 1
 
       - name: Type check standalone package with mypy
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1021,11 +1021,9 @@ jobs:
         run: |
           uv run --with ruff ruff check --select I src tests
 
-      - name: Show standalone package formatting changes
+      - name: Check standalone package formatting with Ruff
         run: |
-          uv run --with ruff ruff format src tests
-          git diff -- src tests
-          exit 1
+          uv run --with ruff ruff format --check src tests
 
       - name: Type check standalone package with mypy
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1024,7 +1024,7 @@ jobs:
       - name: Check standalone package formatting with Ruff
         run: |
           uv run --with ruff ruff format src tests
-          git diff -- tests/test_call_graph_import_statements.py
+          git diff -- src tests
           exit 1
 
       - name: Type check standalone package with mypy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1023,9 +1023,7 @@ jobs:
 
       - name: Check standalone package formatting with Ruff
         run: |
-          uv run --with ruff ruff format src tests
-          git diff -- src/modelaudit_picklescan/call_graph.py tests/test_call_graph_import_statements.py
-          exit 1
+          uv run --with ruff ruff format --check src tests
 
       - name: Type check standalone package with mypy
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1023,7 +1023,9 @@ jobs:
 
       - name: Check standalone package formatting with Ruff
         run: |
-          uv run --with ruff ruff format --check src tests
+          uv run --with ruff ruff format src tests
+          git diff -- tests/test_call_graph_import_statements.py
+          exit 1
 
       - name: Type check standalone package with mypy
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1023,9 +1023,7 @@ jobs:
 
       - name: Check standalone package formatting with Ruff
         run: |
-          uv run --with ruff ruff format src tests
-          git diff -- src tests
-          exit 1
+          uv run --with ruff ruff format --check src tests
 
       - name: Type check standalone package with mypy
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1023,7 +1023,9 @@ jobs:
 
       - name: Check standalone package formatting with Ruff
         run: |
-          uv run --with ruff ruff format --check src tests
+          uv run --with ruff ruff format src tests
+          git diff -- src/modelaudit_picklescan/call_graph.py tests/test_call_graph_import_statements.py
+          exit 1
 
       - name: Type check standalone package with mypy
         run: |
@@ -1031,7 +1033,7 @@ jobs:
 
       - name: Run standalone package tests
         run: |
-          uv run --with pytest --with pytest-xdist pytest -n auto tests --tb=short
+          uv run --with pytest --with pytest-xdist --with 'typing-extensions>=4.14' pytest -n auto tests --tb=short
 
       - name: Build standalone package
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- **picklescan:** resolve reviewed runtime `hasattr` guards without losing call-graph sinks
 - **hashing:** preserve throughput while checking scan deadlines responsively
 - **cli:** handle interrupts during CLI startup without a traceback
 

--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -15,6 +15,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- resolve reviewed runtime `hasattr(typing, ...)` guards before flattening module scope so current `typing_extensions.get_type_hints` remains connected to its evaluation sinks
 - restore Windows call-graph detection by reconciling descriptor and path stats with a cross-view identity that omits `st_ctime` (Windows reports it differently across stat methods); previously every stdlib callable source read failed closed on Windows, collapsing call-graph verdicts to inconclusive
 - preserve POSIX `st_ctime` in call-graph source-read identity checks so same-size, same-mtime inode-reuse swaps still fail closed
 

--- a/packages/modelaudit-picklescan/rust/src/nested.rs
+++ b/packages/modelaudit-picklescan/rust/src/nested.rs
@@ -3108,7 +3108,7 @@ mod tests {
 
     #[test]
     fn base64_prefix_gate_recognizes_complete_long_protocol0_scalar_pickle() {
-        for opcode in [b'F', b'I', b'L', b'P', b'S', b'V'] {
+        for opcode in *b"FILPSV" {
             let payload = long_protocol0_line_payload_for_test(opcode);
             let encoded = encode_base64_for_test(&payload);
 
@@ -3166,7 +3166,7 @@ mod tests {
 
     #[test]
     fn encoded_probe_windows_keep_long_scalar_candidates_at_each_decoded_offset() {
-        for opcode in [b'F', b'I', b'L', b'P', b'S', b'V', b'g', b'p'] {
+        for opcode in *b"FILPSVgp" {
             let payload = long_protocol0_line_payload_for_test(opcode);
             for prefix_len in 0..3usize {
                 let mut wrapped = vec![b'X'; prefix_len];

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -7387,8 +7387,18 @@ def _collect_assignment_aliases(
                 for target_name, node_id in last_resolved_node_ids.items()
             )
             if changed_conditionally or resolved_from_conditional_read:
+                ambiguous_target = next(
+                    (
+                        target_name
+                        for target_name, node_id in (*last_changed_node_ids.items(), *last_resolved_node_ids.items())
+                        if node_id in effective_conditionally_rebound_node_ids.get(target_name, set())
+                        or node_id in propagated_rebound_node_ids.get(target_name, set())
+                    ),
+                    "<unknown>",
+                )
                 raise _CallGraphAnalysisLimitError(
-                    "assignment alias analysis encountered ambiguous conditional rebinding"
+                    "assignment alias analysis encountered ambiguous conditional rebinding for "
+                    f"{ambiguous_target[:64]!r}"
                 )
             break
         if next_state in seen_states:

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -50,11 +50,15 @@ from types import (
     ModuleType,
     WrapperDescriptorType,
 )
-from typing import Any, Protocol, TypeVar, cast
+from typing import Any, Protocol, TypeGuard, TypeVar, cast
 from zipimport import zipimporter
 
 _MAX_DISTRIBUTIONS_PER_TOP_LEVEL = 16
 _MAX_STARTUP_DISTRIBUTION_NAMES = 4096
+
+
+def _is_exact_function(value: object) -> TypeGuard[FunctionType]:
+    return type(value) is FunctionType
 
 
 def _capture_startup_distribution_roots() -> Mapping[str, tuple[tuple[Path, Path], ...]]:
@@ -6260,7 +6264,7 @@ def _typing_extensions_runtime_guard_value(
     exported = extension_namespace.get("get_type_hints")
     typing_export = typing_namespace.get("get_type_hints")
     if (
-        type(typing_export) is FunctionType
+        _is_exact_function(typing_export)
         and exported is typing_export
         and typing_export.__name__ == "get_type_hints"
         and typing_export.__globals__ is typing_namespace

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -6259,7 +6259,9 @@ def _typing_extensions_runtime_guard_value(
     typing_namespace = vars(typing_module)
     exported = extension_namespace.get("get_type_hints")
     typing_export = typing_namespace.get("get_type_hints")
-    trusted_typing_export: FunctionType | None = typing_export if type(typing_export) is FunctionType else None
+    trusted_typing_export: FunctionType | None = None
+    if type(typing_export) is FunctionType:
+        trusted_typing_export = cast(FunctionType, typing_export)
     if (
         trusted_typing_export is not None
         and exported is trusted_typing_export

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -6259,9 +6259,7 @@ def _typing_extensions_runtime_guard_value(
     typing_namespace = vars(typing_module)
     exported = extension_namespace.get("get_type_hints")
     typing_export = typing_namespace.get("get_type_hints")
-    trusted_typing_export: FunctionType | None = (
-        typing_export if type(typing_export) is FunctionType else None
-    )
+    trusted_typing_export: FunctionType | None = typing_export if type(typing_export) is FunctionType else None
     if (
         trusted_typing_export is not None
         and exported is trusted_typing_export

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -6259,16 +6259,13 @@ def _typing_extensions_runtime_guard_value(
     typing_namespace = vars(typing_module)
     exported = extension_namespace.get("get_type_hints")
     typing_export = typing_namespace.get("get_type_hints")
-    trusted_typing_export: FunctionType | None = None
-    if type(typing_export) is FunctionType:
-        trusted_typing_export = cast(FunctionType, typing_export)
     if (
-        trusted_typing_export is not None
-        and exported is trusted_typing_export
-        and trusted_typing_export.__name__ == "get_type_hints"
-        and trusted_typing_export.__globals__ is typing_namespace
+        type(typing_export) is FunctionType
+        and exported is typing_export
+        and typing_export.__name__ == "get_type_hints"
+        and typing_export.__globals__ is typing_namespace
         and _function_owner_matches_trusted_source(
-            trusted_typing_export,
+            typing_export,
             expected_module="typing",
         )
     ):

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -6259,11 +6259,9 @@ def _typing_extensions_runtime_guard_value(
     typing_namespace = vars(typing_module)
     exported = extension_namespace.get("get_type_hints")
     typing_export = typing_namespace.get("get_type_hints")
-    trusted_typing_export: FunctionType | None
-    if type(typing_export) is FunctionType:
-        trusted_typing_export = typing_export
-    else:
-        trusted_typing_export = None
+    trusted_typing_export: FunctionType | None = (
+        typing_export if type(typing_export) is FunctionType else None
+    )
     if (
         trusted_typing_export is not None
         and exported is trusted_typing_export

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -6261,8 +6261,8 @@ def _typing_extensions_runtime_guard_value(
 
     extension_namespace = vars(extension_module)
     typing_namespace = vars(typing_module)
-    exported = extension_namespace.get("get_type_hints")
-    typing_export = typing_namespace.get("get_type_hints")
+    exported = cast(object, extension_namespace.get("get_type_hints"))
+    typing_export = cast(object, typing_namespace.get("get_type_hints"))
     if (
         _is_exact_function(typing_export)
         and exported is typing_export

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -6259,7 +6259,11 @@ def _typing_extensions_runtime_guard_value(
     typing_namespace = vars(typing_module)
     exported = extension_namespace.get("get_type_hints")
     typing_export = typing_namespace.get("get_type_hints")
-    trusted_typing_export = cast(FunctionType, typing_export) if type(typing_export) is FunctionType else None
+    trusted_typing_export: FunctionType | None
+    if type(typing_export) is FunctionType:
+        trusted_typing_export = typing_export
+    else:
+        trusted_typing_export = None
     if (
         trusted_typing_export is not None
         and exported is trusted_typing_export

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -6244,7 +6244,11 @@ def _typing_extensions_runtime_guard_value(
             or vars(builtins_module) is not _IMPORT_RUNTIME_BUILTINS
         ):
             return None
-        return "sentinel" in _IMPORT_RUNTIME_BUILTINS
+        if "sentinel" in _IMPORT_RUNTIME_BUILTINS:
+            return True
+        if "__getattr__" in _IMPORT_RUNTIME_BUILTINS:
+            return None
+        return False
 
     typing_module = sys.modules.get("typing")
     if type(typing_module) is not ModuleType or _trusted_module_origin_kind("typing") != "stdlib":
@@ -6308,6 +6312,7 @@ def _typing_extensions_runtime_guard_value(
     ):
         return None
     return False
+
 
 def _runtime_selected_module_statements(
     statements: Iterable[ast.stmt],
@@ -7397,18 +7402,8 @@ def _collect_assignment_aliases(
                 for target_name, node_id in last_resolved_node_ids.items()
             )
             if changed_conditionally or resolved_from_conditional_read:
-                ambiguous_target = next(
-                    (
-                        target_name
-                        for target_name, node_id in (*last_changed_node_ids.items(), *last_resolved_node_ids.items())
-                        if node_id in effective_conditionally_rebound_node_ids.get(target_name, set())
-                        or node_id in propagated_rebound_node_ids.get(target_name, set())
-                    ),
-                    "<unknown>",
-                )
                 raise _CallGraphAnalysisLimitError(
-                    "assignment alias analysis encountered ambiguous conditional rebinding for "
-                    f"{ambiguous_target[:64]!r}"
+                    "assignment alias analysis encountered ambiguous conditional rebinding"
                 )
             break
         if next_state in seen_states:

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -6259,13 +6259,18 @@ def _typing_extensions_runtime_guard_value(
     typing_namespace = vars(typing_module)
     exported = extension_namespace.get("get_type_hints")
     typing_export = typing_namespace.get("get_type_hints")
+    trusted_typing_export = (
+        cast(FunctionType, typing_export)
+        if type(typing_export) is FunctionType
+        else None
+    )
     if (
-        isinstance(typing_export, FunctionType)
-        and exported is typing_export
-        and typing_export.__name__ == "get_type_hints"
-        and typing_export.__globals__ is typing_namespace
+        trusted_typing_export is not None
+        and exported is trusted_typing_export
+        and trusted_typing_export.__name__ == "get_type_hints"
+        and trusted_typing_export.__globals__ is typing_namespace
         and _function_owner_matches_trusted_source(
-            typing_export,
+            trusted_typing_export,
             expected_module="typing",
         )
     ):

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -7447,6 +7447,8 @@ def _assignment_alias_value(
     ):
         return resolved
     alias_target = _static_import_reference_alias(resolved) or resolved
+    if module_name == "typing_extensions" and alias_target == "typing.get_type_hints":
+        return resolved
     if alias_target.startswith(f"{module_name}."):
         return None
     current_source_path = _resolve_module_source(module_name)

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -6229,10 +6229,7 @@ def _typing_extensions_runtime_guard_value(
 
     _mark_shared_source_snapshot_unreusable()
     extension_module = sys.modules.get("typing_extensions")
-    if (
-        type(extension_module) is not ModuleType
-        or _trusted_module_origin_kind("typing_extensions") != "site_packages"
-    ):
+    if type(extension_module) is not ModuleType or _trusted_module_origin_kind("typing_extensions") != "site_packages":
         return None
     extension_namespace = vars(extension_module)
 

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -6085,7 +6085,7 @@ def _module_source_context(module_name: str) -> _ModuleSourceContext | None:
         return None
 
     is_package = source_path.name == "__init__.py"
-    module_statements = _module_level_statements(tree)
+    module_statements = _module_level_statements(tree, module_name)
     return _ModuleSourceContext(source_path=source_path, module_statements=module_statements, is_package=is_package)
 
 
@@ -6203,8 +6203,116 @@ def _bytecode_cache_can_override_source(
     return cache_bytes[16:] != marshal.dumps(source_code)
 
 
-def _module_level_statements(tree: ast.Module) -> tuple[ast.stmt, ...]:
-    return _definition_scope_statements(tree.body)
+def _typing_extensions_runtime_guard_value(
+    statement: ast.If,
+    module_name: str | None,
+) -> bool | None:
+    test = statement.test
+    if (
+        module_name != "typing_extensions"
+        or not isinstance(test, ast.Call)
+        or not isinstance(test.func, ast.Name)
+        or test.func.id != "hasattr"
+        or len(test.args) != 2
+        or test.keywords
+        or not isinstance(test.args[0], ast.Name)
+        or test.args[0].id != "typing"
+        or not isinstance(test.args[1], ast.Constant)
+        or test.args[1].value != "ReadOnly"
+    ):
+        return None
+
+    aliases_get_type_hints = any(
+        isinstance(branch_statement, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "get_type_hints"
+            for target in branch_statement.targets
+        )
+        and isinstance(branch_statement.value, ast.Attribute)
+        and isinstance(branch_statement.value.value, ast.Name)
+        and branch_statement.value.value.id == "typing"
+        and branch_statement.value.attr == "get_type_hints"
+        for branch_statement in statement.body
+    )
+    wrapper = next(
+        (
+            branch_statement
+            for branch_statement in statement.orelse
+            if isinstance(branch_statement, ast.FunctionDef | ast.AsyncFunctionDef)
+            and branch_statement.name == "get_type_hints"
+        ),
+        None,
+    )
+    if not aliases_get_type_hints or wrapper is None:
+        return None
+
+    extension_module = sys.modules.get("typing_extensions")
+    typing_module = sys.modules.get("typing")
+    if (
+        type(extension_module) is not ModuleType
+        or type(typing_module) is not ModuleType
+        or _trusted_module_origin_kind("typing_extensions") != "site_packages"
+        or _trusted_module_origin_kind("typing") != "stdlib"
+        or "__getattr__" in vars(extension_module)
+        or "__getattr__" in vars(typing_module)
+    ):
+        return None
+
+    extension_namespace = vars(extension_module)
+    typing_namespace = vars(typing_module)
+    exported = extension_namespace.get("get_type_hints")
+    typing_export = typing_namespace.get("get_type_hints")
+    if (
+        type(typing_export) is FunctionType
+        and exported is typing_export
+        and typing_export.__name__ == "get_type_hints"
+        and typing_export.__globals__ is typing_namespace
+        and _function_owner_matches_trusted_source(
+            typing_export,
+            expected_module="typing",
+        )
+    ):
+        return True
+    if (
+        type(exported) is not FunctionType
+        or exported.__name__ != "get_type_hints"
+        or exported.__globals__ is not extension_namespace
+        or extension_namespace.get("typing") is not typing_module
+        or exported.__code__.co_firstlineno != wrapper.lineno
+        or not _function_owner_matches_trusted_source(
+            exported,
+            expected_module="typing_extensions",
+        )
+    ):
+        return None
+    return False
+
+
+def _runtime_selected_module_statements(
+    statements: Iterable[ast.stmt],
+    module_name: str | None = None,
+) -> tuple[ast.stmt, ...]:
+    selected: list[ast.stmt] = []
+    for statement in statements:
+        if isinstance(statement, ast.If):
+            guard_value = _typing_extensions_runtime_guard_value(statement, module_name)
+            if guard_value is not None:
+                active_branch = statement.body if guard_value else statement.orelse
+                selected.extend(
+                    _runtime_selected_module_statements(active_branch, module_name)
+                )
+                continue
+        selected.append(statement)
+    return tuple(selected)
+
+
+def _module_level_statements(
+    tree: ast.Module,
+    module_name: str | None = None,
+) -> tuple[ast.stmt, ...]:
+    return _definition_scope_statements(
+        _runtime_selected_module_statements(tree.body, module_name)
+    )
 
 
 def _module_initialization_statement_is_inert(statement: ast.stmt) -> bool:
@@ -6811,7 +6919,7 @@ def _source_function_context(
     except Exception:
         return None
 
-    module_statements = _module_level_statements(tree)
+    module_statements = _module_level_statements(tree, module_name)
     function_node = _find_qualified_function_def(module_statements, qualified_name)
     if function_node is None:
         return _inherited_source_function_context(module_statements, module_name, source_path, qualified_name)
@@ -6863,7 +6971,7 @@ def _source_class_context(class_name: str) -> _ClassSourceContext | None:
     except Exception:
         return None
 
-    module_statements = _module_level_statements(tree)
+    module_statements = _module_level_statements(tree, module_name)
     class_node = _find_qualified_class_def(module_statements, qualified_name)
     if class_node is None:
         return None
@@ -7624,7 +7732,7 @@ def _constructor_parameter_self_attribute_targets(class_name: str, parameter_nam
     except Exception:
         return ()
 
-    class_node = _find_qualified_class_def(_module_level_statements(tree), qualified_name)
+    class_node = _find_qualified_class_def(_module_level_statements(tree, module_name), qualified_name)
     if class_node is None:
         return ()
     init_node = next(

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -6298,6 +6298,7 @@ def _typing_extensions_runtime_guard_value(
         return None
     return False
 
+
 def _runtime_selected_module_statements(
     statements: Iterable[ast.stmt],
     module_name: str | None = None,

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -6220,24 +6220,35 @@ def _typing_extensions_runtime_guard_value(
         or len(test.args) != 2
         or test.keywords
         or not isinstance(test.args[0], ast.Name)
-        or test.args[0].id != "typing"
         or not isinstance(test.args[1], ast.Constant)
-        or test.args[1].value != "ReadOnly"
     ):
+        return None
+    guard = (test.args[0].id, test.args[1].value)
+    if guard not in {("typing", "ReadOnly"), ("builtins", "sentinel")}:
         return None
 
     _mark_shared_source_snapshot_unreusable()
     extension_module = sys.modules.get("typing_extensions")
-    typing_module = sys.modules.get("typing")
     if (
         type(extension_module) is not ModuleType
-        or type(typing_module) is not ModuleType
         or _trusted_module_origin_kind("typing_extensions") != "site_packages"
-        or _trusted_module_origin_kind("typing") != "stdlib"
     ):
         return None
-
     extension_namespace = vars(extension_module)
+
+    if guard == ("builtins", "sentinel"):
+        builtins_module = extension_namespace.get("builtins")
+        if (
+            type(builtins_module) is not ModuleType
+            or type(_IMPORT_RUNTIME_BUILTINS) is not dict
+            or vars(builtins_module) is not _IMPORT_RUNTIME_BUILTINS
+        ):
+            return None
+        return "sentinel" in _IMPORT_RUNTIME_BUILTINS
+
+    typing_module = sys.modules.get("typing")
+    if type(typing_module) is not ModuleType or _trusted_module_origin_kind("typing") != "stdlib":
+        return None
     typing_namespace = vars(typing_module)
     if "ReadOnly" in typing_namespace:
         guard_value = True
@@ -6297,7 +6308,6 @@ def _typing_extensions_runtime_guard_value(
     ):
         return None
     return False
-
 
 def _runtime_selected_module_statements(
     statements: Iterable[ast.stmt],

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -6259,11 +6259,7 @@ def _typing_extensions_runtime_guard_value(
     typing_namespace = vars(typing_module)
     exported = extension_namespace.get("get_type_hints")
     typing_export = typing_namespace.get("get_type_hints")
-    trusted_typing_export = (
-        cast(FunctionType, typing_export)
-        if type(typing_export) is FunctionType
-        else None
-    )
+    trusted_typing_export = cast(FunctionType, typing_export) if type(typing_export) is FunctionType else None
     if (
         trusted_typing_export is not None
         and exported is trusted_typing_export

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -6226,6 +6226,26 @@ def _typing_extensions_runtime_guard_value(
     ):
         return None
 
+    extension_module = sys.modules.get("typing_extensions")
+    typing_module = sys.modules.get("typing")
+    if (
+        type(extension_module) is not ModuleType
+        or type(typing_module) is not ModuleType
+        or _trusted_module_origin_kind("typing_extensions") != "site_packages"
+        or _trusted_module_origin_kind("typing") != "stdlib"
+    ):
+        return None
+
+    _mark_shared_source_snapshot_unreusable()
+    extension_namespace = vars(extension_module)
+    typing_namespace = vars(typing_module)
+    if "ReadOnly" in typing_namespace:
+        guard_value = True
+    elif "__getattr__" in typing_namespace:
+        return None
+    else:
+        guard_value = False
+
     aliases_get_type_hints = any(
         isinstance(branch_statement, ast.Assign)
         and any(isinstance(target, ast.Name) and target.id == "get_type_hints" for target in branch_statement.targets)
@@ -6244,36 +6264,26 @@ def _typing_extensions_runtime_guard_value(
         ),
         None,
     )
+    if not aliases_get_type_hints and wrapper is None:
+        return guard_value
     if not aliases_get_type_hints or wrapper is None:
         return None
 
-    extension_module = sys.modules.get("typing_extensions")
-    typing_module = sys.modules.get("typing")
-    if (
-        type(extension_module) is not ModuleType
-        or type(typing_module) is not ModuleType
-        or _trusted_module_origin_kind("typing_extensions") != "site_packages"
-        or _trusted_module_origin_kind("typing") != "stdlib"
-        or "__getattr__" in vars(extension_module)
-        or "__getattr__" in vars(typing_module)
-    ):
-        return None
-
-    extension_namespace = vars(extension_module)
-    typing_namespace = vars(typing_module)
     exported = cast(object, extension_namespace.get("get_type_hints"))
     typing_export = cast(object, typing_namespace.get("get_type_hints"))
-    if (
-        _is_exact_function(typing_export)
-        and exported is typing_export
-        and typing_export.__name__ == "get_type_hints"
-        and typing_export.__globals__ is typing_namespace
-        and _function_owner_matches_trusted_source(
-            typing_export,
-            expected_module="typing",
-        )
-    ):
-        return True
+    if guard_value:
+        if (
+            _is_exact_function(typing_export)
+            and exported is typing_export
+            and typing_export.__name__ == "get_type_hints"
+            and typing_export.__globals__ is typing_namespace
+            and _function_owner_matches_trusted_source(
+                typing_export,
+                expected_module="typing",
+            )
+        ):
+            return True
+        return None
     if (
         type(exported) is not FunctionType
         or exported.__name__ != "get_type_hints"
@@ -6287,7 +6297,6 @@ def _typing_extensions_runtime_guard_value(
     ):
         return None
     return False
-
 
 def _runtime_selected_module_statements(
     statements: Iterable[ast.stmt],

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -6260,7 +6260,7 @@ def _typing_extensions_runtime_guard_value(
     exported = extension_namespace.get("get_type_hints")
     typing_export = typing_namespace.get("get_type_hints")
     if (
-        type(typing_export) is FunctionType
+        isinstance(typing_export, FunctionType)
         and exported is typing_export
         and typing_export.__name__ == "get_type_hints"
         and typing_export.__globals__ is typing_namespace

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -6226,6 +6226,7 @@ def _typing_extensions_runtime_guard_value(
     ):
         return None
 
+    _mark_shared_source_snapshot_unreusable()
     extension_module = sys.modules.get("typing_extensions")
     typing_module = sys.modules.get("typing")
     if (
@@ -6236,7 +6237,6 @@ def _typing_extensions_runtime_guard_value(
     ):
         return None
 
-    _mark_shared_source_snapshot_unreusable()
     extension_namespace = vars(extension_module)
     typing_namespace = vars(typing_module)
     if "ReadOnly" in typing_namespace:

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -6224,10 +6224,7 @@ def _typing_extensions_runtime_guard_value(
 
     aliases_get_type_hints = any(
         isinstance(branch_statement, ast.Assign)
-        and any(
-            isinstance(target, ast.Name) and target.id == "get_type_hints"
-            for target in branch_statement.targets
-        )
+        and any(isinstance(target, ast.Name) and target.id == "get_type_hints" for target in branch_statement.targets)
         and isinstance(branch_statement.value, ast.Attribute)
         and isinstance(branch_statement.value.value, ast.Name)
         and branch_statement.value.value.id == "typing"
@@ -6298,9 +6295,7 @@ def _runtime_selected_module_statements(
             guard_value = _typing_extensions_runtime_guard_value(statement, module_name)
             if guard_value is not None:
                 active_branch = statement.body if guard_value else statement.orelse
-                selected.extend(
-                    _runtime_selected_module_statements(active_branch, module_name)
-                )
+                selected.extend(_runtime_selected_module_statements(active_branch, module_name))
                 continue
         selected.append(statement)
     return tuple(selected)
@@ -6310,9 +6305,7 @@ def _module_level_statements(
     tree: ast.Module,
     module_name: str | None = None,
 ) -> tuple[ast.stmt, ...]:
-    return _definition_scope_statements(
-        _runtime_selected_module_statements(tree.body, module_name)
-    )
+    return _definition_scope_statements(_runtime_selected_module_statements(tree.body, module_name))
 
 
 def _module_initialization_statement_is_inert(statement: ast.stmt) -> bool:

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -39,7 +39,7 @@ from importlib.machinery import (
 from importlib.util import cache_from_source
 from pathlib import Path, PurePosixPath
 from types import CodeType, ModuleType
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import pytest
 
@@ -4763,7 +4763,7 @@ def test_scan_file_marks_hidden_pytorch_zip_probe_failure_inconclusive(
     def fail_hidden_probe_open(
         archive: zipfile.ZipFile,
         name: str | zipfile.ZipInfo,
-        mode: str = "r",
+        mode: Literal["r", "w"] = "r",
         pwd: bytes | None = None,
         *,
         force_zip64: bool = False,
@@ -4871,7 +4871,7 @@ def test_scan_file_returns_error_report_for_pytorch_zip_member_access_failure(
     def fail_member_open(
         archive: zipfile.ZipFile,
         name: str | zipfile.ZipInfo,
-        mode: str = "r",
+        mode: Literal["r", "w"] = "r",
         pwd: bytes | None = None,
         *,
         force_zip64: bool = False,

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -3061,52 +3061,35 @@ def _is_typing_readonly_guard(statement: ast.stmt) -> bool:
     )
 
 
+def _is_typing_get_type_hints_guard(statement: ast.stmt) -> bool:
+    return (
+        _is_typing_readonly_guard(statement)
+        and isinstance(statement, ast.If)
+        and any(
+            isinstance(branch_statement, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == "get_type_hints"
+                for target in branch_statement.targets
+            )
+            for branch_statement in statement.body
+        )
+        and any(
+            isinstance(branch_statement, ast.FunctionDef)
+            and branch_statement.name == "get_type_hints"
+            for branch_statement in statement.orelse
+        )
+    )
+
+
 def test_runtime_guard_selects_live_typing_extensions_export() -> None:
     typing_extensions = pytest.importorskip("typing_extensions")
     source_path = Path(typing_extensions.__file__)
     tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
-
-    guard = next(
-        statement for statement in tree.body if _is_typing_readonly_guard(statement)
-    )
-    assert isinstance(guard, ast.If)
-    wrapper = next(
-        (
-            statement
-            for statement in guard.orelse
-            if isinstance(statement, ast.FunctionDef)
-            and statement.name == "get_type_hints"
-        ),
-        None,
-    )
-    exported = vars(typing_extensions).get("get_type_hints")
-    exported_code = getattr(exported, "__code__", None)
-    guard_value = call_graph._typing_extensions_runtime_guard_value(
-        guard, "typing_extensions"
-    )
-    diagnostics = {
-        "extension_origin": call_graph._trusted_module_origin_kind("typing_extensions"),
-        "typing_origin": call_graph._trusted_module_origin_kind("typing"),
-        "extension_getattr": "__getattr__" in vars(typing_extensions),
-        "typing_getattr": "__getattr__" in vars(typing),
-        "export_type": type(exported).__name__,
-        "export_name": getattr(exported, "__name__", None),
-        "export_globals_match": getattr(exported, "__globals__", None)
-        is vars(typing_extensions),
-        "typing_binding_match": vars(typing_extensions).get("typing") is typing,
-        "line_match": wrapper is not None
-        and getattr(exported_code, "co_firstlineno", None) == wrapper.lineno,
-        "source_match": isinstance(exported, FunctionType)
-        and call_graph._function_owner_matches_trusted_source(
-            exported,
-            expected_module="typing_extensions",
-        ),
-    }
-    assert guard_value is not None, diagnostics
+    guard = next(statement for statement in tree.body if _is_typing_get_type_hints_guard(statement))
 
     statements = call_graph._runtime_selected_module_statements(tree.body, "typing_extensions")
 
-    assert not any(_is_typing_readonly_guard(statement) for statement in statements)
+    assert guard not in statements
     if typing_extensions.get_type_hints is typing.get_type_hints:
         assert any(
             isinstance(statement, ast.Assign)
@@ -3129,7 +3112,7 @@ def test_runtime_guard_keeps_mutated_typing_extensions_export_ambiguous(
 
     statements = call_graph._runtime_selected_module_statements(tree.body, "typing_extensions")
 
-    assert any(_is_typing_readonly_guard(statement) for statement in statements)
+    assert any(_is_typing_get_type_hints_guard(statement) for statement in statements)
 
 
 def test_runtime_guard_keeps_shared_replacement_alias_ambiguous(
@@ -3147,7 +3130,7 @@ def test_runtime_guard_keeps_shared_replacement_alias_ambiguous(
 
     statements = call_graph._runtime_selected_module_statements(tree.body, "typing_extensions")
 
-    assert any(_is_typing_readonly_guard(statement) for statement in statements)
+    assert any(_is_typing_get_type_hints_guard(statement) for statement in statements)
 
 
 def test_runtime_guard_keeps_source_location_forgery_ambiguous(
@@ -3156,7 +3139,7 @@ def test_runtime_guard_keeps_source_location_forgery_ambiguous(
     typing_extensions = pytest.importorskip("typing_extensions")
     source_path = Path(typing_extensions.__file__)
     tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
-    guard = next(statement for statement in tree.body if _is_typing_readonly_guard(statement))
+    guard = next(statement for statement in tree.body if _is_typing_get_type_hints_guard(statement))
     assert isinstance(guard, ast.If)
     wrapper = next(
         statement
@@ -3176,7 +3159,7 @@ def test_runtime_guard_keeps_source_location_forgery_ambiguous(
 
     statements = call_graph._runtime_selected_module_statements(tree.body, "typing_extensions")
 
-    assert any(_is_typing_readonly_guard(statement) for statement in statements)
+    assert any(_is_typing_get_type_hints_guard(statement) for statement in statements)
 
 
 def test_call_graph_models_version_gated_typing_extensions_definitions() -> None:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -3100,6 +3100,25 @@ def test_runtime_guard_selects_live_typing_extensions_export() -> None:
         )
 
 
+def test_runtime_guard_marks_unloaded_module_snapshot_unreusable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    typing_extensions = pytest.importorskip("typing_extensions")
+    source_path = Path(typing_extensions.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    guard = next(statement for statement in tree.body if _is_typing_get_type_hints_guard(statement))
+    assert isinstance(guard, ast.If)
+    monkeypatch.delitem(sys.modules, "typing_extensions")
+
+    with call_graph.shared_source_sensitive_caches():
+        snapshot = call_graph._SHARED_SOURCE_SENSITIVE_SNAPSHOT.get()
+        assert snapshot is not None
+        snapshot.reusable = True
+
+        assert call_graph._typing_extensions_runtime_guard_value(guard, "typing_extensions") is None
+        assert snapshot.reusable is False
+
+
 def test_runtime_guard_keeps_mutated_typing_extensions_export_ambiguous(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -3134,9 +3134,7 @@ def test_runtime_guard_selects_live_builtin_sentinel_branch() -> None:
             for statement in statements
         )
     else:
-        assert any(
-            isinstance(statement, ast.ClassDef) and statement.name == "sentinel" for statement in statements
-        )
+        assert any(isinstance(statement, ast.ClassDef) and statement.name == "sentinel" for statement in statements)
 
 
 def test_runtime_guard_keeps_dynamic_builtin_sentinel_ambiguous(

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -3077,6 +3077,7 @@ def test_runtime_guard_selects_live_typing_extensions_export() -> None:
         None,
     )
     exported = vars(typing_extensions).get("get_type_hints")
+    exported_code = getattr(exported, "__code__", None)
     guard_value = call_graph._typing_extensions_runtime_guard_value(guard, "typing_extensions")
     diagnostics = {
         "extension_origin": call_graph._trusted_module_origin_kind("typing_extensions"),
@@ -3087,7 +3088,8 @@ def test_runtime_guard_selects_live_typing_extensions_export() -> None:
         "export_name": getattr(exported, "__name__", None),
         "export_globals_match": getattr(exported, "__globals__", None) is vars(typing_extensions),
         "typing_binding_match": vars(typing_extensions).get("typing") is typing,
-        "line_match": wrapper is not None and getattr(exported, "__code__", None).co_firstlineno == wrapper.lineno,
+        "line_match": wrapper is not None
+        and getattr(exported_code, "co_firstlineno", None) == wrapper.lineno,
         "source_match": isinstance(exported, FunctionType)
         and call_graph._function_owner_matches_trusted_source(
             exported,

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -3066,6 +3066,36 @@ def test_runtime_guard_selects_live_typing_extensions_export() -> None:
     source_path = Path(typing_extensions.__file__)
     tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
 
+    guard = next(statement for statement in tree.body if _is_typing_readonly_guard(statement))
+    assert isinstance(guard, ast.If)
+    wrapper = next(
+        (
+            statement
+            for statement in guard.orelse
+            if isinstance(statement, ast.FunctionDef) and statement.name == "get_type_hints"
+        ),
+        None,
+    )
+    exported = vars(typing_extensions).get("get_type_hints")
+    guard_value = call_graph._typing_extensions_runtime_guard_value(guard, "typing_extensions")
+    diagnostics = {
+        "extension_origin": call_graph._trusted_module_origin_kind("typing_extensions"),
+        "typing_origin": call_graph._trusted_module_origin_kind("typing"),
+        "extension_getattr": "__getattr__" in vars(typing_extensions),
+        "typing_getattr": "__getattr__" in vars(typing),
+        "export_type": type(exported).__name__,
+        "export_name": getattr(exported, "__name__", None),
+        "export_globals_match": getattr(exported, "__globals__", None) is vars(typing_extensions),
+        "typing_binding_match": vars(typing_extensions).get("typing") is typing,
+        "line_match": wrapper is not None and getattr(exported, "__code__", None).co_firstlineno == wrapper.lineno,
+        "source_match": isinstance(exported, FunctionType)
+        and call_graph._function_owner_matches_trusted_source(
+            exported,
+            expected_module="typing_extensions",
+        ),
+    }
+    assert guard_value is not None, diagnostics
+
     statements = call_graph._runtime_selected_module_statements(tree.body, "typing_extensions")
 
     assert not any(_is_typing_readonly_guard(statement) for statement in statements)

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -3120,7 +3120,9 @@ def test_runtime_guard_selects_live_builtin_sentinel_branch() -> None:
     typing_extensions = pytest.importorskip("typing_extensions")
     source_path = Path(typing_extensions.__file__)
     tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
-    guard = next(statement for statement in tree.body if _is_builtin_sentinel_guard(statement))
+    guard = next((statement for statement in tree.body if _is_builtin_sentinel_guard(statement)), None)
+    if guard is None:
+        pytest.skip("installed typing_extensions has no builtins.sentinel runtime guard")
 
     statements = call_graph._runtime_selected_module_statements(tree.body, "typing_extensions")
 
@@ -3147,7 +3149,9 @@ def test_runtime_guard_keeps_dynamic_builtin_sentinel_ambiguous(
         pytest.skip("builtins.sentinel is directly available")
     source_path = Path(typing_extensions.__file__)
     tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
-    guard = next(statement for statement in tree.body if _is_builtin_sentinel_guard(statement))
+    guard = next((statement for statement in tree.body if _is_builtin_sentinel_guard(statement)), None)
+    if guard is None:
+        pytest.skip("installed typing_extensions has no builtins.sentinel runtime guard")
     monkeypatch.setitem(builtins_namespace, "__getattr__", lambda _name: object())
 
     assert hasattr(builtins, "sentinel")

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -11,6 +11,7 @@ import py_compile
 import subprocess
 import sys
 import threading
+import typing
 import zipfile
 from contextvars import copy_context
 from importlib.machinery import (
@@ -23,6 +24,7 @@ from importlib.machinery import (
 )
 from importlib.util import find_spec
 from pathlib import Path
+from types import FunctionType
 from typing import Any
 from zipimport import zipimporter
 
@@ -3044,6 +3046,119 @@ def test_call_graph_models_getattr_default_callable_fallbacks() -> None:
     )
 
 
+def _is_typing_readonly_guard(statement: ast.stmt) -> bool:
+    if not isinstance(statement, ast.If) or not isinstance(statement.test, ast.Call):
+        return False
+    test = statement.test
+    return (
+        isinstance(test.func, ast.Name)
+        and test.func.id == "hasattr"
+        and len(test.args) == 2
+        and isinstance(test.args[0], ast.Name)
+        and test.args[0].id == "typing"
+        and isinstance(test.args[1], ast.Constant)
+        and test.args[1].value == "ReadOnly"
+    )
+
+
+def test_runtime_guard_selects_live_typing_extensions_export() -> None:
+    typing_extensions = pytest.importorskip("typing_extensions")
+    source_path = Path(typing_extensions.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+
+    statements = call_graph._runtime_selected_module_statements(
+        tree.body, "typing_extensions"
+    )
+
+    assert not any(_is_typing_readonly_guard(statement) for statement in statements)
+    if typing_extensions.get_type_hints is typing.get_type_hints:
+        assert any(
+            isinstance(statement, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == "get_type_hints"
+                for target in statement.targets
+            )
+            for statement in statements
+        )
+    else:
+        assert any(
+            isinstance(statement, ast.FunctionDef)
+            and statement.name == "get_type_hints"
+            for statement in statements
+        )
+
+
+def test_runtime_guard_keeps_mutated_typing_extensions_export_ambiguous(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    typing_extensions = pytest.importorskip("typing_extensions")
+    source_path = Path(typing_extensions.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    monkeypatch.setattr(typing_extensions, "get_type_hints", object())
+
+    statements = call_graph._runtime_selected_module_statements(
+        tree.body, "typing_extensions"
+    )
+
+    assert any(_is_typing_readonly_guard(statement) for statement in statements)
+
+
+def test_runtime_guard_keeps_shared_replacement_alias_ambiguous(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    typing_extensions = pytest.importorskip("typing_extensions")
+    source_path = Path(typing_extensions.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+
+    def replacement(*_args: object, **_kwargs: object) -> dict[str, object]:
+        return {}
+
+    monkeypatch.setattr(typing, "get_type_hints", replacement)
+    monkeypatch.setattr(typing_extensions, "get_type_hints", replacement)
+
+    statements = call_graph._runtime_selected_module_statements(
+        tree.body, "typing_extensions"
+    )
+
+    assert any(_is_typing_readonly_guard(statement) for statement in statements)
+
+
+def test_runtime_guard_keeps_source_location_forgery_ambiguous(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    typing_extensions = pytest.importorskip("typing_extensions")
+    source_path = Path(typing_extensions.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    guard = next(
+        statement
+        for statement in tree.body
+        if _is_typing_readonly_guard(statement)
+    )
+    assert isinstance(guard, ast.If)
+    wrapper = next(
+        statement
+        for statement in guard.orelse
+        if isinstance(statement, ast.FunctionDef)
+        and statement.name == "get_type_hints"
+    )
+
+    def replacement(*_args: object, **_kwargs: object) -> dict[str, object]:
+        return {}
+
+    forged_code = replacement.__code__.replace(
+        co_filename=str(source_path),
+        co_firstlineno=wrapper.lineno,
+    )
+    forged = FunctionType(forged_code, vars(typing_extensions), "get_type_hints")
+    monkeypatch.setattr(typing_extensions, "get_type_hints", forged)
+
+    statements = call_graph._runtime_selected_module_statements(
+        tree.body, "typing_extensions"
+    )
+
+    assert any(_is_typing_readonly_guard(statement) for statement in statements)
+
+
 def test_call_graph_models_version_gated_typing_extensions_definitions() -> None:
     pytest.importorskip("typing_extensions")
 
@@ -3051,10 +3166,16 @@ def test_call_graph_models_version_gated_typing_extensions_definitions() -> None
     calls = call_graph._calls_for_function(function_name) or ()
     path = call_graph._find_sink_path(function_name)
 
-    assert call_graph._call_graph_entrypoints(function_name) == (function_name,)
-    assert "typing.get_type_hints" in calls
+    if hasattr(typing, "ReadOnly"):
+        assert (
+            call_graph._resolve_function_target(function_name)
+            == "typing.get_type_hints"
+        )
+    else:
+        assert call_graph._call_graph_entrypoints(function_name) == (function_name,)
+        assert "typing.get_type_hints" in calls
     assert path is not None
-    assert path[0] == function_name
+    assert path[0] in {function_name, "typing.get_type_hints"}
     assert path[-1] in {"builtins.compile", "builtins.eval"}
 
 

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -3137,6 +3137,23 @@ def test_runtime_guard_selects_live_builtin_sentinel_branch() -> None:
         )
 
 
+def test_runtime_guard_keeps_dynamic_builtin_sentinel_ambiguous(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    typing_extensions = pytest.importorskip("typing_extensions")
+    if "sentinel" in call_graph._IMPORT_RUNTIME_BUILTINS:
+        pytest.skip("builtins.sentinel is directly available")
+    source_path = Path(typing_extensions.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    guard = next(statement for statement in tree.body if _is_builtin_sentinel_guard(statement))
+    monkeypatch.setitem(call_graph._IMPORT_RUNTIME_BUILTINS, "__getattr__", lambda _name: object())
+
+    assert hasattr(builtins, "sentinel")
+    statements = call_graph._runtime_selected_module_statements(tree.body, "typing_extensions")
+
+    assert guard in statements
+
+
 def test_runtime_guard_marks_unloaded_module_snapshot_unreusable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -3066,25 +3066,18 @@ def test_runtime_guard_selects_live_typing_extensions_export() -> None:
     source_path = Path(typing_extensions.__file__)
     tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
 
-    statements = call_graph._runtime_selected_module_statements(
-        tree.body, "typing_extensions"
-    )
+    statements = call_graph._runtime_selected_module_statements(tree.body, "typing_extensions")
 
     assert not any(_is_typing_readonly_guard(statement) for statement in statements)
     if typing_extensions.get_type_hints is typing.get_type_hints:
         assert any(
             isinstance(statement, ast.Assign)
-            and any(
-                isinstance(target, ast.Name) and target.id == "get_type_hints"
-                for target in statement.targets
-            )
+            and any(isinstance(target, ast.Name) and target.id == "get_type_hints" for target in statement.targets)
             for statement in statements
         )
     else:
         assert any(
-            isinstance(statement, ast.FunctionDef)
-            and statement.name == "get_type_hints"
-            for statement in statements
+            isinstance(statement, ast.FunctionDef) and statement.name == "get_type_hints" for statement in statements
         )
 
 
@@ -3096,9 +3089,7 @@ def test_runtime_guard_keeps_mutated_typing_extensions_export_ambiguous(
     tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
     monkeypatch.setattr(typing_extensions, "get_type_hints", object())
 
-    statements = call_graph._runtime_selected_module_statements(
-        tree.body, "typing_extensions"
-    )
+    statements = call_graph._runtime_selected_module_statements(tree.body, "typing_extensions")
 
     assert any(_is_typing_readonly_guard(statement) for statement in statements)
 
@@ -3116,9 +3107,7 @@ def test_runtime_guard_keeps_shared_replacement_alias_ambiguous(
     monkeypatch.setattr(typing, "get_type_hints", replacement)
     monkeypatch.setattr(typing_extensions, "get_type_hints", replacement)
 
-    statements = call_graph._runtime_selected_module_statements(
-        tree.body, "typing_extensions"
-    )
+    statements = call_graph._runtime_selected_module_statements(tree.body, "typing_extensions")
 
     assert any(_is_typing_readonly_guard(statement) for statement in statements)
 
@@ -3129,17 +3118,12 @@ def test_runtime_guard_keeps_source_location_forgery_ambiguous(
     typing_extensions = pytest.importorskip("typing_extensions")
     source_path = Path(typing_extensions.__file__)
     tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
-    guard = next(
-        statement
-        for statement in tree.body
-        if _is_typing_readonly_guard(statement)
-    )
+    guard = next(statement for statement in tree.body if _is_typing_readonly_guard(statement))
     assert isinstance(guard, ast.If)
     wrapper = next(
         statement
         for statement in guard.orelse
-        if isinstance(statement, ast.FunctionDef)
-        and statement.name == "get_type_hints"
+        if isinstance(statement, ast.FunctionDef) and statement.name == "get_type_hints"
     )
 
     def replacement(*_args: object, **_kwargs: object) -> dict[str, object]:
@@ -3152,9 +3136,7 @@ def test_runtime_guard_keeps_source_location_forgery_ambiguous(
     forged = FunctionType(forged_code, vars(typing_extensions), "get_type_hints")
     monkeypatch.setattr(typing_extensions, "get_type_hints", forged)
 
-    statements = call_graph._runtime_selected_module_statements(
-        tree.body, "typing_extensions"
-    )
+    statements = call_graph._runtime_selected_module_statements(tree.body, "typing_extensions")
 
     assert any(_is_typing_readonly_guard(statement) for statement in statements)
 
@@ -3167,10 +3149,7 @@ def test_call_graph_models_version_gated_typing_extensions_definitions() -> None
     path = call_graph._find_sink_path(function_name)
 
     if hasattr(typing, "ReadOnly"):
-        assert (
-            call_graph._resolve_function_target(function_name)
-            == "typing.get_type_hints"
-        )
+        assert call_graph._resolve_function_target(function_name) == "typing.get_type_hints"
     else:
         assert call_graph._call_graph_entrypoints(function_name) == (function_name,)
         assert "typing.get_type_hints" in calls

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import builtins
 import importlib
 import io
 import os
@@ -3079,6 +3080,21 @@ def _is_typing_get_type_hints_guard(statement: ast.stmt) -> bool:
     )
 
 
+def _is_builtin_sentinel_guard(statement: ast.stmt) -> bool:
+    if not isinstance(statement, ast.If) or not isinstance(statement.test, ast.Call):
+        return False
+    test = statement.test
+    return (
+        isinstance(test.func, ast.Name)
+        and test.func.id == "hasattr"
+        and len(test.args) == 2
+        and isinstance(test.args[0], ast.Name)
+        and test.args[0].id == "builtins"
+        and isinstance(test.args[1], ast.Constant)
+        and test.args[1].value == "sentinel"
+    )
+
+
 def test_runtime_guard_selects_live_typing_extensions_export() -> None:
     typing_extensions = pytest.importorskip("typing_extensions")
     source_path = Path(typing_extensions.__file__)
@@ -3097,6 +3113,27 @@ def test_runtime_guard_selects_live_typing_extensions_export() -> None:
     else:
         assert any(
             isinstance(statement, ast.FunctionDef) and statement.name == "get_type_hints" for statement in statements
+        )
+
+
+def test_runtime_guard_selects_live_builtin_sentinel_branch() -> None:
+    typing_extensions = pytest.importorskip("typing_extensions")
+    source_path = Path(typing_extensions.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    guard = next(statement for statement in tree.body if _is_builtin_sentinel_guard(statement))
+
+    statements = call_graph._runtime_selected_module_statements(tree.body, "typing_extensions")
+
+    assert guard not in statements
+    if hasattr(builtins, "sentinel"):
+        assert any(
+            isinstance(statement, ast.Assign)
+            and any(isinstance(target, ast.Name) and target.id == "sentinel" for target in statement.targets)
+            for statement in statements
+        )
+    else:
+        assert any(
+            isinstance(statement, ast.ClassDef) and statement.name == "sentinel" for statement in statements
         )
 
 

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -3068,14 +3068,12 @@ def _is_typing_get_type_hints_guard(statement: ast.stmt) -> bool:
         and any(
             isinstance(branch_statement, ast.Assign)
             and any(
-                isinstance(target, ast.Name) and target.id == "get_type_hints"
-                for target in branch_statement.targets
+                isinstance(target, ast.Name) and target.id == "get_type_hints" for target in branch_statement.targets
             )
             for branch_statement in statement.body
         )
         and any(
-            isinstance(branch_statement, ast.FunctionDef)
-            and branch_statement.name == "get_type_hints"
+            isinstance(branch_statement, ast.FunctionDef) and branch_statement.name == "get_type_hints"
             for branch_statement in statement.orelse
         )
     )

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -3066,19 +3066,24 @@ def test_runtime_guard_selects_live_typing_extensions_export() -> None:
     source_path = Path(typing_extensions.__file__)
     tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
 
-    guard = next(statement for statement in tree.body if _is_typing_readonly_guard(statement))
+    guard = next(
+        statement for statement in tree.body if _is_typing_readonly_guard(statement)
+    )
     assert isinstance(guard, ast.If)
     wrapper = next(
         (
             statement
             for statement in guard.orelse
-            if isinstance(statement, ast.FunctionDef) and statement.name == "get_type_hints"
+            if isinstance(statement, ast.FunctionDef)
+            and statement.name == "get_type_hints"
         ),
         None,
     )
     exported = vars(typing_extensions).get("get_type_hints")
     exported_code = getattr(exported, "__code__", None)
-    guard_value = call_graph._typing_extensions_runtime_guard_value(guard, "typing_extensions")
+    guard_value = call_graph._typing_extensions_runtime_guard_value(
+        guard, "typing_extensions"
+    )
     diagnostics = {
         "extension_origin": call_graph._trusted_module_origin_kind("typing_extensions"),
         "typing_origin": call_graph._trusted_module_origin_kind("typing"),
@@ -3086,7 +3091,8 @@ def test_runtime_guard_selects_live_typing_extensions_export() -> None:
         "typing_getattr": "__getattr__" in vars(typing),
         "export_type": type(exported).__name__,
         "export_name": getattr(exported, "__name__", None),
-        "export_globals_match": getattr(exported, "__globals__", None) is vars(typing_extensions),
+        "export_globals_match": getattr(exported, "__globals__", None)
+        is vars(typing_extensions),
         "typing_binding_match": vars(typing_extensions).get("typing") is typing,
         "line_match": wrapper is not None
         and getattr(exported_code, "co_firstlineno", None) == wrapper.lineno,

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -3141,12 +3141,14 @@ def test_runtime_guard_keeps_dynamic_builtin_sentinel_ambiguous(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     typing_extensions = pytest.importorskip("typing_extensions")
-    if "sentinel" in call_graph._IMPORT_RUNTIME_BUILTINS:
+    builtins_namespace = call_graph._IMPORT_RUNTIME_BUILTINS
+    assert isinstance(builtins_namespace, dict)
+    if "sentinel" in builtins_namespace:
         pytest.skip("builtins.sentinel is directly available")
     source_path = Path(typing_extensions.__file__)
     tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
     guard = next(statement for statement in tree.body if _is_builtin_sentinel_guard(statement))
-    monkeypatch.setitem(call_graph._IMPORT_RUNTIME_BUILTINS, "__getattr__", lambda _name: object())
+    monkeypatch.setitem(builtins_namespace, "__getattr__", lambda _name: object())
 
     assert hasattr(builtins, "sentinel")
     statements = call_graph._runtime_selected_module_statements(tree.body, "typing_extensions")


### PR DESCRIPTION
## Summary

Restore standalone picklescan CI under current tool releases and fix a Python 3.10 call-graph regression exposed by current `typing_extensions`.

- resolve the specific `typing_extensions` `hasattr(typing, "ReadOnly")` guard before flattening module scope
- select a branch only when the currently loaded export proves it: exact identity with `typing.get_type_hints`, or the source-defined wrapper at the guarded line
- leave unloaded, mutated, dynamic, or otherwise unproven bindings ambiguous
- preserve `typing_extensions.get_type_hints` evaluation-sink detection on Python 3.10 with current dependency releases
- satisfy Rust 1.97 Clippy and current mypy with behavior-equivalent test code
- exercise `typing-extensions>=4.14` explicitly in every standalone package lane

## Compatibility and false positives

Public APIs, supported Python versions, Rust MSRV, and package output are unchanged. The branch selection is deliberately narrow and tied to the live callable that pickle resolution would use. It does not import or execute scanned code, and it declines any export that cannot be matched to one of the reviewed source branches. Regressions cover both active branch shapes and a mutated export that must remain ambiguous.

## Validation

Exact-head CI runs the full repository suite and all four standalone package lanes, including Rust stable/MSRV checks, Clippy, Python Ruff/mypy/tests, builds, and wheel smoke tests. A fresh independent review is required before merge.