### PR TITLE
fix: install tomli for Python 3.10 runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preserve macOS scan-result cache entries during unrelated temporary-file churn while rejecting replaced source files and directories.
 - Keep macOS scan-result caching enabled when hashing updates a model file's access time.
 - Scan all bounded encoded pickle metadata that fits the decoded-byte budget, avoiding incomplete PyTorch ZIP coverage on harmless small encoded tokens.
+- Install `tomli` for Python 3.10 runtime environments so no-default-groups scanner installs can read ModelAudit TOML configuration.
 
 ## [0.2.52](https://github.com/promptfoo/modelaudit/compare/v0.2.51...v0.2.52) (2026-07-22)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "posthog>=7.0.0",
     "protobuf>=5.29.0",
     "msgpack>=1.2.1,<2.0",
+    "tomli>=2.0.0; python_version < '3.11'",
     "modelaudit-picklescan>=0.1.10,<0.2.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1921,6 +1921,7 @@ dependencies = [
     { name = "s3fs" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "yaspin" },
 ]
 
@@ -2140,6 +2141,7 @@ requires-dist = [
     { name = "sqlparse", marker = "extra == 'mlflow'", specifier = ">=0.6.0" },
     { name = "tensorflow", marker = "python_full_version >= '3.11' and python_full_version < '3.13' and extra == 'tensorflow'", specifier = ">=2.21,<2.22" },
     { name = "tensorrt", marker = "(sys_platform == 'linux' and extra == 'tensorrt') or (sys_platform == 'win32' and extra == 'tensorrt')", specifier = ">=8.6.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
     { name = "tflite", marker = "extra == 'all'", specifier = ">=2.18.0" },
     { name = "tflite", marker = "extra == 'all-ci'", specifier = ">=2.18.0" },
     { name = "tflite", marker = "extra == 'numpy1'", specifier = ">=2.18.0" },


### PR DESCRIPTION
## Summary

- Add `tomli` as a Python <3.11 runtime dependency for the root `modelaudit` package.
- Update `uv.lock` root metadata so frozen Python 3.10/no-default-groups installs include the fallback parser used by `modelaudit.config.rule_config`.
- Add an Unreleased changelog entry.

## Evidence

- Reproduced the Python 3.10 frozen install failure before the lock metadata update: `ModuleNotFoundError: No module named 'tomli'`.
- `UV_PROJECT_ENVIRONMENT=/tmp/modelaudit-tomli-py310-venv uv sync --frozen --no-default-groups --extra onnx --python /home/dev-user/.cache/modelaudit-hf-campaign-py310-yolo-venv/bin/python3.10` now installs `tomli==2.4.1`.
- Python 3.10 import/CLI smoke passed: `modelaudit.config.rule_config`, `modelaudit --version`, and `modelaudit scan --help`.
- `uv pip check` passed for the Python 3.10 validation env and the local Python 3.13 no-default-groups env.
- Two native prepublish review passes found no actionable regression; receipt: `reviews/hf-python310-tomli-dep/prepublish-096d032f/prepublish-review-receipt.json` in the campaign ledger.

## Limits

- Full `uv run` lint gates were not rerun because this environment re-enters the known optional TensorRT/NVIDIA path. A direct `ruff check modelaudit/config/rule_config.py` only reported pre-existing broad-exception findings in unchanged lines.
