### PR TITLE
fix(routing): ignore EXT opcodes as pre-stop security signals in prot…

### DIFF
--- a/modelaudit/utils/file/detection.py
+++ b/modelaudit/utils/file/detection.py
@@ -5633,14 +5633,18 @@ def _classify_initial_pickle_security_signal(
     while stream.tell() < len(sample):
         stream_start = stream.tell()
         has_reachable_security_opcode = False
+        has_pre_stop_security_signal = False
+        saw_proto = False
         stack: list[Any] = []
         try:
             for opcode, argument, _position in _gen_pickle_probe_ops(stream):
                 if _work_budget.remaining_opcodes <= 0:
-                    return True if has_reachable_security_opcode else None
+                    return True if has_pre_stop_security_signal else None
                 _work_budget.remaining_opcodes -= 1
                 saw_opcode = True
                 opcode_name = opcode.name
+                if opcode_name == "PROTO":
+                    saw_proto = True
                 if opcode_name == "FRAME":
                     _work_budget.saw_frame = True
                 invalid_opcode_argument = (
@@ -5662,7 +5666,7 @@ def _classify_initial_pickle_security_signal(
                     opcode_name in {"GLOBAL", "INST"} and not _is_valid_pickle_global_argument(argument)
                 )
                 if invalid_opcode_argument:
-                    return True if has_reachable_security_opcode else negative_result()
+                    return True if has_pre_stop_security_signal else negative_result()
                 if not _apply_pickle_stack_effect(
                     opcode,
                     argument,
@@ -5670,11 +5674,22 @@ def _classify_initial_pickle_security_signal(
                     memo,
                     _work_budget.hashability_cache,
                 ):
-                    if has_reachable_security_opcode:
+                    if has_pre_stop_security_signal:
                         return True
                     return negative_result()
                 if opcode_name in _BINARY_PICKLE_SECURITY_OPCODES:
                     has_reachable_security_opcode = True
+                    if saw_proto or opcode_name not in {"EXT1", "EXT2", "EXT4"}:
+                        has_pre_stop_security_signal = True
+                    elif stream.tell() < len(sample) and sample[stream.tell()] in _PICKLE_OPCODE_BY_BYTE:
+                        # A bare EXT* is only the SafeTensors header-length byte
+                        # collision when the byte after its argument is undecodable
+                        # (the collision aborts there). If that byte is a recognized
+                        # pickle opcode, the stream coherently continues — CPython
+                        # resolves/imports the extension at the EXT* regardless of
+                        # whether that follow-on opcode's own argument reads — so fail
+                        # closed to the pickle scanner.
+                        has_pre_stop_security_signal = True
                 if opcode_name != "STOP":
                     continue
 
@@ -5689,24 +5704,24 @@ def _classify_initial_pickle_security_signal(
                     return True
                 break
         except _PickleNumericOperandLimitExceeded:
-            return True if has_reachable_security_opcode else None
+            return True if has_pre_stop_security_signal else None
         except ValueError as exc:
             exc_message = str(exc)
             position_match = re.search(r"(?:at )?position (\d+)", exc_message)
             if position_match is not None and "opcode" in exc_message:
-                return True if has_reachable_security_opcode else negative_result()
-            if has_reachable_security_opcode:
+                return True if has_pre_stop_security_signal else negative_result()
+            if has_pre_stop_security_signal:
                 return True
             if sample_is_prefix and sample[stream_start] in _PICKLE_OPCODE_BY_BYTE:
                 return None
             return negative_result()
         except (MemoryError, RecursionError):
-            return True if has_reachable_security_opcode else None
+            return True if has_pre_stop_security_signal else None
         except Exception:
-            return True if has_reachable_security_opcode else None
+            return True if has_pre_stop_security_signal else None
 
         if stream.tell() <= stream_start:
-            return True if has_reachable_security_opcode else None
+            return True if has_pre_stop_security_signal else None
 
     if saw_alternate_inconclusive or (sample_is_prefix and saw_opcode):
         return None

--- a/tests/utils/file/test_filetype.py
+++ b/tests/utils/file/test_filetype.py
@@ -1019,6 +1019,97 @@ def test_detect_file_format_from_magic_valid_safetensors_structure(tmp_path: Pat
     assert detect_file_format_from_magic(str(safetensors_path)) == "safetensors"
 
 
+def test_detect_file_format_from_magic_safetensors_header_length_resembling_ext_opcode(tmp_path: Path) -> None:
+    inner = {"t": {"dtype": "F32", "shape": [4], "data_offsets": [0, 16]}}
+    base = json.dumps(inner, separators=(",", ":"))
+    for header_len in (0x282, 0x382, 0x5E82):
+        header = (base + " " * (header_len - len(base))).encode()
+        safetensors_path = tmp_path / f"model-{header_len:x}.safetensors"
+        safetensors_path.write_bytes(struct.pack("<Q", len(header)) + header + b"\x00" * 16)
+        assert detect_file_format_from_magic(str(safetensors_path)) == "safetensors"
+
+
+def test_safetensors_pickle_overlap_ignores_ext_opcode_shaped_header_length() -> None:
+    inner = {"t": {"dtype": "F32", "shape": [4], "data_offsets": [0, 16]}}
+    base = json.dumps(inner, separators=(",", ":"))
+    header = (base + " " * (0x282 - len(base))).encode()
+    sample = struct.pack("<Q", len(header)) + header + b"\x00" * 16
+    assert file_detection.classify_safetensors_pickle_overlap_sample(sample, file_size=len(sample)) is not True
+
+
+def test_safetensors_pickle_overlap_still_flags_proto_prefixed_ext_stream() -> None:
+    sample = b"\x80\x04\x82\x02."
+    assert file_detection.classify_safetensors_pickle_overlap_sample(sample, file_size=len(sample)) is True
+
+
+def test_protocolless_bare_ext_collision_not_treated_as_pre_stop_signal() -> None:
+    # A bare EXT1 opcode followed by an invalid byte (the SafeTensors header-length
+    # collision shape) must not fail closed as a pre-STOP pickle security signal.
+    sample = b"\x82\x01\xff"
+    assert (
+        file_detection._classify_initial_pickle_security_signal(
+            sample, sample_is_prefix=False, available_stream_length=len(sample)
+        )
+        is not True
+    )
+
+
+def test_protocolless_ext_backed_constructor_still_fails_closed() -> None:
+    # EXT1 loads a registered class, EMPTY_TUPLE supplies args, NEWOBJ constructs it
+    # (invoking __new__), then the stream aborts before STOP. Excluding only bare EXT*
+    # must not stop the constructor opcode from failing closed to the pickle scanner.
+    sample = b"\x82\x01)\x81\xff"
+    assert (
+        file_detection._classify_initial_pickle_security_signal(
+            sample, sample_is_prefix=False, available_stream_length=len(sample)
+        )
+        is True
+    )
+
+
+def test_protocolless_ext_stream_flagged_once_it_coherently_continues() -> None:
+    # EXT1 (extension resolution/import) followed by an accepted opcode is a real
+    # pickle stream, not the immediate header-length collision, so it must fail
+    # closed even when it aborts before STOP. Contrast the bare-collision case above
+    # where the EXT* aborts with no accepted follow-on opcode.
+    sample = b"\x82\x01\x4e\x00"  # EXT1 1; NONE; <invalid>
+    assert (
+        file_detection._classify_initial_pickle_security_signal(
+            sample, sample_is_prefix=False, available_stream_length=len(sample)
+        )
+        is True
+    )
+
+
+def test_protocolless_ext_flagged_when_followon_opcode_decodes_but_is_context_invalid() -> None:
+    # EXT1 (extension resolution/import) followed by a byte that decodes as a real
+    # opcode (APPEND) which then fails its stack effect. The EXT* must be promoted the
+    # moment the follow-on opcode is decoded — CPython resolves the extension at EXT1
+    # before failing on APPEND — not only once the follow-on passes its stack effect.
+    sample = b"\x82\x01\x61\x00"  # EXT1 1; APPEND (context-invalid); <invalid>
+    assert (
+        file_detection._classify_initial_pickle_security_signal(
+            sample, sample_is_prefix=False, available_stream_length=len(sample)
+        )
+        is True
+    )
+
+
+def test_protocolless_ext_flagged_when_followon_opcode_argument_read_fails() -> None:
+    # EXT1 followed by a recognized opcode (BINUNICODE8, 0x8d) whose length/payload
+    # read then raises. The follow-on byte is a valid opcode, so the stream coherently
+    # continues past the EXT* — CPython resolves the extension at EXT1 before the
+    # argument read fails — and it must fail closed, not be treated as the collision
+    # (which is followed by an undecodable byte).
+    sample = b"\x82\x01\x8d\x00\x00\x00\x00\x00{}"  # EXT1 1; BINUNICODE8 <truncated len/payload>
+    assert (
+        file_detection._classify_initial_pickle_security_signal(
+            sample, sample_is_prefix=True, available_stream_length=len(sample) + 64
+        )
+        is True
+    )
+
+
 def test_detect_file_format_from_magic_metadata_only_safetensors_structure(tmp_path: Path) -> None:
     metadata = b"{}"
     safetensors_path = tmp_path / "metadata-only.unknown"


### PR DESCRIPTION
## Problem

A valid SafeTensors file whose u64 header length has `0x82` as its low byte (e.g. `0x282`, `0x5e82` — roughly 1 in 256 files) begins with bytes that parse as a pickle `EXT1` opcode. `_classify_initial_pickle_security_signal` counts any `EXT1/EXT2/EXT4` opcode as a reachable security signal, so when the probe then aborts on the next (unknown) opcode it fails closed: the already-validated SafeTensors frame is routed to the pickle scanner, and clean files receive warning findings such as:

- `Encountered EXT1 extension reference code_94; extension resolution is opaque`
- `Pickle parsing failed before full scan completion` → treated as unsafe

Reproduced on v0.2.49 and current `main`. We hit this in production on a genuine Hugging Face `model.safetensors` (header length `0x5e82` → "code_94").

## Fix

Apply the rule the protocol-less classifiers already encode via `_PROTOCOLLESS_BINARY_PICKLE_PRE_STOP_SECURITY_OPCODES`: `EXT1/EXT2/EXT4` do not count as *pre-STOP* security signals unless a `PROTO` opcode was seen. Streams that reach `STOP` keep the full security-opcode semantics, and `PROTO`-prefixed EXT streams remain flagged (covered by a new regression test).

## Testing

- 3 new tests in `tests/utils/file/test_filetype.py`: header lengths `0x282/0x382/0x5e82` route as `safetensors`; the overlap classifier no longer returns `True` for the collision; `b"\x80\x04\x82\x02."` (PROTO-prefixed EXT1) still classifies `True`.
- Full `tests/utils/file/test_filetype.py`: 467 passed.
- Broader detection sweep (`-k "safetensors or file_format or magic or overlap or protocolless or ext"`): 3407 passed; the only failures (4, in `tests/utils/sources/test_cloud_storage.py`) are environment-dependent and fail identically on unpatched `main`.

## Repro

```python
import json, struct, subprocess, tempfile, os

inner = {"t": {"dtype": "F32", "shape": [4], "data_offsets": [0, 16]}}
base = json.dumps(inner, separators=(",", ":"))
for hlen in (0x282, 0x382, 0x5E82):
    header = (base + " " * (hlen - len(base))).encode()
    with tempfile.TemporaryDirectory() as d:
        p = os.path.join(d, "model.safetensors")
        with open(p, "wb") as f:
            f.write(struct.pack("<Q", len(header)) + header + b"\x00" * 16)
        r = subprocess.run(["modelaudit", "scan", p, "--format", "json"], capture_output=True, text=True)
        print(hex(hlen), "->", [i["message"][:60] for i in json.loads(r.stdout)["issues"] if i["severity"] == "warning"])
```

Before this fix the `0x282/0x382/0x5e82` files produce warning-severity `pickle_check` findings; after it they scan clean and route as `safetensors`.
