### PR TITLE
fix(ggml): detect embedded ZIP polyglot payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Inspect hidden ZIP archives and malicious pickle payloads in legacy GGML model variants.
+- Stop reporting a ZIP polyglot for GGUF/GGML files whose tensor data merely contains an end-of-central-directory signature.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Inspect hidden ZIP archives and malicious pickle payloads in legacy GGML model variants.
+
 ### Bug Fixes
 
 - Avoid network false positives for bounded README examples that download sample images over HTTPS from Hugging Face.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Inspect hidden ZIP archives and malicious pickle payloads in legacy GGML model variants.
+
 ## [0.2.52](https://github.com/promptfoo/modelaudit/compare/v0.2.51...v0.2.52) (2026-07-22)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- Preserve incomplete-scan diagnostics for malformed GGUF/GGML ZIP candidates.
+- Preserve incomplete-scan diagnostics for malformed or unsupported ZIP data in GGUF/GGML files, including cached scans.
 - Keep incomplete Joblib NumPy-wrapper scans failed closed when embedded pickle analysis also reports warnings.
 - Upgrade XGBoost to 3.4 on Python 3.12+ while retaining XGBoost 3.2 on Python 3.10 and 3.11.
 - Restore SQL-backed MLflow model registries and upgrade their vulnerable SQL parser.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- Preserve incomplete-scan diagnostics for malformed GGUF/GGML ZIP candidates.
 - Keep incomplete Joblib NumPy-wrapper scans failed closed when embedded pickle analysis also reports warnings.
 - Upgrade XGBoost to 3.4 on Python 3.12+ while retaining XGBoost 3.2 on Python 3.10 and 3.11.
 - Restore SQL-backed MLflow model registries and upgrade their vulnerable SQL parser.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - Preserve incomplete-scan diagnostics for malformed or unsupported ZIP data in GGUF/GGML files, including cached scans.
+- Report incomplete coverage when a GGUF/GGML source changes during scanning.
 - Keep incomplete Joblib NumPy-wrapper scans failed closed when embedded pickle analysis also reports warnings.
 - Upgrade XGBoost to 3.4 on Python 3.12+ while retaining XGBoost 3.2 on Python 3.10 and 3.11.
 - Restore SQL-backed MLflow model registries and upgrade their vulnerable SQL parser.

--- a/modelaudit/scanners/gguf_scanner.py
+++ b/modelaudit/scanners/gguf_scanner.py
@@ -762,31 +762,43 @@ class GgufScanner(BaseScanner):
 
     def _scan_zip_polyglot(self, result: ScanResult, *, format_name: str = "GGUF") -> bool:
         """Inspect ZIP members even when GGUF/GGML header parsing fails."""
-        if not zipfile.is_zipfile(self.current_file_path):
-            return False
-
-        # `is_zipfile` only proves an end-of-central-directory signature is present: it returns True
-        # for any file whose trailing bytes happen to contain b"PK\x05\x06" followed by 18 bytes.
-        # Model tensor data hits that by chance, so a cleanly-readable archive carrying no members
-        # is not a polyglot - a hidden payload always has at least one entry.
-        #
-        # A directory that fails to open is NOT treated as benign here: it falls through to the
-        # preflight below so a corrupted or truncated archive still fails closed as incomplete.
-        try:
-            with zipfile.ZipFile(self.current_file_path) as embedded_archive:
-                embedded_members: list[str] | None = embedded_archive.namelist()
-        except (OSError, zipfile.BadZipFile):
-            embedded_members = None
-        if embedded_members is not None and not embedded_members:
-            return False
-
+        from ._archive_outcomes import mark_archive_scan_incomplete
         from .archive_dispatch import (
             _ZIP_CONTAINER_PREFLIGHT_REJECTED_PATHS_PRIVATE_METADATA_KEY,
             merge_executable_zip_container_findings,
         )
+        from .zip_scanner import ZipPreflightRejected, open_preflighted_zip_handle
 
         archive_config = dict(self.config)
         archive_config.pop(_GGUF_CONTAINER_OWNED_TRAILING_CONFIG_KEY, None)
+
+        # Defer accepting an empty parse until the composed scan reconciles it with the bounded
+        # preflight count. A later EOCD inside the real EOCD comment can otherwise hide entries.
+        parsed_entry_count: int | None = None
+        preflight_accepted = False
+        try:
+            with open_preflighted_zip_handle(self.current_file_path, archive_config) as archive_handle:
+                preflight_accepted = True
+                with zipfile.ZipFile(archive_handle, "r") as embedded_archive:
+                    parsed_entry_count = len(embedded_archive.infolist())
+        except ZipPreflightRejected:
+            # The composed scan below records the fail-closed preflight diagnostics.
+            pass
+        except (OSError, zipfile.BadZipFile):
+            if not preflight_accepted:
+                return False
+            result.add_check(
+                name="ZIP File Format Validation",
+                passed=False,
+                message=f"Not a valid zip file: {self.current_file_path}",
+                severity=IssueSeverity.INFO,
+                rule_code="S902",
+                location=self.current_file_path,
+                details={"path": self.current_file_path},
+            )
+            mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
+            return False
+
         merge_executable_zip_container_findings(
             self.current_file_path,
             result,
@@ -801,6 +813,8 @@ class GgufScanner(BaseScanner):
             isinstance(rejected_paths, (list, tuple, set, frozenset))
             and os.path.realpath(self.current_file_path) in rejected_paths
         ):
+            return False
+        if parsed_entry_count == 0:
             return False
 
         result.add_check(
@@ -1063,9 +1077,13 @@ class GgufScanner(BaseScanner):
         result: ScanResult,
     ) -> None:
         """Basic GGML file validation with security checks."""
+        outer_magic = magic.decode("ascii", "ignore")
         result.metadata["format"] = "ggml"
-        result.metadata["magic"] = magic.decode("ascii", "ignore")
+        result.metadata["magic"] = outer_magic
         self._scan_zip_polyglot(result, format_name="GGML")
+        result.metadata["format"] = "ggml"
+        result.metadata["magic"] = outer_magic
+        result.bytes_scanned = max(result.bytes_scanned, file_size)
 
         if file_size < 32:
             result.add_check(
@@ -1119,8 +1137,6 @@ class GgufScanner(BaseScanner):
                 details={"error": str(e), "error_type": type(e).__name__},
                 rule_code="S902",
             )
-
-        result.bytes_scanned = file_size
 
     def _read_value(
         self,

--- a/modelaudit/scanners/gguf_scanner.py
+++ b/modelaudit/scanners/gguf_scanner.py
@@ -760,8 +760,8 @@ class GgufScanner(BaseScanner):
         )
         result.bytes_scanned = max(result.bytes_scanned, f.tell())
 
-    def _scan_zip_polyglot(self, result: ScanResult) -> bool:
-        """Inspect ZIP members even when GGUF metadata or tensor parsing fails."""
+    def _scan_zip_polyglot(self, result: ScanResult, *, format_name: str = "GGUF") -> bool:
+        """Inspect ZIP members even when GGUF/GGML header parsing fails."""
         if not zipfile.is_zipfile(self.current_file_path):
             return False
 
@@ -776,7 +776,7 @@ class GgufScanner(BaseScanner):
             self.current_file_path,
             result,
             archive_config,
-            context="GGUF trailing ZIP polyglot",
+            context=f"{format_name} trailing ZIP polyglot",
         )
         rejected_paths = result._private_metadata.get(
             _ZIP_CONTAINER_PREFLIGHT_REJECTED_PATHS_PRIVATE_METADATA_KEY,
@@ -789,9 +789,9 @@ class GgufScanner(BaseScanner):
             return False
 
         result.add_check(
-            name="GGUF ZIP Polyglot Detection",
+            name=f"{format_name} ZIP Polyglot Detection",
             passed=False,
-            message="GGUF file is also a valid ZIP archive and may contain hidden archive content",
+            message=f"{format_name} file is also a valid ZIP archive and may contain hidden archive content",
             severity=IssueSeverity.CRITICAL,
             location=self.current_file_path,
             details={"embedded_format": "zip"},
@@ -1050,6 +1050,7 @@ class GgufScanner(BaseScanner):
         """Basic GGML file validation with security checks."""
         result.metadata["format"] = "ggml"
         result.metadata["magic"] = magic.decode("ascii", "ignore")
+        self._scan_zip_polyglot(result, format_name="GGML")
 
         if file_size < 32:
             result.add_check(

--- a/modelaudit/scanners/gguf_scanner.py
+++ b/modelaudit/scanners/gguf_scanner.py
@@ -767,17 +767,24 @@ class GgufScanner(BaseScanner):
             _ZIP_CONTAINER_PREFLIGHT_REJECTED_PATHS_PRIVATE_METADATA_KEY,
             merge_executable_zip_container_findings,
         )
-        from .zip_scanner import ZipPreflightRejected, open_preflighted_zip_handle
+        from .zip_scanner import (
+            ZipPreflightRejected,
+            open_preflighted_zip_handle_with_entry_count,
+        )
 
         archive_config = dict(self.config)
         archive_config.pop(_GGUF_CONTAINER_OWNED_TRAILING_CONFIG_KEY, None)
 
-        # Defer accepting an empty parse until the composed scan reconciles it with the bounded
-        # preflight count. A later EOCD inside the real EOCD comment can otherwise hide entries.
+        # Retain the bounded same-handle preflight count so parser mismatches fail closed even
+        # when nested ZIP scanning is excluded.
+        preflight_entry_count: int | None = None
         parsed_entry_count: int | None = None
         preflight_accepted = False
         try:
-            with open_preflighted_zip_handle(self.current_file_path, archive_config) as archive_handle:
+            with open_preflighted_zip_handle_with_entry_count(
+                self.current_file_path,
+                archive_config,
+            ) as (archive_handle, preflight_entry_count):
                 preflight_accepted = True
                 with zipfile.ZipFile(archive_handle, "r") as embedded_archive:
                     parsed_entry_count = len(embedded_archive.infolist())
@@ -795,6 +802,31 @@ class GgufScanner(BaseScanner):
                 rule_code="S902",
                 location=self.current_file_path,
                 details={"path": self.current_file_path},
+            )
+            mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
+            return False
+
+        if (
+            preflight_entry_count is not None
+            and parsed_entry_count is not None
+            and parsed_entry_count != preflight_entry_count
+        ):
+            result.add_check(
+                name="ZIP Central Directory Preflight",
+                passed=False,
+                message=(
+                    "ZIP central directory changed between preflight and parsing "
+                    f"({preflight_entry_count} != {parsed_entry_count})"
+                ),
+                severity=IssueSeverity.INFO,
+                rule_code="S902",
+                location=self.current_file_path,
+                details={
+                    "preflight_entries": preflight_entry_count,
+                    "parsed_entries": parsed_entry_count,
+                    "analysis_incomplete": True,
+                    "scan_outcome_reason": "zip_analysis_incomplete",
+                },
             )
             mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
             return False

--- a/modelaudit/scanners/gguf_scanner.py
+++ b/modelaudit/scanners/gguf_scanner.py
@@ -765,6 +765,21 @@ class GgufScanner(BaseScanner):
         if not zipfile.is_zipfile(self.current_file_path):
             return False
 
+        # `is_zipfile` only proves an end-of-central-directory signature is present: it returns True
+        # for any file whose trailing bytes happen to contain b"PK\x05\x06" followed by 18 bytes.
+        # Model tensor data hits that by chance, so a cleanly-readable archive carrying no members
+        # is not a polyglot - a hidden payload always has at least one entry.
+        #
+        # A directory that fails to open is NOT treated as benign here: it falls through to the
+        # preflight below so a corrupted or truncated archive still fails closed as incomplete.
+        try:
+            with zipfile.ZipFile(self.current_file_path) as embedded_archive:
+                embedded_members: list[str] | None = embedded_archive.namelist()
+        except (OSError, zipfile.BadZipFile):
+            embedded_members = None
+        if embedded_members is not None and not embedded_members:
+            return False
+
         from .archive_dispatch import (
             _ZIP_CONTAINER_PREFLIGHT_REJECTED_PATHS_PRIVATE_METADATA_KEY,
             merge_executable_zip_container_findings,

--- a/modelaudit/scanners/gguf_scanner.py
+++ b/modelaudit/scanners/gguf_scanner.py
@@ -51,6 +51,7 @@ GGUF_STRUCTURE_INCONCLUSIVE_REASON = "gguf_structure_validation_failed"
 GGUF_DUPLICATE_METADATA_INCONCLUSIVE_REASON = "gguf_duplicate_metadata_keys"
 GGUF_METADATA_LIMIT_INCONCLUSIVE_REASON = "gguf_metadata_limit_exceeded"
 GGUF_TENSOR_LIMIT_INCONCLUSIVE_REASON = "gguf_tensor_limit_exceeded"
+GGUF_SOURCE_CHANGED_REASON = "gguf_source_changed"
 _GGUF_CONTAINER_OWNED_TRAILING_CONFIG_KEY = "_modelaudit_gguf_container_owned_trailing"
 _GGUF_CONTAINER_OWNED_TRAILING_TOKEN = object()
 _GGUF_MAX_METADATA_VALUE_SECURITY_CHECKS = 64
@@ -407,6 +408,7 @@ class GgufScanner(BaseScanner):
         try:
             self.current_file_path = path
             with open(path, "rb") as f:
+                opened_stat = os.fstat(f.fileno())
                 magic = f.read(4)
                 if magic == b"GGUF":
                     self._scan_gguf(f, file_size, result)
@@ -425,6 +427,31 @@ class GgufScanner(BaseScanner):
                     self._mark_inconclusive(result, GGUF_PARSE_INCONCLUSIVE_REASON)
                     result.finish(success=False)
                     return result
+                # Nested scanners reopen the path, so coverage requires every view to match this source.
+                try:
+                    final_stats: tuple[os.stat_result, ...] = (os.fstat(f.fileno()), os.stat(path))
+                except OSError:
+                    final_stats = ()
+                if not final_stats or any(
+                    not os.path.samestat(opened_stat, final_stat)
+                    or opened_stat.st_mode != final_stat.st_mode
+                    or opened_stat.st_size != final_stat.st_size
+                    or opened_stat.st_mtime_ns != final_stat.st_mtime_ns
+                    or opened_stat.st_ctime_ns != final_stat.st_ctime_ns
+                    for final_stat in final_stats
+                ):
+                    result.add_check(
+                        name="GGUF/GGML Source Stability",
+                        passed=False,
+                        message="File changed during GGUF/GGML analysis; coverage is incomplete",
+                        severity=IssueSeverity.INFO,
+                        location=path,
+                        details={
+                            "analysis_incomplete": True,
+                            "scan_outcome_reason": GGUF_SOURCE_CHANGED_REASON,
+                        },
+                    )
+                    self._mark_inconclusive(result, GGUF_SOURCE_CHANGED_REASON)
         except Exception as e:
             result.add_check(
                 name="GGUF/GGML File Scan",
@@ -771,7 +798,7 @@ class GgufScanner(BaseScanner):
         )
         from .zip_scanner import (
             ZipPreflightRejected,
-            open_preflighted_zip_handle_with_entry_count,
+            _open_preflighted_zip_handle_with_entry_count,
         )
 
         archive_config = dict(self.config)
@@ -783,10 +810,13 @@ class GgufScanner(BaseScanner):
         parsed_entry_count: int | None = None
         preflight_accepted = False
         try:
-            with open_preflighted_zip_handle_with_entry_count(
+            with _open_preflighted_zip_handle_with_entry_count(
                 self.current_file_path,
                 archive_config,
-            ) as (archive_handle, preflight_entry_count):
+                require_zip=False,
+            ) as (archive_handle, is_zip, preflight_entry_count):
+                if not is_zip:
+                    return False
                 preflight_accepted = True
                 with zipfile.ZipFile(archive_handle, "r") as embedded_archive:
                     parsed_entry_count = len(embedded_archive.infolist())

--- a/modelaudit/scanners/gguf_scanner.py
+++ b/modelaudit/scanners/gguf_scanner.py
@@ -765,6 +765,8 @@ class GgufScanner(BaseScanner):
         from ._archive_outcomes import mark_archive_scan_incomplete
         from .archive_dispatch import (
             _ZIP_CONTAINER_PREFLIGHT_REJECTED_PATHS_PRIVATE_METADATA_KEY,
+            _mark_zip_container_dispatched,
+            _mark_zip_container_preflight_rejected,
             merge_executable_zip_container_findings,
         )
         from .zip_scanner import (
@@ -788,9 +790,11 @@ class GgufScanner(BaseScanner):
                 preflight_accepted = True
                 with zipfile.ZipFile(archive_handle, "r") as embedded_archive:
                     parsed_entry_count = len(embedded_archive.infolist())
-        except ZipPreflightRejected:
-            # The composed scan below records the fail-closed preflight diagnostics.
-            pass
+        except ZipPreflightRejected as exc:
+            result.merge(exc.result)
+            _mark_zip_container_dispatched(result, self.current_file_path)
+            _mark_zip_container_preflight_rejected(result, self.current_file_path)
+            return False
         except (OSError, zipfile.BadZipFile):
             if not preflight_accepted:
                 return False

--- a/modelaudit/scanners/gguf_scanner.py
+++ b/modelaudit/scanners/gguf_scanner.py
@@ -795,17 +795,21 @@ class GgufScanner(BaseScanner):
             _mark_zip_container_dispatched(result, self.current_file_path)
             _mark_zip_container_preflight_rejected(result, self.current_file_path)
             return False
-        except (OSError, zipfile.BadZipFile):
+        except (OSError, zipfile.BadZipFile, UnicodeError, NotImplementedError) as exc:
             if not preflight_accepted:
                 return False
             result.add_check(
                 name="ZIP File Format Validation",
                 passed=False,
-                message=f"Not a valid zip file: {self.current_file_path}",
+                message=f"Unable to parse ZIP archive: {self.current_file_path}",
                 severity=IssueSeverity.INFO,
                 rule_code="S902",
                 location=self.current_file_path,
-                details={"path": self.current_file_path},
+                details={
+                    "path": self.current_file_path,
+                    "exception": str(exc),
+                    "exception_type": type(exc).__name__,
+                },
             )
             mark_archive_scan_incomplete(result, "zip_analysis_incomplete")
             return False

--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -2345,13 +2345,13 @@ class ZipScanner(BaseScanner):
 
 
 @contextlib.contextmanager
-def _open_preflighted_zip_handle(
+def _open_preflighted_zip_handle_with_entry_count(
     path: str | os.PathLike[str],
     config: dict[str, Any] | None = None,
     *,
     require_zip: bool = True,
-) -> Iterator[tuple[BinaryIO, bool]]:
-    """Open once, preflight that descriptor, and yield it with its ZIP routing state."""
+) -> Iterator[tuple[BinaryIO, bool, int | None]]:
+    """Open once and yield its descriptor, ZIP routing state, and bounded entry count."""
     scanner = ZipScanner(config=config)
     path_text = os.fspath(path)
     with open(path, "rb") as handle:
@@ -2374,7 +2374,7 @@ def _open_preflighted_zip_handle(
                     _ZIP64_EOCD_SIGNATURE,
                 }:
                     handle.seek(0)
-                    yield handle, False
+                    yield handle, False, None
                     return
             raise ZipPreflightRejected(scanner._preflight_rejection_result(path_text, error=exc)) from exc
         if preflight is None:
@@ -2394,7 +2394,35 @@ def _open_preflighted_zip_handle(
                 _ZIP64_EOCD_SIGNATURE,
             }
         handle.seek(0)
-        yield handle, preflight_is_zip
+        yield handle, preflight_is_zip, preflight[0] if preflight is not None else None
+
+
+@contextlib.contextmanager
+def _open_preflighted_zip_handle(
+    path: str | os.PathLike[str],
+    config: dict[str, Any] | None = None,
+    *,
+    require_zip: bool = True,
+) -> Iterator[tuple[BinaryIO, bool]]:
+    """Open once, preflight that descriptor, and yield it with its ZIP routing state."""
+    with _open_preflighted_zip_handle_with_entry_count(path, config, require_zip=require_zip) as (
+        handle,
+        is_zip,
+        _entry_count,
+    ):
+        yield handle, is_zip
+
+
+@contextlib.contextmanager
+def open_preflighted_zip_handle_with_entry_count(
+    path: str | os.PathLike[str],
+    config: dict[str, Any] | None = None,
+) -> Iterator[tuple[BinaryIO, int]]:
+    """Open once and yield the preflighted descriptor with its bounded entry count."""
+    with _open_preflighted_zip_handle_with_entry_count(path, config) as (handle, _is_zip, entry_count):
+        if entry_count is None:
+            raise zipfile.BadZipFile("File is not a valid ZIP archive")
+        yield handle, entry_count
 
 
 @contextlib.contextmanager

--- a/modelaudit/scanners/zip_scanner.py
+++ b/modelaudit/scanners/zip_scanner.py
@@ -1199,19 +1199,14 @@ class ZipScanner(BaseScanner):
                 candidate_errors.append((eocd_index, True))
                 continue
             except _InvalidZipDirectory as exc:
-                candidate_errors.append(
-                    (
-                        eocd_index,
-                        exc.routing_evidence
-                        or cls._candidate_has_directory_signature(
-                            handle,
-                            file_size=file_size,
-                            tail_size=tail_size,
-                            tail=tail,
-                            eocd_index=eocd_index,
-                        ),
-                    )
+                exc.routing_evidence = exc.routing_evidence or cls._candidate_has_directory_signature(
+                    handle,
+                    file_size=file_size,
+                    tail_size=tail_size,
+                    tail=tail,
+                    eocd_index=eocd_index,
                 )
+                candidate_errors.append((eocd_index, exc.routing_evidence))
                 if last_error is None or (exc.routing_evidence and not last_error.routing_evidence):
                     last_error = exc
                 continue

--- a/modelaudit/utils/helpers/cache_decorator.py
+++ b/modelaudit/utils/helpers/cache_decorator.py
@@ -249,7 +249,7 @@ def _has_embedded_keras_hdf5_weights(file_path: str) -> bool:
                 for info in archive.infolist()
                 if info.filename and not info.is_dir()
             }
-    except (OSError, zipfile.BadZipFile, ZipPreflightRejected):
+    except (OSError, zipfile.BadZipFile, ZipPreflightRejected, UnicodeError, NotImplementedError):
         return False
     return "config.json" in member_names and "model.weights.h5" in member_names
 

--- a/tests/scanners/test_gguf_scanner.py
+++ b/tests/scanners/test_gguf_scanner.py
@@ -17,6 +17,7 @@ from modelaudit.cli import cli
 from modelaudit.config import ModelAuditConfig, reset_config, set_config
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.rules import Severity
+from modelaudit.scanners import zip_scanner as zip_scanner_module
 from modelaudit.scanners.base import DEFAULT_MAX_FILE_READ_SIZE, INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, IssueSeverity
 from modelaudit.scanners.gguf_scanner import (
     _GGUF_REMOTE_URL_POSITION_LIMIT,
@@ -117,10 +118,15 @@ def _write_aligned_gguf(path: Path, alignment: int) -> None:
         handle.write(b"\0" * 32)
 
 
-def _append_gguf_zip(path: Path, entries: dict[str, bytes]) -> None:
+def _append_gguf_zip(
+    path: Path,
+    entries: dict[str, bytes],
+    *,
+    compression: int = zipfile.ZIP_STORED,
+) -> None:
     """Append a valid ZIP archive to an existing GGUF fixture."""
     archive_bytes = io.BytesIO()
-    with zipfile.ZipFile(archive_bytes, "w") as archive:
+    with zipfile.ZipFile(archive_bytes, "w", compression=compression) as archive:
         for name, contents in entries.items():
             archive.writestr(name, contents)
     with path.open("ab") as handle:
@@ -2566,6 +2572,307 @@ def test_ggml_scanner_inspects_embedded_zip_polyglot_members(
     assert determine_exit_code(aggregate) == 1
 
 
+def test_ggml_polyglot_with_appended_empty_eocd_fails_closed(tmp_path: Path) -> None:
+    path = tmp_path / "ambiguous-eocd.ggml"
+    _write_ggml_file(path)
+    pickle_path = create_malicious_pickle(tmp_path / "payload.pkl")
+    _append_gguf_zip(path, {"payload.pkl": pickle_path.read_bytes()})
+
+    archive_bytes = bytearray(path.read_bytes())
+    real_eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+    assert real_eocd_index >= 0
+    fake_empty_eocd = b"PK\x05\x06" + (b"\x00" * 18)
+    archive_bytes.extend(fake_empty_eocd)
+    path.write_bytes(archive_bytes)
+
+    with zipfile.ZipFile(path) as archive:
+        assert archive.namelist() == []
+
+    direct = GgufScanner().scan(str(path))
+    aggregate = scan_model_directory_or_file(str(path), cache_enabled=False)
+
+    assert direct.success is False
+    assert direct.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "zip_analysis_incomplete" in direct.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "ZIP Central Directory Preflight"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("analysis_incomplete") is True
+        for check in direct.checks
+    )
+    assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in direct.issues)
+    assert determine_exit_code(aggregate) == 2
+
+
+def test_ggml_polyglot_with_empty_eocd_in_comment_fails_closed(tmp_path: Path) -> None:
+    path = tmp_path / "comment-eocd.ggml"
+    _write_ggml_file(path)
+    pickle_path = create_malicious_pickle(tmp_path / "payload.pkl")
+    _append_gguf_zip(path, {"payload.pkl": pickle_path.read_bytes()})
+
+    archive_bytes = bytearray(path.read_bytes())
+    real_eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+    assert real_eocd_index >= 0
+    fake_empty_eocd = b"PK\x05\x06" + (b"\x00" * 18)
+    archive_bytes[real_eocd_index + 20 : real_eocd_index + 22] = len(fake_empty_eocd).to_bytes(2, "little")
+    archive_bytes.extend(fake_empty_eocd)
+    path.write_bytes(archive_bytes)
+
+    with zipfile.ZipFile(path) as archive:
+        assert archive.namelist() == []
+
+    direct = GgufScanner().scan(str(path))
+    aggregate = scan_model_directory_or_file(str(path), cache_enabled=False)
+
+    assert direct.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "zip_analysis_incomplete" in direct.metadata["scan_outcome_reasons"]
+    for result in (direct, aggregate):
+        assert result.success is False
+        mismatch_checks = [
+            check
+            for check in result.checks
+            if check.name == "ZIP Central Directory Preflight" and check.status == CheckStatus.FAILED
+        ]
+        assert len(mismatch_checks) == 1
+        assert mismatch_checks[0].details == {
+            "preflight_entries": 1,
+            "parsed_entries": 0,
+            "analysis_incomplete": True,
+            "scan_outcome_reason": "zip_analysis_incomplete",
+        }
+        assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
+    assert determine_exit_code(aggregate) == 2
+
+
+def test_ggml_polyglot_with_post_preflight_bad_zip_fails_closed(tmp_path: Path) -> None:
+    path = tmp_path / "malformed-extra.ggml"
+    _write_ggml_file(path)
+    pickle_path = create_malicious_pickle(tmp_path / "payload.pkl")
+    archive_bytes = io.BytesIO()
+    malformed_info = zipfile.ZipInfo("payload.pkl")
+    malformed_info.extra = b"\x01\x00\x04\x00\x00\x00"
+    with zipfile.ZipFile(archive_bytes, "w") as archive:
+        archive.writestr(malformed_info, pickle_path.read_bytes())
+    with path.open("ab") as handle:
+        handle.write(archive_bytes.getvalue())
+
+    with (
+        pytest.raises(zipfile.BadZipFile, match="Corrupt extra field"),
+        zipfile.ZipFile(path) as archive,
+    ):
+        archive.infolist()
+
+    direct = GgufScanner().scan(str(path))
+    aggregate = scan_model_directory_or_file(str(path), cache_enabled=False)
+
+    assert direct.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "zip_analysis_incomplete" in direct.metadata["scan_outcome_reasons"]
+    for result in (direct, aggregate):
+        assert result.success is False
+        format_checks = [
+            check
+            for check in result.checks
+            if check.name == "ZIP File Format Validation" and check.status == CheckStatus.FAILED
+        ]
+        assert len(format_checks) == 1
+        assert format_checks[0].message == f"Not a valid zip file: {path}"
+        assert not any(issue.rule_code == "S908" for issue in result.issues)
+        assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
+    _assert_inconclusive_exit2(aggregate, "zip_analysis_incomplete")
+    _assert_uncached_rerun_preserves_inconclusive_exit2(
+        path,
+        tmp_path / "bad-zip-cache",
+        "zip_analysis_incomplete",
+    )
+
+
+def test_ggml_polyglot_with_post_preflight_oserror_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "post-preflight-oserror.ggml"
+    _write_ggml_file(path)
+    _append_gguf_zip(path, {"payload.txt": b"payload"})
+
+    parser_calls = 0
+
+    def raise_post_preflight_oserror(_archive: zipfile.ZipFile) -> list[zipfile.ZipInfo]:
+        nonlocal parser_calls
+        parser_calls += 1
+        raise OSError("simulated post-preflight ZIP parser failure")
+
+    monkeypatch.setattr(zipfile.ZipFile, "infolist", raise_post_preflight_oserror)
+
+    direct = GgufScanner().scan(str(path))
+    aggregate = scan_model_directory_or_file(str(path), cache_enabled=False)
+
+    assert parser_calls == 2
+    assert direct.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "zip_analysis_incomplete" in direct.metadata["scan_outcome_reasons"]
+    for result in (direct, aggregate):
+        assert result.success is False
+        format_checks = [
+            check
+            for check in result.checks
+            if check.name == "ZIP File Format Validation" and check.status == CheckStatus.FAILED
+        ]
+        assert len(format_checks) == 1
+        assert format_checks[0].message == f"Not a valid zip file: {path}"
+        assert not any(issue.rule_code == "S908" for issue in result.issues)
+        assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
+    _assert_inconclusive_exit2(aggregate, "zip_analysis_incomplete")
+    _assert_uncached_rerun_preserves_inconclusive_exit2(
+        path,
+        tmp_path / "oserror-cache",
+        "zip_analysis_incomplete",
+    )
+
+
+def test_ggml_with_empty_zip_remains_benign(tmp_path: Path) -> None:
+    path = tmp_path / "empty-archive.ggml"
+    _write_ggml_file(path)
+    _append_gguf_zip(path, {})
+
+    with zipfile.ZipFile(path) as archive:
+        assert archive.infolist() == []
+
+    direct = GgufScanner().scan(str(path))
+    aggregate = scan_model_directory_or_file(str(path), cache_enabled=False)
+
+    for result in (direct, aggregate):
+        assert result.success is True
+        assert not any(check.name == "ZIP File Format Validation" for check in result.checks)
+        assert not any(issue.rule_code == "S908" for issue in result.issues)
+    assert determine_exit_code(aggregate) == 0
+
+
+def test_ggml_polyglot_entry_limit_preflights_before_zipfile_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "entry-limit.ggml"
+    _write_ggml_file(path)
+    _append_gguf_zip(path, {"one.txt": b"one", "two.txt": b"two"})
+
+    def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("entry-count preflight must run before ZipFile construction")
+
+    monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+    result = GgufScanner(config={"max_zip_entries": 1}).scan(str(path))
+
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "zip_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Entry Count Limit Check"
+        and check.status == CheckStatus.FAILED
+        and check.details["entries"] == 2
+        and check.details["max_entries"] == 1
+        and check.details["entry_count_source"] == "central_directory_preflight"
+        for check in result.checks
+    )
+    assert not any(issue.rule_code == "S908" for issue in result.issues)
+
+
+def test_ggml_polyglot_directory_size_preflights_before_zipfile_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "directory-size-limit.ggml"
+    _write_ggml_file(path)
+    _append_gguf_zip(path, {"safe.txt": b"safe"})
+    archive_bytes = path.read_bytes()
+    eocd_index = archive_bytes.rfind(b"PK\x05\x06")
+    assert eocd_index >= 0
+    directory_size = int.from_bytes(archive_bytes[eocd_index + 12 : eocd_index + 16], "little")
+    assert directory_size > 1
+
+    def fail_zipfile_open(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("directory-size preflight must run before ZipFile construction")
+
+    monkeypatch.setattr(zip_scanner_module.zipfile, "ZipFile", fail_zipfile_open)
+
+    result = GgufScanner(config={"max_zip_central_directory_size": directory_size - 1}).scan(str(path))
+
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "zip_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Central Directory Size Limit Check"
+        and check.status == CheckStatus.FAILED
+        and check.details["central_directory_size"] == directory_size
+        and check.details["max_central_directory_size"] == directory_size - 1
+        for check in result.checks
+    )
+    assert not any(issue.rule_code == "S908" for issue in result.issues)
+
+
+def test_ggml_polyglot_preserves_nested_bytes_for_aggregate_budget(tmp_path: Path) -> None:
+    member_size = 8 * 1024
+    paths: list[Path] = []
+    for index in range(2):
+        path = tmp_path / f"compressed-{index}.ggml"
+        _write_ggml_file(path)
+        member = bytes([index]) + (b"A" * (member_size - 1))
+        _append_gguf_zip(
+            path,
+            {f"opaque-{index}.data": member},
+            compression=zipfile.ZIP_DEFLATED,
+        )
+        assert path.stat().st_size < member_size
+        paths.append(path)
+
+    per_file_bytes_scanned: list[int] = []
+    for path in paths:
+        direct = GgufScanner().scan(str(path))
+        assert direct.bytes_scanned >= member_size
+        single_file_aggregate = scan_model_directory_or_file(str(path), cache_enabled=False)
+        assert single_file_aggregate.files_scanned == 1
+        assert single_file_aggregate.bytes_scanned >= member_size
+        per_file_bytes_scanned.append(single_file_aggregate.bytes_scanned)
+
+    max_total_size = max(per_file_bytes_scanned) + 1
+    assert all(bytes_scanned <= max_total_size for bytes_scanned in per_file_bytes_scanned)
+    assert sum(per_file_bytes_scanned) > max_total_size
+    aggregate = scan_model_directory_or_file(
+        str(tmp_path),
+        max_total_size=max_total_size,
+        cache_enabled=False,
+    )
+
+    assert aggregate.files_scanned == len(paths)
+    assert aggregate.bytes_scanned > max_total_size
+    assert any(
+        "Total scan size limit exceeded" in issue.message and issue.details.get("max_total_size") == max_total_size
+        for issue in aggregate.issues
+    )
+
+
+@pytest.mark.parametrize(
+    ("nested_magic", "nested_suffix"),
+    [(b"GGUF", ".gguf"), (b"GGJT", ".ggjt")],
+    ids=["nested-gguf-format", "nested-ggml-magic"],
+)
+def test_ggml_polyglot_preserves_outer_format_and_magic(
+    tmp_path: Path,
+    nested_magic: bytes,
+    nested_suffix: str,
+) -> None:
+    outer_path = tmp_path / "outer.ggmf"
+    nested_path = tmp_path / f"nested{nested_suffix}"
+    _write_ggml_variant_file(outer_path, b"GGMF")
+    if nested_magic == b"GGUF":
+        _write_minimal_gguf(nested_path)
+    else:
+        _write_ggml_variant_file(nested_path, nested_magic)
+    _append_gguf_zip(outer_path, {nested_path.name: nested_path.read_bytes()})
+
+    result = GgufScanner().scan(str(outer_path))
+
+    assert any(issue.rule_code == "S908" for issue in result.issues)
+    assert result.metadata["format"] == "ggml"
+    assert result.metadata["magic"] == "GGMF"
+
+
 def test_ggml_scanner_does_not_misclassify_invalid_zip_near_match(tmp_path: Path) -> None:
     path = tmp_path / "zip-near-match.ggml"
     _write_ggml_file(path)
@@ -2970,7 +3277,7 @@ def test_gguf_scanner_last_tensor_size(tmp_path):
     assert len(size_warnings) == 0
 
 
-@pytest.mark.parametrize("magic", [b"GGML", b"GGMF", b"GGJT", b"GGLA", b"GGSN"])
+@pytest.mark.parametrize("magic", [b"GGML", b"GGMF", b"GGJT", b"GGLA", b"GGSA"])
 def test_ggml_scanner_ignores_stray_end_of_central_directory_bytes(tmp_path: Path, magic: bytes) -> None:
     """A bare EOCD signature in tensor data is not a polyglot.
 

--- a/tests/scanners/test_gguf_scanner.py
+++ b/tests/scanners/test_gguf_scanner.py
@@ -2534,6 +2534,51 @@ def test_ggml_variant_scanner_basic(tmp_path):
     assert result.metadata.get("magic") == "GGMF"
 
 
+@pytest.mark.parametrize(
+    ("magic", "suffix"),
+    [
+        (b"GGML", ".ggml"),
+        (b"GGMF", ".ggmf"),
+        (b"GGJT", ".ggjt"),
+        (b"GGLA", ".ggla"),
+        (b"GGSA", ".ggsa"),
+    ],
+    ids=["ggml", "ggmf", "ggjt", "ggla", "ggsa"],
+)
+def test_ggml_scanner_inspects_embedded_zip_polyglot_members(
+    tmp_path: Path,
+    magic: bytes,
+    suffix: str,
+) -> None:
+    path = tmp_path / f"polyglot{suffix}"
+    _write_ggml_variant_file(path, magic)
+    pickle_path = create_malicious_pickle(tmp_path / "payload.pkl")
+    _append_gguf_zip(path, {"payload.pkl": pickle_path.read_bytes(), "../escaped.txt": b"escape"})
+
+    direct = GgufScanner().scan(str(path))
+    aggregate = scan_model_directory_or_file(str(path), cache_enabled=False)
+
+    for result in (direct, aggregate):
+        assert any(issue.rule_code == "S908" and issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+        assert any(issue.rule_code == "S201" and "system" in issue.message.lower() for issue in result.issues)
+        assert any(issue.rule_code == "S405" and "escaped.txt" in issue.message for issue in result.issues)
+    assert any(check.name == "GGML ZIP Polyglot Detection" for check in direct.checks)
+    assert determine_exit_code(aggregate) == 1
+
+
+def test_ggml_scanner_does_not_misclassify_invalid_zip_near_match(tmp_path: Path) -> None:
+    path = tmp_path / "zip-near-match.ggml"
+    _write_ggml_file(path)
+    with path.open("ab") as handle:
+        handle.write(b"PK\x03\x04not-a-valid-archive")
+
+    result = GgufScanner().scan(str(path))
+
+    assert result.success is True
+    assert not any(issue.rule_code == "S908" for issue in result.issues)
+    assert not any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
+
+
 def test_ggml_scanner_suspicious_version(tmp_path):
     """Test that GGML scanner handles unusual versions gracefully."""
     path = tmp_path / "unusual_version.ggml"

--- a/tests/scanners/test_gguf_scanner.py
+++ b/tests/scanners/test_gguf_scanner.py
@@ -2968,3 +2968,41 @@ def test_gguf_scanner_last_tensor_size(tmp_path):
     # Should not have size mismatch warnings
     size_warnings = [i for i in result.issues if "size mismatch" in i.message.lower()]
     assert len(size_warnings) == 0
+
+
+@pytest.mark.parametrize("magic", [b"GGML", b"GGMF", b"GGJT", b"GGLA", b"GGSN"])
+def test_ggml_scanner_ignores_stray_end_of_central_directory_bytes(tmp_path: Path, magic: bytes) -> None:
+    """A bare EOCD signature in tensor data is not a polyglot.
+
+    ``zipfile.is_zipfile`` returns True for any file whose trailing bytes contain ``PK\\x05\\x06``
+    followed by 18 bytes, which model tensor data hits by chance. Reporting CRITICAL S908 for an
+    archive carrying no members at all is a false positive; a hidden payload always has an entry.
+    The existing near-match regression cannot catch this because it appends ``PK\\x03\\x04``, a
+    local-file-header signature that end-of-central-directory scanning never inspects.
+    """
+    path = tmp_path / "stray-eocd.bin"
+    _write_ggml_variant_file(path, magic)
+    with path.open("ab") as handle:
+        handle.write(b"\x00" * 64 + b"PK\x05\x06" + b"\x00" * 18 + b"\x00" * 32)
+
+    assert zipfile.is_zipfile(str(path))
+
+    result = GgufScanner().scan(str(path))
+
+    assert not any("Polyglot" in check.name for check in result.checks)
+    assert not any(issue.rule_code == "S908" for issue in result.issues)
+
+
+def test_gguf_scanner_ignores_stray_end_of_central_directory_bytes(tmp_path: Path) -> None:
+    """The same false positive existed for GGUF before the member check."""
+    path = tmp_path / "stray-eocd.gguf"
+    _write_minimal_gguf(path)
+    with path.open("ab") as handle:
+        handle.write(b"\x00" * 64 + b"PK\x05\x06" + b"\x00" * 18 + b"\x00" * 32)
+
+    assert zipfile.is_zipfile(str(path))
+
+    result = GgufScanner().scan(str(path))
+
+    assert not any("Polyglot" in check.name for check in result.checks)
+    assert not any(issue.rule_code == "S908" for issue in result.issues)

--- a/tests/scanners/test_gguf_scanner.py
+++ b/tests/scanners/test_gguf_scanner.py
@@ -2621,8 +2621,9 @@ def test_ggml_polyglot_with_empty_eocd_in_comment_fails_closed(tmp_path: Path) -
     with zipfile.ZipFile(path) as archive:
         assert archive.namelist() == []
 
-    direct = GgufScanner().scan(str(path))
-    aggregate = scan_model_directory_or_file(str(path), cache_enabled=False)
+    excluded_config = {"exclude_scanners": ["zip"]}
+    direct = GgufScanner(config=excluded_config).scan(str(path))
+    aggregate = scan_model_directory_or_file(str(path), config=excluded_config, cache_enabled=False)
 
     assert direct.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
     assert "zip_analysis_incomplete" in direct.metadata["scan_outcome_reasons"]
@@ -2642,6 +2643,12 @@ def test_ggml_polyglot_with_empty_eocd_in_comment_fails_closed(tmp_path: Path) -
         }
         assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
     assert determine_exit_code(aggregate) == 2
+    _assert_uncached_rerun_preserves_inconclusive_exit2(
+        path,
+        tmp_path / "excluded-zip-cache",
+        "zip_analysis_incomplete",
+        config=excluded_config,
+    )
 
 
 def test_ggml_polyglot_with_post_preflight_bad_zip_fails_closed(tmp_path: Path) -> None:
@@ -2736,11 +2743,13 @@ def test_ggml_with_empty_zip_remains_benign(tmp_path: Path) -> None:
     with zipfile.ZipFile(path) as archive:
         assert archive.infolist() == []
 
-    direct = GgufScanner().scan(str(path))
-    aggregate = scan_model_directory_or_file(str(path), cache_enabled=False)
+    excluded_config = {"exclude_scanners": ["zip"]}
+    direct = GgufScanner(config=excluded_config).scan(str(path))
+    aggregate = scan_model_directory_or_file(str(path), config=excluded_config, cache_enabled=False)
 
     for result in (direct, aggregate):
         assert result.success is True
+        assert not any(check.name == "ZIP Central Directory Preflight" for check in result.checks)
         assert not any(check.name == "ZIP File Format Validation" for check in result.checks)
         assert not any(issue.rule_code == "S908" for issue in result.issues)
     assert determine_exit_code(aggregate) == 0

--- a/tests/scanners/test_gguf_scanner.py
+++ b/tests/scanners/test_gguf_scanner.py
@@ -2732,13 +2732,67 @@ def test_ggml_polyglot_with_post_preflight_bad_zip_fails_closed(tmp_path: Path) 
             if check.name == "ZIP File Format Validation" and check.status == CheckStatus.FAILED
         ]
         assert len(format_checks) == 1
-        assert format_checks[0].message == f"Not a valid zip file: {path}"
+        assert format_checks[0].message == f"Unable to parse ZIP archive: {path}"
         assert not any(issue.rule_code == "S908" for issue in result.issues)
         assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
     _assert_inconclusive_exit2(aggregate, "zip_analysis_incomplete")
     _assert_uncached_rerun_preserves_inconclusive_exit2(
         path,
         tmp_path / "bad-zip-cache",
+        "zip_analysis_incomplete",
+    )
+
+
+@pytest.mark.parametrize("failure", ["invalid_utf8", "unsupported_version"])
+def test_ggml_polyglot_with_rejected_zip_encoding_or_version_fails_closed(
+    tmp_path: Path,
+    failure: str,
+) -> None:
+    path = tmp_path / f"{failure}.ggml"
+    _write_ggml_file(path)
+    _append_gguf_zip(path, {"safe.txt": b"safe"})
+    archive_bytes = bytearray(path.read_bytes())
+    local_offset = archive_bytes.index(b"PK\x03\x04")
+    directory_offset = archive_bytes.index(b"PK\x01\x02")
+    if failure == "invalid_utf8":
+        archive_bytes[local_offset + 6 : local_offset + 8] = (0x800).to_bytes(2, "little")
+        archive_bytes[directory_offset + 8 : directory_offset + 10] = (0x800).to_bytes(2, "little")
+        archive_bytes[local_offset + 30] = 0xFF
+        archive_bytes[directory_offset + 46] = 0xFF
+        expected_error: type[Exception] = UnicodeDecodeError
+    else:
+        version = (zipfile.MAX_EXTRACT_VERSION + 1).to_bytes(2, "little")
+        archive_bytes[local_offset + 4 : local_offset + 6] = version
+        archive_bytes[directory_offset + 6 : directory_offset + 8] = version
+        expected_error = NotImplementedError
+    path.write_bytes(archive_bytes)
+
+    with zip_scanner_module.open_preflighted_zip_handle_with_entry_count(path) as (archive_handle, entry_count):
+        assert entry_count == 1
+        with pytest.raises(expected_error), zipfile.ZipFile(archive_handle):
+            pass
+
+    direct = GgufScanner().scan(str(path))
+    aggregate = scan_model_directory_or_file(str(path), cache_enabled=False)
+
+    assert direct.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert direct.metadata["scan_outcome_reasons"] == ["zip_analysis_incomplete"]
+    for result in (direct, aggregate):
+        assert result.success is False
+        format_checks = [
+            check
+            for check in result.checks
+            if check.name == "ZIP File Format Validation" and check.status == CheckStatus.FAILED
+        ]
+        assert len(format_checks) == 1
+        assert format_checks[0].message == f"Unable to parse ZIP archive: {path}"
+        assert format_checks[0].details["exception_type"] == expected_error.__name__
+        assert not any(issue.rule_code == "S908" for issue in result.issues)
+        _assert_no_warning_or_critical_issues(result)
+    _assert_inconclusive_exit2(aggregate, "zip_analysis_incomplete")
+    _assert_uncached_rerun_preserves_inconclusive_exit2(
+        path,
+        tmp_path / "rejected-parser-cache",
         "zip_analysis_incomplete",
     )
 
@@ -2774,7 +2828,7 @@ def test_ggml_polyglot_with_post_preflight_oserror_fails_closed(
             if check.name == "ZIP File Format Validation" and check.status == CheckStatus.FAILED
         ]
         assert len(format_checks) == 1
-        assert format_checks[0].message == f"Not a valid zip file: {path}"
+        assert format_checks[0].message == f"Unable to parse ZIP archive: {path}"
         assert not any(issue.rule_code == "S908" for issue in result.issues)
         assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
     _assert_inconclusive_exit2(aggregate, "zip_analysis_incomplete")

--- a/tests/scanners/test_gguf_scanner.py
+++ b/tests/scanners/test_gguf_scanner.py
@@ -2651,6 +2651,56 @@ def test_ggml_polyglot_with_empty_eocd_in_comment_fails_closed(tmp_path: Path) -
     )
 
 
+@pytest.mark.parametrize("format_name", ["ggml", "gguf"])
+@pytest.mark.parametrize("exclude_zip", [False, True])
+@pytest.mark.parametrize("strict_zip_probe", [False, True])
+def test_malformed_zip_near_match_preserves_preflight_rejection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    format_name: str,
+    exclude_zip: bool,
+    strict_zip_probe: bool,
+) -> None:
+    path = tmp_path / f"malformed-eocd.{format_name}"
+    if format_name == "gguf":
+        _write_gguf_with_tensor_type(path, 0)
+    else:
+        _write_ggml_file(path)
+    eocd = struct.pack("<4s4H2IH", b"PK\x05\x06", 0, 0, 1, 1, 0, 0, 0)
+    with path.open("r+b") as handle:
+        handle.seek(-len(eocd), 2)
+        handle.write(eocd)
+
+    if strict_zip_probe:
+        # Newer ZIP probes reject this missing central directory before dispatch.
+        monkeypatch.setattr(zipfile, "is_zipfile", lambda _path: False)
+    config = {"exclude_scanners": ["zip"] if exclude_zip else []}
+    direct = GgufScanner(config=config).scan(str(path))
+    aggregate = scan_model_directory_or_file(str(path), config=config, cache_enabled=False)
+
+    assert direct.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert "zip_analysis_incomplete" in direct.metadata["scan_outcome_reasons"]
+    for result in (direct, aggregate):
+        assert result.success is False
+        preflight_checks = [
+            check
+            for check in result.checks
+            if check.name == "ZIP Central Directory Preflight" and check.status == CheckStatus.FAILED
+        ]
+        assert len(preflight_checks) == 1
+        assert "ZIP central-directory validation failed" in preflight_checks[0].message
+        assert preflight_checks[0].details["analysis_incomplete"] is True
+        assert not any(issue.rule_code == "S908" for issue in result.issues)
+        _assert_no_warning_or_critical_issues(result)
+    _assert_inconclusive_exit2(aggregate, "zip_analysis_incomplete")
+    _assert_uncached_rerun_preserves_inconclusive_exit2(
+        path,
+        tmp_path / "malformed-zip-cache",
+        "zip_analysis_incomplete",
+        config=config,
+    )
+
+
 def test_ggml_polyglot_with_post_preflight_bad_zip_fails_closed(tmp_path: Path) -> None:
     path = tmp_path / "malformed-extra.ggml"
     _write_ggml_file(path)

--- a/tests/scanners/test_gguf_scanner.py
+++ b/tests/scanners/test_gguf_scanner.py
@@ -2,6 +2,7 @@
 
 import io
 import json
+import os
 import struct
 import sys
 import time
@@ -24,6 +25,7 @@ from modelaudit.scanners.gguf_scanner import (
     GGUF_DUPLICATE_METADATA_INCONCLUSIVE_REASON,
     GGUF_METADATA_LIMIT_INCONCLUSIVE_REASON,
     GGUF_PARSE_INCONCLUSIVE_REASON,
+    GGUF_SOURCE_CHANGED_REASON,
     GGUF_STRUCTURE_INCONCLUSIVE_REASON,
     GGUF_TENSOR_LIMIT_INCONCLUSIVE_REASON,
     GgufScanner,
@@ -2698,6 +2700,137 @@ def test_malformed_zip_near_match_preserves_preflight_rejection(
         tmp_path / "malformed-zip-cache",
         "zip_analysis_incomplete",
         config=config,
+    )
+
+
+@pytest.mark.parametrize("format_name", ["ggml", "gguf"])
+@pytest.mark.parametrize("strict_zip_probe", [False, True])
+def test_gguf_ggml_ignores_weak_eocd_noise(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    format_name: str,
+    strict_zip_probe: bool,
+) -> None:
+    path = tmp_path / f"eocd-noise.{format_name}"
+    if format_name == "gguf":
+        _write_gguf_with_tensor_type(path, 0)
+    else:
+        _write_ggml_file(path)
+    eocd = struct.pack("<4s4H2IH", b"PK\x05\x06", 1, 0, 0, 0, 0, 0, 0)
+    with path.open("r+b") as handle:
+        handle.seek(-len(eocd), 2)
+        handle.write(eocd)
+    if strict_zip_probe:
+        monkeypatch.setattr(zipfile, "is_zipfile", lambda _path: False)
+
+    direct = GgufScanner().scan(str(path))
+    aggregate = scan_model_directory_or_file(str(path), cache_enabled=False)
+
+    for result in (direct, aggregate):
+        assert result.success is True
+        assert not any(check.name == "ZIP Central Directory Preflight" for check in result.checks)
+        _assert_no_warning_or_critical_issues(result)
+    assert determine_exit_code(aggregate) == 0
+
+
+@pytest.mark.parametrize("format_name", ["ggml", "gguf"])
+def test_gguf_ggml_preserves_strong_directory_routing_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    format_name: str,
+) -> None:
+    path = tmp_path / f"unsupported-directory.{format_name}"
+    if format_name == "gguf":
+        _write_tensor_covered_gguf_zip(path, {"safe.txt": b"safe"})
+    else:
+        _write_ggml_file(path)
+        _append_gguf_zip(path, {"safe.txt": b"safe"})
+    archive_bytes = bytearray(path.read_bytes())
+    eocd_offset = archive_bytes.rfind(b"PK\x05\x06")
+    archive_bytes[eocd_offset + 4 : eocd_offset + 6] = (1).to_bytes(2, "little")
+    path.write_bytes(archive_bytes)
+    monkeypatch.setattr(zipfile, "is_zipfile", lambda _path: False)
+
+    direct = GgufScanner().scan(str(path))
+    aggregate = scan_model_directory_or_file(str(path), cache_enabled=False)
+
+    for result in (direct, aggregate):
+        assert result.success is False
+        checks = [check for check in result.checks if check.name == "ZIP Central Directory Preflight"]
+        assert len(checks) == 1
+        assert checks[0].status == CheckStatus.FAILED
+        assert "multi-disk ZIP archives are unsupported" in checks[0].message
+        _assert_no_warning_or_critical_issues(result)
+    assert direct.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    _assert_inconclusive_exit2(aggregate, "zip_analysis_incomplete")
+
+
+@pytest.mark.parametrize("format_name", ["ggml", "gguf"])
+@pytest.mark.parametrize("stat_source", ["descriptor", "path"])
+@pytest.mark.parametrize("change", ["identity", "metadata"])
+def test_gguf_ggml_source_stability_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    format_name: str,
+    stat_source: str,
+    change: str,
+) -> None:
+    path = tmp_path / f"source-stability.{format_name}"
+    if format_name == "gguf":
+        _write_tensor_covered_gguf_zip(path, {})
+    else:
+        _write_ggml_file(path)
+        _append_gguf_zip(path, {})
+    source_stat = path.stat()
+    changed_values = list(source_stat)
+    if change == "identity":
+        changed_values[1] += 1
+    changed_stat = os.stat_result(
+        changed_values,
+        {
+            "st_atime_ns": source_stat.st_atime_ns,
+            "st_mtime_ns": source_stat.st_mtime_ns + (1 if change == "metadata" else 0),
+            "st_ctime_ns": source_stat.st_ctime_ns,
+        },
+    )
+    original_fstat = os.fstat
+    original_stat = os.stat
+    opened = False
+
+    def simulated_fstat(fd: int) -> os.stat_result:
+        nonlocal opened
+        observed = original_fstat(fd)
+        if os.path.samestat(source_stat, observed):
+            if opened and stat_source == "descriptor":
+                return changed_stat
+            opened = True
+        return observed
+
+    def simulated_stat(*args: Any, **kwargs: Any) -> os.stat_result:
+        observed = original_stat(*args, **kwargs)
+        if opened and stat_source == "path" and os.path.samestat(source_stat, observed):
+            return changed_stat
+        return observed
+
+    monkeypatch.setattr(os, "fstat", simulated_fstat)
+    monkeypatch.setattr(os, "stat", simulated_stat)
+    direct = GgufScanner().scan(str(path))
+    aggregate = scan_model_directory_or_file(str(path), cache_enabled=False)
+
+    for result in (direct, aggregate):
+        assert result.success is False
+        checks = [check for check in result.checks if check.name == "GGUF/GGML Source Stability"]
+        assert len(checks) == 1
+        assert checks[0].status == CheckStatus.FAILED
+        assert "coverage is incomplete" in checks[0].message
+        assert checks[0].details["analysis_incomplete"] is True
+        _assert_no_warning_or_critical_issues(result)
+    assert direct.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    _assert_inconclusive_exit2(aggregate, GGUF_SOURCE_CHANGED_REASON)
+    _assert_uncached_rerun_preserves_inconclusive_exit2(
+        path,
+        tmp_path / "source-stability-cache",
+        GGUF_SOURCE_CHANGED_REASON,
     )
 
 


### PR DESCRIPTION
## Summary

Inspect embedded ZIP content in legacy GGML variants through the bounded ZIP scanner. Preserve nested findings, expanded-byte limits, outer model metadata, and scanner-selection policy.

Keep malformed ZIP data and source changes inconclusive across direct, aggregate, and cached scans. Ignore incidental ZIP footer bytes without archive evidence.

Integrate current main and simplify the shared ZIP preflight helper to return the entry count directly. Remove unused wrappers, redundant state, and repeated regression-test setup while retaining every test case.

## Validation

- 2,239 GGUF, ZIP, Keras, weight-distribution, and cache tests passed on Python 3.10; 36 relevant cases passed on Python 3.11.
- Ruff format/lint, Linux-platform mypy across 479 files, and Prettier passed.
- The broad Python 3.10 fast run stopped after 12,887 passed and 325 skipped at the existing SafeTensors shard-location assertion (`tests/scanners/test_safetensors_scanner.py:2850`).
- Five native macOS mypy extended-attribute stub errors and the SafeTensors shard-location assertion reproduce on main `32023611` using the same sibling package.
