### PR TITLE
fix: preserve ONNX shape provenance during weight analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- Avoid fail-closed ONNX weight analysis when Gather nodes only select from activation tensors.
 - Preserve incomplete-scan diagnostics for malformed or unsupported ZIP data in GGUF/GGML files, including cached scans.
 - Report incomplete coverage when a GGUF/GGML source changes during scanning.
 - Preserve caller-owned Hugging Face cache sidecars during streaming cleanup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- Avoid fail-closed ONNX weight analysis when Gather nodes only select from activation tensors.
+- Avoid incomplete ONNX weight analysis when Gather nodes read dimensions from Shape outputs.
 - Preserve incomplete-scan diagnostics for malformed or unsupported ZIP data in GGUF/GGML files, including cached scans.
 - Report incomplete coverage when a GGUF/GGML source changes during scanning.
 - Preserve caller-owned Hugging Face cache sidecars during streaming cleanup.

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -1926,13 +1926,6 @@ def _build_onnx_weight_analysis_plan(
             if name and name not in value_lineages and name not in constants:
                 dynamic_values.add(name)
 
-        runtime_data_values = (
-            {_onnx_value_name(graph_input) for graph_input in current_graph.input} & dynamic_values
-            if root_graph
-            else set()
-        )
-        constant_fill_values: set[str] = set()
-
         for local_node_index, node in enumerate(getattr(current_graph, "node", ())):
             current_node_index = node_counter
             node_counter += 1
@@ -2013,25 +2006,24 @@ def _build_onnx_weight_analysis_plan(
                     and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
                     and (
                         (node.op_type == "Clip" and input_index > 0)
-                        or (node.op_type == "Where" and input_index == 0)
                         or (
                             not is_model_local_function
-                            and (
-                                (node.op_type in {"Gather", "GatherElements", "GatherND"} and input_index == 1)
-                                or (node.op_type in _RECURRENT_WEIGHT_OPERATORS and input_index == 4)
-                            )
+                            and node.op_type in _RECURRENT_WEIGHT_OPERATORS
+                            and input_index == 4
                         )
                     )
                 )
-                is_expand_shape = (
+                is_shape_control_input = (
                     is_registered_standard_operator
                     and not is_model_local_function
                     and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
-                    and node.op_type == "Expand"
-                    and input_index == 1
+                    and (
+                        (node.op_type in {"Expand", "Gather", "GatherElements", "GatherND"} and input_index == 1)
+                        or (node.op_type == "Where" and input_index == 0)
+                    )
                 )
-                if is_expand_shape:
-                    # Retain shape ownership for subsequent Shape queries without inheriting data values.
+                if is_shape_control_input:
+                    # Shape and Size can later turn output dimensions into numeric data.
                     merge_lineages(
                         all_input_lineages,
                         {
@@ -2314,7 +2306,7 @@ def _build_onnx_weight_analysis_plan(
                 is_registered_standard_operator
                 and not is_model_local_function
                 and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
-                and node.op_type == "Shape"
+                and node.op_type in {"Shape", "Size"}
             )
             output_lineages: dict[int, _OnnxWeightLineage] = {}
             if supported_transform:
@@ -2386,30 +2378,28 @@ def _build_onnx_weight_analysis_plan(
                 carries_dynamic_activation |= any(
                     lineage.unresolved_reason == "dynamic_activation_lineage" for lineage in all_input_lineages.values()
                 )
-                runtime_masks_activation = (
-                    same_type_elementwise
+                preserves_shape_control = (
+                    is_registered_standard_operator
                     and not is_model_local_function
-                    and node.op_type == "Where"
-                    and len(node.input) == 3
-                    and node.input[0] in runtime_data_values
-                    and all(
-                        input_name in constant_fill_values
-                        or input_name in runtime_data_values
-                        or input_index in dynamic_activation_input_indexes
-                        for input_index, input_name in enumerate(node.input[1:], start=1)
-                    )
-                    and any(
-                        input_name in runtime_data_values or input_index in dynamic_activation_input_indexes
-                        for input_index, input_name in enumerate(node.input[1:], start=1)
+                    and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
+                    and (
+                        same_type_elementwise
+                        or (
+                            same_type_unary_elementwise
+                            and node.op_type not in {"Hardmax", "LogSoftmax", "LpNormalization", "Softmax"}
+                        )
+                        or clip_operator
+                        or pow_operator
+                        or node.op_type in {"Expand", "Gather", "GatherElements", "GatherND"}
                     )
                 )
                 for initializer_index, lineage in all_input_lineages.items():
                     if initializer_index in activation_input_lineages:
                         continue
                     unresolved_reason = lineage.unresolved_reason
-                    # Arithmetic on dimension values stays unresolved in either matrix operand.
-                    if unresolved_reason == "shape_dimensions_lineage" and runtime_masks_activation:
-                        unresolved_reason = "dynamic_activation_lineage"
+                    if unresolved_reason == "shape_control_lineage" and not preserves_shape_control:
+                        # Reductions, normalization and unknown operators can turn extents into data values.
+                        unresolved_reason = "shape_dimensions_lineage"
                     if unresolved_reason is None:
                         if carries_dynamic_activation:
                             unresolved_reason = "dynamic_activation_lineage"
@@ -2542,42 +2532,10 @@ def _build_onnx_weight_analysis_plan(
                     )
                     subgraph_output_dynamic[output_index] |= graph_output_dynamic[graph_output_index]
 
-            preserves_runtime_data = (
-                is_registered_standard_operator
-                and not is_model_local_function
-                and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
-                and (supported_transform or node.op_type in {"Abs", "Expand", "Neg", "Not", "Relu", "Sigmoid", "Tanh"})
-                and bool(node.input)
-            )
-            runtime_output = preserves_runtime_data and node.input[0] in runtime_data_values
-            runtime_output |= (
-                is_registered_standard_operator
-                and not is_model_local_function
-                and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
-                and node.op_type in {"Equal", "Greater", "GreaterOrEqual", "Less", "LessOrEqual"}
-                and any(
-                    input_name in runtime_data_values or input_index in dynamic_activation_input_indexes
-                    for input_index, input_name in enumerate(node.input)
-                )
-            )
-            constant_fill_output = (
-                is_registered_standard_operator
-                and not is_model_local_function
-                and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
-                and node.op_type == "ConstantOfShape"
-            ) or (preserves_runtime_data and node.input[0] in constant_fill_values)
             for output_index, output_name in enumerate(node.output):
                 if not output_name:
                     continue
                 name = str(output_name)
-                if runtime_output:
-                    runtime_data_values.add(name)
-                else:
-                    runtime_data_values.discard(name)
-                if constant_fill_output:
-                    constant_fill_values.add(name)
-                else:
-                    constant_fill_values.discard(name)
                 per_output_lineages = dict(output_lineages)
                 merge_lineages(
                     per_output_lineages,

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -2023,6 +2023,7 @@ def _build_onnx_weight_analysis_plan(
                         (node.op_type in {"Expand", "Gather", "GatherElements", "GatherND"} and input_index == 1)
                         or (node.op_type == "Reshape" and input_index == 1)
                         or (node.op_type == "Slice" and input_index > 0)
+                        or (node.op_type in {"Squeeze", "Unsqueeze"} and input_index == 1)
                         or (node.op_type == "Tile" and input_index == 1)
                         or (node.op_type == "Where" and input_index == 0)
                     )

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -1991,7 +1991,11 @@ def _build_onnx_weight_analysis_plan(
                 is_non_data_standard_input = (
                     is_registered_standard_operator
                     and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
-                    and ((node.op_type == "Clip" and input_index > 0) or (node.op_type == "Where" and input_index == 0))
+                    and (
+                        (node.op_type == "Clip" and input_index > 0)
+                        or (node.op_type == "Where" and input_index == 0)
+                        or (node.op_type == "Gather" and input_index == 1 and not is_model_local_function)
+                    )
                 )
                 if not is_array_feature_selector and not is_non_data_standard_input:
                     merge_lineages(
@@ -2037,6 +2041,13 @@ def _build_onnx_weight_analysis_plan(
                             resolved_index != input_index for resolved_index in resolved_weight_input_indexes
                         )
                         prior_layer_activation = lineage.unresolved_reason == "dynamic_activation_lineage"
+                        recurrent_initial_state = (
+                            is_registered_standard_operator
+                            and not is_model_local_function
+                            and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
+                            and node.op_type in _RECURRENT_WEIGHT_OPERATORS
+                            and (input_index == 5 or (node.op_type == "LSTM" and input_index == 6))
+                        )
                         recognized_activation_input = prior_layer_activation and (
                             (
                                 is_registered_standard_operator
@@ -2047,6 +2058,7 @@ def _build_onnx_weight_analysis_plan(
                                 and (opposite_resolved_weight or all_lineage_inputs_are_activation_contraction)
                             )
                         )
+                        recognized_activation_input |= recurrent_initial_state and opposite_resolved_weight
                         if recognized_activation_input:
                             if opposite_resolved_weight:
                                 activation_input_lineages.add(initializer_index)
@@ -2322,10 +2334,22 @@ def _build_onnx_weight_analysis_plan(
                 carries_dynamic_activation |= any(
                     lineage.unresolved_reason == "dynamic_activation_lineage" for lineage in all_input_lineages.values()
                 )
+                shape_scales_activation = (
+                    same_type_elementwise
+                    and not is_model_local_function
+                    and any(
+                        (input_name in dynamic_values and not value_lineages.get(input_name))
+                        or input_index in dynamic_activation_input_indexes
+                        for input_index, input_name in enumerate(node.input)
+                        if node.op_type != "Where" or input_index != 0
+                    )
+                )
                 for initializer_index, lineage in all_input_lineages.items():
                     if initializer_index in activation_input_lineages:
                         continue
                     unresolved_reason = lineage.unresolved_reason
+                    if unresolved_reason == "shape_dimensions_lineage" and shape_scales_activation:
+                        unresolved_reason = "dynamic_activation_lineage"
                     if unresolved_reason is None:
                         if carries_dynamic_activation:
                             unresolved_reason = "dynamic_activation_lineage"

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -2004,7 +2004,10 @@ def _build_onnx_weight_analysis_plan(
                         or (
                             not is_model_local_function
                             and (
-                                (node.op_type in {"Gather", "GatherElements", "GatherND"} and input_index == 1)
+                                (
+                                    node.op_type in {"Expand", "Gather", "GatherElements", "GatherND"}
+                                    and input_index == 1
+                                )
                                 or (node.op_type in _RECURRENT_WEIGHT_OPERATORS and input_index == 4)
                             )
                         )
@@ -2072,6 +2075,17 @@ def _build_onnx_weight_analysis_plan(
                             )
                         )
                         recognized_activation_input |= recurrent_initial_state and opposite_resolved_weight
+                        recognized_activation_input |= (
+                            lineage.unresolved_reason == "runtime_shape_lineage"
+                            and is_registered_standard_operator
+                            and not is_model_local_function
+                            and _onnx_activation_input_candidate(node, input_index)
+                            and (
+                                node.op_type not in {"Einsum", "Gemm", "MatMul"}
+                                or (node.op_type in {"Gemm", "MatMul"} and input_index == 0)
+                            )
+                            and opposite_resolved_weight
+                        )
                         if recognized_activation_input:
                             if opposite_resolved_weight:
                                 activation_input_lineages.add(initializer_index)
@@ -2348,7 +2362,7 @@ def _build_onnx_weight_analysis_plan(
                     lineage.unresolved_reason == "dynamic_activation_lineage" for lineage in all_input_lineages.values()
                 )
                 # Intermediate dynamic values may contain only shape-derived constants.
-                shape_scales_activation = (
+                shape_combines_with_runtime_data = (
                     same_type_elementwise
                     and not is_model_local_function
                     and node.op_type != "Where"
@@ -2379,9 +2393,9 @@ def _build_onnx_weight_analysis_plan(
                         continue
                     unresolved_reason = lineage.unresolved_reason
                     if unresolved_reason == "shape_dimensions_lineage" and (
-                        shape_scales_activation or runtime_masks_activation
+                        shape_combines_with_runtime_data or runtime_masks_activation
                     ):
-                        unresolved_reason = "dynamic_activation_lineage"
+                        unresolved_reason = "runtime_shape_lineage"
                     if unresolved_reason is None:
                         if carries_dynamic_activation:
                             unresolved_reason = "dynamic_activation_lineage"
@@ -2518,10 +2532,20 @@ def _build_onnx_weight_analysis_plan(
                 is_registered_standard_operator
                 and not is_model_local_function
                 and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
-                and (supported_transform or node.op_type in {"Abs", "Neg", "Not", "Relu", "Sigmoid", "Tanh"})
+                and (supported_transform or node.op_type in {"Abs", "Expand", "Neg", "Not", "Relu", "Sigmoid", "Tanh"})
                 and bool(node.input)
             )
             runtime_output = preserves_runtime_data and node.input[0] in runtime_data_values
+            runtime_output |= (
+                is_registered_standard_operator
+                and not is_model_local_function
+                and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
+                and node.op_type in {"Equal", "Greater", "GreaterOrEqual", "Less", "LessOrEqual"}
+                and any(
+                    input_name in runtime_data_values or input_index in dynamic_activation_input_indexes
+                    for input_index, input_name in enumerate(node.input)
+                )
+            )
             constant_fill_output = (
                 is_registered_standard_operator
                 and not is_model_local_function

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -2245,7 +2245,7 @@ def _build_onnx_weight_analysis_plan(
                     ),
                 )
 
-            # Shape exposes dimensions, so input weight values cannot reach its output.
+            # Keep dimension provenance: a later Cast can turn dimensions into weights.
             is_shape_query = (
                 is_registered_standard_operator
                 and not is_model_local_function
@@ -2258,9 +2258,17 @@ def _build_onnx_weight_analysis_plan(
                 for initializer_index, lineage in data_lineages.items():
                     transform_counts[initializer_index] += 1
                     output_lineages[initializer_index] = transformed_lineage(lineage, node, constants)
+            elif is_shape_query:
+                for initializer_index, lineage in all_input_lineages.items():
+                    output_lineages[initializer_index] = _OnnxWeightLineage(
+                        initializer_index=initializer_index,
+                        shape=None,
+                        data_type=onnx.TensorProto.INT64,
+                        transforms=lineage.transforms,
+                        unresolved_reason="shape_dimensions_lineage",
+                    )
             elif (
                 all_input_lineages
-                and not is_shape_query
                 and node.op_type not in _QUANTIZED_WEIGHT_OPERATORS
                 and function is None
                 and not subgraph_results

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -1763,6 +1763,14 @@ def _build_onnx_weight_analysis_plan(
                 break
         return tuple(merged)
 
+    def append_transform_marker(
+        transforms: tuple[_OnnxWeightTransform, ...],
+        marker: _OnnxWeightTransform,
+    ) -> tuple[_OnnxWeightTransform, ...]:
+        if marker in transforms or len(transforms) >= _ONNX_WEIGHT_TRANSFORM_DEPTH_LIMIT:
+            return transforms
+        return (*transforms, marker)
+
     def merge_lineages(
         target: dict[int, _OnnxWeightLineage],
         source: dict[int, _OnnxWeightLineage],
@@ -2615,7 +2623,10 @@ def _build_onnx_weight_analysis_plan(
                                 initializer_index=initializer_index,
                                 shape=lineage.shape,
                                 data_type=lineage.data_type,
-                                transforms=(*lineage.transforms, _OnnxWeightTransform("recurrent_state_output")),
+                                transforms=append_transform_marker(
+                                    lineage.transforms,
+                                    _OnnxWeightTransform("recurrent_state_output"),
+                                ),
                                 unresolved_reason=(
                                     lineage.unresolved_reason
                                     if lineage.unresolved_reason is not None

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -2083,6 +2083,7 @@ def _build_onnx_weight_analysis_plan(
                         and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
                         and node.op_type == "Clip"
                         and input_index > 0
+                        and lineage.unresolved_reason != "shape_control_lineage"
                         and lineage.shape != ()
                     )
                     if invalid_clip_bound:

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -1375,8 +1375,10 @@ def _build_onnx_weight_analysis_plan(
     }
 
     def lineage_could_be_weight(lineage: _OnnxWeightLineage) -> bool:
-        return (lineage.data_type is None or lineage.data_type in floating_types) and (
-            lineage.shape is None or len(lineage.shape) >= 2
+        return (
+            lineage.unresolved_reason != "shape_control_lineage"
+            and (lineage.data_type is None or lineage.data_type in floating_types)
+            and (lineage.shape is None or len(lineage.shape) >= 2)
         )
 
     def value_info_shape(value_info: Any) -> tuple[int, ...] | None:
@@ -1759,6 +1761,17 @@ def _build_onnx_weight_analysis_plan(
                 continue
             if existing == lineage:
                 continue
+            if (
+                existing.unresolved_reason == "shape_control_lineage"
+                and lineage.unresolved_reason != existing.unresolved_reason
+            ):
+                target[initializer_index] = lineage
+                continue
+            if (
+                lineage.unresolved_reason == "shape_control_lineage"
+                and existing.unresolved_reason != lineage.unresolved_reason
+            ):
+                continue
             reasons = {
                 reason for reason in (existing.unresolved_reason, lineage.unresolved_reason) if reason is not None
             }
@@ -2004,16 +2017,36 @@ def _build_onnx_weight_analysis_plan(
                         or (
                             not is_model_local_function
                             and (
-                                (
-                                    node.op_type in {"Expand", "Gather", "GatherElements", "GatherND"}
-                                    and input_index == 1
-                                )
+                                (node.op_type in {"Gather", "GatherElements", "GatherND"} and input_index == 1)
                                 or (node.op_type in _RECURRENT_WEIGHT_OPERATORS and input_index == 4)
                             )
                         )
                     )
                 )
-                if not is_array_feature_selector and not is_non_data_standard_input:
+                is_expand_shape = (
+                    is_registered_standard_operator
+                    and not is_model_local_function
+                    and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
+                    and node.op_type == "Expand"
+                    and input_index == 1
+                )
+                if is_expand_shape:
+                    # Retain shape ownership for subsequent Shape queries without inheriting data values.
+                    merge_lineages(
+                        all_input_lineages,
+                        {
+                            initializer_index: _OnnxWeightLineage(
+                                initializer_index=initializer_index,
+                                shape=None,
+                                data_type=None,
+                                transforms=lineage.transforms,
+                                unresolved_reason="shape_control_lineage",
+                            )
+                            for initializer_index, lineage in input_lineages.items()
+                        },
+                        ambiguous_reason="ambiguous_operator_input_lineage",
+                    )
+                elif not is_array_feature_selector and not is_non_data_standard_input:
                     merge_lineages(
                         all_input_lineages,
                         input_lineages,
@@ -2053,6 +2086,9 @@ def _build_onnx_weight_analysis_plan(
                     terminal_consumer_counts[initializer_index] += 1
                     total_consumer_count += 1
                     if lineage.unresolved_reason is not None:
+                        if lineage.unresolved_reason == "shape_control_lineage":
+                            record_exclusion(initializer_index, "shape_control_input", node, input_index)
+                            continue
                         opposite_resolved_weight = any(
                             resolved_index != input_index for resolved_index in resolved_weight_input_indexes
                         )
@@ -2075,17 +2111,6 @@ def _build_onnx_weight_analysis_plan(
                             )
                         )
                         recognized_activation_input |= recurrent_initial_state and opposite_resolved_weight
-                        recognized_activation_input |= (
-                            lineage.unresolved_reason == "runtime_shape_lineage"
-                            and is_registered_standard_operator
-                            and not is_model_local_function
-                            and _onnx_activation_input_candidate(node, input_index)
-                            and (
-                                node.op_type not in {"Einsum", "Gemm", "MatMul"}
-                                or (node.op_type in {"Gemm", "MatMul"} and input_index == 0)
-                            )
-                            and opposite_resolved_weight
-                        )
                         if recognized_activation_input:
                             if opposite_resolved_weight:
                                 activation_input_lineages.add(initializer_index)
@@ -2361,16 +2386,6 @@ def _build_onnx_weight_analysis_plan(
                 carries_dynamic_activation |= any(
                     lineage.unresolved_reason == "dynamic_activation_lineage" for lineage in all_input_lineages.values()
                 )
-                # Intermediate dynamic values may contain only shape-derived constants.
-                shape_combines_with_runtime_data = (
-                    same_type_elementwise
-                    and not is_model_local_function
-                    and node.op_type != "Where"
-                    and any(
-                        input_name in runtime_data_values and not value_lineages.get(input_name)
-                        for input_name in node.input
-                    )
-                )
                 runtime_masks_activation = (
                     same_type_elementwise
                     and not is_model_local_function
@@ -2392,10 +2407,9 @@ def _build_onnx_weight_analysis_plan(
                     if initializer_index in activation_input_lineages:
                         continue
                     unresolved_reason = lineage.unresolved_reason
-                    if unresolved_reason == "shape_dimensions_lineage" and (
-                        shape_combines_with_runtime_data or runtime_masks_activation
-                    ):
-                        unresolved_reason = "runtime_shape_lineage"
+                    # Arithmetic on dimension values stays unresolved in either matrix operand.
+                    if unresolved_reason == "shape_dimensions_lineage" and runtime_masks_activation:
+                        unresolved_reason = "dynamic_activation_lineage"
                     if unresolved_reason is None:
                         if carries_dynamic_activation:
                             unresolved_reason = "dynamic_activation_lineage"

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -1949,6 +1949,7 @@ def _build_onnx_weight_analysis_plan(
                 "Unsqueeze",
             }
             all_input_lineages: dict[int, _OnnxWeightLineage] = {}
+            shape_control_input_lineages: dict[int, _OnnxWeightLineage] = {}
             terminal_weight_lineages: set[int] = set()
             activation_input_lineages: set[int] = set()
             recurrent_state_lineages: dict[int, _OnnxWeightLineage] = {}
@@ -2020,24 +2021,32 @@ def _build_onnx_weight_analysis_plan(
                     and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
                     and (
                         (node.op_type in {"Expand", "Gather", "GatherElements", "GatherND"} and input_index == 1)
+                        or (node.op_type == "Reshape" and input_index == 1)
                         or (node.op_type == "Slice" and input_index > 0)
+                        or (node.op_type == "Tile" and input_index == 1)
                         or (node.op_type == "Where" and input_index == 0)
                     )
                 )
                 if is_shape_control_input:
                     # Shape and Size can later turn output dimensions into numeric data.
+                    shape_control_lineages = {
+                        initializer_index: _OnnxWeightLineage(
+                            initializer_index=initializer_index,
+                            shape=None,
+                            data_type=None,
+                            transforms=lineage.transforms,
+                            unresolved_reason="shape_control_lineage",
+                        )
+                        for initializer_index, lineage in input_lineages.items()
+                    }
                     merge_lineages(
                         all_input_lineages,
-                        {
-                            initializer_index: _OnnxWeightLineage(
-                                initializer_index=initializer_index,
-                                shape=None,
-                                data_type=None,
-                                transforms=lineage.transforms,
-                                unresolved_reason="shape_control_lineage",
-                            )
-                            for initializer_index, lineage in input_lineages.items()
-                        },
+                        shape_control_lineages,
+                        ambiguous_reason="ambiguous_operator_input_lineage",
+                    )
+                    merge_lineages(
+                        shape_control_input_lineages,
+                        shape_control_lineages,
                         ambiguous_reason="ambiguous_operator_input_lineage",
                     )
                 elif not is_array_feature_selector and not is_non_data_standard_input:
@@ -2047,6 +2056,12 @@ def _build_onnx_weight_analysis_plan(
                         ambiguous_reason="ambiguous_operator_input_lineage",
                     )
                 for initializer_index, lineage in input_lineages.items():
+                    potential_weight_role = _onnx_potential_weight_input(
+                        node,
+                        input_index,
+                        is_model_local_function=is_model_local_function,
+                        is_registered_standard_operator=is_registered_standard_operator,
+                    )
                     invalid_clip_bound = (
                         is_registered_standard_operator
                         and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
@@ -2067,12 +2082,7 @@ def _build_onnx_weight_analysis_plan(
                             current_node_index,
                             input_index,
                         )
-                    potential_weight_input = _onnx_potential_weight_input(
-                        node,
-                        input_index,
-                        is_model_local_function=is_model_local_function,
-                        is_registered_standard_operator=is_registered_standard_operator,
-                    ) and lineage_could_be_weight(lineage)
+                    potential_weight_input = potential_weight_role and lineage_could_be_weight(lineage)
                     if supported_transform and input_index == 0:
                         continue
                     if potential_weight_input:
@@ -2105,20 +2115,15 @@ def _build_onnx_weight_analysis_plan(
                             )
                         )
                         recognized_activation_input |= recurrent_initial_state and opposite_resolved_weight
-                        recognized_activation_input |= (
-                            lineage.unresolved_reason == "recurrent_sequence_state_lineage"
-                            and _onnx_activation_input_candidate(node, input_index)
-                            and input_index == 0
-                            and opposite_resolved_weight
-                            and not potential_weight_input
-                        )
                         if recognized_activation_input:
                             if recurrent_initial_state:
                                 recurrent_state_lineages[initializer_index] = lineage
                             if opposite_resolved_weight:
                                 activation_input_lineages.add(initializer_index)
                             record_exclusion(initializer_index, "dynamic_activation_input", node, input_index)
-                        elif potential_weight_input:
+                        elif potential_weight_input or (
+                            potential_weight_role and lineage.unresolved_reason == "recurrent_sequence_state_lineage"
+                        ):
                             record_unresolved_lineage(lineage, node, current_node_index, input_index)
                         else:
                             record_exclusion(initializer_index, "unresolved_lineage_consumer", node, input_index)
@@ -2325,6 +2330,11 @@ def _build_onnx_weight_analysis_plan(
                 for initializer_index, lineage in data_lineages.items():
                     transform_counts[initializer_index] += 1
                     output_lineages[initializer_index] = transformed_lineage(lineage, node, constants)
+                merge_lineages(
+                    output_lineages,
+                    shape_control_input_lineages,
+                    ambiguous_reason="ambiguous_operator_input_lineage",
+                )
             elif is_shape_query:
                 for initializer_index, lineage in all_input_lineages.items():
                     output_lineages[initializer_index] = _OnnxWeightLineage(
@@ -2401,7 +2411,7 @@ def _build_onnx_weight_analysis_plan(
                         )
                         or clip_operator
                         or pow_operator
-                        or node.op_type in {"Expand", "Gather", "GatherElements", "GatherND", "Slice"}
+                        or node.op_type in {"Expand", "Gather", "GatherElements", "GatherND", "Slice", "Tile"}
                     )
                 )
                 for initializer_index, lineage in all_input_lineages.items():

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -1913,6 +1913,12 @@ def _build_onnx_weight_analysis_plan(
             if name and name not in value_lineages and name not in constants:
                 dynamic_values.add(name)
 
+        runtime_graph_inputs = (
+            {_onnx_value_name(graph_input) for graph_input in current_graph.input} & dynamic_values
+            if root_graph
+            else set()
+        )
+
         for local_node_index, node in enumerate(getattr(current_graph, "node", ())):
             current_node_index = node_counter
             node_counter += 1
@@ -1994,7 +2000,13 @@ def _build_onnx_weight_analysis_plan(
                     and (
                         (node.op_type == "Clip" and input_index > 0)
                         or (node.op_type == "Where" and input_index == 0)
-                        or (node.op_type == "Gather" and input_index == 1 and not is_model_local_function)
+                        or (
+                            not is_model_local_function
+                            and (
+                                (node.op_type in {"Gather", "GatherElements", "GatherND"} and input_index == 1)
+                                or (node.op_type in _RECURRENT_WEIGHT_OPERATORS and input_index == 4)
+                            )
+                        )
                     )
                 )
                 if not is_array_feature_selector and not is_non_data_standard_input:
@@ -2334,14 +2346,14 @@ def _build_onnx_weight_analysis_plan(
                 carries_dynamic_activation |= any(
                     lineage.unresolved_reason == "dynamic_activation_lineage" for lineage in all_input_lineages.values()
                 )
+                # Intermediate dynamic values may contain only shape-derived constants.
                 shape_scales_activation = (
                     same_type_elementwise
                     and not is_model_local_function
+                    and node.op_type != "Where"
                     and any(
-                        (input_name in dynamic_values and not value_lineages.get(input_name))
-                        or input_index in dynamic_activation_input_indexes
-                        for input_index, input_name in enumerate(node.input)
-                        if node.op_type != "Where" or input_index != 0
+                        input_name in runtime_graph_inputs and not value_lineages.get(input_name)
+                        for input_name in node.input
                     )
                 )
                 for initializer_index, lineage in all_input_lineages.items():

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -1251,6 +1251,12 @@ def _onnx_activation_input_candidate(node: Any, input_index: int) -> bool:
     return node.op_type == "Gather" and input_index == 1
 
 
+def _onnx_dynamic_activation_passthrough_input_candidate(node: Any, input_index: int) -> bool:
+    if getattr(node, "domain", "") not in _STANDARD_NEURAL_NETWORK_DOMAINS:
+        return False
+    return node.op_type == "Gather" and input_index == 0
+
+
 def _onnx_opaque_activation_input_candidate(node: Any, _input_index: int) -> bool:
     """Recognize opaque-domain inputs whose schema fixes an activation-only role."""
     return getattr(node, "domain", "") == "ai.onnx.ml"
@@ -2045,6 +2051,10 @@ def _build_onnx_weight_analysis_plan(
                             or (
                                 _onnx_activation_input_candidate(node, input_index)
                                 and (opposite_resolved_weight or all_lineage_inputs_are_activation_contraction)
+                            )
+                            or (
+                                is_registered_standard_operator
+                                and _onnx_dynamic_activation_passthrough_input_candidate(node, input_index)
                             )
                         )
                         if recognized_activation_input:

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -2107,6 +2107,9 @@ def _build_onnx_weight_analysis_plan(
                             resolved_index != input_index for resolved_index in resolved_weight_input_indexes
                         )
                         prior_layer_activation = lineage.unresolved_reason == "dynamic_activation_lineage"
+                        recurrent_final_state_output = any(
+                            transform.kind == "recurrent_state_output" for transform in lineage.transforms
+                        )
                         recognized_activation_input = prior_layer_activation and (
                             (
                                 is_registered_standard_operator
@@ -2125,7 +2128,16 @@ def _build_onnx_weight_analysis_plan(
                                 activation_input_lineages.add(initializer_index)
                             record_exclusion(initializer_index, "dynamic_activation_input", node, input_index)
                         elif potential_weight_input or (
-                            potential_weight_role and lineage.unresolved_reason == "recurrent_sequence_state_lineage"
+                            (
+                                potential_weight_role
+                                and lineage.unresolved_reason
+                                in {"recurrent_sequence_state_lineage", "recurrent_state_lineage"}
+                            )
+                            or (
+                                potential_weight_role
+                                and recurrent_final_state_output
+                                and lineage.unresolved_reason != "shape_control_lineage"
+                            )
                         ):
                             record_unresolved_lineage(lineage, node, current_node_index, input_index)
                         else:
@@ -2570,7 +2582,6 @@ def _build_onnx_weight_analysis_plan(
                 ):
                     for initializer_index in recurrent_state_lineages:
                         per_output_lineages.pop(initializer_index, None)
-                    state_lineages = recurrent_state_lineages
                     if output_index == 0:
                         state_lineages = {
                             initializer_index: _OnnxWeightLineage(
@@ -2588,7 +2599,7 @@ def _build_onnx_weight_analysis_plan(
                                 initializer_index=initializer_index,
                                 shape=lineage.shape,
                                 data_type=lineage.data_type,
-                                transforms=lineage.transforms,
+                                transforms=(*lineage.transforms, _OnnxWeightTransform("recurrent_state_output")),
                                 unresolved_reason=(
                                     lineage.unresolved_reason
                                     if lineage.unresolved_reason is not None

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -1913,11 +1913,12 @@ def _build_onnx_weight_analysis_plan(
             if name and name not in value_lineages and name not in constants:
                 dynamic_values.add(name)
 
-        runtime_graph_inputs = (
+        runtime_data_values = (
             {_onnx_value_name(graph_input) for graph_input in current_graph.input} & dynamic_values
             if root_graph
             else set()
         )
+        constant_fill_values: set[str] = set()
 
         for local_node_index, node in enumerate(getattr(current_graph, "node", ())):
             current_node_index = node_counter
@@ -2352,15 +2353,34 @@ def _build_onnx_weight_analysis_plan(
                     and not is_model_local_function
                     and node.op_type != "Where"
                     and any(
-                        input_name in runtime_graph_inputs and not value_lineages.get(input_name)
+                        input_name in runtime_data_values and not value_lineages.get(input_name)
                         for input_name in node.input
+                    )
+                )
+                runtime_masks_activation = (
+                    same_type_elementwise
+                    and not is_model_local_function
+                    and node.op_type == "Where"
+                    and len(node.input) == 3
+                    and node.input[0] in runtime_data_values
+                    and all(
+                        input_name in constant_fill_values
+                        or input_name in runtime_data_values
+                        or input_index in dynamic_activation_input_indexes
+                        for input_index, input_name in enumerate(node.input[1:], start=1)
+                    )
+                    and any(
+                        input_name in runtime_data_values or input_index in dynamic_activation_input_indexes
+                        for input_index, input_name in enumerate(node.input[1:], start=1)
                     )
                 )
                 for initializer_index, lineage in all_input_lineages.items():
                     if initializer_index in activation_input_lineages:
                         continue
                     unresolved_reason = lineage.unresolved_reason
-                    if unresolved_reason == "shape_dimensions_lineage" and shape_scales_activation:
+                    if unresolved_reason == "shape_dimensions_lineage" and (
+                        shape_scales_activation or runtime_masks_activation
+                    ):
                         unresolved_reason = "dynamic_activation_lineage"
                     if unresolved_reason is None:
                         if carries_dynamic_activation:
@@ -2494,10 +2514,32 @@ def _build_onnx_weight_analysis_plan(
                     )
                     subgraph_output_dynamic[output_index] |= graph_output_dynamic[graph_output_index]
 
+            preserves_runtime_data = (
+                is_registered_standard_operator
+                and not is_model_local_function
+                and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
+                and (supported_transform or node.op_type in {"Abs", "Neg", "Not", "Relu", "Sigmoid", "Tanh"})
+                and bool(node.input)
+            )
+            runtime_output = preserves_runtime_data and node.input[0] in runtime_data_values
+            constant_fill_output = (
+                is_registered_standard_operator
+                and not is_model_local_function
+                and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
+                and node.op_type == "ConstantOfShape"
+            ) or (preserves_runtime_data and node.input[0] in constant_fill_values)
             for output_index, output_name in enumerate(node.output):
                 if not output_name:
                     continue
                 name = str(output_name)
+                if runtime_output:
+                    runtime_data_values.add(name)
+                else:
+                    runtime_data_values.discard(name)
+                if constant_fill_output:
+                    constant_fill_values.add(name)
+                else:
+                    constant_fill_values.discard(name)
                 per_output_lineages = dict(output_lineages)
                 merge_lineages(
                     per_output_lineages,

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -2110,9 +2110,10 @@ def _build_onnx_weight_analysis_plan(
                             and _onnx_activation_input_candidate(node, input_index)
                             and input_index == 0
                             and opposite_resolved_weight
+                            and not potential_weight_input
                         )
                         if recognized_activation_input:
-                            if recurrent_initial_state and lineage.unresolved_reason == "shape_dimensions_lineage":
+                            if recurrent_initial_state:
                                 recurrent_state_lineages[initializer_index] = lineage
                             if opposite_resolved_weight:
                                 activation_input_lineages.add(initializer_index)
@@ -2400,7 +2401,7 @@ def _build_onnx_weight_analysis_plan(
                         )
                         or clip_operator
                         or pow_operator
-                        or node.op_type in {"Expand", "Gather", "GatherElements", "GatherND"}
+                        or node.op_type in {"Expand", "Gather", "GatherElements", "GatherND", "Slice"}
                     )
                 )
                 for initializer_index, lineage in all_input_lineages.items():

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -1251,12 +1251,6 @@ def _onnx_activation_input_candidate(node: Any, input_index: int) -> bool:
     return node.op_type == "Gather" and input_index == 1
 
 
-def _onnx_dynamic_activation_passthrough_input_candidate(node: Any, input_index: int) -> bool:
-    if getattr(node, "domain", "") not in _STANDARD_NEURAL_NETWORK_DOMAINS:
-        return False
-    return node.op_type == "Gather" and input_index == 0
-
-
 def _onnx_opaque_activation_input_candidate(node: Any, _input_index: int) -> bool:
     """Recognize opaque-domain inputs whose schema fixes an activation-only role."""
     return getattr(node, "domain", "") == "ai.onnx.ml"
@@ -2052,10 +2046,6 @@ def _build_onnx_weight_analysis_plan(
                                 _onnx_activation_input_candidate(node, input_index)
                                 and (opposite_resolved_weight or all_lineage_inputs_are_activation_contraction)
                             )
-                            or (
-                                is_registered_standard_operator
-                                and _onnx_dynamic_activation_passthrough_input_candidate(node, input_index)
-                            )
                         )
                         if recognized_activation_input:
                             if opposite_resolved_weight:
@@ -2255,6 +2245,13 @@ def _build_onnx_weight_analysis_plan(
                     ),
                 )
 
+            # Shape exposes dimensions, so input weight values cannot reach its output.
+            is_shape_query = (
+                is_registered_standard_operator
+                and not is_model_local_function
+                and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
+                and node.op_type == "Shape"
+            )
             output_lineages: dict[int, _OnnxWeightLineage] = {}
             if supported_transform:
                 data_lineages = value_lineages.get(str(node.input[0]), {}) if node.input else {}
@@ -2263,6 +2260,7 @@ def _build_onnx_weight_analysis_plan(
                     output_lineages[initializer_index] = transformed_lineage(lineage, node, constants)
             elif (
                 all_input_lineages
+                and not is_shape_query
                 and node.op_type not in _QUANTIZED_WEIGHT_OPERATORS
                 and function is None
                 and not subgraph_results

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -2105,6 +2105,12 @@ def _build_onnx_weight_analysis_plan(
                             )
                         )
                         recognized_activation_input |= recurrent_initial_state and opposite_resolved_weight
+                        recognized_activation_input |= (
+                            lineage.unresolved_reason == "recurrent_sequence_state_lineage"
+                            and _onnx_activation_input_candidate(node, input_index)
+                            and input_index == 0
+                            and opposite_resolved_weight
+                        )
                         if recognized_activation_input:
                             if recurrent_initial_state and lineage.unresolved_reason == "shape_dimensions_lineage":
                                 recurrent_state_lineages[initializer_index] = lineage
@@ -2543,15 +2549,26 @@ def _build_onnx_weight_analysis_plan(
                 per_output_lineages = dict(output_lineages)
                 if (
                     recurrent_state_lineages
-                    and output_index > 0
                     and is_registered_standard_operator
                     and not is_model_local_function
                     and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
                     and node.op_type in _RECURRENT_WEIGHT_OPERATORS
                 ):
+                    state_lineages = recurrent_state_lineages
+                    if output_index == 0:
+                        state_lineages = {
+                            initializer_index: _OnnxWeightLineage(
+                                initializer_index=initializer_index,
+                                shape=lineage.shape,
+                                data_type=lineage.data_type,
+                                transforms=lineage.transforms,
+                                unresolved_reason="recurrent_sequence_state_lineage",
+                            )
+                            for initializer_index, lineage in recurrent_state_lineages.items()
+                        }
                     merge_lineages(
                         per_output_lineages,
-                        recurrent_state_lineages,
+                        state_lineages,
                         ambiguous_reason="ambiguous_operator_input_lineage",
                     )
                 merge_lineages(

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -1748,6 +1748,21 @@ def _build_onnx_weight_analysis_plan(
         )
         return dict(sorted(lineages.items())[:_ONNX_WEIGHT_LINEAGES_PER_VALUE_LIMIT])
 
+    def merge_transform_markers(
+        left: tuple[_OnnxWeightTransform, ...],
+        right: tuple[_OnnxWeightTransform, ...],
+    ) -> tuple[_OnnxWeightTransform, ...]:
+        merged: list[_OnnxWeightTransform] = []
+        seen: set[_OnnxWeightTransform] = set()
+        for transform in (*left, *right):
+            if transform in seen:
+                continue
+            seen.add(transform)
+            merged.append(transform)
+            if len(merged) >= _ONNX_WEIGHT_TRANSFORM_DEPTH_LIMIT:
+                break
+        return tuple(merged)
+
     def merge_lineages(
         target: dict[int, _OnnxWeightLineage],
         source: dict[int, _OnnxWeightLineage],
@@ -1788,7 +1803,7 @@ def _build_onnx_weight_analysis_plan(
                 initializer_index=initializer_index,
                 shape=None,
                 data_type=existing.data_type if existing.data_type == lineage.data_type else None,
-                transforms=existing.transforms,
+                transforms=merge_transform_markers(existing.transforms, lineage.transforms),
                 unresolved_reason=unresolved_reason,
             )
 

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -2090,6 +2090,15 @@ def _build_onnx_weight_analysis_plan(
                         terminal_weight_lineages.add(initializer_index)
                     terminal_consumer_counts[initializer_index] += 1
                     total_consumer_count += 1
+                    recurrent_initial_state = (
+                        is_registered_standard_operator
+                        and not is_model_local_function
+                        and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
+                        and node.op_type in _RECURRENT_WEIGHT_OPERATORS
+                        and (input_index == 5 or (node.op_type == "LSTM" and input_index == 6))
+                    )
+                    if recurrent_initial_state:
+                        recurrent_state_lineages[initializer_index] = lineage
                     if lineage.unresolved_reason is not None:
                         if lineage.unresolved_reason == "shape_control_lineage":
                             record_exclusion(initializer_index, "shape_control_input", node, input_index)
@@ -2098,13 +2107,6 @@ def _build_onnx_weight_analysis_plan(
                             resolved_index != input_index for resolved_index in resolved_weight_input_indexes
                         )
                         prior_layer_activation = lineage.unresolved_reason == "dynamic_activation_lineage"
-                        recurrent_initial_state = (
-                            is_registered_standard_operator
-                            and not is_model_local_function
-                            and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
-                            and node.op_type in _RECURRENT_WEIGHT_OPERATORS
-                            and (input_index == 5 or (node.op_type == "LSTM" and input_index == 6))
-                        )
                         recognized_activation_input = prior_layer_activation and (
                             (
                                 is_registered_standard_operator
@@ -2566,6 +2568,8 @@ def _build_onnx_weight_analysis_plan(
                     and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
                     and node.op_type in _RECURRENT_WEIGHT_OPERATORS
                 ):
+                    for initializer_index in recurrent_state_lineages:
+                        per_output_lineages.pop(initializer_index, None)
                     state_lineages = recurrent_state_lineages
                     if output_index == 0:
                         state_lineages = {
@@ -2575,6 +2579,21 @@ def _build_onnx_weight_analysis_plan(
                                 data_type=lineage.data_type,
                                 transforms=lineage.transforms,
                                 unresolved_reason="recurrent_sequence_state_lineage",
+                            )
+                            for initializer_index, lineage in recurrent_state_lineages.items()
+                        }
+                    else:
+                        state_lineages = {
+                            initializer_index: _OnnxWeightLineage(
+                                initializer_index=initializer_index,
+                                shape=lineage.shape,
+                                data_type=lineage.data_type,
+                                transforms=lineage.transforms,
+                                unresolved_reason=(
+                                    lineage.unresolved_reason
+                                    if lineage.unresolved_reason is not None
+                                    else "recurrent_state_lineage"
+                                ),
                             )
                             for initializer_index, lineage in recurrent_state_lineages.items()
                         }

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -1951,6 +1951,7 @@ def _build_onnx_weight_analysis_plan(
             all_input_lineages: dict[int, _OnnxWeightLineage] = {}
             terminal_weight_lineages: set[int] = set()
             activation_input_lineages: set[int] = set()
+            recurrent_state_lineages: dict[int, _OnnxWeightLineage] = {}
             input_names = [str(input_name) for input_name in node.input if input_name]
             if fail_on_unbound_inputs:
                 for input_name in input_names:
@@ -2019,6 +2020,7 @@ def _build_onnx_weight_analysis_plan(
                     and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
                     and (
                         (node.op_type in {"Expand", "Gather", "GatherElements", "GatherND"} and input_index == 1)
+                        or (node.op_type == "Slice" and input_index > 0)
                         or (node.op_type == "Where" and input_index == 0)
                     )
                 )
@@ -2104,6 +2106,8 @@ def _build_onnx_weight_analysis_plan(
                         )
                         recognized_activation_input |= recurrent_initial_state and opposite_resolved_weight
                         if recognized_activation_input:
+                            if recurrent_initial_state and lineage.unresolved_reason == "shape_dimensions_lineage":
+                                recurrent_state_lineages[initializer_index] = lineage
                             if opposite_resolved_weight:
                                 activation_input_lineages.add(initializer_index)
                             record_exclusion(initializer_index, "dynamic_activation_input", node, input_index)
@@ -2537,6 +2541,19 @@ def _build_onnx_weight_analysis_plan(
                     continue
                 name = str(output_name)
                 per_output_lineages = dict(output_lineages)
+                if (
+                    recurrent_state_lineages
+                    and output_index > 0
+                    and is_registered_standard_operator
+                    and not is_model_local_function
+                    and getattr(node, "domain", "") in _STANDARD_NEURAL_NETWORK_DOMAINS
+                    and node.op_type in _RECURRENT_WEIGHT_OPERATORS
+                ):
+                    merge_lineages(
+                        per_output_lineages,
+                        recurrent_state_lineages,
+                        ambiguous_reason="ambiguous_operator_input_lineage",
+                    )
                 merge_lineages(
                     per_output_lineages,
                     constant_output_lineages.get(name, {}),

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -1389,6 +1389,33 @@ def create_activation_bookkeeping_model(tmp_path: Path, *, malicious: bool, rank
     return path
 
 
+def create_gather_activation_bookkeeping_model(tmp_path: Path, *, malicious: bool) -> Path:
+    """Create a linear stack whose prior activation is gathered before reuse."""
+    first_weight = np.zeros((100, 100), dtype=np.float32)
+    second_weight = np.zeros((100, 10), dtype=np.float32)
+    if malicious:
+        second_weight[50:55, 3] = 10.0
+    initializers = [
+        onnx.numpy_helper.from_array(first_weight, name="W1"),
+        onnx.numpy_helper.from_array(np.arange(100, dtype=np.int64), name="indices"),
+        onnx.numpy_helper.from_array(second_weight, name="W2"),
+    ]
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 10])
+    nodes = [
+        helper.make_node("MatMul", ["X", "W1"], ["hidden"], name="first_linear"),
+        helper.make_node("Gather", ["hidden", "indices"], ["selected"], name="activation_slice", axis=1),
+        helper.make_node("MatMul", ["selected", "W2"], ["Y"], name="second_linear"),
+    ]
+    graph = helper.make_graph(nodes, "gather_activation_bookkeeping_graph", [X], [Y], initializer=initializers)
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    path = tmp_path / f"{'malicious' if malicious else 'benign'}-gather-activation-bookkeeping.onnx"
+    onnx.save(model, str(path))
+    return path
+
+
 def create_einsum_weight_model(tmp_path: Path, weights: np.ndarray) -> Path:
     initializer = onnx.numpy_helper.from_array(weights, name="W")
     X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, weights.shape[0]])
@@ -6390,6 +6417,25 @@ class TestWeightDistributionSemantics:
         assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
         semantics = result.metadata["onnx_weight_distribution_semantics"]
         assert semantics["exclusion_counts"]["bookkeeping_constant"] == 1
+
+    @pytest.mark.parametrize("malicious", [False, True])
+    def test_gathered_activation_path_does_not_create_weight_coverage_gap(
+        self,
+        tmp_path: Path,
+        malicious: bool,
+    ) -> None:
+        model_path = create_gather_activation_bookkeeping_model(tmp_path, malicious=malicious)
+
+        result = OnnxScanner().scan(str(model_path))
+
+        assert result.success is True
+        assert len(self._extreme_checks(result)) == int(malicious)
+        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible_initializer_count"] == 2
+        assert semantics["analyzed_layer_count"] == 2
+        assert semantics["exclusion_counts"]["dynamic_activation_input"] >= 2
+        assert semantics["exclusion_counts"]["non_weight_input"] == 1
 
     @pytest.mark.parametrize("malicious", [False, True])
     def test_standard_einsum_weights_are_oriented_and_analyzed(self, tmp_path: Path, malicious: bool) -> None:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -6437,23 +6437,31 @@ class TestWeightDistributionSemantics:
         assert semantics["eligible_initializer_count"] == 2
         assert semantics["analyzed_layer_count"] == 2
 
+    @pytest.mark.parametrize("separate_slice_data", [False, True])
     @pytest.mark.parametrize("malicious", [False, True])
-    def test_slice_bounds_from_shape_remain_control_lineage(self, tmp_path: Path, malicious: bool) -> None:
+    def test_slice_bounds_from_shape_remain_control_lineage(
+        self, tmp_path: Path, malicious: bool, separate_slice_data: bool
+    ) -> None:
         weights = np.zeros((100, 10), dtype=np.float32)
         if malicious:
             weights[50:55, 3] = 10.0
+        inputs = [
+            helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100]),
+            helper.make_tensor_value_info("starts", TensorProto.INT64, [2]),
+        ]
+        slice_data = "hidden"
+        if separate_slice_data:
+            inputs.append(helper.make_tensor_value_info("Xd", TensorProto.FLOAT, [1, 10]))
+            slice_data = "Xd"
         graph = helper.make_graph(
             [
                 helper.make_node("MatMul", ["X", "W1"], ["hidden"]),
                 helper.make_node("Shape", ["hidden"], ["ends"]),
-                helper.make_node("Slice", ["hidden", "starts", "ends"], ["cropped"]),
+                helper.make_node("Slice", [slice_data, "starts", "ends"], ["cropped"]),
                 helper.make_node("MatMul", ["cropped", "W2"], ["Y"]),
             ],
             "slice_bounds_control_lineage",
-            [
-                helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100]),
-                helper.make_tensor_value_info("starts", TensorProto.INT64, [2]),
-            ],
+            inputs,
             [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [None, 5])],
             initializer=[
                 onnx.numpy_helper.from_array(weights, name="W1"),
@@ -6914,51 +6922,84 @@ class TestWeightDistributionSemantics:
 
         result = OnnxScanner().scan(str(path))
 
-        assert result.success is True
         assert len(self._extreme_checks(result)) == int(malicious)
-        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        if control_input == "sequence_lens":
+            assert result.success is True
+            assert not coverage
+        else:
+            assert result.success is False
+            assert coverage and all(check.status == CheckStatus.FAILED for check in coverage)
+            assert any(
+                sample["consumer_op"] == "MatMul"
+                and sample["consumer_input_index"] == 0
+                and sample["reason"] == "recurrent_sequence_state_lineage"
+                for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+            )
 
     @pytest.mark.parametrize("op_type", ["RNN", "GRU", "LSTM"])
+    @pytest.mark.parametrize("initial_state_lineage", ["shape_dimensions", "unsupported_operator"])
     @pytest.mark.parametrize("output_slot", ["sequence", "state"])
     def test_shape_derived_recurrent_state_generated_weights_fail_closed(
-        self, tmp_path: Path, op_type: str, output_slot: str
+        self, tmp_path: Path, op_type: str, initial_state_lineage: str, output_slot: str
     ) -> None:
         hidden_size = 100
         gate_multiplier = {"RNN": 1, "GRU": 3, "LSTM": 4}[op_type]
-        shape_source = TensorProto()
-        shape_source.name = "shape_source"
-        shape_source.data_type = TensorProto.FLOAT
-        shape_source.dims.extend([0] * 50 + [10] * 5 + [0] * 45)
         recurrent_inputs = ["sequence", "W", "R", "", "", "initial_h"]
         recurrent_outputs = ["sequence_output", "state"]
         if op_type == "LSTM":
             recurrent_inputs.append("initial_h")
             recurrent_outputs.append("cell_state")
         generated_source = "sequence_output" if output_slot == "sequence" else "state"
-        graph = helper.make_graph(
-            [
+        initializers = [
+            onnx.numpy_helper.from_array(np.ones((1, hidden_size), dtype=np.float32), name="X"),
+            onnx.numpy_helper.from_array(np.array([1, 1, hidden_size], dtype=np.int64), name="state_shape"),
+            onnx.numpy_helper.from_array(np.array([hidden_size, 1], dtype=np.int64), name="weight_shape"),
+            onnx.numpy_helper.from_array(
+                np.zeros((1, gate_multiplier * hidden_size, hidden_size), dtype=np.float32), name="W"
+            ),
+            onnx.numpy_helper.from_array(
+                np.zeros((1, gate_multiplier * hidden_size, hidden_size), dtype=np.float32), name="R"
+            ),
+        ]
+        if initial_state_lineage == "shape_dimensions":
+            shape_source = TensorProto()
+            shape_source.name = "shape_source"
+            shape_source.data_type = TensorProto.FLOAT
+            shape_source.dims.extend([0] * 50 + [10] * 5 + [0] * 45)
+            initializers.insert(0, shape_source)
+            nodes = [
                 helper.make_node("Shape", ["shape_source"], ["dimensions"]),
                 helper.make_node("Cast", ["dimensions"], ["numeric_dimensions"], to=TensorProto.FLOAT),
                 helper.make_node("Reshape", ["numeric_dimensions", "state_shape"], ["initial_h"]),
+            ]
+            expected_initializer = "shape_source"
+            state_reason = "shape_dimensions_lineage"
+        else:
+            initializers.extend(
+                [
+                    onnx.numpy_helper.from_array(np.ones((1, 1, hidden_size), dtype=np.float32), name="state_seed"),
+                    onnx.numpy_helper.from_array(np.array([0], dtype=np.int64), name="reduce_axes"),
+                ]
+            )
+            nodes = [
+                helper.make_node("ReduceSum", ["state_seed", "reduce_axes"], ["initial_h"], keepdims=1),
+            ]
+            expected_initializer = "state_seed"
+            state_reason = "unsupported_lineage_operator"
+        nodes.extend(
+            [
                 helper.make_node(op_type, recurrent_inputs, recurrent_outputs, hidden_size=hidden_size),
                 helper.make_node("Reshape", [generated_source, "weight_shape"], ["generated_weight"]),
                 helper.make_node("MatMul", ["X", "generated_weight"], ["Y"]),
-            ],
+            ]
+        )
+        graph = helper.make_graph(
+            nodes,
             f"{op_type.lower()}_state_generated_weight",
             [helper.make_tensor_value_info("sequence", TensorProto.FLOAT, [1, 1, hidden_size])],
             [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 1])],
-            initializer=[
-                shape_source,
-                onnx.numpy_helper.from_array(np.ones((1, hidden_size), dtype=np.float32), name="X"),
-                onnx.numpy_helper.from_array(np.array([1, 1, hidden_size], dtype=np.int64), name="state_shape"),
-                onnx.numpy_helper.from_array(np.array([hidden_size, 1], dtype=np.int64), name="weight_shape"),
-                onnx.numpy_helper.from_array(
-                    np.zeros((1, gate_multiplier * hidden_size, hidden_size), dtype=np.float32), name="W"
-                ),
-                onnx.numpy_helper.from_array(
-                    np.zeros((1, gate_multiplier * hidden_size, hidden_size), dtype=np.float32), name="R"
-                ),
-            ],
+            initializer=initializers,
         )
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 14)])
         model.ir_version = 8
@@ -6971,14 +7012,64 @@ class TestWeightDistributionSemantics:
         assert result.success is False
         coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
         assert coverage and all(check.status == CheckStatus.FAILED for check in coverage)
-        expected_reason = (
-            "recurrent_sequence_state_lineage" if output_slot == "sequence" else "shape_dimensions_lineage"
-        )
+        expected_reason = "recurrent_sequence_state_lineage" if output_slot == "sequence" else state_reason
         assert any(
-            sample["initializer"] == "shape_source"
+            sample["initializer"] == expected_initializer
             and sample["consumer_op"] == "MatMul"
             and sample["consumer_input_index"] == 1
             and sample["reason"] == expected_reason
+            for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+        )
+
+    @pytest.mark.parametrize("consumer", ["Gemm", "MatMul"])
+    def test_recurrent_sequence_lineage_left_operand_fails_closed(self, tmp_path: Path, consumer: str) -> None:
+        hidden_size = 100
+        shape_source = TensorProto()
+        shape_source.name = "shape_source"
+        shape_source.data_type = TensorProto.FLOAT
+        shape_source.dims.extend([0] * 50 + [10] * 5 + [0] * 45)
+        graph = helper.make_graph(
+            [
+                helper.make_node("Shape", ["shape_source"], ["dimensions"]),
+                helper.make_node("Cast", ["dimensions"], ["numeric_dimensions"], to=TensorProto.FLOAT),
+                helper.make_node("Reshape", ["numeric_dimensions", "state_shape"], ["initial_h"]),
+                helper.make_node(
+                    "RNN",
+                    ["sequence", "W", "R", "", "", "initial_h"],
+                    ["sequence_output", "state"],
+                    hidden_size=hidden_size,
+                ),
+                helper.make_node("Reshape", ["sequence_output", "left_shape"], ["left_weight"]),
+                helper.make_node(consumer, ["left_weight", "projection"], ["Y"]),
+            ],
+            "recurrent_sequence_left_operand",
+            [helper.make_tensor_value_info("sequence", TensorProto.FLOAT, [1, 1, hidden_size])],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 1])],
+            initializer=[
+                shape_source,
+                onnx.numpy_helper.from_array(np.array([1, 1, hidden_size], dtype=np.int64), name="state_shape"),
+                onnx.numpy_helper.from_array(np.array([1, hidden_size], dtype=np.int64), name="left_shape"),
+                onnx.numpy_helper.from_array(np.zeros((1, hidden_size, hidden_size), dtype=np.float32), name="W"),
+                onnx.numpy_helper.from_array(np.zeros((1, hidden_size, hidden_size), dtype=np.float32), name="R"),
+                onnx.numpy_helper.from_array(np.zeros((hidden_size, 1), dtype=np.float32), name="projection"),
+            ],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 14)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        path = tmp_path / "recurrent-sequence-left-operand.onnx"
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        assert result.success is False
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert coverage and all(check.status == CheckStatus.FAILED for check in coverage)
+        assert any(
+            sample["initializer"] == "shape_source"
+            and sample["consumer_op"] == consumer
+            and sample["consumer_input_index"] == 0
+            and sample["reason"] == "recurrent_sequence_state_lineage"
             for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
         )
 

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -7136,6 +7136,58 @@ class TestWeightDistributionSemantics:
         )
 
     @pytest.mark.parametrize(
+        ("generated_source", "expected_reason"),
+        [
+            ("sequence_output", "recurrent_sequence_state_lineage"),
+            ("state", "recurrent_state_lineage"),
+        ],
+    )
+    def test_direct_recurrent_initial_state_weight_lineage_fails_closed(
+        self, tmp_path: Path, generated_source: str, expected_reason: str
+    ) -> None:
+        hidden_size = 100
+        graph = helper.make_graph(
+            [
+                helper.make_node(
+                    "RNN",
+                    ["sequence", "W", "R", "", "", "initial_h"],
+                    ["sequence_output", "state"],
+                    hidden_size=hidden_size,
+                ),
+                helper.make_node("Reshape", [generated_source, "weight_shape"], ["generated_weight"]),
+                helper.make_node("MatMul", ["X", "generated_weight"], ["Y"]),
+            ],
+            "direct_recurrent_state_generated_weight",
+            [helper.make_tensor_value_info("sequence", TensorProto.FLOAT, [1, 1, hidden_size])],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 1])],
+            initializer=[
+                onnx.numpy_helper.from_array(np.ones((1, hidden_size), dtype=np.float32), name="X"),
+                onnx.numpy_helper.from_array(np.array([hidden_size, 1], dtype=np.int64), name="weight_shape"),
+                onnx.numpy_helper.from_array(np.zeros((1, hidden_size, hidden_size), dtype=np.float32), name="W"),
+                onnx.numpy_helper.from_array(np.zeros((1, hidden_size, hidden_size), dtype=np.float32), name="R"),
+                onnx.numpy_helper.from_array(np.zeros((1, 1, hidden_size), dtype=np.float32), name="initial_h"),
+            ],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 14)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        path = tmp_path / f"direct-recurrent-{generated_source}-weight.onnx"
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        assert result.success is False
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert coverage and all(check.status == CheckStatus.FAILED for check in coverage)
+        assert any(
+            sample["initializer"] == "initial_h"
+            and sample["consumer_op"] == "MatMul"
+            and sample["consumer_input_index"] == 1
+            and sample["reason"] == expected_reason
+            for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+        )
+
+    @pytest.mark.parametrize(
         "combination", ["where_left", "where_right", "where_runtime", "shape_zeros", "transformed_shape_zeros"]
     )
     def test_shape_only_weight_paths_retain_dimension_coverage(self, tmp_path: Path, combination: str) -> None:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -6528,6 +6528,7 @@ class TestWeightDistributionSemantics:
             "GatherND",
             "activation_scale",
             "transformed_activation_scale",
+            "binary_activation_scale",
             "weight_scale",
         ],
     )
@@ -6565,13 +6566,17 @@ class TestWeightDistributionSemantics:
             output_shape = [2, 10]
         else:
             nodes.append(helper.make_node("Cast", ["dimensions"], ["scale"], to=TensorProto.FLOAT))
-            if use in {"activation_scale", "transformed_activation_scale"}:
+            if use in {"activation_scale", "transformed_activation_scale", "binary_activation_scale"}:
                 inputs.append(helper.make_tensor_value_info("Xd", TensorProto.FLOAT, [100, 2]))
                 initializers.append(onnx.numpy_helper.from_array(np.zeros((2, 10), dtype=np.float32), name="W2"))
                 activation = "Xd"
                 if use == "transformed_activation_scale":
                     nodes.append(helper.make_node("Relu", ["Xd"], ["relu"]))
                     nodes.append(helper.make_node("Identity", ["relu"], ["activation"]))
+                    activation = "activation"
+                elif use == "binary_activation_scale":
+                    inputs.append(helper.make_tensor_value_info("Xe", TensorProto.FLOAT, [100, 2]))
+                    nodes.append(helper.make_node("Add", ["Xd", "Xe"], ["activation"]))
                     activation = "activation"
                 nodes.append(helper.make_node("Mul", [activation, "scale"], ["selected"]))
                 nodes.append(helper.make_node("MatMul", ["selected", "W2"], ["Y"]))
@@ -6597,10 +6602,16 @@ class TestWeightDistributionSemantics:
 
         result = OnnxScanner().scan(str(path))
 
-        assert result.success is (use != "weight_scale")
+        dimension_values_are_data = use in {
+            "activation_scale",
+            "transformed_activation_scale",
+            "binary_activation_scale",
+            "weight_scale",
+        }
+        assert result.success is not dimension_values_are_data
         assert len(self._extreme_checks(result)) == int(malicious)
         coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
-        if use == "weight_scale":
+        if dimension_values_are_data:
             assert coverage and all(check.status == CheckStatus.FAILED for check in coverage)
             assert any(
                 sample["consumer_op"] == "MatMul" and sample["reason"] == "shape_dimensions_lineage"
@@ -6608,26 +6619,32 @@ class TestWeightDistributionSemantics:
             )
         else:
             assert not coverage
+        if use == "Expand":
+            assert result.metadata["onnx_weight_distribution_semantics"]["exclusion_counts"]["shape_control_input"] >= 1
 
     @pytest.mark.parametrize("combination", ["Add", "Mul"])
     @pytest.mark.parametrize("consumer", ["Gemm", "MatMul"])
+    @pytest.mark.parametrize("generated_input_index", [0, 1])
     def test_runtime_adjusted_dimensions_used_as_weights_retain_coverage(
-        self, tmp_path: Path, combination: str, consumer: str
+        self, tmp_path: Path, combination: str, consumer: str, generated_input_index: int
     ) -> None:
+        consumer_inputs = ["weights", "X"] if generated_input_index == 0 else ["X", "weights"]
+        opposite_shape = (2, 3) if generated_input_index == 0 else (3, 10)
+        output_shape = [10, 3] if generated_input_index == 0 else [3, 2]
         graph = helper.make_graph(
             [
                 helper.make_node("Shape", ["source"], ["dimensions"]),
                 helper.make_node("Cast", ["dimensions"], ["dimensions_float"], to=TensorProto.FLOAT),
                 helper.make_node(combination, ["dimensions_float", "runtime_delta"], ["generated"]),
                 helper.make_node("Identity", ["generated"], ["weights"]),
-                helper.make_node(consumer, ["X", "weights"], ["Y"]),
+                helper.make_node(consumer, consumer_inputs, ["Y"]),
             ],
             "runtime_adjusted_dimension_weights",
             [helper.make_tensor_value_info("runtime_delta", TensorProto.FLOAT, [10, 2])],
-            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [3, 2])],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, output_shape)],
             initializer=[
                 onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="source"),
-                onnx.numpy_helper.from_array(np.zeros((3, 10), dtype=np.float32), name="X"),
+                onnx.numpy_helper.from_array(np.zeros(opposite_shape, dtype=np.float32), name="X"),
             ],
         )
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
@@ -6642,8 +6659,79 @@ class TestWeightDistributionSemantics:
         coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
         assert coverage and all(check.status == CheckStatus.FAILED for check in coverage)
         assert any(
-            sample["consumer_op"] == consumer and sample["reason"] == "runtime_shape_lineage"
+            sample["consumer_op"] == consumer
+            and sample["consumer_input_index"] == generated_input_index
+            and sample["reason"] == "shape_dimensions_lineage"
             for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+        )
+
+    @pytest.mark.parametrize("transform", ["Identity", "Relu"])
+    def test_expand_shape_ownership_survives_value_transforms(self, tmp_path: Path, transform: str) -> None:
+        graph = helper.make_graph(
+            [
+                helper.make_node("Shape", ["source"], ["dimensions"]),
+                helper.make_node("Expand", ["runtime", "dimensions"], ["expanded"]),
+                helper.make_node(transform, ["expanded"], ["transformed"]),
+                helper.make_node("Shape", ["transformed"], ["output_dimensions"]),
+                helper.make_node("Cast", ["output_dimensions"], ["dimension_values"], to=TensorProto.FLOAT),
+                helper.make_node("MatMul", ["projection", "dimension_values"], ["Y"]),
+            ],
+            "expanded_shape_ownership",
+            [helper.make_tensor_value_info("runtime", TensorProto.FLOAT, [1, 4])],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])],
+            initializer=[
+                onnx.numpy_helper.from_array(np.ones((2, 4), dtype=np.float32), name="source"),
+                onnx.numpy_helper.from_array(np.ones((1, 2), dtype=np.float32), name="projection"),
+            ],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        path = tmp_path / "expanded-shape-ownership.onnx"
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        assert result.success is False
+        assert any(
+            check.name == "Weight Distribution Analysis Coverage" and check.status == CheckStatus.FAILED
+            for check in result.checks
+        )
+        assert any(
+            sample["initializer"] == "source" and sample["reason"] == "shape_dimensions_lineage"
+            for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+        )
+
+    @pytest.mark.parametrize("weight_first", [False, True])
+    def test_expand_shape_ownership_does_not_replace_weight_values(self, tmp_path: Path, weight_first: bool) -> None:
+        operands = ["source", "expanded"] if weight_first else ["expanded", "source"]
+        graph = helper.make_graph(
+            [
+                helper.make_node("Shape", ["source"], ["dimensions"]),
+                helper.make_node("Expand", ["runtime", "dimensions"], ["expanded"]),
+                helper.make_node("Add", operands, ["weights"]),
+                helper.make_node("MatMul", ["X", "weights"], ["Y"]),
+            ],
+            "expanded_shape_and_values",
+            [
+                helper.make_tensor_value_info("runtime", TensorProto.FLOAT, [1, 4]),
+                helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 2]),
+            ],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 4])],
+            initializer=[onnx.numpy_helper.from_array(np.ones((2, 4), dtype=np.float32), name="source")],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        path = tmp_path / "expanded-shape-and-values.onnx"
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        assert result.success is False
+        assert any(
+            check.name == "Weight Distribution Analysis Coverage" and check.status == CheckStatus.FAILED
+            for check in result.checks
         )
 
     @pytest.mark.parametrize("op_type", ["LSTM", "GRU", "RNN"])

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -7091,25 +7091,41 @@ class TestWeightDistributionSemantics:
             for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
         )
 
-    def test_recurrent_sequence_vector_left_operand_fails_closed(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        ("generated_source", "expected_reason"),
+        [
+            ("sequence_output", "recurrent_sequence_state_lineage"),
+            ("state", "shape_dimensions_lineage"),
+        ],
+    )
+    def test_recurrent_vector_left_operand_fails_closed(
+        self, tmp_path: Path, generated_source: str, expected_reason: str
+    ) -> None:
         hidden_size = 100
+        shape_source = TensorProto()
+        shape_source.name = "shape_source"
+        shape_source.data_type = TensorProto.FLOAT
+        shape_source.dims.extend([0] * 50 + [10] * 5 + [0] * 45)
         graph = helper.make_graph(
             [
-                helper.make_node("Cast", ["state_seed"], ["initial_h"], to=TensorProto.FLOAT),
+                helper.make_node("Shape", ["shape_source"], ["dimensions"]),
+                helper.make_node("Cast", ["dimensions"], ["numeric_dimensions"], to=TensorProto.FLOAT),
+                helper.make_node("Reshape", ["numeric_dimensions", "state_shape"], ["initial_h"]),
                 helper.make_node(
                     "RNN",
                     ["sequence", "W", "R", "", "", "initial_h"],
                     ["sequence_output", "state"],
                     hidden_size=hidden_size,
                 ),
-                helper.make_node("Reshape", ["sequence_output", "left_shape"], ["left_weight"]),
+                helper.make_node("Reshape", [generated_source, "left_shape"], ["left_weight"]),
                 helper.make_node("MatMul", ["left_weight", "projection"], ["Y"]),
             ],
-            "recurrent_sequence_vector_left_operand",
+            "recurrent_vector_left_operand",
             [helper.make_tensor_value_info("sequence", TensorProto.FLOAT, [1, 1, hidden_size])],
             [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])],
             initializer=[
-                onnx.numpy_helper.from_array(np.zeros((1, 1, hidden_size), dtype=np.int64), name="state_seed"),
+                shape_source,
+                onnx.numpy_helper.from_array(np.array([1, 1, hidden_size], dtype=np.int64), name="state_shape"),
                 onnx.numpy_helper.from_array(np.array([hidden_size], dtype=np.int64), name="left_shape"),
                 onnx.numpy_helper.from_array(np.zeros((1, hidden_size, hidden_size), dtype=np.float32), name="W"),
                 onnx.numpy_helper.from_array(np.zeros((1, hidden_size, hidden_size), dtype=np.float32), name="R"),
@@ -7119,7 +7135,7 @@ class TestWeightDistributionSemantics:
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 14)])
         model.ir_version = 8
         onnx.checker.check_model(model)
-        path = tmp_path / "recurrent-sequence-vector-left-operand.onnx"
+        path = tmp_path / f"recurrent-{generated_source}-vector-left-operand.onnx"
         onnx.save(model, str(path))
 
         result = OnnxScanner().scan(str(path))
@@ -7128,10 +7144,10 @@ class TestWeightDistributionSemantics:
         coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
         assert coverage and all(check.status == CheckStatus.FAILED for check in coverage)
         assert any(
-            sample["initializer"] == "state_seed"
+            sample["initializer"] == "shape_source"
             and sample["consumer_op"] == "MatMul"
             and sample["consumer_input_index"] == 0
-            and sample["reason"] == "recurrent_sequence_state_lineage"
+            and sample["reason"] == expected_reason
             for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
         )
 

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -6521,7 +6521,15 @@ class TestWeightDistributionSemantics:
 
     @pytest.mark.parametrize(
         "use",
-        ["Gather", "GatherElements", "GatherND", "activation_scale", "transformed_activation_scale", "weight_scale"],
+        [
+            "Expand",
+            "Gather",
+            "GatherElements",
+            "GatherND",
+            "activation_scale",
+            "transformed_activation_scale",
+            "weight_scale",
+        ],
     )
     @pytest.mark.parametrize("malicious", [False, True])
     def test_shape_dimensions_follow_their_consumer_role(self, tmp_path: Path, use: str, malicious: bool) -> None:
@@ -6534,7 +6542,13 @@ class TestWeightDistributionSemantics:
             helper.make_node("MatMul", ["Xs", "W1"], ["hidden"]),
             helper.make_node("Shape", ["hidden"], ["dimensions"]),
         ]
-        if use in {"Gather", "GatherElements", "GatherND"}:
+        if use == "Expand":
+            inputs.append(helper.make_tensor_value_info("Xd", TensorProto.FLOAT, [1, 10]))
+            initializers.append(onnx.numpy_helper.from_array(np.zeros((10, 5), dtype=np.float32), name="W2"))
+            nodes.append(helper.make_node("Expand", ["Xd", "dimensions"], ["selected"]))
+            nodes.append(helper.make_node("MatMul", ["selected", "W2"], ["Y"]))
+            output_shape = [1, 5]
+        elif use in {"Gather", "GatherElements", "GatherND"}:
             inputs.append(helper.make_tensor_value_info("Xd", TensorProto.FLOAT, [16, 100]))
             columns = 1 if use == "GatherElements" else 100
             initializers.append(onnx.numpy_helper.from_array(np.zeros((columns, 10), dtype=np.float32), name="W2"))
@@ -6594,6 +6608,43 @@ class TestWeightDistributionSemantics:
             )
         else:
             assert not coverage
+
+    @pytest.mark.parametrize("combination", ["Add", "Mul"])
+    @pytest.mark.parametrize("consumer", ["Gemm", "MatMul"])
+    def test_runtime_adjusted_dimensions_used_as_weights_retain_coverage(
+        self, tmp_path: Path, combination: str, consumer: str
+    ) -> None:
+        graph = helper.make_graph(
+            [
+                helper.make_node("Shape", ["source"], ["dimensions"]),
+                helper.make_node("Cast", ["dimensions"], ["dimensions_float"], to=TensorProto.FLOAT),
+                helper.make_node(combination, ["dimensions_float", "runtime_delta"], ["generated"]),
+                helper.make_node("Identity", ["generated"], ["weights"]),
+                helper.make_node(consumer, ["X", "weights"], ["Y"]),
+            ],
+            "runtime_adjusted_dimension_weights",
+            [helper.make_tensor_value_info("runtime_delta", TensorProto.FLOAT, [10, 2])],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [3, 2])],
+            initializer=[
+                onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="source"),
+                onnx.numpy_helper.from_array(np.zeros((3, 10), dtype=np.float32), name="X"),
+            ],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        path = tmp_path / "runtime-adjusted-weights.onnx"
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        assert result.success is False
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert coverage and all(check.status == CheckStatus.FAILED for check in coverage)
+        assert any(
+            sample["consumer_op"] == consumer and sample["reason"] == "runtime_shape_lineage"
+            for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+        )
 
     @pytest.mark.parametrize("op_type", ["LSTM", "GRU", "RNN"])
     @pytest.mark.parametrize("malicious", [False, True])
@@ -6705,8 +6756,9 @@ class TestWeightDistributionSemantics:
     @pytest.mark.parametrize("malicious", [False, True])
     @pytest.mark.parametrize("fill_first", [False, True])
     @pytest.mark.parametrize("explicit_fill", [False, True])
+    @pytest.mark.parametrize("mask_operator", ["input", "Equal", "Greater", "GreaterOrEqual", "Less", "LessOrEqual"])
     def test_runtime_masks_with_shape_derived_fills_preserve_weight_analysis(
-        self, tmp_path: Path, malicious: bool, fill_first: bool, explicit_fill: bool
+        self, tmp_path: Path, malicious: bool, fill_first: bool, explicit_fill: bool, mask_operator: str
     ) -> None:
         weights = np.zeros((100, 10), dtype=np.float32)
         if malicious:
@@ -6736,6 +6788,9 @@ class TestWeightDistributionSemantics:
                 onnx.numpy_helper.from_array(np.zeros((10, 5), dtype=np.float32), name="W2"),
             ],
         )
+        if mask_operator != "input":
+            graph.input[1].CopyFrom(helper.make_tensor_value_info("mask_values", TensorProto.FLOAT, [1, 10]))
+            graph.node.insert(3, helper.make_node(mask_operator, ["hidden", "mask_values"], ["mask"]))
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
         model.ir_version = 8
         onnx.checker.check_model(model)

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -6437,6 +6437,45 @@ class TestWeightDistributionSemantics:
         assert semantics["eligible_initializer_count"] == 2
         assert semantics["analyzed_layer_count"] == 2
 
+    @pytest.mark.parametrize("malicious", [False, True])
+    def test_slice_bounds_from_shape_remain_control_lineage(self, tmp_path: Path, malicious: bool) -> None:
+        weights = np.zeros((100, 10), dtype=np.float32)
+        if malicious:
+            weights[50:55, 3] = 10.0
+        graph = helper.make_graph(
+            [
+                helper.make_node("MatMul", ["X", "W1"], ["hidden"]),
+                helper.make_node("Shape", ["hidden"], ["ends"]),
+                helper.make_node("Slice", ["hidden", "starts", "ends"], ["cropped"]),
+                helper.make_node("MatMul", ["cropped", "W2"], ["Y"]),
+            ],
+            "slice_bounds_control_lineage",
+            [
+                helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100]),
+                helper.make_tensor_value_info("starts", TensorProto.INT64, [2]),
+            ],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [None, 5])],
+            initializer=[
+                onnx.numpy_helper.from_array(weights, name="W1"),
+                onnx.numpy_helper.from_array(np.zeros((10, 5), dtype=np.float32), name="W2"),
+            ],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 14)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        path = tmp_path / "slice-bounds-control-lineage.onnx"
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        if not malicious:
+            assert result.success is True
+        assert len(self._extreme_checks(result)) == int(malicious)
+        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["eligible_initializer_count"] == 2
+        assert semantics["analyzed_layer_count"] == 2
+
     @pytest.mark.parametrize("dynamic_indices", [False, True])
     def test_generated_gather_tables_retain_incomplete_coverage(self, tmp_path: Path, dynamic_indices: bool) -> None:
         inputs = [helper.make_tensor_value_info("seed", TensorProto.FLOAT, [100, 100])]
@@ -6878,6 +6917,63 @@ class TestWeightDistributionSemantics:
         assert result.success is True
         assert len(self._extreme_checks(result)) == int(malicious)
         assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+
+    @pytest.mark.parametrize("op_type", ["RNN", "GRU", "LSTM"])
+    def test_shape_derived_recurrent_state_generated_weights_fail_closed(self, tmp_path: Path, op_type: str) -> None:
+        hidden_size = 100
+        gate_multiplier = {"RNN": 1, "GRU": 3, "LSTM": 4}[op_type]
+        shape_source = TensorProto()
+        shape_source.name = "shape_source"
+        shape_source.data_type = TensorProto.FLOAT
+        shape_source.dims.extend([0] * 50 + [10] * 5 + [0] * 45)
+        recurrent_inputs = ["sequence", "W", "R", "", "", "initial_h"]
+        recurrent_outputs = ["", "state"]
+        if op_type == "LSTM":
+            recurrent_inputs.append("initial_h")
+            recurrent_outputs.append("")
+        graph = helper.make_graph(
+            [
+                helper.make_node("Shape", ["shape_source"], ["dimensions"]),
+                helper.make_node("Cast", ["dimensions"], ["numeric_dimensions"], to=TensorProto.FLOAT),
+                helper.make_node("Reshape", ["numeric_dimensions", "state_shape"], ["initial_h"]),
+                helper.make_node(op_type, recurrent_inputs, recurrent_outputs, hidden_size=hidden_size),
+                helper.make_node("Reshape", ["state", "weight_shape"], ["generated_weight"]),
+                helper.make_node("MatMul", ["X", "generated_weight"], ["Y"]),
+            ],
+            f"{op_type.lower()}_state_generated_weight",
+            [helper.make_tensor_value_info("sequence", TensorProto.FLOAT, [1, 1, hidden_size])],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 1])],
+            initializer=[
+                shape_source,
+                onnx.numpy_helper.from_array(np.ones((1, hidden_size), dtype=np.float32), name="X"),
+                onnx.numpy_helper.from_array(np.array([1, 1, hidden_size], dtype=np.int64), name="state_shape"),
+                onnx.numpy_helper.from_array(np.array([hidden_size, 1], dtype=np.int64), name="weight_shape"),
+                onnx.numpy_helper.from_array(
+                    np.zeros((1, gate_multiplier * hidden_size, hidden_size), dtype=np.float32), name="W"
+                ),
+                onnx.numpy_helper.from_array(
+                    np.zeros((1, gate_multiplier * hidden_size, hidden_size), dtype=np.float32), name="R"
+                ),
+            ],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 14)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        path = tmp_path / f"{op_type.lower()}-state-generated-weight.onnx"
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        assert result.success is False
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert coverage and all(check.status == CheckStatus.FAILED for check in coverage)
+        assert any(
+            sample["initializer"] == "shape_source"
+            and sample["consumer_op"] == "MatMul"
+            and sample["consumer_input_index"] == 1
+            and sample["reason"] == "shape_dimensions_lineage"
+            for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+        )
 
     @pytest.mark.parametrize(
         "combination", ["where_left", "where_right", "where_runtime", "shape_zeros", "transformed_shape_zeros"]

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -6619,7 +6619,7 @@ class TestWeightDistributionSemantics:
             )
         else:
             assert not coverage
-        if use == "Expand":
+        if not dimension_values_are_data:
             assert result.metadata["onnx_weight_distribution_semantics"]["exclusion_counts"]["shape_control_input"] >= 1
 
     @pytest.mark.parametrize("combination", ["Add", "Mul"])
@@ -6666,28 +6666,65 @@ class TestWeightDistributionSemantics:
         )
 
     @pytest.mark.parametrize("transform", ["Identity", "Relu"])
-    def test_expand_shape_ownership_survives_value_transforms(self, tmp_path: Path, transform: str) -> None:
-        graph = helper.make_graph(
+    @pytest.mark.parametrize("observation", ["Shape", "Size"])
+    @pytest.mark.parametrize("control", ["Expand", "Gather", "GatherElements", "GatherND", "Where"])
+    def test_shape_control_ownership_survives_value_transforms(
+        self, tmp_path: Path, transform: str, observation: str, control: str
+    ) -> None:
+        runtime_shape = {
+            "Expand": [1, 4],
+            "Gather": [4],
+            "GatherElements": [2, 4],
+            "GatherND": [4],
+            "Where": [1, 4],
+        }[control]
+        inputs = [helper.make_tensor_value_info("runtime", TensorProto.FLOAT, runtime_shape)]
+        initializers = [
+            onnx.numpy_helper.from_array(
+                np.ones((2, 4) if control == "Expand" else (2, 1), dtype=np.float32), name="source"
+            ),
+        ]
+        nodes = [helper.make_node("Shape", ["source"], ["dimensions"])]
+        if control == "Expand":
+            nodes.append(helper.make_node("Expand", ["runtime", "dimensions"], ["selected"]))
+        else:
+            initializers.append(
+                onnx.numpy_helper.from_array(
+                    np.zeros((1, 1), dtype=np.bool_ if control == "Where" else np.int64), name="seed"
+                )
+            )
+            nodes.append(helper.make_node("Expand", ["seed", "dimensions"], ["control"]))
+            if control == "Where":
+                inputs.append(helper.make_tensor_value_info("other", TensorProto.FLOAT, runtime_shape))
+                nodes.append(helper.make_node("Where", ["control", "runtime", "other"], ["selected"]))
+            else:
+                nodes.append(helper.make_node(control, ["runtime", "control"], ["selected"]))
+        nodes.extend(
             [
-                helper.make_node("Shape", ["source"], ["dimensions"]),
-                helper.make_node("Expand", ["runtime", "dimensions"], ["expanded"]),
-                helper.make_node(transform, ["expanded"], ["transformed"]),
-                helper.make_node("Shape", ["transformed"], ["output_dimensions"]),
-                helper.make_node("Cast", ["output_dimensions"], ["dimension_values"], to=TensorProto.FLOAT),
-                helper.make_node("MatMul", ["projection", "dimension_values"], ["Y"]),
-            ],
-            "expanded_shape_ownership",
-            [helper.make_tensor_value_info("runtime", TensorProto.FLOAT, [1, 4])],
+                helper.make_node(transform, ["selected"], ["transformed"]),
+                helper.make_node(observation, ["transformed"], ["measurement"]),
+                helper.make_node("Cast", ["measurement"], ["measurement_float"], to=TensorProto.FLOAT),
+            ]
+        )
+        values = "measurement_float"
+        if observation == "Size":
+            initializers.append(onnx.numpy_helper.from_array(np.array([0], dtype=np.int64), name="axes"))
+            nodes.append(helper.make_node("Unsqueeze", [values, "axes"], ["dimension_values"]))
+            values = "dimension_values"
+        columns = 1 if observation == "Size" or control == "GatherND" else 2
+        initializers.append(onnx.numpy_helper.from_array(np.ones((1, columns), dtype=np.float32), name="projection"))
+        nodes.append(helper.make_node("MatMul", ["projection", values], ["Y"]))
+        graph = helper.make_graph(
+            nodes,
+            "shape_control_ownership",
+            inputs,
             [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])],
-            initializer=[
-                onnx.numpy_helper.from_array(np.ones((2, 4), dtype=np.float32), name="source"),
-                onnx.numpy_helper.from_array(np.ones((1, 2), dtype=np.float32), name="projection"),
-            ],
+            initializer=initializers,
         )
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
         model.ir_version = 8
         onnx.checker.check_model(model)
-        path = tmp_path / "expanded-shape-ownership.onnx"
+        path = tmp_path / "shape-control-ownership.onnx"
         onnx.save(model, str(path))
 
         result = OnnxScanner().scan(str(path))
@@ -6698,7 +6735,9 @@ class TestWeightDistributionSemantics:
             for check in result.checks
         )
         assert any(
-            sample["initializer"] == "source" and sample["reason"] == "shape_dimensions_lineage"
+            sample["initializer"] == "source"
+            and sample["consumer_op"] == "MatMul"
+            and sample["reason"] == "shape_dimensions_lineage"
             for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
         )
 
@@ -6732,6 +6771,60 @@ class TestWeightDistributionSemantics:
         assert any(
             check.name == "Weight Distribution Analysis Coverage" and check.status == CheckStatus.FAILED
             for check in result.checks
+        )
+
+    @pytest.mark.parametrize(
+        "operation", ["ReduceSum", "Softmax", "LogSoftmax", "LpNormalization", "Hardmax", "Custom"]
+    )
+    @pytest.mark.parametrize("generated_input_index", [0, 1])
+    def test_shape_control_data_operations_preserve_incomplete_coverage(
+        self, tmp_path: Path, operation: str, generated_input_index: int
+    ) -> None:
+        columns = 1 if operation == "ReduceSum" else 4
+        transform = helper.make_node(operation, ["expanded"], ["weights"])
+        opsets = [helper.make_opsetid("", 11)]
+        if operation == "ReduceSum":
+            transform.attribute.append(helper.make_attribute("axes", [1]))
+        elif operation == "Custom":
+            transform.domain = "test.shape"
+            opsets.append(helper.make_opsetid("test.shape", 1))
+        operands = ["weights", "projection"] if generated_input_index == 0 else ["projection", "weights"]
+        projection_shape = (columns, 3) if generated_input_index == 0 else (3, 2)
+        output_shape = [2, 3] if generated_input_index == 0 else [3, columns]
+        graph = helper.make_graph(
+            [
+                helper.make_node("Shape", ["source"], ["dimensions"]),
+                helper.make_node("Expand", ["runtime", "dimensions"], ["expanded"]),
+                transform,
+                helper.make_node("MatMul", operands, ["Y"]),
+            ],
+            "shape_control_data_operations",
+            [helper.make_tensor_value_info("runtime", TensorProto.FLOAT, [1, 4])],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, output_shape)],
+            initializer=[
+                onnx.numpy_helper.from_array(np.ones((2, 4), dtype=np.float32), name="source"),
+                onnx.numpy_helper.from_array(np.ones(projection_shape, dtype=np.float32), name="projection"),
+            ],
+        )
+        model = helper.make_model(graph, opset_imports=opsets)
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        path = tmp_path / "shape-control-data-operations.onnx"
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        assert result.success is False
+        assert any(
+            check.name == "Weight Distribution Analysis Coverage" and check.status == CheckStatus.FAILED
+            for check in result.checks
+        )
+        assert any(
+            sample["initializer"] == "source"
+            and sample["consumer_op"] == "MatMul"
+            and sample["consumer_input_index"] == generated_input_index
+            and sample["reason"] == "shape_dimensions_lineage"
+            for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
         )
 
     @pytest.mark.parametrize("op_type", ["LSTM", "GRU", "RNN"])
@@ -6845,8 +6938,15 @@ class TestWeightDistributionSemantics:
     @pytest.mark.parametrize("fill_first", [False, True])
     @pytest.mark.parametrize("explicit_fill", [False, True])
     @pytest.mark.parametrize("mask_operator", ["input", "Equal", "Greater", "GreaterOrEqual", "Less", "LessOrEqual"])
-    def test_runtime_masks_with_shape_derived_fills_preserve_weight_analysis(
-        self, tmp_path: Path, malicious: bool, fill_first: bool, explicit_fill: bool, mask_operator: str
+    @pytest.mark.parametrize("generated_input_index", [0, 1])
+    def test_runtime_masks_with_shape_derived_fills_preserve_incomplete_coverage(
+        self,
+        tmp_path: Path,
+        malicious: bool,
+        fill_first: bool,
+        explicit_fill: bool,
+        mask_operator: str,
+        generated_input_index: int,
     ) -> None:
         weights = np.zeros((100, 10), dtype=np.float32)
         if malicious:
@@ -6863,17 +6963,19 @@ class TestWeightDistributionSemantics:
                 helper.make_node("Shape", ["hidden"], ["dimensions"]),
                 fill,
                 helper.make_node("Where", ["mask", *branches], ["masked"]),
-                helper.make_node("MatMul", ["masked", "W2"], ["Y"]),
+                helper.make_node("MatMul", ["masked", "W2"] if generated_input_index == 0 else ["W2", "masked"], ["Y"]),
             ],
             "runtime_activation_mask",
             [
                 helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100]),
                 helper.make_tensor_value_info("mask", TensorProto.BOOL, [1, 10]),
             ],
-            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 5])],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 5] if generated_input_index == 0 else [5, 10])],
             initializer=[
                 onnx.numpy_helper.from_array(weights, name="W1"),
-                onnx.numpy_helper.from_array(np.zeros((10, 5), dtype=np.float32), name="W2"),
+                onnx.numpy_helper.from_array(
+                    np.zeros((10, 5) if generated_input_index == 0 else (5, 1), dtype=np.float32), name="W2"
+                ),
             ],
         )
         if mask_operator != "input":
@@ -6887,9 +6989,16 @@ class TestWeightDistributionSemantics:
 
         result = OnnxScanner().scan(str(path))
 
-        assert result.success is True
+        assert result.success is False
         assert len(self._extreme_checks(result)) == int(malicious)
-        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+        assert any(
+            check.name == "Weight Distribution Analysis Coverage" and check.status == CheckStatus.FAILED
+            for check in result.checks
+        )
+        assert any(
+            sample["consumer_op"] == "MatMul" and sample["reason"] == "shape_dimensions_lineage"
+            for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+        )
 
     @pytest.mark.parametrize("malicious", [False, True])
     def test_standard_einsum_weights_are_oriented_and_analyzed(self, tmp_path: Path, malicious: bool) -> None:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -6721,7 +6721,10 @@ class TestWeightDistributionSemantics:
 
     @pytest.mark.parametrize("transform", ["Identity", "Relu"])
     @pytest.mark.parametrize("observation", ["Shape", "Size"])
-    @pytest.mark.parametrize("control", ["Expand", "Gather", "GatherElements", "GatherND", "Reshape", "Where"])
+    @pytest.mark.parametrize(
+        "control",
+        ["Expand", "Gather", "GatherElements", "GatherND", "Reshape", "Squeeze", "Unsqueeze", "Where"],
+    )
     def test_shape_control_ownership_survives_value_transforms(
         self, tmp_path: Path, transform: str, observation: str, control: str
     ) -> None:
@@ -6731,19 +6734,24 @@ class TestWeightDistributionSemantics:
             "GatherElements": [2, 4],
             "GatherND": [4],
             "Reshape": [2, 4],
+            "Squeeze": [1, 4],
+            "Unsqueeze": [4],
             "Where": [1, 4],
         }[control]
         inputs = [helper.make_tensor_value_info("runtime", TensorProto.FLOAT, runtime_shape)]
+        source_shape = (
+            (0,) if control in {"Squeeze", "Unsqueeze"} else (2, 4) if control in {"Expand", "Reshape"} else (2, 1)
+        )
         initializers = [
-            onnx.numpy_helper.from_array(
-                np.ones((2, 4) if control in {"Expand", "Reshape"} else (2, 1), dtype=np.float32), name="source"
-            ),
+            onnx.numpy_helper.from_array(np.ones(source_shape, dtype=np.float32), name="source"),
         ]
         nodes = [helper.make_node("Shape", ["source"], ["dimensions"])]
         if control == "Expand":
             nodes.append(helper.make_node("Expand", ["runtime", "dimensions"], ["selected"]))
         elif control == "Reshape":
             nodes.append(helper.make_node("Reshape", ["runtime", "dimensions"], ["selected"]))
+        elif control in {"Squeeze", "Unsqueeze"}:
+            nodes.append(helper.make_node(control, ["runtime", "dimensions"], ["selected"]))
         else:
             initializers.append(
                 onnx.numpy_helper.from_array(
@@ -6768,7 +6776,7 @@ class TestWeightDistributionSemantics:
             initializers.append(onnx.numpy_helper.from_array(np.array([0], dtype=np.int64), name="axes"))
             nodes.append(helper.make_node("Unsqueeze", [values, "axes"], ["dimension_values"]))
             values = "dimension_values"
-        columns = 1 if observation == "Size" or control == "GatherND" else 2
+        columns = 1 if observation == "Size" or control in {"GatherND", "Squeeze"} else 2
         initializers.append(onnx.numpy_helper.from_array(np.ones((1, columns), dtype=np.float32), name="projection"))
         nodes.append(helper.make_node("MatMul", ["projection", values], ["Y"]))
         graph = helper.make_graph(

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -7204,6 +7204,65 @@ class TestWeightDistributionSemantics:
             for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
         )
 
+    def test_recurrent_final_state_marker_does_not_grow_through_state_chain(self, tmp_path: Path) -> None:
+        hidden_size = 4
+        recurrent_nodes = []
+        recurrent_initializers = [
+            onnx.numpy_helper.from_array(np.zeros((1, 1, hidden_size), dtype=np.float32), name="initial_h")
+        ]
+        previous_state = "initial_h"
+        for index in range(6):
+            state_name = f"state_{index}"
+            recurrent_nodes.append(
+                helper.make_node(
+                    "RNN",
+                    ["sequence", f"W_{index}", f"R_{index}", "", "", previous_state],
+                    [f"sequence_output_{index}", state_name],
+                    hidden_size=hidden_size,
+                )
+            )
+            recurrent_initializers.extend(
+                [
+                    onnx.numpy_helper.from_array(
+                        np.zeros((1, hidden_size, hidden_size), dtype=np.float32), name=f"W_{index}"
+                    ),
+                    onnx.numpy_helper.from_array(
+                        np.zeros((1, hidden_size, hidden_size), dtype=np.float32), name=f"R_{index}"
+                    ),
+                ]
+            )
+            previous_state = state_name
+        graph = helper.make_graph(
+            [
+                *recurrent_nodes,
+                helper.make_node("Reshape", [previous_state, "weight_shape"], ["generated_weight"]),
+                helper.make_node("MatMul", ["X", "generated_weight"], ["Y"]),
+            ],
+            "chained_recurrent_final_state_marker",
+            [helper.make_tensor_value_info("sequence", TensorProto.FLOAT, [1, 1, hidden_size])],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 1])],
+            initializer=[
+                *recurrent_initializers,
+                onnx.numpy_helper.from_array(np.ones((1, hidden_size), dtype=np.float32), name="X"),
+                onnx.numpy_helper.from_array(np.array([hidden_size, 1], dtype=np.int64), name="weight_shape"),
+            ],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 14)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        path = tmp_path / "chained-recurrent-final-state-marker.onnx"
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        assert result.success is False
+        samples = result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+        sample = next(
+            sample for sample in samples if sample["initializer"] == "initial_h" and sample["consumer_op"] == "MatMul"
+        )
+        assert sample["reason"] == "recurrent_state_lineage"
+        assert sample["lineage_transform_count"] == 2
+
     @pytest.mark.parametrize(
         ("generated_source", "expected_reason"),
         [

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -6519,7 +6519,7 @@ class TestWeightDistributionSemantics:
             for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
         )
 
-    @pytest.mark.parametrize("use", ["gather_indices", "activation_scale", "weight_scale"])
+    @pytest.mark.parametrize("use", ["Gather", "GatherElements", "GatherND", "activation_scale", "weight_scale"])
     @pytest.mark.parametrize("malicious", [False, True])
     def test_shape_dimensions_follow_their_consumer_role(self, tmp_path: Path, use: str, malicious: bool) -> None:
         weights = np.zeros((100, 10), dtype=np.float32)
@@ -6531,10 +6531,19 @@ class TestWeightDistributionSemantics:
             helper.make_node("MatMul", ["Xs", "W1"], ["hidden"]),
             helper.make_node("Shape", ["hidden"], ["dimensions"]),
         ]
-        if use == "gather_indices":
+        if use in {"Gather", "GatherElements", "GatherND"}:
             inputs.append(helper.make_tensor_value_info("Xd", TensorProto.FLOAT, [16, 100]))
-            initializers.append(onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="W2"))
-            nodes.append(helper.make_node("Gather", ["Xd", "dimensions"], ["selected"], axis=0))
+            columns = 1 if use == "GatherElements" else 100
+            initializers.append(onnx.numpy_helper.from_array(np.zeros((columns, 10), dtype=np.float32), name="W2"))
+            indices = "dimensions"
+            if use != "Gather":
+                initializers.append(onnx.numpy_helper.from_array(np.array([2, 1], dtype=np.int64), name="index_shape"))
+                nodes.append(helper.make_node("Reshape", ["dimensions", "index_shape"], ["indices"]))
+                indices = "indices"
+            selection = helper.make_node(use, ["Xd", indices], ["selected"])
+            if use != "GatherND":
+                selection.attribute.append(helper.make_attribute("axis", 0))
+            nodes.append(selection)
             nodes.append(helper.make_node("MatMul", ["selected", "W2"], ["Y"]))
             output_shape = [2, 10]
         else:
@@ -6580,32 +6589,43 @@ class TestWeightDistributionSemantics:
 
     @pytest.mark.parametrize("op_type", ["LSTM", "GRU", "RNN"])
     @pytest.mark.parametrize("malicious", [False, True])
-    def test_shape_derived_recurrent_initial_states_are_activations(
-        self, tmp_path: Path, op_type: str, malicious: bool
+    @pytest.mark.parametrize("control_input", ["initial_state", "sequence_lens"])
+    def test_shape_derived_recurrent_control_inputs_are_activations(
+        self, tmp_path: Path, op_type: str, malicious: bool, control_input: str
     ) -> None:
         path = create_recurrent_weight_model(
             tmp_path, op_type=op_type, target_input_index=1, distributed_near_match=not malicious
         )
         model = onnx.load(str(path))
         node = model.graph.node[0]
-        node.input.extend(["", "", "initial_state"])
-        if op_type == "LSTM":
-            node.input.append("initial_state")
+        if control_input == "sequence_lens":
+            node.input.extend(["", "sequence_lens"])
+        else:
+            node.input.extend(["", "", "initial_state"])
+            if op_type == "LSTM":
+                node.input.append("initial_state")
         node.output[0] = "states"
         model.graph.initializer.extend(
             [
-                onnx.numpy_helper.from_array(np.zeros((2, 1, 100), dtype=np.float32), name="shape_source"),
+                onnx.numpy_helper.from_array(
+                    np.zeros((1,) if control_input == "sequence_lens" else (2, 1, 100), dtype=np.float32),
+                    name="shape_source",
+                ),
                 onnx.numpy_helper.from_array(np.array([0, 1, 2], dtype=np.int64), name="indices"),
                 onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="projection"),
             ]
         )
-        nodes = [
-            helper.make_node("Shape", ["shape_source"], ["dimensions"]),
-            helper.make_node("Gather", ["dimensions", "indices"], ["selected"], axis=0),
-            helper.make_node("ConstantOfShape", ["selected"], ["initial_state"]),
-            node,
-            helper.make_node("MatMul", ["states", "projection"], ["Y"]),
-        ]
+        nodes = [helper.make_node("Shape", ["shape_source"], ["dimensions"])]
+        if control_input == "sequence_lens":
+            nodes.append(helper.make_node("Cast", ["dimensions"], ["sequence_lens"], to=TensorProto.INT32))
+        else:
+            nodes.extend(
+                [
+                    helper.make_node("Gather", ["dimensions", "indices"], ["selected"], axis=0),
+                    helper.make_node("ConstantOfShape", ["selected"], ["initial_state"]),
+                ]
+            )
+        nodes.extend([node, helper.make_node("MatMul", ["states", "projection"], ["Y"])])
         del model.graph.node[:]
         model.graph.node.extend(nodes)
         del model.graph.output[:]
@@ -6618,6 +6638,52 @@ class TestWeightDistributionSemantics:
         assert result.success is True
         assert len(self._extreme_checks(result)) == int(malicious)
         assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+
+    @pytest.mark.parametrize("combination", ["where_left", "where_right", "shape_zeros"])
+    def test_shape_only_weight_paths_retain_dimension_coverage(self, tmp_path: Path, combination: str) -> None:
+        branches = ["runtime", "runtime"]
+        branches[0 if combination == "where_left" else 1] = "dimensions_float"
+        nodes = [
+            helper.make_node("Shape", ["source"], ["dimensions"]),
+            helper.make_node("Cast", ["dimensions"], ["dimensions_float"], to=TensorProto.FLOAT),
+        ]
+        if combination == "shape_zeros":
+            nodes.extend(
+                [
+                    helper.make_node("Shape", ["runtime"], ["runtime_shape"]),
+                    helper.make_node("ConstantOfShape", ["runtime_shape"], ["zeros"]),
+                    helper.make_node("Add", ["dimensions_float", "zeros"], ["selected_weights"]),
+                ]
+            )
+        else:
+            nodes.append(helper.make_node("Where", ["condition", *branches], ["selected_weights"]))
+        nodes.append(helper.make_node("MatMul", ["X", "selected_weights"], ["Y"]))
+        graph = helper.make_graph(
+            nodes,
+            "mixed_dimension_weights",
+            [helper.make_tensor_value_info("runtime", TensorProto.FLOAT, [2])],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [4])],
+            initializer=[
+                onnx.numpy_helper.from_array(np.ones((2, 4), dtype=np.float32), name="source"),
+                onnx.numpy_helper.from_array(np.full(2, combination == "where_left", dtype=np.bool_), name="condition"),
+                onnx.numpy_helper.from_array(np.zeros((4, 2), dtype=np.float32), name="X"),
+            ],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        path = tmp_path / "mixed-dimension-weights.onnx"
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        assert result.success is False
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert coverage and all(check.status == CheckStatus.FAILED for check in coverage)
+        assert any(
+            sample["consumer_op"] == "MatMul" and sample["reason"] == "shape_dimensions_lineage"
+            for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+        )
 
     @pytest.mark.parametrize("malicious", [False, True])
     def test_standard_einsum_weights_are_oriented_and_analyzed(self, tmp_path: Path, malicious: bool) -> None:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -7151,6 +7151,58 @@ class TestWeightDistributionSemantics:
             for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
         )
 
+    def test_recurrent_final_state_marker_survives_same_initializer_merge(self, tmp_path: Path) -> None:
+        hidden_size = 100
+        shape_source = TensorProto()
+        shape_source.name = "shape_source"
+        shape_source.data_type = TensorProto.FLOAT
+        shape_source.dims.extend([0] * 50 + [10] * 5 + [0] * 45)
+        graph = helper.make_graph(
+            [
+                helper.make_node("Shape", ["shape_source"], ["dimensions"]),
+                helper.make_node("Cast", ["dimensions"], ["numeric_dimensions"], to=TensorProto.FLOAT),
+                helper.make_node("Reshape", ["numeric_dimensions", "state_shape"], ["initial_h"]),
+                helper.make_node(
+                    "RNN",
+                    ["sequence", "W", "R", "", "", "initial_h"],
+                    ["sequence_output", "state"],
+                    hidden_size=hidden_size,
+                ),
+                helper.make_node("Add", ["initial_h", "state"], ["merged_state"]),
+                helper.make_node("Reshape", ["merged_state", "left_shape"], ["left_weight"]),
+                helper.make_node("MatMul", ["left_weight", "projection"], ["Y"]),
+            ],
+            "merged_recurrent_final_state_operand",
+            [helper.make_tensor_value_info("sequence", TensorProto.FLOAT, [1, 1, hidden_size])],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])],
+            initializer=[
+                shape_source,
+                onnx.numpy_helper.from_array(np.array([1, 1, hidden_size], dtype=np.int64), name="state_shape"),
+                onnx.numpy_helper.from_array(np.array([hidden_size], dtype=np.int64), name="left_shape"),
+                onnx.numpy_helper.from_array(np.zeros((1, hidden_size, hidden_size), dtype=np.float32), name="W"),
+                onnx.numpy_helper.from_array(np.zeros((1, hidden_size, hidden_size), dtype=np.float32), name="R"),
+                onnx.numpy_helper.from_array(np.zeros((hidden_size, 1), dtype=np.float32), name="projection"),
+            ],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 14)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        path = tmp_path / "merged-recurrent-final-state-vector-left-operand.onnx"
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        assert result.success is False
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert coverage and all(check.status == CheckStatus.FAILED for check in coverage)
+        assert any(
+            sample["initializer"] == "shape_source"
+            and sample["consumer_op"] == "MatMul"
+            and sample["consumer_input_index"] == 0
+            and sample["reason"] != "shape_control_lineage"
+            for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+        )
+
     @pytest.mark.parametrize(
         ("generated_source", "expected_reason"),
         [

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -1389,29 +1389,31 @@ def create_activation_bookkeeping_model(tmp_path: Path, *, malicious: bool, rank
     return path
 
 
-def create_gather_activation_bookkeeping_model(tmp_path: Path, *, malicious: bool) -> Path:
-    """Create a linear stack whose prior activation is gathered before reuse."""
+def create_shape_gather_bookkeeping_model(tmp_path: Path, *, malicious: bool) -> Path:
+    """Create a linear stack reshaped using dimensions read through Gather."""
     first_weight = np.zeros((100, 100), dtype=np.float32)
     second_weight = np.zeros((100, 10), dtype=np.float32)
     if malicious:
         second_weight[50:55, 3] = 10.0
     initializers = [
         onnx.numpy_helper.from_array(first_weight, name="W1"),
-        onnx.numpy_helper.from_array(np.arange(100, dtype=np.int64), name="indices"),
+        onnx.numpy_helper.from_array(np.array([0, 1], dtype=np.int64), name="indices"),
         onnx.numpy_helper.from_array(second_weight, name="W2"),
     ]
     X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100])
     Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 10])
     nodes = [
         helper.make_node("MatMul", ["X", "W1"], ["hidden"], name="first_linear"),
-        helper.make_node("Gather", ["hidden", "indices"], ["selected"], name="activation_slice", axis=1),
-        helper.make_node("MatMul", ["selected", "W2"], ["Y"], name="second_linear"),
+        helper.make_node("Shape", ["hidden"], ["dimensions"], name="activation_shape"),
+        helper.make_node("Gather", ["dimensions", "indices"], ["selected"], name="shape_slice", axis=0),
+        helper.make_node("Reshape", ["hidden", "selected"], ["reshaped"], name="activation_reshape"),
+        helper.make_node("MatMul", ["reshaped", "W2"], ["Y"], name="second_linear"),
     ]
-    graph = helper.make_graph(nodes, "gather_activation_bookkeeping_graph", [X], [Y], initializer=initializers)
+    graph = helper.make_graph(nodes, "shape_gather_bookkeeping_graph", [X], [Y], initializer=initializers)
     model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
     model.ir_version = 8
     onnx.checker.check_model(model)
-    path = tmp_path / f"{'malicious' if malicious else 'benign'}-gather-activation-bookkeeping.onnx"
+    path = tmp_path / f"{'malicious' if malicious else 'benign'}-shape-gather-bookkeeping.onnx"
     onnx.save(model, str(path))
     return path
 
@@ -6419,12 +6421,12 @@ class TestWeightDistributionSemantics:
         assert semantics["exclusion_counts"]["bookkeeping_constant"] == 1
 
     @pytest.mark.parametrize("malicious", [False, True])
-    def test_gathered_activation_path_does_not_create_weight_coverage_gap(
+    def test_shape_gather_path_does_not_create_weight_coverage_gap(
         self,
         tmp_path: Path,
         malicious: bool,
     ) -> None:
-        model_path = create_gather_activation_bookkeeping_model(tmp_path, malicious=malicious)
+        model_path = create_shape_gather_bookkeeping_model(tmp_path, malicious=malicious)
 
         result = OnnxScanner().scan(str(model_path))
 
@@ -6434,8 +6436,39 @@ class TestWeightDistributionSemantics:
         semantics = result.metadata["onnx_weight_distribution_semantics"]
         assert semantics["eligible_initializer_count"] == 2
         assert semantics["analyzed_layer_count"] == 2
-        assert semantics["exclusion_counts"]["dynamic_activation_input"] >= 2
-        assert semantics["exclusion_counts"]["non_weight_input"] == 1
+
+    @pytest.mark.parametrize("dynamic_indices", [False, True])
+    def test_generated_gather_tables_retain_incomplete_coverage(self, tmp_path: Path, dynamic_indices: bool) -> None:
+        inputs = [helper.make_tensor_value_info("seed", TensorProto.FLOAT, [100, 100])]
+        initializers = [onnx.numpy_helper.from_array(np.zeros((100, 100), dtype=np.float32), name="P")]
+        if dynamic_indices:
+            inputs.append(helper.make_tensor_value_info("indices", TensorProto.INT64, [1]))
+        else:
+            initializers.append(onnx.numpy_helper.from_array(np.array([0], dtype=np.int64), name="indices"))
+        nodes = [
+            helper.make_node("MatMul", ["seed", "P"], ["table"], name="generated_table"),
+            helper.make_node("Gather", ["table", "indices"], ["Y"], name="lookup", axis=0),
+        ]
+        graph = helper.make_graph(
+            nodes,
+            "generated_gather_table",
+            inputs,
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 100])],
+            initializer=initializers,
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        path = tmp_path / "generated-table.onnx"
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        assert result.success is False
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert len(coverage) == 1
+        assert coverage[0].details["coverage_gap"] == "unresolved_initializer_lineage"
+        assert coverage[0].status == CheckStatus.FAILED
 
     @pytest.mark.parametrize("malicious", [False, True])
     def test_standard_einsum_weights_are_oriented_and_analyzed(self, tmp_path: Path, malicious: bool) -> None:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -6919,7 +6919,10 @@ class TestWeightDistributionSemantics:
         assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
 
     @pytest.mark.parametrize("op_type", ["RNN", "GRU", "LSTM"])
-    def test_shape_derived_recurrent_state_generated_weights_fail_closed(self, tmp_path: Path, op_type: str) -> None:
+    @pytest.mark.parametrize("output_slot", ["sequence", "state"])
+    def test_shape_derived_recurrent_state_generated_weights_fail_closed(
+        self, tmp_path: Path, op_type: str, output_slot: str
+    ) -> None:
         hidden_size = 100
         gate_multiplier = {"RNN": 1, "GRU": 3, "LSTM": 4}[op_type]
         shape_source = TensorProto()
@@ -6927,17 +6930,18 @@ class TestWeightDistributionSemantics:
         shape_source.data_type = TensorProto.FLOAT
         shape_source.dims.extend([0] * 50 + [10] * 5 + [0] * 45)
         recurrent_inputs = ["sequence", "W", "R", "", "", "initial_h"]
-        recurrent_outputs = ["", "state"]
+        recurrent_outputs = ["sequence_output", "state"]
         if op_type == "LSTM":
             recurrent_inputs.append("initial_h")
-            recurrent_outputs.append("")
+            recurrent_outputs.append("cell_state")
+        generated_source = "sequence_output" if output_slot == "sequence" else "state"
         graph = helper.make_graph(
             [
                 helper.make_node("Shape", ["shape_source"], ["dimensions"]),
                 helper.make_node("Cast", ["dimensions"], ["numeric_dimensions"], to=TensorProto.FLOAT),
                 helper.make_node("Reshape", ["numeric_dimensions", "state_shape"], ["initial_h"]),
                 helper.make_node(op_type, recurrent_inputs, recurrent_outputs, hidden_size=hidden_size),
-                helper.make_node("Reshape", ["state", "weight_shape"], ["generated_weight"]),
+                helper.make_node("Reshape", [generated_source, "weight_shape"], ["generated_weight"]),
                 helper.make_node("MatMul", ["X", "generated_weight"], ["Y"]),
             ],
             f"{op_type.lower()}_state_generated_weight",
@@ -6967,11 +6971,14 @@ class TestWeightDistributionSemantics:
         assert result.success is False
         coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
         assert coverage and all(check.status == CheckStatus.FAILED for check in coverage)
+        expected_reason = (
+            "recurrent_sequence_state_lineage" if output_slot == "sequence" else "shape_dimensions_lineage"
+        )
         assert any(
             sample["initializer"] == "shape_source"
             and sample["consumer_op"] == "MatMul"
             and sample["consumer_input_index"] == 1
-            and sample["reason"] == "shape_dimensions_lineage"
+            and sample["reason"] == expected_reason
             for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
         )
 

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -6573,6 +6573,7 @@ class TestWeightDistributionSemantics:
             "Gather",
             "GatherElements",
             "GatherND",
+            "Tile",
             "activation_scale",
             "transformed_activation_scale",
             "binary_activation_scale",
@@ -6594,6 +6595,12 @@ class TestWeightDistributionSemantics:
             inputs.append(helper.make_tensor_value_info("Xd", TensorProto.FLOAT, [1, 10]))
             initializers.append(onnx.numpy_helper.from_array(np.zeros((10, 5), dtype=np.float32), name="W2"))
             nodes.append(helper.make_node("Expand", ["Xd", "dimensions"], ["selected"]))
+            nodes.append(helper.make_node("MatMul", ["selected", "W2"], ["Y"]))
+            output_shape = [1, 5]
+        elif use == "Tile":
+            inputs.append(helper.make_tensor_value_info("Xd", TensorProto.FLOAT, [1, 10]))
+            initializers.append(onnx.numpy_helper.from_array(np.zeros((100, 5), dtype=np.float32), name="W2"))
+            nodes.append(helper.make_node("Tile", ["Xd", "dimensions"], ["selected"]))
             nodes.append(helper.make_node("MatMul", ["selected", "W2"], ["Y"]))
             output_shape = [1, 5]
         elif use in {"Gather", "GatherElements", "GatherND"}:
@@ -6714,7 +6721,7 @@ class TestWeightDistributionSemantics:
 
     @pytest.mark.parametrize("transform", ["Identity", "Relu"])
     @pytest.mark.parametrize("observation", ["Shape", "Size"])
-    @pytest.mark.parametrize("control", ["Expand", "Gather", "GatherElements", "GatherND", "Where"])
+    @pytest.mark.parametrize("control", ["Expand", "Gather", "GatherElements", "GatherND", "Reshape", "Where"])
     def test_shape_control_ownership_survives_value_transforms(
         self, tmp_path: Path, transform: str, observation: str, control: str
     ) -> None:
@@ -6723,17 +6730,20 @@ class TestWeightDistributionSemantics:
             "Gather": [4],
             "GatherElements": [2, 4],
             "GatherND": [4],
+            "Reshape": [2, 4],
             "Where": [1, 4],
         }[control]
         inputs = [helper.make_tensor_value_info("runtime", TensorProto.FLOAT, runtime_shape)]
         initializers = [
             onnx.numpy_helper.from_array(
-                np.ones((2, 4) if control == "Expand" else (2, 1), dtype=np.float32), name="source"
+                np.ones((2, 4) if control in {"Expand", "Reshape"} else (2, 1), dtype=np.float32), name="source"
             ),
         ]
         nodes = [helper.make_node("Shape", ["source"], ["dimensions"])]
         if control == "Expand":
             nodes.append(helper.make_node("Expand", ["runtime", "dimensions"], ["selected"]))
+        elif control == "Reshape":
+            nodes.append(helper.make_node("Reshape", ["runtime", "dimensions"], ["selected"]))
         else:
             initializers.append(
                 onnx.numpy_helper.from_array(
@@ -7068,6 +7078,50 @@ class TestWeightDistributionSemantics:
         assert any(
             sample["initializer"] == "shape_source"
             and sample["consumer_op"] == consumer
+            and sample["consumer_input_index"] == 0
+            and sample["reason"] == "recurrent_sequence_state_lineage"
+            for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+        )
+
+    def test_recurrent_sequence_vector_left_operand_fails_closed(self, tmp_path: Path) -> None:
+        hidden_size = 100
+        graph = helper.make_graph(
+            [
+                helper.make_node("Cast", ["state_seed"], ["initial_h"], to=TensorProto.FLOAT),
+                helper.make_node(
+                    "RNN",
+                    ["sequence", "W", "R", "", "", "initial_h"],
+                    ["sequence_output", "state"],
+                    hidden_size=hidden_size,
+                ),
+                helper.make_node("Reshape", ["sequence_output", "left_shape"], ["left_weight"]),
+                helper.make_node("MatMul", ["left_weight", "projection"], ["Y"]),
+            ],
+            "recurrent_sequence_vector_left_operand",
+            [helper.make_tensor_value_info("sequence", TensorProto.FLOAT, [1, 1, hidden_size])],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])],
+            initializer=[
+                onnx.numpy_helper.from_array(np.zeros((1, 1, hidden_size), dtype=np.int64), name="state_seed"),
+                onnx.numpy_helper.from_array(np.array([hidden_size], dtype=np.int64), name="left_shape"),
+                onnx.numpy_helper.from_array(np.zeros((1, hidden_size, hidden_size), dtype=np.float32), name="W"),
+                onnx.numpy_helper.from_array(np.zeros((1, hidden_size, hidden_size), dtype=np.float32), name="R"),
+                onnx.numpy_helper.from_array(np.zeros((hidden_size, 1), dtype=np.float32), name="projection"),
+            ],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 14)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        path = tmp_path / "recurrent-sequence-vector-left-operand.onnx"
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        assert result.success is False
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert coverage and all(check.status == CheckStatus.FAILED for check in coverage)
+        assert any(
+            sample["initializer"] == "state_seed"
+            and sample["consumer_op"] == "MatMul"
             and sample["consumer_input_index"] == 0
             and sample["reason"] == "recurrent_sequence_state_lineage"
             for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -6471,8 +6471,9 @@ class TestWeightDistributionSemantics:
         assert coverage[0].status == CheckStatus.FAILED
 
     @pytest.mark.parametrize("gather_dimensions", [False, True])
+    @pytest.mark.parametrize("conditional_weights", [False, True])
     def test_dimensions_cast_to_weights_retain_incomplete_coverage(
-        self, tmp_path: Path, gather_dimensions: bool
+        self, tmp_path: Path, gather_dimensions: bool, conditional_weights: bool
     ) -> None:
         initializers = [onnx.numpy_helper.from_array(np.ones((2, 4), dtype=np.float32), name="source")]
         nodes = [helper.make_node("Shape", ["source"], ["dimensions"])]
@@ -6487,11 +6488,19 @@ class TestWeightDistributionSemantics:
                 helper.make_node("MatMul", ["X", "weights"], ["Y"]),
             ]
         )
+        inputs = [helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 2])]
+        output_shape = [1]
+        if conditional_weights:
+            initializers.append(onnx.numpy_helper.from_array(np.zeros((4, 2), dtype=np.float32), name="X"))
+            inputs = [helper.make_tensor_value_info("condition", TensorProto.BOOL, [2])]
+            nodes.insert(-1, helper.make_node("Where", ["condition", "weights", "weights"], ["selected_weights"]))
+            nodes[-1].input[1] = "selected_weights"
+            output_shape = [4]
         graph = helper.make_graph(
             nodes,
             "dimension_weights",
-            [helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 2])],
-            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])],
+            inputs,
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, output_shape)],
             initializer=initializers,
         )
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
@@ -6509,6 +6518,106 @@ class TestWeightDistributionSemantics:
             sample["consumer_op"] == "MatMul" and sample["reason"] == "shape_dimensions_lineage"
             for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
         )
+
+    @pytest.mark.parametrize("use", ["gather_indices", "activation_scale", "weight_scale"])
+    @pytest.mark.parametrize("malicious", [False, True])
+    def test_shape_dimensions_follow_their_consumer_role(self, tmp_path: Path, use: str, malicious: bool) -> None:
+        weights = np.zeros((100, 10), dtype=np.float32)
+        if malicious:
+            weights[50:55, 3] = 10.0
+        inputs = [helper.make_tensor_value_info("Xs", TensorProto.FLOAT, [1, 100])]
+        initializers = [onnx.numpy_helper.from_array(weights, name="W1")]
+        nodes = [
+            helper.make_node("MatMul", ["Xs", "W1"], ["hidden"]),
+            helper.make_node("Shape", ["hidden"], ["dimensions"]),
+        ]
+        if use == "gather_indices":
+            inputs.append(helper.make_tensor_value_info("Xd", TensorProto.FLOAT, [16, 100]))
+            initializers.append(onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="W2"))
+            nodes.append(helper.make_node("Gather", ["Xd", "dimensions"], ["selected"], axis=0))
+            nodes.append(helper.make_node("MatMul", ["selected", "W2"], ["Y"]))
+            output_shape = [2, 10]
+        else:
+            nodes.append(helper.make_node("Cast", ["dimensions"], ["scale"], to=TensorProto.FLOAT))
+            if use == "activation_scale":
+                inputs.append(helper.make_tensor_value_info("Xd", TensorProto.FLOAT, [100, 2]))
+                initializers.append(onnx.numpy_helper.from_array(np.zeros((2, 10), dtype=np.float32), name="W2"))
+                nodes.append(helper.make_node("Mul", ["Xd", "scale"], ["selected"]))
+                nodes.append(helper.make_node("MatMul", ["selected", "W2"], ["Y"]))
+                output_shape = [100, 10]
+            else:
+                inputs.append(helper.make_tensor_value_info("Xd", TensorProto.FLOAT, [1, 2]))
+                initializers.append(onnx.numpy_helper.from_array(np.ones(2, dtype=np.float32), name="factor"))
+                nodes.append(helper.make_node("Mul", ["factor", "scale"], ["weights"]))
+                nodes.append(helper.make_node("MatMul", ["Xd", "weights"], ["Y"]))
+                output_shape = [1]
+        graph = helper.make_graph(
+            nodes,
+            "dimension_roles",
+            inputs,
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, output_shape)],
+            initializer=initializers,
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        path = tmp_path / "dimension-roles.onnx"
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        assert result.success is (use != "weight_scale")
+        assert len(self._extreme_checks(result)) == int(malicious)
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        if use == "weight_scale":
+            assert coverage and all(check.status == CheckStatus.FAILED for check in coverage)
+            assert any(
+                sample["consumer_op"] == "MatMul" and sample["reason"] == "shape_dimensions_lineage"
+                for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+            )
+        else:
+            assert not coverage
+
+    @pytest.mark.parametrize("op_type", ["LSTM", "GRU", "RNN"])
+    @pytest.mark.parametrize("malicious", [False, True])
+    def test_shape_derived_recurrent_initial_states_are_activations(
+        self, tmp_path: Path, op_type: str, malicious: bool
+    ) -> None:
+        path = create_recurrent_weight_model(
+            tmp_path, op_type=op_type, target_input_index=1, distributed_near_match=not malicious
+        )
+        model = onnx.load(str(path))
+        node = model.graph.node[0]
+        node.input.extend(["", "", "initial_state"])
+        if op_type == "LSTM":
+            node.input.append("initial_state")
+        node.output[0] = "states"
+        model.graph.initializer.extend(
+            [
+                onnx.numpy_helper.from_array(np.zeros((2, 1, 100), dtype=np.float32), name="shape_source"),
+                onnx.numpy_helper.from_array(np.array([0, 1, 2], dtype=np.int64), name="indices"),
+                onnx.numpy_helper.from_array(np.zeros((100, 10), dtype=np.float32), name="projection"),
+            ]
+        )
+        nodes = [
+            helper.make_node("Shape", ["shape_source"], ["dimensions"]),
+            helper.make_node("Gather", ["dimensions", "indices"], ["selected"], axis=0),
+            helper.make_node("ConstantOfShape", ["selected"], ["initial_state"]),
+            node,
+            helper.make_node("MatMul", ["states", "projection"], ["Y"]),
+        ]
+        del model.graph.node[:]
+        model.graph.node.extend(nodes)
+        del model.graph.output[:]
+        model.graph.output.append(helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 2, 1, 10]))
+        onnx.checker.check_model(model)
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        assert result.success is True
+        assert len(self._extreme_checks(result)) == int(malicious)
+        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
 
     @pytest.mark.parametrize("malicious", [False, True])
     def test_standard_einsum_weights_are_oriented_and_analyzed(self, tmp_path: Path, malicious: bool) -> None:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -6519,7 +6519,10 @@ class TestWeightDistributionSemantics:
             for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
         )
 
-    @pytest.mark.parametrize("use", ["Gather", "GatherElements", "GatherND", "activation_scale", "weight_scale"])
+    @pytest.mark.parametrize(
+        "use",
+        ["Gather", "GatherElements", "GatherND", "activation_scale", "transformed_activation_scale", "weight_scale"],
+    )
     @pytest.mark.parametrize("malicious", [False, True])
     def test_shape_dimensions_follow_their_consumer_role(self, tmp_path: Path, use: str, malicious: bool) -> None:
         weights = np.zeros((100, 10), dtype=np.float32)
@@ -6548,10 +6551,15 @@ class TestWeightDistributionSemantics:
             output_shape = [2, 10]
         else:
             nodes.append(helper.make_node("Cast", ["dimensions"], ["scale"], to=TensorProto.FLOAT))
-            if use == "activation_scale":
+            if use in {"activation_scale", "transformed_activation_scale"}:
                 inputs.append(helper.make_tensor_value_info("Xd", TensorProto.FLOAT, [100, 2]))
                 initializers.append(onnx.numpy_helper.from_array(np.zeros((2, 10), dtype=np.float32), name="W2"))
-                nodes.append(helper.make_node("Mul", ["Xd", "scale"], ["selected"]))
+                activation = "Xd"
+                if use == "transformed_activation_scale":
+                    nodes.append(helper.make_node("Relu", ["Xd"], ["relu"]))
+                    nodes.append(helper.make_node("Identity", ["relu"], ["activation"]))
+                    activation = "activation"
+                nodes.append(helper.make_node("Mul", [activation, "scale"], ["selected"]))
                 nodes.append(helper.make_node("MatMul", ["selected", "W2"], ["Y"]))
                 output_shape = [100, 10]
             else:
@@ -6639,7 +6647,9 @@ class TestWeightDistributionSemantics:
         assert len(self._extreme_checks(result)) == int(malicious)
         assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
 
-    @pytest.mark.parametrize("combination", ["where_left", "where_right", "shape_zeros"])
+    @pytest.mark.parametrize(
+        "combination", ["where_left", "where_right", "where_runtime", "shape_zeros", "transformed_shape_zeros"]
+    )
     def test_shape_only_weight_paths_retain_dimension_coverage(self, tmp_path: Path, combination: str) -> None:
         branches = ["runtime", "runtime"]
         branches[0 if combination == "where_left" else 1] = "dimensions_float"
@@ -6647,14 +6657,18 @@ class TestWeightDistributionSemantics:
             helper.make_node("Shape", ["source"], ["dimensions"]),
             helper.make_node("Cast", ["dimensions"], ["dimensions_float"], to=TensorProto.FLOAT),
         ]
-        if combination == "shape_zeros":
+        if combination in {"shape_zeros", "transformed_shape_zeros"}:
             nodes.extend(
                 [
                     helper.make_node("Shape", ["runtime"], ["runtime_shape"]),
                     helper.make_node("ConstantOfShape", ["runtime_shape"], ["zeros"]),
-                    helper.make_node("Add", ["dimensions_float", "zeros"], ["selected_weights"]),
                 ]
             )
+            zeros = "zeros"
+            if combination == "transformed_shape_zeros":
+                nodes.append(helper.make_node("Relu", ["zeros"], ["transformed_zeros"]))
+                zeros = "transformed_zeros"
+            nodes.append(helper.make_node("Add", ["dimensions_float", zeros], ["selected_weights"]))
         else:
             nodes.append(helper.make_node("Where", ["condition", *branches], ["selected_weights"]))
         nodes.append(helper.make_node("MatMul", ["X", "selected_weights"], ["Y"]))
@@ -6669,6 +6683,9 @@ class TestWeightDistributionSemantics:
                 onnx.numpy_helper.from_array(np.zeros((4, 2), dtype=np.float32), name="X"),
             ],
         )
+        if combination == "where_runtime":
+            graph.input.append(helper.make_tensor_value_info("condition", TensorProto.BOOL, [2]))
+            del graph.initializer[1]
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
         model.ir_version = 8
         onnx.checker.check_model(model)
@@ -6684,6 +6701,52 @@ class TestWeightDistributionSemantics:
             sample["consumer_op"] == "MatMul" and sample["reason"] == "shape_dimensions_lineage"
             for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
         )
+
+    @pytest.mark.parametrize("malicious", [False, True])
+    @pytest.mark.parametrize("fill_first", [False, True])
+    @pytest.mark.parametrize("explicit_fill", [False, True])
+    def test_runtime_masks_with_shape_derived_fills_preserve_weight_analysis(
+        self, tmp_path: Path, malicious: bool, fill_first: bool, explicit_fill: bool
+    ) -> None:
+        weights = np.zeros((100, 10), dtype=np.float32)
+        if malicious:
+            weights[50:55, 3] = 10.0
+        fill = helper.make_node("ConstantOfShape", ["dimensions"], ["fill"])
+        if explicit_fill:
+            fill.attribute.append(
+                helper.make_attribute("value", onnx.numpy_helper.from_array(np.array([-1.0], dtype=np.float32)))
+            )
+        branches = ["fill", "hidden"] if fill_first else ["hidden", "fill"]
+        graph = helper.make_graph(
+            [
+                helper.make_node("MatMul", ["X", "W1"], ["hidden"]),
+                helper.make_node("Shape", ["hidden"], ["dimensions"]),
+                fill,
+                helper.make_node("Where", ["mask", *branches], ["masked"]),
+                helper.make_node("MatMul", ["masked", "W2"], ["Y"]),
+            ],
+            "runtime_activation_mask",
+            [
+                helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 100]),
+                helper.make_tensor_value_info("mask", TensorProto.BOOL, [1, 10]),
+            ],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 5])],
+            initializer=[
+                onnx.numpy_helper.from_array(weights, name="W1"),
+                onnx.numpy_helper.from_array(np.zeros((10, 5), dtype=np.float32), name="W2"),
+            ],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        path = tmp_path / "runtime-mask.onnx"
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        assert result.success is True
+        assert len(self._extreme_checks(result)) == int(malicious)
+        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
 
     @pytest.mark.parametrize("malicious", [False, True])
     def test_standard_einsum_weights_are_oriented_and_analyzed(self, tmp_path: Path, malicious: bool) -> None:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -6470,6 +6470,46 @@ class TestWeightDistributionSemantics:
         assert coverage[0].details["coverage_gap"] == "unresolved_initializer_lineage"
         assert coverage[0].status == CheckStatus.FAILED
 
+    @pytest.mark.parametrize("gather_dimensions", [False, True])
+    def test_dimensions_cast_to_weights_retain_incomplete_coverage(
+        self, tmp_path: Path, gather_dimensions: bool
+    ) -> None:
+        initializers = [onnx.numpy_helper.from_array(np.ones((2, 4), dtype=np.float32), name="source")]
+        nodes = [helper.make_node("Shape", ["source"], ["dimensions"])]
+        cast_input = "dimensions"
+        if gather_dimensions:
+            initializers.append(onnx.numpy_helper.from_array(np.array([0, 1], dtype=np.int64), name="indices"))
+            nodes.append(helper.make_node("Gather", ["dimensions", "indices"], ["selected"], axis=0))
+            cast_input = "selected"
+        nodes.extend(
+            [
+                helper.make_node("Cast", [cast_input], ["weights"], to=TensorProto.FLOAT),
+                helper.make_node("MatMul", ["X", "weights"], ["Y"]),
+            ]
+        )
+        graph = helper.make_graph(
+            nodes,
+            "dimension_weights",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 2])],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])],
+            initializer=initializers,
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        path = tmp_path / "dimension-weights.onnx"
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        assert result.success is False
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert coverage and all(check.status == CheckStatus.FAILED for check in coverage)
+        assert any(
+            sample["consumer_op"] == "MatMul" and sample["reason"] == "shape_dimensions_lineage"
+            for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+        )
+
     @pytest.mark.parametrize("malicious", [False, True])
     def test_standard_einsum_weights_are_oriented_and_analyzed(self, tmp_path: Path, malicious: bool) -> None:
         weights = np.zeros((100, 10), dtype=np.float32)

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -3783,6 +3783,7 @@ def test_onnx_scanner_transformed_non_scalar_clip_bound_fails_closed(tmp_path: P
     assert len(coverage_checks) == 1
     assert coverage_checks[0].details["coverage_gaps"] == {"unresolved_initializer_lineage": 1}
     samples = result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
+    assert {sample["initializer"] for sample in samples} == {"minimum_matrix"}
     assert {sample["reason"] for sample in samples} == {"invalid_clip_bound_shape"}
 
 


### PR DESCRIPTION
CRNN models use Shape/Gather dimensions for reshaping and recurrent state construction. Treating those dimensions as inherited floating-point weights incorrectly reports incomplete analysis.

Track numeric dimensions separately from shape-only control provenance. Standard index and recurrent-state roles avoid the false positive, while Shape, Size, reductions, normalization and unsupported operators retain coverage when shape effects can become numeric weights. Preserve actual weight values when shape and value paths meet. Remove the runtime-mask activation heuristic and its tracking sets.

Validation:

- 521 ONNX scanner tests passed, including benign and learned-weight detection controls, both matrix operand positions, and shape/index ownership. Seven new static regressions fail on the previous head and pass with this fix.
- Static replay of the pinned CRNN artifact at 3e3cceaf9c27b353b4085e44dd69f8fc15066049: 57/57 eligible weights analyzed, zero coverage gaps; current main reports eight lineage gaps on the identical artifact.
- Ruff and Linux-target mypy passed. Native macOS mypy retains five existing xattr errors.
- Required broad fast run: 11,848 passed and 11 skipped before the known Jinja YAML-routing failure, also reproduced on unchanged main 9631527b3e81e0458fe9e0242c3178af406bfa5f.

Arbitrary dimension arithmetic and uniform-fill runtime masks used as matrix data can still report incomplete analysis. This conservative limit preserves coverage in either operand position. The CRNN replay covers one pinned artifact; it does not establish complete analysis for every ONNX graph.
