### PR TITLE
fix(picklescan): recognize uv bytes-encoded package overlays

### DIFF
--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -7,6 +7,10 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- preserve trusted installed-package and malicious-pickle detection when uv encodes delegated site-package paths as bytes
+
 ## [0.1.9](https://github.com/promptfoo/modelaudit/compare/modelaudit-picklescan-v0.1.8...modelaudit-picklescan-v0.1.9) (2026-07-20)
 
 ### Bug Fixes

--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -9,7 +9,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- preserve trusted installed-package and malicious-pickle detection when uv encodes delegated site-package paths as bytes
+- preserve trusted installed-package and malicious-pickle detection when uv encodes delegated site-packages paths as bytes
 
 ## [0.1.9](https://github.com/promptfoo/modelaudit/compare/modelaudit-picklescan-v0.1.8...modelaudit-picklescan-v0.1.9) (2026-07-20)
 

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1351,7 +1351,7 @@ def _pth_site_directory_value(argument: ast.expr) -> str | None:
     encoded_path = argument.args[0]
     if not isinstance(encoded_path, ast.Constant) or type(encoded_path.value) is not bytes:
         return None
-    return encoded_path.value.decode(sys.getfilesystemencoding(), errors="surrogateescape")
+    return encoded_path.value.decode(sys.getfilesystemencoding(), errors=sys.getfilesystemencodeerrors())
 
 
 def _pth_delegated_site_package_paths(pth_path: Path, trusted_root: Path) -> tuple[Path, ...]:

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1345,7 +1345,7 @@ def _pth_site_directory_value(argument: ast.expr) -> str | None:
         or len(imported_module.args) != 1
         or imported_module.keywords
         or not isinstance(imported_module.args[0], ast.Constant)
-        or imported_module.args[0].value != "os"
+        or imported_module.args[0].value not in _REVIEWED_INERT_STDLIB_IMPORTS
     ):
         return None
     encoded_path = argument.args[0]

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1351,7 +1351,10 @@ def _pth_site_directory_value(argument: ast.expr) -> str | None:
     encoded_path = argument.args[0]
     if not isinstance(encoded_path, ast.Constant) or type(encoded_path.value) is not bytes:
         return None
-    return encoded_path.value.decode(sys.getfilesystemencoding(), errors=sys.getfilesystemencodeerrors())
+    try:
+        return encoded_path.value.decode(sys.getfilesystemencoding(), errors=sys.getfilesystemencodeerrors())
+    except (LookupError, UnicodeError):
+        return None
 
 
 def _pth_delegated_site_package_paths(pth_path: Path, trusted_root: Path) -> tuple[Path, ...]:

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1329,6 +1329,31 @@ def _site_package_root_from_pth_value(value: str, trusted_root: Path) -> Path | 
         return None
 
 
+def _pth_site_directory_value(argument: ast.expr) -> str | None:
+    if isinstance(argument, ast.Constant) and isinstance(argument.value, str):
+        return argument.value
+    if not isinstance(argument, ast.Call) or len(argument.args) != 1 or argument.keywords:
+        return None
+    function = argument.func
+    if not isinstance(function, ast.Attribute) or function.attr != "fsdecode":
+        return None
+    imported_module = function.value
+    if (
+        not isinstance(imported_module, ast.Call)
+        or not isinstance(imported_module.func, ast.Name)
+        or imported_module.func.id != "__import__"
+        or len(imported_module.args) != 1
+        or imported_module.keywords
+        or not isinstance(imported_module.args[0], ast.Constant)
+        or imported_module.args[0].value != "os"
+    ):
+        return None
+    encoded_path = argument.args[0]
+    if not isinstance(encoded_path, ast.Constant) or type(encoded_path.value) is not bytes:
+        return None
+    return encoded_path.value.decode(sys.getfilesystemencoding(), errors="surrogateescape")
+
+
 def _pth_delegated_site_package_paths(pth_path: Path, trusted_root: Path) -> tuple[Path, ...]:
     try:
         if pth_path.stat().st_size > _MAX_TRUSTED_PTH_BYTES:
@@ -1361,11 +1386,11 @@ def _pth_delegated_site_package_paths(pth_path: Path, trusted_root: Path) -> tup
                     and isinstance(function.value, ast.Name)
                     and function.value.id == "site"
                     and function.attr == "addsitedir"
-                    and isinstance(argument, ast.Constant)
-                    and isinstance(argument.value, str)
                 ):
                     continue
-                values.append(argument.value)
+                value = _pth_site_directory_value(argument)
+                if value is not None:
+                    values.append(value)
         else:
             values.append(line)
 

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -240,9 +240,11 @@ def test_trusted_origin_rejects_inactive_lookalike_environment(
     assert call_graph._trusted_module_origin_kind("_pytest._py.path") is None
 
 
+@pytest.mark.parametrize("encoded_path", [False, True], ids=["literal-path", "fsdecode-bytes-path"])
 def test_trusted_origin_recognizes_active_environment_delegated_overlay(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    encoded_path: bool,
 ) -> None:
     active_site_packages = tmp_path / "active" / "lib" / "python" / "site-packages"
     active_site_packages.mkdir(parents=True)
@@ -252,9 +254,13 @@ def test_trusted_origin_recognizes_active_environment_delegated_overlay(
     (overlay_site_packages / "_pytest" / "__init__.py").write_text("", encoding="utf-8")
     (package_dir / "__init__.py").write_text("", encoding="utf-8")
     (package_dir / "path.py").write_text("class LocalPath:\n    pass\n", encoding="utf-8")
+    overlay_argument = (
+        f'__import__("os").fsdecode({os.fsencode(overlay_site_packages)!r})'
+        if encoded_path
+        else repr(str(overlay_site_packages))
+    )
     (active_site_packages / "_uv_ephemeral_overlay.pth").write_text(
-        f"import site; site.addsitedir({str(overlay_site_packages)!r})\n",
-        encoding="utf-8",
+        f"import site; site.addsitedir({overlay_argument})\n", encoding="utf-8"
     )
     monkeypatch.setattr(call_graph, "_TRUSTED_SITE_PACKAGE_PATHS", (active_site_packages.resolve(),))
     monkeypatch.setattr(
@@ -268,6 +274,39 @@ def test_trusted_origin_recognizes_active_environment_delegated_overlay(
     call_graph._clear_source_sensitive_caches()
 
     assert call_graph._trusted_module_origin_kind("_pytest._py.path") == "site_packages"
+
+
+@pytest.mark.parametrize(
+    "argument_template",
+    [
+        '__import__("not_os").fsdecode({path})',
+        '__import__("os").not_fsdecode({path})',
+        '__import__("os").fsdecode({text_path})',
+        '__import__("os").fsdecode(__import__("pathlib").Path({marker}).write_text("executed"))',
+    ],
+    ids=["wrong-module", "wrong-decoder", "string-argument", "dynamic-argument"],
+)
+def test_trusted_origin_rejects_unreviewed_pth_decode_expressions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    argument_template: str,
+) -> None:
+    active_site_packages = tmp_path / "active" / "lib" / "python" / "site-packages"
+    active_site_packages.mkdir(parents=True)
+    overlay_site_packages = tmp_path / "overlay" / "lib" / "python" / "site-packages"
+    overlay_site_packages.mkdir(parents=True)
+    marker = tmp_path / "unexpected-pth-execution"
+    argument = argument_template.format(
+        path=repr(os.fsencode(overlay_site_packages)),
+        text_path=repr(str(overlay_site_packages)),
+        marker=repr(str(marker)),
+    )
+    pth_path = active_site_packages / "unreviewed-overlay.pth"
+    pth_path.write_text(f"import site; site.addsitedir({argument})\n", encoding="utf-8")
+    monkeypatch.setattr(call_graph, "_TRUSTED_SITE_PACKAGE_PATHS", (active_site_packages.resolve(),))
+
+    assert call_graph._trusted_delegated_site_package_paths() == ()
+    assert not marker.exists()
 
 
 def test_trusted_origin_ignores_nonexecuted_pth_addsitedir(

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -289,6 +289,14 @@ def test_pth_site_directory_value_uses_filesystem_error_handler(
     assert call_graph._pth_site_directory_value(expression) == encoded_path.decode("utf-8", errors=filesystem_errors)
 
 
+def test_pth_site_directory_value_rejects_malformed_filesystem_bytes(monkeypatch: pytest.MonkeyPatch) -> None:
+    expression = ast.parse('__import__("os").fsdecode(b"\\xff")', mode="eval").body
+    monkeypatch.setattr(sys, "getfilesystemencoding", lambda: "utf-8")
+    monkeypatch.setattr(sys, "getfilesystemencodeerrors", lambda: "surrogatepass")
+
+    assert call_graph._pth_site_directory_value(expression) is None
+
+
 @pytest.mark.parametrize(
     "argument_template",
     [

--- a/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py
@@ -276,6 +276,19 @@ def test_trusted_origin_recognizes_active_environment_delegated_overlay(
     assert call_graph._trusted_module_origin_kind("_pytest._py.path") == "site_packages"
 
 
+@pytest.mark.parametrize("filesystem_errors", ["surrogateescape", "surrogatepass"])
+def test_pth_site_directory_value_uses_filesystem_error_handler(
+    monkeypatch: pytest.MonkeyPatch,
+    filesystem_errors: str,
+) -> None:
+    encoded_path = b"overlay/\xed\xa0\x80/site-packages"
+    expression = ast.parse(f'__import__("os").fsdecode({encoded_path!r})', mode="eval").body
+    monkeypatch.setattr(sys, "getfilesystemencoding", lambda: "utf-8")
+    monkeypatch.setattr(sys, "getfilesystemencodeerrors", lambda: filesystem_errors)
+
+    assert call_graph._pth_site_directory_value(expression) == encoded_path.decode("utf-8", errors=filesystem_errors)
+
+
 @pytest.mark.parametrize(
     "argument_template",
     [


### PR DESCRIPTION
## Summary
- recognize the exact bytes-encoded site.addsitedir overlays generated by uv 0.11.31 without evaluating arbitrary expressions
- restore trusted typing-extensions, pytest, and execnet call-graph coverage so malicious pickle payloads remain MALICIOUS
- cover legacy overlays, the new uv encoding, and hostile/dynamic near-matches while keeping untrusted paths fail-closed

## Root cause
GitHub Actions upgraded uv from 0.11.30 to 0.11.31 between the last passing main run and the failing main/PR runs. The new release wraps each trusted overlay path in __import__("os").fsdecode(b"..."); the previous parser only accepted string literals and therefore treated every ephemeral dependency as untrusted.

## Verification
- exact uv 0.11.31 standalone suite: 2807 passed, 111 skipped
- previous-uv standalone control suite: 2802 passed, 111 skipped
- focused security and overlay regressions: 14 passed on each Python 3.10, 3.11, 3.12, and 3.13
- uv lock --check
- uv run --with ruff ruff check src tests
- uv run --with ruff ruff format --check src tests
- uv run --with mypy mypy src tests
- prettier --check packages/modelaudit-picklescan/CHANGELOG.md