### PR TITLE
test(picklescan): allow fail-closed dotenv analysis

### DIFF
--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -10782,7 +10782,9 @@ def test_scan_bytes_warns_on_invoked_trusted_import_reference_without_source_ana
 def test_scan_bytes_warns_on_unreviewed_name_from_module_with_dangerous_entries(module: str) -> None:
     report = scan_bytes(f"c{module}\nGadget\n.".encode(), source="dangerous-module-sibling.pkl")
 
-    assert report.status == ScanStatus.COMPLETE
+    assert report.status in {ScanStatus.COMPLETE, ScanStatus.INCONCLUSIVE}
+    if report.status == ScanStatus.INCONCLUSIVE:
+        assert report.metadata.get("analysis_incomplete") is True
     assert report.verdict == SafetyVerdict.SUSPICIOUS
     assert any(
         finding.rule_code == "NON_ALLOWLISTED_GLOBAL" and finding.details.get("import_reference") == f"{module}.Gadget"


### PR DESCRIPTION
## Summary

- Fix the Windows/Python 3.11 Nightly failure in [run 29718536867](https://github.com/promptfoo/modelaudit/actions/runs/29718536867): `test_scan_bytes_warns_on_unreviewed_name_from_module_with_dangerous_entries[dotenv.main]` can safely return `INCONCLUSIVE` when source analysis is unavailable.
- Require `analysis_incomplete=True` for that fail-closed status while preserving the `SUSPICIOUS` verdict and exact `NON_ALLOWLISTED_GLOBAL` assertion.

## Validation

- `ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/`
- `mypy packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests`
- focused pytest cases pass under xdist (3 passed)
- simulated unavailable call-graph analysis returns `inconclusive suspicious True ['NON_ALLOWLISTED_GLOBAL']`
- `git diff --check`

Full local validation on macOS still exposes unrelated baseline issues: 12 existing mypy errors in `cache_decorator.py`, `jit_script.py`, `test_llamafile_scanner.py`, `cli.py`, and `test_cli.py`; cache tests with zero entries; and the existing Torch reconstruction verdict mismatch. None are in this diff or the failing Windows Nightly case.
