### PR TITLE
fix(deps): prevent incompatible XGBoost Renovate upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,13 @@
       "allowedVersions": "<2.5"
     },
     {
+      "description": "Keep XGBoost compatible with supported Python 3.10 and 3.11 runtimes.",
+      "matchFileNames": ["pyproject.toml"],
+      "matchManagers": ["pep621"],
+      "matchPackageNames": ["xgboost"],
+      "allowedVersions": "<3.3"
+    },
+    {
       "description": "Keep Python updates within the project's supported 3.10-3.13 range.",
       "matchPackageNames": ["python"],
       "allowedVersions": "<3.14"

--- a/tests/test_dependency_lock.py
+++ b/tests/test_dependency_lock.py
@@ -1,5 +1,6 @@
 """Regression tests for security-sensitive dependency lock entries."""
 
+import json
 import re
 from pathlib import Path
 
@@ -11,6 +12,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
 ROOT_DIR = Path(__file__).resolve().parents[1]
 LOCKFILE = ROOT_DIR / "uv.lock"
 ROOT_PYPROJECT = ROOT_DIR / "pyproject.toml"
+RENOVATE_CONFIG = ROOT_DIR / "renovate.json"
 PICKLESCAN_PYPROJECT = ROOT_DIR / "packages" / "modelaudit-picklescan" / "pyproject.toml"
 PATCHED_GITPYTHON_FLOOR = (3, 1, 50)
 PINNED_MATURIN_BACKEND = "maturin===1.13.3"
@@ -104,3 +106,26 @@ def test_numpy_requirements_follow_supported_python_versions() -> None:
 
     assert root_requirements == NUMPY_REQUIREMENTS
     assert extra_requirements == NUMPY_REQUIREMENTS
+
+
+def test_renovate_keeps_xgboost_compatible_with_supported_python_versions() -> None:
+    root_config = tomllib.loads(ROOT_PYPROJECT.read_text(encoding="utf-8"))
+    project = root_config["project"]
+    optional_dependencies = project["optional-dependencies"]
+    renovate_config = json.loads(RENOVATE_CONFIG.read_text(encoding="utf-8"))
+
+    assert project["requires-python"] == ">=3.10,<3.14"
+    for extra in ("xgboost", "all-ci", "all"):
+        xgboost_requirements = [
+            requirement for requirement in optional_dependencies[extra] if requirement.startswith("xgboost")
+        ]
+        assert xgboost_requirements == ["xgboost>=3.2,<3.3"]
+
+    compatibility_rules = [
+        rule for rule in renovate_config["packageRules"] if "xgboost" in rule.get("matchPackageNames", [])
+    ]
+
+    assert len(compatibility_rules) == 1
+    assert compatibility_rules[0]["matchManagers"] == ["pep621"]
+    assert compatibility_rules[0]["matchFileNames"] == ["pyproject.toml"]
+    assert compatibility_rules[0]["allowedVersions"] == "<3.3"


### PR DESCRIPTION
## Summary

- Stop Renovate from proposing XGBoost 3.3+ for the Python 3.10-3.13 project: those releases require Python 3.12+ and make every XGBoost extra impossible to resolve on supported older runtimes.
- Add a regression covering the supported Python range, all three XGBoost extras, and the narrowly scoped Renovate compatibility rule.
- Fix the recurring failure seen in #1701 and #1805, where the incompatible upgrade broke 22 Python CI jobs before tests could run.

## Validation

- Regression failed before the Renovate rule (`assert 0 == 1`) and passed afterward.
- `PROMPTFOO_DISABLE_TELEMETRY=1 python -m pytest tests/test_nightly_prerequisites.py tests/test_dependency_lock.py tests/test_perf_workflow.py tests/scanners/test_xgboost_scanner.py -k 'not test_docs_workflow_rejects_invalid_utf8_and_invalid_revisions' -q` — 241 passed, 2 skipped, 1 deselected.
- Repository-wide `ruff check` and `ruff format --check` passed; scoped `mypy tests/test_dependency_lock.py`, `python -m json.tool renovate.json`, and `prettier --check renovate.json` passed.
- Full fast smoke reached 3,326 passes before pre-existing Darwin cache failures. The deterministic compressed-cache failure reproduces on clean main and is already addressed by #1800.
- Full local mypy reports the same 14 pre-existing errors in six unchanged baseline files; the modified test passes scoped mypy.
- One unrelated workflow test requires an invalid-UTF-8 filename, which the macOS filesystem rejects on both this branch and clean main.
