### PR TITLE
fix: downgrade passive model metadata URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- Downgrade passive pickle metadata documentation and license URLs without weakening active network destination findings.
+- Treat documentation, license, and repository links in verified pickle and ONNX metadata as informational while preserving active and unknown network destinations.
 - Preserve incomplete-scan diagnostics for malformed or unsupported ZIP data in GGUF/GGML files, including cached scans.
 - Report incomplete coverage when a GGUF/GGML source changes during scanning.
 - Preserve caller-owned Hugging Face cache sidecars during streaming cleanup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- Downgrade passive pickle metadata documentation and license URLs without weakening active network destination findings.
 - Preserve incomplete-scan diagnostics for malformed or unsupported ZIP data in GGUF/GGML files, including cached scans.
 - Report incomplete coverage when a GGUF/GGML source changes during scanning.
 - Preserve caller-owned Hugging Face cache sidecars during streaming cleanup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- Treat documentation, license, and repository links in verified pickle and ONNX metadata as informational while preserving active and unknown network destinations.
+- Treat documentation, license, and repository links in verified pickle and ONNX metadata as informational across supported Python versions while preserving active and unknown network destinations.
 - Preserve incomplete-scan diagnostics for malformed or unsupported ZIP data in GGUF/GGML files, including cached scans.
 - Report incomplete coverage when a GGUF/GGML source changes during scanning.
 - Preserve caller-owned Hugging Face cache sidecars during streaming cleanup.

--- a/modelaudit/detectors/_metadata.py
+++ b/modelaudit/detectors/_metadata.py
@@ -49,7 +49,7 @@ def _add_items(target: _PickleValue, values: list[_PickleValue]) -> None:
             raise ValueError("Incomplete dictionary entry")
         for key, value in zip(values[::2], values[1::2], strict=True):
             _escape(key)
-            key_name = key.text.strip().casefold() if key.text is not None else None
+            key_name = key.text.casefold() if key.text is not None else None
             if key_name in _METADATA_KEYS and value.kind == "string":
                 value.metadata = True
             elif key_name != "metadata" or value.kind not in {"dict", "list", "tuple"}:

--- a/modelaudit/detectors/_metadata.py
+++ b/modelaudit/detectors/_metadata.py
@@ -1,0 +1,234 @@
+"""Bounded, non-executing ownership checks for model metadata strings."""
+
+import pickletools
+import re
+from dataclasses import dataclass, field
+from io import BytesIO
+
+from modelaudit.utils.file.detection import (
+    _ONNX_MODEL_FIELD_WIRE_TYPES,
+    _read_proto_varint,
+    _skip_proto_value,
+)
+
+_MAX_PICKLE_BYTES = 10 * 1024 * 1024
+_MAX_PICKLE_OPS = 100_000
+_MAX_METADATA_VALUE_BYTES = 64 * 1024
+_METADATA_KEYS = frozenset({"docs", "documentation", "license", "licence", "readme"})
+_ONNX_METADATA_KEYS = _METADATA_KEYS | {"repository", "source", "url"}
+_STRING_HEADERS = {"BINUNICODE": 5, "SHORT_BINUNICODE": 2, "BINUNICODE8": 9, "BINSTRING": 5, "SHORT_BINSTRING": 2}
+
+
+@dataclass(eq=False)
+class _PickleValue:
+    kind: str = "opaque"
+    text: str | None = None
+    span: tuple[int, int] | None = None
+    children: list["_PickleValue"] = field(default_factory=list)
+    metadata: bool = False
+    escaped: bool = False
+
+
+def _escape(value: _PickleValue) -> None:
+    pending = [value]
+    while pending:
+        current = pending.pop()
+        if not current.escaped:
+            current.escaped = True
+            pending.extend(current.children)
+
+
+def _add_items(target: _PickleValue, values: list[_PickleValue]) -> None:
+    target.children.extend(values)
+    if target.escaped or target.kind not in {"dict", "list", "tuple", "set", "frozenset"}:
+        for value in values:
+            _escape(value)
+    elif target.kind == "dict":
+        if len(values) % 2:
+            raise ValueError("Incomplete dictionary entry")
+        for key, value in zip(values[::2], values[1::2], strict=True):
+            _escape(key)
+            if key.text is not None and key.text.strip().casefold() in _METADATA_KEYS and value.kind == "string":
+                value.metadata = True
+            elif value.kind == "string":
+                _escape(value)
+    else:
+        for value in values:
+            if value.kind == "string":
+                _escape(value)
+
+
+def _pickle_metadata(data: bytes) -> tuple[list[tuple[int, int]], list[tuple[int, int]]]:
+    if len(data) > _MAX_PICKLE_BYTES:
+        return [], []
+    stack: list[_PickleValue] = []
+    memo: dict[int, _PickleValue] = {}
+    strings: list[_PickleValue] = []
+    mark = _PickleValue("mark")
+    stream = BytesIO(data)
+    frame_end: int | None = None
+
+    def take(count: int) -> list[_PickleValue]:
+        if count > len(stack):
+            raise ValueError("Incomplete pickle stack")
+        if not count:
+            return []
+        values = stack[-count:]
+        del stack[-count:]
+        return values
+
+    def take_mark() -> list[_PickleValue]:
+        index = len(stack) - 1
+        while index >= 0 and stack[index] is not mark:
+            index -= 1
+        if index < 0:
+            raise ValueError("Missing pickle mark")
+        values = stack[index + 1 :]
+        del stack[index:]
+        return values
+
+    try:
+        for count, (opcode, arg, position) in enumerate(pickletools.genops(stream)):
+            if count >= _MAX_PICKLE_OPS or position is None:
+                return [], []
+            name = opcode.name
+            end = stream.tell()
+            if frame_end == position:
+                frame_end = None
+            if frame_end is not None and end > frame_end:
+                return [], []
+            if name == "FRAME":
+                if not isinstance(arg, int) or frame_end is not None or end + arg > len(data):
+                    return [], []
+                frame_end = end + arg
+            elif name == "PROTO":
+                if not isinstance(arg, int) or arg > 5:
+                    return [], []
+            elif name == "STOP":
+                if end != len(data) or len(stack) != 1:
+                    return [], []
+                return (
+                    [value.span for value in strings if value.span is not None],
+                    [
+                        value.span
+                        for value in strings
+                        if value.span is not None and value.metadata and not value.escaped
+                    ],
+                )
+            elif isinstance(arg, str) and name in {*_STRING_HEADERS, "UNICODE", "STRING"}:
+                if name in _STRING_HEADERS:
+                    span = position + _STRING_HEADERS[name], end
+                elif name == "UNICODE":
+                    span = position + 1, end - 1
+                else:
+                    span = position + 2, end - 2
+                value = _PickleValue("string", arg, span)
+                strings.append(value)
+                stack.append(value)
+            elif name == "MARK":
+                stack.append(mark)
+            elif name == "MEMOIZE":
+                memo[len(memo)] = stack[-1]
+            elif name in {"PUT", "BINPUT", "LONG_BINPUT"}:
+                if not isinstance(arg, int) or arg < 0:
+                    return [], []
+                memo[arg] = stack[-1]
+            elif name in {"GET", "BINGET", "LONG_BINGET"}:
+                if not isinstance(arg, int) or arg < 0:
+                    return [], []
+                stack.append(memo[arg])
+            elif name == "DUP":
+                stack.append(stack[-1])
+            elif name in {"EMPTY_DICT", "EMPTY_LIST", "EMPTY_TUPLE", "EMPTY_SET"}:
+                stack.append(_PickleValue(name.removeprefix("EMPTY_").lower()))
+            elif name in {"DICT", "LIST", "TUPLE", "FROZENSET", "TUPLE1", "TUPLE2", "TUPLE3"}:
+                values = take(int(name[-1])) if name[-1].isdigit() else take_mark()
+                target = _PickleValue("tuple" if name.startswith("TUPLE") else name.lower())
+                _add_items(target, values)
+                stack.append(target)
+            elif name in {"SETITEM", "SETITEMS", "APPEND", "APPENDS", "ADDITEMS"}:
+                values = take(2 if name == "SETITEM" else 1) if name in {"SETITEM", "APPEND"} else take_mark()
+                expected = "dict" if name.startswith("SETITEM") else "set" if name == "ADDITEMS" else "list"
+                if stack[-1].kind not in {expected, "opaque"}:
+                    return [], []
+                _add_items(stack[-1], values)
+            else:
+                if pickletools.markobject in opcode.stack_before:
+                    consumed = take_mark()
+                    consumed.extend(take(opcode.stack_before.index(pickletools.markobject)))
+                else:
+                    consumed = take(len(opcode.stack_before))
+                # Calls, BUILD, persistent IDs and discarded objects provide no passive ownership proof.
+                for value in consumed:
+                    _escape(value)
+                stack.extend(_PickleValue() for _ in opcode.stack_after)
+    except (ValueError, IndexError, KeyError, UnicodeError, OverflowError):
+        pass
+    return [], []
+
+
+def _proto_fields(data: bytes, start: int, end: int, budget: list[int]) -> list[tuple[int, int, int, int]]:
+    fields = []
+    while start < end:
+        budget[0] -= 1
+        tag = _read_proto_varint(data, start, end)
+        if budget[0] < 0 or tag is None or tag[0] >> 3 == 0:
+            raise ValueError("Invalid or oversized protobuf metadata")
+        field_number, wire, value_start = tag[0] >> 3, tag[0] & 7, tag[1]
+        next_offset = _skip_proto_value(data, value_start, wire, end)
+        if next_offset is None:
+            raise ValueError("Incomplete protobuf field")
+        if wire == 2:
+            length = _read_proto_varint(data, value_start, end)
+            if length is None:
+                raise ValueError("Missing protobuf length")
+            value_start = length[1]
+        fields.append((field_number, wire, value_start, next_offset))
+        start = next_offset
+    return fields
+
+
+def _onnx_metadata(data: bytes) -> tuple[list[tuple[int, int]], list[tuple[int, int]]]:
+    strings: list[tuple[int, int]] = []
+    metadata: list[tuple[int, int]] = []
+    has_ir_version = has_graph = False
+    metadata_bytes = 0
+    budget = [10_000]
+    try:
+        for number, wire, start, end in _proto_fields(data, 0, len(data), budget):
+            if _ONNX_MODEL_FIELD_WIRE_TYPES.get(number, wire) != wire:
+                return [], []
+            if number == 1:
+                version = _read_proto_varint(data, start, end)
+                has_ir_version = version is not None and 0 < version[0] <= 1000
+            elif number == 7:
+                has_graph = end > start
+            elif number == 14:
+                metadata_bytes += end - start
+                if metadata_bytes > _MAX_PICKLE_BYTES:
+                    return [], []
+                fields = _proto_fields(data, start, end, budget)
+                if len(fields) != 2 or {(field, kind) for field, kind, _, _ in fields} != {(1, 2), (2, 2)}:
+                    continue
+                key_field, value_field = sorted(fields)
+                if key_field[3] - key_field[2] > 128:
+                    continue
+                key = data[key_field[2] : key_field[3]].decode("utf-8").strip().casefold()
+                span = value_field[2], value_field[3]
+                strings.append(span)
+                if span[1] - span[0] <= _MAX_METADATA_VALUE_BYTES and (
+                    key in _ONNX_METADATA_KEYS or re.fullmatch(r"url_\d+", key)
+                ):
+                    data[span[0] : span[1]].decode("utf-8")
+                    metadata.append(span)
+    except (ValueError, UnicodeError):
+        return [], []
+    return (strings, metadata) if has_ir_version and has_graph else ([], [])
+
+
+def metadata_string_spans(data: bytes) -> tuple[list[tuple[int, int]], list[tuple[int, int]]]:
+    """Return literal boundaries and proven metadata values; uncertainty preserves detections."""
+    strings, metadata = _pickle_metadata(data)
+    if not strings:
+        strings, metadata = _onnx_metadata(data)
+    return sorted(strings), sorted(span for span in metadata if span[1] - span[0] <= _MAX_METADATA_VALUE_BYTES)

--- a/modelaudit/detectors/_metadata.py
+++ b/modelaudit/detectors/_metadata.py
@@ -18,7 +18,7 @@ _MAX_METADATA_VALUE_BYTES = 64 * 1024
 _METADATA_KEYS = frozenset({"docs", "documentation", "license", "licence", "readme"})
 _ONNX_METADATA_KEYS = _METADATA_KEYS | {"repository", "source", "url"}
 _STRING_HEADERS = {"BINUNICODE": 5, "SHORT_BINUNICODE": 2, "BINUNICODE8": 9, "BINSTRING": 5, "SHORT_BINSTRING": 2}
-_NON_TEXT_CONTROLS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_NON_TEXT_CONTROLS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
 
 
 @dataclass(eq=False)
@@ -50,7 +50,7 @@ def _add_items(target: _PickleValue, values: list[_PickleValue]) -> None:
             raise ValueError("Incomplete dictionary entry")
         for key, value in zip(values[::2], values[1::2], strict=True):
             _escape(key)
-            key_name = key.text.casefold() if key.text is not None else None
+            key_name = key.text.lower() if key.text is not None and key.text.isascii() else None
             if key_name in _METADATA_KEYS and value.kind == "string":
                 value.metadata = value.text is not None and _NON_TEXT_CONTROLS.search(value.text) is None
             elif key_name != "metadata" or value.kind not in {"dict", "list", "tuple"}:
@@ -222,11 +222,12 @@ def _onnx_metadata(data: bytes) -> tuple[list[tuple[int, int]], list[tuple[int, 
                 key_field, value_field = sorted(fields)
                 if key_field[3] - key_field[2] > 128:
                     continue
-                key = data[key_field[2] : key_field[3]].decode("utf-8").casefold()
+                key = data[key_field[2] : key_field[3]].decode("utf-8").lower()
                 span = value_field[2], value_field[3]
                 strings.append(span)
                 if (
                     span[1] - span[0] <= _MAX_METADATA_VALUE_BYTES
+                    and key.isascii()
                     and (key in _ONNX_METADATA_KEYS or re.fullmatch(r"url_\d+", key))
                     and _NON_TEXT_CONTROLS.search(data[span[0] : span[1]].decode("utf-8")) is None
                 ):

--- a/modelaudit/detectors/_metadata.py
+++ b/modelaudit/detectors/_metadata.py
@@ -7,6 +7,7 @@ from io import BytesIO
 
 from modelaudit.utils.file.detection import (
     _ONNX_MODEL_FIELD_WIRE_TYPES,
+    _looks_like_onnx_graph_proto_stream,
     _read_proto_varint,
     _skip_proto_value,
 )
@@ -48,9 +49,10 @@ def _add_items(target: _PickleValue, values: list[_PickleValue]) -> None:
             raise ValueError("Incomplete dictionary entry")
         for key, value in zip(values[::2], values[1::2], strict=True):
             _escape(key)
-            if key.text is not None and key.text.strip().casefold() in _METADATA_KEYS and value.kind == "string":
+            key_name = key.text.strip().casefold() if key.text is not None else None
+            if key_name in _METADATA_KEYS and value.kind == "string":
                 value.metadata = True
-            elif value.kind == "string":
+            elif key_name != "metadata" or value.kind not in {"dict", "list", "tuple"}:
                 _escape(value)
     else:
         for value in values:
@@ -163,7 +165,8 @@ def _pickle_metadata(data: bytes) -> tuple[list[tuple[int, int]], list[tuple[int
                     _escape(value)
                 stack.extend(_PickleValue() for _ in opcode.stack_after)
     except (ValueError, IndexError, KeyError, UnicodeError, OverflowError):
-        pass
+        # Incomplete or invalid serialization cannot prove passive ownership.
+        return [], []
     return [], []
 
 
@@ -202,7 +205,12 @@ def _onnx_metadata(data: bytes) -> tuple[list[tuple[int, int]], list[tuple[int, 
                 version = _read_proto_varint(data, start, end)
                 has_ir_version = version is not None and 0 < version[0] <= 1000
             elif number == 7:
-                has_graph = end > start
+                _proto_fields(data, start, end, budget)
+                stream = BytesIO(data)
+                stream.seek(start)
+                if _looks_like_onnx_graph_proto_stream(stream, end, budget) is not True:
+                    return [], []
+                has_graph = True
             elif number == 14:
                 metadata_bytes += end - start
                 if metadata_bytes > _MAX_PICKLE_BYTES:

--- a/modelaudit/detectors/_metadata.py
+++ b/modelaudit/detectors/_metadata.py
@@ -18,6 +18,7 @@ _MAX_METADATA_VALUE_BYTES = 64 * 1024
 _METADATA_KEYS = frozenset({"docs", "documentation", "license", "licence", "readme"})
 _ONNX_METADATA_KEYS = _METADATA_KEYS | {"repository", "source", "url"}
 _STRING_HEADERS = {"BINUNICODE": 5, "SHORT_BINUNICODE": 2, "BINUNICODE8": 9, "BINSTRING": 5, "SHORT_BINSTRING": 2}
+_NON_TEXT_CONTROLS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 
 
 @dataclass(eq=False)
@@ -51,7 +52,7 @@ def _add_items(target: _PickleValue, values: list[_PickleValue]) -> None:
             _escape(key)
             key_name = key.text.casefold() if key.text is not None else None
             if key_name in _METADATA_KEYS and value.kind == "string":
-                value.metadata = True
+                value.metadata = value.text is not None and _NON_TEXT_CONTROLS.search(value.text) is None
             elif key_name != "metadata" or value.kind not in {"dict", "list", "tuple"}:
                 _escape(value)
     else:
@@ -221,13 +222,14 @@ def _onnx_metadata(data: bytes) -> tuple[list[tuple[int, int]], list[tuple[int, 
                 key_field, value_field = sorted(fields)
                 if key_field[3] - key_field[2] > 128:
                     continue
-                key = data[key_field[2] : key_field[3]].decode("utf-8").strip().casefold()
+                key = data[key_field[2] : key_field[3]].decode("utf-8").casefold()
                 span = value_field[2], value_field[3]
                 strings.append(span)
-                if span[1] - span[0] <= _MAX_METADATA_VALUE_BYTES and (
-                    key in _ONNX_METADATA_KEYS or re.fullmatch(r"url_\d+", key)
+                if (
+                    span[1] - span[0] <= _MAX_METADATA_VALUE_BYTES
+                    and (key in _ONNX_METADATA_KEYS or re.fullmatch(r"url_\d+", key))
+                    and _NON_TEXT_CONTROLS.search(data[span[0] : span[1]].decode("utf-8")) is None
                 ):
-                    data[span[0] : span[1]].decode("utf-8")
                     metadata.append(span)
     except (ValueError, UnicodeError):
         return [], []

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -5448,7 +5448,7 @@ class NetworkCommDetector:
         for _ in range(3):
             decoded_url = unquote_plus(decoded_url)
         decoded_url = decoded_url.casefold()
-        if re.search(r"%[0-9a-f]{2}|[\x00-\x1f\x7f]", decoded_url) or any(
+        if re.search(r"%[0-9a-f]{2}|[\x00-\x1f\x7f-\x9f]", decoded_url) or any(
             term in decoded_url for term in self.INFORMATIONAL_URL_RISK_TERMS
         ):
             return None

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -107,9 +107,14 @@ _TRAILING_URL_DELIMITER_PAIRS = {")": "(", "]": "[", "}": "{"}
 _TRAILING_URL_DELIMITERS = frozenset(set(_TRAILING_URL_DELIMITER_PAIRS) | set(_TRAILING_URL_DELIMITER_PAIRS.values()))
 _URL_TEXT_BOUNDARY_BYTES = b" \t\r\n\"'<>`()"
 _METADATA_ACTIVE_CONTEXT_PATTERN = re.compile(
-    rb"\b(?:api|callback|curl|download|endpoint|eval|exec|fetch|from_pretrained|git\s+clone|httpx|http\.client|"
-    rb"os\.system|requests?|shell|socket|subprocess|torch\.hub|urlopen|urlretrieve|urllib|webhook|wget)\b",
+    rb"\b(?:curl|wget|git\s+clone)\b|"
+    rb"\b(?:eval|exec|fetch|from_pretrained|requests?|urlopen|urlretrieve)\s*\(|"
+    rb"\b(?:httpx|http\.client|os|requests?|socket|subprocess|torch\.hub|urllib)\s*\.|"
+    rb"\b(?:api|callback|download|endpoint|fetch|shell|webhook)\s*[:=]",
     re.IGNORECASE,
+)
+_METADATA_HTTP_REQUEST_PATTERN = re.compile(
+    rb"\b(?:GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH|download|fetch)\s+https?://", re.IGNORECASE
 )
 _PROVEN_BARE_QUERY_COMPONENTS = frozenset({"_debug", "debug"})
 _PROVEN_BARE_PROSE_COMPONENTS = frozenset({"section"})
@@ -4975,8 +4980,10 @@ class NetworkCommDetector:
         }
     )
     INFORMATIONAL_URL_RISK_TERMS: ClassVar[tuple[str, ...]] = (
+        "callback",
         "cmd",
         "curl",
+        "endpoint",
         "eval",
         "exec",
         "os.system",
@@ -4985,6 +4992,7 @@ class NetworkCommDetector:
         "socket.",
         "subprocess",
         "urllib.",
+        "webhook",
         "wget",
     )
 
@@ -5056,6 +5064,7 @@ class NetworkCommDetector:
             (start, end)
             for start, end in metadata_bounds
             if _METADATA_ACTIVE_CONTEXT_PATTERN.search(_URL_IN_BYTES_PATTERN.sub(b"", data[start:end])) is None
+            and _METADATA_HTTP_REQUEST_PATTERN.search(data[start:end]) is None
         ]
         self._metadata_starts = [start for start, _end in self._metadata_bounds]
         (
@@ -5443,13 +5452,10 @@ class NetworkCommDetector:
             term in decoded_url for term in self.INFORMATIONAL_URL_RISK_TERMS
         ):
             return None
-        if parsed.query:
-            try:
-                query = parse_qsl(parsed.query, keep_blank_values=True, strict_parsing=True)
-            except ValueError:
-                return None
-        else:
-            query = []
+        try:
+            query = parse_qsl(parsed.query, keep_blank_values=True, strict_parsing=True) if parsed.query else []
+        except ValueError:
+            return None
         for key, value in query:
             if (
                 key.casefold() not in {"lang", "language", "locale", "hl"}
@@ -5458,9 +5464,15 @@ class NetworkCommDetector:
                 return None
 
         hostname = parsed.hostname.casefold().rstrip(".")
+        if _BARE_DOMAIN_PATTERN.fullmatch(hostname.encode("utf-8")) is None or hostname.endswith(
+            (".localhost", ".local", ".internal", ".lan", ".home", ".arpa")
+        ):
+            return None
         decoded_path = parsed.path
         for _ in range(3):
             decoded_path = unquote(decoded_path)
+        if ";" in decoded_path:
+            return None
         path_segments = [
             segment.casefold().strip(_TRAILING_PATH_DELIMITERS) for segment in decoded_path.split("/") if segment
         ]

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -106,7 +106,12 @@ _TRAILING_URL_DELIMITERS = frozenset(set(_TRAILING_URL_DELIMITER_PAIRS) | set(_T
 _URL_TEXT_BOUNDARY_BYTES = b" \t\r\n\"'<>`()"
 _MAX_PICKLE_LITERAL_BOUNDARY_PROBE_BYTES = 8192
 _PICKLE_URL_ACTIVE_CONTEXT_PATTERN = re.compile(
-    rb"api|callback|download|endpoint|fetch|from_pretrained|httpx|request|torch\.hub|urlopen|urlretrieve|urllib|webhook",
+    rb"api|callback|curl|download|endpoint|fetch|from_pretrained|git\s+clone|httpx|request|torch\.hub|urlopen|"
+    rb"urlretrieve|urllib|webhook|wget",
+    re.IGNORECASE,
+)
+_PASSIVE_METADATA_URL_CONTEXT_PATTERN = re.compile(
+    rb"author|doc(?:umentation)?s?|licen[cs]e|metadata|model_author|model_type|readme|repository|source|version",
     re.IGNORECASE,
 )
 _PROVEN_BARE_QUERY_COMPONENTS = frozenset({"_debug", "debug"})
@@ -5454,42 +5459,65 @@ class NetworkCommDetector:
             return urlsplit(url).port in self.SUSPICIOUS_PORTS
         return False
 
-    def _is_informational_url_reference(self, url: str) -> bool:
-        """Return whether a URL is passive documentation/license metadata."""
+    def _informational_url_reference_kind(self, url: str) -> str | None:
         try:
             parsed = urlsplit(url)
         except ValueError:
-            return False
+            return None
         if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
-            return False
+            return None
         if self._url_uses_suspicious_port(url):
-            return False
+            return None
 
         decoded_url = unquote_plus(url).casefold()
         if parsed.query or any(term in decoded_url for term in self.INFORMATIONAL_URL_RISK_TERMS):
-            return False
+            return None
 
         hostname = parsed.hostname.casefold().rstrip(".")
-        for segment in parsed.path.split("/"):
-            normalized_segment = unquote(segment).casefold().strip(_TRAILING_PATH_DELIMITERS)
-            stem = normalized_segment.split(".", 1)[0]
-            if (
-                normalized_segment in self.INFORMATIONAL_URL_PATH_SEGMENTS
-                or stem in self.INFORMATIONAL_URL_PATH_SEGMENTS
-            ):
-                return True
-        return hostname.startswith(self.INFORMATIONAL_URL_HOST_PREFIXES) and parsed.path in {"", "/"}
+        path_segments = [
+            unquote(segment).casefold().strip(_TRAILING_PATH_DELIMITERS)
+            for segment in parsed.path.split("/")
+            if segment
+        ]
+        if any(_looks_like_known_artifact_filename(segment) for segment in path_segments):
+            return None
+        if self._is_public_source_repository_url(hostname, path_segments):
+            return "source_repository"
+        if any(segment in self.INFORMATIONAL_URL_PATH_SEGMENTS for segment in path_segments):
+            return "documentation"
+        if hostname.startswith(self.INFORMATIONAL_URL_HOST_PREFIXES) and parsed.path in {"", "/"}:
+            return "documentation"
+        return None
+
+    @staticmethod
+    def _is_public_source_repository_url(hostname: str, path_segments: list[str]) -> bool:
+        if hostname not in {"github.com", "www.github.com"}:
+            return False
+        return len(path_segments) == 2 and all(path_segments)
 
     def _is_passive_metadata_url_reference(self, data: bytes, url_start: int, url: str) -> bool:
-        if not self._is_informational_url_reference(url):
+        kind = self._informational_url_reference_kind(url)
+        if kind is None:
             return False
         url_end = url_start + len(url.encode("utf-8"))
         bounds = _pickle_literal_payload_bounds_containing(data, url_start, url_end)
-        if bounds is None:
+        if bounds is not None:
+            context_start = max(0, bounds[0] - 128)
+            context_end = min(len(data), bounds[1] + 128)
+            context_data = data[context_start:context_end]
+            return (
+                _PICKLE_URL_ACTIVE_CONTEXT_PATTERN.search(context_data) is None
+                and _PASSIVE_METADATA_URL_CONTEXT_PATTERN.search(context_data) is not None
+            )
+        if kind != "source_repository":
             return False
-        context_start = max(0, bounds[0] - 128)
-        context_end = min(len(data), bounds[1] + 128)
-        return _PICKLE_URL_ACTIVE_CONTEXT_PATTERN.search(data[context_start:context_end]) is None
+        context_start = max(0, url_start - 256)
+        context_end = min(len(data), url_end + 64)
+        context_data = data[context_start:context_end]
+        return (
+            _PICKLE_URL_ACTIVE_CONTEXT_PATTERN.search(context_data) is None
+            and _PASSIVE_METADATA_URL_CONTEXT_PATTERN.search(context_data) is not None
+        )
 
     def _scan_cloud_storage_urls(self, data: bytes, context: str) -> None:
         """Scan for cloud storage URL patterns (S3, GCS, Azure, etc.).

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -5443,10 +5443,13 @@ class NetworkCommDetector:
             term in decoded_url for term in self.INFORMATIONAL_URL_RISK_TERMS
         ):
             return None
-        try:
-            query = parse_qsl(parsed.query, keep_blank_values=True, strict_parsing=True)
-        except ValueError:
-            return None
+        if parsed.query:
+            try:
+                query = parse_qsl(parsed.query, keep_blank_values=True, strict_parsing=True)
+            except ValueError:
+                return None
+        else:
+            query = []
         for key, value in query:
             if (
                 key.casefold() not in {"lang", "language", "locale", "hl"}

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -101,7 +101,14 @@ _KNOWN_ARTIFACT_FILENAME_EXTENSIONS = frozenset(
     }
 )
 _TRAILING_PATH_DELIMITERS = ".,;:)]}'\""
+_TRAILING_URL_DELIMITER_PAIRS = {")": "(", "]": "[", "}": "{"}
+_TRAILING_URL_DELIMITERS = frozenset(set(_TRAILING_URL_DELIMITER_PAIRS) | set(_TRAILING_URL_DELIMITER_PAIRS.values()))
 _URL_TEXT_BOUNDARY_BYTES = b" \t\r\n\"'<>`()"
+_MAX_PICKLE_LITERAL_BOUNDARY_PROBE_BYTES = 8192
+_PICKLE_URL_ACTIVE_CONTEXT_PATTERN = re.compile(
+    rb"api|callback|download|endpoint|fetch|from_pretrained|httpx|request|torch\.hub|urlopen|urlretrieve|urllib|webhook",
+    re.IGNORECASE,
+)
 _PROVEN_BARE_QUERY_COMPONENTS = frozenset({"_debug", "debug"})
 _PROVEN_BARE_PROSE_COMPONENTS = frozenset({"section"})
 _PATH_TOKEN_BOUNDARY_PATTERN = re.compile(r"&amp;|[&,'\"?#\s]")
@@ -1014,15 +1021,90 @@ def _trim_source_literal_url(
     return url.rstrip("'")
 
 
+def _trim_unbalanced_trailing_url_delimiters(url: str) -> str:
+    if not url:
+        return url
+
+    delimiter_counts: Counter[str] = Counter()
+    for character in url:
+        if character in _TRAILING_URL_DELIMITERS:
+            delimiter_counts[character] += 1
+    trim_end = len(url)
+    while trim_end:
+        closer = url[trim_end - 1]
+        opener = _TRAILING_URL_DELIMITER_PAIRS.get(closer)
+        if opener is None or delimiter_counts[closer] <= delimiter_counts[opener]:
+            break
+        delimiter_counts[closer] -= 1
+        trim_end -= 1
+    return url[:trim_end]
+
+
+def _pickle_literal_payload_bounds_at(data: bytes, opcode_index: int) -> tuple[int, int] | None:
+    opcode = data[opcode_index]
+    if opcode == ord("X") and opcode_index + 5 <= len(data):
+        payload_start = opcode_index + 5
+        payload_len = int.from_bytes(data[opcode_index + 1 : payload_start], "little")
+    elif opcode == 0x8C and opcode_index + 2 <= len(data):
+        payload_start = opcode_index + 2
+        payload_len = data[opcode_index + 1]
+    elif opcode == 0x8D and opcode_index + 9 <= len(data):
+        payload_start = opcode_index + 9
+        payload_len = int.from_bytes(data[opcode_index + 1 : payload_start], "little")
+    else:
+        return None
+    payload_end = payload_start + payload_len
+    if payload_end > len(data):
+        return None
+    return payload_start, payload_end
+
+
+def _pickle_literal_payload_start_ending_at(data: bytes, literal_end: int) -> int | None:
+    lower_bound = max(0, literal_end - _MAX_PICKLE_LITERAL_BOUNDARY_PROBE_BYTES)
+    for opcode_index in range(lower_bound, literal_end):
+        bounds = _pickle_literal_payload_bounds_at(data, opcode_index)
+        if bounds is not None and bounds[1] == literal_end:
+            return bounds[0]
+    return None
+
+
+def _pickle_literal_payload_bounds_containing(
+    data: bytes, payload_offset_start: int, payload_offset_end: int
+) -> tuple[int, int] | None:
+    lower_bound = max(0, payload_offset_start - _MAX_PICKLE_LITERAL_BOUNDARY_PROBE_BYTES)
+    for opcode_index in range(lower_bound, payload_offset_start + 1):
+        bounds = _pickle_literal_payload_bounds_at(data, opcode_index)
+        if bounds is not None and bounds[0] <= payload_offset_start and payload_offset_end <= bounds[1]:
+            return bounds
+    return None
+
+
+def _trim_pickle_memo_suffix_from_url(data: bytes, match: re.Match[bytes], url: str) -> str:
+    if not url:
+        return url
+    url_end = match.start() + len(url.encode("utf-8"))
+    if url_end != match.end():
+        return url
+    if data[url_end - 1] != ord("q") or url_end >= len(data):
+        return url
+    literal_end = url_end - 1
+    payload_start = _pickle_literal_payload_start_ending_at(data, literal_end)
+    if payload_start is None or not payload_start <= match.start() < literal_end:
+        return url
+    return url[:-1]
+
+
 def _trim_matched_source_url(data: bytes, match: re.Match[bytes]) -> str:
     prefix = data[max(0, match.start() - _MAX_PROSE_LINE_CONTEXT_BYTES) : match.start()]
     suffix = data[match.end() : match.end() + _MAX_PROSE_LINE_CONTEXT_BYTES]
-    return _trim_source_literal_url(
+    url = _trim_source_literal_url(
         match.group().decode("utf-8", errors="ignore"),
         _source_quote_before_url(data, match.start()),
         re.split(rb"[^\t\r\n\x20-\x7e]", suffix, maxsplit=1)[0].decode("ascii"),
         re.split(rb"[^\t\x20-\x7e]", prefix)[-1].decode("ascii"),
     )
+    url = _trim_pickle_memo_suffix_from_url(data, match, url)
+    return _trim_unbalanced_trailing_url_delimiters(url)
 
 
 def redact_url_for_finding(url: str) -> str:
@@ -4920,6 +5002,42 @@ class NetworkCommDetector:
         "blob.core.windows.net",
         "dfs.core.windows.net",
     )
+    INFORMATIONAL_URL_HOST_PREFIXES: ClassVar[tuple[str, ...]] = (
+        "docs.",
+        "documentation.",
+        "help.",
+        "support.",
+    )
+    INFORMATIONAL_URL_PATH_SEGMENTS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "doc",
+            "docs",
+            "documentation",
+            "legal",
+            "licence",
+            "licences",
+            "license",
+            "licenses",
+            "privacy",
+            "readme",
+            "reference",
+            "references",
+            "terms",
+        }
+    )
+    INFORMATIONAL_URL_RISK_TERMS: ClassVar[tuple[str, ...]] = (
+        "cmd",
+        "curl",
+        "eval",
+        "exec",
+        "os.system",
+        "requests.",
+        "shell",
+        "socket.",
+        "subprocess",
+        "urllib.",
+        "wget",
+    )
 
     def __init__(self, config: dict[str, Any] | None = None):
         """Initialize the detector with optional configuration."""
@@ -5284,7 +5402,10 @@ class NetworkCommDetector:
                         return
                     self._cloud_nested_url_findings.add(nested_url)
             if self.URL_PATTERN.fullmatch(url.encode("utf-8")) is not None and not self._record_url_finding(
-                url, url_start, context
+                url,
+                url_start,
+                context,
+                passive_metadata_reference=self._is_passive_metadata_url_reference(data, url_start, url),
             ):
                 return
             if self.max_findings is None:
@@ -5292,7 +5413,14 @@ class NetworkCommDetector:
                     if not self._record_url_finding(nested_url, url_start, context):
                         return
 
-    def _record_url_finding(self, url: str, position: int, context: str) -> bool:
+    def _record_url_finding(
+        self,
+        url: str,
+        position: int,
+        context: str,
+        *,
+        passive_metadata_reference: bool = False,
+    ) -> bool:
         safe_url = redact_url_for_finding(url)
 
         confidence = 0.5
@@ -5305,8 +5433,9 @@ class NetworkCommDetector:
             severity = "HIGH"
         elif "://" in url and not url.startswith(("http://", "https://")):
             confidence = 0.7
-        elif self._is_cloud_storage_url(url):
+        elif self._is_cloud_storage_url(url) or passive_metadata_reference:
             severity = "INFO"
+            confidence = 0.3
 
         return self._record_finding(
             {
@@ -5324,6 +5453,43 @@ class NetworkCommDetector:
         with suppress(ValueError):
             return urlsplit(url).port in self.SUSPICIOUS_PORTS
         return False
+
+    def _is_informational_url_reference(self, url: str) -> bool:
+        """Return whether a URL is passive documentation/license metadata."""
+        try:
+            parsed = urlsplit(url)
+        except ValueError:
+            return False
+        if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
+            return False
+        if self._url_uses_suspicious_port(url):
+            return False
+
+        decoded_url = unquote_plus(url).casefold()
+        if parsed.query or any(term in decoded_url for term in self.INFORMATIONAL_URL_RISK_TERMS):
+            return False
+
+        hostname = parsed.hostname.casefold().rstrip(".")
+        for segment in parsed.path.split("/"):
+            normalized_segment = unquote(segment).casefold().strip(_TRAILING_PATH_DELIMITERS)
+            stem = normalized_segment.split(".", 1)[0]
+            if (
+                normalized_segment in self.INFORMATIONAL_URL_PATH_SEGMENTS
+                or stem in self.INFORMATIONAL_URL_PATH_SEGMENTS
+            ):
+                return True
+        return hostname.startswith(self.INFORMATIONAL_URL_HOST_PREFIXES) and parsed.path in {"", "/"}
+
+    def _is_passive_metadata_url_reference(self, data: bytes, url_start: int, url: str) -> bool:
+        if not self._is_informational_url_reference(url):
+            return False
+        url_end = url_start + len(url.encode("utf-8"))
+        bounds = _pickle_literal_payload_bounds_containing(data, url_start, url_end)
+        if bounds is None:
+            return False
+        context_start = max(0, bounds[0] - 128)
+        context_end = min(len(data), bounds[1] + 128)
+        return _PICKLE_URL_ACTIVE_CONTEXT_PATTERN.search(data[context_start:context_end]) is None
 
     def _scan_cloud_storage_urls(self, data: bytes, context: str) -> None:
         """Scan for cloud storage URL patterns (S3, GCS, Azure, etc.).
@@ -5473,27 +5639,21 @@ class NetworkCommDetector:
         if context and any(ext in context.lower() for ext in [".bin", ".pt", ".pth", ".ckpt", ".h5", ".pb", ".onnx"]):
             # For ML model files, only look for very explicit domain references
             # that are unlikely to occur randomly
-            explicit_domain_patterns = [
-                rb"https?://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,}",  # Full URLs only
-                # Config-like patterns
-                rb'["\'](?:api|webhook|callback|endpoint)["\']:\s*["\'][a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,}',
-            ]
-
-            for pattern in explicit_domain_patterns:
-                for match in re.finditer(pattern, data, re.IGNORECASE):
-                    domain_match = match.group()
-                    if b"://" in domain_match:
-                        # Extract domain from URL
-                        parts = domain_match.split(b"://", 1)[1].split(b"/")[0]
-                        domain = parts.decode("utf-8", errors="ignore").lower()
-                    else:
-                        domain = match.group().decode("utf-8", errors="ignore").lower()
-
-                    if domain not in seen_domains:
+            for match in self.URL_PATTERN.finditer(data):
+                url = _trim_matched_source_url(data, match)
+                with suppress(ValueError):
+                    parsed = urlsplit(url)
+                    domain = (parsed.hostname or "").casefold().rstrip(".")
+                    if domain and domain not in seen_domains:
                         if self._is_redacted_url_value(data, match.start(), domain):
                             continue
                         seen_domains.add(domain)
-                        severity = "INFO" if self._is_informational_domain(domain) else "MEDIUM"
+                        severity = (
+                            "INFO"
+                            if self._is_passive_metadata_url_reference(data, match.start(), url)
+                            or self._is_informational_domain(domain)
+                            else "MEDIUM"
+                        )
                         confidence = 0.3 if severity == "INFO" else 0.8
                         if not self._record_finding(
                             {
@@ -5507,6 +5667,32 @@ class NetworkCommDetector:
                             }
                         ):
                             return
+
+            config_domain_pattern = re.compile(
+                rb"""["'](?:api|webhook|callback|endpoint)["']:\s*["'](?P<domain>[a-zA-Z0-9\-.]+\.[a-zA-Z]{2,})""",
+                re.IGNORECASE,
+            )
+            for match in config_domain_pattern.finditer(data):
+                domain = match.group("domain").decode("utf-8", errors="ignore").casefold()
+
+                if domain not in seen_domains:
+                    if self._is_redacted_url_value(data, match.start("domain"), domain):
+                        continue
+                    seen_domains.add(domain)
+                    severity = "INFO" if self._is_informational_domain(domain) else "MEDIUM"
+                    confidence = 0.3 if severity == "INFO" else 0.8
+                    if not self._record_finding(
+                        {
+                            "type": "domain",
+                            "severity": severity,
+                            "confidence": confidence,
+                            "message": f"Domain name detected: {domain}",
+                            "domain": domain,
+                            "position": match.start("domain"),
+                            "context": context,
+                        }
+                    ):
+                        return
             return
 
         for match in self.DOMAIN_PATTERN.finditer(data):
@@ -5864,6 +6050,10 @@ class NetworkCommDetector:
                     if pattern_type == "url"
                     else match.group().decode("utf-8", errors="ignore")
                 )
+                if pattern_type == "url" and self._is_passive_metadata_url_reference(
+                    data, match.start(), raw_matched_text
+                ):
+                    continue
                 matched_text = _redact_network_evidence(raw_matched_text)
                 if not self._record_finding(
                     {

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -17,7 +17,9 @@ from functools import lru_cache
 from importlib.resources import files
 from io import BytesIO
 from typing import Any, ClassVar
-from urllib.parse import unquote, unquote_plus, urlsplit, urlunsplit
+from urllib.parse import parse_qsl, unquote, unquote_plus, urlsplit, urlunsplit
+
+from modelaudit.detectors._metadata import metadata_string_spans
 
 _REDACTED_PATH_TOKEN = "<redacted>"
 _URL_IN_TEXT_PATTERN = re.compile(
@@ -104,17 +106,11 @@ _TRAILING_PATH_DELIMITERS = ".,;:)]}'\""
 _TRAILING_URL_DELIMITER_PAIRS = {")": "(", "]": "[", "}": "{"}
 _TRAILING_URL_DELIMITERS = frozenset(set(_TRAILING_URL_DELIMITER_PAIRS) | set(_TRAILING_URL_DELIMITER_PAIRS.values()))
 _URL_TEXT_BOUNDARY_BYTES = b" \t\r\n\"'<>`()"
-_MAX_PICKLE_LITERAL_BOUNDARY_PROBE_BYTES = 8192
-_PICKLE_URL_ACTIVE_CONTEXT_PATTERN = re.compile(
-    rb"api|callback|curl|download|endpoint|fetch|from_pretrained|git\s+clone|httpx|request|torch\.hub|urlopen|"
-    rb"urlretrieve|urllib|webhook|wget",
+_METADATA_ACTIVE_CONTEXT_PATTERN = re.compile(
+    rb"\b(?:api|callback|curl|download|endpoint|eval|exec|fetch|from_pretrained|git\s+clone|httpx|http\.client|"
+    rb"os\.system|requests?|shell|socket|subprocess|torch\.hub|urlopen|urlretrieve|urllib|webhook|wget)\b",
     re.IGNORECASE,
 )
-_PASSIVE_PICKLE_METADATA_URL_KEYS = frozenset({"docs", "documentation", "license", "licence", "readme"})
-_PASSIVE_ONNX_METADATA_URL_KEYS = frozenset(
-    {"docs", "documentation", "license", "licence", "readme", "repository", "source", "url"}
-)
-_PASSIVE_ONNX_NUMBERED_URL_KEY_PATTERN = re.compile(r"url_\d+\Z", re.IGNORECASE)
 _PROVEN_BARE_QUERY_COMPONENTS = frozenset({"_debug", "debug"})
 _PROVEN_BARE_PROSE_COMPONENTS = frozenset({"section"})
 _PATH_TOKEN_BOUNDARY_PATTERN = re.compile(r"&amp;|[&,'\"?#\s]")
@@ -1046,152 +1042,17 @@ def _trim_unbalanced_trailing_url_delimiters(url: str) -> str:
     return url[:trim_end]
 
 
-def _pickle_literal_payload_bounds_at(data: bytes, opcode_index: int) -> tuple[int, int] | None:
-    opcode = data[opcode_index]
-    if opcode == ord("X") and opcode_index + 5 <= len(data):
-        payload_start = opcode_index + 5
-        payload_len = int.from_bytes(data[opcode_index + 1 : payload_start], "little")
-    elif opcode == 0x8C and opcode_index + 2 <= len(data):
-        payload_start = opcode_index + 2
-        payload_len = data[opcode_index + 1]
-    elif opcode == 0x8D and opcode_index + 9 <= len(data):
-        payload_start = opcode_index + 9
-        payload_len = int.from_bytes(data[opcode_index + 1 : payload_start], "little")
-    else:
-        return None
-    payload_end = payload_start + payload_len
-    if payload_end > len(data):
-        return None
-    return payload_start, payload_end
-
-
-def _pickle_literal_payload_start_ending_at(data: bytes, literal_end: int) -> int | None:
-    lower_bound = max(0, literal_end - _MAX_PICKLE_LITERAL_BOUNDARY_PROBE_BYTES)
-    for opcode_index in range(lower_bound, literal_end):
-        bounds = _pickle_literal_payload_bounds_at(data, opcode_index)
-        if bounds is not None and bounds[1] == literal_end:
-            return bounds[0]
-    return None
-
-
-def _pickle_literal_payload_bounds_containing(
-    data: bytes, payload_offset_start: int, payload_offset_end: int
-) -> tuple[int, int] | None:
-    if not 0 <= payload_offset_start <= payload_offset_end <= len(data):
-        return None
-    lower_bound = max(0, payload_offset_start - _MAX_PICKLE_LITERAL_BOUNDARY_PROBE_BYTES)
-    for opcode_index in range(lower_bound, payload_offset_start + 1):
-        bounds = _pickle_literal_payload_bounds_at(data, opcode_index)
-        if bounds is not None and bounds[0] <= payload_offset_start and payload_offset_end <= bounds[1]:
-            return bounds
-    return None
-
-
-def _pickle_literal_opcode_index_for_payload_bounds(data: bytes, payload_bounds: tuple[int, int]) -> int | None:
-    lower_bound = max(0, payload_bounds[0] - _MAX_PICKLE_LITERAL_BOUNDARY_PROBE_BYTES)
-    for opcode_index in range(lower_bound, payload_bounds[0] + 1):
-        bounds = _pickle_literal_payload_bounds_at(data, opcode_index)
-        if bounds == payload_bounds:
-            return opcode_index
-    return None
-
-
-def _skip_pickle_memo_after_literal(data: bytes, cursor: int) -> int:
-    while cursor:
-        if data[cursor - 1] == 0x94:
-            cursor -= 1
-        elif cursor >= 2 and data[cursor - 2] == ord("q"):
-            cursor -= 2
-        elif cursor >= 5 and data[cursor - 5] == ord("r"):
-            cursor -= 5
-        else:
-            break
-    return cursor
-
-
-def _pickle_literal_key_before_payload(data: bytes, payload_bounds: tuple[int, int]) -> str | None:
-    value_opcode_index = _pickle_literal_opcode_index_for_payload_bounds(data, payload_bounds)
-    if value_opcode_index is None:
-        return None
-
-    key_literal_end = _skip_pickle_memo_after_literal(data, value_opcode_index)
-    key_literal_start = _pickle_literal_payload_start_ending_at(data, key_literal_end)
-    if key_literal_start is None:
-        return None
-
-    try:
-        return data[key_literal_start:key_literal_end].decode("utf-8").strip().casefold()
-    except UnicodeDecodeError:
-        return None
-
-
-def _protobuf_varint_ending_at(data: bytes, end: int) -> tuple[int, int] | None:
-    if not 0 <= end <= len(data):
-        return None
-    for start in range(max(0, end - 10), end):
-        value = 0
-        shift = 0
-        for index in range(start, end):
-            byte = data[index]
-            value |= (byte & 0x7F) << shift
-            shift += 7
-            if byte < 0x80:
-                if index == end - 1:
-                    return start, value
-                break
-    return None
-
-
-def _protobuf_length_delimited_field_at(data: bytes, payload_start: int, tag: int) -> tuple[int, int, int] | None:
-    parsed_length = _protobuf_varint_ending_at(data, payload_start)
-    if parsed_length is None:
-        return None
-    length_start, payload_len = parsed_length
-    tag_index = length_start - 1
-    payload_end = payload_start + payload_len
-    if tag_index < 0 or data[tag_index] != tag or payload_end > len(data):
-        return None
-    return tag_index, payload_start, payload_end
-
-
-def _protobuf_length_delimited_field_ending_at(data: bytes, payload_end: int, tag: int) -> bytes | None:
-    min_payload_start = max(0, payload_end - 128)
-    for payload_start in range(min_payload_start, payload_end + 1):
-        parsed_length = _protobuf_varint_ending_at(data, payload_start)
-        if parsed_length is None:
-            continue
-        length_start, payload_len = parsed_length
-        tag_index = length_start - 1
-        if tag_index >= 0 and data[tag_index] == tag and payload_start + payload_len == payload_end:
-            return data[payload_start:payload_end]
-    return None
-
-
-def _trim_pickle_memo_suffix_from_url(data: bytes, match: re.Match[bytes], url: str) -> str:
-    if not url:
-        return url
-    url_end = match.start() + len(url.encode("utf-8"))
-    if url_end != match.end():
-        return url
-    if data[url_end - 1] != ord("q") or url_end >= len(data):
-        return url
-    literal_end = url_end - 1
-    payload_start = _pickle_literal_payload_start_ending_at(data, literal_end)
-    if payload_start is None or not payload_start <= match.start() < literal_end:
-        return url
-    return url[:-1]
-
-
-def _trim_matched_source_url(data: bytes, match: re.Match[bytes]) -> str:
+def _trim_matched_source_url(data: bytes, match: re.Match[bytes], literal_end: int | None = None) -> str:
     prefix = data[max(0, match.start() - _MAX_PROSE_LINE_CONTEXT_BYTES) : match.start()]
     suffix = data[match.end() : match.end() + _MAX_PROSE_LINE_CONTEXT_BYTES]
     url = _trim_source_literal_url(
-        match.group().decode("utf-8", errors="ignore"),
+        data[match.start() : min(match.end(), literal_end if literal_end is not None else match.end())].decode(
+            "utf-8", errors="ignore"
+        ),
         _source_quote_before_url(data, match.start()),
         re.split(rb"[^\t\r\n\x20-\x7e]", suffix, maxsplit=1)[0].decode("ascii"),
         re.split(rb"[^\t\x20-\x7e]", prefix)[-1].decode("ascii"),
     )
-    url = _trim_pickle_memo_suffix_from_url(data, match, url)
     return _trim_unbalanced_trailing_url_delimiters(url)
 
 
@@ -5153,6 +5014,10 @@ class NetworkCommDetector:
         self._cloud_nested_url_findings: set[str] = set()
         self._official_readme_image_fences: list[tuple[int, int, bool]] = []
         self._official_readme_image_unvalidated_requests = False
+        self._literal_bounds: list[tuple[int, int]] = []
+        self._literal_starts: list[int] = []
+        self._metadata_bounds: list[tuple[int, int]] = []
+        self._metadata_starts: list[int] = []
 
         # Clone class-level patterns to avoid cross-instance leakage
         self.cc_patterns: list[bytes] = self.CC_PATTERNS.copy()
@@ -5185,6 +5050,14 @@ class NetworkCommDetector:
         self._evidence_redaction_limit_reached = False
         self._has_sensitive_evidence_hint = _SENSITIVE_EVIDENCE_HINT_PATTERN.search(data) is not None
         self._cloud_nested_url_findings = set()
+        self._literal_bounds, metadata_bounds = metadata_string_spans(data) if b"://" in data else ([], [])
+        self._literal_starts = [start for start, _end in self._literal_bounds]
+        self._metadata_bounds = [
+            (start, end)
+            for start, end in metadata_bounds
+            if _METADATA_ACTIVE_CONTEXT_PATTERN.search(_URL_IN_BYTES_PATTERN.sub(b"", data[start:end])) is None
+        ]
+        self._metadata_starts = [start for start, _end in self._metadata_bounds]
         (
             self._official_readme_image_fences,
             self._official_readme_image_unvalidated_requests,
@@ -5282,20 +5155,25 @@ class NetworkCommDetector:
         self.findings.append(finding)
         return True
 
+    def _trim_url(self, data: bytes, match: re.Match[bytes]) -> str:
+        index = bisect_right(self._literal_starts, match.start()) - 1
+        literal_end = None
+        if index >= 0 and match.start() < self._literal_bounds[index][1]:
+            literal_end = self._literal_bounds[index][1]
+        return _trim_matched_source_url(data, match, literal_end)
+
     def _index_url_contexts(self, data: bytes) -> list[tuple[int, int, str]]:
         return list(self._iter_url_contexts(data))
 
-    @staticmethod
-    def _iter_url_contexts(data: bytes) -> Iterator[tuple[int, int, str]]:
+    def _iter_url_contexts(self, data: bytes) -> Iterator[tuple[int, int, str]]:
         for match in _URL_IN_BYTES_PATTERN.finditer(data):
-            url = _trim_matched_source_url(data, match)
+            url = self._trim_url(data, match)
             yield match.start(), match.start() + len(url.encode("utf-8")), url
 
-    @classmethod
-    def _iter_generic_url_contexts(cls, data: bytes) -> Iterator[tuple[int, int, str]]:
+    def _iter_generic_url_contexts(self, data: bytes) -> Iterator[tuple[int, int, str]]:
         """Yield only schemes handled by generic URL findings."""
-        for match in cls.URL_PATTERN.finditer(data):
-            url = _trim_matched_source_url(data, match)
+        for match in self.URL_PATTERN.finditer(data):
+            url = self._trim_url(data, match)
             yield match.start(), match.start() + len(url.encode("utf-8")), url
 
     def _url_context_redaction_decision(self, data: bytes, match_start: int, value: str) -> bool | None:
@@ -5493,7 +5371,7 @@ class NetworkCommDetector:
                 url,
                 url_start,
                 context,
-                passive_metadata_reference=self._is_passive_metadata_url_reference(data, url_start, url),
+                passive_metadata_reference=self._is_passive_metadata_url_reference(url_start, url),
             ):
                 return
             if self.max_findings is None:
@@ -5519,11 +5397,13 @@ class NetworkCommDetector:
         elif self._url_uses_suspicious_port(url):
             confidence = 0.8
             severity = "HIGH"
-        elif "://" in url and not url.startswith(("http://", "https://")):
-            confidence = 0.7
-        elif self._is_cloud_storage_url(url) or passive_metadata_reference:
+        elif passive_metadata_reference:
             severity = "INFO"
             confidence = 0.3
+        elif "://" in url and not url.startswith(("http://", "https://")):
+            confidence = 0.7
+        elif self._is_cloud_storage_url(url):
+            severity = "INFO"
 
         return self._record_finding(
             {
@@ -5545,6 +5425,7 @@ class NetworkCommDetector:
     def _informational_url_reference_kind(self, url: str) -> str | None:
         try:
             parsed = urlsplit(url)
+            port = parsed.port
         except ValueError:
             return None
         if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
@@ -5552,27 +5433,56 @@ class NetworkCommDetector:
         if self._url_uses_suspicious_port(url):
             return None
 
-        decoded_url = unquote_plus(url).casefold()
-        if parsed.query or any(term in decoded_url for term in self.INFORMATIONAL_URL_RISK_TERMS):
+        if parsed.username is not None or parsed.password is not None or port not in {None, 80, 443}:
             return None
+        decoded_url = url
+        for _ in range(3):
+            decoded_url = unquote_plus(decoded_url)
+        decoded_url = decoded_url.casefold()
+        if re.search(r"%[0-9a-f]{2}", decoded_url) or any(
+            term in decoded_url for term in self.INFORMATIONAL_URL_RISK_TERMS
+        ):
+            return None
+        try:
+            query = parse_qsl(parsed.query, keep_blank_values=True, strict_parsing=True)
+        except ValueError:
+            return None
+        for key, value in query:
+            if (
+                key.casefold() not in {"lang", "language", "locale", "hl"}
+                or re.fullmatch(r"[a-z]{2,8}(?:-[a-z0-9]{2,8})?", value.casefold()) is None
+            ):
+                return None
 
         hostname = parsed.hostname.casefold().rstrip(".")
+        decoded_path = parsed.path
+        for _ in range(3):
+            decoded_path = unquote(decoded_path)
         path_segments = [
-            unquote(segment).casefold().strip(_TRAILING_PATH_DELIMITERS)
-            for segment in parsed.path.split("/")
-            if segment
+            segment.casefold().strip(_TRAILING_PATH_DELIMITERS) for segment in decoded_path.split("/") if segment
         ]
-        if any(_looks_like_known_artifact_filename(segment) for segment in path_segments):
+        if any(segment in {".", ".."} for segment in decoded_path.split("/")):
             return None
+        for segment in path_segments:
+            extension = segment.rsplit(".", 1)[-1]
+            if extension not in {"md", "rst", "txt", "html", "htm"} and (
+                _looks_like_known_artifact_filename(segment)
+                or extension in {"py", "sh", "bash", "ps1", "exe", "dll", "so", "js"}
+            ):
+                return None
         if self._is_public_source_repository_url(hostname, path_segments):
             return "source_repository"
         if self._is_public_model_repository_url(hostname, path_segments):
             return "model_repository"
-        if any(segment in self.INFORMATIONAL_URL_PATH_SEGMENTS for segment in path_segments):
+        if any(
+            segment in self.INFORMATIONAL_URL_PATH_SEGMENTS
+            or segment.rsplit(".", 1)[0] in self.INFORMATIONAL_URL_PATH_SEGMENTS
+            for segment in path_segments
+        ):
             if hostname in _PUBLIC_MODEL_REPOSITORY_HOSTS:
                 return "model_documentation"
             return "documentation"
-        if hostname.startswith(self.INFORMATIONAL_URL_HOST_PREFIXES) and parsed.path in {"", "/"}:
+        if hostname.startswith(self.INFORMATIONAL_URL_HOST_PREFIXES):
             return "documentation"
         return None
 
@@ -5598,51 +5508,11 @@ class NetworkCommDetector:
             return True
         return remaining[0] == "tree" and len(remaining) >= 2
 
-    @staticmethod
-    def _is_passive_pickle_metadata_key(key: str | None) -> bool:
-        return key in _PASSIVE_PICKLE_METADATA_URL_KEYS
-
-    @staticmethod
-    def _is_passive_onnx_metadata_key(key: str) -> bool:
-        return (
-            key in _PASSIVE_ONNX_METADATA_URL_KEYS or _PASSIVE_ONNX_NUMBERED_URL_KEY_PATTERN.fullmatch(key) is not None
-        )
-
-    def _is_passive_onnx_metadata_url_reference(self, data: bytes, url_start: int, url: str) -> bool:
-        value_field = _protobuf_length_delimited_field_at(data, url_start, tag=0x12)
-        if value_field is None:
+    def _is_passive_metadata_url_reference(self, url_start: int, url: str) -> bool:
+        index = bisect_right(self._metadata_starts, url_start) - 1
+        if index < 0 or url_start + len(url.encode("utf-8")) > self._metadata_bounds[index][1]:
             return False
-
-        value_tag_index, value_start, value_end = value_field
-        try:
-            value = data[value_start:value_end].decode("utf-8")
-        except UnicodeDecodeError:
-            return False
-        if not value.startswith(("http://", "https://")) or not url.startswith(value):
-            return False
-
-        kind = self._informational_url_reference_kind(value)
-        if kind not in {"documentation", "model_documentation", "model_repository", "source_repository"}:
-            return False
-
-        key_bytes = _protobuf_length_delimited_field_ending_at(data, value_tag_index, tag=0x0A)
-        if key_bytes is None:
-            return False
-        try:
-            key = key_bytes.decode("utf-8").strip().casefold()
-        except UnicodeDecodeError:
-            return False
-        return self._is_passive_onnx_metadata_key(key)
-
-    def _is_passive_metadata_url_reference(self, data: bytes, url_start: int, url: str) -> bool:
-        url_end = url_start + len(url.encode("utf-8"))
-        bounds = _pickle_literal_payload_bounds_containing(data, url_start, url_end)
-        if bounds is not None:
-            return (
-                self._is_passive_pickle_metadata_key(_pickle_literal_key_before_payload(data, bounds))
-                and _PICKLE_URL_ACTIVE_CONTEXT_PATTERN.search(data[bounds[0] : bounds[1]]) is None
-            )
-        return self._is_passive_onnx_metadata_url_reference(data, url_start, url)
+        return self._informational_url_reference_kind(url) is not None
 
     def _scan_cloud_storage_urls(self, data: bytes, context: str) -> None:
         """Scan for cloud storage URL patterns (S3, GCS, Azure, etc.).
@@ -5792,60 +5662,46 @@ class NetworkCommDetector:
         if context and any(ext in context.lower() for ext in [".bin", ".pt", ".pth", ".ckpt", ".h5", ".pb", ".onnx"]):
             # For ML model files, only look for very explicit domain references
             # that are unlikely to occur randomly
-            for match in self.URL_PATTERN.finditer(data):
-                url = _trim_matched_source_url(data, match)
-                with suppress(ValueError):
-                    parsed = urlsplit(url)
-                    domain = (parsed.hostname or "").casefold().rstrip(".")
-                    if domain and domain not in seen_domains:
-                        if self._is_redacted_url_value(data, match.start(), domain):
-                            continue
-                        seen_domains.add(domain)
-                        severity = (
-                            "INFO"
-                            if self._is_passive_metadata_url_reference(data, match.start(), url)
-                            or self._is_informational_domain(domain)
-                            else "MEDIUM"
-                        )
-                        confidence = 0.3 if severity == "INFO" else 0.8
-                        if not self._record_finding(
-                            {
-                                "type": "domain",
-                                "severity": severity,
-                                "confidence": confidence,
-                                "message": f"Domain name detected: {domain}",
-                                "domain": domain,
-                                "position": match.start(),
-                                "context": context,
-                            }
-                        ):
-                            return
+            model_domains: dict[str, dict[str, Any]] = {}
 
+            def record_domain(domain: str, position: int, passive: bool = False) -> bool:
+                if not domain or self._is_redacted_url_value(data, position, domain):
+                    return True
+                severity = "INFO" if passive or self._is_informational_domain(domain) else "MEDIUM"
+                previous = model_domains.get(domain)
+                if previous is not None and (previous["severity"] == "MEDIUM" or severity == "INFO"):
+                    return True
+                finding = {
+                    "type": "domain",
+                    "severity": severity,
+                    "confidence": 0.3 if severity == "INFO" else 0.8,
+                    "message": f"Domain name detected: {domain}",
+                    "domain": domain,
+                    "position": position,
+                    "context": context,
+                }
+                if previous is not None:
+                    previous.update(finding)
+                    return True
+                model_domains[domain] = finding
+                return self._record_finding(finding)
+
+            for match in self.URL_PATTERN.finditer(data):
+                url = self._trim_url(data, match)
+                with suppress(ValueError):
+                    domain = (urlsplit(url).hostname or "").casefold().rstrip(".")
+                    if not record_domain(
+                        domain, match.start(), self._is_passive_metadata_url_reference(match.start(), url)
+                    ):
+                        return
             config_domain_pattern = re.compile(
-                rb"""["'](?:api|webhook|callback|endpoint)["']:\s*["'](?P<domain>[a-zA-Z0-9\-.]+\.[a-zA-Z]{2,})""",
+                rb"[\"'](?:api|webhook|callback|endpoint)[\"']:\s*[\"'](?P<domain>[a-zA-Z0-9\-.]+\.[a-zA-Z]{2,})",
                 re.IGNORECASE,
             )
             for match in config_domain_pattern.finditer(data):
                 domain = match.group("domain").decode("utf-8", errors="ignore").casefold()
-
-                if domain not in seen_domains:
-                    if self._is_redacted_url_value(data, match.start("domain"), domain):
-                        continue
-                    seen_domains.add(domain)
-                    severity = "INFO" if self._is_informational_domain(domain) else "MEDIUM"
-                    confidence = 0.3 if severity == "INFO" else 0.8
-                    if not self._record_finding(
-                        {
-                            "type": "domain",
-                            "severity": severity,
-                            "confidence": confidence,
-                            "message": f"Domain name detected: {domain}",
-                            "domain": domain,
-                            "position": match.start("domain"),
-                            "context": context,
-                        }
-                    ):
-                        return
+                if not record_domain(domain, match.start("domain")):
+                    return
             return
 
         for match in self.DOMAIN_PATTERN.finditer(data):
@@ -6199,13 +6055,11 @@ class NetworkCommDetector:
                 if printable_ratio <= 0.7:
                     continue
                 raw_matched_text = (
-                    _trim_matched_source_url(data, match)
+                    self._trim_url(data, match)
                     if pattern_type == "url"
                     else match.group().decode("utf-8", errors="ignore")
                 )
-                if pattern_type == "url" and self._is_passive_metadata_url_reference(
-                    data, match.start(), raw_matched_text
-                ):
+                if pattern_type == "url" and self._is_passive_metadata_url_reference(match.start(), raw_matched_text):
                     continue
                 matched_text = _redact_network_evidence(raw_matched_text)
                 if not self._record_finding(

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -5448,7 +5448,7 @@ class NetworkCommDetector:
         for _ in range(3):
             decoded_url = unquote_plus(decoded_url)
         decoded_url = decoded_url.casefold()
-        if re.search(r"%[0-9a-f]{2}", decoded_url) or any(
+        if re.search(r"%[0-9a-f]{2}|[\x00-\x1f\x7f]", decoded_url) or any(
             term in decoded_url for term in self.INFORMATIONAL_URL_RISK_TERMS
         ):
             return None

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -110,10 +110,11 @@ _PICKLE_URL_ACTIVE_CONTEXT_PATTERN = re.compile(
     rb"urlretrieve|urllib|webhook|wget",
     re.IGNORECASE,
 )
-_PASSIVE_METADATA_URL_CONTEXT_PATTERN = re.compile(
-    rb"author|doc(?:umentation)?s?|licen[cs]e|metadata|model_author|model_type|readme|repository|source|version",
-    re.IGNORECASE,
+_PASSIVE_PICKLE_METADATA_URL_KEYS = frozenset({"docs", "documentation", "license", "licence", "readme"})
+_PASSIVE_ONNX_METADATA_URL_KEYS = frozenset(
+    {"docs", "documentation", "license", "licence", "readme", "repository", "source", "url"}
 )
+_PASSIVE_ONNX_NUMBERED_URL_KEY_PATTERN = re.compile(r"url_\d+\Z", re.IGNORECASE)
 _PROVEN_BARE_QUERY_COMPONENTS = frozenset({"_debug", "debug"})
 _PROVEN_BARE_PROSE_COMPONENTS = frozenset({"section"})
 _PATH_TOKEN_BOUNDARY_PATTERN = re.compile(r"&amp;|[&,'\"?#\s]")
@@ -1076,11 +1077,93 @@ def _pickle_literal_payload_start_ending_at(data: bytes, literal_end: int) -> in
 def _pickle_literal_payload_bounds_containing(
     data: bytes, payload_offset_start: int, payload_offset_end: int
 ) -> tuple[int, int] | None:
+    if not 0 <= payload_offset_start <= payload_offset_end <= len(data):
+        return None
     lower_bound = max(0, payload_offset_start - _MAX_PICKLE_LITERAL_BOUNDARY_PROBE_BYTES)
     for opcode_index in range(lower_bound, payload_offset_start + 1):
         bounds = _pickle_literal_payload_bounds_at(data, opcode_index)
         if bounds is not None and bounds[0] <= payload_offset_start and payload_offset_end <= bounds[1]:
             return bounds
+    return None
+
+
+def _pickle_literal_opcode_index_for_payload_bounds(data: bytes, payload_bounds: tuple[int, int]) -> int | None:
+    lower_bound = max(0, payload_bounds[0] - _MAX_PICKLE_LITERAL_BOUNDARY_PROBE_BYTES)
+    for opcode_index in range(lower_bound, payload_bounds[0] + 1):
+        bounds = _pickle_literal_payload_bounds_at(data, opcode_index)
+        if bounds == payload_bounds:
+            return opcode_index
+    return None
+
+
+def _skip_pickle_memo_after_literal(data: bytes, cursor: int) -> int:
+    while cursor:
+        if data[cursor - 1] == 0x94:
+            cursor -= 1
+        elif cursor >= 2 and data[cursor - 2] == ord("q"):
+            cursor -= 2
+        elif cursor >= 5 and data[cursor - 5] == ord("r"):
+            cursor -= 5
+        else:
+            break
+    return cursor
+
+
+def _pickle_literal_key_before_payload(data: bytes, payload_bounds: tuple[int, int]) -> str | None:
+    value_opcode_index = _pickle_literal_opcode_index_for_payload_bounds(data, payload_bounds)
+    if value_opcode_index is None:
+        return None
+
+    key_literal_end = _skip_pickle_memo_after_literal(data, value_opcode_index)
+    key_literal_start = _pickle_literal_payload_start_ending_at(data, key_literal_end)
+    if key_literal_start is None:
+        return None
+
+    try:
+        return data[key_literal_start:key_literal_end].decode("utf-8").strip().casefold()
+    except UnicodeDecodeError:
+        return None
+
+
+def _protobuf_varint_ending_at(data: bytes, end: int) -> tuple[int, int] | None:
+    if not 0 <= end <= len(data):
+        return None
+    for start in range(max(0, end - 10), end):
+        value = 0
+        shift = 0
+        for index in range(start, end):
+            byte = data[index]
+            value |= (byte & 0x7F) << shift
+            shift += 7
+            if byte < 0x80:
+                if index == end - 1:
+                    return start, value
+                break
+    return None
+
+
+def _protobuf_length_delimited_field_at(data: bytes, payload_start: int, tag: int) -> tuple[int, int, int] | None:
+    parsed_length = _protobuf_varint_ending_at(data, payload_start)
+    if parsed_length is None:
+        return None
+    length_start, payload_len = parsed_length
+    tag_index = length_start - 1
+    payload_end = payload_start + payload_len
+    if tag_index < 0 or data[tag_index] != tag or payload_end > len(data):
+        return None
+    return tag_index, payload_start, payload_end
+
+
+def _protobuf_length_delimited_field_ending_at(data: bytes, payload_end: int, tag: int) -> bytes | None:
+    min_payload_start = max(0, payload_end - 128)
+    for payload_start in range(min_payload_start, payload_end + 1):
+        parsed_length = _protobuf_varint_ending_at(data, payload_start)
+        if parsed_length is None:
+            continue
+        length_start, payload_len = parsed_length
+        tag_index = length_start - 1
+        if tag_index >= 0 and data[tag_index] == tag and payload_start + payload_len == payload_end:
+            return data[payload_start:payload_end]
     return None
 
 
@@ -5483,7 +5566,11 @@ class NetworkCommDetector:
             return None
         if self._is_public_source_repository_url(hostname, path_segments):
             return "source_repository"
+        if self._is_public_model_repository_url(hostname, path_segments):
+            return "model_repository"
         if any(segment in self.INFORMATIONAL_URL_PATH_SEGMENTS for segment in path_segments):
+            if hostname in _PUBLIC_MODEL_REPOSITORY_HOSTS:
+                return "model_documentation"
             return "documentation"
         if hostname.startswith(self.INFORMATIONAL_URL_HOST_PREFIXES) and parsed.path in {"", "/"}:
             return "documentation"
@@ -5495,29 +5582,67 @@ class NetworkCommDetector:
             return False
         return len(path_segments) == 2 and all(path_segments)
 
-    def _is_passive_metadata_url_reference(self, data: bytes, url_start: int, url: str) -> bool:
-        kind = self._informational_url_reference_kind(url)
-        if kind is None:
+    @staticmethod
+    def _is_public_model_repository_url(hostname: str, path_segments: list[str]) -> bool:
+        if hostname not in _PUBLIC_MODEL_REPOSITORY_HOSTS:
             return False
+        if not path_segments:
+            return False
+        repo_start = 1 if path_segments[0] in _PUBLIC_MODEL_REPOSITORY_PREFIXES else 0
+        if len(path_segments) < repo_start + 2:
+            return False
+        if not all(path_segments[repo_start : repo_start + 2]):
+            return False
+        remaining = path_segments[repo_start + 2 :]
+        if not remaining:
+            return True
+        return remaining[0] == "tree" and len(remaining) >= 2
+
+    @staticmethod
+    def _is_passive_pickle_metadata_key(key: str | None) -> bool:
+        return key in _PASSIVE_PICKLE_METADATA_URL_KEYS
+
+    @staticmethod
+    def _is_passive_onnx_metadata_key(key: str) -> bool:
+        return (
+            key in _PASSIVE_ONNX_METADATA_URL_KEYS or _PASSIVE_ONNX_NUMBERED_URL_KEY_PATTERN.fullmatch(key) is not None
+        )
+
+    def _is_passive_onnx_metadata_url_reference(self, data: bytes, url_start: int, url: str) -> bool:
+        value_field = _protobuf_length_delimited_field_at(data, url_start, tag=0x12)
+        if value_field is None:
+            return False
+
+        value_tag_index, value_start, value_end = value_field
+        try:
+            value = data[value_start:value_end].decode("utf-8")
+        except UnicodeDecodeError:
+            return False
+        if not value.startswith(("http://", "https://")) or not url.startswith(value):
+            return False
+
+        kind = self._informational_url_reference_kind(value)
+        if kind not in {"documentation", "model_documentation", "model_repository", "source_repository"}:
+            return False
+
+        key_bytes = _protobuf_length_delimited_field_ending_at(data, value_tag_index, tag=0x0A)
+        if key_bytes is None:
+            return False
+        try:
+            key = key_bytes.decode("utf-8").strip().casefold()
+        except UnicodeDecodeError:
+            return False
+        return self._is_passive_onnx_metadata_key(key)
+
+    def _is_passive_metadata_url_reference(self, data: bytes, url_start: int, url: str) -> bool:
         url_end = url_start + len(url.encode("utf-8"))
         bounds = _pickle_literal_payload_bounds_containing(data, url_start, url_end)
         if bounds is not None:
-            context_start = max(0, bounds[0] - 128)
-            context_end = min(len(data), bounds[1] + 128)
-            context_data = data[context_start:context_end]
             return (
-                _PICKLE_URL_ACTIVE_CONTEXT_PATTERN.search(context_data) is None
-                and _PASSIVE_METADATA_URL_CONTEXT_PATTERN.search(context_data) is not None
+                self._is_passive_pickle_metadata_key(_pickle_literal_key_before_payload(data, bounds))
+                and _PICKLE_URL_ACTIVE_CONTEXT_PATTERN.search(data[bounds[0] : bounds[1]]) is None
             )
-        if kind != "source_repository":
-            return False
-        context_start = max(0, url_start - 256)
-        context_end = min(len(data), url_end + 64)
-        context_data = data[context_start:context_end]
-        return (
-            _PICKLE_URL_ACTIVE_CONTEXT_PATTERN.search(context_data) is None
-            and _PASSIVE_METADATA_URL_CONTEXT_PATTERN.search(context_data) is not None
-        )
+        return self._is_passive_onnx_metadata_url_reference(data, url_start, url)
 
     def _scan_cloud_storage_urls(self, data: bytes, context: str) -> None:
         """Scan for cloud storage URL patterns (S3, GCS, Azure, etc.).

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -2816,6 +2816,64 @@ class TestNetworkCommDetector:
         url_finding = next(finding for finding in findings if finding["type"] == "url_detected")
         assert url_finding["severity"] == "MEDIUM"
 
+    @pytest.mark.parametrize(
+        ("data", "url"),
+        [
+            (
+                pickle.dumps({"model_url": "https://example.invalid/license.bin"}, protocol=2),
+                "https://example.invalid/license.bin",
+            ),
+            (
+                pickle.dumps({"source": "https://example.invalid/docs.pkl"}, protocol=2),
+                "https://example.invalid/docs.pkl",
+            ),
+            (
+                pickle.dumps({"license": "curl https://example.invalid/license"}, protocol=2),
+                "https://example.invalid/license",
+            ),
+            (
+                pickle.dumps({"docs": "wget https://example.invalid/docs"}, protocol=2),
+                "https://example.invalid/docs",
+            ),
+        ],
+    )
+    def test_explicit_ml_model_url_patterns_keep_unknown_and_command_urls_critical(self, data: bytes, url: str) -> None:
+        detector = NetworkCommDetector()
+
+        findings = detector.scan(data, "payload.pt")
+
+        explicit_finding = next(
+            finding
+            for finding in findings
+            if finding["type"] == "explicit_network_pattern" and finding["matched_text"] == url
+        )
+        assert explicit_finding["severity"] == "CRITICAL"
+        url_finding = next(
+            finding for finding in findings if finding["type"] == "url_detected" and finding["url"] == url
+        )
+        assert url_finding["severity"] == "MEDIUM"
+
+    def test_explicit_ml_model_url_patterns_treat_passive_onnx_source_repo_as_informational(self) -> None:
+        detector = NetworkCommDetector()
+        url = "https://github.com/RicherMans/CED"
+        data = b"model_type\x12\x03CEDr\x07version\x12\x031.0r\x0cmodel_author\x12\nRicherMansr(" + url.encode()
+
+        findings = detector.scan(data, "model.onnx")
+
+        assert not [
+            finding
+            for finding in findings
+            if finding["type"] == "explicit_network_pattern" and finding["matched_text"] == url
+        ]
+        url_finding = next(
+            finding for finding in findings if finding["type"] == "url_detected" and finding["url"] == url
+        )
+        assert url_finding["severity"] == "INFO"
+        domain_finding = next(
+            finding for finding in findings if finding["type"] == "domain" and finding["domain"] == "github.com"
+        )
+        assert domain_finding["severity"] == "INFO"
+
     def test_cc_pattern_snippet_url_expansion_is_bounded(self) -> None:
         """Long whitespace-free binary regions should not force unbounded URL scans."""
         detector = NetworkCommDetector()

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -2856,7 +2856,12 @@ class TestNetworkCommDetector:
     def test_explicit_ml_model_url_patterns_treat_passive_onnx_source_repo_as_informational(self) -> None:
         detector = NetworkCommDetector()
         url = "https://github.com/RicherMans/CED"
-        data = b"model_type\x12\x03CEDr\x07version\x12\x031.0r\x0cmodel_author\x12\nRicherMansr(" + url.encode()
+        data = (
+            b"\n\nmodel_type\x12\x03CED"
+            b"\n\x07version\x12\x031.0"
+            b"\n\x0cmodel_author\x12\nRicherMans"
+            b"\n\x03url\x12" + bytes([len(url)]) + url.encode()
+        )
 
         findings = detector.scan(data, "model.onnx")
 
@@ -2873,6 +2878,117 @@ class TestNetworkCommDetector:
             finding for finding in findings if finding["type"] == "domain" and finding["domain"] == "github.com"
         )
         assert domain_finding["severity"] == "INFO"
+
+    def test_explicit_ml_model_url_patterns_treat_passive_onnx_hf_model_metadata_as_informational(
+        self,
+    ) -> None:
+        detector = NetworkCommDetector()
+        urls = [
+            "https://huggingface.co/pyannote/segmentation-3.0",
+            "https://huggingface.co/csukuangfj/pyannote-models/tree/main/segmentation-3.0",
+            "https://huggingface.co/pyannote/segmentation-3.0/blob/main/LICENSE",
+        ]
+        metadata_pairs = b"".join(
+            b"\n" + bytes([len(key)]) + key.encode() + b"\x12" + bytes([len(url)]) + url.encode()
+            for key, url in zip(("url_1", "url_2", "license"), urls, strict=True)
+        )
+        data = (
+            b"\n\nmodel_type\x12\x1apyannote-segmentation-3.0"
+            b"\n\x07version\x12\x011"
+            b"\n\x0cmodel_author\x12\x08pyannoter"
+            b"\n\nmaintainer\x12\x06k2-fsa" + metadata_pairs
+        )
+
+        findings = detector.scan(data, "model.onnx")
+
+        explicit_matches = {
+            finding["matched_text"]
+            for finding in findings
+            if finding["type"] == "explicit_network_pattern" and finding["matched_text"] in urls
+        }
+        assert explicit_matches == set()
+        url_findings = {finding["url"]: finding for finding in findings if finding["type"] == "url_detected"}
+        for url in urls:
+            assert url_findings[url]["severity"] == "INFO"
+        domain_finding = next(
+            finding for finding in findings if finding["type"] == "domain" and finding["domain"] == "huggingface.co"
+        )
+        assert domain_finding["severity"] == "INFO"
+
+    @pytest.mark.parametrize(
+        ("data", "url"),
+        [
+            (
+                b"model_author\x12\x06tester download_url\x12https://huggingface.co/owner/repo/blob/main/model.onnx",
+                "https://huggingface.co/owner/repo/blob/main/model.onnx",
+            ),
+            (
+                b"license\x12curl https://huggingface.co/owner/repo/blob/main/LICENSE",
+                "https://huggingface.co/owner/repo/blob/main/LICENSE",
+            ),
+            (
+                b"url_1\x12https://huggingface.co/owner/repo/resolve/main/payload.bin",
+                "https://huggingface.co/owner/repo/resolve/main/payload.bin",
+            ),
+        ],
+    )
+    def test_explicit_ml_model_url_patterns_keep_hf_artifact_and_command_metadata_urls_critical(
+        self, data: bytes, url: str
+    ) -> None:
+        detector = NetworkCommDetector()
+
+        findings = detector.scan(data, "model.onnx")
+
+        explicit_finding = next(
+            finding
+            for finding in findings
+            if finding["type"] == "explicit_network_pattern" and finding["matched_text"] == url
+        )
+        assert explicit_finding["severity"] == "CRITICAL"
+
+    @pytest.mark.parametrize(
+        ("data", "url", "context"),
+        [
+            (
+                pickle.dumps({"model_url": "https://example.invalid/license"}, protocol=2),
+                "https://example.invalid/license",
+                "payload.pt",
+            ),
+            (
+                pickle.dumps({"source": "https://example.invalid/docs"}, protocol=2),
+                "https://example.invalid/docs",
+                "payload.pt",
+            ),
+            (
+                pickle.dumps("https://example.invalid/license", protocol=2),
+                "https://example.invalid/license",
+                "payload.pt",
+            ),
+            (
+                b"\0https://github.com/metadata/payload\0",
+                "https://github.com/metadata/payload",
+                "model.onnx",
+            ),
+            (
+                b"\0metadata\0payload_url\0https://github.com/example/payload\0",
+                "https://github.com/example/payload",
+                "model.onnx",
+            ),
+        ],
+    )
+    def test_explicit_ml_model_url_patterns_keep_unknown_observer_controls_critical(
+        self, data: bytes, url: str, context: str
+    ) -> None:
+        detector = NetworkCommDetector()
+
+        findings = detector.scan(data, context)
+
+        explicit_finding = next(
+            finding
+            for finding in findings
+            if finding["type"] == "explicit_network_pattern" and finding["matched_text"] == url
+        )
+        assert explicit_finding["severity"] == "CRITICAL"
 
     def test_cc_pattern_snippet_url_expansion_is_bounded(self) -> None:
         """Long whitespace-free binary regions should not force unbounded URL scans."""

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -16,6 +16,22 @@ from modelaudit.detectors import network_comm
 from modelaudit.detectors.network_comm import NetworkCommDetector, detect_network_communication
 
 
+def _onnx_model_with_metadata(entries: dict[str, str]) -> bytes:
+    onnx = pytest.importorskip("onnx")
+    helper = onnx.helper
+    tensor = helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1])
+    output = helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [1])
+    graph = helper.make_graph([helper.make_node("Identity", ["X"], ["Y"])], "metadata_control", [tensor], [output])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    helper.set_model_props(
+        model,
+        {"description": "A small identity model used to check metadata reference handling. " * 3, **entries},
+    )
+    onnx.checker.check_model(model)
+    return bytes(model.SerializeToString())
+
+
 def _is_ci_environment() -> bool:
     """Check CI/GitHub Actions env vars to determine whether tests run in CI."""
     return bool(os.getenv("CI") or os.getenv("GITHUB_ACTIONS"))
@@ -2856,12 +2872,7 @@ class TestNetworkCommDetector:
     def test_explicit_ml_model_url_patterns_treat_passive_onnx_source_repo_as_informational(self) -> None:
         detector = NetworkCommDetector()
         url = "https://github.com/RicherMans/CED"
-        data = (
-            b"\n\nmodel_type\x12\x03CED"
-            b"\n\x07version\x12\x031.0"
-            b"\n\x0cmodel_author\x12\nRicherMans"
-            b"\n\x03url\x12" + bytes([len(url)]) + url.encode()
-        )
+        data = _onnx_model_with_metadata({"source": url})
 
         findings = detector.scan(data, "model.onnx")
 
@@ -2888,16 +2899,7 @@ class TestNetworkCommDetector:
             "https://huggingface.co/csukuangfj/pyannote-models/tree/main/segmentation-3.0",
             "https://huggingface.co/pyannote/segmentation-3.0/blob/main/LICENSE",
         ]
-        metadata_pairs = b"".join(
-            b"\n" + bytes([len(key)]) + key.encode() + b"\x12" + bytes([len(url)]) + url.encode()
-            for key, url in zip(("url_1", "url_2", "license"), urls, strict=True)
-        )
-        data = (
-            b"\n\nmodel_type\x12\x1apyannote-segmentation-3.0"
-            b"\n\x07version\x12\x011"
-            b"\n\x0cmodel_author\x12\x08pyannoter"
-            b"\n\nmaintainer\x12\x06k2-fsa" + metadata_pairs
-        )
+        data = _onnx_model_with_metadata(dict(zip(("url_1", "url_2", "license"), urls, strict=True)))
 
         findings = detector.scan(data, "model.onnx")
 
@@ -2989,6 +2991,180 @@ class TestNetworkCommDetector:
             if finding["type"] == "explicit_network_pattern" and finding["matched_text"] == url
         )
         assert explicit_finding["severity"] == "CRITICAL"
+
+    @pytest.mark.parametrize("protocol", range(6))
+    @pytest.mark.parametrize("memo_entries", [0, 32, 300])
+    def test_pickle_metadata_uses_literal_boundaries(self, protocol: int, memo_entries: int) -> None:
+        url = "https://docs.example.invalid/guide?lang=en"
+        padding = {f"key_{index}": f"value_{index}" for index in range(memo_entries)}
+        data = pickle.dumps({**padding, "docs": url}, protocol=protocol)
+
+        findings = NetworkCommDetector().scan(data, "checkpoint.pt")
+
+        assert any(
+            f["type"] == "url_detected" and f["url"] == url.partition("?")[0] and f["severity"] == "INFO"
+            for f in findings
+        )
+        assert not any(f["type"] == "explicit_network_pattern" for f in findings)
+
+    @pytest.mark.parametrize("protocol", range(6))
+    def test_pickle_metadata_resolves_reused_keys_and_long_values(self, protocol: int) -> None:
+        first = "https://api.example.invalid/license"
+        second = "https://capital.example.invalid/license"
+        data = pickle.dumps(
+            [{"license": first}, {"license": "License terms " * 1000 + f"({second})", "download_count": 1}],
+            protocol=protocol,
+        )
+
+        findings = NetworkCommDetector().scan(data, "checkpoint.pt")
+
+        urls = {f["url"]: f["severity"] for f in findings if f["type"] == "url_detected"}
+        assert urls == {first: "INFO", second: "INFO"}
+        assert not any(f["type"] == "explicit_network_pattern" for f in findings)
+
+    @pytest.mark.parametrize("container", [list, tuple])
+    @pytest.mark.parametrize("protocol", range(6))
+    def test_pickle_sequence_strings_do_not_prove_metadata(self, container: Any, protocol: int) -> None:
+        data = pickle.dumps(
+            container(["license", "https://example.invalid/license", "Ordinary descriptive text. " * 8]),
+            protocol=protocol,
+        )
+
+        findings = NetworkCommDetector().scan(data, "checkpoint.pt")
+
+        assert any(f["type"] == "explicit_network_pattern" and f["severity"] == "CRITICAL" for f in findings)
+
+    @pytest.mark.parametrize("protocol", range(6))
+    @pytest.mark.parametrize("keys", [("license", "callback"), ("callback", "license")])
+    def test_pickle_metadata_preserves_reused_endpoint(self, protocol: int, keys: tuple[str, str]) -> None:
+        url = "https://example.invalid/license"
+        data = pickle.dumps(dict.fromkeys(keys, url), protocol=protocol)
+
+        findings = NetworkCommDetector().scan(data, "checkpoint.pt")
+
+        assert any(f["type"] == "explicit_network_pattern" and f["severity"] == "CRITICAL" for f in findings)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://example.invalid/weights.bin",
+            "https://example.invalid/license?target=weights.bin",
+            "https://example.invalid:4444/license",
+            "https://example.invalid:invalid/license",
+            "https://example.invalid/docs/weights%252ebin",
+            "https://example.invalid/docs/%23weights.bin",
+            "https://example.invalid/docs/../callback",
+            "https://docs.example.invalid/model.py",
+        ],
+    )
+    @pytest.mark.parametrize("model_format", ["pickle", "onnx"])
+    def test_metadata_preserves_active_or_uncertain_destinations(self, url: str, model_format: str) -> None:
+        data = (
+            pickle.dumps({"license": url}, protocol=2)
+            if model_format == "pickle"
+            else _onnx_model_with_metadata({"license": url})
+        )
+
+        findings = NetworkCommDetector().scan(data, "checkpoint.pt" if model_format == "pickle" else "model.onnx")
+
+        assert any(f["type"] == "explicit_network_pattern" and f["severity"] == "CRITICAL" for f in findings)
+
+    @pytest.mark.parametrize(
+        "url",
+        ["https://github.com/example/project/blob/main/README.md", "https://example.invalid/licenses/LICENSE.txt"],
+    )
+    def test_onnx_metadata_accepts_documentation_files_with_prefix_text(self, url: str) -> None:
+        data = _onnx_model_with_metadata({"license": f"License information ({url})"})
+
+        findings = NetworkCommDetector().scan(data, "model.onnx")
+
+        assert any(f["type"] == "url_detected" and f["url"] == url and f["severity"] == "INFO" for f in findings)
+        assert not any(f["type"] == "explicit_network_pattern" for f in findings)
+
+    def test_onnx_tensor_strings_do_not_prove_metadata(self) -> None:
+        onnx = pytest.importorskip("onnx")
+        url = b"https://github.com/example/project"
+        entry = b"\x0a\x06source\x12" + bytes([len(url)]) + url
+        tensor = onnx.helper.make_tensor(
+            "text", onnx.TensorProto.STRING, [1], [b"Ordinary descriptive text. " * 8 + entry]
+        )
+        graph = onnx.helper.make_graph(
+            [onnx.helper.make_node("Constant", [], ["Y"], value=tensor)],
+            "tensor_control",
+            [],
+            [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.STRING, [1])],
+        )
+        model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 13)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        assert not model.metadata_props
+
+        for data in (entry, model.SerializeToString()):
+            findings = NetworkCommDetector().scan(data, "model.onnx")
+            assert any(f["type"] == "explicit_network_pattern" and f["severity"] == "CRITICAL" for f in findings)
+
+    @pytest.mark.parametrize("passive_first", [False, True])
+    def test_metadata_domain_deduplication_retains_active_severity(self, passive_first: bool) -> None:
+        entries = [("license", "https://example.invalid/license"), ("callback", "https://example.invalid/endpoint")]
+        if not passive_first:
+            entries.reverse()
+        data = pickle.dumps(dict(entries), protocol=2)
+
+        findings = NetworkCommDetector().scan(data, "checkpoint.pt")
+
+        domains = [f for f in findings if f["type"] == "domain" and f["domain"] == "example.invalid"]
+        assert len(domains) == 1
+        assert domains[0]["severity"] == "MEDIUM"
+
+    def test_metadata_domain_does_not_hide_config_endpoint(self) -> None:
+        data = pickle.dumps({"license": "https://example.invalid/license", "note": '"callback":"example.invalid"'})
+
+        findings = NetworkCommDetector().scan(data, "checkpoint.pt")
+
+        assert any(
+            f["type"] == "domain" and f["domain"] == "example.invalid" and f["severity"] == "MEDIUM" for f in findings
+        )
+
+    @pytest.mark.parametrize("command", ["curl", "wget", "httpx.get", "subprocess.run"])
+    @pytest.mark.parametrize("model_format", ["pickle", "onnx"])
+    def test_commands_in_metadata_remain_actionable(self, command: str, model_format: str) -> None:
+        value = f"{command} https://example.invalid/license"
+        data = (
+            pickle.dumps({"license": value}, protocol=2)
+            if model_format == "pickle"
+            else _onnx_model_with_metadata({"license": value})
+        )
+
+        findings = NetworkCommDetector().scan(data, "checkpoint.pt" if model_format == "pickle" else "model.onnx")
+
+        assert any(f["type"] == "explicit_network_pattern" and f["severity"] == "CRITICAL" for f in findings)
+
+    def test_pickle_object_state_is_not_passive_metadata(self) -> None:
+        from types import SimpleNamespace
+
+        data = pickle.dumps(SimpleNamespace(license="https://example.invalid/license"), protocol=2)
+
+        findings = NetworkCommDetector().scan(data, "checkpoint.pt")
+
+        assert any(f["type"] == "explicit_network_pattern" and f["severity"] == "CRITICAL" for f in findings)
+
+    @pytest.mark.parametrize("limit", ["_MAX_PICKLE_OPS", "_MAX_PICKLE_BYTES", "_MAX_METADATA_VALUE_BYTES"])
+    def test_metadata_budget_exhaustion_preserves_detection(self, monkeypatch: pytest.MonkeyPatch, limit: str) -> None:
+        from modelaudit.detectors import _metadata
+
+        monkeypatch.setattr(_metadata, limit, 1)
+        data = pickle.dumps({"license": "https://example.invalid/license"}, protocol=2)
+
+        findings = NetworkCommDetector().scan(data, "checkpoint.pt")
+
+        assert any(f["type"] == "explicit_network_pattern" and f["severity"] == "CRITICAL" for f in findings)
+
+    def test_incomplete_pickle_metadata_preserves_detection(self) -> None:
+        data = pickle.dumps({"license": "https://example.invalid/license"}, protocol=2)[:-1]
+
+        findings = NetworkCommDetector().scan(data, "checkpoint.pt")
+
+        assert any(f["type"] == "explicit_network_pattern" and f["severity"] == "CRITICAL" for f in findings)
 
     def test_cc_pattern_snippet_url_expansion_is_bounded(self) -> None:
         """Long whitespace-free binary regions should not force unbounded URL scans."""

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -3077,6 +3077,30 @@ class TestNetworkCommDetector:
 
         assert any(f["type"] == "explicit_network_pattern" and f["severity"] == "CRITICAL" for f in findings)
 
+    @pytest.mark.parametrize("key", [" license ", "\tdocs", "url_0\n"])
+    def test_padded_onnx_keys_do_not_prove_metadata(self, key: str) -> None:
+        data = _onnx_model_with_metadata({key: "https://example.invalid/license"})
+
+        findings = NetworkCommDetector().scan(data, "model.onnx")
+
+        assert any(f["type"] == "explicit_network_pattern" and f["severity"] == "CRITICAL" for f in findings)
+
+    @pytest.mark.parametrize("control", ["\x00", "\x0b", "\x1f", "\x7f"])
+    @pytest.mark.parametrize("model_format,protocol", [("pickle", p) for p in range(6)] + [("onnx", None)])
+    def test_raw_controls_prevent_metadata_downgrade(
+        self, control: str, model_format: str, protocol: int | None
+    ) -> None:
+        metadata = {"license": f"https://example.invalid/license/{control}payload"}
+        data = (
+            pickle.dumps(metadata, protocol=protocol)
+            if model_format == "pickle"
+            else _onnx_model_with_metadata(metadata)
+        )
+
+        findings = NetworkCommDetector().scan(data, "checkpoint.pt" if model_format == "pickle" else "model.onnx")
+
+        assert any(f["type"] == "explicit_network_pattern" and f["severity"] == "CRITICAL" for f in findings)
+
     @pytest.mark.parametrize(
         "url",
         [

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -3067,6 +3067,16 @@ class TestNetworkCommDetector:
         assert any(f["type"] == "url_detected" and f["url"] == url and f["severity"] == "INFO" for f in findings)
         assert not any(f["type"] == "explicit_network_pattern" for f in findings)
 
+    @pytest.mark.parametrize("protocol", range(6))
+    @pytest.mark.parametrize("key", [" license ", "\tdocs", "readme\n", " metadata "])
+    def test_padded_pickle_keys_do_not_prove_metadata(self, protocol: int, key: str) -> None:
+        url = "https://example.invalid/license"
+        value = {"license": url} if key.strip() == "metadata" else url
+
+        findings = NetworkCommDetector().scan(pickle.dumps({key: value}, protocol=protocol), "checkpoint.pt")
+
+        assert any(f["type"] == "explicit_network_pattern" and f["severity"] == "CRITICAL" for f in findings)
+
     @pytest.mark.parametrize(
         "url",
         [
@@ -3096,6 +3106,13 @@ class TestNetworkCommDetector:
             "https://example.invalid/webhook/license",
             "https://example.invalid/callback/license",
             "https://example.invalid/endpoint/license",
+            "https://example.invalid/license/%00payload",
+            "https://example.invalid/license/%0apayload",
+            "https://example.invalid/license/%0dpayload",
+            "https://example.invalid/license/%7fpayload",
+            "https://example.invalid/license/%2500payload",
+            "https://example.invalid/license/https%3A%2F%2Fstorage.googleapis.com%2Fbucket%2Fpayload.bin",
+            "https://example.invalid/license/https%253A%252F%252Fstorage.googleapis.com%252Fbucket%252Fpayload.bin",
         ],
     )
     @pytest.mark.parametrize("model_format", ["pickle", "onnx"])

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -3044,6 +3044,29 @@ class TestNetworkCommDetector:
 
         assert any(f["type"] == "explicit_network_pattern" and f["severity"] == "CRITICAL" for f in findings)
 
+    @pytest.mark.parametrize("protocol", range(6))
+    @pytest.mark.parametrize("active_first", [False, True])
+    @pytest.mark.parametrize("field", ["callback", "callback_config", "unknown"])
+    def test_nested_metadata_preserves_unknown_owner(self, protocol: int, active_first: bool, field: str) -> None:
+        nested = {"license": "https://example.invalid/license"}
+        entries = [("metadata", nested), (field, [nested])]
+        if active_first:
+            entries.reverse()
+
+        findings = NetworkCommDetector().scan(pickle.dumps(dict(entries), protocol=protocol), "checkpoint.pt")
+
+        assert any(f["type"] == "explicit_network_pattern" and f["severity"] == "CRITICAL" for f in findings)
+
+    @pytest.mark.parametrize("protocol", range(6))
+    def test_explicit_nested_metadata_remains_informational(self, protocol: int) -> None:
+        url = "https://example.invalid/license"
+        data = pickle.dumps({"metadata": {"license": url}}, protocol=protocol)
+
+        findings = NetworkCommDetector().scan(data, "checkpoint.pt")
+
+        assert any(f["type"] == "url_detected" and f["url"] == url and f["severity"] == "INFO" for f in findings)
+        assert not any(f["type"] == "explicit_network_pattern" for f in findings)
+
     @pytest.mark.parametrize(
         "url",
         [
@@ -3055,6 +3078,24 @@ class TestNetworkCommDetector:
             "https://example.invalid/docs/%23weights.bin",
             "https://example.invalid/docs/../callback",
             "https://docs.example.invalid/model.py",
+            "https://example.invalid/license/weights.bin;v=1",
+            "https://example.invalid/license/weights.bin%3bv=1",
+            "https://example.invalid/license/weights.bin%253bv=1",
+            "http://127.0.0.1/license",
+            "http://[::1]/license",
+            "http://10.0.0.1/license",
+            "http://169.254.169.254/license",
+            "http://192.168.1.1/license",
+            "http://8.8.8.8/license",
+            "http://2130706433/license",
+            "http://localhost/license",
+            "http://model-server/license",
+            "http://docs.localhost/license",
+            "http://docs.local/license",
+            "http://docs.internal/license",
+            "https://example.invalid/webhook/license",
+            "https://example.invalid/callback/license",
+            "https://example.invalid/endpoint/license",
         ],
     )
     @pytest.mark.parametrize("model_format", ["pickle", "onnx"])
@@ -3103,6 +3144,16 @@ class TestNetworkCommDetector:
             findings = NetworkCommDetector().scan(data, "model.onnx")
             assert any(f["type"] == "explicit_network_pattern" and f["severity"] == "CRITICAL" for f in findings)
 
+    @pytest.mark.parametrize("graph", [b"x", b"\x0a\x02\x00", b"\x08\x01"])
+    def test_invalid_onnx_graph_does_not_prove_metadata(self, graph: bytes) -> None:
+        url = b"https://example.invalid/license"
+        entry = b"\x0a\x07license\x12" + bytes([len(url)]) + url
+        data = b"\x08\x08\x3a" + bytes([len(graph)]) + graph + b"\x72" + bytes([len(entry)]) + entry
+
+        findings = NetworkCommDetector().scan(data, "model.onnx")
+
+        assert any(f["type"] == "explicit_network_pattern" and f["severity"] == "CRITICAL" for f in findings)
+
     @pytest.mark.parametrize("passive_first", [False, True])
     def test_metadata_domain_deduplication_retains_active_severity(self, passive_first: bool) -> None:
         entries = [("license", "https://example.invalid/license"), ("callback", "https://example.invalid/endpoint")]
@@ -3125,7 +3176,9 @@ class TestNetworkCommDetector:
             f["type"] == "domain" and f["domain"] == "example.invalid" and f["severity"] == "MEDIUM" for f in findings
         )
 
-    @pytest.mark.parametrize("command", ["curl", "wget", "httpx.get", "subprocess.run"])
+    @pytest.mark.parametrize(
+        "command", ["curl", "wget", "httpx.get", "subprocess.run", "GET", "POST", "OPTIONS", "download", "fetch"]
+    )
     @pytest.mark.parametrize("model_format", ["pickle", "onnx"])
     def test_commands_in_metadata_remain_actionable(self, command: str, model_format: str) -> None:
         value = f"{command} https://example.invalid/license"
@@ -3138,6 +3191,21 @@ class TestNetworkCommDetector:
         findings = NetworkCommDetector().scan(data, "checkpoint.pt" if model_format == "pickle" else "model.onnx")
 
         assert any(f["type"] == "explicit_network_pattern" and f["severity"] == "CRITICAL" for f in findings)
+
+    @pytest.mark.parametrize("model_format", ["pickle", "onnx"])
+    def test_metadata_prose_can_describe_download_instructions(self, model_format: str) -> None:
+        url = "https://docs.example.invalid/license"
+        value = f"For download instructions, see {url}"
+        data = (
+            pickle.dumps({"docs": value}, protocol=4)
+            if model_format == "pickle"
+            else _onnx_model_with_metadata({"docs": value})
+        )
+
+        findings = NetworkCommDetector().scan(data, "checkpoint.pt" if model_format == "pickle" else "model.onnx")
+
+        assert any(f["type"] == "url_detected" and f["url"] == url and f["severity"] == "INFO" for f in findings)
+        assert not any(f["type"] == "explicit_network_pattern" for f in findings)
 
     def test_pickle_object_state_is_not_passive_metadata(self) -> None:
         from types import SimpleNamespace

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -3068,24 +3068,24 @@ class TestNetworkCommDetector:
         assert not any(f["type"] == "explicit_network_pattern" for f in findings)
 
     @pytest.mark.parametrize("protocol", range(6))
-    @pytest.mark.parametrize("key", [" license ", "\tdocs", "readme\n", " metadata "])
-    def test_padded_pickle_keys_do_not_prove_metadata(self, protocol: int, key: str) -> None:
-        url = "https://example.invalid/license"
+    @pytest.mark.parametrize("key", [" license ", "\tdocs", "readme\n", " metadata ", "licen\u017fe", "doc\u017f"])
+    def test_noncanonical_pickle_keys_do_not_prove_metadata(self, protocol: int, key: str) -> None:
+        url = "https://example.invalid/license Ordinary reference text."
         value = {"license": url} if key.strip() == "metadata" else url
 
         findings = NetworkCommDetector().scan(pickle.dumps({key: value}, protocol=protocol), "checkpoint.pt")
 
         assert any(f["type"] == "explicit_network_pattern" and f["severity"] == "CRITICAL" for f in findings)
 
-    @pytest.mark.parametrize("key", [" license ", "\tdocs", "url_0\n"])
-    def test_padded_onnx_keys_do_not_prove_metadata(self, key: str) -> None:
+    @pytest.mark.parametrize("key", [" license ", "\tdocs", "url_0\n", "licen\u017fe", "doc\u017f", "url_\u0661"])
+    def test_noncanonical_onnx_keys_do_not_prove_metadata(self, key: str) -> None:
         data = _onnx_model_with_metadata({key: "https://example.invalid/license"})
 
         findings = NetworkCommDetector().scan(data, "model.onnx")
 
         assert any(f["type"] == "explicit_network_pattern" and f["severity"] == "CRITICAL" for f in findings)
 
-    @pytest.mark.parametrize("control", ["\x00", "\x0b", "\x1f", "\x7f"])
+    @pytest.mark.parametrize("control", ["\x00", "\x0b", "\x1f", "\x7f", "\x80", "\x85", "\x9f"])
     @pytest.mark.parametrize("model_format,protocol", [("pickle", p) for p in range(6)] + [("onnx", None)])
     def test_raw_controls_prevent_metadata_downgrade(
         self, control: str, model_format: str, protocol: int | None
@@ -3135,6 +3135,9 @@ class TestNetworkCommDetector:
             "https://example.invalid/license/%0dpayload",
             "https://example.invalid/license/%7fpayload",
             "https://example.invalid/license/%2500payload",
+            "https://example.invalid/license/%C2%80payload",
+            "https://example.invalid/license/%C2%85payload",
+            "https://example.invalid/license/%25C2%259Fpayload",
             "https://example.invalid/license/https%3A%2F%2Fstorage.googleapis.com%2Fbucket%2Fpayload.bin",
             "https://example.invalid/license/https%253A%252F%252Fstorage.googleapis.com%252Fbucket%252Fpayload.bin",
         ],

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import pickle
 import re
 from collections.abc import Iterator
 from pathlib import Path
@@ -2766,6 +2767,54 @@ class TestNetworkCommDetector:
         explicit_finding = next(finding for finding in findings if finding["type"] == "explicit_network_pattern")
         assert explicit_finding["matched_text"] == "https://example.com/models/checkpoint.bin"
         assert explicit_finding["message"].endswith("https://example.com/models/checkpoint.bin")
+
+    def test_explicit_ml_model_url_patterns_treat_docs_and_license_urls_as_informational(self) -> None:
+        detector = NetworkCommDetector()
+        data = pickle.dumps(
+            {
+                "license": "AGPL-3.0 License (https://ultralytics.com/license)",
+                "docs": "https://docs.ultralytics.com",
+            },
+            protocol=2,
+        )
+
+        findings = detector.scan(data, "payload.pt")
+
+        assert not [finding for finding in findings if finding["type"] == "explicit_network_pattern"]
+        url_findings = {finding["url"]: finding for finding in findings if finding["type"] == "url_detected"}
+        assert url_findings["https://ultralytics.com/license"]["severity"] == "INFO"
+        assert url_findings["https://docs.ultralytics.com"]["severity"] == "INFO"
+        domain_findings = {finding["domain"]: finding for finding in findings if finding["type"] == "domain"}
+        assert domain_findings["ultralytics.com"]["severity"] == "INFO"
+        assert domain_findings["docs.ultralytics.com"]["severity"] == "INFO"
+
+    def test_explicit_ml_model_url_patterns_keep_docs_host_execution_urls_critical(self) -> None:
+        detector = NetworkCommDetector()
+        url = "https://docs.example.invalid/checkpoint.bin"
+        data = f"httpx.get('{url}')".encode()
+
+        findings = detector.scan(data, "payload.pt")
+
+        explicit_finding = next(finding for finding in findings if finding["type"] == "explicit_network_pattern")
+        assert explicit_finding["severity"] == "CRITICAL"
+        assert explicit_finding["matched_text"] == url
+        url_finding = next(finding for finding in findings if finding["type"] == "url_detected")
+        assert url_finding["severity"] == "MEDIUM"
+        domain_finding = next(finding for finding in findings if finding["type"] == "domain")
+        assert domain_finding["severity"] == "MEDIUM"
+
+    def test_explicit_ml_model_url_patterns_keep_pickle_callback_license_urls_critical(self) -> None:
+        detector = NetworkCommDetector()
+        url = "https://docs.example.invalid/license.bin"
+        data = pickle.dumps({"callback_url": url}, protocol=2)
+
+        findings = detector.scan(data, "payload.pt")
+
+        explicit_finding = next(finding for finding in findings if finding["type"] == "explicit_network_pattern")
+        assert explicit_finding["severity"] == "CRITICAL"
+        assert explicit_finding["matched_text"] == url
+        url_finding = next(finding for finding in findings if finding["type"] == "url_detected")
+        assert url_finding["severity"] == "MEDIUM"
 
     def test_cc_pattern_snippet_url_expansion_is_bounded(self) -> None:
         """Long whitespace-free binary regions should not force unbounded URL scans."""
@@ -8228,6 +8277,20 @@ class TestNetworkCommDetector:
 
         assert explicit_finding["matched_text"] == "GET /download?token=<redacted> HTTP/1.1"
         assert "TOPSECRET123" not in serialized
+
+    def test_unbalanced_trailing_url_delimiter_trim_handles_long_suffix(self) -> None:
+        """Malformed trailing delimiters should trim without repeated full-string scans."""
+        import time
+
+        data = b"https://evil.example/model.pt" + (b"]" * 100_000)
+
+        start = time.perf_counter()
+        findings = NetworkCommDetector().scan(data, "model.pt")
+        duration = time.perf_counter() - start
+
+        url_finding = next(finding for finding in findings if finding["type"] == "url_detected")
+        assert url_finding["url"] == "https://evil.example/model.pt"
+        assert duration < 1.0
 
     def test_suspicious_port_scan_performance(self) -> None:
         """Ensure port scanning remains performant with precompiled patterns."""

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -5076,6 +5076,71 @@ def test_pytorch_zip_redacts_signed_urls_in_explicit_network_findings(tmp_path: 
     assert explicit_failure.message == "Explicit network pattern in ML model: https://collector.example/upload"
 
 
+def test_pytorch_zip_treats_untrusted_pickle_docs_and_license_urls_as_informational(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "metadata-urls.pt", with_pickle=False, prefix="archive")
+    license_url = "https://ultralytics.com/license"
+    docs_url = "https://docs.ultralytics.com"
+    payload = (
+        b"\x80\x02}q\x00("
+        + _pickle_binunicode(b"license")
+        + b"q\x01"
+        + _pickle_binunicode(f"AGPL-3.0 License ({license_url})".encode())
+        + b"q\x02"
+        + _pickle_binunicode(b"docs")
+        + b"q\x03"
+        + _pickle_binunicode(docs_url.encode())
+        + b"q\x04"
+        + _pickle_binunicode(b"model")
+        + b"q\x05"
+        + _pickle_global("ultralytics.nn.tasks", "DetectionModel")
+        + b"u."
+    )
+    with zipfile.ZipFile(model_path, "a") as zipf:
+        zipf.writestr("archive/data.pkl", payload)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    url_issues = [
+        issue for issue in result.issues if issue.rule_code == "S309" and issue.details.get("type") == "url_detected"
+    ]
+    assert {
+        issue.details["url"]: issue.severity
+        for issue in url_issues
+        if issue.details.get("url") in {license_url, docs_url}
+    } == {license_url: IssueSeverity.INFO, docs_url: IssueSeverity.INFO}
+    assert not any(
+        issue.rule_code == "S310"
+        and issue.severity == IssueSeverity.CRITICAL
+        and issue.details.get("type") == "explicit_network_pattern"
+        and issue.details.get("matched_text") in {license_url, docs_url}
+        for issue in result.issues
+    )
+
+
+def test_pytorch_zip_keeps_docs_host_execution_urls_actionable(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "docs-host-loader.pt", with_pickle=False, prefix="archive")
+    url = "https://docs.example.invalid/checkpoint.bin"
+    payload = pickle.dumps({"loader": f"requests.get('{url}')"}, protocol=4)
+    with zipfile.ZipFile(model_path, "a") as zipf:
+        zipf.writestr("archive/data.pkl", payload)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert _has_network_evidence_for_url(result, url)
+
+
+def test_pytorch_zip_keeps_callback_license_urls_actionable(tmp_path: Path) -> None:
+    model_path = create_mock_pytorch_zip(tmp_path / "callback-url.pt", with_pickle=False, prefix="archive")
+    url = "https://docs.example.invalid/license.bin"
+    payload = pickle.dumps({"callback_url": url}, protocol=4)
+    with zipfile.ZipFile(model_path, "a") as zipf:
+        zipf.writestr("archive/data.pkl", payload)
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert _has_network_evidence_for_url(result, url)
+
+
 @pytest.mark.parametrize(
     "payload",
     [

--- a/tests/test_pickle_context_filtering.py
+++ b/tests/test_pickle_context_filtering.py
@@ -40,7 +40,7 @@ def test_rust_pickle_scanner_does_not_let_ml_context_hide_dangerous_reduce(tmp_p
 
     result = PickleScanner().scan(str(path))
 
-    assert result.success is True
+    assert result.success is True, result.to_dict()
     assert any(issue.severity == IssueSeverity.CRITICAL for issue in result.issues)
     assert any(
         issue.details.get("import_reference") in {"posix.system", "os.system", "nt.system"} for issue in result.issues


### PR DESCRIPTION
Documentation, license and repository links stored in model metadata can trigger critical network findings. Downgrade links only when a bounded, non-executing parse establishes their metadata ownership and the URL is informational.

Preserve detections for active or unknown fields, non-ASCII or padded metadata keys, C0/C1 control characters in decoded metadata values and URLs, reused/nested values, commands, HTTP requests, local/IP destinations, artifact paths and endpoint markers. Validate ONNX graph structure before trusting metadata. Recognize ordinary documentation prose and handle empty URL queries consistently across supported Python versions.

Validation: 1,460 network-detector tests passed; Python 3.10 passed 1,396 with 64 optional ONNX skips. Root Ruff and Linux-target mypy passed. Full fast suite: 8,758 passed, 8 skipped, the known Jinja YAML-routing failure reproduced on exact main, and a Jinja timeout that passes in isolated branch/main reruns. Native macOS mypy retains five existing xattr errors in unchanged files.

Pinned YOLO11 metadata replay: the two critical documentation-link findings on main become informational on this branch, with both links retained. Artifact SHA256: `0ebbc80d4a7680d14987a577cd21342b65ecfd94632bd9a8da63ae6417644ee1`; Hugging Face revision: `c1ac518816e34361864c80db5bdfc4fa58e68baa`.

Windows CI on the prior commit recorded a critical finding but unexpectedly marked the context-filtering scan incomplete. The same tests pass locally on branch/main; this follow-up adds the complete scan result to that assertion. The Windows cause is unconfirmed and fresh CI must pass before merge.
