### PR TITLE
fix(ci): route hash timing test to performance lane

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -437,7 +437,7 @@ jobs:
     if: needs.changes.outputs.integration == 'true' || needs.changes.outputs.python == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     # Coverage runs in dedicated shards below, and the Python 3.12
-    # slow/integration/performance suite now runs in a separate parallel job.
+    # slow/integration suite now runs in a separate parallel job.
     timeout-minutes: 75
     strategy:
       fail-fast: false
@@ -535,9 +535,9 @@ jobs:
         run: |
           uv sync --extra all-ci
 
-      - name: Run slow, integration, and performance tests
+      - name: Run slow and integration tests
         run: |
-          uv run pytest tests -n auto -m "slow or integration or performance" --tb=short --durations=20
+          uv run pytest tests -n auto -m "(slow or integration) and not performance" --tb=short --durations=20
 
   coverage:
     name: Coverage (${{ matrix.shard }})

--- a/tests/test_perf_workflow.py
+++ b/tests/test_perf_workflow.py
@@ -535,7 +535,7 @@ def test_python_ci_windows_matrix_shards_main_and_workflow_prs() -> None:
     assert "--modelaudit-shard-index ${{ matrix.shard-index }}" in exhaustive_run
 
 
-def test_python_ci_runs_slow_suite_in_a_separate_job() -> None:
+def test_python_ci_keeps_performance_out_of_the_xdist_slow_suite() -> None:
     workflow = _load_workflow("test.yml")
     jobs = _jobs(workflow)
 
@@ -545,13 +545,9 @@ def test_python_ci_runs_slow_suite_in_a_separate_job() -> None:
         "(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-slow-tests'))"
     )
     slow_steps = slow_job["steps"]
-    assert (
-        '-m "slow or integration or performance"'
-        in _step_by_name(
-            slow_steps,
-            "Run slow, integration, and performance tests",
-        )["run"]
-    )
+    slow_run = _step_by_name(slow_steps, "Run slow and integration tests")["run"]
+    assert "pytest tests -n auto" in slow_run
+    assert '-m "(slow or integration) and not performance"' in slow_run
 
     fast_steps = jobs["test"]["steps"]
     fast_step_names = {step.get("name") for step in fast_steps}

--- a/tests/test_regular_scan_hash.py
+++ b/tests/test_regular_scan_hash.py
@@ -1512,7 +1512,8 @@ class TestHashGenerationEdgeCases:
         # files_scanned should include both files
         assert result.files_scanned == 2
 
-    def test_hash_generation_performance(self, tmp_path):
+    @pytest.mark.performance
+    def test_hash_generation_performance(self, tmp_path: Path) -> None:
         """Test that hash generation doesn't significantly impact performance."""
         import time
 

--- a/tests/test_xdist_status.py
+++ b/tests/test_xdist_status.py
@@ -324,6 +324,14 @@ def test_nightly_runs_unsharded_performance_and_rust_once_and_fails_closed() -> 
         assert all("continue-on-error" not in step for step in job["steps"])
 
 
+def test_wall_clock_hash_generation_uses_dedicated_performance_lane() -> None:
+    from tests.test_regular_scan_hash import TestHashGenerationEdgeCases
+
+    marks = getattr(TestHashGenerationEdgeCases.test_hash_generation_performance, "pytestmark", ())
+
+    assert any(mark.name == "performance" for mark in marks)
+
+
 def test_nodeid_sharding_rejects_non_positive_count() -> None:
     root_conftest = _load_root_conftest()
 


### PR DESCRIPTION
## Summary

- Route the wall-clock hash-generation benchmark to the existing `performance` category instead of running its hard two-second assertion in parallel Windows/Linux fast-test shards.
- Keep the benchmark enforced by the dedicated single-process Nightly performance lane and add a failing-first regression that prevents it from silently returning to correctness lanes.

## Reproduction

PR #1817's Windows fast-test job failed after **19,738 passing tests** because `test_hash_generation_performance` took **2.209 seconds** under `pytest-xdist` and asserted a two-second limit: https://github.com/promptfoo/modelaudit/actions/runs/32933707417/job/98070818332.

Before this change, the new marker regression fails, the benchmark is collected by `-m 'not slow and not integration and not performance'`, and `-m performance` deselects it. After this change, fast and Nightly correctness selections exclude the benchmark, while the serial performance lane selects and passes it.

## Verification

- New failing-first marker regression: **failed before, passed after**.
- CI-equivalent four-worker hashing, Nightly, workflow, and utility suites: **142 passed**.
- Focused serial fast-lane suites: **50 passed, 1 performance test deselected**.
- Dedicated serial performance selection: **1 passed, 75 correctly deselected**.
- Repository-wide Ruff lint: **passed**.
- Repository-wide Ruff formatting: **424 files passed**.
- Changed-file mypy: **passed**.

The broad local suite excludes two pre-existing macOS-only baselines: a cache-hit regression already fixed by #1821 (the same test passes on that PR's head) and an invalid-UTF-8 filename case unsupported by the local filesystem. Current default-branch Linux/Windows CI and all 13 jobs in the latest scheduled Nightly are green.
