### PR TITLE
fix: ignore ONNX tensor bytes for network text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Avoid network false positives for bounded README examples that download sample images over HTTPS from Hugging Face.
 - Preserve network security findings in README-named environment files.
 - Preserve README network detections when Transformers examples enable or dynamically configure remote code execution, including through `generate(custom_generate=...)`.
-- Avoid ONNX network false positives from tensor payload bytes while preserving metadata URL/IP detections.
+- Avoid ONNX network false positives from tensor payload bytes while preserving metadata URL/IP ownership and fail-closed coverage for truncated structured extraction or unknown protobuf fields.
 - Preserve Windows source-fingerprint cache hits while continuing to reject swapped or modified files.
 - Prevent Windows cache identity probes from creating locked temporary files inside scanned directories.
 - Preserve locked Windows cache probes reached through directory aliases while clearing stale scan results.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Avoid network false positives for bounded README examples that download sample images over HTTPS from Hugging Face.
 - Preserve network security findings in README-named environment files.
 - Preserve README network detections when Transformers examples enable or dynamically configure remote code execution, including through `generate(custom_generate=...)`.
+- Avoid ONNX network false positives from tensor payload bytes while preserving metadata URL/IP detections.
 - Preserve Windows source-fingerprint cache hits while continuing to reject swapped or modified files.
 - Prevent Windows cache identity probes from creating locked temporary files inside scanned directories.
 - Preserve locked Windows cache probes reached through directory aliases while clearing stale scan results.

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -120,7 +120,12 @@ _ONNX_ACTIVE_METADATA_KEY_PATTERN = re.compile(
     rb"(?:^|[^A-Za-z0-9])(?:api|callback|download|endpoint|fetch|webhook)(?:[^A-Za-z0-9]|$)",
     re.IGNORECASE,
 )
-_ONNX_ACTIVE_METADATA_DOMAIN_CONTEXT_BYTES = 128
+_ONNX_METADATA_ENTRY_FIELD_NUMBER = 14
+_PROTOBUF_LENGTH_DELIMITED_WIRE_TYPE = 2
+_PROTOBUF_VARINT_WIRE_TYPE = 0
+_PROTOBUF_FIXED64_WIRE_TYPE = 1
+_PROTOBUF_FIXED32_WIRE_TYPE = 5
+_ONNX_METADATA_ENTRY_LIMIT = 1024
 _PROVEN_BARE_QUERY_COMPONENTS = frozenset({"_debug", "debug"})
 _PROVEN_BARE_PROSE_COMPONENTS = frozenset({"section"})
 _PATH_TOKEN_BOUNDARY_PATTERN = re.compile(r"&amp;|[&,'\"?#\s]")
@@ -1399,6 +1404,109 @@ def _match_starts_inside_percent_escape(data: bytes, match_start: int) -> bool:
     ):
         return False
     return int(data[match_start : match_start + 2], 16) in b"/=?&#;:@,'\" \t\r\n"
+
+
+def _read_proto_varint_bounds(data: bytes, position: int, end: int) -> tuple[int, int] | None:
+    value = 0
+    shift = 0
+    while position < end and shift < 70:
+        byte = data[position]
+        position += 1
+        value |= (byte & 0x7F) << shift
+        if byte < 0x80:
+            return value, position
+        shift += 7
+    return None
+
+
+def _read_proto_length_bounds(data: bytes, position: int, end: int) -> tuple[int, int, int] | None:
+    decoded = _read_proto_varint_bounds(data, position, end)
+    if decoded is None:
+        return None
+    length, payload_start = decoded
+    payload_end = payload_start + length
+    if payload_end > end:
+        return None
+    return payload_start, payload_end, payload_end
+
+
+def _skip_proto_field(data: bytes, position: int, end: int, wire_type: int) -> int | None:
+    if wire_type == _PROTOBUF_VARINT_WIRE_TYPE:
+        decoded = _read_proto_varint_bounds(data, position, end)
+        return None if decoded is None else decoded[1]
+    if wire_type == _PROTOBUF_FIXED64_WIRE_TYPE:
+        next_position = position + 8
+        return next_position if next_position <= end else None
+    if wire_type == _PROTOBUF_LENGTH_DELIMITED_WIRE_TYPE:
+        bounds = _read_proto_length_bounds(data, position, end)
+        return None if bounds is None else bounds[2]
+    if wire_type == _PROTOBUF_FIXED32_WIRE_TYPE:
+        next_position = position + 4
+        return next_position if next_position <= end else None
+    return None
+
+
+def _parse_onnx_metadata_entry(data: bytes, start: int, end: int) -> tuple[str, bytes, int] | None:
+    key: str | None = None
+    value: bytes | None = None
+    value_start = -1
+    position = start
+    while position < end:
+        decoded_key = _read_proto_varint_bounds(data, position, end)
+        if decoded_key is None:
+            return None
+        proto_key, position = decoded_key
+        field_number = proto_key >> 3
+        wire_type = proto_key & 0x07
+        if field_number in {1, 2} and wire_type == _PROTOBUF_LENGTH_DELIMITED_WIRE_TYPE:
+            bounds = _read_proto_length_bounds(data, position, end)
+            if bounds is None:
+                return None
+            payload_start, payload_end, position = bounds
+            if field_number == 1:
+                key = data[payload_start:payload_end].decode("utf-8", errors="ignore")
+            else:
+                value = data[payload_start:payload_end]
+                value_start = payload_start
+            continue
+        next_position = _skip_proto_field(data, position, end, wire_type)
+        if next_position is None:
+            return None
+        position = next_position
+    if key is None or value is None:
+        return None
+    return key, value, value_start
+
+
+def _iter_onnx_metadata_entries(data: bytes) -> Iterator[tuple[str, bytes, int]]:
+    position = 0
+    end = len(data)
+    yielded = 0
+    while position < end and yielded < _ONNX_METADATA_ENTRY_LIMIT:
+        decoded_key = _read_proto_varint_bounds(data, position, end)
+        if decoded_key is None:
+            return
+        proto_key, position = decoded_key
+        field_number = proto_key >> 3
+        wire_type = proto_key & 0x07
+        if field_number == _ONNX_METADATA_ENTRY_FIELD_NUMBER and wire_type == _PROTOBUF_LENGTH_DELIMITED_WIRE_TYPE:
+            bounds = _read_proto_length_bounds(data, position, end)
+            if bounds is None:
+                return
+            payload_start, payload_end, position = bounds
+            entry = _parse_onnx_metadata_entry(data, payload_start, payload_end)
+            if entry is not None:
+                yielded += 1
+                yield entry
+            continue
+        next_position = _skip_proto_field(data, position, end, wire_type)
+        if next_position is None:
+            return
+        position = next_position
+
+
+def _is_active_onnx_metadata_key(key: str) -> bool:
+    return _ONNX_ACTIVE_METADATA_KEY_PATTERN.search(key.encode("utf-8", errors="ignore")) is not None
 
 
 def _is_match_redacted_from_url(data: bytes, match_start: int, value: str) -> bool:
@@ -5735,11 +5843,23 @@ class NetworkCommDetector:
                 if not record_domain(domain, match.start("domain")):
                     return
             if self._onnx_metadata_context:
+                metadata_entries = list(_iter_onnx_metadata_entries(data))
+                for key, value, value_start in metadata_entries:
+                    if not _is_active_onnx_metadata_key(key):
+                        continue
+                    for match in self.DOMAIN_PATTERN.finditer(value):
+                        if match.start() > 0 and value[match.start() - 1 : match.start()] == b"@":
+                            continue
+                        domain = match.group().decode("utf-8", errors="ignore").casefold()
+                        if not record_domain(domain, value_start + match.start()):
+                            return
                 for match in self.DOMAIN_PATTERN.finditer(data):
                     if match.start() > 0 and data[match.start() - 1 : match.start()] == b"@":
                         continue
-                    prefix_start = max(0, match.start() - _ONNX_ACTIVE_METADATA_DOMAIN_CONTEXT_BYTES)
-                    if _ONNX_ACTIVE_METADATA_KEY_PATTERN.search(data[prefix_start : match.start()]) is None:
+                    if metadata_entries:
+                        continue
+                    line_start = data.rfind(b"\n", 0, match.start()) + 1
+                    if _ONNX_ACTIVE_METADATA_KEY_PATTERN.search(data[line_start : match.start()]) is None:
                         continue
                     domain = match.group().decode("utf-8", errors="ignore").casefold()
                     if not record_domain(domain, match.start()):
@@ -6018,6 +6138,17 @@ class NetworkCommDetector:
 
         # For ML models, we need to be much more conservative to avoid false positives
         # Binary model weights can contain random byte sequences that match port patterns
+        if is_ml_model and self._onnx_metadata_context:
+            metadata_entries = list(_iter_onnx_metadata_entries(data))
+            for key, value, _value_start in metadata_entries:
+                if _is_active_onnx_metadata_key(key):
+                    self._scan_suspicious_ports_in_active_metadata_value(value, context)
+                    if self.findings_truncated:
+                        return
+            if metadata_entries:
+                return
+            self._scan_suspicious_ports_in_active_metadata_text(data, context)
+            return
         if is_ml_model and not self._onnx_metadata_context:
             # Only scan for very explicit network patterns in ML models
             # Skip port scanning for pure binary model files to avoid false positives
@@ -6051,6 +6182,55 @@ class NetworkCommDetector:
                     }
                 ):
                     return
+
+    def _scan_suspicious_ports_in_active_metadata_text(self, data: bytes, context: str) -> None:
+        for port in self.SUSPICIOUS_PORTS:
+            port_bytes = str(port).encode()
+            matched = False
+            for pattern_bytes in self.PORT_PATTERNS[port]:
+                for pattern_start in _iter_pattern_matches(data, pattern_bytes):
+                    line_start = data.rfind(b"\n", 0, pattern_start) + 1
+                    if _ONNX_ACTIVE_METADATA_KEY_PATTERN.search(data[line_start:pattern_start]) is None:
+                        continue
+                    port_start = pattern_start + pattern_bytes.rfind(port_bytes)
+                    if self._is_redacted_url_value(data, port_start, str(port)):
+                        continue
+                    matched = True
+                    break
+                if matched:
+                    break
+            if matched and not self._record_suspicious_port(port, context):
+                return
+
+    def _scan_suspicious_ports_in_active_metadata_value(self, value: bytes, context: str) -> None:
+        for port in self.SUSPICIOUS_PORTS:
+            port_bytes = str(port).encode()
+            matched = False
+            for pattern_bytes in self.PORT_PATTERNS[port]:
+                for pattern_start in _iter_pattern_matches(value, pattern_bytes):
+                    port_start = pattern_start + pattern_bytes.rfind(port_bytes)
+                    if self._is_redacted_url_value(value, port_start, str(port)):
+                        continue
+                    matched = True
+                    break
+                if matched:
+                    break
+            if matched and not self._record_suspicious_port(port, context):
+                return
+
+    def _record_suspicious_port(self, port: int, context: str) -> bool:
+        port_name = self._get_port_name(port)
+        return self._record_finding(
+            {
+                "type": "suspicious_port",
+                "severity": "MEDIUM",
+                "confidence": 0.6,
+                "message": f"Suspicious port detected: {port} ({port_name})",
+                "port": port,
+                "service": port_name,
+                "context": context,
+            }
+        )
 
     def _scan_explicit_network_patterns_in_ml_models(self, data: bytes, context: str) -> None:
         """Scan for very explicit network patterns in ML models with high confidence."""

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -116,6 +116,11 @@ _METADATA_ACTIVE_CONTEXT_PATTERN = re.compile(
 _METADATA_HTTP_REQUEST_PATTERN = re.compile(
     rb"\b(?:GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH|download|fetch)\s+https?://", re.IGNORECASE
 )
+_ONNX_ACTIVE_METADATA_KEY_PATTERN = re.compile(
+    rb"(?:^|[^A-Za-z0-9])(?:api|callback|download|endpoint|fetch|webhook)(?:[^A-Za-z0-9]|$)",
+    re.IGNORECASE,
+)
+_ONNX_ACTIVE_METADATA_DOMAIN_CONTEXT_BYTES = 128
 _PROVEN_BARE_QUERY_COMPONENTS = frozenset({"_debug", "debug"})
 _PROVEN_BARE_PROSE_COMPONENTS = frozenset({"section"})
 _PATH_TOKEN_BOUNDARY_PATTERN = re.compile(r"&amp;|[&,'\"?#\s]")
@@ -5729,6 +5734,16 @@ class NetworkCommDetector:
                 domain = match.group("domain").decode("utf-8", errors="ignore").casefold()
                 if not record_domain(domain, match.start("domain")):
                     return
+            if self._onnx_metadata_context:
+                for match in self.DOMAIN_PATTERN.finditer(data):
+                    if match.start() > 0 and data[match.start() - 1 : match.start()] == b"@":
+                        continue
+                    prefix_start = max(0, match.start() - _ONNX_ACTIVE_METADATA_DOMAIN_CONTEXT_BYTES)
+                    if _ONNX_ACTIVE_METADATA_KEY_PATTERN.search(data[prefix_start : match.start()]) is None:
+                        continue
+                    domain = match.group().decode("utf-8", errors="ignore").casefold()
+                    if not record_domain(domain, match.start()):
+                        return
             return
 
         for match in self.DOMAIN_PATTERN.finditer(data):

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -125,7 +125,6 @@ _PROTOBUF_LENGTH_DELIMITED_WIRE_TYPE = 2
 _PROTOBUF_VARINT_WIRE_TYPE = 0
 _PROTOBUF_FIXED64_WIRE_TYPE = 1
 _PROTOBUF_FIXED32_WIRE_TYPE = 5
-_ONNX_METADATA_ENTRY_LIMIT = 1024
 _PROVEN_BARE_QUERY_COMPONENTS = frozenset({"_debug", "debug"})
 _PROVEN_BARE_PROSE_COMPONENTS = frozenset({"section"})
 _PATH_TOKEN_BOUNDARY_PATTERN = re.compile(r"&amp;|[&,'\"?#\s]")
@@ -1481,8 +1480,7 @@ def _parse_onnx_metadata_entry(data: bytes, start: int, end: int) -> tuple[str, 
 def _iter_onnx_metadata_entries(data: bytes) -> Iterator[tuple[str, bytes, int]]:
     position = 0
     end = len(data)
-    yielded = 0
-    while position < end and yielded < _ONNX_METADATA_ENTRY_LIMIT:
+    while position < end:
         decoded_key = _read_proto_varint_bounds(data, position, end)
         if decoded_key is None:
             return
@@ -1496,7 +1494,6 @@ def _iter_onnx_metadata_entries(data: bytes) -> Iterator[tuple[str, bytes, int]]
             payload_start, payload_end, position = bounds
             entry = _parse_onnx_metadata_entry(data, payload_start, payload_end)
             if entry is not None:
-                yielded += 1
                 yield entry
             continue
         next_position = _skip_proto_field(data, position, end, wire_type)

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -1822,6 +1822,11 @@ def _is_metadata_context(context: str) -> bool:
     return any(segment in _DOC_CONTEXT_SEGMENTS for segment in context_segments[:-1])
 
 
+def _is_extracted_onnx_metadata_context(context: str) -> bool:
+    context_segments = [segment for segment in context.lower().replace("\\", "/").split("/") if segment]
+    return len(context_segments) >= 2 and context_segments[-2:] == ["onnx_metadata", "metadata"]
+
+
 def _iter_pattern_matches(data: bytes, pattern: bytes) -> Iterator[int]:
     """Yield non-overlapping match positions for a byte pattern."""
     start = 0
@@ -5470,7 +5475,10 @@ class NetworkCommDetector:
 
         # Skip domain detection in binary ML model files to avoid false positives
         # Binary weights can randomly match domain patterns
-        if context and any(ext in context.lower() for ext in [".bin", ".pt", ".pth", ".ckpt", ".h5", ".pb", ".onnx"]):
+        if context and (
+            any(ext in context.lower() for ext in [".bin", ".pt", ".pth", ".ckpt", ".h5", ".pb", ".onnx"])
+            or _is_extracted_onnx_metadata_context(context)
+        ):
             # For ML model files, only look for very explicit domain references
             # that are unlikely to occur randomly
             explicit_domain_patterns = [
@@ -5775,11 +5783,11 @@ class NetworkCommDetector:
             ".pickle",
             ".joblib",
         ]
-        is_ml_model = context and any(ext in context.lower() for ext in ml_extensions)
+        is_ml_model = bool(context) and any(ext in context.lower() for ext in ml_extensions)
 
         # For ML models, we need to be much more conservative to avoid false positives
         # Binary model weights can contain random byte sequences that match port patterns
-        if is_ml_model:
+        if is_ml_model and not _is_extracted_onnx_metadata_context(context):
             # Only scan for very explicit network patterns in ML models
             # Skip port scanning for pure binary model files to avoid false positives
             self._scan_explicit_network_patterns_in_ml_models(data, context)

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -1822,11 +1822,6 @@ def _is_metadata_context(context: str) -> bool:
     return any(segment in _DOC_CONTEXT_SEGMENTS for segment in context_segments[:-1])
 
 
-def _is_extracted_onnx_metadata_context(context: str) -> bool:
-    context_segments = [segment for segment in context.lower().replace("\\", "/").split("/") if segment]
-    return len(context_segments) >= 2 and context_segments[-2:] == ["onnx_metadata", "metadata"]
-
-
 def _iter_pattern_matches(data: bytes, pattern: bytes) -> Iterator[int]:
     """Yield non-overlapping match positions for a byte pattern."""
     start = 0
@@ -1862,6 +1857,7 @@ def _is_doc_only_network_reference(
     context: str,
     requires_call: bool,
     requires_explicit_prefix: bool = False,
+    onnx_metadata_context: bool = False,
 ) -> bool:
     """Return whether a raw network token appears in prose instead of executable code."""
     if requires_call and _has_call_syntax(data, match_index, token_len):
@@ -1885,7 +1881,7 @@ def _is_doc_only_network_reference(
     line_lower = line.lower()
     stripped = line_lower.lstrip()
     word_count = len(_WORD_PATTERN.findall(line))
-    metadata_context = _is_metadata_context(context)
+    metadata_context = onnx_metadata_context or _is_metadata_context(context)
     match_offset = match_index - source_line_start
     line_without_match = line[:match_offset] + b" " + line[match_offset + token_len :]
     prefix_before_match = line[:match_offset].strip()
@@ -4952,6 +4948,7 @@ class NetworkCommDetector:
         self._cloud_nested_url_findings: set[str] = set()
         self._official_readme_image_fences: list[tuple[int, int, bool]] = []
         self._official_readme_image_unvalidated_requests = False
+        self._onnx_metadata_context = False
 
         # Clone class-level patterns to avoid cross-instance leakage
         self.cc_patterns: list[bytes] = self.CC_PATTERNS.copy()
@@ -4966,7 +4963,13 @@ class NetworkCommDetector:
         if "custom_blacklist" in self.config:
             self.blacklisted_domains.extend(_to_lower_bytes(d) for d in self.config["custom_blacklist"])
 
-    def scan(self, data: bytes, context: str = "") -> list[dict[str, Any]]:
+    def scan(
+        self,
+        data: bytes,
+        context: str = "",
+        *,
+        onnx_metadata_context: bool = False,
+    ) -> list[dict[str, Any]]:
         """Scan data for network communication patterns.
 
         Args:
@@ -4984,6 +4987,7 @@ class NetworkCommDetector:
         self._evidence_redaction_limit_reached = False
         self._has_sensitive_evidence_hint = _SENSITIVE_EVIDENCE_HINT_PATTERN.search(data) is not None
         self._cloud_nested_url_findings = set()
+        self._onnx_metadata_context = onnx_metadata_context
         (
             self._official_readme_image_fences,
             self._official_readme_image_unvalidated_requests,
@@ -5477,7 +5481,7 @@ class NetworkCommDetector:
         # Binary weights can randomly match domain patterns
         if context and (
             any(ext in context.lower() for ext in [".bin", ".pt", ".pth", ".ckpt", ".h5", ".pb", ".onnx"])
-            or _is_extracted_onnx_metadata_context(context)
+            or self._onnx_metadata_context
         ):
             # For ML model files, only look for very explicit domain references
             # that are unlikely to occur randomly
@@ -5650,6 +5654,7 @@ class NetworkCommDetector:
                         token_len=len(pattern),
                         context=context,
                         requires_call=not pattern.startswith((b"import ", b"from ")),
+                        onnx_metadata_context=self._onnx_metadata_context,
                     ) or (
                         lib == b"requests"
                         and not self._official_readme_image_unvalidated_requests
@@ -5699,6 +5704,7 @@ class NetworkCommDetector:
                     token_len=len(func),
                     context=context,
                     requires_call=True,
+                    onnx_metadata_context=self._onnx_metadata_context,
                 ) or (
                     func == b"requests.get"
                     and _is_official_readme_sample_image_request(
@@ -5787,7 +5793,7 @@ class NetworkCommDetector:
 
         # For ML models, we need to be much more conservative to avoid false positives
         # Binary model weights can contain random byte sequences that match port patterns
-        if is_ml_model and not _is_extracted_onnx_metadata_context(context):
+        if is_ml_model and not self._onnx_metadata_context:
             # Only scan for very explicit network patterns in ML models
             # Skip port scanning for pure binary model files to avoid false positives
             self._scan_explicit_network_patterns_in_ml_models(data, context)
@@ -5848,6 +5854,7 @@ class NetworkCommDetector:
                     token_len=len(match.group()),
                     context=context,
                     requires_call=False,
+                    onnx_metadata_context=self._onnx_metadata_context,
                 ):
                     continue
 

--- a/modelaudit/detectors/network_comm.py
+++ b/modelaudit/detectors/network_comm.py
@@ -6134,7 +6134,9 @@ class NetworkCommDetector:
             ".pickle",
             ".joblib",
         ]
-        is_ml_model = bool(context) and any(ext in context.lower() for ext in ml_extensions)
+        is_ml_model = self._onnx_metadata_context or (
+            bool(context) and any(ext in context.lower() for ext in ml_extensions)
+        )
 
         # For ML models, we need to be much more conservative to avoid false positives
         # Binary model weights can contain random byte sequences that match port patterns

--- a/modelaudit/scanners/base.py
+++ b/modelaudit/scanners/base.py
@@ -1064,9 +1064,9 @@ class BaseScanner(ABC):
         context: str = "",
         enable_check: bool = True,
         raise_on_error: bool = False,
+        max_findings: int | ScanResult | None = None,
         result: ScanResult | None = None,
         *,
-        max_findings: int | None = None,
         onnx_metadata_context: bool = False,
     ) -> list[dict]:
         """Collect network communication findings without creating checks.
@@ -1076,8 +1076,8 @@ class BaseScanner(ABC):
             context: Context string for reporting
             enable_check: Whether to perform the check (allows disabling)
             raise_on_error: Whether detector failures should propagate to the caller
-            result: ScanResult to mark inconclusive if detector analysis fails
             max_findings: Optional finding cap for this detector invocation
+            result: ScanResult to mark inconclusive if detector analysis fails
             onnx_metadata_context: Whether the bytes come from validated ONNX metadata
 
         Returns:
@@ -1088,6 +1088,12 @@ class BaseScanner(ABC):
 
         try:
             from modelaudit.detectors.network_comm import NetworkCommDetector
+
+            if isinstance(max_findings, ScanResult):
+                if result is not None:
+                    raise TypeError("result was provided both positionally and by keyword")
+                result = max_findings
+                max_findings = None
 
             detector_config = self.config.get("network_comm_config")
             if max_findings is not None:

--- a/modelaudit/scanners/base.py
+++ b/modelaudit/scanners/base.py
@@ -1064,9 +1064,10 @@ class BaseScanner(ABC):
         context: str = "",
         enable_check: bool = True,
         raise_on_error: bool = False,
+        result: ScanResult | None = None,
+        *,
         max_findings: int | None = None,
         onnx_metadata_context: bool = False,
-        result: ScanResult | None = None,
     ) -> list[dict]:
         """Collect network communication findings without creating checks.
 
@@ -1075,6 +1076,8 @@ class BaseScanner(ABC):
             context: Context string for reporting
             enable_check: Whether to perform the check (allows disabling)
             raise_on_error: Whether detector failures should propagate to the caller
+            result: ScanResult to mark inconclusive if detector analysis fails
+            max_findings: Optional finding cap for this detector invocation
             onnx_metadata_context: Whether the bytes come from validated ONNX metadata
 
         Returns:

--- a/modelaudit/scanners/base.py
+++ b/modelaudit/scanners/base.py
@@ -1065,6 +1065,7 @@ class BaseScanner(ABC):
         enable_check: bool = True,
         raise_on_error: bool = False,
         max_findings: int | None = None,
+        onnx_metadata_context: bool = False,
         result: ScanResult | None = None,
     ) -> list[dict]:
         """Collect network communication findings without creating checks.
@@ -1074,6 +1075,7 @@ class BaseScanner(ABC):
             context: Context string for reporting
             enable_check: Whether to perform the check (allows disabling)
             raise_on_error: Whether detector failures should propagate to the caller
+            onnx_metadata_context: Whether the bytes come from validated ONNX metadata
 
         Returns:
             List of findings
@@ -1090,7 +1092,10 @@ class BaseScanner(ABC):
                     raise TypeError("network_comm_config must be a mapping")
                 detector_config = {**(detector_config or {}), "max_findings": max_findings}
             detector = NetworkCommDetector(detector_config)
-            findings = detector.scan(data, context)
+            if onnx_metadata_context:
+                findings = detector.scan(data, context, onnx_metadata_context=True)
+            else:
+                findings = detector.scan(data, context)
             return [dict(finding) for finding in findings]
 
         except ImportError:

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -5151,7 +5151,7 @@ class OnnxScanner(BaseScanner):
                     max_network_findings = _network_communication_max_findings(self.config)
                     emitted_network_findings = 0
                     for section_index, section in enumerate(network_detector_input.sections):
-                        detector_context = f"{path}/onnx_metadata/metadata" if section.metadata_owned else path
+                        detector_context = path
                         limit_already_reached = (
                             max_network_findings is not None and emitted_network_findings >= max_network_findings
                         )
@@ -5165,6 +5165,7 @@ class OnnxScanner(BaseScanner):
                             context=detector_context,
                             raise_on_error=True,
                             max_findings=remaining_findings,
+                            onnx_metadata_context=section.metadata_owned,
                         )
                         if limit_already_reached:
                             assert max_network_findings is not None

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -4726,6 +4726,7 @@ class OnnxScanner(BaseScanner):
             # Check for interrupts before starting the potentially long-running load.
             self.check_interrupted()
             file_backed_parse_state: _OnnxStructureParseState | None = None
+            in_memory_unknown_field_bytes_discarded = 0
             model: Any
             if model_data is None:
                 model, file_backed_parse_state = _load_onnx_structure_file_backed(
@@ -4735,24 +4736,10 @@ class OnnxScanner(BaseScanner):
                     expected_stat=source_stat,
                 )
                 result.metadata["onnx_structure_parse"] = file_backed_parse_state.metadata()
-                self._mark_structure_parse_coverage_gaps(result, path, state=file_backed_parse_state)
             else:
                 model = onnx.load_model_from_string(model_data)
                 result.metadata["onnx_structure_parse"] = {"parse_mode": "in_memory_model_proto"}
-                unknown_field_bytes_discarded = _discard_onnx_unknown_field_bytes(model)
-                if unknown_field_bytes_discarded:
-                    result.metadata["onnx_structure_parse"] = {
-                        "parse_mode": "in_memory_model_proto",
-                        "coverage_gaps": {"unknown_protobuf_fields": 1},
-                        "unknown_field_count": 1,
-                        "unknown_field_bytes_discarded": unknown_field_bytes_discarded,
-                        "unknown_field_detection": "discard_unknown_fields_byte_size",
-                    }
-                    self._mark_in_memory_unknown_fields(
-                        result,
-                        path,
-                        unknown_field_bytes_discarded=unknown_field_bytes_discarded,
-                    )
+                in_memory_unknown_field_bytes_discarded = _discard_onnx_unknown_field_bytes(model)
             # Check for interrupts after loading completes.
             self.check_interrupted()
             result.bytes_scanned = file_size
@@ -4829,6 +4816,21 @@ class OnnxScanner(BaseScanner):
                 result.metadata["tentative_protobuf_candidate_rejected"] = True
                 result.finish(success=True)
                 return result
+            if file_backed_parse_state is not None:
+                self._mark_structure_parse_coverage_gaps(result, path, state=file_backed_parse_state)
+            elif in_memory_unknown_field_bytes_discarded:
+                result.metadata["onnx_structure_parse"] = {
+                    "parse_mode": "in_memory_model_proto",
+                    "coverage_gaps": {"unknown_protobuf_fields": 1},
+                    "unknown_field_count": 1,
+                    "unknown_field_bytes_discarded": in_memory_unknown_field_bytes_discarded,
+                    "unknown_field_detection": "discard_unknown_fields_byte_size",
+                }
+                self._mark_in_memory_unknown_fields(
+                    result,
+                    path,
+                    unknown_field_bytes_discarded=in_memory_unknown_field_bytes_discarded,
+                )
             _mark_inconclusive_scan_result(result, ONNX_STRUCTURE_INCONCLUSIVE_REASON)
             result.add_check(
                 name="ONNX Structure Validation",
@@ -4842,6 +4844,21 @@ class OnnxScanner(BaseScanner):
                     "ir_version": model.ir_version,
                     "has_graph": has_graph,
                 },
+            )
+        elif file_backed_parse_state is not None:
+            self._mark_structure_parse_coverage_gaps(result, path, state=file_backed_parse_state)
+        elif in_memory_unknown_field_bytes_discarded:
+            result.metadata["onnx_structure_parse"] = {
+                "parse_mode": "in_memory_model_proto",
+                "coverage_gaps": {"unknown_protobuf_fields": 1},
+                "unknown_field_count": 1,
+                "unknown_field_bytes_discarded": in_memory_unknown_field_bytes_discarded,
+                "unknown_field_detection": "discard_unknown_fields_byte_size",
+            }
+            self._mark_in_memory_unknown_fields(
+                result,
+                path,
+                unknown_field_bytes_discarded=in_memory_unknown_field_bytes_discarded,
             )
 
         if model.ir_version > 0 and has_graph:

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -134,7 +134,9 @@ _ONNX_RAW_DETECTOR_DEFAULT_MAX_BYTES = 512 * 1024 * 1024
 _ONNX_NETWORK_TEXT_MAX_BYTES = 4 * 1024 * 1024
 _ONNX_NETWORK_TEXT_MAX_FIELDS = 100_000
 _ONNX_METADATA_DETECTOR_SECTION_MAX_ENTRIES = 1024
-_ONNX_METADATA_PROP_LABEL_PATTERN = re.compile(r"^model\.metadata_props\[(?P<index>[0-9]+)\]\.(?P<field>key|value)$")
+_ONNX_METADATA_PROP_LABEL_PATTERN = re.compile(
+    r"^(?P<prefix>.+\.metadata_props)\[(?P<index>[0-9]+)\]\.(?P<field>key|value)$"
+)
 _ONNX_RAW_OR_NUMERIC_TENSOR_PAYLOAD_FIELD_NAMES: frozenset[str] = frozenset(
     {
         # TensorProto.string_data is semantic model data and stays in the
@@ -475,7 +477,7 @@ class _OnnxNetworkTextCollector:
         self._omitted_field_count = 0
         self._truncated = False
         self._truncation_reason: str | None = None
-        self._metadata_props: dict[int, dict[str, str]] = {}
+        self._metadata_props: dict[tuple[str, int], dict[str, str]] = {}
 
     def is_truncated(self) -> bool:
         return self._truncated
@@ -532,16 +534,17 @@ class _OnnxNetworkTextCollector:
         match = _ONNX_METADATA_PROP_LABEL_PATTERN.fullmatch(label)
         if match is None:
             return
-        self._metadata_props.setdefault(int(match.group("index")), {})[match.group("field")] = value
+        entry_key = (match.group("prefix"), int(match.group("index")))
+        self._metadata_props.setdefault(entry_key, {})[match.group("field")] = value
 
-    def metadata_prop_entries(self) -> list[tuple[int, str, str]]:
-        entries: list[tuple[int, str, str]] = []
-        for index in sorted(self._metadata_props):
-            fields = self._metadata_props[index]
+    def metadata_prop_entries(self) -> list[tuple[str, int, str, str]]:
+        entries: list[tuple[str, int, str, str]] = []
+        for prefix, index in sorted(self._metadata_props):
+            fields = self._metadata_props[(prefix, index)]
             key = fields.get("key")
             value = fields.get("value")
             if key is not None and value is not None:
-                entries.append((index, key, value))
+                entries.append((prefix, index, key, value))
         return entries
 
     def omit(self, reason: str = "text_field_budget_exceeded") -> None:
@@ -695,23 +698,23 @@ def _collect_onnx_network_detector_input(
 
 def _onnx_metadata_props_detector_sections(
     model: Any,
-    metadata_props: Iterable[tuple[int, str, str]],
+    metadata_props: Iterable[tuple[str, int, str, str]],
     *,
     max_bytes: int,
 ) -> tuple[tuple[frozenset[str], bytes], ...]:
     metadata_entries = list(metadata_props)
     if not metadata_entries:
         return ()
-    candidate_entries: list[tuple[int, str, str]] = []
+    candidate_entries: list[tuple[str, int, str, str]] = []
     estimated_bytes = 0
-    for index, key, value in metadata_entries:
+    for prefix, index, key, value in metadata_entries:
         value_with_boundary = value + "\n"
         entry_bytes = len(key.encode("utf-8", errors="surrogatepass")) + len(
             value_with_boundary.encode("utf-8", errors="surrogatepass")
         )
         if candidate_entries and estimated_bytes + entry_bytes + 64 > max_bytes:
             break
-        candidate_entries.append((index, key, value_with_boundary))
+        candidate_entries.append((prefix, index, key, value_with_boundary))
         estimated_bytes += entry_bytes + 64
     if not candidate_entries:
         return ()
@@ -726,7 +729,7 @@ def _onnx_metadata_props_detector_sections(
                 metadata_model.graph.name = "modelaudit_metadata"
                 metadata_model.graph.input.add().name = "modelaudit_input"
                 metadata_model.graph.output.add().name = "modelaudit_output"
-                for _index, key, value in batch_entries:
+                for _prefix, _index, key, value in batch_entries:
                     metadata_prop = metadata_model.metadata_props.add()
                     metadata_prop.key = key
                     metadata_prop.value = value
@@ -738,8 +741,8 @@ def _onnx_metadata_props_detector_sections(
                 break
             metadata_data_labels = frozenset(
                 label
-                for index, _key, _value in batch_entries
-                for label in (f"model.metadata_props[{index}].key", f"model.metadata_props[{index}].value")
+                for prefix, index, _key, _value in batch_entries
+                for label in (f"{prefix}[{index}].key", f"{prefix}[{index}].value")
             )
             sections.append((metadata_data_labels, metadata_data))
             position += len(batch_entries)

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -133,12 +133,13 @@ _ONNX_WEIGHT_DEFAULT_MAX_ARRAY_SIZE = 100 * 1024 * 1024
 _ONNX_RAW_DETECTOR_DEFAULT_MAX_BYTES = 512 * 1024 * 1024
 _ONNX_NETWORK_TEXT_MAX_BYTES = 4 * 1024 * 1024
 _ONNX_NETWORK_TEXT_MAX_FIELDS = 100_000
-_ONNX_TENSOR_PAYLOAD_FIELD_NAMES: frozenset[str] = frozenset(
+_ONNX_RAW_OR_NUMERIC_TENSOR_PAYLOAD_FIELD_NAMES: frozenset[str] = frozenset(
     {
+        # TensorProto.string_data is semantic model data and stays in the
+        # bounded network-text path; only raw bytes and numeric payloads skip it.
         "raw_data",
         "float_data",
         "int32_data",
-        "string_data",
         "int64_data",
         "double_data",
         "uint64_data",
@@ -446,6 +447,7 @@ class _OnnxNetworkDetectorInput:
     metadata_field_count: int
     omitted_field_count: int
     truncated: bool
+    truncation_reason: str | None
 
 
 class _OnnxNetworkTextCollector:
@@ -469,6 +471,7 @@ class _OnnxNetworkTextCollector:
         self._structural_field_count = 0
         self._omitted_field_count = 0
         self._truncated = False
+        self._truncation_reason: str | None = None
 
     def is_truncated(self) -> bool:
         return self._truncated
@@ -478,8 +481,13 @@ class _OnnxNetworkTextCollector:
 
     def add(self, label: str, value: Any) -> None:
         self.check_interrupted()
+        if value is None:
+            return
+        if isinstance(value, (str, bytes)) and not value:
+            return
         if self._visited_field_count >= self._max_fields:
             self._truncated = True
+            self._truncation_reason = self._truncation_reason or "text_field_budget_exceeded"
             self._omitted_field_count += 1
             return
         self._visited_field_count += 1
@@ -489,6 +497,7 @@ class _OnnxNetworkTextCollector:
         value_bytes = _onnx_network_text_value_bytes(value, max_bytes=remaining_bytes)
         if value_bytes is None:
             self._truncated = True
+            self._truncation_reason = self._truncation_reason or "text_field_budget_exceeded"
             self._omitted_field_count += 1
             return
         if not value_bytes:
@@ -504,8 +513,9 @@ class _OnnxNetworkTextCollector:
         self._byte_count += len(entry)
         self._field_count += 1
 
-    def omit(self) -> None:
+    def omit(self, reason: str = "text_field_budget_exceeded") -> None:
         self._truncated = True
+        self._truncation_reason = self._truncation_reason or reason
         self._omitted_field_count += 1
 
     def finish(self) -> _OnnxNetworkDetectorInput:
@@ -535,6 +545,7 @@ class _OnnxNetworkTextCollector:
             metadata_field_count=self._metadata_field_count,
             omitted_field_count=self._omitted_field_count,
             truncated=self._truncated,
+            truncation_reason=self._truncation_reason,
         )
 
 
@@ -585,6 +596,27 @@ def _collect_onnx_network_detector_input(
     return collector.finish()
 
 
+def _onnx_network_detector_input_metadata(network_detector_input: _OnnxNetworkDetectorInput) -> dict[str, Any]:
+    return {
+        "source": "structured_text_fields",
+        "field_count": network_detector_input.field_count,
+        "metadata_field_count": network_detector_input.metadata_field_count,
+        "omitted_field_count": network_detector_input.omitted_field_count,
+        "truncated": network_detector_input.truncated,
+        "truncation_reason": network_detector_input.truncation_reason,
+        "max_bytes": _ONNX_NETWORK_TEXT_MAX_BYTES,
+        "max_fields": _ONNX_NETWORK_TEXT_MAX_FIELDS,
+        "sections": [
+            {
+                "name": section.name,
+                "field_count": section.field_count,
+                "metadata_owned": section.metadata_owned,
+            }
+            for section in network_detector_input.sections
+        ],
+    }
+
+
 def _collect_onnx_proto_text_fields(
     collector: _OnnxNetworkTextCollector,
     message: Any,
@@ -599,6 +631,8 @@ def _collect_onnx_proto_text_fields(
         return
     descriptor = getattr(message, "DESCRIPTOR", None)
     if descriptor is None:
+        if depth == 0:
+            collector.omit("structured_text_unavailable")
         return
     for proto_field in getattr(descriptor, "fields", []):
         collector.check_interrupted()
@@ -633,7 +667,7 @@ def _collect_onnx_proto_text_fields(
 def _is_onnx_tensor_payload_field(descriptor: Any, proto_field: Any) -> bool:
     return (
         getattr(descriptor, "full_name", "") == "onnx.TensorProto"
-        and proto_field.name in _ONNX_TENSOR_PAYLOAD_FIELD_NAMES
+        and proto_field.name in _ONNX_RAW_OR_NUMERIC_TENSOR_PAYLOAD_FIELD_NAMES
     )
 
 
@@ -4963,40 +4997,11 @@ class OnnxScanner(BaseScanner):
                         model,
                         check_interrupted=self.check_interrupted,
                     )
-                    result.metadata["onnx_network_detector_input"] = {
-                        "source": "structured_text_fields",
-                        "field_count": network_detector_input.field_count,
-                        "metadata_field_count": network_detector_input.metadata_field_count,
-                        "omitted_field_count": network_detector_input.omitted_field_count,
-                        "truncated": network_detector_input.truncated,
-                        "max_bytes": _ONNX_NETWORK_TEXT_MAX_BYTES,
-                        "max_fields": _ONNX_NETWORK_TEXT_MAX_FIELDS,
-                        "sections": [
-                            {
-                                "name": section.name,
-                                "field_count": section.field_count,
-                                "metadata_owned": section.metadata_owned,
-                            }
-                            for section in network_detector_input.sections
-                        ],
-                    }
+                    result.metadata["onnx_network_detector_input"] = _onnx_network_detector_input_metadata(
+                        network_detector_input
+                    )
                     if network_detector_input.truncated:
-                        self._mark_raw_detection_incomplete(
-                            result,
-                            path,
-                            detector="network_communication",
-                            reason="text_field_budget_exceeded",
-                            message=(
-                                "ONNX network detector text input exceeded bounded extraction budget; "
-                                "analysis incomplete"
-                            ),
-                            details={
-                                "field_count": network_detector_input.field_count,
-                                "omitted_field_count": network_detector_input.omitted_field_count,
-                                "max_bytes": _ONNX_NETWORK_TEXT_MAX_BYTES,
-                                "max_fields": _ONNX_NETWORK_TEXT_MAX_FIELDS,
-                            },
-                        )
+                        self._mark_network_text_input_incomplete(result, path, network_detector_input)
                     network_findings: list[dict[str, Any]] = []
                     max_network_findings = _network_communication_max_findings(self.config)
                     emitted_network_findings = 0
@@ -5108,6 +5113,29 @@ class OnnxScanner(BaseScanner):
                             context=path,
                         )
 
+        if model_data is None and check_net:
+            try:
+                network_detector_input = _collect_onnx_network_detector_input(
+                    model,
+                    check_interrupted=self.check_interrupted,
+                )
+                result.metadata["onnx_network_detector_input"] = _onnx_network_detector_input_metadata(
+                    network_detector_input
+                )
+                if network_detector_input.truncated:
+                    self._mark_network_text_input_incomplete(result, path, network_detector_input)
+            except Exception as e:
+                redacted_error = redact_untrusted_error_message(e)
+                logger.warning("ONNX network detector analysis failed: %s", redacted_error)
+                self._mark_raw_detection_incomplete(
+                    result,
+                    path,
+                    detector="network_communication",
+                    reason="analysis_failed",
+                    message=f"ONNX network detector analysis failed: {redacted_error}",
+                    details={"exception": redacted_error, "exception_type": type(e).__name__},
+                )
+
         self._check_custom_ops(model, path, result)
         self._check_external_data(model, path, result)
         self._check_tensor_sizes(model, path, result)
@@ -5134,6 +5162,33 @@ class OnnxScanner(BaseScanner):
 
         _finish_scan_result(result)
         return result
+
+    def _mark_network_text_input_incomplete(
+        self,
+        result: ScanResult,
+        path: str,
+        network_detector_input: _OnnxNetworkDetectorInput,
+    ) -> None:
+        truncation_reason = network_detector_input.truncation_reason or "text_field_budget_exceeded"
+        truncation_message = "ONNX network detector text input exceeded bounded extraction budget; analysis incomplete"
+        if truncation_reason == "structured_text_unavailable":
+            truncation_message = (
+                "ONNX network detector text input unavailable for bounded file-backed structure; analysis incomplete"
+            )
+        self._mark_raw_detection_incomplete(
+            result,
+            path,
+            detector="network_communication",
+            reason=truncation_reason,
+            message=truncation_message,
+            details={
+                "field_count": network_detector_input.field_count,
+                "omitted_field_count": network_detector_input.omitted_field_count,
+                "truncation_reason": truncation_reason,
+                "max_bytes": _ONNX_NETWORK_TEXT_MAX_BYTES,
+                "max_fields": _ONNX_NETWORK_TEXT_MAX_FIELDS,
+            },
+        )
 
     def _mark_raw_detection_incomplete(
         self,

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -633,6 +633,13 @@ def _network_communication_max_findings(config: dict[str, Any] | None) -> int | 
     return None
 
 
+def _is_network_redaction_work_limit(finding: dict[str, Any]) -> bool:
+    return finding.get("type") == "detector_finding_limit" and finding.get("truncated_finding_type") in {
+        "endpoint_redaction_classification",
+        "evidence_redaction",
+    }
+
+
 def _network_finding_limit_payload(
     section: _OnnxNetworkDetectorSection,
     context: str,
@@ -5207,10 +5214,18 @@ class OnnxScanner(BaseScanner):
                                 break
                             continue
                         section_truncated = False
+                        section_redaction_work_limited = False
+                        section_finding_limited = False
+                        section_redaction_work_limit: dict[str, Any] | None = None
                         for finding in section_findings:
                             annotated_finding = dict(finding)
                             if annotated_finding.get("type") == "detector_finding_limit":
                                 section_truncated = True
+                                if _is_network_redaction_work_limit(annotated_finding):
+                                    section_redaction_work_limited = True
+                                    section_redaction_work_limit = annotated_finding
+                                else:
+                                    section_finding_limited = True
                             else:
                                 emitted_network_findings += 1
                             annotated_finding.update(
@@ -5225,10 +5240,18 @@ class OnnxScanner(BaseScanner):
                                 annotated_finding["context"] = f"{path}:metadata_props"
                             network_findings.append(annotated_finding)
                         if section_truncated:
-                            self._mark_network_finding_limit(
-                                result, path, section, section_index, network_detector_input
-                            )
-                            break
+                            if section_redaction_work_limited:
+                                self._mark_network_redaction_work_limit(
+                                    result,
+                                    path,
+                                    section,
+                                    section_redaction_work_limit,
+                                )
+                            if section_finding_limited:
+                                self._mark_network_finding_limit(
+                                    result, path, section, section_index, network_detector_input
+                                )
+                                break
                 except Exception as e:
                     network_detector_failed = True
                     redacted_error = redact_untrusted_error_message(e)
@@ -5301,6 +5324,26 @@ class OnnxScanner(BaseScanner):
 
         _finish_scan_result(result)
         return result
+
+    def _mark_network_redaction_work_limit(
+        self,
+        result: ScanResult,
+        path: str,
+        section: _OnnxNetworkDetectorSection,
+        finding: dict[str, Any] | None,
+    ) -> None:
+        self._mark_raw_detection_incomplete(
+            result,
+            path,
+            detector="network_communication",
+            reason="detector_finding_limit",
+            message="ONNX network detector redaction work limit reached; analysis incomplete",
+            details={
+                "max_classifications": (finding or {}).get("max_classifications"),
+                "truncated_section": section.name,
+                "truncated_section_metadata_owned": section.metadata_owned,
+            },
+        )
 
     def _mark_network_finding_limit(
         self,

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -133,6 +133,17 @@ _ONNX_WEIGHT_DEFAULT_MAX_ARRAY_SIZE = 100 * 1024 * 1024
 _ONNX_RAW_DETECTOR_DEFAULT_MAX_BYTES = 512 * 1024 * 1024
 _ONNX_NETWORK_TEXT_MAX_BYTES = 4 * 1024 * 1024
 _ONNX_NETWORK_TEXT_MAX_FIELDS = 100_000
+_ONNX_TENSOR_PAYLOAD_FIELD_NAMES: frozenset[str] = frozenset(
+    {
+        "raw_data",
+        "float_data",
+        "int32_data",
+        "string_data",
+        "int64_data",
+        "double_data",
+        "uint64_data",
+    }
+)
 _ONNX_STRUCTURE_STRING_MAX_BYTES = 1024 * 1024
 _ONNX_STRUCTURE_MAX_DEPTH = 128
 _ONNX_STRUCTURE_MAX_NODES = 1_000_000
@@ -146,6 +157,7 @@ _ONNX_STRUCTURE_MAX_STRING_DATA_FIELDS = 100_000
 _ONNX_STRUCTURE_MAX_REPEATED_SUBMESSAGES = 100_000
 _ONNX_STRUCTURE_MAX_FIELD_NUMBER = (1 << 29) - 1
 _ONNX_STRUCTURE_MAX_PARSE_STEPS = 5_000_000
+_ONNX_STRUCTURE_MAX_UNKNOWN_FIELD_SAMPLES = 20
 _ONNX_STRUCTURE_MAX_RETAINED_OBJECTS = 1_000_000
 _ONNX_STRUCTURE_MAX_RETAINED_SEQUENCE_ENTRIES = 1_000_000
 _ONNX_STRUCTURE_MAX_RETAINED_STRING_BYTES = 64 * 1024 * 1024
@@ -404,17 +416,34 @@ def _onnx_weight_output_axes(node: Any, input_index: int, rank: int) -> tuple[tu
 def _iter_attribute_graphs(attribute: Any) -> Any:
     """Yield graph values declared by an ONNX attribute."""
     yield from attribute.graphs
-    try:
-        if attribute.HasField("g"):
-            yield attribute.g
-    except (ValueError, AttributeError):  # pragma: no cover - proto edge case
-        pass
+    if _onnx_has_singular_field(attribute, "g"):
+        yield attribute.g
+
+
+def _onnx_has_singular_field(message: Any, field_name: str) -> bool:
+    has_field = getattr(message, "HasField", None)
+    if callable(has_field):
+        try:
+            return bool(has_field(field_name))
+        except (AttributeError, ValueError):
+            pass
+    return getattr(message, field_name, None) is not None
+
+
+@dataclass(frozen=True)
+class _OnnxNetworkDetectorSection:
+    name: str
+    data: bytes
+    field_count: int
+    metadata_owned: bool
 
 
 @dataclass(frozen=True)
 class _OnnxNetworkDetectorInput:
     data: bytes
+    sections: tuple[_OnnxNetworkDetectorSection, ...]
     field_count: int
+    metadata_field_count: int
     omitted_field_count: int
     truncated: bool
 
@@ -428,11 +457,16 @@ class _OnnxNetworkTextCollector:
         check_interrupted: Callable[[], None],
     ) -> None:
         self._chunks: list[bytes] = []
+        self._metadata_chunks: list[bytes] = []
+        self._structural_chunks: list[bytes] = []
         self._max_bytes = max_bytes
         self._max_fields = max_fields
         self._check_interrupted = check_interrupted
         self._byte_count = 0
+        self._visited_field_count = 0
         self._field_count = 0
+        self._metadata_field_count = 0
+        self._structural_field_count = 0
         self._omitted_field_count = 0
         self._truncated = False
 
@@ -444,19 +478,29 @@ class _OnnxNetworkTextCollector:
 
     def add(self, label: str, value: Any) -> None:
         self.check_interrupted()
-        value_bytes = _onnx_network_text_value_bytes(value)
+        if self._visited_field_count >= self._max_fields:
+            self._truncated = True
+            self._omitted_field_count += 1
+            return
+        self._visited_field_count += 1
+        label_bytes = label.encode("utf-8", errors="surrogatepass")
+        entry_overhead = len(label_bytes) + len(b": \n")
+        remaining_bytes = self._max_bytes - self._byte_count - entry_overhead
+        value_bytes = _onnx_network_text_value_bytes(value, max_bytes=remaining_bytes)
+        if value_bytes is None:
+            self._truncated = True
+            self._omitted_field_count += 1
+            return
         if not value_bytes:
             return
-        if self._field_count >= self._max_fields:
-            self._truncated = True
-            self._omitted_field_count += 1
-            return
-        entry = label.encode("utf-8", errors="surrogatepass") + b"=" + value_bytes + b"\n"
-        if self._byte_count + len(entry) > self._max_bytes:
-            self._truncated = True
-            self._omitted_field_count += 1
-            return
+        entry = label_bytes + b": " + value_bytes + b"\n"
         self._chunks.append(entry)
+        if _is_onnx_metadata_text_label(label):
+            self._metadata_chunks.append(entry)
+            self._metadata_field_count += 1
+        else:
+            self._structural_chunks.append(entry)
+            self._structural_field_count += 1
         self._byte_count += len(entry)
         self._field_count += 1
 
@@ -465,22 +509,66 @@ class _OnnxNetworkTextCollector:
         self._omitted_field_count += 1
 
     def finish(self) -> _OnnxNetworkDetectorInput:
+        sections: list[_OnnxNetworkDetectorSection] = []
+        if self._structural_chunks:
+            sections.append(
+                _OnnxNetworkDetectorSection(
+                    name="structured_text_fields",
+                    data=b"".join(self._structural_chunks),
+                    field_count=self._structural_field_count,
+                    metadata_owned=False,
+                )
+            )
+        if self._metadata_chunks:
+            sections.append(
+                _OnnxNetworkDetectorSection(
+                    name="metadata_props",
+                    data=b"".join(self._metadata_chunks),
+                    field_count=self._metadata_field_count,
+                    metadata_owned=True,
+                )
+            )
         return _OnnxNetworkDetectorInput(
             data=b"".join(self._chunks),
+            sections=tuple(sections),
             field_count=self._field_count,
+            metadata_field_count=self._metadata_field_count,
             omitted_field_count=self._omitted_field_count,
             truncated=self._truncated,
         )
 
 
-def _onnx_network_text_value_bytes(value: Any) -> bytes:
+def _onnx_network_text_value_bytes(value: Any, *, max_bytes: int) -> bytes | None:
+    if max_bytes <= 0:
+        return None
     if value is None:
         return b""
     if isinstance(value, bytes):
+        if len(value) > max_bytes:
+            return None
         return value
     if isinstance(value, str):
-        return value.encode("utf-8", errors="surrogatepass")
+        if len(value) > max_bytes:
+            return None
+        value_bytes = value.encode("utf-8", errors="surrogatepass")
+        if len(value_bytes) > max_bytes:
+            return None
+        return value_bytes
     return b""
+
+
+def _network_communication_max_findings(config: dict[str, Any] | None) -> int | None:
+    network_config = (config or {}).get("network_comm_config")
+    if not isinstance(network_config, dict):
+        return None
+    max_findings = network_config.get("max_findings")
+    if isinstance(max_findings, int) and not isinstance(max_findings, bool) and max_findings > 0:
+        return max_findings
+    return None
+
+
+def _is_onnx_metadata_text_label(label: str) -> bool:
+    return ".metadata_props[" in label
 
 
 def _collect_onnx_network_detector_input(
@@ -517,6 +605,12 @@ def _collect_onnx_proto_text_fields(
         field_label = f"{label}.{proto_field.name}"
         if _is_onnx_tensor_payload_field(descriptor, proto_field):
             continue
+        if proto_field.label == proto_field.LABEL_REPEATED and proto_field.type not in {
+            proto_field.TYPE_MESSAGE,
+            proto_field.TYPE_BYTES,
+            proto_field.TYPE_STRING,
+        }:
+            continue
         value = getattr(message, proto_field.name)
         if proto_field.label == proto_field.LABEL_REPEATED:
             for index, item in enumerate(value):
@@ -529,21 +623,18 @@ def _collect_onnx_proto_text_fields(
                     return
             continue
         if proto_field.type == proto_field.TYPE_MESSAGE:
-            try:
-                if not message.HasField(proto_field.name):
-                    continue
-            except ValueError:
-                pass
+            if not _onnx_has_singular_field(message, proto_field.name):
+                continue
             _collect_onnx_proto_text_fields(collector, value, field_label, depth=depth + 1)
         elif proto_field.type in {proto_field.TYPE_BYTES, proto_field.TYPE_STRING}:
             collector.add(field_label, value)
 
 
 def _is_onnx_tensor_payload_field(descriptor: Any, proto_field: Any) -> bool:
-    return getattr(descriptor, "full_name", "") == "onnx.TensorProto" and proto_field.name in {
-        "raw_data",
-        "string_data",
-    }
+    return (
+        getattr(descriptor, "full_name", "") == "onnx.TensorProto"
+        and proto_field.name in _ONNX_TENSOR_PAYLOAD_FIELD_NAMES
+    )
 
 
 def _iter_graph_nodes(graph: Any) -> Any:
@@ -869,16 +960,13 @@ def _iter_attribute_external_data_tensors(
         _check_onnx_traversal_interrupted(interrupt_check)
         yield sparse_tensor.values
         yield sparse_tensor.indices
-    try:
-        if attribute.HasField("t"):
-            _check_onnx_traversal_interrupted(interrupt_check)
-            yield attribute.t
-        if attribute.HasField("sparse_tensor"):
-            _check_onnx_traversal_interrupted(interrupt_check)
-            yield attribute.sparse_tensor.values
-            yield attribute.sparse_tensor.indices
-    except (ValueError, AttributeError):  # pragma: no cover - proto edge case
-        pass
+    if _onnx_has_singular_field(attribute, "t"):
+        _check_onnx_traversal_interrupted(interrupt_check)
+        yield attribute.t
+    if _onnx_has_singular_field(attribute, "sparse_tensor"):
+        _check_onnx_traversal_interrupted(interrupt_check)
+        yield attribute.sparse_tensor.values
+        yield attribute.sparse_tensor.indices
 
 
 def _iter_graph_external_data_tensors(
@@ -979,7 +1067,7 @@ def _confirmed_onnx_operator_findings(findings: list[Any], model: Any) -> list[A
         return confirmed
 
     try:
-        if hasattr(model, "HasField") and not model.HasField("graph"):
+        if hasattr(model, "HasField") and not _onnx_has_singular_field(model, "graph"):
             return confirmed
         for graph in _iter_model_graphs(model):
             for node in _iter_graph_nodes(graph):
@@ -2480,11 +2568,8 @@ def _build_onnx_weight_analysis_plan(
                         unresolved_constant_attribute = True
                         continue
                     if attribute.name == "value":
-                        try:
-                            if resolved_attribute.HasField("t"):
-                                constant_tensor = resolved_attribute.t
-                        except (AttributeError, ValueError):
-                            constant_tensor = None
+                        if _onnx_has_singular_field(resolved_attribute, "t"):
+                            constant_tensor = resolved_attribute.t
                     elif attribute.name == "value_ints":
                         constant_tensor = onnx.helper.make_tensor(
                             "",
@@ -2513,12 +2598,11 @@ def _build_onnx_weight_analysis_plan(
                             [],
                             [resolved_attribute.f],
                         )
-                    elif attribute.name == "sparse_value":
-                        try:
-                            if resolved_attribute.HasField("sparse_tensor"):
-                                sparse_constant = resolved_attribute.sparse_tensor
-                        except (AttributeError, ValueError):
-                            sparse_constant = None
+                    elif attribute.name == "sparse_value" and _onnx_has_singular_field(
+                        resolved_attribute,
+                        "sparse_tensor",
+                    ):
+                        sparse_constant = resolved_attribute.sparse_tensor
                     if constant_tensor is not None or sparse_constant is not None:
                         constant_source_key = (
                             "constant_value",
@@ -3013,6 +3097,65 @@ class _OnnxLengthOnlySequence:
         return iter((_OnnxOmittedBytes(self._total_bytes),))
 
 
+_ONNX_MESSAGE_CLASS_BY_FULL_NAME: dict[str, str] = {
+    "onnx.StringStringEntryProto": "StringStringEntryProto",
+    "onnx.TensorProto": "TensorProto",
+    "onnx.SparseTensorProto": "SparseTensorProto",
+    "onnx.AttributeProto": "AttributeProto",
+    "onnx.NodeProto": "NodeProto",
+    "onnx.ValueInfoProto": "ValueInfoProto",
+    "onnx.GraphProto": "GraphProto",
+    "onnx.OperatorSetIdProto": "OperatorSetIdProto",
+    "onnx.FunctionProto": "FunctionProto",
+    "onnx.TrainingInfoProto": "TrainingInfoProto",
+    "onnx.ModelProto": "ModelProto",
+}
+_FALLBACK_ONNX_KNOWN_FIELD_NUMBERS: dict[str, frozenset[int]] = {
+    "onnx.StringStringEntryProto": frozenset({1, 2}),
+    "onnx.TensorProto": frozenset({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16}),
+    "onnx.SparseTensorProto": frozenset({1, 2, 3}),
+    "onnx.AttributeProto": frozenset({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 20, 21, 22, 23}),
+    "onnx.NodeProto": frozenset({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+    "onnx.ValueInfoProto": frozenset({1, 2, 3, 4}),
+    "onnx.GraphProto": frozenset({1, 2, 5, 10, 11, 12, 13, 14, 15, 16}),
+    "onnx.OperatorSetIdProto": frozenset({1, 2}),
+    "onnx.FunctionProto": frozenset({1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}),
+    "onnx.TrainingInfoProto": frozenset({1, 2, 3, 4}),
+    "onnx.ModelProto": frozenset({1, 2, 3, 4, 5, 6, 7, 8, 14, 20, 25, 26}),
+}
+_ONNX_KNOWN_FIELD_NUMBERS: dict[str, frozenset[int]] | None = None
+
+
+def _onnx_known_field_numbers(message_name: str) -> frozenset[int]:
+    global _ONNX_KNOWN_FIELD_NUMBERS
+    if _ONNX_KNOWN_FIELD_NUMBERS is None:
+        known_fields = dict(_FALLBACK_ONNX_KNOWN_FIELD_NUMBERS)
+        try:
+            import onnx
+
+            for full_name, class_name in _ONNX_MESSAGE_CLASS_BY_FULL_NAME.items():
+                proto_type = getattr(onnx, class_name, None)
+                descriptor = getattr(proto_type, "DESCRIPTOR", None)
+                fields = getattr(descriptor, "fields", None)
+                if fields is not None:
+                    known_fields[full_name] = frozenset(int(field.number) for field in fields)
+        except Exception:
+            logger.debug("Unable to derive installed ONNX protobuf field map", exc_info=True)
+        _ONNX_KNOWN_FIELD_NUMBERS = known_fields
+    return _ONNX_KNOWN_FIELD_NUMBERS.get(message_name, frozenset())
+
+
+def _discard_onnx_unknown_field_bytes(message: Any) -> int:
+    byte_size = getattr(message, "ByteSize", None)
+    discard_unknown_fields = getattr(message, "DiscardUnknownFields", None)
+    if not callable(byte_size) or not callable(discard_unknown_fields):
+        return 0
+    before = int(byte_size())
+    discard_unknown_fields()
+    after = int(byte_size())
+    return max(0, before - after)
+
+
 @dataclass
 class _OnnxLiteStringEntry:
     key: str = ""
@@ -3150,6 +3293,8 @@ class _OnnxStructureParseState:
     retained_string_bytes: int = 0
     retained_allocation_bytes: int = 0
     string_fields_skipped: int = 0
+    unknown_field_count: int = 0
+    unknown_field_samples: list[dict[str, Any]] = field(default_factory=list)
     fields_seen: int = 0
     parse_steps: int = 0
     coverage_gaps: dict[str, int] = field(default_factory=dict)
@@ -3168,6 +3313,19 @@ class _OnnxStructureParseState:
 
     def record_gap(self, reason: str, count: int = 1) -> None:
         self.coverage_gaps[reason] = self.coverage_gaps.get(reason, 0) + count
+
+    def record_unknown_field(self, message_name: str, field_number: int, wire_type: int) -> None:
+        self.unknown_field_count += 1
+        self.record_gap("unknown_protobuf_fields")
+        if len(self.unknown_field_samples) >= _ONNX_STRUCTURE_MAX_UNKNOWN_FIELD_SAMPLES:
+            return
+        self.unknown_field_samples.append(
+            {
+                "message": message_name,
+                "field_number": field_number,
+                "wire_type": wire_type,
+            }
+        )
 
     def record_retained_allocation(self, amount: int) -> None:
         if amount < 0 or amount > _ONNX_STRUCTURE_MAX_RETAINED_ALLOCATION_BYTES - self.retained_allocation_bytes:
@@ -3234,6 +3392,9 @@ class _OnnxStructureParseState:
             "retained_string_bytes": self.retained_string_bytes,
             "retained_allocation_bytes": self.retained_allocation_bytes,
             "string_fields_skipped": self.string_fields_skipped,
+            "unknown_field_count": self.unknown_field_count,
+            "unknown_field_samples": list(self.unknown_field_samples),
+            "unknown_field_samples_truncated": (self.unknown_field_count > len(self.unknown_field_samples)),
             "fields_seen": self.fields_seen,
             "parse_steps": self.parse_steps,
             "coverage_gaps": dict(self.coverage_gaps),
@@ -3288,6 +3449,18 @@ def _read_onnx_key(handle: BinaryIO, end: int, state: _OnnxStructureParseState) 
             f"ONNX protobuf field number exceeds maximum ({_ONNX_STRUCTURE_MAX_FIELD_NUMBER})",
         )
     return field_number, key & 0x07
+
+
+def _read_onnx_message_key(
+    handle: BinaryIO,
+    end: int,
+    state: _OnnxStructureParseState,
+    message_name: str,
+) -> tuple[int, int]:
+    field_number, wire_type = _read_onnx_key(handle, end, state)
+    if field_number not in _onnx_known_field_numbers(message_name):
+        state.record_unknown_field(message_name, field_number, wire_type)
+    return field_number, wire_type
 
 
 def _read_onnx_exact(handle: BinaryIO, length: int, end: int) -> bytes:
@@ -3476,7 +3649,7 @@ def _parse_onnx_string_entry(
     state.record_retained_object()
     entry = _OnnxLiteStringEntry()
     while handle.tell() < end:
-        field_number, wire_type = _read_onnx_key(handle, end, state)
+        field_number, wire_type = _read_onnx_message_key(handle, end, state, "onnx.StringStringEntryProto")
         if field_number == 1 and wire_type == 2:
             entry.key = _read_onnx_string(handle, end, state, field_name="external_data_key")
         elif field_number == 2 and wire_type == 2:
@@ -3511,7 +3684,7 @@ def _parse_onnx_tensor(
     string_data_count = 0
     string_data_bytes = 0
     while handle.tell() < end:
-        field_number, wire_type = _read_onnx_key(handle, end, state)
+        field_number, wire_type = _read_onnx_message_key(handle, end, state, "onnx.TensorProto")
         if field_number == 1:
             if wire_type == 0:
                 _append_onnx_dimension(tensor.dims, _decode_int64_varint(_read_onnx_varint(handle, end)), state)
@@ -3631,7 +3804,7 @@ def _parse_onnx_sparse_tensor(
     seen_values = False
     seen_indices = False
     while handle.tell() < end:
-        field_number, wire_type = _read_onnx_key(handle, end, state)
+        field_number, wire_type = _read_onnx_message_key(handle, end, state, "onnx.SparseTensorProto")
         if field_number == 1 and wire_type == 2:
             if seen_values:
                 _raise_duplicate_onnx_singular_message("SparseTensorProto.values")
@@ -3672,7 +3845,7 @@ def _parse_onnx_attribute(
     state.record_retained_object()
     attribute = _OnnxLiteAttribute()
     while handle.tell() < end:
-        field_number, wire_type = _read_onnx_key(handle, end, state)
+        field_number, wire_type = _read_onnx_message_key(handle, end, state, "onnx.AttributeProto")
         if field_number == 1 and wire_type == 2:
             attribute.name = _read_onnx_string(handle, end, state, field_name="attribute_name")
         elif field_number == 21 and wire_type == 2:
@@ -3766,7 +3939,7 @@ def _parse_onnx_node(
         )
     node = _OnnxLiteNode()
     while handle.tell() < end:
-        field_number, wire_type = _read_onnx_key(handle, end, state)
+        field_number, wire_type = _read_onnx_message_key(handle, end, state, "onnx.NodeProto")
         if field_number == 1 and wire_type == 2:
             _append_onnx_string_value(
                 node.input,
@@ -3819,7 +3992,7 @@ def _parse_onnx_value_info(
     state.record_retained_object()
     value_info = _OnnxLiteValueInfo()
     while handle.tell() < end:
-        field_number, wire_type = _read_onnx_key(handle, end, state)
+        field_number, wire_type = _read_onnx_message_key(handle, end, state, "onnx.ValueInfoProto")
         if field_number == 1 and wire_type == 2:
             value_info.name = _read_onnx_string(handle, end, state, field_name="value_info_name")
         else:
@@ -3843,7 +4016,7 @@ def _parse_onnx_graph(
         )
     graph = _OnnxLiteGraph()
     while handle.tell() < end:
-        field_number, wire_type = _read_onnx_key(handle, end, state)
+        field_number, wire_type = _read_onnx_message_key(handle, end, state, "onnx.GraphProto")
         if field_number == 1 and wire_type == 2:
             _append_onnx_submessage_value(
                 graph.node,
@@ -3927,7 +4100,7 @@ def _parse_onnx_opset_import(
     state.record_retained_object()
     opset = _OnnxLiteOpsetImport()
     while handle.tell() < end:
-        field_number, wire_type = _read_onnx_key(handle, end, state)
+        field_number, wire_type = _read_onnx_message_key(handle, end, state, "onnx.OperatorSetIdProto")
         if field_number == 1 and wire_type == 2:
             opset.domain = _read_onnx_string(handle, end, state, field_name="opset_domain")
         elif field_number == 2 and wire_type == 0:
@@ -3947,7 +4120,7 @@ def _parse_onnx_function(
     state.record_retained_object()
     function = _OnnxLiteFunction()
     while handle.tell() < end:
-        field_number, wire_type = _read_onnx_key(handle, end, state)
+        field_number, wire_type = _read_onnx_message_key(handle, end, state, "onnx.FunctionProto")
         if field_number == 1 and wire_type == 2:
             function.name = _read_onnx_string(handle, end, state, field_name="function_name")
         elif field_number == 4 and wire_type == 2:
@@ -4042,7 +4215,7 @@ def _parse_onnx_training_info(
     seen_initialization = False
     seen_algorithm = False
     while handle.tell() < end:
-        field_number, wire_type = _read_onnx_key(handle, end, state)
+        field_number, wire_type = _read_onnx_message_key(handle, end, state, "onnx.TrainingInfoProto")
         if field_number == 1 and wire_type == 2:
             if seen_initialization:
                 _raise_duplicate_onnx_singular_message("TrainingInfoProto.initialization")
@@ -4090,7 +4263,7 @@ def _parse_onnx_model(
     state.record_retained_object()
     model = _OnnxLiteModel()
     while handle.tell() < end:
-        field_number, wire_type = _read_onnx_key(handle, end, state)
+        field_number, wire_type = _read_onnx_message_key(handle, end, state, "onnx.ModelProto")
         if field_number == 1 and wire_type == 0:
             model.ir_version = _decode_int64_varint(_read_onnx_varint(handle, end))
         elif field_number == 2 and wire_type == 2:
@@ -4381,13 +4554,38 @@ class OnnxScanner(BaseScanner):
         result.add_check(
             name="ONNX Structure Parse Coverage",
             passed=False,
-            message="ONNX structural parser skipped one or more oversized metadata fields",
+            message="ONNX structural parser skipped or encountered protobuf fields outside complete coverage",
             severity=IssueSeverity.INFO,
             location=path,
             rule_code="S902",
             details={
                 "scan_outcome_reason": ONNX_STRUCTURE_INCONCLUSIVE_REASON,
                 **state.metadata(),
+            },
+        )
+
+    def _mark_in_memory_unknown_fields(
+        self,
+        result: ScanResult,
+        path: str,
+        *,
+        unknown_field_bytes_discarded: int,
+    ) -> None:
+        _mark_inconclusive_scan_result(result, ONNX_STRUCTURE_INCONCLUSIVE_REASON)
+        result.add_check(
+            name="ONNX Structure Parse Coverage",
+            passed=False,
+            message="ONNX protobuf contains fields outside the installed schema; analysis incomplete",
+            severity=IssueSeverity.INFO,
+            location=path,
+            rule_code="S902",
+            details={
+                "scan_outcome_reason": ONNX_STRUCTURE_INCONCLUSIVE_REASON,
+                "parse_mode": "in_memory_model_proto",
+                "coverage_gaps": {"unknown_protobuf_fields": 1},
+                "unknown_field_count": 1,
+                "unknown_field_bytes_discarded": unknown_field_bytes_discarded,
+                "unknown_field_detection": "discard_unknown_fields_byte_size",
             },
         )
 
@@ -4541,6 +4739,20 @@ class OnnxScanner(BaseScanner):
             else:
                 model = onnx.load_model_from_string(model_data)
                 result.metadata["onnx_structure_parse"] = {"parse_mode": "in_memory_model_proto"}
+                unknown_field_bytes_discarded = _discard_onnx_unknown_field_bytes(model)
+                if unknown_field_bytes_discarded:
+                    result.metadata["onnx_structure_parse"] = {
+                        "parse_mode": "in_memory_model_proto",
+                        "coverage_gaps": {"unknown_protobuf_fields": 1},
+                        "unknown_field_count": 1,
+                        "unknown_field_bytes_discarded": unknown_field_bytes_discarded,
+                        "unknown_field_detection": "discard_unknown_fields_byte_size",
+                    }
+                    self._mark_in_memory_unknown_fields(
+                        result,
+                        path,
+                        unknown_field_bytes_discarded=unknown_field_bytes_discarded,
+                    )
             # Check for interrupts after loading completes.
             self.check_interrupted()
             result.bytes_scanned = file_size
@@ -4610,7 +4822,7 @@ class OnnxScanner(BaseScanner):
             result.finish(success=False)
             return result
 
-        has_graph = model.HasField("graph")
+        has_graph = _onnx_has_singular_field(model, "graph")
         if model.ir_version <= 0 or not has_graph:
             if self._is_tentative_protobuf_route() and not has_graph:
                 result.scanner_name = "unknown"
@@ -4642,7 +4854,7 @@ class OnnxScanner(BaseScanner):
                     message="ONNX schema checker is unavailable; analysis incomplete",
                     details={"checker_available": False},
                 )
-            elif file_backed_parse_state is not None:
+            elif model_data is None:
                 _mark_onnx_schema_incomplete(
                     result,
                     path,
@@ -4737,9 +4949,19 @@ class OnnxScanner(BaseScanner):
                     result.metadata["onnx_network_detector_input"] = {
                         "source": "structured_text_fields",
                         "field_count": network_detector_input.field_count,
+                        "metadata_field_count": network_detector_input.metadata_field_count,
                         "omitted_field_count": network_detector_input.omitted_field_count,
+                        "truncated": network_detector_input.truncated,
                         "max_bytes": _ONNX_NETWORK_TEXT_MAX_BYTES,
                         "max_fields": _ONNX_NETWORK_TEXT_MAX_FIELDS,
+                        "sections": [
+                            {
+                                "name": section.name,
+                                "field_count": section.field_count,
+                                "metadata_owned": section.metadata_owned,
+                            }
+                            for section in network_detector_input.sections
+                        ],
                     }
                     if network_detector_input.truncated:
                         self._mark_raw_detection_incomplete(
@@ -4758,11 +4980,98 @@ class OnnxScanner(BaseScanner):
                                 "max_fields": _ONNX_NETWORK_TEXT_MAX_FIELDS,
                             },
                         )
-                    network_findings = self.collect_network_communication_findings(
-                        network_detector_input.data,
-                        context=path,
-                        raise_on_error=True,
-                    )
+                    network_findings: list[dict[str, Any]] = []
+                    max_network_findings = _network_communication_max_findings(self.config)
+                    emitted_network_findings = 0
+                    for section_index, section in enumerate(network_detector_input.sections):
+                        detector_context = f"{path}/onnx_metadata/metadata" if section.metadata_owned else path
+                        if max_network_findings is not None:
+                            remaining_findings = max_network_findings - emitted_network_findings
+                            if remaining_findings <= 0:
+                                self._mark_raw_detection_incomplete(
+                                    result,
+                                    path,
+                                    detector="network_communication",
+                                    reason="detector_finding_limit",
+                                    message=(
+                                        "ONNX network detector findings reached the configured reporting limit; "
+                                        "analysis incomplete"
+                                    ),
+                                    details={
+                                        "max_findings": max_network_findings,
+                                        "skipped_section": section.name,
+                                        "skipped_section_metadata_owned": section.metadata_owned,
+                                    },
+                                )
+                                network_findings.append(
+                                    {
+                                        "type": "detector_finding_limit",
+                                        "detector": "network_communication",
+                                        "severity": "INFO",
+                                        "message": (
+                                            "Network communication findings exceeded the configured reporting limit"
+                                        ),
+                                        "max_findings": max_network_findings,
+                                        "truncated_finding_type": "onnx_detector_section",
+                                        "truncated_finding": {
+                                            "onnx_detector_input": section.name,
+                                            "onnx_metadata_owned": section.metadata_owned,
+                                        },
+                                        "analysis_incomplete": True,
+                                        "context": detector_context,
+                                        "onnx_detector_input": section.name,
+                                        "onnx_detector_context": detector_context,
+                                        "onnx_detector_field_count": section.field_count,
+                                        "onnx_metadata_owned": section.metadata_owned,
+                                    }
+                                )
+                                break
+                        else:
+                            remaining_findings = None
+                        section_findings = self.collect_network_communication_findings(
+                            section.data,
+                            context=detector_context,
+                            raise_on_error=True,
+                            max_findings=remaining_findings,
+                        )
+                        section_truncated = False
+                        for finding in section_findings:
+                            annotated_finding = dict(finding)
+                            if annotated_finding.get("type") == "detector_finding_limit":
+                                section_truncated = True
+                            else:
+                                emitted_network_findings += 1
+                            annotated_finding.update(
+                                {
+                                    "onnx_detector_input": section.name,
+                                    "onnx_detector_context": detector_context,
+                                    "onnx_detector_field_count": section.field_count,
+                                    "onnx_metadata_owned": section.metadata_owned,
+                                }
+                            )
+                            if section.metadata_owned:
+                                annotated_finding["context"] = f"{path}:metadata_props"
+                            network_findings.append(annotated_finding)
+                        if section_truncated:
+                            remaining_sections = network_detector_input.sections[section_index + 1 :]
+                            self._mark_raw_detection_incomplete(
+                                result,
+                                path,
+                                detector="network_communication",
+                                reason="detector_finding_limit",
+                                message=(
+                                    "ONNX network detector findings reached the configured reporting limit; "
+                                    "analysis incomplete"
+                                ),
+                                details={
+                                    "max_findings": max_network_findings,
+                                    "truncated_section": section.name,
+                                    "truncated_section_metadata_owned": section.metadata_owned,
+                                    "skipped_section_count": len(remaining_sections),
+                                    "skipped_sections": [item.name for item in remaining_sections[:10]],
+                                },
+                            )
+                            break
                 except Exception as e:
                     redacted_error = redact_untrusted_error_message(e)
                     logger.warning("ONNX network detector analysis failed: %s", redacted_error)
@@ -4775,11 +5084,12 @@ class OnnxScanner(BaseScanner):
                         details={"exception": redacted_error, "exception_type": type(e).__name__},
                     )
                 else:
-                    self.add_network_communication_findings(
-                        network_findings,
-                        result,
-                        context=path,
-                    )
+                    if network_findings or not network_detector_input.truncated:
+                        self.add_network_communication_findings(
+                            network_findings,
+                            result,
+                            context=path,
+                        )
 
         self._check_custom_ops(model, path, result)
         self._check_external_data(model, path, result)

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -482,7 +482,7 @@ class _OnnxNetworkTextCollector:
     def check_interrupted(self) -> None:
         self._check_interrupted()
 
-    def visit_message(self) -> bool:
+    def visit_field(self) -> bool:
         self.check_interrupted()
         if self._visited_field_count >= self._max_fields:
             self.omit()
@@ -490,18 +490,17 @@ class _OnnxNetworkTextCollector:
         self._visited_field_count += 1
         return True
 
-    def add(self, label: str, value: Any) -> None:
+    def visit_message(self) -> bool:
+        return self.visit_field()
+
+    def add(self, label: str, value: Any, *, field_visited: bool = False) -> None:
         self.check_interrupted()
         if value is None:
             return
         if isinstance(value, (str, bytes)) and not value:
             return
-        if self._visited_field_count >= self._max_fields:
-            self._truncated = True
-            self._truncation_reason = self._truncation_reason or "text_field_budget_exceeded"
-            self._omitted_field_count += 1
+        if not field_visited and not self.visit_field():
             return
-        self._visited_field_count += 1
         label_bytes = label.encode("utf-8", errors="surrogatepass")
         entry_overhead = len(label_bytes) + len(b": \n")
         remaining_bytes = self._max_bytes - self._byte_count - entry_overhead
@@ -793,7 +792,9 @@ def _collect_onnx_proto_text_fields(
                         return
                     _collect_onnx_proto_text_fields(collector, item, item_label, depth=depth + 1)
                 elif proto_field.type in {proto_field.TYPE_BYTES, proto_field.TYPE_STRING}:
-                    collector.add(item_label, item)
+                    if not collector.visit_field():
+                        return
+                    collector.add(item_label, item, field_visited=True)
                 if collector.is_truncated():
                     return
             continue

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -674,6 +674,13 @@ def _is_onnx_metadata_text_label(label: str) -> bool:
     return ".metadata_props[" in label
 
 
+def _onnx_proto_field_is_repeated(proto_field: Any) -> bool:
+    is_repeated = getattr(proto_field, "is_repeated", None)
+    if is_repeated is not None:
+        return bool(is_repeated() if callable(is_repeated) else is_repeated)
+    return getattr(proto_field, "label", None) == getattr(proto_field, "LABEL_REPEATED", 3)
+
+
 def _collect_onnx_network_detector_input(
     model: Any,
     *,
@@ -794,14 +801,15 @@ def _collect_onnx_proto_text_fields(
         field_label = f"{label}.{proto_field.name}"
         if _is_onnx_tensor_payload_field(descriptor, proto_field):
             continue
-        if proto_field.label == proto_field.LABEL_REPEATED and proto_field.type not in {
+        repeated_field = _onnx_proto_field_is_repeated(proto_field)
+        if repeated_field and proto_field.type not in {
             proto_field.TYPE_MESSAGE,
             proto_field.TYPE_BYTES,
             proto_field.TYPE_STRING,
         }:
             continue
         value = getattr(message, proto_field.name)
-        if proto_field.label == proto_field.LABEL_REPEATED:
+        if repeated_field:
             for index, item in enumerate(value):
                 item_label = f"{field_label}[{index}]"
                 if proto_field.type == proto_field.TYPE_MESSAGE:

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -133,6 +133,7 @@ _ONNX_WEIGHT_DEFAULT_MAX_ARRAY_SIZE = 100 * 1024 * 1024
 _ONNX_RAW_DETECTOR_DEFAULT_MAX_BYTES = 512 * 1024 * 1024
 _ONNX_NETWORK_TEXT_MAX_BYTES = 4 * 1024 * 1024
 _ONNX_NETWORK_TEXT_MAX_FIELDS = 100_000
+_ONNX_METADATA_PROP_LABEL_PATTERN = re.compile(r"^model\.metadata_props\[(?P<index>[0-9]+)\]\.(?P<field>key|value)$")
 _ONNX_RAW_OR_NUMERIC_TENSOR_PAYLOAD_FIELD_NAMES: frozenset[str] = frozenset(
     {
         # TensorProto.string_data is semantic model data and stays in the
@@ -469,15 +470,25 @@ class _OnnxNetworkTextCollector:
         self._field_count = 0
         self._metadata_field_count = 0
         self._structural_field_count = 0
+        self._metadata_chunk_entries: list[tuple[str, bytes]] = []
         self._omitted_field_count = 0
         self._truncated = False
         self._truncation_reason: str | None = None
+        self._metadata_props: dict[int, dict[str, str]] = {}
 
     def is_truncated(self) -> bool:
         return self._truncated
 
     def check_interrupted(self) -> None:
         self._check_interrupted()
+
+    def visit_message(self) -> bool:
+        self.check_interrupted()
+        if self._visited_field_count >= self._max_fields:
+            self.omit()
+            return False
+        self._visited_field_count += 1
+        return True
 
     def add(self, label: str, value: Any) -> None:
         self.check_interrupted()
@@ -506,19 +517,43 @@ class _OnnxNetworkTextCollector:
         self._chunks.append(entry)
         if _is_onnx_metadata_text_label(label):
             self._metadata_chunks.append(entry)
+            self._metadata_chunk_entries.append((label, entry))
             self._metadata_field_count += 1
+            self._record_metadata_prop(label, value)
         else:
             self._structural_chunks.append(entry)
             self._structural_field_count += 1
         self._byte_count += len(entry)
         self._field_count += 1
 
+    def _record_metadata_prop(self, label: str, value: Any) -> None:
+        if not isinstance(value, str):
+            return
+        match = _ONNX_METADATA_PROP_LABEL_PATTERN.fullmatch(label)
+        if match is None:
+            return
+        self._metadata_props.setdefault(int(match.group("index")), {})[match.group("field")] = value
+
+    def metadata_prop_entries(self) -> list[tuple[int, str, str]]:
+        entries: list[tuple[int, str, str]] = []
+        for index in sorted(self._metadata_props):
+            fields = self._metadata_props[index]
+            key = fields.get("key")
+            value = fields.get("value")
+            if key is not None and value is not None:
+                entries.append((index, key, value))
+        return entries
+
     def omit(self, reason: str = "text_field_budget_exceeded") -> None:
         self._truncated = True
         self._truncation_reason = self._truncation_reason or reason
         self._omitted_field_count += 1
 
-    def finish(self) -> _OnnxNetworkDetectorInput:
+    def finish(
+        self,
+        *,
+        metadata_data_sections: tuple[tuple[frozenset[str], bytes], ...] = (),
+    ) -> _OnnxNetworkDetectorInput:
         sections: list[_OnnxNetworkDetectorSection] = []
         if self._structural_chunks:
             sections.append(
@@ -530,14 +565,35 @@ class _OnnxNetworkTextCollector:
                 )
             )
         if self._metadata_chunks:
-            sections.append(
-                _OnnxNetworkDetectorSection(
-                    name="metadata_props",
-                    data=b"".join(self._metadata_chunks),
-                    field_count=self._metadata_field_count,
-                    metadata_owned=True,
+            metadata_data_labels: set[str] = set()
+            for labels, metadata_data in metadata_data_sections:
+                metadata_data_labels.update(labels)
+                sections.append(
+                    _OnnxNetworkDetectorSection(
+                        name="metadata_props",
+                        data=metadata_data,
+                        field_count=len(labels),
+                        metadata_owned=True,
+                    )
                 )
-            )
+            metadata_text_chunks = [
+                entry for label, entry in self._metadata_chunk_entries if label not in metadata_data_labels
+            ]
+            if metadata_data_sections and not metadata_text_chunks:
+                metadata_text_data = b""
+            else:
+                metadata_text_data = b"".join(metadata_text_chunks or self._metadata_chunks)
+            if metadata_text_data:
+                section_name = "metadata_text_fields" if metadata_data_sections else "metadata_props"
+                field_count = len(metadata_text_chunks) if metadata_data_sections else self._metadata_field_count
+                sections.append(
+                    _OnnxNetworkDetectorSection(
+                        name=section_name,
+                        data=metadata_text_data,
+                        field_count=field_count,
+                        metadata_owned=True,
+                    )
+                )
         return _OnnxNetworkDetectorInput(
             data=b"".join(self._chunks),
             sections=tuple(sections),
@@ -578,6 +634,32 @@ def _network_communication_max_findings(config: dict[str, Any] | None) -> int | 
     return None
 
 
+def _network_finding_limit_payload(
+    section: _OnnxNetworkDetectorSection,
+    context: str,
+    *,
+    max_findings: int,
+) -> dict[str, Any]:
+    return {
+        "type": "detector_finding_limit",
+        "detector": "network_communication",
+        "severity": "INFO",
+        "message": "Network communication findings exceeded the configured reporting limit",
+        "max_findings": max_findings,
+        "truncated_finding_type": "onnx_detector_section",
+        "truncated_finding": {
+            "onnx_detector_input": section.name,
+            "onnx_metadata_owned": section.metadata_owned,
+        },
+        "analysis_incomplete": True,
+        "context": context,
+        "onnx_detector_input": section.name,
+        "onnx_detector_context": context,
+        "onnx_detector_field_count": section.field_count,
+        "onnx_metadata_owned": section.metadata_owned,
+    }
+
+
 def _is_onnx_metadata_text_label(label: str) -> bool:
     return ".metadata_props[" in label
 
@@ -593,7 +675,64 @@ def _collect_onnx_network_detector_input(
         check_interrupted=check_interrupted,
     )
     _collect_onnx_proto_text_fields(collector, model, "model")
-    return collector.finish()
+    metadata_props = collector.metadata_prop_entries()
+    metadata_data_sections = _onnx_metadata_props_detector_sections(
+        model,
+        metadata_props,
+        max_bytes=_ONNX_NETWORK_TEXT_MAX_BYTES,
+    )
+    return collector.finish(
+        metadata_data_sections=metadata_data_sections,
+    )
+
+
+def _onnx_metadata_props_detector_sections(
+    model: Any,
+    metadata_props: Iterable[tuple[int, str, str]],
+    *,
+    max_bytes: int,
+) -> tuple[tuple[frozenset[str], bytes], ...]:
+    metadata_entries = list(metadata_props)
+    if not metadata_entries:
+        return ()
+    included_entries: list[tuple[int, str, str]] = []
+    estimated_bytes = 0
+    for index, key, value in metadata_entries:
+        value_with_boundary = value + "\n"
+        entry_bytes = len(key.encode("utf-8", errors="surrogatepass")) + len(
+            value_with_boundary.encode("utf-8", errors="surrogatepass")
+        )
+        if included_entries and estimated_bytes + entry_bytes + 64 > max_bytes:
+            break
+        included_entries.append((index, key, value_with_boundary))
+        estimated_bytes += entry_bytes + 64
+    if not included_entries:
+        return ()
+    try:
+        while included_entries:
+            metadata_model = type(model)()
+            metadata_model.ir_version = int(getattr(model, "ir_version", 0) or 1)
+            metadata_model.graph.name = "modelaudit_metadata"
+            metadata_model.graph.input.add().name = "modelaudit_input"
+            metadata_model.graph.output.add().name = "modelaudit_output"
+            for _index, key, value in included_entries:
+                metadata_prop = metadata_model.metadata_props.add()
+                metadata_prop.key = key
+                metadata_prop.value = value
+            metadata_data = metadata_model.SerializeToString()
+            if len(metadata_data) <= max_bytes:
+                break
+            included_entries.pop()
+        else:
+            return ()
+        metadata_data_labels = frozenset(
+            label
+            for index, _key, _value in included_entries
+            for label in (f"model.metadata_props[{index}].key", f"model.metadata_props[{index}].value")
+        )
+        return ((metadata_data_labels, metadata_data),)
+    except Exception:  # pragma: no cover - protobuf compatibility fallback
+        return ()
 
 
 def _onnx_network_detector_input_metadata(network_detector_input: _OnnxNetworkDetectorInput) -> dict[str, Any]:
@@ -650,6 +789,8 @@ def _collect_onnx_proto_text_fields(
             for index, item in enumerate(value):
                 item_label = f"{field_label}[{index}]"
                 if proto_field.type == proto_field.TYPE_MESSAGE:
+                    if not collector.visit_message():
+                        return
                     _collect_onnx_proto_text_fields(collector, item, item_label, depth=depth + 1)
                 elif proto_field.type in {proto_field.TYPE_BYTES, proto_field.TYPE_STRING}:
                     collector.add(item_label, item)
@@ -659,6 +800,8 @@ def _collect_onnx_proto_text_fields(
         if proto_field.type == proto_field.TYPE_MESSAGE:
             if not _onnx_has_singular_field(message, proto_field.name):
                 continue
+            if not collector.visit_message():
+                return
             _collect_onnx_proto_text_fields(collector, value, field_label, depth=depth + 1)
         elif proto_field.type in {proto_field.TYPE_BYTES, proto_field.TYPE_STRING}:
             collector.add(field_label, value)
@@ -4992,6 +5135,9 @@ class OnnxScanner(BaseScanner):
                     )
 
             if check_net:
+                network_findings: list[dict[str, Any]] = []
+                network_detector_input: _OnnxNetworkDetectorInput | None = None
+                network_detector_failed = False
                 try:
                     network_detector_input = _collect_onnx_network_detector_input(
                         model,
@@ -5002,60 +5148,62 @@ class OnnxScanner(BaseScanner):
                     )
                     if network_detector_input.truncated:
                         self._mark_network_text_input_incomplete(result, path, network_detector_input)
-                    network_findings: list[dict[str, Any]] = []
                     max_network_findings = _network_communication_max_findings(self.config)
                     emitted_network_findings = 0
                     for section_index, section in enumerate(network_detector_input.sections):
                         detector_context = f"{path}/onnx_metadata/metadata" if section.metadata_owned else path
+                        limit_already_reached = (
+                            max_network_findings is not None and emitted_network_findings >= max_network_findings
+                        )
+                        remaining_findings = None
                         if max_network_findings is not None:
-                            remaining_findings = max_network_findings - emitted_network_findings
-                            if remaining_findings <= 0:
-                                self._mark_raw_detection_incomplete(
-                                    result,
-                                    path,
-                                    detector="network_communication",
-                                    reason="detector_finding_limit",
-                                    message=(
-                                        "ONNX network detector findings reached the configured reporting limit; "
-                                        "analysis incomplete"
-                                    ),
-                                    details={
-                                        "max_findings": max_network_findings,
-                                        "skipped_section": section.name,
-                                        "skipped_section_metadata_owned": section.metadata_owned,
-                                    },
-                                )
-                                network_findings.append(
-                                    {
-                                        "type": "detector_finding_limit",
-                                        "detector": "network_communication",
-                                        "severity": "INFO",
-                                        "message": (
-                                            "Network communication findings exceeded the configured reporting limit"
-                                        ),
-                                        "max_findings": max_network_findings,
-                                        "truncated_finding_type": "onnx_detector_section",
-                                        "truncated_finding": {
-                                            "onnx_detector_input": section.name,
-                                            "onnx_metadata_owned": section.metadata_owned,
-                                        },
-                                        "analysis_incomplete": True,
-                                        "context": detector_context,
-                                        "onnx_detector_input": section.name,
-                                        "onnx_detector_context": detector_context,
-                                        "onnx_detector_field_count": section.field_count,
-                                        "onnx_metadata_owned": section.metadata_owned,
-                                    }
-                                )
-                                break
-                        else:
-                            remaining_findings = None
+                            remaining_findings = (
+                                1 if limit_already_reached else max_network_findings - emitted_network_findings
+                            )
                         section_findings = self.collect_network_communication_findings(
                             section.data,
                             context=detector_context,
                             raise_on_error=True,
                             max_findings=remaining_findings,
                         )
+                        if limit_already_reached:
+                            assert max_network_findings is not None
+                            limit_findings = [
+                                finding
+                                for finding in section_findings
+                                if finding.get("type") == "detector_finding_limit"
+                            ]
+                            if limit_findings:
+                                self._mark_network_finding_limit(
+                                    result, path, section, section_index, network_detector_input
+                                )
+                                for finding in limit_findings:
+                                    annotated_finding = dict(finding)
+                                    annotated_finding.update(
+                                        {
+                                            "onnx_detector_input": section.name,
+                                            "onnx_detector_context": detector_context,
+                                            "onnx_detector_field_count": section.field_count,
+                                            "onnx_metadata_owned": section.metadata_owned,
+                                        }
+                                    )
+                                    if section.metadata_owned:
+                                        annotated_finding["context"] = f"{path}:metadata_props"
+                                    network_findings.append(annotated_finding)
+                                break
+                            if section_findings:
+                                self._mark_network_finding_limit(
+                                    result, path, section, section_index, network_detector_input
+                                )
+                                network_findings.append(
+                                    _network_finding_limit_payload(
+                                        section,
+                                        detector_context,
+                                        max_findings=max_network_findings,
+                                    )
+                                )
+                                break
+                            continue
                         section_truncated = False
                         for finding in section_findings:
                             annotated_finding = dict(finding)
@@ -5075,26 +5223,12 @@ class OnnxScanner(BaseScanner):
                                 annotated_finding["context"] = f"{path}:metadata_props"
                             network_findings.append(annotated_finding)
                         if section_truncated:
-                            remaining_sections = network_detector_input.sections[section_index + 1 :]
-                            self._mark_raw_detection_incomplete(
-                                result,
-                                path,
-                                detector="network_communication",
-                                reason="detector_finding_limit",
-                                message=(
-                                    "ONNX network detector findings reached the configured reporting limit; "
-                                    "analysis incomplete"
-                                ),
-                                details={
-                                    "max_findings": max_network_findings,
-                                    "truncated_section": section.name,
-                                    "truncated_section_metadata_owned": section.metadata_owned,
-                                    "skipped_section_count": len(remaining_sections),
-                                    "skipped_sections": [item.name for item in remaining_sections[:10]],
-                                },
+                            self._mark_network_finding_limit(
+                                result, path, section, section_index, network_detector_input
                             )
                             break
                 except Exception as e:
+                    network_detector_failed = True
                     redacted_error = redact_untrusted_error_message(e)
                     logger.warning("ONNX network detector analysis failed: %s", redacted_error)
                     self._mark_raw_detection_incomplete(
@@ -5105,13 +5239,16 @@ class OnnxScanner(BaseScanner):
                         message=f"ONNX network detector analysis failed: {redacted_error}",
                         details={"exception": redacted_error, "exception_type": type(e).__name__},
                     )
-                else:
-                    if network_findings or not network_detector_input.truncated:
-                        self.add_network_communication_findings(
-                            network_findings,
-                            result,
-                            context=path,
-                        )
+                if network_findings or (
+                    network_detector_input is not None
+                    and not network_detector_input.truncated
+                    and not network_detector_failed
+                ):
+                    self.add_network_communication_findings(
+                        network_findings,
+                        result,
+                        context=path,
+                    )
 
         if model_data is None and check_net:
             try:
@@ -5162,6 +5299,30 @@ class OnnxScanner(BaseScanner):
 
         _finish_scan_result(result)
         return result
+
+    def _mark_network_finding_limit(
+        self,
+        result: ScanResult,
+        path: str,
+        section: _OnnxNetworkDetectorSection,
+        section_index: int,
+        network_detector_input: _OnnxNetworkDetectorInput,
+    ) -> None:
+        remaining_sections = network_detector_input.sections[section_index + 1 :]
+        self._mark_raw_detection_incomplete(
+            result,
+            path,
+            detector="network_communication",
+            reason="detector_finding_limit",
+            message="ONNX network detector findings reached the configured reporting limit; analysis incomplete",
+            details={
+                "max_findings": _network_communication_max_findings(self.config),
+                "truncated_section": section.name,
+                "truncated_section_metadata_owned": section.metadata_owned,
+                "skipped_section_count": len(remaining_sections),
+                "skipped_sections": [item.name for item in remaining_sections[:10]],
+            },
+        )
 
     def _mark_network_text_input_incomplete(
         self,

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -131,6 +131,8 @@ _ONNX_CUSTOM_OPERATOR_SAMPLE_LIMIT = 20
 _ONNX_CUSTOM_OPERATOR_TEXT_LIMIT = 256
 _ONNX_WEIGHT_DEFAULT_MAX_ARRAY_SIZE = 100 * 1024 * 1024
 _ONNX_RAW_DETECTOR_DEFAULT_MAX_BYTES = 512 * 1024 * 1024
+_ONNX_NETWORK_TEXT_MAX_BYTES = 4 * 1024 * 1024
+_ONNX_NETWORK_TEXT_MAX_FIELDS = 100_000
 _ONNX_STRUCTURE_STRING_MAX_BYTES = 1024 * 1024
 _ONNX_STRUCTURE_MAX_DEPTH = 128
 _ONNX_STRUCTURE_MAX_NODES = 1_000_000
@@ -407,6 +409,141 @@ def _iter_attribute_graphs(attribute: Any) -> Any:
             yield attribute.g
     except (ValueError, AttributeError):  # pragma: no cover - proto edge case
         pass
+
+
+@dataclass(frozen=True)
+class _OnnxNetworkDetectorInput:
+    data: bytes
+    field_count: int
+    omitted_field_count: int
+    truncated: bool
+
+
+class _OnnxNetworkTextCollector:
+    def __init__(
+        self,
+        *,
+        max_bytes: int,
+        max_fields: int,
+        check_interrupted: Callable[[], None],
+    ) -> None:
+        self._chunks: list[bytes] = []
+        self._max_bytes = max_bytes
+        self._max_fields = max_fields
+        self._check_interrupted = check_interrupted
+        self._byte_count = 0
+        self._field_count = 0
+        self._omitted_field_count = 0
+        self._truncated = False
+
+    def is_truncated(self) -> bool:
+        return self._truncated
+
+    def check_interrupted(self) -> None:
+        self._check_interrupted()
+
+    def add(self, label: str, value: Any) -> None:
+        self.check_interrupted()
+        value_bytes = _onnx_network_text_value_bytes(value)
+        if not value_bytes:
+            return
+        if self._field_count >= self._max_fields:
+            self._truncated = True
+            self._omitted_field_count += 1
+            return
+        entry = label.encode("utf-8", errors="surrogatepass") + b"=" + value_bytes + b"\n"
+        if self._byte_count + len(entry) > self._max_bytes:
+            self._truncated = True
+            self._omitted_field_count += 1
+            return
+        self._chunks.append(entry)
+        self._byte_count += len(entry)
+        self._field_count += 1
+
+    def omit(self) -> None:
+        self._truncated = True
+        self._omitted_field_count += 1
+
+    def finish(self) -> _OnnxNetworkDetectorInput:
+        return _OnnxNetworkDetectorInput(
+            data=b"".join(self._chunks),
+            field_count=self._field_count,
+            omitted_field_count=self._omitted_field_count,
+            truncated=self._truncated,
+        )
+
+
+def _onnx_network_text_value_bytes(value: Any) -> bytes:
+    if value is None:
+        return b""
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        return value.encode("utf-8", errors="surrogatepass")
+    return b""
+
+
+def _collect_onnx_network_detector_input(
+    model: Any,
+    *,
+    check_interrupted: Callable[[], None],
+) -> _OnnxNetworkDetectorInput:
+    collector = _OnnxNetworkTextCollector(
+        max_bytes=_ONNX_NETWORK_TEXT_MAX_BYTES,
+        max_fields=_ONNX_NETWORK_TEXT_MAX_FIELDS,
+        check_interrupted=check_interrupted,
+    )
+    _collect_onnx_proto_text_fields(collector, model, "model")
+    return collector.finish()
+
+
+def _collect_onnx_proto_text_fields(
+    collector: _OnnxNetworkTextCollector,
+    message: Any,
+    label: str,
+    *,
+    depth: int = 0,
+) -> None:
+    if message is None or collector.is_truncated():
+        return
+    if depth > _ONNX_STRUCTURE_MAX_DEPTH:
+        collector.omit()
+        return
+    descriptor = getattr(message, "DESCRIPTOR", None)
+    if descriptor is None:
+        return
+    for proto_field in getattr(descriptor, "fields", []):
+        collector.check_interrupted()
+        field_label = f"{label}.{proto_field.name}"
+        if _is_onnx_tensor_payload_field(descriptor, proto_field):
+            continue
+        value = getattr(message, proto_field.name)
+        if proto_field.label == proto_field.LABEL_REPEATED:
+            for index, item in enumerate(value):
+                item_label = f"{field_label}[{index}]"
+                if proto_field.type == proto_field.TYPE_MESSAGE:
+                    _collect_onnx_proto_text_fields(collector, item, item_label, depth=depth + 1)
+                elif proto_field.type in {proto_field.TYPE_BYTES, proto_field.TYPE_STRING}:
+                    collector.add(item_label, item)
+                if collector.is_truncated():
+                    return
+            continue
+        if proto_field.type == proto_field.TYPE_MESSAGE:
+            try:
+                if not message.HasField(proto_field.name):
+                    continue
+            except ValueError:
+                pass
+            _collect_onnx_proto_text_fields(collector, value, field_label, depth=depth + 1)
+        elif proto_field.type in {proto_field.TYPE_BYTES, proto_field.TYPE_STRING}:
+            collector.add(field_label, value)
+
+
+def _is_onnx_tensor_payload_field(descriptor: Any, proto_field: Any) -> bool:
+    return getattr(descriptor, "full_name", "") == "onnx.TensorProto" and proto_field.name in {
+        "raw_data",
+        "string_data",
+    }
 
 
 def _iter_graph_nodes(graph: Any) -> Any:
@@ -4593,8 +4730,36 @@ class OnnxScanner(BaseScanner):
 
             if check_net:
                 try:
+                    network_detector_input = _collect_onnx_network_detector_input(
+                        model,
+                        check_interrupted=self.check_interrupted,
+                    )
+                    result.metadata["onnx_network_detector_input"] = {
+                        "source": "structured_text_fields",
+                        "field_count": network_detector_input.field_count,
+                        "omitted_field_count": network_detector_input.omitted_field_count,
+                        "max_bytes": _ONNX_NETWORK_TEXT_MAX_BYTES,
+                        "max_fields": _ONNX_NETWORK_TEXT_MAX_FIELDS,
+                    }
+                    if network_detector_input.truncated:
+                        self._mark_raw_detection_incomplete(
+                            result,
+                            path,
+                            detector="network_communication",
+                            reason="text_field_budget_exceeded",
+                            message=(
+                                "ONNX network detector text input exceeded bounded extraction budget; "
+                                "analysis incomplete"
+                            ),
+                            details={
+                                "field_count": network_detector_input.field_count,
+                                "omitted_field_count": network_detector_input.omitted_field_count,
+                                "max_bytes": _ONNX_NETWORK_TEXT_MAX_BYTES,
+                                "max_fields": _ONNX_NETWORK_TEXT_MAX_FIELDS,
+                            },
+                        )
                     network_findings = self.collect_network_communication_findings(
-                        model_data,
+                        network_detector_input.data,
                         context=path,
                         raise_on_error=True,
                     )

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -133,6 +133,7 @@ _ONNX_WEIGHT_DEFAULT_MAX_ARRAY_SIZE = 100 * 1024 * 1024
 _ONNX_RAW_DETECTOR_DEFAULT_MAX_BYTES = 512 * 1024 * 1024
 _ONNX_NETWORK_TEXT_MAX_BYTES = 4 * 1024 * 1024
 _ONNX_NETWORK_TEXT_MAX_FIELDS = 100_000
+_ONNX_METADATA_DETECTOR_SECTION_MAX_ENTRIES = 1024
 _ONNX_METADATA_PROP_LABEL_PATTERN = re.compile(r"^model\.metadata_props\[(?P<index>[0-9]+)\]\.(?P<field>key|value)$")
 _ONNX_RAW_OR_NUMERIC_TENSOR_PAYLOAD_FIELD_NAMES: frozenset[str] = frozenset(
     {
@@ -701,42 +702,48 @@ def _onnx_metadata_props_detector_sections(
     metadata_entries = list(metadata_props)
     if not metadata_entries:
         return ()
-    included_entries: list[tuple[int, str, str]] = []
+    candidate_entries: list[tuple[int, str, str]] = []
     estimated_bytes = 0
     for index, key, value in metadata_entries:
         value_with_boundary = value + "\n"
         entry_bytes = len(key.encode("utf-8", errors="surrogatepass")) + len(
             value_with_boundary.encode("utf-8", errors="surrogatepass")
         )
-        if included_entries and estimated_bytes + entry_bytes + 64 > max_bytes:
+        if candidate_entries and estimated_bytes + entry_bytes + 64 > max_bytes:
             break
-        included_entries.append((index, key, value_with_boundary))
+        candidate_entries.append((index, key, value_with_boundary))
         estimated_bytes += entry_bytes + 64
-    if not included_entries:
+    if not candidate_entries:
         return ()
     try:
-        while included_entries:
-            metadata_model = type(model)()
-            metadata_model.ir_version = int(getattr(model, "ir_version", 0) or 1)
-            metadata_model.graph.name = "modelaudit_metadata"
-            metadata_model.graph.input.add().name = "modelaudit_input"
-            metadata_model.graph.output.add().name = "modelaudit_output"
-            for _index, key, value in included_entries:
-                metadata_prop = metadata_model.metadata_props.add()
-                metadata_prop.key = key
-                metadata_prop.value = value
-            metadata_data = metadata_model.SerializeToString()
-            if len(metadata_data) <= max_bytes:
+        sections: list[tuple[frozenset[str], bytes]] = []
+        position = 0
+        while position < len(candidate_entries):
+            batch_entries = candidate_entries[position : position + _ONNX_METADATA_DETECTOR_SECTION_MAX_ENTRIES]
+            while batch_entries:
+                metadata_model = type(model)()
+                metadata_model.ir_version = int(getattr(model, "ir_version", 0) or 1)
+                metadata_model.graph.name = "modelaudit_metadata"
+                metadata_model.graph.input.add().name = "modelaudit_input"
+                metadata_model.graph.output.add().name = "modelaudit_output"
+                for _index, key, value in batch_entries:
+                    metadata_prop = metadata_model.metadata_props.add()
+                    metadata_prop.key = key
+                    metadata_prop.value = value
+                metadata_data = metadata_model.SerializeToString()
+                if len(metadata_data) <= max_bytes:
+                    break
+                batch_entries.pop()
+            if not batch_entries:
                 break
-            included_entries.pop()
-        else:
-            return ()
-        metadata_data_labels = frozenset(
-            label
-            for index, _key, _value in included_entries
-            for label in (f"model.metadata_props[{index}].key", f"model.metadata_props[{index}].value")
-        )
-        return ((metadata_data_labels, metadata_data),)
+            metadata_data_labels = frozenset(
+                label
+                for index, _key, _value in batch_entries
+                for label in (f"model.metadata_props[{index}].key", f"model.metadata_props[{index}].value")
+            )
+            sections.append((metadata_data_labels, metadata_data))
+            position += len(batch_entries)
+        return tuple(sections)
     except Exception:  # pragma: no cover - protobuf compatibility fallback
         return ()
 

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -1885,6 +1885,11 @@ class TestNetworkCommDetector:
         suspicious = [f for f in domain_findings if f["confidence"] > 0.6]
         assert len(suspicious) >= 2  # .tk and .ml are suspicious
 
+    def test_metadata_shaped_path_does_not_mark_onnx_metadata(self) -> None:
+        findings = NetworkCommDetector().scan(b"callback host evil.com", "/tmp/onnx_metadata/metadata")
+
+        assert any(finding.get("type") == "domain_name" and finding.get("domain") == "evil.com" for finding in findings)
+
     @pytest.mark.parametrize(
         "command",
         [
@@ -8032,6 +8037,14 @@ class TestNetworkCommDetector:
         data = b"Model documentation includes import socket for demos and troubleshooting examples."
 
         findings = detector.scan(data, "README.txt")
+
+        assert not [finding for finding in findings if finding["type"] == "network_library"]
+
+    def test_onnx_metadata_context_preserves_short_prose_classification(self) -> None:
+        detector = NetworkCommDetector()
+        data = b"Documentation includes import socket for examples."
+
+        findings = detector.scan(data, "model.onnx", onnx_metadata_context=True)
 
         assert not [finding for finding in findings if finding["type"] == "network_library"]
 

--- a/tests/detectors/test_network_comm_detector.py
+++ b/tests/detectors/test_network_comm_detector.py
@@ -8205,6 +8205,11 @@ class TestNetworkCommDetector:
         assert not [finding for finding in findings if finding["type"] == "suspicious_port"]
         assert "4444" not in json.dumps(findings, sort_keys=True)
 
+    def test_binary_model_under_metadata_directory_stays_on_binary_port_path(self) -> None:
+        findings = NetworkCommDetector().scan(b"raw weights port=6379", "/tmp/metadata/model.pt")
+
+        assert not [finding for finding in findings if finding["type"] == "suspicious_port"]
+
     @pytest.mark.parametrize("quote", ['"', "'"])
     def test_explicit_binary_url_findings_do_not_capture_adjacent_credentials(self, quote: str) -> None:
         """Binary-context URL matches must not retain compact adjacent arguments."""

--- a/tests/scanners/test_base_scanner.py
+++ b/tests/scanners/test_base_scanner.py
@@ -3,7 +3,7 @@ import logging
 import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import pytest
 
@@ -100,6 +100,36 @@ def test_base_scanner_create_result():
     assert result.issues == []
     assert result.bytes_scanned == 0
     assert result.success is True
+
+
+def test_collect_network_communication_findings_preserves_positional_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public positional result argument must not be rebound to newer options."""
+    from modelaudit.detectors.network_comm import NetworkCommDetector
+
+    def raise_controlled_failure(
+        self: NetworkCommDetector,
+        data: bytes,
+        context: str = "",
+        *,
+        onnx_metadata_context: bool = False,
+    ) -> list[dict[str, Any]]:
+        raise RuntimeError("controlled network detector failure")
+
+    monkeypatch.setattr(NetworkCommDetector, "scan", raise_controlled_failure)
+    scanner = MockScanner()
+    result = scanner._create_result()
+
+    findings = scanner.collect_network_communication_findings(b"payload", "model.test", True, False, result)
+
+    assert findings == []
+    assert result.metadata["analysis_incomplete"] is True
+    assert any(
+        check.details.get("detector") == "network_communication"
+        and check.details.get("coverage_gap") == "analysis_failed"
+        for check in result.checks
+    )
 
 
 def test_base_scanner_check_path_nonexistent():

--- a/tests/scanners/test_base_scanner.py
+++ b/tests/scanners/test_base_scanner.py
@@ -132,6 +132,50 @@ def test_collect_network_communication_findings_preserves_positional_result(
     )
 
 
+def test_collect_network_communication_findings_preserves_positional_max_findings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public positional max_findings argument must not be rebound to result."""
+    from modelaudit.detectors.network_comm import NetworkCommDetector
+
+    captured_config: dict[str, Any] = {}
+
+    def capture_init(self: NetworkCommDetector, config: dict[str, Any] | None = None) -> None:
+        captured_config.update(config or {})
+
+    def raise_controlled_failure(
+        self: NetworkCommDetector,
+        data: bytes,
+        context: str = "",
+        *,
+        onnx_metadata_context: bool = False,
+    ) -> list[dict[str, Any]]:
+        raise RuntimeError("controlled network detector failure")
+
+    monkeypatch.setattr(NetworkCommDetector, "__init__", capture_init)
+    monkeypatch.setattr(NetworkCommDetector, "scan", raise_controlled_failure)
+    scanner = MockScanner()
+    result = scanner._create_result()
+
+    findings = scanner.collect_network_communication_findings(
+        b"payload",
+        "model.test",
+        True,
+        False,
+        3,
+        result=result,
+    )
+
+    assert findings == []
+    assert captured_config["max_findings"] == 3
+    assert result.metadata["analysis_incomplete"] is True
+    assert any(
+        check.details.get("detector") == "network_communication"
+        and check.details.get("coverage_gap") == "analysis_failed"
+        for check in result.checks
+    )
+
+
 def test_base_scanner_check_path_nonexistent():
     """Test _check_path with nonexistent file."""
     scanner = MockScanner()

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -7307,6 +7307,15 @@ class TestLargeOnnxFileBackedInspection:
         assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
         assert "onnx_raw_detection_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
         assert "onnx_weight_distribution_analysis_incomplete" in result.metadata["scan_outcome_reasons"]
+        assert result.metadata["onnx_network_detector_input"]["truncation_reason"] == "structured_text_unavailable"
+        assert not any(
+            check.status == CheckStatus.PASSED for check in self._checks(result, "Network Communication Detection")
+        )
+        assert any(
+            check.details.get("coverage_gap") == "structured_text_unavailable"
+            and check.details.get("detector") == "network_communication"
+            for check in self._checks(result, "Raw Detector Analysis Coverage")
+        )
         assert self._checks(result, "Custom Operator Domain Check")[-1].status == CheckStatus.PASSED
         assert self._checks(result, "Python Operator Detection")[-1].status == CheckStatus.PASSED
         assert self._checks(result, "Tensor Size Validation")[-1].status == CheckStatus.PASSED
@@ -8342,7 +8351,7 @@ class TestRawDetectorCoverage:
         assert detector_input.field_count == 0
         assert detector_input.sections == ()
 
-    def test_structured_network_text_counts_empty_fields_against_budget(self) -> None:
+    def test_structured_network_text_skips_empty_fields_before_budget(self) -> None:
         collector = onnx_scanner_module._OnnxNetworkTextCollector(
             max_bytes=1024,
             max_fields=1,
@@ -8353,10 +8362,10 @@ class TestRawDetectorCoverage:
         collector.add("model.graph.doc_string", "documentation text")
         detector_input = collector.finish()
 
-        assert detector_input.truncated is True
-        assert detector_input.omitted_field_count == 1
-        assert detector_input.field_count == 0
-        assert detector_input.sections == ()
+        assert detector_input.truncated is False
+        assert detector_input.omitted_field_count == 0
+        assert detector_input.field_count == 1
+        assert detector_input.data == b"model.graph.doc_string: documentation text\n"
 
     def test_structured_network_extraction_skips_repeated_numeric_fields_before_iteration(self) -> None:
         class RepeatedNumericField:
@@ -8417,6 +8426,62 @@ class TestRawDetectorCoverage:
             if check.details.get("type") == "ipv4_address" and check.details.get("ip") == "8.8.8.8"
         ]
         assert any(check.status == CheckStatus.PASSED for check in self._network_detection_checks(result))
+
+    def test_network_detector_scans_onnx_string_initializer_values(self, tmp_path: Path) -> None:
+        endpoint = "https://45.33.32.156/payload"
+        tensor = TensorProto()
+        tensor.name = "S"
+        tensor.data_type = TensorProto.STRING
+        tensor.dims.append(1)
+        tensor.string_data.append(endpoint.encode("utf-8"))
+        output = helper.make_tensor_value_info("output", TensorProto.STRING, [1])
+        node = helper.make_node("Identity", ["S"], ["output"], name="identity")
+        graph = helper.make_graph([node], "string_initializer_graph", [], [output], initializer=[tensor])
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        model_path = tmp_path / "string-initializer-url.onnx"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert any(
+            check.details.get("type") == "url_detected"
+            and "45.33.32.156" in str(check.details.get("url", ""))
+            and check.details.get("onnx_metadata_owned") is False
+            for check in failed_network_checks
+        )
+
+    def test_network_detector_scans_onnx_constant_string_tensor_values(self, tmp_path: Path) -> None:
+        endpoint = "https://45.33.32.157/payload"
+        tensor = TensorProto()
+        tensor.name = "constant_value"
+        tensor.data_type = TensorProto.STRING
+        tensor.dims.append(1)
+        tensor.string_data.append(endpoint.encode("utf-8"))
+        output = helper.make_tensor_value_info("output", TensorProto.STRING, [1])
+        node = helper.make_node("Constant", [], ["output"], name="constant", value=tensor)
+        graph = helper.make_graph([node], "constant_string_graph", [], [output])
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        model_path = tmp_path / "constant-string-url.onnx"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert any(
+            check.details.get("type") == "url_detected"
+            and "45.33.32.157" in str(check.details.get("url", ""))
+            and check.details.get("onnx_metadata_owned") is False
+            for check in failed_network_checks
+        )
 
     def test_network_detector_preserves_onnx_metadata_urls(self, tmp_path: Path) -> None:
         model_path = create_onnx_model(tmp_path, include_initializer=False)

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -8306,6 +8306,87 @@ class TestRawDetectorCoverage:
         assert detector_input.omitted_field_count == 1
         assert detector_input.field_count == 0
 
+    def test_structured_network_extraction_bounds_empty_repeated_scalar_fields(self) -> None:
+        iterations: list[int] = []
+
+        class RepeatedStringField:
+            LABEL_REPEATED = 3
+            TYPE_MESSAGE = 11
+            TYPE_BYTES = 12
+            TYPE_STRING = 9
+            name = "input"
+            label = LABEL_REPEATED
+            type = TYPE_STRING
+
+        class Descriptor:
+            fields: ClassVar[tuple[Any, ...]] = (RepeatedStringField(),)
+
+        class RepeatedValues:
+            def __iter__(self) -> Any:
+                for index in range(100):
+                    iterations.append(index)
+                    yield ""
+
+        class Message:
+            DESCRIPTOR = Descriptor()
+            input = RepeatedValues()
+
+        collector = onnx_scanner_module._OnnxNetworkTextCollector(
+            max_bytes=1024,
+            max_fields=3,
+            check_interrupted=lambda: None,
+        )
+
+        onnx_scanner_module._collect_onnx_proto_text_fields(collector, Message(), "model.graph.node[0]")
+
+        detector_input = collector.finish()
+        assert len(iterations) == 4
+        assert detector_input.truncated is True
+        assert detector_input.omitted_field_count == 1
+        assert detector_input.field_count == 0
+
+    def test_structured_network_extraction_counts_repeated_scalar_values_once(self) -> None:
+        iterations: list[int] = []
+
+        class RepeatedStringField:
+            LABEL_REPEATED = 3
+            TYPE_MESSAGE = 11
+            TYPE_BYTES = 12
+            TYPE_STRING = 9
+            name = "input"
+            label = LABEL_REPEATED
+            type = TYPE_STRING
+
+        class Descriptor:
+            fields: ClassVar[tuple[Any, ...]] = (RepeatedStringField(),)
+
+        class RepeatedValues:
+            def __iter__(self) -> Any:
+                for index, value in enumerate(("alpha", "beta", "gamma")):
+                    iterations.append(index)
+                    yield value
+
+        class Message:
+            DESCRIPTOR = Descriptor()
+            input = RepeatedValues()
+
+        collector = onnx_scanner_module._OnnxNetworkTextCollector(
+            max_bytes=1024,
+            max_fields=2,
+            check_interrupted=lambda: None,
+        )
+
+        onnx_scanner_module._collect_onnx_proto_text_fields(collector, Message(), "model.graph.node[0]")
+
+        detector_input = collector.finish()
+        assert len(iterations) == 3
+        assert detector_input.truncated is True
+        assert detector_input.omitted_field_count == 1
+        assert detector_input.field_count == 2
+        assert b"alpha" in detector_input.data
+        assert b"beta" in detector_input.data
+        assert b"gamma" not in detector_input.data
+
     def test_hasfield_value_error_falls_back_to_attribute_traversal(self) -> None:
         graph = object()
         tensor = object()

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -6,7 +6,7 @@ import sys
 import time
 import tracemalloc
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 
@@ -7528,7 +7528,56 @@ class TestLargeOnnxFileBackedInspection:
         assert native.functions[0].metadata_props[0].key == "owner"
         assert native.functions[0].metadata_props[0].value == "modelaudit"
         assert native_tensors == lite_tensors == []
-        assert state.coverage_gaps == {}
+        assert state.coverage_gaps == {"unknown_protobuf_fields": 2}
+        assert state.unknown_field_count == 2
+        assert {sample["field_number"] for sample in state.unknown_field_samples} == {15, 16}
+
+        result = OnnxScanner(
+            config={
+                "onnx_raw_detector_max_bytes": 1,
+                "check_jit_script": False,
+                "check_network_comm": False,
+            },
+        ).scan(str(model_path))
+        coverage_check = self._checks(result, "ONNX Structure Parse Coverage")[-1]
+        structure_metadata = result.metadata["onnx_structure_parse"]
+        assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert coverage_check.status == CheckStatus.FAILED
+        assert coverage_check.details["coverage_gaps"] == {"unknown_protobuf_fields": 2}
+        assert structure_metadata["unknown_field_count"] == 2
+        assert {sample["field_number"] for sample in structure_metadata["unknown_field_samples"]} == {15, 16}
+
+        in_memory_result = OnnxScanner(
+            config={
+                "check_jit_script": False,
+                "check_network_comm": False,
+            },
+        ).scan(str(model_path))
+        in_memory_checks = self._checks(in_memory_result, "ONNX Structure Parse Coverage")
+        in_memory_structure_metadata = in_memory_result.metadata["onnx_structure_parse"]
+        assert in_memory_result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
+        assert in_memory_checks[-1].details["coverage_gaps"] == {"unknown_protobuf_fields": 1}
+        assert in_memory_structure_metadata["parse_mode"] == "in_memory_model_proto"
+        assert in_memory_structure_metadata["unknown_field_count"] == 1
+        assert in_memory_structure_metadata["unknown_field_bytes_discarded"] > 0
+        assert in_memory_structure_metadata["unknown_field_detection"] == "discard_unknown_fields_byte_size"
+
+    def test_in_memory_unknown_check_does_not_reject_valid_repeated_graph_field(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model_path.write_bytes(model_path.read_bytes() + _proto_bytes(7, b""))
+
+        native = onnx.load_model_from_string(model_path.read_bytes())
+        onnx.checker.check_model(native)
+        result = OnnxScanner(
+            config={
+                "check_jit_script": False,
+                "check_network_comm": False,
+            },
+        ).scan(str(model_path))
+
+        assert result.success is True
+        assert result.metadata["onnx_structure_parse"] == {"parse_mode": "in_memory_model_proto"}
+        assert not [check for check in self._checks(result, "ONNX Model Parsing") if check.status == CheckStatus.FAILED]
 
     def test_forced_file_backed_schema_does_not_reopen_path_or_validate_format(
         self,
@@ -8144,6 +8193,73 @@ class TestRawDetectorCoverage:
     def _network_detection_checks(result: Any) -> list[Any]:
         return [c for c in result.checks if c.name == "Network Communication Detection"]
 
+    def test_structured_network_extraction_skips_numeric_tensor_payloads(self) -> None:
+        class RepeatedPayload:
+            def __iter__(self) -> Any:
+                raise AssertionError("numeric tensor payload field was enumerated")
+
+        class TensorField:
+            LABEL_REPEATED = 3
+            TYPE_MESSAGE = 11
+            TYPE_BYTES = 12
+            TYPE_STRING = 9
+            name = "float_data"
+            label = LABEL_REPEATED
+            type = 2
+
+        class TensorDescriptor:
+            full_name = "onnx.TensorProto"
+
+            def __init__(self) -> None:
+                self.fields = [TensorField()]
+
+        class TensorMessage:
+            def __init__(self) -> None:
+                self.DESCRIPTOR = TensorDescriptor()
+                self.float_data = RepeatedPayload()
+
+        collector = onnx_scanner_module._OnnxNetworkTextCollector(
+            max_bytes=1024,
+            max_fields=10,
+            check_interrupted=lambda: None,
+        )
+
+        onnx_scanner_module._collect_onnx_proto_text_fields(collector, TensorMessage(), "tensor")
+
+        detector_input = collector.finish()
+        assert detector_input.field_count == 0
+        assert detector_input.data == b""
+
+    def test_hasfield_value_error_falls_back_to_attribute_traversal(self) -> None:
+        graph = object()
+        tensor = object()
+
+        class SparseTensor:
+            values = "values"
+            indices = "indices"
+
+        class Attribute:
+            g = graph
+            t = tensor
+            sparse_tensor = SparseTensor()
+
+            def __init__(self) -> None:
+                self.graphs: list[Any] = []
+                self.tensors: list[Any] = []
+                self.sparse_tensors: list[Any] = []
+
+            def HasField(self, _name: str) -> bool:
+                raise ValueError("presence not supported")
+
+        attribute = Attribute()
+
+        assert list(onnx_scanner_module._iter_attribute_graphs(attribute)) == [graph]
+        assert list(onnx_scanner_module._iter_attribute_external_data_tensors(attribute)) == [
+            tensor,
+            "values",
+            "indices",
+        ]
+
     def _assert_inconclusive_exit2(self, model_path: Path, direct: Any, *, detector: str) -> None:
         aggregate = scan_model_directory_or_file(str(model_path), recursive=False)
         metadata = next(iter(aggregate.file_metadata.values()))
@@ -8186,6 +8302,73 @@ class TestRawDetectorCoverage:
         assert leaked_secret not in str(coverage_check.details)
         assert leaked_secret not in caplog.text
         assert "<redacted>" in coverage_check.message
+
+    def test_structured_network_text_bounds_strings_before_encoding(self) -> None:
+        class OversizedString(str):
+            def encode(self, *args: Any, **kwargs: Any) -> bytes:
+                raise AssertionError("oversized text should be omitted before encoding")
+
+        collector = onnx_scanner_module._OnnxNetworkTextCollector(
+            max_bytes=32,
+            max_fields=10,
+            check_interrupted=lambda: None,
+        )
+
+        collector.add("model.graph.name", OversizedString("x" * 64))
+        detector_input = collector.finish()
+
+        assert detector_input.truncated is True
+        assert detector_input.omitted_field_count == 1
+        assert detector_input.field_count == 0
+        assert detector_input.sections == ()
+
+    def test_structured_network_text_counts_empty_fields_against_budget(self) -> None:
+        collector = onnx_scanner_module._OnnxNetworkTextCollector(
+            max_bytes=1024,
+            max_fields=1,
+            check_interrupted=lambda: None,
+        )
+
+        collector.add("model.graph.name", "")
+        collector.add("model.graph.doc_string", "documentation text")
+        detector_input = collector.finish()
+
+        assert detector_input.truncated is True
+        assert detector_input.omitted_field_count == 1
+        assert detector_input.field_count == 0
+        assert detector_input.sections == ()
+
+    def test_structured_network_extraction_skips_repeated_numeric_fields_before_iteration(self) -> None:
+        class RepeatedNumericField:
+            name = "ints"
+            label = 3
+            type = 3
+            LABEL_REPEATED = 3
+            TYPE_MESSAGE = 11
+            TYPE_BYTES = 12
+            TYPE_STRING = 9
+
+        class RepeatedNumericValues:
+            def __iter__(self) -> Any:
+                raise AssertionError("numeric field should be skipped before iteration")
+
+        class AttributeDescriptor:
+            full_name = "onnx.AttributeProto"
+            fields: ClassVar[tuple[Any, ...]] = (RepeatedNumericField(),)
+
+        class AttributeMessage:
+            DESCRIPTOR = AttributeDescriptor()
+            ints = RepeatedNumericValues()
+
+        collector = onnx_scanner_module._OnnxNetworkTextCollector(
+            max_bytes=1024,
+            max_fields=10,
+            check_interrupted=lambda: None,
+        )
+
+        onnx_scanner_module._collect_onnx_proto_text_fields(collector, AttributeMessage(), "attribute")
+
+        assert collector.finish().sections == ()
 
     def test_network_detector_ignores_onnx_raw_tensor_bytes(self, tmp_path: Path) -> None:
         payload = b"quantized calibration bytes 8.8.8.8 are tensor data"
@@ -8232,6 +8415,208 @@ class TestRawDetectorCoverage:
             check.details.get("type") == "url_detected" and "45.33.32.156" in str(check.details.get("url", ""))
             for check in failed_network_checks
         )
+        assert all(check.details.get("onnx_metadata_owned") is True for check in failed_network_checks)
+
+    def test_network_detector_huggingface_metadata_url_stays_informational(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        metadata = model.metadata_props.add()
+        metadata.key = "homepage"
+        metadata.value = "https://huggingface.co/meta-llama/Llama-2-7b"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        metadata_failures = [
+            check for check in failed_network_checks if check.details.get("onnx_metadata_owned") is True
+        ]
+        assert metadata_failures
+        assert all(check.severity == IssueSeverity.INFO for check in metadata_failures)
+        assert not any(check.details.get("type") == "explicit_network_pattern" for check in failed_network_checks)
+
+    def test_network_detector_preserves_docs_url_metadata_ownership(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        metadata = model.metadata_props.add()
+        metadata.key = "documentation"
+        metadata.value = "https://docs.ultralytics.com/"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        metadata_input = result.metadata["onnx_network_detector_input"]
+        assert metadata_input["sections"][-1] == {
+            "name": "metadata_props",
+            "field_count": 2,
+            "metadata_owned": True,
+        }
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        docs_failures = [
+            check
+            for check in failed_network_checks
+            if "docs.ultralytics.com" in str(check.details) and check.details.get("onnx_metadata_owned") is True
+        ]
+        assert docs_failures
+        assert all(
+            str(check.details.get("onnx_detector_context", "")).endswith("/onnx_metadata/metadata")
+            for check in docs_failures
+        )
+
+    def test_network_detector_metadata_contact_domain_stays_clean(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        metadata = model.metadata_props.add()
+        metadata.key = "contact"
+        metadata.value = "owner@company.com"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert not failed_network_checks
+        assert any(check.status == CheckStatus.PASSED for check in self._network_detection_checks(result))
+
+    def test_network_detector_extensionless_metadata_contact_domain_stays_clean(self, tmp_path: Path) -> None:
+        source_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(source_path))
+        metadata = model.metadata_props.add()
+        metadata.key = "contact"
+        metadata.value = "owner@company.com"
+        model_path = tmp_path / "metadata-contact"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert not failed_network_checks
+        assert any(check.status == CheckStatus.PASSED for check in self._network_detection_checks(result))
+
+    def test_network_detector_metadata_prose_import_requests_stays_clean(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        metadata = model.metadata_props.add()
+        metadata.key = "documentation"
+        metadata.value = "This documentation shows how to import requests for the example"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert not failed_network_checks
+        assert any(check.status == CheckStatus.PASSED for check in self._network_detection_checks(result))
+
+    def test_network_detector_pb_metadata_port_remains_actionable(self, tmp_path: Path) -> None:
+        source_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(source_path))
+        metadata = model.metadata_props.add()
+        metadata.key = "callback"
+        metadata.value = "connect port=6379"
+        model_path = tmp_path / "model.pb"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert any(
+            check.details.get("type") == "suspicious_port" and check.details.get("onnx_metadata_owned") is True
+            for check in failed_network_checks
+        )
+
+    def test_network_detector_nonmetadata_url_remains_actionable(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        model.graph.node[0].name = "https://45.33.32.156/payload"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert any(
+            "45.33.32.156" in str(check.details)
+            and check.details.get("onnx_metadata_owned") is False
+            and check.severity in {IssueSeverity.WARNING, IssueSeverity.CRITICAL}
+            for check in failed_network_checks
+        )
+
+    def test_network_detector_max_findings_applies_across_sections(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        model.graph.node[0].name = "https://45.33.32.156/payload"
+        metadata = model.metadata_props.add()
+        metadata.key = "callback"
+        metadata.value = "https://45.33.32.157/payload"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(
+            config={
+                "check_jit_script": False,
+                "network_comm_config": {"max_findings": 1},
+            },
+        ).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        actual_findings = [
+            check for check in failed_network_checks if check.details.get("type") != "detector_finding_limit"
+        ]
+        limit_findings = [
+            check for check in failed_network_checks if check.details.get("type") == "detector_finding_limit"
+        ]
+        coverage_checks = self._coverage_checks(result)
+        assert result.success is False
+        assert any(
+            check.details.get("coverage_gap") == "detector_finding_limit"
+            and check.details.get("detector") == "network_communication"
+            and (
+                check.details.get("skipped_section") == "metadata_props"
+                or "metadata_props" in check.details.get("skipped_sections", [])
+            )
+            for check in coverage_checks
+        )
+        assert len(actual_findings) == 1
+        assert limit_findings
+        assert all("45.33.32.157" not in str(check.details) for check in actual_findings)
+
+    def test_truncated_structured_network_input_does_not_emit_clean_pass(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(onnx_scanner_module, "_ONNX_NETWORK_TEXT_MAX_FIELDS", 1)
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        metadata = model.metadata_props.add()
+        metadata.key = "owner"
+        metadata.value = "modelaudit"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        coverage_checks = self._coverage_checks(result)
+        assert result.metadata["onnx_network_detector_input"]["truncated"] is True
+        assert result.metadata["onnx_network_detector_input"]["omitted_field_count"] > 0
+        assert any(
+            check.details["coverage_gap"] == "text_field_budget_exceeded"
+            and check.details["detector"] == "network_communication"
+            for check in coverage_checks
+        )
+        assert not any(check.status == CheckStatus.PASSED for check in self._network_detection_checks(result))
 
     def test_network_detector_failure_is_inconclusive(
         self,

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -8748,7 +8748,8 @@ class TestRawDetectorCoverage:
         result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
 
         detector_sections = result.metadata["onnx_network_detector_input"]["sections"]
-        assert any(section["name"] == "metadata_text_fields" for section in detector_sections)
+        assert any(section["name"] == "metadata_props" for section in detector_sections)
+        assert not any(section["name"] == "metadata_text_fields" for section in detector_sections)
         assert any(
             check.details.get("type") == "url_detected"
             and check.details.get("url") == url
@@ -8863,6 +8864,39 @@ class TestRawDetectorCoverage:
         callback = model.metadata_props.add()
         callback.key = "callback"
         callback.value = "host evil.com port=6379"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert any(
+            check.details.get("domain") == "evil.com" and check.details.get("onnx_metadata_owned") is True
+            for check in failed_network_checks
+        )
+        assert any(
+            check.details.get("type") == "suspicious_port"
+            and check.details.get("port") == 6379
+            and check.details.get("onnx_metadata_owned") is True
+            for check in failed_network_checks
+        )
+
+    def test_network_detector_preserves_nested_onnx_metadata_props(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        function = helper.make_function(
+            "modelaudit.test",
+            "CallbackFunction",
+            ["function_input"],
+            ["function_output"],
+            [helper.make_node("Identity", ["function_input"], ["function_output"])],
+            [helper.make_opsetid("", 13)],
+        )
+        callback = function.metadata_props.add()
+        callback.key = "callback"
+        callback.value = "host evil.com port=6379"
+        model.functions.extend([function])
         onnx.save(model, str(model_path))
 
         result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -8261,6 +8261,51 @@ class TestRawDetectorCoverage:
         assert detector_input.field_count == 0
         assert detector_input.data == b""
 
+    def test_structured_network_extraction_bounds_empty_repeated_messages(self) -> None:
+        iterations: list[int] = []
+
+        class EmptyMessage:
+            class Descriptor:
+                fields: ClassVar[tuple[Any, ...]] = ()
+
+            DESCRIPTOR = Descriptor()
+
+        class RepeatedMessageField:
+            LABEL_REPEATED = 3
+            TYPE_MESSAGE = 11
+            TYPE_BYTES = 12
+            TYPE_STRING = 9
+            name = "node"
+            label = LABEL_REPEATED
+            type = TYPE_MESSAGE
+
+        class ParentDescriptor:
+            fields: ClassVar[tuple[Any, ...]] = (RepeatedMessageField(),)
+
+        class RepeatedMessages:
+            def __iter__(self) -> Any:
+                for index in range(100):
+                    iterations.append(index)
+                    yield EmptyMessage()
+
+        class ParentMessage:
+            DESCRIPTOR = ParentDescriptor()
+            node = RepeatedMessages()
+
+        collector = onnx_scanner_module._OnnxNetworkTextCollector(
+            max_bytes=1024,
+            max_fields=4,
+            check_interrupted=lambda: None,
+        )
+
+        onnx_scanner_module._collect_onnx_proto_text_fields(collector, ParentMessage(), "model")
+
+        detector_input = collector.finish()
+        assert len(iterations) == 5
+        assert detector_input.truncated is True
+        assert detector_input.omitted_field_count == 1
+        assert detector_input.field_count == 0
+
     def test_hasfield_value_error_falls_back_to_attribute_traversal(self) -> None:
         graph = object()
         tensor = object()
@@ -8556,6 +8601,176 @@ class TestRawDetectorCoverage:
             for check in docs_failures
         )
 
+    def test_network_detector_metadata_section_uses_protobuf_owned_values(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        metadata = model.metadata_props.add()
+        metadata.key = "documentation"
+        metadata.value = "https://docs.ultralytics.com/"
+
+        detector_input = onnx_scanner_module._collect_onnx_network_detector_input(model, check_interrupted=lambda: None)
+        metadata_section = next(section for section in detector_input.sections if section.name == "metadata_props")
+        metadata_view = onnx.load_model_from_string(metadata_section.data)
+
+        assert metadata_section.field_count == 2
+        assert metadata_section.metadata_owned is True
+        assert metadata_view.graph.initializer == []
+        assert [(prop.key, prop.value) for prop in metadata_view.metadata_props] == [
+            ("documentation", "https://docs.ultralytics.com/\n")
+        ]
+
+    def test_network_detector_metadata_protobuf_uses_only_bounded_values(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(onnx_scanner_module, "_ONNX_NETWORK_TEXT_MAX_BYTES", 512)
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        docs_metadata = model.metadata_props.add()
+        docs_metadata.key = "documentation"
+        docs_metadata.value = "https://docs.ultralytics.com/"
+        oversized_metadata = model.metadata_props.add()
+        oversized_metadata.key = "callback"
+        oversized_metadata.value = "https://45.33.32.157/payload/" + ("a" * 2048)
+
+        detector_input = onnx_scanner_module._collect_onnx_network_detector_input(model, check_interrupted=lambda: None)
+        metadata_section = next(section for section in detector_input.sections if section.name == "metadata_props")
+        metadata_view = onnx.load_model_from_string(metadata_section.data)
+
+        assert detector_input.truncated is True
+        assert detector_input.omitted_field_count == 1
+        assert metadata_section.field_count == 2
+        assert [(prop.key, prop.value) for prop in metadata_view.metadata_props] == [
+            ("documentation", "https://docs.ultralytics.com/\n")
+        ]
+        assert b"45.33.32.157" not in metadata_section.data
+        metadata_text_section = next(
+            section for section in detector_input.sections if section.name == "metadata_text_fields"
+        )
+        assert metadata_text_section.field_count == 1
+        assert b"callback" in metadata_text_section.data
+        assert b"45.33.32.157" not in metadata_text_section.data
+
+    def test_network_detector_preserves_function_metadata_text(self, tmp_path: Path) -> None:
+        url = "https://45.33.32.157/payload"
+        model_metadata = _proto_bytes(1, b"documentation") + _proto_bytes(2, b"https://docs.ultralytics.com/")
+        function_metadata = _proto_bytes(1, b"callback") + _proto_bytes(2, url.encode())
+        function = _proto_bytes(1, b"Fn") + _proto_bytes(14, function_metadata)
+        graph = _proto_bytes(2, b"graph")
+        model = (
+            _proto_varint(1, 8) + _proto_bytes(7, graph) + _proto_bytes(14, model_metadata) + _proto_bytes(25, function)
+        )
+        model_path = _write_onnx_payload(tmp_path, "function-metadata-url.onnx", model)
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        detector_sections = result.metadata["onnx_network_detector_input"]["sections"]
+        assert any(section["name"] == "metadata_text_fields" for section in detector_sections)
+        assert any(
+            check.details.get("type") == "url_detected"
+            and check.details.get("url") == url
+            and check.details.get("onnx_metadata_owned") is True
+            for check in self._network_detection_checks(result)
+            if check.status == CheckStatus.FAILED
+        )
+
+    def test_network_detector_preserves_metadata_value_without_admitted_key(self, tmp_path: Path) -> None:
+        url = "https://45.33.32.157/payload"
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        metadata = model.metadata_props.add()
+        metadata.key = ""
+        metadata.value = url
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        detector_sections = result.metadata["onnx_network_detector_input"]["sections"]
+        assert detector_sections[-1]["name"] == "metadata_props"
+        assert any(
+            check.details.get("type") == "url_detected"
+            and check.details.get("url") == url
+            and check.details.get("onnx_metadata_owned") is True
+            for check in self._network_detection_checks(result)
+            if check.status == CheckStatus.FAILED
+        )
+
+    def test_network_detector_preserves_metadata_key_without_admitted_value(self, tmp_path: Path) -> None:
+        url = "https://45.33.32.157/payload"
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        docs_metadata = model.metadata_props.add()
+        docs_metadata.key = "documentation"
+        docs_metadata.value = "https://docs.ultralytics.com/"
+        key_only_metadata = model.metadata_props.add()
+        key_only_metadata.key = url
+        key_only_metadata.value = ""
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        detector_sections = result.metadata["onnx_network_detector_input"]["sections"]
+        assert [section["name"] for section in detector_sections[-2:]] == ["metadata_props", "metadata_text_fields"]
+        assert any(
+            check.details.get("type") == "url_detected"
+            and check.details.get("url") == url
+            and check.details.get("onnx_metadata_owned") is True
+            for check in self._network_detection_checks(result)
+            if check.status == CheckStatus.FAILED
+        )
+
+    def test_network_detector_metadata_props_preserve_value_boundaries(self, tmp_path: Path) -> None:
+        url = "https://45.33.32.158/payload"
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        ip_metadata = model.metadata_props.add()
+        ip_metadata.key = "callback"
+        ip_metadata.value = "45.33.32.157"
+        url_metadata = model.metadata_props.add()
+        url_metadata.key = "documentation"
+        url_metadata.value = url
+        author_metadata = model.metadata_props.add()
+        author_metadata.key = "author"
+        author_metadata.value = "Model Team"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        detector_sections = result.metadata["onnx_network_detector_input"]["sections"]
+        assert [section["name"] for section in detector_sections].count("metadata_props") == 1
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert any(
+            check.details.get("type") == "ipv4_address"
+            and check.details.get("ip") == "45.33.32.157"
+            and check.details.get("onnx_metadata_owned") is True
+            for check in failed_network_checks
+        )
+        assert any(
+            check.details.get("type") == "url_detected"
+            and check.details.get("url") == url
+            and check.details.get("onnx_metadata_owned") is True
+            for check in failed_network_checks
+        )
+        assert all("payloadr" not in str(check.details) for check in failed_network_checks)
+        assert all("45.33.32.157r" not in str(check.details) for check in failed_network_checks)
+
+    def test_network_detector_batches_model_metadata_props(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        for index in range(20):
+            metadata = model.metadata_props.add()
+            metadata.key = f"url_{index}"
+            metadata.value = f"https://docs.example.com/reference/{index}"
+
+        detector_input = onnx_scanner_module._collect_onnx_network_detector_input(model, check_interrupted=lambda: None)
+
+        sections = detector_input.sections
+        assert len([section for section in sections if section.name == "metadata_props"]) == 1
+        assert not [section for section in sections if section.name == "metadata_text_fields"]
+
     def test_network_detector_metadata_contact_domain_stays_clean(self, tmp_path: Path) -> None:
         model_path = create_onnx_model(tmp_path, include_initializer=False)
         model = onnx.load(str(model_path))
@@ -8681,6 +8896,142 @@ class TestRawDetectorCoverage:
         assert len(actual_findings) == 1
         assert limit_findings
         assert all("45.33.32.157" not in str(check.details) for check in actual_findings)
+
+    def test_network_detector_max_findings_ignores_harmless_later_metadata(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        model.graph.node[0].name = "45.33.32.156"
+        metadata = model.metadata_props.add()
+        metadata.key = "author"
+        metadata.value = "Model Team"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(
+            config={
+                "check_jit_script": False,
+                "network_comm_config": {"max_findings": 1},
+            },
+        ).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        actual_findings = [
+            check for check in failed_network_checks if check.details.get("type") != "detector_finding_limit"
+        ]
+        assert len(actual_findings) == 1
+        assert actual_findings[0].details.get("ip") == "45.33.32.156"
+        assert not [check for check in failed_network_checks if check.details.get("type") == "detector_finding_limit"]
+        assert not [
+            check
+            for check in self._coverage_checks(result)
+            if check.details.get("coverage_gap") == "detector_finding_limit"
+        ]
+
+    def test_network_detector_preserves_later_section_limit_marker(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        model.graph.node[0].name = "45.33.32.156"
+        metadata = model.metadata_props.add()
+        metadata.key = "documentation"
+        metadata.value = "https://docs.ultralytics.com/"
+        onnx.save(model, str(model_path))
+
+        def fake_collect_network_findings(
+            self: OnnxScanner,
+            data: bytes,
+            context: str = "",
+            enable_check: bool = True,
+            raise_on_error: bool = False,
+            max_findings: int | None = None,
+            result: Any | None = None,
+        ) -> list[dict[str, Any]]:
+            if context.endswith("/onnx_metadata/metadata"):
+                return [
+                    {
+                        "type": "detector_finding_limit",
+                        "detector": "network_communication",
+                        "severity": "INFO",
+                        "message": "Network detector evidence-redaction work limit reached",
+                        "analysis_incomplete": True,
+                        "truncated_finding_type": "evidence_redaction",
+                    }
+                ]
+            return [
+                {
+                    "type": "ipv4_address",
+                    "severity": "MEDIUM",
+                    "message": "IPv4 address detected: 45.33.32.156",
+                    "ip": "45.33.32.156",
+                    "context": context,
+                }
+            ]
+
+        monkeypatch.setattr(OnnxScanner, "collect_network_communication_findings", fake_collect_network_findings)
+
+        result = OnnxScanner(
+            config={
+                "check_jit_script": False,
+                "network_comm_config": {"max_findings": 1},
+            },
+        ).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert any(
+            check.details.get("type") == "detector_finding_limit"
+            and check.details.get("truncated_finding_type") == "evidence_redaction"
+            and check.details.get("onnx_metadata_owned") is True
+            for check in failed_network_checks
+        )
+        assert any(
+            check.details.get("coverage_gap") == "detector_finding_limit"
+            and check.details.get("detector") == "network_communication"
+            for check in self._coverage_checks(result)
+        )
+
+    def test_network_detector_preserves_prior_section_findings_after_later_failure(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        model.graph.node[0].name = "https://45.33.32.156/payload"
+        metadata = model.metadata_props.add()
+        metadata.key = "documentation"
+        metadata.value = "https://docs.ultralytics.com/"
+        onnx.save(model, str(model_path))
+        original_scan = NetworkCommDetector.scan
+
+        def fail_metadata_section(self: NetworkCommDetector, data: bytes, context: str = "") -> list[dict[str, Any]]:
+            if context.endswith("/onnx_metadata/metadata"):
+                raise RuntimeError("metadata detector failed")
+            return original_scan(self, data, context)
+
+        monkeypatch.setattr(NetworkCommDetector, "scan", fail_metadata_section)
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert any(
+            check.details.get("type") == "url_detected"
+            and "45.33.32.156" in str(check.details.get("url", ""))
+            and check.details.get("onnx_metadata_owned") is False
+            for check in failed_network_checks
+        )
+        assert any(
+            check.details.get("coverage_gap") == "analysis_failed"
+            and check.details.get("detector") == "network_communication"
+            for check in self._coverage_checks(result)
+        )
 
     def test_truncated_structured_network_input_does_not_emit_clean_pass(
         self,

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -8862,7 +8862,7 @@ class TestRawDetectorCoverage:
             metadata.value = "Model Team"
         callback = model.metadata_props.add()
         callback.key = "callback"
-        callback.value = "host evil.com"
+        callback.value = "host evil.com port=6379"
         onnx.save(model, str(model_path))
 
         result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
@@ -8872,6 +8872,12 @@ class TestRawDetectorCoverage:
         ]
         assert any(
             check.details.get("domain") == "evil.com" and check.details.get("onnx_metadata_owned") is True
+            for check in failed_network_checks
+        )
+        assert any(
+            check.details.get("type") == "suspicious_port"
+            and check.details.get("port") == 6379
+            and check.details.get("onnx_metadata_owned") is True
             for check in failed_network_checks
         )
 

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -8905,6 +8905,25 @@ class TestRawDetectorCoverage:
             for check in failed_network_checks
         )
 
+    def test_network_detector_extensionless_metadata_callback_domain_uses_full_value(self, tmp_path: Path) -> None:
+        source_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(source_path))
+        metadata = model.metadata_props.add()
+        metadata.key = "callback"
+        metadata.value = ("A" * 129) + " evil.com"
+        model_path = tmp_path / "metadata-callback-padded"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert any(
+            check.details.get("domain") == "evil.com" and check.details.get("onnx_metadata_owned") is True
+            for check in failed_network_checks
+        )
+
     def test_network_detector_metadata_prose_import_requests_stays_clean(self, tmp_path: Path) -> None:
         model_path = create_onnx_model(tmp_path, include_initializer=False)
         model = onnx.load(str(model_path))
@@ -8919,6 +8938,22 @@ class TestRawDetectorCoverage:
             check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
         ]
         assert not failed_network_checks
+        assert any(check.status == CheckStatus.PASSED for check in self._network_detection_checks(result))
+
+    def test_network_detector_metadata_documentation_port_stays_clean(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        metadata = model.metadata_props.add()
+        metadata.key = "documentation"
+        metadata.value = "The local example uses localhost:8080"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert not [check for check in failed_network_checks if check.details.get("type") == "suspicious_port"]
         assert any(check.status == CheckStatus.PASSED for check in self._network_detection_checks(result))
 
     def test_network_detector_pb_metadata_port_remains_actionable(self, tmp_path: Path) -> None:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -8479,7 +8479,9 @@ class TestRawDetectorCoverage:
         docs_failures = [
             check
             for check in failed_network_checks
-            if "docs.ultralytics.com" in str(check.details) and check.details.get("onnx_metadata_owned") is True
+            if check.details.get("type") == "url_detected"
+            and check.details.get("url") == "https://docs.ultralytics.com/"
+            and check.details.get("onnx_metadata_owned") is True
         ]
         assert docs_failures
         assert all(

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -2330,6 +2330,26 @@ def test_onnx_scanner_tentative_protobuf_parse_failure_is_inconclusive(tmp_path:
     assert any(issue.severity == IssueSeverity.INFO for issue in result.issues)
 
 
+def test_onnx_scanner_tentative_missing_graph_with_unknown_field_is_rejected_cleanly(tmp_path: Path) -> None:
+    model_path = tmp_path / "ambiguous.bin"
+    model_path.write_bytes(_proto_varint(1, 8) + _proto_varint(27, 1))
+    scanner = OnnxScanner(
+        {
+            FORMAT_VALIDATION_CONFIG_KEY: {"routed_format": PROTOBUF_MODEL_CANDIDATE_FORMAT},
+            "check_jit_script": False,
+            "check_network_comm": False,
+        }
+    )
+
+    result = scanner.scan(str(model_path))
+
+    assert result.scanner_name == "unknown"
+    assert result.success is True
+    assert result.metadata["tentative_protobuf_candidate_rejected"] is True
+    assert result.metadata["onnx_structure_parse"] == {"parse_mode": "in_memory_model_proto"}
+    assert not [check for check in result.checks if check.name == "ONNX Structure Parse Coverage"]
+
+
 def test_onnx_scanner_tentative_invalid_version_still_detects_python_operator(tmp_path: Path) -> None:
     model_path = create_python_onnx_model(tmp_path)
     model = onnx.load(str(model_path))

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -8886,6 +8886,25 @@ class TestRawDetectorCoverage:
         assert not failed_network_checks
         assert any(check.status == CheckStatus.PASSED for check in self._network_detection_checks(result))
 
+    def test_network_detector_extensionless_metadata_callback_domain_remains_actionable(self, tmp_path: Path) -> None:
+        source_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(source_path))
+        metadata = model.metadata_props.add()
+        metadata.key = "callback"
+        metadata.value = "host evil.com"
+        model_path = tmp_path / "metadata-callback"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert any(
+            check.details.get("domain") == "evil.com" and check.details.get("onnx_metadata_owned") is True
+            for check in failed_network_checks
+        )
+
     def test_network_detector_metadata_prose_import_requests_stays_clean(self, tmp_path: Path) -> None:
         model_path = create_onnx_model(tmp_path, include_initializer=False)
         model = onnx.load(str(model_path))
@@ -9075,6 +9094,39 @@ class TestRawDetectorCoverage:
         assert any(
             check.details.get("coverage_gap") == "detector_finding_limit"
             and check.details.get("detector") == "network_communication"
+            for check in self._coverage_checks(result)
+        )
+
+    def test_network_detector_redaction_work_limit_continues_to_later_metadata(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        model.doc_string = "".join("api_key=value endpoint=45.33.32.156\n" for _ in range(100))
+        metadata = model.metadata_props.add()
+        metadata.key = "callback"
+        metadata.value = "https://45.33.32.157/payload"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert any(
+            check.details.get("type") == "detector_finding_limit"
+            and check.details.get("truncated_finding_type") == "endpoint_redaction_classification"
+            and check.details.get("onnx_metadata_owned") is False
+            for check in failed_network_checks
+        )
+        assert any(
+            check.details.get("type") == "url_detected"
+            and "45.33.32.157" in str(check.details.get("url", ""))
+            and check.details.get("onnx_metadata_owned") is True
+            for check in failed_network_checks
+        )
+        assert any(
+            check.details.get("coverage_gap") == "detector_finding_limit"
+            and check.details.get("truncated_section") == "structured_text_fields"
+            and "skipped_sections" not in check.details
             for check in self._coverage_checks(result)
         )
 

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -8498,7 +8498,7 @@ class TestRawDetectorCoverage:
     def test_structured_network_extraction_skips_repeated_numeric_fields_before_iteration(self) -> None:
         class RepeatedNumericField:
             name = "ints"
-            label = 3
+            is_repeated = True
             type = 3
             LABEL_REPEATED = 3
             TYPE_MESSAGE = 11
@@ -8526,6 +8526,34 @@ class TestRawDetectorCoverage:
         onnx_scanner_module._collect_onnx_proto_text_fields(collector, AttributeMessage(), "attribute")
 
         assert collector.finish().sections == ()
+
+    def test_structured_network_extraction_accepts_repeated_field_without_label(self) -> None:
+        class RepeatedStringField:
+            name = "input"
+            is_repeated = True
+            type = 9
+            TYPE_MESSAGE = 11
+            TYPE_BYTES = 12
+            TYPE_STRING = 9
+
+        class Descriptor:
+            fields: ClassVar[tuple[Any, ...]] = (RepeatedStringField(),)
+
+        class Message:
+            DESCRIPTOR = Descriptor()
+            input = ("https://docs.ultralytics.com/",)
+
+        collector = onnx_scanner_module._OnnxNetworkTextCollector(
+            max_bytes=1024,
+            max_fields=10,
+            check_interrupted=lambda: None,
+        )
+
+        onnx_scanner_module._collect_onnx_proto_text_fields(collector, Message(), "model.graph.node[0]")
+
+        detector_input = collector.finish()
+        assert detector_input.field_count == 1
+        assert b"model.graph.node[0].input[0]: https://docs.ultralytics.com/" in detector_input.data
 
     def test_network_detector_ignores_onnx_raw_tensor_bytes(self, tmp_path: Path) -> None:
         payload = b"quantized calibration bytes 8.8.8.8 are tensor data"

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -8140,6 +8140,10 @@ class TestRawDetectorCoverage:
     def _coverage_checks(result: Any) -> list[Any]:
         return [c for c in result.checks if c.name == "Raw Detector Analysis Coverage"]
 
+    @staticmethod
+    def _network_detection_checks(result: Any) -> list[Any]:
+        return [c for c in result.checks if c.name == "Network Communication Detection"]
+
     def _assert_inconclusive_exit2(self, model_path: Path, direct: Any, *, detector: str) -> None:
         aggregate = scan_model_directory_or_file(str(model_path), recursive=False)
         metadata = next(iter(aggregate.file_metadata.values()))
@@ -8182,6 +8186,52 @@ class TestRawDetectorCoverage:
         assert leaked_secret not in str(coverage_check.details)
         assert leaked_secret not in caplog.text
         assert "<redacted>" in coverage_check.message
+
+    def test_network_detector_ignores_onnx_raw_tensor_bytes(self, tmp_path: Path) -> None:
+        payload = b"quantized calibration bytes 8.8.8.8 are tensor data"
+        tensor = onnx.TensorProto()
+        tensor.name = "W"
+        tensor.data_type = TensorProto.UINT8
+        tensor.dims.extend([len(payload)])
+        tensor.raw_data = payload
+        output = helper.make_tensor_value_info("output", TensorProto.UINT8, [len(payload)])
+        node = helper.make_node("Identity", ["W"], ["output"], name="identity")
+        graph = helper.make_graph([node], "raw_tensor_graph", [], [output], initializer=[tensor])
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+        model.ir_version = 8
+        model_path = tmp_path / "raw-tensor-ip.onnx"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        assert result.metadata["onnx_network_detector_input"]["source"] == "structured_text_fields"
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert not [
+            check
+            for check in failed_network_checks
+            if check.details.get("type") == "ipv4_address" and check.details.get("ip") == "8.8.8.8"
+        ]
+        assert any(check.status == CheckStatus.PASSED for check in self._network_detection_checks(result))
+
+    def test_network_detector_preserves_onnx_metadata_urls(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        metadata = model.metadata_props.add()
+        metadata.key = "callback"
+        metadata.value = "https://45.33.32.156/payload"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert any(
+            check.details.get("type") == "url_detected" and "45.33.32.156" in str(check.details.get("url", ""))
+            for check in failed_network_checks
+        )
 
     def test_network_detector_failure_is_inconclusive(
         self,

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -2421,9 +2421,11 @@ def test_onnx_scanner_raw_read_failure_falls_back_to_file_backed_parse(
     assert result.bytes_scanned > 0
     assert result.metadata["scan_outcome"] == INCONCLUSIVE_SCAN_OUTCOME
     assert result.metadata["onnx_structure_parse"]["parse_mode"] == "file_backed_structure"
-    assert len(coverage_checks) == 1
-    assert coverage_checks[0].details["detector"] == "raw_file_read"
-    assert coverage_checks[0].details["coverage_gap"] == "file_read_failed"
+    coverage_gaps = {(check.details["detector"], check.details["coverage_gap"]) for check in coverage_checks}
+    assert coverage_gaps == {
+        ("raw_file_read", "file_read_failed"),
+        ("network_communication", "structured_text_unavailable"),
+    }
 
 
 def test_directory_scan_hashes_external_data_for_content_routed_onnx_bin(tmp_path: Path) -> None:

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -8853,6 +8853,28 @@ class TestRawDetectorCoverage:
         assert len([section for section in sections if section.name == "metadata_props"]) == 1
         assert not [section for section in sections if section.name == "metadata_text_fields"]
 
+    def test_network_detector_scans_metadata_entry_after_detector_entry_limit(self, tmp_path: Path) -> None:
+        model_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(model_path))
+        for index in range(1024):
+            metadata = model.metadata_props.add()
+            metadata.key = f"author_{index}"
+            metadata.value = "Model Team"
+        callback = model.metadata_props.add()
+        callback.key = "callback"
+        callback.value = "host evil.com"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert any(
+            check.details.get("domain") == "evil.com" and check.details.get("onnx_metadata_owned") is True
+            for check in failed_network_checks
+        )
+
     def test_network_detector_metadata_contact_domain_stays_clean(self, tmp_path: Path) -> None:
         model_path = create_onnx_model(tmp_path, include_initializer=False)
         model = onnx.load(str(model_path))
@@ -8955,6 +8977,42 @@ class TestRawDetectorCoverage:
         ]
         assert not [check for check in failed_network_checks if check.details.get("type") == "suspicious_port"]
         assert any(check.status == CheckStatus.PASSED for check in self._network_detection_checks(result))
+
+    def test_network_detector_extensionless_metadata_documentation_port_stays_clean(self, tmp_path: Path) -> None:
+        source_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(source_path))
+        metadata = model.metadata_props.add()
+        metadata.key = "documentation"
+        metadata.value = "The local example uses localhost:8080"
+        model_path = tmp_path / "metadata-doc-port"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert not [check for check in failed_network_checks if check.details.get("type") == "suspicious_port"]
+        assert any(check.status == CheckStatus.PASSED for check in self._network_detection_checks(result))
+
+    def test_network_detector_extensionless_metadata_callback_port_remains_actionable(self, tmp_path: Path) -> None:
+        source_path = create_onnx_model(tmp_path, include_initializer=False)
+        model = onnx.load(str(source_path))
+        metadata = model.metadata_props.add()
+        metadata.key = "callback"
+        metadata.value = "connect port=6379"
+        model_path = tmp_path / "metadata-callback-port"
+        onnx.save(model, str(model_path))
+
+        result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
+
+        failed_network_checks = [
+            check for check in self._network_detection_checks(result) if check.status == CheckStatus.FAILED
+        ]
+        assert any(
+            check.details.get("type") == "suspicious_port" and check.details.get("onnx_metadata_owned") is True
+            for check in failed_network_checks
+        )
 
     def test_network_detector_pb_metadata_port_remains_actionable(self, tmp_path: Path) -> None:
         source_path = create_onnx_model(tmp_path, include_initializer=False)
@@ -9083,9 +9141,10 @@ class TestRawDetectorCoverage:
             context: str = "",
             enable_check: bool = True,
             raise_on_error: bool = False,
+            result: Any | None = None,
+            *,
             max_findings: int | None = None,
             onnx_metadata_context: bool = False,
-            result: Any | None = None,
         ) -> list[dict[str, Any]]:
             if onnx_metadata_context:
                 return [

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -8575,6 +8575,9 @@ class TestRawDetectorCoverage:
         metadata = model.metadata_props.add()
         metadata.key = "documentation"
         metadata.value = "https://docs.ultralytics.com/"
+        notes = model.metadata_props.add()
+        notes.key = "notes"
+        notes.value = "Documentation includes import socket for examples."
         onnx.save(model, str(model_path))
 
         result = OnnxScanner(config={"check_jit_script": False}).scan(str(model_path))
@@ -8582,7 +8585,7 @@ class TestRawDetectorCoverage:
         metadata_input = result.metadata["onnx_network_detector_input"]
         assert metadata_input["sections"][-1] == {
             "name": "metadata_props",
-            "field_count": 2,
+            "field_count": 4,
             "metadata_owned": True,
         }
         failed_network_checks = [
@@ -8596,10 +8599,8 @@ class TestRawDetectorCoverage:
             and check.details.get("onnx_metadata_owned") is True
         ]
         assert docs_failures
-        assert all(
-            str(check.details.get("onnx_detector_context", "")).endswith("/onnx_metadata/metadata")
-            for check in docs_failures
-        )
+        assert all(check.details.get("onnx_detector_context") == str(model_path) for check in docs_failures)
+        assert not [check for check in failed_network_checks if check.details.get("type") == "network_library"]
 
     def test_network_detector_metadata_section_uses_protobuf_owned_values(self, tmp_path: Path) -> None:
         model_path = create_onnx_model(tmp_path, include_initializer=False)
@@ -8948,9 +8949,10 @@ class TestRawDetectorCoverage:
             enable_check: bool = True,
             raise_on_error: bool = False,
             max_findings: int | None = None,
+            onnx_metadata_context: bool = False,
             result: Any | None = None,
         ) -> list[dict[str, Any]]:
-            if context.endswith("/onnx_metadata/metadata"):
+            if onnx_metadata_context:
                 return [
                     {
                         "type": "detector_finding_limit",
@@ -9009,10 +9011,16 @@ class TestRawDetectorCoverage:
         onnx.save(model, str(model_path))
         original_scan = NetworkCommDetector.scan
 
-        def fail_metadata_section(self: NetworkCommDetector, data: bytes, context: str = "") -> list[dict[str, Any]]:
-            if context.endswith("/onnx_metadata/metadata"):
+        def fail_metadata_section(
+            self: NetworkCommDetector,
+            data: bytes,
+            context: str = "",
+            *,
+            onnx_metadata_context: bool = False,
+        ) -> list[dict[str, Any]]:
+            if onnx_metadata_context:
                 raise RuntimeError("metadata detector failed")
-            return original_scan(self, data, context)
+            return original_scan(self, data, context, onnx_metadata_context=onnx_metadata_context)
 
         monkeypatch.setattr(NetworkCommDetector, "scan", fail_metadata_section)
 


### PR DESCRIPTION
## Summary
- Route ONNX network detection through bounded protobuf text fields instead of the full serialized ONNX byte stream.
- Skip `TensorProto.raw_data` and `TensorProto.string_data` so quantized tensor payload bytes do not become passive IPv4 network warnings.
- Preserve URL/IP detection in ONNX metadata/string fields and fail closed if extracted text exceeds the bounded budget.

## Campaign Evidence
- Affected HF model: `xybrid-ai/Kokoro-82M-v1.0-ONNX` at immutable revision `79adf49e71955c5f5dd4a3a4a390a33f63309697`.
- Baseline scanner SHA: `9631527b3e81e0458fe9e0242c3178af406bfa5f`.
- Baseline finding: 27 `Network Communication Detection` IPv4 warnings from `kokoro-v1.0.int8.onnx` raw tensor-looking bytes; no URL/socket/code context.
- Deterministic fixture evidence: current `main` warns on `TensorProto.raw_data` containing `8.8.8.8`; this branch does not. A separate metadata URL fixture still reports `https://45.33.32.156/payload`.
- Branch Kokoro validation: scanning the same pinned snapshot on this branch produced zero failed `Network Communication Detection` checks. The scan still exits 2 due existing ONNX weight distribution coverage/anomaly findings, so this PR does not claim complete Kokoro coverage.

## Validation
- `uv sync --frozen --no-default-groups --group dev --extra all-ci`
- `.venv/bin/ruff format --check modelaudit/ tests/`
- `.venv/bin/ruff check modelaudit/ tests/`
- `.venv/bin/ruff check --select I modelaudit/ tests/`
- `.venv/bin/mypy --python-version 3.12 modelaudit/scanners/onnx_scanner.py`
- `.venv/bin/pytest tests/scanners/test_onnx_scanner.py::TestRawDetectorCoverage -q`
- `.venv/bin/pytest tests/scanners/test_onnx_scanner.py -q -k "not pinned_huggingface_large_onnx_reaches_file_backed_terminal_scan"`
- `env -u ALL_PROXY -u all_proxy -u FTP_PROXY -u ftp_proxy PROMPTFOO_DISABLE_TELEMETRY=1 NO_ANALYTICS=1 .venv/bin/pytest tests/test_cli.py::test_scan_huggingface_url_success tests/test_cli.py::test_scan_huggingface_url_download_failure -q --tb=short`

## Limitations
- The broad local fast-test lane was started with all-ci deps and interrupted after unrelated failures around local proxy/HF URL handling; the two identified CLI cases pass narrowly when the local SOCKS `ALL_PROXY` is removed and the HTTP proxy remains. CI should provide the exact branch validation.
- This change intentionally does not change the generic network detector and does not address separate ONNX weight-distribution coverage gaps tracked by the campaign.

## Checklist
- [x] I added/updated tests when behavior changed.
- [x] I preserved security detections with a positive metadata URL regression.
- [x] I avoided loading or executing model-provided code/data.