### PR TITLE
fix(picklescan): preserve Python 3.14 annotation RCE verdicts

### DIFF
--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -15,6 +15,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- preserve malicious annotation-evaluation verdicts on Python 3.14 by treating typing._eval_type as an execution sink
 - resolve reviewed runtime `hasattr(typing, ...)` guards before flattening module scope so current `typing_extensions.get_type_hints` remains connected to its evaluation sinks
 - restore Windows call-graph detection by reconciling descriptor and path stats with a cross-view identity that omits `st_ctime` (Windows reports it differently across stat methods); previously every stdlib callable source read failed closed on Windows, collapsing call-graph verdicts to inconclusive
 - preserve POSIX `st_ctime` in call-graph source-read identity checks so same-size, same-mtime inode-reuse swaps still fail closed

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1717,6 +1717,7 @@ _RCE_SINK_EXACT = frozenset(
         "subprocess.check_call",
         "subprocess.check_output",
         "subprocess.run",
+        "typing._eval_type",
         "yaml.load",
         "yaml.unsafe_load",
     }

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -3251,7 +3251,7 @@ def test_call_graph_models_version_gated_typing_extensions_definitions() -> None
         assert "typing.get_type_hints" in calls
     assert path is not None
     assert path[0] in {function_name, "typing.get_type_hints"}
-    assert path[-1] in {"builtins.compile", "builtins.eval"}
+    assert path[-1] in {"builtins.compile", "builtins.eval", "typing._eval_type"}
 
 
 def test_call_graph_models_required_arg_imports_when_pickle_supplies_args() -> None:
@@ -10152,11 +10152,14 @@ def test_scan_bytes_blocks_typing_extensions_get_type_hints_annotation_rce(tmp_p
     report = scan_bytes(payload, source="typing-extensions-get-type-hints-rce.pkl")
 
     assert report.verdict == SafetyVerdict.MALICIOUS
-    assert _has_critical_call_graph_finding_with_sink_prefix(
-        report,
-        "typing_extensions",
-        "get_type_hints",
-        "builtins.",
+    assert any(
+        _has_critical_call_graph_finding_with_sink_prefix(
+            report,
+            "typing_extensions",
+            "get_type_hints",
+            sink_prefix,
+        )
+        for sink_prefix in ("builtins.", "typing._eval_type")
     )
 
     assert not marker.exists()


### PR DESCRIPTION
## Summary

- treat Python 3.14 typing._eval_type as an execution sink in picklescan call-graph analysis
- preserve MALICIOUS verdicts for typing_extensions.get_type_hints annotation payloads
- update regression expectations and package changelog

## Validation

- uv run --with=pytest --with=typing-extensions pytest tests/test_call_graph_import_statements.py -k 'typing_extensions_get_type_hints_annotation_rce or version_gated_typing_extensions_definitions' -vv
- uv run --with=ruff ruff check src tests
- uv run --with=ruff ruff format --check src tests
- uv run --with=mypy mypy src tests
- cargo fmt --manifest-path Cargo.toml -- --check
- cargo check --manifest-path Cargo.toml
- cargo clippy --manifest-path Cargo.toml --all-targets -- -D warnings
- cargo test --manifest-path Cargo.toml

## Notes

- Root uv validation remains blocked on macOS arm64 by the unavailable tensorrt-cu13-libs wheel.
- Repository-wide Ruff reports pre-existing import-order findings outside this diff; package-local Ruff is clean.
