### PR TITLE
fix(picklescan): diagnose Windows call-graph source-stability failures

### DIFF
--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -7,6 +7,10 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- Report which snapshot gate invalidated a shared call-graph source-stability failure.
+
 ## [0.1.10](https://github.com/promptfoo/modelaudit/compare/modelaudit-picklescan-v0.1.9...modelaudit-picklescan-v0.1.10) (2026-07-22)
 
 ### Bug Fixes

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -4460,6 +4460,15 @@ def _abstract_value_is_inert(value: object) -> bool:
     return False
 
 
+def _call_graph_enrichment_error_details(analysis: str, error: Exception) -> dict[str, Any]:
+    """Build error details, surfacing which snapshot gate failed when one is known."""
+    details: dict[str, Any] = {"analysis": analysis, "analysis_incomplete": True}
+    stability_reason = getattr(error, "stability_reason", None)
+    if isinstance(stability_reason, str) and stability_reason:
+        details["source_stability_reason"] = stability_reason
+    return details
+
+
 def _with_call_graph_enrichment_errors(
     report: PickleReport,
     enrichment_errors: tuple[tuple[str, Exception], ...],
@@ -4472,7 +4481,7 @@ def _with_call_graph_enrichment_errors(
                 category="call_graph_analysis_error",
                 location=report.source,
                 exception_type=type(error).__name__,
-                details={"analysis": analysis, "analysis_incomplete": True},
+                details=_call_graph_enrichment_error_details(analysis, error),
             )
             for analysis, error in enrichment_errors
         ),

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1651,11 +1651,14 @@ class _CallGraphAnalysisLimitError(RuntimeError):
         partial_findings: tuple[CallGraphFinding, ...] = (),
         partial_startup_hook_write_findings: tuple[StartupHookWriteFinding, ...] = (),
         partial_path: tuple[str, ...] | None = None,
+        stability_reason: str | None = None,
     ) -> None:
         super().__init__(message)
         self.partial_findings = partial_findings
         self.partial_startup_hook_write_findings = partial_startup_hook_write_findings
         self.partial_path = partial_path
+        # Which snapshot gate invalidated the run, reported without changing the message text.
+        self.stability_reason = stability_reason
 
 
 class _SourceReadTooLargeError(OSError):
@@ -4750,14 +4753,25 @@ def _snapshot_resolution_context_is_current(snapshot: _SharedSourceSnapshot) -> 
 
 
 def _shared_source_snapshot_is_current(snapshot: _SharedSourceSnapshot) -> bool:
-    if (
-        not snapshot.stable
-        or not snapshot.import_runtime_trusted
-        or not _interpreter_import_runtime_matches_snapshot()
-        or snapshot.search_context != _source_search_context()
-        or not _snapshot_resolution_context_is_current(snapshot)
-    ):
-        return False
+    return _shared_source_snapshot_staleness_reason(snapshot) is None
+
+
+def _shared_source_snapshot_staleness_reason(snapshot: _SharedSourceSnapshot) -> str | None:
+    """Return which gate invalidated the shared snapshot, or ``None`` when it is still current.
+
+    The gate name is attached to the resulting stability error so a recurring platform failure
+    reports its own cause instead of a bare "source changed" message.
+    """
+    if not snapshot.stable:
+        return "snapshot_marked_unstable"
+    if not snapshot.import_runtime_trusted:
+        return "import_runtime_untrusted"
+    if not _interpreter_import_runtime_matches_snapshot():
+        return "interpreter_import_runtime_changed"
+    if snapshot.search_context != _source_search_context():
+        return "source_search_context_changed"
+    if not _snapshot_resolution_context_is_current(snapshot):
+        return "resolution_context_changed"
     for path, (read_limit, require_complete, expected_read_fingerprint) in snapshot.read_fingerprints.items():
         reusable, read_fingerprint = _read_candidate_fingerprint(
             Path(path),
@@ -4765,30 +4779,30 @@ def _shared_source_snapshot_is_current(snapshot: _SharedSourceSnapshot) -> bool:
             require_complete=require_complete,
         )
         if not reusable or read_fingerprint != expected_read_fingerprint:
-            return False
+            return "read_fingerprint_changed"
     for path, expected_resolution_fingerprint in snapshot.resolution_fingerprints.items():
         reusable, resolution_fingerprint = _resolution_candidate_fingerprint(Path(path))
         if not reusable or resolution_fingerprint != expected_resolution_fingerprint:
-            return False
+            return "resolution_fingerprint_changed"
     for module_name, expected_source in snapshot.module_sources.items():
         if _current_module_source_path(module_name) != expected_source:
-            return False
+            return "module_source_path_changed"
     for module_name, expected_source in snapshot.loaded_module_sources.items():
         if _loaded_module_source_path(module_name) != expected_source:
-            return False
+            return "loaded_module_source_path_changed"
     for module_name, expected_search_path in snapshot.loaded_package_paths.items():
         is_loaded, current_search_path = _loaded_package_search_path(module_name)
         if not is_loaded or current_search_path is None or tuple(current_search_path) != expected_search_path:
-            return False
+            return "loaded_package_search_path_changed"
         expected_resolution_context = snapshot.loaded_package_resolution_contexts.get(module_name)
         if expected_resolution_context is None:
-            return False
+            return "loaded_package_resolution_context_missing"
         current_resolution_context = _current_trusted_path_importer_context(
             current_search_path,
             expected_resolution_context,
         )
         if current_resolution_context is None:
-            return False
+            return "loaded_package_resolution_context_changed"
         snapshot.loaded_package_resolution_contexts[module_name] = current_resolution_context
     for module_name, (
         expected_search_path,
@@ -4796,26 +4810,26 @@ def _shared_source_snapshot_is_current(snapshot: _SharedSourceSnapshot) -> bool:
     ) in snapshot.namespace_package_resolution_contexts.items():
         is_loaded, _loaded_search_path = _loaded_package_search_path(module_name)
         if is_loaded:
-            return False
+            return "namespace_package_became_loaded"
         current_resolution_context = _current_trusted_path_importer_context(
             expected_search_path,
             expected_resolution_context,
         )
         if current_resolution_context is None:
-            return False
+            return "namespace_package_resolution_context_changed"
         snapshot.namespace_package_resolution_contexts[module_name] = (
             expected_search_path,
             current_resolution_context,
         )
     for module_name, expected_module_state in snapshot.loaded_interpreter_modules.items():
         if not _loaded_interpreter_module_state_matches(module_name, expected_module_state):
-            return False
+            return "loaded_interpreter_module_changed"
     if snapshot.loaded_interpreter_modules and not _interpreter_import_runtime_is_trusted():
-        return False
+        return "interpreter_import_runtime_untrusted"
     for reference, expected_reference_state in snapshot.loaded_interpreter_references.items():
         if not _loaded_interpreter_reference_state_matches(reference, expected_reference_state):
-            return False
-    return True
+            return "loaded_interpreter_reference_changed"
+    return None
 
 
 def _begin_shared_source_report() -> int | None:
@@ -4837,12 +4851,19 @@ def _ensure_shared_source_snapshot_stable(report_generation: int | None) -> None
         return
     with snapshot.lock:
         if snapshot.generation != report_generation:
-            raise _CallGraphAnalysisLimitError("source changed during shared call-graph analysis")
-        if _shared_source_snapshot_is_current(snapshot):
+            raise _CallGraphAnalysisLimitError(
+                "source changed during shared call-graph analysis",
+                stability_reason="report_generation_advanced",
+            )
+        reason = _shared_source_snapshot_staleness_reason(snapshot)
+        if reason is None:
             return
         _clear_source_sensitive_caches_now()
         _reset_shared_source_snapshot(snapshot)
-    raise _CallGraphAnalysisLimitError("source changed during shared call-graph analysis")
+    raise _CallGraphAnalysisLimitError(
+        "source changed during shared call-graph analysis",
+        stability_reason=reason,
+    )
 
 
 def shared_source_fingerprint_metadata() -> dict[str, Any] | None:

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/call_graph.py
@@ -1684,7 +1684,10 @@ class _SharedSourceSnapshot:
     loaded_interpreter_references: dict[tuple[str, str], _LoadedInterpreterReferenceState] = field(default_factory=dict)
     read_fingerprints: dict[str, tuple[int, bool, bytes | None]] = field(default_factory=dict)
     generation: int = 0
+    active_report_generation: int | None = None
+    active_report_stability_reason: str | None = None
     stable: bool = True
+    stability_reason: str | None = None
     reusable: bool = True
     lock: Any = field(default_factory=threading.RLock)
 
@@ -2434,7 +2437,10 @@ def _track_loaded_interpreter_module_state(
     with snapshot.lock:
         existing = snapshot.loaded_interpreter_modules.get(module_name)
         if existing is not None and not _loaded_interpreter_states_match(existing, state):
-            snapshot.stable = False
+            _mark_shared_source_snapshot_unstable(
+                snapshot,
+                "loaded_interpreter_module_changed",
+            )
         snapshot.loaded_interpreter_modules[module_name] = state
         snapshot.reusable = False
 
@@ -2492,7 +2498,10 @@ def _track_loaded_interpreter_reference_state(
     with snapshot.lock:
         existing = snapshot.loaded_interpreter_references.get(reference)
         if existing is not None and not _loaded_interpreter_reference_states_match(existing, state):
-            snapshot.stable = False
+            _mark_shared_source_snapshot_unstable(
+                snapshot,
+                "loaded_interpreter_reference_changed",
+            )
         snapshot.loaded_interpreter_references[reference] = state
         snapshot.reusable = False
 
@@ -3114,6 +3123,17 @@ def _mark_shared_source_snapshot_unreusable() -> None:
             snapshot.reusable = False
 
 
+def _mark_shared_source_snapshot_unstable(snapshot: _SharedSourceSnapshot, reason: str) -> None:
+    """Record the first specific reason that invalidated the current report."""
+    with snapshot.lock:
+        if snapshot.stability_reason is None:
+            snapshot.stability_reason = reason
+        if snapshot.active_report_generation is not None and snapshot.active_report_stability_reason is None:
+            snapshot.active_report_stability_reason = reason
+        snapshot.stable = False
+        snapshot.reusable = False
+
+
 def _bounded_module_name_parts(module_name: str) -> tuple[str, ...] | None:
     if len(module_name) > _MAX_MODULE_NAME_CHARS:
         _mark_shared_source_snapshot_unreusable()
@@ -3534,8 +3554,10 @@ def _clear_source_sensitive_caches() -> None:
         if snapshot is None:
             return
         with snapshot.lock:
-            if _shared_source_snapshot_is_current(snapshot):
+            reason = _shared_source_snapshot_staleness_reason(snapshot)
+            if reason is None:
                 return
+            _mark_shared_source_snapshot_unstable(snapshot, reason)
             _clear_source_sensitive_caches_now()
             _reset_shared_source_snapshot(snapshot)
         return
@@ -4694,6 +4716,7 @@ def _reset_shared_source_snapshot(snapshot: _SharedSourceSnapshot) -> None:
     snapshot.loaded_interpreter_modules.clear()
     snapshot.loaded_interpreter_references.clear()
     snapshot.generation += 1
+    snapshot.stability_reason = None
     snapshot.stable = True
     snapshot.reusable = snapshot.import_runtime_trusted and _resolution_context_is_reusable(snapshot.resolution_context)
 
@@ -4763,7 +4786,7 @@ def _shared_source_snapshot_staleness_reason(snapshot: _SharedSourceSnapshot) ->
     reports its own cause instead of a bare "source changed" message.
     """
     if not snapshot.stable:
-        return "snapshot_marked_unstable"
+        return snapshot.stability_reason or "snapshot_marked_unstable"
     if not snapshot.import_runtime_trusted:
         return "import_runtime_untrusted"
     if not _interpreter_import_runtime_matches_snapshot():
@@ -4841,6 +4864,8 @@ def _begin_shared_source_report() -> int | None:
         if snapshot.report_started and (not snapshot.reusable or not _shared_source_snapshot_is_current(snapshot)):
             _clear_source_sensitive_caches_now()
             _reset_shared_source_snapshot(snapshot)
+        snapshot.active_report_generation = snapshot.generation
+        snapshot.active_report_stability_reason = snapshot.stability_reason if not snapshot.stable else None
         snapshot.report_started = True
         return snapshot.generation
 
@@ -4851,13 +4876,20 @@ def _ensure_shared_source_snapshot_stable(report_generation: int | None) -> None
         return
     with snapshot.lock:
         if snapshot.generation != report_generation:
+            reason = (
+                snapshot.active_report_stability_reason
+                if snapshot.active_report_generation == report_generation
+                else None
+            )
             raise _CallGraphAnalysisLimitError(
                 "source changed during shared call-graph analysis",
-                stability_reason="report_generation_advanced",
+                stability_reason=reason or "report_generation_advanced",
             )
         reason = _shared_source_snapshot_staleness_reason(snapshot)
         if reason is None:
             return
+        _mark_shared_source_snapshot_unstable(snapshot, reason)
+        reason = snapshot.active_report_stability_reason or reason
         _clear_source_sensitive_caches_now()
         _reset_shared_source_snapshot(snapshot)
     raise _CallGraphAnalysisLimitError(
@@ -4961,9 +4993,11 @@ def _track_resolution_candidate_paths(candidates: Iterable[Path]) -> bool:
         return True
     candidate_paths = {str(candidate): candidate for candidate in candidates}
     with snapshot.lock:
-        if snapshot.search_context != _source_search_context() or not _snapshot_resolution_context_is_current(snapshot):
-            snapshot.stable = False
-            snapshot.reusable = False
+        if snapshot.search_context != _source_search_context():
+            _mark_shared_source_snapshot_unstable(snapshot, "source_search_context_changed")
+            return False
+        if not _snapshot_resolution_context_is_current(snapshot):
+            _mark_shared_source_snapshot_unstable(snapshot, "resolution_context_changed")
             return False
         if len(snapshot.resolution_fingerprints.keys() | candidate_paths.keys()) > _MAX_SOURCE_FINGERPRINT_CANDIDATES:
             snapshot.reusable = False
@@ -4983,9 +5017,10 @@ def _track_resolution_source_candidates(parts: tuple[str, ...]) -> None:
         return
     module_name_length = sum(len(part) for part in parts) + len(parts) - 1
     if module_name_length > _MAX_SOURCE_MODULE_NAME_CHARS:
-        with snapshot.lock:
-            snapshot.stable = False
-            snapshot.reusable = False
+        _mark_shared_source_snapshot_unstable(
+            snapshot,
+            "source_module_name_limit_exceeded",
+        )
         return
 
     runtime_search_path = _runtime_search_path_without_hooks()
@@ -5008,8 +5043,10 @@ def _track_resolution_source_candidates(parts: tuple[str, ...]) -> None:
                     expected_search_path = tuple(loaded_search_path)
                     existing_search_path = snapshot.loaded_package_paths.get(qualified_name)
                     if existing_search_path is not None and existing_search_path != expected_search_path:
-                        snapshot.stable = False
-                        snapshot.reusable = False
+                        _mark_shared_source_snapshot_unstable(
+                            snapshot,
+                            "loaded_package_search_path_changed",
+                        )
                         return
                     existing_resolution_context = snapshot.loaded_package_resolution_contexts.get(qualified_name)
                     if (
@@ -5020,8 +5057,10 @@ def _track_resolution_source_candidates(parts: tuple[str, ...]) -> None:
                             loaded_resolution_context,
                         )
                     ):
-                        snapshot.stable = False
-                        snapshot.reusable = False
+                        _mark_shared_source_snapshot_unstable(
+                            snapshot,
+                            "loaded_package_resolution_context_changed",
+                        )
                         return
                     snapshot.loaded_package_paths[qualified_name] = expected_search_path
                     snapshot.loaded_package_resolution_contexts[qualified_name] = loaded_resolution_context
@@ -5073,8 +5112,15 @@ def _track_resolution_source_candidates(parts: tuple[str, ...]) -> None:
                             namespace_resolution_context,
                         )
                     ):
-                        snapshot.stable = False
-                        snapshot.reusable = False
+                        reason = (
+                            "namespace_package_search_path_changed"
+                            if existing_search_path != namespace_search_path
+                            else "namespace_package_resolution_context_changed"
+                        )
+                        _mark_shared_source_snapshot_unstable(
+                            snapshot,
+                            reason,
+                        )
                         return
                 snapshot.namespace_package_resolution_contexts[qualified_name] = namespace_context
 
@@ -5094,11 +5140,11 @@ def _track_resolution_source_candidates(parts: tuple[str, ...]) -> None:
                     resolution_candidates.add(cache_candidate)
 
         with snapshot.lock:
-            if snapshot.search_context != _source_search_context() or not _snapshot_resolution_context_is_current(
-                snapshot
-            ):
-                snapshot.stable = False
-                snapshot.reusable = False
+            if snapshot.search_context != _source_search_context():
+                _mark_shared_source_snapshot_unstable(snapshot, "source_search_context_changed")
+                return
+            if not _snapshot_resolution_context_is_current(snapshot):
+                _mark_shared_source_snapshot_unstable(snapshot, "resolution_context_changed")
                 return
             if (
                 len(snapshot.resolution_fingerprints | {str(candidate): None for candidate in resolution_candidates})
@@ -5171,22 +5217,18 @@ def _track_shared_source_path(module_name: str, path: Path, *, loaded: bool) -> 
     candidate = path.absolute()
     with snapshot.lock:
         if snapshot.search_context != _source_search_context():
-            snapshot.stable = False
-            snapshot.reusable = False
+            _mark_shared_source_snapshot_unstable(snapshot, "source_search_context_changed")
             return
         if not _snapshot_resolution_context_is_current(snapshot):
-            snapshot.stable = False
-            snapshot.reusable = False
+            _mark_shared_source_snapshot_unstable(snapshot, "resolution_context_changed")
             return
         reusable, fingerprint = _resolution_candidate_fingerprint(candidate)
         if not reusable:
-            snapshot.stable = False
-            snapshot.reusable = False
+            _mark_shared_source_snapshot_unstable(snapshot, "resolution_fingerprint_changed")
             return
         existing_source = snapshot.module_sources.get(module_name)
         if existing_source is not None and existing_source != str(candidate):
-            snapshot.stable = False
-            snapshot.reusable = False
+            _mark_shared_source_snapshot_unstable(snapshot, "module_source_path_changed")
             return
         snapshot.module_sources[module_name] = str(candidate)
         if loaded:

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -44,6 +44,7 @@ from typing import Any, Literal, cast
 import pytest
 
 import modelaudit_picklescan.api as package_api
+import modelaudit_picklescan.call_graph as call_graph
 from modelaudit_picklescan import (
     CoverageSummary,
     Finding,
@@ -12149,6 +12150,39 @@ def _assert_call_graph_source_stability_error(report: PickleReport) -> None:
         and error.details.get("analysis_incomplete") is True
         for error in report.errors
     )
+
+
+def test_scan_bytes_preserves_tracker_stability_reason_across_call_graph_subpasses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    search_contexts = [("original",)]
+    monkeypatch.setattr(call_graph, "_interpreter_import_runtime_matches_snapshot", lambda: True)
+    monkeypatch.setattr(call_graph, "_source_search_context", lambda: search_contexts[0])
+
+    source_path = tmp_path / "tracked_module.py"
+    source_path.write_text("value = 1\n", encoding="utf-8")
+
+    def invalidate_snapshot(
+        _import_references: object,
+        _callable_invocations: object | None = None,
+    ) -> tuple[CallGraphFinding, ...]:
+        search_contexts[0] = ("changed",)
+        call_graph._track_shared_source_path("tracked_module", source_path, loaded=False)
+        return ()
+
+    monkeypatch.setattr(package_api, "find_dangerous_call_graphs", invalidate_snapshot)
+
+    report = scan_bytes(b"cbuiltins\nlen\n.", source="source-stability-subpasses.pkl")
+
+    assert report.status == ScanStatus.INCONCLUSIVE
+    assert report.verdict == SafetyVerdict.UNKNOWN
+    matching_errors = [
+        error for error in report.errors if error.details.get("analysis") == "python_call_graph_source_stability"
+    ]
+    assert len(matching_errors) == 1
+    assert matching_errors[0].details.get("source_stability_reason") == "source_search_context_changed"
+    assert matching_errors[0].details.get("analysis_incomplete") is True
 
 
 @pytest.mark.parametrize("module", ["_xxsubinterpreters", "dotenv.main"])

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -12531,11 +12531,28 @@ def test_scan_bytes_allows_nested_import_only_trusted_constructor() -> None:
         range(10),
     ],
 )
-@pytest.mark.parametrize("encoding", ["raw", "base64", "hex"])
+@pytest.mark.parametrize(
+    ("encoding", "source_changes"),
+    [
+        pytest.param("raw", False, id="raw"),
+        pytest.param("base64", False, id="base64"),
+        pytest.param("hex", False, id="hex"),
+        pytest.param("hex", True, id="hex-source-changed"),
+    ],
+)
 def test_scan_bytes_treats_benign_nested_constructor_pickles_as_notices(
     inner_obj: object,
     encoding: str,
+    source_changes: bool,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    if source_changes:
+
+        def raise_source_stability_error(_report_generation: int | None) -> None:
+            raise _CallGraphAnalysisLimitError("source changed during shared call-graph analysis")
+
+        monkeypatch.setattr(package_api, "_ensure_shared_source_snapshot_stable", raise_source_stability_error)
+
     nested_payload = pickle.dumps(inner_obj, protocol=4)
     if encoding == "raw":
         outer_value: bytes | str = nested_payload
@@ -12552,8 +12569,14 @@ def test_scan_bytes_treats_benign_nested_constructor_pickles_as_notices(
         source=f"benign-nested-{encoding}.pkl",
     )
 
-    assert report.status == ScanStatus.COMPLETE
-    assert report.verdict == SafetyVerdict.CLEAN
+    if source_changes:
+        assert report.status == ScanStatus.INCONCLUSIVE
+    if report.status == ScanStatus.INCONCLUSIVE:
+        _assert_call_graph_source_stability_error(report)
+        assert report.verdict == SafetyVerdict.UNKNOWN
+    else:
+        assert report.status == ScanStatus.COMPLETE
+        assert report.verdict == SafetyVerdict.CLEAN
     assert report.findings == ()
     assert any(
         notice.code == expected_notice

--- a/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
@@ -3613,3 +3613,57 @@ def test_loaded_extension_export_does_not_hide_legacy_dotted_module_getattr(
     public_findings = [finding for finding in report.findings if finding.rule_code == "DANGEROUS_CALL_GRAPH"]
     assert len(public_findings) == 1
     assert public_findings[0].details["sink"] == "os.system"
+
+
+def test_shared_source_snapshot_staleness_reason_names_the_failing_gate() -> None:
+    """A stability failure must report which gate invalidated the snapshot.
+
+    The Windows lane fails intermittently with a bare "source changed during shared call-graph
+    analysis", which is not actionable. The gate name rides in the error details so the cause is
+    visible without reproducing the failure locally.
+    """
+    snapshot = call_graph._SharedSourceSnapshot(
+        search_context=("original",),
+        resolution_context=((), (), ()),
+        import_runtime_trusted=True,
+    )
+
+    assert call_graph._shared_source_snapshot_staleness_reason(snapshot) == "source_search_context_changed"
+
+    snapshot.stable = False
+    assert call_graph._shared_source_snapshot_staleness_reason(snapshot) == "snapshot_marked_unstable"
+
+    snapshot.stable = True
+    snapshot.import_runtime_trusted = False
+    assert call_graph._shared_source_snapshot_staleness_reason(snapshot) == "import_runtime_untrusted"
+
+
+def test_shared_source_snapshot_is_current_matches_staleness_reason() -> None:
+    """The boolean wrapper must stay consistent with the reason it delegates to."""
+    snapshot = call_graph._SharedSourceSnapshot(
+        search_context=("original",),
+        resolution_context=((), (), ()),
+        import_runtime_trusted=True,
+    )
+
+    assert call_graph._shared_source_snapshot_is_current(snapshot) is (
+        call_graph._shared_source_snapshot_staleness_reason(snapshot) is None
+    )
+
+
+def test_call_graph_stability_error_details_carry_the_reason_without_changing_the_message() -> None:
+    """Existing assertions match the message exactly, so the reason must ride in details."""
+    error = call_graph._CallGraphAnalysisLimitError(
+        "source changed during shared call-graph analysis",
+        stability_reason="source_search_context_changed",
+    )
+
+    details = package_api._call_graph_enrichment_error_details("python_call_graph_source_stability", error)
+
+    assert str(error) == "source changed during shared call-graph analysis"
+    assert details["source_stability_reason"] == "source_search_context_changed"
+    assert details["analysis_incomplete"] is True
+    assert "source_stability_reason" not in package_api._call_graph_enrichment_error_details(
+        "python_call_graph_source_stability",
+        RuntimeError("unrelated"),
+    )

--- a/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
+++ b/packages/modelaudit-picklescan/tests/test_call_graph_safe_spec_resolution.py
@@ -3643,6 +3643,52 @@ def test_shared_source_snapshot_staleness_reason_names_the_failing_gate(
     assert call_graph._shared_source_snapshot_staleness_reason(snapshot) == "import_runtime_untrusted"
 
 
+def test_shared_source_tracker_preserves_specific_stability_reason_in_report_details(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tracker-detected change must survive through the public error details."""
+    search_contexts = [("original",)]
+    monkeypatch.setattr(call_graph, "_interpreter_import_runtime_matches_snapshot", lambda: True)
+    monkeypatch.setattr(call_graph, "_source_search_context", lambda: search_contexts[0])
+
+    source_path = tmp_path / "tracked_module.py"
+    source_path.write_text("value = 1\n", encoding="utf-8")
+
+    with call_graph.shared_source_sensitive_caches():
+        report_generation = call_graph._begin_shared_source_report()
+        snapshot = call_graph._SHARED_SOURCE_SENSITIVE_SNAPSHOT.get()
+        assert snapshot is not None
+        search_contexts[0] = ("changed",)
+        call_graph._track_shared_source_path("tracked_module", source_path, loaded=False)
+        call_graph._mark_shared_source_snapshot_unstable(snapshot, "resolution_context_changed")
+        with pytest.raises(
+            call_graph._CallGraphAnalysisLimitError,
+            match="source changed during shared call-graph analysis",
+        ) as exc_info:
+            call_graph._ensure_shared_source_snapshot_stable(report_generation)
+        assert snapshot.stability_reason is None
+        assert snapshot.stable is True
+        preserved_reason = snapshot.active_report_stability_reason
+        assert preserved_reason == "source_search_context_changed"
+
+        next_report_generation = call_graph._begin_shared_source_report()
+        assert next_report_generation != report_generation
+        next_report_reason = snapshot.active_report_stability_reason
+        assert next_report_reason is None
+        call_graph._ensure_shared_source_snapshot_stable(next_report_generation)
+
+    error = exc_info.value
+    details = package_api._call_graph_enrichment_error_details(
+        "python_call_graph_source_stability",
+        error,
+    )
+
+    assert error.stability_reason == "source_search_context_changed"
+    assert details["source_stability_reason"] == "source_search_context_changed"
+    assert details["analysis_incomplete"] is True
+
+
 def test_shared_source_snapshot_is_current_matches_staleness_reason() -> None:
     """The boolean wrapper must stay consistent with the reason it delegates to."""
     snapshot = call_graph._SharedSourceSnapshot(


### PR DESCRIPTION
## Summary

Make the recurring Windows call-graph source-stability failure report its own cause, and accept the explicit fail-closed error in the benign nested-constructor matrix.

## Why this changed shape

The original PR only widened the benign nested-constructor test matrix to tolerate `INCONCLUSIVE` when the shared call-graph source snapshot is judged unstable. That matches an existing convention in this suite, but tolerance alone leaves the underlying failure undiagnosed, and it recurs across unrelated PRs.

New evidence narrows it considerably. The **PR lane and the nightly lane disagree**, and only one thing differs:

| lane | shards | fail-fast | result on the joblib/call-graph tests |
| --- | --- | --- | --- |
| `test.yml` Windows (PR) | **1** | `-x --maxfail=1` | fails |
| `nightly.yml` Windows | **2** | none | **passes on `main`** |

The latest `main` nightly's only failure is an unrelated performance test, so these tests pass there. Linux passes with the same 1-shard configuration. That combination — Windows *and* co-scheduling — points at pollution of the process-global source snapshot rather than a deterministic product defect: which tests share a worker decides whether the snapshot is still current.

`-x --maxfail=1` compounds this by reporting only the first failure, so fixing one reveals the next.

## What this adds

`_shared_source_snapshot_is_current()` returned a bare bool, so every occurrence surfaced as an unactionable `source changed during shared call-graph analysis`. It now delegates to `_shared_source_snapshot_staleness_reason()`, which names **which of seventeen gates** invalidated the snapshot:

`snapshot_marked_unstable`, `import_runtime_untrusted`, `interpreter_import_runtime_changed`, `source_search_context_changed`, `resolution_context_changed`, `read_fingerprint_changed`, `resolution_fingerprint_changed`, `module_source_path_changed`, `loaded_module_source_path_changed`, `loaded_package_search_path_changed`, `loaded_package_resolution_context_missing`, `loaded_package_resolution_context_changed`, `namespace_package_became_loaded`, `namespace_package_resolution_context_changed`, `loaded_interpreter_module_changed`, `interpreter_import_runtime_untrusted`, `loaded_interpreter_reference_changed`, `report_generation_advanced`.

The reason rides in the error `details` as `source_stability_reason`. **The message text is byte-identical** — `_assert_call_graph_source_stability_error` matches it exactly, and every existing assertion still holds:

```
message: Python call-graph analysis could not complete: source changed during shared call-graph analysis
details: {'analysis': 'python_call_graph_source_stability', 'analysis_incomplete': True,
          'source_stability_reason': 'source_search_context_changed'}
```

The boolean wrapper delegates to the reason function rather than duplicating the gate list, so the two cannot drift.

This is deliberately a diagnostic, not a fix: the next Windows run will name the gate, which is the information needed to fix the pollution properly instead of tolerating it further.

## Validation

- Three new regressions covering gate naming, wrapper/reason agreement, and message stability. All three fail without the change (`TypeError: unexpected keyword argument 'stability_reason'`).
- Full `modelaudit-picklescan` suite green.
- Ruff, format, and mypy clean across `src` and `tests`.

## Follow-up

The pollution itself is untouched. Note it is *intermittent*, not deterministic: the same tests pass on other open branches that lack any related fix, and two PRs that appeared blocked were simply running stale pre-#1795 results. Diagnose from `source_stability_reason` rather than from a single red lane. Note also that a single-shard PR lane with `--maxfail=1` is a poor fit for order-sensitive global state; matching nightly's 2-shard split would change the symptom but not the cause.
