### PR TITLE
fix: recover root release build and PyPI smoke gates

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -955,7 +955,13 @@ jobs:
               try:
                   with urllib.request.urlopen(url, timeout=20) as response:
                       payload = json.load(response)
-                  request = urllib.request.Request(simple_url, headers={"Accept": "application/vnd.pypi.simple.v1+json"})
+                  request = urllib.request.Request(
+                      simple_url,
+                      headers={
+                          "Accept": "application/vnd.pypi.simple.v1+json, application/vnd.pypi.simple.v1+html; q=0.1, text/html; q=0.01",
+                          "Cache-Control": "max-age=0",
+                      },
+                  )
                   with urllib.request.urlopen(request, timeout=20) as response:
                       simple_payload = json.load(response)
                   filenames = {entry["filename"] for entry in payload.get("urls", [])}
@@ -1071,7 +1077,13 @@ jobs:
               try:
                   with urllib.request.urlopen(url, timeout=20) as response:
                       payload = json.load(response)
-                  request = urllib.request.Request(simple_url, headers={"Accept": "application/vnd.pypi.simple.v1+json"})
+                  request = urllib.request.Request(
+                      simple_url,
+                      headers={
+                          "Accept": "application/vnd.pypi.simple.v1+json, application/vnd.pypi.simple.v1+html; q=0.1, text/html; q=0.01",
+                          "Cache-Control": "max-age=0",
+                      },
+                  )
                   with urllib.request.urlopen(request, timeout=20) as response:
                       simple_payload = json.load(response)
                   filenames = {entry["filename"] for entry in payload.get("urls", [])}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -283,6 +283,7 @@ jobs:
           # Match tool.mypy.python_version so version-gated dependency stubs use valid syntax.
           uv sync --python 3.10 --frozen --extra all-ci
           uv run --python 3.10 --frozen mypy modelaudit/ tests/
+          uv cache prune --ci
 
       - name: Sync dependencies for root runtime checks
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -973,11 +973,20 @@ jobs:
           set -euo pipefail
           python -m venv /tmp/modelaudit-picklescan-pypi-smoke
           /tmp/modelaudit-picklescan-pypi-smoke/bin/python -m pip install --upgrade pip
-          /tmp/modelaudit-picklescan-pypi-smoke/bin/python -m pip install \
-            --no-cache-dir \
-            --retries 10 \
-            --timeout 60 \
-            "modelaudit-picklescan==${EXPECTED_VERSION}"
+          for attempt in {1..30}; do
+            if /tmp/modelaudit-picklescan-pypi-smoke/bin/python -m pip install \
+              --no-cache-dir \
+              --retries 10 \
+              --timeout 60 \
+              "modelaudit-picklescan==${EXPECTED_VERSION}"; then
+              break
+            fi
+            if [[ "$attempt" -eq 30 ]]; then
+              echo "Timed out waiting for modelaudit-picklescan ${EXPECTED_VERSION} on the PyPI simple index" >&2
+              exit 1
+            fi
+            sleep 10
+          done
 
           /tmp/modelaudit-picklescan-pypi-smoke/bin/python - <<'PY'
           import importlib.metadata as md
@@ -1081,11 +1090,20 @@ jobs:
           set -euo pipefail
           python -m venv /tmp/modelaudit-pypi-smoke
           /tmp/modelaudit-pypi-smoke/bin/python -m pip install --upgrade pip
-          /tmp/modelaudit-pypi-smoke/bin/python -m pip install \
-            --no-cache-dir \
-            --retries 10 \
-            --timeout 60 \
-            "modelaudit[all]==${EXPECTED_VERSION}"
+          for attempt in {1..30}; do
+            if /tmp/modelaudit-pypi-smoke/bin/python -m pip install \
+              --no-cache-dir \
+              --retries 10 \
+              --timeout 60 \
+              "modelaudit[all]==${EXPECTED_VERSION}"; then
+              break
+            fi
+            if [[ "$attempt" -eq 30 ]]; then
+              echo "Timed out waiting for modelaudit ${EXPECTED_VERSION} on the PyPI simple index" >&2
+              exit 1
+            fi
+            sleep 10
+          done
 
           /tmp/modelaudit-pypi-smoke/bin/python - <<'PY'
           import importlib.metadata as md

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -281,15 +281,15 @@ jobs:
       - name: Type check root package with mypy
         run: |
           # Match tool.mypy.python_version so version-gated dependency stubs use valid syntax.
-          uv sync --python 3.10 --frozen --extra all-ci
-          uv run --python 3.10 --frozen mypy modelaudit/ tests/
+          uv sync --python 3.10 --locked --extra all-ci
+          uv run --python 3.10 --locked mypy modelaudit/ tests/
           uv cache prune --ci
 
       - name: Sync dependencies for root runtime checks
         run: |
           # Keep the release security tests and artifact smoke tests on modern Python.
           uv python pin 3.12
-          uv sync --frozen --extra all-ci
+          uv sync --locked --extra all-ci
 
       - name: Lint root package with Ruff
         run: uv run ruff check modelaudit/ tests/

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -932,10 +932,12 @@ jobs:
       - name: Wait for modelaudit-picklescan files on PyPI
         run: |
           python - <<'PY'
+          import gzip
           import json
           import os
           import time
           import urllib.request
+          import zlib
 
           version = os.environ["EXPECTED_VERSION"]
           expected_files = {
@@ -959,11 +961,20 @@ jobs:
                       simple_url,
                       headers={
                           "Accept": "application/vnd.pypi.simple.v1+json, application/vnd.pypi.simple.v1+html; q=0.1, text/html; q=0.01",
+                          "Accept-Encoding": "gzip, deflate",
                           "Cache-Control": "max-age=0",
                       },
                   )
                   with urllib.request.urlopen(request, timeout=20) as response:
-                      simple_payload = json.load(response)
+                      simple_body = response.read()
+                      content_encoding = response.headers.get("Content-Encoding", "identity").lower()
+                  if content_encoding == "gzip":
+                      simple_body = gzip.decompress(simple_body)
+                  elif content_encoding == "deflate":
+                      simple_body = zlib.decompress(simple_body)
+                  elif content_encoding not in ("", "identity"):
+                      raise ValueError(f"Unsupported Simple API Content-Encoding: {content_encoding!r}")
+                  simple_payload = json.loads(simple_body)
                   filenames = {entry["filename"] for entry in payload.get("urls", [])}
                   simple_filenames = {
                       entry["filename"] for entry in simple_payload.get("files", []) if not entry.get("yanked", False)
@@ -1058,10 +1069,12 @@ jobs:
       - name: Wait for modelaudit files on PyPI
         run: |
           python - <<'PY'
+          import gzip
           import json
           import os
           import time
           import urllib.request
+          import zlib
 
           version = os.environ["EXPECTED_VERSION"]
           expected_files = {
@@ -1081,11 +1094,20 @@ jobs:
                       simple_url,
                       headers={
                           "Accept": "application/vnd.pypi.simple.v1+json, application/vnd.pypi.simple.v1+html; q=0.1, text/html; q=0.01",
+                          "Accept-Encoding": "gzip, deflate",
                           "Cache-Control": "max-age=0",
                       },
                   )
                   with urllib.request.urlopen(request, timeout=20) as response:
-                      simple_payload = json.load(response)
+                      simple_body = response.read()
+                      content_encoding = response.headers.get("Content-Encoding", "identity").lower()
+                  if content_encoding == "gzip":
+                      simple_body = gzip.decompress(simple_body)
+                  elif content_encoding == "deflate":
+                      simple_body = zlib.decompress(simple_body)
+                  elif content_encoding not in ("", "identity"):
+                      raise ValueError(f"Unsupported Simple API Content-Encoding: {content_encoding!r}")
+                  simple_payload = json.loads(simple_body)
                   filenames = {entry["filename"] for entry in payload.get("urls", [])}
                   simple_filenames = {
                       entry["filename"] for entry in simple_payload.get("files", []) if not entry.get("yanked", False)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -947,6 +947,7 @@ jobs:
               f"modelaudit_picklescan-{version}.tar.gz",
           }
           url = f"https://pypi.org/pypi/modelaudit-picklescan/{version}/json"
+          simple_url = "https://pypi.org/simple/modelaudit-picklescan/"
           deadline = time.monotonic() + 600
           last_status = "not checked"
 
@@ -954,13 +955,20 @@ jobs:
               try:
                   with urllib.request.urlopen(url, timeout=20) as response:
                       payload = json.load(response)
+                  request = urllib.request.Request(simple_url, headers={"Accept": "application/vnd.pypi.simple.v1+json"})
+                  with urllib.request.urlopen(request, timeout=20) as response:
+                      simple_payload = json.load(response)
                   filenames = {entry["filename"] for entry in payload.get("urls", [])}
+                  simple_filenames = {
+                      entry["filename"] for entry in simple_payload.get("files", []) if not entry.get("yanked", False)
+                  }
                   missing = sorted(expected_files - filenames)
+                  missing_simple = sorted(expected_files - simple_filenames)
                   info_version = payload.get("info", {}).get("version")
-                  if info_version == version and not missing:
+                  if info_version == version and not missing and not missing_simple:
                       print(f"PyPI has modelaudit-picklescan {version}: {sorted(filenames)}")
                       break
-                  last_status = f"version={info_version!r}, missing={missing}"
+                  last_status = f"version={info_version!r}, missing={missing}, missing_simple={missing_simple}"
               except Exception as exc:
                   last_status = repr(exc)
               time.sleep(10)
@@ -973,20 +981,11 @@ jobs:
           set -euo pipefail
           python -m venv /tmp/modelaudit-picklescan-pypi-smoke
           /tmp/modelaudit-picklescan-pypi-smoke/bin/python -m pip install --upgrade pip
-          for attempt in {1..30}; do
-            if /tmp/modelaudit-picklescan-pypi-smoke/bin/python -m pip install \
-              --no-cache-dir \
-              --retries 10 \
-              --timeout 60 \
-              "modelaudit-picklescan==${EXPECTED_VERSION}"; then
-              break
-            fi
-            if [[ "$attempt" -eq 30 ]]; then
-              echo "Timed out waiting for modelaudit-picklescan ${EXPECTED_VERSION} on the PyPI simple index" >&2
-              exit 1
-            fi
-            sleep 10
-          done
+          /tmp/modelaudit-picklescan-pypi-smoke/bin/python -m pip install \
+            --no-cache-dir \
+            --retries 10 \
+            --timeout 60 \
+            "modelaudit-picklescan==${EXPECTED_VERSION}"
 
           /tmp/modelaudit-picklescan-pypi-smoke/bin/python - <<'PY'
           import importlib.metadata as md
@@ -1064,6 +1063,7 @@ jobs:
               f"modelaudit-{version}.tar.gz",
           }
           url = f"https://pypi.org/pypi/modelaudit/{version}/json"
+          simple_url = "https://pypi.org/simple/modelaudit/"
           deadline = time.monotonic() + 600
           last_status = "not checked"
 
@@ -1071,13 +1071,20 @@ jobs:
               try:
                   with urllib.request.urlopen(url, timeout=20) as response:
                       payload = json.load(response)
+                  request = urllib.request.Request(simple_url, headers={"Accept": "application/vnd.pypi.simple.v1+json"})
+                  with urllib.request.urlopen(request, timeout=20) as response:
+                      simple_payload = json.load(response)
                   filenames = {entry["filename"] for entry in payload.get("urls", [])}
+                  simple_filenames = {
+                      entry["filename"] for entry in simple_payload.get("files", []) if not entry.get("yanked", False)
+                  }
                   missing = sorted(expected_files - filenames)
+                  missing_simple = sorted(expected_files - simple_filenames)
                   info_version = payload.get("info", {}).get("version")
-                  if info_version == version and not missing:
+                  if info_version == version and not missing and not missing_simple:
                       print(f"PyPI has modelaudit {version}: {sorted(filenames)}")
                       break
-                  last_status = f"version={info_version!r}, missing={missing}"
+                  last_status = f"version={info_version!r}, missing={missing}, missing_simple={missing_simple}"
               except Exception as exc:
                   last_status = repr(exc)
               time.sleep(10)
@@ -1090,20 +1097,11 @@ jobs:
           set -euo pipefail
           python -m venv /tmp/modelaudit-pypi-smoke
           /tmp/modelaudit-pypi-smoke/bin/python -m pip install --upgrade pip
-          for attempt in {1..30}; do
-            if /tmp/modelaudit-pypi-smoke/bin/python -m pip install \
-              --no-cache-dir \
-              --retries 10 \
-              --timeout 60 \
-              "modelaudit[all]==${EXPECTED_VERSION}"; then
-              break
-            fi
-            if [[ "$attempt" -eq 30 ]]; then
-              echo "Timed out waiting for modelaudit ${EXPECTED_VERSION} on the PyPI simple index" >&2
-              exit 1
-            fi
-            sleep 10
-          done
+          /tmp/modelaudit-pypi-smoke/bin/python -m pip install \
+            --no-cache-dir \
+            --retries 10 \
+            --timeout 60 \
+            "modelaudit[all]==${EXPECTED_VERSION}"
 
           /tmp/modelaudit-pypi-smoke/bin/python - <<'PY'
           import importlib.metadata as md

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -273,6 +273,12 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Pin Python version for root type check
+        run: |
+          # Match tool.mypy.python_version so version-gated dependency stubs use
+          # syntax valid for the minimum supported Python target.
+          uv python pin 3.10
+
       - name: Install Rust toolchain
         run: |
           rustup toolchain install stable --profile minimal

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -278,22 +278,23 @@ jobs:
           rustup toolchain install stable --profile minimal
           rustup default stable
 
-      - name: Sync dependencies
-        run: uv sync --extra all-ci
+      - name: Type check root package with mypy
+        run: |
+          # Match tool.mypy.python_version so version-gated dependency stubs use valid syntax.
+          uv sync --python 3.10 --frozen --extra all-ci
+          uv run --python 3.10 --frozen mypy modelaudit/ tests/
+
+      - name: Sync dependencies for root runtime checks
+        run: |
+          # Keep the release security tests and artifact smoke tests on modern Python.
+          uv python pin 3.12
+          uv sync --frozen --extra all-ci
 
       - name: Lint root package with Ruff
         run: uv run ruff check modelaudit/ tests/
 
       - name: Check root package formatting with Ruff
         run: uv run ruff format --check modelaudit/ tests/
-
-      - name: Type check root package with mypy
-        env:
-          UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/modelaudit-mypy-venv
-        run: |
-          # Match tool.mypy.python_version without moving runtime tests off the runner Python.
-          uv sync --python 3.10 --frozen --extra all-ci
-          uv run --python 3.10 --frozen mypy modelaudit/ tests/
 
       - name: Run root package tests
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -273,12 +273,6 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Pin Python version for root type check
-        run: |
-          # Match tool.mypy.python_version so version-gated dependency stubs use
-          # syntax valid for the minimum supported Python target.
-          uv python pin 3.10
-
       - name: Install Rust toolchain
         run: |
           rustup toolchain install stable --profile minimal
@@ -294,7 +288,12 @@ jobs:
         run: uv run ruff format --check modelaudit/ tests/
 
       - name: Type check root package with mypy
-        run: uv run mypy modelaudit/ tests/
+        env:
+          UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/modelaudit-mypy-venv
+        run: |
+          # Match tool.mypy.python_version without moving runtime tests off the runner Python.
+          uv sync --python 3.10 --frozen --extra all-ci
+          uv run --python 3.10 --frozen mypy modelaudit/ tests/
 
       - name: Run root package tests
         run: |

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -153,19 +153,24 @@ def test_release_workflow_picklescan_artifacts_stay_in_package_workspace() -> No
     }
 
 
-def test_release_workflow_isolates_root_type_check_python_from_runtime_tests() -> None:
+def test_release_workflow_restores_root_runtime_python_after_type_check() -> None:
     workflow = _load_release_workflow()
     steps = _job_steps(workflow, "build")
 
-    sync_step = _step_by_name(steps, "Sync dependencies")
     type_check_step = _step_by_name(steps, "Type check root package with mypy")
+    sync_step = _step_by_name(steps, "Sync dependencies for root runtime checks")
+    lint_step = _step_by_name(steps, "Lint root package with Ruff")
     test_step = _step_by_name(steps, "Run root package tests")
+    build_step = _step_by_name(steps, "Build package")
 
-    assert type_check_step["env"] == {"UV_PROJECT_ENVIRONMENT": "${{ runner.temp }}/modelaudit-mypy-venv"}
     assert "uv sync --python 3.10 --frozen --extra all-ci" in type_check_step["run"]
     assert "uv run --python 3.10 --frozen mypy modelaudit/ tests/" in type_check_step["run"]
+    assert "UV_PROJECT_ENVIRONMENT" not in type_check_step.get("env", {})
+    assert "uv python pin 3.12" in sync_step["run"]
+    assert "uv sync --frozen --extra all-ci" in sync_step["run"]
     assert "uv python pin 3.10" not in "\n".join(step.get("run", "") for step in steps)
-    assert steps.index(sync_step) < steps.index(type_check_step) < steps.index(test_step)
+    assert steps.index(type_check_step) < steps.index(sync_step) < steps.index(lint_step) < steps.index(test_step)
+    assert steps.index(test_step) < steps.index(build_step)
 
 
 def test_release_workflow_refreshes_both_standalone_package_locks() -> None:

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -165,6 +165,9 @@ def test_release_workflow_restores_root_runtime_python_after_type_check() -> Non
 
     assert "uv sync --python 3.10 --frozen --extra all-ci" in type_check_step["run"]
     assert "uv run --python 3.10 --frozen mypy modelaudit/ tests/" in type_check_step["run"]
+    assert type_check_step["run"].index("uv run --python 3.10 --frozen mypy") < type_check_step["run"].index(
+        "uv cache prune --ci"
+    )
     assert "UV_PROJECT_ENVIRONMENT" not in type_check_step.get("env", {})
     assert "uv python pin 3.12" in sync_step["run"]
     assert "uv sync --frozen --extra all-ci" in sync_step["run"]

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -299,7 +299,11 @@ def test_release_workflow_verifies_published_picklescan_package() -> None:
     wait_step = _step_by_name(steps, "Wait for modelaudit-picklescan files on PyPI")
     wait_run = wait_step["run"]
     assert "https://pypi.org/pypi/modelaudit-picklescan/{version}/json" in wait_run
+    assert "https://pypi.org/simple/modelaudit-picklescan/" in wait_run
+    assert "application/vnd.pypi.simple.v1+json" in wait_run
     assert "deadline = time.monotonic() + 600" in wait_run
+    assert 'if not entry.get("yanked", False)' in wait_run
+    assert "missing_simple={missing_simple}" in wait_run
     for expected_fragment in (
         "modelaudit_picklescan-{version}-cp310-abi3-macosx_10_12_x86_64.whl",
         "modelaudit_picklescan-{version}-cp310-abi3-macosx_11_0_arm64.whl",
@@ -312,13 +316,8 @@ def test_release_workflow_verifies_published_picklescan_package() -> None:
 
     smoke_step = _step_by_name(steps, "Install published modelaudit-picklescan and smoke test API")
     smoke_run = smoke_step["run"]
-    assert "for attempt in {1..30}; do" in smoke_run
     assert "--no-cache-dir" in smoke_run
     assert '"modelaudit-picklescan==${EXPECTED_VERSION}"' in smoke_run
-    assert 'if [[ "$attempt" -eq 30 ]]; then' in smoke_run
-    assert "PyPI simple index" in smoke_run
-    assert "exit 1" in smoke_run
-    assert "sleep 10" in smoke_run
     assert 'md.version("modelaudit-picklescan")' in smoke_run
     assert 'find_spec("modelaudit_picklescan._rust")' in smoke_run
     assert 'clean_report.status.value != "complete"' in smoke_run
@@ -468,19 +467,18 @@ def test_release_workflow_verifies_published_root_package_after_picklescan() -> 
     wait_step = _step_by_name(steps, "Wait for modelaudit files on PyPI")
     wait_run = wait_step["run"]
     assert "https://pypi.org/pypi/modelaudit/{version}/json" in wait_run
+    assert "https://pypi.org/simple/modelaudit/" in wait_run
+    assert "application/vnd.pypi.simple.v1+json" in wait_run
     assert "deadline = time.monotonic() + 600" in wait_run
+    assert 'if not entry.get("yanked", False)' in wait_run
+    assert "missing_simple={missing_simple}" in wait_run
     assert "modelaudit-{version}-py3-none-any.whl" in wait_run
     assert "modelaudit-{version}.tar.gz" in wait_run
 
     smoke_step = _step_by_name(steps, "Install published modelaudit and run end-to-end smoke tests")
     smoke_run = smoke_step["run"]
-    assert "for attempt in {1..30}; do" in smoke_run
     assert "--no-cache-dir" in smoke_run
     assert '"modelaudit[all]==${EXPECTED_VERSION}"' in smoke_run
-    assert 'if [[ "$attempt" -eq 30 ]]; then' in smoke_run
-    assert "PyPI simple index" in smoke_run
-    assert "exit 1" in smoke_run
-    assert "sleep 10" in smoke_run
     assert 'md.version("modelaudit")' in smoke_run
     assert 'md.version("modelaudit-picklescan")' in smoke_run
     assert 'os.environ.get("PICKLESCAN_RELEASE_CREATED") == "true"' in smoke_run

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import gzip
 import io
 import json
 import time
 import urllib.request
 import zipfile
+import zlib
 from pathlib import Path
 from typing import Any, cast
 
@@ -304,7 +306,10 @@ def test_release_workflow_verifies_published_picklescan_package() -> None:
         '"Accept": "application/vnd.pypi.simple.v1+json, application/vnd.pypi.simple.v1+html; q=0.1, '
         'text/html; q=0.01"' in wait_run
     )
+    assert '"Accept-Encoding": "gzip, deflate"' in wait_run
     assert '"Cache-Control": "max-age=0"' in wait_run
+    assert 'content_encoding == "gzip"' in wait_run
+    assert 'content_encoding == "deflate"' in wait_run
     assert "deadline = time.monotonic() + 600" in wait_run
     assert 'if not entry.get("yanked", False)' in wait_run
     assert "missing_simple={missing_simple}" in wait_run
@@ -327,6 +332,86 @@ def test_release_workflow_verifies_published_picklescan_package() -> None:
     assert 'clean_report.status.value != "complete"' in smoke_run
     assert 'malicious_report.verdict.value != "malicious"' in smoke_run
     assert 'finding.rule_code == "DANGEROUS_CALL"' in smoke_run
+
+
+@pytest.mark.parametrize(
+    ("job_name", "step_name", "project", "version", "expected_files"),
+    [
+        (
+            "verify-picklescan-pypi",
+            "Wait for modelaudit-picklescan files on PyPI",
+            "modelaudit-picklescan",
+            "0.1.9",
+            (
+                "modelaudit_picklescan-0.1.9-cp310-abi3-macosx_10_12_x86_64.whl",
+                "modelaudit_picklescan-0.1.9-cp310-abi3-macosx_11_0_arm64.whl",
+                "modelaudit_picklescan-0.1.9-cp310-abi3-manylinux_2_28_aarch64.whl",
+                "modelaudit_picklescan-0.1.9-cp310-abi3-manylinux_2_28_x86_64.whl",
+                "modelaudit_picklescan-0.1.9-cp310-abi3-win_amd64.whl",
+                "modelaudit_picklescan-0.1.9.tar.gz",
+            ),
+        ),
+        (
+            "verify-pypi",
+            "Wait for modelaudit files on PyPI",
+            "modelaudit",
+            "0.2.50",
+            ("modelaudit-0.2.50-py3-none-any.whl", "modelaudit-0.2.50.tar.gz"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("content_encoding", ["gzip", "deflate"])
+def test_release_workflow_waits_for_compressed_pypi_simple_index(
+    job_name: str,
+    step_name: str,
+    project: str,
+    version: str,
+    expected_files: tuple[str, ...],
+    content_encoding: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = _load_release_workflow()
+    wait_run = _step_by_name(_job_steps(workflow, job_name), step_name)["run"]
+    lines = wait_run.splitlines()
+    assert lines[0] == "python - <<'PY'"
+    assert lines[-1] == "PY"
+    script = "\n".join(lines[1:-1])
+
+    class EncodedResponse(io.BytesIO):
+        def __init__(self, body: bytes, encoding: str) -> None:
+            super().__init__(body)
+            self.headers = {"Content-Encoding": encoding}
+
+    calls = {"api": 0, "simple": 0}
+    api_payload = {"info": {"version": version}, "urls": [{"filename": name} for name in expected_files]}
+
+    def fake_urlopen(url: str | urllib.request.Request, timeout: int = 20) -> io.BytesIO:
+        assert timeout == 20
+        if isinstance(url, str):
+            assert url == f"https://pypi.org/pypi/{project}/{version}/json"
+            calls["api"] += 1
+            return io.BytesIO(json.dumps(api_payload).encode())
+
+        assert url.full_url == f"https://pypi.org/simple/{project}/"
+        assert url.get_header("Accept-encoding") == "gzip, deflate"
+        assert url.get_header("Cache-control") == "max-age=0"
+        calls["simple"] += 1
+        files = [
+            {"filename": name, "yanked": calls["simple"] == 1 and index == 0}
+            for index, name in enumerate(expected_files)
+        ]
+        body = json.dumps({"files": files}).encode()
+        encoded_body = gzip.compress(body) if content_encoding == "gzip" else zlib.compress(body)
+        return EncodedResponse(encoded_body, content_encoding)
+
+    ticks = iter((0.0, 1.0, 2.0, 3.0))
+    monkeypatch.setenv("EXPECTED_VERSION", version)
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(time, "monotonic", lambda: next(ticks, 3.0))
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+
+    exec(compile(script, "release-pypi-propagation-step", "exec"), {})
+    assert calls == {"api": 2, "simple": 2}
 
 
 def test_release_workflow_publishes_picklescan_before_dependent_root() -> None:
@@ -476,7 +561,10 @@ def test_release_workflow_verifies_published_root_package_after_picklescan() -> 
         '"Accept": "application/vnd.pypi.simple.v1+json, application/vnd.pypi.simple.v1+html; q=0.1, '
         'text/html; q=0.01"' in wait_run
     )
+    assert '"Accept-Encoding": "gzip, deflate"' in wait_run
     assert '"Cache-Control": "max-age=0"' in wait_run
+    assert 'content_encoding == "gzip"' in wait_run
+    assert 'content_encoding == "deflate"' in wait_run
     assert "deadline = time.monotonic() + 600" in wait_run
     assert 'if not entry.get("yanked", False)' in wait_run
     assert "missing_simple={missing_simple}" in wait_run

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -300,7 +300,11 @@ def test_release_workflow_verifies_published_picklescan_package() -> None:
     wait_run = wait_step["run"]
     assert "https://pypi.org/pypi/modelaudit-picklescan/{version}/json" in wait_run
     assert "https://pypi.org/simple/modelaudit-picklescan/" in wait_run
-    assert "application/vnd.pypi.simple.v1+json" in wait_run
+    assert (
+        '"Accept": "application/vnd.pypi.simple.v1+json, application/vnd.pypi.simple.v1+html; q=0.1, '
+        'text/html; q=0.01"' in wait_run
+    )
+    assert '"Cache-Control": "max-age=0"' in wait_run
     assert "deadline = time.monotonic() + 600" in wait_run
     assert 'if not entry.get("yanked", False)' in wait_run
     assert "missing_simple={missing_simple}" in wait_run
@@ -468,7 +472,11 @@ def test_release_workflow_verifies_published_root_package_after_picklescan() -> 
     wait_run = wait_step["run"]
     assert "https://pypi.org/pypi/modelaudit/{version}/json" in wait_run
     assert "https://pypi.org/simple/modelaudit/" in wait_run
-    assert "application/vnd.pypi.simple.v1+json" in wait_run
+    assert (
+        '"Accept": "application/vnd.pypi.simple.v1+json, application/vnd.pypi.simple.v1+html; q=0.1, '
+        'text/html; q=0.01"' in wait_run
+    )
+    assert '"Cache-Control": "max-age=0"' in wait_run
     assert "deadline = time.monotonic() + 600" in wait_run
     assert 'if not entry.get("yanked", False)' in wait_run
     assert "missing_simple={missing_simple}" in wait_run

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -153,6 +153,16 @@ def test_release_workflow_picklescan_artifacts_stay_in_package_workspace() -> No
     }
 
 
+def test_release_workflow_pins_root_build_python_to_mypy_target() -> None:
+    workflow = _load_release_workflow()
+    steps = _job_steps(workflow, "build")
+
+    pin_step = _step_by_name(steps, "Pin Python version for root type check")
+    assert "uv python pin 3.10" in pin_step["run"]
+    assert steps.index(pin_step) < steps.index(_step_by_name(steps, "Sync dependencies"))
+    assert steps.index(pin_step) < steps.index(_step_by_name(steps, "Type check root package with mypy"))
+
+
 def test_release_workflow_refreshes_both_standalone_package_locks() -> None:
     workflow = _load_release_workflow()
     sync_job = _jobs(workflow)["sync-release-metadata"]

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -153,14 +153,19 @@ def test_release_workflow_picklescan_artifacts_stay_in_package_workspace() -> No
     }
 
 
-def test_release_workflow_pins_root_build_python_to_mypy_target() -> None:
+def test_release_workflow_isolates_root_type_check_python_from_runtime_tests() -> None:
     workflow = _load_release_workflow()
     steps = _job_steps(workflow, "build")
 
-    pin_step = _step_by_name(steps, "Pin Python version for root type check")
-    assert "uv python pin 3.10" in pin_step["run"]
-    assert steps.index(pin_step) < steps.index(_step_by_name(steps, "Sync dependencies"))
-    assert steps.index(pin_step) < steps.index(_step_by_name(steps, "Type check root package with mypy"))
+    sync_step = _step_by_name(steps, "Sync dependencies")
+    type_check_step = _step_by_name(steps, "Type check root package with mypy")
+    test_step = _step_by_name(steps, "Run root package tests")
+
+    assert type_check_step["env"] == {"UV_PROJECT_ENVIRONMENT": "${{ runner.temp }}/modelaudit-mypy-venv"}
+    assert "uv sync --python 3.10 --frozen --extra all-ci" in type_check_step["run"]
+    assert "uv run --python 3.10 --frozen mypy modelaudit/ tests/" in type_check_step["run"]
+    assert "uv python pin 3.10" not in "\n".join(step.get("run", "") for step in steps)
+    assert steps.index(sync_step) < steps.index(type_check_step) < steps.index(test_step)
 
 
 def test_release_workflow_refreshes_both_standalone_package_locks() -> None:

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -317,6 +317,8 @@ def test_release_workflow_verifies_published_picklescan_package() -> None:
     assert '"modelaudit-picklescan==${EXPECTED_VERSION}"' in smoke_run
     assert 'if [[ "$attempt" -eq 30 ]]; then' in smoke_run
     assert "PyPI simple index" in smoke_run
+    assert "exit 1" in smoke_run
+    assert "sleep 10" in smoke_run
     assert 'md.version("modelaudit-picklescan")' in smoke_run
     assert 'find_spec("modelaudit_picklescan._rust")' in smoke_run
     assert 'clean_report.status.value != "complete"' in smoke_run
@@ -477,6 +479,8 @@ def test_release_workflow_verifies_published_root_package_after_picklescan() -> 
     assert '"modelaudit[all]==${EXPECTED_VERSION}"' in smoke_run
     assert 'if [[ "$attempt" -eq 30 ]]; then' in smoke_run
     assert "PyPI simple index" in smoke_run
+    assert "exit 1" in smoke_run
+    assert "sleep 10" in smoke_run
     assert 'md.version("modelaudit")' in smoke_run
     assert 'md.version("modelaudit-picklescan")' in smoke_run
     assert 'os.environ.get("PICKLESCAN_RELEASE_CREATED") == "true"' in smoke_run

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -312,8 +312,11 @@ def test_release_workflow_verifies_published_picklescan_package() -> None:
 
     smoke_step = _step_by_name(steps, "Install published modelaudit-picklescan and smoke test API")
     smoke_run = smoke_step["run"]
+    assert "for attempt in {1..30}; do" in smoke_run
     assert "--no-cache-dir" in smoke_run
     assert '"modelaudit-picklescan==${EXPECTED_VERSION}"' in smoke_run
+    assert 'if [[ "$attempt" -eq 30 ]]; then' in smoke_run
+    assert "PyPI simple index" in smoke_run
     assert 'md.version("modelaudit-picklescan")' in smoke_run
     assert 'find_spec("modelaudit_picklescan._rust")' in smoke_run
     assert 'clean_report.status.value != "complete"' in smoke_run
@@ -469,8 +472,11 @@ def test_release_workflow_verifies_published_root_package_after_picklescan() -> 
 
     smoke_step = _step_by_name(steps, "Install published modelaudit and run end-to-end smoke tests")
     smoke_run = smoke_step["run"]
+    assert "for attempt in {1..30}; do" in smoke_run
     assert "--no-cache-dir" in smoke_run
     assert '"modelaudit[all]==${EXPECTED_VERSION}"' in smoke_run
+    assert 'if [[ "$attempt" -eq 30 ]]; then' in smoke_run
+    assert "PyPI simple index" in smoke_run
     assert 'md.version("modelaudit")' in smoke_run
     assert 'md.version("modelaudit-picklescan")' in smoke_run
     assert 'os.environ.get("PICKLESCAN_RELEASE_CREATED") == "true"' in smoke_run

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -163,14 +163,14 @@ def test_release_workflow_restores_root_runtime_python_after_type_check() -> Non
     test_step = _step_by_name(steps, "Run root package tests")
     build_step = _step_by_name(steps, "Build package")
 
-    assert "uv sync --python 3.10 --frozen --extra all-ci" in type_check_step["run"]
-    assert "uv run --python 3.10 --frozen mypy modelaudit/ tests/" in type_check_step["run"]
-    assert type_check_step["run"].index("uv run --python 3.10 --frozen mypy") < type_check_step["run"].index(
+    assert "uv sync --python 3.10 --locked --extra all-ci" in type_check_step["run"]
+    assert "uv run --python 3.10 --locked mypy modelaudit/ tests/" in type_check_step["run"]
+    assert type_check_step["run"].index("uv run --python 3.10 --locked mypy") < type_check_step["run"].index(
         "uv cache prune --ci"
     )
     assert "UV_PROJECT_ENVIRONMENT" not in type_check_step.get("env", {})
     assert "uv python pin 3.12" in sync_step["run"]
-    assert "uv sync --frozen --extra all-ci" in sync_step["run"]
+    assert "uv sync --locked --extra all-ci" in sync_step["run"]
     assert "uv python pin 3.10" not in "\n".join(step.get("run", "") for step in steps)
     assert steps.index(type_check_step) < steps.index(sync_step) < steps.index(lint_step) < steps.index(test_step)
     assert steps.index(test_step) < steps.index(build_step)


### PR DESCRIPTION
## Summary

- restore the root release build by type-checking with the supported Python 3.10/NumPy 1.x environment, pruning its large prebuilt-wheel cache, and then rebuilding the single project environment on Python 3.12/NumPy 2.x before runtime tests and artifact smoke checks
- enforce `uv.lock` consistency with `--locked` and preserve the Python-3.11+ `except*` scanner security regressions instead of silently skipping them
- tolerate PyPI JSON/simple-index propagation by polling the exact `Vary: Accept` and `Vary: Accept-Encoding` cache variant used by pip, safely decoding gzip/deflate responses, and waiting for every expected, non-yanked artifact before the existing exact-version smoke install

The authoritative release run [29783437439](https://github.com/promptfoo/modelaudit/actions/runs/29783437439) reproduced both failures: NumPy 2.5 stubs were parsed with mypy's Python 3.10 target, and all six picklescan artifacts were visible through the JSON API immediately before the simple-index install reported only 0.1.2--0.1.8.

## Validation

- 78 focused release/dependency/workflow tests passed (one unrelated test deselected)
- all four Python-3.11+ JIT/TorchServe `except*` security regressions passed
- Ruff, Ruff format, changed-test mypy, actionlint, Prettier, and `git diff --check` passed
- exercised both Simple-API gates against pip's exact `Accept`/`Accept-Encoding`/`Cache-Control` headers with gzip and deflate responses, a yanked/missing first response, and propagation on retry
- confirmed sequential `uv` interpreter replacement (3.10 -> 3.12); local full `--locked` resolution is blocked only by the known Darwin TensorRT placeholder and is covered by the authoritative Ubuntu lane
