### PR TITLE
fix(network): preserve detections in README environment files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - Avoid network false positives for bounded README examples that download sample images over HTTPS from Hugging Face.
+- Preserve network security findings in README-named environment files.
 - Prevent Windows cache identity probes from creating locked temporary files inside scanned directories.
 - Preserve locked Windows cache probes reached through directory aliases while clearing stale scan results.
 

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -2011,7 +2011,7 @@ def _contains_executable_requests_reference(data: bytes) -> bool:
 def _is_readme_image_example_context(context: str) -> bool:
     filename = context.replace("\\", "/").rsplit("/", 1)[-1].lower()
     return filename == "readme" or (
-        filename.startswith("readme.") and filename.rsplit(".", 1)[-1] in {"txt", "md", "markdown", "rst", "env"}
+        filename.startswith("readme.") and filename.rsplit(".", 1)[-1] in {"txt", "md", "markdown", "rst"}
     )
 
 

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -2790,6 +2790,19 @@ class TestNetworkCommDetector:
         assert not [finding for finding in findings if finding["type"] in {"network_library", "network_function"}]
         assert any(finding["type"] == "cloud_storage_url" for finding in findings)
 
+    @pytest.mark.parametrize("context", ["README.env", "readme.env", "README.ENV", "README.md.env"])
+    def test_readme_environment_files_preserve_network_findings(self, context: str) -> None:
+        data = (
+            b"```python\nimport requests\n"
+            b"image_url = 'https://huggingface.co/spaces/org/demo/resolve/main/image.png'\n"
+            b"image = Image.open(requests.get(image_url, stream=True).raw)\n```\n"
+        )
+
+        findings = NetworkCommDetector().scan(data, context)
+
+        assert any(finding["type"] == "network_library" for finding in findings)
+        assert any(finding["type"] == "network_function" for finding in findings)
+
     @pytest.mark.parametrize(
         ("opening", "closing"),
         [("```", "````"), ("````", "````"), ("````", "`````"), ("~~~", "~~~~"), ("~~~~", "~~~~")],

--- a/tests/scanners/test_text_scanner.py
+++ b/tests/scanners/test_text_scanner.py
@@ -440,6 +440,27 @@ def test_text_scanner_readme_official_sample_image_request_is_informational(tmp_
     )
 
 
+@pytest.mark.parametrize("filename", ["README.env", "readme.env", "README.ENV", "README.md.env"])
+def test_text_scanner_readme_environment_files_preserve_network_findings(tmp_path: Path, filename: str) -> None:
+    text_path = tmp_path / filename
+    text_path.write_text(
+        "```python\nimport requests\n"
+        "image_url = 'https://huggingface.co/spaces/org/demo/resolve/main/image.png'\n"
+        "image = Image.open(requests.get(image_url, stream=True).raw)\n```\n",
+        encoding="utf-8",
+    )
+
+    result = TextScanner().scan(str(text_path))
+
+    assert result.success is False
+    failed_network_checks = {
+        check.details.get("type")
+        for check in result.checks
+        if check.name == "Network Communication Detection" and check.status == CheckStatus.FAILED
+    }
+    assert {"network_library", "network_function"} <= failed_network_checks
+
+
 def test_text_scanner_readme_plain_http_sample_image_stays_actionable(tmp_path: Path) -> None:
     text_path = tmp_path / "README.md"
     text_path.write_text(


### PR DESCRIPTION
## Summary

- Treat `README.env`, `readme.env`, `README.ENV`, and `README.md.env` as executable environment files instead of trusted README documentation.
- Preserve both `network_library` and `network_function` findings at detector and TextScanner layers while keeping legitimate README image examples informational.
- Document the user-visible scanner correction under `[Unreleased]`.

## Validation

- Confirmed both detector and TextScanner regressions fail on current `main` before the fix.
- `PROMPTFOO_DISABLE_TELEMETRY=1 python -m pytest tests/detectors/test_network_comm_detector.py tests/scanners/test_text_scanner.py -q --maxfail=1`: **1,299 passed**.
- Ruff lint and format checks, changed-file Python 3.13 mypy, and CHANGELOG Prettier check passed.
- Three independent exact-head Codex security reviews and fresh verification completed without findings.
