### PR TITLE
test(picklescan): allow fail-closed source status

### DIFF
--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -10778,16 +10778,48 @@ def test_scan_bytes_warns_on_invoked_trusted_import_reference_without_source_ana
     )
 
 
+def _assert_call_graph_source_stability_error(report: PickleReport) -> None:
+    assert report.metadata.get("analysis_incomplete") is True
+    assert any(
+        error.message
+        == "Python call-graph analysis could not complete: source changed during shared call-graph analysis"
+        and error.category == "call_graph_analysis_error"
+        and error.exception_type == "_CallGraphAnalysisLimitError"
+        and error.details.get("analysis") == "python_call_graph_source_stability"
+        and error.details.get("analysis_incomplete") is True
+        for error in report.errors
+    )
+
+
 @pytest.mark.parametrize("module", ["_xxsubinterpreters", "dotenv.main"])
 def test_scan_bytes_warns_on_unreviewed_name_from_module_with_dangerous_entries(module: str) -> None:
     report = scan_bytes(f"c{module}\nGadget\n.".encode(), source="dangerous-module-sibling.pkl")
 
-    assert report.status in {ScanStatus.COMPLETE, ScanStatus.INCONCLUSIVE}
-    if report.status == ScanStatus.INCONCLUSIVE:
-        assert report.metadata.get("analysis_incomplete") is True
+    if module == "dotenv.main" and report.status == ScanStatus.INCONCLUSIVE:
+        _assert_call_graph_source_stability_error(report)
+    else:
+        assert report.status == ScanStatus.COMPLETE
     assert report.verdict == SafetyVerdict.SUSPICIOUS
     assert any(
         finding.rule_code == "NON_ALLOWLISTED_GLOBAL" and finding.details.get("import_reference") == f"{module}.Gadget"
+        for finding in report.findings
+    )
+
+
+def test_scan_bytes_warns_on_unreviewed_dotenv_global_when_source_changes(monkeypatch: pytest.MonkeyPatch) -> None:
+    def raise_source_stability_error(_report_generation: int | None) -> None:
+        raise _CallGraphAnalysisLimitError("source changed during shared call-graph analysis")
+
+    monkeypatch.setattr(package_api, "_ensure_shared_source_snapshot_stable", raise_source_stability_error)
+
+    report = scan_bytes(b"cdotenv.main\nGadget\n.", source="dangerous-module-sibling-source-change.pkl")
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    _assert_call_graph_source_stability_error(report)
+    assert report.verdict == SafetyVerdict.SUSPICIOUS
+    assert any(
+        finding.rule_code == "NON_ALLOWLISTED_GLOBAL"
+        and finding.details.get("import_reference") == "dotenv.main.Gadget"
         for finding in report.findings
     )
 

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -10782,7 +10782,9 @@ def test_scan_bytes_warns_on_invoked_trusted_import_reference_without_source_ana
 def test_scan_bytes_warns_on_unreviewed_name_from_module_with_dangerous_entries(module: str) -> None:
     report = scan_bytes(f"c{module}\nGadget\n.".encode(), source="dangerous-module-sibling.pkl")
 
-    assert report.status == ScanStatus.COMPLETE
+    assert report.status in {ScanStatus.COMPLETE, ScanStatus.INCONCLUSIVE}
+    if report.status == ScanStatus.INCONCLUSIVE:
+        assert report.metadata.get("analysis_incomplete") is True
     assert report.verdict == SafetyVerdict.SUSPICIOUS
     assert any(
         finding.rule_code == "NON_ALLOWLISTED_GLOBAL" and finding.details.get("import_reference") == f"{module}.Gadget"


### PR DESCRIPTION
## Summary

- Fix the repeated Windows/Python 3.11 Nightly failure for `test_scan_bytes_warns_on_unreviewed_name_from_module_with_dangerous_entries[dotenv.main]`.
- Restrict the fail-closed fallback to the observed `dotenv.main` source-stability condition: require the explicit `python_call_graph_source_stability` error, message, exception type, and `analysis_incomplete=True`; keep `_xxsubinterpreters` strictly `COMPLETE`.
- Add a deterministic source-change regression that preserves the `SUSPICIOUS` verdict and exact `NON_ALLOWLISTED_GLOBAL` finding.

## Validation

- Repository Ruff check and format check pass.
- Standalone picklescan mypy passes (26 source files).
- Focused xdist source-stability/fail-closed suite passes twice (8 passed each run).
- Positive simulation accepts only the expected dotenv source-change fallback; negative simulations reject unrelated analysis failures for both parameters.
- `git diff --check` passes.
- Full local macOS validation reproduces unrelated baseline issues only: 12 existing mypy errors and cache assertions; the focused Windows lane is the authoritative platform gate.

Addresses the actionable review finding on duplicate PR #1750.