### PR TITLE
fix: remove tensor_name_count retention budget dimension for remote SafeTensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- Remove `tensor_name_count` as a retention budget dimension for remote SafeTensors streaming; the `result_bytes` cap already bounds aggregate serialized size, so large multi-shard models (e.g. 141 shards) no longer fail closed prematurely.
 - Avoid false-positive `urllib` network findings for model cards whose only `urlopen` use is the documented `Image.open(urlopen(...))` sample-image example.
 - Upgrade vulnerable locked dependencies, use the hardened MLflow tracking client, and audit all installed CI extras.
 - Avoid network false positives for bounded README examples that download sample images over HTTPS from Hugging Face.

--- a/modelaudit/utils/sources/huggingface.py
+++ b/modelaudit/utils/sources/huggingface.py
@@ -26,6 +26,7 @@ from urllib.parse import parse_qsl, quote, urlencode, urljoin, urlparse, urlspli
 
 from ..file.detection import detect_file_format_for_skip_filter
 from ..file.streaming import StreamedSourceByteAccounting
+from ..helpers.assets import asset_from_scan_result
 from ..helpers.disk_space import check_disk_space
 from ..helpers.interrupt_handler import check_interrupted
 from .huggingface_paths import (
@@ -184,9 +185,18 @@ class _HuggingFaceSafeTensorsRetentionBudget:
         tensor_name_count = sum(1 for name in raw_names if isinstance(name, str)) if isinstance(raw_names, list) else 0
         serialization_failed = False
         try:
+            # Streaming output retains metadata and a separately derived asset, so charge both representations.
+            report_path = str(metadata.get("source_path") or metadata.get("remote_source_path") or "")
+            asset = asset_from_scan_result(report_path, result, metadata=metadata)
+            asset["is_streamed"] = True
+            asset["is_remote_header_only"] = bool(metadata.get("remote_header_only"))
             result_bytes = len(
                 json.dumps(
-                    result.to_dict(),
+                    {
+                        "result": result.to_dict(),
+                        "file_metadata_path": report_path,
+                        "asset": asset,
+                    },
                     ensure_ascii=False,
                     separators=(",", ":"),
                     default=str,

--- a/modelaudit/utils/sources/huggingface.py
+++ b/modelaudit/utils/sources/huggingface.py
@@ -61,7 +61,6 @@ _MAX_HF_SAFETENSORS_INDEX_DETAIL_ITEMS = 20
 _HF_SAFETENSORS_INDEX_RECONCILIATION_REASON = "remote_safetensors_index_reconciliation_incomplete"
 _HF_SAFETENSORS_REMOTE_OVERLAP_REASON = "remote_safetensors_overlap_coverage_incomplete"
 _MAX_HF_SAFETENSORS_RETAINED_RESULTS = 512
-_MAX_HF_SAFETENSORS_RETAINED_TENSOR_NAMES = 65_536
 _MAX_HF_SAFETENSORS_RETAINED_RESULT_BYTES = 32 * 1024 * 1024
 _HF_SAFETENSORS_RESULT_BUDGET_FAILURE_RESERVE_BYTES = 256 * 1024
 _HF_SAFETENSORS_RESULT_BUDGET_REASON = "remote_safetensors_result_budget_exceeded"
@@ -173,7 +172,6 @@ class _HuggingFaceSafeTensorsRetentionBudget:
             "projected_tensor_names": self.retained_tensor_names,
             "projected_result_bytes": self.retained_result_bytes,
             "max_retained_results": _MAX_HF_SAFETENSORS_RETAINED_RESULTS,
-            "max_retained_tensor_names": _MAX_HF_SAFETENSORS_RETAINED_TENSOR_NAMES,
             "max_retained_result_bytes": _MAX_HF_SAFETENSORS_RETAINED_RESULT_BYTES,
             "candidate_serialization_failed": False,
             "candidate_scan_preflighted": True,
@@ -208,8 +206,6 @@ class _HuggingFaceSafeTensorsRetentionBudget:
         exceeded = []
         if projected_results >= _MAX_HF_SAFETENSORS_RETAINED_RESULTS:
             exceeded.append("result_count")
-        if projected_tensor_names > _MAX_HF_SAFETENSORS_RETAINED_TENSOR_NAMES:
-            exceeded.append("tensor_name_count")
         if projected_result_bytes > result_byte_limit:
             exceeded.append("result_bytes")
         if exceeded:
@@ -224,7 +220,6 @@ class _HuggingFaceSafeTensorsRetentionBudget:
                 "projected_tensor_names": projected_tensor_names,
                 "projected_result_bytes": projected_result_bytes,
                 "max_retained_results": _MAX_HF_SAFETENSORS_RETAINED_RESULTS,
-                "max_retained_tensor_names": _MAX_HF_SAFETENSORS_RETAINED_TENSOR_NAMES,
                 "max_retained_result_bytes": _MAX_HF_SAFETENSORS_RETAINED_RESULT_BYTES,
                 "candidate_serialization_failed": serialization_failed,
             }

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -8363,7 +8363,7 @@ class TestModelDownloadStreaming:
         monkeypatch.setattr(
             huggingface_module,
             "_MAX_HF_SAFETENSORS_RETAINED_RESULT_BYTES",
-            _HF_SAFETENSORS_RESULT_BUDGET_FAILURE_RESERVE_BYTES + 900,
+            _HF_SAFETENSORS_RESULT_BUDGET_FAILURE_RESERVE_BYTES + 1_500,
         )
 
         def fake_scan(_repo_id: str, filename: str, _revision: str, **_kwargs: object) -> Any:
@@ -8437,6 +8437,77 @@ class TestModelDownloadStreaming:
         assert determine_exit_code(aggregate) == 2
         assert sum(len(asset.tensors or []) for asset in aggregate.assets) == 2
         mock_cache_store.assert_not_called()
+
+    def test_remote_safetensors_result_budget_bounds_final_stream_output(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from modelaudit.utils.sources import huggingface as huggingface_module
+
+        filenames = [f"model-{index:05d}-of-00300.safetensors" for index in range(1, 301)]
+        tensor_names = [f"tensor_{index:04d}_{'x' * 80}" for index in range(1024)]
+        monkeypatch.setattr(
+            huggingface_module,
+            "_list_repo_files_with_timeout",
+            lambda *_args, **_kwargs: (filenames, _HF_TEST_REVISION, None),
+        )
+        monkeypatch.setattr(
+            huggingface_module,
+            "_get_huggingface_path_sizes",
+            lambda *_args, **_kwargs: (dict.fromkeys(filenames, 500), _HF_TEST_REVISION),
+        )
+
+        def fake_scan(_repo_id: str, filename: str, _revision: str, **_kwargs: object) -> Any:
+            result = _fake_remote_safetensors_scan(filename)
+            result.metadata["tensors"] = tensor_names
+            result.metadata["tensor_count"] = len(tensor_names)
+            return result
+
+        with (
+            patch(
+                "modelaudit.utils.sources.huggingface._scan_remote_huggingface_safetensors_header",
+                side_effect=fake_scan,
+            ) as mock_scan,
+            patch("huggingface_hub.hf_hub_download") as mock_download,
+        ):
+            aggregate = scan_model_streaming(
+                download_model_streaming(
+                    f"hf://test/model?revision={_HF_TEST_REVISION}",
+                    scannable_extensions={".safetensors"},
+                    scannable_scanner_ids={"safetensors"},
+                    _include_scan_results=True,
+                ),
+                timeout=60,
+                delete_after_scan=False,
+                cache_enabled=False,
+                scanners=["safetensors"],
+                skip_file_types=False,
+            )
+
+        budget = next(
+            metadata["remote_result_retention_budget"]
+            for metadata in aggregate.model_dump(mode="json")["file_metadata"].values()
+            if "remote_result_retention_budget" in metadata
+        )
+        serialized_bytes = len(aggregate.model_dump_json().encode())
+        retained_results = aggregate.files_scanned - 1
+
+        assert aggregate.files_scanned == mock_scan.call_count
+        assert aggregate.files_scanned < len(filenames)
+        assert aggregate.success is False
+        assert determine_exit_code(aggregate) == 2
+        assert budget["exceeded"] == ["result_bytes"]
+        assert budget["retained_results"] == retained_results
+        assert budget["retained_result_bytes"] <= (
+            _MAX_HF_SAFETENSORS_RETAINED_RESULT_BYTES - _HF_SAFETENSORS_RESULT_BUDGET_FAILURE_RESERVE_BYTES
+        )
+        assert budget["projected_result_bytes"] > (
+            _MAX_HF_SAFETENSORS_RETAINED_RESULT_BYTES - _HF_SAFETENSORS_RESULT_BUDGET_FAILURE_RESERVE_BYTES
+        )
+        assert sum(len(asset.tensors or []) for asset in aggregate.assets) == retained_results * len(tensor_names)
+        assert serialized_bytes > _MAX_HF_SAFETENSORS_RETAINED_RESULT_BYTES - (1024 * 1024)
+        assert serialized_bytes < _MAX_HF_SAFETENSORS_RETAINED_RESULT_BYTES
+        mock_download.assert_not_called()
 
     @pytest.mark.parametrize("with_index", [False, True], ids=["huge-header-name", "huge-index-name"])
     def test_remote_safetensors_huge_tensor_names_are_source_native_and_result_bounded(
@@ -9146,6 +9217,7 @@ class TestModelDownloadStreaming:
         assert metrics["download_calls"] == 0
         assert metrics["success"] is True
         assert metrics["exit_code"] == 0
+        assert metrics["retained_tensor_names"] == 100 * 1024
         assert metrics["serialized_bytes"] < _MAX_HF_SAFETENSORS_RETAINED_RESULT_BYTES
         assert metrics["peak_delta_bytes"] < 64 * 1024 * 1024
         assert metrics["header_bytes"] > 250_000

--- a/tests/utils/sources/test_huggingface.py
+++ b/tests/utils/sources/test_huggingface.py
@@ -53,7 +53,6 @@ from modelaudit.utils.sources.huggingface import (
     _MAX_HF_REPOSITORY_PATH_CHARS,
     _MAX_HF_SAFETENSORS_RETAINED_RESULT_BYTES,
     _MAX_HF_SAFETENSORS_RETAINED_RESULTS,
-    _MAX_HF_SAFETENSORS_RETAINED_TENSOR_NAMES,
     _build_huggingface_model_info,
     _check_hf_acquisition_interrupted,
     _combine_remote_safetensors_shard_details,
@@ -8238,7 +8237,6 @@ class TestModelDownloadStreaming:
         ("dimension", "constant_name", "constant_value", "metadata"),
         [
             ("result_count", "_MAX_HF_SAFETENSORS_RETAINED_RESULTS", 1, {}),
-            ("tensor_name_count", "_MAX_HF_SAFETENSORS_RETAINED_TENSOR_NAMES", 1, {"tensors": ["a", "b"]}),
             (
                 "result_bytes",
                 "_MAX_HF_SAFETENSORS_RETAINED_RESULT_BYTES",
@@ -8362,7 +8360,11 @@ class TestModelDownloadStreaming:
             "_get_huggingface_path_sizes",
             lambda *_args, **_kwargs: (dict.fromkeys(filenames, 500), _HF_TEST_REVISION),
         )
-        monkeypatch.setattr(huggingface_module, "_MAX_HF_SAFETENSORS_RETAINED_TENSOR_NAMES", 3)
+        monkeypatch.setattr(
+            huggingface_module,
+            "_MAX_HF_SAFETENSORS_RETAINED_RESULT_BYTES",
+            _HF_SAFETENSORS_RESULT_BUDGET_FAILURE_RESERVE_BYTES + 900,
+        )
 
         def fake_scan(_repo_id: str, filename: str, _revision: str, **_kwargs: object) -> Any:
             result = _fake_remote_safetensors_scan(filename)
@@ -8403,7 +8405,7 @@ class TestModelDownloadStreaming:
         assert failure_result.success is False
         assert _HF_SAFETENSORS_RESULT_BUDGET_REASON in failure_result.metadata["scan_outcome_reasons"]
         budget = failure_result.metadata["remote_result_retention_budget"]
-        assert budget["exceeded"] == ["tensor_name_count"]
+        assert "result_bytes" in budget["exceeded"]
         assert budget["retained_tensor_names"] == 2
         assert bool(budget["candidate_security_record_count"]) is candidate_security_finding
         budget_checks = [
@@ -9008,7 +9010,7 @@ class TestModelDownloadStreaming:
 
     @pytest.mark.skipif(os.name == "nt", reason="resource peak RSS is unavailable on Windows")
     def test_remote_safetensors_max_cardinality_repository_retention_is_measured_and_bounded(self) -> None:
-        """One hundred maximum-cardinality headers must stop at the aggregate retention cap."""
+        """One hundred maximum-cardinality headers must complete within result_count and result_bytes caps."""
         repo_root = Path(__file__).resolve().parents[3]
         script = textwrap.dedent(
             """
@@ -9140,16 +9142,14 @@ class TestModelDownloadStreaming:
         assert completed.returncode == 0, completed.stderr
         metrics = json.loads(completed.stdout.strip().splitlines()[-1])
 
-        assert metrics["files_scanned"] == 65
+        assert metrics["files_scanned"] == 100
         assert metrics["download_calls"] == 0
-        assert metrics["success"] is False
-        assert metrics["exit_code"] == 2
-        assert metrics["retained_tensor_names"] == _MAX_HF_SAFETENSORS_RETAINED_TENSOR_NAMES
+        assert metrics["success"] is True
+        assert metrics["exit_code"] == 0
         assert metrics["serialized_bytes"] < _MAX_HF_SAFETENSORS_RETAINED_RESULT_BYTES
         assert metrics["peak_delta_bytes"] < 64 * 1024 * 1024
         assert metrics["header_bytes"] > 250_000
-        assert metrics["budget"]["exceeded"] == ["tensor_name_count"]
-        assert metrics["budget"]["retained_results"] < _MAX_HF_SAFETENSORS_RETAINED_RESULTS
+        assert metrics["budget"] is None
 
     def test_remote_safetensors_zero_based_index_is_authoritative(self) -> None:
         first = "model-00000-of-00002.safetensors"


### PR DESCRIPTION
Fixes #1823

## Summary

The `tensor_name_count` dimension in `_HuggingFaceSafeTensorsRetentionBudget` caused large multi-shard SafeTensors models to fail closed prematurely. Specifically, `RedHatAI/GLM-5.2-FP8` (753B params, 141 safetensors shards, ~756 GB) hit the 65,536 tensor-name cap at shard ~84/141 and produced an incomplete scan (exit 2).

The `result_bytes` cap (32 MB serialized JSON) already bounds aggregate output size, making `tensor_name_count` redundant — removing it lets large models complete without losing protection against pathological inputs.

### Changes

- Remove `_MAX_HF_SAFETENSORS_RETAINED_TENSOR_NAMES` constant and the `tensor_name_count` exceeded check from `_HuggingFaceSafeTensorsRetentionBudget.retain()`.
- Remove all references to `max_retained_tensor_names` in preflight and retain return dicts.
- Update tests: max-cardinality repository test now expects success (all 100 files scanned), fail-closed test triggers via `result_bytes` instead.
- Add CHANGELOG entry under `[Unreleased]`.

The `result_count` (512) and `result_bytes` (32 MB) budget dimensions remain unchanged.

## Testing

Tested locally against 6 HuggingFace models spanning a wide range of sizes:

| Model | Params | Disk size | ST shards | Result (fix branch) | Result (main) |
|---|---|---|---|---|---|
| `RedHatAI/SmolLM3-3B-FP8-dynamic` | 3B | ~3.3 GB | 1 | pass | pass |
| `Qwen/Qwen3-8B` | 8.2B | ~16.4 GB | 5 | pass | pass |
| `google/gemma-4-26B-A4B-it` | 25.2B | ~51.6 GB | 2 | pass | pass |
| `RedHatAI/gpt-oss-120b-FP8-Dynamic` | 120B | ~117 GB | 24 | pass | pass |
| `moonshotai/Kimi-K2-Thinking` | 1T | ~594 GB | 62 | pass | pass |
| **`RedHatAI/GLM-5.2-FP8`** | **753B** | **~756 GB** | **141** | **pass (all 141 scanned)** | **fail** (`tensor_name_count` exceeded at shard 84) |

GLM-5.2-FP8 is the only model that failed on `main`. All six pass on the fix branch with zero budget failures.

```bash
uv run ruff format ... && uv run ruff check ... && uv run mypy ... && uv run pytest -n auto -m "not slow and not integration" --maxfail=1
```

All clean.