### PR TITLE
fix(cache): keep Windows probes out of concurrently scanned trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Avoid network false positives for bounded README examples that download sample images over HTTPS from Hugging Face.
 - Prevent Windows cache identity probes from creating locked temporary files inside scanned directories.
 - Preserve locked Windows cache probes reached through directory aliases while clearing stale scan results.
+- Place cross-volume Windows cache identity probes near the volume root instead of the nearest ancestor of the scanned path, so a probe can no longer appear inside a directory tree that a concurrent scan is walking.
 
 ## [0.2.52](https://github.com/promptfoo/modelaudit/compare/v0.2.51...v0.2.52) (2026-07-22)
 

--- a/modelaudit/cache/scan_results_cache.py
+++ b/modelaudit/cache/scan_results_cache.py
@@ -1136,9 +1136,14 @@ class ScanResultsCache:
                     return existing[0]
 
             if os.name == "nt":
-                # Windows keeps TemporaryFile names visible and locked until close.
+                # Windows keeps TemporaryFile names visible and locked until close, so a
+                # probe is observable to every concurrent scan that walks the directory
+                # holding it. Ancestors are only reached when the temp and cache
+                # directories live on another volume; walk them outermost-first so the
+                # fallback settles near the volume root instead of inside a deep tree
+                # that an unrelated scan is enumerating.
                 candidates = [Path(tempfile.gettempdir()), self.cache_dir]
-                candidates.extend(protected_root.parents)
+                candidates.extend(reversed(protected_root.parents))
             else:
                 candidates = [self.cache_dir, Path(tempfile.gettempdir())]
                 ancestor = scanned_parent

--- a/tests/cache/test_cache_correctness.py
+++ b/tests/cache/test_cache_correctness.py
@@ -550,6 +550,59 @@ def test_windows_change_clock_probe_uses_safe_ancestor_without_scan_root(
         cache._change_clock_probes.clear()
 
 
+def test_windows_change_clock_probe_prefers_outermost_ancestor_over_scanned_tree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cross-volume probes must not land inside a tree a concurrent scan walks.
+
+    Windows CI keeps the checkout on one volume and the temp/cache directories on
+    another, so probe placement falls through to the scanned file's ancestors. The
+    nearest ancestor is normally still inside the asset tree another xdist worker is
+    enumerating, and the probe races that walk into ``file_size_check_failed``.
+    """
+    volume_root = tmp_path / "volume"
+    assets_root = volume_root / "repository" / "tests" / "assets"
+    scanned_parent = assets_root / "samples" / "pickles"
+    scanned_parent.mkdir(parents=True)
+    file_path = _make_cacheable_file(scanned_parent)
+    file_device = file_path.stat().st_dev
+    off_device_cache = tmp_path / "off-device-cache"
+    off_device_temp = tmp_path / "off-device-temp"
+    cache = ScanResultsCache(str(off_device_cache))
+    attempted_probe_dirs: list[Path] = []
+
+    with tempfile.TemporaryFile(mode="w+b", dir=volume_root) as probe:
+
+        def record_probe_directory(*_args: Any, dir: str | Path, **_kwargs: Any) -> BinaryIO:
+            attempted_probe_dirs.append(type(file_path)(dir))
+            return cast(BinaryIO, probe)
+
+        with monkeypatch.context() as patch:
+            patch.setattr(os, "name", "nt")
+            patch.setattr(scan_results_cache_module, "Path", type(file_path))
+            patch.setattr(tempfile, "gettempdir", lambda: str(off_device_temp))
+            # Every ancestor shares the scanned file's volume; only the off-device
+            # temp and cache directories are unreachable.
+            patch.setattr(
+                cache,
+                "_directory_is_on_device",
+                lambda directory, _device: directory not in {off_device_cache, off_device_temp},
+            )
+            patch.setattr(tempfile, "TemporaryFile", record_probe_directory)
+
+            selected_probe = cache._get_change_clock_probe(str(file_path), file_device)
+
+        assert selected_probe is probe
+        selected_directory = attempted_probe_dirs[0]
+        resolved_assets_root = assets_root.resolve()
+        # The probe must sit above the asset tree, not inside it.
+        assert selected_directory != resolved_assets_root
+        assert resolved_assets_root not in selected_directory.parents
+        assert selected_directory in scanned_parent.resolve().parents
+        cache._change_clock_probes.clear()
+
+
 def test_windows_change_clock_probe_uses_safe_ancestor_outside_scan_root(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_security_asset_integration.py
+++ b/tests/test_security_asset_integration.py
@@ -17,7 +17,25 @@ from click.testing import CliRunner
 
 from modelaudit.cli import cli
 from modelaudit.core import determine_exit_code, scan_model_directory_or_file
+from modelaudit.models import ModelAuditResultModel
 from modelaudit.scanners.base import IssueSeverity
+
+
+def describe_operational_errors(results: ModelAuditResultModel) -> str:
+    """Summarize which files carried operational errors, for assertion messages.
+
+    ``has_errors`` alone truncates to an unhelpful model repr in CI logs, which
+    hides whichever file actually failed. Naming the paths and reasons keeps a
+    recurrence diagnosable from the log without a Windows reproduction.
+    """
+    offenders = []
+    for path, metadata in results.file_metadata.items():
+        dump = getattr(metadata, "model_dump", None)
+        payload = dump() if callable(dump) else metadata
+        if not isinstance(payload, dict) or not payload.get("operational_error"):
+            continue
+        offenders.append(f"{path}: {payload.get('operational_error_reason', 'unknown reason')}")
+    return "; ".join(sorted(offenders)) or "no per-file operational_error metadata recorded"
 
 
 class TestSecurityAssetIntegration:
@@ -393,7 +411,10 @@ class TestSecurityAssetIntegration:
                     # Scan the mixed directory
                     results = scan_model_directory_or_file(str(temp_path), cache_enabled=False)
                     assert results.files_scanned >= len(copied_files)
-                    assert results.has_errors is False, "Mixed directory scan should not have operational errors"
+                    assert results.has_errors is False, (
+                        f"Mixed directory scan should not have operational errors: "
+                        f"{describe_operational_errors(results)}"
+                    )
 
     @pytest.mark.skipif(
         sys.version_info[:2] in [(3, 10), (3, 12)],
@@ -411,7 +432,9 @@ class TestSecurityAssetIntegration:
 
         # Should find various file types
         assert results.files_scanned > 0, "Should find some files to scan"
-        assert results.has_errors is False, "Assets directory scan should not have operational errors"
+        assert results.has_errors is False, (
+            f"Assets directory scan should not have operational errors: {describe_operational_errors(results)}"
+        )
         assert len(results.issues) > 0, "Assets tree contains exploits; findings expected"
 
         # Check for different file extensions in issues (indicates they were processed)
@@ -450,7 +473,9 @@ class TestSecurityAssetIntegration:
         # so success is expected to be False; assert the scan ran and produced
         # findings rather than demanding success on malicious inputs.
         assert results.files_scanned > 0, "Performance test scan should process files"
-        assert results.has_errors is False, "Performance test scan should not have operational errors"
+        assert results.has_errors is False, (
+            f"Performance test scan should not have operational errors: {describe_operational_errors(results)}"
+        )
         assert len(results.issues) > 0, "Assets tree contains exploits; findings expected"
         is_ci = bool(os.getenv("CI") or os.getenv("GITHUB_ACTIONS"))
         threshold = 120 if is_ci else 60


### PR DESCRIPTION
## Why

Nightly CI failed on `windows-latest` / Python 3.11 for three consecutive runs (Jul 29, 30, 31), plus Jul 26 and Jul 22. The recurring failure is the assets-tree scan in `tests/test_security_asset_integration.py`:

```
FAILED tests/test_security_asset_integration.py::TestSecurityAssetIntegration::test_performance_with_organized_structure
  AssertionError: Performance test scan should not have operational errors
```

## Root cause

On Windows a cache identity probe is a `TemporaryFile` whose **name stays visible until close**, so it is observable to any scan walking the directory that holds it. (On POSIX the file is unlinked immediately and never appears in a directory walk — which is why this is Windows-only.)

`_get_change_clock_probe` only reaches its ancestor fallback when the temp and cache directories are on a *different volume* from the scanned file — exactly the Windows CI layout, where the checkout is on `D:` while `%TEMP%` and `~/.modelaudit` are on `C:`. Both preferred candidates fail the same-device check, and the code then walked `protected_root.parents` **nearest-first**, so the probe landed just above the scanned file — inside `tests/assets`.

A concurrent `pytest-xdist` worker scanning `tests/assets` then enumerated that probe, and `os.path.getsize` raised once the probe was released, yielding `operational_error_reason: file_size_check_failed` → `has_errors=True` → whole scan fails.

The Jul 26 nightly log captured the probe directly:

```json
"D:\\a\\modelaudit\\modelaudit\\tests\\assets\\samples\\pickles\\.modelaudit-cache-clock-20tlhazm": {
  "scanner_dependency_ids": ["error"],
  "operational_error": true,
  "operational_error_reason": "file_size_check_failed"
}
```

This is a real product defect beyond CI: modelaudit could write temporary probe files into a user's model directory whenever the scan target is on a different volume from temp/cache (e.g. a mounted model volume on Windows).

## Fix

Walk the ancestors **outermost-first** so the cross-volume fallback settles near the volume root instead of inside a deep tree an unrelated scan is enumerating. The change is confined to the `os.name == "nt"` branch; POSIX ordering is untouched and correct as-is.

Also made the asset-scan assertions self-diagnosing — they previously truncated to an unhelpful model repr that hid *which* file failed, which is why this took several nightlies to pin down.

## Tests

`test_windows_change_clock_probe_prefers_outermost_ancestor_over_scanned_tree` reproduces the CI topology (off-device temp/cache, every ancestor on-device). It fails on the pre-fix code with the probe landing in `.../tests/assets/samples` — the exact CI signature — and passes after.

## Validation

- `ruff format` / `ruff check`: clean
- `mypy`: clean (only 5 pre-existing macOS-only `os.setxattr`/`getxattr` errors, present on `main`)
- Full lane `pytest -n auto -m "not slow and not integration"`: 81 failures on this branch vs **84 on clean `main`** in the same local macOS environment; 70 shared. The 11 branch-only entries all pass in isolation (xdist-load flakes in the cache-invalidation family, churning in both directions — 14 tests failed only on `main`). No regressions.

## Known remaining nightly flakes (not addressed here)

Two other Windows-only flake classes appeared in the same nightlies and are **separate root causes**:

1. `packages/modelaudit-picklescan/tests/test_api.py` — `ScanStatus.INCONCLUSIVE` instead of `COMPLETE` from the shared call-graph source-stability guard (Jul 26, Jul 29). #1782 established a narrow tolerance helper (`_assert_call_graph_source_stability_error`) for this; extending it needs a real Windows reproduction to know which assertions still hold under `INCONCLUSIVE`, so it is deliberately not guessed at here.
2. `tests/utils/file/test_large_file_handler.py::test_large_handler_cache_preserves_private_metadata_for_internal_results` — `assert 2 == 1`, a cache-store decline under load (Jul 30). Same family as the locally-flaky cache tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)