### PR TITLE
fix(joblib): fail closed on inconclusive warning scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- Keep incomplete Joblib NumPy-wrapper scans failed closed when embedded pickle analysis also reports warnings.
 - Avoid network false positives for bounded README examples that download sample images over HTTPS from Hugging Face.
 - Prevent Windows cache identity probes from creating locked temporary files inside scanned directories.
 - Preserve locked Windows cache probes reached through directory aliases while clearing stale scan results.

--- a/modelaudit/scanners/joblib_scanner.py
+++ b/modelaudit/scanners/joblib_scanner.py
@@ -1530,15 +1530,8 @@ class JoblibScanner(BaseScanner):
             result.finish(success=False)
             return result
 
-        has_security_findings = any(
-            issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues
-        )
         has_trusted_incomplete_tail = result.metadata.get("trusted_incomplete_tail") is True
-        if (
-            result.metadata.get("scan_outcome") == INCONCLUSIVE_SCAN_OUTCOME
-            and not has_security_findings
-            and not has_trusted_incomplete_tail
-        ):
+        if result.metadata.get("scan_outcome") == INCONCLUSIVE_SCAN_OUTCOME and not has_trusted_incomplete_tail:
             result.finish(success=False)
         else:
             result.finish(success=not result.has_errors)

--- a/tests/scanners/test_joblib_scanner_codecs.py
+++ b/tests/scanners/test_joblib_scanner_codecs.py
@@ -35,6 +35,7 @@ from modelaudit.scanners.joblib_scanner import (
     _validated_numpy_dtype,
     np,
 )
+from modelaudit.scanners.pickle_scanner import PickleScanner
 from modelaudit.utils.file.detection import _LZ4_FRAME_MAGIC, validate_file_type_with_formats
 
 
@@ -1400,6 +1401,42 @@ def test_scan_fails_closed_on_invalid_numpy_wrapper_with_origin_warning(tmp_path
     assert result.metadata["analysis_incomplete"] is True
     assert "joblib_numpy_array_wrapper_validation_failed" in result.metadata["scan_outcome_reasons"]
     assert result.has_warnings is True
+    assert "trusted_incomplete_tail" not in result.metadata
+    assert should_cache_scan_result(result.to_dict(include_private_metadata=True)) is False
+
+
+def test_scan_fails_closed_when_embedded_pickle_reports_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Joblib must fail closed on its own wrapper validation, not on the embedded verdict.
+
+    Windows CI reaches this state through the real pickle scanner: the embedded result keeps a
+    trusted incomplete tail and finishes ``success=True`` while Joblib NumPy-wrapper validation
+    is still inconclusive. Forcing only the embedded verdict reproduces that lane deterministically
+    on every platform while leaving payload parsing and metadata composition untouched.
+    """
+    original_finish = PickleScanner._finish_after_wrapper_analysis
+
+    def finish_as_successful(self: PickleScanner, result: ScanResult, *, base_success: bool) -> None:
+        original_finish(self, result, base_success=base_success)
+        if not result.success:
+            result.success = True
+            result._merged_children_success = True
+
+    monkeypatch.setattr(PickleScanner, "_finish_after_wrapper_analysis", finish_as_successful)
+
+    result = _scan_payload(
+        tmp_path,
+        _joblib_numpy_list_payload(resumed_ops=b"\x80\x01K\x01."),
+        "numpy_array_protocol1_embedded_success.joblib",
+    )
+
+    assert result.success is False
+    assert result.has_errors is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert result.metadata["analysis_incomplete"] is True
+    assert "joblib_numpy_array_wrapper_validation_failed" in result.metadata["scan_outcome_reasons"]
     assert "trusted_incomplete_tail" not in result.metadata
     assert should_cache_scan_result(result.to_dict(include_private_metadata=True)) is False
 

--- a/tests/scanners/test_joblib_scanner_codecs.py
+++ b/tests/scanners/test_joblib_scanner_codecs.py
@@ -1376,6 +1376,34 @@ def test_scan_fails_closed_on_protocol1_pickle_in_numpy_wrapper_tail(tmp_path: P
     assert "trusted_incomplete_tail" not in result.metadata
 
 
+def test_scan_fails_closed_on_invalid_numpy_wrapper_with_origin_warning(tmp_path: Path) -> None:
+    path = tmp_path / "numpy_array_protocol1_origin_warning.joblib"
+    path.write_bytes(_joblib_numpy_list_payload(resumed_ops=b"\x80\x01K\x01."))
+
+    embedded_result = ScanResult("pickle")
+    embedded_result.add_check(
+        name="Standalone Pickle Finding",
+        passed=False,
+        message="Joblib NumPy wrapper requires origin verification",
+        severity=IssueSeverity.WARNING,
+        details={"import_reference": "joblib.numpy_pickle.NumpyArrayWrapper"},
+        rule_code="NON_ALLOWLISTED_GLOBAL",
+    )
+    embedded_result.finish(success=True)
+
+    scanner = JoblibScanner()
+    scanner.pickle_scanner = _StaticEmbeddedPickleScanner(embedded_result)
+    result = scanner.scan(str(path))
+
+    assert result.success is False
+    assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+    assert result.metadata["analysis_incomplete"] is True
+    assert "joblib_numpy_array_wrapper_validation_failed" in result.metadata["scan_outcome_reasons"]
+    assert result.has_warnings is True
+    assert "trusted_incomplete_tail" not in result.metadata
+    assert should_cache_scan_result(result.to_dict(include_private_metadata=True)) is False
+
+
 def test_scan_detects_gzip_compressed_pickle_joblib(tmp_path: Path) -> None:
     path = tmp_path / "gzip_protocol4.joblib"
     path.write_bytes(gzip.compress(pickle.dumps(_Payload(), protocol=4)))


### PR DESCRIPTION
## Summary

Keep Joblib scans failed closed whenever NumPy-wrapper validation is inconclusive, regardless of what the embedded pickle scanner reports.

## The defect

`JoblibScanner.scan()` failed an inconclusive scan only when there were *no* WARNING/CRITICAL findings:

```python
if scan_outcome == INCONCLUSIVE and not has_security_findings and not has_trusted_incomplete_tail:
    result.finish(success=False)
else:
    result.finish(success=not result.has_errors)
```

That conflates "we found something" with "we finished the analysis". When findings exist the scanner takes the `else` branch and reports `success=True` as long as no finding is CRITICAL — even though `scan_outcome=inconclusive` and `analysis_incomplete=true`.

Joblib was the outlier. Roughly a dozen scanners already use the unconditional form this PR adopts — `lightgbm`, `catboost`, `coreml`, `rknn`, `r_serialized`, `paddle`, `xgboost`, `skops`, `flax_msgpack`, `llamafile`, `pytorch_zip`, `torchserve_mar` all finish with `scan_outcome != INCONCLUSIVE and not has_errors`. This change brings joblib in line, keeping only the joblib-specific `trusted_incomplete_tail` exemption.

## Correction to the original justification

This PR was originally filed as the fix for a recurring Windows CI failure of `test_scan_fails_closed_on_protocol1_pickle_in_numpy_wrapper_tail`. **That claim was wrong and has been removed.**

The Windows lane passes on #1780, #1783, #1788, #1790 and #1791 — every one of which contains `main` *without* this fix. The test is therefore intermittent, not deterministically failing, and this change is not what makes it pass. The Windows failures on #1792/#1793 were separately traced to stale July-30 runs that predated #1795.

The defect above is real and reproducible on POSIX independently of any platform flake, which is the basis for merging this. It is a correctness fix, not a CI fix.

Why it stays hidden on POSIX in normal runs: `ScanResult.finish()` computes `success and self._merged_children_success`, and the embedded pickle scanner usually returns `success=False`, which pins the parent to `False`. The joblib-level guard only becomes observable when the embedded result reports success.

## Coverage

Two regressions, both failing on `main` and passing here:

- `test_scan_fails_closed_on_invalid_numpy_wrapper_with_origin_warning` — stubs the embedded scanner to isolate the guard.
- `test_scan_fails_closed_when_embedded_pickle_reports_success` — keeps the real pickle scanner, real payload parsing, and real metadata composition, forcing only the embedded verdict.

Demonstrated behaviour change with the embedded verdict forced to success:

| | `success` | `scan_outcome` | `trusted_incomplete_tail` |
| --- | --- | --- | --- |
| main | `True` | `inconclusive` | absent |
| this PR | `False` | `inconclusive` | absent |

## Validation

- `tests/scanners/test_joblib_scanner_codecs.py`, `test_joblib_scanner.py`, `test_pickle_scanner.py`: **472 passed**.
- Ruff lint + format clean; mypy clean on both changed files.
