### PR TITLE
fix(deps): update pyasn1 to 0.6.4

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3824,11 +3824,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988388Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.920042Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- upgrade transitive `pyasn1` from `0.6.3` to the upstream security-fixed `0.6.4` in `uv.lock`
- repair the newly failing Dependency Audit without suppressing CVEs; upstream 0.6.4 fixes CVE-2026-59885 (quadratic OID decoding), CVE-2026-59886 (unbounded REAL conversion), and CVE-2026-59884 (unbounded BER tag IDs)
- keep the update limited to the official wheel/sdist URLs, hashes, sizes, and upload times; `pyasn1` remains compatible with the supported Python range and is only transitive via `google-auth -> pyasn1-modules`

Upstream release notes: https://github.com/pyasn1/pyasn1/blob/v0.6.4/CHANGES.rst

## Validation

- verified official GitHub Release wheel/sdist SHA256 and sizes match `uv.lock`
- frozen-lock strict audit with the repository's existing Pygments exception: **No known vulnerabilities found**
- `PROMPTFOO_DISABLE_TELEMETRY=1 pytest -q -n0 tests/utils/sources/test_cloud_storage.py tests/test_auth_config.py --tb=short --maxfail=1` (**473 passed**)
- `git diff --check`
- fresh exact-head native review: no actionable findings

The local macOS resolver cannot build the pre-existing Linux-only TensorRT placeholder, so the lock was checked using frozen export; Linux CI remains the authoritative full-resolution lane.
