### PR TITLE
fix: preserve PyTorch storage import trust

### DIFF
--- a/packages/modelaudit-picklescan/CHANGELOG.md
+++ b/packages/modelaudit-picklescan/CHANGELOG.md
@@ -9,6 +9,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- Ignore canonical PyTorch storage persistent-ID globals during source-sensitive call-graph enrichment.
 - Report which snapshot gate invalidated a shared call-graph source-stability failure.
 - Validate bounded batched PyTorch state-dictionary entries without falsely flagging canonical tensor reconstruction.
 - Keep scanning storage members between the trusted and expanded pickle probe sizes.

--- a/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
+++ b/packages/modelaudit-picklescan/src/modelaudit_picklescan/api.py
@@ -3386,6 +3386,7 @@ def _with_canonical_pytorch_storage_persistent_id_metadata(
         and bool(trusted_storage_keys)
     )
     rust_canonical_storage_ids = _rust_pytorch_storage_persistent_id_flags_are_canonical(report)
+    storage_global_positions = storage_reference_parse.storage_global_positions
     single_storage_key = next(iter(trusted_storage_keys)) if len(trusted_storage_keys) == 1 else None
 
     findings = tuple(
@@ -3407,7 +3408,8 @@ def _with_canonical_pytorch_storage_persistent_id_metadata(
             _canonical_pytorch_storage_import_reference(
                 _mapping(reference),
                 proven_canonical_storage_ids=proven_canonical_storage_ids,
-                storage_global_positions=storage_reference_parse.storage_global_positions,
+                rust_canonical_storage_ids=rust_canonical_storage_ids,
+                storage_global_positions=storage_global_positions,
             )
             for reference in import_references
         ]
@@ -3443,12 +3445,15 @@ def _canonical_pytorch_storage_import_reference(
     reference: Mapping[str, Any],
     *,
     proven_canonical_storage_ids: bool,
+    rust_canonical_storage_ids: bool,
     storage_global_positions: set[int],
 ) -> dict[str, Any]:
     normalized = dict(reference)
     module = normalized.get("module")
     name = normalized.get("name")
     if type(module) is str and type(name) is str and (module, name) in _PYTORCH_STORAGE_GLOBALS:
+        if rust_canonical_storage_ids and normalized.get("pytorch_storage_persistent_id") is True:
+            return normalized
         if proven_canonical_storage_ids and _optional_int(normalized.get("position")) in storage_global_positions:
             normalized["pytorch_storage_persistent_id"] = True
         else:

--- a/packages/modelaudit-picklescan/tests/test_api.py
+++ b/packages/modelaudit-picklescan/tests/test_api.py
@@ -3002,6 +3002,7 @@ def test_scan_bytes_marks_only_pytorch_storage_global_used_by_persistent_id() ->
             "pytorch_storage_persistent_id": True,
         },
         proven_canonical_storage_ids=True,
+        rust_canonical_storage_ids=False,
         storage_global_positions={10},
     )
 
@@ -3174,6 +3175,72 @@ def test_scan_bytes_marks_only_matched_pytorch_storage_persistent_id_import_refe
     assert flagged_positions == [first_storage_position]
     assert storage_flags_by_position[first_storage_position] is True
     assert storage_flags_by_position.get(extra_storage_position) is not True
+
+
+def test_scan_bytes_preserves_native_storage_pid_flags_when_trust_parser_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _require_torch_distribution()
+    payload = _pytorch_storage_persistent_id_payload("0")
+
+    def fail_trust_parse(*_args: object, **_kwargs: object) -> package_api._PytorchStorageReferenceParse:
+        return package_api._PytorchStorageReferenceParse(set(), {}, set(), set(), False, False)
+
+    monkeypatch.setattr(package_api, "_pytorch_storage_keys_from_pickle_bytes", fail_trust_parse)
+    _clear_source_sensitive_caches()
+    try:
+        report = scan_bytes(payload, source="parser-failed-pytorch-storage.pkl")
+    finally:
+        _clear_source_sensitive_caches()
+
+    assert report.status == ScanStatus.COMPLETE
+    assert not any(
+        finding.rule_code == "DANGEROUS_CALL_GRAPH" and finding.details.get("import_reference") == "torch.FloatStorage"
+        for finding in report.findings
+    )
+    assert not any(
+        finding.rule_code == "NON_ALLOWLISTED_GLOBAL"
+        and finding.details.get("import_reference") == "torch.FloatStorage"
+        for finding in report.findings
+    )
+    storage_references = [
+        reference
+        for reference in report.metadata["import_references"]
+        if reference.get("import_reference") == "torch.FloatStorage"
+    ]
+    assert storage_references
+    assert all(reference.get("pytorch_storage_persistent_id") is True for reference in storage_references)
+
+
+def test_scan_bytes_preserves_unmatched_storage_global_call_graph_when_trust_parser_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _require_torch_distribution()
+    payload = _pytorch_storage_persistent_id_payload("0")
+    payload = payload[:-1] + b"0" + _short_binunicode(b"torch") + _short_binunicode(b"FloatStorage") + b"\x93."
+
+    def fail_trust_parse(*_args: object, **_kwargs: object) -> package_api._PytorchStorageReferenceParse:
+        return package_api._PytorchStorageReferenceParse(set(), {}, set(), set(), False, False)
+
+    monkeypatch.setattr(package_api, "_pytorch_storage_keys_from_pickle_bytes", fail_trust_parse)
+    _clear_source_sensitive_caches()
+    try:
+        report = scan_bytes(payload, source="parser-failed-mixed-pytorch-storage.pkl")
+    finally:
+        _clear_source_sensitive_caches()
+
+    assert report.status == ScanStatus.COMPLETE
+    assert any(
+        finding.rule_code == "DANGEROUS_CALL_GRAPH" and finding.details.get("import_reference") == "torch.FloatStorage"
+        for finding in report.findings
+    )
+    storage_references = [
+        reference
+        for reference in report.metadata["import_references"]
+        if reference.get("import_reference") == "torch.FloatStorage"
+    ]
+    assert len(storage_references) == 2
+    assert [reference.get("pytorch_storage_persistent_id") for reference in storage_references].count(True) == 1
 
 
 def test_scan_bytes_does_not_mark_synthetic_torch_storage_name_as_storage_persistent_id() -> None:


### PR DESCRIPTION
## Problem

The Hugging Face publisher-verification campaign found a false-positive critical call-graph finding while scanning `leonelhs/realesrgan` at immutable HF revision `202572d83c120aca8bd247f1b7698f37feddec20` from current `origin/main` (`9631527b3e81e0458fe9e0242c3178af406bfa5f`).

The affected checkpoint `realesr-animevideov3.pth` was downloaded from the official `xinntao/Real-ESRGAN` GitHub release and verified against the HF LFS pointer:

- bytes: `2504012`
- SHA-256: `b8a8376811077954d82ca3fcf476f1ac3da3e8a68a4f4d71363008000a18b75d`

Baseline ModelAudit flagged `torch.FloatStorage` as `DANGEROUS_CALL_GRAPH` because Python enrichment stripped the native scanner's `pytorch_storage_persistent_id` flag from matching import references when the heavier Python storage trust parser failed closed. Those globals are part of PyTorch storage persistent IDs, not direct callable invocations.

## Fix

Preserve native Rust `pytorch_storage_persistent_id` import-reference flags when they are canonical, while retaining the existing Python parser position proof path. This keeps canonical PyTorch storage globals out of source-sensitive call-graph enrichment without weakening unmatched or synthetic storage globals.

The regression tests cover both sides:

- forced Python trust-parser failure still suppresses canonical storage persistent-ID globals;
- an extra unmatched `torch.FloatStorage` global still produces a call-graph finding.

## Campaign Evidence

Evidence files on the campaign coordinator:

- baseline worker scan: `/home/dev-user/code/modelaudit-hf-campaign-20260908/publisher-scans/leonelhs_realesrgan-202572d83c12/runs/publisher-worker-leonelhs-realesrgan-mdangelo-mono-13-20260909T054514Z/publisher-scan-result.json`
- static opcode inspection: `/home/dev-user/code/modelaudit-hf-campaign-20260908/triage/leonelhs-realesrgan-static-pickle-inspection.json`
- ZIP member inspection: `/home/dev-user/code/modelaudit-hf-campaign-20260908/triage/leonelhs-realesrgan-zip-members.json`
- branch after-fix evidence: `/home/dev-user/code/modelaudit-hf-campaign-20260908/triage/leonelhs-realesrgan-storage-callgraph-fp-evidence.json`
- branch CLI result: `/home/dev-user/code/modelaudit-hf-campaign-20260908/triage/leonelhs-realesrgan-storage-callgraph-fp-branch-cli-result.json`

After the fix, the pinned RealESRGAN artifact has zero `DANGEROUS_CALL_GRAPH` findings for `torch.FloatStorage`; the storage import reference remains marked `pytorch_storage_persistent_id: true`. The branch CLI scan still preserves security-relevant PyTorch pickle warnings and exits nonzero where appropriate; this PR does not suppress generic pickle risk.

## Validation

- `uv lock --check`
- `../../.venv/bin/ruff format --check src tests`
- `../../.venv/bin/ruff check src tests`
- `../../.venv/bin/mypy --python-version 3.12 src tests`
- `.venv/bin/ruff format --check modelaudit packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests`
- `.venv/bin/ruff check modelaudit packages/modelaudit-picklescan/src packages/modelaudit-picklescan/tests tests`
- `.venv/bin/pytest packages/modelaudit-picklescan/tests/test_api.py::test_scan_bytes_preserves_native_storage_pid_flags_when_trust_parser_fails packages/modelaudit-picklescan/tests/test_api.py::test_scan_bytes_preserves_unmatched_storage_global_call_graph_when_trust_parser_fails -q`
- `.venv/bin/pytest packages/modelaudit-picklescan/tests/test_api.py -q -k 'pytorch_storage or pytorch_zip or tensor_rebuild'`
- `.venv/bin/pytest packages/modelaudit-picklescan/tests/test_call_graph_import_statements.py -q -k 'torch_module_lifecycle or pytorch_storage or FloatStorage'`
- `.venv/bin/pytest tests/scanners/test_pickle_scanner.py tests/scanners/test_picklescan_adapter.py -q -k 'call_graph or pytorch or persistent_id or FloatStorage'`
- `../../.venv/bin/pytest -n auto tests --tb=short` from `packages/modelaudit-picklescan` (`3041 passed, 5 skipped, 2 warnings`)
- Real pinned artifact CLI scan under this branch with telemetry disabled, no whitelist, no cache, `--max-size 8GB`, `--timeout 5400`

## Limitations

The full `leonelhs/realesrgan` repository scan remains partial in the campaign ledger because separate encoded-text coverage findings are still pending under the existing PyTorch encoded-text PR. This PR only fixes the canonical storage import call-graph false positive.
