### PR TITLE
fix: keep root-only release branches componentless

### DIFF
--- a/docs/agents/release-process.md
+++ b/docs/agents/release-process.md
@@ -9,6 +9,8 @@ This repo is a monorepo with **two independently versioned PyPI packages**:
 
 Both packages are driven by a single [release-please](https://github.com/googleapis/release-please) workflow (`.github/workflows/release-please.yml`) with two components declared in `release-please-config.json` and current versions pinned in `.release-please-manifest.json`.
 
+The root release intentionally omits `package-name` and `component`. Release-please reads `project.name` from `pyproject.toml` for Python updates, while the empty branch component lets a root-only grouped Release PR match `release-please--branches--main` and keeps the existing `v{X.Y.Z}` tags. Restoring a non-empty `package-name` or `component` makes root-only releases look like a different component and silently skips publication after merge.
+
 The root `modelaudit` wheel declares a **hard dependency** on `modelaudit-picklescan>=0.1.9,<0.2.0` in `pyproject.toml`. When the sibling version crosses `0.2.0`, the constraint must be bumped in the same PR.
 
 ## Normal flow

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,6 @@
   "packages": {
     ".": {
       "release-type": "python",
-      "package-name": "modelaudit",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -13,6 +13,11 @@ from typing import Any, cast
 import pytest
 import yaml
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib  # type: ignore[no-redef]
+
 
 def _load_release_workflow() -> dict[str, Any]:
     workflow_path = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "release-please.yml"
@@ -49,6 +54,26 @@ def _jobs(workflow: dict[str, Any]) -> dict[str, Any]:
     jobs = workflow["jobs"]
     assert isinstance(jobs, dict)
     return jobs
+
+
+def test_release_please_keeps_root_componentless_for_grouped_root_only_releases() -> None:
+    root_dir = Path(__file__).resolve().parents[1]
+    release_config = json.loads((root_dir / "release-please-config.json").read_text(encoding="utf-8"))
+    root_package = release_config["packages"]["."]
+    picklescan_package = release_config["packages"]["packages/modelaudit-picklescan"]
+    pyproject = tomllib.loads((root_dir / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert release_config["include-component-in-tag"] is False
+    assert release_config["include-v-in-tag"] is True
+    assert release_config.get("separate-pull-requests", False) is False
+    assert root_package["release-type"] == "python"
+    assert "component" not in root_package
+    assert "package-name" not in root_package
+    assert root_package.get("separate-pull-requests", False) is False
+    assert pyproject["project"]["name"] == "modelaudit"
+    assert picklescan_package["component"] == "modelaudit-picklescan"
+    assert picklescan_package["include-component-in-tag"] is True
+    assert picklescan_package.get("separate-pull-requests", False) is False
 
 
 def test_release_workflow_manual_dispatch_inputs_and_guardrails() -> None:


### PR DESCRIPTION
## Summary

- keep the root release-please package componentless so root-only grouped release PRs match `release-please--branches--main` and trigger publication after merge
- preserve the existing `v{X.Y.Z}` root tags, component-prefixed picklescan tags, coordinated releases, and Python project-name updates
- add a regression test and concise maintainer documentation for the component and grouping invariants

The exact 0.2.51 tag-triggered run [29787342071](https://github.com/promptfoo/modelaudit/actions/runs/29787342071) logged `PR component: undefined does not match configured component: modelaudit`; every build, publish, and PyPI-verification job was then skipped. A pinned release-please 17.3.0 harness reproduces that failure and verifies root-only, sibling-only, and coordinated releases with this fix.

## Validation

- 79 focused release/dependency/workflow tests passed
- pinned release-please 17.3.0 reproduction passed for root-only, picklescan-only, and coordinated release paths
- Ruff, format, mypy, Prettier, and `git diff --check` passed
- three independent exact-head prepublish reviews were clear
