### PR TITLE
fix(cache): retry transient identity barrier churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- retry transient cache identity-barrier churn without weakening fail-closed cache validation
 - avoid logging file-derived header-format values while preserving format-mismatch detections, and clean up CodeQL quality findings
 - inspect LZ4-compressed Joblib payloads with bounded decompression and preserve fail-closed optional dependency handling; thanks to @PowerliftLog for the report
 

--- a/modelaudit/cache/scan_results_cache.py
+++ b/modelaudit/cache/scan_results_cache.py
@@ -931,7 +931,9 @@ class ScanResultsCache:
                 preliminary_change_token = initial_change_token
                 preliminary_ancestor_identity = initial_ancestor_identity
             else:
-                raise ValueError(f"File kept changing while capturing cache identity: {file_path}")
+                last_change_error = ValueError(f"File kept changing while capturing cache identity: {file_path}")
+                time.sleep(0.01)
+                continue
 
             monitored_ancestor_identity = self._monitor_ancestor_identity(file_path, initial_ancestor_identity)
             try:

--- a/modelaudit/cache/scan_results_cache.py
+++ b/modelaudit/cache/scan_results_cache.py
@@ -931,7 +931,7 @@ class ScanResultsCache:
                 preliminary_change_token = initial_change_token
                 preliminary_ancestor_identity = initial_ancestor_identity
             else:
-                last_change_error = ValueError(f"File kept changing while capturing cache identity: {file_path}")
+                last_change_error = ValueError(f"Cache identity barrier did not settle: {file_path}")
                 time.sleep(0.01)
                 continue
 

--- a/tests/cache/test_cache_correctness.py
+++ b/tests/cache/test_cache_correctness.py
@@ -376,7 +376,7 @@ def test_capture_file_identity_retries_transient_change_clock_barrier(
     identity = cache.capture_file_identity(str(file_path))
     try:
         assert identity[1].startswith("secure:")
-        assert barrier_attempts["count"] == 4
+        assert barrier_attempts["count"] >= 4
     finally:
         cache.release_ancestor_identity(identity[-1])
 

--- a/tests/cache/test_cache_correctness.py
+++ b/tests/cache/test_cache_correctness.py
@@ -400,10 +400,11 @@ def test_capture_file_identity_fails_closed_for_persistent_change_clock_barrier(
 
     monkeypatch.setattr(cache, "_advance_change_clock", blocked_barrier)
 
-    with pytest.raises(ValueError, match="File kept changing while capturing cache identity"):
+    with pytest.raises(ValueError, match="File kept changing while capturing cache identity") as exc_info:
         cache.capture_file_identity(str(file_path))
 
     assert barrier_attempts["count"] == 15
+    assert str(exc_info.value.__cause__).startswith("Cache identity barrier did not settle:")
 
 
 def test_capture_file_identity_advances_clock_before_hashing(

--- a/tests/cache/test_cache_correctness.py
+++ b/tests/cache/test_cache_correctness.py
@@ -46,6 +46,8 @@ from modelaudit.cache.optimized_config import (
 )
 from modelaudit.cache.scan_results_cache import (
     _CALL_GRAPH_REGULAR_FILE_FINGERPRINT,
+    _MAX_IDENTITY_BARRIER_ATTEMPTS,
+    _MAX_IDENTITY_CAPTURE_ATTEMPTS,
     AncestorIdentity,
     ScanResultsCache,
     _current_module_source_path,
@@ -369,14 +371,14 @@ def test_capture_file_identity_retries_transient_change_clock_barrier(
     ) -> int:
         barrier_attempts["count"] += 1
         newest_token = cache._newest_identity_change_token(file_change_token, ancestor_identity)
-        return newest_token + int(barrier_attempts["count"] > 3)
+        return newest_token + int(barrier_attempts["count"] > _MAX_IDENTITY_BARRIER_ATTEMPTS)
 
     monkeypatch.setattr(cache, "_advance_change_clock", transient_barrier)
 
     identity = cache.capture_file_identity(str(file_path))
     try:
         assert identity[1].startswith("secure:")
-        assert barrier_attempts["count"] >= 4
+        assert barrier_attempts["count"] > _MAX_IDENTITY_BARRIER_ATTEMPTS
     finally:
         cache.release_ancestor_identity(identity[-1])
 
@@ -403,7 +405,7 @@ def test_capture_file_identity_fails_closed_for_persistent_change_clock_barrier(
     with pytest.raises(ValueError, match="File kept changing while capturing cache identity") as exc_info:
         cache.capture_file_identity(str(file_path))
 
-    assert barrier_attempts["count"] == 15
+    assert barrier_attempts["count"] == _MAX_IDENTITY_BARRIER_ATTEMPTS * _MAX_IDENTITY_CAPTURE_ATTEMPTS
     assert str(exc_info.value.__cause__).startswith("Cache identity barrier did not settle:")
 
 

--- a/tests/cache/test_cache_correctness.py
+++ b/tests/cache/test_cache_correctness.py
@@ -353,6 +353,59 @@ def test_capture_file_identity_retries_transient_monitor_start_change(
         cache.release_ancestor_identity(identity[-1])
 
 
+def test_capture_file_identity_retries_transient_change_clock_barrier(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    file_path = _make_cacheable_file(tmp_path)
+    cache = ScanResultsCache(str(tmp_path / "cache"))
+    barrier_attempts = {"count": 0}
+
+    def transient_barrier(
+        _path: str,
+        _probe: Any,
+        file_change_token: int,
+        ancestor_identity: AncestorIdentity,
+    ) -> int:
+        barrier_attempts["count"] += 1
+        newest_token = cache._newest_identity_change_token(file_change_token, ancestor_identity)
+        return newest_token + int(barrier_attempts["count"] > 3)
+
+    monkeypatch.setattr(cache, "_advance_change_clock", transient_barrier)
+
+    identity = cache.capture_file_identity(str(file_path))
+    try:
+        assert identity[1].startswith("secure:")
+        assert barrier_attempts["count"] == 4
+    finally:
+        cache.release_ancestor_identity(identity[-1])
+
+
+def test_capture_file_identity_fails_closed_for_persistent_change_clock_barrier(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    file_path = _make_cacheable_file(tmp_path)
+    cache = ScanResultsCache(str(tmp_path / "cache"))
+    barrier_attempts = {"count": 0}
+
+    def blocked_barrier(
+        _path: str,
+        _probe: Any,
+        file_change_token: int,
+        ancestor_identity: AncestorIdentity,
+    ) -> int:
+        barrier_attempts["count"] += 1
+        return cache._newest_identity_change_token(file_change_token, ancestor_identity)
+
+    monkeypatch.setattr(cache, "_advance_change_clock", blocked_barrier)
+
+    with pytest.raises(ValueError, match="File kept changing while capturing cache identity"):
+        cache.capture_file_identity(str(file_path))
+
+    assert barrier_attempts["count"] == 15
+
+
 def test_capture_file_identity_advances_clock_before_hashing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -2793,9 +2846,11 @@ def test_scan_cache_rejects_malformed_source_independent_call_graph_metadata(
 def test_scan_cache_rejects_source_independent_marker_with_source_inputs(
     tmp_path: Path,
     metadata_update: dict[str, object],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     file_path = _make_cacheable_file(tmp_path, "model.pkl")
     cache = ScanResultsCache(str(tmp_path / "cache"))
+    _scope_cache_ancestor_identity_to_tree(cache, tmp_path, monkeypatch)
     version_context = build_cache_version_context({})
     metadata = {
         "pickle_report_status": "complete",


### PR DESCRIPTION
## Summary

- retry transient change-clock barrier churn through the existing bounded capture loop instead of failing before the outer retries can run
- keep persistent churn fail-closed and isolate the source-independent cache regression from unrelated shared pytest-ancestor activity
- add deterministic transient and persistent barrier regressions plus a changelog entry

## Evidence

Nightly [29892590286](https://github.com/promptfoo/modelaudit/actions/runs/29892590286/job/88835841907) failed only `Correctness (ubuntu-latest, Python 3.13, Shard 1)` at `test_scan_cache_rejects_source_independent_marker_with_source_inputs[metadata_update5]` with:

```text
ValueError: File kept changing while capturing cache identity
1 failed, 11166 passed, 505 skipped
```

The deterministic transient-barrier regression fails on the exact current main and passes with this change. Persistent churn still raises after the bounded 15 attempts.

## Validation

- `PYTHONPATH=/private/tmp/modelaudit-cache-identity-barrier-20260722 PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest -n 4 tests/cache/test_cache_correctness.py::test_capture_file_identity_retries_transient_change_clock_barrier tests/cache/test_cache_correctness.py::test_capture_file_identity_fails_closed_for_persistent_change_clock_barrier tests/cache/test_cache_correctness.py::test_capture_file_identity_retries_transient_monitor_start_change tests/cache/test_cache_correctness.py::test_capture_file_identity_advances_clock_before_hashing tests/cache/test_cache_correctness.py::test_scan_cache_rejects_source_independent_marker_with_source_inputs -q --tb=short --maxfail=1` — 10 passed
- `PYTHONPATH=/private/tmp/modelaudit-cache-identity-barrier-20260722 PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest -n 4 tests/cache --ignore=tests/cache/test_cache_correctness.py -q --tb=short --maxfail=1` — 22 passed
- Ruff, Ruff format check, changed-file mypy (Python 3.10), Prettier, and `git diff --check` clean

The full cache-correctness xdist run on this macOS environment still hits three pre-existing source-identity store assertions in unrelated tests; the exact Ubuntu CI lane is authoritative.