### PR TITLE
fix(tests): preserve fail-closed Joblib source stability

### DIFF
--- a/tests/scanners/test_joblib_scanner_codecs.py
+++ b/tests/scanners/test_joblib_scanner_codecs.py
@@ -22,6 +22,8 @@ from modelaudit_picklescan.call_graph import _CallGraphAnalysisLimitError, _clea
 
 from modelaudit.cache.cache_policy import should_cache_scan_result
 from modelaudit.core import determine_exit_code, scan_file, scan_model_directory_or_file
+from modelaudit.core_results import merge_scan_result
+from modelaudit.models import create_initial_audit_result
 from modelaudit.scanner_results import ACTIONABLE_FAILED_CHECKS_METADATA_KEY, INCONCLUSIVE_SCAN_OUTCOME, Issue
 from modelaudit.scanners.base import Check, CheckStatus, IssueSeverity, ScanResult
 from modelaudit.scanners.compressed_scanner import CompressedScanner, _MissingOptionalDependencyError
@@ -1343,33 +1345,81 @@ def test_scan_accepts_security_like_bytes_inside_numpy_array(
     raw_seed: bytes,
     source_snapshot_changes: bool,
 ) -> None:
+    expected_source_stability_message = (
+        "Python call-graph analysis could not complete: source changed during shared call-graph analysis"
+    )
     if source_snapshot_changes:
 
         def raise_source_stability_error(_report_generation: int | None) -> None:
             raise _CallGraphAnalysisLimitError("source changed during shared call-graph analysis")
 
         monkeypatch.setattr(picklescan_api, "_ensure_shared_source_snapshot_stable", raise_source_stability_error)
+    else:
+        monkeypatch.setattr(
+            picklescan_api,
+            "_ensure_shared_source_snapshot_stable",
+            lambda _report_generation: None,
+        )
 
     raw_data = raw_seed.ljust(32, b"\x00")
     payload = _joblib_numpy_list_payload(raw_data=raw_data, shape=len(raw_data), dtype="u1")
+    filename = "benign_security_like_array_bytes.joblib"
 
-    result = _scan_payload(tmp_path, payload, "benign_security_like_array_bytes.joblib")
+    result = _scan_payload(tmp_path, payload, filename)
 
-    if result.success:
-        assert source_snapshot_changes is False
+    if not source_snapshot_changes:
+        assert result.success is True
         assert result.metadata["trusted_incomplete_tail"] is True
+        assert result.metadata.get("operational_error") is not True
     else:
+        assert result.success is False
         assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
         assert result.metadata["analysis_incomplete"] is True
+        assert result.metadata["operational_error"] is True
         assert result.metadata["operational_error_reason"] == "call_graph_analysis_error"
+        assert result.metadata["pickle_report_status"] == "inconclusive"
+        assert result.metadata["pickle_verdict"] == "suspicious"
         assert "trusted_incomplete_tail" not in result.metadata
-        assert any(
-            issue.details.get("category") == "call_graph_analysis_error"
+        source_stability_checks = [
+            check
+            for check in result.checks
+            if check.status == CheckStatus.FAILED
+            and check.details.get("category") == "call_graph_analysis_error"
+            and check.details.get("analysis") == "python_call_graph_source_stability"
+            and check.details.get("analysis_incomplete") is True
+        ]
+        assert len(source_stability_checks) == 1
+        assert source_stability_checks[0].severity == IssueSeverity.INFO
+        assert source_stability_checks[0].message == expected_source_stability_message
+        assert source_stability_checks[0].rule_code == "S902"
+        source_stability_issues = [
+            issue
+            for issue in result.issues
+            if issue.details.get("category") == "call_graph_analysis_error"
             and issue.details.get("analysis") == "python_call_graph_source_stability"
             and issue.details.get("analysis_incomplete") is True
-            for issue in result.issues
+        ]
+        assert len(source_stability_issues) == 1
+        assert source_stability_issues[0].severity == IssueSeverity.INFO
+        assert source_stability_issues[0].message == expected_source_stability_message
+        assert source_stability_issues[0].rule_code == "S902"
+        assert should_cache_scan_result(result.to_dict(include_private_metadata=True)) is False
+        result.metadata["file_path"] = str(tmp_path / filename)
+        aggregate = create_initial_audit_result()
+        merge_scan_result(aggregate, result)
+        assert aggregate.success is False
+        assert aggregate.files_scanned == 1
+        assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in aggregate.issues)
+        assert not any(
+            check.status == CheckStatus.FAILED and check.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL}
+            for check in aggregate.checks
         )
+        assert determine_exit_code(aggregate) == 2
     assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
+    assert not any(
+        check.status == CheckStatus.FAILED and check.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL}
+        for check in result.checks
+    )
 
 
 def test_scan_does_not_trust_joblib_tail_when_literal_coverage_is_incomplete(tmp_path: Path) -> None:

--- a/tests/scanners/test_joblib_scanner_codecs.py
+++ b/tests/scanners/test_joblib_scanner_codecs.py
@@ -18,7 +18,7 @@ from unittest.mock import patch
 
 import modelaudit_picklescan.api as picklescan_api
 import pytest
-from modelaudit_picklescan.call_graph import _clear_source_sensitive_caches
+from modelaudit_picklescan.call_graph import _CallGraphAnalysisLimitError, _clear_source_sensitive_caches
 
 from modelaudit.cache.cache_policy import should_cache_scan_result
 from modelaudit.core import determine_exit_code, scan_file, scan_model_directory_or_file
@@ -1336,14 +1336,39 @@ def test_scan_accepts_lzma_compressed_numpy_array_payload(tmp_path: Path) -> Non
 
 
 @pytest.mark.parametrize("raw_seed", [b"builtins", b"os.system", b"subprocess", b"pickle.loads"])
-def test_scan_accepts_security_like_bytes_inside_numpy_array(tmp_path: Path, raw_seed: bytes) -> None:
+@pytest.mark.parametrize("source_snapshot_changes", [False, True], ids=["stable-source", "changed-source"])
+def test_scan_accepts_security_like_bytes_inside_numpy_array(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    raw_seed: bytes,
+    source_snapshot_changes: bool,
+) -> None:
+    if source_snapshot_changes:
+
+        def raise_source_stability_error(_report_generation: int | None) -> None:
+            raise _CallGraphAnalysisLimitError("source changed during shared call-graph analysis")
+
+        monkeypatch.setattr(picklescan_api, "_ensure_shared_source_snapshot_stable", raise_source_stability_error)
+
     raw_data = raw_seed.ljust(32, b"\x00")
     payload = _joblib_numpy_list_payload(raw_data=raw_data, shape=len(raw_data), dtype="u1")
 
     result = _scan_payload(tmp_path, payload, "benign_security_like_array_bytes.joblib")
 
-    assert result.success is True
-    assert result.metadata["trusted_incomplete_tail"] is True
+    if result.success:
+        assert source_snapshot_changes is False
+        assert result.metadata["trusted_incomplete_tail"] is True
+    else:
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert result.metadata["analysis_incomplete"] is True
+        assert result.metadata["operational_error_reason"] == "call_graph_analysis_error"
+        assert "trusted_incomplete_tail" not in result.metadata
+        assert any(
+            issue.details.get("category") == "call_graph_analysis_error"
+            and issue.details.get("analysis") == "python_call_graph_source_stability"
+            and issue.details.get("analysis_incomplete") is True
+            for issue in result.issues
+        )
     assert not any(issue.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL} for issue in result.issues)
 
 


### PR DESCRIPTION
## Summary

- Fix the current-main Windows Nightly failure in `test_scan_accepts_security_like_bytes_inside_numpy_array` without changing production scanner behavior or weakening fail-closed handling.
- Exercise each benign security-like NumPy byte payload with deterministic stable-source and changed-source controls.
- Require the changed-source path to remain inconclusive, operationally failed, non-cacheable, free of actionable findings, and mapped to exit code 2.

## Regression evidence

- Failed scheduled Windows Nightly: https://github.com/promptfoo/modelaudit/actions/runs/31863628197/job/94961018248
- The same benign-array failure also appears in an unrelated Windows PR lane: https://github.com/promptfoo/modelaudit/actions/runs/30955349897/job/92147028207
- Stable-source controls require a successful trusted-tail result.
- Changed-source controls require the exact source-stability diagnostic on the INFO S902 check and issue, preserve inconclusive report status/verdict, and reject warning or critical findings across both scanner-local and aggregate results.

## Validation

- Focused stable/changed-source regression: **8 passed**.
- Focused regression plus package-level source-stability coverage: **9 passed**.
- Required fast suite: **21,778 passed, 903 skipped**.
- Repository Ruff format: **424 files unchanged**; full Ruff check clean.
- Python 3.10 full mypy: **no issues in 479 source files**.
- Exact-head CI and repository Codex review are running on `4de1bf2`.

## Stack

This PR is temporarily based on #1812 so CI includes the sqlparse audit fix. After terminal green checks and exact-head review, it will be squash-merged into #1812's branch; #1812 then flows into #1813 before the combined stack is revalidated against `main`.
