### PR TITLE
fix(network): reject side-effectful model-card image examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Upgrade Debian util-linux packages in all Docker runtime images to remediate CVE-2026-53615.
-- Preserve model-card network alerts when documented image examples invoke side-effectful image methods or debugger builtins.
+- Preserve model-card network alerts when documented image examples contain code outside the reviewed generated forms.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Upgrade Debian util-linux packages in all Docker runtime images to remediate CVE-2026-53615.
-- Preserve model-card network alerts when documented image examples invoke file-writing or debugger builtins.
+- Preserve model-card network alerts when documented image examples invoke file-writing calls or debugger builtins.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Upgrade Debian util-linux packages in all Docker runtime images to remediate CVE-2026-53615.
+- Preserve model-card network alerts when documented image examples invoke file-writing or debugger builtins.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Upgrade Debian util-linux packages in all Docker runtime images to remediate CVE-2026-53615.
-- Preserve model-card network alerts when documented image examples invoke file-writing calls or debugger builtins.
+- Preserve model-card network alerts when documented image examples invoke side-effectful image methods or debugger builtins.
 
 ### Bug Fixes
 

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -4621,9 +4621,12 @@ def _is_official_readme_urlopen_image_example(example: bytes) -> bool:
             or not isinstance(node.ctx, ast.Load)
         ):
             return False
-        if isinstance(node, ast.MatchClass) and any(
-            attribute in _DOCUMENTED_EXAMPLE_FORBIDDEN_ATTRIBUTES or attribute.startswith("__")
-            for attribute in node.kwd_attrs
+        if isinstance(node, ast.MatchClass) and (
+            node.patterns
+            or any(
+                attribute in _DOCUMENTED_EXAMPLE_FORBIDDEN_ATTRIBUTES or attribute.startswith("__")
+                for attribute in node.kwd_attrs
+            )
         ):
             return False
         if isinstance(node, ast.Subscript) and not isinstance(node.ctx, ast.Load):

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -4508,6 +4508,7 @@ _DOCUMENTED_EXAMPLE_FORBIDDEN_ATTRIBUTES = frozenset(
         "locals",
         "popen",
         "save",
+        "show",
         "setattr",
         "system",
         "vars",

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -4397,25 +4397,70 @@ def _is_huggingface_image_url(url: str) -> bool:
     )
 
 
-_TRUSTED_HUGGINGFACE_DOCUMENTATION_IMAGE_URLS = frozenset(
-    {("https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png")}
+_TRUSTED_HUGGINGFACE_DOCUMENTATION_IMAGE_URL = (
+    "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png"
+)
+_DOCUMENTED_IMAGE_MODEL_NAME_SENTINEL = "<model-name>"
+_DOCUMENTED_IMAGE_VARIABLE_SENTINEL = "_documented_image"
+_DOCUMENTED_IMAGE_TIMM_REGISTRY_NAME_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+_DOCUMENTED_IMAGE_EXAMPLE_PREFIX = "from urllib.request import urlopen\nfrom PIL import Image\n"
+_DOCUMENTED_IMAGE_ASSIGNMENT = (
+    f"{_DOCUMENTED_IMAGE_VARIABLE_SENTINEL} = Image.open(urlopen(\n"
+    f'    "{_TRUSTED_HUGGINGFACE_DOCUMENTATION_IMAGE_URL}"\n))\n'
+)
+_DOCUMENTED_IMAGE_EXAMPLE_SOURCES = (
+    _DOCUMENTED_IMAGE_EXAMPLE_PREFIX + _DOCUMENTED_IMAGE_ASSIGNMENT,
+    _DOCUMENTED_IMAGE_EXAMPLE_PREFIX
+    + "import timm\n"
+    + _DOCUMENTED_IMAGE_ASSIGNMENT
+    + f'model = timm.create_model("{_DOCUMENTED_IMAGE_MODEL_NAME_SENTINEL}", pretrained=True)\n',
+    _DOCUMENTED_IMAGE_EXAMPLE_PREFIX
+    + "import timm\n"
+    + _DOCUMENTED_IMAGE_ASSIGNMENT
+    + (
+        f'model = timm.create_model("{_DOCUMENTED_IMAGE_MODEL_NAME_SENTINEL}", pretrained=True)\n'
+        "model = model.eval()\n"
+        "data_config = timm.data.resolve_model_data_config(model)\n"
+        "transforms = timm.data.create_transform(**data_config, is_training=False)\n"
+        f"output = model(transforms({_DOCUMENTED_IMAGE_VARIABLE_SENTINEL}).unsqueeze(0))\n"
+        "top5_probabilities, top5_class_indices = torch.topk("
+        "output.softmax(dim=1) * 100, k=5)\n"
+    ),
+    _DOCUMENTED_IMAGE_EXAMPLE_PREFIX
+    + "import timm\n"
+    + _DOCUMENTED_IMAGE_ASSIGNMENT
+    + (
+        f'model = timm.create_model("{_DOCUMENTED_IMAGE_MODEL_NAME_SENTINEL}", '
+        "pretrained=True, features_only=True)\n"
+        "model = model.eval()\n"
+        "data_config = timm.data.resolve_model_data_config(model)\n"
+        "transforms = timm.data.create_transform(**data_config, is_training=False)\n"
+        f"output = model(transforms({_DOCUMENTED_IMAGE_VARIABLE_SENTINEL}).unsqueeze(0))\n"
+        "for o in output:\n"
+        "    print(o.shape)\n"
+    ),
+    _DOCUMENTED_IMAGE_EXAMPLE_PREFIX
+    + "import timm\n"
+    + _DOCUMENTED_IMAGE_ASSIGNMENT
+    + (
+        f'model = timm.create_model("{_DOCUMENTED_IMAGE_MODEL_NAME_SENTINEL}", '
+        "pretrained=True, num_classes=0)\n"
+        "model = model.eval()\n"
+        "data_config = timm.data.resolve_model_data_config(model)\n"
+        "transforms = timm.data.create_transform(**data_config, is_training=False)\n"
+        f"output = model(transforms({_DOCUMENTED_IMAGE_VARIABLE_SENTINEL}).unsqueeze(0))\n"
+        f"output = model.forward_features("
+        f"transforms({_DOCUMENTED_IMAGE_VARIABLE_SENTINEL}).unsqueeze(0))\n"
+        "output = model.forward_head(output, pre_logits=True)\n"
+    ),
+)
+_DOCUMENTED_IMAGE_EXAMPLE_AST_DUMPS = frozenset(
+    ast.dump(ast.parse(source), include_attributes=False) for source in _DOCUMENTED_IMAGE_EXAMPLE_SOURCES
 )
 
 
-def _is_trusted_huggingface_documentation_image_url(url: str) -> bool:
-    """Return whether a URL exactly matches a reviewed documentation-image location."""
-    return url in _TRUSTED_HUGGINGFACE_DOCUMENTATION_IMAGE_URLS
-
-
 def official_readme_urlopen_image_example_spans(data: bytes) -> tuple[tuple[int, int], ...]:
-    """Return byte spans of Python fences whose only ``urlopen`` use fetches a documented image.
-
-    Model-card generators (notably ``timm``) emit a fixed ``Image.open(urlopen(<literal URL>))``
-    snippet, so this exact generated shape is recognized without pinning whole-file
-    digests. Callers use the returned spans to decide whether an individual ``urllib``/``urlopen``
-    finding sits inside a recognized generated example.
-
-    """
+    """Return byte spans of exact generated sample-image examples."""
     if b"urlopen" not in data:
         return ()
 
@@ -4442,15 +4487,6 @@ def official_readme_urlopen_image_example_spans(data: bytes) -> tuple[tuple[int,
             spans.append((opening.end(), closing.start()))
         cursor = closing.end()
 
-    # A recognized fence covers only its own token positions. If any urllib reference sits outside
-    # a recognized fence - a second fence, prose, or trailing payload - the whole file stays actionable,
-    # mirroring how the `requests` example tracks unvalidated references.
-    #
-    # Guard on the bare substrings `urllib` and `urlopen` rather than on the specific tokens the
-    # findings report. The detector emits a single `network_library: urllib` finding per file and
-    # then retargets it to the earliest urllib token, so a narrower guard lets an unrelated
-    # `import urllib.request` + `urllib.request.build_opener()` fence inherit the benign example's
-    # position and be downgraded with it.
     if not spans or _tokens_appear_outside_spans(data, (b"urllib", b"urlopen"), spans):
         return ()
     return tuple(spans)
@@ -4476,48 +4512,64 @@ def _tokens_appear_outside_spans(
     return False
 
 
-# Bare-name execution primitives. Attribute access is checked separately: documented model cards
-# legitimately call `model.eval()` and `torch.compile()`, while mutation/introspection helpers are
-# never part of the generated example.
-_DOCUMENTED_EXAMPLE_FORBIDDEN_NAMES = frozenset(
-    {
-        "__builtins__",
-        "__import__",
-        "breakpoint",
-        "builtins",
-        "compile",
-        "delattr",
-        "eval",
-        "exec",
-        "getattr",
-        "globals",
-        "locals",
-        "open",
-        "setattr",
-        "vars",
-    }
-)
-_DOCUMENTED_EXAMPLE_FORBIDDEN_ATTRIBUTES = frozenset(
-    {
-        "_dump",
-        "__import__",
-        "delattr",
-        "exec",
-        "getattr",
-        "globals",
-        "locals",
-        "popen",
-        "save",
-        "show",
-        "setattr",
-        "system",
-        "vars",
-    }
-)
+def _is_timm_create_model_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "create_model"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "timm"
+    )
+
+
+def _documented_image_binding_name(node: ast.AST) -> str | None:
+    if (
+        not isinstance(node, ast.Assign)
+        or len(node.targets) != 1
+        or not isinstance(node.targets[0], ast.Name)
+        or not isinstance(node.value, ast.Call)
+        or node.value.keywords
+        or len(node.value.args) != 1
+        or not isinstance(node.value.func, ast.Attribute)
+        or node.value.func.attr != "open"
+        or not isinstance(node.value.func.value, ast.Name)
+        or node.value.func.value.id != "Image"
+        or not isinstance(node.value.args[0], ast.Call)
+        or node.value.args[0].keywords
+        or len(node.value.args[0].args) != 1
+        or not isinstance(node.value.args[0].func, ast.Name)
+        or node.value.args[0].func.id != "urlopen"
+    ):
+        return None
+    return node.targets[0].id
+
+
+def _canonical_documented_image_example_dump(tree: ast.Module) -> str:
+    image_binding_names = [
+        binding_name
+        for statement in tree.body
+        if (binding_name := _documented_image_binding_name(statement)) is not None
+    ]
+    if len(image_binding_names) == 1:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Name) and node.id == image_binding_names[0]:
+                node.id = _DOCUMENTED_IMAGE_VARIABLE_SENTINEL
+
+    for node in ast.walk(tree):
+        if (
+            _is_timm_create_model_call(node)
+            and isinstance(node, ast.Call)
+            and len(node.args) == 1
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+            and _DOCUMENTED_IMAGE_TIMM_REGISTRY_NAME_PATTERN.fullmatch(node.args[0].value) is not None
+        ):
+            node.args[0] = ast.Constant(value=_DOCUMENTED_IMAGE_MODEL_NAME_SENTINEL)
+    return ast.dump(tree, include_attributes=False)
 
 
 def _is_official_readme_urlopen_image_example(example: bytes) -> bool:
-    """Return whether every ``urlopen`` use in one fence is a documented sample-image fetch."""
+    """Return whether a fence matches one exact generated sample-image shape."""
     if (
         len(example) > _MAX_README_IMAGE_EXAMPLE_BYTES
         or example.count(b"urllib") != 1
@@ -4534,147 +4586,8 @@ def _is_official_readme_urlopen_image_example(example: bytes) -> bool:
         if len(nodes) >= _MAX_README_IMAGE_EXAMPLE_AST_NODES:
             return False
         nodes.append(node)
-    parents = {id(child): parent for parent in nodes for child in ast.iter_child_nodes(parent)}
 
-    if len(tree.body) < 3:
-        return False
-    urlopen_import = tree.body[0]
-    if (
-        not isinstance(urlopen_import, ast.ImportFrom)
-        or urlopen_import.level != 0
-        or urlopen_import.module != "urllib.request"
-        or len(urlopen_import.names) != 1
-    ):
-        return False
-    alias = urlopen_import.names[0]
-    if alias.name != "urlopen" or alias.asname is not None:
-        return False
-
-    pil_image_import = tree.body[1]
-    if (
-        not isinstance(pil_image_import, ast.ImportFrom)
-        or pil_image_import.level != 0
-        or pil_image_import.module != "PIL"
-        or len(pil_image_import.names) != 1
-    ):
-        return False
-    pil_image_alias = pil_image_import.names[0]
-    if pil_image_alias.name != "Image" or pil_image_alias.asname is not None:
-        return False
-
-    image_assignment_index = 2
-    timm_import: ast.Import | None = None
-    possible_timm_import = tree.body[image_assignment_index]
-    if isinstance(possible_timm_import, ast.Import):
-        timm_import = possible_timm_import
-        if (
-            len(timm_import.names) != 1
-            or timm_import.names[0].name != "timm"
-            or timm_import.names[0].asname is not None
-        ):
-            return False
-        image_assignment_index += 1
-    if len(tree.body) <= image_assignment_index or not isinstance(
-        image_assignment := tree.body[image_assignment_index],
-        ast.Assign,
-    ):
-        return False
-
-    urlopen_calls: list[ast.Call] = []
-    for node in nodes:
-        # The generated cards use only these two exact imports plus an optional plain `timm`
-        # import. Keeping the import grammar positive prevents package/module aliases from
-        # reaching and mutating the protected PIL sink.
-        if isinstance(node, ast.ImportFrom) and node is not urlopen_import and node is not pil_image_import:
-            return False
-        if isinstance(node, ast.Import) and node is not timm_import:
-            return False
-        # Neither `urlopen` nor `Image` may be rebound, shadowed, aliased, or reached via attribute.
-        if isinstance(node, ast.Attribute) and node.attr == "urlopen":
-            return False
-        if isinstance(node, ast.arg) and node.arg in {"urlopen", "Image"}:
-            return False
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)) and node.name in {
-            "urlopen",
-            "Image",
-        }:
-            return False
-        if isinstance(node, ast.ExceptHandler) and node.name in {"urlopen", "Image"}:
-            return False
-        if isinstance(node, (ast.MatchAs, ast.MatchStar)) and node.name in {"urlopen", "Image"}:
-            return False
-        if isinstance(node, ast.MatchMapping) and node.rest in {"urlopen", "Image"}:
-            return False
-        if isinstance(node, ast.Name) and node.id == "Image":
-            parent = parents.get(id(node))
-            if (
-                not isinstance(node.ctx, ast.Load)
-                or not isinstance(parent, ast.Attribute)
-                or parent.value is not node
-                or parent.attr != "open"
-            ):
-                return False
-        # Execution primitives are outside the recognized generated-example grammar.
-        if isinstance(node, ast.Name) and node.id in _DOCUMENTED_EXAMPLE_FORBIDDEN_NAMES:
-            return False
-        if isinstance(node, ast.Attribute) and (
-            node.attr in _DOCUMENTED_EXAMPLE_FORBIDDEN_ATTRIBUTES
-            or node.attr.startswith("__")
-            or not isinstance(node.ctx, ast.Load)
-        ):
-            return False
-        if isinstance(node, ast.MatchClass) and (
-            node.patterns
-            or any(
-                attribute in _DOCUMENTED_EXAMPLE_FORBIDDEN_ATTRIBUTES or attribute.startswith("__")
-                for attribute in node.kwd_attrs
-            )
-        ):
-            return False
-        if isinstance(node, ast.Subscript) and not isinstance(node.ctx, ast.Load):
-            return False
-        if isinstance(node, (ast.Global, ast.Nonlocal, ast.Delete)):
-            return False
-        if not isinstance(node, ast.Name) or node.id != "urlopen":
-            continue
-        parent = parents.get(id(node))
-        if not isinstance(node.ctx, ast.Load) or not isinstance(parent, ast.Call) or parent.func is not node:
-            return False
-        urlopen_calls.append(parent)
-    if len(urlopen_calls) != 1:
-        return False
-
-    for call in urlopen_calls:
-        if call.keywords or len(call.args) != 1:
-            return False
-        argument = call.args[0]
-        if not isinstance(argument, ast.Constant) or not isinstance(argument.value, str):
-            return False
-        if not _is_trusted_huggingface_documentation_image_url(argument.value):
-            return False
-        # The response must flow straight into `Image.open(...)` and nowhere else.
-        parent = parents.get(id(call))
-        if (
-            not isinstance(parent, ast.Call)
-            or parent.keywords
-            or len(parent.args) != 1
-            or parent.args[0] is not call
-            or not isinstance(parent.func, ast.Attribute)
-            or parent.func.attr != "open"
-            or not isinstance(parent.func.value, ast.Name)
-            or parent.func.value.id != "Image"
-        ):
-            return False
-        assignment = parents.get(id(parent))
-        if (
-            not isinstance(assignment, ast.Assign)
-            or assignment is not image_assignment
-            or assignment.value is not parent
-            or len(assignment.targets) != 1
-            or not isinstance(assignment.targets[0], ast.Name)
-        ):
-            return False
-    return True
+    return _canonical_documented_image_example_dump(tree) in _DOCUMENTED_IMAGE_EXAMPLE_AST_DUMPS
 
 
 class NetworkCommDetector:

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -4506,6 +4506,7 @@ _DOCUMENTED_EXAMPLE_FORBIDDEN_ATTRIBUTES = frozenset(
         "globals",
         "locals",
         "popen",
+        "save",
         "setattr",
         "system",
         "vars",
@@ -4618,6 +4619,11 @@ def _is_official_readme_urlopen_image_example(example: bytes) -> bool:
             node.attr in _DOCUMENTED_EXAMPLE_FORBIDDEN_ATTRIBUTES
             or node.attr.startswith("__")
             or not isinstance(node.ctx, ast.Load)
+        ):
+            return False
+        if isinstance(node, ast.MatchClass) and any(
+            attribute in _DOCUMENTED_EXAMPLE_FORBIDDEN_ATTRIBUTES or attribute.startswith("__")
+            for attribute in node.kwd_attrs
         ):
             return False
         if isinstance(node, ast.Subscript) and not isinstance(node.ctx, ast.Load):

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -4483,6 +4483,7 @@ _DOCUMENTED_EXAMPLE_FORBIDDEN_NAMES = frozenset(
     {
         "__builtins__",
         "__import__",
+        "breakpoint",
         "builtins",
         "compile",
         "delattr",
@@ -4491,6 +4492,7 @@ _DOCUMENTED_EXAMPLE_FORBIDDEN_NAMES = frozenset(
         "getattr",
         "globals",
         "locals",
+        "open",
         "setattr",
         "vars",
     }

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -4499,6 +4499,7 @@ _DOCUMENTED_EXAMPLE_FORBIDDEN_NAMES = frozenset(
 )
 _DOCUMENTED_EXAMPLE_FORBIDDEN_ATTRIBUTES = frozenset(
     {
+        "_dump",
         "__import__",
         "delattr",
         "exec",

--- a/tests/scanners/test_text_scanner.py
+++ b/tests/scanners/test_text_scanner.py
@@ -617,6 +617,14 @@ def test_text_scanner_documentation_image_binding_bypasses_stay_actionable(
             id="startup-hook-direct-open",
         ),
         pytest.param(
+            "img.save('sitecustomize.py', format='PNG')",
+            id="pillow-image-save",
+        ),
+        pytest.param(
+            "match img:\n    case object(save=writer):\n        writer('sitecustomize.py', format='PNG')",
+            id="pillow-image-save-match-class-alias",
+        ),
+        pytest.param(
             "writer = open\nwriter('usercustomize.py', 'w').write('print(1)')",
             id="startup-hook-aliased-open",
         ),

--- a/tests/scanners/test_text_scanner.py
+++ b/tests/scanners/test_text_scanner.py
@@ -625,6 +625,17 @@ def test_text_scanner_documentation_image_binding_bypasses_stay_actionable(
             id="pillow-image-save-match-class-alias",
         ),
         pytest.param(
+            "class Meta(type):\n"
+            "    def __instancecheck__(cls, value):\n"
+            "        return True\n"
+            "class Matcher(metaclass=Meta):\n"
+            "    __match_args__ = ('save',)\n"
+            "match img:\n"
+            "    case Matcher(writer):\n"
+            "        writer('sitecustomize.py', format='PNG')",
+            id="pillow-image-save-positional-match-class-alias",
+        ),
+        pytest.param(
             "writer = open\nwriter('usercustomize.py', 'w').write('print(1)')",
             id="startup-hook-aliased-open",
         ),

--- a/tests/scanners/test_text_scanner.py
+++ b/tests/scanners/test_text_scanner.py
@@ -621,6 +621,10 @@ def test_text_scanner_documentation_image_binding_bypasses_stay_actionable(
             id="pillow-image-save",
         ),
         pytest.param(
+            "img._dump('sitecustomize.py', format='PNG')",
+            id="pillow-image-dump",
+        ),
+        pytest.param(
             "match img:\n    case object(save=writer):\n        writer('sitecustomize.py', format='PNG')",
             id="pillow-image-save-match-class-alias",
         ),

--- a/tests/scanners/test_text_scanner.py
+++ b/tests/scanners/test_text_scanner.py
@@ -463,6 +463,48 @@ def test_text_scanner_unpinned_model_cards_are_informational(
 
 
 @pytest.mark.parametrize(
+    "model_name",
+    [
+        pytest.param("hf-hub:attacker/payload", id="huggingface-hub-source"),
+        pytest.param("local-dir:payload", id="local-directory-source"),
+    ],
+)
+@pytest.mark.parametrize("crlf", [False, True], ids=["lf", "crlf"])
+def test_text_scanner_documentation_image_rejects_timm_source_prefixes(
+    tmp_path: Path,
+    model_name: str,
+    crlf: bool,
+) -> None:
+    example = (
+        "# Model card\n\n"
+        "```python\n"
+        "from urllib.request import urlopen\n"
+        "from PIL import Image\n"
+        "import timm\n\n"
+        "img = Image.open(urlopen(\n"
+        '    "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/'
+        'beignets-task-guide.png"\n'
+        "))\n"
+        f"model = timm.create_model('{model_name}', pretrained=True)\n"
+        "```\n"
+    )
+    payload = example.replace("\n", "\r\n").encode() if crlf else example.encode()
+    path = tmp_path / "README.md"
+    path.write_bytes(payload)
+
+    result = TextScanner().scan(str(path))
+    aggregate = scan_model_directory_or_file(str(path), cache_enabled=False)
+
+    assert result.success is False
+    assert network_comm.official_readme_urlopen_image_example_spans(payload) == ()
+    assert any(
+        check.details.get("function") == "urlopen" and check.severity == IssueSeverity.CRITICAL
+        for check in _failed_network_detection_checks(result)
+    )
+    assert determine_exit_code(aggregate) == 1
+
+
+@pytest.mark.parametrize(
     ("mutation", "replacement"),
     [
         pytest.param(
@@ -617,6 +659,14 @@ def test_text_scanner_documentation_image_binding_bypasses_stay_actionable(
             id="startup-hook-direct-open",
         ),
         pytest.param(
+            "__loader__.set_data('sitecustomize.py', b'print(1)')",
+            id="import-loader-set-data",
+        ),
+        pytest.param(
+            "help('payload')",
+            id="pydoc-help-import",
+        ),
+        pytest.param(
             "img.save('sitecustomize.py', format='PNG')",
             id="pillow-image-save",
         ),
@@ -654,7 +704,7 @@ def test_text_scanner_documentation_image_binding_bypasses_stay_actionable(
         pytest.param("breakpoint()", id="interactive-debugger"),
     ],
 )
-def test_text_scanner_documentation_image_rejects_side_effectful_builtin_calls(
+def test_text_scanner_documentation_image_rejects_side_effectful_code(
     tmp_path: Path,
     injected_code: str,
 ) -> None:
@@ -662,6 +712,33 @@ def test_text_scanner_documentation_image_rejects_side_effectful_builtin_calls(
         "))\n```\n",
         f"))\n{injected_code}\n```\n",
     ).encode()
+    path = tmp_path / "README.md"
+    path.write_bytes(payload)
+
+    result = TextScanner().scan(str(path))
+    aggregate = scan_model_directory_or_file(str(path), cache_enabled=False)
+
+    assert result.success is False
+    assert network_comm.official_readme_urlopen_image_example_spans(payload) == ()
+    assert any(
+        check.details.get("function") == "urlopen" and check.severity == IssueSeverity.CRITICAL
+        for check in _failed_network_detection_checks(result)
+    )
+    assert determine_exit_code(aggregate) == 1
+
+
+def test_text_scanner_documentation_image_rejects_timm_checkpoint_load(tmp_path: Path) -> None:
+    payload = (
+        HUGGINGFACE_DOCUMENTATION_IMAGE_EXAMPLE.replace(
+            "from PIL import Image\n",
+            "from PIL import Image\nimport timm\n",
+        )
+        .replace(
+            "))\n```\n",
+            "))\ntimm.create_model('resnet18', checkpoint_path='payload.pth')\n```\n",
+        )
+        .encode()
+    )
     path = tmp_path / "README.md"
     path.write_bytes(payload)
 

--- a/tests/scanners/test_text_scanner.py
+++ b/tests/scanners/test_text_scanner.py
@@ -625,6 +625,10 @@ def test_text_scanner_documentation_image_binding_bypasses_stay_actionable(
             id="pillow-image-dump",
         ),
         pytest.param(
+            "img.show()",
+            id="pillow-image-show",
+        ),
+        pytest.param(
             "match img:\n    case object(save=writer):\n        writer('sitecustomize.py', format='PNG')",
             id="pillow-image-save-match-class-alias",
         ),

--- a/tests/scanners/test_text_scanner.py
+++ b/tests/scanners/test_text_scanner.py
@@ -610,6 +610,47 @@ def test_text_scanner_documentation_image_binding_bypasses_stay_actionable(
 
 
 @pytest.mark.parametrize(
+    "injected_code",
+    [
+        pytest.param(
+            "open('sitecustomize.py', 'w').write('print(1)')",
+            id="startup-hook-direct-open",
+        ),
+        pytest.param(
+            "writer = open\nwriter('usercustomize.py', 'w').write('print(1)')",
+            id="startup-hook-aliased-open",
+        ),
+        pytest.param(
+            "(lambda writer: writer('sitecustomize.py', 'w').write('print(1)'))(open)",
+            id="startup-hook-higher-order-open",
+        ),
+        pytest.param("breakpoint()", id="interactive-debugger"),
+    ],
+)
+def test_text_scanner_documentation_image_rejects_side_effectful_builtin_calls(
+    tmp_path: Path,
+    injected_code: str,
+) -> None:
+    payload = HUGGINGFACE_DOCUMENTATION_IMAGE_EXAMPLE.replace(
+        "))\n```\n",
+        f"))\n{injected_code}\n```\n",
+    ).encode()
+    path = tmp_path / "README.md"
+    path.write_bytes(payload)
+
+    result = TextScanner().scan(str(path))
+    aggregate = scan_model_directory_or_file(str(path), cache_enabled=False)
+
+    assert result.success is False
+    assert network_comm.official_readme_urlopen_image_example_spans(payload) == ()
+    assert any(
+        check.details.get("function") == "urlopen" and check.severity == IssueSeverity.CRITICAL
+        for check in _failed_network_detection_checks(result)
+    )
+    assert determine_exit_code(aggregate) == 1
+
+
+@pytest.mark.parametrize(
     "example",
     [
         pytest.param(


### PR DESCRIPTION
## Summary

- Stop treating model-card image examples as trusted when they call the filesystem-writing `open` builtin or enter `breakpoint`.
- Preserve CRITICAL `urlopen` and `urllib` findings plus exit code 1 for direct startup-hook writes, aliased writers, higher-order writers, and debugger entry.
- Keep legitimate `Image.open(...)` usage and pinned Hugging Face/timm model cards informational.

## Reproduction

Appending `open('sitecustomize.py', 'w').write('print(1)')` to the otherwise trusted Hugging Face documentation-image example previously returned a successful scan and exit code 0. The four new regression cases all failed before the detector change and pass afterward.

## Validation

- Focused malicious and benign model-card coverage: **51 passed**.
- Network detector, text scanner, and security-asset suites: **2,333 passed**.
- Release-workflow and Nightly-prerequisite controls: **135 passed**.
- Repository-wide Ruff lint passed; all **424 files** passed Ruff formatting.
- Changed production/test files passed mypy; `CHANGELOG.md` passed Prettier.
- Latest scheduled Nightly CI passed all **13 jobs** before selecting this bug.

One unrelated macOS baseline test, `test_text_metadata_read_failure_bypasses_stale_clean_cache`, fails unchanged on current `main` because cache identity rejects access-time events. Existing ready-for-review PR #1821 fixes that issue and has fully passing CI; only that existing baseline case was excluded from the 2,333-test run.
