### PR TITLE
test: clean up picklescan import calls

### DIFF
--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -10,7 +10,6 @@ import datetime
 import decimal
 import faulthandler
 import functools
-import importlib
 import io
 import json
 import logging
@@ -25,6 +24,7 @@ import tarfile
 import uuid
 import warnings
 import zipfile
+from importlib import import_module, invalidate_caches
 from importlib import metadata as importlib_metadata
 from importlib.abc import Loader
 from importlib.machinery import (
@@ -7772,11 +7772,11 @@ def test_scan_bytes_uses_current_import_origin_instead_of_stale_loaded_source(
         encoding="utf-8",
     )
     monkeypatch.syspath_prepend(str(loaded_dir))
-    importlib.invalidate_caches()
-    imported_module = importlib.import_module(module_name)
+    invalidate_caches()
+    imported_module = import_module(module_name)
     assert Path(cast(str, imported_module.__file__)).parent == loaded_dir
     monkeypatch.syspath_prepend(str(active_dir))
-    importlib.invalidate_caches()
+    invalidate_caches()
     payload = f"c{module_name}\nGadget\n.".encode()
 
     try:


### PR DESCRIPTION
## Summary

- isolate the picklescan-only CodeQL quality cleanup from #1769 so squash-merging the root `fix:` PR cannot trigger an unintended `modelaudit-picklescan` release
- replace the three module-qualified `importlib` calls with the equivalent directly imported functions; runtime and security assertions are unchanged

## Validation

- `ruff check packages/modelaudit-picklescan/tests/test_api.py`
- `ruff format --check packages/modelaudit-picklescan/tests/test_api.py`
- `mypy packages/modelaudit-picklescan/tests/test_api.py`
- `PROMPTFOO_DISABLE_TELEMETRY=1 pytest -q -n0 packages/modelaudit-picklescan/tests/test_api.py::test_scan_bytes_uses_current_import_origin_instead_of_stale_loaded_source --tb=short --maxfail=1` (1 passed)
- fresh exact-head native review: no actionable findings

This PR intentionally keeps the `test:` title/type so release-please does not publish the sibling package for a test-only cleanup.
