### PR TITLE
fix: scan encoded pickle metadata within byte budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep published scan-result cache entries readable when concurrent or interrupted hits update access metadata.
 - Preserve macOS scan-result cache entries during unrelated temporary-file churn while rejecting replaced source files and directories.
 - Keep macOS scan-result caching enabled when hashing updates a model file's access time.
+- Scan all bounded encoded pickle metadata that fits the decoded-byte budget, avoiding incomplete PyTorch ZIP coverage on harmless small encoded tokens.
 
 ## [0.2.52](https://github.com/promptfoo/modelaudit/compare/v0.2.51...v0.2.52) (2026-07-22)
 

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -63,10 +63,12 @@ _JOBLIB_NUMPY_ARRAY_WRAPPER_SPAN_PROOF_MAX_BYTES = 10 * 1024 * 1024
 _PYTORCH_CONTAINER_EXTENSIONS = frozenset({".bin", ".pt", ".pth", ".ckpt", ".pkl"})
 _BASE64_TOKEN_RE = re.compile(rb"(?<![A-Za-z0-9+/=])[A-Za-z0-9+/]{10,}={0,2}(?![A-Za-z0-9+/=])")
 _HEX_TOKEN_RE = re.compile(rb"(?<![A-Fa-f0-9])[A-Fa-f0-9]{20,}(?![A-Fa-f0-9])")
+_ENCODED_TEXT_PREFIX_RE = re.compile(rb"(?i)\b(encoded|base64|hex)\s{0,32}[:=]\s{0,128}$")
 _IPV4_DOT_DIGIT_RE = re.compile(rb"\d\.\d")
 _LOCATION_POSITION_RE = re.compile(r"\(pos (?P<position>\d+)\)\s*$")
 _MAX_RAW_ENCODED_BYTES = 1024 * 1024
 _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES = 4096
+_ENCODED_TEXT_PREFIX_CONTEXT_BYTES = 256
 _CALL_TOKEN_SEPARATOR_SCAN_LIMIT_BYTES = 4096
 _MAX_RAW_CODE_LITERAL_VALIDATION_CHARS = 8192
 _MAX_PICKLE_LITERAL_URL_CONTEXT_CHARS = 16 * 1024
@@ -80,6 +82,37 @@ _PYTORCH_LEGACY_STREAM_COUNT = 5
 _PYTORCH_LEGACY_MAGIC_BINARY = _PYTORCH_LEGACY_MAGIC_NUMBER.to_bytes(10, "little")
 _PYTORCH_LEGACY_MAGIC_DECIMAL = str(_PYTORCH_LEGACY_MAGIC_NUMBER).encode("ascii")
 _PYTORCH_LEGACY_PREAMBLE_PROBE_BYTES = 128
+
+
+def _encoded_token_decoded_size(encoding: str, token: bytes) -> int | None:
+    if encoding == "hex":
+        return len(token) // 2 if len(token) % 2 == 0 else None
+
+    stripped = token.rstrip(b"=")
+    if b"=" in stripped:
+        return None
+    explicit_padding = len(token) - len(stripped)
+    stripped_remainder = len(stripped) % 4
+    if stripped_remainder == 1:
+        return None
+
+    if explicit_padding:
+        if len(token) % 4 != 0 or explicit_padding != 4 - stripped_remainder:
+            return None
+        padding = explicit_padding
+    else:
+        padding = (4 - stripped_remainder) % 4
+    return ((len(stripped) + padding) // 4 * 3) - padding
+
+
+def _encoded_text_prefix_encoding(data: bytes, match: re.Match[bytes]) -> str | None:
+    context_start = max(0, match.start() - _ENCODED_TEXT_PREFIX_CONTEXT_BYTES)
+    prefix_match = _ENCODED_TEXT_PREFIX_RE.search(data[context_start : match.start()])
+    if prefix_match is None:
+        return None
+    return prefix_match.group(1).decode("ascii").lower()
+
+
 _PYTORCH_LEGACY_INITIAL_LAYOUT_PROBE_BYTES = 512
 _PYTORCH_LEGACY_SYS_INFO_KEYS = frozenset({"protocol_version", "little_endian", "type_sizes"})
 _PYTORCH_LEGACY_MAX_CONTROL_BYTES = 10 * 1024 * 1024
@@ -4670,25 +4703,36 @@ class PickleScanner(BaseScanner):
         limit_type: str,
         decoded_tokens_analyzed: int,
         decoded_budget: int,
+        *,
+        skipped_decoded_bytes_accounted: int = 0,
+        skipped_tokens_accounted: int = 0,
     ) -> None:
         reason = "pickle_encoded_text_scan_limit_exceeded"
         mark_inconclusive_scan_result(result, reason)
         result.metadata[reason] = True
+        details: dict[str, Any] = {
+            "encoding": encoding,
+            "limit_type": limit_type,
+            "tokens_analyzed": decoded_tokens_analyzed,
+            "decoded_bytes_analyzed": _MAX_RAW_ENCODED_BYTES - decoded_budget,
+            "max_decoded_bytes": _MAX_RAW_ENCODED_BYTES,
+            "analysis_incomplete": True,
+            "scan_outcome_reason": reason,
+        }
+        if skipped_tokens_accounted:
+            details.update(
+                {
+                    "skipped_tokens_accounted": skipped_tokens_accounted,
+                    "skipped_decoded_bytes_accounted": skipped_decoded_bytes_accounted,
+                }
+            )
         result.add_check(
             name="Pickle Encoded Text Coverage",
             passed=False,
             message=f"{encoding} encoded-text analysis exceeded its bounded {limit_type} limit",
             severity=IssueSeverity.INFO,
             location=source,
-            details={
-                "encoding": encoding,
-                "limit_type": limit_type,
-                "tokens_analyzed": decoded_tokens_analyzed,
-                "decoded_bytes_analyzed": _MAX_RAW_ENCODED_BYTES - decoded_budget,
-                "max_decoded_bytes": _MAX_RAW_ENCODED_BYTES,
-                "analysis_incomplete": True,
-                "scan_outcome_reason": reason,
-            },
+            details=details,
             rule_code="S902",
         )
         result.finish(success=False)
@@ -4703,21 +4747,74 @@ class PickleScanner(BaseScanner):
     ) -> None:
         for encoding, token_pattern in (("base64", _BASE64_TOKEN_RE), ("hex", _HEX_TOKEN_RE)):
             seen_tokens: set[bytes] = set()
+            analyzed_tokens: set[bytes] = set()
+            seen_prefixed_tokens: set[bytes] = set()
             decoded_budget = _MAX_RAW_ENCODED_BYTES
+            skipped_decoded_budget = _MAX_RAW_ENCODED_BYTES
             decoded_token_count = 0
+            skipped_token_count = 0
+            skipped_limit_reported = False
             for match in token_pattern.finditer(data):
                 token = match.group(0)
-                if encoding == "base64" and len(token) % 2 == 0 and _HEX_TOKEN_RE.fullmatch(token) is not None:
+                prefix_encoding = _encoded_text_prefix_encoding(data, match)
+                if (
+                    encoding == "base64"
+                    and prefix_encoding != "base64"
+                    and len(token) % 2 == 0
+                    and _HEX_TOKEN_RE.fullmatch(token) is not None
+                ):
                     continue
-                if token in seen_tokens:
-                    continue
-                seen_tokens.add(token)
+                if prefix_encoding is None:
+                    if token in seen_tokens:
+                        continue
+                    seen_tokens.add(token)
+                else:
+                    if token in seen_prefixed_tokens:
+                        continue
+                    if token in analyzed_tokens:
+                        continue
+                    seen_prefixed_tokens.add(token)
+                    seen_tokens.add(token)
                 has_seed = (
                     any(seed in token for seed in _BASE64_CODE_EXECUTION_SEEDS)
                     if encoding == "base64"
                     else _hex_token_has_execution_seed(token)
                 )
                 if len(token) > _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES and not has_seed:
+                    if prefix_encoding is None:
+                        continue
+                    decoded_size = _encoded_token_decoded_size(encoding, token)
+                    if decoded_size is not None:
+                        if decoded_size > skipped_decoded_budget:
+                            if not skipped_limit_reported:
+                                self._mark_encoded_text_scan_limit(
+                                    result,
+                                    source,
+                                    encoding,
+                                    "decoded_byte",
+                                    decoded_token_count,
+                                    decoded_budget,
+                                    skipped_tokens_accounted=skipped_token_count + 1,
+                                    skipped_decoded_bytes_accounted=(
+                                        _MAX_RAW_ENCODED_BYTES - skipped_decoded_budget + decoded_size
+                                    ),
+                                )
+                                skipped_limit_reported = True
+                            continue
+                        skipped_token_count += 1
+                        skipped_decoded_budget -= decoded_size
+                        if skipped_decoded_budget == 0 and not skipped_limit_reported:
+                            self._mark_encoded_text_scan_limit(
+                                result,
+                                source,
+                                encoding,
+                                "decoded_byte",
+                                decoded_token_count,
+                                decoded_budget,
+                                skipped_tokens_accounted=skipped_token_count,
+                                skipped_decoded_bytes_accounted=(_MAX_RAW_ENCODED_BYTES - skipped_decoded_budget),
+                            )
+                            skipped_limit_reported = True
                     continue
 
                 try:
@@ -4739,6 +4836,7 @@ class PickleScanner(BaseScanner):
                     break
                 decoded_token_count += 1
                 decoded_budget -= len(decoded)
+                analyzed_tokens.add(token)
                 decoded_scan_data = _inert_literal_url_stripped_scan_view(decoded) if allow_url_filtering else decoded
                 decoded_lower = decoded_scan_data.lower()
                 for pattern, label in _ENCODED_CODE_EXECUTION_PATTERNS:

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -66,11 +66,12 @@ _HEX_TOKEN_RE = re.compile(rb"(?<![A-Fa-f0-9])[A-Fa-f0-9]{20,}(?![A-Fa-f0-9])")
 _ENCODED_TEXT_PREFIX_RE = re.compile(rb"(?i)\b(encoded|base64|hex)\s{0,32}[:=]\s{0,128}$")
 _IPV4_DOT_DIGIT_RE = re.compile(rb"\d\.\d")
 _LOCATION_POSITION_RE = re.compile(r"\(pos (?P<position>\d+)\)\s*$")
+_MAX_RAW_ENCODED_TOKENS = 4096
 _MAX_RAW_ENCODED_BYTES = 1024 * 1024
 _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES = 4096
 _MAX_RAW_ENCODED_POST_LIMIT_BYTES = _MAX_RAW_ENCODED_BYTES
+_MAX_UNPREFIXED_SEEDLESS_ENCODED_TOKENS = 64
 _ENCODED_TEXT_SAMPLE_DECODED_BYTES = 512
-_MIN_ENCODED_TEXT_SAMPLE_PRINTABLE_RATIO = 0.85
 _ENCODED_TEXT_PREFIX_CONTEXT_BYTES = 256
 _CALL_TOKEN_SEPARATOR_SCAN_LIMIT_BYTES = 4096
 _MAX_RAW_CODE_LITERAL_VALIDATION_CHARS = 8192
@@ -147,18 +148,6 @@ def _encoded_token_decode(encoding: str, token: bytes) -> bytes | None:
     except (binascii.Error, ValueError):
         return None
     return None
-
-
-def _decoded_bytes_look_textual(data: bytes) -> bool:
-    if not data:
-        return False
-    printable = sum(byte in b"\t\n\r" or 32 <= byte < 127 for byte in data)
-    return printable / len(data) >= _MIN_ENCODED_TEXT_SAMPLE_PRINTABLE_RATIO
-
-
-def _unprefixed_seedless_encoded_token_looks_textual(encoding: str, token: bytes) -> bool:
-    decoded = _encoded_token_decode(encoding, token)
-    return decoded is not None and _decoded_bytes_look_textual(decoded)
 
 
 def _encoded_token_decoded_sample_has_execution_pattern(encoding: str, token: bytes) -> bool:
@@ -4762,6 +4751,7 @@ class PickleScanner(BaseScanner):
         *,
         skipped_decoded_bytes_accounted: int = 0,
         skipped_tokens_accounted: int = 0,
+        max_tokens: int = _MAX_RAW_ENCODED_TOKENS,
     ) -> None:
         reason = "pickle_encoded_text_scan_limit_exceeded"
         mark_inconclusive_scan_result(result, reason)
@@ -4775,6 +4765,8 @@ class PickleScanner(BaseScanner):
             "analysis_incomplete": True,
             "scan_outcome_reason": reason,
         }
+        if limit_type == "token":
+            details["max_tokens"] = max_tokens
         if skipped_tokens_accounted:
             details.update(
                 {
@@ -4814,7 +4806,11 @@ class PickleScanner(BaseScanner):
             decoded_token_count = 0
             skipped_token_count = 0
             skipped_limit_reported = False
+            unprefixed_seedless_token_count = 0
+            unprefixed_seedless_decoded_bytes = 0
             for match in token_pattern.finditer(data):
+                if skipped_limit_reported and post_limit_decoded_budget <= 0:
+                    break
                 token = match.group(0)
                 prefix_encoding = _encoded_text_prefix_encoding(data, match)
                 if (
@@ -4841,24 +4837,92 @@ class PickleScanner(BaseScanner):
                     else _hex_token_has_execution_seed(token)
                 )
                 decoded_size = _encoded_token_decoded_size(encoding, token)
+                if decoded_size is None:
+                    continue
                 seedless_budget_already_accounted = False
                 seedless_budget_overflow_reported = False
-                seedless_sample_has_execution_pattern = False
-                if len(token) > _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES and not has_seed:
-                    if decoded_size is None:
-                        continue
-                    if prefix_encoding is None and not _unprefixed_seedless_encoded_token_looks_textual(
-                        encoding, token
+                seedless_sample_has_execution_pattern = (
+                    len(token) > _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES
+                    and not has_seed
+                    and _encoded_token_decoded_sample_has_execution_pattern(encoding, token)
+                )
+                is_oversized_seedless_token = len(token) > _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES and not has_seed
+                if (
+                    is_oversized_seedless_token
+                    and prefix_encoding is None
+                    and not seedless_sample_has_execution_pattern
+                ):
+                    unprefixed_seedless_token_count += 1
+                    unprefixed_seedless_decoded_bytes += decoded_size
+                    if not skipped_limit_reported and (
+                        unprefixed_seedless_token_count > _MAX_UNPREFIXED_SEEDLESS_ENCODED_TOKENS
+                        or (
+                            unprefixed_seedless_token_count + decoded_token_count
+                            > _MAX_UNPREFIXED_SEEDLESS_ENCODED_TOKENS
+                        )
                     ):
-                        continue
+                        self._mark_encoded_text_scan_limit(
+                            result,
+                            source,
+                            encoding,
+                            "token",
+                            decoded_token_count,
+                            decoded_budget,
+                            skipped_tokens_accounted=unprefixed_seedless_token_count,
+                            skipped_decoded_bytes_accounted=unprefixed_seedless_decoded_bytes,
+                            max_tokens=_MAX_UNPREFIXED_SEEDLESS_ENCODED_TOKENS,
+                        )
+                        skipped_limit_reported = True
+                    continue
+
+                if (
+                    not skipped_limit_reported
+                    and unprefixed_seedless_token_count
+                    and unprefixed_seedless_token_count + decoded_token_count + 1
+                    > _MAX_UNPREFIXED_SEEDLESS_ENCODED_TOKENS
+                ):
+                    self._mark_encoded_text_scan_limit(
+                        result,
+                        source,
+                        encoding,
+                        "token",
+                        decoded_token_count,
+                        decoded_budget,
+                        skipped_tokens_accounted=unprefixed_seedless_token_count,
+                        skipped_decoded_bytes_accounted=unprefixed_seedless_decoded_bytes,
+                        max_tokens=_MAX_UNPREFIXED_SEEDLESS_ENCODED_TOKENS,
+                    )
+                    skipped_limit_reported = True
+
+                if not skipped_limit_reported and decoded_token_count >= _MAX_RAW_ENCODED_TOKENS:
+                    self._mark_encoded_text_scan_limit(
+                        result,
+                        source,
+                        encoding,
+                        "token",
+                        decoded_token_count,
+                        decoded_budget,
+                        skipped_tokens_accounted=skipped_token_count,
+                        skipped_decoded_bytes_accounted=skipped_decoded_bytes_accounted,
+                    )
+                    skipped_limit_reported = True
+
+                if not skipped_limit_reported and accounted_decoded_budget == 0:
+                    self._mark_encoded_text_scan_limit(
+                        result,
+                        source,
+                        encoding,
+                        "decoded_byte",
+                        decoded_token_count,
+                        decoded_budget,
+                        skipped_tokens_accounted=skipped_token_count,
+                        skipped_decoded_bytes_accounted=skipped_decoded_bytes_accounted,
+                    )
+                    skipped_limit_reported = True
+
+                if is_oversized_seedless_token:
                     seedless_budget_already_accounted = token in accounted_seedless_tokens
                     seedless_budget_overflow_reported = token in over_budget_seedless_tokens
-                    if prefix_encoding is not None and (
-                        skipped_limit_reported or seedless_budget_already_accounted or seedless_budget_overflow_reported
-                    ):
-                        seedless_sample_has_execution_pattern = _encoded_token_decoded_sample_has_execution_pattern(
-                            encoding, token
-                        )
                     if skipped_limit_reported and (prefix_encoding is None or decoded_size > post_limit_decoded_budget):
                         continue
                     if (
@@ -4886,23 +4950,9 @@ class PickleScanner(BaseScanner):
                             if prefix_encoding is None or decoded_size > post_limit_decoded_budget:
                                 continue
                         else:
-                            skipped_token_count += 1
-                            skipped_decoded_bytes_accounted = attempted_skipped_decoded_bytes
                             accounted_decoded_budget -= decoded_size
                             accounted_seedless_tokens.add(token)
-                            if accounted_decoded_budget == 0:
-                                self._mark_encoded_text_scan_limit(
-                                    result,
-                                    source,
-                                    encoding,
-                                    "decoded_byte",
-                                    decoded_token_count,
-                                    decoded_budget,
-                                    skipped_tokens_accounted=skipped_token_count,
-                                    skipped_decoded_bytes_accounted=skipped_decoded_bytes_accounted,
-                                )
-                                skipped_limit_reported = True
-                            continue
+                            seedless_budget_already_accounted = True
 
                 if skipped_limit_reported:
                     if decoded_size is None or decoded_size > post_limit_decoded_budget:

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -65,7 +65,6 @@ _BASE64_TOKEN_RE = re.compile(rb"(?<![A-Za-z0-9+/=])[A-Za-z0-9+/]{10,}={0,2}(?![
 _HEX_TOKEN_RE = re.compile(rb"(?<![A-Fa-f0-9])[A-Fa-f0-9]{20,}(?![A-Fa-f0-9])")
 _IPV4_DOT_DIGIT_RE = re.compile(rb"\d\.\d")
 _LOCATION_POSITION_RE = re.compile(r"\(pos (?P<position>\d+)\)\s*$")
-_MAX_RAW_ENCODED_TOKENS = 64
 _MAX_RAW_ENCODED_BYTES = 1024 * 1024
 _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES = 4096
 _CALL_TOKEN_SEPARATOR_SCAN_LIMIT_BYTES = 4096
@@ -4669,7 +4668,7 @@ class PickleScanner(BaseScanner):
         source: str,
         encoding: str,
         limit_type: str,
-        tokens_analyzed: int,
+        decoded_tokens_analyzed: int,
         decoded_budget: int,
     ) -> None:
         reason = "pickle_encoded_text_scan_limit_exceeded"
@@ -4684,8 +4683,7 @@ class PickleScanner(BaseScanner):
             details={
                 "encoding": encoding,
                 "limit_type": limit_type,
-                "tokens_analyzed": tokens_analyzed,
-                "max_tokens": _MAX_RAW_ENCODED_TOKENS,
+                "tokens_analyzed": decoded_tokens_analyzed,
                 "decoded_bytes_analyzed": _MAX_RAW_ENCODED_BYTES - decoded_budget,
                 "max_decoded_bytes": _MAX_RAW_ENCODED_BYTES,
                 "analysis_incomplete": True,
@@ -4706,18 +4704,14 @@ class PickleScanner(BaseScanner):
         for encoding, token_pattern in (("base64", _BASE64_TOKEN_RE), ("hex", _HEX_TOKEN_RE)):
             seen_tokens: set[bytes] = set()
             decoded_budget = _MAX_RAW_ENCODED_BYTES
-            token_count = 0
+            decoded_token_count = 0
             for match in token_pattern.finditer(data):
                 token = match.group(0)
                 if encoding == "base64" and len(token) % 2 == 0 and _HEX_TOKEN_RE.fullmatch(token) is not None:
                     continue
                 if token in seen_tokens:
                     continue
-                if token_count >= _MAX_RAW_ENCODED_TOKENS:
-                    self._mark_encoded_text_scan_limit(result, source, encoding, "token", token_count, decoded_budget)
-                    break
                 seen_tokens.add(token)
-                token_count += 1
                 has_seed = (
                     any(seed in token for seed in _BASE64_CODE_EXECUTION_SEEDS)
                     if encoding == "base64"
@@ -4740,9 +4734,10 @@ class PickleScanner(BaseScanner):
                     continue
                 if len(decoded) > decoded_budget:
                     self._mark_encoded_text_scan_limit(
-                        result, source, encoding, "decoded_byte", token_count, decoded_budget
+                        result, source, encoding, "decoded_byte", decoded_token_count, decoded_budget
                     )
                     break
+                decoded_token_count += 1
                 decoded_budget -= len(decoded)
                 decoded_scan_data = _inert_literal_url_stripped_scan_view(decoded) if allow_url_filtering else decoded
                 decoded_lower = decoded_scan_data.lower()

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -68,6 +68,7 @@ _IPV4_DOT_DIGIT_RE = re.compile(rb"\d\.\d")
 _LOCATION_POSITION_RE = re.compile(r"\(pos (?P<position>\d+)\)\s*$")
 _MAX_RAW_ENCODED_BYTES = 1024 * 1024
 _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES = 4096
+_MAX_RAW_ENCODED_POST_LIMIT_BYTES = _MAX_RAW_ENCODED_BYTES
 _ENCODED_TEXT_PREFIX_CONTEXT_BYTES = 256
 _CALL_TOKEN_SEPARATOR_SCAN_LIMIT_BYTES = 4096
 _MAX_RAW_CODE_LITERAL_VALIDATION_CHARS = 8192
@@ -4750,7 +4751,9 @@ class PickleScanner(BaseScanner):
             analyzed_tokens: set[bytes] = set()
             seen_prefixed_tokens: set[bytes] = set()
             decoded_budget = _MAX_RAW_ENCODED_BYTES
-            skipped_decoded_budget = _MAX_RAW_ENCODED_BYTES
+            accounted_decoded_budget = _MAX_RAW_ENCODED_BYTES
+            skipped_decoded_bytes_accounted = 0
+            post_limit_decoded_budget = _MAX_RAW_ENCODED_POST_LIMIT_BYTES
             decoded_token_count = 0
             skipped_token_count = 0
             skipped_limit_reported = False
@@ -4780,30 +4783,33 @@ class PickleScanner(BaseScanner):
                     if encoding == "base64"
                     else _hex_token_has_execution_seed(token)
                 )
+                decoded_size = _encoded_token_decoded_size(encoding, token)
                 if len(token) > _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES and not has_seed:
-                    if prefix_encoding is None:
+                    if prefix_encoding is None or decoded_size is None:
                         continue
-                    decoded_size = _encoded_token_decoded_size(encoding, token)
-                    if decoded_size is not None:
-                        if decoded_size > skipped_decoded_budget:
-                            if not skipped_limit_reported:
-                                self._mark_encoded_text_scan_limit(
-                                    result,
-                                    source,
-                                    encoding,
-                                    "decoded_byte",
-                                    decoded_token_count,
-                                    decoded_budget,
-                                    skipped_tokens_accounted=skipped_token_count + 1,
-                                    skipped_decoded_bytes_accounted=(
-                                        _MAX_RAW_ENCODED_BYTES - skipped_decoded_budget + decoded_size
-                                    ),
-                                )
-                                skipped_limit_reported = True
+                    if skipped_limit_reported:
+                        continue
+                    attempted_skipped_decoded_bytes = skipped_decoded_bytes_accounted + decoded_size
+                    if decoded_size > accounted_decoded_budget:
+                        if not skipped_limit_reported:
+                            self._mark_encoded_text_scan_limit(
+                                result,
+                                source,
+                                encoding,
+                                "decoded_byte",
+                                decoded_token_count,
+                                decoded_budget,
+                                skipped_tokens_accounted=skipped_token_count + 1,
+                                skipped_decoded_bytes_accounted=attempted_skipped_decoded_bytes,
+                            )
+                            skipped_limit_reported = True
+                        if decoded_size > post_limit_decoded_budget:
                             continue
+                    else:
                         skipped_token_count += 1
-                        skipped_decoded_budget -= decoded_size
-                        if skipped_decoded_budget == 0 and not skipped_limit_reported:
+                        skipped_decoded_bytes_accounted = attempted_skipped_decoded_bytes
+                        accounted_decoded_budget -= decoded_size
+                        if accounted_decoded_budget == 0 and not skipped_limit_reported:
                             self._mark_encoded_text_scan_limit(
                                 result,
                                 source,
@@ -4812,10 +4818,28 @@ class PickleScanner(BaseScanner):
                                 decoded_token_count,
                                 decoded_budget,
                                 skipped_tokens_accounted=skipped_token_count,
-                                skipped_decoded_bytes_accounted=(_MAX_RAW_ENCODED_BYTES - skipped_decoded_budget),
+                                skipped_decoded_bytes_accounted=skipped_decoded_bytes_accounted,
                             )
                             skipped_limit_reported = True
-                    continue
+                        continue
+
+                if skipped_limit_reported:
+                    if decoded_size is None or decoded_size > post_limit_decoded_budget:
+                        continue
+                elif decoded_size is not None and decoded_size > accounted_decoded_budget:
+                    self._mark_encoded_text_scan_limit(
+                        result,
+                        source,
+                        encoding,
+                        "decoded_byte",
+                        decoded_token_count,
+                        decoded_budget,
+                        skipped_tokens_accounted=skipped_token_count,
+                        skipped_decoded_bytes_accounted=skipped_decoded_bytes_accounted,
+                    )
+                    skipped_limit_reported = True
+                    if decoded_size > post_limit_decoded_budget:
+                        continue
 
                 try:
                     if encoding == "base64":
@@ -4829,13 +4853,12 @@ class PickleScanner(BaseScanner):
                     continue
                 if not decoded:
                     continue
-                if len(decoded) > decoded_budget:
-                    self._mark_encoded_text_scan_limit(
-                        result, source, encoding, "decoded_byte", decoded_token_count, decoded_budget
-                    )
-                    break
-                decoded_token_count += 1
-                decoded_budget -= len(decoded)
+                if skipped_limit_reported:
+                    post_limit_decoded_budget -= len(decoded)
+                else:
+                    decoded_token_count += 1
+                    decoded_budget -= len(decoded)
+                    accounted_decoded_budget -= len(decoded)
                 analyzed_tokens.add(token)
                 decoded_scan_data = _inert_literal_url_stripped_scan_view(decoded) if allow_url_filtering else decoded
                 decoded_lower = decoded_scan_data.lower()

--- a/modelaudit/scanners/pickle_scanner.py
+++ b/modelaudit/scanners/pickle_scanner.py
@@ -69,6 +69,8 @@ _LOCATION_POSITION_RE = re.compile(r"\(pos (?P<position>\d+)\)\s*$")
 _MAX_RAW_ENCODED_BYTES = 1024 * 1024
 _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES = 4096
 _MAX_RAW_ENCODED_POST_LIMIT_BYTES = _MAX_RAW_ENCODED_BYTES
+_ENCODED_TEXT_SAMPLE_DECODED_BYTES = 512
+_MIN_ENCODED_TEXT_SAMPLE_PRINTABLE_RATIO = 0.85
 _ENCODED_TEXT_PREFIX_CONTEXT_BYTES = 256
 _CALL_TOKEN_SEPARATOR_SCAN_LIMIT_BYTES = 4096
 _MAX_RAW_CODE_LITERAL_VALIDATION_CHARS = 8192
@@ -112,6 +114,59 @@ def _encoded_text_prefix_encoding(data: bytes, match: re.Match[bytes]) -> str | 
     if prefix_match is None:
         return None
     return prefix_match.group(1).decode("ascii").lower()
+
+
+def _encoded_token_decoded_sample(encoding: str, token: bytes) -> bytes | None:
+    if encoding == "hex":
+        sample_token = token[: _ENCODED_TEXT_SAMPLE_DECODED_BYTES * 2]
+        if len(sample_token) % 2:
+            sample_token = sample_token[:-1]
+        try:
+            return binascii.unhexlify(sample_token)
+        except (binascii.Error, ValueError):
+            return None
+    else:
+        sample_token = token[: ((_ENCODED_TEXT_SAMPLE_DECODED_BYTES + 2) // 3 * 4)]
+        sample_token = sample_token.rstrip(b"=")
+        if len(sample_token) % 4 == 1:
+            sample_token = sample_token[:-1]
+        padding = b"=" * ((4 - len(sample_token) % 4) % 4)
+        try:
+            return base64.b64decode(sample_token + padding, validate=True)
+        except (binascii.Error, ValueError):
+            return None
+
+
+def _encoded_token_decode(encoding: str, token: bytes) -> bytes | None:
+    try:
+        if encoding == "base64":
+            padded_token = token + (b"=" * ((4 - (len(token) % 4)) % 4))
+            return base64.b64decode(padded_token, validate=True)
+        if len(token) % 2 == 0:
+            return binascii.unhexlify(token)
+    except (binascii.Error, ValueError):
+        return None
+    return None
+
+
+def _decoded_bytes_look_textual(data: bytes) -> bool:
+    if not data:
+        return False
+    printable = sum(byte in b"\t\n\r" or 32 <= byte < 127 for byte in data)
+    return printable / len(data) >= _MIN_ENCODED_TEXT_SAMPLE_PRINTABLE_RATIO
+
+
+def _unprefixed_seedless_encoded_token_looks_textual(encoding: str, token: bytes) -> bool:
+    decoded = _encoded_token_decode(encoding, token)
+    return decoded is not None and _decoded_bytes_look_textual(decoded)
+
+
+def _encoded_token_decoded_sample_has_execution_pattern(encoding: str, token: bytes) -> bool:
+    sample = _encoded_token_decoded_sample(encoding, token)
+    if not sample:
+        return False
+    sample_lower = sample.lower()
+    return any(pattern in sample_lower for pattern, _ in _ENCODED_CODE_EXECUTION_PATTERNS)
 
 
 _PYTORCH_LEGACY_INITIAL_LAYOUT_PROBE_BYTES = 512
@@ -4749,6 +4804,8 @@ class PickleScanner(BaseScanner):
         for encoding, token_pattern in (("base64", _BASE64_TOKEN_RE), ("hex", _HEX_TOKEN_RE)):
             seen_tokens: set[bytes] = set()
             analyzed_tokens: set[bytes] = set()
+            accounted_seedless_tokens: set[bytes] = set()
+            over_budget_seedless_tokens: set[bytes] = set()
             seen_prefixed_tokens: set[bytes] = set()
             decoded_budget = _MAX_RAW_ENCODED_BYTES
             accounted_decoded_budget = _MAX_RAW_ENCODED_BYTES
@@ -4784,14 +4841,36 @@ class PickleScanner(BaseScanner):
                     else _hex_token_has_execution_seed(token)
                 )
                 decoded_size = _encoded_token_decoded_size(encoding, token)
+                seedless_budget_already_accounted = False
+                seedless_budget_overflow_reported = False
+                seedless_sample_has_execution_pattern = False
                 if len(token) > _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES and not has_seed:
-                    if prefix_encoding is None or decoded_size is None:
+                    if decoded_size is None:
                         continue
-                    if skipped_limit_reported:
+                    if prefix_encoding is None and not _unprefixed_seedless_encoded_token_looks_textual(
+                        encoding, token
+                    ):
+                        continue
+                    seedless_budget_already_accounted = token in accounted_seedless_tokens
+                    seedless_budget_overflow_reported = token in over_budget_seedless_tokens
+                    if prefix_encoding is not None and (
+                        skipped_limit_reported or seedless_budget_already_accounted or seedless_budget_overflow_reported
+                    ):
+                        seedless_sample_has_execution_pattern = _encoded_token_decoded_sample_has_execution_pattern(
+                            encoding, token
+                        )
+                    if skipped_limit_reported and (prefix_encoding is None or decoded_size > post_limit_decoded_budget):
+                        continue
+                    if (
+                        skipped_limit_reported
+                        and not seedless_budget_already_accounted
+                        and not seedless_budget_overflow_reported
+                        and not seedless_sample_has_execution_pattern
+                    ):
                         continue
                     attempted_skipped_decoded_bytes = skipped_decoded_bytes_accounted + decoded_size
-                    if decoded_size > accounted_decoded_budget:
-                        if not skipped_limit_reported:
+                    if not skipped_limit_reported and not seedless_budget_already_accounted:
+                        if decoded_size > accounted_decoded_budget:
                             self._mark_encoded_text_scan_limit(
                                 result,
                                 source,
@@ -4803,30 +4882,36 @@ class PickleScanner(BaseScanner):
                                 skipped_decoded_bytes_accounted=attempted_skipped_decoded_bytes,
                             )
                             skipped_limit_reported = True
-                        if decoded_size > post_limit_decoded_budget:
+                            over_budget_seedless_tokens.add(token)
+                            if prefix_encoding is None or decoded_size > post_limit_decoded_budget:
+                                continue
+                        else:
+                            skipped_token_count += 1
+                            skipped_decoded_bytes_accounted = attempted_skipped_decoded_bytes
+                            accounted_decoded_budget -= decoded_size
+                            accounted_seedless_tokens.add(token)
+                            if accounted_decoded_budget == 0:
+                                self._mark_encoded_text_scan_limit(
+                                    result,
+                                    source,
+                                    encoding,
+                                    "decoded_byte",
+                                    decoded_token_count,
+                                    decoded_budget,
+                                    skipped_tokens_accounted=skipped_token_count,
+                                    skipped_decoded_bytes_accounted=skipped_decoded_bytes_accounted,
+                                )
+                                skipped_limit_reported = True
                             continue
-                    else:
-                        skipped_token_count += 1
-                        skipped_decoded_bytes_accounted = attempted_skipped_decoded_bytes
-                        accounted_decoded_budget -= decoded_size
-                        if accounted_decoded_budget == 0 and not skipped_limit_reported:
-                            self._mark_encoded_text_scan_limit(
-                                result,
-                                source,
-                                encoding,
-                                "decoded_byte",
-                                decoded_token_count,
-                                decoded_budget,
-                                skipped_tokens_accounted=skipped_token_count,
-                                skipped_decoded_bytes_accounted=skipped_decoded_bytes_accounted,
-                            )
-                            skipped_limit_reported = True
-                        continue
 
                 if skipped_limit_reported:
                     if decoded_size is None or decoded_size > post_limit_decoded_budget:
                         continue
-                elif decoded_size is not None and decoded_size > accounted_decoded_budget:
+                elif (
+                    not seedless_budget_already_accounted
+                    and decoded_size is not None
+                    and decoded_size > accounted_decoded_budget
+                ):
                     self._mark_encoded_text_scan_limit(
                         result,
                         source,
@@ -4841,24 +4926,19 @@ class PickleScanner(BaseScanner):
                     if decoded_size > post_limit_decoded_budget:
                         continue
 
-                try:
-                    if encoding == "base64":
-                        padded_token = token + (b"=" * ((4 - (len(token) % 4)) % 4))
-                        decoded = base64.b64decode(padded_token, validate=True)
-                    elif len(token) % 2 == 0:
-                        decoded = binascii.unhexlify(token)
-                    else:
-                        continue
-                except (binascii.Error, ValueError):
+                decoded = _encoded_token_decode(encoding, token)
+                if decoded is None:
                     continue
                 if not decoded:
                     continue
                 if skipped_limit_reported:
-                    post_limit_decoded_budget -= len(decoded)
+                    if not seedless_budget_already_accounted:
+                        post_limit_decoded_budget -= len(decoded)
                 else:
                     decoded_token_count += 1
                     decoded_budget -= len(decoded)
-                    accounted_decoded_budget -= len(decoded)
+                    if not seedless_budget_already_accounted:
+                        accounted_decoded_budget -= len(decoded)
                 analyzed_tokens.add(token)
                 decoded_scan_data = _inert_literal_url_stripped_scan_view(decoded) if allow_url_filtering else decoded
                 decoded_lower = decoded_scan_data.lower()

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -23,7 +23,9 @@ from modelaudit.scanners.base import INCONCLUSIVE_SCAN_OUTCOME, CheckStatus, Iss
 from modelaudit.scanners.joblib_scanner import JoblibScanner
 from modelaudit.scanners.pickle_scanner import (
     _BINARY_TAIL_SCAN_BYTES,
+    _ENCODED_TEXT_SAMPLE_DECODED_BYTES,
     _MAX_RAW_ENCODED_BYTES,
+    _MAX_RAW_ENCODED_POST_LIMIT_BYTES,
     _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES,
     ALWAYS_DANGEROUS_FUNCTIONS,
     ALWAYS_DANGEROUS_MODULES,
@@ -1606,6 +1608,180 @@ def test_scan_stream_late_shifted_encoded_payload_after_seedless_budget_limit_st
     payload = pickle.dumps([*skipped_values, f"encoded:{shifted_payload}"], protocol=4)
 
     result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="late-shifted-base64.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.rule_code == "S604"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("encoding") == "base64"
+        and check.details.get("pattern") == "os.system"
+        for check in result.checks
+    )
+
+
+def test_scan_stream_unprefixed_seedless_oversized_tokens_share_decoded_budget() -> None:
+    decoded_size = _MAX_RAW_ENCODED_BYTES // 8
+    values = []
+    for index in range(8):
+        prefix = f"benign unprefixed token {index}:".encode()
+        values.append(base64.b64encode(prefix + (b"a" * (decoded_size - len(prefix)))).decode())
+    payload = pickle.dumps(values, protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="unprefixed-budget-base64.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    coverage_checks = [check for check in result.checks if check.rule_code == "S902"]
+    assert any(
+        check.details.get("encoding") == "base64"
+        and check.details.get("skipped_tokens_accounted") == 8
+        and check.details.get("skipped_decoded_bytes_accounted") == _MAX_RAW_ENCODED_BYTES
+        for check in coverage_checks
+    )
+
+
+@pytest.mark.parametrize("encoding", ["base64", "hex"])
+def test_scan_stream_unprefixed_encoded_binary_with_text_header_is_not_encoded_text(encoding: str) -> None:
+    def encode(value: bytes) -> str:
+        return base64.b64encode(value).decode("ascii") if encoding == "base64" else value.hex()
+
+    decoded_size = _MAX_RAW_ENCODED_BYTES // 8
+    values = []
+    for index in range(8):
+        prefix = f"printable-header-{index}:".encode() + (b"a" * _ENCODED_TEXT_SAMPLE_DECODED_BYTES)
+        values.append(encode(prefix + (b"\x00" * (decoded_size - len(prefix)))))
+    payload = pickle.dumps(values, protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source=f"encoded-binary-{encoding}.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" not in result.metadata.get("scan_outcome_reasons", [])
+
+
+def test_scan_stream_prefixed_duplicate_after_unprefixed_oversized_token_does_not_double_charge_budget() -> None:
+    decoded_size = (_MAX_RAW_ENCODED_BYTES // 2) + 1
+    encoded = base64.b64encode(b"a" * decoded_size).decode()
+    payload = pickle.dumps([encoded, f"encoded:{encoded}"], protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="prefixed-accounted-duplicate.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" not in result.metadata.get("scan_outcome_reasons", [])
+
+
+def test_scan_stream_large_prefixed_shifted_payload_after_seedless_budget_limit_stays_actionable() -> None:
+    skipped_values = [
+        base64.b64encode(f"benign unprefixed token {index}:".encode() + (b"a" * (_MAX_RAW_ENCODED_BYTES // 8))).decode()
+        for index in range(8)
+    ]
+    shifted_payload_prefix = b"xos.system('id'):"
+    shifted_payload_size = _MAX_RAW_ENCODED_POST_LIMIT_BYTES
+    shifted_payload = base64.b64encode(
+        shifted_payload_prefix + (b"a" * (shifted_payload_size - len(shifted_payload_prefix)))
+    ).decode()
+    payload = pickle.dumps([*skipped_values, f"encoded:{shifted_payload}"], protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="post-limit-large-shifted.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.rule_code == "S604"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("encoding") == "base64"
+        and check.details.get("pattern") == "os.system"
+        for check in result.checks
+    )
+
+
+def test_scan_stream_budget_crossing_prefixed_payload_scans_beyond_decoded_sample() -> None:
+    skipped_values = []
+    for index in range(7):
+        prefix = f"benign prefixed token {index}:".encode()
+        decoded = prefix + (b"a" * ((_MAX_RAW_ENCODED_BYTES // 8) - len(prefix)))
+        skipped_values.append("encoded:" + base64.b64encode(decoded).decode())
+    shifted_payload_prefix = (b"x" * (_ENCODED_TEXT_SAMPLE_DECODED_BYTES + 2)) + b"os.system('id'):"
+    shifted_payload_size = 300_000
+    shifted_payload = (
+        "encoded:"
+        + base64.b64encode(
+            shifted_payload_prefix + (b"a" * (shifted_payload_size - len(shifted_payload_prefix)))
+        ).decode()
+    )
+    payload = pickle.dumps([*skipped_values, shifted_payload], protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="budget-crossing-shifted.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.rule_code == "S604"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("encoding") == "base64"
+        and check.details.get("pattern") == "os.system"
+        for check in result.checks
+    )
+
+
+def test_scan_stream_prefixed_duplicate_after_unprefixed_budget_limit_scans_beyond_decoded_sample() -> None:
+    decoded_size = _MAX_RAW_ENCODED_BYTES // 8
+    shifted_payload_prefix = (b"x" * (_ENCODED_TEXT_SAMPLE_DECODED_BYTES + 2)) + b"os.system('id'):"
+    shifted_decoded = shifted_payload_prefix + (b"a" * (decoded_size - len(shifted_payload_prefix)))
+    shifted_encoded = base64.b64encode(shifted_decoded).decode()
+    values = [shifted_encoded]
+    for index in range(7):
+        prefix = f"benign prefixed token {index}:".encode()
+        decoded = prefix + (b"a" * (decoded_size - len(prefix)))
+        values.append("encoded:" + base64.b64encode(decoded).decode())
+    values.append(f"encoded:{shifted_encoded}")
+    payload = pickle.dumps(values, protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="prefixed-duplicate-shifted.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.rule_code == "S604"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("encoding") == "base64"
+        and check.details.get("pattern") == "os.system"
+        for check in result.checks
+    )
+
+
+def test_scan_stream_prefixed_duplicate_after_unprefixed_overbudget_token_scans_beyond_sample() -> None:
+    skipped_values = []
+    decoded_size = _MAX_RAW_ENCODED_BYTES // 8
+    for index in range(7):
+        prefix = f"benign prefixed token {index}:".encode()
+        decoded = prefix + (b"a" * (decoded_size - len(prefix)))
+        skipped_values.append("encoded:" + base64.b64encode(decoded).decode())
+    shifted_payload_prefix = (b"x" * (_ENCODED_TEXT_SAMPLE_DECODED_BYTES + 2)) + b"os.system('id'):"
+    shifted_payload_size = 300_000
+    shifted_encoded = base64.b64encode(
+        shifted_payload_prefix + (b"a" * (shifted_payload_size - len(shifted_payload_prefix)))
+    ).decode()
+    payload = pickle.dumps([*skipped_values, shifted_encoded, f"encoded:{shifted_encoded}"], protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="overbudget-duplicate-shifted.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.rule_code == "S604"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("encoding") == "base64"
+        and check.details.get("pattern") == "os.system"
+        for check in result.checks
+    )
+
+
+def test_scan_stream_accounted_prefixed_duplicate_preserves_late_post_limit_budget() -> None:
+    decoded_size = _MAX_RAW_ENCODED_BYTES // 8
+    duplicate_encoded = base64.b64encode(b"b" * decoded_size).decode()
+    values = [duplicate_encoded]
+    for index in range(7):
+        prefix = f"benign prefixed token {index}:".encode()
+        decoded = prefix + (b"a" * (decoded_size - len(prefix)))
+        values.append("encoded:" + base64.b64encode(decoded).decode())
+    values.append(f"encoded:{duplicate_encoded}")
+    values.append("encoded:" + base64.b64encode(b"xos.system('id')").decode())
+    payload = pickle.dumps(values, protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="accounted-duplicate-late.pkl")
 
     assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
     assert any(

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -24,6 +24,7 @@ from modelaudit.scanners.joblib_scanner import JoblibScanner
 from modelaudit.scanners.pickle_scanner import (
     _BINARY_TAIL_SCAN_BYTES,
     _MAX_RAW_ENCODED_BYTES,
+    _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES,
     ALWAYS_DANGEROUS_FUNCTIONS,
     ALWAYS_DANGEROUS_MODULES,
     PickleScanner,
@@ -1369,6 +1370,197 @@ def test_scan_stream_keeps_scanning_many_small_encoded_tokens(encoding: str) -> 
         for check in result.checks
     )
     assert "pickle_encoded_text_scan_limit_exceeded" not in result.metadata.get("scan_outcome_reasons", [])
+
+
+@pytest.mark.parametrize("encoding", ["base64", "hex"])
+def test_scan_stream_oversized_seedless_encoded_tokens_charge_decoded_budget(encoding: str) -> None:
+    def encode(value: bytes) -> str:
+        return base64.b64encode(value).decode("ascii") if encoding == "base64" else value.hex()
+
+    decoded_size = max(_MAX_RAW_ENCODED_BYTES // 8, _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES + 1)
+    values = []
+    for index in range(10):
+        prefix = f"benign oversized encoded token {index}:".encode()
+        values.append("encoded:" + encode(prefix + (b"a" * (decoded_size - len(prefix)))))
+    payload = pickle.dumps(values, protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source=f"oversized-{encoding}.pkl")
+
+    assert result.success is False
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Pickle Encoded Text Coverage"
+        and check.details.get("encoding") == encoding
+        and check.details.get("limit_type") == "decoded_byte"
+        and check.details.get("decoded_bytes_analyzed") == 0
+        and check.details.get("skipped_decoded_bytes_accounted") == _MAX_RAW_ENCODED_BYTES
+        for check in result.checks
+    )
+
+
+@pytest.mark.parametrize("encoding", ["base64", "hex"])
+def test_scan_stream_single_oversized_seedless_encoded_token_reports_budget_accounting(encoding: str) -> None:
+    decoded_size = _MAX_RAW_ENCODED_BYTES + 1
+    decoded = b"a" * decoded_size
+    encoded = base64.b64encode(decoded).decode("ascii") if encoding == "base64" else decoded.hex()
+    payload = pickle.dumps(f"encoded:{encoded}", protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source=f"single-oversized-{encoding}.pkl")
+
+    assert result.success is False
+    assert any(
+        check.name == "Pickle Encoded Text Coverage"
+        and check.details.get("encoding") == encoding
+        and check.details.get("limit_type") == "decoded_byte"
+        and check.details.get("decoded_bytes_analyzed") == 0
+        and check.details.get("skipped_tokens_accounted") == 1
+        and check.details.get("skipped_decoded_bytes_accounted") == decoded_size
+        for check in result.checks
+    )
+
+
+def test_scan_stream_oversized_invalid_base64_padding_remains_skipped() -> None:
+    invalid_encoded = ("A" * (_MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES + 2)) + "=="
+    payload = pickle.dumps({"loader": f"encoded:{invalid_encoded}"}, protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="invalid-oversized-base64.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" not in result.metadata.get("scan_outcome_reasons", [])
+
+
+def test_scan_stream_large_base64_like_bytes_literal_is_not_encoded_text() -> None:
+    payload = pickle.dumps(b"G" * (_MAX_RAW_ENCODED_BYTES + _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES), protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="large-bytes.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" not in result.metadata.get("scan_outcome_reasons", [])
+
+
+def test_scan_stream_large_base64_like_text_literal_is_not_encoded_text() -> None:
+    payload = pickle.dumps("G" * (_MAX_RAW_ENCODED_BYTES + _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES), protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="large-text.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" not in result.metadata.get("scan_outcome_reasons", [])
+
+
+def test_scan_stream_unencoded_label_is_not_encoded_text_prefix() -> None:
+    payload = pickle.dumps("unencoded:" + ("G" * (_MAX_RAW_ENCODED_BYTES + 1)), protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="unencoded-near-match.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" not in result.metadata.get("scan_outcome_reasons", [])
+
+
+def test_scan_stream_truncated_encoded_text_prefix_still_charges_budget() -> None:
+    encoded = base64.b64encode(b"a" * (_MAX_RAW_ENCODED_BYTES + 1)).decode("ascii")
+    payload = pickle.dumps(f"encoded:{encoded}", protocol=4)[:-1]
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="truncated-encoded-text.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+
+
+def test_scan_stream_prefixed_duplicate_after_unprefixed_token_still_charges_budget() -> None:
+    encoded = base64.b64encode(b"a" * (_MAX_RAW_ENCODED_BYTES + 1)).decode("ascii")
+    payload = pickle.dumps([encoded, f"encoded:{encoded}"], protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="prefixed-duplicate.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+
+
+@pytest.mark.parametrize(
+    ("encoding", "decoded_size", "token_count"),
+    [
+        ("base64", 3000, 310),
+        ("hex", 2000, 270),
+    ],
+)
+def test_scan_stream_prefixed_duplicates_already_analyzed_do_not_consume_budget(
+    encoding: str, decoded_size: int, token_count: int
+) -> None:
+    def encode(value: bytes) -> str:
+        return base64.b64encode(value).decode("ascii") if encoding == "base64" else value.hex()
+
+    encoded_values = []
+    for index in range(token_count):
+        prefix = f"benign token {index}:".encode()
+        encoded_values.append(encode(prefix + (b"a" * (decoded_size - len(prefix)))))
+    payload = pickle.dumps([*encoded_values, *(f"encoded:{value}" for value in encoded_values)], protocol=4)
+
+    result = PickleScanner().scan_stream(
+        io.BytesIO(payload), len(payload), source=f"analyzed-duplicates-{encoding}.pkl"
+    )
+
+    assert "pickle_encoded_text_scan_limit_exceeded" not in result.metadata.get("scan_outcome_reasons", [])
+
+
+def test_scan_stream_encoded_text_prefix_allows_bounded_whitespace() -> None:
+    encoded = base64.b64encode(b"a" * (_MAX_RAW_ENCODED_BYTES + 1)).decode("ascii")
+    payload = pickle.dumps("encoded:" + (" " * 65) + encoded, protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="prefixed-whitespace.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+
+
+def test_scan_stream_base64_labeled_hex_chars_use_base64_budget() -> None:
+    payload = pickle.dumps("base64:" + ("A" * 1_400_000), protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="base64-labeled-hexchars.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Pickle Encoded Text Coverage"
+        and check.details.get("encoding") == "base64"
+        and check.details.get("limit_type") == "decoded_byte"
+        for check in result.checks
+    )
+
+
+@pytest.mark.parametrize(
+    ("label", "encoded", "detected_encoding"),
+    [
+        ("hex", base64.b64encode(b"os.system('id')").decode(), "base64"),
+        ("base64", b"os.system('id')".hex(), "hex"),
+    ],
+)
+def test_scan_stream_conflicting_encoded_label_does_not_suppress_detection(
+    label: str, encoded: str, detected_encoding: str
+) -> None:
+    payload = pickle.dumps(f"{label}:{encoded}", protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="conflicting-label.pkl")
+
+    assert any(
+        check.rule_code == "S604"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("encoding") == detected_encoding
+        and check.details.get("pattern") == "os.system"
+        for check in result.checks
+    )
+
+
+def test_scan_stream_late_seeded_token_after_seedless_budget_limit_stays_actionable() -> None:
+    decoded_size = max(_MAX_RAW_ENCODED_BYTES // 8, _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES + 1)
+    values = [
+        "encoded:" + base64.b64encode(f"benign oversized token {index}:".encode() + (b"a" * decoded_size)).decode()
+        for index in range(10)
+    ]
+    values.append("encoded:" + base64.b64encode(b"os.system('id')").decode())
+    payload = pickle.dumps(values, protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="late-seeded-base64.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.rule_code == "S604"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("encoding") == "base64"
+        and check.details.get("pattern") == "os.system"
+        for check in result.checks
+    )
 
 
 @pytest.mark.parametrize("encoding", ["base64", "hex"])

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -1398,6 +1398,38 @@ def test_scan_stream_oversized_seedless_encoded_tokens_charge_decoded_budget(enc
     )
 
 
+def test_scan_stream_prefixed_seedless_oversized_token_shares_decoded_budget() -> None:
+    def encode(value: bytes) -> str:
+        return base64.b64encode(value).decode("ascii")
+
+    small_decoded_size = 3000
+    values = [
+        "encoded:" + encode(f"benign token {index}:".encode() + (b"a" * small_decoded_size)) for index in range(240)
+    ]
+    shifted_payload_prefix = b"xos.system('id'):"
+    oversized_decoded_size = 360_000
+    values.append(
+        "encoded:" + encode(shifted_payload_prefix + (b"a" * (oversized_decoded_size - len(shifted_payload_prefix))))
+    )
+    payload = pickle.dumps(values, protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="shared-encoded-budget.pkl")
+
+    assert result.success is False
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Pickle Encoded Text Coverage"
+        and check.details.get("encoding") == "base64"
+        and check.details.get("limit_type") == "decoded_byte"
+        and check.details.get("tokens_analyzed") == len(values) - 1
+        and isinstance(check.details.get("decoded_bytes_analyzed"), int)
+        and check.details["decoded_bytes_analyzed"] > 0
+        and check.details.get("skipped_tokens_accounted") == 1
+        and check.details.get("skipped_decoded_bytes_accounted") == oversized_decoded_size
+        for check in result.checks
+    )
+
+
 @pytest.mark.parametrize("encoding", ["base64", "hex"])
 def test_scan_stream_single_oversized_seedless_encoded_token_reports_budget_accounting(encoding: str) -> None:
     decoded_size = _MAX_RAW_ENCODED_BYTES + 1
@@ -1552,6 +1584,98 @@ def test_scan_stream_late_seeded_token_after_seedless_budget_limit_stays_actiona
     payload = pickle.dumps(values, protocol=4)
 
     result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="late-seeded-base64.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.rule_code == "S604"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("encoding") == "base64"
+        and check.details.get("pattern") == "os.system"
+        for check in result.checks
+    )
+
+
+def test_scan_stream_late_shifted_encoded_payload_after_seedless_budget_limit_stays_actionable() -> None:
+    skipped_values = []
+    for index in range(8):
+        decoded = (f"benign oversized token {index}:".encode() + (b"a" * _MAX_RAW_ENCODED_BYTES))[
+            : _MAX_RAW_ENCODED_BYTES // 8
+        ]
+        skipped_values.append("encoded:" + base64.b64encode(decoded).decode())
+    shifted_payload = base64.b64encode(b"xos.system('id')").decode()
+    payload = pickle.dumps([*skipped_values, f"encoded:{shifted_payload}"], protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="late-shifted-base64.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.rule_code == "S604"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("encoding") == "base64"
+        and check.details.get("pattern") == "os.system"
+        for check in result.checks
+    )
+
+
+def test_scan_stream_late_shifted_payload_survives_benign_seedless_post_limit_token() -> None:
+    skipped_values = []
+    for index in range(8):
+        decoded = (f"benign oversized token {index}:".encode() + (b"a" * _MAX_RAW_ENCODED_BYTES))[
+            : _MAX_RAW_ENCODED_BYTES // 8
+        ]
+        skipped_values.append("encoded:" + base64.b64encode(decoded).decode())
+    benign_post_limit_token = "encoded:" + base64.b64encode(b"b" * _MAX_RAW_ENCODED_BYTES).decode()
+    shifted_payload = "encoded:" + base64.b64encode(b"xos.system('id')").decode()
+    payload = pickle.dumps([*skipped_values, benign_post_limit_token, shifted_payload], protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="late-after-benign-base64.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.rule_code == "S604"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("encoding") == "base64"
+        and check.details.get("pattern") == "os.system"
+        for check in result.checks
+    )
+
+
+def test_scan_stream_large_shifted_encoded_payload_crossing_budget_stays_actionable() -> None:
+    skipped_values = []
+    for index in range(6):
+        decoded = (f"benign oversized token {index}:".encode() + (b"a" * _MAX_RAW_ENCODED_BYTES))[
+            : _MAX_RAW_ENCODED_BYTES // 8
+        ]
+        skipped_values.append("encoded:" + base64.b64encode(decoded).decode())
+    shifted_payload_prefix = b"xos.system('id'):"
+    shifted_payload_size = 300_000
+    shifted_payload = base64.b64encode(
+        shifted_payload_prefix + (b"a" * (shifted_payload_size - len(shifted_payload_prefix)))
+    ).decode()
+    payload = pickle.dumps([*skipped_values, f"encoded:{shifted_payload}"], protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="large-shifted-base64.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.rule_code == "S604"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("encoding") == "base64"
+        and check.details.get("pattern") == "os.system"
+        for check in result.checks
+    )
+
+
+def test_scan_stream_continues_after_decodable_token_exceeds_shared_encoded_budget() -> None:
+    skipped_decoded_size = _MAX_RAW_ENCODED_BYTES - 1500
+    values = [
+        "encoded:" + base64.b64encode(b"a" * skipped_decoded_size).decode(),
+        "encoded:" + base64.b64encode(b"benign follow-on text" + (b"b" * 3000)).decode(),
+        "encoded:" + base64.b64encode(b"xos.system('id')").decode(),
+    ]
+    payload = pickle.dumps(values, protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="post-overflow-continuation.pkl")
 
     assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
     assert any(

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -24,7 +24,6 @@ from modelaudit.scanners.joblib_scanner import JoblibScanner
 from modelaudit.scanners.pickle_scanner import (
     _BINARY_TAIL_SCAN_BYTES,
     _MAX_RAW_ENCODED_BYTES,
-    _MAX_RAW_ENCODED_TOKENS,
     ALWAYS_DANGEROUS_FUNCTIONS,
     ALWAYS_DANGEROUS_MODULES,
     PickleScanner,
@@ -1353,24 +1352,23 @@ def test_scan_stream_keeps_encoded_execution_outside_url_actionable(encoding: st
 
 
 @pytest.mark.parametrize("encoding", ["base64", "hex"])
-def test_scan_stream_encoded_token_budgets_fail_closed(encoding: str) -> None:
+def test_scan_stream_keeps_scanning_many_small_encoded_tokens(encoding: str) -> None:
     def encode(value: bytes) -> str:
         return base64.b64encode(value).decode("ascii") if encoding == "base64" else value.hex()
 
-    values = [f"encoded:{encode(f'benign-token-{index}'.encode())}" for index in range(_MAX_RAW_ENCODED_TOKENS)]
+    values = [f"encoded:{encode(f'benign-token-{index}'.encode())}" for index in range(128)]
     values.append("encoded:" + encode(b"os.system('id')"))
     payload = pickle.dumps(values, protocol=4)
 
-    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source=f"late-{encoding}.pkl")
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source=f"many-{encoding}.pkl")
 
-    assert result.success is False
-    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
     assert any(
-        check.name == "Pickle Encoded Text Coverage"
+        check.rule_code == "S604"
         and check.details.get("encoding") == encoding
-        and check.details.get("limit_type") == "token"
+        and check.details.get("pattern") == "os.system"
         for check in result.checks
     )
+    assert "pickle_encoded_text_scan_limit_exceeded" not in result.metadata.get("scan_outcome_reasons", [])
 
 
 @pytest.mark.parametrize("encoding", ["base64", "hex"])

--- a/tests/scanners/test_pickle_scanner.py
+++ b/tests/scanners/test_pickle_scanner.py
@@ -27,6 +27,8 @@ from modelaudit.scanners.pickle_scanner import (
     _MAX_RAW_ENCODED_BYTES,
     _MAX_RAW_ENCODED_POST_LIMIT_BYTES,
     _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES,
+    _MAX_RAW_ENCODED_TOKENS,
+    _MAX_UNPREFIXED_SEEDLESS_ENCODED_TOKENS,
     ALWAYS_DANGEROUS_FUNCTIONS,
     ALWAYS_DANGEROUS_MODULES,
     PickleScanner,
@@ -1394,8 +1396,8 @@ def test_scan_stream_oversized_seedless_encoded_tokens_charge_decoded_budget(enc
         check.name == "Pickle Encoded Text Coverage"
         and check.details.get("encoding") == encoding
         and check.details.get("limit_type") == "decoded_byte"
-        and check.details.get("decoded_bytes_analyzed") == 0
-        and check.details.get("skipped_decoded_bytes_accounted") == _MAX_RAW_ENCODED_BYTES
+        and check.details.get("decoded_bytes_analyzed") == _MAX_RAW_ENCODED_BYTES
+        and "skipped_tokens_accounted" not in check.details
         for check in result.checks
     )
 
@@ -1463,7 +1465,7 @@ def test_scan_stream_oversized_invalid_base64_padding_remains_skipped() -> None:
 
 
 def test_scan_stream_large_base64_like_bytes_literal_is_not_encoded_text() -> None:
-    payload = pickle.dumps(b"G" * (_MAX_RAW_ENCODED_BYTES + _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES), protocol=4)
+    payload = pickle.dumps(b"G" * (_MAX_RAW_ENCODED_BYTES * 2), protocol=4)
 
     result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="large-bytes.pkl")
 
@@ -1471,7 +1473,7 @@ def test_scan_stream_large_base64_like_bytes_literal_is_not_encoded_text() -> No
 
 
 def test_scan_stream_large_base64_like_text_literal_is_not_encoded_text() -> None:
-    payload = pickle.dumps("G" * (_MAX_RAW_ENCODED_BYTES + _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES), protocol=4)
+    payload = pickle.dumps("G" * (_MAX_RAW_ENCODED_BYTES * 2), protocol=4)
 
     result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="large-text.pkl")
 
@@ -1576,6 +1578,174 @@ def test_scan_stream_conflicting_encoded_label_does_not_suppress_detection(
     )
 
 
+@pytest.mark.parametrize("prefix", ["", "encoded:"])
+def test_scan_stream_binary_oversized_seedless_base64_under_budget_stays_actionable(prefix: str) -> None:
+    decoded_size = 3100
+    values = []
+    skipped_limit_headroom = 1 if prefix == "" else 0
+    for index in range(_MAX_UNPREFIXED_SEEDLESS_ENCODED_TOKENS - skipped_limit_headroom):
+        body = f"benign binary token {index}:".encode()
+        values.append(prefix + base64.b64encode(body + (b"\x00" * (decoded_size - len(body)))).decode())
+    shifted_payload = b"xos.system('id')" + (b"\x00" * (decoded_size - len(b"xos.system('id')")))
+    values.append(prefix + base64.b64encode(shifted_payload).decode())
+    payload = pickle.dumps(values, protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="binary-under-budget-base64.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" not in result.metadata.get("scan_outcome_reasons", [])
+    assert any(
+        check.rule_code == "S604"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("encoding") == "base64"
+        and check.details.get("pattern") == "os.system"
+        for check in result.checks
+    )
+
+
+def test_scan_stream_binary_oversized_seedless_base64_over_budget_fails_closed() -> None:
+    decoded_size = 20_000
+    values = []
+    for index in range(65):
+        body = f"binary token {index}:".encode()
+        values.append(base64.b64encode(body + (b"\x00" * (decoded_size - len(body)))).decode())
+    payload = pickle.dumps(values, protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="binary-over-budget-base64.pkl")
+
+    assert result.success is False
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Pickle Encoded Text Coverage"
+        and check.rule_code == "S902"
+        and check.details.get("encoding") == "base64"
+        and check.details.get("limit_type") == "token"
+        and check.details.get("max_tokens") == _MAX_UNPREFIXED_SEEDLESS_ENCODED_TOKENS
+        and check.details.get("analysis_incomplete") is True
+        for check in result.checks
+    )
+
+
+def test_scan_stream_unprefixed_seedless_base64_token_count_limit_fails_closed() -> None:
+    decoded_size = 5000
+    values = []
+    for index in range(_MAX_UNPREFIXED_SEEDLESS_ENCODED_TOKENS + 1):
+        body = f"binary token {index}:".encode()
+        if index == _MAX_UNPREFIXED_SEEDLESS_ENCODED_TOKENS:
+            body = (b"x" * (_ENCODED_TEXT_SAMPLE_DECODED_BYTES + 2)) + b"exec('id')"
+        values.append(base64.b64encode(body + (b"\x00" * (decoded_size - len(body)))).decode())
+    payload = pickle.dumps(values, protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="binary-token-limit-base64.pkl")
+
+    assert result.success is False
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Pickle Encoded Text Coverage"
+        and check.rule_code == "S902"
+        and check.details.get("encoding") == "base64"
+        and check.details.get("limit_type") == "token"
+        and check.details.get("max_tokens") == _MAX_UNPREFIXED_SEEDLESS_ENCODED_TOKENS
+        and check.details.get("skipped_tokens_accounted") == _MAX_UNPREFIXED_SEEDLESS_ENCODED_TOKENS + 1
+        and check.details.get("skipped_decoded_bytes_accounted")
+        == decoded_size * (_MAX_UNPREFIXED_SEEDLESS_ENCODED_TOKENS + 1)
+        for check in result.checks
+    )
+
+
+def test_scan_stream_unprefixed_oversized_base64_after_analyzed_token_limit_fails_closed() -> None:
+    values = [
+        base64.b64encode(f"benign-token-{index}".encode()).decode()
+        for index in range(_MAX_UNPREFIXED_SEEDLESS_ENCODED_TOKENS)
+    ]
+    skipped_decoded = (b"x" * (_ENCODED_TEXT_SAMPLE_DECODED_BYTES + 2)) + b"exec('id')"
+    skipped_decoded += b"\x00" * (_MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES + 1 - len(skipped_decoded))
+    values.append(base64.b64encode(skipped_decoded).decode())
+    payload = pickle.dumps(values, protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="skipped-after-token-limit.pkl")
+
+    assert result.success is False
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Pickle Encoded Text Coverage"
+        and check.rule_code == "S902"
+        and check.details.get("encoding") == "base64"
+        and check.details.get("limit_type") == "token"
+        and check.details.get("max_tokens") == _MAX_UNPREFIXED_SEEDLESS_ENCODED_TOKENS
+        and check.details.get("skipped_tokens_accounted") == 1
+        for check in result.checks
+    )
+
+
+def test_scan_stream_unprefixed_oversized_base64_before_analyzed_token_limit_fails_closed() -> None:
+    skipped_decoded = (b"x" * (_ENCODED_TEXT_SAMPLE_DECODED_BYTES + 2)) + b"exec('id')"
+    skipped_decoded += b"\x00" * (_MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES + 1 - len(skipped_decoded))
+    values = [base64.b64encode(skipped_decoded).decode()]
+    values.extend(
+        base64.b64encode(f"benign-token-{index}".encode()).decode()
+        for index in range(_MAX_UNPREFIXED_SEEDLESS_ENCODED_TOKENS)
+    )
+    payload = pickle.dumps(values, protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="skipped-before-token-limit.pkl")
+
+    assert result.success is False
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Pickle Encoded Text Coverage"
+        and check.rule_code == "S902"
+        and check.details.get("encoding") == "base64"
+        and check.details.get("limit_type") == "token"
+        and check.details.get("max_tokens") == _MAX_UNPREFIXED_SEEDLESS_ENCODED_TOKENS
+        and check.details.get("skipped_tokens_accounted") == 1
+        for check in result.checks
+    )
+
+
+def test_scan_stream_many_small_encoded_tokens_fail_closed_but_preserve_late_detection() -> None:
+    values = [
+        "encoded:" + base64.b64encode(f"benign-token-{index}".encode()).decode()
+        for index in range(_MAX_RAW_ENCODED_TOKENS + 1)
+    ]
+    values.append("encoded:" + base64.b64encode(b"os.system('id')").decode())
+    payload = pickle.dumps(values, protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="many-small-encoded-tokens.pkl")
+
+    assert result.success is False
+    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert any(
+        check.name == "Pickle Encoded Text Coverage"
+        and check.rule_code == "S902"
+        and check.details.get("encoding") == "base64"
+        and check.details.get("limit_type") == "token"
+        and check.details.get("max_tokens") == _MAX_RAW_ENCODED_TOKENS
+        and check.details.get("tokens_analyzed") == _MAX_RAW_ENCODED_TOKENS
+        for check in result.checks
+    )
+    assert any(
+        check.rule_code == "S604"
+        and check.status == CheckStatus.FAILED
+        and check.details.get("encoding") == "base64"
+        and check.details.get("pattern") == "os.system"
+        for check in result.checks
+    )
+
+
+def test_scan_stream_ignored_unlabelled_literal_after_exact_prefixed_budget_does_not_fail_closed() -> None:
+    decoded_size = _MAX_RAW_ENCODED_BYTES // 8
+    values = []
+    for index in range(8):
+        prefix = f"benign prefixed token {index}:".encode()
+        values.append("encoded:" + base64.b64encode(prefix + (b"a" * (decoded_size - len(prefix)))).decode())
+    values.append("G" * (_MAX_RAW_ENCODED_BYTES * 2))
+    payload = pickle.dumps(values, protocol=4)
+
+    result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="exact-budget-then-literal.pkl")
+
+    assert "pickle_encoded_text_scan_limit_exceeded" not in result.metadata.get("scan_outcome_reasons", [])
+
+
 def test_scan_stream_late_seeded_token_after_seedless_budget_limit_stays_actionable() -> None:
     decoded_size = max(_MAX_RAW_ENCODED_BYTES // 8, _MAX_RAW_ENCODED_TOKEN_WITHOUT_SEED_BYTES + 1)
     values = [
@@ -1619,24 +1789,17 @@ def test_scan_stream_late_shifted_encoded_payload_after_seedless_budget_limit_st
     )
 
 
-def test_scan_stream_unprefixed_seedless_oversized_tokens_share_decoded_budget() -> None:
+def test_scan_stream_unprefixed_seedless_oversized_text_tokens_without_label_do_not_fail_closed() -> None:
     decoded_size = _MAX_RAW_ENCODED_BYTES // 8
     values = []
-    for index in range(8):
+    for index in range(9):
         prefix = f"benign unprefixed token {index}:".encode()
         values.append(base64.b64encode(prefix + (b"a" * (decoded_size - len(prefix)))).decode())
     payload = pickle.dumps(values, protocol=4)
 
     result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="unprefixed-budget-base64.pkl")
 
-    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
-    coverage_checks = [check for check in result.checks if check.rule_code == "S902"]
-    assert any(
-        check.details.get("encoding") == "base64"
-        and check.details.get("skipped_tokens_accounted") == 8
-        and check.details.get("skipped_decoded_bytes_accounted") == _MAX_RAW_ENCODED_BYTES
-        for check in coverage_checks
-    )
+    assert "pickle_encoded_text_scan_limit_exceeded" not in result.metadata.get("scan_outcome_reasons", [])
 
 
 @pytest.mark.parametrize("encoding", ["base64", "hex"])
@@ -1667,10 +1830,11 @@ def test_scan_stream_prefixed_duplicate_after_unprefixed_oversized_token_does_no
 
 
 def test_scan_stream_large_prefixed_shifted_payload_after_seedless_budget_limit_stays_actionable() -> None:
-    skipped_values = [
-        base64.b64encode(f"benign unprefixed token {index}:".encode() + (b"a" * (_MAX_RAW_ENCODED_BYTES // 8))).decode()
-        for index in range(8)
-    ]
+    skipped_values = []
+    for index in range(8):
+        prefix = f"benign prefixed token {index}:".encode()
+        decoded = prefix + (b"a" * ((_MAX_RAW_ENCODED_BYTES // 8) - len(prefix)))
+        skipped_values.append("encoded:" + base64.b64encode(decoded).decode())
     shifted_payload_prefix = b"xos.system('id'):"
     shifted_payload_size = _MAX_RAW_ENCODED_POST_LIMIT_BYTES
     shifted_payload = base64.b64encode(
@@ -1718,13 +1882,13 @@ def test_scan_stream_budget_crossing_prefixed_payload_scans_beyond_decoded_sampl
     )
 
 
-def test_scan_stream_prefixed_duplicate_after_unprefixed_budget_limit_scans_beyond_decoded_sample() -> None:
+def test_scan_stream_prefixed_shifted_payload_under_budget_scans_beyond_decoded_sample() -> None:
     decoded_size = _MAX_RAW_ENCODED_BYTES // 8
     shifted_payload_prefix = (b"x" * (_ENCODED_TEXT_SAMPLE_DECODED_BYTES + 2)) + b"os.system('id'):"
     shifted_decoded = shifted_payload_prefix + (b"a" * (decoded_size - len(shifted_payload_prefix)))
     shifted_encoded = base64.b64encode(shifted_decoded).decode()
-    values = [shifted_encoded]
-    for index in range(7):
+    values = [f"encoded:{shifted_encoded}"]
+    for index in range(8):
         prefix = f"benign prefixed token {index}:".encode()
         decoded = prefix + (b"a" * (decoded_size - len(prefix)))
         values.append("encoded:" + base64.b64encode(decoded).decode())
@@ -1733,7 +1897,7 @@ def test_scan_stream_prefixed_duplicate_after_unprefixed_budget_limit_scans_beyo
 
     result = PickleScanner().scan_stream(io.BytesIO(payload), len(payload), source="prefixed-duplicate-shifted.pkl")
 
-    assert "pickle_encoded_text_scan_limit_exceeded" in result.metadata["scan_outcome_reasons"]
+    assert "pickle_encoded_text_scan_limit_exceeded" not in result.metadata.get("scan_outcome_reasons", [])
     assert any(
         check.rule_code == "S604"
         and check.status == CheckStatus.FAILED

--- a/tests/scanners/test_pytorch_zip_scanner.py
+++ b/tests/scanners/test_pytorch_zip_scanner.py
@@ -1403,6 +1403,17 @@ def test_pytorch_zip_scanner_can_handle(tmp_path):
     assert PyTorchZipScanner.can_handle(str(test_file)) is False
 
 
+def test_pytorch_zip_allows_many_small_encoded_metadata_tokens(tmp_path: Path) -> None:
+    values = [f"encoded:{base64.b64encode(f'benign-token-{index}'.encode()).decode('ascii')}" for index in range(128)]
+    model_path = create_mock_pytorch_zip(tmp_path / "many-encoded-metadata.pth", data={"metadata": values})
+
+    result = PyTorchZipScanner().scan(str(model_path))
+
+    assert result.success is True
+    assert "pickle_encoded_text_scan_limit_exceeded" not in result.metadata.get("scan_outcome_reasons", [])
+    assert not any(check.name == "Pickle Encoded Text Coverage" for check in result.checks)
+
+
 def test_pytorch_zip_training_args_unresolved_framework_metadata_refs_warn(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Benign PyTorch metadata can exceed the old 64-token limit and make an otherwise clean scan exit 2. Scan small encoded tokens within a 4,096-token limit and the existing decoded-byte budget. Retain the 64-token bound when oversized unlabelled candidates are skipped.

Inspect labelled oversized tokens within the byte budget, report incomplete coverage when a limit is reached, and preserve late execution-pattern detection within a bounded follow-up budget.

## Campaign Evidence

Paired static replay on 2026-09-09 used the same artifact, Python dependency runtime and scan options (`--no-whitelist --no-cache --max-size 8GB --timeout 5400`). Imported source paths, clean worktrees and artifact hashes were verified before and after scanning.

- Model: `amd/realesrgan-x4plus`, HF revision `9af1b12e679374d2f0b0ccdb2488cee92e2525e1`.
- Artifact: `RealESRGAN_x4plus.pth`, 67,040,989 bytes, SHA-256 `4fa0d38905f75ac06eb49a7951b426670021be3018265fd191d2125df9d682f1`.
- Main `9631527b3e81e0458fe9e0242c3178af406bfa5f`: exit 2, `success=false`, S902 `pickle_encoded_text_scan_limit_exceeded` on `archive/data.pkl`.
- PR `38d0479d2d0d8b97ccdd3c6bab90311a06e46266`: exit 0, `success=true`, no issues or failed checks.
- Both runs recognize one PyTorch ZIP artifact and report 322,652 scanned bytes. This is a regression replay, not an additional completed-main campaign model.

## Validation

- 41 focused pickle/PyTorch ZIP tests passed using `-k 'encoded or base64 or seedless or shifted'`.
- 48 bounded static comparisons cover binary/printable and labelled/unlabelled tokens, shared byte budgets, benign controls and late execution-pattern detection. Both previously reported gaps now produce S604 or fail closed with S902.
- Full `tests/scanners/test_pickle_scanner.py` and `tests/scanners/test_pytorch_zip_scanner.py` runs passed on the coordinator.
- Current-head CI lint, formatting and type checks passed; the full CI result remains tracked separately on this PR.

## Local Limitations

- The canonical local mypy command is blocked on this 3.12-only coordinator because project config targets Python 3.10 while the local NumPy 2.5 stubs use Python 3.12 `type` syntax. A Python 3.12 full mypy run then reported one unrelated unreachable TensorFlow import in `tests/scanners/test_weight_distribution_scanner.py`.
- The full local non-slow pytest-xdist gate was inconclusive: it recorded failures outside the touched tests, then spent several minutes draining long `tests/detectors/test_cve_detection.py_cases/test_pickle_binunicode8_setitem.py` parameters without producing a final traceback before interruption. The touched tests and relevant PyTorch ZIP suite pass under xdist locally; repository CI should be treated as the full-gate authority.
