### PR TITLE
fix(picklescan): restore standalone CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1031,7 +1031,7 @@ jobs:
 
       - name: Run standalone package tests
         run: |
-          uv run --with pytest --with pytest-xdist pytest -n auto tests --tb=short
+          uv run --with pytest --with pytest-xdist --with 'typing-extensions>=4.14' pytest -n auto tests --tb=short
 
       - name: Build standalone package
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- **deps:** require Click 8.3.3 or newer to address PYSEC-2026-2132
 - **picklescan:** resolve reviewed runtime `hasattr` guards without losing call-graph sinks
 - **hashing:** preserve throughput while checking scan deadlines responsively
 - **cli:** handle interrupts during CLI startup without a traceback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- **picklescan:** resolve reviewed runtime `hasattr` guards without losing call-graph sinks
 - **hashing:** preserve throughput while checking scan deadlines responsively
 - **cli:** handle interrupts during CLI startup without a traceback
 

--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -15,6 +15,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- resolve reviewed runtime `hasattr(typing, ...)` guards before flattening module scope so current `typing_extensions.get_type_hints` remains connected to its evaluation sinks
 - restore Windows call-graph detection by reconciling descriptor and path stats with a cross-view identity that omits `st_ctime` (Windows reports it differently across stat methods); previously every stdlib callable source read failed closed on Windows, collapsing call-graph verdicts to inconclusive
 - preserve POSIX `st_ctime` in call-graph source-read identity checks so same-size, same-mtime inode-reuse swaps still fail closed
 

--- a/packages/modelaudit-picklescan/rust/src/nested.rs
+++ b/packages/modelaudit-picklescan/rust/src/nested.rs
@@ -3108,7 +3108,7 @@ mod tests {
 
     #[test]
     fn base64_prefix_gate_recognizes_complete_long_protocol0_scalar_pickle() {
-        for opcode in [b'F', b'I', b'L', b'P', b'S', b'V'] {
+        for opcode in *b"FILPSV" {
             let payload = long_protocol0_line_payload_for_test(opcode);
             let encoded = encode_base64_for_test(&payload);
 
@@ -3166,7 +3166,7 @@ mod tests {
 
     #[test]
     fn encoded_probe_windows_keep_long_scalar_candidates_at_each_decoded_offset() {
-        for opcode in [b'F', b'I', b'L', b'P', b'S', b'V', b'g', b'p'] {
+        for opcode in *b"FILPSVgp" {
             let payload = long_protocol0_line_payload_for_test(opcode);
             for prefix_len in 0..3usize {
                 let mut wrapped = vec![b'X'; prefix_len];

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -50,11 +50,15 @@ from types import (
     ModuleType,
     WrapperDescriptorType,
 )
-from typing import Any, Protocol, TypeVar, cast
+from typing import Any, Protocol, TypeGuard, TypeVar, cast
 from zipimport import zipimporter
 
 _MAX_DISTRIBUTIONS_PER_TOP_LEVEL = 16
 _MAX_STARTUP_DISTRIBUTION_NAMES = 4096
+
+
+def _is_exact_function(value: object) -> TypeGuard[FunctionType]:
+    return type(value) is FunctionType
 
 
 def _capture_startup_distribution_roots() -> Mapping[str, tuple[tuple[Path, Path], ...]]:
@@ -6085,7 +6089,7 @@ def _module_source_context(module_name: str) -> _ModuleSourceContext | None:
         return None
 
     is_package = source_path.name == "__init__.py"
-    module_statements = _module_level_statements(tree)
+    module_statements = _module_level_statements(tree, module_name)
     return _ModuleSourceContext(source_path=source_path, module_statements=module_statements, is_package=is_package)
 
 
@@ -6203,8 +6207,131 @@ def _bytecode_cache_can_override_source(
     return cache_bytes[16:] != marshal.dumps(source_code)
 
 
-def _module_level_statements(tree: ast.Module) -> tuple[ast.stmt, ...]:
-    return _definition_scope_statements(tree.body)
+def _typing_extensions_runtime_guard_value(
+    statement: ast.If,
+    module_name: str | None,
+) -> bool | None:
+    test = statement.test
+    if (
+        module_name != "typing_extensions"
+        or not isinstance(test, ast.Call)
+        or not isinstance(test.func, ast.Name)
+        or test.func.id != "hasattr"
+        or len(test.args) != 2
+        or test.keywords
+        or not isinstance(test.args[0], ast.Name)
+        or not isinstance(test.args[1], ast.Constant)
+    ):
+        return None
+    guard = (test.args[0].id, test.args[1].value)
+    if guard not in {("typing", "ReadOnly"), ("builtins", "sentinel")}:
+        return None
+
+    _mark_shared_source_snapshot_unreusable()
+    extension_module = sys.modules.get("typing_extensions")
+    if type(extension_module) is not ModuleType or _trusted_module_origin_kind("typing_extensions") != "site_packages":
+        return None
+    extension_namespace = vars(extension_module)
+
+    if guard == ("builtins", "sentinel"):
+        builtins_module = extension_namespace.get("builtins")
+        if (
+            type(builtins_module) is not ModuleType
+            or type(_IMPORT_RUNTIME_BUILTINS) is not dict
+            or vars(builtins_module) is not _IMPORT_RUNTIME_BUILTINS
+        ):
+            return None
+        if "sentinel" in _IMPORT_RUNTIME_BUILTINS:
+            return True
+        if "__getattr__" in _IMPORT_RUNTIME_BUILTINS:
+            return None
+        return False
+
+    typing_module = sys.modules.get("typing")
+    if type(typing_module) is not ModuleType or _trusted_module_origin_kind("typing") != "stdlib":
+        return None
+    typing_namespace = vars(typing_module)
+    if "ReadOnly" in typing_namespace:
+        guard_value = True
+    elif "__getattr__" in typing_namespace:
+        return None
+    else:
+        guard_value = False
+
+    aliases_get_type_hints = any(
+        isinstance(branch_statement, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "get_type_hints" for target in branch_statement.targets)
+        and isinstance(branch_statement.value, ast.Attribute)
+        and isinstance(branch_statement.value.value, ast.Name)
+        and branch_statement.value.value.id == "typing"
+        and branch_statement.value.attr == "get_type_hints"
+        for branch_statement in statement.body
+    )
+    wrapper = next(
+        (
+            branch_statement
+            for branch_statement in statement.orelse
+            if isinstance(branch_statement, ast.FunctionDef | ast.AsyncFunctionDef)
+            and branch_statement.name == "get_type_hints"
+        ),
+        None,
+    )
+    if not aliases_get_type_hints and wrapper is None:
+        return guard_value
+    if not aliases_get_type_hints or wrapper is None:
+        return None
+
+    exported = cast(object, extension_namespace.get("get_type_hints"))
+    typing_export = cast(object, typing_namespace.get("get_type_hints"))
+    if guard_value:
+        if (
+            _is_exact_function(typing_export)
+            and exported is typing_export
+            and typing_export.__name__ == "get_type_hints"
+            and typing_export.__globals__ is typing_namespace
+            and _function_owner_matches_trusted_source(
+                typing_export,
+                expected_module="typing",
+            )
+        ):
+            return True
+        return None
+    if (
+        type(exported) is not FunctionType
+        or exported.__name__ != "get_type_hints"
+        or exported.__globals__ is not extension_namespace
+        or extension_namespace.get("typing") is not typing_module
+        or exported.__code__.co_firstlineno != wrapper.lineno
+        or not _function_owner_matches_trusted_source(
+            exported,
+            expected_module="typing_extensions",
+        )
+    ):
+        return None
+    return False
+
+
+def _runtime_selected_module_statements(
+    statements: Iterable[ast.stmt],
+    module_name: str | None = None,
+) -> tuple[ast.stmt, ...]:
+    selected: list[ast.stmt] = []
+    for statement in statements:
+        if isinstance(statement, ast.If):
+            guard_value = _typing_extensions_runtime_guard_value(statement, module_name)
+            if guard_value is not None:
+                active_branch = statement.body if guard_value else statement.orelse
+                selected.extend(_runtime_selected_module_statements(active_branch, module_name))
+                continue
+        selected.append(statement)
+    return tuple(selected)
+
+
+def _module_level_statements(
+    tree: ast.Module,
+    module_name: str | None = None,
+) -> tuple[ast.stmt, ...]:
+    return _definition_scope_statements(_runtime_selected_module_statements(tree.body, module_name))
 
 
 def _module_initialization_statement_is_inert(statement: ast.stmt) -> bool:
@@ -6811,7 +6938,7 @@ def _source_function_context(
     except Exception:
         return None
 
-    module_statements = _module_level_statements(tree)
+    module_statements = _module_level_statements(tree, module_name)
     function_node = _find_qualified_function_def(module_statements, qualified_name)
     if function_node is None:
         return _inherited_source_function_context(module_statements, module_name, source_path, qualified_name)
@@ -6863,7 +6990,7 @@ def _source_class_context(class_name: str) -> _ClassSourceContext | None:
     except Exception:
         return None
 
-    module_statements = _module_level_statements(tree)
+    module_statements = _module_level_statements(tree, module_name)
     class_node = _find_qualified_class_def(module_statements, qualified_name)
     if class_node is None:
         return None
@@ -7317,6 +7444,8 @@ def _assignment_alias_value(
     ):
         return resolved
     alias_target = _static_import_reference_alias(resolved) or resolved
+    if module_name == "typing_extensions" and alias_target == "typing.get_type_hints":
+        return resolved
     if alias_target.startswith(f"{module_name}."):
         return None
     current_source_path = _resolve_module_source(module_name)
@@ -7624,7 +7753,7 @@ def _constructor_parameter_self_attribute_targets(class_name: str, parameter_nam
     except Exception:
         return ()
 
-    class_node = _find_qualified_class_def(_module_level_statements(tree), qualified_name)
+    class_node = _find_qualified_class_def(_module_level_statements(tree, module_name), qualified_name)
     if class_node is None:
         return ()
     init_node = next(

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -39,7 +39,7 @@ from importlib.machinery import (
 from importlib.util import cache_from_source
 from pathlib import Path, PurePosixPath
 from types import CodeType, ModuleType
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import pytest
 
@@ -4763,7 +4763,7 @@ def test_scan_file_marks_hidden_pytorch_zip_probe_failure_inconclusive(
     def fail_hidden_probe_open(
         archive: zipfile.ZipFile,
         name: str | zipfile.ZipInfo,
-        mode: str = "r",
+        mode: Literal["r", "w"] = "r",
         pwd: bytes | None = None,
         *,
         force_zip64: bool = False,
@@ -4871,7 +4871,7 @@ def test_scan_file_returns_error_report_for_pytorch_zip_member_access_failure(
     def fail_member_open(
         archive: zipfile.ZipFile,
         name: str | zipfile.ZipInfo,
-        mode: str = "r",
+        mode: Literal["r", "w"] = "r",
         pwd: bytes | None = None,
         *,
         force_zip64: bool = False,

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import builtins
 import importlib
 import io
 import os
@@ -11,6 +12,7 @@ import py_compile
 import subprocess
 import sys
 import threading
+import typing
 import zipfile
 from contextvars import copy_context
 from importlib.machinery import (
@@ -23,6 +25,7 @@ from importlib.machinery import (
 )
 from importlib.util import find_spec
 from pathlib import Path
+from types import FunctionType
 from typing import Any
 from zipimport import zipimporter
 
@@ -3044,6 +3047,196 @@ def test_call_graph_models_getattr_default_callable_fallbacks() -> None:
     )
 
 
+def _is_typing_readonly_guard(statement: ast.stmt) -> bool:
+    if not isinstance(statement, ast.If) or not isinstance(statement.test, ast.Call):
+        return False
+    test = statement.test
+    return (
+        isinstance(test.func, ast.Name)
+        and test.func.id == "hasattr"
+        and len(test.args) == 2
+        and isinstance(test.args[0], ast.Name)
+        and test.args[0].id == "typing"
+        and isinstance(test.args[1], ast.Constant)
+        and test.args[1].value == "ReadOnly"
+    )
+
+
+def _is_typing_get_type_hints_guard(statement: ast.stmt) -> bool:
+    return (
+        _is_typing_readonly_guard(statement)
+        and isinstance(statement, ast.If)
+        and any(
+            isinstance(branch_statement, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == "get_type_hints" for target in branch_statement.targets
+            )
+            for branch_statement in statement.body
+        )
+        and any(
+            isinstance(branch_statement, ast.FunctionDef) and branch_statement.name == "get_type_hints"
+            for branch_statement in statement.orelse
+        )
+    )
+
+
+def _is_builtin_sentinel_guard(statement: ast.stmt) -> bool:
+    if not isinstance(statement, ast.If) or not isinstance(statement.test, ast.Call):
+        return False
+    test = statement.test
+    return (
+        isinstance(test.func, ast.Name)
+        and test.func.id == "hasattr"
+        and len(test.args) == 2
+        and isinstance(test.args[0], ast.Name)
+        and test.args[0].id == "builtins"
+        and isinstance(test.args[1], ast.Constant)
+        and test.args[1].value == "sentinel"
+    )
+
+
+def test_runtime_guard_selects_live_typing_extensions_export() -> None:
+    typing_extensions = pytest.importorskip("typing_extensions")
+    source_path = Path(typing_extensions.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    guard = next(statement for statement in tree.body if _is_typing_get_type_hints_guard(statement))
+
+    statements = call_graph._runtime_selected_module_statements(tree.body, "typing_extensions")
+
+    assert guard not in statements
+    if typing_extensions.get_type_hints is typing.get_type_hints:
+        assert any(
+            isinstance(statement, ast.Assign)
+            and any(isinstance(target, ast.Name) and target.id == "get_type_hints" for target in statement.targets)
+            for statement in statements
+        )
+    else:
+        assert any(
+            isinstance(statement, ast.FunctionDef) and statement.name == "get_type_hints" for statement in statements
+        )
+
+
+def test_runtime_guard_selects_live_builtin_sentinel_branch() -> None:
+    typing_extensions = pytest.importorskip("typing_extensions")
+    source_path = Path(typing_extensions.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    guard = next((statement for statement in tree.body if _is_builtin_sentinel_guard(statement)), None)
+    if guard is None:
+        pytest.skip("installed typing_extensions has no builtins.sentinel runtime guard")
+
+    statements = call_graph._runtime_selected_module_statements(tree.body, "typing_extensions")
+
+    assert guard not in statements
+    if hasattr(builtins, "sentinel"):
+        assert any(
+            isinstance(statement, ast.Assign)
+            and any(isinstance(target, ast.Name) and target.id == "sentinel" for target in statement.targets)
+            for statement in statements
+        )
+    else:
+        assert any(isinstance(statement, ast.ClassDef) and statement.name == "sentinel" for statement in statements)
+
+
+def test_runtime_guard_keeps_dynamic_builtin_sentinel_ambiguous(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    typing_extensions = pytest.importorskip("typing_extensions")
+    builtins_namespace = call_graph._IMPORT_RUNTIME_BUILTINS
+    assert isinstance(builtins_namespace, dict)
+    if "sentinel" in builtins_namespace:
+        pytest.skip("builtins.sentinel is directly available")
+    source_path = Path(typing_extensions.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    guard = next((statement for statement in tree.body if _is_builtin_sentinel_guard(statement)), None)
+    if guard is None:
+        pytest.skip("installed typing_extensions has no builtins.sentinel runtime guard")
+    monkeypatch.setitem(builtins_namespace, "__getattr__", lambda _name: object())
+
+    assert hasattr(builtins, "sentinel")
+    statements = call_graph._runtime_selected_module_statements(tree.body, "typing_extensions")
+
+    assert guard in statements
+
+
+def test_runtime_guard_marks_unloaded_module_snapshot_unreusable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    typing_extensions = pytest.importorskip("typing_extensions")
+    source_path = Path(typing_extensions.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    guard = next(statement for statement in tree.body if _is_typing_get_type_hints_guard(statement))
+    assert isinstance(guard, ast.If)
+    monkeypatch.delitem(sys.modules, "typing_extensions")
+
+    with call_graph.shared_source_sensitive_caches():
+        snapshot = call_graph._SHARED_SOURCE_SENSITIVE_SNAPSHOT.get()
+        assert snapshot is not None
+        snapshot.reusable = True
+
+        assert call_graph._typing_extensions_runtime_guard_value(guard, "typing_extensions") is None
+        assert snapshot.reusable is False
+
+
+def test_runtime_guard_keeps_mutated_typing_extensions_export_ambiguous(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    typing_extensions = pytest.importorskip("typing_extensions")
+    source_path = Path(typing_extensions.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    monkeypatch.setattr(typing_extensions, "get_type_hints", object())
+
+    statements = call_graph._runtime_selected_module_statements(tree.body, "typing_extensions")
+
+    assert any(_is_typing_get_type_hints_guard(statement) for statement in statements)
+
+
+def test_runtime_guard_keeps_shared_replacement_alias_ambiguous(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    typing_extensions = pytest.importorskip("typing_extensions")
+    source_path = Path(typing_extensions.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+
+    def replacement(*_args: object, **_kwargs: object) -> dict[str, object]:
+        return {}
+
+    monkeypatch.setattr(typing, "get_type_hints", replacement)
+    monkeypatch.setattr(typing_extensions, "get_type_hints", replacement)
+
+    statements = call_graph._runtime_selected_module_statements(tree.body, "typing_extensions")
+
+    assert any(_is_typing_get_type_hints_guard(statement) for statement in statements)
+
+
+def test_runtime_guard_keeps_source_location_forgery_ambiguous(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    typing_extensions = pytest.importorskip("typing_extensions")
+    source_path = Path(typing_extensions.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    guard = next(statement for statement in tree.body if _is_typing_get_type_hints_guard(statement))
+    assert isinstance(guard, ast.If)
+    wrapper = next(
+        statement
+        for statement in guard.orelse
+        if isinstance(statement, ast.FunctionDef) and statement.name == "get_type_hints"
+    )
+
+    def replacement(*_args: object, **_kwargs: object) -> dict[str, object]:
+        return {}
+
+    forged_code = replacement.__code__.replace(
+        co_filename=str(source_path),
+        co_firstlineno=wrapper.lineno,
+    )
+    forged = FunctionType(forged_code, vars(typing_extensions), "get_type_hints")
+    monkeypatch.setattr(typing_extensions, "get_type_hints", forged)
+
+    statements = call_graph._runtime_selected_module_statements(tree.body, "typing_extensions")
+
+    assert any(_is_typing_get_type_hints_guard(statement) for statement in statements)
+
+
 def test_call_graph_models_version_gated_typing_extensions_definitions() -> None:
     pytest.importorskip("typing_extensions")
 
@@ -3051,10 +3244,13 @@ def test_call_graph_models_version_gated_typing_extensions_definitions() -> None
     calls = call_graph._calls_for_function(function_name) or ()
     path = call_graph._find_sink_path(function_name)
 
-    assert call_graph._call_graph_entrypoints(function_name) == (function_name,)
-    assert "typing.get_type_hints" in calls
+    if hasattr(typing, "ReadOnly"):
+        assert call_graph._resolve_function_target(function_name) == "typing.get_type_hints"
+    else:
+        assert call_graph._call_graph_entrypoints(function_name) == (function_name,)
+        assert "typing.get_type_hints" in calls
     assert path is not None
-    assert path[0] == function_name
+    assert path[0] in {function_name, "typing.get_type_hints"}
     assert path[-1] in {"builtins.compile", "builtins.eval"}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "click>=8.1.7",
+    "click>=8.3.3",
     "yaspin>=2.5.0",
     # NumPy version depends on Python version for compatibility
     # Python 3.10: NumPy 1.x (NumPy 2.x requires Python >=3.11)

--- a/uv.lock
+++ b/uv.lock
@@ -621,14 +621,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.2"
+version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
 ]
 
 [[package]]
@@ -2562,7 +2562,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8.1.7" },
+    { name = "click", specifier = ">=8.3.3" },
     { name = "cyclonedx-python-lib", specifier = ">=11.0.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "dill", marker = "extra == 'all'", specifier = ">=0.3.0,<1.0" },


### PR DESCRIPTION
## Summary

Restores the standalone picklescan CI path on current tool releases, preserves annotation-RCE detection with current `typing_extensions`, and clears the dependency-audit failure.

- replace the two Rust byte-character arrays rejected by Rust 1.97 Clippy with equivalent byte-string iteration
- align the two `ZipFile.open` test doubles with the `Literal["r", "w"]` mode accepted by current typeshed/mypy
- resolve the reviewed `typing_extensions` runtime guards before flattening module scope, retain the `get_type_hints` sink path, and invalidate reusable source snapshots when the decision depends on runtime state
- exercise `typing-extensions>=4.14` explicitly in every standalone-package CI lane and add benign/mutated/forged-export regressions
- require and lock Click 8.3.3 to resolve `PYSEC-2026-2132` and restore Dependency Audit

## Root cause

The latest failing main-branch Python CI run stops in all four standalone lanes on Rust 1.97's new `clippy::byte_char_slices` lint. Once that is corrected, standalone mypy rejects two archive test-double signatures. Running the complete standalone suite with current `typing_extensions` then exposes ambiguous conditional rebinding: the Python 3.10 call graph loses the `typing_extensions.get_type_hints` evaluation-sink path and an annotation-RCE verdict degrades from malicious to suspicious.

The initial PR run also exposed `PYSEC-2026-2132`: the lockfile selected Click 8.3.2, while the advisory is fixed in 8.3.3. The project does not call `click.edit()`, but raising the direct dependency floor ensures downstream installs cannot resolve the vulnerable release.

This supersedes the incomplete Clippy-only attempt in #1739 and carries the already-reviewed, exact-head-green standalone fix from #1736 into a fresh PR.

## Validation

- `cargo +1.97.0 fmt --manifest-path Cargo.toml -- --check`
- `cargo +1.97.0 check --manifest-path Cargo.toml`
- `cargo +1.83.0 check --manifest-path Cargo.toml --locked`
- `cargo +1.97.0 clippy --manifest-path Cargo.toml --all-targets -- -D warnings`
- `cargo +1.97.0 test --manifest-path Cargo.toml` — 187 passed
- standalone Ruff lint/import/format and mypy — clean
- standalone Python 3.10 with `typing-extensions 4.16.0` — 2,794 passed, 117 expected optional-dependency skips
- root pickle/PyTorch integration slice — 1,531 passed, 2 expected skips
- repository-wide Ruff — clean
- frozen lockfile export and strict `pip-audit` with the CI ignore list — no known vulnerabilities found
- Click 8.3.3 CLI smoke and focused CLI suites — 24 passed
- independent prepublish review passes plus verifier — clean, zero findings

Repository-wide mypy and several broader CLI tests on the local macOS paired environment still encounter pre-existing, unrelated typeshed/platform and ACL/descriptor-pinning limitations; the original equivalent standalone diff has exact-head green Linux CI in #1736.
