### PR TITLE
test(picklescan): make legacy alias stability checks deterministic

### DIFF
--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -10875,19 +10875,16 @@ def test_scan_bytes_keeps_legacy_python_two_globals_clean(
     source_changed: bool,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    if source_changed:
-
-        def raise_source_stability_error(_report_generation: int | None) -> None:
+    def verify_source_stability(_report_generation: int | None) -> None:
+        if source_changed:
             raise _CallGraphAnalysisLimitError("source changed during shared call-graph analysis")
 
-        monkeypatch.setattr(package_api, "_ensure_shared_source_snapshot_stable", raise_source_stability_error)
+    monkeypatch.setattr(package_api, "_ensure_shared_source_snapshot_stable", verify_source_stability)
 
     report = scan_bytes(payload, source="legacy-python-two-global.pkl")
 
     if source_changed:
         assert report.status == ScanStatus.INCONCLUSIVE
-
-    if report.status == ScanStatus.INCONCLUSIVE:
         _assert_call_graph_source_stability_error(report)
         assert report.verdict == SafetyVerdict.UNKNOWN
     else:

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -10868,20 +10868,27 @@ def test_scan_bytes_keeps_allowlisted_import_only_global_clean() -> None:
         (b"cexceptions\nWindowsError\n.", "exceptions.WindowsError"),
     ],
 )
-def test_scan_bytes_keeps_legacy_python_two_globals_clean(payload: bytes, import_reference: str) -> None:
+@pytest.mark.parametrize("source_changed", [False, True], ids=["stable-source", "changed-source"])
+def test_scan_bytes_keeps_legacy_python_two_globals_clean(
+    payload: bytes,
+    import_reference: str,
+    source_changed: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if source_changed:
+
+        def raise_source_stability_error(_report_generation: int | None) -> None:
+            raise _CallGraphAnalysisLimitError("source changed during shared call-graph analysis")
+
+        monkeypatch.setattr(package_api, "_ensure_shared_source_snapshot_stable", raise_source_stability_error)
+
     report = scan_bytes(payload, source="legacy-python-two-global.pkl")
 
-    if import_reference == "exceptions.ValueError" and report.status == ScanStatus.INCONCLUSIVE:
-        assert report.metadata.get("analysis_incomplete") is True
-        assert any(
-            error.message
-            == "Python call-graph analysis could not complete: source changed during shared call-graph analysis"
-            and error.category == "call_graph_analysis_error"
-            and error.exception_type == "_CallGraphAnalysisLimitError"
-            and error.details.get("analysis") == "python_call_graph_source_stability"
-            and error.details.get("analysis_incomplete") is True
-            for error in report.errors
-        )
+    if source_changed:
+        assert report.status == ScanStatus.INCONCLUSIVE
+
+    if report.status == ScanStatus.INCONCLUSIVE:
+        _assert_call_graph_source_stability_error(report)
         assert report.verdict == SafetyVerdict.UNKNOWN
     else:
         assert report.status == ScanStatus.COMPLETE


### PR DESCRIPTION
## Summary

- Make the legacy Python 2 global-alias regression deterministic for `copy_reg._reconstructor`, `exceptions.ValueError`, and `exceptions.WindowsError`.
- Exercise both stable and changed shared-source snapshots for every alias: stable scans must stay `COMPLETE` / `CLEAN`, while changed snapshots must fail closed as `INCONCLUSIVE` / `UNKNOWN` with the source-stability diagnostic and incomplete-analysis metadata.
- Remove the now-redundant single-case `exceptions.ValueError` regression and integrate current `main` without changing production code.

This covers the Windows/Python 3.11 failure from scheduled [Nightly run 32214858406](https://github.com/promptfoo/modelaudit/actions/runs/32214858406), where `copy_reg._reconstructor` legitimately failed closed during shared-source instability.

## Validation

- Focused legacy/source-stability checks: **10 passed**.
- Standalone `modelaudit-picklescan` gate: **2,924 passed, 120 skipped**; Rust **187 passed**; lock, Ruff, formatting, mypy, cargo check/clippy, wheel/sdist build, and Twine checks passed.
- Root Python 3.10 all-ci precommit: Ruff formatting/checks passed; mypy passed across **479 source files**; pytest **23,403 passed, 806 skipped** in 17:37.
- Exact-head prepublish review: two independent native review passes plus independent verification, with no P0-P3 findings.
