### PR TITLE
chore(deps): keep Renovate Python updates in supported range

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,11 @@
       "matchPackageNames": ["numpy"],
       "matchCurrentValue": "/<2\\.5/",
       "allowedVersions": "<2.5"
+    },
+    {
+      "description": "Keep Python updates within the project's supported 3.10-3.13 range.",
+      "matchPackageNames": ["python"],
+      "allowedVersions": "<3.14"
     }
   ],
   "vulnerabilityAlerts": {

--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,12 @@
       "description": "Keep Python updates within the project's supported 3.10-3.13 range.",
       "matchPackageNames": ["python"],
       "allowedVersions": "<3.14"
+    },
+    {
+      "description": "Keep the TensorFlow image on a runtime supported by the tensorflow extra.",
+      "matchFileNames": ["Dockerfile.tensorflow"],
+      "matchPackageNames": ["python"],
+      "allowedVersions": "<3.13"
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary

Prevents Renovate from repeatedly proposing unsupported Python upgrades that remove installable runtimes or silently omit the TensorFlow extra.

- keep root metadata and general Docker Python updates below 3.14 while preserving digest updates
- keep `Dockerfile.tensorflow` below 3.13 to match the TensorFlow extra marker

## Validation

- Renovate 43.272.4 strict configuration validation and direct extractor/matcher/filter probes
- confirmed both package rules and precedence with real Docker tags; digest updates remain available
- `tests/test_docker_workflow.py`: 32 passed
- Prettier and `git diff --check` clean
- two independent prepublish review passes: zero findings

Supersedes the repeatedly recreated Python-upgrade PR (#1751).