### PR TITLE
fix(cache): preserve locked probes under directory aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - Prevent Windows cache identity probes from creating locked temporary files inside scanned directories.
+- Preserve locked Windows cache probes reached through directory aliases while clearing stale scan results.
 
 ## [0.2.52](https://github.com/promptfoo/modelaudit/compare/v0.2.51...v0.2.52) (2026-07-22)
 

--- a/modelaudit/cache/scan_results_cache.py
+++ b/modelaudit/cache/scan_results_cache.py
@@ -2270,12 +2270,13 @@ class ScanResultsCache:
                         if isinstance(probe_name, str):
                             probe_path = Path(os.path.abspath(probe_name))
                             cache_path = Path(os.path.abspath(self.cache_dir))
+                            normalized_cache_path = cache_path.resolve(strict=False)
                             if (
-                                probe_directory == self.cache_dir
-                                and probe_path.parent == cache_path
+                                probe_directory.resolve(strict=False) == normalized_cache_path
+                                and probe_path.parent.resolve(strict=False) == normalized_cache_path
                                 and probe_path.name.startswith(".modelaudit-cache-clock-")
                             ):
-                                retained_probe_paths.add(probe_path)
+                                retained_probe_paths.add(cache_path / probe_path.name)
                         continue
 
                     self._change_clock_probes.pop(file_device, None)

--- a/tests/cache/test_cache_correctness.py
+++ b/tests/cache/test_cache_correctness.py
@@ -1195,6 +1195,57 @@ def test_clear_cache_closes_remaining_probes_after_close_failure(
     assert metadata["statistics"]["total_entries"] == 0
 
 
+def test_clear_cache_retains_locked_probe_in_aliased_cache_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = ScanResultsCache(str(tmp_path / "cache"))
+    cache_alias = tmp_path / "cache-alias"
+    try:
+        cache_alias.symlink_to(cache.cache_dir, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory aliases unavailable: {exc}")
+
+    stale_result = cache.cache_dir / "stale-clean-result.json"
+    stale_result.write_text('{"verdict":"CLEAN"}', encoding="utf-8")
+    probe_path = cache.cache_dir / ".modelaudit-cache-clock-aliased"
+    probe_path.write_bytes(b"locked probe")
+    original_unlink = Path.unlink
+
+    class LockedProbe:
+        def __init__(self) -> None:
+            self.name = str(cache_alias / probe_path.name)
+            self.closed = False
+            self.fail_close = True
+
+        def close(self) -> None:
+            if self.fail_close:
+                raise OSError("simulated Windows probe close failure")
+            self.closed = True
+
+    probe = LockedProbe()
+    cache._change_clock_probes[probe_path.stat().st_dev] = (cast(BinaryIO, probe), cache_alias)
+
+    def reject_locked_probe(path: Path, *, missing_ok: bool = False) -> None:
+        if path.resolve(strict=False) == probe_path and not probe.closed:
+            raise PermissionError("Windows cannot unlink an open aliased cache clock probe")
+        original_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", reject_locked_probe)
+
+    cache.clear_cache()
+
+    assert (probe.closed, probe_path.exists()) == (False, True)
+    assert not stale_result.exists()
+    assert cache.metadata_file.exists()
+
+    probe.fail_close = False
+    cache.clear_cache()
+
+    assert (probe.closed, probe_path.exists()) == (True, False)
+    assert cache._change_clock_probes == {}
+
+
 def test_clear_cache_retries_real_temporary_file_wrapper(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Normalize cache-directory aliases before retaining a locked Windows identity probe during cache clearing.
- Keep stale results removable after a probe-close failure, then remove the retained probe when a later close succeeds.
- Add a deterministic failing-before regression and document the user-visible cache fix.

## Validation
- Complete cache suite: 222 passed, 6 skipped.
- Release-workflow regressions: 132 passed.
- Failing-before aliased-probe regression plus existing close-failure/retry regressions: passed.
- Repository-wide Ruff lint and format checks: passed.
- Changed-file mypy and strict modified-test mypy: passed.
- Changelog Prettier and git diff whitespace checks: passed.

Full repository mypy on macOS still reports pre-existing platform/baseline findings; the exact-main GitHub Type Check is green.