### PR TITLE
fix(ci): accept rotated pinned checkout digests

### DIFF
--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -5,7 +5,6 @@ import hashlib
 import io
 import json
 import os
-import re
 import subprocess
 import sys
 import tarfile
@@ -26,6 +25,18 @@ try:
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
     import tomli as tomllib  # type: ignore[no-redef]
+
+
+_TRUSTED_CHECKOUT_V6_PINS = frozenset(
+    {
+        "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+        "actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803",
+    },
+)
+
+
+def _is_trusted_checkout_v6_pin(uses: object) -> bool:
+    return isinstance(uses, str) and uses in _TRUSTED_CHECKOUT_V6_PINS
 
 
 def _load_release_workflow() -> dict[str, Any]:
@@ -753,6 +764,33 @@ def test_release_workflow_generates_root_provenance_after_successful_publish() -
     assert job["needs"] == ["build", "publish-pypi", "verify-pypi", "release-please"]
 
 
+@pytest.mark.parametrize(
+    ("uses", "expected"),
+    [
+        pytest.param(
+            "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+            True,
+            id="previous-v6-digest",
+        ),
+        pytest.param(
+            "actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803",
+            True,
+            id="rotated-v6-digest",
+        ),
+        pytest.param("actions/checkout@0000000000000000000000000000000000000000", False, id="arbitrary-digest"),
+        pytest.param("actions/checkout@v6", False, id="mutable-tag"),
+        pytest.param(
+            "untrusted/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+            False,
+            id="different-action",
+        ),
+        pytest.param(None, False, id="non-string"),
+    ],
+)
+def test_checkout_v6_pin_validator(uses: object, expected: bool) -> None:
+    assert _is_trusted_checkout_v6_pin(uses) is expected
+
+
 def test_release_workflow_recovers_root_provenance_without_republishing() -> None:
     workflow = _load_release_workflow()
 
@@ -777,7 +815,7 @@ def test_release_workflow_recovers_root_provenance_without_republishing() -> Non
 
     steps = _job_steps(workflow, "root-provenance-recovery")
     checkout_step = _step_by_name(steps, "Checkout tagged root release")
-    assert re.fullmatch(r"actions/checkout@[0-9a-f]{40}", checkout_step["uses"])
+    assert _is_trusted_checkout_v6_pin(checkout_step["uses"])
     assert checkout_step["with"] == {
         "ref": "refs/tags/${{ needs.release-please.outputs.tag_name }}",
         "sparse-checkout": "pyproject.toml\nuv.lock\n",

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -753,16 +753,7 @@ def test_release_workflow_generates_root_provenance_after_successful_publish() -
     assert job["needs"] == ["build", "publish-pypi", "verify-pypi", "release-please"]
 
 
-@pytest.mark.parametrize(
-    "updated_checkout_digest",
-    [
-        pytest.param(None, id="current-pinned-digest"),
-        pytest.param("d23441a48e516b6c34aea4fa41551a30e30af803", id="rotated-pinned-digest"),
-    ],
-)
-def test_release_workflow_recovers_root_provenance_without_republishing(
-    updated_checkout_digest: str | None,
-) -> None:
+def test_release_workflow_recovers_root_provenance_without_republishing() -> None:
     workflow = _load_release_workflow()
 
     release_job = _jobs(workflow)["release-please"]
@@ -786,8 +777,6 @@ def test_release_workflow_recovers_root_provenance_without_republishing(
 
     steps = _job_steps(workflow, "root-provenance-recovery")
     checkout_step = _step_by_name(steps, "Checkout tagged root release")
-    if updated_checkout_digest is not None:
-        checkout_step = {**checkout_step, "uses": f"actions/checkout@{updated_checkout_digest}"}
     assert re.fullmatch(r"actions/checkout@[0-9a-f]{40}", checkout_step["uses"])
     assert checkout_step["with"] == {
         "ref": "refs/tags/${{ needs.release-please.outputs.tag_name }}",

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -5,6 +5,7 @@ import hashlib
 import io
 import json
 import os
+import re
 import subprocess
 import sys
 import tarfile
@@ -752,7 +753,16 @@ def test_release_workflow_generates_root_provenance_after_successful_publish() -
     assert job["needs"] == ["build", "publish-pypi", "verify-pypi", "release-please"]
 
 
-def test_release_workflow_recovers_root_provenance_without_republishing() -> None:
+@pytest.mark.parametrize(
+    "updated_checkout_digest",
+    [
+        pytest.param(None, id="current-pinned-digest"),
+        pytest.param("d23441a48e516b6c34aea4fa41551a30e30af803", id="rotated-pinned-digest"),
+    ],
+)
+def test_release_workflow_recovers_root_provenance_without_republishing(
+    updated_checkout_digest: str | None,
+) -> None:
     workflow = _load_release_workflow()
 
     release_job = _jobs(workflow)["release-please"]
@@ -776,7 +786,9 @@ def test_release_workflow_recovers_root_provenance_without_republishing() -> Non
 
     steps = _job_steps(workflow, "root-provenance-recovery")
     checkout_step = _step_by_name(steps, "Checkout tagged root release")
-    assert checkout_step["uses"] == "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+    if updated_checkout_digest is not None:
+        checkout_step = {**checkout_step, "uses": f"actions/checkout@{updated_checkout_digest}"}
+    assert re.fullmatch(r"actions/checkout@[0-9a-f]{40}", checkout_step["uses"])
     assert checkout_step["with"] == {
         "ref": "refs/tags/${{ needs.release-please.outputs.tag_name }}",
         "sparse-checkout": "pyproject.toml\nuv.lock\n",


### PR DESCRIPTION
## Summary

- Allow the release-provenance recovery regression test to accept rotated `actions/checkout` commit digests while still requiring an immutable, lowercase 40-character SHA pin.
- Add regression coverage for both the current pin and the exact replacement digest from blocked Renovate PR #1797.
- Preserve the existing tagged-release ref, sparse checkout, and disabled persisted-credentials assertions.

## Validation

- `PYTHONPATH=$PWD:$PWD/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest tests/test_release_workflow.py -q --tb=short` — **133 passed**.
- `PYTHONPATH=$PWD:$PWD/packages/modelaudit-picklescan/src PROMPTFOO_DISABLE_TELEMETRY=1 /Users/mdangelo/code/modelaudit/.venv/bin/python -m pytest packages/modelaudit-picklescan/tests/test_call_graph_instance_defaults.py -q --tb=short` — **4 passed**, including the exact failing Nightly botocore case.
- `/Users/mdangelo/code/modelaudit/.venv/bin/ruff check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` — passed.
- `/Users/mdangelo/code/modelaudit/.venv/bin/ruff format --check modelaudit/ packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests/` — **424 files already formatted**.
- `PYTHONPATH=$PWD:$PWD/packages/modelaudit-picklescan/src /Users/mdangelo/code/modelaudit/.venv/bin/mypy tests/test_release_workflow.py` — passed.
- Full fast suite: **5,338 passed** before three pre-existing local cache failures in unchanged cache/compressed-scanner files; rerunning the compressed-cache node independently reproduces the failure. Current `main` Python CI is green.
- Full local mypy reproduces **14 existing errors in six unchanged files**, matching the previous automation run; the changed release test passes scoped mypy.

## CI context

Renovate PR #1797 currently fails all affected Python, Windows, and coverage lanes solely because the release test hard-codes the previous checkout digest. This change keeps the supply-chain pinning requirement and removes that false failure.
