### PR TITLE
fix(onnx): compact runtime lineage fanout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - Avoid incomplete ONNX weight analysis when Gather nodes read dimensions from Shape outputs.
+- Avoid incomplete ONNX weight analysis when large runtime-activation fanout only adds dynamic bookkeeping lineage.
 - Treat documentation, license, and repository links in verified pickle and ONNX metadata as informational across supported Python versions while preserving active and unknown network destinations.
 - Preserve incomplete-scan diagnostics for malformed or unsupported ZIP data in GGUF/GGML files, including cached scans.
 - Report incomplete coverage when a GGUF/GGML source changes during scanning.

--- a/modelaudit/scanners/onnx_scanner.py
+++ b/modelaudit/scanners/onnx_scanner.py
@@ -124,6 +124,9 @@ _ONNX_WEIGHT_ANALYSIS_GROUP_LIMIT = 100
 _ONNX_WEIGHT_LINEAGES_PER_VALUE_LIMIT = 32
 _ONNX_WEIGHT_TRANSFORM_DEPTH_LIMIT = 32
 _ONNX_WEIGHT_RESHAPE_RANK_LIMIT = 64
+_ONNX_RUNTIME_BOOKKEEPING_LINEAGE_REASONS: frozenset[str] = frozenset(
+    {"dynamic_activation_lineage", "dynamic_input_lineage"}
+)
 _ONNX_WEIGHT_METADATA_TEXT_LIMIT = 256
 _ONNX_WEIGHT_METADATA_SEQUENCE_LIMIT = 64
 _ONNX_CUSTOM_OPERATOR_REPRESENTATIVE_LIMIT = 5
@@ -2167,14 +2170,43 @@ def _build_onnx_weight_analysis_plan(
             unresolved_reason=lineage.unresolved_reason,
         )
 
+    def compact_runtime_bookkeeping_lineages(
+        lineages: dict[int, _OnnxWeightLineage],
+    ) -> dict[int, _OnnxWeightLineage]:
+        if len(lineages) <= _ONNX_WEIGHT_LINEAGES_PER_VALUE_LIMIT:
+            return lineages
+        representatives: dict[str, tuple[int, _OnnxWeightLineage]] = {}
+        compacted: dict[int, _OnnxWeightLineage] = {}
+        for initializer_index, lineage in sorted(lineages.items()):
+            if lineage.unresolved_reason in _ONNX_RUNTIME_BOOKKEEPING_LINEAGE_REASONS:
+                if lineage.transforms:
+                    compacted[initializer_index] = lineage
+                else:
+                    representatives.setdefault(lineage.unresolved_reason, (initializer_index, lineage))
+            else:
+                compacted[initializer_index] = lineage
+        if not representatives:
+            return lineages
+        compacted.update(dict(representatives.values()))
+        return dict(sorted(compacted.items()))
+
     def bounded_lineages(lineages: dict[int, _OnnxWeightLineage]) -> dict[int, _OnnxWeightLineage]:
+        lineages = compact_runtime_bookkeeping_lineages(lineages)
         if len(lineages) <= _ONNX_WEIGHT_LINEAGES_PER_VALUE_LIMIT:
             return lineages
         plan.record_coverage_gap(
             "lineages_per_value_limit",
             len(lineages) - _ONNX_WEIGHT_LINEAGES_PER_VALUE_LIMIT,
         )
-        return dict(sorted(lineages.items())[:_ONNX_WEIGHT_LINEAGES_PER_VALUE_LIMIT])
+        return dict(
+            sorted(
+                lineages.items(),
+                key=lambda item: (
+                    item[1].unresolved_reason in _ONNX_RUNTIME_BOOKKEEPING_LINEAGE_REASONS,
+                    item[0],
+                ),
+            )[:_ONNX_WEIGHT_LINEAGES_PER_VALUE_LIMIT]
+        )
 
     def merge_transform_markers(
         left: tuple[_OnnxWeightTransform, ...],

--- a/tests/scanners/test_onnx_scanner.py
+++ b/tests/scanners/test_onnx_scanner.py
@@ -6443,6 +6443,105 @@ class TestWeightDistributionSemantics:
         semantics = result.metadata["onnx_weight_distribution_semantics"]
         assert semantics["exclusion_counts"]["bookkeeping_constant"] == 1
 
+    def test_runtime_activation_lineage_fanout_stays_under_value_cap(self, tmp_path: Path) -> None:
+        inputs = [helper.make_tensor_value_info(f"X{index}", TensorProto.FLOAT, [1, 4]) for index in range(40)]
+        initializers = [
+            onnx.numpy_helper.from_array(np.zeros((4, 4), dtype=np.float32), name=f"W{index}") for index in range(40)
+        ]
+        initializers.append(onnx.numpy_helper.from_array(np.zeros((4, 2), dtype=np.float32), name="W_out"))
+        nodes = [helper.make_node("MatMul", [f"X{index}", f"W{index}"], [f"hidden{index}"]) for index in range(40)]
+        nodes.extend(
+            [
+                helper.make_node("Sum", [f"hidden{index}" for index in range(40)], ["merged"]),
+                helper.make_node("Relu", ["merged"], ["activated"]),
+                helper.make_node("MatMul", ["activated", "W_out"], ["Y"]),
+            ]
+        )
+        graph = helper.make_graph(
+            nodes,
+            "runtime_activation_lineage_fanout",
+            inputs,
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 2])],
+            initializer=initializers,
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        path = tmp_path / "runtime-activation-lineage-fanout.onnx"
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        assert result.success is True
+        assert self._extreme_checks(result) == []
+        assert not any(check.name == "Weight Distribution Analysis Coverage" for check in result.checks)
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["coverage_gaps"] == {}
+        assert semantics["eligible_initializer_count"] == 41
+        assert semantics["analyzed_layer_count"] == 41
+
+    def test_runtime_bookkeeping_recurrent_marker_survives_fanout_compaction(self, tmp_path: Path) -> None:
+        initializers = [
+            onnx.numpy_helper.from_array(np.zeros(4, dtype=np.float32), name=f"C{index}") for index in range(33)
+        ]
+        initializers.extend(
+            [
+                onnx.numpy_helper.from_array(np.zeros((1, 4, 4), dtype=np.float32), name="W"),
+                onnx.numpy_helper.from_array(np.zeros((1, 4, 4), dtype=np.float32), name="R"),
+                onnx.numpy_helper.from_array(np.zeros((4, 1), dtype=np.float32), name="P"),
+                onnx.numpy_helper.from_array(np.array([1, 1, 4], dtype=np.int64), name="state_shape"),
+                onnx.numpy_helper.from_array(np.array([4], dtype=np.int64), name="flat_shape"),
+            ]
+        )
+        nodes = [helper.make_node("Add", [f"C{index}", "X"], [f"A{index}"]) for index in range(33)]
+        nodes.extend(
+            [
+                helper.make_node("Reshape", ["A32", "state_shape"], ["initial_h"]),
+                helper.make_node(
+                    "RNN",
+                    ["sequence", "W", "R", "", "", "initial_h"],
+                    ["sequence_output", "state"],
+                    hidden_size=4,
+                ),
+                helper.make_node("Reshape", ["state", "flat_shape"], ["state_vector"]),
+                helper.make_node("Sum", [*[f"A{index}" for index in range(32)], "state_vector"], ["mixed"]),
+                helper.make_node("MatMul", ["mixed", "P"], ["Y"]),
+            ]
+        )
+        graph = helper.make_graph(
+            nodes,
+            "runtime_bookkeeping_recurrent_marker_compaction",
+            [
+                helper.make_tensor_value_info("X", TensorProto.FLOAT, [4]),
+                helper.make_tensor_value_info("sequence", TensorProto.FLOAT, [1, 1, 4]),
+            ],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])],
+            initializer=initializers,
+            value_info=[helper.make_tensor_value_info("state_vector", TensorProto.FLOAT, [4])],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 14)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        path = tmp_path / "runtime-bookkeeping-recurrent-marker-compaction.onnx"
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        assert result.success is False
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert coverage and all(check.status == CheckStatus.FAILED for check in coverage)
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["coverage_gaps"]["unresolved_initializer_lineage"] == 1
+        assert semantics["coverage_gaps"].get("lineages_per_value_limit", 0) == 0
+        assert any(
+            sample["initializer"] == "C32"
+            and sample["consumer_op"] == "MatMul"
+            and sample["consumer_input_index"] == 0
+            and sample["reason"] == "dynamic_input_lineage"
+            and sample["lineage_transform_count"] >= 2
+            for sample in semantics["unresolved_lineage_samples"]
+        )
+
     @pytest.mark.parametrize("malicious", [False, True])
     def test_shape_gather_path_does_not_create_weight_coverage_gap(
         self,
@@ -6588,6 +6687,72 @@ class TestWeightDistributionSemantics:
             sample["consumer_op"] == "MatMul" and sample["reason"] == "shape_dimensions_lineage"
             for sample in result.metadata["onnx_weight_distribution_semantics"]["unresolved_lineage_samples"]
         )
+
+    def test_shape_dimension_lineage_fanout_still_fails_closed(self, tmp_path: Path) -> None:
+        initializers = [
+            onnx.numpy_helper.from_array(np.zeros((40, 40), dtype=np.float32), name=f"W_runtime{index}")
+            for index in range(40)
+        ]
+        initializers.extend(
+            onnx.numpy_helper.from_array(np.ones((1,), dtype=np.float32), name=f"source{index}") for index in range(40)
+        )
+        initializers.append(onnx.numpy_helper.from_array(np.array([40, 1], dtype=np.int64), name="weight_shape"))
+        runtime_inputs = [
+            helper.make_tensor_value_info(f"runtime{index}", TensorProto.FLOAT, [40]) for index in range(40)
+        ]
+        nodes = [
+            helper.make_node("MatMul", [f"runtime{index}", f"W_runtime{index}"], [f"runtime_delta{index}"])
+            for index in range(40)
+        ]
+        nodes.append(helper.make_node("Sum", [f"runtime_delta{index}" for index in range(40)], ["runtime_delta"]))
+        for index in range(40):
+            nodes.extend(
+                [
+                    helper.make_node("Shape", [f"source{index}"], [f"dimensions{index}"]),
+                    helper.make_node(
+                        "Cast", [f"dimensions{index}"], [f"dimension_weight{index}"], to=TensorProto.FLOAT
+                    ),
+                ]
+            )
+        nodes.extend(
+            [
+                helper.make_node(
+                    "Concat",
+                    [f"dimension_weight{index}" for index in range(40)],
+                    ["flat_weight"],
+                    axis=0,
+                ),
+                helper.make_node("Add", ["flat_weight", "runtime_delta"], ["mixed_flat_weight"]),
+                helper.make_node("Reshape", ["mixed_flat_weight", "weight_shape"], ["generated_weight"]),
+                helper.make_node("MatMul", ["X", "generated_weight"], ["Y"]),
+            ]
+        )
+        graph = helper.make_graph(
+            nodes,
+            "shape_dimension_lineage_fanout",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 40]), *runtime_inputs],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 1])],
+            initializer=initializers,
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+        model.ir_version = 8
+        onnx.checker.check_model(model)
+        path = tmp_path / "shape-dimension-lineage-fanout.onnx"
+        onnx.save(model, str(path))
+
+        result = OnnxScanner().scan(str(path))
+
+        assert result.success is False
+        coverage = [check for check in result.checks if check.name == "Weight Distribution Analysis Coverage"]
+        assert coverage and all(check.status == CheckStatus.FAILED for check in coverage)
+        semantics = result.metadata["onnx_weight_distribution_semantics"]
+        assert semantics["coverage_gaps"]["lineages_per_value_limit"] >= 8
+        assert semantics["coverage_gaps"]["unresolved_initializer_lineage"] == 32
+        assert any(
+            sample["consumer_op"] == "MatMul" and sample["reason"] == "shape_dimensions_lineage"
+            for sample in semantics["unresolved_lineage_samples"]
+        )
+        assert all(sample["reason"] == "shape_dimensions_lineage" for sample in semantics["unresolved_lineage_samples"])
 
     @pytest.mark.parametrize(
         "use",


### PR DESCRIPTION
## Summary

Fixes ONNX weight-lineage cap behavior for large runtime bookkeeping fanout. Plain dynamic activation/input bookkeeping lineages are compacted before the per-value cap, but transformed runtime lineages are preserved so later fail-closed checks still see security-relevant markers such as recurrent final-state output.

## Evidence

- Campaign leads: YuNet, NanoDet, ShuffleNet and PPOCR produced ONNX lineage-cap coverage gaps on current main with complete artifact identity receipts, but no high/critical security detections.
- Added deterministic inert ONNX regressions for benign runtime activation fanout and transformed recurrent-state fanout.
- The new recurrent-state regression fails closed with `unresolved_initializer_lineage` while keeping the cap event count at zero after safe compaction.

## Validation

- `pytest tests/scanners/test_onnx_scanner.py::TestWeightDistributionSemantics::test_runtime_bookkeeping_recurrent_marker_survives_fanout_compaction -q`: 1 passed.
- `pytest tests/scanners/test_onnx_scanner.py::TestWeightDistributionSemantics::test_runtime_activation_lineage_fanout_stays_under_value_cap tests/scanners/test_onnx_scanner.py::TestWeightDistributionSemantics::test_shape_dimension_lineage_fanout_still_fails_closed tests/scanners/test_onnx_scanner.py::TestWeightDistributionSemantics::test_runtime_bookkeeping_recurrent_marker_survives_fanout_compaction -q`: 3 passed.
- `pytest tests/scanners/test_onnx_scanner.py::TestWeightDistributionSemantics -q`: 310 passed.
- `pytest tests/scanners/test_onnx_scanner.py -q -k 'not pinned_huggingface_large_onnx_reaches_file_backed_terminal_scan'`: 604 passed, 3 skipped, 2 deselected.
- `ruff format --check`, `ruff check`, `mypy --python-version 3.12` on touched files, and `git diff --check`: passed.
- High-risk native prepublish review gate: 3 independent clean passes plus independent verifier, zero candidates. Receipt: `/home/dev-user/code/modelaudit-hf-campaign-20260908/reviews/pr-1838-mdangelo-codex-hf-onnx-gather-lineage/prepublish-d977ee76/prepublish-review-receipt.json`.

## Limits

- Full live ONNX download tests were not used for validation because the current environment lacks the SOCKS dependency needed by `huggingface_hub` under the configured proxy path.
- This PR repairs coverage handling only; it does not count any HF repository scan as complete by itself.
